### PR TITLE
Always sample the heightmap with linear filtering in BaseMaterial3D

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -359,6 +359,7 @@
 		</member>
 		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="BaseMaterial3D.TextureFilter" default="3">
 			Filter flags for the texture. See [enum TextureFilter] for options.
+			[b]Note:[/b] [member heightmap_texture] is always sampled with linear filtering, even if nearest-neighbor filtering is selected here. This is to ensure the heightmap effect looks as intended. If you need sharper height transitions between pixels, resize the heightmap texture in an image editor with nearest-neighbor filtering.
 		</member>
 		<member name="texture_repeat" type="bool" setter="set_flag" getter="get_flag" default="true">
 			Repeat flags for the texture. See [enum TextureFilter] for options.

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -472,24 +472,33 @@ void BaseMaterial3D::_update_shader() {
 	}
 
 	String texfilter_str;
+	// Force linear filtering for the heightmap texture, as the heightmap effect
+	// looks broken with nearest-neighbor filtering (with and without Deep Parallax).
+	String texfilter_height_str;
 	switch (texture_filter) {
 		case TEXTURE_FILTER_NEAREST:
 			texfilter_str = "filter_nearest";
+			texfilter_height_str = "filter_linear";
 			break;
 		case TEXTURE_FILTER_LINEAR:
 			texfilter_str = "filter_linear";
+			texfilter_height_str = "filter_linear";
 			break;
 		case TEXTURE_FILTER_NEAREST_WITH_MIPMAPS:
 			texfilter_str = "filter_nearest_mipmap";
+			texfilter_height_str = "filter_linear_mipmap";
 			break;
 		case TEXTURE_FILTER_LINEAR_WITH_MIPMAPS:
 			texfilter_str = "filter_linear_mipmap";
+			texfilter_height_str = "filter_linear_mipmap";
 			break;
 		case TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC:
 			texfilter_str = "filter_nearest_mipmap_anisotropic";
+			texfilter_height_str = "filter_linear_mipmap_anisotropic";
 			break;
 		case TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC:
 			texfilter_str = "filter_linear_mipmap_anisotropic";
+			texfilter_height_str = "filter_linear_mipmap_anisotropic";
 			break;
 		case TEXTURE_FILTER_MAX:
 			break; // Internal value, skip.
@@ -497,8 +506,10 @@ void BaseMaterial3D::_update_shader() {
 
 	if (flags[FLAG_USE_TEXTURE_REPEAT]) {
 		texfilter_str += ",repeat_enable";
+		texfilter_height_str += ",repeat_enable";
 	} else {
 		texfilter_str += ",repeat_disable";
+		texfilter_height_str += ",repeat_disable";
 	}
 
 	//must create a shader!
@@ -763,7 +774,7 @@ void BaseMaterial3D::_update_shader() {
 	}
 
 	if (features[FEATURE_HEIGHT_MAPPING]) {
-		code += "uniform sampler2D texture_heightmap : hint_default_black," + texfilter_str + ";\n";
+		code += "uniform sampler2D texture_heightmap : hint_default_black," + texfilter_height_str + ";\n";
 		code += "uniform float heightmap_scale;\n";
 		code += "uniform int heightmap_min_layers;\n";
 		code += "uniform int heightmap_max_layers;\n";


### PR DESCRIPTION
Nearest-neighbor filtering of the heightmap results in a broken appearance, with and without Deep Parallax enabled on the material. Even setting the number of steps to 64 doesn't fully resolve the issue (and it's pretty expensive to do so).

Linear filtering results in a more expected appearance. This PR doesn't affect other texture maps such as albedo, normal or roughness.

**Note:** Not cherry-pickable to `3.x`, as import flags are set on a per-texture basis here (so this can already be worked around). This may be worth documenting in the class reference in `3.x` still.

**Testing project:** [test_heightmap_nearest.zip](https://github.com/godotengine/godot/files/8901912/test_heightmap_nearest.zip)

## Preview

### Deep Parallax disabled

| Before | After |
|-|-|
| ![2022-06-14_18 49 22_deep_before](https://user-images.githubusercontent.com/180032/173634188-97572cde-c447-4661-8c9e-9d385f896b7b.png) | ![2022-06-14_18 49 05_deep_after](https://user-images.githubusercontent.com/180032/173634179-d9f29a95-9ebf-4035-80c5-b3773cc92b1a.png) |

### Deep Parallax enabled (default number of steps)

| Before | After |
|-|-|
| ![2022-06-14_18 53 53_simple_before](https://user-images.githubusercontent.com/180032/173634195-5e5e08c7-865d-4586-8c2a-046082c3daf9.png) | ![2022-06-14_18 53 41_simple_after](https://user-images.githubusercontent.com/180032/173634190-924bc232-d74a-4a73-88be-41d410d0311b.png) |