### PR TITLE
Cleanup AudioEffectRecord thread_active variable

### DIFF
--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -71,8 +71,6 @@ bool AudioEffectRecordInstance::process_silence() const {
 }
 
 void AudioEffectRecordInstance::_io_thread_process() {
-	thread_active = true;
-
 	while (is_recording) {
 		//Check: The current recording has been requested to stop
 		if (!base->recording_active) {
@@ -86,8 +84,6 @@ void AudioEffectRecordInstance::_io_thread_process() {
 			OS::get_singleton()->delay_usec(500);
 		}
 	}
-
-	thread_active = false;
 }
 
 void AudioEffectRecordInstance::_io_store_buffer() {

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -48,7 +48,6 @@ class AudioEffectRecordInstance : public AudioEffectInstance {
 
 	bool is_recording;
 	Thread io_thread;
-	bool thread_active = false;
 
 	Vector<AudioFrame> ring_buffer;
 	Vector<float> recording_data;


### PR DESCRIPTION
As identified in #62135, #45315 removed the dependence on `thread_active`, but did not remove the variable. This PR removes the `thread_active` variable.
