### PR TITLE
Add Multi-caret support to TextEdit

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		TextEdit is meant for editing large, multiline text. It also has facilities for editing code, such as syntax highlighting support and multiple levels of undo/redo.
+		[b]Note:[/b] Most viewport, caret and edit methods contain a [code]caret_index[/code] argument for [member caret_multiple] support. The argument should be one of the following: [code]-1[/code] for all carets, [code]0[/code] for the main caret, or greater than [code]0[/code] for secondary carets.
 		[b]Note:[/b] When holding down [kbd]Alt[/kbd], the vertical scroll wheel will scroll 5 times as fast as it would normally do. This also works in the Godot script editor.
 	</description>
 	<tutorials>
@@ -12,18 +13,21 @@
 	<methods>
 		<method name="_backspace" qualifiers="virtual">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" />
 			<description>
 				Override this method to define what happens when the user presses the backspace key.
 			</description>
 		</method>
 		<method name="_copy" qualifiers="virtual">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" />
 			<description>
 				Override this method to define what happens when the user performs a copy operation.
 			</description>
 		</method>
 		<method name="_cut" qualifiers="virtual">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" />
 			<description>
 				Override this method to define what happens when the user performs a cut operation.
 			</description>
@@ -31,21 +35,32 @@
 		<method name="_handle_unicode_input" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="unicode_char" type="int" />
+			<param index="1" name="caret_index" type="int" />
 			<description>
 				Override this method to define what happens when the user types in the provided key [param unicode_char].
 			</description>
 		</method>
 		<method name="_paste" qualifiers="virtual">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" />
 			<description>
 				Override this method to define what happens when the user performs a paste operation.
 			</description>
 		</method>
 		<method name="_paste_primary_clipboard" qualifiers="virtual">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" />
 			<description>
 				Override this method to define what happens when the user performs a paste operation with middle mouse button.
 				[b]Note:[/b] This method is only implemented on Linux.
+			</description>
+		</method>
+		<method name="add_caret">
+			<return type="int" />
+			<param index="0" name="line" type="int" />
+			<param index="1" name="col" type="int" />
+			<description>
+				Adds a new caret at the given location. Returns the index of the new caret, or [code]-1[/code] if the location is invalid.
 			</description>
 		</method>
 		<method name="add_gutter">
@@ -55,14 +70,27 @@
 				Register a new gutter to this [TextEdit]. Use [param at] to have a specific gutter order. A value of [code]-1[/code] appends the gutter to the right.
 			</description>
 		</method>
+		<method name="adjust_carets_after_edit">
+			<return type="void" />
+			<param index="0" name="caret" type="int" />
+			<param index="1" name="from_line" type="int" />
+			<param index="2" name="from_col" type="int" />
+			<param index="3" name="to_line" type="int" />
+			<param index="4" name="to_col" type="int" />
+			<description>
+				Reposition the carets affected by the edit. This assumes edits are applied in edit order, see [method get_caret_index_edit_order].
+			</description>
+		</method>
 		<method name="adjust_viewport_to_caret">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Adjust the viewport so the caret is visible.
 			</description>
 		</method>
 		<method name="backspace">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Called when the user presses the backspace key. Can be overridden with [method _backspace].
 			</description>
@@ -75,6 +103,7 @@
 		</method>
 		<method name="center_viewport_to_caret">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Centers the viewport on the line the editing caret is at. This also resets the [member scroll_horizontal] value to [code]0[/code].
 			</description>
@@ -93,26 +122,36 @@
 		</method>
 		<method name="copy">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Copies the current text selection. Can be overridden with [method _copy].
 			</description>
 		</method>
 		<method name="cut">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Cut's the current selection. Can be overridden with [method _cut].
 			</description>
 		</method>
 		<method name="delete_selection">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Deletes the selected text.
 			</description>
 		</method>
 		<method name="deselect">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Deselects the current selection.
+			</description>
+		</method>
+		<method name="end_action">
+			<return type="void" />
+			<description>
+				Marks the end of steps in the current action started with [method start_action].
 			</description>
 		</method>
 		<method name="end_complex_operation">
@@ -123,24 +162,40 @@
 		</method>
 		<method name="get_caret_column" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the column the editing caret is at.
 			</description>
 		</method>
+		<method name="get_caret_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of carets in this [TextEdit].
+			</description>
+		</method>
 		<method name="get_caret_draw_pos" qualifiers="const">
 			<return type="Vector2" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the caret pixel draw position.
 			</description>
 		</method>
+		<method name="get_caret_index_edit_order">
+			<return type="PackedInt32Array" />
+			<description>
+				Returns a list of caret indexes in their edit order, this done from bottom to top. Edit order refers to the way actions such as [method insert_text_at_caret] are applied.
+			</description>
+		</method>
 		<method name="get_caret_line" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the line the editing caret is on.
 			</description>
 		</method>
 		<method name="get_caret_wrap_index" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the wrap index the editing caret is on.
 			</description>
@@ -381,32 +436,37 @@
 				Returns the scroll position for [param wrap_index] of [param line].
 			</description>
 		</method>
-		<method name="get_selected_text" qualifiers="const">
+		<method name="get_selected_text">
 			<return type="String" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Returns the text inside the selection.
 			</description>
 		</method>
 		<method name="get_selection_column" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the original start column of the selection.
 			</description>
 		</method>
 		<method name="get_selection_from_column" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the selection begin column.
 			</description>
 		</method>
 		<method name="get_selection_from_line" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the selection begin line.
 			</description>
 		</method>
 		<method name="get_selection_line" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the original start line of the selection.
 			</description>
@@ -419,12 +479,14 @@
 		</method>
 		<method name="get_selection_to_column" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the selection end column.
 			</description>
 		</method>
 		<method name="get_selection_to_line" qualifiers="const">
 			<return type="int" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns the selection end line.
 			</description>
@@ -476,6 +538,7 @@
 		</method>
 		<method name="get_word_under_caret" qualifiers="const">
 			<return type="String" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Returns a [String] text with the word under the caret's location.
 			</description>
@@ -494,6 +557,7 @@
 		</method>
 		<method name="has_selection" qualifiers="const">
 			<return type="bool" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Returns [code]true[/code] if the user has selected text.
 			</description>
@@ -515,12 +579,14 @@
 		<method name="insert_text_at_caret">
 			<return type="void" />
 			<param index="0" name="text" type="String" />
+			<param index="1" name="caret_index" type="int" default="-1" />
 			<description>
 				Insert the specified text at the caret position.
 			</description>
 		</method>
 		<method name="is_caret_visible" qualifiers="const">
 			<return type="bool" />
+			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
 				Returns [code]true[/code] if the caret is visible on the screen.
 			</description>
@@ -576,6 +642,7 @@
 		<method name="is_mouse_over_selection" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="edges" type="bool" />
+			<param index="1" name="caret_index" type="int" default="-1" />
 			<description>
 				Returns whether the mouse is over selection. If [param edges] is [code]true[/code], the edges are considered part of the selection.
 			</description>
@@ -601,10 +668,25 @@
 				Merge the gutters from [param from_line] into [param to_line]. Only overwritable gutters will be copied.
 			</description>
 		</method>
-		<method name="paste">
+		<method name="merge_overlapping_carets">
 			<return type="void" />
 			<description>
+				Merges any overlapping carets. Will favour the newest caret, or the caret with a selection.
+				[b]Note:[/b] This is not called when a caret changes position but after certain actions, so it is possible to get into a state where carets overlap.
+			</description>
+		</method>
+		<method name="paste">
+			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="-1" />
+			<description>
 				Paste at the current location. Can be overridden with [method _paste].
+			</description>
+		</method>
+		<method name="paste_primary_clipboard">
+			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="-1" />
+			<description>
+				Pastes the primary clipboard.
 			</description>
 		</method>
 		<method name="redo">
@@ -613,11 +695,25 @@
 				Perform redo operation.
 			</description>
 		</method>
+		<method name="remove_caret">
+			<return type="void" />
+			<param index="0" name="caret" type="int" />
+			<description>
+				Removes the given caret index.
+				[b]Note:[/b] This can result in adjustment of all other caret indices.
+			</description>
+		</method>
 		<method name="remove_gutter">
 			<return type="void" />
 			<param index="0" name="gutter" type="int" />
 			<description>
 				Removes the gutter from this [TextEdit].
+			</description>
+		</method>
+		<method name="remove_secondary_carets">
+			<return type="void" />
+			<description>
+				Removes all additional carets.
 			</description>
 		</method>
 		<method name="remove_text">
@@ -666,6 +762,7 @@
 			<param index="1" name="from_column" type="int" />
 			<param index="2" name="to_line" type="int" />
 			<param index="3" name="to_column" type="int" />
+			<param index="4" name="caret_index" type="int" default="0" />
 			<description>
 				Perform selection, from line/column to line/column.
 				If [member selecting_enabled] is [code]false[/code], no selection will occur.
@@ -680,6 +777,7 @@
 		</method>
 		<method name="select_word_under_caret">
 			<return type="void" />
+			<param index="0" name="caret_index" type="int" default="-1" />
 			<description>
 				Selects the word under the caret.
 			</description>
@@ -688,9 +786,11 @@
 			<return type="void" />
 			<param index="0" name="column" type="int" />
 			<param index="1" name="adjust_viewport" type="bool" default="true" />
+			<param index="2" name="caret_index" type="int" default="0" />
 			<description>
 				Moves the caret to the specified [param column] index.
 				If [param adjust_viewport] is [code]true[/code], the viewport will center at the caret position after the move occurs.
+				[b]Note:[/b] If supporting multiple carets this will not check for any overlap. See [method merge_overlapping_carets].
 			</description>
 		</method>
 		<method name="set_caret_line">
@@ -699,10 +799,12 @@
 			<param index="1" name="adjust_viewport" type="bool" default="true" />
 			<param index="2" name="can_be_hidden" type="bool" default="true" />
 			<param index="3" name="wrap_index" type="int" default="0" />
+			<param index="4" name="caret_index" type="int" default="0" />
 			<description>
 				Moves the caret to the specified [param line] index.
 				If [param adjust_viewport] is [code]true[/code], the viewport will center at the caret position after the move occurs.
 				If [param can_be_hidden] is [code]true[/code], the specified [code]line[/code] can be hidden.
+				[b]Note:[/b] If supporting multiple carets this will not check for any overlap. See [method merge_overlapping_carets].
 			</description>
 		</method>
 		<method name="set_gutter_clickable">
@@ -872,6 +974,7 @@
 			<param index="0" name="mode" type="int" enum="TextEdit.SelectionMode" />
 			<param index="1" name="line" type="int" default="-1" />
 			<param index="2" name="column" type="int" default="-1" />
+			<param index="3" name="caret_index" type="int" default="0" />
 			<description>
 				Sets the current selection mode.
 			</description>
@@ -888,6 +991,14 @@
 			<param index="0" name="callback" type="Callable" />
 			<description>
 				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String[/code]
+			</description>
+		</method>
+		<method name="start_action">
+			<return type="void" />
+			<param index="0" name="action" type="int" enum="TextEdit.EditAction" />
+			<description>
+				Starts an action, will end the current action if [code]action[/code] is different.
+				An action will also end after a call to [method end_action], after [member ProjectSettings.gui/timers/text_edit_idle_detect_sec] is triggered or a new undoable step outside the [method start_action] and [method end_action] calls.
 			</description>
 		</method>
 		<method name="swap_lines">
@@ -925,6 +1036,9 @@
 		<member name="caret_move_on_right_click" type="bool" setter="set_move_caret_on_right_click_enabled" getter="is_move_caret_on_right_click_enabled" default="true">
 			If [code]true[/code], a right-click moves the caret at the mouse position before displaying the context menu.
 			If [code]false[/code], the context menu disregards mouse location.
+		</member>
+		<member name="caret_multiple" type="bool" setter="set_multiple_carets_enabled" getter="is_multiple_carets_enabled" default="true">
+			Sets if multiple carets are allowed.
 		</member>
 		<member name="caret_type" type="int" setter="set_caret_type" getter="get_caret_type" enum="TextEdit.CaretType" default="0">
 			Set the type of caret to draw.
@@ -1153,6 +1267,18 @@
 		</constant>
 		<constant name="MENU_MAX" value="28" enum="MenuItems">
 			Represents the size of the [enum MenuItems] enum.
