### PR TITLE
ProjectSettings: Ensure 'editor/' settings aren't nested

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1096,14 +1096,17 @@ ProjectSettings::ProjectSettings() {
 
 	GLOBAL_DEF("editor/main_run_args", "");
 
+	GLOBAL_DEF("editor/scene_naming", 0); // Sync enum values with EditorNode.
+	ProjectSettings::get_singleton()->set_custom_property_info("editor/scene_naming", PropertyInfo(Variant::INT, "editor/scene_naming", PROPERTY_HINT_ENUM, "Auto,PascalCase,snake_case"));
+
 	GLOBAL_DEF("editor/search_in_file_extensions", extensions);
 	custom_prop_info["editor/search_in_file_extensions"] = PropertyInfo(Variant::POOL_STRING_ARRAY, "editor/search_in_file_extensions");
 
 	GLOBAL_DEF("editor/script_templates_search_path", "res://script_templates");
 	custom_prop_info["editor/script_templates_search_path"] = PropertyInfo(Variant::STRING, "editor/script_templates_search_path", PROPERTY_HINT_DIR);
 
-	GLOBAL_DEF("editor/version_control/autoload_on_startup", false);
-	GLOBAL_DEF("editor/version_control/plugin_name", "");
+	GLOBAL_DEF("editor/version_control_autoload_on_startup", false);
+	GLOBAL_DEF("editor/version_control_plugin_name", "");
 
 	action = Dictionary();
 	action["deadzone"] = Variant(0.5f);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -530,16 +530,22 @@
 			prime-run %command%
 			[/codeblock]
 		</member>
+		<member name="editor/scene_naming" type="int" setter="" getter="" default="0">
+			Default naming style for scene files to infer from their root nodes. Possible options are:
+			- [code]0[/code] (Auto): Uses the scene root name as is without changing its casing.
+			- [code]1[/code] (PascalCase): Converts the scene root name to PascalCase casing.
+			- [code]2[/code] (snake_case): Converts the scene root name to snake_case casing.
+		</member>
 		<member name="editor/script_templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
 			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path.
 		</member>
 		<member name="editor/search_in_file_extensions" type="PoolStringArray" setter="" getter="" default="PoolStringArray( &quot;gd&quot;, &quot;gdshader&quot;, &quot;shader&quot; )">
 			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
 		</member>
-		<member name="editor/version_control/autoload_on_startup" type="bool" setter="" getter="" default="false">
+		<member name="editor/version_control_autoload_on_startup" type="bool" setter="" getter="" default="false">
 			Load the previously opened VCS plugin when the editor starts up. This is set to [code]true[/code] whenever a new VCS plugin is initialized.
 		</member>
-		<member name="editor/version_control/plugin_name" type="String" setter="" getter="" default="&quot;&quot;">
+		<member name="editor/version_control_plugin_name" type="String" setter="" getter="" default="&quot;&quot;">
 			Last loaded VCS plugin name. Used to autoload the plugin when the editor starts up.
 		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2453,7 +2453,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			} else if (extensions.size()) {
 				String root_name = scene->get_name();
 				// Very similar to node naming logic.
-				switch (ProjectSettings::get_singleton()->get("editor/scene/scene_naming").operator int()) {
+				switch (ProjectSettings::get_singleton()->get("editor/scene_naming").operator int()) {
 					case SCENE_NAME_CASING_AUTO:
 						// Use casing of the root node.
 						break;
@@ -5650,9 +5650,6 @@ void EditorNode::_feature_profile_changed() {
 }
 
 void EditorNode::_bind_methods() {
-	GLOBAL_DEF("editor/scene/scene_naming", SCENE_NAME_CASING_AUTO);
-	ProjectSettings::get_singleton()->set_custom_property_info("editor/scene/scene_naming", PropertyInfo(Variant::INT, "editor/scene/scene_naming", PROPERTY_HINT_ENUM, "Auto,PascalCase,snake_case"));
-
 	ClassDB::bind_method("_menu_option", &EditorNode::_menu_option);
 	ClassDB::bind_method("_tool_menu_option", &EditorNode::_tool_menu_option);
 	ClassDB::bind_method("_menu_confirm_current", &EditorNode::_menu_confirm_current);

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -84,8 +84,8 @@ void VersionControlEditorPlugin::_bind_methods() {
 
 void VersionControlEditorPlugin::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
-		String installed_plugin = GLOBAL_GET("editor/version_control/plugin_name");
-		bool has_autoload_enable = GLOBAL_GET("editor/version_control/autoload_on_startup");
+		String installed_plugin = GLOBAL_GET("editor/version_control_plugin_name");
+		bool has_autoload_enable = GLOBAL_GET("editor/version_control_autoload_on_startup");
 
 		if (installed_plugin != "" && has_autoload_enable) {
 			if (_load_plugin(installed_plugin)) {
@@ -139,8 +139,8 @@ void VersionControlEditorPlugin::_initialize_vcs() {
 	if (_load_plugin(selected_plugin)) {
 		_set_up();
 
-		ProjectSettings::get_singleton()->set("editor/version_control/autoload_on_startup", true);
-		ProjectSettings::get_singleton()->set("editor/version_control/plugin_name", selected_plugin);
+		ProjectSettings::get_singleton()->set("editor/version_control_autoload_on_startup", true);
+		ProjectSettings::get_singleton()->set("editor/version_control_plugin_name", selected_plugin);
 		ProjectSettings::get_singleton()->save();
 	}
 }


### PR DESCRIPTION
Having a mix of settings with and without subcategory makes the 'Editor'
section stand out with a weird UX, as instead of simply being a foldable
section like the others, it also holds its own top-level settings and is
therefore selectable.

This wasn't the case in 3.4, and is fixed in 4.0 by refactoring, so for
3.5 we should preserve the 3.4 UX, even if it's not the best. This was
reported [in this Reddit thread](https://www.reddit.com/r/godot/comments/vebzza/comment/icqr9sg/?utm_source=reddit&utm_medium=web2x&context=3).

### Project Settings in 3.4.4

![image](https://user-images.githubusercontent.com/4701338/174475130-94faab3e-4599-4d16-8403-dfbaa616a875.png)

### Project Settings in 3.5 RC 4

![image](https://user-images.githubusercontent.com/4701338/174475155-12f019ef-7a2f-48f6-ad70-b3a8d76ea793.png)
(It's hardly visible but the "Editor" foldable section is selected here and included some properties. No other foldable section has this behavior.)

### Project Settings in this PR

![image](https://user-images.githubusercontent.com/4701338/174475279-35d7465f-a856-42b4-99de-45f2d6475fab.png)

Breaks compat for the renamed settings which have been introduced in 3.5 development - if some plugins rely on them they will need to be adjusted (CC @ChronicallySerious for the VCS plugin).

