### PR TITLE
Refactored `rotation_mode` in Node3D

### DIFF
--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -81,6 +81,7 @@ private:
 		mutable Transform3D global_transform;
 		mutable Transform3D local_transform;
 		mutable Basis::EulerOrder rotation_order = Basis::EULER_ORDER_YXZ;
+		mutable Quaternion quaternion;
 		mutable Vector3 rotation;
 		mutable Vector3 scale = Vector3(1, 1, 1);
 		mutable RotationEditMode rotation_edit_mode = ROTATION_EDIT_MODE_EULER;


### PR DESCRIPTION
Fixed #62225. Contained fix for non-orthonormalized Quaternion bug.

`set_euler_scale()` in `Node3D::_update_local_transform()` has not work and reset rotation value in Quaternion and Basis mode in Node3D. This PR fixed it.