### PR TITLE
Physics Interpolation - fix continuous updating in unmoving objects

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1159,6 +1159,15 @@ void VisualServerScene::instance_set_visible(RID p_instance, bool p_visible) {
 		_interpolation_data.instance_interpolate_update_list.push_back(p_instance);
 		instance->on_interpolate_list = true;
 		_instance_queue_update(instance, true);
+
+		// We must also place on the transform update list for a tick, so the system
+		// can auto-detect if the instance is no longer moving, and remove from the interpolate lists again.
+		// If this step is ignored, an unmoving instance could remain on the interpolate lists indefinitely
+		// (or rather until the object is deleted) and cause unnecessary updates and drawcalls.
+		if (!instance->on_interpolate_transform_list) {
+			_interpolation_data.instance_transform_update_list_curr->push_back(p_instance);
+			instance->on_interpolate_transform_list = true;
+		}
 	}
 
 	// give the opportunity for the spatial partitioning scene to use a special implementation of visibility


### PR DESCRIPTION
Adds instances to the transform update list as well as the interpolate update list when unhiding them. This ensures that the system auto-detects non-moving objects, and removes them from the interpolate update list on the next tick, preventing unnecessary updates.

Fixes #62111

## Notes
* I introduced this regression with #62018 which was created rather hurriedly on the day of the last RC, my bad.
* Instances made visible were being added to interpolation update list, and updated every frame, thus causing drawcalls, however the mechanism for _removing_ them when they weren't moving I forgot to add. This worked by checking whether they had an `instance_set_transform()` call in the preceding tick.
* This PR ensures the instances are added to both lists, and will therefore be auto-removed when not-moving.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
