### PR TITLE
Remove duplicate assignment of AnimationNode::State.valid

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -919,7 +919,6 @@ void AnimationTree::_process_graph(double p_delta) {
 		state.valid = true;
 		state.invalid_reasons = "";
 		state.animation_states.clear(); //will need to be re-created
-		state.valid = true;
 		state.player = player;
 		state.last_pass = process_pass;
 		state.tree = this;


### PR DESCRIPTION
In `AnimationTree::_process_graph`, the `State.valid` variable is set to true.
A few lines later, it's set again. Probably a copy/paste mistake. This
commit removes the second line.