### PR TITLE
Cleanup audio effect class reference pages

### DIFF
--- a/doc/classes/AudioEffectAmplify.xml
+++ b/doc/classes/AudioEffectAmplify.xml
@@ -2,12 +2,12 @@
 <class name="AudioEffectAmplify" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Adds an amplifying audio effect to an audio bus.
-		Increases or decreases the volume of the selected audio bus.
 	</brief_description>
 	<description>
 		Increases or decreases the volume being routed through the audio bus.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<members>
 		<member name="volume_db" type="float" setter="set_volume_db" getter="get_volume_db" default="0.0">

--- a/doc/classes/AudioEffectBandLimitFilter.xml
+++ b/doc/classes/AudioEffectBandLimitFilter.xml
@@ -7,5 +7,6 @@
 		Limits the frequencies in a range around the [member AudioEffectFilter.cutoff_hz] and allows frequencies outside of this range to pass.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectBandPassFilter.xml
+++ b/doc/classes/AudioEffectBandPassFilter.xml
@@ -7,5 +7,6 @@
 		Attenuates the frequencies inside of a range around the [member AudioEffectFilter.cutoff_hz] and cuts frequencies outside of this band.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectCapture.xml
+++ b/doc/classes/AudioEffectCapture.xml
@@ -8,6 +8,7 @@
 		Application code should consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating point PCM.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
 		<method name="can_get_buffer" qualifiers="const">

--- a/doc/classes/AudioEffectChorus.xml
+++ b/doc/classes/AudioEffectChorus.xml
@@ -7,6 +7,7 @@
 		Adds a chorus audio effect. The effect applies a filter with voices to duplicate the audio source and manipulate it through the filter.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_voice_cutoff_hz" qualifiers="const">

--- a/doc/classes/AudioEffectCompressor.xml
+++ b/doc/classes/AudioEffectCompressor.xml
@@ -13,6 +13,7 @@
 		- Accentuates transients by using a wider attack, making effects sound more punchy.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<members>
 		<member name="attack_us" type="float" setter="set_attack_us" getter="get_attack_us" default="20.0">

--- a/doc/classes/AudioEffectDelay.xml
+++ b/doc/classes/AudioEffectDelay.xml
@@ -8,6 +8,7 @@
 		Plays input signal back after a period of time. The delayed signal may be played back multiple times to create the sound of a repeating, decaying echo. Delay effects range from a subtle echo effect to a pronounced blending of previous sounds with new sounds.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<members>
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">

--- a/doc/classes/AudioEffectEQ.xml
+++ b/doc/classes/AudioEffectEQ.xml
@@ -8,6 +8,7 @@
 		AudioEffectEQ gives you control over frequencies. Use it to compensate for existing deficiencies in audio. AudioEffectEQs are useful on the Master bus to completely master a mix and give it more character. They are also useful when a game is run on a mobile device, to adjust the mix to that kind of speakers (it can be added but disabled when headphones are plugged).
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_band_count" qualifiers="const">

--- a/doc/classes/AudioEffectEQ10.xml
+++ b/doc/classes/AudioEffectEQ10.xml
@@ -19,5 +19,6 @@
 		See also [AudioEffectEQ], [AudioEffectEQ6], [AudioEffectEQ21].
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectEQ21.xml
+++ b/doc/classes/AudioEffectEQ21.xml
@@ -30,5 +30,6 @@
 		See also [AudioEffectEQ], [AudioEffectEQ6], [AudioEffectEQ10].
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectEQ6.xml
+++ b/doc/classes/AudioEffectEQ6.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectEQ6" inherits="AudioEffectEQ" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a 6-band equalizer audio effect to an Audio bus. Gives you control over frequencies from 32 Hz to 10000 Hz.
+		Adds a 6-band equalizer audio effect to an audio bus. Gives you control over frequencies from 32 Hz to 10000 Hz.
 		Each frequency can be modulated between -60/+24 dB.
 	</brief_description>
 	<description>
@@ -15,5 +15,6 @@
 		See also [AudioEffectEQ], [AudioEffectEQ10], [AudioEffectEQ21].
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectHighPassFilter.xml
+++ b/doc/classes/AudioEffectHighPassFilter.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectHighPassFilter" inherits="AudioEffectFilter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a high-pass filter to the Audio Bus.
+		Adds a high-pass filter to the audio bus.
 	</brief_description>
 	<description>
 		Cuts frequencies lower than the [member AudioEffectFilter.cutoff_hz] and allows higher frequencies to pass.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectHighShelfFilter.xml
+++ b/doc/classes/AudioEffectHighShelfFilter.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectHighShelfFilter" inherits="AudioEffectFilter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Reduces all frequencies above the [member AudioEffectFilter.cutoff_hz].
+		Adds a high-shelf filter to the audio bus.
 	</brief_description>
 	<description>
