### PR TITLE
Fix `CPUParticles2D.emission_shape` enum hint

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1362,7 +1362,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("convert_from_particles", "particles"), &CPUParticles2D::convert_from_particles);
 
 	ADD_GROUP("Emission Shape", "emission_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_shape", PROPERTY_HINT_ENUM, "Point,Sphere,Sphere Surface,Box,Points,Directed Points", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_emission_shape", "get_emission_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_shape", PROPERTY_HINT_ENUM, "Point,Sphere,Sphere Surface,Rectangle,Points,Directed Points", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_emission_shape", "get_emission_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_sphere_radius", PROPERTY_HINT_RANGE, "0.01,128,0.01,suffix:px"), "set_emission_sphere_radius", "get_emission_sphere_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "emission_rect_extents", PROPERTY_HINT_NONE, "suffix:px"), "set_emission_rect_extents", "get_emission_rect_extents");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "emission_points"), "set_emission_points", "get_emission_points");


### PR DESCRIPTION
Enum hint for `CPUParticles2D.emission_shape` had `Box` listed instead of `Rectangle`:
![CVLjt9ODqo](https://user-images.githubusercontent.com/9283098/174442766-e44ba9b4-c1d5-4964-a489-3f78379c467d.png) ![Godot_v4 0-alpha9_win64_wDY2LpEA0P](https://user-images.githubusercontent.com/9283098/174442734-736f86b7-dd78-4b7d-8d75-b6529fa93cc5.png)
https://github.com/godotengine/godot/blob/f41cb30f9b7fe46a014162aba9c0e9a9697343d2/scene/2d/cpu_particles_2d.h#L69-L77
https://github.com/godotengine/godot/blob/f41cb30f9b7fe46a014162aba9c0e9a9697343d2/scene/3d/cpu_particles_3d.h#L71-L80