### PR TITLE
Update OccluderInstance3D warnings on project setting changes

### DIFF
--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -467,6 +467,11 @@ void OccluderInstance3D::_occluder_changed() {
 	update_configuration_warnings();
 }
 
+void OccluderInstance3D::_project_settings_changed() {
+	// Use Occlusion Culling project setting affects node configuration warnings.
+	update_configuration_warnings();
+}
+
 Ref<Occluder3D> OccluderInstance3D::get_occluder() const {
 	return occluder;
 }
@@ -717,6 +722,19 @@ bool OccluderInstance3D::_is_editable_3d_polygon() const {
 
 Ref<Resource> OccluderInstance3D::_get_editable_3d_polygon_resource() const {
 	return occluder;
+}
+
+void OccluderInstance3D::_notification(int p_what) {
+#ifdef TOOLS_ENABLED
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				// Use Occlusion Culling project setting affects node configuration warnings.
+				EditorNode::get_singleton()->connect("project_settings_changed", callable_mp(this, &OccluderInstance3D::_project_settings_changed));
+			}
+		} break;
+	}
+#endif
 }
 
 void OccluderInstance3D::_bind_methods() {

--- a/scene/3d/occluder_instance_3d.h
+++ b/scene/3d/occluder_instance_3d.h
@@ -169,6 +169,7 @@ private:
 	float bake_simplification_dist = 0.1f;
 
 	void _occluder_changed();
+	void _project_settings_changed();
 
 	static bool _bake_material_check(Ref<Material> p_material);
 	static void _bake_surface(const Transform3D &p_transform, Array p_surface_arrays, Ref<Material> p_material, float p_simplification_dist, PackedVector3Array &r_vertices, PackedInt32Array &r_indices);
@@ -178,6 +179,7 @@ private:
 	Ref<Resource> _get_editable_3d_polygon_resource() const;
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
This ensures the node configuration warning is always up-to-date, even when the Use Occlusion Culling project setting is changed while a scene with an OccluderInstance3D is being edited.