### PR TITLE
Add missing new function parameter to fix button presses.

### DIFF
--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -419,12 +419,12 @@ void AnimationLibraryEditor::_item_renamed() {
 	}
 }
 
-void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int p_button) {
+void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int p_id, MouseButton p_button) {
 	if (p_item->get_parent() == tree->get_root()) {
 		// Library
 		StringName lib_name = p_item->get_metadata(0);
 		Ref<AnimationLibrary> al = player->call("get_animation_library", lib_name);
-		switch (p_button) {
+		switch (p_id) {
 			case LIB_BUTTON_ADD: {
 				add_library_dialog->set_title(TTR("Animation Name:"));
 				add_library_name->set_text("");
@@ -519,7 +519,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 		Ref<AnimationLibrary> al = player->call("get_animation_library", lib_name);
 		Ref<Animation> anim = al->get_animation(anim_name);
 		ERR_FAIL_COND(!anim.is_valid());
-		switch (p_button) {
+		switch (p_id) {
 			case ANIM_BUTTON_COPY: {
 				if (anim->get_name() == "") {
 					anim->set_name(anim_name); // Keep the name around

--- a/editor/plugins/animation_library_editor.h
+++ b/editor/plugins/animation_library_editor.h
@@ -99,7 +99,7 @@ class AnimationLibraryEditor : public AcceptDialog {
 	void _load_file(String p_path);
 
 	void _item_renamed();
-	void _button_pressed(TreeItem *p_item, int p_column, int p_button);
+	void _button_pressed(TreeItem *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void _file_popup_selected(int p_id);
 


### PR DESCRIPTION
Fix the _button_pressed method to include 4 parameters instead of 3 so it doesn't fail when called.

*Bugsquad edit: This closes #62149 and closes https://github.com/godotengine/godot/issues/61422.*