### PR TITLE
Move duplicate AutoWrap, Overrun and VisibleChar behavior enums to the TextServer.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -92,8 +92,8 @@
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="Control.TextDirection" default="0">
 			Base text writing direction.
 		</member>
-		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextParagraph.OverrunBehavior" default="0">
-			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum TextParagraph.OverrunBehavior] for a description of all modes.
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
+			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
 		</member>
 	</members>
 	<theme_items>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -402,8 +402,8 @@
 		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" enum="ItemList.SelectMode" default="0">
 			Allows single or multiple item selection. See the [enum SelectMode] constants.
 		</member>
-		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextParagraph.OverrunBehavior" default="3">
-			Sets the clipping behavior when the text exceeds an item's bounding rectangle. See [enum TextParagraph.OverrunBehavior] for a description of all modes.
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="3">
+			Sets the clipping behavior when the text exceeds an item's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -61,8 +61,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="Label.AutowrapMode" default="0">
-			If set to something other than [constant AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. To see how each mode behaves, see [enum AutowrapMode].
+		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="0">
+			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. To see how each mode behaves, see [enum TextServer.AutowrapMode].
 		</member>
 		<member name="clip_text" type="bool" setter="set_clip_text" getter="is_clipping_text" default="false">
 			If [code]true[/code], the Label only shows the text that fits inside its bounding rectangle and will clip text horizontally.
@@ -97,8 +97,8 @@
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" enum="Control.TextDirection" default="0">
 			Base text writing direction.
 		</member>
-		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="Label.OverrunBehavior" default="0">
-			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum OverrunBehavior] for a description of all modes.
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
+			Sets the clipping behavior when the text exceeds the node's bounding rectangle. See [enum TextServer.OverrunBehavior] for a description of all modes.
 		</member>
 		<member name="uppercase" type="bool" setter="set_uppercase" getter="is_uppercase" default="false">
 			If [code]true[/code], all the text displays as UPPERCASE.
@@ -110,54 +110,10 @@
 			Restricts the number of characters to display. Set to -1 to disable.
 			[b]Note:[/b] Setting this property updates [member percent_visible] based on current [method get_total_character_count].
 		</member>
-		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="Label.VisibleCharactersBehavior" default="0">
-			Sets the clipping behavior when [member visible_characters] or [member percent_visible] is set. See [enum VisibleCharactersBehavior] for more info.
+		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
+			Sets the clipping behavior when [member visible_characters] or [member percent_visible] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
 		</member>
 	</members>
-	<constants>
-		<constant name="AUTOWRAP_OFF" value="0" enum="AutowrapMode">
-			Autowrap is disabled.
-		</constant>
-		<constant name="AUTOWRAP_ARBITRARY" value="1" enum="AutowrapMode">
-			Wraps the text inside the node's bounding rectangle by allowing to break lines at arbitrary positions, which is useful when very limited space is available.
-		</constant>
-		<constant name="AUTOWRAP_WORD" value="2" enum="AutowrapMode">
-			Wraps the text inside the node's bounding rectangle by soft-breaking between words.
-		</constant>
-		<constant name="AUTOWRAP_WORD_SMART" value="3" enum="AutowrapMode">
-			Behaves similarly to [constant AUTOWRAP_WORD], but force-breaks a word if that single word does not fit in one line.
-		</constant>
-		<constant name="OVERRUN_NO_TRIMMING" value="0" enum="OverrunBehavior">
-			No text trimming is performed.
-		</constant>
-		<constant name="OVERRUN_TRIM_CHAR" value="1" enum="OverrunBehavior">
-			Trims the text per character.
-		</constant>
-		<constant name="OVERRUN_TRIM_WORD" value="2" enum="OverrunBehavior">
-			Trims the text per word.
-		</constant>
-		<constant name="OVERRUN_TRIM_ELLIPSIS" value="3" enum="OverrunBehavior">
-			Trims the text per character and adds an ellipsis to indicate that parts are hidden.
-		</constant>
-		<constant name="OVERRUN_TRIM_WORD_ELLIPSIS" value="4" enum="OverrunBehavior">
-			Trims the text per word and adds an ellipsis to indicate that parts are hidden.
-		</constant>
-		<constant name="VC_CHARS_BEFORE_SHAPING" value="0" enum="VisibleCharactersBehavior">
-			Trims text before the shaping. e.g, increasing [member visible_characters] value is visually identical to typing the text.
-		</constant>
-		<constant name="VC_CHARS_AFTER_SHAPING" value="1" enum="VisibleCharactersBehavior">
-			Displays glyphs that are mapped to the first [member visible_characters] characters from the beginning of the text.
-		</constant>
-		<constant name="VC_GLYPHS_AUTO" value="2" enum="VisibleCharactersBehavior">
-			Displays [member percent_visible] glyphs, starting from the left or from the right, depending on [member Control.layout_direction] value.
-		</constant>
-		<constant name="VC_GLYPHS_LTR" value="3" enum="VisibleCharactersBehavior">
-			Displays [member percent_visible] glyphs, starting from the left.
-		</constant>
-		<constant name="VC_GLYPHS_RTL" value="4" enum="VisibleCharactersBehavior">
-			Displays [member percent_visible] glyphs, starting from the right.
-		</constant>
-	</constants>
 	<theme_items>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Default text [Color] of the [Label].

--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -59,8 +59,8 @@
 		<member name="alpha_scissor_threshold" type="float" setter="set_alpha_scissor_threshold" getter="get_alpha_scissor_threshold" default="0.5">
 			Threshold at which the alpha scissor will discard values.
 		</member>
