### PR TITLE
Update editor doc links to 3.5 branch

### DIFF
--- a/version.py
+++ b/version.py
@@ -7,4 +7,4 @@ status = "rc"
 module_config = ""
 year = 2022
 website = "https://godotengine.org"
-docs = "3.4"
+docs = "3.5"


### PR DESCRIPTION
So that `DOCS_URL` and other editor links point to the current version.