### PR TITLE
[3.x] Fix scene tree dock focus after using "Add Child Node" button

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2348,7 +2348,7 @@ void SceneTreeDock::_create() {
 		_do_reparent(last_created, -1, nodes, true);
 	}
 
-	scene_tree->get_scene_tree()->grab_focus();
+	scene_tree->get_scene_tree()->call_deferred("grab_focus");
 }
 
 void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties, bool p_remove_old) {


### PR DESCRIPTION
In recent Godot versions, the scene tree is no longer focused after adding new nodes with the "Add Child Node" button. Pressing Enter after adding a new node opens the Add Node dialog instead of triggering the rename of the newly created node.

This happens since 3.4.beta4 and is an regression introduced by #49521. (`master` is not affected, probably because its popup window logic changed.)

This PR restores the `call_deferred()` call.

p.s. As noted in https://github.com/godotengine/godot/pull/49521#discussion_r686977536, the main viewport will grab focus if your mouse is over it when you close the Add Node dialog with your mouse. You can try using the Add Node dialog with keyboard (enter the class name and then hit OK) when testing this.