### PR TITLE
Typo: Changed "forech" into "foreach" in string_utils.cpp

### DIFF
--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -145,7 +145,7 @@ bool is_csharp_keyword(const String &p_name) {
 			p_name == "do" || p_name == "double" || p_name == "else" || p_name == "enum" ||
 			p_name == "event" || p_name == "explicit" || p_name == "extern" || p_name == "false" ||
 			p_name == "finally" || p_name == "fixed" || p_name == "float" || p_name == "for" ||
-			p_name == "forech" || p_name == "goto" || p_name == "if" || p_name == "implicit" ||
+			p_name == "foreach" || p_name == "goto" || p_name == "if" || p_name == "implicit" ||
 			p_name == "in" || p_name == "int" || p_name == "interface" || p_name == "internal" ||
 			p_name == "is" || p_name == "lock" || p_name == "long" || p_name == "namespace" ||
 			p_name == "new" || p_name == "null" || p_name == "object" || p_name == "operator" ||


### PR DESCRIPTION
Solves #62049

*Bugsquad edit:*
- Fixes #62049