### PR TITLE
Revert "Disable VRAM compression by default for small textures in Detect 3D"

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1250,9 +1250,6 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_INTERNAL("application/config/features", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_remaps", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations", PackedStringArray());
-
-	GLOBAL_DEF("rendering/textures/vram_compression/minimum_size", 512);
-	custom_prop_info["rendering/textures/vram_compression/minimum_size"] = PropertyInfo(Variant::INT, "rendering/textures/vram_compression/minimum_size", PROPERTY_HINT_RANGE, "16,16384,1");
 }
 
 ProjectSettings::~ProjectSettings() {

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1933,11 +1933,6 @@
 			If [code]true[/code], the texture importer will import VRAM-compressed textures using the S3 Texture Compression algorithm. This algorithm is only supported on desktop platforms and consoles.
 			[b]Note:[/b] Changing this setting does [i]not[/i] impact textures that were already imported before. To make this setting apply to textures that were already imported, exit the editor, remove the [code].godot/imported/[/code] folder located inside the project folder then restart the editor (see [member application/config/use_hidden_project_data_directory]).
 		</member>
-		<member name="rendering/textures/vram_compression/minimum_size" type="int" setter="" getter="" default="512">
-			When a texture is detected as used in 3D in the editor, only enable VRAM compression if its size is greater than or equal to [code]minimum_size * minimum_size[/code] pixels. This is done to prevent reducing texture quality when it doesn't save much video memory, especially for pixel art.
-			For non-square textures, the pixel count is used. For example, with [member rendering/textures/vram_compression/minimum_size] set to [code]512[/code], a 512×512 texture will use VRAM compression, while 256×256 textures, 256×512 and 1024×64 textures will keep their existing compression mode (Lossless by default).
-			[b]Note:[/b] This project setting only affects textures that are detected to be used in 3D at a given time. Textures that were already imported will not be affected by changes to this setting. To force 3D detection to occur again, select a texture in the FileSystem dock, change its Detect 3D import option in the Import dock to [b]VRAM Compressed[/b] or [b]Basis Universal[/b] then click [b]Reimport[/b].
-		</member>
 		<member name="rendering/vulkan/descriptor_pools/max_descriptors_per_pool" type="int" setter="" getter="" default="64">
 		</member>
 		<member name="rendering/vulkan/rendering/back_end" type="int" setter="" getter="" default="0">

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -65,15 +65,6 @@ void ResourceImporterTexture::_texture_reimport_3d(const Ref<CompressedTexture2D
 	}
 
 	singleton->make_flags[path].flags |= MAKE_3D_FLAG;
-
-	// For small textures, don't use VRAM compression as it decreases quality too much compared to the memory saved.
-	// The minimum size for VRAM compression is defined on each axis.
-	// It is then squared to handle non-square input texture sizes in a more human-readable manner.
-	const float minimum_size = float(GLOBAL_GET("rendering/textures/vram_compression/minimum_size"));
-	if (p_tex->get_width() * p_tex->get_height() >= int(Math::pow(minimum_size, 2.0f) - CMP_EPSILON)) {
-		// Texture is larger than `minimum_size × minimum_size` pixels (if square).
-		singleton->make_flags[path].flags |= MAKE_VRAM_COMPRESS_FLAG;
-	}
 }
 
 void ResourceImporterTexture::_texture_reimport_normal(const Ref<CompressedTexture2D> &p_tex) {
@@ -112,33 +103,7 @@ void ResourceImporterTexture::update_imports() {
 
 			bool changed = false;
 
-			if (E.value.flags & MAKE_3D_FLAG && bool(cf->get_value("params", "detect_3d/compress_to"))) {
-				if (E.value.flags & MAKE_VRAM_COMPRESS_FLAG) {
-					// Texture is large enough to benefit from VRAM compression.
-					const int compress_to = cf->get_value("params", "detect_3d/compress_to");
-					String compress_string;
-					if (compress_to == 1) {
-						cf->set_value("params", "compress/mode", COMPRESS_VRAM_COMPRESSED);
-						compress_string = "VRAM Compressed (S3TC/ETC/BPTC)";
-					} else if (compress_to == 2) {
-						cf->set_value("params", "compress/mode", COMPRESS_BASIS_UNIVERSAL);
-						compress_string = "Basis Universal";
-					}
-					print_line(vformat(TTR("%s: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to %s."), String(E.key), compress_string));
-				} else {
-					print_line(vformat(TTR("%s: Small texture detected as used in 3D. Enabling mipmap generation but not VRAM compression."), String(E.key)));
-				}
-
-				cf->set_value("params", "mipmaps/generate", true);
-				cf->set_value("params", "detect_3d/compress_to", 0);
-
-				changed = true;
-			}
-
-			if (E.value.flags & MAKE_NORMAL_FLAG && int(cf->get_value("params", "compress/normal_map")) == 0 && int(cf->get_value("params", "compress/mode")) != COMPRESS_LOSSLESS) {
-				// Normal map compression is not available for textures with Lossless compression.
-				// This is ignored in the importer, but printing a message about normal map compression
-				// being enabled in this case is misleading.
+			if (E.value.flags & MAKE_NORMAL_FLAG && int(cf->get_value("params", "compress/normal_map")) == 0) {
 				print_line(vformat(TTR("%s: Texture detected as used as a normal map in 3D. Enabling red-green texture compression to reduce memory usage (blue channel is discarded)."), String(E.key)));
 				cf->set_value("params", "compress/normal_map", 1);
 				changed = true;
@@ -148,6 +113,22 @@ void ResourceImporterTexture::update_imports() {
 				print_line(vformat(TTR("%s: Texture detected as used as a roughness map in 3D. Enabling roughness limiter based on the detected associated normal map at %s."), String(E.key), E.value.normal_path_for_roughness));
 				cf->set_value("params", "roughness/mode", E.value.channel_for_roughness + 2);
 				cf->set_value("params", "roughness/src_normal", E.value.normal_path_for_roughness);
+				changed = true;
+			}
+
+			if (E.value.flags & MAKE_3D_FLAG && bool(cf->get_value("params", "detect_3d/compress_to"))) {
+				const int compress_to = cf->get_value("params", "detect_3d/compress_to");
+				String compress_string;
+				cf->set_value("params", "detect_3d/compress_to", 0);
+				if (compress_to == 1) {
+					cf->set_value("params", "compress/mode", COMPRESS_VRAM_COMPRESSED);
+					compress_string = "VRAM Compressed (S3TC/ETC/BPTC)";
+				} else if (compress_to == 2) {
+					cf->set_value("params", "compress/mode", COMPRESS_BASIS_UNIVERSAL);
+					compress_string = "Basis Universal";
+				}
+				print_line(vformat(TTR("%s: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to %s."), String(E.key), compress_string));
+				cf->set_value("params", "mipmaps/generate", true);
 				changed = true;
 			}
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -54,9 +54,8 @@ public:
 protected:
 	enum {
 		MAKE_3D_FLAG = 1,
-		MAKE_VRAM_COMPRESS_FLAG = 2,
-		MAKE_ROUGHNESS_FLAG = 4,
-		MAKE_NORMAL_FLAG = 8,
+		MAKE_ROUGHNESS_FLAG = 2,
+		MAKE_NORMAL_FLAG = 4
 	};
 
 	Mutex mutex;


### PR DESCRIPTION
Reverts godotengine/godot#62023