### PR TITLE
[GDNative] Fix GDN_EXPORT define with mingw.

### DIFF
--- a/modules/gdnative/include/gdnative/gdnative.h
+++ b/modules/gdnative/include/gdnative/gdnative.h
@@ -53,12 +53,14 @@ extern "C" {
 #endif
 
 // This is for libraries *using* the header, NOT GODOT EXPOSING STUFF!!
-#ifdef __GNUC__
-#define GDN_EXPORT __attribute__((visibility("default")))
-#elif defined(_WIN32)
+#if !defined(GDN_EXPORT)
+#if defined(_WIN32)
 #define GDN_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__)
+#define GDN_EXPORT __attribute__((visibility("default")))
 #else
 #define GDN_EXPORT
+#endif
 #endif
 
 #include <stdbool.h>


### PR DESCRIPTION
The define is **not used by godot**, but in GDNative libraries.

I'm not sure it should be defined there in the first place, though we shouldn't change that (for compatibility).

This commit changes the platform detection order to detect mingw compiling for windows (which defines `__GNUC__`).

This commit also wraps the definition around a guard to let libraries override it with a build-time define.

Refs: godotengine/godot-cpp#673 , godotengine/godot-cpp#468 (?), godotengine/webrtc-native#52 .
