### PR TITLE
GDExtension: print error messages for different error paths during loading

### DIFF
--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -281,6 +281,7 @@ void NativeExtension::_get_library_path(const GDNativeExtensionClassLibraryPtr p
 Error NativeExtension::open_library(const String &p_path, const String &p_entry_symbol) {
 	Error err = OS::get_singleton()->open_dynamic_library(p_path, library, true, &library_path);
 	if (err != OK) {
+		ERR_PRINT("GDExtension dynamic library not found: " + p_path);
 		return err;
 	}
 
@@ -289,6 +290,7 @@ Error NativeExtension::open_library(const String &p_path, const String &p_entry_
 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(library, p_entry_symbol, entry_funcptr, false);
 
 	if (err != OK) {
+		ERR_PRINT("GDExtension entry point '" + p_entry_symbol + "' not found in library " + p_path);
 		OS::get_singleton()->close_dynamic_library(library);
 		return err;
 	}
@@ -299,6 +301,7 @@ Error NativeExtension::open_library(const String &p_path, const String &p_entry_
 		level_initialized = -1;
 		return OK;
 	} else {
+		ERR_PRINT("GDExtension initialization function '" + p_entry_symbol + "' returned an error.");
 		return FAILED;
 	}
 }
@@ -387,6 +390,7 @@ Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const St
 	}
 
 	if (err != OK) {
+		ERR_PRINT("Error loading GDExtension config file: " + p_path);
 		return Ref<Resource>();
 	}
 
@@ -394,6 +398,7 @@ Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const St
 		if (r_error) {
 			*r_error = ERR_INVALID_DATA;
 		}
+		ERR_PRINT("GDExtension config file must contain 'configuration.entry_symbol' key: " + p_path);
 		return Ref<Resource>();
 	}
 
@@ -426,6 +431,7 @@ Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const St
 		if (r_error) {
 			*r_error = ERR_FILE_NOT_FOUND;
 		}
+		ERR_PRINT("No GDExtension library found for current architecture; in config file " + p_path);
 		return Ref<Resource>();
 	}
 
@@ -443,6 +449,7 @@ Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const St
 	}
 
 	if (err != OK) {
+		// Errors already logged in open_library()
 		return Ref<Resource>();
 	}
 


### PR DESCRIPTION
When _anything_ goes wrong with loading an extension, we currently get the error message:
```yaml
ERROR: Failed loading resource: res://demo.gdextension. 
Make sure resources have been imported by opening the project in the editor at least once.
```

I just spent a lot of time trying to reproduce and debug a problem, which turned out to be my init function not returning `true`. So I thought I'll attempt to make the errors more descriptive, and express at which stage the loading fails. These are some of the error messages that this PR adds:
```yaml
ERROR: No GDExtension library found for current architecture; in config file res://demo.gdextension
ERROR: GDExtension config file must contain 'configuration.entry_symbol' key: res://demo.gdextension

ERROR: GDExtension dynamic library not found: G:/<path>/demo.dll
ERROR: GDExtension entry point 'demo_init' not found in library G:/<path>/demo.dll
ERROR: GDExtension initialization function 'demo_init' returned an error.
```
This means that potentially multiple errors could be logged for one thing that went wrong, but it seems this is already done in many other places.