### PR TITLE
Fix glow in Mix mode not working correctly when FXAA is enabled

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -448,16 +448,17 @@ void main() {
 
 	// Early Tonemap & SRGB Conversion
 #ifndef SUBPASS
+	if (params.use_fxaa) {
+		// FXAA must be performed before glow to preserve the "bleed" effect of glow.
+		color.rgb = do_fxaa(color.rgb, exposure, uv_interp);
+	}
+
 	if (params.use_glow && params.glow_mode == GLOW_MODE_MIX) {
 		vec3 glow = gather_glow(source_glow, uv_interp) * params.luminance_multiplier;
 		if (params.glow_map_strength > 0.001) {
 			glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
 		}
 		color.rgb = mix(color.rgb, glow, params.glow_intensity);
-	}
-
-	if (params.use_fxaa) {
-		color.rgb = do_fxaa(color.rgb, exposure, uv_interp);
 	}
 #endif
 


### PR DESCRIPTION
Glow must be performed after FXAA to ensure correct appearance.

This closes https://github.com/godotengine/godot/issues/61717.

## Preview


| Before (with FXAA) | *After (with FXAA, this PR)* | No FXAA |
|-|-|-|
| ![2022-06-15_22 24 56](https://user-images.githubusercontent.com/180032/173920623-cf03b92e-5939-461b-8475-0c71300f3a07.png) | ![2022-06-15_22 24 43](https://user-images.githubusercontent.com/180032/173920617-eea18808-d750-40da-a8cd-0fb6b509f07d.png) | ![image](https://user-images.githubusercontent.com/180032/173920877-07ecc054-eafa-4e02-bd3e-efad42c18912.png) |