### PR TITLE
Add a description to ORMMaterial3D and StandardMaterial3D

### DIFF
--- a/doc/classes/ORMMaterial3D.xml
+++ b/doc/classes/ORMMaterial3D.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ORMMaterial3D" inherits="BaseMaterial3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Physically based rendering (PBR) material that can be applied to 3D objects, can use an ORM texture.
 	</brief_description>
 	<description>
+		ORMMaterial3D's properties are inherited from [BaseMaterial3D]. Unlike [StandardMaterial3D], ORMMaterial3D uses a single texture for ambient occlusion, roughness and metallic maps, known as an ORM texture.
 	</description>
 	<tutorials>
+		<link title="Standard Material 3D and ORM Material 3D">$DOCS_URL/tutorials/3d/standard_material_3d.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/StandardMaterial3D.xml
+++ b/doc/classes/StandardMaterial3D.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StandardMaterial3D" inherits="BaseMaterial3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Physically based rendering (PBR) material that can be applied to 3D objects.
 	</brief_description>
 	<description>
+		StandardMaterial3D's properties are inherited from [BaseMaterial3D].
 	</description>
 	<tutorials>
-		<link title="Standard Material 3D">$DOCS_URL/tutorials/3d/standard_material_3d.html</link>
+		<link title="Standard Material 3D and ORM Material 3D">$DOCS_URL/tutorials/3d/standard_material_3d.html</link>
 	</tutorials>
 </class>


### PR DESCRIPTION
Adds a brief description and description to ORMMateiral3D and StandardMaterial3D. Adds a link to the tutorial page to ORMMaterial3D. Renames the tutorial link for StandardMaterial3D.

I'm not sure if these descriptions are too short or not because their properties are from BaseMaterial3D.