### PR TITLE
Fixes #62096: LightmapGIData::_get_light_textures_data crash on empty image

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -116,7 +116,7 @@ void LightmapGIData::_set_light_textures_data(const Array &p_data) {
 
 Array LightmapGIData::_get_light_textures_data() const {
 	Array ret;
-	if (light_texture.is_null()) {
+	if (light_texture.is_null() || light_texture->get_layers() == 0) {
 		return ret;
 	}
 


### PR DESCRIPTION
The program crashes when trying to determine slice width/height if the
light texture is empty. This fix just returns an empty array, as if the
light texture does not exist.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

*Bugsquad edit: This closes #62096.*
