### PR TITLE
[3.5] Mark Navigation/Navigation2D nodes as deprecated

### DIFF
--- a/doc/classes/Navigation.xml
+++ b/doc/classes/Navigation.xml
@@ -4,6 +4,7 @@
 		Mesh-based navigation and pathfinding node.
 	</brief_description>
 	<description>
+		[i]Deprecated.[/i] [Navigation] node and [method get_simple_path] are deprecated and will be removed in a future version. Use [method NavigationServer.map_get_path] instead.
 		Provides navigation and pathfinding within a collection of [NavigationMesh]es. By default, these will be automatically collected from child [NavigationMeshInstance] nodes. In addition to basic pathfinding, this class also assists with aligning navigation agents with the meshes they are navigating on.
 	</description>
 	<tutorials>
@@ -52,6 +53,7 @@
 			<argument index="1" name="end" type="Vector3" />
 			<argument index="2" name="optimize" type="bool" default="true" />
 			<description>
+				[i]Deprecated.[/i] [Navigation] node and [method get_simple_path] are deprecated and will be removed in a future version. Use [method NavigationServer.map_get_path] instead.
 				Returns the path between two given points. Points are in local coordinate space. If [code]optimize[/code] is [code]true[/code] (the default), the agent properties associated with each [NavigationMesh] (radius, height, etc.) are considered in the path calculation, otherwise they are ignored.
 			</description>
 		</method>

--- a/doc/classes/Navigation2D.xml
+++ b/doc/classes/Navigation2D.xml
@@ -4,6 +4,7 @@
 		2D navigation and pathfinding node.
 	</brief_description>
 	<description>
+		[i]Deprecated.[/i] [Navigation2D] node and [method get_simple_path] are deprecated and will be removed in a future version. Use [method Navigation2DServer.map_get_path] instead.
 		Navigation2D provides navigation and pathfinding within a 2D area, specified as a collection of [NavigationPolygon] resources. By default, these are automatically collected from child [NavigationPolygonInstance] nodes.
 	</description>
 	<tutorials>
@@ -36,6 +37,7 @@
 			<argument index="1" name="end" type="Vector2" />
 			<argument index="2" name="optimize" type="bool" default="true" />
 			<description>
+				[i]Deprecated.[/i] [Navigation2D] node and [method get_simple_path] are deprecated and will be removed in a future version. Use [method Navigation2DServer.map_get_path] instead.
 				Returns the path between two given points. Points are in local coordinate space. If [code]optimize[/code] is [code]true[/code] (the default), the path is smoothed by merging path segments where possible.
 			</description>
 		</method>

--- a/scene/2d/navigation_2d.cpp
+++ b/scene/2d/navigation_2d.cpp
@@ -78,7 +78,12 @@ void Navigation2D::set_edge_connection_margin(float p_edge_connection_margin) {
 }
 
 Vector<Vector2> Navigation2D::get_simple_path(const Vector2 &p_start, const Vector2 &p_end, bool p_optimize) const {
+	WARN_DEPRECATED_MSG("'Navigation2D' node and 'Navigation2D.get_simple_path()' are deprecated and will be removed in a future version. Use 'Navigation2DServer.map_get_path()' instead.");
 	return Navigation2DServer::get_singleton()->map_get_path(map, p_start, p_end, p_optimize, navigation_layers);
+}
+
+String Navigation2D::get_configuration_warning() const {
+	return TTR("'Navigation2D' node and 'Navigation2D.get_simple_path()' are deprecated and will be removed in a future version. Use 'Navigation2DServer.map_get_path()' instead.");
 }
 
 Vector2 Navigation2D::get_closest_point(const Vector2 &p_point) const {

--- a/scene/2d/navigation_2d.h
+++ b/scene/2d/navigation_2d.h
@@ -68,6 +68,8 @@ public:
 	Vector2 get_closest_point(const Vector2 &p_point) const;
 	RID get_closest_point_owner(const Vector2 &p_point) const;
 
+	virtual String get_configuration_warning() const;
+
 	Navigation2D();
 	~Navigation2D();
 };

--- a/scene/3d/navigation.cpp
+++ b/scene/3d/navigation.cpp
@@ -33,7 +33,12 @@
 #include "servers/navigation_server.h"
 
 Vector<Vector3> Navigation::get_simple_path(const Vector3 &p_start, const Vector3 &p_end, bool p_optimize) const {
+	WARN_DEPRECATED_MSG("'Navigation' node and 'Navigation.get_simple_path()' are deprecated and will be removed in a future version. Use 'NavigationServer.map_get_path()' instead.");
 	return NavigationServer::get_singleton()->map_get_path(map, p_start, p_end, p_optimize, navigation_layers);
+}
+
+String Navigation::get_configuration_warning() const {
+	return TTR("'Navigation' node and 'Navigation.get_simple_path()' are deprecated and will be removed in a future version. Use 'NavigationServer.map_get_path()' instead.");
 }
 
 Vector3 Navigation::get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, bool p_use_collision) const {

--- a/scene/3d/navigation.h
+++ b/scene/3d/navigation.h
@@ -82,6 +82,8 @@ public:
 	Vector3 get_closest_point_normal(const Vector3 &p_point) const;
 	RID get_closest_point_owner(const Vector3 &p_point) const;
 
+	virtual String get_configuration_warning() const;
+
 	Navigation();
 	~Navigation();
 };


### PR DESCRIPTION
Mark Navigation/Navigation2D nodes as deprecated. They already just redirect calls to the NavigationServer and have no longer a real purpose. In Godot 4.0 both nodes are already removed for good reasons outlined here #46786 or discussed here [#691](https://github.com/godotengine/godot-proposals/issues/691)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
