### PR TITLE
Add `animation_changed` signal to `AnimationLibrary`, have `AnimationPlayer` connect to it instead of `Animation`'s `changed`

### DIFF
--- a/doc/classes/AnimationLibrary.xml
+++ b/doc/classes/AnimationLibrary.xml
@@ -65,6 +65,13 @@
 				Emitted when an [Animation] is added, under the key [param name].
 			</description>
 		</signal>
+		<signal name="animation_changed">
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Emitted when there's a change in one of the animations, e.g. tracks are added, moved or have changed paths. [param name] is the key of the animation that was changed.
+				See also [signal Resource.changed], which this acts as a relay for.
+			</description>
+		</signal>
 		<signal name="animation_removed">
 			<param index="0" name="name" type="StringName" />
 			<description>

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -291,9 +291,7 @@ private:
 		return ret;
 	}
 
-	void _animation_changed();
-	void _ref_anim(const Ref<Animation> &p_anim);
-	void _unref_anim(const Ref<Animation> &p_anim);
+	void _animation_changed(const StringName &p_name);
 
 	void _set_process(bool p_process, bool p_force = false);
 

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -52,11 +52,13 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 	ERR_FAIL_COND_V(p_animation.is_null(), ERR_INVALID_PARAMETER);
 
 	if (animations.has(p_name)) {
+		animations.get(p_name)->disconnect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed));
 		animations.erase(p_name);
 		emit_signal(SNAME("animation_removed"), p_name);
 	}
 
 	animations.insert(p_name, p_animation);
+	animations.get(p_name)->connect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_name));
 	emit_signal(SNAME("animation_added"), p_name);
 	notify_property_list_changed();
 	return OK;
@@ -65,6 +67,7 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 void AnimationLibrary::remove_animation(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(!animations.has(p_name), vformat("Animation not found: %s.", p_name));
 
+	animations.get(p_name)->disconnect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed));
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_removed"), p_name);
 	notify_property_list_changed();
@@ -75,6 +78,8 @@ void AnimationLibrary::rename_animation(const StringName &p_name, const StringNa
 	ERR_FAIL_COND_MSG(!is_valid_animation_name(p_new_name), "Invalid animation name: '" + String(p_new_name) + "'.");
 	ERR_FAIL_COND_MSG(animations.has(p_new_name), vformat("Animation name \"%s\" already exists in library.", p_new_name));
 
+	animations.get(p_name)->disconnect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed));
+	animations.get(p_name)->connect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_new_name));
 	animations.insert(p_new_name, animations[p_name]);
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_renamed"), p_name, p_new_name);
@@ -100,6 +105,10 @@ TypedArray<StringName> AnimationLibrary::_get_animation_list() const {
 	return ret;
 }
 
+void AnimationLibrary::_animation_changed(const StringName &p_name) {
+	emit_signal(SNAME("animation_changed"), p_name);
+}
+
 void AnimationLibrary::get_animation_list(List<StringName> *p_animations) const {
 	List<StringName> anims;
 
@@ -115,6 +124,9 @@ void AnimationLibrary::get_animation_list(List<StringName> *p_animations) const 
 }
 
 void AnimationLibrary::_set_data(const Dictionary &p_data) {
+	for (KeyValue<StringName, Ref<Animation>> &K : animations) {
+		K.value->disconnect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed));
+	}
 	animations.clear();
 	List<Variant> keys;
 	p_data.get_key_list(&keys);
@@ -146,6 +158,7 @@ void AnimationLibrary::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("animation_added", PropertyInfo(Variant::STRING_NAME, "name")));
 	ADD_SIGNAL(MethodInfo("animation_removed", PropertyInfo(Variant::STRING_NAME, "name")));
 	ADD_SIGNAL(MethodInfo("animation_renamed", PropertyInfo(Variant::STRING_NAME, "name"), PropertyInfo(Variant::STRING_NAME, "to_name")));
+	ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING_NAME, "name")));
 }
 AnimationLibrary::AnimationLibrary() {
 }

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -42,6 +42,8 @@ class AnimationLibrary : public Resource {
 
 	TypedArray<StringName> _get_animation_list() const;
 
+	void _animation_changed(const StringName &p_name);
+
 	friend class AnimationPlayer; //for faster access
 	HashMap<StringName, Ref<Animation>> animations;
 


### PR DESCRIPTION
This was intended to fix several bugs, but the bugs seem to have been fixed by other PRs in the meantime, though their issues were not closed. This PR takes a different approach, which I think is better, so this is now just a refactoring PR as far as I can tell.

Having AnimationPlayer skip past AnimationLibrary and connect to signals directly on the animations is IMO poor design. Handling individual animations is AnimationLibrary's purpose, better to leave that responsibility to it whenever possible. This better follows object-oriented design principles, and is also simpler.

<details>
<summary>Original description</summary>
<p>Originally, AnimationPlayer connected to the `tracks_changed` signal on an Animation whenever one was added, and disconnected it when it was removed. This worked fine, until AnimationLibraries were introduced. After that, AnimationPlayer would iterate over every animation in a library to disconnect the signal from each animation, but connecting the signals was overlooked. This caused #60566.
The obvious fix seemed to be to just similarly iterate to connect these signals, which I tried in #61513. However, that was still not correct, the signal didn't get connected if a new animation was added to a library that was already added to a player.</p>
<p>This was the wrong approach, since AnimationPlayer doesn't store animations anymore, it stores AnimationLibraries. Instead, now AnimationLibrary relays the signal through its own `animation_tracks_changed` signal. The new signal might also be more convenient to use than Animation's one in some situations, for that reason it also includes the key of the animation that changed.</p>
<p>Fixes #60566, fixes #63796, (_Bugsquads edited:_ fixes #64990) and probably other unreported issues caused by the caches not updating because the signal wasn't connected. Also possibly #62288 but I can't test since there's no MRP.</p>
<p>Supersedes #61513.</p>
</details>