### PR TITLE
[3.x] Improve GDScript autocomplete type detection with the most-specific types available

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -309,6 +309,12 @@
 		<member name="debug/gdscript/completion/autocomplete_setters_and_getters" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], displays getters and setters in autocompletion results in the script editor. This setting is meant to be used when porting old projects (Godot 2), as using member variables is the preferred style from Godot 3 onwards.
 		</member>
+		<member name="debug/gdscript/warnings/always_false_is" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables warnings when an [code]is[/code] operator would always return [code]false[/code].
+		</member>
+		<member name="debug/gdscript/warnings/always_null_as" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables warnings when an [code]as[/code] operator would always return [code]null[/code].
+		</member>
 		<member name="debug/gdscript/warnings/constant_used_as_function" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables warnings when a constant is used as a function.
 		</member>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2030,6 +2030,11 @@ String GDScriptWarning::get_message() const {
 			CHECK_SYMBOLS(2);
 			return vformat("The type of the default value (%s) doesn't match the type of the export hint (%s). The type won't be coerced.", symbols[0], symbols[1]);
 		}
+		case ALWAYS_FALSE_IS:
+		case ALWAYS_NULL_AS: {
+			CHECK_SYMBOLS(1);
+			return vformat("A value of type '%s' will never be of type '%s'.", symbols[0], symbols[1]);
+		}
 		case WARNING_MAX:
 			break; // Can't happen, but silences warning
 	}
@@ -2074,6 +2079,8 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"DEPRECATED_KEYWORD",
 		"STANDALONE_TERNARY",
 		"EXPORT_HINT_TYPE_MISTMATCH",
+		"ALWAYS_FALSE_IS",
+		"ALWAYS_NULL_AS",
 		nullptr
 	};
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -305,6 +305,8 @@ struct GDScriptWarning {
 		DEPRECATED_KEYWORD, // The keyword is deprecated and should be replaced
 		STANDALONE_TERNARY, // Return value of ternary expression is discarded
 		EXPORT_HINT_TYPE_MISTMATCH, // The type of the variable's default value doesn't match its export hint
+		ALWAYS_FALSE_IS, // The is operator will never return true here as the checked type is not a valid base
+		ALWAYS_NULL_AS, // The as operator will never return a value here as the checked type is not a valid base
 		WARNING_MAX,
 	} code;
 	Vector<String> symbols;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -148,7 +148,7 @@ protected:
 public:
 	virtual bool is_valid() const { return valid; }
 
