### PR TITLE
Disable thread-unsafe EditorProgress for navmesh baking

### DIFF
--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -631,6 +631,13 @@ void NavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node)
 
 #ifdef TOOLS_ENABLED
 	EditorProgress *ep(nullptr);
+	// FIXME
+#endif
+#if 0
+	// After discussion on devchat disabled EditorProgress for now as it is not thread-safe and uses hacks and Main::iteration() for steps.
+	// EditorProgress randomly crashes the Engine when the bake function is used with a thread e.g. inside Editor with a tool script and procedural navigation
+	// This was not a problem in older versions as previously Godot was unable to (re)bake NavigationMesh at runtime.
+	// If EditorProgress is fixed and made thread-safe this should be enabled again.
 	if (Engine::get_singleton()->is_editor_hint()) {
 		ep = memnew(EditorProgress("bake", TTR("Navigation Mesh Generator Setup:"), 11));
 	}


### PR DESCRIPTION
As discussed in devchat disables navmesh baking EditorProgress for now until EditorProgress is reworked to be thread-safe.

Fixes #57815 and other random reported navmesh baking crashes when using threads and a tool build.

EditorProgress is currently not thread-safe and uses hacks and Main::iteration() for steps() which can result in random crashes when baking navmesh on a thread (which is enabled by default). Should be enabled again when EditorProgress is fixed so left a FIXME note.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
