### PR TITLE
`SurfaceTool.set_custom_format` Fixes and documentation.

### DIFF
--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -39,6 +39,16 @@
 				Removes all surfaces and blend shapes from this [ImporterMesh].
 			</description>
 		</method>
+		<method name="generate_lods">
+			<return type="void" />
+			<argument index="0" name="normal_merge_angle" type="float" />
+			<argument index="1" name="normal_split_angle" type="float" />
+			<description>
+				Generates all lods for this ImporterMesh.
+				[code]normal_merge_angle[/code] and [code]normal_split_angle[/code] are in degrees and used in the same way as the importer settings in [code]lods[/code]. As a good default, use 25 and 60 respectively.
+				The number of generated lods can be accessed using [method get_surface_lod_count], and each LOD is available in [method get_surface_lod_size] and [method get_surface_lod_indices].
+			</description>
+		</method>
 		<method name="get_blend_shape_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -215,12 +215,16 @@
 			[PackedVector2Array] for second UV coordinates.
 		</constant>
 		<constant name="ARRAY_CUSTOM0" value="6" enum="ArrayType">
+			Contains custom color channel 0. [PackedByteArray] if [code](format &gt;&gt; [constant ARRAY_FORMAT_CUSTOM0_SHIFT]) &amp; [constant ARRAY_FORMAT_CUSTOM_MASK])[/code] is [constant ARRAY_CUSTOM_RGBA8_UNORM], [constant ARRAY_CUSTOM_RGBA8_UNORM], [constant ARRAY_CUSTOM_RG_HALF] or [constant ARRAY_CUSTOM_RGBA_HALF]. [PackedFloat32Array] otherwise.
 		</constant>
 		<constant name="ARRAY_CUSTOM1" value="7" enum="ArrayType">
+			Contains custom color channel 1. [PackedByteArray] if [code](format &gt;&gt; [constant ARRAY_FORMAT_CUSTOM1_SHIFT]) &amp; [constant ARRAY_FORMAT_CUSTOM_MASK])[/code] is [constant ARRAY_CUSTOM_RGBA8_UNORM], [constant ARRAY_CUSTOM_RGBA8_UNORM], [constant ARRAY_CUSTOM_RG_HALF] or [constant ARRAY_CUSTOM_RGBA_HALF]. [PackedFloat32Array] otherwise.
 		</constant>
 		<constant name="ARRAY_CUSTOM2" value="8" enum="ArrayType">
+			Contains custom color channel 2. [PackedByteArray] if [code](format &gt;&gt; [constant ARRAY_FORMAT_CUSTOM2_SHIFT]) &amp; [constant ARRAY_FORMAT_CUSTOM_MASK])[/code] is [constant ARRAY_CUSTOM_RGBA8_UNORM], [constant ARRAY_CUSTOM_RGBA8_UNORM], [constant ARRAY_CUSTOM_RG_HALF] or [constant ARRAY_CUSTOM_RGBA_HALF]. [PackedFloat32Array] otherwise.
 		</constant>
 		<constant name="ARRAY_CUSTOM3" value="9" enum="ArrayType">
+			Contains custom color channel 3. [PackedByteArray] if [code](format &gt;&gt; [constant ARRAY_FORMAT_CUSTOM3_SHIFT]) &amp; [constant ARRAY_FORMAT_CUSTOM_MASK])[/code] is [constant ARRAY_CUSTOM_RGBA8_UNORM], [constant ARRAY_CUSTOM_RGBA8_UNORM], [constant ARRAY_CUSTOM_RG_HALF] or [constant ARRAY_CUSTOM_RGBA_HALF]. [PackedFloat32Array] otherwise.
 		</constant>
 		<constant name="ARRAY_BONES" value="10" enum="ArrayType">
 			[PackedFloat32Array] or [PackedInt32Array] of bone indices. Each element is a group of 4 numbers.
@@ -236,20 +240,28 @@
 			Represents the size of the [enum ArrayType] enum.
 		</constant>
 		<constant name="ARRAY_CUSTOM_RGBA8_UNORM" value="0" enum="ArrayCustomFormat">
