### PR TITLE
Ensure AudioFrame variables l and r are always initialised

### DIFF
--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -52,7 +52,7 @@ static const float AUDIO_MIN_PEAK_DB = -200.0f; // linear2db(AUDIO_PEAK_OFFSET)
 
 struct AudioFrame {
 	//left and right samples
-	float l, r;
+	float l = 0.f, r = 0.f;
 
 	_ALWAYS_INLINE_ const float &operator[](int idx) const { return idx == 0 ? l : r; }
 	_ALWAYS_INLINE_ float &operator[](int idx) { return idx == 0 ? l : r; }


### PR DESCRIPTION
Closes #61457.

Can be cherry-picked onto 3.x.