+		Reduces all frequencies above the [member AudioEffectFilter.cutoff_hz].
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>

--- a/doc/classes/AudioEffectLimiter.xml
+++ b/doc/classes/AudioEffectLimiter.xml
@@ -8,6 +8,7 @@
 		Soft clipping starts to reduce the peaks a little below the threshold level and progressively increases its effect as the input level increases such that the threshold is never exceeded.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<members>
 		<member name="ceiling_db" type="float" setter="set_ceiling_db" getter="get_ceiling_db" default="-0.1">

--- a/doc/classes/AudioEffectLowPassFilter.xml
+++ b/doc/classes/AudioEffectLowPassFilter.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectLowPassFilter" inherits="AudioEffectFilter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a low-pass filter to the Audio bus.
+		Adds a low-pass filter to the audio bus.
 	</brief_description>
 	<description>
 		Cuts frequencies higher than the [member AudioEffectFilter.cutoff_hz] and allows lower frequencies to pass.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectLowShelfFilter.xml
+++ b/doc/classes/AudioEffectLowShelfFilter.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectLowShelfFilter" inherits="AudioEffectFilter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Reduces all frequencies below the [member AudioEffectFilter.cutoff_hz].
+		Adds a low-shelf filter to the audio bus.
 	</brief_description>
 	<description>
+		Reduces all frequencies below the [member AudioEffectFilter.cutoff_hz].
 	</description>
 	<tutorials>
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>

--- a/doc/classes/AudioEffectNotchFilter.xml
+++ b/doc/classes/AudioEffectNotchFilter.xml
@@ -7,5 +7,6 @@
 		Attenuates frequencies in a narrow band around the [member AudioEffectFilter.cutoff_hz] and cuts frequencies outside of this range.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/AudioEffectPanner.xml
+++ b/doc/classes/AudioEffectPanner.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectPanner" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a panner audio effect to an Audio bus. Pans sound left or right.
+		Adds a panner audio effect to an audio bus. Pans sound left or right.
 	</brief_description>
 	<description>
 		Determines how much of an audio signal is sent to the left and right buses.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<members>
 		<member name="pan" type="float" setter="set_pan" getter="get_pan" default="0.0">

--- a/doc/classes/AudioEffectPhaser.xml
+++ b/doc/classes/AudioEffectPhaser.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectPhaser" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a phaser audio effect to an Audio bus.
+		Adds a phaser audio effect to an audio bus.
 		Combines the original signal with a copy that is slightly out of phase with the original.
 	</brief_description>
 	<description>
 		Combines phase-shifted signals with the original signal. The movement of the phase-shifted signals is controlled using a low-frequency oscillator.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<members>
 		<member name="depth" type="float" setter="set_depth" getter="get_depth" default="1.0">

--- a/doc/classes/AudioEffectPitchShift.xml
+++ b/doc/classes/AudioEffectPitchShift.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectPitchShift" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Adds a pitch-shifting audio effect to an Audio bus.
+		Adds a pitch-shifting audio effect to an audio bus.
 		Raises or lowers the pitch of original sound.
 	</brief_description>
 	<description>
 		Allows modulation of pitch independently of tempo. All frequencies can be increased/decreased with minimal effect on transients.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<members>
 		<member name="fft_size" type="int" setter="set_fft_size" getter="get_fft_size" enum="AudioEffectPitchShift.FFTSize" default="3">

--- a/doc/classes/AudioEffectReverb.xml
+++ b/doc/classes/AudioEffectReverb.xml
@@ -2,12 +2,12 @@
 <class name="AudioEffectReverb" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Adds a reverberation audio effect to an Audio bus.
-		Simulates the sound of acoustic environments such as rooms, concert halls, caverns, or an open spaces.
 	</brief_description>
 	<description>
-		Simulates rooms of different sizes. Its parameters can be adjusted to simulate the sound of a specific room.
+		Simulates the sound of acoustic environments such as rooms, concert halls, caverns, or an open spaces.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
 	<members>

--- a/doc/classes/AudioEffectStereoEnhance.xml
+++ b/doc/classes/AudioEffectStereoEnhance.xml
@@ -7,6 +7,7 @@
 		An audio effect that can be used to adjust the intensity of stereo panning.
 	</description>
 	<tutorials>
+		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<members>
 		<member name="pan_pullout" type="float" setter="set_pan_pullout" getter="get_pan_pullout" default="1.0">


### PR DESCRIPTION
Most of this PR is adding a link to the audio bus tutorial to pages. For high shelf filter and low shelf filter I made their brief description the regular description, and added a brief description consistent with other audio effect pages. For the amplify page I removed the line from the brief description that's the regular description.