+			Indicates this custom channel contains unsigned normalized byte colors from 0 to 1, encoded as [PackedByteArray].
 		</constant>
 		<constant name="ARRAY_CUSTOM_RGBA8_SNORM" value="1" enum="ArrayCustomFormat">
+			Indicates this custom channel contains signed normalized byte colors from -1 to 1, encoded as [PackedByteArray].
 		</constant>
 		<constant name="ARRAY_CUSTOM_RG_HALF" value="2" enum="ArrayCustomFormat">
+			Indicates this custom channel contains half precision float colors, encoded as [PackedByteArray]. Only red and green channels are used.
 		</constant>
 		<constant name="ARRAY_CUSTOM_RGBA_HALF" value="3" enum="ArrayCustomFormat">
+			Indicates this custom channel contains half precision float colors, encoded as [PackedByteArray].
 		</constant>
 		<constant name="ARRAY_CUSTOM_R_FLOAT" value="4" enum="ArrayCustomFormat">
+			Indicates this custom channel contains full float colors, in a [PackedFloat32Array]. Only the red green channel is used.
 		</constant>
 		<constant name="ARRAY_CUSTOM_RG_FLOAT" value="5" enum="ArrayCustomFormat">
+			Indicates this custom channel contains full float colors, in a [PackedFloat32Array]. Only red and green channels are used.
 		</constant>
 		<constant name="ARRAY_CUSTOM_RGB_FLOAT" value="6" enum="ArrayCustomFormat">
+			Indicates this custom channel contains full float colors, in a [PackedFloat32Array]. Only red, green and blue channels are used.
 		</constant>
 		<constant name="ARRAY_CUSTOM_RGBA_FLOAT" value="7" enum="ArrayCustomFormat">
+			Indicates this custom channel contains full float colors, in a [PackedFloat32Array].
 		</constant>
 		<constant name="ARRAY_CUSTOM_MAX" value="8" enum="ArrayCustomFormat">
 			Represents the size of the [enum ArrayCustomFormat] enum.
@@ -273,12 +285,16 @@
 			Mesh array contains second UV.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM0" value="64" enum="ArrayFormat">
+			Mesh array contains custom channel index 0.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM1" value="128" enum="ArrayFormat">
+			Mesh array contains custom channel index 1.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM2" value="256" enum="ArrayFormat">
+			Mesh array contains custom channel index 2.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM3" value="512" enum="ArrayFormat">
+			Mesh array contains custom channel index 3.
 		</constant>
 		<constant name="ARRAY_FORMAT_BONES" value="1024" enum="ArrayFormat">
 			Mesh array contains bones.
@@ -290,29 +306,40 @@
 			Mesh array uses indices.
 		</constant>
 		<constant name="ARRAY_FORMAT_BLEND_SHAPE_MASK" value="7" enum="ArrayFormat">
+			Mask of mesh channels permitted in blend shapes.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM_BASE" value="13" enum="ArrayFormat">
+			Shift of first custom channel.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM_BITS" value="3" enum="ArrayFormat">
+			Number of format bits per custom channel. See [enum ArrayCustomFormat].
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM0_SHIFT" value="13" enum="ArrayFormat">
+			Amount to shift [enum ArrayCustomFormat] for custom channel index 0.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM1_SHIFT" value="16" enum="ArrayFormat">
+			Amount to shift [enum ArrayCustomFormat] for custom channel index 1.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM2_SHIFT" value="19" enum="ArrayFormat">
+			Amount to shift [enum ArrayCustomFormat] for custom channel index 2.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM3_SHIFT" value="22" enum="ArrayFormat">
+			Amount to shift [enum ArrayCustomFormat] for custom channel index 3.
 		</constant>
 		<constant name="ARRAY_FORMAT_CUSTOM_MASK" value="7" enum="ArrayFormat">
+			Mask of custom format bits per custom channel. Must be shifted by one of the SHIFT constants. See [enum ArrayCustomFormat].
 		</constant>
 		<constant name="ARRAY_COMPRESS_FLAGS_BASE" value="25" enum="ArrayFormat">
