### PR TITLE
added alert install libvulkan or vulkan apis [linux]

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -4320,6 +4320,7 @@ DisplayServer *DisplayServerX11::create_func(const String &p_rendering_driver, W
 	DisplayServer *ds = memnew(DisplayServerX11(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_resolution, r_error));
 	if (r_error != OK) {
 		OS::get_singleton()->alert("Your video card driver does not support any of the supported Vulkan or OpenGL versions.\n"
+								   "Can't find vulkan drivers, Please install vulkan api or libvulkan for your platform.\n"
 								   "Please update your drivers or if you have a very old or integrated GPU, upgrade it.\n"
 								   "If you have updated your graphics drivers recently, try rebooting.",
 				"Unable to initialize Video driver");


### PR DESCRIPTION
Installed opensuse tumbleweed and it was showing that vulkan not supported but it does. Then I installed libvulkan-intel, libvulkan-32 and the issue get fixed. So for anyone else getting these errors can read on the dialog and install the vulkan apis or drivers. In this PR I added one line about vulkan drivers in the alerts.