### PR TITLE
[3.x] Cleanup AudioEffectRecord thread_active variable

### DIFF
--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -66,8 +66,6 @@ bool AudioEffectRecordInstance::process_silence() const {
 }
 
 void AudioEffectRecordInstance::_io_thread_process() {
-	thread_active = true;
-
 	while (is_recording) {
 		//Check: The current recording has been requested to stop
 		if (!base->recording_active) {
@@ -81,8 +79,6 @@ void AudioEffectRecordInstance::_io_thread_process() {
 			OS::get_singleton()->delay_usec(500);
 		}
 	}
-
-	thread_active = false;
 }
 
 void AudioEffectRecordInstance::_io_store_buffer() {
@@ -126,9 +122,7 @@ void AudioEffectRecordInstance::finish() {
 #ifdef NO_THREADS
 	AudioServer::get_singleton()->remove_update_callback(&AudioEffectRecordInstance::_update, this);
 #else
-	if (thread_active) {
-		io_thread.wait_to_finish();
-	}
+	io_thread.wait_to_finish();
 #endif
 }
 

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -49,7 +49,6 @@ class AudioEffectRecordInstance : public AudioEffectInstance {
 
 	bool is_recording;
 	Thread io_thread;
-	bool thread_active;
 
 	Vector<AudioFrame> ring_buffer;
 	Vector<float> recording_data;
@@ -70,8 +69,7 @@ public:
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count);
 	virtual bool process_silence() const;
 
-	AudioEffectRecordInstance() :
-			thread_active(false) {}
+	AudioEffectRecordInstance() {}
 	~AudioEffectRecordInstance();
 };
 


### PR DESCRIPTION
When updating `AudioEffectRecordInstance`, #45618 did not remove the no longer needed dependence on `thread_active` as done in #45315:
https://github.com/godotengine/godot/blob/362f53ff02c381ea94640baa16e84e6f6956efef/servers/audio/effects/audio_effect_record.cpp#L130-L136
This PR removes that dependence and removes the no longer used variable `thread_active`.

Fixes #60712. 