+			Shift of first compress flag. Compress flags should be passed to [method ArrayMesh.add_surface_from_arrays] and [method SurfaceTool.commit].
 		</constant>
 		<constant name="ARRAY_FLAG_USE_2D_VERTICES" value="33554432" enum="ArrayFormat">
 			Flag used to mark that the array contains 2D vertices.
 		</constant>
 		<constant name="ARRAY_FLAG_USE_DYNAMIC_UPDATE" value="67108864" enum="ArrayFormat">
+			Flag indices that the mesh data will use [code]GL_DYNAMIC_DRAW[/code] on GLES. Unused on Vulkan.
 		</constant>
 		<constant name="ARRAY_FLAG_USE_8_BONE_WEIGHTS" value="134217728" enum="ArrayFormat">
+			Flag used to mark that the mesh contains up to 8 bone influences per vertex. This flag indicates that [constant ARRAY_BONES] and [constant ARRAY_WEIGHTS] elements will have double length.
 		</constant>
 		<constant name="BLEND_SHAPE_MODE_NORMALIZED" value="0" enum="BlendShapeMode">
 			Blend shapes are normalized.

--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -35,7 +35,7 @@
 			<return type="void" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Adds an index to index array if you are using indexed vertices. Does not need to be called before adding vertices.
+				Adds a vertex to index array if you are using indexed vertices. Does not need to be called before adding vertices.
 			</description>
 		</method>
 		<method name="add_triangle_fan">
@@ -123,6 +123,8 @@
 			<argument index="0" name="nd_threshold" type="float" />
 			<argument index="1" name="target_index_count" type="int" default="3" />
 			<description>
+				Generates a LOD for a given [code]nd_threshold[/code] in linear units (square root of quadric error metric), using at most [code]target_index_count[/code] indices.
+				Deprecated. Unused internally and neglects to preserve normals or UVs. Consider using [method ImporterMesh.generate_lods] instead.
 			</description>
 		</method>
 		<method name="generate_normals">
@@ -139,25 +141,31 @@
 				Generates a tangent vector for each vertex. Requires that each vertex have UVs and normals set already (see [method generate_normals]).
 			</description>
 		</method>
+		<method name="get_aabb" qualifiers="const">
+			<return type="AABB" />
+			<description>
+				Returns the axis-aligned bounding box of the vertex positions.
+			</description>
+		</method>
 		<method name="get_custom_format" qualifiers="const">
 			<return type="int" enum="SurfaceTool.CustomFormat" />
-			<argument index="0" name="index" type="int" />
+			<argument index="0" name="channel_index" type="int" />
 			<description>
+				Returns the format for custom [code]channel_index[/code] (currently up to 4). Returns [constant CUSTOM_MAX] if this custom channel is unused.
 			</description>
 		</method>
-		<method name="get_max_axis_length" qualifiers="const">
-			<return type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="get_primitive" qualifiers="const">
+		<method name="get_primitive_type" qualifiers="const">
 			<return type="int" enum="Mesh.PrimitiveType" />
 			<description>
+				Returns the type of mesh geometry, such as [constant Mesh.PRIMITIVE_TRIANGLES].
 			</description>
 		</method>
 		<method name="get_skin_weight_count" qualifiers="const">
 			<return type="int" enum="SurfaceTool.SkinWeightCount" />
 			<description>
+				By default, returns [constant SKIN_4_WEIGHTS] to indicate only 4 bone influences per vertex are used.
+				Returns [constant SKIN_8_WEIGHTS] if up to 8 influences are used.
+				[b]Note:[/b] This function returns an enum, not the exact number of weights.
 			</description>
 		</method>
 		<method name="index">
@@ -169,6 +177,7 @@
 		<method name="optimize_indices_for_cache">
 			<return type="void" />
 			<description>
+				Optimizes triangle sorting for performance. Requires that [method get_primitive_type] is [constant Mesh.PRIMITIVE_TRIANGLES].
 			</description>
 		</method>
 		<method name="set_bones">
@@ -188,16 +197,20 @@
 		</method>
 		<method name="set_custom">
 			<return type="void" />
-			<argument index="0" name="index" type="int" />
-			<argument index="1" name="custom" type="Color" />
+			<argument index="0" name="channel_index" type="int" />
+			<argument index="1" name="custom_color" type="Color" />
 			<description>
