### PR TITLE
[3.x] Use signed integers for async shader conditionals

### DIFF
--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -2,7 +2,7 @@
 [vertex]
 
 #if defined(IS_UBERSHADER)
-uniform highp uint ubershader_flags;
+uniform highp int ubershader_flags;
 #endif
 
 layout(location = 0) in highp vec4 color;
@@ -222,7 +222,7 @@ VERTEX_SHADER_CODE
 [fragment]
 
 #if defined(IS_UBERSHADER)
-uniform highp uint ubershader_flags;
+uniform highp int ubershader_flags;
 #endif
 
 // any code here is never executed, stuff is filled just so it works

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2,7 +2,7 @@
 [vertex]
 
 #if defined(IS_UBERSHADER)
-uniform highp uint ubershader_flags;
+uniform highp int ubershader_flags;
 #endif
 
 #define M_PI 3.14159265359
@@ -645,7 +645,7 @@ VERTEX_SHADER_CODE
 [fragment]
 
 #if defined(IS_UBERSHADER)
-uniform highp uint ubershader_flags;
+uniform highp int ubershader_flags;
 // These are more performant and make the ubershaderification simpler
 #define VCT_QUALITY_HIGH
 #define USE_LIGHTMAP_FILTER_BICUBIC


### PR DESCRIPTION
My great suspect for the regression is #57674, which was merged between those two milestones. Looks like Intel's GLSL implementation is not very compliant with unsigned literals. Maybe the more recent ones are.

**NOTE:** In order to be sure we're happy with this, we'd have to check again async compilation on a bit more GL ES implementations. I've tested myself on recent integrated AMD and discrete Nvidia GPUs, with no issues. Of course, someone should check Intel HD Graphics. Some Androids would be cool as well, ensuring project settings don't forbid it, which is the default, if I recall correctly.

Fixes #62203.