### PR TITLE
Added z-corrected option for parallax

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -217,6 +217,9 @@
 		<member name="grow_amount" type="float" setter="set_grow" getter="get_grow" default="0.0">
 			Grows object vertices in the direction of their normals.
 		</member>
+		<member name="heightmap_corrected_z" type="bool" setter="set_heightmap_corrected_z" getter="is_heightmap_corrected_z_enabled" default="true">
+			If [code]true[/code] applies a correction on the parallax effect to better represent depth under certain view angles. However it might introduce undesirable artifacts on boundaries.
+		</member>
 		<member name="heightmap_deep_parallax" type="bool" setter="set_heightmap_deep_parallax" getter="is_heightmap_deep_parallax_enabled" default="false">
 		</member>
 		<member name="heightmap_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -965,7 +965,11 @@ void BaseMaterial3D::_update_shader() {
 			code += "		float num_layers = mix(float(heightmap_max_layers),float(heightmap_min_layers), abs(dot(vec3(0.0, 0.0, 1.0), view_dir)));\n";
 			code += "		float layer_depth = 1.0 / num_layers;\n";
 			code += "		float current_layer_depth = 0.0;\n";
-			code += "		vec2 P = view_dir.xy * heightmap_scale;\n";
+			if (!heightmap_corrected_z) {
+				code += "		vec2 P = view_dir.xy * heightmap_scale;\n";
+			} else {
+				code += "		vec2 P = view_dir.xy / view_dir.z * heightmap_scale;\n";
+			}
 			code += "		vec2 delta = P / num_layers;\n";
 			code += "		vec2 ofs = base_uv;\n";
 			if (flags[FLAG_INVERT_HEIGHTMAP]) {
@@ -2022,6 +2026,16 @@ bool BaseMaterial3D::get_particles_anim_loop() const {
 	return particles_anim_loop;
 }
 
+void BaseMaterial3D::set_heightmap_corrected_z(bool p_enable) {
+	heightmap_corrected_z = p_enable;
+	_queue_shader_change();
+	notify_property_list_changed();
+}
+
+bool BaseMaterial3D::is_heightmap_corrected_z_enabled() const {
+	return heightmap_corrected_z;
+}
+
 void BaseMaterial3D::set_heightmap_deep_parallax(bool p_enable) {
 	deep_parallax = p_enable;
 	_queue_shader_change();
@@ -2467,6 +2481,9 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_particles_anim_loop", "loop"), &BaseMaterial3D::set_particles_anim_loop);
 	ClassDB::bind_method(D_METHOD("get_particles_anim_loop"), &BaseMaterial3D::get_particles_anim_loop);
 
+	ClassDB::bind_method(D_METHOD("set_heightmap_corrected_z", "enable"), &BaseMaterial3D::set_heightmap_corrected_z);
+	ClassDB::bind_method(D_METHOD("is_heightmap_corrected_z_enabled"), &BaseMaterial3D::is_heightmap_corrected_z_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_heightmap_deep_parallax", "enable"), &BaseMaterial3D::set_heightmap_deep_parallax);
 	ClassDB::bind_method(D_METHOD("is_heightmap_deep_parallax_enabled"), &BaseMaterial3D::is_heightmap_deep_parallax_enabled);
 
@@ -2614,6 +2631,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_GROUP("Height", "heightmap_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "heightmap_enabled"), "set_feature", "get_feature", FEATURE_HEIGHT_MAPPING);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "heightmap_scale", PROPERTY_HINT_RANGE, "-16,16,0.001"), "set_heightmap_scale", "get_heightmap_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "heightmap_corrected_z"), "set_heightmap_corrected_z", "is_heightmap_corrected_z_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "heightmap_deep_parallax"), "set_heightmap_deep_parallax", "is_heightmap_deep_parallax_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "heightmap_min_layers", PROPERTY_HINT_RANGE, "1,64,1"), "set_heightmap_deep_parallax_min_layers", "get_heightmap_deep_parallax_min_layers");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "heightmap_max_layers", PROPERTY_HINT_RANGE, "1,64,1"), "set_heightmap_deep_parallax_max_layers", "get_heightmap_deep_parallax_max_layers");

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -312,6 +312,7 @@ private:
 		uint64_t distance_fade : get_num_bits(DISTANCE_FADE_MAX - 1);
 		// booleans
 		uint64_t deep_parallax : 1;
+		uint64_t heightmap_corrected_z : 1;
 		uint64_t grow : 1;
 		uint64_t proximity_fade : 1;
 
@@ -360,6 +361,7 @@ private:
 		mk.specular_mode = specular_mode;
 		mk.billboard_mode = billboard_mode;
 		mk.deep_parallax = deep_parallax;
+		mk.heightmap_corrected_z = heightmap_corrected_z;
 		mk.grow = grow_enabled;
 		mk.proximity_fade = proximity_fade_enabled;
 		mk.distance_fade = distance_fade;
@@ -498,6 +500,7 @@ private:
 	DetailUV detail_uv = DETAIL_UV_1;
 
 	bool deep_parallax = false;
+	bool heightmap_corrected_z = true;
 	int deep_parallax_min_layers = 0;
 	int deep_parallax_max_layers = 0;
 	bool heightmap_parallax_flip_tangent = false;
@@ -588,6 +591,9 @@ public:
 
 	void set_heightmap_scale(float p_heightmap_scale);
 	float get_heightmap_scale() const;
+
+	void set_heightmap_corrected_z(bool p_enable);
+	bool is_heightmap_corrected_z_enabled() const;
 
 	void set_heightmap_deep_parallax(bool p_enable);
 	bool is_heightmap_deep_parallax_enabled() const;


### PR DESCRIPTION
A copy of https://github.com/godotengine/godot/pull/61990 on a new fork to better follow the guidelines about rebasing.
Hopefully this time I learned how to do it properly.

Fixing https://github.com/godotengine/godot/issues/61903