### PR TITLE
Use min_size/max_size to limit window size and position while popup center

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -276,10 +276,6 @@ Size2 AcceptDialog::_get_contents_minimum_size() const {
 	// Plus there is a separation size added on top.
 	content_minsize.y += theme_cache.buttons_separation;
 
-	// Last, we make sure that we aren't below the minimum window size.
-	Size2 window_minsize = get_min_size();
-	content_minsize.x = MAX(window_minsize.x, content_minsize.x);
-	content_minsize.y = MAX(window_minsize.y, content_minsize.y);
 	return content_minsize;
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2556,20 +2556,14 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 			if (gui.subwindow_drag == SUB_WINDOW_DRAG_RESIZE) {
 				Vector2i diff = mm->get_position() - gui.subwindow_drag_from;
 				Size2i min_size = gui.subwindow_focused->get_min_size();
+				Size2i min_size_clamped = gui.subwindow_focused->get_clamped_minimum_size();
 
-				Size2i min_size_adjusted = min_size;
-				if (gui.subwindow_focused->is_wrapping_controls()) {
-					Size2i cms = gui.subwindow_focused->get_contents_minimum_size();
-					min_size_adjusted.x = MAX(cms.x, min_size.x);
-					min_size_adjusted.y = MAX(cms.y, min_size.y);
-				}
-
-				min_size_adjusted.x = MAX(min_size_adjusted.x, 1);
-				min_size_adjusted.y = MAX(min_size_adjusted.y, 1);
+				min_size_clamped.x = MAX(min_size_clamped.x, 1);
+				min_size_clamped.y = MAX(min_size_clamped.y, 1);
 
 				Rect2i r = gui.subwindow_resize_from_rect;
 
-				Size2i limit = r.size - min_size_adjusted;
+				Size2i limit = r.size - min_size_clamped;
 
 				switch (gui.subwindow_resize_mode) {
 					case SUB_WINDOW_RESIZE_TOP_LEFT: {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -349,8 +349,30 @@ Size2i Window::get_size_with_decorations() const {
 	return size;
 }
 
+Size2i Window::_clamp_limit_size(const Size2i &p_limit_size) {
+	// Force window limits to respect size limitations of rendering server.
+	Size2i max_window_size = RS::get_singleton()->get_maximum_viewport_size();
+	if (max_window_size != Size2i()) {
+		return p_limit_size.clamp(Vector2i(), max_window_size);
+	} else {
+		return p_limit_size.max(Vector2i());
+	}
+}
+
+void Window::_validate_limit_size() {
+	// When max_size is invalid, max_size_used falls back to respect size limitations of rendering server.
+	bool max_size_valid = (max_size.x > 0 || max_size.y > 0) && max_size.x >= min_size.x && max_size.y >= min_size.y;
+	max_size_used = max_size_valid ? max_size : RS::get_singleton()->get_maximum_viewport_size();
+}
+
 void Window::set_max_size(const Size2i &p_max_size) {
-	max_size = p_max_size;
+	Size2i max_size_clamped = _clamp_limit_size(p_max_size);
+	if (max_size == max_size_clamped) {
+		return;
+	}
+	max_size = max_size_clamped;
+
+	_validate_limit_size();
 	_update_window_size();
 }
 
@@ -359,7 +381,13 @@ Size2i Window::get_max_size() const {
 }
 
 void Window::set_min_size(const Size2i &p_min_size) {
-	min_size = p_min_size;
+	Size2i min_size_clamped = _clamp_limit_size(p_min_size);
+	if (min_size == min_size_clamped) {
+		return;
+	}
+	min_size = min_size_clamped;
+
+	_validate_limit_size();
 	_update_window_size();
 }
 
@@ -833,49 +861,35 @@ bool Window::is_visible() const {
 	return visible;
 }
 
+Size2i Window::_clamp_window_size(const Size2i &p_size) {
+	Size2i window_size_clamped = p_size;
+	Size2 minsize = get_clamped_minimum_size();
+	window_size_clamped = window_size_clamped.max(minsize);
+
+	if (max_size_used != Size2i()) {
+		window_size_clamped = window_size_clamped.min(max_size_used);
+	}
+
+	return window_size_clamped;
+}
+
 void Window::_update_window_size() {
-	// Force window to respect size limitations of rendering server.
-	RenderingServer *rendering_server = RenderingServer::get_singleton();
-	if (rendering_server) {
-		Size2i max_window_size = rendering_server->get_maximum_viewport_size();
+	Size2i size_limit = get_clamped_minimum_size();
 
-		if (max_window_size != Size2i()) {
-			size = size.min(max_window_size);
-			min_size = min_size.min(max_window_size);
-			max_size = max_size.min(max_window_size);
-		}
-	}
-
-	Size2i size_limit;
-	if (wrap_controls) {
-		size_limit = get_contents_minimum_size();
-	}
-
-	size_limit.x = MAX(size_limit.x, min_size.x);
-	size_limit.y = MAX(size_limit.y, min_size.y);
-
-	size.x = MAX(size_limit.x, size.x);
-	size.y = MAX(size_limit.y, size.y);
+	size = size.max(size_limit);
 
 	bool reset_min_first = false;
 
-	bool max_size_valid = false;
-	if ((max_size.x > 0 || max_size.y > 0) && (max_size.x >= min_size.x && max_size.y >= min_size.y)) {
-		max_size_valid = true;
+	if (max_size_used != Size2i()) {
+		// Force window size to respect size limitations of max_size_used.
+		size = size.min(max_size_used);
 
-		if (size.x > max_size.x) {
-			size.x = max_size.x;
-		}
-		if (size_limit.x > max_size.x) {
-			size_limit.x = max_size.x;
+		if (size_limit.x > max_size_used.x) {
+			size_limit.x = max_size_used.x;
 			reset_min_first = true;
 		}
-
-		if (size.y > max_size.y) {
-			size.y = max_size.y;
-		}
-		if (size_limit.y > max_size.y) {
-			size_limit.y = max_size.y;
+		if (size_limit.y > max_size_used.y) {
+			size_limit.y = max_size_used.y;
 			reset_min_first = true;
 		}
 	}
@@ -891,7 +905,7 @@ void Window::_update_window_size() {
 			DisplayServer::get_singleton()->window_set_min_size(Size2i(), window_id);
 		}
 
-		DisplayServer::get_singleton()->window_set_max_size(max_size_valid ? max_size : Size2i(), window_id);
+		DisplayServer::get_singleton()->window_set_max_size(max_size_used, window_id);
 		DisplayServer::get_singleton()->window_set_min_size(size_limit, window_id);
 		DisplayServer::get_singleton()->window_set_size(size, window_id);
 	}
@@ -1423,6 +1437,8 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 
 	Rect2i popup_rect;
 	popup_rect.size = Vector2i(MIN(size_ratio.x, p_size.x), MIN(size_ratio.y, p_size.y));
+	popup_rect.size = _clamp_window_size(popup_rect.size);
+
 	if (parent_rect != Rect2()) {
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
 	}
@@ -1446,9 +1462,7 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	}
 
 	Rect2i popup_rect;
-	Size2 contents_minsize = _get_contents_minimum_size();
-	popup_rect.size.x = MAX(p_minsize.x, contents_minsize.x);
-	popup_rect.size.y = MAX(p_minsize.y, contents_minsize.y);
+	popup_rect.size = _clamp_window_size(p_minsize);
 
 	if (parent_rect != Rect2()) {
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
@@ -1476,6 +1490,7 @@ void Window::popup_centered_ratio(float p_ratio) {
 	Rect2i popup_rect;
 	if (parent_rect != Rect2()) {
 		popup_rect.size = parent_rect.size * p_ratio;
+		popup_rect.size = _clamp_window_size(popup_rect.size);
 		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
 	}
 
@@ -1537,6 +1552,14 @@ void Window::popup(const Rect2i &p_screen_rect) {
 
 Size2 Window::get_contents_minimum_size() const {
 	return _get_contents_minimum_size();
+}
+
+Size2 Window::get_clamped_minimum_size() const {
+	if (!wrap_controls) {
+		return min_size;
+	}
+
+	return min_size.max(get_contents_minimum_size());
 }
 
 void Window::grab_focus() {
@@ -2389,6 +2412,7 @@ Window::Window() {
 	RenderingServer *rendering_server = RenderingServer::get_singleton();
 	if (rendering_server) {
 		max_size = rendering_server->get_maximum_viewport_size();
+		max_size_used = max_size; // Update max_size_used.
 	}
 
 	theme_owner = memnew(ThemeOwner);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -135,6 +135,11 @@ private:
 	void _clear_window();
 	void _update_from_window();
 
+	Size2i max_size_used;
+
+	Size2i _clamp_limit_size(const Size2i &p_limit_size);
+	Size2i _clamp_window_size(const Size2i &p_size);
+	void _validate_limit_size();
 	void _update_viewport_size();
 	void _update_window_size();
 
@@ -306,6 +311,7 @@ public:
 	void popup_centered_clamped(const Size2i &p_size = Size2i(), float p_fallback_ratio = 0.75);
 
 	Size2 get_contents_minimum_size() const;
+	Size2 get_clamped_minimum_size() const;
 
 	void grab_focus();
 	bool has_focus() const;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->


Fix #62163.

The `popup_center*` methods need to determine the popup position according to the actual size of the window.

Previously, `max_size`/`min_size` was not considered in these methods, which in some cases could cause the window to actually be off-center.

In this PR, Add a method to get the minimum size of content that has been clamped by a custom minimum size. `Window::get_clamped_minimum_size`.

`min_size` will be considered in `Window::get_clamped_minimum_size`. The result is to return the value clamped by the custom min size.

And `wrap_controls` is also taken into account. if `wrap_controls` is not enabled, `Window::get_clamped_minimum_size` return `min_size` directly.

The return value of `get_clamped_minimum_size` is the actual **lower** limit of the window `size`, and `max_size` is the actual **upper** limit of the window `size`.

~~If a component of `max_size` is `0`, it means there is no limit on the corresponding axis. This is the same as before.~~

Follow the rules of `min_size`/`max_size`, but at this stage `max_size` seems to be unable to limit only one axis when resize, and let the other axis unlimited. Only `(0, 0)` means unlimited, a single component of `0` is not yet possible, it may only invalidate the entire `max_size`. Therefore, for consistency, `max_size` will use the same invalidation rules as in #63925.

Edit:

| Control | Window | Explanation |
| :--------: | :---------: | :--------------: |
| `get_custom_minimum_size` | `get_min_size` | Get custom min size limit |
| `get_minimum_size` | `get_contents_minimum_size` | Get contents minimum size |
| `get_combined_minimum_size` | `get_clamped_minimum_size` | Get the minimum size of the content that has been clamped by the custom min size |

| Before | After | Explanation |
| :-------: | :-----: | :-------------: |
| ![0](https://user-images.githubusercontent.com/30386067/190615521-fd91e856-d467-4fc9-84a1-848de0ec3312.gif) | ![1](https://user-images.githubusercontent.com/30386067/190615544-afc010e6-9464-4d6c-ad82-f14fcf251dcd.gif) | `max_size = (300, 200)` |
| ![3](https://user-images.githubusercontent.com/30386067/190615659-908074f2-b808-407a-b94f-6789705a1d9c.gif) | ![2](https://user-images.githubusercontent.com/30386067/190615687-d4e2500e-9d50-44e1-9c69-47fbe26a1ab6.gif) | `max_size = (0, 0)` or **invalid** (eg. `max_size = (300, 200)`; `min_size = (0, 300)`)

Edit:

Test project
[popup-center-off-center.zip](https://github.com/godotengine/godot/files/10670960/popup-center-off-center.zip)

Beta17:

https://user-images.githubusercontent.com/30386067/217132685-533c74c1-4968-4541-84ae-5ac020d8d2b5.mp4

This PR:

https://user-images.githubusercontent.com/30386067/217132734-7c15cc43-9fe4-4c0b-8009-c6ac358aa48e.mp4









