### PR TITLE
Streamline Navigation layer function names.

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -108,8 +108,8 @@
 		<member name="max_speed" type="float" setter="set_max_speed" getter="get_max_speed" default="200.0">
 			The maximum speed that an agent can move.
 		</member>
-		<member name="navigable_layers" type="int" setter="set_navigable_layers" getter="get_navigable_layers" default="1">
-			A bitfield determining what layers of navigation regions this agent will use to calculate path. Changing it runtime will clear current navigation path and generate new one, according to new layers.
+		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
+			A bitfield determining what navigation layers of navigation regions this agent will use to calculate path. Changing it runtime will clear current navigation path and generate new one, according to new navigation layers.
 		</member>
 		<member name="neighbor_dist" type="float" setter="set_neighbor_dist" getter="get_neighbor_dist" default="500.0">
 			The distance to search for other agents.

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -114,8 +114,8 @@
 		<member name="max_speed" type="float" setter="set_max_speed" getter="get_max_speed" default="10.0">
 			The maximum speed that an agent can move.
 		</member>
-		<member name="navigable_layers" type="int" setter="set_navigable_layers" getter="get_navigable_layers" default="1">
-			A bitfield determining what layers of navigation regions this agent will use to calculate path. Changing it runtime will clear current navigation path and generate new one, according to new layers.
+		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
+			A bitfield determining what navigation layers of navigation regions this NavigationAgent will use to calculate path. Changing it runtime will clear current navigation path and generate new one, according to new navigation layers.
 		</member>
 		<member name="neighbor_dist" type="float" setter="set_neighbor_dist" getter="get_neighbor_dist" default="50.0">
 			The distance to search for other agents.

--- a/doc/classes/NavigationRegion2D.xml
+++ b/doc/classes/NavigationRegion2D.xml
@@ -28,8 +28,8 @@
 		<member name="enter_cost" type="float" setter="set_enter_cost" getter="get_enter_cost" default="0.0">
 			When pathfinding enters this regions navmesh from another regions navmesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
 		</member>
-		<member name="layers" type="int" setter="set_layers" getter="get_layers" default="1">
-			A bitfield determining all layers the region belongs to. These layers can be checked upon when requesting a path with [method NavigationServer2D.map_get_path].
+		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
+			A bitfield determining all navigation layers the region belongs to. These navigation layers can be checked upon when requesting a path with [method NavigationServer2D.map_get_path].
 		</member>
 		<member name="navpoly" type="NavigationPolygon" setter="set_navigation_polygon" getter="get_navigation_polygon">
 			The [NavigationPolygon] resource to use.

--- a/doc/classes/NavigationRegion3D.xml
+++ b/doc/classes/NavigationRegion3D.xml
@@ -35,8 +35,8 @@
 		<member name="enter_cost" type="float" setter="set_enter_cost" getter="get_enter_cost" default="0.0">
 			When pathfinding enters this regions navmesh from another regions navmesh the [code]enter_cost[/code] value is added to the path distance for determining the shortest path.
 		</member>
-		<member name="layers" type="int" setter="set_layers" getter="get_layers" default="1">
-			A bitfield determining all layers the region belongs to. These layers can be checked upon when requesting a path with [method NavigationServer3D.map_get_path].
+		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
+			A bitfield determining all navigation layers the region belongs to. These navigation layers can be checked upon when requesting a path with [method NavigationServer3D.map_get_path].
 		</member>
 		<member name="navmesh" type="NavigationMesh" setter="set_navigation_mesh" getter="get_navigation_mesh">
 			The [NavigationMesh] resource to use.

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -8,7 +8,7 @@
 		Maps are made up of regions, which are made of navigation polygons. Together, they define the navigable areas in the 2D world.
 		[b]Note:[/b] Most NavigationServer changes take effect after the next physics frame and not immediately. This includes all changes made to maps, regions or agents by navigation related Nodes in the SceneTree or made through scripts.
 		For two regions to be connected to each other, they must share a similar edge. An edge is considered connected to another if both of its two vertices are at a distance less than [code]edge_connection_margin[/code] to the respective other edge's vertex.
-		You may assign navigation layers to regions with [method NavigationServer2D.region_set_layers], which then can be checked upon when requesting a path with [method NavigationServer2D.map_get_path]. This allows allowing or forbidding some areas to 2D objects.
+		You may assign navigation layers to regions with [method NavigationServer2D.region_set_navigation_layers], which then can be checked upon when requesting a path with [method NavigationServer2D.map_get_path]. This allows allowing or forbidding some areas to 2D objects.
 		To use the collision avoidance system, you may use agents. You can set an agent's target velocity, then the servers will emit a callback with a modified velocity.
 		[b]Note:[/b] The collision avoidance system ignores regions. Using the modified velocity as-is might lead to pushing and agent outside of a navigable area. This is a limitation of the collision avoidance system, any more complex situation may require the use of the physics engine.
 		This server keeps tracks of any call and executes them during the sync phase. This means that you can request any change to the map, using any thread, without worrying.
