### PR TITLE
Fix infinite loop in animation compress

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4619,6 +4619,7 @@ void Animation::compress(uint32_t p_page_size, uint32_t p_fps, float p_split_tol
 	data_tracks.resize(tracks_to_compress.size());
 	time_tracks.resize(tracks_to_compress.size());
 
+	uint32_t needed_min_page_size = base_page_size;
 	for (uint32_t i = 0; i < data_tracks.size(); i++) {
 		data_tracks[i].split_tolerance = p_split_tolerance;
 		if (track_get_type(tracks_to_compress[i]) == TYPE_BLEND_SHAPE) {
@@ -4626,7 +4627,12 @@ void Animation::compress(uint32_t p_page_size, uint32_t p_fps, float p_split_tol
 		} else {
 			data_tracks[i].components = 3;
 		}
+		needed_min_page_size += data_tracks[i].data.size() + data_tracks[i].get_temp_packet_size();
 	}
+	for (uint32_t i = 0; i < time_tracks.size(); i++) {
+		needed_min_page_size += time_tracks[i].packets.size() * 4; // time packet is 32 bits
+	}
+	ERR_FAIL_COND_MSG(p_page_size < needed_min_page_size, "Cannot compress with the given page size");
 
 	while (true) {
 		// Begin by finding the keyframe in all tracks with the time closest to the current time


### PR DESCRIPTION
Fixed an infinite loop caused when given page size is too small to store anything.

If, in the first step of compression, we attempt a rollback, we end up calling LocalVector::resize with AnimationCompressionDataState::validated_packet_count which is -1.  This resize function takes a uint, and there's a bitshift operation that assumes that by bitshifting enough times, we'll reach a number greater than or equal to the requested memory amount, which we'll never do for uint(-1), and this causes an infinite loop.

To fix, I'm adding an early failure in case the given page size isn't enough.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

*Bugsquad edit: This closes #62097.*
