### PR TITLE
[3.x] [HTML5] Add GDNative+Threads build.

### DIFF
--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -37,6 +37,8 @@ for ext in env["JS_EXTERNS"]:
 build = []
 if env["gdnative_enabled"]:
     build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
+    if env["threads_enabled"]:
+        build_targets.append("#bin/godot${PROGSUFFIX}.worker.js")
     # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
     sys_env["LIBS"] = []
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
@@ -58,7 +60,7 @@ if env["gdnative_enabled"]:
     wasm_env.Append(CCFLAGS=["-s", "SIDE_MODULE=2"])
     wasm_env.Append(LINKFLAGS=["-s", "SIDE_MODULE=2"])
     wasm = wasm_env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", javascript_files)
-    build = [sys[0], sys[1], wasm[0]]
+    build = sys + [wasm[0]]
 else:
     build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
     if env["threads_enabled"]:
@@ -87,5 +89,5 @@ wrap_list = [
 js_wrapped = env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
 
 # Extra will be the thread worker, or the GDNative side, or None
-extra = build[2] if len(build) > 2 else None
+extra = build[2:] if len(build) > 2 else None
 env.CreateTemplateZip(js_wrapped, build[1], extra)

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -174,10 +174,6 @@ def configure(env):
     if env["javascript_eval"]:
         env.Append(CPPDEFINES=["JAVASCRIPT_EVAL_ENABLED"])
 
-    if env["threads_enabled"] and env["gdnative_enabled"]:
-        print("Threads and GDNative support can't be both enabled due to WebAssembly limitations")
-        sys.exit(255)
-
     # Thread support (via SharedArrayBuffer).
     if env["threads_enabled"]:
         env.Append(CPPDEFINES=["PTHREAD_NO_RENAME"])
@@ -193,6 +189,9 @@ def configure(env):
         major, minor, patch = get_compiler_version(env)
         if major < 2 or (major == 2 and minor == 0 and patch < 10):
             print("GDNative support requires emscripten >= 2.0.10, detected: %s.%s.%s" % (major, minor, patch))
+            sys.exit(255)
+        if env["threads_enabled"] and major < 3 or (major == 3 and minor < 1) or (major == 3 and minor == 1 and patch < 14):
+            print("Threads and GDNative requires emscripten => 3.1.14, detected: %s.%s.%s" % (major, minor, patch))
             sys.exit(255)
         env.Append(CCFLAGS=["-s", "RELOCATABLE=1"])
         env.Append(LINKFLAGS=["-s", "RELOCATABLE=1"])

--- a/platform/javascript/emscripten_helpers.py
+++ b/platform/javascript/emscripten_helpers.py
@@ -52,10 +52,10 @@ def create_template_zip(env, js, wasm, extra):
     ]
     # GDNative/Threads specific
     if env["gdnative_enabled"]:
-        in_files.append(extra)  # Runtime
+        in_files.append(extra.pop())  # Runtime
         out_files.append(zip_dir.File(binary_name + ".side.wasm"))
-    elif env["threads_enabled"]:
-        in_files.append(extra)  # Worker
+    if env["threads_enabled"]:
+        in_files.append(extra.pop())  # Worker
         out_files.append(zip_dir.File(binary_name + ".worker.js"))
 
     service_worker = "#misc/dist/html/service-worker.js"

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -271,19 +271,16 @@ class EditorExportPlatformJavaScript : public EditorExportPlatform {
 		EXPORT_MODE_NORMAL = 0,
 		EXPORT_MODE_THREADS = 1,
 		EXPORT_MODE_GDNATIVE = 2,
+		EXPORT_MODE_THREADS_GDNATIVE = 3,
 	};
 
 	String _get_template_name(ExportMode p_mode, bool p_debug) const {
 		String name = "webassembly";
-		switch (p_mode) {
-			case EXPORT_MODE_THREADS:
-				name += "_threads";
-				break;
-			case EXPORT_MODE_GDNATIVE:
-				name += "_gdnative";
-				break;
-			default:
-				break;
+		if (p_mode & EXPORT_MODE_GDNATIVE) {
+			name += "_gdnative";
+		}
+		if (p_mode & EXPORT_MODE_THREADS) {
+			name += "_threads";
 		}
 		if (p_debug) {
 			name += "_debug.zip";
@@ -540,7 +537,7 @@ Error EditorExportPlatformJavaScript::_build_pwa(const Ref<EditorExportPreset> &
 		cache_files.push_back(name + ".icon.png");
 		cache_files.push_back(name + ".apple-touch-icon.png");
 	}
-	if (mode == EXPORT_MODE_THREADS) {
+	if (mode & EXPORT_MODE_THREADS) {
 		cache_files.push_back(name + ".worker.js");
 		cache_files.push_back(name + ".audio.worklet.js");
 	}
@@ -550,7 +547,7 @@ Error EditorExportPlatformJavaScript::_build_pwa(const Ref<EditorExportPreset> &
 	Array opt_cache_files;
 	opt_cache_files.push_back(name + ".wasm");
 	opt_cache_files.push_back(name + ".pck");
-	if (mode == EXPORT_MODE_GDNATIVE) {
+	if (mode & EXPORT_MODE_GDNATIVE) {
 		opt_cache_files.push_back(name + ".side.wasm");
 		for (int i = 0; i < p_shared_objects.size(); i++) {
 			opt_cache_files.push_back(p_shared_objects[i].path.get_file());
@@ -646,9 +643,10 @@ void EditorExportPlatformJavaScript::get_preset_features(const Ref<EditorExportP
 		}
 	}
 	ExportMode mode = (ExportMode)(int)p_preset->get("variant/export_type");
-	if (mode == EXPORT_MODE_THREADS) {
+	if (mode & EXPORT_MODE_THREADS) {
 		r_features->push_back("threads");
-	} else if (mode == EXPORT_MODE_GDNATIVE) {
+	}
+	if (mode & EXPORT_MODE_GDNATIVE) {
 		r_features->push_back("wasm32");
 	}
 }


### PR DESCRIPTION
Requires an unreleased version of emscripten (or more correctly, a recent LLVM patch, see: https://github.com/emscripten-core/emscripten/issues/17150 and https://reviews.llvm.org/D127333).

You can try it out by building LLVM from source, and overriding the LLVM version used by emscripten via the `EM_LLVM_ROOT` env variable ([see here](https://emscripten.org/docs/building_from_source/index.html#building-llvm)).

Only template versions work, the editor fails to start (possibly related to https://github.com/emscripten-core/emscripten/issues/15487):

```
WebAssembly.instantiate(): imports count of 132022 exceeds internal limit of 100000
```

Will open on a dedicated PR for master soon.