### PR TITLE
Add static methods to create RayQueryParameters

### DIFF
--- a/doc/classes/PhysicsRayQueryParameters2D.xml
+++ b/doc/classes/PhysicsRayQueryParameters2D.xml
@@ -8,6 +8,22 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="create" qualifiers="static">
+			<return type="PhysicsRayQueryParameters2D" />
+			<argument index="0" name="from" type="Vector2" />
+			<argument index="1" name="to" type="Vector2" />
+			<argument index="2" name="collision_mask" type="int" default="4294967295" />
+			<argument index="3" name="exclude" type="Array" default="[]" />
+			<description>
+				Returns a new, pre-configured [PhysicsRayQueryParameters2D] object. Use it to quickly create query parameters using the most common options.
+				[codeblock]
+				var query = PhysicsRayQueryParameters2D.create(global_position, global_position + Vector2(0, 100))
+				var collision = get_world_2d().direct_space_state.intersect_ray(query)
+				[/codeblock]
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
 			If [code]true[/code], the query will take [Area2D]s into account.

--- a/doc/classes/PhysicsRayQueryParameters3D.xml
+++ b/doc/classes/PhysicsRayQueryParameters3D.xml
@@ -8,6 +8,22 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="create" qualifiers="static">
+			<return type="PhysicsRayQueryParameters3D" />
+			<argument index="0" name="from" type="Vector3" />
+			<argument index="1" name="to" type="Vector3" />
+			<argument index="2" name="collision_mask" type="int" default="4294967295" />
+			<argument index="3" name="exclude" type="Array" default="[]" />
+			<description>
+				Returns a new, pre-configured [PhysicsRayQueryParameters3D] object. Use it to quickly create query parameters using the most common options.
+				[codeblock]
+				var query = PhysicsRayQueryParameters3D.create(position, position + Vector3(0, -10, 0))
+				var collision = get_world_3d().direct_space_state.intersect_ray(query)
+				[/codeblock]
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
 			If [code]true[/code], the query will take [Area3D]s into account.

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -147,6 +147,16 @@ PhysicsDirectBodyState2D::PhysicsDirectBodyState2D() {}
 
 ///////////////////////////////////////////////////////
 
+Ref<PhysicsRayQueryParameters2D> PhysicsRayQueryParameters2D::create(Vector2 p_from, Vector2 p_to, uint32_t p_mask, const Vector<RID> &p_exclude) {
+	Ref<PhysicsRayQueryParameters2D> params;
+	params.instantiate();
+	params->set_from(p_from);
+	params->set_to(p_to);
+	params->set_collision_mask(p_mask);
+	params->set_exclude(p_exclude);
+	return params;
+}
+
 void PhysicsRayQueryParameters2D::set_exclude(const Vector<RID> &p_exclude) {
 	parameters.exclude.clear();
 	for (int i = 0; i < p_exclude.size(); i++) {
@@ -165,6 +175,8 @@ Vector<RID> PhysicsRayQueryParameters2D::get_exclude() const {
 }
 
 void PhysicsRayQueryParameters2D::_bind_methods() {
+	ClassDB::bind_static_method("PhysicsRayQueryParameters2D", D_METHOD("create", "from", "to", "collision_mask", "exclude"), &PhysicsRayQueryParameters2D::create, DEFVAL(UINT32_MAX), DEFVAL(Vector<RID>()));
+
 	ClassDB::bind_method(D_METHOD("set_from", "from"), &PhysicsRayQueryParameters2D::set_from);
 	ClassDB::bind_method(D_METHOD("get_from"), &PhysicsRayQueryParameters2D::get_from);
 

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -605,6 +605,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	static Ref<PhysicsRayQueryParameters2D> create(Vector2 p_from, Vector2 p_to, uint32_t p_mask, const Vector<RID> &p_exclude);
 	const PhysicsDirectSpaceState2D::RayParameters &get_parameters() const { return parameters; }
 
 	void set_from(const Vector2 &p_from) { parameters.from = p_from; }

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -184,6 +184,8 @@ Vector<RID> PhysicsRayQueryParameters3D::get_exclude() const {
 }
 
 void PhysicsRayQueryParameters3D::_bind_methods() {
+	ClassDB::bind_static_method("PhysicsRayQueryParameters3D", D_METHOD("create", "from", "to", "collision_mask", "exclude"), &PhysicsRayQueryParameters3D::create, DEFVAL(UINT32_MAX), DEFVAL(Vector<RID>()));
+
 	ClassDB::bind_method(D_METHOD("set_from", "from"), &PhysicsRayQueryParameters3D::set_from);
 	ClassDB::bind_method(D_METHOD("get_from"), &PhysicsRayQueryParameters3D::get_from);
 
@@ -219,6 +221,16 @@ void PhysicsRayQueryParameters3D::_bind_methods() {
 }
 
 ///////////////////////////////////////////////////////
+
+Ref<PhysicsRayQueryParameters3D> PhysicsRayQueryParameters3D::create(Vector3 p_from, Vector3 p_to, uint32_t p_mask, const Vector<RID> &p_exclude) {
+	Ref<PhysicsRayQueryParameters3D> params;
+	params.instantiate();
+	params->set_from(p_from);
+	params->set_to(p_to);
+	params->set_collision_mask(p_mask);
+	params->set_exclude(p_exclude);
+	return params;
+}
 
 void PhysicsPointQueryParameters3D::set_exclude(const Vector<RID> &p_exclude) {
 	parameters.exclude.clear();

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -816,6 +816,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	static Ref<PhysicsRayQueryParameters3D> create(Vector3 p_from, Vector3 p_to, uint32_t p_mask, const Vector<RID> &p_exclude);
 	const PhysicsDirectSpaceState3D::RayParameters &get_parameters() const { return parameters; }
 
 	void set_from(const Vector3 &p_from) { parameters.from = p_from; }


### PR DESCRIPTION
The `intersect_ray()` method was changed to take single PhysicsRayQueryParameters object instead of several arguments. This is great for flexibility, but not for convenience, as a one-line is turned into a 4-liner (in the minimal case). So I added some static methods with most common parameters to quickly create query objects.

Originally discussed here:
https://chat.godotengine.org/channel/physics?msg=i4n2dWWm3XbYAGHHt