### PR TITLE
Hash function improvements

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2788,106 +2788,50 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		// math types
 		case VECTOR2: {
-			uint32_t hash = hash_djb2_one_float(reinterpret_cast<const Vector2 *>(_data._mem)->x);
-			return hash_djb2_one_float(reinterpret_cast<const Vector2 *>(_data._mem)->y, hash);
+			return hash_murmur3_32(reinterpret_cast<const Vector2 *>(_data._mem), sizeof(Vector2));
 		} break;
 		case VECTOR2I: {
-			uint32_t hash = hash_djb2_one_32((uint32_t) reinterpret_cast<const Vector2i *>(_data._mem)->x);
-			return hash_djb2_one_32((uint32_t) reinterpret_cast<const Vector2i *>(_data._mem)->y, hash);
+			return hash_murmur3_32(reinterpret_cast<const Vector2i *>(_data._mem), sizeof(Vector2i));
 		} break;
 		case RECT2: {
-			uint32_t hash = hash_djb2_one_float(reinterpret_cast<const Rect2 *>(_data._mem)->position.x);
-			hash = hash_djb2_one_float(reinterpret_cast<const Rect2 *>(_data._mem)->position.y, hash);
-			hash = hash_djb2_one_float(reinterpret_cast<const Rect2 *>(_data._mem)->size.x, hash);
-			return hash_djb2_one_float(reinterpret_cast<const Rect2 *>(_data._mem)->size.y, hash);
+			return hash_murmur3_32(reinterpret_cast<const Rect2 *>(_data._mem), sizeof(Rect2));
 		} break;
 		case RECT2I: {
-			uint32_t hash = hash_djb2_one_32((uint32_t) reinterpret_cast<const Rect2i *>(_data._mem)->position.x);
-			hash = hash_djb2_one_32((uint32_t) reinterpret_cast<const Rect2i *>(_data._mem)->position.y, hash);
-			hash = hash_djb2_one_32((uint32_t) reinterpret_cast<const Rect2i *>(_data._mem)->size.x, hash);
-			return hash_djb2_one_32((uint32_t) reinterpret_cast<const Rect2i *>(_data._mem)->size.y, hash);
+			return hash_murmur3_32(reinterpret_cast<const Rect2i *>(_data._mem), sizeof(Rect2i));
 		} break;
 		case TRANSFORM2D: {
-			uint32_t hash = 5831;
-			for (int i = 0; i < 3; i++) {
-				for (int j = 0; j < 2; j++) {
-					hash = hash_djb2_one_float(_data._transform2d->columns[i][j], hash);
-				}
-			}
-
-			return hash;
+			return hash_murmur3_32(reinterpret_cast<const Transform2D *>(_data._transform2d), sizeof(Transform2D));
 		} break;
 		case VECTOR3: {
-			uint32_t hash = hash_djb2_one_float(reinterpret_cast<const Vector3 *>(_data._mem)->x);
-			hash = hash_djb2_one_float(reinterpret_cast<const Vector3 *>(_data._mem)->y, hash);
-			return hash_djb2_one_float(reinterpret_cast<const Vector3 *>(_data._mem)->z, hash);
+			return hash_murmur3_32(reinterpret_cast<const Vector3 *>(_data._mem), sizeof(Vector3));
 		} break;
 		case VECTOR3I: {
-			uint32_t hash = hash_djb2_one_32((uint32_t) reinterpret_cast<const Vector3i *>(_data._mem)->x);
-			hash = hash_djb2_one_32((uint32_t) reinterpret_cast<const Vector3i *>(_data._mem)->y, hash);
-			return hash_djb2_one_32((uint32_t) reinterpret_cast<const Vector3i *>(_data._mem)->z, hash);
+			return hash_murmur3_32(reinterpret_cast<const Vector3i *>(_data._mem), sizeof(Vector3i));
 		} break;
 		case PLANE: {
-			uint32_t hash = hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->normal.x);
-			hash = hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->normal.y, hash);
-			hash = hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->normal.z, hash);
-			return hash_djb2_one_float(reinterpret_cast<const Plane *>(_data._mem)->d, hash);
-
+			return hash_murmur3_32(reinterpret_cast<const Plane *>(_data._mem), sizeof(Plane));
 		} break;
 		case AABB: {
-			uint32_t hash = 5831;
-			for (int i = 0; i < 3; i++) {
-				hash = hash_djb2_one_float(_data._aabb->position[i], hash);
-				hash = hash_djb2_one_float(_data._aabb->size[i], hash);
-			}
-
-			return hash;
-
+			return hash_murmur3_32(_data._aabb, sizeof(AABB));
 		} break;
 		case QUATERNION: {
-			uint32_t hash = hash_djb2_one_float(reinterpret_cast<const Quaternion *>(_data._mem)->x);
-			hash = hash_djb2_one_float(reinterpret_cast<const Quaternion *>(_data._mem)->y, hash);
-			hash = hash_djb2_one_float(reinterpret_cast<const Quaternion *>(_data._mem)->z, hash);
-			return hash_djb2_one_float(reinterpret_cast<const Quaternion *>(_data._mem)->w, hash);
-
+			return hash_murmur3_32(reinterpret_cast<const Quaternion *>(_data._mem), sizeof(Quaternion));
 		} break;
 		case BASIS: {
-			uint32_t hash = 5831;
-			for (int i = 0; i < 3; i++) {
-				for (int j = 0; j < 3; j++) {
-					hash = hash_djb2_one_float(_data._basis->rows[i][j], hash);
-				}
-			}
-
-			return hash;
-
+			return hash_murmur3_32(_data._basis, sizeof(Basis));
 		} break;
 		case TRANSFORM3D: {
-			uint32_t hash = 5831;
-			for (int i = 0; i < 3; i++) {
-				for (int j = 0; j < 3; j++) {
-					hash = hash_djb2_one_float(_data._transform3d->basis.rows[i][j], hash);
-				}
-				hash = hash_djb2_one_float(_data._transform3d->origin[i], hash);
-			}
-
-			return hash;
-
+			return hash_murmur3_32(_data._transform3d, sizeof(Transform3D));
 		} break;