+				Sets the custom value on this vertex for [code]channel_index[/code].
+				[method set_custom_format] must be called first for this [code]channel_index[/code]. Formats which are not RGBA will ignore other color channels.
 			</description>
 		</method>
 		<method name="set_custom_format">
 			<return type="void" />
-			<argument index="0" name="index" type="int" />
+			<argument index="0" name="channel_index" type="int" />
 			<argument index="1" name="format" type="int" enum="SurfaceTool.CustomFormat" />
 			<description>
+				Sets the color format for this custom [code]channel_index[/code]. Use [constant CUSTOM_MAX] to disable.
+				Must be invoked after [method begin] and should be set before [method commit] or [method commit_to_arrays].
 			</description>
 		</method>
 		<method name="set_material">
@@ -218,6 +231,9 @@
 			<return type="void" />
 			<argument index="0" name="count" type="int" enum="SurfaceTool.SkinWeightCount" />
 			<description>
+				Set to [constant SKIN_8_WEIGHTS] to indicate that up to 8 bone influences per vertex may be used.
+				By default, only 4 bone influences are used ([constant SKIN_4_WEIGHTS])
+				[b]Note:[/b] This function takes an enum, not the exact number of weights.
 			</description>
 		</method>
 		<method name="set_smooth_group">
@@ -258,26 +274,37 @@
 	</methods>
 	<constants>
 		<constant name="CUSTOM_RGBA8_UNORM" value="0" enum="CustomFormat">
+			Limits range of data passed to `set_custom` to unsigned normalized 0 to 1 stored in 8 bits per channel. See [constant Mesh.ARRAY_CUSTOM_RGBA8_UNORM].
 		</constant>
 		<constant name="CUSTOM_RGBA8_SNORM" value="1" enum="CustomFormat">
+			Limits range of data passed to `set_custom` to signed normalized -1 to 1 stored in 8 bits per channel. See [constant Mesh.ARRAY_CUSTOM_RGBA8_SNORM].
 		</constant>
 		<constant name="CUSTOM_RG_HALF" value="2" enum="CustomFormat">
+			Stores data passed to `set_custom` as half precision floats, and uses only red and green color channels. See [constant Mesh.ARRAY_CUSTOM_RG_HALF].
 		</constant>
 		<constant name="CUSTOM_RGBA_HALF" value="3" enum="CustomFormat">
+			Stores data passed to `set_custom` as half precision floats and uses all color channels. See [constant Mesh.ARRAY_CUSTOM_RGBA_HALF].
 		</constant>
 		<constant name="CUSTOM_R_FLOAT" value="4" enum="CustomFormat">
+			Stores data passed to `set_custom` as full precision floats, and uses only red color channel. See [constant Mesh.ARRAY_CUSTOM_R_FLOAT].
 		</constant>
 		<constant name="CUSTOM_RG_FLOAT" value="5" enum="CustomFormat">
+			Stores data passed to `set_custom` as full precision floats, and uses only red and green color channels. See [constant Mesh.ARRAY_CUSTOM_RG_FLOAT].
 		</constant>
 		<constant name="CUSTOM_RGB_FLOAT" value="6" enum="CustomFormat">
+			Stores data passed to `set_custom` as full precision floats, and uses only red, green and blue color channels. See [constant Mesh.ARRAY_CUSTOM_RGB_FLOAT].
 		</constant>
 		<constant name="CUSTOM_RGBA_FLOAT" value="7" enum="CustomFormat">
+			Stores data passed to `set_custom` as full precision floats, and uses all color channels. See [constant Mesh.ARRAY_CUSTOM_RGBA_FLOAT].
 		</constant>
 		<constant name="CUSTOM_MAX" value="8" enum="CustomFormat">
+			Used to indicate a disabled custom channel.
 		</constant>
 		<constant name="SKIN_4_WEIGHTS" value="0" enum="SkinWeightCount">
+			Each individual vertex can be influenced by only 4 bone weights.
 		</constant>
 		<constant name="SKIN_8_WEIGHTS" value="1" enum="SkinWeightCount">
