### PR TITLE
Enable asynchronous shader compilation + cache by default in GLES3

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1320,7 +1320,7 @@
 			An override for [code]rendering/gles3/shaders/ubershader_cache_size_mb[/code], so a smaller maximum size can be configured for mobile platforms, where storage space is more limited.
 			[b]Note:[/b] This setting is only meaningful if [code]rendering/gles3/shaders/shader_compilation_mode[/code] is set to [code]Asynchronous + Cache[/code].
 		</member>
-		<member name="rendering/gles3/shaders/shader_compilation_mode" type="int" setter="" getter="" default="0">
+		<member name="rendering/gles3/shaders/shader_compilation_mode" type="int" setter="" getter="" default="2">
 			If set to [code]Asynchronous[/code] and available on the target device, asynchronous compilation of shaders is enabled (in contrast to [code]Asynchronous[/code]).
 			That means that when a shader is first used under some new rendering situation, the game won't stall while such shader is being compiled. Instead, a fallback will be used and the real shader will be compiled in the background. Once the actual shader is compiled, it will be used the next times it's used to draw a frame.
 			Depending on the async mode configured for a given material/shader, the fallback will be an "ubershader" (the default) or just skip rendering any item it is applied to.

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2734,7 +2734,7 @@ VisualServer::VisualServer() {
 		force_shader_fallbacks = GLOBAL_GET("rendering/gles3/shaders/debug_shader_fallbacks");
 	}
 #endif
-	GLOBAL_DEF("rendering/gles3/shaders/shader_compilation_mode", 0);
+	GLOBAL_DEF("rendering/gles3/shaders/shader_compilation_mode", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/gles3/shaders/shader_compilation_mode", PropertyInfo(Variant::INT, "rendering/gles3/shaders/shader_compilation_mode", PROPERTY_HINT_ENUM, "Synchronous,Asynchronous,Asynchronous + Cache"));
 	GLOBAL_DEF("rendering/gles3/shaders/shader_compilation_mode.mobile", 0);
 	GLOBAL_DEF("rendering/gles3/shaders/max_simultaneous_compiles", 2);


### PR DESCRIPTION
This reduces stuttering when a material is displayed for the first time, and prevents stuttering from occurring entirely after the project is restarted when a similar situation is encountered. See https://github.com/godotengine/godot/pull/53411 for context.

This default setting only affects desktop platforms.

This was discussed with @RandomShaper during the Godot sprint, and it _should_ be good to go for 3.5.