### PR TITLE
Implement MultiMesh in 3D and flesh out MultiMesh functions

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -238,6 +238,8 @@ public:
 		GLuint vertex_array;
 		GLuint index_buffer;
 		int count;
+		bool color_disabled = false;
+		Color color;
 	};
 
 	struct {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -277,7 +277,7 @@ private:
 		int32_t shader_parameters_offset = -1;
 
 		uint32_t layer_mask = 1;
-		uint32_t instance_count = 0;
+		int32_t instance_count = 0;
 
 		RID mesh_instance;
 		bool can_sdfgi = false;

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -98,6 +98,9 @@ public:
 		}
 	}
 
+	// Buffer size is specified in bytes
+	static Vector<uint8_t> buffer_get_data(GLenum p_target, GLuint p_buffer, uint32_t p_buffer_size);
+
 	struct Resources {
 		GLuint mipmap_blur_fbo;
 		GLuint mipmap_blur_color;
@@ -295,27 +298,9 @@ public:
 		return String();
 	}
 
-	//bool validate_framebuffer(); // Validate currently bound framebuffer, does not touch global state
-	String get_framebuffer_error(GLenum p_status);
-
 	RasterizerStorageGLES3();
 	~RasterizerStorageGLES3();
 };
-
-inline String RasterizerStorageGLES3::get_framebuffer_error(GLenum p_status) {
-#if defined(DEBUG_ENABLED) && defined(GLES_OVER_GL)
-	if (p_status == GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT) {
-		return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
-	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT) {
-		return "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
-	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER) {
-		return "GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER";
-	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER) {
-		return "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER";
-	}
-#endif
-	return itos(p_status);
-}
 
 #endif // GLES3_ENABLED
 

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -23,10 +23,9 @@ layout(location = 11) in vec4 weight_attrib;
 
 #ifdef USE_INSTANCING
 
-layout(location = 5) in highp vec4 instance_xform0;
-layout(location = 6) in highp vec4 instance_xform1;
-layout(location = 7) in lowp vec4 instance_color;
-layout(location = 8) in highp vec4 instance_custom_data;
+layout(location = 1) in highp vec4 instance_xform0;
+layout(location = 2) in highp vec4 instance_xform1;
+layout(location = 5) in highp uvec4 instance_color_custom_data; // Color packed into xy, custom_data packed into zw for compatibility with 3D
 
 #endif
 
@@ -98,8 +97,9 @@ void main() {
 	vec4 bone_weights = weight_attrib;
 
 #ifdef USE_INSTANCING
+	vec4 instance_color = vec4(unpackHalf2x16(instance_color_custom_data.x), unpackHalf2x16(instance_color_custom_data.y));
 	color *= instance_color;
-	instance_custom = instance_custom_data;
+	instance_custom = vec4(unpackHalf2x16(instance_color_custom_data.z), unpackHalf2x16(instance_color_custom_data.w));
 #endif
 
 #else

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -90,6 +90,7 @@ struct Mesh {
 		struct LOD {
 			float edge_length = 0.0;
 			uint32_t index_count = 0;
+			uint32_t index_buffer_size = 0;
 			GLuint index_buffer;
 		};
 


### PR DESCRIPTION
This PR implements the MultiMesh for 3D in GLES3 which, among other things, allows CPUParticles to be used. 

Notably, due to the limited number of Vertex Attributes (and the fact that we have allocated 4 attributes to custom data) I have combined instance color and instance custom_data into a single uvec4 attribute. Accordingly, both color and custom data are packed into 2 unsigned 32 bit integers.

Unfortunately, because of this packing, we need to compress/decompress the data at calls to set_buffer and get_buffer respectively. For small data sets this is negligible, but for large data sets it may become problematic. As usual it will be best to  update the buffer as infrequently as possible and avoid retrieving the buffer from the RenderingServer at all costs.

Also contained in this PR is a change to the 2D Polygon rendering which was required to make 3D MultiMesh rendering work. The problem came from Polygon's use of VertexAttrib4f which sets a fallback color that can be used when ``color_attrib`` is disabled, but still accessed from the shader. Values set by VertexAttrib4f are not captured by VAOs which means they set global state that ultimately bleeds out into regular rendering. The impact of this issue was that the color used by the most recent Polygon would bleed into all the MultiMeshes being drawn. The solution is to force Polygons only to set their state at render time, and then to reset it after drawing. 