### PR TITLE
Update name of Convert to MeshInstance2D button in MeshInstance2D doc

### DIFF
--- a/doc/classes/MeshInstance2D.xml
+++ b/doc/classes/MeshInstance2D.xml
@@ -4,7 +4,7 @@
 		Node used for displaying a [Mesh] in 2D.
 	</brief_description>
 	<description>
-		Node used for displaying a [Mesh] in 2D. Can be constructed from an existing [Sprite2D] via a tool in the editor toolbar. Select "Sprite2D" then "Convert to Mesh2D", select settings in popup and press "Create Mesh2D".
+		Node used for displaying a [Mesh] in 2D. A [MeshInstance2D] can be automatically created from an existing [Sprite2D] via a tool in the editor toolbar. Select the [Sprite2D] node, then choose [b]Sprite2D &gt; Convert to MeshInstance2D[/b] at the top of the 2D editor viewport.
 	</description>
 	<tutorials>
 		<link title="2D meshes">$DOCS_URL/tutorials/2d/2d_meshes.html</link>


### PR DESCRIPTION
See https://github.com/godotengine/godot-docs/issues/5872.

Should be cherry-picked to `3.x` *after* https://github.com/godotengine/godot/pull/61940.