### PR TITLE
Increase Script Class Name access.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -405,6 +405,15 @@ void Object::get_valid_parents_static(List<String> *p_parents) {
 void Object::_get_valid_parents_static(List<String> *p_parents) {
 }
 
+StringName Object::get_script_class_name() const {
+	if (!script.is_null()) {
+		Ref<Script> s = script;
+		return s->get_global_class_name();
+	}
+
+	return StringName();
+}
+
 void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid) {
 #ifdef TOOLS_ENABLED
 
@@ -1575,6 +1584,7 @@ void Object::notify_property_list_changed() {
 
 void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_class"), &Object::get_class);
+	ClassDB::bind_method(D_METHOD("get_script_class_name"), &Object::get_script_class_name);
 	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
 	ClassDB::bind_method(D_METHOD("set", "property", "value"), &Object::_set_bind);
 	ClassDB::bind_method(D_METHOD("get", "property"), &Object::_get_bind);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -348,6 +348,15 @@ public:                                                                         
 		p_inheritance_list->push_back(String(#m_class));                                                                                         \
 	}                                                                                                                                            \
 	virtual bool is_class(const String &p_class) const override {                                                                                \
+		if (!p_class.is_empty() && !get_script().is_null()) {                                                                                    \
+			Object *s = get_script();                                                                                                            \
+			while (s) {                                                                                                                          \
+				if (s->call(StringName("get_global_class_name")).operator String() == p_class) {                                                 \
+					return true;                                                                                                                 \
+				}                                                                                                                                \
+				s = s->call(StringName("get_base_script"));                                                                                      \
+			}                                                                                                                                    \
+		}                                                                                                                                        \
 		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                           \
 			return true;                                                                                                                         \
 		}                                                                                                                                        \
@@ -690,7 +699,19 @@ public:
 	}
 	virtual String get_save_class() const { return get_class(); } //class stored when saving
 
+	StringName get_script_class_name() const;
+
 	virtual bool is_class(const String &p_class) const {
+		if (!p_class.is_empty() && !script.is_null()) {
+			Object *s = script;
+			while (s) {
+				if (s->call(StringName("get_global_class_name")).operator String() == p_class) {
+					return true;
+				}
+				s = s->call(StringName("get_base_script"));
+			}
+		}
+
 		if (_extension && _extension->is_class(p_class)) {
 			return true;
 		}

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -101,6 +101,10 @@ Dictionary Script::_get_script_constant_map() {
 	return ret;
 }
 
+StringName Script::get_global_class_name() const {
+	return ScriptServer::get_global_class_name(get_path());
+}
+
 void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &Script::can_instantiate);
 	//ClassDB::bind_method(D_METHOD("instance_create","base_object"),&Script::instance_create);
@@ -110,6 +114,7 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_source_code", "source"), &Script::set_source_code);
 	ClassDB::bind_method(D_METHOD("reload", "keep_state"), &Script::reload, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_base_script"), &Script::get_base_script);
+	ClassDB::bind_method(D_METHOD("get_global_class_name"), &Script::get_global_class_name);
 	ClassDB::bind_method(D_METHOD("get_instance_base_type"), &Script::get_instance_base_type);
 
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
@@ -226,6 +231,16 @@ void ScriptServer::remove_global_class(const StringName &p_class) {
 
 bool ScriptServer::is_global_class(const StringName &p_class) {
 	return global_classes.has(p_class);
+}
+
+StringName ScriptServer::get_global_class_name(const StringName &p_path) {
+	for (const KeyValue<StringName, GlobalScriptClass> &E : global_classes) {
+		if (E.value.path == p_path) {
+			return E.key;
+		}
+	}
+
+	return StringName();
 }
 
 StringName ScriptServer::get_global_class_language(const StringName &p_class) {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -80,6 +80,7 @@ public:
 	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path);
 	static void remove_global_class(const StringName &p_class);
 	static bool is_global_class(const StringName &p_class);
+	static StringName get_global_class_name(const StringName &p_path);
 	static StringName get_global_class_language(const StringName &p_class);
 	static String get_global_class_path(const String &p_class);
 	static StringName get_global_class_base(const String &p_class);
@@ -118,6 +119,7 @@ public:
 	virtual bool can_instantiate() const = 0;
 
 	virtual Ref<Script> get_base_script() const = 0; //for script inheritance
+	virtual StringName get_global_class_name() const;
 
 	virtual bool inherits_script(const Ref<Script> &p_script) const = 0;
 

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -397,6 +397,12 @@
 				Returns the object's [Script] instance, or [code]null[/code] if none is assigned.
 			</description>
 		</method>
+		<method name="get_script_class_name" qualifiers="const">
+			<return type="StringName" />
+			<description>
+				Returns the object's [Script] global class name.
+			</description>
+		</method>
 		<method name="get_signal_connection_list" qualifiers="const">
 			<return type="Array" />
 			<argument index="0" name="signal" type="StringName" />

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -24,6 +24,12 @@
 				Returns the script directly inherited by this script.
 			</description>
 		</method>
+		<method name="get_global_class_name" qualifiers="const">
+			<return type="StringName" />
+			<description>
+				Returns the script's global class name.
+			</description>
+		</method>
 		<method name="get_instance_base_type" qualifiers="const">
 			<return type="StringName" />
 			<description>


### PR DESCRIPTION
Added `StringName ScriptServer::get_global_class_name(StringName script_path)`
Added `StringName Object::get_script_class_name()`
Added `StringName Script::get_global_class_name()`
Changed `*::is_class()` to check Script Class Names as well. (Supports Script Inheritance)

Fixes: https://github.com/godotengine/godot/issues/21789
Might Fix: https://github.com/godotengine/godot-proposals/issues/4708

Test Project: [ClassNameTest.zip](https://github.com/godotengine/godot/files/8948213/ClassNameTest.zip)
