### PR TITLE
Allow folding in sub-inspectors in Array and Dictionary editors

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -347,6 +347,7 @@ void EditorPropertyArray::update_property() {
 			prop->set_object_and_property(object.ptr(), prop_name);
 			prop->set_label(itos(i + offset));
 			prop->set_selectable(false);
+			prop->set_use_folding(is_using_folding());
 			prop->connect("property_changed", callable_mp(this, &EditorPropertyArray::_property_changed));
 			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyArray::_object_id_selected));
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1006,6 +1007,7 @@ void EditorPropertyDictionary::update_property() {
 					} else {
 						EditorPropertyResource *editor = memnew(EditorPropertyResource);
 						editor->setup(object.ptr(), prop_name, "Resource");
+						editor->set_use_folding(is_using_folding());
 						prop = editor;
 					}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/23759

Allows folding sections in resource sub-inspectors within the Array and Dictionary editors.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/173766236-e5f82267-73e8-45aa-868b-b1c3c0df7149.png) | ![image](https://user-images.githubusercontent.com/67974470/173765379-e66e759f-8da3-46c0-8b6b-088413b8f3a3.png) |