### PR TITLE
Document the CurveXYZTexture class, improve CurveTexture documentation

### DIFF
--- a/doc/classes/CurveTexture.xml
+++ b/doc/classes/CurveTexture.xml
@@ -5,23 +5,27 @@
 	</brief_description>
 	<description>
 		Renders a given [Curve] provided to it. Simplifies the task of drawing curves and/or saving them as image files.
+		If you need to store up to 3 curves within a single texture, use [CurveXYZTexture] instead. See also [GradientTexture1D] and [GradientTexture2D].
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
-			The [code]curve[/code] rendered onto the texture.
+			The [Curve] that is rendered onto the texture.
 		</member>
 		<member name="texture_mode" type="int" setter="set_texture_mode" getter="get_texture_mode" enum="CurveTexture.TextureMode" default="0">
+			The format the texture should be generated with. When passing a CurveTexture as a input to a [Shader], this may need to be adjusted.
 		</member>
 		<member name="width" type="int" setter="set_width" getter="get_width" default="256">
-			The width of the texture.
+			The width of the texture (in pixels). Higher values make it possible to represent high-frequency data better (such as sudden direction changes), at the cost of increased generation time and memory usage.
 		</member>
 	</members>
 	<constants>
 		<constant name="TEXTURE_MODE_RGB" value="0" enum="TextureMode">
+			Store the curve equally across the red, green and blue channels. This uses more video memory, but is more compatible with shaders that only read the green and blue values.
 		</constant>
 		<constant name="TEXTURE_MODE_RED" value="1" enum="TextureMode">
+			Store the curve only in the red channel. This saves video memory, but some custom shaders may not be able to work with this.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/CurveXYZTexture.xml
+++ b/doc/classes/CurveXYZTexture.xml
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="CurveXYZTexture" inherits="Texture2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		A texture that shows 3 different curves (stored on the red, green and blue color channels).
 	</brief_description>
 	<description>
+		Renders 3 given [Curve]s provided to it, on the red, green and blue channels respectively. Compared to using separate [CurveTexture]s, this further simplifies the task of drawing curves and/or saving them as image files.
+		If you only need to store one curve within a single texture, use [CurveTexture] instead. See also [GradientTexture1D] and [GradientTexture2D].
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="curve_x" type="Curve" setter="set_curve_x" getter="get_curve_x">
+			The [Curve] that is rendered onto the texture's red channel.
 		</member>
 		<member name="curve_y" type="Curve" setter="set_curve_y" getter="get_curve_y">
+			The [Curve] that is rendered onto the texture's green channel.
 		</member>
 		<member name="curve_z" type="Curve" setter="set_curve_z" getter="get_curve_z">
+			The [Curve] that is rendered onto the texture's blue channel.
 		</member>
 		<member name="width" type="int" setter="set_width" getter="get_width" default="256">
+			The width of the texture (in pixels). Higher values make it possible to represent high-frequency data better (such as sudden direction changes), at the cost of increased generation time and memory usage.
 		</member>
 	</members>
 </class>

--- a/doc/classes/GradientTexture1D.xml
+++ b/doc/classes/GradientTexture1D.xml
@@ -4,7 +4,7 @@
 		Gradient-filled texture.
 	</brief_description>
 	<description>
-		GradientTexture1D uses a [Gradient] to fill the texture data. The gradient will be filled from left to right using colors obtained from the gradient. This means the texture does not necessarily represent an exact copy of the gradient, but instead an interpolation of samples obtained from the gradient at fixed steps (see [member width]).
+		GradientTexture1D uses a [Gradient] to fill the texture data. The gradient will be filled from left to right using colors obtained from the gradient. This means the texture does not necessarily represent an exact copy of the gradient, but instead an interpolation of samples obtained from the gradient at fixed steps (see [member width]). See also [GradientTexture2D], [CurveTexture] and [CurveXYZTexture].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/GradientTexture2D.xml
+++ b/doc/classes/GradientTexture2D.xml
@@ -4,7 +4,7 @@
 		Gradient-filled 2D texture.
 	</brief_description>
 	<description>
-		The texture uses a [Gradient] to fill the texture data in 2D space. The gradient is filled according to the specified [member fill] and [member repeat] types using colors obtained from the gradient. The texture does not necessarily represent an exact copy of the gradient, but instead an interpolation of samples obtained from the gradient at fixed steps (see [member width] and [member height]).
+		The texture uses a [Gradient] to fill the texture data in 2D space. The gradient is filled according to the specified [member fill] and [member repeat] types using colors obtained from the gradient. The texture does not necessarily represent an exact copy of the gradient, but instead an interpolation of samples obtained from the gradient at fixed steps (see [member width] and [member height]). See also [GradientTexture1D], [CurveTexture] and [CurveXYZTexture].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Some of those changes are relevant for `3.x` too, so I could backport them in a separate PR.
**Edit:** Done in https://github.com/godotengine/godot/pull/61916.