### PR TITLE
Fix renaming active animation state machine nodes.

### DIFF
--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -134,6 +134,7 @@
 			<return type="void" />
 			<argument index="0" name="name" type="StringName" />
 			<argument index="1" name="new_name" type="StringName" />
+			<argument index="2" name="arg2" type="AnimationNodeStateMachinePlayback" />
 			<description>
 				Renames the given node.
 			</description>

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1720,10 +1720,12 @@ void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 		name = base_name + " " + itos(base);
 	}
 
+	Ref<AnimationNodeStateMachinePlayback> playback = AnimationTreeEditor::get_singleton()->get_tree()->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
+
 	updating = true;
 	undo_redo->create_action(TTR("Node Renamed"));
-	undo_redo->add_do_method(state_machine.ptr(), "rename_node", prev_name, name);
-	undo_redo->add_undo_method(state_machine.ptr(), "rename_node", name, prev_name);
+	undo_redo->add_do_method(state_machine.ptr(), "rename_node", prev_name, name, playback);
+	undo_redo->add_undo_method(state_machine.ptr(), "rename_node", name, prev_name, playback);
 	undo_redo->add_do_method(this, "_update_graph");
 	undo_redo->add_undo_method(this, "_update_graph");
 	undo_redo->commit_action();

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -158,6 +158,24 @@ StringName AnimationNodeStateMachinePlayback::get_current_node() const {
 	return current;
 }
 
+void AnimationNodeStateMachinePlayback::rename(const StringName &p_name, const StringName &p_new_name) {
+	if (current == p_name) {
+		current = p_new_name;
+	}
+
+	if (current_transition.to == p_name) {
+		current_transition.to = p_new_name;
+	}
+
+	if (current_transition.from == p_name) {
+		current_transition.from = p_new_name;
+	}
+
+	if (current_transition.next == p_name) {
+		current_transition.next = p_new_name;
+	}
+}
+
 StringName AnimationNodeStateMachinePlayback::get_blend_from_node() const {
 	return fading_from;
 }
@@ -755,7 +773,7 @@ void AnimationNodeStateMachine::remove_node(const StringName &p_name) {
 	emit_signal(SNAME("tree_changed"));
 }
 
-void AnimationNodeStateMachine::rename_node(const StringName &p_name, const StringName &p_new_name) {
+void AnimationNodeStateMachine::rename_node(const StringName &p_name, const StringName &p_new_name, Ref<AnimationNodeStateMachinePlayback> playback) {
 	ERR_FAIL_COND(!states.has(p_name));
 	ERR_FAIL_COND(states.has(p_new_name));
 	ERR_FAIL_COND(!can_edit_node(p_name));
@@ -771,11 +789,17 @@ void AnimationNodeStateMachine::rename_node(const StringName &p_name, const Stri
 	for (int i = 0; i < transitions.size(); i++) {
 		if (transitions[i].local_from == p_name) {
 			_rename_transition(transitions[i].from, String(transitions[i].from).replace_first(p_name, p_new_name));
+			transitions.write[i].local_from = p_new_name;
 		}
 
 		if (transitions[i].local_to == p_name) {
 			_rename_transition(transitions[i].to, String(transitions[i].to).replace_first(p_name, p_new_name));
+			transitions.write[i].local_to = p_new_name;
 		}
+	}
+
+	if (playback.is_valid()) {
+		playback->rename(p_name, p_new_name);
 	}
 
 	emit_signal("tree_changed");

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -124,6 +124,8 @@ class AnimationNodeStateMachinePlayback : public Resource {
 
 	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
 
+	void rename(const StringName &p_name, const StringName &p_new_name);
+
 protected:
 	static void _bind_methods();
 
@@ -198,7 +200,7 @@ public:
 	void replace_node(const StringName &p_name, Ref<AnimationNode> p_node);
 	Ref<AnimationNode> get_node(const StringName &p_name) const;
 	void remove_node(const StringName &p_name);
-	void rename_node(const StringName &p_name, const StringName &p_new_name);
+	void rename_node(const StringName &p_name, const StringName &p_new_name, Ref<AnimationNodeStateMachinePlayback> playback);
 	bool has_node(const StringName &p_name) const;
 	StringName get_node_name(const Ref<AnimationNode> &p_node) const;
 	void get_node_list(List<StringName> *r_nodes) const;


### PR DESCRIPTION
Some parts are not getting renamed when a node name changes.  This results in an invalid node access later which crashes the editor.

*Bugsquad edit: This closes #62056.*