### PR TITLE
Update android:targetSdkVersion from 30 to 31

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -245,7 +245,7 @@ static const char *APK_ASSETS_DIRECTORY = "res://android/build/assets";
 static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPacks/installTime/src/main/assets";
 
 static const int DEFAULT_MIN_SDK_VERSION = 19; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
-static const int DEFAULT_TARGET_SDK_VERSION = 30; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
+static const int DEFAULT_TARGET_SDK_VERSION = 31; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 const String SDK_VERSION_RANGE = vformat("%s,%s,1", DEFAULT_MIN_SDK_VERSION, DEFAULT_TARGET_SDK_VERSION);
 
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -59,6 +59,7 @@
             android:theme="@style/GodotAppSplashTheme"
             android:launchMode="singleTask"
             android:excludeFromRecents="false"
+            android:exported="true"
             android:screenOrientation="landscape"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:resizeableActivity="false"

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -2,7 +2,7 @@ ext.versions = [
     androidGradlePlugin: '7.0.3',
     compileSdk         : 31,
     minSdk             : 19, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
-    targetSdk          : 30, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
+    targetSdk          : 31, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '30.0.3',
     kotlinVersion      : '1.6.21',
     fragmentVersion    : '1.3.6',

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
             android:process=":GodotEditor"
             android:launchMode="singleTask"
             android:screenOrientation="userLandscape"
+            android:exported="false"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
             <layout android:defaultHeight="@dimen/editor_default_window_height"
                 android:defaultWidth="@dimen/editor_default_window_width" />
@@ -60,6 +61,7 @@
             android:label="@string/godot_project_name_string"
             android:process=":GodotGame"
             android:launchMode="singleTask"
+            android:exported="false"
             android:screenOrientation="userLandscape"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
             <layout android:defaultHeight="@dimen/editor_default_window_height"

--- a/platform/android/java/lib/AndroidManifest.xml
+++ b/platform/android/java/lib/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="1.0">
 
     <!-- Should match the mindSdk and targetSdk values in platform/android/java/app/config.gradle -->
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
+    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="31" />
 
     <application>
 


### PR DESCRIPTION
Starting in August 2022, new apps will need to target API level 31 (Android 12) or higher and adjust for behavioral changes.

Read more here: https://developer.android.com/google/play/requirements/target-sdk

This change should be easily cherry-picked for `3.x` and maybe release on `3.5` before release the stable version.

Btw this is my first PR on Godot 😁, if i need to do other thing that i don't know to this be merged please let me know.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
