### PR TITLE
Add NavigationServer map_force_update() function

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -133,6 +133,16 @@
 				Create a new map.
 			</description>
 		</method>
+		<method name="map_force_update">
+			<return type="void" />
+			<argument index="0" name="map" type="RID" />
+			<description>
+				This function immediately forces synchronization of the specified navigation [code]map[/code] [RID]. By default navigation maps are only synchronized at the end of each physics frame. This function can be used to immediately (re)calculate all the navigation meshes and region connections of the navigation map. This makes it possible to query a navigation path for a changed map immediately and in the same frame (multiple times if needed).
+				Due to technical restrictions the current NavigationServer command queue will be flushed. This means all already queued update commands for this physics frame will be executed, even those intended for other maps, regions and agents not part of the specified map. The expensive computation of the navigation meshes and region connections of a map will only be done for the specified map. Other maps will receive the normal synchronization at the end of the physics frame. Should the specified map receive changes after the forced update it will update again as well when the other maps receive their update.
+				Avoidance processing and dispatch of the [code]safe_velocity[/code] signals is untouched by this function and continues to happen for all maps and agents at the end of the physics frame.
+				[b]Note:[/b] With great power comes great responsibility. This function should only be used by users that really know what they are doing and have a good reason for it. Forcing an immediate update of a navigation map requires locking the NavigationServer and flushing the entire NavigationServer command queue. Not only can this severely impact the performance of a game but it can also introduce bugs if used inappropriately without much foresight.
+			</description>
+		</method>
 		<method name="map_get_agents" qualifiers="const">
 			<return type="Array" />
 			<argument index="0" name="map" type="RID" />

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -133,6 +133,16 @@
 				Create a new map.
 			</description>
 		</method>
+		<method name="map_force_update">
+			<return type="void" />
+			<argument index="0" name="map" type="RID" />
+			<description>
+				This function immediately forces synchronization of the specified navigation [code]map[/code] [RID]. By default navigation maps are only synchronized at the end of each physics frame. This function can be used to immediately (re)calculate all the navigation meshes and region connections of the navigation map. This makes it possible to query a navigation path for a changed map immediately and in the same frame (multiple times if needed).
+				Due to technical restrictions the current NavigationServer command queue will be flushed. This means all already queued update commands for this physics frame will be executed, even those intended for other maps, regions and agents not part of the specified map. The expensive computation of the navigation meshes and region connections of a map will only be done for the specified map. Other maps will receive the normal synchronization at the end of the physics frame. Should the specified map receive changes after the forced update it will update again as well when the other maps receive their update.
+				Avoidance processing and dispatch of the [code]safe_velocity[/code] signals is untouched by this function and continues to happen for all maps and agents at the end of the physics frame.
+				[b]Note:[/b] With great power comes great responsibility. This function should only be used by users that really know what they are doing and have a good reason for it. Forcing an immediate update of a navigation map requires locking the NavigationServer and flushing the entire NavigationServer command queue. Not only can this severely impact the performance of a game but it can also introduce bugs if used inappropriately without much foresight.
+			</description>
+		</method>
 		<method name="map_get_agents" qualifiers="const">
 			<return type="Array" />
 			<argument index="0" name="map" type="RID" />

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -580,6 +580,15 @@ void GodotNavigationServer::flush_queries() {
 	commands.clear();
 }
 