+			Each individual vertex can be influenced by up to 8 bone weights.
 		</constant>
 	</constants>
 </class>

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -1185,7 +1185,7 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 	for (unsigned int i = 0; i < surfaces_tools.size(); i++) {
 		surfaces_tools[i]->index();
 		Array arrays = surfaces_tools[i]->commit_to_arrays();
-		add_surface(surfaces_tools[i]->get_primitive(), arrays, Array(), Dictionary(), surfaces_tools[i]->get_material(), surfaces_tools[i]->get_meta("name"));
+		add_surface(surfaces_tools[i]->get_primitive_type(), arrays, Array(), Dictionary(), surfaces_tools[i]->get_material(), surfaces_tools[i]->get_meta("name"));
 	}
 
 	set_lightmap_size_hint(Size2(size_x, size_y));
@@ -1238,6 +1238,7 @@ void ImporterMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_surface_name", "surface_idx", "name"), &ImporterMesh::set_surface_name);
 	ClassDB::bind_method(D_METHOD("set_surface_material", "surface_idx", "material"), &ImporterMesh::set_surface_material);
 
+	ClassDB::bind_method(D_METHOD("generate_lods", "normal_merge_angle", "normal_split_angle"), &ImporterMesh::generate_lods);
 	ClassDB::bind_method(D_METHOD("get_mesh", "base_mesh"), &ImporterMesh::get_mesh, DEFVAL(Ref<ArrayMesh>()));
 	ClassDB::bind_method(D_METHOD("clear"), &ImporterMesh::clear);
 

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -154,10 +154,10 @@ public:
 	void set_skin_weight_count(SkinWeightCount p_weights);
 	SkinWeightCount get_skin_weight_count() const;
 
-	void set_custom_format(int p_index, CustomFormat p_format);
-	CustomFormat get_custom_format(int p_index) const;
+	void set_custom_format(int p_channel_index, CustomFormat p_format);
+	CustomFormat get_custom_format(int p_channel_index) const;
 
-	Mesh::PrimitiveType get_primitive() const;
+	Mesh::PrimitiveType get_primitive_type() const;
 
 	void begin(Mesh::PrimitiveType p_primitive);
 
@@ -166,7 +166,7 @@ public:
 	void set_tangent(const Plane &p_tangent);
 	void set_uv(const Vector2 &p_uv);
 	void set_uv2(const Vector2 &p_uv2);
-	void set_custom(int p_index, const Color &p_custom);
+	void set_custom(int p_channel_index, const Color &p_custom);
 	void set_bones(const Vector<int> &p_bones);
 	void set_weights(const Vector<float> &p_weights);
 	void set_smooth_group(uint32_t p_group);
@@ -183,7 +183,7 @@ public:
 	void generate_tangents();
 
 	void optimize_indices_for_cache();
-	float get_max_axis_length() const;
+	AABB get_aabb() const;
 	Vector<int> generate_lod(float p_threshold, int p_target_index_count = 3);
 
 	void set_material(const Ref<Material> &p_material);
@@ -199,7 +199,7 @@ public:
 	void create_from(const Ref<Mesh> &p_existing, int p_surface);
 	void create_from_blend_shape(const Ref<Mesh> &p_existing, int p_surface, const String &p_blend_shape_name);
 	void append_from(const Ref<Mesh> &p_existing, int p_surface, const Transform3D &p_xform);
-	Ref<ArrayMesh> commit(const Ref<ArrayMesh> &p_existing = Ref<ArrayMesh>(), uint32_t p_flags = 0);
+	Ref<ArrayMesh> commit(const Ref<ArrayMesh> &p_existing = Ref<ArrayMesh>(), uint32_t p_compress_flags = 0);
 
 	SurfaceTool();
 };


### PR DESCRIPTION
Fix mistake making `set_custom_format` impossible to use.
Automatically forward custom flags in `SurfaceTool.commit`.
Add documentation in `SurfaceTool` and `Mesh` for custom channels.
Deprecate `SurfaceTool.generate_lod` and expose `ImporterMesh.generate_lods`.

This change is to address issues @fire and I uncovered when attempting to use custom channels to create an IK gizmo.
Found a lot of missing documentation which contained critical information.

While writing documentation, I discovered that `generate_lod` was broken.

The previous code for `SKIN_8_WEIGHTS` did not forward that flag to the mesh in `commit`, but I did not test if this was broken before, nor if this fixes anything.

This PR still needs testing.