### PR TITLE
Allow to disable TextEdit vertical scroll

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -998,13 +998,16 @@
 		<member name="placeholder_text" type="String" setter="set_placeholder" getter="get_placeholder" default="&quot;&quot;">
 			Text shown when the [TextEdit] is empty. It is [b]not[/b] the [TextEdit]'s default value (see [member text]).
 		</member>
+		<member name="scroll_fit_content_height" type="bool" setter="set_fit_content_height_enabled" getter="is_fit_content_height_enabled" default="false">
+			If [code]true[/code], [TextEdit] will disable vertical scroll and fit minimum height to the number of visible lines.
+		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			If there is a horizontal scrollbar, this determines the current horizontal scroll value in pixels.
 		</member>
 		<member name="scroll_past_end_of_file" type="bool" setter="set_scroll_past_end_of_file_enabled" getter="is_scroll_past_end_of_file_enabled" default="false">
 			Allow scrolling past the last line into "virtual" space.
 		</member>
-		<member name="scroll_smooth" type="bool" setter="set_smooth_scroll_enable" getter="is_smooth_scroll_enabled" default="false">
+		<member name="scroll_smooth" type="bool" setter="set_smooth_scroll_enabled" getter="is_smooth_scroll_enabled" default="false">
 			Scroll smoothly over the text rather then jumping to the next location.
 		</member>
 		<member name="scroll_v_scroll_speed" type="float" setter="set_v_scroll_speed" getter="get_v_scroll_speed" default="80.0">

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -456,6 +456,8 @@ private:
 	HScrollBar *h_scroll = nullptr;
 	VScrollBar *v_scroll = nullptr;
 
+	float content_height_cache = 0.0;
+	bool fit_content_height = false;
 	bool scroll_past_end_of_file_enabled = false;
 
 	// Smooth scrolling.
@@ -850,6 +852,9 @@ public:
 
 	void set_v_scroll_speed(float p_speed);
 	float get_v_scroll_speed() const;
+
+	void set_fit_content_height_enabled(const bool p_enabled);
+	bool is_fit_content_height_enabled() const;
 
 	double get_scroll_pos_for_line(int p_line, int p_wrap_index = 0) const;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4546
![godot windows tools 64_RjBLImp3JP](https://user-images.githubusercontent.com/2223172/174688109-45107c71-86d7-4725-aaba-e58559ad4c72.gif)

Horizontal scroll can be disabled by using autowrap. Not sure if there is use-case for horizontal expanding (it's something more fit for LineEdit).