### PR TITLE
Fix wrong sampling in ColorPicker

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1108,7 +1108,7 @@ void ColorPicker::_screen_input(const Ref<InputEvent> &p_event) {
 		Ref<Image> img = r->get_texture()->get_image();
 		if (img.is_valid() && !img->is_empty()) {
 			Vector2 ofs = mev->get_global_position() - r->get_visible_rect().get_position();
-			Color c = img->get_pixel(ofs.x, r->get_visible_rect().size.height - ofs.y);
+			Color c = img->get_pixel(ofs.x, ofs.y);
 
 			set_pick_color(c);
 		}
@@ -1135,6 +1135,8 @@ void ColorPicker::_screen_pick_pressed() {
 		screen->connect("gui_input", callable_mp(this, &ColorPicker::_screen_input));
 		// It immediately toggles off in the first press otherwise.
 		screen->call_deferred(SNAME("connect"), "hidden", Callable(btn_pick, "set_pressed"), varray(false));
+	} else {
+		screen->show();
 	}
 	screen->raise();
 #ifndef _MSC_VER


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Quick fix #46334.

Previously, the position was calculated incorrectly, resulting in incorrect sampling. This may not be the best solution, the `ColorPickerButton` still has problems in play mode and `interface/editor/single_window_mode`.

| Editor | Play |
| :------: | :-----: |
| ![1](https://user-images.githubusercontent.com/30386067/173387372-e8457ec8-8198-41be-aaee-70797150a7ae.gif) | ![2](https://user-images.githubusercontent.com/30386067/173387381-001c7d8a-f0f8-4a25-bace-945df9738461.gif) |

#25358 appears to have been fixed.

**Edit:**

~~Make `deferred_mode` available again. If enabled, only display and record the different colors when the `LMB` is pressed/released in the shape, or the color obtained when the sampling is ended.~~



