### PR TITLE
Disable VRAM compression by default for small textures in Detect 3D (reverted)

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1246,6 +1246,9 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_INTERNAL("application/config/features", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_remaps", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations", PackedStringArray());
+
+	GLOBAL_DEF("rendering/textures/vram_compression/minimum_size", 512);
+	custom_prop_info["rendering/textures/vram_compression/minimum_size"] = PropertyInfo(Variant::INT, "rendering/textures/vram_compression/minimum_size", PROPERTY_HINT_RANGE, "16,16384,1");
 }
 
 ProjectSettings::~ProjectSettings() {

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1924,6 +1924,11 @@
 			If [code]true[/code], the texture importer will import VRAM-compressed textures using the S3 Texture Compression algorithm. This algorithm is only supported on desktop platforms and consoles.
 			[b]Note:[/b] Changing this setting does [i]not[/i] impact textures that were already imported before. To make this setting apply to textures that were already imported, exit the editor, remove the [code].godot/imported/[/code] folder located inside the project folder then restart the editor (see [member application/config/use_hidden_project_data_directory]).
 		</member>
+		<member name="rendering/textures/vram_compression/minimum_size" type="int" setter="" getter="" default="512">
+			When a texture is detected as used in 3D in the editor, only enable VRAM compression if its size is greater than or equal to [code]minimum_size * minimum_size[/code] pixels. This is done to prevent reducing texture quality when it doesn't save much video memory, especially for pixel art.
+			For non-square textures, the pixel count is used. For example, with [member rendering/textures/vram_compression/minimum_size] set to [code]512[/code], a 512×512 texture will use VRAM compression, while 256×256 textures, 256×512 and 1024×64 textures will keep their existing compression mode (Lossless by default).
+			[b]Note:[/b] This project setting only affects textures that are detected to be used in 3D at a given time. Textures that were already imported will not be affected by changes to this setting. To force 3D detection to occur again, select a texture in the FileSystem dock, change its Detect 3D import option in the Import dock to [b]VRAM Compressed[/b] or [b]Basis Universal[/b] then click [b]Reimport[/b].
+		</member>
 		<member name="rendering/vulkan/descriptor_pools/max_descriptors_per_pool" type="int" setter="" getter="" default="64">
 		</member>
 		<member name="rendering/vulkan/rendering/back_end" type="int" setter="" getter="" default="0">

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -54,8 +54,9 @@ public:
 protected:
 	enum {
 		MAKE_3D_FLAG = 1,
-		MAKE_ROUGHNESS_FLAG = 2,
-		MAKE_NORMAL_FLAG = 4
+		MAKE_VRAM_COMPRESS_FLAG = 2,
+		MAKE_ROUGHNESS_FLAG = 4,
+		MAKE_NORMAL_FLAG = 8,
 	};
 
 	Mutex mutex;


### PR DESCRIPTION
More flexible redone version of https://github.com/godotengine/godot/pull/45587.

This is done to prevent reducing texture quality when it doesn't save much video memory, especially for pixel art.

The size threshold can be adjusted in the project settings. To get the previous behavior where textures detected to be used in 3D had their compression mode always set to VRAM, set this to the lowest value (16).

Already imported textures are not affected by this change unless you remove the associated `*.import` *file* for a given texture.

I reordered the normal map detection logic to be *after* the compression mode logic, as the compression mode affects whether normal map compression can be used.

This closes https://github.com/godotengine/godot-proposals/issues/4669.

**Testing project:** [test_vram_compress_small.zip](https://github.com/godotengine/godot/files/8899179/test_vram_compress_small.zip)
*To test reimport behavior, remember to remove *all* `*.import` files and `.godot/` in the project folder. The testing project already has those files removed, so it will perform 3D detection the first time you open it.*
 