### PR TITLE
Fix directional LightmapGI being too dark with static lights

### DIFF
--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -415,7 +415,7 @@ void main() {
 			);
 
 			for (uint j = 0; j < 4; j++) {
-				sh_accum[j].rgb += light * c[j] * (1.0 / 3.0);
+				sh_accum[j].rgb += light * c[j] * 8.0;
 			}
 #endif
 


### PR DESCRIPTION
The brightness now matches dynamic lights (indirect light baked only) when Directional is enabled. Thanks @techiepriyansh for the suggestion :slightly_smiling_face:

The brightness of lightmapping for lights marked as dynamic is unchanged by this PR.

I ended up using an even stronger multiplier (`(24 / 3.0) = 8.0`). Static directional lightmapping now matches dynamic directional lightmapping exactly.

This closes https://github.com/godotengine/godot/issues/49936.

## Preview

### Dynamic

| No Directional | With Directional |
|-|-|
| ![2022-06-10_19 19 35_dynamic_no_directional](https://user-images.githubusercontent.com/180032/173122089-55782717-be75-46ef-bd0f-b5130673c40b.png) | ![2022-06-10_19 20 11_dynamic_with_directional](https://user-images.githubusercontent.com/180032/173122114-0dd5ed51-4e2a-4b96-851d-009120f5a042.png) |

### Static

| No Directional | With Directional (before PR) | With Directional *(after PR)* |
|-|-|-|
| ![2022-06-10_19 21 00_static_no_directional](https://user-images.githubusercontent.com/180032/173122133-c782bd28-f396-4c6d-b2d6-70c1de113889.png) | ![2022-06-10_19 21 18_static_with_directional](https://user-images.githubusercontent.com/180032/173122146-ad240dcd-a4c9-43c8-8cb7-bfa4d2a1830b.png) | ![2022-06-10_19 35 21_static_with_directional_8](https://user-images.githubusercontent.com/180032/173122152-09bd76c2-bbb1-4cda-af3e-97cb4430a591.png) |