+void GodotNavigationServer::map_force_update(RID p_map) {
+	NavMap *map = map_owner.get_or_null(p_map);
+	ERR_FAIL_COND(map == nullptr);
+
+	flush_queries();
+
+	map->sync();
+}
+
 void GodotNavigationServer::process(real_t p_delta_time) {
 	flush_queries();
 

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -108,6 +108,8 @@ public:
 	virtual Array map_get_regions(RID p_map) const override;
 	virtual Array map_get_agents(RID p_map) const override;
 
+	virtual void map_force_update(RID p_map) override;
+
 	virtual RID region_create() const override;
 
 	COMMAND_2(region_set_enter_cost, RID, p_region, real_t, p_enter_cost);

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -173,6 +173,8 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_get_regions", "map"), &NavigationServer2D::map_get_regions);
 	ClassDB::bind_method(D_METHOD("map_get_agents", "map"), &NavigationServer2D::map_get_agents);
 
+	ClassDB::bind_method(D_METHOD("map_force_update", "map"), &NavigationServer2D::map_force_update);
+
 	ClassDB::bind_method(D_METHOD("region_create"), &NavigationServer2D::region_create);
 	ClassDB::bind_method(D_METHOD("region_set_enter_cost", "region", "enter_cost"), &NavigationServer2D::region_set_enter_cost);
 	ClassDB::bind_method(D_METHOD("region_get_enter_cost", "region"), &NavigationServer2D::region_get_enter_cost);
@@ -230,6 +232,10 @@ RID FORWARD_0_C(map_create);
 void FORWARD_2_C(map_set_active, RID, p_map, bool, p_active, rid_to_rid, bool_to_bool);
 
 bool FORWARD_1_C(map_is_active, RID, p_map, rid_to_rid);
+
+void NavigationServer2D::map_force_update(RID p_map) {
+	NavigationServer3D::get_singleton_mut()->map_force_update(p_map);
+}
 
 void FORWARD_2_C(map_set_cell_size, RID, p_map, real_t, p_cell_size, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(map_get_cell_size, RID, p_map, rid_to_rid);

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -83,6 +83,8 @@ public:
 	virtual Array map_get_regions(RID p_map) const;
 	virtual Array map_get_agents(RID p_map) const;
 
+	virtual void map_force_update(RID p_map);
+
 	/// Creates a new region.
 	virtual RID region_create() const;
 

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -51,6 +51,8 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_get_regions", "map"), &NavigationServer3D::map_get_regions);
 	ClassDB::bind_method(D_METHOD("map_get_agents", "map"), &NavigationServer3D::map_get_agents);
 
+	ClassDB::bind_method(D_METHOD("map_force_update", "map"), &NavigationServer3D::map_force_update);
+
 	ClassDB::bind_method(D_METHOD("region_create"), &NavigationServer3D::region_create);
 	ClassDB::bind_method(D_METHOD("region_set_enter_cost", "region", "enter_cost"), &NavigationServer3D::region_set_enter_cost);
 	ClassDB::bind_method(D_METHOD("region_get_enter_cost", "region"), &NavigationServer3D::region_get_enter_cost);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -94,6 +94,8 @@ public:
 	virtual Array map_get_regions(RID p_map) const = 0;
 	virtual Array map_get_agents(RID p_map) const = 0;
 
+	virtual void map_force_update(RID p_map) = 0;
+
 	/// Creates a new region.
 	virtual RID region_create() const = 0;
 


### PR DESCRIPTION
Adds `map_force_update()` function to `NavigationServer`. This function immediately flushes the Navigationserver command queue and recalculates all navigationmeshes and region connections for a single, specific map.

If used appropriately can be a very powerful tool to do crazy stuff with procedual navigation and path queries but can also cause a lot of misery for ppl that just want to use it because they do not like to wait for something without understanding the impact so I hope the warning is clear enough.

Can be used to make situations like in #57815  and #57022 or any situations where users want to do procedual levels more controllable. Sometimes it is very inconvenient to wait for a full physics frame to make (correct) path queries, e.g. if you use one map on the NavigationServer for AI queries and want to check this map under multiple different region constellations all in the same frame.

Actually the real bug potential of this function for now is very little. I just added some drama to get the warning across. It would create just more lag when a long command queue is updated by accident and some regions and avoidance agents would surprisingly be already placed on the new update map. Since everything would still process normally in the synchronisation phase nothing would break without recovering. With already disabled dirty flags on the updated objects it would also do no double processing if not required e.g. because other change commands were send later.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
