### PR TITLE
Fix mouse position in sub-viewports

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1152,7 +1152,11 @@ Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {
 }
 
 Vector2 Viewport::get_mouse_position() const {
-	return gui.last_mouse_pos;
+	Vector2 window_offset;
+	if (get_parent() && get_parent()->has_method(SNAME("get_global_position"))) {
+		window_offset = get_parent()->call(SNAME("get_global_position"));
+	}
+	return (get_final_transform().affine_inverse()).xform(Input::get_singleton()->get_mouse_position() - window_offset);
 }
 
 void Viewport::warp_mouse(const Vector2 &p_position) {


### PR DESCRIPTION
Fixes #60390

As I was debugging the issue, I discovered that the problem lies in Viewport's method to get mouse position:
https://github.com/godotengine/godot/blob/b5f20a49a16d23e6f9f9f349087af5620ed64cd3/scene/main/viewport.cpp#L1100-L1102
It's returning the last recorded mouse position. The problem is that sub-viewports (or at least the 2D editor viewport) never updates this value, so it was always returning (0, 0).

This was originally changed in:
https://github.com/godotengine/godot/commit/c7b4dcae2f3b75ad7146e36f196893731f403144
Not sure why. I copied the previous code and it fixes the issue.