### PR TITLE
Implements GPUParticles3d layer mask

### DIFF
--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -54,7 +54,7 @@
 			<return type="void" />
 			<argument index="0" name="mask" type="int" />
 			<description>
-				Update the layer mask which help GPUParticles3D interact with Collider and Attractor via cull_musk
+				Update the layer mask which helps [GPUParticles3D] interact with [GPUParticlesCollision3D] and [GPUParticlesAttractor3D]'s cull mask.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -50,6 +50,13 @@
 				Sets the [Mesh] that is drawn at index [code]pass[/code].
 			</description>
 		</method>
+		<method name="update_layer_mask">
+			<return type="void" />
+			<argument index="0" name="mask" type="int" />
+			<description>
+				Update the layer mask which help GPUParticles3D interact with Collider and Attractor via cull_musk
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="amount" type="int" setter="set_amount" getter="get_amount" default="8">

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -130,6 +130,13 @@ void ParticlesStorage::particles_set_trails(RID p_particles, bool p_enable, doub
 void ParticlesStorage::particles_set_trail_bind_poses(RID p_particles, const Vector<Transform3D> &p_bind_poses) {
 }
 
+void ParticlesStorage::particles_set_layer_mask(RID p_particles, uint32_t layer_mask_value) {
+}
+
+uint32_t ParticlesStorage::particles_get_layer_mask(RID p_particles) const {
+	return 0;
+}
+
 void ParticlesStorage::particles_restart(RID p_particles) {
 }
 

--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -76,6 +76,8 @@ public:
 	virtual void particles_set_subemitter(RID p_particles, RID p_subemitter_particles) override;
 	virtual void particles_set_view_axis(RID p_particles, const Vector3 &p_axis, const Vector3 &p_up_axis) override;
 	virtual void particles_set_collision_base_size(RID p_particles, real_t p_size) override;
+	virtual void particles_set_layer_mask(RID p_particles, uint32_t layer_mask_value) override;
+	virtual uint32_t particles_get_layer_mask(RID p_particles) const override;
 
 	virtual void particles_set_transform_align(RID p_particles, RS::ParticlesTransformAlign p_transform_align) override;
 

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -31,6 +31,7 @@
 #include "gpu_particles_3d.h"
 
 #include "scene/resources/particles_material.h"
+#include "servers/rendering_server.h"
 
 AABB GPUParticles3D::get_aabb() const {
 	return AABB();
@@ -499,6 +500,10 @@ GPUParticles3D::TransformAlign GPUParticles3D::get_transform_align() const {
 	return transform_align;
 }
 
+void GPUParticles3D::update_layer_mask(uint32_t p_mask) {
+	RenderingServer::get_singleton()->particles_set_layer_mask(particles, p_mask);
+}
+
 void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &GPUParticles3D::set_emitting);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &GPUParticles3D::set_amount);
@@ -561,6 +566,7 @@ void GPUParticles3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_transform_align", "align"), &GPUParticles3D::set_transform_align);
 	ClassDB::bind_method(D_METHOD("get_transform_align"), &GPUParticles3D::get_transform_align);
+	ClassDB::bind_method(D_METHOD("update_layer_mask", "mask"), &GPUParticles3D::update_layer_mask);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY_DEFAULT("emitting", true); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -113,6 +113,7 @@ public:
 	void set_collision_base_size(real_t p_ratio);
 	void set_trail_enabled(bool p_enabled);
 	void set_trail_length(double p_seconds);
+	void update_layer_mask(uint32_t p_mask);
 
 	bool is_emitting() const;
 	int get_amount() const;

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "visual_instance_3d.h"
 
