### PR TITLE
Show a GUI alert when crashing on desktop platforms

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -36,6 +36,7 @@
 #include "core/string/print_string.h"
 #include "core/version.h"
 #include "main/main.h"
+#include "servers/display_server.h"
 
 #ifndef DEBUG_ENABLED
 #undef CRASH_HANDLER_ENABLED
@@ -67,8 +68,12 @@ static void handle_crash(int sig) {
 	String _execpath = OS::get_singleton()->get_executable_path();
 
 	String msg;
+	String log_path;
 	if (ProjectSettings::get_singleton()) {
 		msg = GLOBAL_GET("debug/settings/crash_handler/message");
+		if (GLOBAL_GET("debug/file_logging/enable_file_logging")) {
+			log_path = ProjectSettings::get_singleton()->globalize_path(GLOBAL_GET("debug/file_logging/log_path"));
+		}
 	}
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
@@ -76,9 +81,12 @@ static void handle_crash(int sig) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
 	}
 
+	// Set window title while dumping the backtrace, as this can take 10+ seconds to finish.
+	DisplayServer::get_singleton()->window_set_title("ERROR: Program crashed, dumping backtrace...");
+
 	// Dump the backtrace to stderr with a message to the user
 	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed with signal %d", __FUNCTION__, sig));
+	print_error(vformat("%s: Program crashed with signal %d.", __FUNCTION__, sig));
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
 	if (String(GODOT_VERSION_HASH).is_empty()) {
@@ -155,6 +163,24 @@ static void handle_crash(int sig) {
 				print_error("================================================================");
 			}
 		}
+	}
+
+	// Notify the user that backtrace dumping is finished.
+	DisplayServer::get_singleton()->window_set_title("ERROR: Program crashed, dumped backtrace");
+
+	// Show alert so the user is aware of the crash, even if the engine wasn't started with visible stdout/stderr.
+	// This must be done after printing the backtrace to prevent the process from being blocked too early (`OS::alert()` is blocking).
+	if (!log_path.is_empty()) {
+		// `fprintf()` is used instead of `print_error()`, as this printed line must not be present
+		// in the log file (it references the log file itself).
+		fprintf(stderr, "\nFind the log file for this session at:\n%s\n\n", log_path.utf8().get_data());
+
+		if (DisplayServer::get_singleton()->get_name() != "headless") {
+			OS::get_singleton()->alert(vformat("%s: Program crashed with signal %d.\n\nFind the log file for this session at:\n%s\n\nClicking OK will open this log file. Please include the this log file's contents in bug reports.", __FUNCTION__, sig, log_path), "Crash");
+			OS::get_singleton()->shell_open(log_path.utf8().get_data());
+		}
+	} else if (DisplayServer::get_singleton()->get_name() != "headless") {
+		OS::get_singleton()->alert(vformat("%s: Program crashed with signal %d.", __FUNCTION__, sig), "Crash");
 	}
 
 	// Abort to pass the error to the OS

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -36,6 +36,7 @@
 #include "core/string/print_string.h"
 #include "core/version.h"
 #include "main/main.h"
+#include "servers/display_server.h"
 
 #include <unistd.h>
 
@@ -90,8 +91,12 @@ static void handle_crash(int sig) {
 	String _execpath = OS::get_singleton()->get_executable_path();
 
 	String msg;
+	String log_path;
 	if (ProjectSettings::get_singleton()) {
 		msg = GLOBAL_GET("debug/settings/crash_handler/message");
+		if (GLOBAL_GET("debug/file_logging/enable_file_logging")) {
+			log_path = ProjectSettings::get_singleton()->globalize_path(GLOBAL_GET("debug/file_logging/log_path"));
+		}
 	}
 
 	// Tell MainLoop about the crash. This can be handled by users too in Node.
@@ -99,9 +104,12 @@ static void handle_crash(int sig) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
 	}
 
+	// Set window title while dumping the backtrace, as this can take 10+ seconds to finish.
+	DisplayServer::get_singleton()->window_set_title("ERROR: Program crashed, dumping backtrace...");
+
 	// Dump the backtrace to stderr with a message to the user
 	print_error("\n================================================================");
