### PR TITLE
Remove spaces in `SubResource()/ExtResource/Resource()` in text resources

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1564,17 +1564,17 @@ String ResourceFormatSaverTextInstance::_write_resources(void *ud, const Ref<Res
 
 String ResourceFormatSaverTextInstance::_write_resource(const Ref<Resource> &res) {
 	if (external_resources.has(res)) {
-		return "ExtResource( \"" + external_resources[res] + "\" )";
+		return "ExtResource(\"" + external_resources[res] + "\")";
 	} else {
 		if (internal_resources.has(res)) {
-			return "SubResource( \"" + internal_resources[res] + "\" )";
+			return "SubResource(\"" + internal_resources[res] + "\")";
 		} else if (!res->is_built_in()) {
 			if (res->get_path() == local_path) { //circular reference attempt
 				return "null";
 			}
 			//external resource
 			String path = relative_paths ? local_path.path_to_file(res->get_path()) : res->get_path();
-			return "Resource( \"" + path + "\" )";
+			return "Resource(\"" + path + "\")";
 		} else {
 			ERR_FAIL_V_MSG("null", "Resource was not pre cached for the resource section, bug?");
 			//internal resource


### PR DESCRIPTION
Split from https://github.com/godotengine/godot/pull/32124.

These spaces are not needed for the file to be successfully parsed.

[Other types such as Vector3 are no longer serialized with spaces after the opening parenthesis and before the closing parenthesis](https://github.com/godotengine/godot/pull/32313), so this is also more consistent.

This is technically cherry-pickable to `3.x`, but I don't recommend doing so due to the large VCS diffs it can generate (and because Variant types in `3.x` are serialized with extraneous spaces).