### PR TITLE
Fix setting owner on internal nodes when save branch as scene

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2418,8 +2418,8 @@ void SceneTreeDock::_new_scene_from(String p_file) {
 	Node *copy = base->duplicate_from_editor(duplimap);
 
 	if (copy) {
-		for (int i = 0; i < copy->get_child_count(); i++) {
-			_set_node_owner_recursive(copy->get_child(i), copy);
+		for (int i = 0; i < copy->get_child_count(false); i++) {
+			_set_node_owner_recursive(copy->get_child(i, false), copy);
 		}
 
 		Ref<PackedScene> sdata = memnew(PackedScene);
@@ -2456,8 +2456,8 @@ void SceneTreeDock::_set_node_owner_recursive(Node *p_node, Node *p_owner) {
 		p_node->set_owner(p_owner);
 	}
 
-	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_set_node_owner_recursive(p_node->get_child(i), p_owner);
+	for (int i = 0; i < p_node->get_child_count(false); i++) {
+		_set_node_owner_recursive(p_node->get_child(i, false), p_owner);
 	}
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fix #54960.

Previously, setting owner was performed on all child nodes. Actually, it should not be performed on internal nodes.