### PR TITLE
Add `settings_changed` signal to ProjectSettings

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -45,6 +45,8 @@ class ProjectSettings : public Object {
 	_THREAD_SAFE_CLASS_
 	friend class TestProjectSettingsInternalsAccessor;
 
+	bool is_changed = false;
+
 public:
 	typedef HashMap<String, Variant> CustomMap;
 	static const String PROJECT_DATA_DIR_NAME_SUFFIX;
@@ -114,6 +116,9 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+
+	void _queue_changed();
+	void _emit_changed();
 
 	static ProjectSettings *singleton;
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2710,4 +2710,11 @@
 			If [code]true[/code], Godot will compile shaders required for XR.
 		</member>
 	</members>
+	<signals>
+		<signal name="settings_changed">
+			<description>
+				Emitted when any setting is changed, up to once per process frame.
+			</description>
+		</signal>
+	</signals>
 </class>


### PR DESCRIPTION
Closes #62020

This is done differently than in 3.x and the signal is named `settings_changed` for consistency with EditorSettings.

For some reason I get a crash when closing though:
```
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.0.alpha.custom_build (111a3ca09711862e08ced7fa445801e2b89ffe4c)
Dumping the backtrace.
[0] mtx_do_lock (d:\a01\_work\2\s\src\vctools\crt\github\stl\src\mutex.cpp:91)
[1] std::_Mutex_base::lock (C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\mutex:51)
[2] MutexImpl<std::recursive_mutex>::lock (C:\Users\Tomek\Desktop\Godot\godot\core\os\mutex.h:48)
[3] MutexLock<MutexImpl<std::recursive_mutex> >::MutexLock<MutexImpl<std::recursive_mutex> > (C:\Users\Tomek\Desktop\Godot\godot\core\os\mutex.h:67)
[4] GDScript::~GDScript (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript.cpp:1244)
[5] GDScript::`scalar deleting destructor'
[6] memdelete<GDScript> (C:\Users\Tomek\Desktop\Godot\godot\core\os\memory.h:111)
[7] Ref<GDScript>::unref (C:\Users\Tomek\Desktop\Godot\godot\core\object\ref_counted.h:223)
[8] Ref<GDScript>::~Ref<GDScript> (C:\Users\Tomek\Desktop\Godot\godot\core\object\ref_counted.h:233)
[9] GDScriptLambdaCallable::~GDScriptLambdaCallable (C:\Users\Tomek\Desktop\Godot\godot\modules\gdscript\gdscript_lambda_callable.h:62)
[10] GDScriptLambdaCallable::`scalar deleting destructor'
[11] memdelete<CallableCustom> (C:\Users\Tomek\Desktop\Godot\godot\core\os\memory.h:111)
[12] Callable::~Callable (C:\Users\Tomek\Desktop\Godot\godot\core\variant\callable.cpp:312)
[13] VMap<Callable,Object::SignalData::Slot>::Pair::~Pair
[14] VMap<Callable,Object::SignalData::Slot>::Pair::`scalar deleting destructor'
[15] CowData<VMap<Callable,Object::SignalData::Slot>::Pair>::_unref (C:\Users\Tomek\Desktop\Godot\godot\core\templates\cowdata.h:214)
[16] CowData<VMap<Callable,Object::SignalData::Slot>::Pair>::~CowData<VMap<Callable,Object::SignalData::Slot>::Pair> (C:\Users\Tomek\Desktop\Godot\godot\core\templates\cowdata.h:409)
[17] VMap<Callable,Object::SignalData::Slot>::~VMap<Callable,Object::SignalData::Slot>
[18] Object::SignalData::~SignalData
[19] KeyValue<StringName,Object::SignalData>::~KeyValue<StringName,Object::SignalData>
[20] HashMapElement<StringName,Object::SignalData>::~HashMapElement<StringName,Object::SignalData>
[21] HashMapElement<StringName,Object::SignalData>::`scalar deleting destructor'
[22] memdelete<HashMapElement<StringName,Object::SignalData> > (C:\Users\Tomek\Desktop\Godot\godot\core\os\memory.h:111)
[23] DefaultTypedAllocator<HashMapElement<StringName,Object::SignalData> >::delete_allocation (C:\Users\Tomek\Desktop\Godot\godot\core\os\memory.h:205)
[24] HashMap<StringName,Object::SignalData,HashMapHasherDefault,HashMapComparatorDefault<StringName>,DefaultTypedAllocator<HashMapElement<StringName,Object::SignalData> > >::erase (C:\Users\Tomek\Desktop\Godot\godot\core\templates\hash_map.h:347)
[25] Object::~Object (C:\Users\Tomek\Desktop\Godot\godot\core\object\object.cpp:1882)
[26] _GLOBAL_DEF (C:\Users\Tomek\Desktop\Godot\godot\core\config\project_settings.cpp:1273)
[27] ProjectSettings::`scalar deleting destructor'
[28] memdelete<ProjectSettings> (C:\Users\Tomek\Desktop\Godot\godot\core\os\memory.h:111)
[29] Main::cleanup (C:\Users\Tomek\Desktop\Godot\godot\main\main.cpp:2941)
[30] widechar_main (C:\Users\Tomek\Desktop\Godot\godot\platform\windows\godot_windows.cpp:177)
[31] _main (C:\Users\Tomek\Desktop\Godot\godot\platform\windows\godot_windows.cpp:197)
[32] main (C:\Users\Tomek\Desktop\Godot\godot\platform\windows\godot_windows.cpp:211)
[33] WinMain (C:\Users\Tomek\Desktop\Godot\godot\platform\windows\godot_windows.cpp:225)
[34] __scrt_common_main_seh (d:\a01\_work\2\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[35] BaseThreadInitThunk
-- END OF BACKTRACE --
```
Not sure why.