### PR TITLE
Fix crash of navigation agents callback when object is invalid

### DIFF
--- a/modules/navigation/rvo_agent.cpp
+++ b/modules/navigation/rvo_agent.cpp
@@ -65,8 +65,9 @@ void RvoAgent::dispatch_callback() {
 		return;
 	}
 	Object *obj = ObjectDB::get_instance(callback.id);
-	if (obj == nullptr) {
+	if (!obj) {
 		callback.id = ObjectID();
+		return;
 	}
 
 	Callable::CallError responseCallError;


### PR DESCRIPTION
Fix crash of navigation agents callback when object is invalid.

The callback was designed for NavigationAgent nodes which do a cleanup for their callbacks when deleted.

If users use pure agents manually on the NavigationServer directly the cleanup also needs to happen manually. The callback for an just deleted object (e.g. due to reloading the SceneTree) was still attempted leading to a crash.

Fixes #61944

(tested and can be cherry-picked for 3.5)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