-
 		// misc types
 		case COLOR: {
-			uint32_t hash = hash_djb2_one_float(reinterpret_cast<const Color *>(_data._mem)->r);
-			hash = hash_djb2_one_float(reinterpret_cast<const Color *>(_data._mem)->g, hash);
-			hash = hash_djb2_one_float(reinterpret_cast<const Color *>(_data._mem)->b, hash);
-			return hash_djb2_one_float(reinterpret_cast<const Color *>(_data._mem)->a, hash);
-
+			return hash_murmur3_32(reinterpret_cast<const Color *>(_data._mem), sizeof(Color));
 		} break;
 		case RID: {
-			return hash_djb2_one_64(reinterpret_cast<const ::RID *>(_data._mem)->get_id());
+			return hash_one_uint64(reinterpret_cast<const ::RID *>(_data._mem)->get_id());
 		} break;
 		case OBJECT: {
-			return hash_djb2_one_64(make_uint64_t(_get_obj().obj));
+			return hash_one_uint64(make_uint64_t(_get_obj().obj));
 		} break;
 		case STRING_NAME: {
 			return reinterpret_cast<const StringName *>(_data._mem)->hash();
@@ -2918,7 +2862,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 			int len = arr.size();
 			if (likely(len)) {
 				const uint8_t *r = arr.ptr();
-				return hash_djb2_buffer((uint8_t *)&r[0], len);
+				return hash_murmur3_32((uint8_t *)&r[0], len);
 			} else {
 				return hash_djb2_one_64(0);
 			}
@@ -2929,7 +2873,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 			int len = arr.size();
 			if (likely(len)) {
 				const int32_t *r = arr.ptr();
-				return hash_djb2_buffer((uint8_t *)&r[0], len * sizeof(int32_t));
+				return hash_murmur3_32((uint8_t *)&r[0], len * sizeof(int32_t));
 			} else {
 				return hash_djb2_one_64(0);
 			}
@@ -2940,7 +2884,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 			int len = arr.size();
 			if (likely(len)) {
 				const int64_t *r = arr.ptr();
-				return hash_djb2_buffer((uint8_t *)&r[0], len * sizeof(int64_t));
+				return hash_murmur3_32((uint8_t *)&r[0], len * sizeof(int64_t));
 			} else {
 				return hash_djb2_one_64(0);
 			}
@@ -2952,7 +2896,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 			if (likely(len)) {
 				const float *r = arr.ptr();
-				return hash_djb2_buffer((uint8_t *)&r[0], len * sizeof(float));
+				return hash_murmur3_32((uint8_t *)&r[0], len * sizeof(float));
 			} else {
 				return hash_djb2_one_float(0.0);
 			}
@@ -2964,7 +2908,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 			if (likely(len)) {
 				const double *r = arr.ptr();
-				return hash_djb2_buffer((uint8_t *)&r[0], len * sizeof(double));
+				return hash_murmur3_32((uint8_t *)&r[0], len * sizeof(double));
 			} else {
 				return hash_djb2_one_float(0.0);
 			}

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2780,7 +2780,7 @@ Vector2 TextServerAdvanced::font_get_kerning(const RID &p_font_rid, int64_t p_si
 
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Vector2());
 
-	const HashMap<Vector2i, Vector2, VariantHasher, VariantComparator> &kern = fd->cache[size]->kerning_map;
+	const HashMap<Vector2i, Vector2> &kern = fd->cache[size]->kerning_map;
 
 	if (kern.has(p_glyph_pair)) {
 		if (fd->msdf) {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -191,7 +191,7 @@ class TextServerAdvanced : public TextServerExtension {
 
 		Vector<FontTexture> textures;
 		HashMap<int32_t, FontGlyph> glyph_map;
-		HashMap<Vector2i, Vector2, VariantHasher, VariantComparator> kerning_map;
+		HashMap<Vector2i, Vector2> kerning_map;
 		hb_font_t *hb_handle = nullptr;
 
 #ifdef MODULE_FREETYPE_ENABLED

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1928,7 +1928,7 @@ Vector2 TextServerFallback::font_get_kerning(const RID &p_font_rid, int64_t p_si
 
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Vector2());
 
-	const HashMap<Vector2i, Vector2, VariantHasher, VariantComparator> &kern = fd->cache[size]->kerning_map;
+	const HashMap<Vector2i, Vector2> &kern = fd->cache[size]->kerning_map;
 
 	if (kern.has(p_glyph_pair)) {
 		if (fd->msdf) {

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -159,7 +159,7 @@ class TextServerFallback : public TextServerExtension {
 
 		Vector<FontTexture> textures;
 		HashMap<int32_t, FontGlyph> glyph_map;
-		HashMap<Vector2i, Vector2, VariantHasher, VariantComparator> kerning_map;
+		HashMap<Vector2i, Vector2> kerning_map;
 
 #ifdef MODULE_FREETYPE_ENABLED
 		FT_Face face = nullptr;


### PR DESCRIPTION
This PR aims to improve the performance of data structures which rely on hashing functions (such as HashMap and HashSet). For some types (most noticeably Vector2i) the currently used hash function provides a seemingly bad distribution, resulting in lots of collisions and therefore severely degraded lookup performance of the affected data structures.

For Vector2i, the currently used DBJ2 function performs bad with numbers that are close together, making the tilemap editor unusable if you have more than a few hundred tiles.

Detailed changes:
- Use the murmur3 hash function for all basic numeric types as it provides a better distribution (murmur3 should be a little bit slower than DBJ2, but provides a much better random distribution, resulting in an overall better lookup performance)
- Use Thomas Wang's 64-bit to 32-bit hash functions for RID and OBJECT in VariantHasher (this was already done in HashMapHasherDefault)
- Removed VariantHasher template argument in text_server_adv/fb as it seems like it is not needed anymore (however I am not sure)

Supercedes #61833, as this makes the tilemap editor at least as fast as with #61833 and fixes the underlying issue.

~~Marked as draft, since I came across some strange issues with string hashing when I tried to switch from DBJ2 to any other hash function (murmur2/3 or meiyan): The engine crashes on startup because ClassDB completely breaks (as I conclude based on the message "Request for nonexistent class 'Object'."). Just changing the string hash functions of HashMapHasherDefault (in hashfuncs.h) works, but I think we should have one common hash function for strings.
I left the murmur2 and meiyan hash functions in hashfuncs.h in case someone wants to do some further experiments. (can be stripped when this PR is fully tested and ready to merge)~~

HashMaps with Vector2i are also used in some places of TextServer so we should check performance there. Benchmarking/testing is very appreciated :)

The editor's startup time seems to be unchanged [project manager/release_debug]: 
```
hyperfine -iw1 "godot_before.exe --quit" "godot.windows.opt.tools.64.exe --quit"
Benchmark 1: godot_before.exe --quit
  Time (mean ± σ):      1.793 s ±  0.024 s    [User: 0.000 s, System: 0.008 s]
  Range (min … max):    1.770 s …  1.851 s    10 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: godot.windows.opt.tools.64.exe --quit
  Time (mean ± σ):      1.797 s ±  0.021 s    [User: 0.003 s, System: 0.008 s]
  Range (min … max):    1.778 s …  1.846 s    10 runs

  Warning: Ignoring non-zero exit code.

Summary
  'godot_before.exe --quit' ran
    1.00 ± 0.02 times faster than 'godot.windows.opt.tools.64.exe --quit'
```

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/61645