### PR TITLE
Fix high-precision scrolling direction in the canvas editor zoom.

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1289,7 +1289,7 @@ void CanvasItemEditor::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bo
 	zoom_widget->set_zoom_by_increments(-scroll_sign, p_alt);
 	if (!Math::is_equal_approx(ABS(p_scroll_vec.y), (real_t)1.0)) {
 		// Handle high-precision (analog) scrolling.
-		zoom_widget->set_zoom(zoom * ((zoom_widget->get_zoom() / zoom - 1.f) * p_scroll_vec.y + 1.f));
+		zoom_widget->set_zoom(zoom * ((zoom_widget->get_zoom() / zoom - 1.f) * ABS(p_scroll_vec.y) + 1.f));
 	}
 	_zoom_on_position(zoom_widget->get_zoom(), p_origin);
 }


### PR DESCRIPTION
Fixes regression from #61690, that was causing both scroll wheel directions to zoom out.

I'm not entirely sure how this code works, but it fixes the bug for me.

*Bugsquad edit:*
- Fixes #61914