### PR TITLE
Don't request redraw in AnimatedTexture to decrease editor CPU/GPU usage

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2837,7 +2837,6 @@ AnimatedTexture::AnimatedTexture() {
 	proxy_ph = RS::get_singleton()->texture_2d_placeholder_create();
 	proxy = RS::get_singleton()->texture_proxy_create(proxy_ph);
 
-	RenderingServer::get_singleton()->texture_set_force_redraw_if_visible(proxy, true);
 	RenderingServer::get_singleton()->connect("frame_pre_draw", callable_mp(this, &AnimatedTexture::_update_proxy));
 }
 


### PR DESCRIPTION
This means AnimatedTextures will update at an erratic rate if nothing else is causing the editor to redraw continuously (or projects, if Low Processor Mode is enabled). However, lowering the CPU/GPU usage by a significant amount is probably preferred in most situations.

This will not affect the editor if Update Continuously is enabled, or if Low Processor Mode is disabled in the project (which is the default).

This partially addresses https://github.com/godotengine/godot/issues/39758.

PS: I wonder why the old code isn't forcing a redraw request here instead: https://github.com/godotengine/godot/blob/40963cc9200d0f2f0990df05b9271e3772f57c70/scene/resources/texture.cpp#L2185
This would lead to lower CPU/GPU usage already, butit wouldn't fully resolve the original issue (especially at higher animation FPS).