### PR TITLE
[3.x] Synchronous shaders in editor

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -34,6 +34,7 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "core/threaded_callable_queue.h"
+#include "main/main.h"
 #include "rasterizer_canvas_gles3.h"
 #include "rasterizer_scene_gles3.h"
 #include "servers/visual_server.h"
@@ -8098,7 +8099,10 @@ void RasterizerStorageGLES3::initialize() {
 	config.parallel_shader_compile_supported = config.extensions.has("GL_KHR_parallel_shader_compile") || config.extensions.has("GL_ARB_parallel_shader_compile");
 #endif
 
-	const int compilation_mode = ProjectSettings::get_singleton()->get("rendering/gles3/shaders/shader_compilation_mode");
+	int compilation_mode = 0;
+	if (!(Engine::get_singleton()->is_editor_hint() || Main::is_project_manager())) {
+		compilation_mode = ProjectSettings::get_singleton()->get("rendering/gles3/shaders/shader_compilation_mode");
+	}
 	config.async_compilation_enabled = compilation_mode >= 1;
 	config.shader_cache_enabled = compilation_mode == 2;
 


### PR DESCRIPTION
The old style synchronous shaders allow the project manager and editor to load faster.

Fixes #62244

## Notes
Based on discussions with @akien-mga there seem to be some pros and cons for defaulting asynchronous shaders in the editor which occurred in #61995 :

* pros: enables finding async shader compilation bugs in the editor faster
* cons: on some systems, seems to significantly slow down the editor / project manager, even with caching. Additionally, if there are problems compiling async shaders with some drivers, it could mean the editor not working at all (e.g. #62203 )

In particular it doesn't seem as though compiling all the shaders in a project ahead of time is advantageous in the editor. You may only be editing certain scenes, and the editor startup time is crucial to keep as low as possible for devs.

Some options (not exhaustive):

* Do nothing (deal with the decreased editor performance)
* Fix the performance to be as good as before
* Disable async in the editor / project manager (easy for users, but means no feedback on async shader compilation issues)
* Add a separate editor setting to enable / disable async in the editor, rather than using the project setting (if this defaulted to async, we would still get feedback, but most people's editor would run slower)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
