### PR TITLE
[3.x] Fix `EditorFileDialog` filename default selection

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1687,6 +1687,7 @@ EditorFileDialog::EditorFileDialog() {
 	file = memnew(LineEdit);
 	file->set_stretch_ratio(4);
 	file->set_h_size_flags(SIZE_EXPAND_FILL);
+	file->set_deselect_on_focus_loss_enabled(false);
 	file_box->add_child(file);
 	filter = memnew(OptionButton);
 	filter->set_stretch_ratio(3);


### PR DESCRIPTION
In recent versions, `EditorFileDialog` no longer selects the default filename by default. (e.g. when saving scene/resource.)

This is because `LineEdit` now deselects current selection when focus is lost. Calling `set_deselect_on_focus_loss_enabled(false)` fixes it.

`master` does not have this problem, so there's no corresponding PR for it.