### PR TITLE
Fix not visible last character of long text in line edit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -868,6 +868,7 @@ void LineEdit::_notification(int p_what) {
 			ofs.y += TS->shaped_text_get_ascent(text_rid);
 			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
 			int outline_size = get_theme_constant(SNAME("outline_size"));
+			ofs_max += style->get_margin(SIDE_LEFT);
 			if (outline_size > 0 && font_outline_color.a > 0) {
 				Vector2 oofs = ofs;
 				for (int i = 0; i < gl_size; i++) {


### PR DESCRIPTION
This is attempt at fixing https://github.com/godotengine/godot/issues/61069. This issue was present for all line edits, not just editors node name.

My fix accounts for left margin while drawing glyphs, before that only right margin was subtracted from total width of the control.

I wrote `attempt` because I am not 100% sure this is the right way to fix it, also I don't really like this fix because this adds yet another piece of offset complexity to already complicated code. Maybe someone can advice cleaner solution.

Small demo:
Before: note missing 8 glyph at the end of line edit
![before_missing_char](https://user-images.githubusercontent.com/9964886/173186663-1f6c6c48-4ea5-4588-ab32-c063cb2856a0.gif)

After:
![after_missing_char](https://user-images.githubusercontent.com/9964886/173185848-9a117755-db51-4ae3-aced-629eb1d86670.gif)