-		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="Label3D.AutowrapMode" default="0">
-			If set to something other than [constant AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. To see how each mode behaves, see [enum AutowrapMode].
+		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="0">
+			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. To see how each mode behaves, see [enum TextServer.AutowrapMode].
 		</member>
 		<member name="billboard" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="BaseMaterial3D.BillboardMode" default="0">
 			The billboard mode to use for the label. See [enum BaseMaterial3D.BillboardMode] for possible values.
@@ -143,18 +143,6 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="AUTOWRAP_OFF" value="0" enum="AutowrapMode">
-			Autowrap is disabled.
-		</constant>
-		<constant name="AUTOWRAP_ARBITRARY" value="1" enum="AutowrapMode">
-			Wraps the text inside the node's bounding rectangle by allowing to break lines at arbitrary positions, which is useful when very limited space is available.
-		</constant>
-		<constant name="AUTOWRAP_WORD" value="2" enum="AutowrapMode">
-			Wraps the text inside the node's bounding rectangle by soft-breaking between words.
-		</constant>
-		<constant name="AUTOWRAP_WORD_SMART" value="3" enum="AutowrapMode">
-			Behaves similarly to [constant AUTOWRAP_WORD], but force-breaks a word if that single word does not fit in one line.
-		</constant>
 		<constant name="FLAG_SHADED" value="0" enum="DrawFlags">
 			If set, lights in the environment affect the label.
 		</constant>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -454,8 +454,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="RichTextLabel.AutowrapMode" default="3">
-			If set to something other than [constant AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. To see how each mode behaves, see [enum AutowrapMode].
+		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="TextServer.AutowrapMode" default="3">
+			If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. To see how each mode behaves, see [enum TextServer.AutowrapMode].
 		</member>
 		<member name="bbcode_enabled" type="bool" setter="set_use_bbcode" getter="is_using_bbcode" default="false">
 			If [code]true[/code], the label uses BBCode formatting.
@@ -530,8 +530,8 @@
 			The restricted number of characters to display in the label. If [code]-1[/code], all characters will be displayed.
 			[b]Note:[/b] Setting this property updates [member percent_visible] based on current [method get_total_character_count].
 		</member>
-		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="RichTextLabel.VisibleCharactersBehavior" default="0">
-			Sets the clipping behavior when [member visible_characters] or [member percent_visible] is set. See [enum VisibleCharactersBehavior] for more info.
+		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
+			Sets the clipping behavior when [member visible_characters] or [member percent_visible] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
 		</member>
 	</members>
 	<signals>
@@ -560,18 +560,6 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="AUTOWRAP_OFF" value="0" enum="AutowrapMode">
-			Autowrap is disabled.
-		</constant>
-		<constant name="AUTOWRAP_ARBITRARY" value="1" enum="AutowrapMode">
-			Wraps the text inside the node's bounding rectangle by allowing to break lines at arbitrary positions, which is useful when very limited space is available.
-		</constant>
-		<constant name="AUTOWRAP_WORD" value="2" enum="AutowrapMode">
-			Wraps the text inside the node's bounding rectangle by soft-breaking between words.
-		</constant>
-		<constant name="AUTOWRAP_WORD_SMART" value="3" enum="AutowrapMode">
-			Behaves similarly to [constant AUTOWRAP_WORD], but force-breaks a word if that single word does not fit in one line.
-		</constant>
 		<constant name="LIST_NUMBERS" value="0" enum="ListType">
 			Each list item has a number marker.
 		</constant>
@@ -637,21 +625,6 @@
 		<constant name="ITEM_DROPCAP" value="25" enum="ItemType">
 		</constant>
 		<constant name="ITEM_CUSTOMFX" value="26" enum="ItemType">
-		</constant>
-		<constant name="VC_CHARS_BEFORE_SHAPING" value="0" enum="VisibleCharactersBehavior">
-			Trims text before the shaping. e.g, increasing [member visible_characters] value is visually identical to typing the text.
-		</constant>
-		<constant name="VC_CHARS_AFTER_SHAPING" value="1" enum="VisibleCharactersBehavior">
-			Displays glyphs that are mapped to the first [member visible_characters] characters from the beginning of the text.
-		</constant>
-		<constant name="VC_GLYPHS_AUTO" value="2" enum="VisibleCharactersBehavior">
-			Displays [member percent_visible] glyphs, starting from the left or from the right, depending on [member Control.layout_direction] value.
-		</constant>
-		<constant name="VC_GLYPHS_LTR" value="3" enum="VisibleCharactersBehavior">
-			Displays [member percent_visible] glyphs, starting from the left.
-		</constant>
-		<constant name="VC_GLYPHS_RTL" value="4" enum="VisibleCharactersBehavior">
-			Displays [member percent_visible] glyphs, starting from the right.
 		</constant>
 	</constants>
 	<theme_items>

--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -161,28 +161,11 @@
 		<member name="preserve_invalid" type="bool" setter="set_preserve_invalid" getter="get_preserve_invalid" default="true">
 			If set to [code]true[/code] text will display invalid characters.
 		</member>
-		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextLine.OverrunBehavior" default="3">
-			Sets the clipping behavior when the text exceeds the text line's set width. See [enum OverrunBehavior] for a description of all modes.
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="3">
+			Sets the clipping behavior when the text exceeds the text line's set width. See [enum TextServer.OverrunBehavior] for a description of all modes.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="-1.0">
 			Text line width.
 		</member>
 	</members>
-	<constants>
-		<constant name="OVERRUN_NO_TRIMMING" value="0" enum="OverrunBehavior">
-			No text trimming is performed.
-		</constant>
-		<constant name="OVERRUN_TRIM_CHAR" value="1" enum="OverrunBehavior">
-			Trims the text per character.
-		</constant>
-		<constant name="OVERRUN_TRIM_WORD" value="2" enum="OverrunBehavior">
-			Trims the text per word.
-		</constant>
-		<constant name="OVERRUN_TRIM_ELLIPSIS" value="3" enum="OverrunBehavior">
-			Trims the text per character and adds an ellipsis to indicate that parts are hidden.
-		</constant>
-		<constant name="OVERRUN_TRIM_WORD_ELLIPSIS" value="4" enum="OverrunBehavior">
-			Trims the text per word and adds an ellipsis to indicate that parts are hidden.
-		</constant>
-	</constants>
 </class>

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -298,28 +298,11 @@
 		<member name="preserve_invalid" type="bool" setter="set_preserve_invalid" getter="get_preserve_invalid" default="true">
 			If set to [code]true[/code] text will display invalid characters.
 		</member>
-		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextParagraph.OverrunBehavior" default="0">
-			Sets the clipping behavior when the text exceeds the paragraph's set width. See [enum OverrunBehavior] for a description of all modes.
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextServer.OverrunBehavior" default="0">
+			Sets the clipping behavior when the text exceeds the paragraph's set width. See [enum TextServer.OverrunBehavior] for a description of all modes.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="-1.0">
 			Paragraph width.
 		</member>
 	</members>
-	<constants>
-		<constant name="OVERRUN_NO_TRIMMING" value="0" enum="OverrunBehavior">
-			No text trimming is performed.
-		</constant>
-		<constant name="OVERRUN_TRIM_CHAR" value="1" enum="OverrunBehavior">
-			Trims the text per character.
-		</constant>
-		<constant name="OVERRUN_TRIM_WORD" value="2" enum="OverrunBehavior">
-			Trims the text per word.
-		</constant>
-		<constant name="OVERRUN_TRIM_ELLIPSIS" value="3" enum="OverrunBehavior">
-			Trims the text per character and adds an ellipsis to indicate that parts are hidden.
-		</constant>
-		<constant name="OVERRUN_TRIM_WORD_ELLIPSIS" value="4" enum="OverrunBehavior">
-			Trims the text per word and adds an ellipsis to indicate that parts are hidden.
-		</constant>
-	</constants>
 </class>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1542,6 +1542,18 @@
 		<constant name="JUSTIFICATION_CONSTRAIN_ELLIPSIS" value="16" enum="JustificationFlag">
 			Apply justification to the trimmed line with ellipsis.
 		</constant>
+		<constant name="AUTOWRAP_OFF" value="0" enum="AutowrapMode">
+			Autowrap is disabled.
+		</constant>
+		<constant name="AUTOWRAP_ARBITRARY" value="1" enum="AutowrapMode">
+			Wraps the text inside the node's bounding rectangle by allowing to break lines at arbitrary positions, which is useful when very limited space is available.
+		</constant>
+		<constant name="AUTOWRAP_WORD" value="2" enum="AutowrapMode">
+			Wraps the text inside the node's bounding rectangle by soft-breaking between words.
+		</constant>
+		<constant name="AUTOWRAP_WORD_SMART" value="3" enum="AutowrapMode">
+			Behaves similarly to [constant AUTOWRAP_WORD], but force-breaks a word if that single word does not fit in one line.
+		</constant>
 		<constant name="BREAK_NONE" value="0" enum="LineBreakFlag">
 			Do not break the line.
 		</constant>
@@ -1557,7 +1569,37 @@
 		<constant name="BREAK_WORD_BOUND_ADAPTIVE" value="320" enum="LineBreakFlag">
 			Break the line between the words, or any unconnected graphemes if line is too short to fit the whole word.
 		</constant>
-		<constant name="OVERRUN_NO_TRIMMING" value="0" enum="TextOverrunFlag">
+		<constant name="VC_CHARS_BEFORE_SHAPING" value="0" enum="VisibleCharactersBehavior">
+			Trims text before the shaping. e.g, increasing [member Label.visible_characters] or [member RichTextLabel.visible_characters] value is visually identical to typing the text.
+		</constant>
+		<constant name="VC_CHARS_AFTER_SHAPING" value="1" enum="VisibleCharactersBehavior">
+			Displays glyphs that are mapped to the first [member Label.visible_characters] or [member RichTextLabel.visible_characters] characters from the beginning of the text.
+		</constant>
+		<constant name="VC_GLYPHS_AUTO" value="2" enum="VisibleCharactersBehavior">
+			Displays [member Label.percent_visible] or [member RichTextLabel.percent_visible] glyphs, starting from the left or from the right, depending on [member Control.layout_direction] value.
+		</constant>
+		<constant name="VC_GLYPHS_LTR" value="3" enum="VisibleCharactersBehavior">
+			Displays [member Label.percent_visible] or [member RichTextLabel.percent_visible] glyphs, starting from the left.
+		</constant>
+		<constant name="VC_GLYPHS_RTL" value="4" enum="VisibleCharactersBehavior">
+			Displays [member Label.percent_visible] or [member RichTextLabel.percent_visible] glyphs, starting from the right.
+		</constant>
+		<constant name="OVERRUN_NO_TRIMMING" value="0" enum="OverrunBehavior">
+			No text trimming is performed.
+		</constant>
+		<constant name="OVERRUN_TRIM_CHAR" value="1" enum="OverrunBehavior">
+			Trims the text per character.
+		</constant>
+		<constant name="OVERRUN_TRIM_WORD" value="2" enum="OverrunBehavior">
+			Trims the text per word.
+		</constant>
+		<constant name="OVERRUN_TRIM_ELLIPSIS" value="3" enum="OverrunBehavior">
+			Trims the text per character and adds an ellipsis to indicate that parts are hidden.
+		</constant>
+		<constant name="OVERRUN_TRIM_WORD_ELLIPSIS" value="4" enum="OverrunBehavior">
+			Trims the text per word and adds an ellipsis to indicate that parts are hidden.
+		</constant>
+		<constant name="OVERRUN_NO_TRIM" value="0" enum="TextOverrunFlag">
 			No trimming is performed.
 		</constant>
 		<constant name="OVERRUN_TRIM" value="1" enum="TextOverrunFlag">

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6239,7 +6239,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	info_message->set_text(TTR("Select an AnimationPlayer node to create and edit animations."));
 	info_message->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	info_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	info_message->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	info_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_offsets_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	main_panel->add_child(info_message);

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -391,7 +391,7 @@ EditorPerformanceProfiler::EditorPerformanceProfiler() {
 	info_message->set_text(TTR("Pick one or more items from the list to display the graph."));
 	info_message->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	info_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	info_message->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	info_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_offsets_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	monitor_draw->add_child(info_message);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1686,7 +1686,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		reason->set_text("");
 		hbc->add_child(reason);
 		reason->set_h_size_flags(SIZE_EXPAND_FILL);
-		reason->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+		reason->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 		reason->set_max_lines_visible(3);
 		reason->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -213,7 +213,7 @@ EditorAbout::EditorAbout() {
 
 	Label *tpl_label = memnew(Label);
 	tpl_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	tpl_label->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	tpl_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	tpl_label->set_text(TTR("Godot Engine relies on a number of third-party free and open source libraries, all compatible with the terms of its MIT license. The following is an exhaustive list of all such third-party components with their respective copyright statements and license terms."));
 	tpl_label->set_size(Size2(630, 1) * EDSCALE);
 	license_thirdparty->add_child(tpl_label);

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -756,7 +756,7 @@ void EditorFileDialog::update_file_list() {
 		item_list->set_icon_mode(ItemList::ICON_MODE_TOP);
 		item_list->set_fixed_column_width(thumbnail_size * 3 / 2);
 		item_list->set_max_text_lines(2);
-		item_list->set_text_overrun_behavior(TextParagraph::OVERRUN_TRIM_ELLIPSIS);
+		item_list->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 		item_list->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
 
 		if (thumbnail_size < 64) {

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -559,7 +559,7 @@ GroupDialog::GroupDialog() {
 	group_empty->set_text(TTR("Empty groups will be automatically removed."));
 	group_empty->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	group_empty->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	group_empty->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	group_empty->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	group_empty->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	nodes_to_remove->add_child(group_empty);
 	group_empty->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1455,7 +1455,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	font_preview_label->add_theme_font_size_override("font_size", 200 * EDSCALE);
 	font_preview_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	font_preview_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
-	font_preview_label->set_autowrap_mode(Label::AUTOWRAP_ARBITRARY);
+	font_preview_label->set_autowrap_mode(TextServer::AUTOWRAP_ARBITRARY);
 	font_preview_label->set_clip_text(true);
 	font_preview_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	font_preview_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1475,7 +1475,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	page2_description = memnew(Label);
 	page2_description->set_text(TTR("Add font size, variation coordinates, and extra spacing combinations to pre-render:"));
 	page2_description->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	page2_description->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	page2_description->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	page2_vb->add_child(page2_description);
 
 	HSplitContainer *page2_hb = memnew(HSplitContainer);
@@ -1527,7 +1527,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	page3_description = memnew(Label);
 	page3_description->set_text(TTR("Enter a text to shape and add all required glyphs to pre-render list:"));
 	page3_description->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	page3_description->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	page3_description->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	page3_vb->add_child(page3_description);
 
 	HBoxContainer *ot_hb = memnew(HBoxContainer);
@@ -1584,7 +1584,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	page4_description = memnew(Label);
 	page4_description->set_text(TTR("Add or remove additional glyphs from the character map to pre-render list:\nNote: Some stylistic alternatives and glyph variants do not have one-to-one correspondence to character, and not shown in this map, use \"Glyphs from the text\" to add these."));
 	page4_description->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	page4_description->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	page4_description->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	page4_vb->add_child(page4_description);
 
 	HSplitContainer *glyphs_split = memnew(HSplitContainer);
@@ -1635,7 +1635,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	page5_description = memnew(Label);
 	page5_description->set_text(TTR("Add or remove language and script support overrides, to control fallback font selection order:"));
 	page5_description->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	page5_description->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	page5_description->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	page5_vb->add_child(page5_description);
 
 	HBoxContainer *hb_lang = memnew(HBoxContainer);

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -685,7 +685,7 @@ ImportDock::ImportDock() {
 
 	select_a_resource = memnew(Label);
 	select_a_resource->set_text(TTR("Select a resource file in the filesystem or in the inspector to adjust import settings."));
-	select_a_resource->set_autowrap_mode(Label::AUTOWRAP_WORD);
+	select_a_resource->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 	select_a_resource->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	select_a_resource->set_v_size_flags(SIZE_EXPAND_FILL);
 	select_a_resource->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -134,7 +134,7 @@ NodeDock::NodeDock() {
 	select_a_node->set_v_size_flags(SIZE_EXPAND_FILL);
 	select_a_node->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	select_a_node->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	select_a_node->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	select_a_node->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	add_child(select_a_node);
 }
 

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -120,7 +120,7 @@ ControlPositioningWarning::ControlPositioningWarning() {
 	grid->add_child(title_icon);
 
 	title_label = memnew(Label);
-	title_label->set_autowrap_mode(Label::AutowrapMode::AUTOWRAP_WORD);
+	title_label->set_autowrap_mode(TextServer::AutowrapMode::AUTOWRAP_WORD);
 	title_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	title_label->set_vertical_alignment(VerticalAlignment::VERTICAL_ALIGNMENT_CENTER);
 	grid->add_child(title_label);
@@ -135,7 +135,7 @@ ControlPositioningWarning::ControlPositioningWarning() {
 	grid->add_child(hint_filler_left);
 
 	hint_label = memnew(Label);
-	hint_label->set_autowrap_mode(Label::AutowrapMode::AUTOWRAP_WORD);
+	hint_label->set_autowrap_mode(TextServer::AutowrapMode::AUTOWRAP_WORD);
 	hint_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hint_label->set_vertical_alignment(VerticalAlignment::VERTICAL_ALIGNMENT_CENTER);
 	hint_label->hide();

--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -80,7 +80,7 @@ void InputEventConfigContainer::set_event(const Ref<InputEvent> &p_event) {
 InputEventConfigContainer::InputEventConfigContainer() {
 	input_event_text = memnew(Label);
 	input_event_text->set_h_size_flags(SIZE_EXPAND_FILL);
-	input_event_text->set_autowrap_mode(Label::AutowrapMode::AUTOWRAP_WORD_SMART);
+	input_event_text->set_autowrap_mode(TextServer::AutowrapMode::AUTOWRAP_WORD_SMART);
 	input_event_text->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	add_child(input_event_text);
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1119,7 +1119,7 @@ ThemeItemImportTree::ThemeItemImportTree() {
 
 			select_icons_warning = memnew(Label);
 			select_icons_warning->set_text(TTR("Caution: Adding icon data may considerably increase the size of your Theme resource."));
-			select_icons_warning->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+			select_icons_warning->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 			select_icons_warning->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			select_icons_warning_hb->add_child(select_icons_warning);
 		}
@@ -2021,7 +2021,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	edit_items_message->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	edit_items_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	edit_items_message->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
-	edit_items_message->set_autowrap_mode(Label::AUTOWRAP_WORD);
+	edit_items_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 	edit_items_tree->add_child(edit_items_message);
 
 	edit_theme_item_dialog = memnew(ConfirmationDialog);
@@ -3443,7 +3443,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	type_variation_locked = memnew(Label);
 	type_variation_vb->add_child(type_variation_locked);
 	type_variation_locked->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	type_variation_locked->set_autowrap_mode(Label::AUTOWRAP_WORD);
+	type_variation_locked->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 	type_variation_locked->set_text(TTR("A type associated with a built-in class cannot be marked as a variation of another type."));
 	type_variation_locked->hide();
 

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -3998,7 +3998,7 @@ TileMapEditor::TileMapEditor() {
 	// Layer selector.
 	layers_selection_button = memnew(OptionButton);
 	layers_selection_button->set_custom_minimum_size(Size2(200, 0));
-	layers_selection_button->set_text_overrun_behavior(TextParagraph::OVERRUN_TRIM_ELLIPSIS);
+	layers_selection_button->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	layers_selection_button->set_tooltip(TTR("TileMap Layers"));
 	layers_selection_button->connect("item_selected", callable_mp(this, &TileMapEditor::_layers_selection_item_selected));
 	tile_map_toolbar->add_child(layers_selection_button);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4851,7 +4851,7 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	error_label = memnew(Label);
 	error_panel->add_child(error_label);
-	error_label->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	error_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 
 	///////////////////////////////////////
 	// POPUP MENU
@@ -5008,7 +5008,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	}
 
 	alert = memnew(AcceptDialog);
-	alert->get_label()->set_autowrap_mode(Label::AUTOWRAP_WORD);
+	alert->get_label()->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 	alert->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	alert->get_label()->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	alert->get_label()->set_custom_minimum_size(Size2(400, 60) * EDSCALE);

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -283,7 +283,7 @@ RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor, UndoRedo *p_und
 	vbc->add_child(lbl_preview_title);
 
 	lbl_preview = memnew(Label);
-	lbl_preview->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	lbl_preview->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	vbc->add_child(lbl_preview);
 
 	// ---- Dialog related

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -940,7 +940,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	builtin_warning_label->set_text(
 			TTR("Note: Built-in scripts have some limitations and can't be edited using an external editor."));
 	vb->add_child(builtin_warning_label);
-	builtin_warning_label->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	builtin_warning_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	builtin_warning_label->hide();
 
 	script_name_warning_label = memnew(Label);
@@ -948,12 +948,12 @@ ScriptCreateDialog::ScriptCreateDialog() {
 			TTR("Warning: Having the script name be the same as a built-in type is usually not desired."));
 	vb->add_child(script_name_warning_label);
 	script_name_warning_label->add_theme_color_override("font_color", Color(1, 0.85, 0.4));
-	script_name_warning_label->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	script_name_warning_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	script_name_warning_label->hide();
 
 	template_info_label = memnew(Label);
 	vb->add_child(template_info_label);
-	template_info_label->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	template_info_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 
 	status_panel = memnew(PanelContainer);
 	status_panel->set_h_size_flags(Control::SIZE_FILL);
@@ -1090,7 +1090,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	add_child(file_browse);
 	get_ok_button()->set_text(TTR("Create"));
 	alert = memnew(AcceptDialog);
-	alert->get_label()->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	alert->get_label()->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	alert->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	alert->get_label()->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	alert->get_label()->set_custom_minimum_size(Size2(325, 60) * EDSCALE);

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -529,7 +529,7 @@ ShaderCreateDialog::ShaderCreateDialog() {
 	builtin_warning_label->set_text(
 			TTR("Note: Built-in shaders can't be edited using an external editor."));
 	vb->add_child(builtin_warning_label);
-	builtin_warning_label->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	builtin_warning_label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	builtin_warning_label->hide();
 
 	status_panel = memnew(PanelContainer);
@@ -633,7 +633,7 @@ ShaderCreateDialog::ShaderCreateDialog() {
 	add_child(file_browse);
 
 	alert = memnew(AcceptDialog);
-	alert->get_label()->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	alert->get_label()->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	alert->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	alert->get_label()->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	alert->get_label()->set_custom_minimum_size(Size2(325, 60) * EDSCALE);

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1260,7 +1260,7 @@ GridMapEditor::GridMapEditor() {
 	info_message->set_text(TTR("Give a MeshLibrary resource to this GridMap to use its meshes."));
 	info_message->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	info_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	info_message->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
+	info_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	info_message->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	info_message->set_anchors_and_offsets_preset(PRESET_WIDE, PRESET_MODE_KEEP_SIZE, 8 * EDSCALE);
 	mesh_library_palette->add_child(info_message);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -4204,7 +4204,7 @@ void TextServerAdvanced::shaped_text_overrun_trim_to_width(const RID &p_shaped_l
 
 	Glyph *sd_glyphs = sd->glyphs.ptrw();
 
-	if ((p_trim_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIMMING || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
+	if ((p_trim_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIM || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
 		sd->overrun_trim_data.trim_pos = -1;
 		sd->overrun_trim_data.ellipsis_pos = -1;
 		return;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -3236,7 +3236,7 @@ void TextServerFallback::shaped_text_overrun_trim_to_width(const RID &p_shaped_l
 
 	Glyph *sd_glyphs = sd->glyphs.ptrw();
 
-	if ((p_trim_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIMMING || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
+	if ((p_trim_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIM || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
 		sd->overrun_trim_data.trim_pos = -1;
 		sd->overrun_trim_data.ellipsis_pos = -1;
 		return;

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -155,11 +155,6 @@ void Label3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left"), "set_text_direction", "get_text_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "language", PROPERTY_HINT_LOCALE_ID, ""), "set_language", "get_language");
 
-	BIND_ENUM_CONSTANT(AUTOWRAP_OFF);
-	BIND_ENUM_CONSTANT(AUTOWRAP_ARBITRARY);
-	BIND_ENUM_CONSTANT(AUTOWRAP_WORD);
-	BIND_ENUM_CONSTANT(AUTOWRAP_WORD_SMART);
-
 	BIND_ENUM_CONSTANT(FLAG_SHADED);
 	BIND_ENUM_CONSTANT(FLAG_DOUBLE_SIDED);
 	BIND_ENUM_CONSTANT(FLAG_DISABLE_DEPTH_TEST);
@@ -514,16 +509,16 @@ void Label3D::_shape() {
 
 		uint16_t autowrap_flags = TextServer::BREAK_MANDATORY;
 		switch (autowrap_mode) {
-			case AUTOWRAP_WORD_SMART:
+			case TextServer::AUTOWRAP_WORD_SMART:
 				autowrap_flags = TextServer::BREAK_WORD_BOUND_ADAPTIVE | TextServer::BREAK_MANDATORY;
 				break;
-			case AUTOWRAP_WORD:
+			case TextServer::AUTOWRAP_WORD:
 				autowrap_flags = TextServer::BREAK_WORD_BOUND | TextServer::BREAK_MANDATORY;
 				break;
-			case AUTOWRAP_ARBITRARY:
+			case TextServer::AUTOWRAP_ARBITRARY:
 				autowrap_flags = TextServer::BREAK_GRAPHEME_BOUND | TextServer::BREAK_MANDATORY;
 				break;
-			case AUTOWRAP_OFF:
+			case TextServer::AUTOWRAP_OFF:
 				break;
 		}
 		PackedInt32Array line_breaks = TS->shaped_text_get_line_breaks(text_rid, width, 0, autowrap_flags);
@@ -885,7 +880,7 @@ Color Label3D::get_outline_modulate() const {
 	return outline_modulate;
 }
 
-void Label3D::set_autowrap_mode(Label3D::AutowrapMode p_mode) {
+void Label3D::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
 	if (autowrap_mode != p_mode) {
 		autowrap_mode = p_mode;
 		dirty_lines = true;
@@ -893,7 +888,7 @@ void Label3D::set_autowrap_mode(Label3D::AutowrapMode p_mode) {
 	}
 }
 
-Label3D::AutowrapMode Label3D::get_autowrap_mode() const {
+TextServer::AutowrapMode Label3D::get_autowrap_mode() const {
 	return autowrap_mode;
 }
 

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -54,13 +54,6 @@ public:
 		ALPHA_CUT_OPAQUE_PREPASS
 	};
 
-	enum AutowrapMode {
-		AUTOWRAP_OFF,
-		AUTOWRAP_ARBITRARY,
-		AUTOWRAP_WORD,
-		AUTOWRAP_WORD_SMART
-	};
-
 private:
 	real_t pixel_size = 0.01;
 	bool flags[FLAG_MAX] = {};
@@ -91,7 +84,7 @@ private:
 	String xl_text;
 	bool uppercase = false;
 
-	AutowrapMode autowrap_mode = AUTOWRAP_OFF;
+	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
 	float width = 500.0;
 
 	int font_size = 16;
@@ -200,8 +193,8 @@ public:
 	void set_outline_modulate(const Color &p_color);
 	Color get_outline_modulate() const;
 
-	void set_autowrap_mode(AutowrapMode p_mode);
-	AutowrapMode get_autowrap_mode() const;
+	void set_autowrap_mode(TextServer::AutowrapMode p_mode);
+	TextServer::AutowrapMode get_autowrap_mode() const;
 
 	void set_width(float p_width);
 	float get_width() const;
@@ -234,7 +227,6 @@ public:
 	~Label3D();
 };
 
-VARIANT_ENUM_CAST(Label3D::AutowrapMode);
 VARIANT_ENUM_CAST(Label3D::DrawFlags);
 VARIANT_ENUM_CAST(Label3D::AlphaCutMode);
 

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -35,7 +35,7 @@
 
 Size2 Button::get_minimum_size() const {
 	Size2 minsize = text_buf->get_size();
-	if (clip_text || overrun_behavior != TextParagraph::OVERRUN_NO_TRIMMING) {
+	if (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		minsize.width = 0;
 	}
 
@@ -292,9 +292,9 @@ void Button::_notification(int p_what) {
 				icon_ofs.x = 0.0;
 			}
 			int text_clip = size.width - style->get_minimum_size().width - icon_ofs.width;
-			text_buf->set_width((clip_text || overrun_behavior != TextParagraph::OVERRUN_NO_TRIMMING) ? text_clip : -1);
+			text_buf->set_width((clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? text_clip : -1);
 
-			int text_width = MAX(1, (clip_text || overrun_behavior != TextParagraph::OVERRUN_NO_TRIMMING) ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x);
+			int text_width = MAX(1, (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x);
 
 			if (_internal_margin[SIDE_LEFT] > 0) {
 				text_clip -= _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("h_separation"));
@@ -367,7 +367,7 @@ void Button::_shape() {
 	text_buf->set_text_overrun_behavior(overrun_behavior);
 }
 
-void Button::set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavior) {
+void Button::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 	if (overrun_behavior != p_behavior) {
 		overrun_behavior = p_behavior;
 		_shape();
@@ -377,7 +377,7 @@ void Button::set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavior
 	}
 }
 
-TextParagraph::OverrunBehavior Button::get_text_overrun_behavior() const {
+TextServer::OverrunBehavior Button::get_text_overrun_behavior() const {
 	return overrun_behavior;
 }
 

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -46,7 +46,7 @@ private:
 	Dictionary opentype_features;
 	String language;
 	TextDirection text_direction = TEXT_DIRECTION_AUTO;
-	TextParagraph::OverrunBehavior overrun_behavior = TextParagraph::OVERRUN_NO_TRIMMING;
+	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
 
 	Ref<Texture2D> icon;
 	bool expand_icon = false;
@@ -72,8 +72,8 @@ public:
 	void set_text(const String &p_text);
 	String get_text() const;
 
-	void set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavior);
-	TextParagraph::OverrunBehavior get_text_overrun_behavior() const;
+	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
+	TextServer::OverrunBehavior get_text_overrun_behavior() const;
 
 	void set_text_direction(TextDirection p_text_direction);
 	TextDirection get_text_direction() const;

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -154,11 +154,11 @@ bool AcceptDialog::get_close_on_escape() const {
 }
 
 void AcceptDialog::set_autowrap(bool p_autowrap) {
-	label->set_autowrap_mode(p_autowrap ? Label::AUTOWRAP_WORD : Label::AUTOWRAP_OFF);
+	label->set_autowrap_mode(p_autowrap ? TextServer::AUTOWRAP_WORD : TextServer::AUTOWRAP_OFF);
 }
 
 bool AcceptDialog::has_autowrap() {
-	return label->get_autowrap_mode() != Label::AUTOWRAP_OFF;
+	return label->get_autowrap_mode() != TextServer::AUTOWRAP_OFF;
 }
 
 void AcceptDialog::register_text_enter(Control *p_line_edit) {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1550,7 +1550,7 @@ bool ItemList::has_auto_height() const {
 	return auto_height;
 }
 
-void ItemList::set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavior) {
+void ItemList::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 	if (text_overrun_behavior != p_behavior) {
 		text_overrun_behavior = p_behavior;
 		for (int i = 0; i < items.size(); i++) {
@@ -1561,7 +1561,7 @@ void ItemList::set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavi
 	}
 }
 
-TextParagraph::OverrunBehavior ItemList::get_text_overrun_behavior() const {
+TextServer::OverrunBehavior ItemList::get_text_overrun_behavior() const {
 	return text_overrun_behavior;
 }
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -99,7 +99,7 @@ private:
 	SelectMode select_mode = SELECT_SINGLE;
 	IconMode icon_mode = ICON_MODE_LEFT;
 	VScrollBar *scroll_bar = nullptr;
-	TextParagraph::OverrunBehavior text_overrun_behavior = TextParagraph::OVERRUN_TRIM_ELLIPSIS;
+	TextServer::OverrunBehavior text_overrun_behavior = TextServer::OVERRUN_TRIM_ELLIPSIS;
 
 	uint64_t search_time_msec = 0;
 	String search_string;
@@ -188,8 +188,8 @@ public:
 	void set_item_custom_fg_color(int p_idx, const Color &p_custom_fg_color);
 	Color get_item_custom_fg_color(int p_idx) const;
 
-	void set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavior);
-	TextParagraph::OverrunBehavior get_text_overrun_behavior() const;
+	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
+	TextServer::OverrunBehavior get_text_overrun_behavior() const;
 
 	void select(int p_idx, bool p_single = true);
 	void deselect(int p_idx);

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -36,19 +36,19 @@
 
 #include "servers/text_server.h"
 
-void Label::set_autowrap_mode(Label::AutowrapMode p_mode) {
+void Label::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
 	if (autowrap_mode != p_mode) {
 		autowrap_mode = p_mode;
 		lines_dirty = true;
 	}
 	update();
 
-	if (clip || overrun_behavior != OVERRUN_NO_TRIMMING) {
+	if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		update_minimum_size();
 	}
 }
 
-Label::AutowrapMode Label::get_autowrap_mode() const {
+TextServer::AutowrapMode Label::get_autowrap_mode() const {
 	return autowrap_mode;
 }
 
@@ -96,7 +96,7 @@ void Label::_shape() {
 		int font_size = get_theme_font_size(SNAME("font_size"));
 		ERR_FAIL_COND(font.is_null());
 		String text = (uppercase) ? TS->string_to_upper(xl_text, lang) : xl_text;
-		if (visible_chars >= 0 && visible_chars_behavior == VC_CHARS_BEFORE_SHAPING) {
+		if (visible_chars >= 0 && visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			text = text.substr(0, visible_chars);
 		}
 		if (dirty) {
@@ -121,16 +121,16 @@ void Label::_shape() {
 
 		uint16_t autowrap_flags = TextServer::BREAK_MANDATORY;
 		switch (autowrap_mode) {
-			case AUTOWRAP_WORD_SMART:
+			case TextServer::AUTOWRAP_WORD_SMART:
 				autowrap_flags = TextServer::BREAK_WORD_BOUND_ADAPTIVE | TextServer::BREAK_MANDATORY;
 				break;
-			case AUTOWRAP_WORD:
+			case TextServer::AUTOWRAP_WORD:
 				autowrap_flags = TextServer::BREAK_WORD_BOUND | TextServer::BREAK_MANDATORY;
 				break;
-			case AUTOWRAP_ARBITRARY:
+			case TextServer::AUTOWRAP_ARBITRARY:
 				autowrap_flags = TextServer::BREAK_GRAPHEME_BOUND | TextServer::BREAK_MANDATORY;
 				break;
-			case AUTOWRAP_OFF:
+			case TextServer::AUTOWRAP_OFF:
 				break;
 		}
 		PackedInt32Array line_breaks = TS->shaped_text_get_line_breaks(text_rid, width, 0, autowrap_flags);
@@ -146,7 +146,7 @@ void Label::_shape() {
 		return;
 	}
 
-	if (autowrap_mode == AUTOWRAP_OFF) {
+	if (autowrap_mode == TextServer::AUTOWRAP_OFF) {
 		minsize.width = 0.0f;
 		for (int i = 0; i < lines_rid.size(); i++) {
 			if (minsize.width < TS->shaped_text_get_size(lines_rid[i]).x) {
@@ -156,31 +156,31 @@ void Label::_shape() {
 	}
 
 	if (lines_dirty) {
-		uint16_t overrun_flags = TextServer::OVERRUN_NO_TRIMMING;
+		uint16_t overrun_flags = TextServer::OVERRUN_NO_TRIM;
 		switch (overrun_behavior) {
-			case OVERRUN_TRIM_WORD_ELLIPSIS:
+			case TextServer::OVERRUN_TRIM_WORD_ELLIPSIS:
 				overrun_flags |= TextServer::OVERRUN_TRIM;
 				overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
 				overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
 				break;
-			case OVERRUN_TRIM_ELLIPSIS:
+			case TextServer::OVERRUN_TRIM_ELLIPSIS:
 				overrun_flags |= TextServer::OVERRUN_TRIM;
 				overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
 				break;
-			case OVERRUN_TRIM_WORD:
+			case TextServer::OVERRUN_TRIM_WORD:
 				overrun_flags |= TextServer::OVERRUN_TRIM;
 				overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
 				break;
-			case OVERRUN_TRIM_CHAR:
+			case TextServer::OVERRUN_TRIM_CHAR:
 				overrun_flags |= TextServer::OVERRUN_TRIM;
 				break;
-			case OVERRUN_NO_TRIMMING:
+			case TextServer::OVERRUN_NO_TRIMMING:
 				break;
 		}
 
 		// Fill after min_size calculation.
 
-		if (autowrap_mode != AUTOWRAP_OFF) {
+		if (autowrap_mode != TextServer::AUTOWRAP_OFF) {
 			int visible_lines = get_visible_line_count();
 			bool lines_hidden = visible_lines > 0 && visible_lines < lines_rid.size();
 			if (lines_hidden) {
@@ -215,7 +215,7 @@ void Label::_shape() {
 
 	_update_visible();
 
-	if (autowrap_mode == AUTOWRAP_OFF || !clip || overrun_behavior == OVERRUN_NO_TRIMMING) {
+	if (autowrap_mode == TextServer::AUTOWRAP_OFF || !clip || overrun_behavior == TextServer::OVERRUN_NO_TRIMMING) {
 		update_minimum_size();
 	}
 }
@@ -326,9 +326,9 @@ void Label::_notification(int p_what) {
 			}
 
 			int last_line = MIN(lines_rid.size(), lines_visible + lines_skipped);
-			bool trim_chars = (visible_chars >= 0) && (visible_chars_behavior == VC_CHARS_AFTER_SHAPING);
-			bool trim_glyphs_ltr = (visible_chars >= 0) && ((visible_chars_behavior == VC_GLYPHS_LTR) || ((visible_chars_behavior == VC_GLYPHS_AUTO) && !rtl_layout));
-			bool trim_glyphs_rtl = (visible_chars >= 0) && ((visible_chars_behavior == VC_GLYPHS_RTL) || ((visible_chars_behavior == VC_GLYPHS_AUTO) && rtl_layout));
+			bool trim_chars = (visible_chars >= 0) && (visible_chars_behavior == TextServer::VC_CHARS_AFTER_SHAPING);
+			bool trim_glyphs_ltr = (visible_chars >= 0) && ((visible_chars_behavior == TextServer::VC_GLYPHS_LTR) || ((visible_chars_behavior == TextServer::VC_GLYPHS_AUTO) && !rtl_layout));
+			bool trim_glyphs_rtl = (visible_chars >= 0) && ((visible_chars_behavior == TextServer::VC_GLYPHS_RTL) || ((visible_chars_behavior == TextServer::VC_GLYPHS_AUTO) && rtl_layout));
 
 			// Get real total height.
 			int total_glyphs = 0;
@@ -377,7 +377,7 @@ void Label::_notification(int p_what) {
 				ofs.y += TS->shaped_text_get_ascent(lines_rid[i]) + font->get_spacing(TextServer::SPACING_TOP);
 				switch (horizontal_alignment) {
 					case HORIZONTAL_ALIGNMENT_FILL:
-						if (rtl && autowrap_mode != AUTOWRAP_OFF) {
+						if (rtl && autowrap_mode != TextServer::AUTOWRAP_OFF) {
 							ofs.x = int(size.width - style->get_margin(SIDE_RIGHT) - line_size.width);
 						} else {
 							ofs.x = style->get_offset().x;
@@ -554,10 +554,10 @@ Size2 Label::get_minimum_size() const {
 	min_size.height = MAX(min_size.height, font->get_height(get_theme_font_size(SNAME("font_size"))) + font->get_spacing(TextServer::SPACING_TOP) + font->get_spacing(TextServer::SPACING_BOTTOM));
 
 	Size2 min_style = get_theme_stylebox(SNAME("normal"))->get_minimum_size();
-	if (autowrap_mode != AUTOWRAP_OFF) {
-		return Size2(1, (clip || overrun_behavior != OVERRUN_NO_TRIMMING) ? 1 : min_size.height) + min_style;
+	if (autowrap_mode != TextServer::AUTOWRAP_OFF) {
+		return Size2(1, (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? 1 : min_size.height) + min_style;
 	} else {
-		if (clip || overrun_behavior != OVERRUN_NO_TRIMMING) {
+		if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 			min_size.width = 1;
 		}
 		return min_size + min_style;
@@ -719,18 +719,18 @@ bool Label::is_clipping_text() const {
 	return clip;
 }
 
-void Label::set_text_overrun_behavior(Label::OverrunBehavior p_behavior) {
+void Label::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 	if (overrun_behavior != p_behavior) {
 		overrun_behavior = p_behavior;
 		lines_dirty = true;
 	}
 	update();
-	if (clip || overrun_behavior != OVERRUN_NO_TRIMMING) {
+	if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		update_minimum_size();
 	}
 }
 
-Label::OverrunBehavior Label::get_text_overrun_behavior() const {
+TextServer::OverrunBehavior Label::get_text_overrun_behavior() const {
 	return overrun_behavior;
 }
 
@@ -746,7 +746,7 @@ void Label::set_visible_characters(int p_amount) {
 		} else {
 			percent_visible = 1.0;
 		}
-		if (visible_chars_behavior == VC_CHARS_BEFORE_SHAPING) {
+		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			dirty = true;
 		}
 		update();
@@ -766,7 +766,7 @@ void Label::set_percent_visible(float p_percent) {
 			visible_chars = get_total_character_count() * p_percent;
 			percent_visible = p_percent;
 		}
-		if (visible_chars_behavior == VC_CHARS_BEFORE_SHAPING) {
+		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			dirty = true;
 		}
 		update();
@@ -777,11 +777,11 @@ float Label::get_percent_visible() const {
 	return percent_visible;
 }
 
-Label::VisibleCharactersBehavior Label::get_visible_characters_behavior() const {
+TextServer::VisibleCharactersBehavior Label::get_visible_characters_behavior() const {
 	return visible_chars_behavior;
 }
 
-void Label::set_visible_characters_behavior(Label::VisibleCharactersBehavior p_behavior) {
+void Label::set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior) {
 	if (visible_chars_behavior != p_behavior) {
 		visible_chars_behavior = p_behavior;
 		dirty = true;
@@ -908,23 +908,6 @@ void Label::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_structured_text_bidi_override"), &Label::get_structured_text_bidi_override);
 	ClassDB::bind_method(D_METHOD("set_structured_text_bidi_override_options", "args"), &Label::set_structured_text_bidi_override_options);
 	ClassDB::bind_method(D_METHOD("get_structured_text_bidi_override_options"), &Label::get_structured_text_bidi_override_options);
-
-	BIND_ENUM_CONSTANT(AUTOWRAP_OFF);
-	BIND_ENUM_CONSTANT(AUTOWRAP_ARBITRARY);
-	BIND_ENUM_CONSTANT(AUTOWRAP_WORD);
-	BIND_ENUM_CONSTANT(AUTOWRAP_WORD_SMART);
-
-	BIND_ENUM_CONSTANT(OVERRUN_NO_TRIMMING);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_CHAR);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_ELLIPSIS);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD_ELLIPSIS);
-
-	BIND_ENUM_CONSTANT(VC_CHARS_BEFORE_SHAPING);
-	BIND_ENUM_CONSTANT(VC_CHARS_AFTER_SHAPING);
-	BIND_ENUM_CONSTANT(VC_GLYPHS_AUTO);
-	BIND_ENUM_CONSTANT(VC_GLYPHS_LTR);
-	BIND_ENUM_CONSTANT(VC_GLYPHS_RTL);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_DEFAULT_INTL), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "horizontal_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_horizontal_alignment", "get_horizontal_alignment");

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -36,38 +36,14 @@
 class Label : public Control {
 	GDCLASS(Label, Control);
 
-public:
-	enum AutowrapMode {
-		AUTOWRAP_OFF,
-		AUTOWRAP_ARBITRARY,
-		AUTOWRAP_WORD,
-		AUTOWRAP_WORD_SMART
-	};
-
-	enum OverrunBehavior {
-		OVERRUN_NO_TRIMMING,
-		OVERRUN_TRIM_CHAR,
-		OVERRUN_TRIM_WORD,
-		OVERRUN_TRIM_ELLIPSIS,
-		OVERRUN_TRIM_WORD_ELLIPSIS,
-	};
-
-	enum VisibleCharactersBehavior {
-		VC_CHARS_BEFORE_SHAPING,
-		VC_CHARS_AFTER_SHAPING,
-		VC_GLYPHS_AUTO,
-		VC_GLYPHS_LTR,
-		VC_GLYPHS_RTL,
-	};
-
 private:
 	HorizontalAlignment horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT;
 	VerticalAlignment vertical_alignment = VERTICAL_ALIGNMENT_TOP;
 	String text;
 	String xl_text;
-	AutowrapMode autowrap_mode = AUTOWRAP_OFF;
+	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
 	bool clip = false;
-	OverrunBehavior overrun_behavior = OVERRUN_NO_TRIMMING;
+	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
 	Size2 minsize;
 	bool uppercase = false;
 
@@ -85,7 +61,7 @@ private:
 
 	float percent_visible = 1.0;
 
-	VisibleCharactersBehavior visible_chars_behavior = VC_CHARS_BEFORE_SHAPING;
+	TextServer::VisibleCharactersBehavior visible_chars_behavior = TextServer::VC_CHARS_BEFORE_SHAPING;
 	int visible_chars = -1;
 	int lines_skipped = 0;
 	int max_lines_visible = -1;
@@ -130,14 +106,14 @@ public:
 	void set_structured_text_bidi_override_options(Array p_args);
 	Array get_structured_text_bidi_override_options() const;
 
-	void set_autowrap_mode(AutowrapMode p_mode);
-	AutowrapMode get_autowrap_mode() const;
+	void set_autowrap_mode(TextServer::AutowrapMode p_mode);
+	TextServer::AutowrapMode get_autowrap_mode() const;
 
 	void set_uppercase(bool p_uppercase);
 	bool is_uppercase() const;
 
-	VisibleCharactersBehavior get_visible_characters_behavior() const;
-	void set_visible_characters_behavior(VisibleCharactersBehavior p_behavior);
+	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
+	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);
 
 	void set_visible_characters(int p_amount);
 	int get_visible_characters() const;
@@ -146,8 +122,8 @@ public:
 	void set_clip_text(bool p_clip);
 	bool is_clipping_text() const;
 
-	void set_text_overrun_behavior(OverrunBehavior p_behavior);
-	OverrunBehavior get_text_overrun_behavior() const;
+	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
+	TextServer::OverrunBehavior get_text_overrun_behavior() const;
 
 	void set_percent_visible(float p_percent);
 	float get_percent_visible() const;
@@ -165,9 +141,5 @@ public:
 	Label(const String &p_text = String());
 	~Label();
 };
-
-VARIANT_ENUM_CAST(Label::AutowrapMode);
-VARIANT_ENUM_CAST(Label::OverrunBehavior);
-VARIANT_ENUM_CAST(Label::VisibleCharactersBehavior);
 
 #endif

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -426,16 +426,16 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 
 	uint16_t autowrap_flags = TextServer::BREAK_MANDATORY;
 	switch (autowrap_mode) {
-		case AUTOWRAP_WORD_SMART:
+		case TextServer::AUTOWRAP_WORD_SMART:
 			autowrap_flags = TextServer::BREAK_WORD_BOUND_ADAPTIVE | TextServer::BREAK_MANDATORY;
 			break;
-		case AUTOWRAP_WORD:
+		case TextServer::AUTOWRAP_WORD:
 			autowrap_flags = TextServer::BREAK_WORD_BOUND | TextServer::BREAK_MANDATORY;
 			break;
-		case AUTOWRAP_ARBITRARY:
+		case TextServer::AUTOWRAP_ARBITRARY:
 			autowrap_flags = TextServer::BREAK_GRAPHEME_BOUND | TextServer::BREAK_MANDATORY;
 			break;
-		case AUTOWRAP_OFF:
+		case TextServer::AUTOWRAP_OFF:
 			break;
 	}
 
@@ -462,7 +462,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	Item *it_to = (p_line + 1 < (int)p_frame->lines.size()) ? p_frame->lines[p_line + 1].from : nullptr;
 	int remaining_characters = visible_characters - l.char_offset;
 	for (Item *it = l.from; it && it != it_to; it = _get_next_item(it)) {
-		if (visible_chars_behavior == VC_CHARS_BEFORE_SHAPING && visible_characters >= 0 && remaining_characters <= 0) {
+		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING && visible_characters >= 0 && remaining_characters <= 0) {
 			break;
 		}
 		switch (it->type) {
@@ -501,7 +501,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				Dictionary font_ftr = _find_font_features(it);
 				String lang = _find_language(it);
 				String tx = t->text;
-				if (visible_chars_behavior == VC_CHARS_BEFORE_SHAPING && visible_characters >= 0 && remaining_characters >= 0) {
+				if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING && visible_characters >= 0 && remaining_characters >= 0) {
 					tx = tx.substr(0, remaining_characters);
 				}
 				remaining_characters -= tx.length();
@@ -707,9 +707,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	bool rtl = (l.text_buf->get_direction() == TextServer::DIRECTION_RTL);
 	bool lrtl = is_layout_rtl();
 
-	bool trim_chars = (visible_characters >= 0) && (visible_chars_behavior == VC_CHARS_AFTER_SHAPING);
-	bool trim_glyphs_ltr = (visible_characters >= 0) && ((visible_chars_behavior == VC_GLYPHS_LTR) || ((visible_chars_behavior == VC_GLYPHS_AUTO) && !lrtl));
-	bool trim_glyphs_rtl = (visible_characters >= 0) && ((visible_chars_behavior == VC_GLYPHS_RTL) || ((visible_chars_behavior == VC_GLYPHS_AUTO) && lrtl));
+	bool trim_chars = (visible_characters >= 0) && (visible_chars_behavior == TextServer::VC_CHARS_AFTER_SHAPING);
+	bool trim_glyphs_ltr = (visible_characters >= 0) && ((visible_chars_behavior == TextServer::VC_GLYPHS_LTR) || ((visible_chars_behavior == TextServer::VC_GLYPHS_AUTO) && !lrtl));
+	bool trim_glyphs_rtl = (visible_characters >= 0) && ((visible_chars_behavior == TextServer::VC_GLYPHS_RTL) || ((visible_chars_behavior == TextServer::VC_GLYPHS_AUTO) && lrtl));
 	int total_glyphs = (trim_glyphs_ltr || trim_glyphs_rtl) ? get_total_glyph_count() : 0;
 	int visible_glyphs = total_glyphs * percent_visible;
 
@@ -4752,7 +4752,7 @@ String RichTextLabel::get_language() const {
 	return language;
 }
 
-void RichTextLabel::set_autowrap_mode(RichTextLabel::AutowrapMode p_mode) {
+void RichTextLabel::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
 	if (autowrap_mode != p_mode) {
 		_stop_thread();
 
@@ -4763,7 +4763,7 @@ void RichTextLabel::set_autowrap_mode(RichTextLabel::AutowrapMode p_mode) {
 	}
 }
 
-RichTextLabel::AutowrapMode RichTextLabel::get_autowrap_mode() const {
+TextServer::AutowrapMode RichTextLabel::get_autowrap_mode() const {
 	return autowrap_mode;
 }
 
@@ -4778,7 +4778,7 @@ void RichTextLabel::set_percent_visible(float p_percent) {
 			visible_characters = get_total_character_count() * p_percent;
 			percent_visible = p_percent;
 		}
-		if (visible_chars_behavior == VC_CHARS_BEFORE_SHAPING) {
+		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			main->first_invalid_line.store(0); //invalidate ALL
 			_validate_line_caches();
 		}
@@ -5032,11 +5032,6 @@ void RichTextLabel::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("finished"));
 
-	BIND_ENUM_CONSTANT(AUTOWRAP_OFF);
-	BIND_ENUM_CONSTANT(AUTOWRAP_ARBITRARY);
-	BIND_ENUM_CONSTANT(AUTOWRAP_WORD);
-	BIND_ENUM_CONSTANT(AUTOWRAP_WORD_SMART);
-
 	BIND_ENUM_CONSTANT(LIST_NUMBERS);
 	BIND_ENUM_CONSTANT(LIST_LETTERS);
 	BIND_ENUM_CONSTANT(LIST_ROMAN);
@@ -5069,19 +5064,13 @@ void RichTextLabel::_bind_methods() {
 	BIND_ENUM_CONSTANT(ITEM_HINT);
 	BIND_ENUM_CONSTANT(ITEM_DROPCAP);
 	BIND_ENUM_CONSTANT(ITEM_CUSTOMFX);
-
-	BIND_ENUM_CONSTANT(VC_CHARS_BEFORE_SHAPING);
-	BIND_ENUM_CONSTANT(VC_CHARS_AFTER_SHAPING);
-	BIND_ENUM_CONSTANT(VC_GLYPHS_AUTO);
-	BIND_ENUM_CONSTANT(VC_GLYPHS_LTR);
-	BIND_ENUM_CONSTANT(VC_GLYPHS_RTL);
 }
 
-RichTextLabel::VisibleCharactersBehavior RichTextLabel::get_visible_characters_behavior() const {
+TextServer::VisibleCharactersBehavior RichTextLabel::get_visible_characters_behavior() const {
 	return visible_chars_behavior;
 }
 
-void RichTextLabel::set_visible_characters_behavior(RichTextLabel::VisibleCharactersBehavior p_behavior) {
+void RichTextLabel::set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior) {
 	if (visible_chars_behavior != p_behavior) {
 		_stop_thread();
 
@@ -5105,7 +5094,7 @@ void RichTextLabel::set_visible_characters(int p_visible) {
 				percent_visible = (float)p_visible / (float)total_char_count;
 			}
 		}
-		if (visible_chars_behavior == VC_CHARS_BEFORE_SHAPING) {
+		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			main->first_invalid_line.store(0); //invalidate ALL
 			_validate_line_caches();
 		}

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -40,13 +40,6 @@ class RichTextLabel : public Control {
 	GDCLASS(RichTextLabel, Control);
 
 public:
-	enum AutowrapMode {
-		AUTOWRAP_OFF,
-		AUTOWRAP_ARBITRARY,
-		AUTOWRAP_WORD,
-		AUTOWRAP_WORD_SMART
-	};
-
 	enum ListType {
 		LIST_NUMBERS,
 		LIST_LETTERS,
@@ -82,14 +75,6 @@ public:
 		ITEM_HINT,
 		ITEM_DROPCAP,
 		ITEM_CUSTOMFX
-	};
-
-	enum VisibleCharactersBehavior {
-		VC_CHARS_BEFORE_SHAPING,
-		VC_CHARS_AFTER_SHAPING,
-		VC_GLYPHS_AUTO,
-		VC_GLYPHS_LTR,
-		VC_GLYPHS_RTL,
 	};
 
 	enum MenuItems {
@@ -384,7 +369,7 @@ private:
 
 	VScrollBar *vscroll = nullptr;
 
-	AutowrapMode autowrap_mode = AUTOWRAP_WORD_SMART;
+	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_WORD_SMART;
 
 	bool scroll_visible = false;
 	bool scroll_follow = false;
@@ -460,7 +445,7 @@ private:
 
 	int visible_characters = -1;
 	float percent_visible = 1.0;
-	VisibleCharactersBehavior visible_chars_behavior = VC_CHARS_BEFORE_SHAPING;
+	TextServer::VisibleCharactersBehavior visible_chars_behavior = TextServer::VC_CHARS_BEFORE_SHAPING;
 
 	bool _is_click_inside_selection() const;
 	void _find_click(ItemFrame *p_frame, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr, bool *r_outside = nullptr);
@@ -664,8 +649,8 @@ public:
 	void set_language(const String &p_language);
 	String get_language() const;
 
-	void set_autowrap_mode(AutowrapMode p_mode);
-	AutowrapMode get_autowrap_mode() const;
+	void set_autowrap_mode(TextServer::AutowrapMode p_mode);
+	TextServer::AutowrapMode get_autowrap_mode() const;
 
 	void set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override() const;
@@ -683,8 +668,8 @@ public:
 	void set_percent_visible(float p_percent);
 	float get_percent_visible() const;
 
-	VisibleCharactersBehavior get_visible_characters_behavior() const;
-	void set_visible_characters_behavior(VisibleCharactersBehavior p_behavior);
+	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
+	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);
 
 	void set_effects(Array p_effects);
 	Array get_effects();
@@ -698,9 +683,7 @@ public:
 	~RichTextLabel();
 };
 
-VARIANT_ENUM_CAST(RichTextLabel::AutowrapMode);
 VARIANT_ENUM_CAST(RichTextLabel::ListType);
 VARIANT_ENUM_CAST(RichTextLabel::ItemType);
-VARIANT_ENUM_CAST(RichTextLabel::VisibleCharactersBehavior);
 
 #endif // RICH_TEXT_LABEL_H

--- a/scene/resources/text_line.cpp
+++ b/scene/resources/text_line.cpp
@@ -98,12 +98,6 @@ void TextLine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_outline", "canvas", "pos", "outline_size", "color"), &TextLine::draw_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
 
 	ClassDB::bind_method(D_METHOD("hit_test", "coords"), &TextLine::hit_test);
-
-	BIND_ENUM_CONSTANT(OVERRUN_NO_TRIMMING);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_CHAR);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_ELLIPSIS);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD_ELLIPSIS);
 }
 
 void TextLine::_shape() {
@@ -112,26 +106,26 @@ void TextLine::_shape() {
 			TS->shaped_text_tab_align(rid, tab_stops);
 		}
 
-		uint16_t overrun_flags = TextServer::OVERRUN_NO_TRIMMING;
-		if (overrun_behavior != OVERRUN_NO_TRIMMING) {
+		uint16_t overrun_flags = TextServer::OVERRUN_NO_TRIM;
+		if (overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 			switch (overrun_behavior) {
-				case OVERRUN_TRIM_WORD_ELLIPSIS:
+				case TextServer::OVERRUN_TRIM_WORD_ELLIPSIS:
 					overrun_flags |= TextServer::OVERRUN_TRIM;
 					overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
 					overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
 					break;
-				case OVERRUN_TRIM_ELLIPSIS:
+				case TextServer::OVERRUN_TRIM_ELLIPSIS:
 					overrun_flags |= TextServer::OVERRUN_TRIM;
 					overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
 					break;
-				case OVERRUN_TRIM_WORD:
+				case TextServer::OVERRUN_TRIM_WORD:
 					overrun_flags |= TextServer::OVERRUN_TRIM;
 					overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
 					break;
-				case OVERRUN_TRIM_CHAR:
+				case TextServer::OVERRUN_TRIM_CHAR:
 					overrun_flags |= TextServer::OVERRUN_TRIM;
 					break;
-				case OVERRUN_NO_TRIMMING:
+				case TextServer::OVERRUN_NO_TRIMMING:
 					break;
 			}
 
@@ -259,20 +253,20 @@ uint16_t TextLine::get_flags() const {
 	return flags;
 }
 
-void TextLine::set_text_overrun_behavior(TextLine::OverrunBehavior p_behavior) {
+void TextLine::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 	if (overrun_behavior != p_behavior) {
 		overrun_behavior = p_behavior;
 		dirty = true;
 	}
 }
 
-TextLine::OverrunBehavior TextLine::get_text_overrun_behavior() const {
+TextServer::OverrunBehavior TextLine::get_text_overrun_behavior() const {
 	return overrun_behavior;
 }
 
 void TextLine::set_width(float p_width) {
 	width = p_width;
-	if (alignment == HORIZONTAL_ALIGNMENT_FILL || overrun_behavior != OVERRUN_NO_TRIMMING) {
+	if (alignment == HORIZONTAL_ALIGNMENT_FILL || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		dirty = true;
 	}
 }

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -39,15 +39,6 @@
 class TextLine : public RefCounted {
 	GDCLASS(TextLine, RefCounted);
 
-public:
-	enum OverrunBehavior {
-		OVERRUN_NO_TRIMMING,
-		OVERRUN_TRIM_CHAR,
-		OVERRUN_TRIM_WORD,
-		OVERRUN_TRIM_ELLIPSIS,
-		OVERRUN_TRIM_WORD_ELLIPSIS,
-	};
-
 private:
 	RID rid;
 	int spacing_top = 0;
@@ -58,7 +49,7 @@ private:
 	float width = -1.0;
 	uint16_t flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_LEFT;
-	OverrunBehavior overrun_behavior = OVERRUN_TRIM_ELLIPSIS;
+	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_TRIM_ELLIPSIS;
 
 	Vector<float> tab_stops;
 
@@ -98,8 +89,8 @@ public:
 	void set_flags(uint16_t p_flags);
 	uint16_t get_flags() const;
 
-	void set_text_overrun_behavior(OverrunBehavior p_behavior);
-	OverrunBehavior get_text_overrun_behavior() const;
+	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
+	TextServer::OverrunBehavior get_text_overrun_behavior() const;
 
 	void set_width(float p_width);
 	float get_width() const;
@@ -124,7 +115,5 @@ public:
 	TextLine();
 	~TextLine();
 };
-
-VARIANT_ENUM_CAST(TextLine::OverrunBehavior);
 
 #endif // TEXT_LINE_H

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -129,12 +129,6 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_dropcap_outline", "canvas", "pos", "outline_size", "color"), &TextParagraph::draw_dropcap_outline, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
 
 	ClassDB::bind_method(D_METHOD("hit_test", "coords"), &TextParagraph::hit_test);
-
-	BIND_ENUM_CONSTANT(OVERRUN_NO_TRIMMING);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_CHAR);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_ELLIPSIS);
-	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD_ELLIPSIS);
 }
 
 void TextParagraph::_shape_lines() {
@@ -190,26 +184,26 @@ void TextParagraph::_shape_lines() {
 			lines_rid.push_back(line);
 		}
 
-		uint16_t overrun_flags = TextServer::OVERRUN_NO_TRIMMING;
-		if (overrun_behavior != OVERRUN_NO_TRIMMING) {
+		uint16_t overrun_flags = TextServer::OVERRUN_NO_TRIM;
+		if (overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 			switch (overrun_behavior) {
-				case OVERRUN_TRIM_WORD_ELLIPSIS:
+				case TextServer::OVERRUN_TRIM_WORD_ELLIPSIS:
 					overrun_flags |= TextServer::OVERRUN_TRIM;
 					overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
 					overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
 					break;
-				case OVERRUN_TRIM_ELLIPSIS:
+				case TextServer::OVERRUN_TRIM_ELLIPSIS:
 					overrun_flags |= TextServer::OVERRUN_TRIM;
 					overrun_flags |= TextServer::OVERRUN_ADD_ELLIPSIS;
 					break;
-				case OVERRUN_TRIM_WORD:
+				case TextServer::OVERRUN_TRIM_WORD:
 					overrun_flags |= TextServer::OVERRUN_TRIM;
 					overrun_flags |= TextServer::OVERRUN_TRIM_WORD_ONLY;
 					break;
-				case OVERRUN_TRIM_CHAR:
+				case TextServer::OVERRUN_TRIM_CHAR:
 					overrun_flags |= TextServer::OVERRUN_TRIM;
 					break;
-				case OVERRUN_NO_TRIMMING:
+				case TextServer::OVERRUN_NO_TRIMMING:
 					break;
 			}
 		}
@@ -451,7 +445,7 @@ uint16_t TextParagraph::get_flags() const {
 	return flags;
 }
 
-void TextParagraph::set_text_overrun_behavior(TextParagraph::OverrunBehavior p_behavior) {
+void TextParagraph::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 	_THREAD_SAFE_METHOD_
 
 	if (overrun_behavior != p_behavior) {
@@ -460,7 +454,7 @@ void TextParagraph::set_text_overrun_behavior(TextParagraph::OverrunBehavior p_b
 	}
 }
 
-TextParagraph::OverrunBehavior TextParagraph::get_text_overrun_behavior() const {
+TextServer::OverrunBehavior TextParagraph::get_text_overrun_behavior() const {
 	return overrun_behavior;
 }
 

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -41,15 +41,6 @@ class TextParagraph : public RefCounted {
 	GDCLASS(TextParagraph, RefCounted);
 	_THREAD_SAFE_CLASS_
 
-public:
-	enum OverrunBehavior {
-		OVERRUN_NO_TRIMMING,
-		OVERRUN_TRIM_CHAR,
-		OVERRUN_TRIM_WORD,
-		OVERRUN_TRIM_ELLIPSIS,
-		OVERRUN_TRIM_WORD_ELLIPSIS,
-	};
-
 private:
 	RID dropcap_rid;
 	int dropcap_lines = 0;
@@ -66,7 +57,7 @@ private:
 	int max_lines_visible = -1;
 
 	uint16_t flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA;
-	OverrunBehavior overrun_behavior = OVERRUN_NO_TRIMMING;
+	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
 
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_LEFT;
 
@@ -116,8 +107,8 @@ public:
 	void set_flags(uint16_t p_flags);
 	uint16_t get_flags() const;
 
-	void set_text_overrun_behavior(OverrunBehavior p_behavior);
-	OverrunBehavior get_text_overrun_behavior() const;
+	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
+	TextServer::OverrunBehavior get_text_overrun_behavior() const;
 
 	void set_width(float p_width);
 	float get_width() const;
@@ -164,7 +155,5 @@ public:
 	TextParagraph();
 	~TextParagraph();
 };
-
-VARIANT_ENUM_CAST(TextParagraph::OverrunBehavior);
 
 #endif // TEXT_PARAGRAPH_H

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -413,7 +413,7 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shaped_text_get_ellipsis_glyphs", "shaped"), &TextServer::_shaped_text_get_ellipsis_glyphs_wrapper);
 	ClassDB::bind_method(D_METHOD("shaped_text_get_ellipsis_glyph_count", "shaped"), &TextServer::shaped_text_get_ellipsis_glyph_count);
 
-	ClassDB::bind_method(D_METHOD("shaped_text_overrun_trim_to_width", "shaped", "width", "overrun_trim_flags"), &TextServer::shaped_text_overrun_trim_to_width, DEFVAL(0), DEFVAL(OVERRUN_NO_TRIMMING));
+	ClassDB::bind_method(D_METHOD("shaped_text_overrun_trim_to_width", "shaped", "width", "overrun_trim_flags"), &TextServer::shaped_text_overrun_trim_to_width, DEFVAL(0), DEFVAL(OVERRUN_NO_TRIM));
 
 	ClassDB::bind_method(D_METHOD("shaped_text_get_objects", "shaped"), &TextServer::shaped_text_get_objects);
 	ClassDB::bind_method(D_METHOD("shaped_text_get_object_rect", "shaped", "key"), &TextServer::shaped_text_get_object_rect);
@@ -470,6 +470,12 @@ void TextServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(JUSTIFICATION_AFTER_LAST_TAB);
 	BIND_ENUM_CONSTANT(JUSTIFICATION_CONSTRAIN_ELLIPSIS);
 
+	/* AutowrapMode */
+	BIND_ENUM_CONSTANT(AUTOWRAP_OFF);
+	BIND_ENUM_CONSTANT(AUTOWRAP_ARBITRARY);
+	BIND_ENUM_CONSTANT(AUTOWRAP_WORD);
+	BIND_ENUM_CONSTANT(AUTOWRAP_WORD_SMART);
+
 	/* LineBreakFlag */
 	BIND_ENUM_CONSTANT(BREAK_NONE);
 	BIND_ENUM_CONSTANT(BREAK_MANDATORY);
@@ -477,8 +483,22 @@ void TextServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(BREAK_GRAPHEME_BOUND);
 	BIND_ENUM_CONSTANT(BREAK_WORD_BOUND_ADAPTIVE);
 
-	/* TextOverrunFlag */
+	/* VisibleCharactersBehavior */
+	BIND_ENUM_CONSTANT(VC_CHARS_BEFORE_SHAPING);
+	BIND_ENUM_CONSTANT(VC_CHARS_AFTER_SHAPING);
+	BIND_ENUM_CONSTANT(VC_GLYPHS_AUTO);
+	BIND_ENUM_CONSTANT(VC_GLYPHS_LTR);
+	BIND_ENUM_CONSTANT(VC_GLYPHS_RTL);
+
+	/* OverrunBehavior */
 	BIND_ENUM_CONSTANT(OVERRUN_NO_TRIMMING);
+	BIND_ENUM_CONSTANT(OVERRUN_TRIM_CHAR);
+	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD);
+	BIND_ENUM_CONSTANT(OVERRUN_TRIM_ELLIPSIS);
+	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD_ELLIPSIS);
+
+	/* TextOverrunFlag */
+	BIND_ENUM_CONSTANT(OVERRUN_NO_TRIM);
 	BIND_ENUM_CONSTANT(OVERRUN_TRIM);
 	BIND_ENUM_CONSTANT(OVERRUN_TRIM_WORD_ONLY);
 	BIND_ENUM_CONSTANT(OVERRUN_ADD_ELLIPSIS);

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -64,6 +64,21 @@ public:
 		JUSTIFICATION_CONSTRAIN_ELLIPSIS = 1 << 4,
 	};
 
+	enum VisibleCharactersBehavior {
+		VC_CHARS_BEFORE_SHAPING,
+		VC_CHARS_AFTER_SHAPING,
+		VC_GLYPHS_AUTO,
+		VC_GLYPHS_LTR,
+		VC_GLYPHS_RTL,
+	};
+
+	enum AutowrapMode {
+		AUTOWRAP_OFF,
+		AUTOWRAP_ARBITRARY,
+		AUTOWRAP_WORD,
+		AUTOWRAP_WORD_SMART
+	};
+
 	enum LineBreakFlag { // LineBreakFlag can be passed in the same value as the JustificationFlag, do not use the same values.
 		BREAK_NONE = 0,
 		BREAK_MANDATORY = 1 << 5,
@@ -72,8 +87,16 @@ public:
 		BREAK_WORD_BOUND_ADAPTIVE = 1 << 6 | 1 << 8,
 	};
 
+	enum OverrunBehavior {
+		OVERRUN_NO_TRIMMING,
+		OVERRUN_TRIM_CHAR,
+		OVERRUN_TRIM_WORD,
+		OVERRUN_TRIM_ELLIPSIS,
+		OVERRUN_TRIM_WORD_ELLIPSIS,
+	};
+
 	enum TextOverrunFlag {
-		OVERRUN_NO_TRIMMING = 0,
+		OVERRUN_NO_TRIM = 0,
 		OVERRUN_TRIM = 1 << 0,
 		OVERRUN_TRIM_WORD_ONLY = 1 << 1,
 		OVERRUN_ADD_ELLIPSIS = 1 << 2,
@@ -522,6 +545,9 @@ public:
 
 #define TS TextServerManager::get_singleton()->get_primary_interface()
 
+VARIANT_ENUM_CAST(TextServer::VisibleCharactersBehavior);
+VARIANT_ENUM_CAST(TextServer::AutowrapMode);
+VARIANT_ENUM_CAST(TextServer::OverrunBehavior);
 VARIANT_ENUM_CAST(TextServer::Direction);
 VARIANT_ENUM_CAST(TextServer::Orientation);
 VARIANT_ENUM_CAST(TextServer::JustificationFlag);


### PR DESCRIPTION
Move `AutowrapMode`, `OverrunBehavior` and `VisibleCharactersBehavior` enums to `TextServer`. These enums were originally introduced as part of the `Label`. But later were copied to the other controls.

This PR replaces multiple versions of the same enum in different controls, with the single version in the `TextServer`.