### PR TITLE
Use the new inspector button style in the InputEvent editor

### DIFF
--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -84,8 +84,7 @@ InputEventConfigContainer::InputEventConfigContainer() {
 	input_event_text->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	add_child(input_event_text);
 
-	open_config_button = memnew(Button);
-	open_config_button->set_text(TTR("Configure"));
+	open_config_button = EditorInspector::create_inspector_action_button(TTR("Configure"));
 	open_config_button->connect("pressed", callable_mp(this, &InputEventConfigContainer::_configure_pressed));
 	add_child(open_config_button);
 


### PR DESCRIPTION
Makes the InputEvent editor use the new inspector button style (see https://github.com/godotengine/godot/pull/61387)

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/173773570-d00eb41b-767f-4309-9fe0-026adee7ef8d.png) | ![image](https://user-images.githubusercontent.com/67974470/173773335-65e4f3e8-cfc2-45d8-9c6b-a8969ac08d3f.png) |
