### PR TITLE
re-license default project icon as public domain

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -55,6 +55,11 @@ Comment: Godot Engine logo
 Copyright: 2017, Andrea Calabró
 License: CC-BY-4.0
 
+Files: ./editor/icons/DefaultProjectIcon.svg
+Comment: Default Project Icon
+Copyright: 2017, Andrea Calabró
+License: public-domain or CC0-1.0 or CC-BY-4.0
+
 Files: ./core/math/convex_hull.cpp
  ./core/math/convex_hull.h
 Comment: Bullet Continuous Collision Detection and Physics Library


### PR DESCRIPTION
**Edit:** Marked as draft since this needs maintainer approval.

**Edit:** Closing for two reasons:

- Changing copyright should be discussed as an issue or Godot Improvement Proposal (GIP)
- Public domain is not a worldwide solution to attribution; see [Moral rights](https://en.wikipedia.org/wiki/Moral_rights) (wikipedia.org)

See also: https://github.com/godotengine/godot/pull/105358

~~If I'm not mistaken, every new Godot project (once distributed) is technically in violation of copyright because it does not attribute the copyright of icon.png.~~ (True, but public domain doesn't necessarily help this)

Of course, we would need clear permission from the creator to do this change.