+		</constant>
+		<constant name="ACTION_NONE" value="0" enum="EditAction">
+			No current action.
+		</constant>
+		<constant name="ACTION_TYPING" value="1" enum="EditAction">
+			A typing action.
+		</constant>
+		<constant name="ACTION_BACKSPACE" value="2" enum="EditAction">
+			A backwards delete action.
+		</constant>
+		<constant name="ACTION_DELETE" value="3" enum="EditAction">
+			A forward delete action.
 		</constant>
 		<constant name="SEARCH_MATCH_CASE" value="1" enum="SearchFlags">
 			Match case when searching.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -55,6 +55,7 @@ void GotoLineDialog::ok_pressed() {
 	if (get_line() < 1 || get_line() > text_editor->get_line_count()) {
 		return;
 	}
+	text_editor->remove_secondary_carets();
 	text_editor->unfold_line(get_line() - 1);
 	text_editor->set_caret_line(get_line() - 1);
 	hide();
@@ -149,7 +150,7 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 			text_editor->unfold_line(pos.y);
 			text_editor->set_caret_line(pos.y, false);
 			text_editor->set_caret_column(pos.x + text.length(), false);
-			text_editor->center_viewport_to_caret();
+			text_editor->center_viewport_to_caret(0);
 			text_editor->select(pos.y, pos.x, pos.y, pos.x + text.length());
 
 			line_col_changed_for_result = true;
@@ -176,11 +177,11 @@ bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) 
 }
 
 void FindReplaceBar::_replace() {
-	bool selection_enabled = text_editor->has_selection();
+	bool selection_enabled = text_editor->has_selection(0);
 	Point2i selection_begin, selection_end;
 	if (selection_enabled) {
-		selection_begin = Point2i(text_editor->get_selection_from_line(), text_editor->get_selection_from_column());
-		selection_end = Point2i(text_editor->get_selection_to_line(), text_editor->get_selection_to_column());
+		selection_begin = Point2i(text_editor->get_selection_from_line(0), text_editor->get_selection_from_column(0));
+		selection_end = Point2i(text_editor->get_selection_to_line(0), text_editor->get_selection_to_column(0));
 	}
 
 	String replace_text = get_replace_text();
@@ -188,25 +189,25 @@ void FindReplaceBar::_replace() {
 
 	text_editor->begin_complex_operation();
 	if (selection_enabled && is_selection_only()) { // To restrict search_current() to selected region
-		text_editor->set_caret_line(selection_begin.width);
-		text_editor->set_caret_column(selection_begin.height);
+		text_editor->set_caret_line(selection_begin.width, false, true, 0, 0);
+		text_editor->set_caret_column(selection_begin.height, true, 0);
 	}
 
 	if (search_current()) {
 		text_editor->unfold_line(result_line);
-		text_editor->select(result_line, result_col, result_line, result_col + search_text_len);
+		text_editor->select(result_line, result_col, result_line, result_col + search_text_len, 0);
 
 		if (selection_enabled && is_selection_only()) {
 			Point2i match_from(result_line, result_col);
 			Point2i match_to(result_line, result_col + search_text_len);
 			if (!(match_from < selection_begin || match_to > selection_end)) {
-				text_editor->insert_text_at_caret(replace_text);
+				text_editor->insert_text_at_caret(replace_text, 0);
 				if (match_to.x == selection_end.x) { // Adjust selection bounds if necessary
 					selection_end.y += replace_text.length() - search_text_len;
 				}
 			}
 		} else {
-			text_editor->insert_text_at_caret(replace_text);
+			text_editor->insert_text_at_caret(replace_text, 0);
 		}
 	}
 	text_editor->end_complex_operation();
@@ -216,29 +217,29 @@ void FindReplaceBar::_replace() {
 
 	if (selection_enabled && is_selection_only()) {
 		// Reselect in order to keep 'Replace' restricted to selection
-		text_editor->select(selection_begin.x, selection_begin.y, selection_end.x, selection_end.y);
+		text_editor->select(selection_begin.x, selection_begin.y, selection_end.x, selection_end.y, 0);
 	} else {
-		text_editor->deselect();
+		text_editor->deselect(0);
 	}
 }
 
 void FindReplaceBar::_replace_all() {
 	text_editor->disconnect("text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
 	// Line as x so it gets priority in comparison, column as y.
-	Point2i orig_cursor(text_editor->get_caret_line(), text_editor->get_caret_column());
+	Point2i orig_cursor(text_editor->get_caret_line(0), text_editor->get_caret_column(0));
 	Point2i prev_match = Point2(-1, -1);
 
-	bool selection_enabled = text_editor->has_selection();
+	bool selection_enabled = text_editor->has_selection(0);
 	Point2i selection_begin, selection_end;
 	if (selection_enabled) {
-		selection_begin = Point2i(text_editor->get_selection_from_line(), text_editor->get_selection_from_column());
-		selection_end = Point2i(text_editor->get_selection_to_line(), text_editor->get_selection_to_column());
+		selection_begin = Point2i(text_editor->get_selection_from_line(0), text_editor->get_selection_from_column(0));
+		selection_end = Point2i(text_editor->get_selection_to_line(0), text_editor->get_selection_to_column(0));
 	}
 
 	int vsval = text_editor->get_v_scroll();
 
-	text_editor->set_caret_line(0);
-	text_editor->set_caret_column(0);
+	text_editor->set_caret_line(0, false, true, 0, 0);
+	text_editor->set_caret_column(0, true, 0);
 
 	String replace_text = get_replace_text();
 	int search_text_len = get_search_text().length();
@@ -250,8 +251,8 @@ void FindReplaceBar::_replace_all() {
 	text_editor->begin_complex_operation();
 
 	if (selection_enabled && is_selection_only()) {
-		text_editor->set_caret_line(selection_begin.width);
-		text_editor->set_caret_column(selection_begin.height);
+		text_editor->set_caret_line(selection_begin.width, false, true, 0, 0);
+		text_editor->set_caret_column(selection_begin.height, true, 0);
 	}
 	if (search_current()) {
 		do {
@@ -266,7 +267,7 @@ void FindReplaceBar::_replace_all() {
 			prev_match = Point2i(result_line, result_col + replace_text.length());
 
 			text_editor->unfold_line(result_line);
-			text_editor->select(result_line, result_col, result_line, match_to.y);
+			text_editor->select(result_line, result_col, result_line, match_to.y, 0);
 
 			if (selection_enabled && is_selection_only()) {
 				if (match_from < selection_begin || match_to > selection_end) {
@@ -274,14 +275,14 @@ void FindReplaceBar::_replace_all() {
 				}
 
 				// Replace but adjust selection bounds.
-				text_editor->insert_text_at_caret(replace_text);
+				text_editor->insert_text_at_caret(replace_text, 0);
 				if (match_to.x == selection_end.x) {
 					selection_end.y += replace_text.length() - search_text_len;
 				}
 
 			} else {
 				// Just replace.
-				text_editor->insert_text_at_caret(replace_text);
+				text_editor->insert_text_at_caret(replace_text, 0);
 			}
 
 			rc++;
@@ -293,14 +294,14 @@ void FindReplaceBar::_replace_all() {
 	replace_all_mode = false;
 
 	// Restore editor state (selection, cursor, scroll).
-	text_editor->set_caret_line(orig_cursor.x);
-	text_editor->set_caret_column(orig_cursor.y);
+	text_editor->set_caret_line(orig_cursor.x, false, true, 0, 0);
+	text_editor->set_caret_column(orig_cursor.y, true, 0);
 
 	if (selection_enabled && is_selection_only()) {
 		// Reselect.
-		text_editor->select(selection_begin.x, selection_begin.y, selection_end.x, selection_end.y);
+		text_editor->select(selection_begin.x, selection_begin.y, selection_end.x, selection_end.y, 0);
 	} else {
-		text_editor->deselect();
+		text_editor->deselect(0);
 	}
 
 	text_editor->set_v_scroll(vsval);
@@ -314,10 +315,10 @@ void FindReplaceBar::_replace_all() {
 }
 
 void FindReplaceBar::_get_search_from(int &r_line, int &r_col) {
-	r_line = text_editor->get_caret_line();
-	r_col = text_editor->get_caret_column();
+	r_line = text_editor->get_caret_line(0);
+	r_col = text_editor->get_caret_column(0);
 
-	if (text_editor->has_selection() && is_selection_only()) {
+	if (text_editor->has_selection(0) && is_selection_only()) {
 		return;
 	}
 
@@ -434,7 +435,7 @@ bool FindReplaceBar::search_prev() {
 
 	int line, col;
 	_get_search_from(line, col);
-	if (text_editor->has_selection()) {
+	if (text_editor->has_selection(0)) {
 		col--; // Skip currently selected word.
 	}
 
@@ -512,8 +513,8 @@ void FindReplaceBar::_show_search(bool p_focus_replace, bool p_show_only) {
 		search_text->call_deferred(SNAME("grab_focus"));
 	}
 
-	if (text_editor->has_selection() && !selection_only->is_pressed()) {
-		search_text->set_text(text_editor->get_selected_text());
+	if (text_editor->has_selection(0) && !selection_only->is_pressed()) {
+		search_text->set_text(text_editor->get_selected_text(0));
 	}
 
 	if (!get_search_text().is_empty()) {
@@ -548,9 +549,9 @@ void FindReplaceBar::popup_replace() {
 		hbc_option_replace->show();
 	}
 
-	selection_only->set_pressed((text_editor->has_selection() && text_editor->get_selection_from_line() < text_editor->get_selection_to_line()));
+	selection_only->set_pressed((text_editor->has_selection(0) && text_editor->get_selection_from_line(0) < text_editor->get_selection_to_line(0)));
 
-	_show_search(is_visible() || text_editor->has_selection());
+	_show_search(is_visible() || text_editor->has_selection(0));
 }
 
 void FindReplaceBar::_search_options_changed(bool p_pressed) {
@@ -587,7 +588,7 @@ void FindReplaceBar::_search_text_submitted(const String &p_text) {
 }
 
 void FindReplaceBar::_replace_text_submitted(const String &p_text) {
-	if (selection_only->is_pressed() && text_editor->has_selection()) {
+	if (selection_only->is_pressed() && text_editor->has_selection(0)) {
 		_replace_all();
 		_hide_bar();
 	} else if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
@@ -1091,6 +1092,7 @@ void CodeTextEditor::trim_trailing_whitespace() {
 	}
 
 	if (trimed_whitespace) {
+		text_editor->merge_overlapping_carets();
 		text_editor->end_complex_operation();
 		text_editor->queue_redraw();
 	}
@@ -1122,8 +1124,11 @@ void CodeTextEditor::convert_indent_to_spaces() {
 		indent += " ";
 	}
 
-	int cursor_line = text_editor->get_caret_line();
-	int cursor_column = text_editor->get_caret_column();
+	Vector<int> cursor_columns;
+	cursor_columns.resize(text_editor->get_caret_count());
+	for (int c = 0; c < text_editor->get_caret_count(); c++) {
+		cursor_columns.write[c] = text_editor->get_caret_column(c);
+	}
 
 	bool changed_indentation = false;
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
@@ -1140,8 +1145,10 @@ void CodeTextEditor::convert_indent_to_spaces() {
 					text_editor->begin_complex_operation();
 					changed_indentation = true;
 				}
-				if (cursor_line == i && cursor_column > j) {
-					cursor_column += indent_size - 1;
+				for (int c = 0; c < text_editor->get_caret_count(); c++) {
+					if (text_editor->get_caret_line(c) == i && text_editor->get_caret_column(c) > j) {
+						cursor_columns.write[c] += indent_size - 1;
+					}
 				}
 				line = line.left(j) + indent + line.substr(j + 1);
 			}
@@ -1152,7 +1159,10 @@ void CodeTextEditor::convert_indent_to_spaces() {
 		}
 	}
 	if (changed_indentation) {
-		text_editor->set_caret_column(cursor_column);
+		for (int c = 0; c < text_editor->get_caret_count(); c++) {
+			text_editor->set_caret_column(cursor_columns[c], c == 0, c);
+		}
+		text_editor->merge_overlapping_carets();
 		text_editor->end_complex_operation();
 		text_editor->queue_redraw();
 	}
@@ -1162,8 +1172,11 @@ void CodeTextEditor::convert_indent_to_tabs() {
 	int indent_size = EditorSettings::get_singleton()->get("text_editor/behavior/indent/size");
 	indent_size -= 1;
 
-	int cursor_line = text_editor->get_caret_line();
-	int cursor_column = text_editor->get_caret_column();
+	Vector<int> cursor_columns;
+	cursor_columns.resize(text_editor->get_caret_count());
+	for (int c = 0; c < text_editor->get_caret_count(); c++) {
+		cursor_columns.write[c] = text_editor->get_caret_column(c);
+	}
 
 	bool changed_indentation = false;
 	for (int i = 0; i < text_editor->get_line_count(); i++) {
@@ -1184,8 +1197,10 @@ void CodeTextEditor::convert_indent_to_tabs() {
 						text_editor->begin_complex_operation();
 						changed_indentation = true;
 					}
-					if (cursor_line == i && cursor_column > j) {
-						cursor_column -= indent_size;
+					for (int c = 0; c < text_editor->get_caret_count(); c++) {
+						if (text_editor->get_caret_line(c) == i && text_editor->get_caret_column(c) > j) {
+							cursor_columns.write[c] -= indent_size;
+						}
 					}
 					line = line.left(j - indent_size) + "\t" + line.substr(j + 1);
 					j = 0;
@@ -1201,7 +1216,10 @@ void CodeTextEditor::convert_indent_to_tabs() {
 		}
 	}
 	if (changed_indentation) {
-		text_editor->set_caret_column(cursor_column);
+		for (int c = 0; c < text_editor->get_caret_count(); c++) {
+			text_editor->set_caret_column(cursor_columns[c], c == 0, c);
+		}
+		text_editor->merge_overlapping_carets();
 		text_editor->end_complex_operation();
 		text_editor->queue_redraw();
 	}
@@ -1211,59 +1229,128 @@ void CodeTextEditor::convert_case(CaseStyle p_case) {
 	if (!text_editor->has_selection()) {
 		return;
 	}
-
 	text_editor->begin_complex_operation();
 
-	int begin = text_editor->get_selection_from_line();
-	int end = text_editor->get_selection_to_line();
-	int begin_col = text_editor->get_selection_from_column();
-	int end_col = text_editor->get_selection_to_column();
-
-	for (int i = begin; i <= end; i++) {
-		int len = text_editor->get_line(i).length();
-		if (i == end) {
-			len = end_col;
-		}
-		if (i == begin) {
-			len -= begin_col;
-		}
-		String new_line = text_editor->get_line(i).substr(i == begin ? begin_col : 0, len);
-
-		switch (p_case) {
-			case UPPER: {
-				new_line = new_line.to_upper();
-			} break;
-			case LOWER: {
-				new_line = new_line.to_lower();
-			} break;
-			case CAPITALIZE: {
-				new_line = new_line.capitalize();
-			} break;
+	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
+	for (const int &c : caret_edit_order) {
+		if (!text_editor->has_selection(c)) {
+			continue;
 		}
 
-		if (i == begin) {
-			new_line = text_editor->get_line(i).left(begin_col) + new_line;
+		int begin = text_editor->get_selection_from_line(c);
+		int end = text_editor->get_selection_to_line(c);
+		int begin_col = text_editor->get_selection_from_column(c);
+		int end_col = text_editor->get_selection_to_column(c);
+
+		for (int i = begin; i <= end; i++) {
+			int len = text_editor->get_line(i).length();
+			if (i == end) {
+				len = end_col;
+			}
+			if (i == begin) {
+				len -= begin_col;
+			}
+			String new_line = text_editor->get_line(i).substr(i == begin ? begin_col : 0, len);
+
+			switch (p_case) {
+				case UPPER: {
+					new_line = new_line.to_upper();
+				} break;
+				case LOWER: {
+					new_line = new_line.to_lower();
+				} break;
+				case CAPITALIZE: {
+					new_line = new_line.capitalize();
+				} break;
+			}
+
+			if (i == begin) {
+				new_line = text_editor->get_line(i).left(begin_col) + new_line;
+			}
+			if (i == end) {
+				new_line = new_line + text_editor->get_line(i).substr(end_col);
+			}
+			text_editor->set_line(i, new_line);
 		}
-		if (i == end) {
-			new_line = new_line + text_editor->get_line(i).substr(end_col);
-		}
-		text_editor->set_line(i, new_line);
 	}
 	text_editor->end_complex_operation();
 }
 
 void CodeTextEditor::move_lines_up() {
 	text_editor->begin_complex_operation();
-	if (text_editor->has_selection()) {
-		int from_line = text_editor->get_selection_from_line();
-		int from_col = text_editor->get_selection_from_column();
-		int to_line = text_editor->get_selection_to_line();
-		int to_column = text_editor->get_selection_to_column();
-		int cursor_line = text_editor->get_caret_line();
 
-		for (int i = from_line; i <= to_line; i++) {
-			int line_id = i;
-			int next_id = i - 1;
+	Vector<int> carets_to_remove;
+
+	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
+	for (int i = 0; i < caret_edit_order.size(); i++) {
+		int c = caret_edit_order[i];
+		int cl = text_editor->get_caret_line(c);
+
+		bool swaped_caret = false;
+		for (int j = i + 1; j < caret_edit_order.size(); j++) {
+			if (text_editor->has_selection(caret_edit_order[j])) {
+				if (text_editor->get_selection_from_line() == cl) {
+					carets_to_remove.push_back(caret_edit_order[j]);
+					continue;
+				}
+
+				if (text_editor->get_selection_to_line() == cl) {
+					if (text_editor->has_selection(c)) {
+						if (text_editor->get_selection_to_line(c) != cl) {
+							text_editor->select(cl + 1, 0, text_editor->get_selection_to_line(c), text_editor->get_selection_to_column(c), c);
+							break;
+						}
+					}
+
+					carets_to_remove.push_back(c);
+					i = j - 1;
+					swaped_caret = true;
+					break;
+				}
+				break;
+			}
+
+			if (text_editor->get_caret_line(caret_edit_order[j]) == cl) {
+				carets_to_remove.push_back(caret_edit_order[j]);
+				i = j;
+				continue;
+			}
+			break;
+		}
+
+		if (swaped_caret) {
+			continue;
+		}
+
+		if (text_editor->has_selection(c)) {
+			int from_line = text_editor->get_selection_from_line(c);
+			int from_col = text_editor->get_selection_from_column(c);
+			int to_line = text_editor->get_selection_to_line(c);
+			int to_column = text_editor->get_selection_to_column(c);
+			int cursor_line = text_editor->get_caret_line(c);
+
+			for (int j = from_line; j <= to_line; j++) {
+				int line_id = j;
+				int next_id = j - 1;
+
+				if (line_id == 0 || next_id < 0) {
+					return;
+				}
+
+				text_editor->unfold_line(line_id);
+				text_editor->unfold_line(next_id);
+
+				text_editor->swap_lines(line_id, next_id);
+				text_editor->set_caret_line(next_id, c == 0, true, 0, c);
+			}
+			int from_line_up = from_line > 0 ? from_line - 1 : from_line;
+			int to_line_up = to_line > 0 ? to_line - 1 : to_line;
+			int cursor_line_up = cursor_line > 0 ? cursor_line - 1 : cursor_line;
+			text_editor->select(from_line_up, from_col, to_line_up, to_column, c);
+			text_editor->set_caret_line(cursor_line_up, c == 0, true, 0, c);
+		} else {
+			int line_id = text_editor->get_caret_line(c);
+			int next_id = line_id - 1;
 
 			if (line_id == 0 || next_id < 0) {
 				return;
@@ -1273,238 +1360,336 @@ void CodeTextEditor::move_lines_up() {
 			text_editor->unfold_line(next_id);
 
 			text_editor->swap_lines(line_id, next_id);
-			text_editor->set_caret_line(next_id);
+			text_editor->set_caret_line(next_id, c == 0, true, 0, c);
 		}
-		int from_line_up = from_line > 0 ? from_line - 1 : from_line;
-		int to_line_up = to_line > 0 ? to_line - 1 : to_line;
-		int cursor_line_up = cursor_line > 0 ? cursor_line - 1 : cursor_line;
-		text_editor->select(from_line_up, from_col, to_line_up, to_column);
-		text_editor->set_caret_line(cursor_line_up);
-	} else {
-		int line_id = text_editor->get_caret_line();
-		int next_id = line_id - 1;
-
-		if (line_id == 0 || next_id < 0) {
-			return;
-		}
-
-		text_editor->unfold_line(line_id);
-		text_editor->unfold_line(next_id);
-
-		text_editor->swap_lines(line_id, next_id);
-		text_editor->set_caret_line(next_id);
 	}
 	text_editor->end_complex_operation();
+	text_editor->merge_overlapping_carets();
 	text_editor->queue_redraw();
 }
 
 void CodeTextEditor::move_lines_down() {
 	text_editor->begin_complex_operation();
-	if (text_editor->has_selection()) {
-		int from_line = text_editor->get_selection_from_line();
-		int from_col = text_editor->get_selection_from_column();
-		int to_line = text_editor->get_selection_to_line();
-		int to_column = text_editor->get_selection_to_column();
-		int cursor_line = text_editor->get_caret_line();
 
-		for (int i = to_line; i >= from_line; i--) {
-			int line_id = i;
-			int next_id = i + 1;
+	Vector<int> carets_to_remove;
+
+	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
+	for (int i = 0; i < caret_edit_order.size(); i++) {
+		int c = caret_edit_order[i];
+		int cl = text_editor->get_caret_line(c);
+
+		bool swaped_caret = false;
+		for (int j = i + 1; j < caret_edit_order.size(); j++) {
+			if (text_editor->has_selection(caret_edit_order[j])) {
+				if (text_editor->get_selection_from_line() == cl) {
+					carets_to_remove.push_back(caret_edit_order[j]);
+					continue;
+				}
+
+				if (text_editor->get_selection_to_line() == cl) {
+					if (text_editor->has_selection(c)) {
+						if (text_editor->get_selection_to_line(c) != cl) {
+							text_editor->select(cl + 1, 0, text_editor->get_selection_to_line(c), text_editor->get_selection_to_column(c), c);
+							break;
+						}
+					}
+
+					carets_to_remove.push_back(c);
+					i = j - 1;
+					swaped_caret = true;
+					break;
+				}
+				break;
+			}
+
+			if (text_editor->get_caret_line(caret_edit_order[j]) == cl) {
+				carets_to_remove.push_back(caret_edit_order[j]);
+				i = j;
+				continue;
+			}
+			break;
+		}
+
+		if (swaped_caret) {
+			continue;
+		}
+
+		if (text_editor->has_selection(c)) {
+			int from_line = text_editor->get_selection_from_line(c);
+			int from_col = text_editor->get_selection_from_column(c);
+			int to_line = text_editor->get_selection_to_line(c);
+			int to_column = text_editor->get_selection_to_column(c);
+			int cursor_line = text_editor->get_caret_line(c);
+
+			for (int l = to_line; l >= from_line; l--) {
+				int line_id = l;
+				int next_id = l + 1;
+
+				if (line_id == text_editor->get_line_count() - 1 || next_id > text_editor->get_line_count()) {
+					continue;
+				}
+
+				text_editor->unfold_line(line_id);
+				text_editor->unfold_line(next_id);
+
+				text_editor->swap_lines(line_id, next_id);
+				text_editor->set_caret_line(next_id, c == 0, true, 0, c);
+			}
+			int from_line_down = from_line < text_editor->get_line_count() ? from_line + 1 : from_line;
+			int to_line_down = to_line < text_editor->get_line_count() ? to_line + 1 : to_line;
+			int cursor_line_down = cursor_line < text_editor->get_line_count() ? cursor_line + 1 : cursor_line;
+			text_editor->select(from_line_down, from_col, to_line_down, to_column, c);
+			text_editor->set_caret_line(cursor_line_down, c == 0, true, 0, c);
+		} else {
+			int line_id = text_editor->get_caret_line(c);
+			int next_id = line_id + 1;
 
 			if (line_id == text_editor->get_line_count() - 1 || next_id > text_editor->get_line_count()) {
-				return;
+				continue;
 			}
 
 			text_editor->unfold_line(line_id);
 			text_editor->unfold_line(next_id);
 
 			text_editor->swap_lines(line_id, next_id);
-			text_editor->set_caret_line(next_id);
+			text_editor->set_caret_line(next_id, c == 0, true, 0, c);
 		}
-		int from_line_down = from_line < text_editor->get_line_count() ? from_line + 1 : from_line;
-		int to_line_down = to_line < text_editor->get_line_count() ? to_line + 1 : to_line;
-		int cursor_line_down = cursor_line < text_editor->get_line_count() ? cursor_line + 1 : cursor_line;
-		text_editor->select(from_line_down, from_col, to_line_down, to_column);
-		text_editor->set_caret_line(cursor_line_down);
-	} else {
-		int line_id = text_editor->get_caret_line();
-		int next_id = line_id + 1;
-
-		if (line_id == text_editor->get_line_count() - 1 || next_id > text_editor->get_line_count()) {
-			return;
-		}
-
-		text_editor->unfold_line(line_id);
-		text_editor->unfold_line(next_id);
-
-		text_editor->swap_lines(line_id, next_id);
-		text_editor->set_caret_line(next_id);
 	}
+
+	// Sort and remove backwards to preserve indexes.
+	carets_to_remove.sort();
+	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
+		text_editor->remove_caret(carets_to_remove[i]);
+	}
+
+	text_editor->merge_overlapping_carets();
 	text_editor->end_complex_operation();
 	text_editor->queue_redraw();
 }
 
-void CodeTextEditor::_delete_line(int p_line) {
+void CodeTextEditor::_delete_line(int p_line, int p_caret) {
 	// this is currently intended to be called within delete_lines()
 	// so `begin_complex_operation` is omitted here
 	text_editor->set_line(p_line, "");
 	if (p_line == 0 && text_editor->get_line_count() > 1) {
-		text_editor->set_caret_line(1);
-		text_editor->set_caret_column(0);
+		text_editor->set_caret_line(1, p_caret == 0, true, 0, p_caret);
+		text_editor->set_caret_column(0, p_caret == 0, p_caret);
 	}
-	text_editor->backspace();
+	text_editor->backspace(p_caret);
 	if (p_line < text_editor->get_line_count()) {
 		text_editor->unfold_line(p_line);
 	}
-	text_editor->set_caret_line(p_line);
+	text_editor->set_caret_line(p_line, p_caret == 0, true, 0, p_caret);
 }
 
 void CodeTextEditor::delete_lines() {
 	text_editor->begin_complex_operation();
-	if (text_editor->has_selection()) {
-		int to_line = text_editor->get_selection_to_line();
-		int from_line = text_editor->get_selection_from_line();
-		int count = Math::abs(to_line - from_line) + 1;
 
-		text_editor->set_caret_line(from_line, false);
-		text_editor->deselect();
-		for (int i = 0; i < count; i++) {
-			_delete_line(from_line);
+	Vector<int> carets_to_remove;
+
+	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
+	for (int i = 0; i < caret_edit_order.size(); i++) {
+		int c = caret_edit_order[i];
+		int cl = text_editor->get_caret_line(c);
+
+		bool swaped_caret = false;
+		for (int j = i + 1; j < caret_edit_order.size(); j++) {
+			if (text_editor->has_selection(caret_edit_order[j])) {
+				if (text_editor->get_selection_from_line() == cl) {
+					carets_to_remove.push_back(caret_edit_order[j]);
+					continue;
+				}
+
+				if (text_editor->get_selection_to_line() == cl) {
+					if (text_editor->has_selection(c)) {
+						if (text_editor->get_selection_to_line(c) != cl) {
+							text_editor->select(cl + 1, 0, text_editor->get_selection_to_line(c), text_editor->get_selection_to_column(c), c);
+							break;
+						}
+					}
+
+					carets_to_remove.push_back(c);
+					i = j - 1;
+					swaped_caret = true;
+					break;
+				}
+				break;
+			}
+
+			if (text_editor->get_caret_line(caret_edit_order[j]) == cl) {
+				carets_to_remove.push_back(caret_edit_order[j]);
+				i = j;
+				continue;
+			}
+			break;
 		}
-	} else {
-		_delete_line(text_editor->get_caret_line());
+
+		if (swaped_caret) {
+			continue;
+		}
+
+		if (text_editor->has_selection(c)) {
+			int to_line = text_editor->get_selection_to_line(c);
+			int from_line = text_editor->get_selection_from_line(c);
+			int count = Math::abs(to_line - from_line) + 1;
+
+			text_editor->set_caret_line(from_line, false, true, 0, c);
+			text_editor->deselect(c);
+			for (int j = 0; j < count; j++) {
+				_delete_line(from_line, c);
+			}
+		} else {
+			_delete_line(text_editor->get_caret_line(c), c);
+		}
 	}
+
+	// Sort and remove backwards to preserve indexes.
+	carets_to_remove.sort();
+	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
+		text_editor->remove_caret(carets_to_remove[i]);
+	}
+	text_editor->merge_overlapping_carets();
 	text_editor->end_complex_operation();
 }
 
 void CodeTextEditor::duplicate_selection() {
-	const int cursor_column = text_editor->get_caret_column();
-	int from_line = text_editor->get_caret_line();
-	int to_line = text_editor->get_caret_line();
-	int from_column = 0;
-	int to_column = 0;
-	int cursor_new_line = to_line + 1;
-	int cursor_new_column = text_editor->get_caret_column();
-	String new_text = "\n" + text_editor->get_line(from_line);
-	bool selection_active = false;
-
-	text_editor->set_caret_column(text_editor->get_line(from_line).length());
-	if (text_editor->has_selection()) {
-		from_column = text_editor->get_selection_from_column();
-		to_column = text_editor->get_selection_to_column();
-
-		from_line = text_editor->get_selection_from_line();
-		to_line = text_editor->get_selection_to_line();
-		cursor_new_line = to_line + text_editor->get_caret_line() - from_line;
-		cursor_new_column = to_column == cursor_column ? 2 * to_column - from_column : to_column;
-		new_text = text_editor->get_selected_text();
-		selection_active = true;
-
-		text_editor->set_caret_line(to_line);
-		text_editor->set_caret_column(to_column);
-	}
-
 	text_editor->begin_complex_operation();
 
-	for (int i = from_line; i <= to_line; i++) {
-		text_editor->unfold_line(i);
-	}
-	text_editor->deselect();
-	text_editor->insert_text_at_caret(new_text);
-	text_editor->set_caret_line(cursor_new_line);
-	text_editor->set_caret_column(cursor_new_column);
-	if (selection_active) {
-		text_editor->select(to_line, to_column, 2 * to_line - from_line, to_line == from_line ? 2 * to_column - from_column : to_column);
-	}
+	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
+	for (const int &c : caret_edit_order) {
+		const int cursor_column = text_editor->get_caret_column(c);
+		int from_line = text_editor->get_caret_line(c);
+		int to_line = text_editor->get_caret_line(c);
+		int from_column = 0;
+		int to_column = 0;
+		int cursor_new_line = to_line + 1;
+		int cursor_new_column = text_editor->get_caret_column(c);
+		String new_text = "\n" + text_editor->get_line(from_line);
+		bool selection_active = false;
 
+		text_editor->set_caret_column(text_editor->get_line(from_line).length(), c == 0, c);
+		if (text_editor->has_selection(c)) {
+			from_column = text_editor->get_selection_from_column(c);
+			to_column = text_editor->get_selection_to_column(c);
+
+			from_line = text_editor->get_selection_from_line(c);
+			to_line = text_editor->get_selection_to_line(c);
+			cursor_new_line = to_line + text_editor->get_caret_line(c) - from_line;
+			cursor_new_column = to_column == cursor_column ? 2 * to_column - from_column : to_column;
+			new_text = text_editor->get_selected_text(c);
+			selection_active = true;
+
+			text_editor->set_caret_line(to_line, c == 0, true, 0, c);
+			text_editor->set_caret_column(to_column, c == 0, c);
+		}
+
+		for (int i = from_line; i <= to_line; i++) {
+			text_editor->unfold_line(i);
+		}
+		text_editor->deselect(c);
+		text_editor->insert_text_at_caret(new_text, c);
+		text_editor->set_caret_line(cursor_new_line, c == 0, true, 0, c);
+		text_editor->set_caret_column(cursor_new_column, c == 0, c);
+		if (selection_active) {
+			text_editor->select(to_line, to_column, 2 * to_line - from_line, to_line == from_line ? 2 * to_column - from_column : to_column, c);
+		}
+	}
+	text_editor->merge_overlapping_carets();
 	text_editor->end_complex_operation();
 	text_editor->queue_redraw();
 }
 
 void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 	text_editor->begin_complex_operation();
-	if (text_editor->has_selection()) {
-		int begin = text_editor->get_selection_from_line();
-		int end = text_editor->get_selection_to_line();
 
-		// End of selection ends on the first column of the last line, ignore it.
-		if (text_editor->get_selection_to_column() == 0) {
-			end -= 1;
-		}
+	Vector<int> caret_edit_order = text_editor->get_caret_index_edit_order();
+	for (const int &c : caret_edit_order) {
+		if (text_editor->has_selection(c)) {
+			int begin = text_editor->get_selection_from_line(c);
+			int end = text_editor->get_selection_to_line(c);
 
-		int col_to = text_editor->get_selection_to_column();
-		int cursor_pos = text_editor->get_caret_column();
-
-		// Check if all lines in the selected block are commented.
-		bool is_commented = true;
-		for (int i = begin; i <= end; i++) {
-			if (!text_editor->get_line(i).begins_with(delimiter)) {
-				is_commented = false;
-				break;
+			// End of selection ends on the first column of the last line, ignore it.
+			if (text_editor->get_selection_to_column(c) == 0) {
+				end -= 1;
 			}
-		}
-		for (int i = begin; i <= end; i++) {
-			String line_text = text_editor->get_line(i);
 
-			if (line_text.strip_edges().is_empty()) {
-				line_text = delimiter;
-			} else {
-				if (is_commented) {
-					line_text = line_text.substr(delimiter.length(), line_text.length());
-				} else {
-					line_text = delimiter + line_text;
+			int col_to = text_editor->get_selection_to_column(c);
+			int cursor_pos = text_editor->get_caret_column(c);
+
+			// Check if all lines in the selected block are commented.
+			bool is_commented = true;
+			for (int i = begin; i <= end; i++) {
+				if (!text_editor->get_line(i).begins_with(delimiter)) {
+					is_commented = false;
+					break;
 				}
 			}
-			text_editor->set_line(i, line_text);
-		}
+			for (int i = begin; i <= end; i++) {
+				String line_text = text_editor->get_line(i);
 
-		// Adjust selection & cursor position.
-		int offset = (is_commented ? -1 : 1) * delimiter.length();
-		int col_from = text_editor->get_selection_from_column() > 0 ? text_editor->get_selection_from_column() + offset : 0;
+				if (line_text.strip_edges().is_empty()) {
+					line_text = delimiter;
+				} else {
+					if (is_commented) {
+						line_text = line_text.substr(delimiter.length(), line_text.length());
+					} else {
+						line_text = delimiter + line_text;
+					}
+				}
+				text_editor->set_line(i, line_text);
+			}
 
-		if (is_commented && text_editor->get_caret_column() == text_editor->get_line(text_editor->get_caret_line()).length() + 1) {
-			cursor_pos += 1;
-		}
+			// Adjust selection & cursor position.
+			int offset = (is_commented ? -1 : 1) * delimiter.length();
+			int col_from = text_editor->get_selection_from_column(c) > 0 ? text_editor->get_selection_from_column(c) + offset : 0;
 
-		if (text_editor->get_selection_to_column() != 0 && col_to != text_editor->get_line(text_editor->get_selection_to_line()).length() + 1) {
-			col_to += offset;
-		}
+			if (is_commented && text_editor->get_caret_column(c) == text_editor->get_line(text_editor->get_caret_line(c)).length() + 1) {
+				cursor_pos += 1;
+			}
 
-		if (text_editor->get_caret_column() != 0) {
-			cursor_pos += offset;
-		}
+			if (text_editor->get_selection_to_column(c) != 0 && col_to != text_editor->get_line(text_editor->get_selection_to_line(c)).length() + 1) {
+				col_to += offset;
+			}
 
-		text_editor->select(begin, col_from, text_editor->get_selection_to_line(), col_to);
-		text_editor->set_caret_column(cursor_pos);
+			if (text_editor->get_caret_column(c) != 0) {
+				cursor_pos += offset;
+			}
 
-	} else {
-		int begin = text_editor->get_caret_line();
-		String line_text = text_editor->get_line(begin);
-		int delimiter_length = delimiter.length();
+			text_editor->select(begin, col_from, text_editor->get_selection_to_line(c), col_to, c);
+			text_editor->set_caret_column(cursor_pos, c == 0, c);
 
-		int col = text_editor->get_caret_column();
-		if (line_text.begins_with(delimiter)) {
-			line_text = line_text.substr(delimiter_length, line_text.length());
-			col -= delimiter_length;
 		} else {
-			line_text = delimiter + line_text;
-			col += delimiter_length;
-		}
+			int begin = text_editor->get_caret_line(c);
+			String line_text = text_editor->get_line(begin);
+			int delimiter_length = delimiter.length();
 
-		text_editor->set_line(begin, line_text);
-		text_editor->set_caret_column(col);
+			int col = text_editor->get_caret_column(c);
+			if (line_text.begins_with(delimiter)) {
+				line_text = line_text.substr(delimiter_length, line_text.length());
+				col -= delimiter_length;
+			} else {
+				line_text = delimiter + line_text;
+				col += delimiter_length;
+			}
+
+			text_editor->set_line(begin, line_text);
+			text_editor->set_caret_column(col, c == 0, c);
+		}
 	}
+	text_editor->merge_overlapping_carets();
 	text_editor->end_complex_operation();
 	text_editor->queue_redraw();
 }
 
 void CodeTextEditor::goto_line(int p_line) {
+	text_editor->remove_secondary_carets();
 	text_editor->deselect();
 	text_editor->unfold_line(p_line);
 	text_editor->call_deferred(SNAME("set_caret_line"), p_line);
 }
 
 void CodeTextEditor::goto_line_selection(int p_line, int p_begin, int p_end) {
+	text_editor->remove_secondary_carets();
 	text_editor->unfold_line(p_line);
 	text_editor->call_deferred(SNAME("set_caret_line"), p_line);
 	text_editor->call_deferred(SNAME("set_caret_column"), p_begin);
@@ -1608,6 +1793,7 @@ void CodeTextEditor::goto_error() {
 		if (text_editor->get_line_count() != error_line) {
 			text_editor->unfold_line(error_line);
 		}
+		text_editor->remove_secondary_carets();
 		text_editor->set_caret_line(error_line);
 		text_editor->set_caret_column(error_column);
 		text_editor->center_viewport_to_caret();
@@ -1784,8 +1970,10 @@ void CodeTextEditor::set_warning_count(int p_warning_count) {
 }
 
 void CodeTextEditor::toggle_bookmark() {
-	int line = text_editor->get_caret_line();
-	text_editor->set_line_as_bookmarked(line, !text_editor->is_line_bookmarked(line));
+	for (int i = 0; i < text_editor->get_caret_count(); i++) {
+		int line = text_editor->get_caret_line(i);
+		text_editor->set_line_as_bookmarked(line, !text_editor->is_line_bookmarked(line));
+	}
 }
 
 void CodeTextEditor::goto_next_bookmark() {
@@ -1794,6 +1982,7 @@ void CodeTextEditor::goto_next_bookmark() {
 		return;
 	}
 
+	text_editor->remove_secondary_carets();
 	int line = text_editor->get_caret_line();
 	if (line >= (int)bmarks[bmarks.size() - 1]) {
 		text_editor->unfold_line(bmarks[0]);
@@ -1818,6 +2007,7 @@ void CodeTextEditor::goto_prev_bookmark() {
 		return;
 	}
 
+	text_editor->remove_secondary_carets();
 	int line = text_editor->get_caret_line();
 	if (line <= (int)bmarks[0]) {
 		text_editor->unfold_line(bmarks[bmarks.size() - 1]);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -197,7 +197,7 @@ class CodeTextEditor : public VBoxContainer {
 
 	void _update_status_bar_theme();
 
-	void _delete_line(int p_line);
+	void _delete_line(int p_line, int p_caret);
 	void _toggle_scripts_pressed();
 
 protected:

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -267,6 +267,7 @@ void ScriptTextEditor::_warning_clicked(Variant p_line) {
 
 void ScriptTextEditor::_error_clicked(Variant p_line) {
 	if (p_line.get_type() == Variant::INT) {
+		code_editor->get_text_editor()->remove_secondary_carets();
 		code_editor->get_text_editor()->set_caret_line(p_line.operator int64_t());
 	}
 }
@@ -295,6 +296,7 @@ void ScriptTextEditor::reload_text() {
 void ScriptTextEditor::add_callback(const String &p_function, PackedStringArray p_args) {
 	String code = code_editor->get_text_editor()->get_text();
 	int pos = script->get_language()->find_function(p_function, code);
+	code_editor->get_text_editor()->remove_secondary_carets();
 	if (pos == -1) {
 		//does not exist
 		code_editor->get_text_editor()->deselect();
@@ -1363,6 +1365,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
+			tx->remove_secondary_carets();
 			int line = tx->get_caret_line();
 
 			// wrap around
@@ -1389,6 +1392,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 				return;
 			}
 
+			tx->remove_secondary_carets();
 			int line = tx->get_caret_line();
 			// wrap around
 			if (line <= (int)bpoints[0]) {
@@ -1409,21 +1413,21 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 		} break;
 		case HELP_CONTEXTUAL: {
-			String text = tx->get_selected_text();
+			String text = tx->get_selected_text(0);
 			if (text.is_empty()) {
-				text = tx->get_word_under_caret();
+				text = tx->get_word_under_caret(0);
 			}
 			if (!text.is_empty()) {
 				emit_signal(SNAME("request_help"), text);
 			}
 		} break;
 		case LOOKUP_SYMBOL: {
-			String text = tx->get_word_under_caret();
+			String text = tx->get_word_under_caret(0);
 			if (text.is_empty()) {
-				text = tx->get_selected_text();
+				text = tx->get_selected_text(0);
 			}
 			if (!text.is_empty()) {
-				_lookup_symbol(text, tx->get_caret_line(), tx->get_caret_column());
+				_lookup_symbol(text, tx->get_caret_line(0), tx->get_caret_column(0));
 			}
 		} break;
 	}
@@ -1601,6 +1605,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	int col = pos.x;
 
 	if (d.has("type") && String(d["type"]) == "resource") {
+		te->remove_secondary_carets();
 		Ref<Resource> res = d["resource"];
 		if (!res.is_valid()) {
 			return;
@@ -1618,6 +1623,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	}
 
 	if (d.has("type") && (String(d["type"]) == "files" || String(d["type"]) == "files_and_dirs")) {
+		te->remove_secondary_carets();
 		Array files = d["files"];
 
 		String text_to_drop;
@@ -1641,6 +1647,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	}
 
 	if (d.has("type") && String(d["type"]) == "nodes") {
+		te->remove_secondary_carets();
 		Node *scene_root = get_tree()->get_edited_scene_root();
 		if (!scene_root) {
 			EditorNode::get_singleton()->show_warning(TTR("Can't drop nodes without an open scene."));
@@ -1725,6 +1732,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	}
 
 	if (d.has("type") && String(d["type"]) == "obj_property") {
+		te->remove_secondary_carets();
 		const String text_to_drop = String(d["property"]).c_escape().quote(quote_style);
 
 		te->set_caret_line(row);
@@ -1745,8 +1753,8 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		local_pos = mb->get_global_position() - tx->get_global_position();
 		create_menu = true;
 	} else if (k.is_valid() && k->is_action("ui_menu", true)) {
-		tx->adjust_viewport_to_caret();
-		local_pos = tx->get_caret_draw_pos();
+		tx->adjust_viewport_to_caret(0);
+		local_pos = tx->get_caret_draw_pos(0);
 		create_menu = true;
 	}
 
@@ -1757,6 +1765,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 		tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/behavior/navigation/move_caret_on_right_click"));
 		if (tx->is_move_caret_on_right_click_enabled()) {
+			tx->remove_secondary_carets();
 			if (tx->has_selection()) {
 				int from_line = tx->get_selection_from_line();
 				int to_line = tx->get_selection_to_line();
@@ -1776,10 +1785,10 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 		String word_at_pos = tx->get_word_at_pos(local_pos);
 		if (word_at_pos.is_empty()) {
-			word_at_pos = tx->get_word_under_caret();
+			word_at_pos = tx->get_word_under_caret(0);
 		}
 		if (word_at_pos.is_empty()) {
-			word_at_pos = tx->get_selected_text();
+			word_at_pos = tx->get_selected_text(0);
 		}
 
 		bool has_color = (word_at_pos == "Color");

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -441,6 +441,7 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			bool is_folded = tx->is_line_folded(row);
 
 			if (tx->is_move_caret_on_right_click_enabled()) {
+				tx->remove_secondary_carets();
 				if (tx->has_selection()) {
 					int from_line = tx->get_selection_from_line();
 					int to_line = tx->get_selection_to_line();
@@ -467,9 +468,9 @@ void TextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	Ref<InputEventKey> k = ev;
 	if (k.is_valid() && k->is_pressed() && k->is_action("ui_menu", true)) {
 		CodeEdit *tx = code_editor->get_text_editor();
-		int line = tx->get_caret_line();
-		tx->adjust_viewport_to_caret();
-		_make_context_menu(tx->has_selection(), tx->can_fold_line(line), tx->is_line_folded(line), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->get_caret_draw_pos()));
+		int line = tx->get_caret_line(0);
+		tx->adjust_viewport_to_caret(0);
+		_make_context_menu(tx->has_selection(0), tx->can_fold_line(line), tx->is_line_folded(line), (get_global_transform().inverse() * tx->get_global_transform()).xform(tx->get_caret_draw_pos(0)));
 		context_menu->grab_focus();
 	}
 }

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -954,6 +954,7 @@ void TextShaderEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			tx->set_move_caret_on_right_click_enabled(EditorSettings::get_singleton()->get("text_editor/behavior/navigation/move_caret_on_right_click"));
 
 			if (tx->is_move_caret_on_right_click_enabled()) {
+				tx->remove_secondary_carets();
 				if (tx->has_selection()) {
 					int from_line = tx->get_selection_from_line();
 					int to_line = tx->get_selection_to_line();

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -609,7 +609,7 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 /* Text manipulation */
 
 // Overridable actions
-void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode) {
+void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_caret) {
 	bool had_selection = has_selection();
 	String selection_text = (had_selection ? get_selected_text() : "");
 
@@ -674,7 +674,7 @@ void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode) {
 	}
 }
 
-void CodeEdit::_backspace_internal() {
+void CodeEdit::_backspace_internal(int p_caret) {
 	if (!is_editable()) {
 		return;
 	}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -610,68 +610,70 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 
 // Overridable actions
 void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_caret) {
-	bool had_selection = has_selection();
-	String selection_text = (had_selection ? get_selected_text() : "");
-
-	if (had_selection) {
-		begin_complex_operation();
-		delete_selection();
-	}
-
-	// Remove the old character if in overtype mode and no selection.
-	if (is_overtype_mode_enabled() && !had_selection) {
-		begin_complex_operation();
-
-		/* Make sure we don't try and remove empty space. */
-		if (get_caret_column() < get_line(get_caret_line()).length()) {
-			remove_text(get_caret_line(), get_caret_column(), get_caret_line(), get_caret_column() + 1);
+	start_action(EditAction::ACTION_TYPING);
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
 		}
-	}
 
-	const char32_t chr[2] = { (char32_t)p_unicode, 0 };
-
-	if (auto_brace_completion_enabled) {
-		int cl = get_caret_line();
-		int cc = get_caret_column();
+		bool had_selection = has_selection(i);
+		String selection_text = (had_selection ? get_selected_text(i) : "");
 
 		if (had_selection) {
-			insert_text_at_caret(chr);
+			delete_selection(i);
+		}
 
-			String close_key = get_auto_brace_completion_close_key(chr);
-			if (!close_key.is_empty()) {
-				insert_text_at_caret(selection_text + close_key);
-				set_caret_column(get_caret_column() - 1);
+		// Remove the old character if in overtype mode and no selection.
+		if (is_overtype_mode_enabled() && !had_selection) {
+			// Make sure we don't try and remove empty space.
+			if (get_caret_column(i) < get_line(get_caret_line(i)).length()) {
+				remove_text(get_caret_line(i), get_caret_column(i), get_caret_line(i), get_caret_column(i) + 1);
+			}
+		}
+
+		const char32_t chr[2] = { (char32_t)p_unicode, 0 };
+
+		if (auto_brace_completion_enabled) {
+			int cl = get_caret_line(i);
+			int cc = get_caret_column(i);
+
+			if (had_selection) {
+				insert_text_at_caret(chr, i);
+
+				String close_key = get_auto_brace_completion_close_key(chr);
+				if (!close_key.is_empty()) {
+					insert_text_at_caret(selection_text + close_key, i);
+					set_caret_column(get_caret_column(i) - 1, i == 0, i);
+				}
+			} else {
+				int caret_move_offset = 1;
+
+				int post_brace_pair = cc < get_line(cl).length() ? _get_auto_brace_pair_close_at_pos(cl, cc) : -1;
+
+				if (has_string_delimiter(chr) && cc > 0 && !is_symbol(get_line(cl)[cc - 1]) && post_brace_pair == -1) {
+					insert_text_at_caret(chr, i);
+				} else if (cc < get_line(cl).length() && !is_symbol(get_line(cl)[cc])) {
+					insert_text_at_caret(chr, i);
+				} else if (post_brace_pair != -1 && auto_brace_completion_pairs[post_brace_pair].close_key[0] == chr[0]) {
+					caret_move_offset = auto_brace_completion_pairs[post_brace_pair].close_key.length();
+				} else if (is_in_comment(cl, cc) != -1 || (is_in_string(cl, cc) != -1 && has_string_delimiter(chr))) {
+					insert_text_at_caret(chr, i);
+				} else {
+					insert_text_at_caret(chr, i);
+
+					int pre_brace_pair = _get_auto_brace_pair_open_at_pos(cl, cc + 1);
+					if (pre_brace_pair != -1) {
+						insert_text_at_caret(auto_brace_completion_pairs[pre_brace_pair].close_key, i);
+					}
+				}
+				set_caret_column(cc + caret_move_offset, i == 0, i);
 			}
 		} else {
-			int caret_move_offset = 1;
-
-			int post_brace_pair = cc < get_line(cl).length() ? _get_auto_brace_pair_close_at_pos(cl, cc) : -1;
-
-			if (has_string_delimiter(chr) && cc > 0 && !is_symbol(get_line(cl)[cc - 1]) && post_brace_pair == -1) {
-				insert_text_at_caret(chr);
-			} else if (cc < get_line(cl).length() && !is_symbol(get_line(cl)[cc])) {
-				insert_text_at_caret(chr);
-			} else if (post_brace_pair != -1 && auto_brace_completion_pairs[post_brace_pair].close_key[0] == chr[0]) {
-				caret_move_offset = auto_brace_completion_pairs[post_brace_pair].close_key.length();
-			} else if (is_in_comment(cl, cc) != -1 || (is_in_string(cl, cc) != -1 && has_string_delimiter(chr))) {
-				insert_text_at_caret(chr);
-			} else {
-				insert_text_at_caret(chr);
-
-				int pre_brace_pair = _get_auto_brace_pair_open_at_pos(cl, cc + 1);
-				if (pre_brace_pair != -1) {
-					insert_text_at_caret(auto_brace_completion_pairs[pre_brace_pair].close_key);
-				}
-			}
-			set_caret_column(cc + caret_move_offset);
+			insert_text_at_caret(chr, i);
 		}
-	} else {
-		insert_text_at_caret(chr);
 	}
-
-	if ((is_overtype_mode_enabled() && !had_selection) || (had_selection)) {
-		end_complex_operation();
-	}
+	end_action();
 }
 
 void CodeEdit::_backspace_internal(int p_caret) {
@@ -684,51 +686,65 @@ void CodeEdit::_backspace_internal(int p_caret) {
 		return;
 	}
 
-	int cc = get_caret_column();
-	int cl = get_caret_line();
+	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
 
-	if (cc == 0 && cl == 0) {
-		return;
-	}
+		int cc = get_caret_column(i);
+		int cl = get_caret_line(i);
 
-	if (cl > 0 && _is_line_hidden(cl - 1)) {
-		unfold_line(get_caret_line() - 1);
-	}
+		if (cc == 0 && cl == 0) {
+			continue;
+		}
 
-	int prev_line = cc ? cl : cl - 1;
-	int prev_column = cc ? (cc - 1) : (get_line(cl - 1).length());
+		if (cl > 0 && _is_line_hidden(cl - 1)) {
+			unfold_line(get_caret_line(i) - 1);
+		}
 
-	merge_gutters(prev_line, cl);
+		int prev_line = cc ? cl : cl - 1;
+		int prev_column = cc ? (cc - 1) : (get_line(cl - 1).length());
 
-	if (auto_brace_completion_enabled && cc > 0) {
-		int idx = _get_auto_brace_pair_open_at_pos(cl, cc);
-		if (idx != -1) {
-			prev_column = cc - auto_brace_completion_pairs[idx].open_key.length();
+		merge_gutters(prev_line, cl);
 
-			if (_get_auto_brace_pair_close_at_pos(cl, cc) == idx) {
-				remove_text(prev_line, prev_column, cl, cc + auto_brace_completion_pairs[idx].close_key.length());
-			} else {
-				remove_text(prev_line, prev_column, cl, cc);
+		if (auto_brace_completion_enabled && cc > 0) {
+			int idx = _get_auto_brace_pair_open_at_pos(cl, cc);
+			if (idx != -1) {
+				prev_column = cc - auto_brace_completion_pairs[idx].open_key.length();
+
+				if (_get_auto_brace_pair_close_at_pos(cl, cc) == idx) {
+					remove_text(prev_line, prev_column, cl, cc + auto_brace_completion_pairs[idx].close_key.length());
+				} else {
+					remove_text(prev_line, prev_column, cl, cc);
+				}
+				set_caret_line(prev_line, false, true, 0, i);
+				set_caret_column(prev_column, i == 0, i);
+
+				adjust_carets_after_edit(i, prev_line, prev_column, cl, cc + auto_brace_completion_pairs[idx].close_key.length());
+				continue;
 			}
-			set_caret_line(prev_line, false, true);
-			set_caret_column(prev_column);
-			return;
 		}
-	}
 
-	// For space indentation we need to do a simple unindent if there are no chars to the left, acting in the
-	// same way as tabs.
-	if (indent_using_spaces && cc != 0) {
-		if (get_first_non_whitespace_column(cl) >= cc) {
-			prev_column = cc - _calculate_spaces_till_next_left_indent(cc);
-			prev_line = cl;
+		// For space indentation we need to do a simple unindent if there are no chars to the left, acting in the
+		// same way as tabs.
+		if (indent_using_spaces && cc != 0) {
+			if (get_first_non_whitespace_column(cl) >= cc) {
+				prev_column = cc - _calculate_spaces_till_next_left_indent(cc);
+				prev_line = cl;
+			}
 		}
+
+		remove_text(prev_line, prev_column, cl, cc);
+
+		set_caret_line(prev_line, false, true, 0, i);
+		set_caret_column(prev_column, i == 0, i);
+
+		adjust_carets_after_edit(i, prev_line, prev_column, cl, cc);
 	}
-
-	remove_text(prev_line, prev_column, cl, cc);
-
-	set_caret_line(prev_line, false, true);
-	set_caret_column(prev_column);
+	merge_overlapping_carets();
+	end_complex_operation();
 }
 
 /* Indent management */
@@ -803,10 +819,15 @@ void CodeEdit::do_indent() {
 		return;
 	}
 
-	int spaces_to_add = _calculate_spaces_till_next_right_indent(get_caret_column());
-	if (spaces_to_add > 0) {
-		insert_text_at_caret(String(" ").repeat(spaces_to_add));
+	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		int spaces_to_add = _calculate_spaces_till_next_right_indent(get_caret_column(i));
+		if (spaces_to_add > 0) {
+			insert_text_at_caret(String(" ").repeat(spaces_to_add), i);
+		}
 	}
+	end_complex_operation();
 }
 
 void CodeEdit::indent_lines() {
@@ -815,48 +836,49 @@ void CodeEdit::indent_lines() {
 	}
 
 	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &c : caret_edit_order) {
+		// This value informs us by how much we changed selection position by indenting right.
+		// Default is 1 for tab indentation.
+		int selection_offset = 1;
 
-	/* This value informs us by how much we changed selection position by indenting right. */
-	/* Default is 1 for tab indentation.                                                   */
-	int selection_offset = 1;
+		int start_line = get_caret_line(c);
+		int end_line = start_line;
+		if (has_selection(c)) {
+			start_line = get_selection_from_line(c);
+			end_line = get_selection_to_line(c);
 
-	int start_line = get_caret_line();
-	int end_line = start_line;
-	if (has_selection()) {
-		start_line = get_selection_from_line();
-		end_line = get_selection_to_line();
-
-		/* Ignore the last line if the selection is not past the first column. */
-		if (get_selection_to_column() == 0) {
-			selection_offset = 0;
-			end_line--;
-		}
-	}
-
-	for (int i = start_line; i <= end_line; i++) {
-		const String line_text = get_line(i);
-		if (line_text.size() == 0 && has_selection()) {
-			continue;
+			// Ignore the last line if the selection is not past the first column.
+			if (get_selection_to_column(c) == 0) {
+				selection_offset = 0;
+				end_line--;
+			}
 		}
 
-		if (!indent_using_spaces) {
-			set_line(i, '\t' + line_text);
-			continue;
+		for (int i = start_line; i <= end_line; i++) {
+			const String line_text = get_line(i);
+			if (line_text.size() == 0 && has_selection(c)) {
+				continue;
+			}
+
+			if (!indent_using_spaces) {
+				set_line(i, '\t' + line_text);
+				continue;
+			}
+
+			// We don't really care where selection is - we just need to know indentation level at the beginning of the line.
+			// Since we will add this many spaces, we want to move the whole selection and caret by this much.
+			int spaces_to_add = _calculate_spaces_till_next_right_indent(get_first_non_whitespace_column(i));
+			set_line(i, String(" ").repeat(spaces_to_add) + line_text);
+			selection_offset = spaces_to_add;
 		}
 
-		/* We don't really care where selection is - we just need to know indentation level at the beginning of the line. */
-		/* Since we will add this many spaces, we want to move the whole selection and caret by this much.                */
-		int spaces_to_add = _calculate_spaces_till_next_right_indent(get_first_non_whitespace_column(i));
-		set_line(i, String(" ").repeat(spaces_to_add) + line_text);
-		selection_offset = spaces_to_add;
+		// Fix selection and caret being off after shifting selection right.
+		if (has_selection(c)) {
+			select(start_line, get_selection_from_column(c) + selection_offset, get_selection_to_line(c), get_selection_to_column(c) + selection_offset, c);
+		}
+		set_caret_column(get_caret_column(c) + selection_offset, false, c);
 	}
-
-	/* Fix selection and caret being off after shifting selection right.*/
-	if (has_selection()) {
-		select(start_line, get_selection_from_column() + selection_offset, get_selection_to_line(), get_selection_to_column() + selection_offset);
-	}
-	set_caret_column(get_caret_column() + selection_offset, false);
-
 	end_complex_operation();
 }
 
@@ -872,30 +894,36 @@ void CodeEdit::do_unindent() {
 		return;
 	}
 
-	int cl = get_caret_line();
-	const String &line = get_line(cl);
+	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &c : caret_edit_order) {
+		int cl = get_caret_line(c);
+		const String &line = get_line(cl);
 
-	if (line[cc - 1] == '\t') {
-		remove_text(cl, cc - 1, cl, cc);
-		set_caret_column(MAX(0, cc - 1));
-		return;
-	}
-
-	if (line[cc - 1] != ' ') {
-		return;
-	}
-
-	int spaces_to_remove = _calculate_spaces_till_next_left_indent(cc);
-	if (spaces_to_remove > 0) {
-		for (int i = 1; i <= spaces_to_remove; i++) {
-			if (line[cc - i] != ' ') {
-				spaces_to_remove = i - 1;
-				break;
-			}
+		if (line[cc - 1] == '\t') {
+			remove_text(cl, cc - 1, cl, cc);
+			set_caret_column(MAX(0, cc - 1), c == 0, c);
+			adjust_carets_after_edit(c, cl, cc, cl, cc - 1);
+			continue;
 		}
-		remove_text(cl, cc - spaces_to_remove, cl, cc);
-		set_caret_column(MAX(0, cc - spaces_to_remove));
+
+		if (line[cc - 1] != ' ') {
+			continue;
+		}
+
+		int spaces_to_remove = _calculate_spaces_till_next_left_indent(cc);
+		if (spaces_to_remove > 0) {
+			for (int i = 1; i <= spaces_to_remove; i++) {
+				if (line[cc - i] != ' ') {
+					spaces_to_remove = i - 1;
+					break;
+				}
+			}
+			remove_text(cl, cc - spaces_to_remove, cl, cc);
+			set_caret_column(MAX(0, cc - spaces_to_remove), c == 0, c);
+		}
 	}
+	end_complex_operation();
 }
 
 void CodeEdit::unindent_lines() {
@@ -905,71 +933,73 @@ void CodeEdit::unindent_lines() {
 
 	begin_complex_operation();
 
-	/* Moving caret and selection after unindenting can get tricky because                                                      */
-	/* changing content of line can move caret and selection on its own (if new line ends before previous position of either),  */
-	/* therefore we just remember initial values and at the end of the operation offset them by number of removed characters.   */
-	int removed_characters = 0;
-	int initial_selection_end_column = 0;
-	int initial_cursor_column = get_caret_column();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &c : caret_edit_order) {
+		// Moving caret and selection after unindenting can get tricky because
+		// changing content of line can move caret and selection on its own (if new line ends before previous position of either)
+		// therefore we just remember initial values and at the end of the operation offset them by number of removed characters.
+		int removed_characters = 0;
+		int initial_selection_end_column = 0;
+		int initial_cursor_column = get_caret_column(c);
 
-	int start_line = get_caret_line();
-	int end_line = start_line;
-	if (has_selection()) {
-		start_line = get_selection_from_line();
-		end_line = get_selection_to_line();
+		int start_line = get_caret_line(c);
+		int end_line = start_line;
+		if (has_selection(c)) {
+			start_line = get_selection_from_line(c);
+			end_line = get_selection_to_line(c);
 
-		/* Ignore the last line if the selection is not past the first column. */
-		initial_selection_end_column = get_selection_to_column();
-		if (initial_selection_end_column == 0) {
-			end_line--;
+			// Ignore the last line if the selection is not past the first column.
+			initial_selection_end_column = get_selection_to_column(c);
+			if (initial_selection_end_column == 0) {
+				end_line--;
+			}
 		}
+
+		bool first_line_edited = false;
+		bool last_line_edited = false;
+
+		for (int i = start_line; i <= end_line; i++) {
+			String line_text = get_line(i);
+
+			if (line_text.begins_with("\t")) {
+				line_text = line_text.substr(1, line_text.length());
+
+				set_line(i, line_text);
+				removed_characters = 1;
+
+				first_line_edited = (i == start_line) ? true : first_line_edited;
+				last_line_edited = (i == end_line) ? true : last_line_edited;
+				continue;
+			}
+
+			if (line_text.begins_with(" ")) {
+				// When unindenting we aim to remove spaces before line that has selection no matter what is selected.
+				// Here we remove only enough spaces to align text to nearest full multiple of indentation_size.
+				// In case where selection begins at the start of indentation_size multiple we remove whole indentation level.
+				int spaces_to_remove = _calculate_spaces_till_next_left_indent(get_first_non_whitespace_column(i));
+				line_text = line_text.substr(spaces_to_remove, line_text.length());
+
+				set_line(i, line_text);
+				removed_characters = spaces_to_remove;
+
+				first_line_edited = (i == start_line) ? true : first_line_edited;
+				last_line_edited = (i == end_line) ? true : last_line_edited;
+			}
+		}
+
+		if (has_selection(c)) {
+			// Fix selection being off by one on the first line.
+			if (first_line_edited) {
+				select(get_selection_from_line(c), get_selection_from_column(c) - removed_characters, get_selection_to_line(c), initial_selection_end_column, c);
+			}
+
+			// Fix selection being off by one on the last line.
+			if (last_line_edited) {
+				select(get_selection_from_line(c), get_selection_from_column(c), get_selection_to_line(c), initial_selection_end_column - removed_characters, c);
+			}
+		}
+		set_caret_column(initial_cursor_column - removed_characters, false, c);
 	}
-
-	bool first_line_edited = false;
-	bool last_line_edited = false;
-
-	for (int i = start_line; i <= end_line; i++) {
-		String line_text = get_line(i);
-
-		if (line_text.begins_with("\t")) {
-			line_text = line_text.substr(1, line_text.length());
-
-			set_line(i, line_text);
-			removed_characters = 1;
-
-			first_line_edited = (i == start_line) ? true : first_line_edited;
-			last_line_edited = (i == end_line) ? true : last_line_edited;
-			continue;
-		}
-
-		if (line_text.begins_with(" ")) {
-			/* When unindenting we aim to remove spaces before line that has selection no matter what is selected,         */
-			/* Here we remove only enough spaces to align text to nearest full multiple of indentation_size.               */
-			/* In case where selection begins at the start of indentation_size multiple we remove whole indentation level. */
-			int spaces_to_remove = _calculate_spaces_till_next_left_indent(get_first_non_whitespace_column(i));
-			line_text = line_text.substr(spaces_to_remove, line_text.length());
-
-			set_line(i, line_text);
-			removed_characters = spaces_to_remove;
-
-			first_line_edited = (i == start_line) ? true : first_line_edited;
-			last_line_edited = (i == end_line) ? true : last_line_edited;
-		}
-	}
-
-	if (has_selection()) {
-		/* Fix selection being off by one on the first line. */
-		if (first_line_edited) {
-			select(get_selection_from_line(), get_selection_from_column() - removed_characters, get_selection_to_line(), initial_selection_end_column);
-		}
-
-		/* Fix selection being off by one on the last line. */
-		if (last_line_edited) {
-			select(get_selection_from_line(), get_selection_from_column(), get_selection_to_line(), initial_selection_end_column - removed_characters);
-		}
-	}
-	set_caret_column(initial_cursor_column - removed_characters, false);
-
 	end_complex_operation();
 }
 
@@ -990,106 +1020,108 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 		return;
 	}
 
-	/* When not splitting the line, we need to factor in indentation from the end of the current line. */
-	const int cc = p_split_current_line ? get_caret_column() : get_line(get_caret_line()).length();
-	const int cl = get_caret_line();
+	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		// When not splitting the line, we need to factor in indentation from the end of the current line.
+		const int cc = p_split_current_line ? get_caret_column(i) : get_line(get_caret_line(i)).length();
+		const int cl = get_caret_line(i);
 
-	const String line = get_line(cl);
+		const String line = get_line(cl);
 
-	String ins = "\n";
+		String ins = "\n";
 
-	/* Append current indentation. */
-	int space_count = 0;
-	int line_col = 0;
-	for (; line_col < cc; line_col++) {
-		if (line[line_col] == '\t') {
-			ins += indent_text;
-			space_count = 0;
-			continue;
-		}
-
-		if (line[line_col] == ' ') {
-			space_count++;
-
-			if (space_count == indent_size) {
+		// Append current indentation.
+		int space_count = 0;
+		int line_col = 0;
+		for (; line_col < cc; line_col++) {
+			if (line[line_col] == '\t') {
 				ins += indent_text;
 				space_count = 0;
-			}
-			continue;
-		}
-		break;
-	}
-
-	if (is_line_folded(cl)) {
-		unfold_line(cl);
-	}
-
-	/* Indent once again if the previous line needs it, ie ':'.          */
-	/* Then add an addition new line for any closing pairs aka '()'.     */
-	/* Skip this in comments or if we are going above.                   */
-	bool brace_indent = false;
-	if (auto_indent && !p_above && cc > 0 && is_in_comment(cl) == -1) {
-		bool should_indent = false;
-		char32_t indent_char = ' ';
-
-		for (; line_col < cc; line_col++) {
-			char32_t c = line[line_col];
-			if (auto_indent_prefixes.has(c)) {
-				should_indent = true;
-				indent_char = c;
 				continue;
 			}
 
-			/* Make sure this is the last char, trailing whitespace or comments are okay. */
-			/* Increment column for comments because the delimiter (#) should be ignored. */
-			if (should_indent && (!is_whitespace(c) && is_in_comment(cl, line_col + 1) == -1)) {
-				should_indent = false;
+			if (line[line_col] == ' ') {
+				space_count++;
+
+				if (space_count == indent_size) {
+					ins += indent_text;
+					space_count = 0;
+				}
+				continue;
 			}
+			break;
 		}
 
-		if (should_indent) {
-			ins += indent_text;
+		if (is_line_folded(cl)) {
+			unfold_line(cl);
+		}
 
-			String closing_pair = get_auto_brace_completion_close_key(String::chr(indent_char));
-			if (!closing_pair.is_empty() && line.find(closing_pair, cc) == cc) {
-				/* No need to move the brace below if we are not taking the text with us. */
-				if (p_split_current_line) {
-					brace_indent = true;
-					ins += "\n" + ins.substr(indent_text.size(), ins.length() - 2);
-				} else {
-					brace_indent = false;
-					ins = "\n" + ins.substr(indent_text.size(), ins.length() - 2);
+		// Indent once again if the previous line needs it, ie ':'.
+		// Then add an addition new line for any closing pairs aka '()'.
+		// Skip this in comments or if we are going above.
+		bool brace_indent = false;
+		if (auto_indent && !p_above && cc > 0 && is_in_comment(cl) == -1) {
+			bool should_indent = false;
+			char32_t indent_char = ' ';
+
+			for (; line_col < cc; line_col++) {
+				char32_t c = line[line_col];
+				if (auto_indent_prefixes.has(c)) {
+					should_indent = true;
+					indent_char = c;
+					continue;
+				}
+
+				// Make sure this is the last char, trailing whitespace or comments are okay.
+				// Increment column for comments because the delimiter (#) should be ignored.
+				if (should_indent && (!is_whitespace(c) && is_in_comment(cl, line_col + 1) == -1)) {
+					should_indent = false;
+				}
+			}
+
+			if (should_indent) {
+				ins += indent_text;
+
+				String closing_pair = get_auto_brace_completion_close_key(String::chr(indent_char));
+				if (!closing_pair.is_empty() && line.find(closing_pair, cc) == cc) {
+					// No need to move the brace below if we are not taking the text with us.
+					if (p_split_current_line) {
+						brace_indent = true;
+						ins += "\n" + ins.substr(indent_text.size(), ins.length() - 2);
+					} else {
+						brace_indent = false;
+						ins = "\n" + ins.substr(indent_text.size(), ins.length() - 2);
+					}
 				}
 			}
 		}
-	}
 
-	begin_complex_operation();
+		bool first_line = false;
+		if (!p_split_current_line) {
+			deselect(i);
 
-	bool first_line = false;
-	if (!p_split_current_line) {
-		deselect();
-
-		if (p_above) {
-			if (cl > 0) {
-				set_caret_line(cl - 1, false);
-				set_caret_column(get_line(get_caret_line()).length());
+			if (p_above) {
+				if (cl > 0) {
+					set_caret_line(cl - 1, false, true, 0, i);
+					set_caret_column(get_line(get_caret_line(i)).length(), i == 0, i);
+				} else {
+					set_caret_column(0, i == 0, i);
+					first_line = true;
+				}
 			} else {
-				set_caret_column(0);
-				first_line = true;
+				set_caret_column(line.length(), i == 0, i);
 			}
-		} else {
-			set_caret_column(line.length());
 		}
-	}
 
-	insert_text_at_caret(ins);
+		insert_text_at_caret(ins, i);
 
-	if (first_line) {
-		set_caret_line(0);
-	} else if (brace_indent) {
-		set_caret_line(get_caret_line() - 1, false);
-		set_caret_column(get_line(get_caret_line()).length());
+		if (first_line) {
+			set_caret_line(0, i == 0, true, 0, i);
+		} else if (brace_indent) {
+			set_caret_line(get_caret_line(i) - 1, false, true, 0, i);
+			set_caret_column(get_line(get_caret_line(i)).length(), i == 0, i);
+		}
 	}
 
 	end_complex_operation();
@@ -1522,22 +1554,26 @@ void CodeEdit::fold_line(int p_line) {
 		_set_line_as_hidden(i, true);
 	}
 
-	/* Fix selection. */
-	if (has_selection()) {
-		if (_is_line_hidden(get_selection_from_line()) && _is_line_hidden(get_selection_to_line())) {
-			deselect();
-		} else if (_is_line_hidden(get_selection_from_line())) {
-			select(p_line, 9999, get_selection_to_line(), get_selection_to_column());
-		} else if (_is_line_hidden(get_selection_to_line())) {
-			select(get_selection_from_line(), get_selection_from_column(), p_line, 9999);
+	for (int i = 0; i < get_caret_count(); i++) {
+		// Fix selection.
+		if (has_selection(i)) {
+			if (_is_line_hidden(get_selection_from_line(i)) && _is_line_hidden(get_selection_to_line(i))) {
+				deselect(i);
+			} else if (_is_line_hidden(get_selection_from_line(i))) {
+				select(p_line, 9999, get_selection_to_line(i), get_selection_to_column(i), i);
+			} else if (_is_line_hidden(get_selection_to_line(i))) {
+				select(get_selection_from_line(i), get_selection_from_column(i), p_line, 9999, i);
+			}
+		}
+
+		// Reset caret.
+		if (_is_line_hidden(get_caret_line(i))) {
+			set_caret_line(p_line, false, false, 0, i);
+			set_caret_column(get_line(p_line).length(), false, i);
 		}
 	}
 
-	/* Reset caret. */
-	if (_is_line_hidden(get_caret_line())) {
-		set_caret_line(p_line, false, false);
-		set_caret_column(get_line(p_line).length(), false);
-	}
+	merge_overlapping_carets();
 	queue_redraw();
 }
 
@@ -1950,98 +1986,108 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 		return;
 	}
 
+	char32_t caret_last_completion_char;
 	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		int caret_line = get_caret_line(i);
 
-	int caret_line = get_caret_line();
+		const String &insert_text = code_completion_options[code_completion_current_selected].insert_text;
+		const String &display_text = code_completion_options[code_completion_current_selected].display;
 
-	const String &insert_text = code_completion_options[code_completion_current_selected].insert_text;
-	const String &display_text = code_completion_options[code_completion_current_selected].display;
+		if (p_replace) {
+			// Find end of current section.
+			const String line = get_line(caret_line);
+			int caret_col = get_caret_column(i);
+			int caret_remove_line = caret_line;
 
-	if (p_replace) {
-		/* Find end of current section */
-		const String line = get_line(caret_line);
-		int caret_col = get_caret_column();
-		int caret_remove_line = caret_line;
-
-		bool merge_text = true;
-		int in_string = is_in_string(caret_line, caret_col);
-		if (in_string != -1) {
-			Point2 string_end = get_delimiter_end_position(caret_line, caret_col);
-			if (string_end.x != -1) {
-				merge_text = false;
-				caret_remove_line = string_end.y;
-				caret_col = string_end.x - 1;
+			bool merge_text = true;
+			int in_string = is_in_string(caret_line, caret_col);
+			if (in_string != -1) {
+				Point2 string_end = get_delimiter_end_position(caret_line, caret_col);
+				if (string_end.x != -1) {
+					merge_text = false;
+					caret_remove_line = string_end.y;
+					caret_col = string_end.x - 1;
+				}
 			}
+
+			if (merge_text) {
+				for (; caret_col < line.length(); caret_col++) {
+					if (is_symbol(line[caret_col])) {
+						break;
+					}
+				}
+			}
+
+			// Replace.
+			remove_text(caret_line, get_caret_column(i) - code_completion_base.length(), caret_remove_line, caret_col);
+			adjust_carets_after_edit(i, caret_line, caret_col - code_completion_base.length(), caret_remove_line, caret_col);
+			set_caret_column(get_caret_column(i) - code_completion_base.length(), false, i);
+			insert_text_at_caret(insert_text, i);
+		} else {
+			// Get first non-matching char.
+			const String line = get_line(caret_line);
+			int caret_col = get_caret_column(i);
+			int matching_chars = code_completion_base.length();
+			for (; matching_chars <= insert_text.length(); matching_chars++) {
+				if (caret_col >= line.length() || line[caret_col] != insert_text[matching_chars]) {
+					break;
+				}
+				caret_col++;
+			}
+
+			// Remove base completion text.
+			remove_text(caret_line, get_caret_column(i) - code_completion_base.length(), caret_line, get_caret_column(i));
+			adjust_carets_after_edit(i, caret_line, get_caret_column(i) - code_completion_base.length(), caret_line, get_caret_column(i));
+			set_caret_column(get_caret_column(i) - code_completion_base.length(), false, i);
+
+			// Merge with text.
+			insert_text_at_caret(insert_text.substr(0, code_completion_base.length()), i);
+			set_caret_column(caret_col, false, i);
+			insert_text_at_caret(insert_text.substr(matching_chars), i);
 		}
 
-		if (merge_text) {
-			for (; caret_col < line.length(); caret_col++) {
-				if (is_symbol(line[caret_col])) {
-					break;
+		//* Handle merging of symbols eg strings, brackets.
+		const String line = get_line(caret_line);
+		char32_t next_char = line[get_caret_column(i)];
+		char32_t last_completion_char = insert_text[insert_text.length() - 1];
+		if (i == 0) {
+			caret_last_completion_char = last_completion_char;
+		}
+		char32_t last_completion_char_display = display_text[display_text.length() - 1];
+
+		int pre_brace_pair = get_caret_column(i) > 0 ? _get_auto_brace_pair_open_at_pos(caret_line, get_caret_column(i)) : -1;
+		int post_brace_pair = get_caret_column(i) < get_line(caret_line).length() ? _get_auto_brace_pair_close_at_pos(caret_line, get_caret_column(i)) : -1;
+
+		if (post_brace_pair != -1 && (last_completion_char == next_char || last_completion_char_display == next_char)) {
+			remove_text(caret_line, get_caret_column(i), caret_line, get_caret_column(i) + 1);
+			adjust_carets_after_edit(i, caret_line, get_caret_column(i), caret_line, get_caret_column(i) + 1);
+		}
+
+		if (pre_brace_pair != -1 && pre_brace_pair != post_brace_pair && (last_completion_char == next_char || last_completion_char_display == next_char)) {
+			remove_text(caret_line, get_caret_column(i), caret_line, get_caret_column(i) + 1);
+			adjust_carets_after_edit(i, caret_line, get_caret_column(i), caret_line, get_caret_column(i) + 1);
+		} else if (auto_brace_completion_enabled && pre_brace_pair != -1 && post_brace_pair == -1) {
+			insert_text_at_caret(auto_brace_completion_pairs[pre_brace_pair].close_key, i);
+			set_caret_column(get_caret_column(i) - auto_brace_completion_pairs[pre_brace_pair].close_key.length(), i == 0, i);
+		}
+
+		if (pre_brace_pair == -1 && post_brace_pair == -1 && get_caret_column(i) > 0 && get_caret_column(i) < get_line(caret_line).length()) {
+			pre_brace_pair = _get_auto_brace_pair_open_at_pos(caret_line, get_caret_column(i) + 1);
+			if (pre_brace_pair != -1 && pre_brace_pair == _get_auto_brace_pair_close_at_pos(caret_line, get_caret_column(i) - 1)) {
+				remove_text(caret_line, get_caret_column(i) - 2, caret_line, get_caret_column(i));
+				adjust_carets_after_edit(i, caret_line, get_caret_column(i) - 2, caret_line, get_caret_column(i));
+				if (_get_auto_brace_pair_close_at_pos(caret_line, get_caret_column(i) - 1) != pre_brace_pair) {
+					set_caret_column(get_caret_column(i) - 1, i == 0, i);
 				}
 			}
 		}
-
-		/* Replace. */
-		remove_text(caret_line, get_caret_column() - code_completion_base.length(), caret_remove_line, caret_col);
-		set_caret_column(get_caret_column() - code_completion_base.length(), false);
-		insert_text_at_caret(insert_text);
-	} else {
-		/* Get first non-matching char. */
-		const String line = get_line(caret_line);
-		int caret_col = get_caret_column();
-		int matching_chars = code_completion_base.length();
-		for (; matching_chars <= insert_text.length(); matching_chars++) {
-			if (caret_col >= line.length() || line[caret_col] != insert_text[matching_chars]) {
-				break;
-			}
-			caret_col++;
-		}
-
-		/* Remove base completion text. */
-		remove_text(caret_line, get_caret_column() - code_completion_base.length(), caret_line, get_caret_column());
-		set_caret_column(get_caret_column() - code_completion_base.length(), false);
-
-		/* Merge with text. */
-		insert_text_at_caret(insert_text.substr(0, code_completion_base.length()));
-		set_caret_column(caret_col, false);
-		insert_text_at_caret(insert_text.substr(matching_chars));
 	}
-
-	/* Handle merging of symbols eg strings, brackets. */
-	const String line = get_line(caret_line);
-	char32_t next_char = line[get_caret_column()];
-	char32_t last_completion_char = insert_text[insert_text.length() - 1];
-	char32_t last_completion_char_display = display_text[display_text.length() - 1];
-
-	int pre_brace_pair = get_caret_column() > 0 ? _get_auto_brace_pair_open_at_pos(caret_line, get_caret_column()) : -1;
-	int post_brace_pair = get_caret_column() < get_line(caret_line).length() ? _get_auto_brace_pair_close_at_pos(caret_line, get_caret_column()) : -1;
-
-	if (post_brace_pair != -1 && (last_completion_char == next_char || last_completion_char_display == next_char)) {
-		remove_text(caret_line, get_caret_column(), caret_line, get_caret_column() + 1);
-	}
-
-	if (pre_brace_pair != -1 && pre_brace_pair != post_brace_pair && (last_completion_char == next_char || last_completion_char_display == next_char)) {
-		remove_text(caret_line, get_caret_column(), caret_line, get_caret_column() + 1);
-	} else if (auto_brace_completion_enabled && pre_brace_pair != -1 && post_brace_pair == -1) {
-		insert_text_at_caret(auto_brace_completion_pairs[pre_brace_pair].close_key);
-		set_caret_column(get_caret_column() - auto_brace_completion_pairs[pre_brace_pair].close_key.length());
-	}
-
-	if (pre_brace_pair == -1 && post_brace_pair == -1 && get_caret_column() > 0 && get_caret_column() < get_line(caret_line).length()) {
-		pre_brace_pair = _get_auto_brace_pair_open_at_pos(caret_line, get_caret_column() + 1);
-		if (pre_brace_pair != -1 && pre_brace_pair == _get_auto_brace_pair_close_at_pos(caret_line, get_caret_column() - 1)) {
-			remove_text(caret_line, get_caret_column() - 2, caret_line, get_caret_column());
-			if (_get_auto_brace_pair_close_at_pos(caret_line, get_caret_column() - 1) != pre_brace_pair) {
-				set_caret_column(get_caret_column() - 1);
-			}
-		}
-	}
-
 	end_complex_operation();
 
 	cancel_code_completion();
-	if (code_completion_prefixes.has(last_completion_char)) {
+	if (code_completion_prefixes.has(caret_last_completion_char)) {
 		request_code_completion();
 	}
 }
@@ -2399,6 +2445,7 @@ void CodeEdit::_gutter_clicked(int p_line, int p_gutter) {
 	}
 
 	if (p_gutter == line_number_gutter) {
+		remove_secondary_carets();
 		set_selection_mode(TextEdit::SelectionMode::SELECTION_MODE_LINE, p_line, 0);
 		select(p_line, 0, p_line + 1, 0);
 		set_caret_line(p_line + 1);

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -261,8 +261,8 @@ protected:
 	/* Text manipulation */
 
 	// Overridable actions
-	virtual void _handle_unicode_input_internal(const uint32_t p_unicode) override;
-	virtual void _backspace_internal() override;
+	virtual void _handle_unicode_input_internal(const uint32_t p_unicode, int p_caret) override;
+	virtual void _backspace_internal(int p_caret) override;
 
 	GDVIRTUAL1(_confirm_code_completion, bool)
 	GDVIRTUAL1(_request_code_completion, bool)

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -536,145 +536,145 @@ void TextEdit::_notification(int p_what) {
 				RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(Point2i(), get_size()), background_color);
 			}
 
-			int brace_open_match_line = -1;
-			int brace_open_match_column = -1;
-			bool brace_open_matching = false;
-			bool brace_open_mismatch = false;
-			int brace_close_match_line = -1;
-			int brace_close_match_column = -1;
-			bool brace_close_matching = false;
-			bool brace_close_mismatch = false;
+			Vector<BraceMatchingData> brace_matching;
+			if (highlight_matching_braces_enabled) {
+				brace_matching.resize(carets.size());
 
-			if (highlight_matching_braces_enabled && caret.line >= 0 && caret.line < text.size() && caret.column >= 0) {
-				if (caret.column < text[caret.line].length()) {
-					// Check for open.
-					char32_t c = text[caret.line][caret.column];
-					char32_t closec = 0;
-
-					if (c == '[') {
-						closec = ']';
-					} else if (c == '{') {
-						closec = '}';
-					} else if (c == '(') {
-						closec = ')';
+				for (int caret = 0; caret < carets.size(); caret++) {
+					if (get_caret_line(caret) < 0 || get_caret_line(caret) >= text.size() || get_caret_column(caret) < 0) {
+						continue;
 					}
 
-					if (closec != 0) {
-						int stack = 1;
+					if (get_caret_column(caret) < text[get_caret_line(caret)].length()) {
+						// Check for open.
+						char32_t c = text[get_caret_line(caret)][get_caret_column(caret)];
+						char32_t closec = 0;
 
-						for (int i = caret.line; i < text.size(); i++) {
-							int from = i == caret.line ? caret.column + 1 : 0;
-							for (int j = from; j < text[i].length(); j++) {
-								char32_t cc = text[i][j];
-								// Ignore any brackets inside a string.
-								if (cc == '"' || cc == '\'') {
-									char32_t quotation = cc;
-									do {
-										j++;
-										if (!(j < text[i].length())) {
-											break;
-										}
-										cc = text[i][j];
-										// Skip over escaped quotation marks inside strings.
-										if (cc == '\\') {
-											bool escaped = true;
-											while (j + 1 < text[i].length() && text[i][j + 1] == '\\') {
-												escaped = !escaped;
-												j++;
+						if (c == '[') {
+							closec = ']';
+						} else if (c == '{') {
+							closec = '}';
+						} else if (c == '(') {
+							closec = ')';
+						}
+
+						if (closec != 0) {
+							int stack = 1;
+
+							for (int i = get_caret_line(caret); i < text.size(); i++) {
+								int from = i == get_caret_line(caret) ? get_caret_column(caret) + 1 : 0;
+								for (int j = from; j < text[i].length(); j++) {
+									char32_t cc = text[i][j];
+									// Ignore any brackets inside a string.
+									if (cc == '"' || cc == '\'') {
+										char32_t quotation = cc;
+										do {
+											j++;
+											if (!(j < text[i].length())) {
+												break;
 											}
-											if (escaped) {
-												j++;
-												continue;
+											cc = text[i][j];
+											// Skip over escaped quotation marks inside strings.
+											if (cc == '\\') {
+												bool escaped = true;
+												while (j + 1 < text[i].length() && text[i][j + 1] == '\\') {
+													escaped = !escaped;
+													j++;
+												}
+												if (escaped) {
+													j++;
+													continue;
+												}
 											}
-										}
-									} while (cc != quotation);
-								} else if (cc == c) {
-									stack++;
-								} else if (cc == closec) {
-									stack--;
+										} while (cc != quotation);
+									} else if (cc == c) {
+										stack++;
+									} else if (cc == closec) {
+										stack--;
+									}
+
+									if (stack == 0) {
+										brace_matching.write[caret].open_match_line = i;
+										brace_matching.write[caret].open_match_column = j;
+										brace_matching.write[caret].open_matching = true;
+
+										break;
+									}
 								}
-
-								if (stack == 0) {
-									brace_open_match_line = i;
-									brace_open_match_column = j;
-									brace_open_matching = true;
-
+								if (brace_matching.write[caret].open_match_line != -1) {
 									break;
 								}
 							}
-							if (brace_open_match_line != -1) {
-								break;
+
+							if (!brace_matching.write[caret].open_matching) {
+								brace_matching.write[caret].open_mismatch = true;
 							}
 						}
+					}
 
-						if (!brace_open_matching) {
-							brace_open_mismatch = true;
+					if (get_caret_column(caret) > 0) {
+						char32_t c = text[get_caret_line(caret)][get_caret_column(caret) - 1];
+						char32_t closec = 0;
+
+						if (c == ']') {
+							closec = '[';
+						} else if (c == '}') {
+							closec = '{';
+						} else if (c == ')') {
+							closec = '(';
 						}
-					}
-				}
 
-				if (caret.column > 0) {
-					char32_t c = text[caret.line][caret.column - 1];
-					char32_t closec = 0;
+						if (closec != 0) {
+							int stack = 1;
 
-					if (c == ']') {
-						closec = '[';
-					} else if (c == '}') {
-						closec = '{';
-					} else if (c == ')') {
-						closec = '(';
-					}
-
-					if (closec != 0) {
-						int stack = 1;
-
-						for (int i = caret.line; i >= 0; i--) {
-							int from = i == caret.line ? caret.column - 2 : text[i].length() - 1;
-							for (int j = from; j >= 0; j--) {
-								char32_t cc = text[i][j];
-								// Ignore any brackets inside a string.
-								if (cc == '"' || cc == '\'') {
-									char32_t quotation = cc;
-									do {
-										j--;
-										if (!(j >= 0)) {
-											break;
-										}
-										cc = text[i][j];
-										// Skip over escaped quotation marks inside strings.
-										if (cc == quotation) {
-											bool escaped = false;
-											while (j - 1 >= 0 && text[i][j - 1] == '\\') {
-												escaped = !escaped;
-												j--;
+							for (int i = get_caret_line(caret); i >= 0; i--) {
+								int from = i == get_caret_line(caret) ? get_caret_column(caret) - 2 : text[i].length() - 1;
+								for (int j = from; j >= 0; j--) {
+									char32_t cc = text[i][j];
+									// Ignore any brackets inside a string.
+									if (cc == '"' || cc == '\'') {
+										char32_t quotation = cc;
+										do {
+											j--;
+											if (!(j >= 0)) {
+												break;
 											}
-											if (escaped) {
-												cc = '\\';
-												continue;
+											cc = text[i][j];
+											// Skip over escaped quotation marks inside strings.
+											if (cc == quotation) {
+												bool escaped = false;
+												while (j - 1 >= 0 && text[i][j - 1] == '\\') {
+													escaped = !escaped;
+													j--;
+												}
+												if (escaped) {
+													cc = '\\';
+													continue;
+												}
 											}
-										}
-									} while (cc != quotation);
-								} else if (cc == c) {
-									stack++;
-								} else if (cc == closec) {
-									stack--;
+										} while (cc != quotation);
+									} else if (cc == c) {
+										stack++;
+									} else if (cc == closec) {
+										stack--;
+									}
+
+									if (stack == 0) {
+										brace_matching.write[caret].close_match_line = i;
+										brace_matching.write[caret].close_match_column = j;
+										brace_matching.write[caret].close_matching = true;
+
+										break;
+									}
 								}
-
-								if (stack == 0) {
-									brace_close_match_line = i;
-									brace_close_match_column = j;
-									brace_close_matching = true;
-
+								if (brace_matching.write[caret].close_match_line != -1) {
 									break;
 								}
 							}
-							if (brace_close_match_line != -1) {
-								break;
-							}
-						}
 
-						if (!brace_close_matching) {
-							brace_close_mismatch = true;
+							if (!brace_matching.write[caret].close_matching) {
+								brace_matching.write[caret].close_mismatch = true;
+							}
 						}
 					}
 				}
@@ -683,12 +683,20 @@ void TextEdit::_notification(int p_what) {
 			bool draw_placeholder = text.size() == 1 && text[0].length() == 0;
 
 			// Get the highlighted words.
-			String highlighted_text = get_selected_text();
+			String highlighted_text = get_selected_text(0);
 
 			// Check if highlighted words contain only whitespaces (tabs or spaces).
 			bool only_whitespaces_highlighted = highlighted_text.strip_edges().is_empty();
 
-			const int caret_wrap_index = get_caret_wrap_index();
+			HashMap<int, HashSet<int>> caret_line_wrap_index_map;
+			Vector<int> carets_wrap_index;
+			carets_wrap_index.resize(carets.size());
+			for (int i = 0; i < carets.size(); i++) {
+				carets.write[i].visible = false;
+				int wrap_index = get_caret_wrap_index(i);
+				caret_line_wrap_index_map[get_caret_line(i)].insert(wrap_index);
+				carets_wrap_index.write[i] = wrap_index;
+			}
 
 			int first_visible_line = get_first_visible_line() - 1;
 			int draw_amount = visible_rows + (smooth_scroll_enabled ? 1 : 0);
@@ -783,7 +791,7 @@ void TextEdit::_notification(int p_what) {
 							last_wrap_column += wrap_rows[line_wrap_index - 1].length();
 						}
 
-						if (minimap_line == caret.line && caret_wrap_index == line_wrap_index && highlight_current_line) {
+						if (caret_line_wrap_index_map.has(minimap_line) && caret_line_wrap_index_map[minimap_line].has(line_wrap_index) && highlight_current_line) {
 							if (rtl) {
 								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - (xmargin_end + 2) - minimap_width, i * 3, minimap_width, 2), current_line_color);
 							} else {
@@ -875,7 +883,6 @@ void TextEdit::_notification(int p_what) {
 			}
 
 			// Draw main text.
-			caret.visible = false;
 			line_drawing_cache.clear();
 			int row_height = draw_placeholder ? placeholder_line_height + line_spacing : get_line_height();
 			int line = first_visible_line;
@@ -960,7 +967,7 @@ void TextEdit::_notification(int p_what) {
 
 					if (str.length() == 0) {
 						// Draw line background if empty as we won't loop at all.
-						if (line == caret.line && caret_wrap_index == line_wrap_index && highlight_current_line) {
+						if (caret_line_wrap_index_map.has(line) && caret_line_wrap_index_map[line].has(line_wrap_index) && highlight_current_line) {
 							if (rtl) {
 								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - ofs_x - xmargin_end, ofs_y, xmargin_end, row_height), current_line_color);
 							} else {
@@ -969,17 +976,19 @@ void TextEdit::_notification(int p_what) {
 						}
 
 						// Give visual indication of empty selected line.
-						if (has_selection() && line >= get_selection_from_line() && line <= get_selection_to_line() && char_margin >= xmargin_beg) {
-							float char_w = font->get_char_size(' ', font_size).width;
-							if (rtl) {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - xmargin_beg - ofs_x - char_w, ofs_y, char_w, row_height), selection_color);
-							} else {
-								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg + ofs_x, ofs_y, char_w, row_height), selection_color);
+						for (int c = 0; c < carets.size(); c++) {
+							if (has_selection(c) && line >= get_selection_from_line(c) && line <= get_selection_to_line(c) && char_margin >= xmargin_beg) {
+								float char_w = font->get_char_size(' ', font_size).width;
+								if (rtl) {
+									RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - xmargin_beg - ofs_x - char_w, ofs_y, char_w, row_height), selection_color);
+								} else {
+									RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(xmargin_beg + ofs_x, ofs_y, char_w, row_height), selection_color);
+								}
 							}
 						}
 					} else {
 						// If it has text, then draw current line marker in the margin, as line number etc will draw over it, draw the rest of line marker later.
-						if (line == caret.line && caret_wrap_index == line_wrap_index && highlight_current_line) {
+						if (caret_line_wrap_index_map.has(line) && caret_line_wrap_index_map[line].has(line_wrap_index) && highlight_current_line) {
 							if (rtl) {
 								RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(size.width - ofs_x - xmargin_end, ofs_y, xmargin_end, row_height), current_line_color);
 							} else {
@@ -1074,23 +1083,25 @@ void TextEdit::_notification(int p_what) {
 						char_margin = size.width - char_margin - TS->shaped_text_get_size(rid).x;
 					}
 
-					if (!clipped && has_selection() && line >= get_selection_from_line() && line <= get_selection_to_line()) { // Selection
-						int sel_from = (line > get_selection_from_line()) ? TS->shaped_text_get_range(rid).x : get_selection_from_column();
-						int sel_to = (line < get_selection_to_line()) ? TS->shaped_text_get_range(rid).y : get_selection_to_column();
-						Vector<Vector2> sel = TS->shaped_text_get_selection(rid, sel_from, sel_to);
-						for (int j = 0; j < sel.size(); j++) {
-							Rect2 rect = Rect2(sel[j].x + char_margin + ofs_x, ofs_y, sel[j].y - sel[j].x, row_height);
-							if (rect.position.x + rect.size.x <= xmargin_beg || rect.position.x > xmargin_end) {
-								continue;
+					for (int c = 0; c < carets.size(); c++) {
+						if (!clipped && has_selection(c) && line >= get_selection_from_line(c) && line <= get_selection_to_line(c)) { // Selection
+							int sel_from = (line > get_selection_from_line(c)) ? TS->shaped_text_get_range(rid).x : get_selection_from_column(c);
+							int sel_to = (line < get_selection_to_line(c)) ? TS->shaped_text_get_range(rid).y : get_selection_to_column(c);
+							Vector<Vector2> sel = TS->shaped_text_get_selection(rid, sel_from, sel_to);
+							for (int j = 0; j < sel.size(); j++) {
+								Rect2 rect = Rect2(sel[j].x + char_margin + ofs_x, ofs_y, sel[j].y - sel[j].x, row_height);
+								if (rect.position.x + rect.size.x <= xmargin_beg || rect.position.x > xmargin_end) {
+									continue;
+								}
+								if (rect.position.x < xmargin_beg) {
+									rect.size.x -= (xmargin_beg - rect.position.x);
+									rect.position.x = xmargin_beg;
+								}
+								if (rect.position.x + rect.size.x > xmargin_end) {
+									rect.size.x = xmargin_end - rect.position.x;
+								}
+								draw_rect(rect, selection_color, true);
 							}
-							if (rect.position.x < xmargin_beg) {
-								rect.size.x -= (xmargin_beg - rect.position.x);
-								rect.position.x = xmargin_beg;
-							}
-							if (rect.position.x + rect.size.x > xmargin_end) {
-								rect.size.x = xmargin_end - rect.position.x;
-							}
-							draw_rect(rect, selection_color, true);
 						}
 					}
 
@@ -1203,34 +1214,38 @@ void TextEdit::_notification(int p_what) {
 						}
 						Color gl_color = current_color;
 
-						if (has_selection() && line >= get_selection_from_line() && line <= get_selection_to_line()) { // Selection
-							int sel_from = (line > get_selection_from_line()) ? TS->shaped_text_get_range(rid).x : get_selection_from_column();
-							int sel_to = (line < get_selection_to_line()) ? TS->shaped_text_get_range(rid).y : get_selection_to_column();
+						for (int c = 0; c < carets.size(); c++) {
+							if (has_selection(c) && line >= get_selection_from_line(c) && line <= get_selection_to_line(c)) { // Selection
+								int sel_from = (line > get_selection_from_line(c)) ? TS->shaped_text_get_range(rid).x : get_selection_from_column(c);
+								int sel_to = (line < get_selection_to_line(c)) ? TS->shaped_text_get_range(rid).y : get_selection_to_column(c);
 
-							if (glyphs[j].start >= sel_from && glyphs[j].end <= sel_to && override_selected_font_color) {
-								gl_color = font_selected_color;
+								if (glyphs[j].start >= sel_from && glyphs[j].end <= sel_to && override_selected_font_color) {
+									gl_color = font_selected_color;
+								}
 							}
 						}
 
 						float char_pos = char_ofs + char_margin + ofs_x;
 						if (char_pos >= xmargin_beg) {
 							if (highlight_matching_braces_enabled) {
-								if ((brace_open_match_line == line && brace_open_match_column == glyphs[j].start) ||
-										(caret.column == glyphs[j].start && caret.line == line && caret_wrap_index == line_wrap_index && (brace_open_matching || brace_open_mismatch))) {
-									if (brace_open_mismatch) {
-										gl_color = brace_mismatch_color;
+								for (int c = 0; c < carets.size(); c++) {
+									if ((brace_matching[c].open_match_line == line && brace_matching[c].open_match_column == glyphs[j].start) ||
+											(get_caret_column(c) == glyphs[j].start && get_caret_line(c) == line && carets_wrap_index[c] == line_wrap_index && (brace_matching[c].open_matching || brace_matching[c].open_mismatch))) {
+										if (brace_matching[c].open_mismatch) {
+											gl_color = brace_mismatch_color;
+										}
+										Rect2 rect = Rect2(char_pos, ofs_y + font->get_underline_position(font_size), glyphs[j].advance * glyphs[j].repeat, MAX(font->get_underline_thickness(font_size) * get_theme_default_base_scale(), 1));
+										draw_rect(rect, gl_color);
 									}
-									Rect2 rect = Rect2(char_pos, ofs_y + font->get_underline_position(font_size), glyphs[j].advance * glyphs[j].repeat, MAX(font->get_underline_thickness(font_size) * get_theme_default_base_scale(), 1));
-									draw_rect(rect, gl_color);
-								}
 
-								if ((brace_close_match_line == line && brace_close_match_column == glyphs[j].start) ||
-										(caret.column == glyphs[j].start + 1 && caret.line == line && caret_wrap_index == line_wrap_index && (brace_close_matching || brace_close_mismatch))) {
-									if (brace_close_mismatch) {
-										gl_color = brace_mismatch_color;
+									if ((brace_matching[c].close_match_line == line && brace_matching[c].close_match_column == glyphs[j].start) ||
+											(get_caret_column(c) == glyphs[j].start + 1 && get_caret_line(c) == line && carets_wrap_index[c] == line_wrap_index && (brace_matching[c].close_matching || brace_matching[c].close_mismatch))) {
+										if (brace_matching[c].close_mismatch) {
+											gl_color = brace_mismatch_color;
+										}
+										Rect2 rect = Rect2(char_pos, ofs_y + font->get_underline_position(font_size), glyphs[j].advance * glyphs[j].repeat, MAX(font->get_underline_thickness(font_size) * get_theme_default_base_scale(), 1));
+										draw_rect(rect, gl_color);
 									}
-									Rect2 rect = Rect2(char_pos, ofs_y + font->get_underline_position(font_size), glyphs[j].advance * glyphs[j].repeat, MAX(font->get_underline_thickness(font_size) * get_theme_default_base_scale(), 1));
-									draw_rect(rect, gl_color);
 								}
 							}
 
@@ -1289,137 +1304,139 @@ void TextEdit::_notification(int p_what) {
 					// Prevent carets from disappearing at theme scales below 1.0 (if the caret width is 1).
 					const int caret_width = get_theme_constant(SNAME("caret_width")) * MAX(1, get_theme_default_base_scale());
 
-					if (!clipped && caret.line == line && line_wrap_index == caret_wrap_index) {
-						caret.draw_pos.y = ofs_y + ldata->get_line_descent(line_wrap_index);
+					for (int c = 0; c < carets.size(); c++) {
+						if (!clipped && get_caret_line(c) == line && carets_wrap_index[c] == line_wrap_index) {
+							carets.write[c].draw_pos.y = ofs_y + ldata->get_line_descent(line_wrap_index);
 
-						if (ime_text.length() == 0) {
-							CaretInfo ts_caret;
-							if (str.length() != 0) {
-								// Get carets.
-								ts_caret = TS->shaped_text_get_carets(rid, caret.column);
-							} else {
-								// No carets, add one at the start.
-								int h = font->get_height(font_size);
-								if (rtl) {
-									ts_caret.l_dir = TextServer::DIRECTION_RTL;
-									ts_caret.l_caret = Rect2(Vector2(xmargin_end - char_margin + ofs_x, -h / 2), Size2(caret_width * 4, h));
+							if (ime_text.length() == 0) {
+								CaretInfo ts_caret;
+								if (str.length() != 0) {
+									// Get carets.
+									ts_caret = TS->shaped_text_get_carets(rid, get_caret_column(c));
 								} else {
-									ts_caret.l_dir = TextServer::DIRECTION_LTR;
-									ts_caret.l_caret = Rect2(Vector2(char_ofs, -h / 2), Size2(caret_width * 4, h));
+									// No carets, add one at the start.
+									int h = font->get_height(font_size);
+									if (rtl) {
+										ts_caret.l_dir = TextServer::DIRECTION_RTL;
+										ts_caret.l_caret = Rect2(Vector2(xmargin_end - char_margin + ofs_x, -h / 2), Size2(caret_width * 4, h));
+									} else {
+										ts_caret.l_dir = TextServer::DIRECTION_LTR;
+										ts_caret.l_caret = Rect2(Vector2(char_ofs, -h / 2), Size2(caret_width * 4, h));
+									}
 								}
-							}
 
-							if ((ts_caret.l_caret != Rect2() && (ts_caret.l_dir == TextServer::DIRECTION_AUTO || ts_caret.l_dir == (TextServer::Direction)input_direction)) || (ts_caret.t_caret == Rect2())) {
-								caret.draw_pos.x = char_margin + ofs_x + ts_caret.l_caret.position.x;
-							} else {
-								caret.draw_pos.x = char_margin + ofs_x + ts_caret.t_caret.position.x;
-							}
+								if ((ts_caret.l_caret != Rect2() && (ts_caret.l_dir == TextServer::DIRECTION_AUTO || ts_caret.l_dir == (TextServer::Direction)input_direction)) || (ts_caret.t_caret == Rect2())) {
+									carets.write[c].draw_pos.x = char_margin + ofs_x + ts_caret.l_caret.position.x;
+								} else {
+									carets.write[c].draw_pos.x = char_margin + ofs_x + ts_caret.t_caret.position.x;
+								}
 
-							if (caret.draw_pos.x >= xmargin_beg && caret.draw_pos.x < xmargin_end) {
-								caret.visible = true;
-								if (draw_caret || drag_caret_force_displayed) {
-									if (caret_type == CaretType::CARET_TYPE_BLOCK || overtype_mode) {
-										//Block or underline caret, draw trailing carets at full height.
-										int h = font->get_height(font_size);
+								if (get_caret_draw_pos(c).x >= xmargin_beg && get_caret_draw_pos(c).x < xmargin_end) {
+									carets.write[c].visible = true;
+									if (draw_caret || drag_caret_force_displayed) {
+										if (caret_type == CaretType::CARET_TYPE_BLOCK || overtype_mode) {
+											//Block or underline caret, draw trailing carets at full height.
+											int h = font->get_height(font_size);
 
-										if (ts_caret.t_caret != Rect2()) {
-											if (overtype_mode) {
-												ts_caret.t_caret.position.y = TS->shaped_text_get_descent(rid);
-												ts_caret.t_caret.size.y = caret_width;
-											} else {
-												ts_caret.t_caret.position.y = -TS->shaped_text_get_ascent(rid);
-												ts_caret.t_caret.size.y = h;
-											}
-											ts_caret.t_caret.position += Vector2(char_margin + ofs_x, ofs_y);
-											draw_rect(ts_caret.t_caret, caret_color, overtype_mode);
-
-											if (ts_caret.l_caret != Rect2() && ts_caret.l_dir != ts_caret.t_dir) {
-												ts_caret.l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
-												ts_caret.l_caret.size.x = caret_width;
-												draw_rect(ts_caret.l_caret, caret_color * Color(1, 1, 1, 0.5));
-											}
-										} else { // End of the line.
-											if (gl_size > 0) {
-												// Adjust for actual line dimensions.
+											if (ts_caret.t_caret != Rect2()) {
 												if (overtype_mode) {
-													ts_caret.l_caret.position.y = TS->shaped_text_get_descent(rid);
-													ts_caret.l_caret.size.y = caret_width;
+													ts_caret.t_caret.position.y = TS->shaped_text_get_descent(rid);
+													ts_caret.t_caret.size.y = caret_width;
 												} else {
-													ts_caret.l_caret.position.y = -TS->shaped_text_get_ascent(rid);
-													ts_caret.l_caret.size.y = h;
+													ts_caret.t_caret.position.y = -TS->shaped_text_get_ascent(rid);
+													ts_caret.t_caret.size.y = h;
 												}
-											} else if (overtype_mode) {
-												ts_caret.l_caret.position.y += ts_caret.l_caret.size.y;
-												ts_caret.l_caret.size.y = caret_width;
+												ts_caret.t_caret.position += Vector2(char_margin + ofs_x, ofs_y);
+												draw_rect(ts_caret.t_caret, caret_color, overtype_mode);
+
+												if (ts_caret.l_caret != Rect2() && ts_caret.l_dir != ts_caret.t_dir) {
+													ts_caret.l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
+													ts_caret.l_caret.size.x = caret_width;
+													draw_rect(ts_caret.l_caret, caret_color * Color(1, 1, 1, 0.5));
+												}
+											} else { // End of the line.
+												if (gl_size > 0) {
+													// Adjust for actual line dimensions.
+													if (overtype_mode) {
+														ts_caret.l_caret.position.y = TS->shaped_text_get_descent(rid);
+														ts_caret.l_caret.size.y = caret_width;
+													} else {
+														ts_caret.l_caret.position.y = -TS->shaped_text_get_ascent(rid);
+														ts_caret.l_caret.size.y = h;
+													}
+												} else if (overtype_mode) {
+													ts_caret.l_caret.position.y += ts_caret.l_caret.size.y;
+													ts_caret.l_caret.size.y = caret_width;
+												}
+												if (ts_caret.l_caret.position.x >= TS->shaped_text_get_size(rid).x) {
+													ts_caret.l_caret.size.x = font->get_char_size('m', font_size).x;
+												} else {
+													ts_caret.l_caret.size.x = 3 * caret_width;
+												}
+												ts_caret.l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
+												if (ts_caret.l_dir == TextServer::DIRECTION_RTL) {
+													ts_caret.l_caret.position.x -= ts_caret.l_caret.size.x;
+												}
+												draw_rect(ts_caret.l_caret, caret_color, overtype_mode);
 											}
-											if (ts_caret.l_caret.position.x >= TS->shaped_text_get_size(rid).x) {
-												ts_caret.l_caret.size.x = font->get_char_size('m', font_size).x;
-											} else {
-												ts_caret.l_caret.size.x = 3 * caret_width;
+										} else {
+											// Normal caret.
+											if (ts_caret.l_caret != Rect2() && ts_caret.l_dir == TextServer::DIRECTION_AUTO) {
+												// Draw extra marker on top of mid caret.
+												Rect2 trect = Rect2(ts_caret.l_caret.position.x - 3 * caret_width, ts_caret.l_caret.position.y, 6 * caret_width, caret_width);
+												trect.position += Vector2(char_margin + ofs_x, ofs_y);
+												RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
 											}
 											ts_caret.l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
-											if (ts_caret.l_dir == TextServer::DIRECTION_RTL) {
-												ts_caret.l_caret.position.x -= ts_caret.l_caret.size.x;
-											}
-											draw_rect(ts_caret.l_caret, caret_color, overtype_mode);
+											ts_caret.l_caret.size.x = caret_width;
+
+											draw_rect(ts_caret.l_caret, caret_color);
+
+											ts_caret.t_caret.position += Vector2(char_margin + ofs_x, ofs_y);
+											ts_caret.t_caret.size.x = caret_width;
+
+											draw_rect(ts_caret.t_caret, caret_color);
 										}
-									} else {
-										// Normal caret.
-										if (ts_caret.l_caret != Rect2() && ts_caret.l_dir == TextServer::DIRECTION_AUTO) {
-											// Draw extra marker on top of mid caret.
-											Rect2 trect = Rect2(ts_caret.l_caret.position.x - 3 * caret_width, ts_caret.l_caret.position.y, 6 * caret_width, caret_width);
-											trect.position += Vector2(char_margin + ofs_x, ofs_y);
-											RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
-										}
-										ts_caret.l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
-										ts_caret.l_caret.size.x = caret_width;
-
-										draw_rect(ts_caret.l_caret, caret_color);
-
-										ts_caret.t_caret.position += Vector2(char_margin + ofs_x, ofs_y);
-										ts_caret.t_caret.size.x = caret_width;
-
-										draw_rect(ts_caret.t_caret, caret_color);
 									}
 								}
-							}
-						} else {
-							{
-								// IME Intermediate text range.
-								Vector<Vector2> sel = TS->shaped_text_get_selection(rid, caret.column, caret.column + ime_text.length());
-								for (int j = 0; j < sel.size(); j++) {
-									Rect2 rect = Rect2(sel[j].x + char_margin + ofs_x, ofs_y, sel[j].y - sel[j].x, text_height);
-									if (rect.position.x + rect.size.x <= xmargin_beg || rect.position.x > xmargin_end) {
-										continue;
+							} else {
+								{
+									// IME Intermediate text range.
+									Vector<Vector2> sel = TS->shaped_text_get_selection(rid, get_caret_column(c), get_caret_column(c) + ime_text.length());
+									for (int j = 0; j < sel.size(); j++) {
+										Rect2 rect = Rect2(sel[j].x + char_margin + ofs_x, ofs_y, sel[j].y - sel[j].x, text_height);
+										if (rect.position.x + rect.size.x <= xmargin_beg || rect.position.x > xmargin_end) {
+											continue;
+										}
+										if (rect.position.x < xmargin_beg) {
+											rect.size.x -= (xmargin_beg - rect.position.x);
+											rect.position.x = xmargin_beg;
+										} else if (rect.position.x + rect.size.x > xmargin_end) {
+											rect.size.x = xmargin_end - rect.position.x;
+										}
+										rect.size.y = caret_width;
+										draw_rect(rect, caret_color);
+										carets.write[c].draw_pos.x = rect.position.x;
 									}
-									if (rect.position.x < xmargin_beg) {
-										rect.size.x -= (xmargin_beg - rect.position.x);
-										rect.position.x = xmargin_beg;
-									} else if (rect.position.x + rect.size.x > xmargin_end) {
-										rect.size.x = xmargin_end - rect.position.x;
-									}
-									rect.size.y = caret_width;
-									draw_rect(rect, caret_color);
-									caret.draw_pos.x = rect.position.x;
 								}
-							}
-							{
-								// IME caret.
-								Vector<Vector2> sel = TS->shaped_text_get_selection(rid, caret.column + ime_selection.x, caret.column + ime_selection.x + ime_selection.y);
-								for (int j = 0; j < sel.size(); j++) {
-									Rect2 rect = Rect2(sel[j].x + char_margin + ofs_x, ofs_y, sel[j].y - sel[j].x, text_height);
-									if (rect.position.x + rect.size.x <= xmargin_beg || rect.position.x > xmargin_end) {
-										continue;
+								{
+									// IME caret.
+									Vector<Vector2> sel = TS->shaped_text_get_selection(rid, get_caret_column(c) + ime_selection.x, get_caret_column(c) + ime_selection.x + ime_selection.y);
+									for (int j = 0; j < sel.size(); j++) {
+										Rect2 rect = Rect2(sel[j].x + char_margin + ofs_x, ofs_y, sel[j].y - sel[j].x, text_height);
+										if (rect.position.x + rect.size.x <= xmargin_beg || rect.position.x > xmargin_end) {
+											continue;
+										}
+										if (rect.position.x < xmargin_beg) {
+											rect.size.x -= (xmargin_beg - rect.position.x);
+											rect.position.x = xmargin_beg;
+										} else if (rect.position.x + rect.size.x > xmargin_end) {
+											rect.size.x = xmargin_end - rect.position.x;
+										}
+										rect.size.y = caret_width * 3;
+										draw_rect(rect, caret_color);
+										carets.write[c].draw_pos.x = rect.position.x;
 									}
-									if (rect.position.x < xmargin_beg) {
-										rect.size.x -= (xmargin_beg - rect.position.x);
-										rect.position.x = xmargin_beg;
-									} else if (rect.position.x + rect.size.x > xmargin_end) {
-										rect.size.x = xmargin_end - rect.position.x;
-									}
-									rect.size.y = caret_width * 3;
-									draw_rect(rect, caret_color);
-									caret.draw_pos.x = rect.position.x;
 								}
 							}
 						}
@@ -1434,7 +1451,7 @@ void TextEdit::_notification(int p_what) {
 			if (has_focus()) {
 				if (get_viewport()->get_window_id() != DisplayServer::INVALID_WINDOW_ID && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 					DisplayServer::get_singleton()->window_set_ime_active(true, get_viewport()->get_window_id());
-					DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + caret.draw_pos, get_viewport()->get_window_id());
+					DisplayServer::get_singleton()->window_set_ime_position(get_global_position() + get_caret_draw_pos(), get_viewport()->get_window_id());
 				}
 			}
 		} break;
@@ -1455,13 +1472,13 @@ void TextEdit::_notification(int p_what) {
 				int caret_start = -1;
 				int caret_end = -1;
 
-				if (!has_selection()) {
-					String full_text = _base_get_text(0, 0, caret.line, caret.column);
+				if (!has_selection(0)) {
+					String full_text = _base_get_text(0, 0, get_caret_line(), get_caret_column());
 
 					caret_start = full_text.length();
 				} else {
 					String pre_text = _base_get_text(0, 0, get_selection_from_line(), get_selection_from_column());
-					String post_text = get_selected_text();
+					String post_text = get_selected_text(0);
 
 					caret_start = pre_text.length();
 					caret_end = caret_start + post_text.length();
@@ -1483,7 +1500,9 @@ void TextEdit::_notification(int p_what) {
 			if (!ime_text.is_empty()) {
 				ime_text = "";
 				ime_selection = Point2();
-				text.invalidate_cache(caret.line, caret.column, true, ime_text);
+				for (int i = 0; i < carets.size(); i++) {
+					text.invalidate_cache(get_caret_line(i), get_caret_column(i), true, ime_text);
+				}
 			}
 
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
@@ -1500,14 +1519,15 @@ void TextEdit::_notification(int p_what) {
 				ime_text = DisplayServer::get_singleton()->ime_get_text();
 				ime_selection = DisplayServer::get_singleton()->ime_get_selection();
 
-				String t;
-				if (caret.column >= 0) {
-					t = text[caret.line].substr(0, caret.column) + ime_text + text[caret.line].substr(caret.column, text[caret.line].length());
-				} else {
-					t = ime_text;
+				for (int i = 0; i < carets.size(); i++) {
+					String t;
+					if (get_caret_column(i) >= 0) {
+						t = text[get_caret_line(i)].substr(0, get_caret_column(i)) + ime_text + text[get_caret_line(i)].substr(get_caret_column(i), text[get_caret_line(i)].length());
+					} else {
+						t = ime_text;
+					}
+					text.invalidate_cache(get_caret_line(i), get_caret_column(i), true, t, structured_text_parser(st_parser, st_args, t));
 				}
-
-				text.invalidate_cache(caret.line, caret.column, true, t, structured_text_parser(st_parser, st_args, t));
 				queue_redraw();
 			}
 		} break;
@@ -1672,73 +1692,101 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					}
 				}
 
-				int prev_col = caret.column;
-				int prev_line = caret.line;
+				int caret = carets.size() - 1;
+				int prev_col = get_caret_column(caret);
+				int prev_line = get_caret_line(caret);
 
-				set_caret_line(row, false, false);
-				set_caret_column(col);
+				const int triple_click_timeout = 600;
+				const int triple_click_tolerance = 5;
+				bool is_triple_click = (!mb->is_double_click() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < triple_click_timeout && mb->get_position().distance_to(last_dblclk_pos) < triple_click_tolerance);
+
+				if (!is_mouse_over_selection() && !mb->is_double_click() && !is_triple_click) {
+					if (mb->is_alt_pressed()) {
+						prev_line = row;
+						prev_col = col;
+
+						caret = add_caret(row, col);
+						if (caret == -1) {
+							return;
+						}
+
+						carets.write[caret].selection.selecting_line = row;
+						carets.write[caret].selection.selecting_column = col;
+
+						last_dblclk = 0;
+					} else if (!mb->is_shift_pressed()) {
+						caret = 0;
+						remove_secondary_carets();
+					}
+				}
+
+				set_caret_line(row, false, true, 0, caret);
+				set_caret_column(col, false, caret);
 				selection_drag_attempt = false;
 
-				if (selecting_enabled && mb->is_shift_pressed() && (caret.column != prev_col || caret.line != prev_line)) {
-					if (!caret.selection.active) {
-						caret.selection.active = true;
+				if (selecting_enabled && mb->is_shift_pressed() && (get_caret_column(caret) != prev_col || get_caret_line(caret) != prev_line)) {
+					if (!has_selection(caret)) {
+						carets.write[caret].selection.active = true;
 						selecting_mode = SelectionMode::SELECTION_MODE_POINTER;
-						caret.selection.from_column = prev_col;
-						caret.selection.from_line = prev_line;
-						caret.selection.to_column = caret.column;
-						caret.selection.to_line = caret.line;
+						carets.write[caret].selection.from_column = prev_col;
+						carets.write[caret].selection.from_line = prev_line;
+						carets.write[caret].selection.to_column = carets[caret].column;
+						carets.write[caret].selection.to_line = carets[caret].line;
 
-						if (caret.selection.from_line > caret.selection.to_line || (caret.selection.from_line == caret.selection.to_line && caret.selection.from_column > caret.selection.to_column)) {
-							SWAP(caret.selection.from_column, caret.selection.to_column);
-							SWAP(caret.selection.from_line, caret.selection.to_line);
-							caret.selection.shiftclick_left = false;
+						if (carets[caret].selection.from_line > carets[caret].selection.to_line || (carets[caret].selection.from_line == carets[caret].selection.to_line && carets[caret].selection.from_column > carets[caret].selection.to_column)) {
+							SWAP(carets.write[caret].selection.from_column, carets.write[caret].selection.to_column);
+							SWAP(carets.write[caret].selection.from_line, carets.write[caret].selection.to_line);
+							carets.write[caret].selection.shiftclick_left = false;
 						} else {
-							caret.selection.shiftclick_left = true;
+							carets.write[caret].selection.shiftclick_left = true;
 						}
-						caret.selection.selecting_line = prev_line;
-						caret.selection.selecting_column = prev_col;
+						carets.write[caret].selection.selecting_line = prev_line;
+						carets.write[caret].selection.selecting_column = prev_col;
+						caret_index_edit_dirty = true;
+						merge_overlapping_carets();
 						queue_redraw();
 					} else {
-						if (caret.line < caret.selection.selecting_line || (caret.line == caret.selection.selecting_line && caret.column < caret.selection.selecting_column)) {
-							if (caret.selection.shiftclick_left) {
-								caret.selection.shiftclick_left = !caret.selection.shiftclick_left;
+						if (carets[caret].line < carets[caret].selection.selecting_line || (carets[caret].line == carets[caret].selection.selecting_line && carets[caret].column < carets[caret].selection.selecting_column)) {
+							if (carets[caret].selection.shiftclick_left) {
+								carets.write[caret].selection.shiftclick_left = !carets[caret].selection.shiftclick_left;
 							}
-							caret.selection.from_column = caret.column;
-							caret.selection.from_line = caret.line;
+							carets.write[caret].selection.from_column = carets[caret].column;
+							carets.write[caret].selection.from_line = carets[caret].line;
 
-						} else if (caret.line > caret.selection.selecting_line || (caret.line == caret.selection.selecting_line && caret.column > caret.selection.selecting_column)) {
-							if (!caret.selection.shiftclick_left) {
-								SWAP(caret.selection.from_column, caret.selection.to_column);
-								SWAP(caret.selection.from_line, caret.selection.to_line);
-								caret.selection.shiftclick_left = !caret.selection.shiftclick_left;
+						} else if (carets[caret].line > carets[caret].selection.selecting_line || (carets[caret].line == carets[caret].selection.selecting_line && carets[caret].column > carets[caret].selection.selecting_column)) {
+							if (!carets[caret].selection.shiftclick_left) {
+								SWAP(carets.write[caret].selection.from_column, carets.write[caret].selection.to_column);
+								SWAP(carets.write[caret].selection.from_line, carets.write[caret].selection.to_line);
+								carets.write[caret].selection.shiftclick_left = !carets[caret].selection.shiftclick_left;
 							}
-							caret.selection.to_column = caret.column;
-							caret.selection.to_line = caret.line;
+							carets.write[caret].selection.to_column = carets[caret].column;
+							carets.write[caret].selection.to_line = carets[caret].line;
 
 						} else {
-							deselect();
+							deselect(caret);
 						}
-
+						caret_index_edit_dirty = true;
+						merge_overlapping_carets();
 						queue_redraw();
 					}
 				} else if (drag_and_drop_selection_enabled && is_mouse_over_selection()) {
-					set_selection_mode(SelectionMode::SELECTION_MODE_NONE);
+					set_selection_mode(SelectionMode::SELECTION_MODE_NONE, get_selection_line(caret), get_selection_column(caret), caret);
+					// We use the main caret for dragging, so reset this one.
+					set_caret_line(prev_line, false, true, 0, caret);
+					set_caret_column(prev_col, false, caret);
 					selection_drag_attempt = true;
-				} else {
+				} else if (caret == 0) {
 					deselect();
 					set_selection_mode(SelectionMode::SELECTION_MODE_POINTER, row, col);
 				}
 
-				const int triple_click_timeout = 600;
-				const int triple_click_tolerance = 5;
-
-				if (!mb->is_double_click() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < triple_click_timeout && mb->get_position().distance_to(last_dblclk_pos) < triple_click_tolerance) {
+				if (is_triple_click) {
 					// Triple-click select line.
 					selecting_mode = SelectionMode::SELECTION_MODE_LINE;
 					selection_drag_attempt = false;
 					_update_selection_mode_line();
 					last_dblclk = 0;
-				} else if (mb->is_double_click() && text[caret.line].length()) {
+				} else if (mb->is_double_click() && text[get_caret_line(caret)].length()) {
 					// Double-click select word.
 					selecting_mode = SelectionMode::SELECTION_MODE_WORD;
 					_update_selection_mode_word();
@@ -1758,23 +1806,25 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				Point2i pos = get_line_column_at_pos(mpos);
 				int row = pos.y;
 				int col = pos.x;
+				int caret = carets.size() - 1;
 
 				if (is_move_caret_on_right_click_enabled()) {
-					if (has_selection()) {
-						int from_line = get_selection_from_line();
-						int to_line = get_selection_to_line();
-						int from_column = get_selection_from_column();
-						int to_column = get_selection_to_column();
+					if (has_selection(caret)) {
+						int from_line = get_selection_from_line(caret);
+						int to_line = get_selection_to_line(caret);
+						int from_column = get_selection_from_column(caret);
+						int to_column = get_selection_to_column(caret);
 
 						if (row < from_line || row > to_line || (row == from_line && col < from_column) || (row == to_line && col > to_column)) {
 							// Right click is outside the selected text.
-							deselect();
+							deselect(caret);
 						}
 					}
-					if (!has_selection()) {
-						set_caret_line(row, true, false);
-						set_caret_column(col);
+					if (!has_selection(caret)) {
+						set_caret_line(row, true, false, 0, caret);
+						set_caret_column(col, true, caret);
 					}
+					merge_overlapping_carets();
 				}
 
 				if (context_menu_enabled) {
@@ -1788,7 +1838,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		} else {
 			if (mb->get_button_index() == MouseButton::LEFT) {
 				if (selection_drag_attempt && is_mouse_over_selection()) {
-					caret.selection.active = false;
+					deselect();
 				}
 				dragging_minimap = false;
 				dragging_selection = false;
@@ -1885,8 +1935,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		if (drag_action && can_drop_data(mpos, get_viewport()->gui_get_drag_data())) {
 			drag_caret_force_displayed = true;
 			Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
-			set_caret_line(pos.y, false);
-			set_caret_column(pos.x);
+			set_caret_line(pos.y, false, true, 0, 0);
+			set_caret_column(pos.x, true, 0);
 			dragging_selection = true;
 		}
 	}
@@ -2142,7 +2192,9 @@ void TextEdit::_swap_current_input_direction() {
 	} else {
 		input_direction = TEXT_DIRECTION_LTR;
 	}
-	set_caret_column(caret.column);
+	for (int i = 0; i < carets.size(); i++) {
+		set_caret_column(get_caret_column(i), i == 0, i);
+	}
 	queue_redraw();
 }
 
@@ -2152,325 +2204,429 @@ void TextEdit::_new_line(bool p_split_current_line, bool p_above) {
 	}
 
 	begin_complex_operation();
-
-	bool first_line = false;
-	if (!p_split_current_line) {
-		deselect();
-		if (p_above) {
-			if (caret.line > 0) {
-				set_caret_line(caret.line - 1, false);
-				set_caret_column(text[caret.line].length());
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		bool first_line = false;
+		if (!p_split_current_line) {
+			deselect(i);
+			if (p_above) {
+				if (get_caret_line(i) > 0) {
+					set_caret_line(get_caret_line(i) - 1, false, true, 0, i);
+					set_caret_column(text[get_caret_line(i)].length(), i == 0, i);
+				} else {
+					set_caret_column(0, i == 0, i);
+					first_line = true;
+				}
 			} else {
-				set_caret_column(0);
-				first_line = true;
+				set_caret_column(text[get_caret_line(i)].length(), i == 0, i);
 			}
-		} else {
-			set_caret_column(text[caret.line].length());
+		}
+
+		insert_text_at_caret("\n", i);
+
+		if (first_line) {
+			set_caret_line(0, i == 0, true, 0, i);
 		}
 	}
-
-	insert_text_at_caret("\n");
-
-	if (first_line) {
-		set_caret_line(0);
-	}
-
 	end_complex_operation();
 }
 
 void TextEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
-	// Handle selection
-	if (p_select) {
-		_pre_shift_selection();
-	} else if (has_selection() && !p_move_by_word) {
-		// If a selection is active, move caret to start of selection
-		set_caret_line(get_selection_from_line());
-		set_caret_column(get_selection_from_column());
-		deselect();
-		return;
-	} else {
-		deselect();
-	}
-
-	if (p_move_by_word) {
-		int cc = caret.column;
-		// If the caret is at the start of the line, and not on the first line, move it up to the end of the previous line.
-		if (cc == 0 && caret.line > 0) {
-			set_caret_line(caret.line - 1);
-			set_caret_column(text[caret.line].length());
+	for (int i = 0; i < carets.size(); i++) {
+		// Handle selection.
+		if (p_select) {
+			_pre_shift_selection(i);
+		} else if (has_selection(i) && !p_move_by_word) {
+			// If a selection is active, move caret to start of selection.
+			set_caret_line(get_selection_from_line(i), false, true, 0, i);
+			set_caret_column(get_selection_from_column(i), i == 0, i);
+			deselect(i);
+			continue;
 		} else {
-			PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(caret.line)->get_rid());
-			if (words.is_empty() || cc <= words[0]) {
-				// This solves the scenario where there are no words but glyfs that can be ignored.
-				cc = 0;
+			deselect(i);
+		}
+
+		if (p_move_by_word) {
+			int cc = get_caret_column(i);
+			// If the caret is at the start of the line, and not on the first line, move it up to the end of the previous line.
+			if (cc == 0 && get_caret_line(i) > 0) {
+				set_caret_line(get_caret_line(i) - 1, false, true, 0, i);
+				set_caret_column(text[get_caret_line(i)].length(), i == 0, i);
 			} else {
-				for (int i = words.size() - 2; i >= 0; i = i - 2) {
-					if (words[i] < cc) {
-						cc = words[i];
-						break;
+				PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(get_caret_line(i))->get_rid());
+				if (words.is_empty() || cc <= words[0]) {
+					// This solves the scenario where there are no words but glyfs that can be ignored.
+					cc = 0;
+				} else {
+					for (int j = words.size() - 2; j >= 0; j = j - 2) {
+						if (words[j] < cc) {
+							cc = words[j];
+							break;
+						}
 					}
 				}
-			}
-			set_caret_column(cc);
-		}
-	} else {
-		// If the caret is at the start of the line, and not on the first line, move it up to the end of the previous line.
-		if (caret.column == 0) {
-			if (caret.line > 0) {
-				set_caret_line(caret.line - get_next_visible_line_offset_from(CLAMP(caret.line - 1, 0, text.size() - 1), -1));
-				set_caret_column(text[caret.line].length());
+				set_caret_column(cc, i == 0, i);
 			}
 		} else {
-			if (caret_mid_grapheme_enabled) {
-				set_caret_column(get_caret_column() - 1);
+			// If the caret is at the start of the line, and not on the first line, move it up to the end of the previous line.
+			if (get_caret_column(i) == 0) {
+				if (get_caret_line(i) > 0) {
+					set_caret_line(get_caret_line(i) - get_next_visible_line_offset_from(CLAMP(get_caret_line(i) - 1, 0, text.size() - 1), -1), false, true, 0, i);
+					set_caret_column(text[get_caret_line(i)].length(), i == 0, i);
+				}
 			} else {
-				set_caret_column(TS->shaped_text_prev_grapheme_pos(text.get_line_data(caret.line)->get_rid(), get_caret_column()));
+				if (caret_mid_grapheme_enabled) {
+					set_caret_column(get_caret_column(i) - 1, i == 0, i);
+				} else {
+					set_caret_column(TS->shaped_text_prev_grapheme_pos(text.get_line_data(get_caret_line(i))->get_rid(), get_caret_column(i)), i == 0, i);
+				}
 			}
 		}
-	}
 
-	if (p_select) {
-		_post_shift_selection();
+		if (p_select) {
+			_post_shift_selection(i);
+		}
 	}
+	merge_overlapping_carets();
 }
 
 void TextEdit::_move_caret_right(bool p_select, bool p_move_by_word) {
-	// Handle selection
-	if (p_select) {
-		_pre_shift_selection();
-	} else if (has_selection() && !p_move_by_word) {
-		// If a selection is active, move caret to end of selection
-		set_caret_line(get_selection_to_line());
-		set_caret_column(get_selection_to_column());
-		deselect();
+	for (int i = 0; i < carets.size(); i++) {
+		// Handle selection
+		if (p_select) {
+			_pre_shift_selection(i);
+		} else if (has_selection(i) && !p_move_by_word) {
+			// If a selection is active, move caret to end of selection
+			set_caret_line(get_selection_to_line(i), false, true, 0, i);
+			set_caret_column(get_selection_to_column(i), i == 0, i);
+			deselect(i);
+			continue;
+		} else {
+			deselect(i);
+		}
+
+		if (p_move_by_word) {
+			int cc = get_caret_column(i);
+			// If the caret is at the end of the line, and not on the last line, move it down to the beginning of the next line.
+			if (cc == text[get_caret_line(i)].length() && get_caret_line(i) < text.size() - 1) {
+				set_caret_line(get_caret_line(i) + 1, false, true, 0, i);
+				set_caret_column(0, i == 0, i);
+			} else {
+				PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(get_caret_line(i))->get_rid());
+				if (words.is_empty() || cc >= words[words.size() - 1]) {
+					// This solves the scenario where there are no words but glyfs that can be ignored.
+					cc = text[get_caret_line(i)].length();
+				} else {
+					for (int j = 1; j < words.size(); j = j + 2) {
+						if (words[j] > cc) {
+							cc = words[j];
+							break;
+						}
+					}
+				}
+				set_caret_column(cc, i == 0, i);
+			}
+		} else {
+			// If we are at the end of the line, move the caret to the next line down.
+			if (get_caret_column(i) == text[get_caret_line(i)].length()) {
+				if (get_caret_line(i) < text.size() - 1) {
+					set_caret_line(get_caret_line(i) + get_next_visible_line_offset_from(CLAMP(get_caret_line(i) + 1, 0, text.size() - 1), 1), false, false, 0, i);
+					set_caret_column(0, i == 0, i);
+				}
+			} else {
+				if (caret_mid_grapheme_enabled) {
+					set_caret_column(get_caret_column(i) + 1, i == 0, i);
+				} else {
+					set_caret_column(TS->shaped_text_next_grapheme_pos(text.get_line_data(get_caret_line(i))->get_rid(), get_caret_column(i)), i == 0, i);
+				}
+			}
+		}
+
+		if (p_select) {
+			_post_shift_selection(i);
+		}
+	}
+	merge_overlapping_carets();
+}
+
+void TextEdit::_move_caret_up(bool p_select) {
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_select) {
+			_pre_shift_selection(i);
+		} else {
+			deselect(i);
+		}
+
+		int cur_wrap_index = get_caret_wrap_index(i);
+		if (cur_wrap_index > 0) {
+			set_caret_line(get_caret_line(i), true, false, cur_wrap_index - 1, i);
+		} else if (get_caret_line(i) == 0) {
+			set_caret_column(0, i == 0, i);
+		} else {
+			int new_line = get_caret_line(i) - get_next_visible_line_offset_from(get_caret_line(i) - 1, -1);
+			if (is_line_wrapped(new_line)) {
+				set_caret_line(new_line, i == 0, false, get_line_wrap_count(new_line), i);
+			} else {
+				set_caret_line(new_line, i == 0, false, 0, i);
+			}
+		}
+
+		if (p_select) {
+			_post_shift_selection(i);
+		}
+	}
+	merge_overlapping_carets();
+}
+
+void TextEdit::_move_caret_down(bool p_select) {
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_select) {
+			_pre_shift_selection(i);
+		} else {
+			deselect(i);
+		}
+
+		int cur_wrap_index = get_caret_wrap_index(i);
+		if (cur_wrap_index < get_line_wrap_count(get_caret_line(i))) {
+			set_caret_line(get_caret_line(i), i == 0, false, cur_wrap_index + 1, i);
+		} else if (get_caret_line(i) == get_last_unhidden_line()) {
+			set_caret_column(text[get_caret_line(i)].length());
+		} else {
+			int new_line = get_caret_line(i) + get_next_visible_line_offset_from(CLAMP(get_caret_line(i) + 1, 0, text.size() - 1), 1);
+			set_caret_line(new_line, i == 0, false, 0, i);
+		}
+
+		if (p_select) {
+			_post_shift_selection(i);
+		}
+	}
+	merge_overlapping_carets();
+}
+
+void TextEdit::_move_caret_to_line_start(bool p_select) {
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_select) {
+			_pre_shift_selection(i);
+		} else {
+			deselect(i);
+		}
+
+		// Move caret column to start of wrapped row and then to start of text.
+		Vector<String> rows = get_line_wrapped_text(get_caret_line(i));
+		int wi = get_caret_wrap_index(i);
+		int row_start_col = 0;
+		for (int j = 0; j < wi; j++) {
+			row_start_col += rows[j].length();
+		}
+		if (get_caret_column(i) == row_start_col || wi == 0) {
+			// Compute whitespace symbols sequence length.
+			int current_line_whitespace_len = get_first_non_whitespace_column(get_caret_line(i));
+			if (get_caret_column(i) == current_line_whitespace_len) {
+				set_caret_column(0, i == 0, i);
+			} else {
+				set_caret_column(current_line_whitespace_len, i == 0, i);
+			}
+		} else {
+			set_caret_column(row_start_col, i == 0, i);
+		}
+
+		if (p_select) {
+			_post_shift_selection(i);
+		}
+	}
+	merge_overlapping_carets();
+}
+
+void TextEdit::_move_caret_to_line_end(bool p_select) {
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_select) {
+			_pre_shift_selection(i);
+		} else {
+			deselect(i);
+		}
+
+		// Move caret column to end of wrapped row and then to end of text.
+		Vector<String> rows = get_line_wrapped_text(get_caret_line(i));
+		int wi = get_caret_wrap_index(i);
+		int row_end_col = -1;
+		for (int j = 0; j < wi + 1; j++) {
+			row_end_col += rows[j].length();
+		}
+		if (wi == rows.size() - 1 || get_caret_column(i) == row_end_col) {
+			set_caret_column(text[get_caret_line(i)].length(), i == 0, i);
+		} else {
+			set_caret_column(row_end_col, i == 0, i);
+		}
+
+		carets.write[i].last_fit_x = INT_MAX;
+
+		if (p_select) {
+			_post_shift_selection(i);
+		}
+	}
+	merge_overlapping_carets();
+}
+
+void TextEdit::_move_caret_page_up(bool p_select) {
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_select) {
+			_pre_shift_selection(i);
+		} else {
+			deselect(i);
+		}
+
+		Point2i next_line = get_next_visible_line_index_offset_from(get_caret_line(i), get_caret_wrap_index(i), -get_visible_line_count());
+		int n_line = get_caret_line(i) - next_line.x + 1;
+		set_caret_line(n_line, i == 0, false, next_line.y, i);
+
+		if (p_select) {
+			_post_shift_selection(i);
+		}
+	}
+	merge_overlapping_carets();
+}
+
+void TextEdit::_move_caret_page_down(bool p_select) {
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_select) {
+			_pre_shift_selection(i);
+		} else {
+			deselect(i);
+		}
+
+		Point2i next_line = get_next_visible_line_index_offset_from(get_caret_line(i), get_caret_wrap_index(i), get_visible_line_count());
+		int n_line = get_caret_line(i) + next_line.x - 1;
+		set_caret_line(n_line, i == 0, false, next_line.y, i);
+
+		if (p_select) {
+			_post_shift_selection(i);
+		}
+	}
+	merge_overlapping_carets();
+}
+
+void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
+	if (!editable) {
 		return;
-	} else {
-		deselect();
 	}
 
-	if (p_move_by_word) {
-		int cc = caret.column;
-		// If the caret is at the end of the line, and not on the last line, move it down to the beginning of the next line.
-		if (cc == text[caret.line].length() && caret.line < text.size() - 1) {
-			set_caret_line(caret.line + 1);
-			set_caret_column(0);
-		} else {
-			PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(caret.line)->get_rid());
-			if (words.is_empty() || cc >= words[words.size() - 1]) {
-				// This solves the scenario where there are no words but glyfs that can be ignored.
-				cc = text[caret.line].length();
+	start_action(EditAction::ACTION_BACKSPACE);
+	Vector<int> carets_to_remove;
+
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (int i = 0; i < caret_edit_order.size(); i++) {
+		int caret_idx = caret_edit_order[i];
+		if (get_caret_column(caret_idx) == 0 && get_caret_line(caret_idx) == 0 && !has_selection(caret_idx)) {
+			continue;
+		}
+
+		if (has_selection(caret_idx) || (!p_all_to_left && !p_word) || get_caret_column(caret_idx) == 0) {
+			backspace(caret_idx);
+			continue;
+		}
+
+		if (p_all_to_left) {
+			int caret_current_column = get_caret_column(caret_idx);
+			set_caret_column(0, caret_idx == 0, caret_idx);
+			_remove_text(get_caret_line(caret_idx), 0, get_caret_line(caret_idx), caret_current_column);
+			adjust_carets_after_edit(caret_idx, get_caret_line(caret_idx), caret_current_column, get_caret_line(caret_idx), get_caret_column(caret_idx));
+
+			// Check for any overlapping carets since we removed the entire line.
+			for (int j = i + 1; j < caret_edit_order.size(); j++) {
+				// Selection only end on this line, only the one as carets cannot overlap.
+				if (has_selection(caret_edit_order[j]) && get_selection_from_line(caret_edit_order[j]) != get_caret_line(caret_idx) && get_selection_to_line(caret_edit_order[j]) == get_caret_line(caret_idx)) {
+					carets.write[caret_edit_order[j]].selection.to_column = 0;
+					break;
+				}
+
+				// Check for caret.
+				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx) || (has_selection(caret_edit_order[j]) && get_selection_from_line(caret_edit_order[j]) != get_caret_line(caret_idx))) {
+					break;
+				}
+
+				deselect(caret_edit_order[j]);
+				carets_to_remove.push_back(caret_edit_order[j]);
+				set_caret_column(0, caret_idx == 0, caret_idx);
+				i = j;
+			}
+			continue;
+		}
+
+		if (p_word) {
+			// Save here as the caret may change when resolving overlaps.
+			int from_column = get_caret_column(caret_idx);
+			int column = get_caret_column(caret_idx);
+			// Check for the case "<word><space><caret>" and ignore the space.
+			// No need to check for column being 0 since it is checked above.
+			if (is_whitespace(text[get_caret_line(caret_idx)][get_caret_column(caret_idx) - 1])) {
+				column -= 1;
+			}
+			// Get a list with the indices of the word bounds of the given text line.
+			const PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(get_caret_line(caret_idx))->get_rid());
+			if (words.is_empty() || column <= words[0]) {
+				// If "words" is empty, meaning no words are left, we can remove everything until the beginning of the line.
+				column = 0;
 			} else {
-				for (int i = 1; i < words.size(); i = i + 2) {
-					if (words[i] > cc) {
-						cc = words[i];
+				// Otherwise search for the first word break that is smaller than the index from we're currently deleting.
+				for (int c = words.size() - 2; c >= 0; c = c - 2) {
+					if (words[c] < column) {
+						column = words[c];
 						break;
 					}
 				}
 			}
-			set_caret_column(cc);
-		}
-	} else {
-		// If we are at the end of the line, move the caret to the next line down.
-		if (caret.column == text[caret.line].length()) {
-			if (caret.line < text.size() - 1) {
-				set_caret_line(get_caret_line() + get_next_visible_line_offset_from(CLAMP(caret.line + 1, 0, text.size() - 1), 1), true, false);
-				set_caret_column(0);
-			}
-		} else {
-			if (caret_mid_grapheme_enabled) {
-				set_caret_column(get_caret_column() + 1);
-			} else {
-				set_caret_column(TS->shaped_text_next_grapheme_pos(text.get_line_data(caret.line)->get_rid(), get_caret_column()));
-			}
-		}
-	}
 
-	if (p_select) {
-		_post_shift_selection();
-	}
-}
-
-void TextEdit::_move_caret_up(bool p_select) {
-	if (p_select) {
-		_pre_shift_selection();
-	} else {
-		deselect();
-	}
-
-	int cur_wrap_index = get_caret_wrap_index();
-	if (cur_wrap_index > 0) {
-		set_caret_line(caret.line, true, false, cur_wrap_index - 1);
-	} else if (caret.line == 0) {
-		set_caret_column(0);
-	} else {
-		int new_line = caret.line - get_next_visible_line_offset_from(caret.line - 1, -1);
-		if (is_line_wrapped(new_line)) {
-			set_caret_line(new_line, true, false, get_line_wrap_count(new_line));
-		} else {
-			set_caret_line(new_line, true, false);
-		}
-	}
-
-	if (p_select) {
-		_post_shift_selection();
-	}
-}
-
-void TextEdit::_move_caret_down(bool p_select) {
-	if (p_select) {
-		_pre_shift_selection();
-	} else {
-		deselect();
-	}
-
-	int cur_wrap_index = get_caret_wrap_index();
-	if (cur_wrap_index < get_line_wrap_count(caret.line)) {
-		set_caret_line(caret.line, true, false, cur_wrap_index + 1);
-	} else if (caret.line == get_last_unhidden_line()) {
-		set_caret_column(text[caret.line].length());
-	} else {
-		int new_line = caret.line + get_next_visible_line_offset_from(CLAMP(caret.line + 1, 0, text.size() - 1), 1);
-		set_caret_line(new_line, true, false, 0);
-	}
-
-	if (p_select) {
-		_post_shift_selection();
-	}
-}
-
-void TextEdit::_move_caret_to_line_start(bool p_select) {
-	if (p_select) {
-		_pre_shift_selection();
-	} else {
-		deselect();
-	}
-
-	// Move caret column to start of wrapped row and then to start of text.
-	Vector<String> rows = get_line_wrapped_text(caret.line);
-	int wi = get_caret_wrap_index();
-	int row_start_col = 0;
-	for (int i = 0; i < wi; i++) {
-		row_start_col += rows[i].length();
-	}
-	if (caret.column == row_start_col || wi == 0) {
-		// Compute whitespace symbols sequence length.
-		int current_line_whitespace_len = get_first_non_whitespace_column(caret.line);
-		if (get_caret_column() == current_line_whitespace_len) {
-			set_caret_column(0);
-		} else {
-			set_caret_column(current_line_whitespace_len);
-		}
-	} else {
-		set_caret_column(row_start_col);
-	}
-
-	if (p_select) {
-		_post_shift_selection();
-	}
-}
-
-void TextEdit::_move_caret_to_line_end(bool p_select) {
-	if (p_select) {
-		_pre_shift_selection();
-	} else {
-		deselect();
-	}
-
-	// Move caret column to end of wrapped row and then to end of text.
-	Vector<String> rows = get_line_wrapped_text(caret.line);
-	int wi = get_caret_wrap_index();
-	int row_end_col = -1;
-	for (int i = 0; i < wi + 1; i++) {
-		row_end_col += rows[i].length();
-	}
-	if (wi == rows.size() - 1 || caret.column == row_end_col) {
-		set_caret_column(text[caret.line].length());
-	} else {
-		set_caret_column(row_end_col);
-	}
-
-	if (p_select) {
-		_post_shift_selection();
-	}
-}
-
-void TextEdit::_move_caret_page_up(bool p_select) {
-	if (p_select) {
-		_pre_shift_selection();
-	} else {
-		deselect();
-	}
-
-	Point2i next_line = get_next_visible_line_index_offset_from(caret.line, get_caret_wrap_index(), -get_visible_line_count());
-	int n_line = caret.line - next_line.x + 1;
-	set_caret_line(n_line, true, false, next_line.y);
-
-	if (p_select) {
-		_post_shift_selection();
-	}
-}
-
-void TextEdit::_move_caret_page_down(bool p_select) {
-	if (p_select) {
-		_pre_shift_selection();
-	} else {
-		deselect();
-	}
-
-	Point2i next_line = get_next_visible_line_index_offset_from(caret.line, get_caret_wrap_index(), get_visible_line_count());
-	int n_line = caret.line + next_line.x - 1;
-	set_caret_line(n_line, true, false, next_line.y);
-
-	if (p_select) {
-		_post_shift_selection();
-	}
-}
-
-void TextEdit::_do_backspace(bool p_word, bool p_all_to_left) {
-	if (!editable || (caret.column == 0 && caret.line == 0 && !has_selection())) {
-		return;
-	}
-
-	if (has_selection() || (!p_all_to_left && !p_word) || caret.column == 0) {
-		backspace();
-		return;
-	}
-
-	if (p_all_to_left) {
-		int caret_current_column = caret.column;
-		set_caret_column(0);
-		_remove_text(caret.line, 0, caret.line, caret_current_column);
-		return;
-	}
-
-	if (p_word) {
-		int column = caret.column;
-		// Check for the case "<word><space><caret>" and ignore the space.
-		// No need to check for column being 0 since it is checked above.
-		if (is_whitespace(text[caret.line][caret.column - 1])) {
-			column -= 1;
-		}
-		// Get a list with the indices of the word bounds of the given text line.
-		const PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(caret.line)->get_rid());
-		if (words.is_empty() || column <= words[0]) {
-			// If "words" is empty, meaning no words are left, we can remove everything until the beginning of the line.
-			column = 0;
-		} else {
-			// Otherwise search for the first word break that is smaller than the index from which we're currently deleting.
-			for (int i = words.size() - 2; i >= 0; i = i - 2) {
-				if (words[i] < column) {
-					column = words[i];
+			// Check for any other carets in this range.
+			int overlapping_caret_index = -1;
+			for (int j = i + 1; j < caret_edit_order.size(); j++) {
+				// Check caret and selection in on the right line.
+				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx) && (!has_selection(caret_edit_order[j]) || get_selection_to_line(caret_edit_order[j]) != get_caret_line(caret_idx))) {
 					break;
 				}
+
+				// If it has a selection, check it ends with in the range.
+				if ((has_selection(caret_edit_order[j]) && get_selection_to_column(caret_edit_order[j]) < column)) {
+					break;
+				}
+
+				// If it has a selection and it starts outside our word, we need to adjust the selection, and handle it later to prevent overlap.
+				if ((has_selection(caret_edit_order[j]) && get_selection_from_column(caret_edit_order[j]) < column)) {
+					carets.write[caret_edit_order[j]].selection.to_column = column;
+					overlapping_caret_index = caret_edit_order[j];
+					break;
+				}
+
+				// Otherwise we can remove it.
+				if (get_caret_column(caret_edit_order[j]) > column || (has_selection(caret_edit_order[j]) && get_selection_from_column(caret_edit_order[j]) > column)) {
+					deselect(caret_edit_order[j]);
+					carets_to_remove.push_back(caret_edit_order[j]);
+					set_caret_column(0, caret_idx == 0, caret_idx);
+					i = j;
+				}
 			}
+
+			_remove_text(get_caret_line(caret_idx), column, get_caret_line(caret_idx), from_column);
+
+			set_caret_line(get_caret_line(caret_idx), false, true, 0, caret_idx);
+			set_caret_column(column, caret_idx == 0, caret_idx);
+
+			// Now we can clean up the overlaping caret.
+			if (overlapping_caret_index != -1) {
+				backspace(overlapping_caret_index);
+				i++;
+				carets_to_remove.push_back(overlapping_caret_index);
+				set_caret_column(get_caret_column(overlapping_caret_index), caret_idx == 0, caret_idx);
+			}
+			continue;
 		}
-
-		_remove_text(caret.line, column, caret.line, caret.column);
-
-		set_caret_line(caret.line, false);
-		set_caret_column(column);
-		return;
 	}
+
+	// Sort and remove backwards to preserve indexes.
+	carets_to_remove.sort();
+	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
+		remove_caret(carets_to_remove[i]);
+	}
+	end_action();
 }
 
 void TextEdit::_delete(bool p_word, bool p_all_to_right) {
@@ -2478,82 +2634,147 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 		return;
 	}
 
-	if (has_selection()) {
-		delete_selection();
-		return;
-	}
-	int curline_len = text[caret.line].length();
+	start_action(EditAction::ACTION_DELETE);
+	Vector<int> carets_to_remove;
 
-	if (caret.line == text.size() - 1 && caret.column == curline_len) {
-		return; // Last line, last column: Nothing to do.
-	}
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (int i = 0; i < caret_edit_order.size(); i++) {
+		int caret_idx = caret_edit_order[i];
+		if (has_selection(caret_idx)) {
+			delete_selection(caret_idx);
+			continue;
+		}
+		int curline_len = text[get_caret_line(caret_idx)].length();
 
-	int next_line = caret.column < curline_len ? caret.line : caret.line + 1;
-	int next_column;
-
-	if (p_all_to_right) {
-		if (caret.column == curline_len) {
-			return;
+		if (get_caret_line(caret_idx) == text.size() - 1 && get_caret_column(caret_idx) == curline_len) {
+			continue; // Last line, last column: Nothing to do.
 		}
 
-		// Delete everything to right of caret
-		next_column = curline_len;
-		next_line = caret.line;
-	} else if (p_word && caret.column < curline_len - 1) {
-		// Delete next word to right of caret
-		int line = caret.line;
-		int column = caret.column;
+		int next_line = get_caret_column(caret_idx) < curline_len ? get_caret_line(caret_idx) : get_caret_line(caret_idx) + 1;
+		int next_column;
 
-		PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(line)->get_rid());
-		for (int i = 1; i < words.size(); i = i + 2) {
-			if (words[i] > column) {
-				column = words[i];
-				break;
+		if (p_all_to_right) {
+			// Get caret furthest to the left
+			for (int j = i + 1; j < caret_edit_order.size(); j++) {
+				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
+					break;
+				}
+
+				if (has_selection(caret_edit_order[j]) && get_selection_from_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
+					break;
+				}
+
+				if (!has_selection(caret_edit_order[j])) {
+					i = j;
+					caret_idx = caret_edit_order[i];
+				}
+			}
+
+			if (get_caret_column(caret_idx) == curline_len) {
+				continue;
+			}
+
+			// Delete everything to right of caret
+			next_column = curline_len;
+			next_line = get_caret_line(caret_idx);
+
+			// Remove overlapping carets.
+			for (int j = i - 1; j >= 0; j--) {
+				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
+					break;
+				}
+				carets_to_remove.push_back(caret_edit_order[j]);
+			}
+
+		} else if (p_word && get_caret_column(caret_idx) < curline_len - 1) {
+			// Delete next word to right of caret
+			int line = get_caret_line(caret_idx);
+			int column = get_caret_column(caret_idx);
+
+			PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(line)->get_rid());
+			for (int j = 1; j < words.size(); j = j + 2) {
+				if (words[j] > column) {
+					column = words[j];
+					break;
+				}
+			}
+
+			next_line = line;
+			next_column = column;
+
+			// Remove overlapping carets.
+			for (int j = i - 1; j >= 0; j--) {
+				if (get_caret_line(caret_edit_order[j]) != get_caret_line(caret_idx)) {
+					break;
+				}
+
+				if (get_caret_column(caret_edit_order[j]) > column) {
+					break;
+				}
+				carets_to_remove.push_back(caret_edit_order[j]);
+			}
+		} else {
+			// Delete one character
+			if (caret_mid_grapheme_enabled) {
+				next_column = get_caret_column(caret_idx) < curline_len ? (get_caret_column(caret_idx) + 1) : 0;
+			} else {
+				next_column = get_caret_column(caret_idx) < curline_len ? TS->shaped_text_next_grapheme_pos(text.get_line_data(get_caret_line(caret_idx))->get_rid(), (get_caret_column(caret_idx))) : 0;
+			}
+
+			// Remove overlapping carets.
+			if (i > 0) {
+				int prev_caret_idx = caret_edit_order[i - 1];
+				if (get_caret_line(prev_caret_idx) == next_line && get_caret_column(prev_caret_idx) == next_column) {
+					carets_to_remove.push_back(prev_caret_idx);
+				}
 			}
 		}
 
-		next_line = line;
-		next_column = column;
-	} else {
-		// Delete one character
-		if (caret_mid_grapheme_enabled) {
-			next_column = caret.column < curline_len ? (caret.column + 1) : 0;
-		} else {
-			next_column = caret.column < curline_len ? TS->shaped_text_next_grapheme_pos(text.get_line_data(caret.line)->get_rid(), (caret.column)) : 0;
-		}
+		_remove_text(get_caret_line(caret_idx), get_caret_column(caret_idx), next_line, next_column);
+		adjust_carets_after_edit(caret_idx, get_caret_line(caret_idx), get_caret_column(caret_idx), next_line, next_column);
 	}
 
-	_remove_text(caret.line, caret.column, next_line, next_column);
+	// Sort and remove backwards to preserve indexes.
+	carets_to_remove.sort();
+	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
+		remove_caret(carets_to_remove[i]);
+	}
+
+	// If we are deleting from the end of a line, due to column preservation we could still overlap with another caret.
+	merge_overlapping_carets();
+	end_action();
 	queue_redraw();
 }
 
 void TextEdit::_move_caret_document_start(bool p_select) {
+	remove_secondary_carets();
 	if (p_select) {
-		_pre_shift_selection();
+		_pre_shift_selection(0);
 	} else {
 		deselect();
 	}
 
-	set_caret_line(0);
+	set_caret_line(0, false);
 	set_caret_column(0);
 
 	if (p_select) {
-		_post_shift_selection();
+		_post_shift_selection(0);
 	}
 }
 
 void TextEdit::_move_caret_document_end(bool p_select) {
+	remove_secondary_carets();
 	if (p_select) {
-		_pre_shift_selection();
+		_pre_shift_selection(0);
 	} else {
 		deselect();
 	}
 
 	set_caret_line(get_last_unhidden_line(), true, false, 9999);
-	set_caret_column(text[caret.line].length());
+	set_caret_column(text[get_caret_line()].length());
 
 	if (p_select) {
-		_post_shift_selection();
+		_post_shift_selection(0);
 	}
 }
 
@@ -2703,24 +2924,30 @@ void TextEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 		if (selection_drag_attempt) {
 			selection_drag_attempt = false;
 			if (!is_mouse_over_selection(!Input::get_singleton()->is_key_pressed(Key::CTRL))) {
+				// Set caret back at selection for undo / redo.
+				set_caret_line(get_selection_to_line(), false, false);
+				set_caret_column(get_selection_to_column());
+
 				begin_complex_operation();
 				if (!Input::get_singleton()->is_key_pressed(Key::CTRL)) {
 					if (caret_row_tmp > get_selection_to_line()) {
 						caret_row_tmp = caret_row_tmp - (get_selection_to_line() - get_selection_from_line());
 					} else if (caret_row_tmp == get_selection_to_line() && caret_column_tmp >= get_selection_to_column()) {
-						caret_column_tmp = caret_column_tmp - (caret.selection.to_column - caret.selection.from_column);
+						caret_column_tmp = caret_column_tmp - (get_selection_to_column() - get_selection_from_column());
 					}
 					delete_selection();
 				} else {
 					deselect();
 				}
 
+				remove_secondary_carets();
 				set_caret_line(caret_row_tmp, true, false);
 				set_caret_column(caret_column_tmp);
 				insert_text_at_caret(p_data);
 				end_complex_operation();
 			}
 		} else if (is_mouse_over_selection()) {
+			remove_secondary_carets();
 			caret_row_tmp = get_selection_from_line();
 			caret_column_tmp = get_selection_from_column();
 			set_caret_line(caret_row_tmp, true, false);
@@ -2728,6 +2955,7 @@ void TextEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 			insert_text_at_caret(p_data);
 			grab_focus();
 		} else {
+			remove_secondary_carets();
 			deselect();
 			set_caret_line(caret_row_tmp, true, false);
 			set_caret_column(caret_column_tmp);
@@ -2735,8 +2963,8 @@ void TextEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 			grab_focus();
 		}
 
-		if (caret_row_tmp != caret.line || caret_column_tmp != caret.column) {
-			select(caret_row_tmp, caret_column_tmp, caret.line, caret.column);
+		if (caret_row_tmp != get_caret_line() || caret_column_tmp != get_caret_column()) {
+			select(caret_row_tmp, caret_column_tmp, get_caret_line(), get_caret_column());
 		}
 	}
 }
@@ -2972,6 +3200,7 @@ void TextEdit::clear() {
 
 void TextEdit::_clear() {
 	if (editable && undo_enabled) {
+		remove_secondary_carets();
 		_move_caret_document_start(false);
 		begin_complex_operation();
 
@@ -2987,13 +3216,14 @@ void TextEdit::_clear() {
 
 	clear_undo_history();
 	text.clear();
+	remove_secondary_carets();
 	set_caret_line(0, false);
 	set_caret_column(0);
 	first_visible_col = 0;
 	first_visible_line = 0;
 	first_visible_line_wrap_ofs = 0;
-	caret.last_fit_x = 0;
-	caret.selection.active = false;
+	carets.write[0].last_fit_x = 0;
+	deselect();
 
 	emit_signal(SNAME("lines_edited_from"), old_text_size, 0);
 }
@@ -3006,6 +3236,7 @@ void TextEdit::set_text(const String &p_text) {
 	}
 
 	if (undo_enabled) {
+		remove_secondary_carets();
 		set_caret_line(0);
 		set_caret_column(0);
 
@@ -3061,11 +3292,14 @@ void TextEdit::set_line(int p_line, const String &p_new_text) {
 	begin_complex_operation();
 	_remove_text(p_line, 0, p_line, text[p_line].length());
 	_insert_text(p_line, 0, p_new_text);
-	if (caret.line == p_line && caret.column > p_new_text.length()) {
-		set_caret_column(p_new_text.length(), false);
-	}
-	if (has_selection() && p_line == get_selection_to_line() && get_selection_to_column() > text[p_line].length()) {
-		caret.selection.to_column = text[p_line].length();
+	for (int i = 0; i < carets.size(); i++) {
+		if (get_caret_line(i) == p_line && get_caret_column(i) > p_new_text.length()) {
+			set_caret_column(p_new_text.length(), false, i);
+		}
+
+		if (has_selection(i) && p_line == get_selection_to_line(i) && get_selection_to_column(i) > text[p_line].length()) {
+			carets.write[i].selection.to_column = text[p_line].length();
+		}
 	}
 	end_complex_operation();
 }
@@ -3132,41 +3366,54 @@ void TextEdit::insert_line_at(int p_at, const String &p_text) {
 	ERR_FAIL_INDEX(p_at, text.size());
 
 	_insert_text(p_at, 0, p_text + "\n");
-	if (caret.line >= p_at) {
-		// offset caret when located after inserted line
-		set_caret_line(caret.line + 1, false);
-	}
-	if (has_selection()) {
-		if (get_selection_from_line() >= p_at) {
-			// offset selection when located after inserted line
-			select(get_selection_from_line() + 1, get_selection_from_column(), get_selection_to_line() + 1, get_selection_to_column());
-		} else if (get_selection_to_line() >= p_at) {
-			// extend selection that includes inserted line
-			select(get_selection_from_line(), get_selection_from_column(), get_selection_to_line() + 1, get_selection_to_column());
+
+	for (int i = 0; i < carets.size(); i++) {
+		if (get_caret_line(i) >= p_at) {
+			// offset caret when located after inserted line
+			set_caret_line(get_caret_line(i) + 1, false, true, 0, i);
+		}
+		if (has_selection(i)) {
+			if (get_selection_from_line(i) >= p_at) {
+				// offset selection when located after inserted line
+				select(get_selection_from_line(i) + 1, get_selection_from_column(i), get_selection_to_line(i) + 1, get_selection_to_column(i), i);
+			} else if (get_selection_to_line(i) >= p_at) {
+				// extend selection that includes inserted line
+				select(get_selection_from_line(i), get_selection_from_column(i), get_selection_to_line(i) + 1, get_selection_to_column(i), i);
+			}
 		}
 	}
+
+	// Need to apply the above adjustments to the undo / redo carets.
+	current_op.end_carets = carets;
 	queue_redraw();
 }
 
-void TextEdit::insert_text_at_caret(const String &p_text) {
-	bool had_selection = has_selection();
-	if (had_selection) {
-		begin_complex_operation();
+void TextEdit::insert_text_at_caret(const String &p_text, int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
+
+	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+
+		delete_selection(i);
+
+		int from_line = get_caret_line(i);
+		int from_col = get_caret_column(i);
+
+		int new_column, new_line;
+		_insert_text(from_line, from_col, p_text, &new_line, &new_column);
+		_update_scrollbars();
+
+		set_caret_line(new_line, false, true, 0, i);
+		set_caret_column(new_column, i == 0, i);
+
+		adjust_carets_after_edit(i, new_line, new_column, from_line, from_col);
 	}
-
-	delete_selection();
-
-	int new_column, new_line;
-	_insert_text(caret.line, caret.column, p_text, &new_line, &new_column);
-	_update_scrollbars();
-
-	set_caret_line(new_line, false);
-	set_caret_column(new_column);
+	end_complex_operation();
 	queue_redraw();
-
-	if (had_selection) {
-		end_complex_operation();
-	}
 }
 
 void TextEdit::remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column) {
@@ -3290,46 +3537,46 @@ Point2i TextEdit::get_next_visible_line_index_offset_from(int p_line_from, int p
 }
 
 // Overridable actions
-void TextEdit::handle_unicode_input(const uint32_t p_unicode) {
-	if (GDVIRTUAL_CALL(_handle_unicode_input, p_unicode)) {
+void TextEdit::handle_unicode_input(const uint32_t p_unicode, int p_caret) {
+	if (GDVIRTUAL_CALL(_handle_unicode_input, p_unicode, p_caret)) {
 		return;
 	}
-	_handle_unicode_input_internal(p_unicode);
+	_handle_unicode_input_internal(p_unicode, p_caret);
 }
 
-void TextEdit::backspace() {
-	if (GDVIRTUAL_CALL(_backspace)) {
+void TextEdit::backspace(int p_caret) {
+	if (GDVIRTUAL_CALL(_backspace, p_caret)) {
 		return;
 	}
-	_backspace_internal();
+	_backspace_internal(p_caret);
 }
 
-void TextEdit::cut() {
-	if (GDVIRTUAL_CALL(_cut)) {
+void TextEdit::cut(int p_caret) {
+	if (GDVIRTUAL_CALL(_cut, p_caret)) {
 		return;
 	}
-	_cut_internal();
+	_cut_internal(p_caret);
 }
 
-void TextEdit::copy() {
-	if (GDVIRTUAL_CALL(_copy)) {
+void TextEdit::copy(int p_caret) {
+	if (GDVIRTUAL_CALL(_copy, p_caret)) {
 		return;
 	}
-	_copy_internal();
+	_copy_internal(p_caret);
 }
 
-void TextEdit::paste() {
-	if (GDVIRTUAL_CALL(_paste)) {
+void TextEdit::paste(int p_caret) {
+	if (GDVIRTUAL_CALL(_paste, p_caret)) {
 		return;
 	}
-	_paste_internal();
+	_paste_internal(p_caret);
 }
 
-void TextEdit::paste_primary_clipboard() {
-	if (GDVIRTUAL_CALL(_paste_primary_clipboard)) {
+void TextEdit::paste_primary_clipboard(int p_caret) {
+	if (GDVIRTUAL_CALL(_paste_primary_clipboard, p_caret)) {
 		return;
 	}
-	_paste_primary_clipboard_internal();
+	_paste_primary_clipboard_internal(p_caret);
 }
 
 // Context menu.
@@ -3466,22 +3713,53 @@ void TextEdit::menu_option(int p_option) {
 }
 
 /* Versioning */
+void TextEdit::start_action(EditAction p_action) {
+	if (current_action != p_action) {
+		if (current_action != EditAction::ACTION_NONE) {
+			in_action = false;
+			pending_action_end = false;
+			end_complex_operation();
+		}
+
+		if (p_action != EditAction::ACTION_NONE) {
+			in_action = true;
+			begin_complex_operation();
+		}
+	} else if (current_action != EditAction::ACTION_NONE) {
+		pending_action_end = false;
+	}
+	current_action = p_action;
+}
+
+void TextEdit::end_action() {
+	if (current_action != EditAction::ACTION_NONE) {
+		pending_action_end = true;
+	}
+}
+
+TextEdit::EditAction TextEdit::get_current_action() const {
+	return current_action;
+}
+
 void TextEdit::begin_complex_operation() {
 	_push_current_op();
 	if (complex_operation_count == 0) {
 		next_operation_is_complex = true;
+		current_op.start_carets = carets;
 	}
 	complex_operation_count++;
 }
 
 void TextEdit::end_complex_operation() {
 	_push_current_op();
-	ERR_FAIL_COND(undo_stack.size() == 0);
 
 	complex_operation_count = MAX(complex_operation_count - 1, 0);
 	if (complex_operation_count > 0) {
 		return;
 	}
+	ERR_FAIL_COND(undo_stack.size() == 0);
+
+	undo_stack.back()->get().end_carets = carets;
 	if (undo_stack.back()->get().chain_forward) {
 		undo_stack.back()->get().chain_forward = false;
 		return;
@@ -3541,17 +3819,24 @@ void TextEdit::undo() {
 		}
 	}
 
-	if (op.type != TextOperation::TYPE_INSERT && (op.from_line != op.to_line || op.to_column != op.from_column + 1)) {
-		select(op.from_line, op.from_column, op.to_line, op.to_column);
+	_update_scrollbars();
+	bool dirty_carets = carets.size() != undo_stack_pos->get().start_carets.size();
+	if (!dirty_carets) {
+		for (int i = 0; i < carets.size(); i++) {
+			if (carets[i].line != undo_stack_pos->get().start_carets[i].line || carets[i].column != undo_stack_pos->get().start_carets[i].column) {
+				dirty_carets = true;
+				break;
+			}
+		}
 	}
 
-	_update_scrollbars();
-	if (undo_stack_pos->get().type == TextOperation::TYPE_REMOVE) {
-		set_caret_line(undo_stack_pos->get().to_line, false);
-		set_caret_column(undo_stack_pos->get().to_column);
-	} else {
-		set_caret_line(undo_stack_pos->get().from_line, false);
-		set_caret_column(undo_stack_pos->get().from_column);
+	carets = undo_stack_pos->get().start_carets;
+
+	if (dirty_carets && !caret_pos_dirty) {
+		if (is_inside_tree()) {
+			MessageQueue::get_singleton()->push_call(this, "_emit_caret_changed");
+		}
+		caret_pos_dirty = true;
 	}
 	queue_redraw();
 }
@@ -3560,6 +3845,7 @@ void TextEdit::redo() {
 	if (!editable) {
 		return;
 	}
+
 	_push_current_op();
 
 	if (undo_stack_pos == nullptr) {
@@ -3585,9 +3871,25 @@ void TextEdit::redo() {
 	}
 
 	_update_scrollbars();
-	set_caret_line(undo_stack_pos->get().to_line, false);
-	set_caret_column(undo_stack_pos->get().to_column);
+	bool dirty_carets = carets.size() != undo_stack_pos->get().end_carets.size();
+	if (!dirty_carets) {
+		for (int i = 0; i < carets.size(); i++) {
+			if (carets[i].line != undo_stack_pos->get().end_carets[i].line || carets[i].column != undo_stack_pos->get().end_carets[i].column) {
+				dirty_carets = true;
+				break;
+			}
+		}
+	}
+
+	carets = undo_stack_pos->get().end_carets;
 	undo_stack_pos = undo_stack_pos->next();
+
+	if (dirty_carets && !caret_pos_dirty) {
+		if (is_inside_tree()) {
+			MessageQueue::get_singleton()->push_call(this, "_emit_caret_changed");
+		}
+		caret_pos_dirty = true;
+	}
 	queue_redraw();
 }
 
@@ -3599,7 +3901,7 @@ void TextEdit::clear_undo_history() {
 }
 
 bool TextEdit::is_insert_text_operation() const {
-	return (current_op.type == TextOperation::TYPE_INSERT);
+	return (current_op.type == TextOperation::TYPE_INSERT || current_action == EditAction::ACTION_TYPING);
 }
 
 void TextEdit::tag_saved_version() {
@@ -3936,19 +4238,31 @@ bool TextEdit::is_dragging_cursor() const {
 	return dragging_selection || dragging_minimap;
 }
 
-bool TextEdit::is_mouse_over_selection(bool p_edges) const {
-	if (!has_selection()) {
-		return false;
-	}
-	Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
-	int row = pos.y;
-	int col = pos.x;
-	if (p_edges) {
-		if ((row == get_selection_from_line() && col == get_selection_from_column()) || (row == get_selection_to_line() && col == get_selection_to_column())) {
+bool TextEdit::is_mouse_over_selection(bool p_edges, int p_caret) const {
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+
+		if (!has_selection(i)) {
+			continue;
+		}
+
+		Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
+		int row = pos.y;
+		int col = pos.x;
+		if (p_edges) {
+			if ((row == get_selection_from_line(i) && col == get_selection_from_column(i)) || (row == get_selection_to_line(i) && col == get_selection_to_column(i))) {
+				return true;
+			}
+		}
+
+		if (row >= get_selection_from_line(i) && row <= get_selection_to_line(i) && (row > get_selection_from_line(i) || col > get_selection_from_column(i)) && (row < get_selection_to_line(i) || col < get_selection_to_column(i))) {
 			return true;
 		}
 	}
-	return (row >= get_selection_from_line() && row <= get_selection_to_line() && (row > get_selection_from_line() || col > get_selection_from_column()) && (row < get_selection_to_line() || col < get_selection_to_column()));
+
+	return false;
 }
 
 /* Caret */
@@ -4011,15 +4325,233 @@ bool TextEdit::is_caret_mid_grapheme_enabled() const {
 	return caret_mid_grapheme_enabled;
 }
 
-bool TextEdit::is_caret_visible() const {
-	return caret.visible;
+void TextEdit::set_multiple_carets_enabled(bool p_enabled) {
+	multi_carets_enabled = p_enabled;
+	if (!multi_carets_enabled) {
+		remove_secondary_carets();
+	}
 }
 
-Point2 TextEdit::get_caret_draw_pos() const {
-	return caret.draw_pos;
+bool TextEdit::is_multiple_carets_enabled() const {
+	return multi_carets_enabled;
 }
 
-void TextEdit::set_caret_line(int p_line, bool p_adjust_viewport, bool p_can_be_hidden, int p_wrap_index) {
+int TextEdit::add_caret(int p_line, int p_col) {
+	if (!multi_carets_enabled) {
+		return -1;
+	}
+
+	p_line = CLAMP(p_line, 0, text.size() - 1);
+	p_col = CLAMP(p_col, 0, get_line(p_line).length());
+
+	for (int i = 0; i < carets.size(); i++) {
+		if (get_caret_line(i) == p_line && get_caret_column(i) == p_col) {
+			return -1;
+		}
+
+		if (has_selection(i)) {
+			if (p_line >= get_selection_from_line(i) && p_line <= get_selection_to_line(i) && (p_line > get_selection_from_line(i) || p_col >= get_selection_from_column(i)) && (p_line < get_selection_to_line(i) || p_col <= get_selection_to_column(i))) {
+				return -1;
+			}
+		}
+	}
+
+	carets.push_back(Caret());
+	set_caret_line(p_line, false, false, 0, carets.size() - 1);
+	set_caret_column(p_col, false, carets.size() - 1);
+	caret_index_edit_dirty = true;
+	return carets.size() - 1;
+}
+
+void TextEdit::remove_caret(int p_caret) {
+	ERR_FAIL_COND(carets.size() <= 0);
+	ERR_FAIL_INDEX(p_caret, carets.size());
+	carets.remove_at(p_caret);
+	caret_index_edit_dirty = true;
+}
+
+void TextEdit::remove_secondary_carets() {
+	carets.resize(1);
+	caret_index_edit_dirty = true;
+	queue_redraw();
+}
+
+void TextEdit::merge_overlapping_carets() {
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (int i = 0; i < caret_edit_order.size() - 1; i++) {
+		int first_caret = caret_edit_order[i];
+		int second_caret = caret_edit_order[i + 1];
+
+		// Both have selection.
+		if (has_selection(first_caret) && has_selection(second_caret)) {
+			bool should_merge = false;
+			if (get_selection_from_line(first_caret) >= get_selection_from_line(second_caret) && get_selection_from_line(first_caret) <= get_selection_to_line(second_caret) && (get_selection_from_line(first_caret) > get_selection_from_line(second_caret) || get_selection_from_column(first_caret) >= get_selection_from_column(second_caret)) && (get_selection_from_line(first_caret) < get_selection_to_line(second_caret) || get_selection_from_column(first_caret) <= get_selection_to_column(second_caret))) {
+				should_merge = true;
+			}
+
+			if (get_selection_to_line(first_caret) >= get_selection_from_line(second_caret) && get_selection_to_line(first_caret) <= get_selection_to_line(second_caret) && (get_selection_to_line(first_caret) > get_selection_from_line(second_caret) || get_selection_to_column(first_caret) >= get_selection_from_column(second_caret)) && (get_selection_to_line(first_caret) < get_selection_to_line(second_caret) || get_selection_to_column(first_caret) <= get_selection_to_column(second_caret))) {
+				should_merge = true;
+			}
+
+			if (!should_merge) {
+				continue;
+			}
+
+			// Save the newest one for click+drag.
+			int caret_to_save = first_caret;
+			int caret_to_remove = second_caret;
+			if (first_caret < second_caret) {
+				caret_to_save = second_caret;
+				caret_to_remove = first_caret;
+			}
+
+			int from_line = MIN(get_selection_from_line(caret_to_save), get_selection_from_line(caret_to_remove));
+			int to_line = MAX(get_selection_to_line(caret_to_save), get_selection_to_line(caret_to_remove));
+			int from_col = get_selection_from_column(caret_to_save);
+			int to_col = get_selection_to_column(caret_to_save);
+			int selection_line = get_selection_line(caret_to_save);
+			int selection_col = get_selection_column(caret_to_save);
+
+			bool at_from = (get_caret_line(caret_to_save) == get_selection_from_line(caret_to_save) && get_caret_column(caret_to_save) == get_selection_from_column(caret_to_save));
+
+			if (at_from) {
+				if (get_selection_line(caret_to_remove) > get_selection_line(caret_to_save) || (get_selection_line(caret_to_remove) == get_selection_line(caret_to_save) && get_selection_column(caret_to_remove) >= get_selection_column(caret_to_save))) {
+					selection_line = get_selection_line(caret_to_remove);
+					selection_col = get_selection_column(caret_to_remove);
+				}
+			} else if (get_selection_line(caret_to_remove) < get_selection_line(caret_to_save) || (get_selection_line(caret_to_remove) == get_selection_line(caret_to_save) && get_selection_column(caret_to_remove) <= get_selection_column(caret_to_save))) {
+				selection_line = get_selection_line(caret_to_remove);
+				selection_col = get_selection_column(caret_to_remove);
+			}
+
+			if (get_selection_from_line(caret_to_remove) < get_selection_from_line(caret_to_save) || (get_selection_from_line(caret_to_remove) == get_selection_from_line(caret_to_save) && get_selection_from_column(caret_to_remove) <= get_selection_from_column(caret_to_save))) {
+				from_col = get_selection_from_column(caret_to_remove);
+			} else {
+				to_col = get_selection_to_column(caret_to_remove);
+			}
+
+			select(from_line, from_col, to_line, to_col, caret_to_save);
+			set_selection_mode(selecting_mode, selection_line, selection_col, caret_to_save);
+			set_caret_line((at_from ? from_line : to_line), caret_to_save == 0, true, 0, caret_to_save);
+			set_caret_column((at_from ? from_col : to_col), caret_to_save == 0, caret_to_save);
+			remove_caret(caret_to_remove);
+			i--;
+			caret_edit_order = get_caret_index_edit_order();
+			continue;
+		}
+
+		// Only first has selection.
+		if (has_selection(first_caret)) {
+			if (get_caret_line(second_caret) >= get_selection_from_line(first_caret) && get_caret_line(second_caret) <= get_selection_to_line(first_caret) && (get_caret_line(second_caret) > get_selection_from_line(first_caret) || get_caret_column(second_caret) >= get_selection_from_column(first_caret)) && (get_caret_line(second_caret) < get_selection_to_line(first_caret) || get_caret_column(second_caret) <= get_selection_to_column(first_caret))) {
+				remove_caret(second_caret);
+				caret_edit_order = get_caret_index_edit_order();
+				i--;
+			}
+			continue;
+		}
+
+		// Only second has Selection.
+		if (has_selection(second_caret)) {
+			if (get_caret_line(first_caret) >= get_selection_from_line(second_caret) && get_caret_line(first_caret) <= get_selection_to_line(second_caret) && (get_caret_line(first_caret) > get_selection_from_line(second_caret) || get_caret_column(first_caret) >= get_selection_from_column(second_caret)) && (get_caret_line(first_caret) < get_selection_to_line(second_caret) || get_caret_column(first_caret) <= get_selection_to_column(second_caret))) {
+				remove_caret(first_caret);
+				caret_edit_order = get_caret_index_edit_order();
+				i--;
+			}
+			continue;
+		}
+
+		// Both have no selection.
+		if (get_caret_line(first_caret) == get_caret_line(second_caret) && get_caret_column(first_caret) == get_caret_column(second_caret)) {
+			// Save the newest one for click+drag.
+			if (first_caret < second_caret) {
+				remove_caret(first_caret);
+			} else {
+				remove_caret(second_caret);
+			}
+			i--;
+			caret_edit_order = get_caret_index_edit_order();
+			continue;
+		}
+	}
+}
+
+int TextEdit::get_caret_count() const {
+	return carets.size();
+}
+
+Vector<int> TextEdit::get_caret_index_edit_order() {
+	if (!caret_index_edit_dirty) {
+		return caret_index_edit_order;
+	}
+
+	caret_index_edit_order.clear();
+	caret_index_edit_order.push_back(0);
+	for (int i = 1; i < carets.size(); i++) {
+		int j = 0;
+
+		int line = carets[i].selection.active ? carets[i].selection.to_line : carets[i].line;
+		int col = carets[i].selection.active ? carets[i].selection.to_column : carets[i].column;
+
+		for (; j < caret_index_edit_order.size(); j++) {
+			int idx = caret_index_edit_order[j];
+			int other_line = carets[idx].selection.active ? carets[idx].selection.to_line : carets[idx].line;
+			int other_col = carets[idx].selection.active ? carets[idx].selection.to_column : carets[idx].column;
+			if (line > other_line || (line == other_line && col > other_col)) {
+				break;
+			}
+		}
+		caret_index_edit_order.insert(j, i);
+	}
+	caret_index_edit_dirty = false;
+	return caret_index_edit_order;
+}
+
+void TextEdit::adjust_carets_after_edit(int p_caret, int p_from_line, int p_from_col, int p_to_line, int p_to_col) {
+	int edit_height = p_from_line - p_to_line;
+	int edit_size = ((edit_height == 0) ? p_from_col : 0) - p_to_col;
+
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (int j = 0; j < caret_edit_order.size(); j++) {
+		if (caret_edit_order[j] == p_caret) {
+			return;
+		}
+
+		// Adjust caret.
+		// set_caret_line could adjust the column, so save here.
+		int cc = get_caret_column(caret_edit_order[j]);
+		if (edit_height != 0) {
+			set_caret_line(get_caret_line(caret_edit_order[j]) + edit_height, false, true, 0, caret_edit_order[j]);
+		}
+		if (get_caret_line(p_caret) == get_caret_line(caret_edit_order[j])) {
+			set_caret_column(cc + edit_size, false, caret_edit_order[j]);
+		}
+
+		// Adjust selection.
+		if (!has_selection(caret_edit_order[j])) {
+			continue;
+		}
+		if (edit_height != 0) {
+			carets.write[caret_edit_order[j]].selection.from_line += edit_height;
+			carets.write[caret_edit_order[j]].selection.to_line += edit_height;
+		}
+		if (get_caret_line(p_caret) == carets[caret_edit_order[j]].selection.from_line) {
+			carets.write[caret_edit_order[j]].selection.from_column += edit_size;
+		}
+	}
+}
+
+bool TextEdit::is_caret_visible(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), 0);
+	return carets[p_caret].visible;
+}
+
+Point2 TextEdit::get_caret_draw_pos(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), Point2(0, 0));
+	return carets[p_caret].draw_pos;
+}
+
+void TextEdit::set_caret_line(int p_line, bool p_adjust_viewport, bool p_can_be_hidden, int p_wrap_index, int p_caret) {
+	ERR_FAIL_INDEX(p_caret, carets.size());
 	if (setting_caret_line) {
 		return;
 	}
@@ -4048,10 +4580,10 @@ void TextEdit::set_caret_line(int p_line, bool p_adjust_viewport, bool p_can_be_
 			}
 		}
 	}
-	bool caret_moved = caret.line != p_line;
-	caret.line = p_line;
+	bool caret_moved = get_caret_line(p_caret) != p_line;
+	carets.write[p_caret].line = p_line;
 
-	int n_col = _get_char_pos_for_line(caret.last_fit_x, p_line, p_wrap_index);
+	int n_col = _get_char_pos_for_line(carets[p_caret].last_fit_x, p_line, p_wrap_index);
 	if (n_col != 0 && get_line_wrapping_mode() != LineWrappingMode::LINE_WRAPPING_NONE && p_wrap_index < get_line_wrap_count(p_line)) {
 		Vector<String> rows = get_line_wrapped_text(p_line);
 		int row_end_col = 0;
@@ -4062,11 +4594,11 @@ void TextEdit::set_caret_line(int p_line, bool p_adjust_viewport, bool p_can_be_
 			n_col -= 1;
 		}
 	}
-	caret_moved = (caret_moved || caret.column != n_col);
-	caret.column = n_col;
+	caret_moved = (caret_moved || get_caret_column(p_caret) != n_col);
+	carets.write[p_caret].column = n_col;
 
 	if (is_inside_tree() && p_adjust_viewport) {
-		adjust_viewport_to_caret();
+		adjust_viewport_to_caret(p_caret);
 	}
 
 	setting_caret_line = false;
@@ -4079,25 +4611,27 @@ void TextEdit::set_caret_line(int p_line, bool p_adjust_viewport, bool p_can_be_
 	}
 }
 
-int TextEdit::get_caret_line() const {
-	return caret.line;
+int TextEdit::get_caret_line(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), 0);
+	return carets[p_caret].line;
 }
 
-void TextEdit::set_caret_column(int p_col, bool p_adjust_viewport) {
+void TextEdit::set_caret_column(int p_col, bool p_adjust_viewport, int p_caret) {
+	ERR_FAIL_INDEX(p_caret, carets.size());
 	if (p_col < 0) {
 		p_col = 0;
 	}
-	if (p_col > get_line(caret.line).length()) {
-		p_col = get_line(caret.line).length();
+	if (p_col > get_line(get_caret_line(p_caret)).length()) {
+		p_col = get_line(get_caret_line(p_caret)).length();
 	}
 
-	bool caret_moved = caret.column != p_col;
-	caret.column = p_col;
+	bool caret_moved = get_caret_column(p_caret) != p_col;
+	carets.write[p_caret].column = p_col;
 
-	caret.last_fit_x = _get_column_x_offset_for_line(caret.column, caret.line);
+	carets.write[p_caret].last_fit_x = _get_column_x_offset_for_line(get_caret_column(p_caret), get_caret_line(p_caret), get_caret_column(p_caret));
 
 	if (is_inside_tree() && p_adjust_viewport) {
-		adjust_viewport_to_caret();
+		adjust_viewport_to_caret(p_caret);
 	}
 
 	if (caret_moved && !caret_pos_dirty) {
@@ -4108,24 +4642,36 @@ void TextEdit::set_caret_column(int p_col, bool p_adjust_viewport) {
 	}
 }
 
-int TextEdit::get_caret_column() const {
-	return caret.column;
+int TextEdit::get_caret_column(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), 0);
+	return carets[p_caret].column;
 }
 
-int TextEdit::get_caret_wrap_index() const {
-	return get_line_wrap_index_at_column(caret.line, caret.column);
+int TextEdit::get_caret_wrap_index(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), 0);
+	return get_line_wrap_index_at_column(get_caret_line(p_caret), get_caret_column(p_caret));
 }
 
-String TextEdit::get_word_under_caret() const {
-	ERR_FAIL_INDEX_V(caret.line, text.size(), "");
-	ERR_FAIL_INDEX_V(caret.column, text[caret.line].length() + 1, "");
-	PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(caret.line)->get_rid());
-	for (int i = 0; i < words.size(); i = i + 2) {
-		if (words[i] <= caret.column && words[i + 1] > caret.column) {
-			return text[caret.line].substr(words[i], words[i + 1] - words[i]);
+String TextEdit::get_word_under_caret(int p_caret) const {
+	ERR_FAIL_COND_V(p_caret > carets.size(), "");
+
+	StringBuilder selected_text;
+	for (int c = 0; c < carets.size(); c++) {
+		if (p_caret != -1 && p_caret != c) {
+			continue;
+		}
+
+		PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(get_caret_line(c))->get_rid());
+		for (int i = 0; i < words.size(); i = i + 2) {
+			if (words[i] <= get_caret_column(c) && words[i + 1] > get_caret_column(c)) {
+				selected_text += text[get_caret_line(c)].substr(words[i], words[i + 1] - words[i]);
+				if (p_caret == -1 && c != carets.size() - 1) {
+					selected_text += "\n";
+				}
+			}
 		}
 	}
-	return "";
+	return selected_text.as_string();
 }
 
 /* Selection. */
@@ -4176,17 +4722,19 @@ bool TextEdit::is_overriding_selected_font_color() const {
 	return override_selected_font_color;
 }
 
-void TextEdit::set_selection_mode(SelectionMode p_mode, int p_line, int p_column) {
+void TextEdit::set_selection_mode(SelectionMode p_mode, int p_line, int p_column, int p_caret) {
+	ERR_FAIL_INDEX(p_caret, carets.size());
+
 	selecting_mode = p_mode;
 	if (p_line >= 0) {
 		ERR_FAIL_INDEX(p_line, text.size());
-		caret.selection.selecting_line = p_line;
-		caret.selection.selecting_column = CLAMP(caret.selection.selecting_column, 0, text[caret.selection.selecting_line].length());
+		carets.write[p_caret].selection.selecting_line = p_line;
+		carets.write[p_caret].selection.selecting_column = CLAMP(carets[p_caret].selection.selecting_column, 0, text[carets[p_caret].selection.selecting_line].length());
 	}
 	if (p_column >= 0) {
-		ERR_FAIL_INDEX(caret.selection.selecting_line, text.size());
-		ERR_FAIL_INDEX(p_column, text[caret.selection.selecting_line].length() + 1);
-		caret.selection.selecting_column = p_column;
+		ERR_FAIL_INDEX(carets[p_caret].selection.selecting_line, text.size());
+		ERR_FAIL_INDEX(p_column, text[carets[p_caret].selection.selecting_line].length() + 1);
+		carets.write[p_caret].selection.selecting_column = p_column;
 	}
 }
 
@@ -4203,15 +4751,18 @@ void TextEdit::select_all() {
 		return;
 	}
 
+	remove_secondary_carets();
 	select(0, 0, text.size() - 1, text[text.size() - 1].length());
 	set_selection_mode(SelectionMode::SELECTION_MODE_SHIFT, 0, 0);
-	caret.selection.shiftclick_left = true;
+	carets.write[0].selection.shiftclick_left = true;
 	set_caret_line(get_selection_to_line(), false);
 	set_caret_column(get_selection_to_column(), false);
 	queue_redraw();
 }
 
-void TextEdit::select_word_under_caret() {
+void TextEdit::select_word_under_caret(int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
+
 	if (!selecting_enabled) {
 		return;
 	}
@@ -4220,36 +4771,43 @@ void TextEdit::select_word_under_caret() {
 		return;
 	}
 
-	if (has_selection()) {
-		/* Allow toggling selection by pressing the shortcut a second time.   */
-		/* This is also usable as a general-purpose "deselect" shortcut after */
-		/* selecting anything.                                                */
-		deselect();
-		return;
-	}
-
-	int begin = 0;
-	int end = 0;
-	const PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(caret.line)->get_rid());
-	for (int i = 0; i < words.size(); i = i + 2) {
-		if ((words[i] <= caret.column && words[i + 1] >= caret.column) || (i == words.size() - 2 && caret.column == words[i + 1])) {
-			begin = words[i];
-			end = words[i + 1];
-			break;
+	for (int c = 0; c < carets.size(); c++) {
+		if (p_caret != -1 && p_caret != c) {
+			continue;
 		}
-	}
 
-	// No word found.
-	if (begin == 0 && end == 0) {
-		return;
-	}
+		if (has_selection(c)) {
+			// Allow toggling selection by pressing the shortcut a second time.
+			// This is also usable as a general-purpose "deselect" shortcut after
+			// selecting anything.
+			deselect(c);
+			continue;
+		}
 
-	select(caret.line, begin, caret.line, end);
-	/* Move the caret to the end of the word for easier editing. */
-	set_caret_column(end, false);
+		int begin = 0;
+		int end = 0;
+		const PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(get_caret_line(c))->get_rid());
+		for (int i = 0; i < words.size(); i = i + 2) {
+			if ((words[i] <= get_caret_column(c) && words[i + 1] >= get_caret_column(c)) || (i == words.size() - 2 && get_caret_column(c) == words[i + 1])) {
+				begin = words[i];
+				end = words[i + 1];
+				break;
+			}
+		}
+
+		// No word found.
+		if (begin == 0 && end == 0) {
+			continue;
+		}
+
+		select(get_caret_line(c), begin, get_caret_column(c), end, c);
+		// Move the caret to the end of the word for easier editing.
+		set_caret_column(end, false, c);
+	}
 }
 
-void TextEdit::select(int p_from_line, int p_from_column, int p_to_line, int p_to_column) {
+void TextEdit::select(int p_from_line, int p_from_column, int p_to_line, int p_to_column, int p_caret) {
+	ERR_FAIL_INDEX(p_caret, carets.size());
 	if (!selecting_enabled) {
 		return;
 	}
@@ -4278,91 +4836,143 @@ void TextEdit::select(int p_from_line, int p_from_column, int p_to_line, int p_t
 		p_to_column = 0;
 	}
 
-	caret.selection.from_line = p_from_line;
-	caret.selection.from_column = p_from_column;
-	caret.selection.to_line = p_to_line;
-	caret.selection.to_column = p_to_column;
+	carets.write[p_caret].selection.from_line = p_from_line;
+	carets.write[p_caret].selection.from_column = p_from_column;
+	carets.write[p_caret].selection.to_line = p_to_line;
+	carets.write[p_caret].selection.to_column = p_to_column;
 
-	caret.selection.active = true;
+	carets.write[p_caret].selection.active = true;
 
-	if (caret.selection.from_line == caret.selection.to_line) {
-		if (caret.selection.from_column == caret.selection.to_column) {
-			caret.selection.active = false;
+	if (carets[p_caret].selection.from_line == carets[p_caret].selection.to_line) {
+		if (carets[p_caret].selection.from_column == carets[p_caret].selection.to_column) {
+			carets.write[p_caret].selection.active = false;
 
-		} else if (caret.selection.from_column > caret.selection.to_column) {
-			caret.selection.shiftclick_left = false;
-			SWAP(caret.selection.from_column, caret.selection.to_column);
+		} else if (carets[p_caret].selection.from_column > carets[p_caret].selection.to_column) {
+			carets.write[p_caret].selection.shiftclick_left = false;
+			SWAP(carets.write[p_caret].selection.from_column, carets.write[p_caret].selection.to_column);
 		} else {
-			caret.selection.shiftclick_left = true;
+			carets.write[p_caret].selection.shiftclick_left = true;
 		}
-	} else if (caret.selection.from_line > caret.selection.to_line) {
-		caret.selection.shiftclick_left = false;
-		SWAP(caret.selection.from_line, caret.selection.to_line);
-		SWAP(caret.selection.from_column, caret.selection.to_column);
+	} else if (carets[p_caret].selection.from_line > carets[p_caret].selection.to_line) {
+		carets.write[p_caret].selection.shiftclick_left = false;
+		SWAP(carets.write[p_caret].selection.from_line, carets.write[p_caret].selection.to_line);
+		SWAP(carets.write[p_caret].selection.from_column, carets.write[p_caret].selection.to_column);
 	} else {
-		caret.selection.shiftclick_left = true;
+		carets.write[p_caret].selection.shiftclick_left = true;
 	}
 
+	caret_index_edit_dirty = true;
 	queue_redraw();
 }
 
-bool TextEdit::has_selection() const {
-	return caret.selection.active;
+bool TextEdit::has_selection(int p_caret) const {
+	ERR_FAIL_COND_V(p_caret > carets.size(), false);
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+
+		if (carets[i].selection.active) {
+			return true;
+		}
+	}
+	return false;
 }
 
-String TextEdit::get_selected_text() const {
-	if (!has_selection()) {
-		return "";
+String TextEdit::get_selected_text(int p_caret) {
+	ERR_FAIL_COND_V(p_caret > carets.size(), "");
+
+	StringBuilder selected_text;
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (int i = caret_edit_order.size() - 1; i >= 0; i--) {
+		int caret_idx = caret_edit_order[i];
+		if (p_caret != -1 && p_caret != caret_idx) {
+			continue;
+		}
+
+		if (!has_selection(caret_idx)) {
+			continue;
+		}
+		selected_text += _base_get_text(get_selection_from_line(caret_idx), get_selection_from_column(caret_idx), get_selection_to_line(caret_idx), get_selection_to_column(caret_idx));
+		if (p_caret == -1 && i != 0) {
+			selected_text += "\n";
+		}
 	}
 
-	return _base_get_text(get_selection_from_line(), get_selection_from_column(), get_selection_to_line(), get_selection_to_column());
+	return selected_text.as_string();
 }
 
-int TextEdit::get_selection_line() const {
-	ERR_FAIL_COND_V(!has_selection(), -1);
-	return caret.selection.selecting_line;
+int TextEdit::get_selection_line(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), -1);
+	ERR_FAIL_COND_V(!has_selection(p_caret), -1);
+	return carets[p_caret].selection.selecting_line;
 }
 
-int TextEdit::get_selection_column() const {
-	ERR_FAIL_COND_V(!has_selection(), -1);
-	return caret.selection.selecting_column;
+int TextEdit::get_selection_column(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), -1);
+	ERR_FAIL_COND_V(!has_selection(p_caret), -1);
+	return carets[p_caret].selection.selecting_column;
 }
 
-int TextEdit::get_selection_from_line() const {
-	ERR_FAIL_COND_V(!has_selection(), -1);
-	return caret.selection.from_line;
+int TextEdit::get_selection_from_line(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), -1);
+	ERR_FAIL_COND_V(!has_selection(p_caret), -1);
+	return carets[p_caret].selection.from_line;
 }
 
-int TextEdit::get_selection_from_column() const {
-	ERR_FAIL_COND_V(!has_selection(), -1);
-	return caret.selection.from_column;
+int TextEdit::get_selection_from_column(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), -1);
+	ERR_FAIL_COND_V(!has_selection(p_caret), -1);
+	return carets[p_caret].selection.from_column;
 }
 
-int TextEdit::get_selection_to_line() const {
-	ERR_FAIL_COND_V(!has_selection(), -1);
-	return caret.selection.to_line;
+int TextEdit::get_selection_to_line(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), -1);
+	ERR_FAIL_COND_V(!has_selection(p_caret), -1);
+	return carets[p_caret].selection.to_line;
 }
 
-int TextEdit::get_selection_to_column() const {
-	ERR_FAIL_COND_V(!has_selection(), -1);
-	return caret.selection.to_column;
+int TextEdit::get_selection_to_column(int p_caret) const {
+	ERR_FAIL_INDEX_V(p_caret, carets.size(), -1);
+	ERR_FAIL_COND_V(!has_selection(p_caret), -1);
+	return carets[p_caret].selection.to_column;
 }
 
-void TextEdit::deselect() {
-	caret.selection.active = false;
+void TextEdit::deselect(int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
+	for (int i = 0; i < carets.size(); i++) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+		carets.write[i].selection.active = false;
+	}
+	caret_index_edit_dirty = true;
 	queue_redraw();
 }
 
-void TextEdit::delete_selection() {
-	if (!has_selection()) {
-		return;
-	}
+void TextEdit::delete_selection(int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
 
-	caret.selection.active = false;
-	selecting_mode = SelectionMode::SELECTION_MODE_NONE;
-	_remove_text(caret.selection.from_line, caret.selection.from_column, caret.selection.to_line, caret.selection.to_column);
-	set_caret_line(caret.selection.from_line, false, false);
-	set_caret_column(caret.selection.from_column);
+	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+
+		if (!has_selection(i)) {
+			continue;
+		}
+
+		selecting_mode = SelectionMode::SELECTION_MODE_NONE;
+		_remove_text(carets[i].selection.from_line, carets[i].selection.from_column, carets[i].selection.to_line, carets[i].selection.to_column);
+		set_caret_line(carets[i].selection.from_line, false, false, 0, i);
+		set_caret_column(carets[i].selection.from_column, i == 0, i);
+		carets.write[i].selection.active = false;
+
+		adjust_carets_after_edit(i, carets[i].selection.from_line, carets[i].selection.from_column, carets[i].selection.to_line, carets[i].selection.to_column);
+	}
+	end_complex_operation();
 	queue_redraw();
 }
 
@@ -4615,13 +5225,15 @@ int TextEdit::get_total_visible_line_count() const {
 }
 
 // Auto adjust
-void TextEdit::adjust_viewport_to_caret() {
+void TextEdit::adjust_viewport_to_caret(int p_caret) {
+	ERR_FAIL_INDEX(p_caret, carets.size());
+
 	// Make sure Caret is visible on the screen.
 	scrolling = false;
 	minimap_clicked = false;
 
-	int cur_line = caret.line;
-	int cur_wrap = get_caret_wrap_index();
+	int cur_line = get_caret_line(p_caret);
+	int cur_wrap = get_caret_wrap_index(p_caret);
 
 	int first_vis_line = get_first_visible_line();
 	int first_vis_wrap = first_visible_line_wrap_ofs;
@@ -4651,17 +5263,17 @@ void TextEdit::adjust_viewport_to_caret() {
 
 		// Get position of the start of caret.
 		if (ime_text.length() != 0 && ime_selection.x != 0) {
-			caret_pos.x = _get_column_x_offset_for_line(caret.column + ime_selection.x, caret.line);
+			caret_pos.x = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_selection.x, get_caret_line(p_caret), get_caret_column(p_caret));
 		} else {
-			caret_pos.x = _get_column_x_offset_for_line(caret.column, caret.line);
+			caret_pos.x = _get_column_x_offset_for_line(get_caret_column(p_caret), get_caret_line(p_caret), get_caret_column(p_caret));
 		}
 
 		// Get position of the end of caret.
 		if (ime_text.length() != 0) {
 			if (ime_selection.y != 0) {
-				caret_pos.y = _get_column_x_offset_for_line(caret.column + ime_selection.x + ime_selection.y, caret.line);
+				caret_pos.y = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_selection.x + ime_selection.y, get_caret_line(p_caret), get_caret_column(p_caret));
 			} else {
-				caret_pos.y = _get_column_x_offset_for_line(caret.column + ime_text.size(), caret.line);
+				caret_pos.y = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_text.size(), get_caret_line(p_caret), get_caret_column(p_caret));
 			}
 		} else {
 			caret_pos.y = caret_pos.x;
@@ -4682,12 +5294,14 @@ void TextEdit::adjust_viewport_to_caret() {
 	queue_redraw();
 }
 
-void TextEdit::center_viewport_to_caret() {
+void TextEdit::center_viewport_to_caret(int p_caret) {
+	ERR_FAIL_INDEX(p_caret, carets.size());
+
 	// Move viewport so the caret is in the center of the screen.
 	scrolling = false;
 	minimap_clicked = false;
 
-	set_line_as_center_visible(caret.line, get_caret_wrap_index());
+	set_line_as_center_visible(get_caret_line(p_caret), get_caret_wrap_index(p_caret));
 	int visible_width = get_size().width - style_normal->get_minimum_size().width - gutters_width - gutter_padding;
 	if (draw_minimap) {
 		visible_width -= minimap_width;
@@ -4704,17 +5318,17 @@ void TextEdit::center_viewport_to_caret() {
 
 		// Get position of the start of caret.
 		if (ime_text.length() != 0 && ime_selection.x != 0) {
-			caret_pos.x = _get_column_x_offset_for_line(caret.column + ime_selection.x, caret.line);
+			caret_pos.x = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_selection.x, get_caret_line(p_caret), get_caret_column(p_caret));
 		} else {
-			caret_pos.x = _get_column_x_offset_for_line(caret.column, caret.line);
+			caret_pos.x = _get_column_x_offset_for_line(get_caret_column(p_caret), get_caret_line(p_caret), get_caret_column(p_caret));
 		}
 
 		// Get position of the end of caret.
 		if (ime_text.length() != 0) {
 			if (ime_selection.y != 0) {
-				caret_pos.y = _get_column_x_offset_for_line(caret.column + ime_selection.x + ime_selection.y, caret.line);
+				caret_pos.y = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_selection.x + ime_selection.y, get_caret_line(p_caret), get_caret_column(p_caret));
 			} else {
-				caret_pos.y = _get_column_x_offset_for_line(caret.column + ime_text.size(), caret.line);
+				caret_pos.y = _get_column_x_offset_for_line(get_caret_column(p_caret) + ime_text.size(), get_caret_line(p_caret), get_caret_column(p_caret));
 			}
 		} else {
 			caret_pos.y = caret_pos.x;
@@ -5177,7 +5791,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("swap_lines", "from_line", "to_line"), &TextEdit::swap_lines);
 
 	ClassDB::bind_method(D_METHOD("insert_line_at", "line", "text"), &TextEdit::insert_line_at);
-	ClassDB::bind_method(D_METHOD("insert_text_at_caret", "text"), &TextEdit::insert_text_at_caret);
+	ClassDB::bind_method(D_METHOD("insert_text_at_caret", "text", "caret_index"), &TextEdit::insert_text_at_caret, DEFVAL(-1));
 
 	ClassDB::bind_method(D_METHOD("remove_text", "from_line", "from_column", "to_line", "to_column"), &TextEdit::remove_text);
 
@@ -5186,18 +5800,19 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_next_visible_line_index_offset_from", "line", "wrap_index", "visible_amount"), &TextEdit::get_next_visible_line_index_offset_from);
 
 	// Overridable actions
-	ClassDB::bind_method(D_METHOD("backspace"), &TextEdit::backspace);
+	ClassDB::bind_method(D_METHOD("backspace", "caret_index"), &TextEdit::backspace, DEFVAL(-1));
 
-	ClassDB::bind_method(D_METHOD("cut"), &TextEdit::cut);
-	ClassDB::bind_method(D_METHOD("copy"), &TextEdit::copy);
-	ClassDB::bind_method(D_METHOD("paste"), &TextEdit::paste);
+	ClassDB::bind_method(D_METHOD("cut", "caret_index"), &TextEdit::cut, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("copy", "caret_index"), &TextEdit::copy, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("paste", "caret_index"), &TextEdit::paste, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("paste_primary_clipboard", "caret_index"), &TextEdit::paste_primary_clipboard, DEFVAL(-1));
 
-	GDVIRTUAL_BIND(_handle_unicode_input, "unicode_char")
-	GDVIRTUAL_BIND(_backspace)
-	GDVIRTUAL_BIND(_cut)
-	GDVIRTUAL_BIND(_copy)
-	GDVIRTUAL_BIND(_paste)
-	GDVIRTUAL_BIND(_paste_primary_clipboard)
+	GDVIRTUAL_BIND(_handle_unicode_input, "unicode_char", "caret_index")
+	GDVIRTUAL_BIND(_backspace, "caret_index")
+	GDVIRTUAL_BIND(_cut, "caret_index")
+	GDVIRTUAL_BIND(_copy, "caret_index")
+	GDVIRTUAL_BIND(_paste, "caret_index")
+	GDVIRTUAL_BIND(_paste_primary_clipboard, "caret_index")
 
 	// Context Menu
 	BIND_ENUM_CONSTANT(MENU_CUT);
@@ -5231,6 +5846,14 @@ void TextEdit::_bind_methods() {
 	BIND_ENUM_CONSTANT(MENU_MAX);
 
 	/* Versioning */
+	BIND_ENUM_CONSTANT(ACTION_NONE);
+	BIND_ENUM_CONSTANT(ACTION_TYPING);
+	BIND_ENUM_CONSTANT(ACTION_BACKSPACE);
+	BIND_ENUM_CONSTANT(ACTION_DELETE);
+
+	ClassDB::bind_method(D_METHOD("start_action", "action"), &TextEdit::start_action);
+	ClassDB::bind_method(D_METHOD("end_action"), &TextEdit::end_complex_operation);
+
 	ClassDB::bind_method(D_METHOD("begin_complex_operation"), &TextEdit::begin_complex_operation);
 	ClassDB::bind_method(D_METHOD("end_complex_operation"), &TextEdit::end_complex_operation);
 
@@ -5270,7 +5893,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_minimap_line_at_pos", "position"), &TextEdit::get_minimap_line_at_pos);
 
 	ClassDB::bind_method(D_METHOD("is_dragging_cursor"), &TextEdit::is_dragging_cursor);
-	ClassDB::bind_method(D_METHOD("is_mouse_over_selection", "edges"), &TextEdit::is_mouse_over_selection);
+	ClassDB::bind_method(D_METHOD("is_mouse_over_selection", "edges", "caret_index"), &TextEdit::is_mouse_over_selection, DEFVAL(-1));
 
 	/* Caret. */
 	BIND_ENUM_CONSTANT(CARET_TYPE_LINE);
@@ -5294,18 +5917,30 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_caret_mid_grapheme_enabled", "enabled"), &TextEdit::set_caret_mid_grapheme_enabled);
 	ClassDB::bind_method(D_METHOD("is_caret_mid_grapheme_enabled"), &TextEdit::is_caret_mid_grapheme_enabled);
 
-	ClassDB::bind_method(D_METHOD("is_caret_visible"), &TextEdit::is_caret_visible);
-	ClassDB::bind_method(D_METHOD("get_caret_draw_pos"), &TextEdit::get_caret_draw_pos);
+	ClassDB::bind_method(D_METHOD("set_multiple_carets_enabled", "enabled"), &TextEdit::set_multiple_carets_enabled);
+	ClassDB::bind_method(D_METHOD("is_multiple_carets_enabled"), &TextEdit::is_multiple_carets_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_caret_line", "line", "adjust_viewport", "can_be_hidden", "wrap_index"), &TextEdit::set_caret_line, DEFVAL(true), DEFVAL(true), DEFVAL(0));
-	ClassDB::bind_method(D_METHOD("get_caret_line"), &TextEdit::get_caret_line);
+	ClassDB::bind_method(D_METHOD("add_caret", "line", "col"), &TextEdit::add_caret);
+	ClassDB::bind_method(D_METHOD("remove_caret", "caret"), &TextEdit::remove_caret);
+	ClassDB::bind_method(D_METHOD("remove_secondary_carets"), &TextEdit::remove_secondary_carets);
+	ClassDB::bind_method(D_METHOD("merge_overlapping_carets"), &TextEdit::merge_overlapping_carets);
+	ClassDB::bind_method(D_METHOD("get_caret_count"), &TextEdit::get_caret_count);
 
-	ClassDB::bind_method(D_METHOD("set_caret_column", "column", "adjust_viewport"), &TextEdit::set_caret_column, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("get_caret_column"), &TextEdit::get_caret_column);
+	ClassDB::bind_method(D_METHOD("get_caret_index_edit_order"), &TextEdit::get_caret_index_edit_order);
+	ClassDB::bind_method(D_METHOD("adjust_carets_after_edit", "caret", "from_line", "from_col", "to_line", "to_col"), &TextEdit::adjust_carets_after_edit);
 
-	ClassDB::bind_method(D_METHOD("get_caret_wrap_index"), &TextEdit::get_caret_wrap_index);
+	ClassDB::bind_method(D_METHOD("is_caret_visible", "caret_index"), &TextEdit::is_caret_visible, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_caret_draw_pos", "caret_index"), &TextEdit::get_caret_draw_pos, DEFVAL(0));
 
-	ClassDB::bind_method(D_METHOD("get_word_under_caret"), &TextEdit::get_word_under_caret);
+	ClassDB::bind_method(D_METHOD("set_caret_line", "line", "adjust_viewport", "can_be_hidden", "wrap_index", "caret_index"), &TextEdit::set_caret_line, DEFVAL(true), DEFVAL(true), DEFVAL(0), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_caret_line", "caret_index"), &TextEdit::get_caret_line, DEFVAL(0));
+
+	ClassDB::bind_method(D_METHOD("set_caret_column", "column", "adjust_viewport", "caret_index"), &TextEdit::set_caret_column, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_caret_column", "caret_index"), &TextEdit::get_caret_column, DEFVAL(0));
+
+	ClassDB::bind_method(D_METHOD("get_caret_wrap_index", "caret_index"), &TextEdit::get_caret_wrap_index, DEFVAL(0));
+
+	ClassDB::bind_method(D_METHOD("get_word_under_caret", "caret_index"), &TextEdit::get_word_under_caret, DEFVAL(-1));
 
 	/* Selection. */
 	BIND_ENUM_CONSTANT(SELECTION_MODE_NONE);
@@ -5326,27 +5961,27 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_override_selected_font_color", "override"), &TextEdit::set_override_selected_font_color);
 	ClassDB::bind_method(D_METHOD("is_overriding_selected_font_color"), &TextEdit::is_overriding_selected_font_color);
 
-	ClassDB::bind_method(D_METHOD("set_selection_mode", "mode", "line", "column"), &TextEdit::set_selection_mode, DEFVAL(-1), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("set_selection_mode", "mode", "line", "column", "caret_index"), &TextEdit::set_selection_mode, DEFVAL(-1), DEFVAL(-1), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_selection_mode"), &TextEdit::get_selection_mode);
 
 	ClassDB::bind_method(D_METHOD("select_all"), &TextEdit::select_all);
-	ClassDB::bind_method(D_METHOD("select_word_under_caret"), &TextEdit::select_word_under_caret);
-	ClassDB::bind_method(D_METHOD("select", "from_line", "from_column", "to_line", "to_column"), &TextEdit::select);
+	ClassDB::bind_method(D_METHOD("select_word_under_caret", "caret_index"), &TextEdit::select_word_under_caret, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("select", "from_line", "from_column", "to_line", "to_column", "caret_index"), &TextEdit::select, DEFVAL(0));
 
-	ClassDB::bind_method(D_METHOD("has_selection"), &TextEdit::has_selection);
+	ClassDB::bind_method(D_METHOD("has_selection", "caret_index"), &TextEdit::has_selection, DEFVAL(-1));
 
-	ClassDB::bind_method(D_METHOD("get_selected_text"), &TextEdit::get_selected_text);
+	ClassDB::bind_method(D_METHOD("get_selected_text", "caret_index"), &TextEdit::get_selected_text, DEFVAL(-1));
 
-	ClassDB::bind_method(D_METHOD("get_selection_line"), &TextEdit::get_selection_line);
-	ClassDB::bind_method(D_METHOD("get_selection_column"), &TextEdit::get_selection_column);
+	ClassDB::bind_method(D_METHOD("get_selection_line", "caret_index"), &TextEdit::get_selection_line, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_selection_column", "caret_index"), &TextEdit::get_selection_column, DEFVAL(0));
 
-	ClassDB::bind_method(D_METHOD("get_selection_from_line"), &TextEdit::get_selection_from_line);
-	ClassDB::bind_method(D_METHOD("get_selection_from_column"), &TextEdit::get_selection_from_column);
-	ClassDB::bind_method(D_METHOD("get_selection_to_line"), &TextEdit::get_selection_to_line);
-	ClassDB::bind_method(D_METHOD("get_selection_to_column"), &TextEdit::get_selection_to_column);
+	ClassDB::bind_method(D_METHOD("get_selection_from_line", "caret_index"), &TextEdit::get_selection_from_line, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_selection_from_column", "caret_index"), &TextEdit::get_selection_from_column, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_selection_to_line", "caret_index"), &TextEdit::get_selection_to_line, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_selection_to_column", "caret_index"), &TextEdit::get_selection_to_column, DEFVAL(0));
 
-	ClassDB::bind_method(D_METHOD("deselect"), &TextEdit::deselect);
-	ClassDB::bind_method(D_METHOD("delete_selection"), &TextEdit::delete_selection);
+	ClassDB::bind_method(D_METHOD("deselect", "caret_index"), &TextEdit::deselect, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("delete_selection", "caret_index"), &TextEdit::delete_selection, DEFVAL(-1));
 
 	/* Line wrapping. */
 	BIND_ENUM_CONSTANT(LINE_WRAPPING_NONE);
@@ -5401,8 +6036,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_total_visible_line_count"), &TextEdit::get_total_visible_line_count);
 
 	// Auto adjust
-	ClassDB::bind_method(D_METHOD("adjust_viewport_to_caret"), &TextEdit::adjust_viewport_to_caret);
-	ClassDB::bind_method(D_METHOD("center_viewport_to_caret"), &TextEdit::center_viewport_to_caret);
+	ClassDB::bind_method(D_METHOD("adjust_viewport_to_caret", "caret_index"), &TextEdit::adjust_viewport_to_caret, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("center_viewport_to_caret", "caret_index"), &TextEdit::center_viewport_to_caret, DEFVAL(0));
 
 	// Minimap
 	ClassDB::bind_method(D_METHOD("set_draw_minimap", "enabled"), &TextEdit::set_draw_minimap);
@@ -5518,6 +6153,7 @@ void TextEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "caret_blink_interval", PROPERTY_HINT_RANGE, "0.1,10,0.01,suffix:s"), "set_caret_blink_interval", "get_caret_blink_interval");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_move_on_right_click"), "set_move_caret_on_right_click_enabled", "is_move_caret_on_right_click_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_mid_grapheme"), "set_caret_mid_grapheme_enabled", "is_caret_mid_grapheme_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_multiple"), "set_multiple_carets_enabled", "is_multiple_carets_enabled");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");
@@ -5603,157 +6239,238 @@ void TextEdit::_set_symbol_lookup_word(const String &p_symbol) {
 /* Text manipulation */
 
 // Overridable actions
-void TextEdit::_handle_unicode_input_internal(const uint32_t p_unicode) {
+void TextEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
 	if (!editable) {
 		return;
 	}
 
-	bool had_selection = has_selection();
-	if (had_selection) {
-		begin_complex_operation();
-		delete_selection();
+	start_action(EditAction::ACTION_TYPING);
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+
+		/* Remove the old character if in insert mode and no selection. */
+		if (overtype_mode && !has_selection(i)) {
+			/* Make sure we don't try and remove empty space. */
+			int cl = get_caret_line(i);
+			int cc = get_caret_column(i);
+			if (cc < get_line(cl).length()) {
+				_remove_text(cl, cc, cl, cc + 1);
+			}
+		}
+
+		const char32_t chr[2] = { (char32_t)p_unicode, 0 };
+		insert_text_at_caret(chr, i);
+	}
+	end_action();
+}
+
+void TextEdit::_backspace_internal(int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
+	if (!editable) {
+		return;
 	}
 
-	/* Remove the old character if in insert mode and no selection. */
-	if (overtype_mode && !had_selection) {
-		begin_complex_operation();
+	if (has_selection(p_caret)) {
+		delete_selection(p_caret);
+		return;
+	}
 
-		/* Make sure we don't try and remove empty space. */
-		int cl = get_caret_line();
-		int cc = get_caret_column();
-		if (cc < get_line(cl).length()) {
-			_remove_text(cl, cc, cl, cc + 1);
+	begin_complex_operation();
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (const int &i : caret_edit_order) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
+
+		int cc = get_caret_column(i);
+		int cl = get_caret_line(i);
+
+		if (cc == 0 && cl == 0) {
+			continue;
+		}
+
+		int prev_line = cc ? cl : cl - 1;
+		int prev_column = cc ? (cc - 1) : (text[cl - 1].length());
+
+		merge_gutters(prev_line, cl);
+
+		if (_is_line_hidden(cl)) {
+			_set_line_as_hidden(prev_line, true);
+		}
+		_remove_text(prev_line, prev_column, cl, cc);
+
+		set_caret_line(prev_line, false, true, 0, i);
+		set_caret_column(prev_column, i == 0, i);
+
+		adjust_carets_after_edit(i, prev_line, prev_column, cl, cc);
+	}
+	merge_overlapping_carets();
+	end_complex_operation();
+}
+
+void TextEdit::_cut_internal(int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
+	if (!editable) {
+		return;
+	}
+
+	if (has_selection(p_caret)) {
+		DisplayServer::get_singleton()->clipboard_set(get_selected_text(p_caret));
+		delete_selection(p_caret);
+		cut_copy_line = "";
+		return;
+	}
+
+	begin_complex_operation();
+	Vector<int> carets_to_remove;
+
+	StringBuilder clipboard;
+	// This is the exception and has to edit in reverse order else the string copied to the clipboard will be backwards.
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (int i = caret_edit_order.size() - 1; i >= 0; i--) {
+		int caret_idx = caret_edit_order[i];
+		if (p_caret != -1 && p_caret != caret_idx) {
+			continue;
+		}
+
+		int cl = get_caret_line(caret_idx);
+		int cc = get_caret_column(caret_idx);
+		int indent_level = get_indent_level(cl);
+		double hscroll = get_h_scroll();
+
+		// Check for overlaping carets.
+		// We don't need to worry about selections as that is caught before this entire section.
+		for (int j = i - 1; j >= 0; j--) {
+			if (get_caret_line(caret_edit_order[j]) == cl) {
+				carets_to_remove.push_back(caret_edit_order[j]);
+				i = j;
+			}
+		}
+
+		clipboard += text[cl];
+		if (p_caret == -1 && caret_idx != 0) {
+			clipboard += "\n";
+		}
+
+		if (cl == 0 && get_line_count() > 1) {
+			_remove_text(cl, 0, cl + 1, 0);
+			adjust_carets_after_edit(caret_idx, cl, 0, cl + 1, text[cl].length());
+		} else {
+			_remove_text(cl, 0, cl, text[cl].length());
+			set_caret_column(0, false, caret_idx);
+			backspace(caret_idx);
+			set_caret_line(get_caret_line(caret_idx) + 1, caret_idx == 0, 0, 0, caret_idx);
+		}
+
+		// Correct the visually perceived caret column taking care of indentation level of the lines.
+		int diff_indent = indent_level - get_indent_level(get_caret_line(caret_idx));
+		cc += diff_indent;
+		if (diff_indent != 0) {
+			cc += diff_indent > 0 ? -1 : 1;
+		}
+
+		// Restore horizontal scroll and caret column modified by the backspace() call.
+		set_h_scroll(hscroll);
+		set_caret_column(cc, caret_idx == 0, caret_idx);
+	}
+
+	// Sort and remove backwards to preserve indexes.
+	carets_to_remove.sort();
+	for (int i = carets_to_remove.size() - 1; i >= 0; i--) {
+		remove_caret(carets_to_remove[i]);
+	}
+	end_complex_operation();
+
+	String clipboard_string = clipboard.as_string();
+	DisplayServer::get_singleton()->clipboard_set(clipboard_string);
+	cut_copy_line = clipboard_string;
+}
+
+void TextEdit::_copy_internal(int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
+	if (has_selection(p_caret)) {
+		DisplayServer::get_singleton()->clipboard_set(get_selected_text(p_caret));
+		cut_copy_line = "";
+		return;
+	}
+
+	StringBuilder clipboard;
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	for (int i = caret_edit_order.size() - 1; i >= 0; i--) {
+		int caret_idx = caret_edit_order[i];
+		if (p_caret != -1 && p_caret != caret_idx) {
+			continue;
+		}
+
+		int cl = get_caret_line(caret_idx);
+		if (text[cl].length() != 0) {
+			clipboard += _base_get_text(cl, 0, cl, text[cl].length());
+			if (p_caret == -1 && i != 0) {
+				clipboard += "\n";
+			}
 		}
 	}
 
-	const char32_t chr[2] = { (char32_t)p_unicode, 0 };
-	insert_text_at_caret(chr);
-
-	if ((overtype_mode && !had_selection) || (had_selection)) {
-		end_complex_operation();
-	}
+	String clipboard_string = clipboard.as_string();
+	DisplayServer::get_singleton()->clipboard_set(clipboard_string);
+	cut_copy_line = clipboard_string;
 }
 
-void TextEdit::_backspace_internal() {
-	if (!editable) {
-		return;
-	}
-
-	if (has_selection()) {
-		delete_selection();
-		return;
-	}
-
-	int cc = get_caret_column();
-	int cl = get_caret_line();
-
-	if (cc == 0 && cl == 0) {
-		return;
-	}
-
-	int prev_line = cc ? cl : cl - 1;
-	int prev_column = cc ? (cc - 1) : (text[cl - 1].length());
-
-	merge_gutters(prev_line, cl);
-
-	if (_is_line_hidden(cl)) {
-		_set_line_as_hidden(prev_line, true);
-	}
-	_remove_text(prev_line, prev_column, cl, cc);
-
-	set_caret_line(prev_line, false, true);
-	set_caret_column(prev_column);
-}
-
-void TextEdit::_cut_internal() {
-	if (!editable) {
-		return;
-	}
-
-	if (has_selection()) {
-		DisplayServer::get_singleton()->clipboard_set(get_selected_text());
-		delete_selection();
-		cut_copy_line = "";
-		return;
-	}
-
-	int cl = get_caret_line();
-	int cc = get_caret_column();
-	int indent_level = get_indent_level(cl);
-	double hscroll = get_h_scroll();
-
-	String clipboard = text[cl];
-	DisplayServer::get_singleton()->clipboard_set(clipboard);
-	set_caret_column(0);
-
-	if (cl == 0 && get_line_count() > 1) {
-		_remove_text(cl, 0, cl + 1, 0);
-	} else {
-		_remove_text(cl, 0, cl, text[cl].length());
-		backspace();
-		set_caret_line(get_caret_line() + 1);
-	}
-
-	// Correct the visually perceived caret column taking care of indentation level of the lines.
-	int diff_indent = indent_level - get_indent_level(get_caret_line());
-	cc += diff_indent;
-	if (diff_indent != 0) {
-		cc += diff_indent > 0 ? -1 : 1;
-	}
-
-	// Restore horizontal scroll and caret column modified by the backspace() call.
-	set_h_scroll(hscroll);
-	set_caret_column(cc);
-
-	cut_copy_line = clipboard;
-}
-
-void TextEdit::_copy_internal() {
-	if (has_selection()) {
-		DisplayServer::get_singleton()->clipboard_set(get_selected_text());
-		cut_copy_line = "";
-		return;
-	}
-
-	int cl = get_caret_line();
-	if (text[cl].length() != 0) {
-		String clipboard = _base_get_text(cl, 0, cl, text[cl].length());
-		DisplayServer::get_singleton()->clipboard_set(clipboard);
-		cut_copy_line = clipboard;
-	}
-}
-
-void TextEdit::_paste_internal() {
+void TextEdit::_paste_internal(int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
 	if (!editable) {
 		return;
 	}
 
 	String clipboard = DisplayServer::get_singleton()->clipboard_get();
+	Vector<String> clipboad_lines = clipboard.split("\n");
+	bool insert_line_per_caret = p_caret == -1 && carets.size() > 1 && clipboad_lines.size() == carets.size();
 
 	begin_complex_operation();
-	if (has_selection()) {
-		delete_selection();
-	} else if (!cut_copy_line.is_empty() && cut_copy_line == clipboard) {
-		set_caret_column(0);
-		String ins = "\n";
-		clipboard += ins;
-	}
+	Vector<int> caret_edit_order = get_caret_index_edit_order();
+	int clipboad_line = clipboad_lines.size() - 1;
+	for (const int &i : caret_edit_order) {
+		if (p_caret != -1 && p_caret != i) {
+			continue;
+		}
 
-	insert_text_at_caret(clipboard);
+		if (has_selection(i)) {
+			delete_selection(i);
+		} else if (!cut_copy_line.is_empty() && cut_copy_line == clipboard) {
+			set_caret_column(0, i == 0, i);
+			String ins = "\n";
+			clipboard += ins;
+		}
+
+		if (insert_line_per_caret) {
+			clipboard = clipboad_lines[clipboad_line];
+		}
+
+		insert_text_at_caret(clipboard, i);
+		clipboad_line--;
+	}
 	end_complex_operation();
 }
 
-void TextEdit::_paste_primary_clipboard_internal() {
+void TextEdit::_paste_primary_clipboard_internal(int p_caret) {
+	ERR_FAIL_COND(p_caret > carets.size());
 	if (!is_editable() || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIPBOARD_PRIMARY)) {
 		return;
 	}
 
 	String paste_buffer = DisplayServer::get_singleton()->clipboard_get_primary();
 
-	Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
-	deselect();
-	set_caret_line(pos.y, true, false);
-	set_caret_column(pos.x);
+	if (carets.size() == 1) {
+		Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
+		deselect();
+		set_caret_line(pos.y, true, false);
+		set_caret_column(pos.x);
+	}
+
 	if (!paste_buffer.is_empty()) {
 		insert_text_at_caret(paste_buffer);
 	}
@@ -5870,6 +6587,10 @@ Key TextEdit::_get_menu_action_accelerator(const String &p_action) {
 
 /* Versioning */
 void TextEdit::_push_current_op() {
+	if (pending_action_end) {
+		start_action(EditAction::ACTION_NONE);
+		return;
+	}
 	if (current_op.type == TextOperation::TYPE_NONE) {
 		return; // Nothing to do.
 	}
@@ -5971,6 +6692,7 @@ int TextEdit::_get_char_pos_for_line(int p_px, int p_line, int p_wrap_index) con
 void TextEdit::_emit_caret_changed() {
 	emit_signal(SNAME("caret_changed"));
 	caret_pos_dirty = false;
+	caret_index_edit_dirty = true;
 }
 
 void TextEdit::_reset_caret_blink_timer() {
@@ -5993,7 +6715,7 @@ void TextEdit::_toggle_draw_caret() {
 	}
 }
 
-int TextEdit::_get_column_x_offset_for_line(int p_char, int p_line) const {
+int TextEdit::_get_column_x_offset_for_line(int p_char, int p_line, int p_column) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), 0);
 
 	int row = 0;
@@ -6006,7 +6728,7 @@ int TextEdit::_get_column_x_offset_for_line(int p_char, int p_line) const {
 	}
 
 	RID text_rid = text.get_line_data(p_line)->get_line_rid(row);
-	CaretInfo ts_caret = TS->shaped_text_get_carets(text_rid, caret.column);
+	CaretInfo ts_caret = TS->shaped_text_get_carets(text_rid, p_column);
 	if ((ts_caret.l_caret != Rect2() && (ts_caret.l_dir == TextServer::DIRECTION_AUTO || ts_caret.l_dir == (TextServer::Direction)input_direction)) || (ts_caret.t_caret == Rect2())) {
 		return ts_caret.l_caret.position.x;
 	} else {
@@ -6046,14 +6768,16 @@ void TextEdit::_update_selection_mode_pointer() {
 	Point2i pos = get_line_column_at_pos(mp);
 	int line = pos.y;
 	int col = pos.x;
+	int caret_idx = carets.size() - 1;
 
-	select(caret.selection.selecting_line, caret.selection.selecting_column, line, col);
+	select(carets[caret_idx].selection.selecting_line, carets[caret_idx].selection.selecting_column, line, col, caret_idx);
 
-	set_caret_line(line, false);
-	set_caret_column(col);
+	set_caret_line(line, false, true, 0, caret_idx);
+	set_caret_column(col, true, caret_idx);
 	queue_redraw();
 
 	click_select_held->start();
+	merge_overlapping_carets();
 }
 
 void TextEdit::_update_selection_mode_word() {
@@ -6063,6 +6787,7 @@ void TextEdit::_update_selection_mode_word() {
 	Point2i pos = get_line_column_at_pos(mp);
 	int line = pos.y;
 	int col = pos.x;
+	int caret_idx = carets.size() - 1;
 
 	int caret_pos = CLAMP(col, 0, text[line].length());
 	int beg = caret_pos;
@@ -6077,25 +6802,25 @@ void TextEdit::_update_selection_mode_word() {
 	}
 
 	/* Initial selection. */
-	if (!has_selection()) {
-		select(line, beg, line, end);
-		caret.selection.selecting_column = beg;
-		caret.selection.selected_word_beg = beg;
-		caret.selection.selected_word_end = end;
-		caret.selection.selected_word_origin = beg;
-		set_caret_line(line, false);
-		set_caret_column(end);
+	if (!has_selection(caret_idx)) {
+		select(line, beg, line, end, caret_idx);
+		carets.write[caret_idx].selection.selecting_column = beg;
+		carets.write[caret_idx].selection.selected_word_beg = beg;
+		carets.write[caret_idx].selection.selected_word_end = end;
+		carets.write[caret_idx].selection.selected_word_origin = beg;
+		set_caret_line(line, false, true, 0, caret_idx);
+		set_caret_column(end, true, caret_idx);
 	} else {
-		if ((col <= caret.selection.selected_word_origin && line == get_selection_line()) || line < get_selection_line()) {
-			caret.selection.selecting_column = caret.selection.selected_word_end;
-			select(line, beg, get_selection_line(), caret.selection.selected_word_end);
-			set_caret_line(get_selection_from_line(), false);
-			set_caret_column(get_selection_from_column());
+		if ((col <= carets[caret_idx].selection.selected_word_origin && line == get_selection_line(caret_idx)) || line < get_selection_line(caret_idx)) {
+			carets.write[caret_idx].selection.selecting_column = carets[caret_idx].selection.selected_word_end;
+			select(line, beg, get_selection_line(caret_idx), carets[caret_idx].selection.selected_word_end, caret_idx);
+			set_caret_line(get_selection_from_line(caret_idx), false, true, 0, caret_idx);
+			set_caret_column(get_selection_from_column(caret_idx), true, caret_idx);
 		} else {
-			caret.selection.selecting_column = caret.selection.selected_word_beg;
-			select(get_selection_line(), caret.selection.selected_word_beg, line, end);
-			set_caret_line(get_selection_to_line(), false);
-			set_caret_column(get_selection_to_column());
+			carets.write[caret_idx].selection.selecting_column = carets[caret_idx].selection.selected_word_beg;
+			select(get_selection_line(caret_idx), carets[caret_idx].selection.selected_word_beg, line, end, caret_idx);
+			set_caret_line(get_selection_to_line(caret_idx), false, true, 0, caret_idx);
+			set_caret_column(get_selection_to_column(caret_idx), true, caret_idx);
 		}
 	}
 
@@ -6106,6 +6831,7 @@ void TextEdit::_update_selection_mode_word() {
 	queue_redraw();
 
 	click_select_held->start();
+	merge_overlapping_carets();
 }
 
 void TextEdit::_update_selection_mode_line() {
@@ -6115,21 +6841,22 @@ void TextEdit::_update_selection_mode_line() {
 	Point2i pos = get_line_column_at_pos(mp);
 	int line = pos.y;
 	int col = pos.x;
+	int caret_idx = carets.size() - 1;
 
 	col = 0;
-	if (line < caret.selection.selecting_line) {
+	if (line < carets[caret_idx].selection.selecting_line) {
 		/* Caret is above us. */
-		set_caret_line(line - 1, false);
-		caret.selection.selecting_column = text[get_selection_line()].length();
+		set_caret_line(line - 1, false, true, 0, caret_idx);
+		carets.write[caret_idx].selection.selecting_column = text[get_selection_line(caret_idx)].length();
 	} else {
 		/* Caret is below us. */
-		set_caret_line(line + 1, false);
-		caret.selection.selecting_column = 0;
+		set_caret_line(line + 1, false, true, 0, caret_idx);
+		carets.write[caret_idx].selection.selecting_column = 0;
 		col = text[line].length();
 	}
-	set_caret_column(0);
+	set_caret_column(0, false, caret_idx);
 
-	select(caret.selection.selecting_line, caret.selection.selecting_column, line, col);
+	select(carets[caret_idx].selection.selecting_line, carets[caret_idx].selection.selecting_column, line, col, caret_idx);
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIPBOARD_PRIMARY)) {
 		DisplayServer::get_singleton()->clipboard_set_primary(get_selected_text());
 	}
@@ -6137,28 +6864,30 @@ void TextEdit::_update_selection_mode_line() {
 	queue_redraw();
 
 	click_select_held->start();
+	merge_overlapping_carets();
 }
 
-void TextEdit::_pre_shift_selection() {
+void TextEdit::_pre_shift_selection(int p_caret) {
 	if (!selecting_enabled) {
 		return;
 	}
 
-	if (!has_selection() || get_selection_mode() == SelectionMode::SELECTION_MODE_NONE) {
-		caret.selection.active = true;
-		set_selection_mode(SelectionMode::SELECTION_MODE_SHIFT, caret.line, caret.column);
+	if (!has_selection(p_caret) || get_selection_mode() == SelectionMode::SELECTION_MODE_NONE) {
+		carets.write[p_caret].selection.active = true;
+		set_selection_mode(SelectionMode::SELECTION_MODE_SHIFT, get_caret_line(p_caret), get_caret_column(p_caret), p_caret);
+		return;
 	}
 
-	set_selection_mode(SelectionMode::SELECTION_MODE_SHIFT);
+	set_selection_mode(SelectionMode::SELECTION_MODE_SHIFT, get_selection_line(p_caret), get_selection_column(p_caret), p_caret);
 }
 
-void TextEdit::_post_shift_selection() {
+void TextEdit::_post_shift_selection(int p_caret) {
 	if (!selecting_enabled) {
 		return;
 	}
 
-	if (has_selection() && get_selection_mode() == SelectionMode::SELECTION_MODE_SHIFT) {
-		select(get_selection_line(), get_selection_column(), caret.line, caret.column);
+	if (has_selection(p_caret) && get_selection_mode() == SelectionMode::SELECTION_MODE_SHIFT) {
+		select(get_selection_line(p_caret), get_selection_column(p_caret), get_caret_line(p_caret), get_caret_column(p_caret), p_caret);
 	}
 }
 
@@ -6394,16 +7123,18 @@ void TextEdit::_scroll_lines_up() {
 	set_v_scroll(get_v_scroll() - 1);
 
 	// Adjust the caret to viewport.
-	if (!has_selection()) {
-		int cur_line = caret.line;
-		int cur_wrap = get_caret_wrap_index();
+	for (int i = 0; i < carets.size(); i++) {
+		if (has_selection(i)) {
+			continue;
+		}
+
 		int last_vis_line = get_last_full_visible_line();
 		int last_vis_wrap = get_last_full_visible_line_wrap_index();
-
-		if (cur_line > last_vis_line || (cur_line == last_vis_line && cur_wrap > last_vis_wrap)) {
-			set_caret_line(last_vis_line, false, false, last_vis_wrap);
+		if (get_caret_line(i) > last_vis_line || (get_caret_line(i) == last_vis_line && get_caret_wrap_index(i) > last_vis_wrap)) {
+			set_caret_line(last_vis_line, false, false, last_vis_wrap, i);
 		}
 	}
+	merge_overlapping_carets();
 }
 
 void TextEdit::_scroll_lines_down() {
@@ -6414,16 +7145,17 @@ void TextEdit::_scroll_lines_down() {
 	set_v_scroll(get_v_scroll() + 1);
 
 	// Adjust the caret to viewport.
-	if (!has_selection()) {
-		int cur_line = caret.line;
-		int cur_wrap = get_caret_wrap_index();
-		int first_vis_line = get_first_visible_line();
-		int first_vis_wrap = first_visible_line_wrap_ofs;
+	for (int i = 0; i < carets.size(); i++) {
+		if (has_selection(i)) {
+			continue;
+		}
 
-		if (cur_line < first_vis_line || (cur_line == first_vis_line && cur_wrap < first_vis_wrap)) {
-			set_caret_line(first_vis_line, false, false, first_vis_wrap);
+		int first_vis_line = get_first_visible_line();
+		if (get_caret_line(i) < first_vis_line || (get_caret_line(i) == first_vis_line && get_caret_wrap_index(i) < first_visible_line_wrap_ofs)) {
+			set_caret_line(first_vis_line, false, false, first_visible_line_wrap_ofs, i);
 		}
 	}
+	merge_overlapping_carets();
 }
 
 // Minimap
@@ -6560,6 +7292,8 @@ void TextEdit::_insert_text(int p_line, int p_char, const String &p_text, int *r
 	op.version = ++version;
 	op.chain_forward = false;
 	op.chain_backward = false;
+	op.start_carets = carets;
+	op.end_carets = carets;
 
 	// See if it should just be set as current op.
 	if (current_op.type != op.type) {
@@ -6582,6 +7316,7 @@ void TextEdit::_insert_text(int p_line, int p_char, const String &p_text, int *r
 	current_op.to_column = retchar;
 	current_op.to_line = retline;
 	current_op.version = op.version;
+	current_op.end_carets = carets;
 }
 
 void TextEdit::_remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column) {
@@ -6612,6 +7347,8 @@ void TextEdit::_remove_text(int p_from_line, int p_from_column, int p_to_line, i
 	op.version = ++version;
 	op.chain_forward = false;
 	op.chain_backward = false;
+	op.start_carets = carets;
+	op.end_carets = carets;
 
 	// See if it should just be set as current op.
 	if (current_op.type != op.type) {
@@ -6626,6 +7363,7 @@ void TextEdit::_remove_text(int p_from_line, int p_from_column, int p_to_line, i
 		current_op.text = text + current_op.text;
 		current_op.from_line = p_from_line;
 		current_op.from_column = p_from_column;
+		current_op.end_carets = carets;
 		return; // Update current op.
 	}
 
@@ -6675,7 +7413,7 @@ void TextEdit::_base_insert_text(int p_line, int p_char, const String &p_text, i
 	r_end_line = p_line + substrings.size() - 1;
 	r_end_column = text[r_end_line].length() - postinsert_text.length();
 
-	TextServer::Direction dir = TS->shaped_text_get_dominant_direction_in_range(text.get_line_data(r_end_line)->get_rid(), (r_end_line == p_line) ? caret.column : 0, r_end_column);
+	TextServer::Direction dir = TS->shaped_text_get_dominant_direction_in_range(text.get_line_data(r_end_line)->get_rid(), (r_end_line == p_line) ? carets[0].column : 0, r_end_column);
 	if (dir != TextServer::DIRECTION_AUTO) {
 		input_direction = (TextDirection)dir;
 	}
@@ -6737,6 +7475,7 @@ void TextEdit::_base_remove_text(int p_from_line, int p_from_column, int p_to_li
 
 TextEdit::TextEdit(const String &p_placeholder) {
 	placeholder_data_buf.instantiate();
+	carets.push_back(Caret());
 
 	clear();
 	set_focus_mode(FOCUS_ALL);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -42,6 +42,14 @@ class TextEdit : public Control {
 	GDCLASS(TextEdit, Control);
 
 public:
+	/* Edit Actions. */
+	enum EditAction {
+		ACTION_NONE,
+		ACTION_TYPING,
+		ACTION_BACKSPACE,
+		ACTION_DELETE,
+	};
+
 	/* Caret. */
 	enum CaretType {
 		CARET_TYPE_LINE,
@@ -299,12 +307,15 @@ private:
 	Key _get_menu_action_accelerator(const String &p_action);
 
 	/* Versioning */
+	struct Caret;
 	struct TextOperation {
 		enum Type {
 			TYPE_NONE,
 			TYPE_INSERT,
 			TYPE_REMOVE
 		};
+		Vector<Caret> start_carets;
+		Vector<Caret> end_carets;
 
 		Type type = TYPE_NONE;
 		int from_line = 0;
@@ -320,6 +331,10 @@ private:
 
 	bool undo_enabled = true;
 	int undo_stack_max_size = 50;
+
+	EditAction current_action = EditAction::ACTION_NONE;
+	bool pending_action_end = false;
+	bool in_action = false;
 
 	int complex_operation_count = 0;
 	bool next_operation_is_complex = false;
@@ -385,10 +400,15 @@ private:
 		int last_fit_x = 0;
 		int line = 0;
 		int column = 0;
-	} caret;
+	};
+
+	// Vector containing all the carets, index '0' is the "main caret" and should never be removed.
+	Vector<Caret> carets;
+	Vector<int> caret_index_edit_order;
 
 	bool setting_caret_line = false;
 	bool caret_pos_dirty = false;
+	bool caret_index_edit_dirty = true;
 
 	Color caret_color = Color(1, 1, 1);
 	Color caret_background_color = Color(0, 0, 0);
@@ -404,6 +424,8 @@ private:
 
 	bool caret_mid_grapheme_enabled = true;
 
+	bool multi_carets_enabled = true;
+
 	bool drag_action = false;
 	bool drag_caret_force_displayed = false;
 
@@ -412,7 +434,7 @@ private:
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();
 
-	int _get_column_x_offset_for_line(int p_char, int p_line) const;
+	int _get_column_x_offset_for_line(int p_char, int p_line, int p_column) const;
 
 	/* Selection. */
 	SelectionMode selecting_mode = SelectionMode::SELECTION_MODE_NONE;
@@ -437,8 +459,8 @@ private:
 	void _update_selection_mode_word();
 	void _update_selection_mode_line();
 
-	void _pre_shift_selection();
-	void _post_shift_selection();
+	void _pre_shift_selection(int p_caret);
+	void _post_shift_selection(int p_caret);
 
 	/* Line wrapping. */
 	LineWrappingMode line_wrapping_mode = LineWrappingMode::LINE_WRAPPING_NONE;
@@ -583,6 +605,17 @@ protected:
 
 	/* Internal API for CodeEdit, pending public API. */
 	// brace matching
+	struct BraceMatchingData {
+		int open_match_line = -1;
+		int open_match_column = -1;
+		bool open_matching = false;
+		bool open_mismatch = false;
+		int close_match_line = -1;
+		int close_match_column = -1;
+		bool close_matching = false;
+		bool close_mismatch = false;
+	};
+
 	bool highlight_matching_braces_enabled = false;
 	Color brace_mismatch_color;
 
@@ -607,20 +640,20 @@ protected:
 	/* Text manipulation */
 
 	// Overridable actions
-	virtual void _handle_unicode_input_internal(const uint32_t p_unicode);
-	virtual void _backspace_internal();
+	virtual void _handle_unicode_input_internal(const uint32_t p_unicode, int p_caret);
+	virtual void _backspace_internal(int p_caret);
 
-	virtual void _cut_internal();
-	virtual void _copy_internal();
-	virtual void _paste_internal();
-	virtual void _paste_primary_clipboard_internal();
+	virtual void _cut_internal(int p_caret);
+	virtual void _copy_internal(int p_caret);
+	virtual void _paste_internal(int p_caret);
+	virtual void _paste_primary_clipboard_internal(int p_caret);
 
-	GDVIRTUAL1(_handle_unicode_input, int)
-	GDVIRTUAL0(_backspace)
-	GDVIRTUAL0(_cut)
-	GDVIRTUAL0(_copy)
-	GDVIRTUAL0(_paste)
-	GDVIRTUAL0(_paste_primary_clipboard)
+	GDVIRTUAL2(_handle_unicode_input, int, int)
+	GDVIRTUAL1(_backspace, int)
+	GDVIRTUAL1(_cut, int)
+	GDVIRTUAL1(_copy, int)
+	GDVIRTUAL1(_paste, int)
+	GDVIRTUAL1(_paste_primary_clipboard, int)
 
 public:
 	/* General overrides. */
@@ -696,7 +729,7 @@ public:
 	void swap_lines(int p_from_line, int p_to_line);
 
 	void insert_line_at(int p_at, const String &p_text);
-	void insert_text_at_caret(const String &p_text);
+	void insert_text_at_caret(const String &p_text, int p_caret = -1);
 
 	void remove_text(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
 
@@ -705,13 +738,13 @@ public:
 	Point2i get_next_visible_line_index_offset_from(int p_line_from, int p_wrap_index_from, int p_visible_amount) const;
 
 	// Overridable actions
-	void handle_unicode_input(const uint32_t p_unicode);
-	void backspace();
+	void handle_unicode_input(const uint32_t p_unicode, int p_caret = -1);
+	void backspace(int p_caret = -1);
 
-	void cut();
-	void copy();
-	void paste();
-	void paste_primary_clipboard();
+	void cut(int p_caret = -1);
+	void copy(int p_caret = -1);
+	void paste(int p_caret = -1);
+	void paste_primary_clipboard(int p_caret = -1);
 
 	// Context menu.
 	PopupMenu *get_menu() const;
@@ -719,6 +752,10 @@ public:
 	void menu_option(int p_option);
 
 	/* Versioning */
+	void start_action(EditAction p_action);
+	void end_action();
+	EditAction get_current_action() const;
+
 	void begin_complex_operation();
 	void end_complex_operation();
 
@@ -753,7 +790,7 @@ public:
 	int get_minimap_line_at_pos(const Point2i &p_pos) const;
 
 	bool is_dragging_cursor() const;
-	bool is_mouse_over_selection(bool p_edges = true) const;
+	bool is_mouse_over_selection(bool p_edges = true, int p_caret = -1) const;
 
 	/* Caret */
 	void set_caret_type(CaretType p_type);
@@ -771,18 +808,30 @@ public:
 	void set_caret_mid_grapheme_enabled(const bool p_enabled);
 	bool is_caret_mid_grapheme_enabled() const;
 
-	bool is_caret_visible() const;
-	Point2 get_caret_draw_pos() const;
+	void set_multiple_carets_enabled(bool p_enabled);
+	bool is_multiple_carets_enabled() const;
 
-	void set_caret_line(int p_line, bool p_adjust_viewport = true, bool p_can_be_hidden = true, int p_wrap_index = 0);
-	int get_caret_line() const;
+	int add_caret(int p_line, int p_col);
+	void remove_caret(int p_caret);
+	void remove_secondary_carets();
+	void merge_overlapping_carets();
+	int get_caret_count() const;
 
-	void set_caret_column(int p_col, bool p_adjust_viewport = true);
-	int get_caret_column() const;
+	Vector<int> get_caret_index_edit_order();
+	void adjust_carets_after_edit(int p_caret, int p_from_line, int p_from_col, int p_to_line, int p_to_col);
 
-	int get_caret_wrap_index() const;
+	bool is_caret_visible(int p_caret = 0) const;
+	Point2 get_caret_draw_pos(int p_caret = 0) const;
 
-	String get_word_under_caret() const;
+	void set_caret_line(int p_line, bool p_adjust_viewport = true, bool p_can_be_hidden = true, int p_wrap_index = 0, int p_caret = 0);
+	int get_caret_line(int p_caret = 0) const;
+
+	void set_caret_column(int p_col, bool p_adjust_viewport = true, int p_caret = 0);
+	int get_caret_column(int p_caret = 0) const;
+
+	int get_caret_wrap_index(int p_caret = 0) const;
+
+	String get_word_under_caret(int p_caret = -1) const;
 
 	/* Selection. */
 	void set_selecting_enabled(const bool p_enabled);
@@ -797,27 +846,27 @@ public:
 	void set_override_selected_font_color(bool p_override_selected_font_color);
 	bool is_overriding_selected_font_color() const;
 
-	void set_selection_mode(SelectionMode p_mode, int p_line = -1, int p_column = -1);
+	void set_selection_mode(SelectionMode p_mode, int p_line = -1, int p_column = -1, int p_caret = 0);
 	SelectionMode get_selection_mode() const;
 
 	void select_all();
-	void select_word_under_caret();
-	void select(int p_from_line, int p_from_column, int p_to_line, int p_to_column);
+	void select_word_under_caret(int p_caret = -1);
+	void select(int p_from_line, int p_from_column, int p_to_line, int p_to_column, int p_caret = 0);
 
-	bool has_selection() const;
+	bool has_selection(int p_caret = -1) const;
 
-	String get_selected_text() const;
+	String get_selected_text(int p_caret = -1);
 
-	int get_selection_line() const;
-	int get_selection_column() const;
+	int get_selection_line(int p_caret = 0) const;
+	int get_selection_column(int p_caret = 0) const;
 
-	int get_selection_from_line() const;
-	int get_selection_from_column() const;
-	int get_selection_to_line() const;
-	int get_selection_to_column() const;
+	int get_selection_from_line(int p_caret = 0) const;
+	int get_selection_from_column(int p_caret = 0) const;
+	int get_selection_to_line(int p_caret = 0) const;
+	int get_selection_to_column(int p_caret = 0) const;
 
-	void deselect();
-	void delete_selection();
+	void deselect(int p_caret = -1);
+	void delete_selection(int p_caret = -1);
 
 	/* Line wrapping. */
 	void set_line_wrapping_mode(LineWrappingMode p_wrapping_mode);
@@ -866,8 +915,8 @@ public:
 	int get_total_visible_line_count() const;
 
 	// Auto Adjust
-	void adjust_viewport_to_caret();
-	void center_viewport_to_caret();
+	void adjust_viewport_to_caret(int p_caret = 0);
+	void center_viewport_to_caret(int p_caret = 0);
 
 	// Minimap
 	void set_draw_minimap(bool p_enabled);
@@ -949,6 +998,7 @@ public:
 	TextEdit(const String &p_placeholder = String());
 };
 
+VARIANT_ENUM_CAST(TextEdit::EditAction);
 VARIANT_ENUM_CAST(TextEdit::CaretType);
 VARIANT_ENUM_CAST(TextEdit::LineWrappingMode);
 VARIANT_ENUM_CAST(TextEdit::SelectionMode);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -361,15 +361,30 @@ private:
 	int _get_char_pos_for_line(int p_px, int p_line, int p_wrap_index = 0) const;
 
 	/* Caret. */
+	struct Selection {
+		bool active = false;
+		bool shiftclick_left = false;
+
+		int selecting_line = 0;
+		int selecting_column = 0;
+		int selected_word_beg = 0;
+		int selected_word_end = 0;
+		int selected_word_origin = 0;
+
+		int from_line = 0;
+		int from_column = 0;
+		int to_line = 0;
+		int to_column = 0;
+	};
+
 	struct Caret {
+		Selection selection;
+
 		Point2 draw_pos;
 		bool visible = false;
 		int last_fit_x = 0;
 		int line = 0;
 		int column = 0;
-		int x_ofs = 0;
-		int line_ofs = 0;
-		int wrap_ofs = 0;
 	} caret;
 
 	bool setting_caret_line = false;
@@ -400,25 +415,7 @@ private:
 	int _get_column_x_offset_for_line(int p_char, int p_line) const;
 
 	/* Selection. */
-	struct Selection {
-		SelectionMode selecting_mode = SelectionMode::SELECTION_MODE_NONE;
-		int selecting_line = 0;
-		int selecting_column = 0;
-		int selected_word_beg = 0;
-		int selected_word_end = 0;
-		int selected_word_origin = 0;
-		bool selecting_text = false;
-
-		bool active = false;
-
-		int from_line = 0;
-		int from_column = 0;
-		int to_line = 0;
-		int to_column = 0;
-
-		bool shiftclick_left = false;
-		bool drag_attempt = false;
-	} selection;
+	SelectionMode selecting_mode = SelectionMode::SELECTION_MODE_NONE;
 
 	bool selecting_enabled = true;
 	bool deselect_on_focus_loss_enabled = true;
@@ -428,6 +425,7 @@ private:
 	Color selection_color = Color(1, 1, 1);
 	bool override_selected_font_color = false;
 
+	bool selection_drag_attempt = false;
 	bool dragging_selection = false;
 
 	Timer *click_select_held = nullptr;
@@ -450,8 +448,6 @@ private:
 
 	void _update_wrap_at_column(bool p_force = false);
 
-	void _update_caret_wrap_offset();
-
 	/* Viewport. */
 	HScrollBar *h_scroll = nullptr;
 	VScrollBar *v_scroll = nullptr;
@@ -466,6 +462,10 @@ private:
 	float v_scroll_speed = 80.0;
 
 	// Scrolling.
+	int first_visible_line = 0;
+	int first_visible_line_wrap_ofs = 0;
+	int first_visible_col = 0;
+
 	bool scrolling = false;
 	bool updating_scrolls = false;
 

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -93,10 +93,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "test text");
-			CHECK(text_edit->get_caret_column() == 9);
+			CHECK(text_edit->get_caret_column() == 0);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_set");
 
 			text_edit->redo();
@@ -104,18 +104,18 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_text() == "");
 			CHECK(text_edit->get_caret_column() == 0);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Cannot undo when not-editable but should still clear.
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "test text");
-			CHECK(text_edit->get_caret_column() == 9);
+			CHECK(text_edit->get_caret_column() == 0);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Clear.
@@ -131,8 +131,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_text() == "");
 			CHECK(text_edit->get_caret_column() == 0);
 			SIGNAL_CHECK("text_set", empty_signal_args);
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_clear_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 
 			text_edit->set_editable(true);
@@ -252,6 +252,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_line(0) == "te");
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selected_text() == "te");
+			CHECK(text_edit->get_caret_column() == 2);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -263,6 +264,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_line(0) == "test text");
 			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text() == "test");
+			CHECK(text_edit->get_caret_column() == 4);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -271,7 +274,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->redo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_line(0) == "te");
-			CHECK_FALSE(text_edit->has_selection()); // Currently not handled.
+			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_caret_column() == 2);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -425,7 +429,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "testing\nswap");
-			CHECK_FALSE(text_edit->has_selection()); // Not currently handled.
+			CHECK(text_edit->has_selection());
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -436,7 +440,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->redo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "new\ntesting\nswap");
-			CHECK_FALSE(text_edit->has_selection()); // Not currently handled.
+			CHECK(text_edit->has_selection());
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -448,7 +452,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->has_selection());
 			CHECK(text_edit->get_selection_from_line() == 0);
 			CHECK(text_edit->get_selection_to_line() == 2);
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
 
 			((Array)lines_edited_args[0])[0] = 2;
 			((Array)lines_edited_args[0])[1] = 3;
@@ -533,7 +537,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "temidsting\nswap");
 			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 10);
+			CHECK(text_edit->get_caret_column() == 5);
 			CHECK(text_edit->has_selection());
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -950,11 +954,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->delete_selection();
 			CHECK(text_edit->get_text() == "this is some text\nfor selection");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 8);
 
 			text_edit->select(0, 8, 0, 4);
 			CHECK(text_edit->has_selection());
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
 			CHECK(text_edit->get_text() == "thissome text\nfor selection");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
 
 			text_edit->undo();
 			CHECK(text_edit->has_selection());
@@ -966,7 +974,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_text() == "thissome text\nfor selection");
 			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 8);
+			CHECK(text_edit->get_caret_column() == 4);
 
 			text_edit->undo();
 			CHECK(text_edit->has_selection());
@@ -991,7 +999,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK_FALSE(text_edit->has_selection());
 			CHECK(text_edit->get_text() == "thissome text\nfor selection");
 			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 8);
+			CHECK(text_edit->get_caret_column() == 4);
 
 			text_edit->undo();
 			CHECK(text_edit->has_selection());
@@ -1176,8 +1184,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "this is\nsome\n");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 6);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1187,9 +1195,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->redo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "some\n");
-			CHECK(text_edit->get_caret_line() == 1);
-			CHECK(text_edit->get_caret_column() == 0);
-			SIGNAL_CHECK_FALSE("caret_changed");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 4);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
@@ -1259,9 +1267,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		lines_edited_args.push_back(args1);
 
 		SUBCASE("[TextEdit] ui_text_newline_above") {
-			text_edit->set_text("this is some test text.");
+			text_edit->set_text("this is some test text.\nthis is some test text.");
 			text_edit->select(0, 0, 0, 4);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(1, 4);
+			text_edit->select(1, 0, 1, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1269,50 +1282,78 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			((Array)lines_edited_args[0])[1] = 1;
+			// For the second caret.
+			Array args2;
+			args2.push_back(0);
+			args2.push_back(1);
+			lines_edited_args.push_front(args2);
+
+			((Array)lines_edited_args[1])[1] = 1;
 			SEND_GUI_ACTION(text_edit, "ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
+			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(4);
-			text_edit->select(0, 0, 0, 4);
+
+			text_edit->set_caret_line(3, false, true, 0, 1);
+			text_edit->set_caret_column(4, false, 1);
 			MessageQueue::get_singleton()->flush();
 			SIGNAL_DISCARD("caret_changed");
 
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
+			CHECK(text_edit->get_text() == "\nthis is some test text.\n\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 4);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 4);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
+			((Array)lines_edited_args[0])[0] = 2;
+			((Array)lines_edited_args[0])[1] = 3;
+
 			SEND_GUI_ACTION(text_edit, "ui_text_newline_above");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n\nthis is some test text.");
+			CHECK(text_edit->get_text() == "\n\nthis is some test text.\n\n\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 4);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 		}
 
 		SUBCASE("[TextEdit] ui_text_newline_blank") {
-			text_edit->set_text("this is some test text.");
+			text_edit->set_text("this is some test text.\nthis is some test text.");
 			text_edit->select(0, 0, 0, 4);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(1, 4);
+			text_edit->select(1, 0, 1, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1320,13 +1361,23 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			((Array)lines_edited_args[0])[1] = 1;
+			// For the second caret.
+			Array args2;
+			args2.push_back(1);
+			args2.push_back(2);
+			lines_edited_args.push_front(args2);
+
+			((Array)lines_edited_args[1])[1] = 1;
 			SEND_GUI_ACTION(text_edit, "ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text.\n");
+			CHECK(text_edit->get_text() == "this is some test text.\n\nthis is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1334,10 +1385,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_newline_blank");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text.\n");
+			CHECK(text_edit->get_text() == "this is some test text.\n\nthis is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -1345,9 +1400,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] ui_text_newline") {
-			text_edit->set_text("this is some test text.");
+			text_edit->set_text("this is some test text.\nthis is some test text.");
 			text_edit->select(0, 0, 0, 4);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(1, 4);
+			text_edit->select(1, 0, 1, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1355,14 +1415,27 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			lines_edited_args.push_back(lines_edited_args[0].duplicate());
-			((Array)lines_edited_args[1])[1] = 1;
+			// For the second caret.
+			Array args2;
+			args2.push_back(1);
+			args2.push_back(1);
+			lines_edited_args.push_front(args2);
+			lines_edited_args.push_front(args2.duplicate());
+			((Array)lines_edited_args[1])[1] = 2;
+
+			lines_edited_args.push_back(lines_edited_args[2].duplicate());
+			((Array)lines_edited_args[3])[1] = 1;
+
 			SEND_GUI_ACTION(text_edit, "ui_text_newline");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.");
+			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1370,10 +1443,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_newline");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.");
+			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -1381,10 +1458,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] ui_text_backspace_all_to_left") {
-			text_edit->set_text("\nthis is some test text.");
+			text_edit->set_text("\nthis is some test text.\n\nthis is some test text.");
 			text_edit->select(1, 0, 1, 4);
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(3, 4);
+			text_edit->select(3, 0, 3, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			Ref<InputEvent> tmpevent = InputEventKey::create_reference(Key::BACKSPACE | KeyModifierMask::ALT | KeyModifierMask::CMD_OR_CTRL);
@@ -1395,34 +1477,50 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// For the second caret.
+			Array args2;
+			args2.push_back(3);
+			args2.push_back(3);
+			lines_edited_args.push_front(args2);
+
 			// With selection should be a normal backspace.
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 1;
+			((Array)lines_edited_args[1])[0] = 1;
+			((Array)lines_edited_args[1])[1] = 1;
 
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.");
+			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[1] = 0;
+			((Array)lines_edited_args[0])[1] = 2;
+			((Array)lines_edited_args[1])[1] = 0;
 
 			// Start of line should also be a normal backspace.
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->set_caret_column(text_edit->get_line(0).length());
+			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1433,23 +1531,33 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			((Array)lines_edited_args[0])[0] = 0;
+			((Array)lines_edited_args[0])[0] = 1;
+			((Array)lines_edited_args[0])[1] = 1;
+			((Array)lines_edited_args[1])[0] = 0;
 
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace_all_to_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_text() == "\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1458,10 +1566,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		}
 
 		SUBCASE("[TextEdit] ui_text_backspace_word") {
-			text_edit->set_text("\nthis is some test text.");
+			text_edit->set_text("\nthis is some test text.\n\nthis is some test text.");
 			text_edit->select(1, 0, 1, 4);
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(3, 4);
+			text_edit->select(3, 0, 3, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1469,30 +1581,45 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// For the second caret.
+			Array args2;
+			args2.push_back(3);
+			args2.push_back(3);
+			lines_edited_args.push_front(args2);
+
 			// With selection should be a normal backspace.
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 1;
+			((Array)lines_edited_args[1])[0] = 1;
+			((Array)lines_edited_args[1])[1] = 1;
 
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.");
+			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			text_edit->end_complex_operation();
 
-			((Array)lines_edited_args[0])[1] = 0;
+			((Array)lines_edited_args[0])[1] = 2;
+			((Array)lines_edited_args[1])[1] = 0;
 
 			// Start of line should also be a normal backspace.
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1500,16 +1627,21 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
 			text_edit->set_caret_column(text_edit->get_line(0).length());
+			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1517,24 +1649,35 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			((Array)lines_edited_args[0])[0] = 0;
+			((Array)lines_edited_args[0])[0] = 1;
+			((Array)lines_edited_args[0])[1] = 1;
+			((Array)lines_edited_args[1])[0] = 0;
 
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test ");
+			CHECK(text_edit->get_text() == " is some test \n is some test ");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 14);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 14);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 		}
 
 		SUBCASE("[TextEdit] ui_text_backspace") {
-			text_edit->set_text("\nthis is some test text.");
+			text_edit->set_text("\nthis is some test text.\n\nthis is some test text.");
 			text_edit->select(1, 0, 1, 4);
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(3, 4);
+			text_edit->select(3, 0, 3, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1542,34 +1685,50 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// For the second caret.
+			Array args2;
+			args2.push_back(3);
+			args2.push_back(3);
+			lines_edited_args.push_front(args2);
+
 			// With selection should be a normal backspace.
-			((Array)lines_edited_args[0])[0] = 1;
-			((Array)lines_edited_args[0])[1] = 1;
+			((Array)lines_edited_args[1])[0] = 1;
+			((Array)lines_edited_args[1])[1] = 1;
 
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n is some test text.");
+			CHECK(text_edit->get_text() == "\n is some test text.\n\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[1] = 0;
+			((Array)lines_edited_args[0])[1] = 2;
+			((Array)lines_edited_args[1])[1] = 0;
 
 			// Start of line should also be a normal backspace.
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->set_caret_column(text_edit->get_line(0).length());
+			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1580,23 +1739,33 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			((Array)lines_edited_args[0])[0] = 0;
+			((Array)lines_edited_args[0])[0] = 1;
+			((Array)lines_edited_args[0])[1] = 1;
+			((Array)lines_edited_args[1])[0] = 0;
 
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text");
+			CHECK(text_edit->get_text() == " is some test text\n is some test text");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 18);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 18);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1605,6 +1774,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->select(0, 18, 0, 0);
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(0);
+
+			text_edit->select(1, 18, 1, 0, 1);
+			text_edit->set_caret_line(1, false, true, 0, 1);
+			text_edit->set_caret_column(0, false, 1);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1612,12 +1785,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
-			((Array)lines_edited_args[0])[0] = 0;
-
 			SEND_GUI_ACTION(text_edit, "ui_text_backspace");
-			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_text() == "\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1627,10 +1800,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			Ref<InputEvent> tmpevent = InputEventKey::create_reference(Key::BACKSPACE | KeyModifierMask::ALT | KeyModifierMask::CMD_OR_CTRL);
 			InputMap::get_singleton()->action_add_event("ui_text_delete_all_to_right", tmpevent);
 
-			text_edit->set_text("this is some test text.\n");
+			text_edit->set_text("this is some test text.\nthis is some test text.\n");
 			text_edit->select(0, 0, 0, 4);
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(1, 4);
+			text_edit->select(1, 0, 1, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1638,19 +1816,30 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// For the second caret.
+			Array args2;
+			args2.push_back(1);
+			args2.push_back(1);
+			lines_edited_args.push_front(args2);
+
 			// With selection should be a normal delete.
 			SEND_GUI_ACTION(text_edit, "ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// End of line should not do anything.
 			text_edit->set_caret_column(text_edit->get_line(0).length());
+			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1660,15 +1849,20 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			SEND_GUI_ACTION(text_edit, "ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
 			text_edit->set_caret_column(0);
+			text_edit->set_caret_column(0, false, 1);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1679,10 +1873,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " is some test text.\n");
+			CHECK(text_edit->get_text() == " is some test text.\n is some test text.\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -1690,10 +1888,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			SEND_GUI_ACTION(text_edit, "ui_text_delete_all_to_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\n");
+			CHECK(text_edit->get_text() == "\n\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1705,10 +1907,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_mid_grapheme_enabled(true);
 			CHECK(text_edit->is_caret_mid_grapheme_enabled());
 
-			text_edit->set_text("this ffi some test text.\n");
+			text_edit->set_text("this ffi some test text.\n\nthis ffi some test text.\n");
 			text_edit->select(0, 0, 0, 4);
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(2, 4);
+			text_edit->select(2, 0, 2, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1716,20 +1923,32 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// For the second caret.
+			Array args2;
+			args2.push_back(2);
+			args2.push_back(2);
+			lines_edited_args.push_front(args2);
+
 			// With selection should be a normal delete.
 			SEND_GUI_ACTION(text_edit, "ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.\n");
+			CHECK(text_edit->get_text() == " ffi some test text.\n\n ffi some test text.\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// With selection should be a normal delete.
-			((Array)lines_edited_args[0])[0] = 1;
+			((Array)lines_edited_args[0])[0] = 3;
+			((Array)lines_edited_args[1])[0] = 1;
 			text_edit->set_caret_column(text_edit->get_line(0).length());
+			text_edit->set_caret_column(text_edit->get_line(2).length(), false, 1);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1739,16 +1958,23 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			SEND_GUI_ACTION(text_edit, "ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.");
+			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
 			CHECK_FALSE(text_edit->has_selection());
-			SIGNAL_CHECK_FALSE("caret_changed");
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
+			CHECK_FALSE(text_edit->has_selection(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[0] = 0;
+			((Array)lines_edited_args[1])[0] = 0;
+			((Array)lines_edited_args[0])[0] = 1;
+			((Array)lines_edited_args[0])[1] = 1;
 			text_edit->set_caret_column(0);
+			text_edit->set_caret_column(0, false, 1);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1759,10 +1985,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.");
+			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -1770,10 +2000,14 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			SEND_GUI_ACTION(text_edit, "ui_text_delete_word");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " some test text.");
+			CHECK(text_edit->get_text() == " some test text.\n some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -1783,10 +2017,15 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_caret_mid_grapheme_enabled(true);
 			CHECK(text_edit->is_caret_mid_grapheme_enabled());
 
-			text_edit->set_text("this ffi some test text.\n");
+			text_edit->set_text("this ffi some test text.\nthis ffi some test text.");
 			text_edit->select(0, 0, 0, 4);
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(4);
+
+			text_edit->add_caret(1, 4);
+			text_edit->select(1, 0, 1, 4, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1794,19 +2033,31 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// For the second caret.
+			Array args2;
+			args2.push_back(1);
+			args2.push_back(1);
+			lines_edited_args.push_front(args2);
+
 			// With selection should be a normal delete.
 			SEND_GUI_ACTION(text_edit, "ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.\n");
+			CHECK(text_edit->get_text() == " ffi some test text.\n ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			// With selection should be a normal delete.
+			lines_edited_args.remove_at(0);
 			((Array)lines_edited_args[0])[0] = 1;
+			text_edit->set_caret_column(text_edit->get_line(1).length(), false, 1);
 			text_edit->set_caret_column(text_edit->get_line(0).length());
 			MessageQueue::get_singleton()->flush();
 
@@ -1817,16 +2068,25 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			SEND_GUI_ACTION(text_edit, "ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.");
+			CHECK(text_edit->get_text() == " ffi some test text. ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
-			CHECK_FALSE(text_edit->has_selection());
-			SIGNAL_CHECK_FALSE("caret_changed");
+			CHECK(text_edit->get_caret_column() == 20);
+			CHECK_FALSE(text_edit->has_selection(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
-			((Array)lines_edited_args[0])[0] = 0;
+			// Caret should be removed due to column preservation.
+			CHECK(text_edit->get_caret_count() == 1);
+
+			// Lets add it back.
 			text_edit->set_caret_column(0);
+			text_edit->add_caret(0, 20);
+
+			((Array)lines_edited_args[0])[0] = 0;
+			lines_edited_args.push_back(args2);
+			((Array)lines_edited_args[1])[0] = 0;
+			((Array)lines_edited_args[1])[1] = 0;
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1837,43 +2097,59 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_ACTION(text_edit, "ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " ffi some test text.");
+			CHECK(text_edit->get_text() == " ffi some test text. ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 20);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			SEND_GUI_ACTION(text_edit, "ui_text_delete");
-			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "ffi some test text.");
-			CHECK(text_edit->get_caret_line() == 0);
-			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
-			SIGNAL_CHECK_FALSE("caret_changed");
-			SIGNAL_CHECK("text_changed", empty_signal_args);
-			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
 
 			SEND_GUI_ACTION(text_edit, "ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "fi some test text.");
+			CHECK(text_edit->get_text() == "ffi some test text.ffi some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
-			SIGNAL_CHECK_FALSE("caret_changed");
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 19);
+			CHECK_FALSE(text_edit->has_selection(0));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+
+			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
+
+			SEND_GUI_ACTION(text_edit, "ui_text_delete");
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_text() == "fi some test text.fi some test text.");
+			CHECK(text_edit->get_caret_line() == 0);
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 18);
+			CHECK_FALSE(text_edit->has_selection(1));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->set_caret_mid_grapheme_enabled(false);
 			CHECK_FALSE(text_edit->is_caret_mid_grapheme_enabled());
 
+			text_edit->start_action(TextEdit::EditAction::ACTION_NONE);
+
 			text_edit->undo();
-			text_edit->set_caret_line(0);
-			text_edit->set_caret_column(0);
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_text() == "ffi some test text.");
+			CHECK(text_edit->get_text() == "ffi some test text.ffi some test text.");
 
 			SIGNAL_DISCARD("text_set");
 			SIGNAL_DISCARD("text_changed");
@@ -1882,19 +2158,26 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			SEND_GUI_ACTION(text_edit, "ui_text_delete");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == " some test text.");
+			CHECK(text_edit->get_text() == " some test text. some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
-			SIGNAL_CHECK_FALSE("caret_changed");
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 0);
+			CHECK(text_edit->get_caret_column(1) == 16);
+			CHECK_FALSE(text_edit->has_selection(1));
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 		}
 
 		SUBCASE("[TextEdit] ui_text_caret_word_left") {
-			text_edit->set_text("\nthis is some test text.");
+			text_edit->set_text("\nthis is some test text.\nthis is some test text.");
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(7);
+
+			text_edit->add_caret(2, 7);
+			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1902,47 +2185,67 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Shift should select.
 #ifdef MACOS_ENABLED
 			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
 #else
 			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
-			CHECK(text_edit->get_selected_text() == "is");
-			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text(0) == "is");
+			CHECK(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 5);
+			CHECK(text_edit->get_selected_text(1) == "is");
+			CHECK(text_edit->has_selection(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Should still move caret with selection.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_word_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Normal word left.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_word_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 23);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 		}
 
 		SUBCASE("[TextEdit] ui_text_caret_left") {
-			text_edit->set_text("\nthis is some test text.");
+			text_edit->set_text("\nthis is some test text.\nthis is some test text.");
 			text_edit->set_caret_line(1);
 			text_edit->set_caret_column(7);
 			text_edit->select(1, 2, 1, 7);
+
+			text_edit->add_caret(2, 7);
+			text_edit->select(2, 2, 2, 7, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -1950,62 +2253,91 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Normal left shoud deselect and place at selection start.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
+
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 2);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			CHECK_FALSE(text_edit->has_selection(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// With shift should select.
 			SEND_GUI_KEY_EVENT(text_edit, Key::LEFT | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 1);
-			CHECK(text_edit->get_selected_text() == "h");
-			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text(0) == "h");
+			CHECK(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 1);
+			CHECK(text_edit->get_selected_text(1) == "h");
+			CHECK(text_edit->has_selection(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// All ready at select left, should only deselect.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 1);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 1);
+			CHECK_FALSE(text_edit->has_selection(1));
+
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Normal left.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 0);
 			CHECK_FALSE(text_edit->has_selection());
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Left at col 0 should go up a line.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_left");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "\nthis is some test text.");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 23);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 		}
 
 		SUBCASE("[TextEdit] ui_text_caret_word_right") {
-			text_edit->set_text("this is some test text\n");
+			text_edit->set_text("this is some test text\n\nthis is some test text\n");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(13);
+
+			text_edit->add_caret(2, 13);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -2013,47 +2345,67 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Shift should select.
 #ifdef MACOS_ENABLED
 			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::ALT | KeyModifierMask::SHIFT);
 #else
 			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT);
 #endif
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 17);
-			CHECK(text_edit->get_selected_text() == "test");
-			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text(0) == "test");
+			CHECK(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 17);
+			CHECK(text_edit->get_selected_text(1) == "test");
+			CHECK(text_edit->has_selection(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Should still move caret with selection.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_word_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 22);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 22);
+			CHECK_FALSE(text_edit->has_selection(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Normal word right.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_word_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text\n");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 		}
 
 		SUBCASE("[TextEdit] ui_text_caret_right") {
-			text_edit->set_text("this is some test text\n");
+			text_edit->set_text("this is some test text\n\nthis is some test text\n");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(16);
 			text_edit->select(0, 16, 0, 20);
+
+			text_edit->add_caret(2, 16);
+			text_edit->select(2, 16, 2, 20, 1);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			SIGNAL_DISCARD("text_set");
@@ -2061,53 +2413,76 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Normal right shoud deselect and place at selection start.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 20);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 20);
+			CHECK_FALSE(text_edit->has_selection(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// With shift should select.
 			SEND_GUI_KEY_EVENT(text_edit, Key::RIGHT | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 21);
-			CHECK(text_edit->get_selected_text() == "x");
-			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text(0) == "x");
+			CHECK(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 21);
+			CHECK(text_edit->get_selected_text(1) == "x");
+			CHECK(text_edit->has_selection(1));
+
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// All ready at select right, should only deselect.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 21);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 21);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Normal right.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text\n");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 22);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 2);
+			CHECK(text_edit->get_caret_column(1) == 22);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Right at end col should go down a line.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_right");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some test text\n");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 3);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2117,9 +2492,13 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 
 			text_edit->set_size(Size2(110, 100));
-			text_edit->set_text("this is some\nother test\nlines\ngo here");
-			text_edit->set_caret_line(4);
+			text_edit->set_text("this is some\nother test\nlines\ngo here\nthis is some\nother test\nlines\ngo here");
+			text_edit->set_caret_line(3);
 			text_edit->set_caret_column(7);
+
+			text_edit->add_caret(7, 7);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			CHECK(text_edit->is_line_wrapped(0));
@@ -2128,44 +2507,61 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Select + up should select everything to the left on that line.
 			SEND_GUI_KEY_EVENT(text_edit, Key::UP | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some\nother test\nlines\ngo here");
 			CHECK(text_edit->get_caret_line() == 2);
 			CHECK(text_edit->get_caret_column() == 5);
-			CHECK(text_edit->get_selected_text() == "\ngo here");
-			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text(0) == "\ngo here");
+			CHECK(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 6);
+			CHECK(text_edit->get_caret_column(1) == 5);
+			CHECK(text_edit->get_selected_text(1) == "\ngo here");
+			CHECK(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Should deselect and move up.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_up");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some\nother test\nlines\ngo here");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 8);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 5);
+			CHECK(text_edit->get_caret_column(1) == 8);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Normal up over wrapped line.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_up");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some\nother test\nlines\ngo here");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 12);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 4);
+			CHECK(text_edit->get_caret_column(1) == 12);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_caret_column(12, false);
 
+			// Normal up over wrapped line to line 0.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_up");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "this is some\nother test\nlines\ngo here");
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 7);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 4);
+			CHECK(text_edit->get_caret_column(1) == 7);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2175,9 +2571,13 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 
 			text_edit->set_size(Size2(110, 100));
-			text_edit->set_text("go here\nlines\nother test\nthis is some");
+			text_edit->set_text("go here\nlines\nother test\nthis is some\ngo here\nlines\nother test\nthis is some");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(7);
+
+			text_edit->add_caret(4, 7);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			CHECK(text_edit->is_line_wrapped(3));
@@ -2186,44 +2586,61 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// Select + down should select everything to the right on that line.
 			SEND_GUI_KEY_EVENT(text_edit, Key::DOWN | KeyModifierMask::SHIFT);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "go here\nlines\nother test\nthis is some");
 			CHECK(text_edit->get_caret_line() == 1);
 			CHECK(text_edit->get_caret_column() == 5);
-			CHECK(text_edit->get_selected_text() == "\nlines");
-			CHECK(text_edit->has_selection());
+			CHECK(text_edit->get_selected_text(0) == "\nlines");
+			CHECK(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 5);
+			CHECK(text_edit->get_caret_column(1) == 5);
+			CHECK(text_edit->get_selected_text(1) == "\nlines");
+			CHECK(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Should deselect and move down.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_down");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "go here\nlines\nother test\nthis is some");
 			CHECK(text_edit->get_caret_line() == 2);
 			CHECK(text_edit->get_caret_column() == 8);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 6);
+			CHECK(text_edit->get_caret_column(1) == 8);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 
+			// Normal down over wrapped line.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_down");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "go here\nlines\nother test\nthis is some");
 			CHECK(text_edit->get_caret_line() == 3);
 			CHECK(text_edit->get_caret_column() == 7);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 7);
+			CHECK(text_edit->get_caret_column(1) == 7);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_caret_column(7, false);
 
+			// Normal down over wrapped line to last wrapped line.
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_down");
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "go here\nlines\nother test\nthis is some");
 			CHECK(text_edit->get_caret_line() == 3);
 			CHECK(text_edit->get_caret_column() == 12);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 7);
+			CHECK(text_edit->get_caret_column(1) == 12);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2236,6 +2653,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_text("this is some\nother test\nlines\ngo here");
 			text_edit->set_caret_line(4);
 			text_edit->set_caret_column(7);
+
+			text_edit->add_caret(3, 2);
+			CHECK(text_edit->get_caret_count() == 2);
+
 			MessageQueue::get_singleton()->flush();
 
 			CHECK(text_edit->is_line_wrapped(0));
@@ -2258,6 +2679,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
+			CHECK(text_edit->get_caret_count() == 1);
 
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_document_start");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -2277,6 +2699,9 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_text("go here\nlines\nother test\nthis is some");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(0);
+
+			text_edit->add_caret(1, 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 
 			CHECK(text_edit->is_line_wrapped(3));
@@ -2299,6 +2724,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
+			CHECK(text_edit->get_caret_count() == 1);
 
 			SEND_GUI_ACTION(text_edit, "ui_text_caret_document_end");
 			CHECK(text_edit->get_viewport()->is_input_handled());
@@ -2315,9 +2741,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 
 			text_edit->set_size(Size2(110, 100));
-			text_edit->set_text("  this is some");
+			text_edit->set_text("  this is some\n  this is some");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(text_edit->get_line(0).length());
+
+			text_edit->add_caret(1, text_edit->get_line(1).length());
+			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 
 			CHECK(text_edit->is_line_wrapped(0));
@@ -2334,8 +2763,13 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 10);
-			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_selected_text() == "some");
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "some");
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 10);
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "some");
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2344,7 +2778,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 2);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2353,7 +2791,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 0);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 0);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2362,7 +2804,11 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 2);
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 2);
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2372,9 +2818,12 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 
 			text_edit->set_size(Size2(110, 100));
-			text_edit->set_text("  this is some");
+			text_edit->set_text("  this is some\n  this is some");
 			text_edit->set_caret_line(0);
 			text_edit->set_caret_column(0);
+
+			text_edit->add_caret(1, 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			MessageQueue::get_singleton()->flush();
 
 			CHECK(text_edit->is_line_wrapped(0));
@@ -2391,8 +2840,13 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == 9);
-			CHECK(text_edit->has_selection());
-			CHECK(text_edit->get_selected_text() == "  this is");
+			CHECK(text_edit->has_selection(0));
+			CHECK(text_edit->get_selected_text(0) == "  this is");
+
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == 9);
+			CHECK(text_edit->has_selection(1));
+			CHECK(text_edit->get_selected_text(1) == "  this is");
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
@@ -2401,13 +2855,24 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_viewport()->is_input_handled());
 			CHECK(text_edit->get_caret_line() == 0);
 			CHECK(text_edit->get_caret_column() == text_edit->get_line(0).length());
-			CHECK_FALSE(text_edit->has_selection());
+			CHECK_FALSE(text_edit->has_selection(0));
+
+			CHECK(text_edit->get_viewport()->is_input_handled());
+			CHECK(text_edit->get_caret_line(1) == 1);
+			CHECK(text_edit->get_caret_column(1) == text_edit->get_line(1).length());
+			CHECK_FALSE(text_edit->has_selection(1));
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 		}
 
 		SUBCASE("[TextEdit] unicode") {
+			text_edit->set_text("\n");
+			text_edit->set_caret_line(0);
+			text_edit->set_caret_column(0);
+
+			text_edit->add_caret(1, 0);
+			CHECK(text_edit->get_caret_count() == 2);
 			text_edit->insert_text_at_caret("a");
 			MessageQueue::get_singleton()->flush();
 
@@ -2416,10 +2881,17 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_DISCARD("lines_edited_from");
 			SIGNAL_DISCARD("caret_changed");
 
+			// For the second caret.
+			Array args2;
+			args2.push_back(1);
+			args2.push_back(1);
+			lines_edited_args.push_front(args2);
+
 			SEND_GUI_KEY_EVENT(text_edit, Key::A);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "aA");
+			CHECK(text_edit->get_text() == "aA\naA");
 			CHECK(text_edit->get_caret_column() == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -2427,20 +2899,24 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->set_editable(false);
 			SEND_GUI_KEY_EVENT(text_edit, Key::A);
 			CHECK_FALSE(text_edit->get_viewport()->is_input_handled()); // Should this be handled?
-			CHECK(text_edit->get_text() == "aA");
+			CHECK(text_edit->get_text() == "aA\naA");
 			CHECK(text_edit->get_caret_column() == 2);
+			CHECK(text_edit->get_caret_column(1) == 2);
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("lines_edited_from");
 			text_edit->set_editable(true);
 
-			lines_edited_args.push_back(lines_edited_args[0].duplicate());
+			lines_edited_args.push_back(lines_edited_args[1].duplicate());
+			lines_edited_args.push_front(args2.duplicate());
 
 			text_edit->select(0, 0, 0, 1);
+			text_edit->select(1, 0, 1, 1, 1);
 			SEND_GUI_KEY_EVENT(text_edit, Key::B);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "BA");
+			CHECK(text_edit->get_text() == "BA\nBA");
 			CHECK(text_edit->get_caret_column() == 1);
+			CHECK(text_edit->get_caret_column(1) == 1);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -2450,17 +2926,19 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			SEND_GUI_KEY_EVENT(text_edit, Key::B);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "BB");
+			CHECK(text_edit->get_text() == "BB\nBB");
 			CHECK(text_edit->get_caret_column() == 2);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 
 			text_edit->select(0, 0, 0, 1);
+			text_edit->select(1, 0, 1, 1, 1);
 			SEND_GUI_KEY_EVENT(text_edit, Key::A);
 			CHECK(text_edit->get_viewport()->is_input_handled());
-			CHECK(text_edit->get_text() == "AB");
+			CHECK(text_edit->get_text() == "AB\nAB");
 			CHECK(text_edit->get_caret_column() == 1);
+			CHECK(text_edit->get_caret_column(1) == 1);
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
@@ -2558,7 +3036,7 @@ TEST_CASE("[SceneTree][TextEdit] versioning") {
 	CHECK(text_edit->has_redo());
 
 	text_edit->redo();
-	CHECK(text_edit->get_line(0) == "test nested ops");
+	CHECK(text_edit->get_line(0) == "test ops nested");
 	CHECK(text_edit->get_version() == 3);
 	CHECK(text_edit->get_saved_version() == 3);
 	CHECK(text_edit->has_undo());
@@ -2775,6 +3253,94 @@ TEST_CASE("[SceneTree][TextEdit] caret") {
 	CHECK(text_edit->get_caret_column() == 0);
 	text_edit->set_caret_column(10000000);
 	CHECK(text_edit->get_caret_column() == 141);
+
+	memdelete(text_edit);
+}
+
+TEST_CASE("[SceneTree][TextEdit] muiticaret") {
+	TextEdit *text_edit = memnew(TextEdit);
+	SceneTree::get_singleton()->get_root()->add_child(text_edit);
+	text_edit->set_multiple_carets_enabled(true);
+
+	Array empty_signal_args;
+	empty_signal_args.push_back(Array());
+
+	SIGNAL_WATCH(text_edit, "caret_changed");
+
+	text_edit->set_text("this is\nsome test\ntext");
+	text_edit->set_caret_line(0);
+	text_edit->set_caret_column(0);
+	MessageQueue::get_singleton()->flush();
+	SIGNAL_DISCARD("caret_changed");
+
+	SUBCASE("[TextEdit] add remove caret") {
+		// Overlapping
+		CHECK(text_edit->add_caret(0, 0) == -1);
+		MessageQueue::get_singleton()->flush();
+		SIGNAL_CHECK_FALSE("caret_changed");
+
+		// Selection
+		text_edit->select(0, 0, 2, 4);
+		CHECK(text_edit->add_caret(0, 0) == -1);
+		CHECK(text_edit->add_caret(2, 4) == -1);
+		CHECK(text_edit->add_caret(1, 2) == -1);
+
+		// Out of bounds
+		CHECK(text_edit->add_caret(-1, 0) == -1);
+		CHECK(text_edit->add_caret(5, 0) == -1);
+		CHECK(text_edit->add_caret(0, 100) == -1);
+
+		MessageQueue::get_singleton()->flush();
+		SIGNAL_CHECK_FALSE("caret_changed");
+
+		CHECK(text_edit->get_caret_count() == 1);
+
+		text_edit->deselect();
+		SIGNAL_CHECK_FALSE("caret_changed");
+
+		CHECK(text_edit->add_caret(0, 1) == 1);
+		MessageQueue::get_singleton()->flush();
+		SIGNAL_CHECK("caret_changed", empty_signal_args);
+		CHECK(text_edit->get_caret_count() == 2);
+
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 0);
+
+		CHECK(text_edit->get_caret_line(1) == 0);
+		CHECK(text_edit->get_caret_column(1) == 1);
+
+		ERR_PRINT_OFF;
+		text_edit->remove_caret(-1);
+		text_edit->remove_caret(5);
+		ERR_PRINT_ON;
+		CHECK(text_edit->get_caret_count() == 2);
+		SIGNAL_CHECK_FALSE("caret_changed");
+
+		text_edit->remove_caret(0);
+		SIGNAL_CHECK_FALSE("caret_changed");
+		CHECK(text_edit->get_caret_count() == 1);
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 1);
+	}
+
+	SUBCASE("[TextEdit] caret index edit order") {
+		Vector<int> caret_index_get_order;
+		caret_index_get_order.push_back(1);
+		caret_index_get_order.push_back(0);
+
+		CHECK(text_edit->add_caret(1, 0));
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK(text_edit->get_caret_index_edit_order() == caret_index_get_order);
+
+		text_edit->remove_secondary_carets();
+		text_edit->set_caret_line(1);
+		CHECK(text_edit->add_caret(0, 0));
+		CHECK(text_edit->get_caret_count() == 2);
+
+		caret_index_get_order.write[0] = 0;
+		caret_index_get_order.write[1] = 1;
+		CHECK(text_edit->get_caret_index_edit_order() == caret_index_get_order);
+	}
 
 	memdelete(text_edit);
 }


### PR DESCRIPTION
This PR implements the initial support for multiple carets in `TextEdit`. Adjusted `CodeEdit` and the Editor to support them.

This will most likely be the last major feature that I have time to make for 4.0.

Will look at adding multi-caret tests in a separate PR(s), as those will take a little while as this change is quite large.

---

For the initial support currently it's pretty bare bones, it's enabled by default. You can add an additional caret by `Alt + LeftClick`. Typing will insert at all carets etc. Caret '0' is the main caret, the viewport will always follow this caret unless selecting via the mouse with a secondary caret. Each caret also has it's own selection.

I've tried to make the behaviour when using multiple carets intuitive based on VSCode, SublimeText and QTCreator, but even between them there are a lot of differences and bugs. Not sure on performance with a lot of carets due to the checks etc but happy to optimise after.

In terms of API changes most of the viewport, caret and edit methods now take in a caret index, the caret index is one of the following:
- `-1` for all carets
- `0` for the main caret
- `1-x` for the rest

Each method is defaulted as appropriate so existing code should still work (as seen in current tests).

Each method will only accept `-1` where it makes sense. For example `has_selection(-1)` will return `true` if any caret has a selection. Whereas `get_caret_line` does not have a strong use case for supporting `-1`, so is defaulted to `0`.

Some utility methods have been exposed for handing multiple carets, they are as follows:
    - `add_caret` - Adds a caret.
    - `remove_caret` - Removes a caret.
    - `get_caret_count` - Gets the number of carets.
    - `remove_secondary_carets` - Removes all additional carets.
    - `merge_overlapping_carets` - Merges any carets and selections that are overlapping. Note this is not called when a caret changes position but after "actions", so if using the API it is possible to get into a state where carets do overlap. 
    - `get_caret_index_edit_order` - Returns a list of caret indexes in their edit order, this done from bottom to top. Edit order refers to the way action such as `insert_text_at_caret` are applied.
    - `adjust_carets_after_edit` - Should be called after editing a caret to reposition the carets affected by the edit such as adding a new line will need to push all carets and selection after that point down a line. This assumes edits are applied in edit order.

Do due a typing now having the potential to consist of multiple edits, the undo redo system would put each caret as a separate step. Using `[begin|end]_complex_operation` around this would force it into a single step. However this would only make each letter when typing a step, the typing session would not be. We needed a way to have a "hanging" complex op, this comes in the form of an "action". 

Calling `start_action` will end the current action if it is not the same, before starting the new one. `end_action` marks that the any changes from the action are over, however the action does not end until the timeout or another action is started. This can be done via directly calling `start_action`, `[begin|end]_complex_operation` or via a edit that triggers and undo redo step outside of the `[start|end]_action` calls.

There are currently four supported actions, intended as follow:
    - `None` - No current action.
    - `Typing` - Normal typing
    - `Backspace` - A backwards delete typically using the backspace
    - `Delete` - A forwards delete typically using the delete key.

This fixes some old issues where typing when the caret had a selection would be treated as an entire step, so completion would not work etc. Similarly, pressing the delete key would create an undo step for each letter, now they are treated like typing where multiple deletes are a single action.

Final notes on the undo redo, the system used to use a best guess approach to determine where the caret went, it will now restore the carets exactly as they were. One thing to watch out for, is many carets can spam the undo stack as it becomes difficult to merge them into a single item, as they move about due to other edits, this may cause the undo stack to fill up pretty fast.

Lastly, in order to get this is work, moved the viewport variables outside of the caret and gave them some slightly better names, and currently only the main caret is restored on launch.

---

closes godotengine/godot-proposals/issues/245
closes godotengine/godot-proposals/issues/3455