@@ -176,9 +176,9 @@
 			<argument index="1" name="origin" type="Vector2" />
 			<argument index="2" name="destination" type="Vector2" />
 			<argument index="3" name="optimize" type="bool" />
-			<argument index="4" name="layers" type="int" default="1" />
+			<argument index="4" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns the navigation path to reach the destination from the origin. [code]layers[/code] is a bitmask of all region layers that are allowed to be in the path.
+				Returns the navigation path to reach the destination from the origin. [code]navigation_layers[/code] is a bitmask of all region navigation layers that are allowed to be in the path.
 			</description>
 		</method>
 		<method name="map_get_regions" qualifiers="const">
@@ -255,18 +255,18 @@
 				Returns the [code]enter_cost[/code] of this [code]region[/code].
 			</description>
 		</method>
-		<method name="region_get_layers" qualifiers="const">
-			<return type="int" />
-			<argument index="0" name="region" type="RID" />
-			<description>
-				Returns the region's layers.
-			</description>
-		</method>
 		<method name="region_get_map" qualifiers="const">
 			<return type="RID" />
 			<argument index="0" name="region" type="RID" />
 			<description>
 				Returns the navigation map [RID] the requested [code]region[/code] is currently assigned to.
+			</description>
+		</method>
+		<method name="region_get_navigation_layers" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="region" type="RID" />
+			<description>
+				Returns the region's navigation layers.
 			</description>
 		</method>
 		<method name="region_get_travel_cost" qualifiers="const">
@@ -284,20 +284,20 @@
 				Sets the [code]enter_cost[/code] for this [code]region[/code].
 			</description>
 		</method>
-		<method name="region_set_layers" qualifiers="const">
-			<return type="void" />
-			<argument index="0" name="region" type="RID" />
-			<argument index="1" name="layers" type="int" />
-			<description>
-				Set the region's layers. This allows selecting regions from a path request (when using [method NavigationServer2D.map_get_path]).
-			</description>
-		</method>
 		<method name="region_set_map" qualifiers="const">
 			<return type="void" />
 			<argument index="0" name="region" type="RID" />
 			<argument index="1" name="map" type="RID" />
 			<description>
 				Sets the map for the region.
+			</description>
+		</method>
+		<method name="region_set_navigation_layers" qualifiers="const">
+			<return type="void" />
+			<argument index="0" name="region" type="RID" />
+			<argument index="1" name="navigation_layers" type="int" />
+			<description>
+				Set the region's navigation layers. This allows selecting regions from a path request (when using [method NavigationServer2D.map_get_path]).
 			</description>
 		</method>
 		<method name="region_set_navpoly" qualifiers="const">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -8,7 +8,7 @@
 		Maps are made up of regions, which are made of navigation meshes. Together, they define the navigable areas in the 3D world.
 		[b]Note:[/b] Most NavigationServer changes take effect after the next physics frame and not immediately. This includes all changes made to maps, regions or agents by navigation related Nodes in the SceneTree or made through scripts.
 		For two regions to be connected to each other, they must share a similar edge. An edge is considered connected to another if both of its two vertices are at a distance less than [code]edge_connection_margin[/code] to the respective other edge's vertex.
-		You may assign navigation layers to regions with [method NavigationServer3D.region_set_layers], which then can be checked upon when requesting a path with [method NavigationServer3D.map_get_path]. This allows allowing or forbidding some areas to 3D objects.
+		You may assign navigation layers to regions with [method NavigationServer3D.region_set_navigation_layers], which then can be checked upon when requesting a path with [method NavigationServer3D.map_get_path]. This allows allowing or forbidding some areas to 3D objects.
 		To use the collision avoidance system, you may use agents. You can set an agent's target velocity, then the servers will emit a callback with a modified velocity.
 		[b]Note:[/b] The collision avoidance system ignores regions. Using the modified velocity as-is might lead to pushing and agent outside of a navigable area. This is a limitation of the collision avoidance system, any more complex situation may require the use of the physics engine.
 		This server keeps tracks of any call and executes them during the sync phase. This means that you can request any change to the map, using any thread, without worrying.
@@ -194,9 +194,9 @@
 			<argument index="1" name="origin" type="Vector3" />
 			<argument index="2" name="destination" type="Vector3" />
 			<argument index="3" name="optimize" type="bool" />
-			<argument index="4" name="layers" type="int" default="1" />
+			<argument index="4" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns the navigation path to reach the destination from the origin. [code]layers[/code] is a bitmask of all region layers that are allowed to be in the path.
+				Returns the navigation path to reach the destination from the origin. [code]navigation_layers[/code] is a bitmask of all region navigation layers that are allowed to be in the path.
 			</description>
 		</method>
 		<method name="map_get_regions" qualifiers="const">
@@ -305,18 +305,18 @@
 				Returns the [code]enter_cost[/code] of this [code]region[/code].
 			</description>
 		</method>
-		<method name="region_get_layers" qualifiers="const">
-			<return type="int" />
-			<argument index="0" name="region" type="RID" />
-			<description>
-				Returns the region's layers.
-			</description>
-		</method>
 		<method name="region_get_map" qualifiers="const">
 			<return type="RID" />
 			<argument index="0" name="region" type="RID" />
 			<description>
 				Returns the navigation map [RID] the requested [code]region[/code] is currently assigned to.
