### PR TITLE
Ensure joystick has been added or not already removed when processing input on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java
@@ -186,6 +186,9 @@ public class GodotInputHandler implements InputManager.InputDeviceListener {
 			if (mJoystickIds.indexOfKey(deviceId) >= 0) {
 				final int godotJoyId = mJoystickIds.get(deviceId);
 				Joystick joystick = mJoysticksDevices.get(deviceId);
+				if (joystick == null) {
+					return true;
+				}
 
 				for (int i = 0; i < joystick.axes.size(); i++) {
 					final int axis = joystick.axes.get(i);


### PR DESCRIPTION
[`onGenericMotionEvent()`](https://developer.android.com/reference/android/view/View#onGenericMotionEvent(android.view.MotionEvent)) is part of the `View` interface, while, `onInputDeviceAdded()` and `onInputDeviceRemoved()` is part of the [`InputManager.InputDeviceListener`](https://developer.android.com/reference/android/hardware/input/InputManager.InputDeviceListener). #61731 shows that it's possible that either a call to [`onGenericMotionEvent()`](https://github.com/godotengine/godot/blob/c02325ffda2258172385e70e160cd476fb19a004/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java#L181-L187) can happen before a call to [`onInputDeviceAdded()`](https://github.com/godotengine/godot/blob/c02325ffda2258172385e70e160cd476fb19a004/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java#L276-L308) or a call to `onGenericMotionEvent()` can happen after a call to [`onInputDeviceRemoved()`](https://github.com/godotengine/godot/blob/c02325ffda2258172385e70e160cd476fb19a004/platform/android/java/lib/src/org/godotengine/godot/input/GodotInputHandler.java#L321). Either way, we need to check whether or not our `Joystick` information is available in `mJoysticksDevices` before trying to use it.

Fixes #61731

Can be cherry-picked onto 3.x.