### PR TITLE
Fix gendered pronoun in InputEventJoypadButton documentation translations

### DIFF
--- a/doc/translations/ar.po
+++ b/doc/translations/ar.po
@@ -29789,7 +29789,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/ca.po
+++ b/doc/translations/ca.po
@@ -29786,7 +29786,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/classes.pot
+++ b/doc/translations/classes.pot
@@ -29663,7 +29663,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/cs.po
+++ b/doc/translations/cs.po
@@ -30251,7 +30251,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/de.po
+++ b/doc/translations/de.po
@@ -32021,7 +32021,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/el.po
+++ b/doc/translations/el.po
@@ -29707,7 +29707,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/es.po
+++ b/doc/translations/es.po
@@ -39495,7 +39495,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 "Representa la presión que el usuario ejerce sobre el botón con su dedo, si "

--- a/doc/translations/fa.po
+++ b/doc/translations/fa.po
@@ -30105,7 +30105,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/fi.po
+++ b/doc/translations/fi.po
@@ -29790,7 +29790,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/fil.po
+++ b/doc/translations/fil.po
@@ -29673,7 +29673,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/fr.po
+++ b/doc/translations/fr.po
@@ -32160,7 +32160,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/gl.po
+++ b/doc/translations/gl.po
@@ -29671,7 +29671,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/hi.po
+++ b/doc/translations/hi.po
@@ -29670,7 +29670,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/hu.po
+++ b/doc/translations/hu.po
@@ -29688,7 +29688,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/id.po
+++ b/doc/translations/id.po
@@ -30090,7 +30090,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/is.po
+++ b/doc/translations/is.po
@@ -29670,7 +29670,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/it.po
+++ b/doc/translations/it.po
@@ -30826,7 +30826,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/ja.po
+++ b/doc/translations/ja.po
@@ -32925,7 +32925,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/ko.po
+++ b/doc/translations/ko.po
@@ -29925,7 +29925,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/lv.po
+++ b/doc/translations/lv.po
@@ -29688,7 +29688,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/mr.po
+++ b/doc/translations/mr.po
@@ -29668,7 +29668,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/nb.po
+++ b/doc/translations/nb.po
@@ -29680,7 +29680,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/ne.po
+++ b/doc/translations/ne.po
@@ -29668,7 +29668,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/nl.po
+++ b/doc/translations/nl.po
@@ -29740,7 +29740,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/pl.po
+++ b/doc/translations/pl.po
@@ -30219,7 +30219,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/pt.po
+++ b/doc/translations/pt.po
@@ -30518,7 +30518,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/pt_BR.po
+++ b/doc/translations/pt_BR.po
@@ -30874,7 +30874,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/ro.po
+++ b/doc/translations/ro.po
@@ -29691,7 +29691,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/ru.po
+++ b/doc/translations/ru.po
@@ -31513,7 +31513,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/sk.po
+++ b/doc/translations/sk.po
@@ -29674,7 +29674,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/sr_Cyrl.po
+++ b/doc/translations/sr_Cyrl.po
@@ -29685,7 +29685,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/sv.po
+++ b/doc/translations/sv.po
@@ -29671,7 +29671,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/th.po
+++ b/doc/translations/th.po
@@ -29823,7 +29823,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/tl.po
+++ b/doc/translations/tl.po
@@ -29757,7 +29757,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/tr.po
+++ b/doc/translations/tr.po
@@ -30492,7 +30492,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/uk.po
+++ b/doc/translations/uk.po
@@ -29866,7 +29866,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/vi.po
+++ b/doc/translations/vi.po
@@ -30161,7 +30161,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 

--- a/doc/translations/zh_CN.po
+++ b/doc/translations/zh_CN.po
@@ -37268,7 +37268,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 "如果控制器支持，则表示用户用手指在按钮上施加的压力。范围从 [code]0[/code] 到 "

--- a/doc/translations/zh_TW.po
+++ b/doc/translations/zh_TW.po
@@ -29819,7 +29819,7 @@ msgstr ""
 
 #: doc/classes/InputEventJoypadButton.xml
 msgid ""
-"Represents the pressure the user puts on the button with his finger, if the "
+"Represents the pressure the user puts on the button with their finger, if the "
 "controller supports it. Ranges from [code]0[/code] to [code]1[/code]."
 msgstr ""
 


### PR DESCRIPTION
The neutral pronoun "their" is used to replace the masculine pronoun "his", to be more inclusive. This applies most to the UK translation.