### PR TITLE
[3.5] Fix change to signed shader conditional flags

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -194,7 +194,7 @@ bool ShaderGLES3::_bind_ubershader() {
 	// which are more compatible across GL driver vendors.
 	CRASH_COND(new_conditional_version.version >= 0x80000000);
 #endif
-	glUniform1ui(conditionals_uniform, new_conditional_version.version);
+	glUniform1i(conditionals_uniform, new_conditional_version.version);
 	return bound;
 }
 


### PR DESCRIPTION
This change was missing from commit d3d8ccea60fb846a87d221bea659b09c0f46afe1; therefore, it's a fixup for #62226.

Fixes #62243.
And probably #62244.