### PR TITLE
Add TAA to the list of editor capitalizations

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -213,6 +213,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["stdout"] = "stdout";
 	capitalize_string_remaps["sv"] = "SV";
 	capitalize_string_remaps["svg"] = "SVG";
+	capitalize_string_remaps["taa"] = "TAA";
 	capitalize_string_remaps["tcp"] = "TCP";
 	capitalize_string_remaps["ui"] = "UI";
 	capitalize_string_remaps["url"] = "URL";


### PR DESCRIPTION
This is used in the "Use Taa" setting (for [temporal antialiasing](https://github.com/godotengine/godot/pull/61319)).

**Note:** Not cherry-pickable for `3.x` as TAA isn't implemented there.

## Preview

![image](https://user-images.githubusercontent.com/180032/173206882-c68934c8-e79e-4ad6-8af6-0aedf1b94599.png)
