### PR TITLE
Avoid possibly showing two Dialogs at the same time

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1353,8 +1353,9 @@ void SceneTreeDialog::_cancel() {
 
 void SceneTreeDialog::_select() {
 	if (tree->get_selected()) {
-		emit_signal(SNAME("selected"), tree->get_selected()->get_path());
+		// The signal may cause another dialog to be displayed, so be sure to hide this one first.
 		hide();
+		emit_signal(SNAME("selected"), tree->get_selected()->get_path());
 	}
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fix #55133.

This signal `selected` of `SceneTreeDialog` may cause another dialog to be displayed, so it is more appropriate to hide at first and then emit the signal.