-	print_error(vformat("%s: Program crashed with signal %d", __FUNCTION__, sig));
+	print_error(vformat("%s: Program crashed with signal %d.", __FUNCTION__, sig));
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
 	if (String(GODOT_VERSION_HASH).is_empty()) {
@@ -185,6 +193,36 @@ static void handle_crash(int sig) {
 				print_error("================================================================");
 			}
 		}
+	}
+
+	// Notify the user that backtrace dumping is finished.
+	DisplayServer::get_singleton()->window_set_title("ERROR: Program crashed, dumped backtrace");
+
+	// Show alert so the user is aware of the crash, even if the engine wasn't started with visible stdout/stderr.
+	// This must be done after printing the backtrace to prevent the process from being blocked too early (`OS::alert()` is blocking).
+	if (!log_path.is_empty()) {
+		// `fprintf()` is used instead of `print_error()`, as this printed line must not be present
+		// in the log file (it references the log file itself).
+		fprintf(stderr, "\nFind the log file for this session at:\n%s\n\n", log_path.utf8().get_data());
+
+		if (DisplayServer::get_singleton()->get_name() != "headless") {
+			// Use AppleScript in `OS::execute()` instead of `OS::alert()` so that it works even when the OS event loop is blocked by the crash handler.
+			// (this is only required on macOS).
+			List<String> args;
+			args.push_back("-e");
+			args.push_back(vformat("display alert \"Crash\" message \"%s: Program crashed with signal %d.\\n\\nFind the log file for this session at:\\n%s\\n\\nClicking OK will open this log file. Please include the this log file's contents in bug reports.\"", __FUNCTION__, sig, log_path.c_escape()));
+			OS::get_singleton()->execute("osascript", args);
+			args.clear();
+			args.push_back(log_path);
+			// Use `OS::execute()` instead of `OS::shell_open()` so that it works even when the OS event loop is blocked by the crash handler.
+			OS::get_singleton()->execute("open", args);
+		}
+	} else if (DisplayServer::get_singleton()->get_name() != "headless") {
+		// Use AppleScript in `OS::execute()` instead of `OS::alert()` so that it works even when the OS event loop is blocked by the crash handler.
+		List<String> args;
+		args.push_back("-e");
+		args.push_back(vformat("display alert \"Crash\" message \"%s: Program crashed with signal %d.\"", __FUNCTION__, sig));
+		OS::get_singleton()->execute("osascript", args);
 	}
 
 	// Abort to pass the error to the OS


### PR DESCRIPTION
This makes it possible to know that Godot has crashed without looking at the console (which may not be visible to the user).

- Change the window title while dumping the backtrace, as this can take a while to finish.
- If file logging is enabled, print path to log file to standard error and the GUI alert.
- Clicking OK will open the log file in the default program associated with `.log` files. Notepad has native associations for `.log` on Windows, so this will work on Windows too (once this PR is ported to Windows).

___

- This closes https://github.com/godotengine/godot-proposals/issues/7917.

## Preview

### Linux

https://user-images.githubusercontent.com/180032/173110079-8756207b-cb3d-4b31-af61-6ccf0d690129.mp4

### Windows

![image](https://github.com/godotengine/godot/assets/180032/63715cc7-7017-428c-a141-64b6df59b722)

### macOS

![Screenshot_20240206_195358](https://github.com/godotengine/godot/assets/180032/cbd942a6-75cf-414e-9a60-ee306576a0f4) | ![Screenshot_20240206_195417](https://github.com/godotengine/godot/assets/180032/492ae0be-ca54-402f-abf8-a9a6bd97bf4c)
-|-

## TODO

- [ ] Consider adding a headless handler for `OS::alert()`, so we don't have to hack around it here. Make this handler print the string with some special formatting around it, but without the blocking behavior (as this behavior is undesired in headless mode).
- [x] Port changes to Windows. Everything seems to work there 🙂
- [x] Port changes to macOS. This is now functional thanks to @bruvzg~~, but https://github.com/godotengine/godot/pull/87842 needs to be merged if we want it to work with `OS.crash()` (the method used for testing this crash handler).~~

_Production edit: closes godotengine/godot-roadmap#5_