+			</description>
+		</method>
+		<method name="region_get_navigation_layers" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="region" type="RID" />
+			<description>
+				Returns the region's navigation layers.
 			</description>
 		</method>
 		<method name="region_get_travel_cost" qualifiers="const">
@@ -334,20 +334,20 @@
 				Sets the [code]enter_cost[/code] for this [code]region[/code].
 			</description>
 		</method>
-		<method name="region_set_layers" qualifiers="const">
-			<return type="void" />
-			<argument index="0" name="region" type="RID" />
-			<argument index="1" name="layers" type="int" />
-			<description>
-				Set the region's layers. This allows selecting regions from a path request (when using [method NavigationServer3D.map_get_path]).
-			</description>
-		</method>
 		<method name="region_set_map" qualifiers="const">
 			<return type="void" />
 			<argument index="0" name="region" type="RID" />
 			<argument index="1" name="map" type="RID" />
 			<description>
 				Sets the map for the region.
+			</description>
+		</method>
+		<method name="region_set_navigation_layers" qualifiers="const">
+			<return type="void" />
+			<argument index="0" name="region" type="RID" />
+			<argument index="1" name="navigation_layers" type="int" />
+			<description>
+				Set the region's navigation layers. This allows selecting regions from a path request (when using [method NavigationServer3D.map_get_path]).
 			</description>
 		</method>
 		<method name="region_set_navmesh" qualifiers="const">

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -226,8 +226,8 @@ bool GridMap::is_baking_navigation() {
 	return bake_navigation;
 }
 
