### PR TITLE
makerst: Fix file name not appearing in error message

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -913,9 +913,9 @@ def format_codeblock(code_type, post_text, indent_level, state):  # types: str, 
 
         if to_skip > indent_level:
             print_error(
-                "{}.xml: Four spaces should be used for indentation within ["
-                + code_type
-                + "].".format(state.current_class),
+                "{}.xml: Four spaces should be used for indentation within [{}].".format(
+                    state.current_class, code_type
+                ),
                 state,
             )
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/61920 (it's not a regression from that PR though).

### Before

```
ERROR: {}.xml: Four spaces should be used for indentation within [codeblock].
1 error was found in the class reference XML. Please check the messages above.
```

### After

```
ERROR: MovieWriter.xml: Four spaces should be used for indentation within [codeblock].
1 error was found in the class reference XML. Please check the messages above.
```