### PR TITLE
Print messages when textures are detected as used in 3D/normal map (3.x)

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -102,11 +102,13 @@ void ResourceImporterTexture::update_imports() {
 		}
 
 		if (E->get() & MAKE_NORMAL_FLAG && int(cf->get_value("params", "compress/normal_map")) == 0) {
+			print_line(vformat(TTR("%s: Texture detected as used as a normal map in 3D. Enabling red-green texture compression to reduce memory usage (blue channel is discarded)."), String(E->key())));
 			cf->set_value("params", "compress/normal_map", 1);
 			changed = true;
 		}
 
 		if (E->get() & MAKE_3D_FLAG && bool(cf->get_value("params", "detect_3d"))) {
+			print_line(vformat(TTR("%s: Texture detected as used in 3D. Enabling filter, repeat, mipmap generation and VRAM texture compression."), String(E->key())));
 			cf->set_value("params", "detect_3d", false);
 			cf->set_value("params", "compress/mode", 2);
 			cf->set_value("params", "flags/repeat", true);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/61497 (does not include roughness detection, as that's only in `master`).

This detection automatically changes some import options, so it's important that users are aware of this.

Unlike https://github.com/godotengine/godot/pull/61497, I made the strings translatable as I forgot to do that in the original PR.
**Edit:** Done in https://github.com/godotengine/godot/pull/62005 for `master`.