-	bool inherits_script(const Ref<Script> &p_script) const;
+	virtual bool inherits_script(const Ref<Script> &p_script) const;
 
 	const Map<StringName, Ref<GDScript>> &get_subclasses() const { return subclasses; }
 	const Map<StringName, Variant> &get_constants() const { return constants; }

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -499,6 +499,11 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					codegen.opcodes.push_back(cast_type.builtin_type);
 				} break;
 				case GDScriptDataType::NATIVE: {
+					if (!ClassDB::class_exists(cast_type.native_type)) {
+						_set_error("Unable to cast to internal native class type '" + String(cast_type.native_type) + "'.", cn);
+						return -1;
+					}
+
 					int class_idx;
 					if (GDScriptLanguage::get_singleton()->get_global_map().has(cast_type.native_type)) {
 						class_idx = GDScriptLanguage::get_singleton()->get_global_map()[cast_type.native_type];

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -6622,11 +6622,10 @@ GDScriptParser::DataType GDScriptParser::_reduce_node_type(Node *p_node) {
 					_reduce_node_type(op->arguments[0]);
 
 					// If types are equal, then the expression is of the same type
-					// If they are compatible, return the broader type
-					if (true_type == false_type || _is_type_compatible(true_type, false_type)) {
-						node_type = true_type;
-					} else if (_is_type_compatible(false_type, true_type)) {
-						node_type = false_type;
+					// If they are compatible, return the common type
+					DataType common_type = get_common_type(true_type, false_type);
+					if (common_type.has_type) {
+						node_type = common_type;
 					} else {
 #ifdef DEBUG_ENABLED
 						_add_warning(GDScriptWarning::INCOMPATIBLE_TERNARY, op->line);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -6195,7 +6195,12 @@ bool GDScriptParser::_is_type_compatible(const DataType &p_container, const Data
 	if (!check_types || for_completion) {
 		return true;
 	}
-	// Can't test if not all have type
+
+	return is_type_assignable_from(p_container, p_expression, p_allow_implicit_conversion);
+}
+
+bool GDScriptParser::is_type_assignable_from(const DataType &p_container, const DataType &p_expression, bool p_allow_implicit_conversion) {
+	// Can't test if any types are empty
 	if (!p_container.has_type || !p_expression.has_type) {
 		return true;
 	}
@@ -6234,106 +6239,110 @@ bool GDScriptParser::_is_type_compatible(const DataType &p_container, const Data
 		return true;
 	}
 
-	StringName expr_native;
-	Ref<Script> expr_script;
-	ClassNode *expr_class = nullptr;
+	return is_type_derived_from(p_expression, p_container);
+}
 
-	switch (p_expression.kind) {
+GDScriptParser::DataType GDScriptParser::get_base_data_type(const DataType &p_type) {
+	if (!p_type.has_type) {
+		return DataType();
+	}
+
+	switch (p_type.kind) {
+		case DataType::BUILTIN: {
+			// builtin types don't have inheritance
+		} break;
 		case DataType::NATIVE: {
-			if (p_container.kind != DataType::NATIVE) {
-				// Non-native type can't be a superclass of a native type
-				return false;
-			}
-			if (p_expression.is_meta_type) {
-				expr_native = GDScriptNativeClass::get_class_static();
+			DataType base_type = p_type;
+			if (ClassDB::class_exists(p_type.native_type)) {
+				base_type.native_type = ClassDB::get_parent_class(p_type.native_type);
 			} else {
-				expr_native = p_expression.native_type;
-			}
+				// some classes are prefixed with `_` internally
+				base_type.native_type = ClassDB::get_parent_class(StringName("_" + p_type.native_type));
+			};
+			base_type.has_type = base_type.native_type != StringName();
+			return base_type;
 		} break;
 		case DataType::SCRIPT:
 		case DataType::GDSCRIPT: {
-			if (p_container.kind == DataType::CLASS) {
-				// This cannot be resolved without cyclic dependencies, so just bail out
-				return false;
+			if (!p_type.script_type.is_valid()) {
+				break;
 			}
-			if (p_expression.is_meta_type) {
-				expr_native = p_expression.script_type->get_class_name();
-			} else {
-				expr_script = p_expression.script_type;
-				expr_native = expr_script->get_instance_base_type();
+
+			DataType base_type = p_type;
+			base_type.script_type = p_type.script_type->get_base_script();
+
+			// no base script? then it must inherit a native type
+			if (!base_type.script_type.is_valid()) {
+				base_type.kind = DataType::NATIVE;
+				base_type.native_type = p_type.script_type->get_instance_base_type();
+				base_type.has_type = base_type.native_type != StringName();
 			}
+
+			return base_type;
 		} break;
 		case DataType::CLASS: {
-			if (p_expression.is_meta_type) {
-				expr_native = GDScript::get_class_static();
-			} else {
-				expr_class = p_expression.class_type;
-				ClassNode *base = expr_class;
-				while (base->base_type.kind == DataType::CLASS) {
-					base = base->base_type.class_type;
-				}
-				expr_native = base->base_type.native_type;
-				expr_script = base->base_type.script_type;
-			}
+			return p_type.class_type->base_type;
 		} break;
-		case DataType::BUILTIN: // Already handled above
-		case DataType::UNRESOLVED: // Not allowed, see above
-			break;
+		case DataType::UNRESOLVED: {
+			// unresolved types can't be queried
+		} break;
 	}
 
-	// Some classes are prefixed with `_` internally
-	if (!ClassDB::class_exists(expr_native)) {
-		expr_native = "_" + expr_native;
+	return DataType();
+}
+
+GDScriptParser::DataType GDScriptParser::get_common_type(const DataType &p_type, const DataType &p_other_type) {
+	if (!p_type.has_type || !p_other_type.has_type) {
+		return DataType();
 	}
 
-	switch (p_container.kind) {
-		case DataType::NATIVE: {
-			if (p_container.is_meta_type) {
-				return ClassDB::is_parent_class(expr_native, GDScriptNativeClass::get_class_static());
-			} else {
-				StringName container_native = ClassDB::class_exists(p_container.native_type) ? p_container.native_type : StringName("_" + p_container.native_type);
-				return ClassDB::is_parent_class(expr_native, container_native);
-			}
-		} break;
-		case DataType::SCRIPT:
-		case DataType::GDSCRIPT: {
-			if (p_container.is_meta_type) {
-				return ClassDB::is_parent_class(expr_native, GDScript::get_class_static());
-			}
-			if (expr_class == head && p_container.script_type->get_path() == self_path) {
-				// Special case: container is self script and expression is self
-				return true;
-			}
-			while (expr_script.is_valid()) {
-				if (expr_script == p_container.script_type) {
-					return true;
-				}
-				expr_script = expr_script->get_base_script();
-			}
-			return false;
-		} break;
-		case DataType::CLASS: {
-			if (p_container.is_meta_type) {
-				return ClassDB::is_parent_class(expr_native, GDScript::get_class_static());
-			}
-			if (p_container.class_type == head && expr_script.is_valid() && expr_script->get_path() == self_path) {
-				// Special case: container is self and expression is self script
-				return true;
-			}
-			while (expr_class) {
-				if (expr_class == p_container.class_type) {
-					return true;
-				}
-				expr_class = expr_class->base_type.class_type;
-			}
-			return false;
-		} break;
-		case DataType::BUILTIN: // Already handled above
-		case DataType::UNRESOLVED: // Not allowed, see above
-			break;
+	// NOTE: Climb the left type in order to return `p_type` instead of `p_other_type` when `(p_type == p_other_type)`.
+	DataType common_type = p_type;
+	while (common_type.has_type) {
+		if (is_type_derived_from(p_other_type, common_type)) {
+			return common_type;
+		}
+		common_type = get_base_data_type(common_type);
+	}
+
+	return DataType();
+}
+
+bool GDScriptParser::has_common_type(const DataType &p_type, const DataType &p_other_type) {
+	return get_common_type(p_type, p_other_type).has_type;
+}
+
+bool GDScriptParser::is_type_derived_from(const DataType &p_type, const DataType &p_other_type) {
+	if (!p_type.has_type || !p_other_type.has_type) {
+		return false; // empty types aren't inheritable
+	}
+
+	// NOTE: currently this function can't resolve cyclic dependencies when
+	// `p_type.kind == GDSCRIPT` and `p_other_type.kind == CLASS`
+	// due to the unhandled DataType comparison.
+
+	GDScriptParser::DataType specific_type = p_type;
+	while (specific_type.has_type) {
+		if (specific_type == p_other_type) {
+			return true;
+		}
+		specific_type = get_base_data_type(specific_type); // climb inheritance tree and compare again
 	}
 
 	return false;
+}
+
+// Checks that p_type is more specific (a subclass) of p_other_type.
+// A more specific type allows autocomplete to show the user the most relevant information.
+bool GDScriptParser::is_type_more_specific_than(const DataType &p_type, const DataType &p_other_type) {
+	if (p_type.has_type && !p_other_type.has_type) {
+		return true; // any valid type is always more specific than an empty type
+	}
+	if (p_type == p_other_type) {
+		return false; // the same type can't be more specific than itself!
+	}
+
+	return GDScriptParser::is_type_derived_from(p_type, p_other_type);
 }
 
 GDScriptParser::Node *GDScriptParser::_get_default_value_for_type(const DataType &p_type, int p_line) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -67,6 +67,10 @@ public:
 
 		String to_string() const;
 
+		_FORCE_INLINE_ bool operator!=(const DataType &other) const {
+			return !operator==(other);
+		}
+
 		bool operator==(const DataType &other) const {
 			if (!has_type || !other.has_type) {
 				return true; // Can be considered equal for parsing purpose
@@ -681,6 +685,13 @@ public:
 	int get_completion_identifier_is_function();
 
 	const List<String> &get_dependencies() const { return dependencies; }
+
+	static bool is_type_assignable_from(const DataType &p_container, const DataType &p_expression, bool p_allow_implicit_conversion = false);
+	static DataType get_base_data_type(const DataType &p_type);
+	static DataType get_common_type(const DataType &p_type, const DataType &p_other_type);
+	static bool has_common_type(const DataType &p_type, const DataType &p_other_type);
+	static bool is_type_derived_from(const DataType &p_type, const DataType &p_other_type);
+	static bool is_type_more_specific_than(const DataType &p_type, const DataType &p_other_type);
 
 	void clear();
 	GDScriptParser();


### PR DESCRIPTION
See #39228 #53318 #61978. This change would fix those issues in 3.x. It may fix others that depend on autocomplete type information.

This change also improves #31818. The correct signals now show up in `obj.connect(<autocomplete here>)` in many new scenarios.