+#include "scene/3d/gpu_particles_3d.h"
 #include "scene/scene_string_names.h"
 
 AABB VisualInstance3D::get_aabb() const {
@@ -87,6 +88,10 @@ RID VisualInstance3D::_get_visual_instance_rid() const {
 void VisualInstance3D::set_layer_mask(uint32_t p_mask) {
 	layers = p_mask;
 	RenderingServer::get_singleton()->instance_set_layer_mask(instance, p_mask);
+	GPUParticles3D *gpuparticles3d = Object::cast_to<GPUParticles3D>(this);
+	if (gpuparticles3d) {
+		gpuparticles3d->update_layer_mask(p_mask);
+	}
 }
 
 uint32_t VisualInstance3D::get_layer_mask() const {

--- a/servers/rendering/dummy/storage/particles_storage.h
+++ b/servers/rendering/dummy/storage/particles_storage.h
@@ -85,6 +85,8 @@ public:
 	virtual bool particles_get_emitting(RID p_particles) override { return false; }
 	virtual int particles_get_draw_passes(RID p_particles) const override { return 0; }
 	virtual RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const override { return RID(); }
+	virtual void particles_set_layer_mask(RID p_particles, uint32_t layer_mask_value) override {}
+	virtual uint32_t particles_get_layer_mask(RID p_particles) const override { return 0; }
 
 	virtual void particles_add_collision(RID p_particles, RID p_instance) override {}
 	virtual void particles_remove_collision(RID p_particles, RID p_instance) override {}

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -842,6 +842,9 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 			}
 			ParticlesCollision *pc = particles_collision_owner.get_or_null(pci->collision);
 			ERR_CONTINUE(!pc);
+			if (!(pc->cull_mask & p_particles->layer_mask)) {
+				continue;
+			}
 
 			Transform3D to_collider = pci->transform;
 			if (p_particles->use_local_coords) {
@@ -1110,6 +1113,20 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 	}
 
 	RD::get_singleton()->compute_list_end();
+}
+
+void ParticlesStorage::particles_set_layer_mask(RID p_particles, uint32_t layer_mask_value) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_COND(!particles);
+	particles->layer_mask = layer_mask_value;
+}
+
+uint32_t ParticlesStorage::particles_get_layer_mask(RID p_particles) const {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	if (!particles) {
+		return 0;
+	}
+	return particles->layer_mask;
 }
 
 void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p_axis, const Vector3 &p_up_axis) {

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -157,6 +157,7 @@ struct Particles {
 	AABB custom_aabb = AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8));
 	bool use_local_coords = true;
 	bool has_collision_cache = false;
+	uint32_t layer_mask = 1;
 
 	bool has_sdf_collision = false;
 	Transform2D sdf_collision_transform;
@@ -463,6 +464,9 @@ public:
 	virtual void particles_set_view_axis(RID p_particles, const Vector3 &p_axis, const Vector3 &p_up_axis) override;
 
 	virtual bool particles_is_inactive(RID p_particles) const override;
+
+	virtual void particles_set_layer_mask(RID p_particles, uint32_t layer_mask_value) override;
+	virtual uint32_t particles_get_layer_mask(RID p_particles) const override;
 
 	_FORCE_INLINE_ RS::ParticlesMode particles_get_mode(RID p_particles) {
 		Particles *particles = particles_owner.get_or_null(p_particles);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -488,6 +488,8 @@ public:
 	FUNC1R(bool, particles_is_inactive, RID)
 	FUNC3(particles_set_trails, RID, bool, float)
 	FUNC2(particles_set_trail_bind_poses, RID, const Vector<Transform3D> &)
+	FUNC2(particles_set_layer_mask, RID, uint32_t);
+	FUNC1RC(uint32_t, particles_get_layer_mask, RID);
 
 	FUNC1(particles_request_process, RID)
 	FUNC1(particles_restart, RID)

--- a/servers/rendering/storage/particles_storage.h
+++ b/servers/rendering/storage/particles_storage.h
@@ -97,6 +97,9 @@ public:
 
 	virtual void particles_set_canvas_sdf_collision(RID p_particles, bool p_enable, const Transform2D &p_xform, const Rect2 &p_to_screen, RID p_texture) = 0;
 
+	virtual void particles_set_layer_mask(RID p_particles, uint32_t layer_mask_value) = 0;
+	virtual uint32_t particles_get_layer_mask(RID p_particles) const = 0;
+
 	virtual void update_particles() = 0;
 
 	/* PARTICLES COLLISION */

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -636,6 +636,8 @@ public:
 	virtual void particles_set_interpolate(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_fractional_delta(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_collision_base_size(RID p_particles, float p_size) = 0;
+	virtual void particles_set_layer_mask(RID p_particles, uint32_t layer_mask_value) = 0;
+	virtual uint32_t particles_get_layer_mask(RID p_particles) const = 0;
 
 	enum ParticlesTransformAlign {
 		PARTICLES_TRANSFORM_ALIGN_DISABLED,


### PR DESCRIPTION
Fix #61014

By mistake(while trying to merge all the commits), I delete the last pull request commits so it got closed automatically.

Explanation of code: The collision is filtered while pushing GPU according to the cull mask and layer mask.

Thank you. I am sorry for my mistake.