### PR TITLE
Allow to specify a default value in `ProjectSettings.get_setting()`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1124,8 +1124,12 @@ void ProjectSettings::set_setting(const String &p_setting, const Variant &p_valu
 	set(p_setting, p_value);
 }
 
-Variant ProjectSettings::get_setting(const String &p_setting) const {
-	return get(p_setting);
+Variant ProjectSettings::get_setting(const String &p_setting, const Variant &p_default_value) const {
+	if (has_setting(p_setting)) {
+		return get(p_setting);
+	} else {
+		return p_default_value;
+	}
 }
 
 bool ProjectSettings::has_custom_feature(const String &p_feature) const {
@@ -1158,7 +1162,7 @@ ProjectSettings::AutoloadInfo ProjectSettings::get_autoload(const StringName &p_
 void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_setting", "name"), &ProjectSettings::has_setting);
 	ClassDB::bind_method(D_METHOD("set_setting", "name", "value"), &ProjectSettings::set_setting);
-	ClassDB::bind_method(D_METHOD("get_setting", "name"), &ProjectSettings::get_setting);
+	ClassDB::bind_method(D_METHOD("get_setting", "name", "default_value"), &ProjectSettings::get_setting, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("set_order", "name", "position"), &ProjectSettings::set_order);
 	ClassDB::bind_method(D_METHOD("get_order", "name"), &ProjectSettings::get_order);
 	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value"), &ProjectSettings::set_initial_value);

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -141,7 +141,7 @@ public:
 	static const int CONFIG_VERSION = 5;
 
 	void set_setting(const String &p_setting, const Variant &p_value);
-	Variant get_setting(const String &p_setting) const;
+	Variant get_setting(const String &p_setting, const Variant &p_default_value = Variant()) const;
 
 	bool has_setting(String p_var) const;
 	String localize_path(const String &p_path) const;

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -70,15 +70,18 @@
 		<method name="get_setting" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="name" type="String" />
+			<param index="1" name="default_value" type="Variant" default="null" />
 			<description>
-				Returns the value of a setting.
+				Returns the value of the setting identified by [param name]. If the setting doesn't exist and [param default_value] is specified, the value of [param default_value] is returned. Otherwise, [code]null[/code] is returned.
 				[b]Example:[/b]
 				[codeblocks]
 				[gdscript]
 				print(ProjectSettings.get_setting("application/config/name"))
+				print(ProjectSettings.get_setting("application/config/custom_description", "No description specified."))
 				[/gdscript]
 				[csharp]
 				GD.Print(ProjectSettings.GetSetting("application/config/name"));
+				GD.Print(ProjectSettings.GetSetting("application/config/custom_description", "No description specified."));
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/tests/core/config/test_project_settings.h
+++ b/tests/core/config/test_project_settings.h
@@ -1,0 +1,102 @@
+/*************************************************************************/
+/*  test_project_settings.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_PROJECT_SETTINGS_H
+#define TEST_PROJECT_SETTINGS_H
+
+#include "core/config/project_settings.h"
+#include "core/variant/variant.h"
+#include "tests/test_macros.h"
+
+namespace TestProjectSettings {
+
+TEST_CASE("[ProjectSettings] Get existing setting") {
+	CHECK(ProjectSettings::get_singleton()->has_setting("application/config/name"));
+
+	Variant variant = ProjectSettings::get_singleton()->get_setting("application/config/name");
+	CHECK_EQ(variant.get_type(), Variant::STRING);
+
+	String name = variant;
+	CHECK_EQ(name, "GDScript Integration Test Suite");
+}
+
+TEST_CASE("[ProjectSettings] Default value is ignored if setting exists") {
+	CHECK(ProjectSettings::get_singleton()->has_setting("application/config/name"));
+
+	Variant variant = ProjectSettings::get_singleton()->get_setting("application/config/name", "SomeDefaultValue");
+	CHECK_EQ(variant.get_type(), Variant::STRING);
+
+	String name = variant;
+	CHECK_EQ(name, "GDScript Integration Test Suite");
+}
+
+TEST_CASE("[ProjectSettings] Non existing setting is null") {
+	CHECK_FALSE(ProjectSettings::get_singleton()->has_setting("not_existing_setting"));
+
+	Variant variant = ProjectSettings::get_singleton()->get_setting("not_existing_setting");
+	CHECK_EQ(variant.get_type(), Variant::NIL);
+}
+
+TEST_CASE("[ProjectSettings] Non existing setting should return default value") {
+	CHECK_FALSE(ProjectSettings::get_singleton()->has_setting("not_existing_setting"));
+
+	Variant variant = ProjectSettings::get_singleton()->get_setting("not_existing_setting");
+	CHECK_EQ(variant.get_type(), Variant::NIL);
+
+	variant = ProjectSettings::get_singleton()->get_setting("not_existing_setting", "my_nice_default_value");
+	CHECK_EQ(variant.get_type(), Variant::STRING);
+
+	String name = variant;
+	CHECK_EQ(name, "my_nice_default_value");
+
+	CHECK_FALSE(ProjectSettings::get_singleton()->has_setting("not_existing_setting"));
+}
+
+TEST_CASE("[ProjectSettings] Set value should be returned when retrieved") {
+	CHECK_FALSE(ProjectSettings::get_singleton()->has_setting("my_custom_setting"));
+
+	Variant variant = ProjectSettings::get_singleton()->get_setting("my_custom_setting");
+	CHECK_EQ(variant.get_type(), Variant::NIL);
+
+	ProjectSettings::get_singleton()->set_setting("my_custom_setting", true);
+	CHECK(ProjectSettings::get_singleton()->has_setting("my_custom_setting"));
+
+	variant = ProjectSettings::get_singleton()->get_setting("my_custom_setting");
+	CHECK_EQ(variant.get_type(), Variant::BOOL);
+
+	bool value = variant;
+	CHECK_EQ(true, value);
+
+	CHECK(ProjectSettings::get_singleton()->has_setting("my_custom_setting"));
+}
+
+} // namespace TestProjectSettings
+
+#endif // TEST_PROJECT_SETTINGS_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -30,6 +30,7 @@
 
 #include "test_main.h"
 
+#include "tests/core/config/test_project_settings.h"
 #include "tests/core/input/test_input_event_key.h"
 #include "tests/core/input/test_shortcut.h"
 #include "tests/core/io/test_config_file.h"


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4649

`ProjectSettings.get_setting()` now has an optional parameter, which can be used to specify a default value that is used in case the setting does not exist.

Example:
`ProjectSettings.get_setting('some_setting', 'my_default_value')`

I also added tests for `ProjectSettings.set_setting()`, `ProjectSettings.get_setting()`, `ProjectSettings.has_setting()`.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
