### PR TITLE
Improvements to multi-node editing

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -52,13 +52,9 @@ public:
 	bool setting = false;
 	bool animation_read_only = false;
 
-	bool _hide_script_from_inspector() {
-		return true;
-	}
-
-	bool _dont_undo_redo() {
-		return true;
-	}
+	bool _hide_script_from_inspector() { return true; }
+	bool _hide_metadata_from_inspector() { return true; }
+	bool _dont_undo_redo() { return true; }
 
 	bool _is_read_only() {
 		return animation_read_only;
@@ -68,6 +64,7 @@ public:
 		ClassDB::bind_method(D_METHOD("_update_obj"), &AnimationTrackKeyEdit::_update_obj);
 		ClassDB::bind_method(D_METHOD("_key_ofs_changed"), &AnimationTrackKeyEdit::_key_ofs_changed);
 		ClassDB::bind_method(D_METHOD("_hide_script_from_inspector"), &AnimationTrackKeyEdit::_hide_script_from_inspector);
+		ClassDB::bind_method(D_METHOD("_hide_metadata_from_inspector"), &AnimationTrackKeyEdit::_hide_metadata_from_inspector);
 		ClassDB::bind_method(D_METHOD("get_root_path"), &AnimationTrackKeyEdit::get_root_path);
 		ClassDB::bind_method(D_METHOD("_dont_undo_redo"), &AnimationTrackKeyEdit::_dont_undo_redo);
 		ClassDB::bind_method(D_METHOD("_is_read_only"), &AnimationTrackKeyEdit::_is_read_only);
@@ -719,13 +716,9 @@ public:
 	bool setting = false;
 	bool animation_read_only = false;
 
-	bool _hide_script_from_inspector() {
-		return true;
-	}
-
-	bool _dont_undo_redo() {
-		return true;
-	}
+	bool _hide_script_from_inspector() { return true; }
+	bool _hide_metadata_from_inspector() { return true; }
+	bool _dont_undo_redo() { return true; }
 
 	bool _is_read_only() {
 		return animation_read_only;
@@ -735,6 +728,7 @@ public:
 		ClassDB::bind_method(D_METHOD("_update_obj"), &AnimationMultiTrackKeyEdit::_update_obj);
 		ClassDB::bind_method(D_METHOD("_key_ofs_changed"), &AnimationMultiTrackKeyEdit::_key_ofs_changed);
 		ClassDB::bind_method(D_METHOD("_hide_script_from_inspector"), &AnimationMultiTrackKeyEdit::_hide_script_from_inspector);
+		ClassDB::bind_method(D_METHOD("_hide_metadata_from_inspector"), &AnimationMultiTrackKeyEdit::_hide_metadata_from_inspector);
 		ClassDB::bind_method(D_METHOD("get_root_path"), &AnimationMultiTrackKeyEdit::get_root_path);
 		ClassDB::bind_method(D_METHOD("_dont_undo_redo"), &AnimationMultiTrackKeyEdit::_dont_undo_redo);
 		ClassDB::bind_method(D_METHOD("_is_read_only"), &AnimationMultiTrackKeyEdit::_is_read_only);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2711,6 +2711,11 @@ void EditorInspector::update_tree() {
 				continue;
 			}
 
+			// Hide the "MultiNodeEdit" category for MultiNodeEdit.
+			if (Object::cast_to<MultiNodeEdit>(object) && p.name == "MultiNodeEdit") {
+				continue;
+			}
+
 			// Iterate over remaining properties. If no properties in category, skip the category.
 			List<PropertyInfo>::Element *N = E_property->next();
 			bool valid = true;
@@ -2816,6 +2821,11 @@ void EditorInspector::update_tree() {
 
 		if (p.name == "script" && (hide_script || bool(object->call("_hide_script_from_inspector")))) {
 			// Hide script variables from inspector if required.
+			continue;
+		}
+
+		if (p.name.begins_with("metadata/") && bool(object->call("_hide_metadata_from_inspector"))) {
+			// Hide metadata from inspector if required.
 			continue;
 		}
 
@@ -3089,6 +3099,8 @@ void EditorInspector::update_tree() {
 			StringName classname = doc_name == "" ? object->get_class_name() : doc_name;
 			if (!object_class.is_empty()) {
 				classname = object_class;
+			} else if (Object::cast_to<MultiNodeEdit>(object)) {
+				classname = Object::cast_to<MultiNodeEdit>(object)->get_edited_class_name();
 			}
 
 			StringName propname = property_prefix + p.name;
@@ -3242,7 +3254,7 @@ void EditorInspector::update_tree() {
 		}
 	}
 
-	if (!hide_metadata) {
+	if (!hide_metadata && !object->call("_hide_metadata_from_inspector")) {
 		// Add 4px of spacing between the "Add Metadata" button and the content above it.
 		Control *spacer = memnew(Control);
 		spacer->set_custom_minimum_size(Size2(0, 4) * EDSCALE);

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -33,6 +33,7 @@
 #include "editor/editor_data.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "editor/multi_node_edit.h"
 
 void EditorPath::_add_children_to_popup(Object *p_obj, int p_depth) {
 	if (p_depth > 8) {
@@ -121,14 +122,22 @@ void EditorPath::update_path() {
 			continue;
 		}
 
-		Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(obj);
+		Ref<Texture2D> icon;
+		if (Object::cast_to<MultiNodeEdit>(obj)) {
+			icon = EditorNode::get_singleton()->get_class_icon(Object::cast_to<MultiNodeEdit>(obj)->get_edited_class_name());
+		} else {
+			icon = EditorNode::get_singleton()->get_object_icon(obj);
+		}
+
 		if (icon.is_valid()) {
 			current_object_icon->set_texture(icon);
 		}
 
 		if (i == history->get_path_size() - 1) {
 			String name;
-			if (Object::cast_to<Resource>(obj)) {
+			if (obj->has_method("_get_editor_name")) {
+				name = obj->call("_get_editor_name");
+			} else if (Object::cast_to<Resource>(obj)) {
 				Resource *r = Object::cast_to<Resource>(obj);
 				if (r->get_path().is_resource_file()) {
 					name = r->get_path().get_file();
@@ -149,7 +158,7 @@ void EditorPath::update_path() {
 				name = obj->get_class();
 			}
 
-			current_object_label->set_text(" " + name); // An extra space so the text is not too close of the icon.
+			current_object_label->set_text(name);
 			set_tooltip_text(obj->get_class());
 		}
 	}
@@ -161,12 +170,12 @@ void EditorPath::clear_path() {
 
 	current_object_label->set_text("");
 	current_object_icon->set_texture(nullptr);
-	sub_objects_icon->set_visible(false);
+	sub_objects_icon->hide();
 }
 
 void EditorPath::enable_path() {
 	set_disabled(false);
-	sub_objects_icon->set_visible(true);
+	sub_objects_icon->show();
 }
 
 void EditorPath::_id_pressed(int p_idx) {
@@ -186,7 +195,7 @@ void EditorPath::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			update_path();
 
-			sub_objects_icon->set_texture(get_theme_icon(SNAME("select_arrow"), SNAME("Tree")));
+			sub_objects_icon->set_texture(get_theme_icon(SNAME("arrow"), SNAME("OptionButton")));
 			current_object_label->add_theme_font_override("font", get_theme_font(SNAME("main"), SNAME("EditorFonts")));
 		} break;
 
@@ -216,13 +225,12 @@ EditorPath::EditorPath(EditorSelectionHistory *p_history) {
 	main_hb->add_child(current_object_icon);
 
 	current_object_label = memnew(Label);
-	current_object_label->set_clip_text(true);
-	current_object_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
+	current_object_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	current_object_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	main_hb->add_child(current_object_label);
 
 	sub_objects_icon = memnew(TextureRect);
-	sub_objects_icon->set_visible(false);
+	sub_objects_icon->hide();
 	sub_objects_icon->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
 	main_hb->add_child(sub_objects_icon);
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -311,7 +311,6 @@ void InspectorDock::_prepare_history() {
 
 	history_menu->get_popup()->clear();
 
-	Ref<Texture2D> base_icon = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 	HashSet<ObjectID> already;
 	for (int i = editor_history->get_history_len() - 1; i >= history_to; i--) {
 		ObjectID id = editor_history->get_history_obj(i);
@@ -325,13 +324,12 @@ void InspectorDock::_prepare_history() {
 
 		already.insert(id);
 
-		Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(obj, "");
-		if (icon.is_null()) {
-			icon = base_icon;
-		}
+		Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(obj, "Object");
 
 		String text;
-		if (Object::cast_to<Resource>(obj)) {
+		if (obj->has_method("_get_editor_name")) {
+			text = obj->call("_get_editor_name");
+		} else if (Object::cast_to<Resource>(obj)) {
 			Resource *r = Object::cast_to<Resource>(obj);
 			if (r->get_path().is_resource_file()) {
 				text = r->get_path().get_file();
@@ -349,14 +347,14 @@ void InspectorDock::_prepare_history() {
 		}
 
 		if (i == editor_history->get_history_pos() && current) {
-			text = "[" + text + "]";
+			text += " " + TTR("(Current)");
 		}
 		history_menu->get_popup()->add_icon_item(icon, text, i);
 	}
 }
 
 void InspectorDock::_select_history(int p_idx) {
-	//push it to the top, it is not correct, but it's more useful
+	// Push it to the top, it is not correct, but it's more useful.
 	ObjectID id = EditorNode::get_singleton()->get_editor_selection_history()->get_history_obj(p_idx);
 	Object *obj = ObjectDB::get_instance(id);
 	if (!obj) {

--- a/editor/multi_node_edit.h
+++ b/editor/multi_node_edit.h
@@ -45,15 +45,25 @@ class MultiNodeEdit : public RefCounted {
 	bool _set_impl(const StringName &p_name, const Variant &p_value, const String &p_field);
 
 protected:
+	static void _bind_methods();
+
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
+	bool _hide_script_from_inspector() { return true; }
+	bool _hide_metadata_from_inspector() { return true; }
+
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+	String _get_editor_name() const;
+
 	void add_node(const NodePath &p_node);
 
 	int get_node_count() const;
 	NodePath get_node(int p_index) const;
+	StringName get_edited_class_name() const;
 
 	void set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field);
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/62192

This PR makes several improvements to multi-node editing. The general idea here is to remove all visible references to MultiNodeEdit so that multi-node editing is done behind-the-scenes.

- Show the revert button for properties that are not default for all selected nodes
![image](https://user-images.githubusercontent.com/67974470/174666998-95de685d-fc68-48f0-b1e1-214cecf2e2d9.png)
- Hide metadata on MultiNodeEdit and AnimationMultiTrackKeyEdit
- Show documentation in property tooltips.
- When all selected nodes have a property that is not from the same class, it's treated the same way it was before this PR with no documentation tooltips or revert button. This is because documentation and default values can be different between the different classes.
e.g. if you select a Control and a Node2D, both have `rotation` and `scale` even though CanvasItem doesn't.
![image](https://user-images.githubusercontent.com/67974470/174666451-2d58adb3-6584-457b-9f7e-02dc6e803ea2.png)
- Hide the "MultiNodeEdit" category header
	- I had to hardcode this into EditorInspector because it appears that `_validate_property()`, which is used to dynamically hide properties, doesn't run for categories (`PROPERTY_HINT_CATEGORY`). I tried to enable this but I looked all over and couldn't figure out how to. I'm still not a C++ wizard yet :(
- MultiNodeEdit: Show the most common class name and icon and the number of selected nodes at the top of the inspector.
The "most common" class is determined by finding the highest level class that all of the selected nodes have in common.
![image](https://user-images.githubusercontent.com/67974470/174666692-26279f28-c1d8-4862-a166-0198e573add1.png)