### PR TITLE
Stop CI when Godot crash

### DIFF
--- a/misc/scripts/check_ci_log.py
+++ b/misc/scripts/check_ci_log.py
@@ -25,6 +25,8 @@ if (
     file_contents.find("Program crashed with signal") != -1
     or file_contents.find("Dumping the backtrace") != -1
     or file_contents.find("Segmentation fault (core dumped)") != -1
+    or file_contents.find("Aborted (core dumped)") != -1
+    or file_contents.find("terminate called without an active exception") != -1
 ):
     print("FATAL ERROR: Godot has been crashed.")
     sys.exit(52)


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/61600

Added simple check for specific messages in logs.
This already works fine in Godot fuzzer for a while, so I don't expect any strange CI failures

In future it is possible that most of this checks won't be needed, but this require to fix this strange leaks which comes from thirdparty libraries(probably xserver) but to test it I need to recompile mesa from source or add debug symbols to OS

```
Direct leak of 72704 byte(s) in 1 object(s) allocated from:
    #0 0x7f69ee7b3868 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7f69c1ca1335  (/usr/bin/godot4s+0x8bc4c335)
    #2 0x7f69c1c61bda  (/usr/bin/godot4s+0x8bc0cbda)

Direct leak of 6304 byte(s) in 4 object(s) allocated from:
    #0 0x7f69ee7b3a66 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:153
    #1 0x7f69dde6630f  (<unknown module>)

Direct leak of 1024 byte(s) in 1 object(s) allocated from:
    #0 0x7f69ee7b3c9e in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:163
    #1 0x7f69dde6554a  (<unknown module>)
```