-void GridMap::set_navigation_layers(uint32_t p_layers) {
-	navigation_layers = p_layers;
+void GridMap::set_navigation_layers(uint32_t p_navigation_layers) {
+	navigation_layers = p_navigation_layers;
 	_recreate_octant_data();
 }
 
@@ -548,7 +548,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 			if (bake_navigation) {
 				RID region = NavigationServer3D::get_singleton()->region_create();
-				NavigationServer3D::get_singleton()->region_set_layers(region, navigation_layers);
+				NavigationServer3D::get_singleton()->region_set_navigation_layers(region, navigation_layers);
 				NavigationServer3D::get_singleton()->region_set_navmesh(region, navmesh);
 				NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * nm.xform);
 				NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
@@ -659,7 +659,7 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 				Ref<NavigationMesh> nm = mesh_library->get_item_navmesh(cell_map[F.key].item);
 				if (nm.is_valid()) {
 					RID region = NavigationServer3D::get_singleton()->region_create();
-					NavigationServer3D::get_singleton()->region_set_layers(region, navigation_layers);
+					NavigationServer3D::get_singleton()->region_set_navigation_layers(region, navigation_layers);
 					NavigationServer3D::get_singleton()->region_set_navmesh(region, nm);
 					NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * F.value.xform);
 					NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -238,7 +238,7 @@ public:
 	void set_bake_navigation(bool p_bake_navigation);
 	bool is_baking_navigation();
 
-	void set_navigation_layers(uint32_t p_layers);
+	void set_navigation_layers(uint32_t p_navigation_layers);
 	uint32_t get_navigation_layers();
 
 	void set_mesh_library(const Ref<MeshLibrary> &p_mesh_library);

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -198,11 +198,11 @@ real_t GodotNavigationServer::map_get_edge_connection_margin(RID p_map) const {
 	return map->get_edge_connection_margin();
 }
 
-Vector<Vector3> GodotNavigationServer::map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_layers) const {
+Vector<Vector3> GodotNavigationServer::map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers) const {
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_COND_V(map == nullptr, Vector<Vector3>());
 
-	return map->get_path(p_origin, p_destination, p_optimize, p_layers);
+	return map->get_path(p_origin, p_destination, p_optimize, p_navigation_layers);
 }
 
 Vector3 GodotNavigationServer::map_get_closest_point_to_segment(RID p_map, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision) const {
@@ -339,18 +339,18 @@ real_t GodotNavigationServer::region_get_travel_cost(RID p_region) const {
 	return region->get_travel_cost();
 }
 
-COMMAND_2(region_set_layers, RID, p_region, uint32_t, p_layers) {
+COMMAND_2(region_set_navigation_layers, RID, p_region, uint32_t, p_navigation_layers) {
 	NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_COND(region == nullptr);
 
-	region->set_layers(p_layers);
+	region->set_navigation_layers(p_navigation_layers);
 }
 
-uint32_t GodotNavigationServer::region_get_layers(RID p_region) const {
+uint32_t GodotNavigationServer::region_get_navigation_layers(RID p_region) const {
 	NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_COND_V(region == nullptr, 0);
 
-	return region->get_layers();
+	return region->get_navigation_layers();
 }
 
 COMMAND_2(region_set_navmesh, RID, p_region, Ref<NavigationMesh>, p_nav_mesh) {

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -98,7 +98,7 @@ public:
 	COMMAND_2(map_set_edge_connection_margin, RID, p_map, real_t, p_connection_margin);
 	virtual real_t map_get_edge_connection_margin(RID p_map) const override;
 
-	virtual Vector<Vector3> map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_layers = 1) const override;
+	virtual Vector<Vector3> map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) const override;
 
 	virtual Vector3 map_get_closest_point_to_segment(RID p_map, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision = false) const override;
 	virtual Vector3 map_get_closest_point(RID p_map, const Vector3 &p_point) const override;
@@ -117,8 +117,8 @@ public:
 
 	COMMAND_2(region_set_map, RID, p_region, RID, p_map);
 	virtual RID region_get_map(RID p_region) const override;
-	COMMAND_2(region_set_layers, RID, p_region, uint32_t, p_layers);
-	virtual uint32_t region_get_layers(RID p_region) const override;
+	COMMAND_2(region_set_navigation_layers, RID, p_region, uint32_t, p_navigation_layers);
+	virtual uint32_t region_get_navigation_layers(RID p_region) const override;
 	COMMAND_2(region_set_transform, RID, p_region, Transform3D, p_transform);
 	COMMAND_2(region_set_navmesh, RID, p_region, Ref<NavigationMesh>, p_nav_mesh);
 	virtual void region_bake_navmesh(Ref<NavigationMesh> r_mesh, Node *p_node) const override;

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -65,7 +65,7 @@ gd::PointKey NavMap::get_point_key(const Vector3 &p_pos) const {
 	return p;
 }
 
-Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_layers) const {
+Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers) const {
 	// Find the start poly and the end poly on this map.
 	const gd::Polygon *begin_poly = nullptr;
 	const gd::Polygon *end_poly = nullptr;
@@ -78,7 +78,7 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 		const gd::Polygon &p = polygons[i];
 
 		// Only consider the polygon if it in a region with compatible layers.
-		if ((p_layers & p.owner->get_layers()) == 0) {
+		if ((p_navigation_layers & p.owner->get_navigation_layers()) == 0) {
 			continue;
 		}
 
@@ -154,7 +154,7 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 				const gd::Edge::Connection &connection = edge.connections[connection_index];
 
 				// Only consider the connection to another polygon if this polygon is in a region with compatible layers.
-				if ((p_layers & connection.polygon->owner->get_layers()) == 0) {
+				if ((p_navigation_layers & connection.polygon->owner->get_navigation_layers()) == 0) {
 					continue;
 				}
 

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -105,7 +105,7 @@ public:
 
 	gd::PointKey get_point_key(const Vector3 &p_pos) const;
 
-	Vector<Vector3> get_path(Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_layers = 1) const;
+	Vector<Vector3> get_path(Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) const;
 	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision) const;
 	Vector3 get_closest_point(const Vector3 &p_point) const;
 	Vector3 get_closest_point_normal(const Vector3 &p_point) const;

--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -40,12 +40,12 @@ void NavRegion::set_map(NavMap *p_map) {
 	}
 }
 
-void NavRegion::set_layers(uint32_t p_layers) {
-	layers = p_layers;
+void NavRegion::set_navigation_layers(uint32_t p_navigation_layers) {
+	navigation_layers = p_navigation_layers;
 }
 
-uint32_t NavRegion::get_layers() const {
-	return layers;
+uint32_t NavRegion::get_navigation_layers() const {
+	return navigation_layers;
 }
 
 void NavRegion::set_transform(Transform3D p_transform) {

--- a/modules/navigation/nav_region.h
+++ b/modules/navigation/nav_region.h
@@ -45,7 +45,7 @@ class NavRegion : public NavRid {
 	NavMap *map = nullptr;
 	Transform3D transform;
 	Ref<NavigationMesh> mesh;
-	uint32_t layers = 1;
+	uint32_t navigation_layers = 1;
 	float enter_cost = 0.0;
 	float travel_cost = 1.0;
 	Vector<gd::Edge::Connection> connections;
@@ -73,8 +73,8 @@ public:
 	void set_travel_cost(float p_travel_cost) { travel_cost = MAX(p_travel_cost, 0.0); }
 	float get_travel_cost() const { return travel_cost; }
 
-	void set_layers(uint32_t p_layers);
-	uint32_t get_layers() const;
+	void set_navigation_layers(uint32_t p_navigation_layers);
+	uint32_t get_navigation_layers() const;
 
 	void set_transform(Transform3D transform);
 	const Transform3D &get_transform() const {

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -61,8 +61,8 @@ void NavigationAgent2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_path_max_distance", "max_speed"), &NavigationAgent2D::set_path_max_distance);
 	ClassDB::bind_method(D_METHOD("get_path_max_distance"), &NavigationAgent2D::get_path_max_distance);
 
-	ClassDB::bind_method(D_METHOD("set_navigable_layers", "navigable_layers"), &NavigationAgent2D::set_navigable_layers);
-	ClassDB::bind_method(D_METHOD("get_navigable_layers"), &NavigationAgent2D::get_navigable_layers);
+	ClassDB::bind_method(D_METHOD("set_navigation_layers", "navigation_layers"), &NavigationAgent2D::set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_navigation_layers"), &NavigationAgent2D::get_navigation_layers);
 
 	ClassDB::bind_method(D_METHOD("set_navigation_map", "navigation_map"), &NavigationAgent2D::set_navigation_map);
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &NavigationAgent2D::get_navigation_map);
@@ -89,7 +89,7 @@ void NavigationAgent2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_speed", PROPERTY_HINT_RANGE, "0.1,100000,0.01,suffix:px/s"), "set_max_speed", "get_max_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_max_distance", PROPERTY_HINT_RANGE, "10,100,1,suffix:px"), "set_path_max_distance", "get_path_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "avoidance_enabled"), "set_avoidance_enabled", "get_avoidance_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigable_layers", PROPERTY_HINT_LAYERS_2D_NAVIGATION), "set_navigable_layers", "get_navigable_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_2D_NAVIGATION), "set_navigation_layers", "get_navigation_layers");
 
 	ADD_SIGNAL(MethodInfo("path_changed"));
 	ADD_SIGNAL(MethodInfo("target_reached"));
@@ -207,16 +207,16 @@ void NavigationAgent2D::set_agent_parent(Node *p_agent_parent) {
 	}
 }
 
-void NavigationAgent2D::set_navigable_layers(uint32_t p_layers) {
-	bool layers_changed = navigable_layers != p_layers;
-	navigable_layers = p_layers;
-	if (layers_changed) {
+void NavigationAgent2D::set_navigation_layers(uint32_t p_navigation_layers) {
+	bool navigation_layers_changed = navigation_layers != p_navigation_layers;
+	navigation_layers = p_navigation_layers;
+	if (navigation_layers_changed) {
 		_request_repath();
 	}
 }
 
-uint32_t NavigationAgent2D::get_navigable_layers() const {
-	return navigable_layers;
+uint32_t NavigationAgent2D::get_navigation_layers() const {
+	return navigation_layers;
 }
 
 void NavigationAgent2D::set_navigation_map(RID p_navigation_map) {
@@ -383,9 +383,9 @@ void NavigationAgent2D::update_navigation() {
 
 	if (reload_path) {
 		if (map_override.is_valid()) {
-			navigation_path = NavigationServer2D::get_singleton()->map_get_path(map_override, o, target_location, true, navigable_layers);
+			navigation_path = NavigationServer2D::get_singleton()->map_get_path(map_override, o, target_location, true, navigation_layers);
 		} else {
-			navigation_path = NavigationServer2D::get_singleton()->map_get_path(agent_parent->get_world_2d()->get_navigation_map(), o, target_location, true, navigable_layers);
+			navigation_path = NavigationServer2D::get_singleton()->map_get_path(agent_parent->get_world_2d()->get_navigation_map(), o, target_location, true, navigation_layers);
 		}
 		navigation_finished = false;
 		nav_path_index = 0;

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -45,7 +45,7 @@ class NavigationAgent2D : public Node {
 	RID map_override;
 
 	bool avoidance_enabled = false;
-	uint32_t navigable_layers = 1;
+	uint32_t navigation_layers = 1;
 
 	real_t target_desired_distance = 1.0;
 	real_t radius = 0.0;
@@ -85,8 +85,8 @@ public:
 
 	void set_agent_parent(Node *p_agent_parent);
 
-	void set_navigable_layers(uint32_t p_layers);
-	uint32_t get_navigable_layers() const;
+	void set_navigation_layers(uint32_t p_navigation_layers);
+	uint32_t get_navigation_layers() const;
 
 	void set_navigation_map(RID p_navigation_map);
 	RID get_navigation_map() const;

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -380,12 +380,12 @@ bool NavigationRegion2D::is_enabled() const {
 	return enabled;
 }
 
-void NavigationRegion2D::set_layers(uint32_t p_layers) {
-	NavigationServer2D::get_singleton()->region_set_layers(region, p_layers);
+void NavigationRegion2D::set_navigation_layers(uint32_t p_navigation_layers) {
+	NavigationServer2D::get_singleton()->region_set_navigation_layers(region, p_navigation_layers);
 }
 
-uint32_t NavigationRegion2D::get_layers() const {
-	return NavigationServer2D::get_singleton()->region_get_layers(region);
+uint32_t NavigationRegion2D::get_navigation_layers() const {
+	return NavigationServer2D::get_singleton()->region_get_navigation_layers(region);
 }
 
 void NavigationRegion2D::set_enter_cost(real_t p_enter_cost) {
@@ -559,8 +559,8 @@ void NavigationRegion2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &NavigationRegion2D::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &NavigationRegion2D::is_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_layers", "layers"), &NavigationRegion2D::set_layers);
-	ClassDB::bind_method(D_METHOD("get_layers"), &NavigationRegion2D::get_layers);
+	ClassDB::bind_method(D_METHOD("set_navigation_layers", "navigation_layers"), &NavigationRegion2D::set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_navigation_layers"), &NavigationRegion2D::get_navigation_layers);
 
 	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion2D::get_region_rid);
 
@@ -574,7 +574,7 @@ void NavigationRegion2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "navpoly", PROPERTY_HINT_RESOURCE_TYPE, "NavigationPolygon"), "set_navigation_polygon", "get_navigation_polygon");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_2D_NAVIGATION), "set_layers", "get_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_2D_NAVIGATION), "set_navigation_layers", "get_navigation_layers");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "enter_cost"), "set_enter_cost", "get_enter_cost");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "travel_cost"), "set_travel_cost", "get_travel_cost");
 }

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -117,8 +117,8 @@ public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 
-	void set_layers(uint32_t p_layers);
-	uint32_t get_layers() const;
+	void set_navigation_layers(uint32_t p_navigation_layers);
+	uint32_t get_navigation_layers() const;
 
 	RID get_region_rid() const;
 

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -65,8 +65,8 @@ void NavigationAgent3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_path_max_distance", "max_speed"), &NavigationAgent3D::set_path_max_distance);
 	ClassDB::bind_method(D_METHOD("get_path_max_distance"), &NavigationAgent3D::get_path_max_distance);
 
-	ClassDB::bind_method(D_METHOD("set_navigable_layers", "navigable_layers"), &NavigationAgent3D::set_navigable_layers);
-	ClassDB::bind_method(D_METHOD("get_navigable_layers"), &NavigationAgent3D::get_navigable_layers);
+	ClassDB::bind_method(D_METHOD("set_navigation_layers", "navigation_layers"), &NavigationAgent3D::set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_navigation_layers"), &NavigationAgent3D::get_navigation_layers);
 
 	ClassDB::bind_method(D_METHOD("set_navigation_map", "navigation_map"), &NavigationAgent3D::set_navigation_map);
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &NavigationAgent3D::get_navigation_map);
@@ -95,7 +95,7 @@ void NavigationAgent3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_max_distance", PROPERTY_HINT_RANGE, "0.01,100,0.1,suffix:m"), "set_path_max_distance", "get_path_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_y"), "set_ignore_y", "get_ignore_y");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "avoidance_enabled"), "set_avoidance_enabled", "get_avoidance_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigable_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_navigable_layers", "get_navigable_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_navigation_layers", "get_navigation_layers");
 
 	ADD_SIGNAL(MethodInfo("path_changed"));
 	ADD_SIGNAL(MethodInfo("target_reached"));
@@ -214,16 +214,16 @@ void NavigationAgent3D::set_agent_parent(Node *p_agent_parent) {
 	}
 }
 
-void NavigationAgent3D::set_navigable_layers(uint32_t p_layers) {
-	bool layers_changed = navigable_layers != p_layers;
-	navigable_layers = p_layers;
-	if (layers_changed) {
+void NavigationAgent3D::set_navigation_layers(uint32_t p_navigation_layers) {
+	bool navigation_layers_changed = navigation_layers != p_navigation_layers;
+	navigation_layers = p_navigation_layers;
+	if (navigation_layers_changed) {
 		_request_repath();
 	}
 }
 
-uint32_t NavigationAgent3D::get_navigable_layers() const {
-	return navigable_layers;
+uint32_t NavigationAgent3D::get_navigation_layers() const {
+	return navigation_layers;
 }
 
 void NavigationAgent3D::set_navigation_map(RID p_navigation_map) {
@@ -400,9 +400,9 @@ void NavigationAgent3D::update_navigation() {
 
 	if (reload_path) {
 		if (map_override.is_valid()) {
-			navigation_path = NavigationServer3D::get_singleton()->map_get_path(map_override, o, target_location, true, navigable_layers);
+			navigation_path = NavigationServer3D::get_singleton()->map_get_path(map_override, o, target_location, true, navigation_layers);
 		} else {
-			navigation_path = NavigationServer3D::get_singleton()->map_get_path(agent_parent->get_world_3d()->get_navigation_map(), o, target_location, true, navigable_layers);
+			navigation_path = NavigationServer3D::get_singleton()->map_get_path(agent_parent->get_world_3d()->get_navigation_map(), o, target_location, true, navigation_layers);
 		}
 		navigation_finished = false;
 		nav_path_index = 0;

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -45,7 +45,7 @@ class NavigationAgent3D : public Node {
 	RID map_override;
 
 	bool avoidance_enabled = false;
-	uint32_t navigable_layers = 1;
+	uint32_t navigation_layers = 1;
 
 	real_t target_desired_distance = 1.0;
 	real_t radius = 0.0;
@@ -87,8 +87,8 @@ public:
 
 	void set_agent_parent(Node *p_agent_parent);
 
-	void set_navigable_layers(uint32_t p_layers);
-	uint32_t get_navigable_layers() const;
+	void set_navigation_layers(uint32_t p_navigation_layers);
+	uint32_t get_navigation_layers() const;
 
 	void set_navigation_map(RID p_navigation_map);
 	RID get_navigation_map() const;

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -65,12 +65,12 @@ bool NavigationRegion3D::is_enabled() const {
 	return enabled;
 }
 
-void NavigationRegion3D::set_layers(uint32_t p_layers) {
-	NavigationServer3D::get_singleton()->region_set_layers(region, p_layers);
+void NavigationRegion3D::set_navigation_layers(uint32_t p_navigation_layers) {
+	NavigationServer3D::get_singleton()->region_set_navigation_layers(region, p_navigation_layers);
 }
 
-uint32_t NavigationRegion3D::get_layers() const {
-	return NavigationServer3D::get_singleton()->region_get_layers(region);
+uint32_t NavigationRegion3D::get_navigation_layers() const {
+	return NavigationServer3D::get_singleton()->region_get_navigation_layers(region);
 }
 
 void NavigationRegion3D::set_enter_cost(real_t p_enter_cost) {
@@ -239,8 +239,8 @@ void NavigationRegion3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &NavigationRegion3D::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &NavigationRegion3D::is_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_layers", "layers"), &NavigationRegion3D::set_layers);
-	ClassDB::bind_method(D_METHOD("get_layers"), &NavigationRegion3D::get_layers);
+	ClassDB::bind_method(D_METHOD("set_navigation_layers", "navigation_layers"), &NavigationRegion3D::set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_navigation_layers"), &NavigationRegion3D::get_navigation_layers);
 
 	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion3D::get_region_rid);
 
@@ -255,7 +255,7 @@ void NavigationRegion3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "navmesh", PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"), "set_navigation_mesh", "get_navigation_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_layers", "get_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_navigation_layers", "get_navigation_layers");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "enter_cost"), "set_enter_cost", "get_enter_cost");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "travel_cost"), "set_travel_cost", "get_travel_cost");
 

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -57,8 +57,8 @@ public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 
-	void set_layers(uint32_t p_layers);
-	uint32_t get_layers() const;
+	void set_navigation_layers(uint32_t p_navigation_layers);
+	uint32_t get_navigation_layers() const;
 
 	RID get_region_rid() const;
 

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -166,7 +166,7 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_get_cell_size", "map"), &NavigationServer2D::map_get_cell_size);
 	ClassDB::bind_method(D_METHOD("map_set_edge_connection_margin", "map", "margin"), &NavigationServer2D::map_set_edge_connection_margin);
 	ClassDB::bind_method(D_METHOD("map_get_edge_connection_margin", "map"), &NavigationServer2D::map_get_edge_connection_margin);
-	ClassDB::bind_method(D_METHOD("map_get_path", "map", "origin", "destination", "optimize", "layers"), &NavigationServer2D::map_get_path, DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("map_get_path", "map", "origin", "destination", "optimize", "navigation_layers"), &NavigationServer2D::map_get_path, DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("map_get_closest_point", "map", "to_point"), &NavigationServer2D::map_get_closest_point);
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_owner", "map", "to_point"), &NavigationServer2D::map_get_closest_point_owner);
 
@@ -180,8 +180,8 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_get_travel_cost", "region"), &NavigationServer2D::region_get_travel_cost);
 	ClassDB::bind_method(D_METHOD("region_set_map", "region", "map"), &NavigationServer2D::region_set_map);
 	ClassDB::bind_method(D_METHOD("region_get_map", "region"), &NavigationServer2D::region_get_map);
-	ClassDB::bind_method(D_METHOD("region_set_layers", "region", "layers"), &NavigationServer2D::region_set_layers);
-	ClassDB::bind_method(D_METHOD("region_get_layers", "region"), &NavigationServer2D::region_get_layers);
+	ClassDB::bind_method(D_METHOD("region_set_navigation_layers", "region", "navigation_layers"), &NavigationServer2D::region_set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("region_get_navigation_layers", "region"), &NavigationServer2D::region_get_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_set_transform", "region", "transform"), &NavigationServer2D::region_set_transform);
 	ClassDB::bind_method(D_METHOD("region_set_navpoly", "region", "nav_poly"), &NavigationServer2D::region_set_navpoly);
 	ClassDB::bind_method(D_METHOD("region_get_connections_count", "region"), &NavigationServer2D::region_get_connections_count);
@@ -250,8 +250,8 @@ void FORWARD_2_C(region_set_travel_cost, RID, p_region, real_t, p_travel_cost, r
 real_t FORWARD_1_C(region_get_travel_cost, RID, p_region, rid_to_rid);
 
 void FORWARD_2_C(region_set_map, RID, p_region, RID, p_map, rid_to_rid, rid_to_rid);
-void FORWARD_2_C(region_set_layers, RID, p_region, uint32_t, p_layers, rid_to_rid, uint32_to_uint32);
-uint32_t FORWARD_1_C(region_get_layers, RID, p_region, rid_to_rid);
+void FORWARD_2_C(region_set_navigation_layers, RID, p_region, uint32_t, p_navigation_layers, rid_to_rid, uint32_to_uint32);
+uint32_t FORWARD_1_C(region_get_navigation_layers, RID, p_region, rid_to_rid);
 void FORWARD_2_C(region_set_transform, RID, p_region, Transform2D, p_transform, rid_to_rid, trf2_to_trf3);
 
 void NavigationServer2D::region_set_navpoly(RID p_region, Ref<NavigationPolygon> p_nav_mesh) const {

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -75,7 +75,7 @@ public:
 	virtual real_t map_get_edge_connection_margin(RID p_map) const;
 
 	/// Returns the navigation path to reach the destination from the origin.
-	virtual Vector<Vector2> map_get_path(RID p_map, Vector2 p_origin, Vector2 p_destination, bool p_optimize, uint32_t p_layers = 1) const;
+	virtual Vector<Vector2> map_get_path(RID p_map, Vector2 p_origin, Vector2 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) const;
 
 	virtual Vector2 map_get_closest_point(RID p_map, const Vector2 &p_point) const;
 	virtual RID map_get_closest_point_owner(RID p_map, const Vector2 &p_point) const;
@@ -99,8 +99,8 @@ public:
 	virtual RID region_get_map(RID p_region) const;
 
 	/// Set the region's layers
-	virtual void region_set_layers(RID p_region, uint32_t p_layers) const;
-	virtual uint32_t region_get_layers(RID p_region) const;
+	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) const;
+	virtual uint32_t region_get_navigation_layers(RID p_region) const;
 
 	/// Set the global transformation of this region.
 	virtual void region_set_transform(RID p_region, Transform2D p_transform) const;

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -42,7 +42,7 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_get_cell_size", "map"), &NavigationServer3D::map_get_cell_size);
 	ClassDB::bind_method(D_METHOD("map_set_edge_connection_margin", "map", "margin"), &NavigationServer3D::map_set_edge_connection_margin);
 	ClassDB::bind_method(D_METHOD("map_get_edge_connection_margin", "map"), &NavigationServer3D::map_get_edge_connection_margin);
-	ClassDB::bind_method(D_METHOD("map_get_path", "map", "origin", "destination", "optimize", "layers"), &NavigationServer3D::map_get_path, DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("map_get_path", "map", "origin", "destination", "optimize", "navigation_layers"), &NavigationServer3D::map_get_path, DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_to_segment", "map", "start", "end", "use_collision"), &NavigationServer3D::map_get_closest_point_to_segment, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("map_get_closest_point", "map", "to_point"), &NavigationServer3D::map_get_closest_point);
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_normal", "map", "to_point"), &NavigationServer3D::map_get_closest_point_normal);
@@ -58,8 +58,8 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_get_travel_cost", "region"), &NavigationServer3D::region_get_travel_cost);
 	ClassDB::bind_method(D_METHOD("region_set_map", "region", "map"), &NavigationServer3D::region_set_map);
 	ClassDB::bind_method(D_METHOD("region_get_map", "region"), &NavigationServer3D::region_get_map);
-	ClassDB::bind_method(D_METHOD("region_set_layers", "region", "layers"), &NavigationServer3D::region_set_layers);
-	ClassDB::bind_method(D_METHOD("region_get_layers", "region"), &NavigationServer3D::region_get_layers);
+	ClassDB::bind_method(D_METHOD("region_set_navigation_layers", "region", "navigation_layers"), &NavigationServer3D::region_set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("region_get_navigation_layers", "region"), &NavigationServer3D::region_get_navigation_layers);
 	ClassDB::bind_method(D_METHOD("region_set_transform", "region", "transform"), &NavigationServer3D::region_set_transform);
 	ClassDB::bind_method(D_METHOD("region_set_navmesh", "region", "nav_mesh"), &NavigationServer3D::region_set_navmesh);
 	ClassDB::bind_method(D_METHOD("region_bake_navmesh", "mesh", "node"), &NavigationServer3D::region_bake_navmesh);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -84,7 +84,7 @@ public:
 	virtual real_t map_get_edge_connection_margin(RID p_map) const = 0;
 
 	/// Returns the navigation path to reach the destination from the origin.
-	virtual Vector<Vector3> map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigable_layers = 1) const = 0;
+	virtual Vector<Vector3> map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) const = 0;
 
 	virtual Vector3 map_get_closest_point_to_segment(RID p_map, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision = false) const = 0;
 	virtual Vector3 map_get_closest_point(RID p_map, const Vector3 &p_point) const = 0;
@@ -110,8 +110,8 @@ public:
 	virtual RID region_get_map(RID p_region) const = 0;
 
 	/// Set the region's layers
-	virtual void region_set_layers(RID p_region, uint32_t p_layers) const = 0;
-	virtual uint32_t region_get_layers(RID p_region) const = 0;
+	virtual void region_set_navigation_layers(RID p_region, uint32_t p_navigation_layers) const = 0;
+	virtual uint32_t region_get_navigation_layers(RID p_region) const = 0;
 
 	/// Set the global transformation of this region.
 	virtual void region_set_transform(RID p_region, Transform3D p_transform) const = 0;


### PR DESCRIPTION
Streamline Navigation layer function names to `set_navigation_layers` and `get_navigation_layers` and all variables and parameters to `navigation_layers `as already done for the 3.5 navigation backport #61996.

The navigation layer functions used 2-3 different name and variable versions to great confusion. Especially such generic names as "set_layer" need to go yesterday as they always turn into a problem both in documentation and conversations as well as when new layer types are added.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
