### PR TITLE
Add gesture callback to ViewPanner

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -365,6 +365,7 @@ private:
 	void _scroll_callback(Vector2 p_scroll_vec, bool p_alt);
 	void _pan_callback(Vector2 p_scroll_vec);
 	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
+	void _gesture_callback(Ref<InputEvent> p_gesture);
 
 	bool _is_node_locked(const Node *p_node);
 	bool _is_node_movable(const Node *p_node, bool p_popup_warning = false);

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -63,6 +63,19 @@ void TileAtlasView::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool 
 	_update_zoom_and_panning(true);
 }
 
+void TileAtlasView::_gesture_callback(Ref<InputEvent> p_gesture) {
+	Ref<InputEventMagnifyGesture> magnify_gesture = p_gesture;
+	if (magnify_gesture.is_valid()) {
+		_zoom_callback(Vector2(0, magnify_gesture->get_factor()), Vector2(), false);
+		return;
+	}
+
+	Ref<InputEventPanGesture> pan_gesture = p_gesture;
+	if (pan_gesture.is_valid()) {
+		_pan_callback(pan_gesture->get_delta());
+	}
+}
+
 Size2i TileAtlasView::_compute_base_tiles_control_size() {
 	// Update the texture.
 	Vector2i size;
@@ -565,7 +578,7 @@ TileAtlasView::TileAtlasView() {
 	add_child(button_center_view);
 
 	panner.instantiate();
-	panner->set_callbacks(callable_mp(this, &TileAtlasView::_scroll_callback), callable_mp(this, &TileAtlasView::_pan_callback), callable_mp(this, &TileAtlasView::_zoom_callback));
+	panner->set_callbacks(callable_mp(this, &TileAtlasView::_scroll_callback), callable_mp(this, &TileAtlasView::_pan_callback), callable_mp(this, &TileAtlasView::_zoom_callback), callable_mp(this, &TileAtlasView::_gesture_callback));
 	panner->set_enable_rmb(true);
 
 	center_container = memnew(CenterContainer);

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -68,6 +68,7 @@ private:
 	void _scroll_callback(Vector2 p_scroll_vec, bool p_alt);
 	void _pan_callback(Vector2 p_scroll_vec);
 	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
+	void _gesture_callback(Ref<InputEvent> p_gesture);
 
 	HashMap<Vector2, HashMap<int, Rect2i>> alternative_tiles_rect_cache;
 	void _update_alternative_tiles_rect_cache();

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -119,6 +119,10 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 		}
 	}
 
+	if (gesture_callback.is_valid() && (Object::cast_to<InputEventMagnifyGesture>(p_event.ptr()) || Object::cast_to<InputEventPanGesture>(p_event.ptr()))) {
+		callback_helper(gesture_callback, varray(p_event));
+		return true;
+	}
 	return false;
 }
 
@@ -138,10 +142,11 @@ void ViewPanner::callback_helper(Callable p_callback, Vector<Variant> p_args) {
 	p_callback.call(argptr, p_args.size(), result, ce);
 }
 
-void ViewPanner::set_callbacks(Callable p_scroll_callback, Callable p_pan_callback, Callable p_zoom_callback) {
+void ViewPanner::set_callbacks(Callable p_scroll_callback, Callable p_pan_callback, Callable p_zoom_callback, Callable p_gesture_callback) {
 	scroll_callback = p_scroll_callback;
 	pan_callback = p_pan_callback;
 	zoom_callback = p_zoom_callback;
+	gesture_callback = p_gesture_callback;
 }
 
 void ViewPanner::set_control_scheme(ControlScheme p_scheme) {

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -58,12 +58,13 @@ private:
 	Callable scroll_callback;
 	Callable pan_callback;
 	Callable zoom_callback;
+	Callable gesture_callback;
 
 	void callback_helper(Callable p_callback, Vector<Variant> p_args);
 	ControlScheme control_scheme = SCROLL_ZOOMS;
 
 public:
-	void set_callbacks(Callable p_scroll_callback, Callable p_pan_callback, Callable p_zoom_callback);
+	void set_callbacks(Callable p_scroll_callback, Callable p_pan_callback, Callable p_zoom_callback, Callable p_gesture_callback = Callable());
 	void set_control_scheme(ControlScheme p_scheme);
 	void set_enable_rmb(bool p_enable);
 	void set_pan_shortcut(Ref<Shortcut> p_shortcut);


### PR DESCRIPTION
This PR adds an optional gesture callback to ViewPanner. As there are multiple gestures with different properties, it's not that easy to pass only relevant values like in other callbacks, so this one just comes with the event.

I don't have any means to test it, so it would be nice if someone could check if it works. I reworked the 2D editor gestures and added them to tile editor. If it works, I can copy-paste the code to other editors so we can have gesture controls available in most places.

Closes #58014