### PR TITLE
[RTL] Fix underline/overline/strikethrough interaction with the "visible characters" property.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1243,8 +1243,8 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 
 			// Draw glyphs.
 			for (int j = 0; j < glyphs[i].repeat; j++) {
+				bool skip = (trim_chars && l.char_offset + glyphs[i].end > visible_characters) || (trim_glyphs_ltr && (r_processed_glyphs >= visible_glyphs)) || (trim_glyphs_rtl && (r_processed_glyphs < total_glyphs - visible_glyphs));
 				if (visible) {
-					bool skip = (trim_chars && l.char_offset + glyphs[i].end > visible_characters) || (trim_glyphs_ltr && (r_processed_glyphs >= visible_glyphs)) || (trim_glyphs_rtl && (r_processed_glyphs < total_glyphs - visible_glyphs));
 					if (!skip) {
 						if (frid != RID()) {
 							TS->font_draw_glyph(frid, ci, glyphs[i].font_size, p_ofs + fx_offset + off, gl, selected ? selection_fg : font_color);
@@ -1253,6 +1253,27 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						}
 					}
 					r_processed_glyphs++;
+				}
+				if (skip) {
+					// End underline/overline/strikethrough is previous glyph is skipped.
+					if (ul_started) {
+						ul_started = false;
+						float y_off = TS->shaped_text_get_underline_position(rid);
+						float underline_width = TS->shaped_text_get_underline_thickness(rid) * get_theme_default_base_scale();
+						draw_line(ul_start + Vector2(0, y_off), p_ofs + Vector2(off.x, off.y + y_off), ul_color, underline_width);
+					}
+					if (dot_ul_started) {
+						dot_ul_started = false;
+						float y_off = TS->shaped_text_get_underline_position(rid);
+						float underline_width = TS->shaped_text_get_underline_thickness(rid) * get_theme_default_base_scale();
+						draw_dashed_line(dot_ul_start + Vector2(0, y_off), p_ofs + Vector2(off.x, off.y + y_off), dot_ul_color, underline_width, underline_width * 2);
+					}
+					if (st_started) {
+						st_started = false;
+						float y_off = -TS->shaped_text_get_ascent(rid) + TS->shaped_text_get_size(rid).y / 2;
+						float underline_width = TS->shaped_text_get_underline_thickness(rid) * get_theme_default_base_scale();
+						draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off.x, off.y + y_off), st_color, underline_width);
+					}
 				}
 				off.x += glyphs[i].advance;
 			}


### PR DESCRIPTION
Fixes #61976