### PR TITLE
Rename String.is_empty() to String.is_empty_string()

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -95,7 +95,7 @@ Dictionary Engine::get_version_info() const {
 	dict["year"] = VERSION_YEAR;
 
 	String hash = String(VERSION_HASH);
-	dict["hash"] = hash.is_empty() ? String("unknown") : hash;
+	dict["hash"] = hash.is_empty_string() ? String("unknown") : hash;
 
 	String stringver = String(dict["major"]) + "." + String(dict["minor"]);
 	if ((int)dict["patch"] != 0) {

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -65,7 +65,7 @@ String ProjectSettings::get_resource_path() const {
 
 String ProjectSettings::get_safe_project_name() const {
 	String safe_name = OS::get_singleton()->get_safe_dir_name(get("application/config/name"));
-	if (safe_name.is_empty()) {
+	if (safe_name.is_empty_string()) {
 		safe_name = "UnnamedProject";
 	}
 	return safe_name;
@@ -139,7 +139,7 @@ const PackedStringArray ProjectSettings::_trim_to_supported_features(const Packe
 }
 
 String ProjectSettings::localize_path(const String &p_path) const {
-	if (resource_path.is_empty() || p_path.begins_with("res://") || p_path.begins_with("user://") ||
+	if (resource_path.is_empty_string() || p_path.begins_with("res://") || p_path.begins_with("user://") ||
 			(p_path.is_absolute_path() && !p_path.begins_with(resource_path))) {
 		return p_path.simplify_path();
 	}
@@ -178,7 +178,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 		String parent = path.substr(0, sep);
 
 		String plocal = localize_path(parent);
-		if (plocal.is_empty()) {
+		if (plocal.is_empty_string()) {
 			return "";
 		}
 		// Only strip the starting '/' from 'path' if its parent ('plocal') ends with '/'
@@ -227,13 +227,13 @@ bool ProjectSettings::get_ignore_value_in_docs(const String &p_name) const {
 
 String ProjectSettings::globalize_path(const String &p_path) const {
 	if (p_path.begins_with("res://")) {
-		if (!resource_path.is_empty()) {
+		if (!resource_path.is_empty_string()) {
 			return p_path.replace("res:/", resource_path);
 		}
 		return p_path.replace("res://", "");
 	} else if (p_path.begins_with("user://")) {
 		String data_dir = OS::get_singleton()->get_user_data_dir();
-		if (!data_dir.is_empty()) {
+		if (!data_dir.is_empty_string()) {
 			return p_path.replace("user:/", data_dir);
 		}
 		return p_path.replace("user://", "");
@@ -455,7 +455,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 
 	// Attempt with a user-defined main pack first
 
-	if (!p_main_pack.is_empty()) {
+	if (!p_main_pack.is_empty_string()) {
 		bool ok = _load_resource_pack(p_main_pack);
 		ERR_FAIL_COND_V_MSG(!ok, ERR_CANT_OPEN, "Cannot open resource pack '" + p_main_pack + "'.");
 
@@ -470,7 +470,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 
 	String exec_path = OS::get_singleton()->get_executable_path();
 
-	if (!exec_path.is_empty()) {
+	if (!exec_path.is_empty_string()) {
 		// We do several tests sequentially until one succeeds to find a PCK,
 		// and if so, we attempt loading it at the end.
 
@@ -522,11 +522,11 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 	// Try to use the filesystem for files, according to OS.
 	// (Only Android -when reading from pck- and iOS use this.)
 
-	if (!OS::get_singleton()->get_resource_dir().is_empty()) {
+	if (!OS::get_singleton()->get_resource_dir().is_empty_string()) {
 		// OS will call ProjectSettings->get_resource_path which will be empty if not overridden!
 		// If the OS would rather use a specific location, then it will not be empty.
 		resource_path = OS::get_singleton()->get_resource_dir().replace("\\", "/");
-		if (!resource_path.is_empty() && resource_path[resource_path.length() - 1] == '/') {
+		if (!resource_path.is_empty_string() && resource_path[resource_path.length() - 1] == '/') {
 			resource_path = resource_path.substr(0, resource_path.length() - 1); // Chop end.
 		}
 
@@ -588,7 +588,7 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 	Error err = _setup(p_path, p_main_pack, p_upwards, p_ignore_override);
 	if (err == OK) {
 		String custom_settings = GLOBAL_DEF("application/config/project_settings_override", "");
-		if (!custom_settings.is_empty()) {
+		if (!custom_settings.is_empty_string()) {
 			_load_settings_text(custom_settings);
 		}
 	}
@@ -687,18 +687,18 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 		}
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Error parsing " + p_path + " at line " + itos(lines) + ": " + error_text + " File might be corrupted.");
 
-		if (!assign.is_empty()) {
-			if (section.is_empty() && assign == "config_version") {
+		if (!assign.is_empty_string()) {
+			if (section.is_empty_string() && assign == "config_version") {
 				config_version = value;
 				ERR_FAIL_COND_V_MSG(config_version > CONFIG_VERSION, ERR_FILE_CANT_OPEN, vformat("Can't open project at '%s', its `config_version` (%d) is from a more recent and incompatible version of the engine. Expected config version: %d.", p_path, config_version, CONFIG_VERSION));
 			} else {
-				if (section.is_empty()) {
+				if (section.is_empty_string()) {
 					set(assign, value);
 				} else {
 					set(section + "/" + assign, value);
 				}
 			}
-		} else if (!next_tag.name.is_empty()) {
+		} else if (!next_tag.name.is_empty_string()) {
 			section = next_tag.name;
 		}
 	}
@@ -782,7 +782,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<S
 		count += E.value.size();
 	}
 
-	if (!p_custom_features.is_empty()) {
+	if (!p_custom_features.is_empty_string()) {
 		file->store_32(count + 1);
 		//store how many properties are saved, add one for custom featuers, which must always go first
 		String key = CoreStringNames::get_singleton()->_custom_features;
@@ -807,7 +807,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<S
 	for (const KeyValue<String, List<String>> &E : props) {
 		for (const String &key : E.value) {
 			String k = key;
-			if (!E.key.is_empty()) {
+			if (!E.key.is_empty_string()) {
 				k = E.key + "/" + k;
 			}
 			Variant value;
@@ -852,7 +852,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const RBMap<Str
 	file->store_line("");
 
 	file->store_string("config_version=" + itos(CONFIG_VERSION) + "\n");
-	if (!p_custom_features.is_empty()) {
+	if (!p_custom_features.is_empty_string()) {
 		file->store_string("custom_features=\"" + p_custom_features + "\"\n");
 	}
 	file->store_string("\n");
@@ -862,12 +862,12 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const RBMap<Str
 			file->store_string("\n");
 		}
 
-		if (!E.key.is_empty()) {
+		if (!E.key.is_empty_string()) {
 			file->store_string("[" + E.key + "]\n\n");
 		}
 		for (const String &F : E.value) {
 			String key = F;
-			if (!E.key.is_empty()) {
+			if (!E.key.is_empty_string()) {
 				key = E.key + "/" + key;
 			}
 			Variant value;
@@ -892,7 +892,7 @@ Error ProjectSettings::_save_custom_bnd(const String &p_file) { // add other par
 }
 
 Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_custom, const Vector<String> &p_custom_features, bool p_merge_with_current) {
-	ERR_FAIL_COND_V_MSG(p_path.is_empty(), ERR_INVALID_PARAMETER, "Project settings save path cannot be empty.");
+	ERR_FAIL_COND_V_MSG(p_path.is_empty_string(), ERR_INVALID_PARAMETER, "Project settings save path cannot be empty.");
 
 	PackedStringArray project_features = get_setting("application/config/features");
 	// If there is no feature list currently present, force one to generate.
@@ -901,7 +901,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 	}
 	// Check the rendering API.
 	const String rendering_api = has_setting("rendering/quality/driver/driver_name") ? (String)get_setting("rendering/quality/driver/driver_name") : String();
-	if (!rendering_api.is_empty()) {
+	if (!rendering_api.is_empty_string()) {
 		// Add the rendering API as a project feature if it doesn't already exist.
 		if (!project_features.has(rendering_api)) {
 			project_features.append(rendering_api);

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1473,7 +1473,7 @@ String Directory::get_next() {
 	ERR_FAIL_COND_V_MSG(!is_open(), "", "Directory must be opened before use.");
 
 	String next = d->get_next();
-	while (!next.is_empty() && ((!include_navigational && (next == "." || next == "..")) || (!include_hidden && d->current_is_hidden()))) {
+	while (!next.is_empty_string() && ((!include_navigational && (next == "." || next == "..")) || (!include_hidden && d->current_is_hidden()))) {
 		next = d->get_next();
 	}
 	return next;
@@ -1503,7 +1503,7 @@ PackedStringArray Directory::_get_contents(bool p_directories) {
 
 	list_dir_begin();
 	String s = get_next();
-	while (!s.is_empty()) {
+	while (!s.is_empty_string()) {
 		if (current_is_dir() == p_directories) {
 			ret.append(s);
 		}
@@ -1608,7 +1608,7 @@ Error Directory::copy(String p_from, String p_to) {
 
 Error Directory::rename(String p_from, String p_to) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
-	ERR_FAIL_COND_V_MSG(p_from.is_empty() || p_from == "." || p_from == "..", ERR_INVALID_PARAMETER, "Invalid path to rename.");
+	ERR_FAIL_COND_V_MSG(p_from.is_empty_string() || p_from == "." || p_from == "..", ERR_INVALID_PARAMETER, "Invalid path to rename.");
 
 	if (!p_from.is_relative_path()) {
 		Ref<DirAccess> da = DirAccess::create_for_path(p_from);
@@ -1686,7 +1686,7 @@ String Marshalls::variant_to_base64(const Variant &p_var, bool p_full_objects) {
 	ERR_FAIL_COND_V_MSG(err != OK, "", "Error when trying to encode Variant.");
 
 	String ret = CryptoCore::b64_encode_str(&w[0], len);
-	ERR_FAIL_COND_V(ret.is_empty(), ret);
+	ERR_FAIL_COND_V(ret.is_empty_string(), ret);
 
 	return ret;
 }
@@ -1711,7 +1711,7 @@ Variant Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects) 
 
 String Marshalls::raw_to_base64(const Vector<uint8_t> &p_arr) {
 	String ret = CryptoCore::b64_encode_str(p_arr.ptr(), p_arr.size());
-	ERR_FAIL_COND_V(ret.is_empty(), ret);
+	ERR_FAIL_COND_V(ret.is_empty_string(), ret);
 	return ret;
 }
 
@@ -1735,7 +1735,7 @@ Vector<uint8_t> Marshalls::base64_to_raw(const String &p_str) {
 String Marshalls::utf8_to_base64(const String &p_str) {
 	CharString cstr = p_str.utf8();
 	String ret = CryptoCore::b64_encode_str((unsigned char *)cstr.get_data(), cstr.length());
-	ERR_FAIL_COND_V(ret.is_empty(), ret);
+	ERR_FAIL_COND_V(ret.is_empty_string(), ret);
 	return ret;
 }
 

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -135,7 +135,7 @@ void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks,
 
 void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Vector<String> p_breakpoints) {
 	register_uri_handler("tcp://", RemoteDebuggerPeerTCP::create); // TCP is the default protocol. Platforms/modules can add more.
-	if (p_uri.is_empty()) {
+	if (p_uri.is_empty_string()) {
 		return;
 	}
 	if (p_uri == "local://") {

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -116,7 +116,7 @@ struct LocalDebugger::ScriptsProfiler {
 void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	ScriptLanguage *script_lang = script_debugger->get_break_language();
 
-	if (!target_function.is_empty()) {
+	if (!target_function.is_empty_string()) {
 		String current_function = script_lang->debug_get_stack_level_function(0);
 		if (current_function != target_function) {
 			script_debugger->set_depth(0);
@@ -138,7 +138,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 		// Cache options
 		String variable_prefix = options["variable_prefix"];
 
-		if (line.is_empty()) {
+		if (line.is_empty_string()) {
 			print_line("\nDebugger Break, Reason: '" + script_lang->debug_get_error() + "'");
 			print_line("*Frame " + itos(current_frame) + " - " + script_lang->debug_get_stack_level_source(current_frame) + ":" + itos(script_lang->debug_get_stack_level_line(current_frame)) + " in function '" + script_lang->debug_get_stack_level_function(current_frame) + "'");
 			print_line("Enter \"help\" for assistance.");
@@ -258,7 +258,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				String source = breakpoint.first;
 				int linenr = breakpoint.second;
 
-				if (source.is_empty()) {
+				if (source.is_empty_string()) {
 					continue;
 				}
 
@@ -284,7 +284,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				String source = breakpoint.first;
 				int linenr = breakpoint.second;
 
-				if (source.is_empty()) {
+				if (source.is_empty_string()) {
 					continue;
 				}
 
@@ -322,7 +322,7 @@ void LocalDebugger::print_variables(const List<String> &names, const List<Varian
 	for (const String &E : names) {
 		value = String(V->get());
 
-		if (variable_prefix.is_empty()) {
+		if (variable_prefix.is_empty_string()) {
 			print_line(E + ": " + String(V->get()));
 		} else {
 			print_line(E + ":");
@@ -358,7 +358,7 @@ void LocalDebugger::send_message(const String &p_message, const Array &p_args) {
 }
 
 void LocalDebugger::send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type) {
-	print_line("ERROR: '" + (p_descr.is_empty() ? p_err : p_descr) + "'");
+	print_line("ERROR: '" + (p_descr.is_empty_string() ? p_err : p_descr) + "'");
 }
 
 LocalDebugger::LocalDebugger() {

--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -33,7 +33,7 @@
 void DocData::return_doc_from_retinfo(DocData::MethodDoc &p_method, const PropertyInfo &p_retinfo) {
 	if (p_retinfo.type == Variant::INT && p_retinfo.hint == PROPERTY_HINT_INT_IS_POINTER) {
 		p_method.return_type = p_retinfo.hint_string;
-		if (p_method.return_type.is_empty()) {
+		if (p_method.return_type.is_empty_string()) {
 			p_method.return_type = "void*";
 		} else {
 			p_method.return_type += "*";
@@ -64,7 +64,7 @@ void DocData::argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const 
 
 	if (p_arginfo.type == Variant::INT && p_arginfo.hint == PROPERTY_HINT_INT_IS_POINTER) {
 		p_argument.type = p_arginfo.hint_string;
-		if (p_argument.type.is_empty()) {
+		if (p_argument.type.is_empty_string()) {
 			p_argument.type = "void*";
 		} else {
 			p_argument.type += "*";

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -40,7 +40,7 @@
 
 static String get_type_name(const PropertyInfo &p_info) {
 	if (p_info.type == Variant::INT && (p_info.hint == PROPERTY_HINT_INT_IS_POINTER)) {
-		if (p_info.hint_string.is_empty()) {
+		if (p_info.hint_string.is_empty_string()) {
 			return "void*";
 		} else {
 			return p_info.hint_string + "*";
@@ -340,7 +340,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 			int64_t value = CoreConstants::get_global_constant_value(i);
 			String enum_name = CoreConstants::get_global_constant_enum(i);
 			String name = CoreConstants::get_global_constant_name(i);
-			if (!enum_name.is_empty()) {
+			if (!enum_name.is_empty_string()) {
 				enum_list[enum_name].push_back(Pair<String, int64_t>(name, value));
 			} else {
 				Dictionary d;

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -427,7 +427,7 @@ Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const St
 		}
 	}
 
-	if (library_path.is_empty()) {
+	if (library_path.is_empty_string()) {
 		if (r_error) {
 			*r_error = ERR_FILE_NOT_FOUND;
 		}

--- a/core/extension/native_extension_manager.cpp
+++ b/core/extension/native_extension_manager.cpp
@@ -115,7 +115,7 @@ void NativeExtensionManager::load_extensions() {
 	Ref<FileAccess> f = FileAccess::open(NativeExtension::get_extension_list_config_file(), FileAccess::READ);
 	while (f.is_valid() && !f->eof_reached()) {
 		String s = f->get_line().strip_edges();
-		if (!s.is_empty()) {
+		if (!s.is_empty_string()) {
 			LoadStatus err = load_extension(s);
 			ERR_CONTINUE_MSG(err == LOAD_STATUS_FAILED, "Error loading extension: " + s);
 		}

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -426,7 +426,7 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, S
 
 	if (p_connected) {
 		String uidname = p_guid;
-		if (p_guid.is_empty()) {
+		if (p_guid.is_empty_string()) {
 			int uidlen = MIN(p_name.length(), 16);
 			for (int i = 0; i < uidlen; i++) {
 				uidname = uidname + _hex_str(p_name[i]);
@@ -1272,7 +1272,7 @@ void Input::parse_mapping(String p_mapping) {
 
 	int idx = 1;
 	while (++idx < entry.size()) {
-		if (entry[idx].is_empty()) {
+		if (entry[idx].is_empty_string()) {
 			continue;
 		}
 
@@ -1443,10 +1443,10 @@ Input::Input() {
 
 	// If defined, parse SDL_GAMECONTROLLERCONFIG for possible new mappings/overrides.
 	String env_mapping = OS::get_singleton()->get_environment("SDL_GAMECONTROLLERCONFIG");
-	if (!env_mapping.is_empty()) {
+	if (!env_mapping.is_empty_string()) {
 		Vector<String> entries = env_mapping.split("\n");
 		for (int i = 0; i < entries.size(); i++) {
-			if (entries[i].is_empty()) {
+			if (entries[i].is_empty_string()) {
 				continue;
 			}
 			parse_mapping(entries[i]);

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -360,12 +360,12 @@ String InputEventKey::as_text() const {
 		kc = keycode_get_string(keycode);
 	}
 
-	if (kc.is_empty()) {
+	if (kc.is_empty_string()) {
 		return kc;
 	}
 
 	String mods_text = InputEventWithModifiers::as_text();
-	return mods_text.is_empty() ? kc : mods_text + "+" + kc;
+	return mods_text.is_empty_string() ? kc : mods_text + "+" + kc;
 }
 
 String InputEventKey::to_string() {
@@ -382,7 +382,7 @@ String InputEventKey::to_string() {
 	}
 
 	String mods = InputEventWithModifiers::as_text();
-	mods = mods.is_empty() ? "none" : mods;
+	mods = mods.is_empty_string() ? "none" : mods;
 
 	return vformat("InputEventKey: keycode=%s, mods=%s, physical=%s, pressed=%s, echo=%s", kc, mods, physical, p, e);
 }
@@ -644,7 +644,7 @@ static const char *_mouse_button_descriptions[9] = {
 String InputEventMouseButton::as_text() const {
 	// Modifiers
 	String mods_text = InputEventWithModifiers::as_text();
-	String full_string = mods_text.is_empty() ? "" : mods_text + "+";
+	String full_string = mods_text.is_empty_string() ? "" : mods_text + "+";
 
 	// Button
 	MouseButton idx = get_button_index();
@@ -697,7 +697,7 @@ String InputEventMouseButton::to_string() {
 	}
 
 	String mods = InputEventWithModifiers::as_text();
-	mods = mods.is_empty() ? "none" : mods;
+	mods = mods.is_empty_string() ? "none" : mods;
 
 	// Work around the fact vformat can only take 5 substitutions but 6 need to be passed.
 	String index_and_mods = vformat("button_index=%s, mods=%s", button_index, mods);

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -704,7 +704,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_featur
 		String name = split[0];
 		String override_for = split.size() > 1 ? split[1] : String();
 
-		if (!override_for.is_empty() && OS::get_singleton()->has_feature(override_for)) {
+		if (!override_for.is_empty_string() && OS::get_singleton()->has_feature(override_for)) {
 			builtins_with_overrides[name].push_back(override_for);
 		}
 	}
@@ -716,12 +716,12 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_featur
 		String name = split[0];
 		String override_for = split.size() > 1 ? split[1] : String();
 
-		if (builtins_with_overrides.has(name) && override_for.is_empty()) {
+		if (builtins_with_overrides.has(name) && override_for.is_empty_string()) {
 			// Builtin has an override but this particular one is not an override, so skip.
 			continue;
 		}
 
-		if (!override_for.is_empty() && !OS::get_singleton()->has_feature(override_for)) {
+		if (!override_for.is_empty_string() && !OS::get_singleton()->has_feature(override_for)) {
 			// OS does not support this override - skip.
 			continue;
 		}

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -73,7 +73,7 @@ void ConfigFile::set_value(const String &p_section, const String &p_key, const V
 	} else {
 		if (!values.has(p_section)) {
 			// Insert section-less keys at the beginning.
-			values.insert(p_section, HashMap<String, Variant>(), p_section.is_empty());
+			values.insert(p_section, HashMap<String, Variant>(), p_section.is_empty_string());
 		}
 
 		values[p_section][p_key] = p_value;
@@ -184,7 +184,7 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 		} else {
 			file->store_string("\n");
 		}
-		if (!E.key.is_empty()) {
+		if (!E.key.is_empty_string()) {
 			file->store_string("[" + E.key + "]\n\n");
 		}
 
@@ -282,9 +282,9 @@ Error ConfigFile::_parse(const String &p_path, VariantParser::Stream *p_stream) 
 			return err;
 		}
 
-		if (!assign.is_empty()) {
+		if (!assign.is_empty_string()) {
 			set_value(section, assign, value);
-		} else if (!next_tag.name.is_empty()) {
+		} else if (!next_tag.name.is_empty_string()) {
 			section = next_tag.name;
 		}
 	}

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -79,7 +79,7 @@ static Error _erase_recursive(DirAccess *da) {
 
 	da->list_dir_begin();
 	String n = da->get_next();
-	while (!n.is_empty()) {
+	while (!n.is_empty_string()) {
 		if (n != "." && n != "..") {
 			if (da->current_is_dir()) {
 				dirs.push_back(n);
@@ -187,7 +187,7 @@ String DirAccess::fix_path(String p_path) const {
 			if (ProjectSettings::get_singleton()) {
 				if (p_path.begins_with("res://")) {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-					if (!resource_path.is_empty()) {
+					if (!resource_path.is_empty_string()) {
 						return p_path.replace_first("res:/", resource_path);
 					}
 					return p_path.replace_first("res://", "");
@@ -198,7 +198,7 @@ String DirAccess::fix_path(String p_path) const {
 		case ACCESS_USERDATA: {
 			if (p_path.begins_with("user://")) {
 				String data_dir = OS::get_singleton()->get_user_data_dir();
-				if (!data_dir.is_empty()) {
+				if (!data_dir.is_empty_string()) {
 					return p_path.replace_first("user:/", data_dir);
 				}
 				return p_path.replace_first("user://", "");
@@ -335,7 +335,7 @@ Error DirAccess::_copy_dir(Ref<DirAccess> &p_target_da, String p_to, int p_chmod
 	String curdir = get_current_dir();
 	list_dir_begin();
 	String n = get_next();
-	while (!n.is_empty()) {
+	while (!n.is_empty_string()) {
 		if (n != "." && n != "..") {
 			if (p_copy_links && is_link(get_current_dir().plus_file(n))) {
 				create_link(read_link(get_current_dir().plus_file(n)), p_to + n);

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -125,7 +125,7 @@ String FileAccess::fix_path(const String &p_path) const {
 			if (ProjectSettings::get_singleton()) {
 				if (r_path.begins_with("res://")) {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-					if (!resource_path.is_empty()) {
+					if (!resource_path.is_empty_string()) {
 						return r_path.replace("res:/", resource_path);
 					}
 					return r_path.replace("res://", "");
@@ -136,7 +136,7 @@ String FileAccess::fix_path(const String &p_path) const {
 		case ACCESS_USERDATA: {
 			if (r_path.begins_with("user://")) {
 				String data_dir = OS::get_singleton()->get_user_data_dir();
-				if (!data_dir.is_empty()) {
+				if (!data_dir.is_empty_string()) {
 					return r_path.replace("user:/", data_dir);
 				}
 				return r_path.replace("user://", "");

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -89,7 +89,7 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 		}
 		String filename = p_path.get_file();
 		// Don't add as a file if the path points to a directory
-		if (!filename.is_empty()) {
+		if (!filename.is_empty_string()) {
 			cd->files.insert(filename);
 		}
 	}
@@ -466,7 +466,7 @@ PackedData::PackedDir *DirAccessPack::_find_dir(String p_dir) {
 
 	nd = nd.simplify_path();
 
-	if (nd.is_empty()) {
+	if (nd.is_empty_string()) {
 		nd = ".";
 	}
 

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -99,7 +99,7 @@ String HTTPClient::query_string_from_dict(const Dictionary &p_dict) {
 Error HTTPClient::verify_headers(const Vector<String> &p_headers) {
 	for (int i = 0; i < p_headers.size(); i++) {
 		String sanitized = p_headers[i].strip_edges();
-		ERR_FAIL_COND_V_MSG(sanitized.is_empty(), ERR_INVALID_PARAMETER, "Invalid HTTP header at index " + itos(i) + ": empty.");
+		ERR_FAIL_COND_V_MSG(sanitized.is_empty_string(), ERR_INVALID_PARAMETER, "Invalid HTTP header at index " + itos(i) + ": empty.");
 		ERR_FAIL_COND_V_MSG(sanitized.find(":") < 1, ERR_INVALID_PARAMETER,
 				"Invalid HTTP header at index " + itos(i) + ": String must contain header-value pair, delimited by ':', but was: " + p_headers[i]);
 	}

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -762,7 +762,7 @@ int HTTPClientTCP::get_read_chunk_size() const {
 }
 
 void HTTPClientTCP::set_http_proxy(const String &p_host, int p_port) {
-	if (p_host.is_empty() || p_port == -1) {
+	if (p_host.is_empty_string() || p_port == -1) {
 		http_proxy_host = "";
 		http_proxy_port = -1;
 	} else {
@@ -772,7 +772,7 @@ void HTTPClientTCP::set_http_proxy(const String &p_host, int p_port) {
 }
 
 void HTTPClientTCP::set_https_proxy(const String &p_host, int p_port) {
-	if (p_host.is_empty() || p_port == -1) {
+	if (p_host.is_empty_string() || p_port == -1) {
 		https_proxy_host = "";
 		https_proxy_port = -1;
 	} else {

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -244,7 +244,7 @@ void IP::erase_resolve_item(ResolverID p_id) {
 void IP::clear_cache(const String &p_hostname) {
 	MutexLock lock(resolver->mutex);
 
-	if (p_hostname.is_empty()) {
+	if (p_hostname.is_empty_string()) {
 		resolver->cache.clear();
 	} else {
 		resolver->cache.erase(_IP_ResolverPrivate::get_cache_key(p_hostname, IP::TYPE_NONE));

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -47,7 +47,7 @@ const char *JSON::tk_name[TK_MAX] = {
 
 String JSON::_make_indent(const String &p_indent, int p_size) {
 	String indent_text = "";
-	if (!p_indent.is_empty()) {
+	if (!p_indent.is_empty_string()) {
 		for (int i = 0; i < p_size; i++) {
 			indent_text += p_indent;
 		}
@@ -59,7 +59,7 @@ String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_
 	String colon = ":";
 	String end_statement = "";
 
-	if (!p_indent.is_empty()) {
+	if (!p_indent.is_empty_string()) {
 		colon += " ";
 		end_statement += "\n";
 	}

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -129,7 +129,7 @@ void RotatedFileLogger::clear_old_backups() {
 	da->list_dir_begin();
 	String f = da->get_next();
 	HashSet<String> backups;
-	while (!f.is_empty()) {
+	while (!f.is_empty_string()) {
 		if (!da->current_is_dir() && f.begins_with(basename) && f.get_extension() == extension && f != base_path.get_file()) {
 			backups.insert(f);
 		}
@@ -154,7 +154,7 @@ void RotatedFileLogger::rotate_file() {
 		if (max_files > 1) {
 			String timestamp = Time::get_singleton()->get_datetime_string_from_system().replace(":", ".");
 			String backup_name = base_path.get_basename() + timestamp;
-			if (!base_path.get_extension().is_empty()) {
+			if (!base_path.get_extension().is_empty_string()) {
 				backup_name += "." + base_path.get_extension();
 			}
 

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -562,7 +562,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 					return err;
 				}
 
-				if (str.is_empty()) {
+				if (str.is_empty_string()) {
 					r_variant = (Object *)nullptr;
 				} else {
 					Object *obj = ClassDB::instantiate(str);

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -53,7 +53,7 @@ void PCKPacker::_bind_methods() {
 }
 
 Error PCKPacker::pck_start(const String &p_file, int p_alignment, const String &p_key, bool p_encrypt_directory) {
-	ERR_FAIL_COND_V_MSG((p_key.is_empty() || !p_key.is_valid_hex_number(false) || p_key.length() != 64), ERR_CANT_CREATE, "Invalid Encryption Key (must be 64 characters long).");
+	ERR_FAIL_COND_V_MSG((p_key.is_empty_string() || !p_key.is_valid_hex_number(false) || p_key.length() != 64), ERR_CANT_CREATE, "Invalid Encryption Key (must be 64 characters long).");
 	ERR_FAIL_COND_V_MSG(p_alignment <= 0, ERR_CANT_CREATE, "Invalid alignment, must be greater then 0.");
 
 	String _key = p_key.to_lower();

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -52,7 +52,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 		return;
 	}
 
-	if (!path_cache.is_empty()) {
+	if (!path_cache.is_empty_string()) {
 		ResourceCache::lock.write_lock();
 		ResourceCache::resources.erase(path_cache);
 		ResourceCache::lock.write_unlock();
@@ -82,7 +82,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 	}
 	path_cache = p_path;
 
-	if (!path_cache.is_empty()) {
+	if (!path_cache.is_empty_string()) {
 		ResourceCache::lock.write_lock();
 		ResourceCache::resources[path_cache] = this;
 		ResourceCache::lock.write_unlock();
@@ -398,7 +398,7 @@ bool Resource::is_translation_remapped() const {
 #ifdef TOOLS_ENABLED
 //helps keep IDs same number when loading/saving scenes. -1 clears ID and it Returns -1 when no id stored
 void Resource::set_id_for_path(const String &p_path, const String &p_id) {
-	if (p_id.is_empty()) {
+	if (p_id.is_empty_string()) {
 		ResourceCache::path_cache_lock.write_lock();
 		ResourceCache::resource_path_cache[p_path].erase(get_path());
 		ResourceCache::path_cache_lock.write_unlock();
@@ -454,7 +454,7 @@ Resource::Resource() :
 		remapped_list(this) {}
 
 Resource::~Resource() {
-	if (!path_cache.is_empty()) {
+	if (!path_cache.is_empty_string()) {
 		ResourceCache::lock.write_lock();
 		ResourceCache::resources.erase(path_cache);
 		ResourceCache::lock.write_unlock();

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -104,7 +104,7 @@ public:
 
 	virtual void set_path(const String &p_path, bool p_take_over = false);
 	String get_path() const;
-	_FORCE_INLINE_ bool is_built_in() const { return path_cache.is_empty() || path_cache.contains("::") || path_cache.begins_with("local://"); }
+	_FORCE_INLINE_ bool is_built_in() const { return path_cache.is_empty_string() || path_cache.contains("::") || path_cache.begins_with("local://"); }
 
 	static String generate_scene_unique_id();
 	void set_scene_unique_id(const String &p_id);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -752,7 +752,7 @@ Error ResourceLoaderBinary::load() {
 			}
 
 			res = Ref<Resource>(r);
-			if (!path.is_empty() && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
+			if (!path.is_empty_string() && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 				r->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE); //if got here because the resource with same path has different type, replace it
 			}
 			r->set_scene_unique_id(id);
@@ -879,7 +879,7 @@ void ResourceLoaderBinary::get_dependencies(Ref<FileAccess> p_f, List<String> *p
 			dep = external_resources[i].path;
 		}
 
-		if (p_add_types && !external_resources[i].type.is_empty()) {
+		if (p_add_types && !external_resources[i].type.is_empty_string()) {
 			dep += "::" + external_resources[i].type;
 		}
 
@@ -1071,7 +1071,7 @@ Ref<Resource> ResourceFormatLoaderBinary::load(const String &p_path, const Strin
 	loader.cache_mode = p_cache_mode;
 	loader.use_sub_threads = p_use_sub_threads;
 	loader.progress = r_progress;
-	String path = !p_original_path.is_empty() ? p_original_path : p_path;
+	String path = !p_original_path.is_empty_string() ? p_original_path : p_path;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(path);
 	loader.res_path = loader.local_path;
 	loader.open(f);
@@ -1089,7 +1089,7 @@ Ref<Resource> ResourceFormatLoaderBinary::load(const String &p_path, const Strin
 }
 
 void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
-	if (p_type.is_empty()) {
+	if (p_type.is_empty_string()) {
 		get_recognized_extensions(p_extensions);
 		return;
 	}
@@ -2027,7 +2027,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 
 	for (Ref<Resource> &r : saved_resources) {
 		if (r->is_built_in()) {
-			if (!r->get_scene_unique_id().is_empty()) {
+			if (!r->get_scene_unique_id().is_empty_string()) {
 				if (used_unique_ids.has(r->get_scene_unique_id())) {
 					r->set_scene_unique_id("");
 				} else {
@@ -2041,7 +2041,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	int res_index = 0;
 	for (Ref<Resource> &r : saved_resources) {
 		if (r->is_built_in()) {
-			if (r->get_scene_unique_id().is_empty()) {
+			if (r->get_scene_unique_id().is_empty_string()) {
 				String new_id;
 
 				while (true) {

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -76,8 +76,8 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 			return err;
 		}
 
-		if (!assign.is_empty()) {
-			if (!path_found && assign.begins_with("path.") && r_path_and_type.path.is_empty()) {
+		if (!assign.is_empty_string()) {
+			if (!path_found && assign.begins_with("path.") && r_path_and_type.path.is_empty_string()) {
 				String feature = assign.get_slicec('.', 1);
 				if (OS::get_singleton()->has_feature(feature)) {
 					r_path_and_type.path = value;
@@ -108,7 +108,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 		}
 	}
 
-	if (r_path_and_type.path.is_empty() || r_path_and_type.type.is_empty()) {
+	if (r_path_and_type.path.is_empty_string() || r_path_and_type.type.is_empty_string()) {
 		return ERR_FILE_CORRUPT;
 	}
 	return OK;
@@ -154,7 +154,7 @@ void ResourceFormatImporter::get_recognized_extensions(List<String> *p_extension
 }
 
 void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
-	if (p_type.is_empty()) {
+	if (p_type.is_empty_string()) {
 		get_recognized_extensions(p_extensions);
 		return;
 	}
@@ -163,7 +163,7 @@ void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_
 
 	for (int i = 0; i < importers.size(); i++) {
 		String res_type = importers[i]->get_resource_type();
-		if (res_type.is_empty()) {
+		if (res_type.is_empty_string()) {
 			continue;
 		}
 
@@ -242,7 +242,7 @@ int ResourceFormatImporter::get_import_order(const String &p_path) const {
 bool ResourceFormatImporter::handles_type(const String &p_type) const {
 	for (int i = 0; i < importers.size(); i++) {
 		String res_type = importers[i]->get_resource_type();
-		if (res_type.is_empty()) {
+		if (res_type.is_empty_string()) {
 			continue;
 		}
 		if (ClassDB::is_parent_class(res_type, p_type)) {
@@ -294,7 +294,7 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 			return;
 		}
 
-		if (!assign.is_empty()) {
+		if (!assign.is_empty_string()) {
 			if (assign.begins_with("path.")) {
 				r_paths->push_back(value);
 			} else if (assign == "path") {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -52,7 +52,7 @@ bool ResourceFormatLoader::recognize_path(const String &p_path, const String &p_
 	String extension = p_path.get_extension();
 
 	List<String> extensions;
-	if (p_for_type.is_empty()) {
+	if (p_for_type.is_empty_string()) {
 		get_recognized_extensions(&extensions);
 	} else {
 		get_recognized_extensions_for_type(p_for_type, &extensions);
@@ -96,7 +96,7 @@ ResourceUID::ID ResourceFormatLoader::get_resource_uid(const String &p_path) con
 }
 
 void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
-	if (p_type.is_empty() || handles_type(p_type)) {
+	if (p_type.is_empty_string() || handles_type(p_type)) {
 		get_recognized_extensions(p_extensions);
 	}
 }
@@ -194,7 +194,7 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 			continue;
 		}
 		found = true;
-		Ref<Resource> res = loader[i]->load(p_path, !p_original_path.is_empty() ? p_original_path : p_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
+		Ref<Resource> res = loader[i]->load(p_path, !p_original_path.is_empty_string() ? p_original_path : p_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
 		if (res.is_null()) {
 			continue;
 		}
@@ -289,7 +289,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 
 	thread_load_mutex->lock();
 
-	if (!p_source_resource.is_empty()) {
+	if (!p_source_resource.is_empty_string()) {
 		//must be loading from this resource
 		if (!thread_load_tasks.has(p_source_resource)) {
 			thread_load_mutex->unlock();
@@ -310,7 +310,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 
 	if (thread_load_tasks.has(local_path)) {
 		thread_load_tasks[local_path].requests++;
-		if (!p_source_resource.is_empty()) {
+		if (!p_source_resource.is_empty_string()) {
 			thread_load_tasks[p_source_resource].sub_tasks.insert(local_path);
 		}
 		thread_load_mutex->unlock();
@@ -354,7 +354,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 			ResourceCache::lock.read_unlock();
 		}
 
-		if (!p_source_resource.is_empty()) {
+		if (!p_source_resource.is_empty_string()) {
 			thread_load_tasks[p_source_resource].sub_tasks.insert(local_path);
 		}
 
@@ -574,7 +574,7 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 		bool xl_remapped = false;
 		String path = _path_remap(local_path, &xl_remapped);
 
-		if (path.is_empty()) {
+		if (path.is_empty_string()) {
 			ERR_FAIL_V_MSG(Ref<Resource>(), "Remapping '" + local_path + "' failed.");
 		}
 
@@ -752,7 +752,7 @@ String ResourceLoader::get_resource_type(const String &p_path) {
 
 	for (int i = 0; i < loader_count; i++) {
 		String result = loader[i]->get_resource_type(local_path);
-		if (!result.is_empty()) {
+		if (!result.is_empty_string()) {
 			return result;
 		}
 	}

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -104,7 +104,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 				f->get_buffer(data.ptrw(), str_len);
 				data.write[str_len] = 0;
 
-				if (msg_id.is_empty()) {
+				if (msg_id.is_empty_string()) {
 					config = String::utf8((const char *)data.ptr(), str_len);
 					// Record plural rule.
 					int p_start = config.find("Plural-Forms");
@@ -117,7 +117,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 					Vector<String> plural_msg;
 					for (uint32_t j = 0; j < str_len + 1; j++) {
 						if (data[j] == 0x00) {
-							if (msg_id_plural.is_empty()) {
+							if (msg_id_plural.is_empty_string()) {
 								translation->add_message(msg_id, String::utf8((const char *)(data.ptr() + str_start), j - str_start), msg_context);
 							} else {
 								plural_msg.push_back(String::utf8((const char *)(data.ptr() + str_start), j - str_start));
@@ -168,7 +168,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 			is_eof = f->eof_reached();
 
 			// If we reached last line and it's not a content line, break, otherwise let processing that last loop
-			if (is_eof && l.is_empty()) {
+			if (is_eof && l.is_empty_string()) {
 				if (status == STATUS_READING_ID || status == STATUS_READING_CONTEXT || (status == STATUS_READING_PLURAL && plural_index != plural_forms - 1)) {
 					ERR_FAIL_V_MSG(Ref<Resource>(), "Unexpected EOF while reading PO file at: " + path + ":" + itos(line));
 				} else {
@@ -181,7 +181,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 
 				// In PO file, "msgctxt" appears before "msgid". If we encounter a "msgctxt", we add what we have read
 				// and set "entered_context" to true to prevent adding twice.
-				if (!skip_this && !msg_id.is_empty()) {
+				if (!skip_this && !msg_id.is_empty_string()) {
 					if (status == STATUS_READING_STRING) {
 						translation->add_message(msg_id, msg_str, msg_context);
 					} else if (status == STATUS_READING_PLURAL) {
@@ -211,7 +211,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 			} else if (l.begins_with("msgid")) {
 				ERR_FAIL_COND_V_MSG(status == STATUS_READING_ID, Ref<Resource>(), "Unexpected 'msgid', was expecting 'msgstr' while parsing: " + path + ":" + itos(line));
 
-				if (!msg_id.is_empty()) {
+				if (!msg_id.is_empty_string()) {
 					if (!skip_this && !entered_context) {
 						if (status == STATUS_READING_STRING) {
 							translation->add_message(msg_id, msg_str, msg_context);
@@ -220,7 +220,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 							translation->add_plural_message(msg_id, msgs_plural, msg_context);
 						}
 					}
-				} else if (config.is_empty()) {
+				} else if (config.is_empty_string()) {
 					config = msg_str;
 					// Record plural rule.
 					int p_start = config.find("Plural-Forms");
@@ -254,7 +254,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 				status = STATUS_READING_STRING;
 			}
 
-			if (l.is_empty() || l.begins_with("#")) {
+			if (l.is_empty_string() || l.begins_with("#")) {
 				if (l.contains("fuzzy")) {
 					skip_next = true;
 				}
@@ -305,22 +305,22 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 
 		// Add the last set of data from last iteration.
 		if (status == STATUS_READING_STRING) {
-			if (!msg_id.is_empty()) {
+			if (!msg_id.is_empty_string()) {
 				if (!skip_this) {
 					translation->add_message(msg_id, msg_str, msg_context);
 				}
-			} else if (config.is_empty()) {
+			} else if (config.is_empty_string()) {
 				config = msg_str;
 			}
 		} else if (status == STATUS_READING_PLURAL) {
-			if (!skip_this && !msg_id.is_empty()) {
+			if (!skip_this && !msg_id.is_empty_string()) {
 				ERR_FAIL_COND_V_MSG(plural_index != plural_forms - 1, Ref<Resource>(), "Number of 'msgstr[]' doesn't match with number of plural forms: " + path + ":" + itos(line));
 				translation->add_plural_message(msg_id, msgs_plural, msg_context);
 			}
 		}
 	}
 
-	ERR_FAIL_COND_V_MSG(config.is_empty(), Ref<Resource>(), "No config found in file: " + path + ".");
+	ERR_FAIL_COND_V_MSG(config.is_empty_string(), Ref<Resource>(), "No config found in file: " + path + ".");
 
 	Vector<String> configs = config.split("\n");
 	for (int i = 0; i < configs.size(); i++) {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -187,7 +187,7 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 			for (const KeyValue<StringName, MethodBind *> &F : t->method_map) {
 				String name = F.key.operator String();
 
-				ERR_CONTINUE(name.is_empty());
+				ERR_CONTINUE(name.is_empty_string());
 
 				if (name[0] == '_') {
 					continue; // Ignore non-virtual methods that start with an underscore
@@ -550,7 +550,7 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 	type->constant_map[p_name] = p_constant;
 
 	String enum_name = p_enum;
-	if (!enum_name.is_empty()) {
+	if (!enum_name.is_empty_string()) {
 		if (enum_name.contains(".")) {
 			enum_name = enum_name.get_slicec('.', 1);
 		}

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1042,7 +1042,7 @@ void Object::get_meta_list(List<StringName> *p_list) const {
 }
 
 void Object::add_user_signal(const MethodInfo &p_signal) {
-	ERR_FAIL_COND_MSG(p_signal.name.is_empty(), "Signal name cannot be empty.");
+	ERR_FAIL_COND_MSG(p_signal.name.is_empty_string(), "Signal name cannot be empty.");
 	ERR_FAIL_COND_MSG(ClassDB::has_signal(get_class_name(), p_signal.name), "User signal's name conflicts with a built-in signal of '" + get_class_name() + "'.");
 	ERR_FAIL_COND_MSG(signal_map.has(p_signal.name), "Trying to add already existing signal '" + p_signal.name + "'.");
 	SignalData s;
@@ -1287,7 +1287,7 @@ void Object::get_signal_list(List<MethodInfo> *p_signals) const {
 	//find maybe usersignals?
 
 	for (const KeyValue<StringName, SignalData> &E : signal_map) {
-		if (!E.value.user.name.is_empty()) {
+		if (!E.value.user.name.is_empty_string()) {
 			//user signal
 			p_signals->push_back(E.value.user);
 		}
@@ -1705,7 +1705,7 @@ void Object::get_translatable_strings(List<String> *p_strings) const {
 
 		String text = get(E.name);
 
-		if (text.is_empty()) {
+		if (text.is_empty_string()) {
 			continue;
 		}
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -196,8 +196,8 @@ static void _OS_printres(Object *p_obj) {
 }
 
 void OS::print_all_resources(String p_to_file) {
-	ERR_FAIL_COND(!p_to_file.is_empty() && _OSPRF.is_valid());
-	if (!p_to_file.is_empty()) {
+	ERR_FAIL_COND(!p_to_file.is_empty_string() && _OSPRF.is_valid());
+	if (!p_to_file.is_empty_string()) {
 		Error err;
 		_OSPRF = FileAccess::open(p_to_file, FileAccess::WRITE, &err);
 		if (err != OK) {

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -368,7 +368,7 @@ NodePath::NodePath(const String &p_path) {
 		for (int i = from; i <= path.length(); i++) {
 			if (path[i] == ':' || path[i] == 0) {
 				String str = path.substr(from, i - from);
-				if (str.is_empty()) {
+				if (str.is_empty_string()) {
 					if (path[i] == 0) {
 						continue; // Allow end-of-path :
 					}

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -40,7 +40,7 @@ class StringBuffer {
 	int string_length = 0;
 
 	_FORCE_INLINE_ char32_t *current_buffer_ptr() {
-		return static_cast<String &>(buffer).is_empty() ? short_buffer : buffer.ptrw();
+		return static_cast<String &>(buffer).is_empty_string() ? short_buffer : buffer.ptrw();
 	}
 
 public:
@@ -122,7 +122,7 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::reserve(int p_
 		return *this;
 	}
 
-	bool need_copy = string_length > 0 && buffer.is_empty();
+	bool need_copy = string_length > 0 && buffer.is_empty_string();
 	buffer.resize(next_power_of_2(p_size));
 	if (need_copy) {
 		memcpy(buffer.ptrw(), short_buffer, string_length * sizeof(char32_t));
@@ -139,7 +139,7 @@ int StringBuffer<SHORT_BUFFER_SIZE>::length() const {
 template <int SHORT_BUFFER_SIZE>
 String StringBuffer<SHORT_BUFFER_SIZE>::as_string() {
 	current_buffer_ptr()[string_length] = '\0';
-	if (buffer.is_empty()) {
+	if (buffer.is_empty_string()) {
 		return String(short_buffer);
 	} else {
 		buffer.resize(string_length + 1);

--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -33,7 +33,7 @@
 #include <string.h>
 
 StringBuilder &StringBuilder::append(const String &p_string) {
-	if (p_string.is_empty()) {
+	if (p_string.is_empty_string()) {
 		return *this;
 	}
 

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -326,7 +326,7 @@ StringName::StringName(const String &p_name, bool p_static) {
 
 	ERR_FAIL_COND(!configured);
 
-	if (p_name.is_empty()) {
+	if (p_name.is_empty_string()) {
 		return;
 	}
 
@@ -450,7 +450,7 @@ StringName StringName::search(const char32_t *p_name) {
 }
 
 StringName StringName::search(const String &p_name) {
-	ERR_FAIL_COND_V(p_name.is_empty(), StringName());
+	ERR_FAIL_COND_V(p_name.is_empty_string(), StringName());
 
 	MutexLock lock(mutex);
 

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -97,7 +97,7 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	operator const void *() const { return (_data && (_data->cname || !_data->name.is_empty())) ? (void *)1 : nullptr; }
+	operator const void *() const { return (_data && (_data->cname || !_data->name.is_empty_string())) ? (void *)1 : nullptr; }
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -267,7 +267,7 @@ void TranslationServer::init_locale_info() {
 	locale_rename_map.clear();
 	idx = 0;
 	while (locale_renames[idx][0] != nullptr) {
-		if (!String(locale_renames[idx][1]).is_empty()) {
+		if (!String(locale_renames[idx][1]).is_empty_string()) {
 			locale_rename_map[locale_renames[idx][0]] = locale_renames[idx][1];
 		}
 		idx++;
@@ -285,7 +285,7 @@ void TranslationServer::init_locale_info() {
 	country_rename_map.clear();
 	idx = 0;
 	while (country_renames[idx][0] != nullptr) {
-		if (!String(country_renames[idx][1]).is_empty()) {
+		if (!String(country_renames[idx][1]).is_empty_string()) {
 			country_rename_map[country_renames[idx][0]] = country_renames[idx][1];
 		}
 		idx++;
@@ -354,18 +354,18 @@ String TranslationServer::standardize_locale(const String &p_locale) const {
 	}
 
 	// Add script code base on language and country codes for some ambiguous cases.
-	if (script.is_empty()) {
+	if (script.is_empty_string()) {
 		for (int i = 0; i < locale_script_info.size(); i++) {
 			const LocaleScriptInfo &info = locale_script_info[i];
 			if (info.name == lang) {
-				if (country.is_empty() || info.supported_countries.has(country)) {
+				if (country.is_empty_string() || info.supported_countries.has(country)) {
 					script = info.script;
 					break;
 				}
 			}
 		}
 	}
-	if (!script.is_empty() && country.is_empty()) {
+	if (!script.is_empty_string() && country.is_empty_string()) {
 		// Add conntry code based on script for some ambiguous cases.
 		for (int i = 0; i < locale_script_info.size(); i++) {
 			const LocaleScriptInfo &info = locale_script_info[i];
@@ -378,13 +378,13 @@ String TranslationServer::standardize_locale(const String &p_locale) const {
 
 	// Combine results.
 	String locale = lang;
-	if (!script.is_empty()) {
+	if (!script.is_empty_string()) {
 		locale = locale + "_" + script;
 	}
-	if (!country.is_empty()) {
+	if (!country.is_empty_string()) {
 		locale = locale + "_" + country;
 	}
-	if (!variant.is_empty()) {
+	if (!variant.is_empty_string()) {
 		locale = locale + "_" + variant;
 	}
 	return locale;
@@ -440,10 +440,10 @@ String TranslationServer::get_locale_name(const String &p_locale) const {
 	}
 
 	String name = language_map[lang];
-	if (!script.is_empty()) {
+	if (!script.is_empty_string()) {
 		name = name + " (" + script_map[script] + ")";
 	}
-	if (!country.is_empty()) {
+	if (!country.is_empty_string()) {
 		name = name + ", " + country_name_map[country];
 	}
 	return name;
@@ -653,7 +653,7 @@ bool TranslationServer::_load_translations(const String &p_from) {
 void TranslationServer::setup() {
 	String test = GLOBAL_DEF("internationalization/locale/test", "");
 	test = test.strip_edges();
-	if (!test.is_empty()) {
+	if (!test.is_empty_string()) {
 		set_locale(test);
 	} else {
 		set_locale(OS::get_singleton()->get_locale());

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -286,7 +286,7 @@ Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r
 			base = base.substr(pos, base.length() - pos);
 		}
 	}
-	if (r_host.is_empty()) {
+	if (r_host.is_empty_string()) {
 		return ERR_INVALID_PARAMETER;
 	}
 	r_host = r_host.to_lower();
@@ -576,7 +576,7 @@ bool String::operator==(const char *p_str) const {
 	if (length() != len) {
 		return false;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return true;
 	}
 
@@ -615,7 +615,7 @@ bool String::operator==(const char32_t *p_str) const {
 	if (length() != len) {
 		return false;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return true;
 	}
 
@@ -637,7 +637,7 @@ bool String::operator==(const String &p_str) const {
 	if (length() != p_str.length()) {
 		return false;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return true;
 	}
 
@@ -662,7 +662,7 @@ bool String::operator==(const StrRange &p_str_range) const {
 	if (length() != len) {
 		return false;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return true;
 	}
 
@@ -736,20 +736,20 @@ bool String::operator>=(const String &p_str) const {
 }
 
 bool String::operator<(const char *p_str) const {
-	if (is_empty() && p_str[0] == 0) {
+	if (is_empty_string() && p_str[0] == 0) {
 		return false;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return true;
 	}
 	return is_str_less(get_data(), p_str);
 }
 
 bool String::operator<(const wchar_t *p_str) const {
-	if (is_empty() && p_str[0] == 0) {
+	if (is_empty_string() && p_str[0] == 0) {
 		return false;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return true;
 	}
 
@@ -763,10 +763,10 @@ bool String::operator<(const wchar_t *p_str) const {
 }
 
 bool String::operator<(const char32_t *p_str) const {
-	if (is_empty() && p_str[0] == 0) {
+	if (is_empty_string() && p_str[0] == 0) {
 		return false;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return true;
 	}
 
@@ -778,13 +778,13 @@ bool String::operator<(const String &p_str) const {
 }
 
 signed char String::nocasecmp_to(const String &p_str) const {
-	if (is_empty() && p_str.is_empty()) {
+	if (is_empty_string() && p_str.is_empty_string()) {
 		return 0;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return -1;
 	}
-	if (p_str.is_empty()) {
+	if (p_str.is_empty_string()) {
 		return 1;
 	}
 
@@ -810,13 +810,13 @@ signed char String::nocasecmp_to(const String &p_str) const {
 }
 
 signed char String::casecmp_to(const String &p_str) const {
-	if (is_empty() && p_str.is_empty()) {
+	if (is_empty_string() && p_str.is_empty_string()) {
 		return 0;
 	}
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return -1;
 	}
-	if (p_str.is_empty()) {
+	if (p_str.is_empty_string()) {
 		return 1;
 	}
 
@@ -1002,10 +1002,10 @@ String String::get_with_code_lines() const {
 }
 
 int String::get_slice_count(String p_splitter) const {
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return 0;
 	}
-	if (p_splitter.is_empty()) {
+	if (p_splitter.is_empty_string()) {
 		return 0;
 	}
 
@@ -1021,7 +1021,7 @@ int String::get_slice_count(String p_splitter) const {
 }
 
 String String::get_slice(String p_splitter, int p_slice) const {
-	if (is_empty() || p_splitter.is_empty()) {
+	if (is_empty_string() || p_splitter.is_empty_string()) {
 		return "";
 	}
 
@@ -1061,7 +1061,7 @@ String String::get_slice(String p_splitter, int p_slice) const {
 }
 
 String String::get_slicec(char32_t p_splitter, int p_slice) const {
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return String();
 	}
 
@@ -2500,7 +2500,7 @@ int64_t String::to_int(const char32_t *p_str, int p_len, bool p_clamp) {
 }
 
 double String::to_float() const {
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return 0;
 	}
 	return built_in_strtod<char32_t>(get_data());
@@ -2682,7 +2682,7 @@ String String::substr(int p_from, int p_chars) const {
 		p_chars = length() - p_from;
 	}
 
-	if (is_empty() || p_from < 0 || p_from >= length() || p_chars <= 0) {
+	if (is_empty_string() || p_from < 0 || p_from >= length() || p_chars <= 0) {
 		return "";
 	}
 
@@ -3069,7 +3069,7 @@ bool String::is_quoted() const {
 }
 
 int String::_count(const String &p_string, int p_from, int p_to, bool p_case_insensitive) const {
-	if (p_string.is_empty()) {
+	if (p_string.is_empty_string()) {
 		return 0;
 	}
 	int len = length();
@@ -3663,7 +3663,7 @@ static _FORCE_INLINE_ bool _is_valid_identifier_bit(int p_index, char32_t p_char
 }
 
 String String::validate_identifier() const {
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return "_"; // Empty string is not a valid identifier;
 	}
 
@@ -4209,7 +4209,7 @@ bool String::is_valid_filename() const {
 		return false;
 	}
 
-	if (stripped.is_empty()) {
+	if (stripped.is_empty_string()) {
 		return false;
 	}
 
@@ -4221,7 +4221,7 @@ bool String::is_valid_ip_address() const {
 		Vector<String> ip = split(":");
 		for (int i = 0; i < ip.size(); i++) {
 			String n = ip[i];
-			if (n.is_empty()) {
+			if (n.is_empty_string()) {
 				continue;
 			}
 			if (n.is_valid_hex_number(false)) {
@@ -4344,7 +4344,7 @@ String String::get_extension() const {
 }
 
 String String::plus_file(const String &p_file) const {
-	if (is_empty()) {
+	if (is_empty_string()) {
 		return p_file;
 	}
 	if (operator[](length() - 1) == '/' || (p_file.size() > 0 && p_file.operator[](0) == '/')) {
@@ -4731,7 +4731,7 @@ String String::unquote() const {
 
 Vector<uint8_t> String::to_ascii_buffer() const {
 	const String *s = this;
-	if (s->is_empty()) {
+	if (s->is_empty_string()) {
 		return Vector<uint8_t>();
 	}
 	CharString charstr = s->ascii();
@@ -4747,7 +4747,7 @@ Vector<uint8_t> String::to_ascii_buffer() const {
 
 Vector<uint8_t> String::to_utf8_buffer() const {
 	const String *s = this;
-	if (s->is_empty()) {
+	if (s->is_empty_string()) {
 		return Vector<uint8_t>();
 	}
 	CharString charstr = s->utf8();
@@ -4763,7 +4763,7 @@ Vector<uint8_t> String::to_utf8_buffer() const {
 
 Vector<uint8_t> String::to_utf16_buffer() const {
 	const String *s = this;
-	if (s->is_empty()) {
+	if (s->is_empty_string()) {
 		return Vector<uint8_t>();
 	}
 	Char16String charstr = s->utf16();
@@ -4779,7 +4779,7 @@ Vector<uint8_t> String::to_utf16_buffer() const {
 
 Vector<uint8_t> String::to_utf32_buffer() const {
 	const String *s = this;
-	if (s->is_empty()) {
+	if (s->is_empty_string()) {
 		return Vector<uint8_t>();
 	}
 
@@ -4891,7 +4891,7 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 String RTR(const String &p_text, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		String rtr = TranslationServer::get_singleton()->tool_translate(p_text, p_context);
-		if (rtr.is_empty() || rtr == p_text) {
+		if (rtr.is_empty_string() || rtr == p_text) {
 			return TranslationServer::get_singleton()->translate(p_text, p_context);
 		} else {
 			return rtr;
@@ -4918,7 +4918,7 @@ String RTR(const String &p_text, const String &p_context) {
 String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		String rtr = TranslationServer::get_singleton()->tool_translate_plural(p_text, p_text_plural, p_n, p_context);
-		if (rtr.is_empty() || rtr == p_text || rtr == p_text_plural) {
+		if (rtr.is_empty_string() || rtr == p_text || rtr == p_text_plural) {
 			return TranslationServer::get_singleton()->translate_plural(p_text, p_text_plural, p_n, p_context);
 		} else {
 			return rtr;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -395,7 +395,7 @@ public:
 	Vector<uint8_t> sha1_buffer() const;
 	Vector<uint8_t> sha256_buffer() const;
 
-	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
+	_FORCE_INLINE_ bool is_empty_string() const { return length() == 0; }
 	_FORCE_INLINE_ bool contains(const char *p_str) const { return find(p_str) != -1; }
 	_FORCE_INLINE_ bool contains(const String &p_str) const { return find(p_str) != -1; }
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1422,7 +1422,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, md5_buffer, sarray(), varray());
 	bind_method(String, sha1_buffer, sarray(), varray());
 	bind_method(String, sha256_buffer, sarray(), varray());
-	bind_method(String, is_empty, sarray(), varray());
+	bind_method(String, is_empty_string, sarray(), varray());
 	bind_methodv(String, contains, static_cast<bool (String::*)(const String &) const>(&String::contains), sarray("what"), varray());
 
 	bind_method(String, is_absolute_path, sarray(), varray());

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1637,14 +1637,14 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				}
 
 				//try path because it's a file
-				if (res_text.is_empty() && res->get_path().is_resource_file()) {
+				if (res_text.is_empty_string() && res->get_path().is_resource_file()) {
 					//external resource
 					String path = res->get_path();
 					res_text = "Resource(\"" + path + "\")";
 				}
 
 				//could come up with some sort of text
-				if (!res_text.is_empty()) {
+				if (!res_text.is_empty_string()) {
 					p_store_string_func(p_store_string_ud, res_text);
 					break;
 				}

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1312,7 +1312,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 		case STRING: {
 			const String *str = reinterpret_cast<const String *>(_data._mem);
-			if (str->is_empty()) {
+			if (str->is_empty_string()) {
 				return false;
 			}
 			r_iter = 0;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1172,7 +1172,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 				}
 			}
 #ifdef TOOLS_ENABLED
-			if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
+			if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty_string()) {
 				roughness_detect_texture->detect_roughness_callback(roughness_detect_texture->detect_roughness_callback_ud, normal_detect_texture->path, roughness_channel);
 			}
 #endif
@@ -1207,7 +1207,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 #endif
 				}
 #ifdef TOOLS_ENABLED
-				if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
+				if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty_string()) {
 					roughness_detect_texture->detect_roughness_callback(roughness_detect_texture->detect_roughness_callback_ud, normal_detect_texture->path, roughness_channel);
 				}
 #endif
@@ -2737,7 +2737,7 @@ void CanvasShaderData::set_code(const String &p_code) {
 	uses_sdf = false;
 	uses_time = false;
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 
@@ -2945,7 +2945,7 @@ void SkyShaderData::set_code(const String &p_code) {
 	ubo_size = 0;
 	uniforms.clear();
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 
@@ -3170,7 +3170,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	uniforms.clear();
 	uses_screen_texture = false;
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -299,7 +299,7 @@ Error AudioDriverPulseAudio::init() {
 		context_name = VERSION_NAME " Editor";
 	} else {
 		context_name = GLOBAL_GET("application/config/name");
-		if (context_name.is_empty()) {
+		if (context_name.is_empty_string()) {
 			context_name = VERSION_NAME " Project";
 		}
 	}

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -358,7 +358,7 @@ Error DirAccessUnix::change_dir(String p_dir) {
 	}
 
 	String base = _get_root_path();
-	if (!base.is_empty() && !try_dir.begins_with(base)) {
+	if (!base.is_empty_string() && !try_dir.begins_with(base)) {
 		ERR_FAIL_COND_V(getcwd(real_current_dir_name, 2048) == nullptr, ERR_BUG);
 		String new_dir;
 		new_dir.parse_utf8(real_current_dir_name);
@@ -376,7 +376,7 @@ Error DirAccessUnix::change_dir(String p_dir) {
 
 String DirAccessUnix::get_current_dir(bool p_include_drive) const {
 	String base = _get_root_path();
-	if (!base.is_empty()) {
+	if (!base.is_empty_string()) {
 		String bd = current_dir.replace_first(base, "");
 		if (bd.begins_with("/")) {
 			return _get_root_string() + bd.substr(1, bd.length());

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -157,7 +157,7 @@ void FileAccessUnix::_close() {
 		close_notification_func(path, flags);
 	}
 
-	if (!save_path.is_empty()) {
+	if (!save_path.is_empty_string()) {
 		int rename_error = rename((save_path + ".tmp").utf8().get_data(), save_path.utf8().get_data());
 
 		if (rename_error && close_fail_notify) {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -514,11 +514,11 @@ int OS_Unix::get_processor_count() const {
 
 String OS_Unix::get_user_data_dir() const {
 	String appname = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/name"));
-	if (!appname.is_empty()) {
+	if (!appname.is_empty_string()) {
 		bool use_custom_dir = ProjectSettings::get_singleton()->get("application/config/use_custom_user_dir");
 		if (use_custom_dir) {
 			String custom_dir = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/custom_user_dir_name"), true);
-			if (custom_dir.is_empty()) {
+			if (custom_dir.is_empty_string()) {
 				custom_dir = appname;
 			}
 			return get_data_path().plus_file(custom_dir);
@@ -540,7 +540,7 @@ String OS_Unix::get_executable_path() const {
 	if (len > 0) {
 		b.parse_utf8(buf, len);
 	}
-	if (b.is_empty()) {
+	if (b.is_empty_string()) {
 		WARN_PRINT("Couldn't get executable path from /proc/self/exe, using argv[0]");
 		return OS::get_executable_path();
 	}

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4339,7 +4339,7 @@ String RenderingDeviceVulkan::_shader_uniform_debug(RID p_shader, int p_set) {
 		}
 		for (int j = 0; j < shader->sets[i].uniform_info.size(); j++) {
 			const UniformInfo &ui = shader->sets[i].uniform_info[j];
-			if (!ret.is_empty()) {
+			if (!ret.is_empty_string()) {
 				ret += "\n";
 			}
 			ret += "Set: " + itos(i) + " Binding: " + itos(ui.binding) + " Type: " + shader_uniform_names[ui.type] + " Length: " + itos(ui.length);

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -133,7 +133,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 	bool worked = (SetCurrentDirectoryW((LPCWSTR)(p_dir.utf16().get_data())) != 0);
 
 	String base = _get_root_path();
-	if (!base.is_empty()) {
+	if (!base.is_empty_string()) {
 		GetCurrentDirectoryW(2048, real_current_dir_name);
 		String new_dir = String::utf16((const char16_t *)real_current_dir_name).replace("\\", "/");
 		if (!new_dir.begins_with(base)) {
@@ -187,7 +187,7 @@ Error DirAccessWindows::make_dir(String p_dir) {
 
 String DirAccessWindows::get_current_dir(bool p_include_drive) const {
 	String base = _get_root_path();
-	if (!base.is_empty()) {
+	if (!base.is_empty_string()) {
 		String bd = current_dir.replace("\\", "/").replace_first(base, "");
 		if (bd.begins_with("/")) {
 			return _get_root_string() + bd.substr(1, bd.length());
@@ -199,7 +199,7 @@ String DirAccessWindows::get_current_dir(bool p_include_drive) const {
 	if (p_include_drive) {
 		return current_dir;
 	} else {
-		if (_get_root_string().is_empty()) {
+		if (_get_root_string().is_empty_string()) {
 			int p = current_dir.find(":");
 			if (p != -1) {
 				return current_dir.substr(p + 1);

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -98,7 +98,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 		HANDLE f = FindFirstFileW((LPCWSTR)(path.utf16().get_data()), &d);
 		if (f != INVALID_HANDLE_VALUE) {
 			String fname = String::utf16((const char16_t *)(d.cFileName));
-			if (!fname.is_empty()) {
+			if (!fname.is_empty_string()) {
 				String base_file = path.get_file();
 				if (base_file != fname && base_file.findn(fname) == 0) {
 					WARN_PRINT("Case mismatch opening requested file '" + base_file + "', stored as '" + fname + "' in the filesystem. This file will not open when exported to other case-sensitive platforms.");
@@ -141,7 +141,7 @@ void FileAccessWindows::_close() {
 	fclose(f);
 	f = nullptr;
 
-	if (!save_path.is_empty()) {
+	if (!save_path.is_empty_string()) {
 		bool rename_error = true;
 		int attempts = 4;
 		while (rename_error && attempts) {

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -309,7 +309,7 @@ void InputEventConfigurationDialog::_update_input_list() {
 	TreeItem *root = input_list_tree->create_item();
 	String search_term = input_list_search->get_text();
 
-	bool collapse = input_list_search->get_text().is_empty();
+	bool collapse = input_list_search->get_text().is_empty_string();
 
 	if (allowed_input_types & INPUT_KEY) {
 		TreeItem *kb_root = input_list_tree->create_item(root);
@@ -321,7 +321,7 @@ void InputEventConfigurationDialog::_update_input_list() {
 		for (int i = 0; i < keycode_get_count(); i++) {
 			String name = keycode_get_name_by_index(i);
 
-			if (!search_term.is_empty() && name.findn(search_term) == -1) {
+			if (!search_term.is_empty_string() && name.findn(search_term) == -1) {
 				continue;
 			}
 
@@ -345,7 +345,7 @@ void InputEventConfigurationDialog::_update_input_list() {
 			mb->set_button_index(mouse_buttons[i]);
 			String desc = get_event_text(mb, false);
 
-			if (!search_term.is_empty() && desc.findn(search_term) == -1) {
+			if (!search_term.is_empty_string() && desc.findn(search_term) == -1) {
 				continue;
 			}
 
@@ -368,7 +368,7 @@ void InputEventConfigurationDialog::_update_input_list() {
 			joyb->set_button_index((JoyButton)i);
 			String desc = get_event_text(joyb, false);
 
-			if (!search_term.is_empty() && desc.findn(search_term) == -1) {
+			if (!search_term.is_empty_string() && desc.findn(search_term) == -1) {
 				continue;
 			}
 
@@ -394,7 +394,7 @@ void InputEventConfigurationDialog::_update_input_list() {
 			joym->set_axis_value(direction);
 			String desc = get_event_text(joym, false);
 
-			if (!search_term.is_empty() && desc.findn(search_term) == -1) {
+			if (!search_term.is_empty_string() && desc.findn(search_term) == -1) {
 				continue;
 			}
 
@@ -792,7 +792,7 @@ void ActionMapEditor::_add_action_pressed() {
 }
 
 String ActionMapEditor::_check_new_action_name(const String &p_name) {
-	if (p_name.is_empty() || !_is_action_name_valid(p_name)) {
+	if (p_name.is_empty_string() || !_is_action_name_valid(p_name)) {
 		return TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'");
 	}
 
@@ -806,7 +806,7 @@ String ActionMapEditor::_check_new_action_name(const String &p_name) {
 void ActionMapEditor::_add_edit_text_changed(const String &p_name) {
 	String error = _check_new_action_name(p_name);
 	add_button->set_tooltip(error);
-	add_button->set_disabled(!error.is_empty());
+	add_button->set_disabled(!error.is_empty_string());
 }
 
 bool ActionMapEditor::_has_action(const String &p_name) const {
@@ -820,7 +820,7 @@ bool ActionMapEditor::_has_action(const String &p_name) const {
 
 void ActionMapEditor::_add_action(const String &p_name) {
 	String error = _check_new_action_name(p_name);
-	if (!error.is_empty()) {
+	if (!error.is_empty_string()) {
 		show_message(error);
 		return;
 	}
@@ -844,7 +844,7 @@ void ActionMapEditor::_action_edited() {
 			return;
 		}
 
-		if (new_name.is_empty() || !_is_action_name_valid(new_name)) {
+		if (new_name.is_empty_string() || !_is_action_name_valid(new_name)) {
 			ti->set_text(0, old_name);
 			show_message(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
 			return;
@@ -1103,7 +1103,7 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 		}
 
 		String search_term = action_list_search->get_text();
-		if (!search_term.is_empty() && action_info.name.findn(search_term) == -1) {
+		if (!search_term.is_empty_string() && action_info.name.findn(search_term) == -1) {
 			continue;
 		}
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -649,7 +649,7 @@ public:
 						List<StringName> anims;
 						ap->get_animation_list(&anims);
 						for (const StringName &E : anims) {
-							if (!animations.is_empty()) {
+							if (!animations.is_empty_string()) {
 								animations += ",";
 							}
 
@@ -658,7 +658,7 @@ public:
 					}
 				}
 
-				if (!animations.is_empty()) {
+				if (!animations.is_empty_string()) {
 					animations += ",";
 				}
 				animations += "[stop]";
@@ -1331,7 +1331,7 @@ public:
 							List<StringName> anims;
 							ap->get_animation_list(&anims);
 							for (List<StringName>::Element *G = anims.front(); G; G = G->next()) {
-								if (!animations.is_empty()) {
+								if (!animations.is_empty_string()) {
 									animations += ",";
 								}
 
@@ -1340,7 +1340,7 @@ public:
 						}
 					}
 
-					if (!animations.is_empty()) {
+					if (!animations.is_empty_string()) {
 						animations += ",";
 					}
 					animations += "[stop]";
@@ -2690,7 +2690,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 					if (stream.is_valid()) {
 						if (stream->get_path().is_resource_file()) {
 							stream_name = stream->get_path().get_file();
-						} else if (!stream->get_name().is_empty()) {
+						} else if (!stream->get_name().is_empty_string()) {
 							stream_name = stream->get_name();
 						} else {
 							stream_name = stream->get_class();
@@ -3776,7 +3776,7 @@ void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_
 
 	// Let's build a node path.
 	String path = root->get_path_to(p_node);
-	if (!p_sub.is_empty()) {
+	if (!p_sub.is_empty_string()) {
 		path += ":" + p_sub;
 	}
 
@@ -3816,7 +3816,7 @@ bool AnimationTrackEditor::has_track(Node3D *p_node, const String &p_sub, const 
 
 	// Let's build a node path.
 	String path = root->get_path_to(p_node);
-	if (!p_sub.is_empty()) {
+	if (!p_sub.is_empty_string()) {
 		path += ":" + p_sub;
 	}
 
@@ -3881,7 +3881,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 	EditorSelectionHistory *history = EditorNode::get_singleton()->get_editor_selection_history();
 	for (int i = 1; i < history->get_path_size(); i++) {
 		String prop = history->get_path_property(i);
-		ERR_FAIL_COND(prop.is_empty());
+		ERR_FAIL_COND(prop.is_empty_string());
 		path += ":" + prop;
 	}
 
@@ -3981,7 +3981,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 
 	for (int i = 1; i < history->get_path_size(); i++) {
 		String prop = history->get_path_property(i);
-		ERR_FAIL_COND(prop.is_empty());
+		ERR_FAIL_COND(prop.is_empty_string());
 		path += ":" + prop;
 	}
 
@@ -4417,7 +4417,7 @@ void AnimationTrackEditor::_update_tracks() {
 				}
 
 				if (object && !leftover_path.is_empty()) {
-					if (pinfo.name.is_empty()) {
+					if (pinfo.name.is_empty_string()) {
 						pinfo.name = leftover_path[leftover_path.size() - 1];
 					}
 
@@ -5684,7 +5684,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 					default: {
 					};
 				}
-				if (!track_type.is_empty()) {
+				if (!track_type.is_empty_string()) {
 					text += vformat(" (%s)", track_type);
 				}
 
@@ -6188,7 +6188,7 @@ void AnimationTrackEditor::_pick_track_select_recursive(TreeItem *p_item, const 
 	NodePath np = p_item->get_metadata(0);
 	Node *node = get_node(np);
 
-	if (!p_filter.is_empty() && ((String)node->get_name()).findn(p_filter) != -1) {
+	if (!p_filter.is_empty_string() && ((String)node->get_name()).findn(p_filter) != -1) {
 		p_select_candidates.push_back(node);
 	}
 

--- a/editor/array_property_edit.cpp
+++ b/editor/array_property_edit.cpp
@@ -253,7 +253,7 @@ void ArrayPropertyEdit::edit(Object *p_obj, const StringName &p_prop, const Stri
 	obj = p_obj->get_instance_id();
 	default_type = p_deftype;
 
-	if (!p_hint_string.is_empty()) {
+	if (!p_hint_string.is_empty_string()) {
 		int hint_subtype_separator = p_hint_string.find(":");
 		if (hint_subtype_separator >= 0) {
 			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -343,7 +343,7 @@ void FindReplaceBar::_update_results_count() {
 	results_count_to_current = 0;
 
 	String searched = get_search_text();
-	if (searched.is_empty()) {
+	if (searched.is_empty_string()) {
 		return;
 	}
 
@@ -382,7 +382,7 @@ void FindReplaceBar::_update_results_count() {
 }
 
 void FindReplaceBar::_update_matches_label() {
-	if (search_text->get_text().is_empty() || results_count == -1) {
+	if (search_text->get_text().is_empty_string() || results_count == -1) {
 		matches_label->hide();
 	} else {
 		matches_label->show();
@@ -516,7 +516,7 @@ void FindReplaceBar::_show_search(bool p_focus_replace, bool p_show_only) {
 		search_text->set_text(text_editor->get_selected_text());
 	}
 
-	if (!get_search_text().is_empty()) {
+	if (!get_search_text().is_empty_string()) {
 		if (p_focus_replace) {
 			replace_text->select_all();
 			replace_text->set_caret_column(replace_text->get_text().length());
@@ -1440,7 +1440,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		for (int i = begin; i <= end; i++) {
 			String line_text = text_editor->get_line(i);
 
-			if (line_text.strip_edges().is_empty()) {
+			if (line_text.strip_edges().is_empty_string()) {
 				line_text = delimiter;
 			} else {
 				if (is_commented) {
@@ -1581,7 +1581,7 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 
 void CodeTextEditor::set_error(const String &p_error) {
 	error->set_text(p_error);
-	if (!p_error.is_empty()) {
+	if (!p_error.is_empty_string()) {
 		error->set_default_cursor_shape(CURSOR_POINTING_HAND);
 	} else {
 		error->set_default_cursor_shape(CURSOR_ARROW);
@@ -1594,7 +1594,7 @@ void CodeTextEditor::set_error_pos(int p_line, int p_column) {
 }
 
 void CodeTextEditor::goto_error() {
-	if (!error->get_text().is_empty()) {
+	if (!error->get_text().is_empty_string()) {
 		if (text_editor->get_line_count() != error_line) {
 			text_editor->unfold_line(error_line);
 		}

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -109,7 +109,7 @@ public:
 void ConnectDialog::ok_pressed() {
 	String method_name = dst_method->get_text();
 
-	if (method_name.is_empty()) {
+	if (method_name.is_empty_string()) {
 		error->set_text(TTR("Method in target node must be specified."));
 		error->popup_centered();
 		return;
@@ -195,7 +195,7 @@ void ConnectDialog::_add_bind() {
  */
 void ConnectDialog::_remove_bind() {
 	String st = bind_editor->get_selected_path();
-	if (st.is_empty()) {
+	if (st.is_empty_string()) {
 		return;
 	}
 	int idx = st.get_slice("/", 1).to_int() - 1;
@@ -755,7 +755,7 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &p_item) {
 
 	String s = node_name.capitalize().replace(" ", "");
 	subst["NodeName"] = s;
-	if (!s.is_empty()) {
+	if (!s.is_empty_string()) {
 		s[0] = s.to_lower()[0];
 	}
 	subst["nodeName"] = s;
@@ -763,7 +763,7 @@ void ConnectionsDock::_open_connection_dialog(TreeItem &p_item) {
 
 	s = signal_name.capitalize().replace(" ", "");
 	subst["SignalName"] = s;
-	if (!s.is_empty()) {
+	if (!s.is_empty_string()) {
 		s[0] = s.to_lower()[0];
 	}
 	subst["signalName"] = s;
@@ -1013,7 +1013,7 @@ void ConnectionsDock::update_tree() {
 					} else if (pi.type != Variant::NIL) {
 						tname = Variant::get_type_name(pi.type);
 					}
-					signaldesc += (pi.name.is_empty() ? String("arg " + itos(i)) : pi.name) + ": " + tname;
+					signaldesc += (pi.name.is_empty_string() ? String("arg " + itos(i)) : pi.name) + ": " + tname;
 					argnames.push_back(pi.name + ":" + tname);
 				}
 			}
@@ -1045,14 +1045,14 @@ void ConnectionsDock::update_tree() {
 				if (!found) {
 					DocTools *dd = EditorHelp::get_doc_data();
 					HashMap<String, DocData::ClassDoc>::Iterator F = dd->class_list.find(base);
-					while (F && descr.is_empty()) {
+					while (F && descr.is_empty_string()) {
 						for (int i = 0; i < F->value.signals.size(); i++) {
 							if (F->value.signals[i].name == signal_name.operator String()) {
 								descr = DTR(F->value.signals[i].description);
 								break;
 							}
 						}
-						if (!F->value.inherits.is_empty()) {
+						if (!F->value.inherits.is_empty_string()) {
 							F = dd->class_list.find(F->value.inherits);
 						} else {
 							break;

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -173,7 +173,7 @@ void CreateDialog::_update_search() {
 	_configure_search_option_item(root, base_type, ClassDB::class_exists(base_type) ? TypeCategory::CPP_TYPE : TypeCategory::OTHER_TYPE);
 
 	const String search_text = search_box->get_text();
-	bool empty_search = search_text.is_empty();
+	bool empty_search = search_text.is_empty_string();
 
 	// Filter all candidate results.
 	Vector<String> candidates;
@@ -228,7 +228,7 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 			inherited_type = TypeCategory::CPP_TYPE;
 		} else {
 			inherits = script->get_language()->get_global_class_name(base->get_path());
-			if (inherits.is_empty()) {
+			if (inherits.is_empty_string()) {
 				inherits = base->get_path();
 				inherited_type = TypeCategory::PATH_TYPE;
 			}
@@ -247,7 +247,7 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 				inherited_type = TypeCategory::CPP_TYPE;
 			} else {
 				inherits = script->get_language()->get_global_class_name(base->get_path());
-				if (inherits.is_empty()) {
+				if (inherits.is_empty_string()) {
 					inherits = base->get_path();
 					inherited_type = TypeCategory::PATH_TYPE;
 				}
@@ -261,7 +261,7 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 	}
 
 	// Should never happen, but just in case...
-	ERR_FAIL_COND(inherits.is_empty());
+	ERR_FAIL_COND(inherits.is_empty_string());
 
 	_add_type(inherits, inherited_type);
 
@@ -295,7 +295,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
 	}
 
-	if (!search_box->get_text().is_empty()) {
+	if (!search_box->get_text().is_empty_string()) {
 		r_item->set_collapsed(false);
 	} else {
 		// Don't collapse the root node or an abstract node on the first tree level.
@@ -373,7 +373,7 @@ void CreateDialog::_cleanup() {
 
 void CreateDialog::_confirmed() {
 	String selected_item = get_selected_type();
-	if (selected_item.is_empty()) {
+	if (selected_item.is_empty_string()) {
 		return;
 	}
 
@@ -458,7 +458,7 @@ void CreateDialog::select_type(const String &p_type, bool p_center_on_item) {
 	to_select->select(0);
 	search_options->scroll_to_item(to_select, p_center_on_item);
 
-	if (EditorHelp::get_doc_data()->class_list.has(p_type) && !DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description).is_empty()) {
+	if (EditorHelp::get_doc_data()->class_list.has(p_type) && !DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description).is_empty_string()) {
 		// Display both class name and description, since the help bit may be displayed
 		// far away from the location (especially if the dialog was resized to be taller).
 		help_bit->set_text(vformat("[b]%s[/b]: %s", p_type, DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description)));
@@ -691,7 +691,7 @@ void CreateDialog::_load_favorites_and_history() {
 		while (!f->eof_reached()) {
 			String l = f->get_line().strip_edges();
 
-			if (!l.is_empty()) {
+			if (!l.is_empty_string()) {
 				favorite_list.push_back(l);
 			}
 		}

--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -67,7 +67,7 @@ public:
 	String path;
 
 	void compute_checksums() {
-		ERR_FAIL_COND(path.is_empty());
+		ERR_FAIL_COND(path.is_empty_string());
 
 		// MD5
 		Checksum md5;

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -143,7 +143,7 @@ void EditorDebuggerNode::_error_selected(const String &p_file, int p_line, int p
 
 void EditorDebuggerNode::_text_editor_stack_goto(const ScriptEditorDebugger *p_debugger) {
 	String file = p_debugger->get_stack_script_file();
-	if (file.is_empty()) {
+	if (file.is_empty_string()) {
 		return;
 	}
 	if (file.is_resource_file()) {

--- a/editor/debugger/editor_debugger_server.cpp
+++ b/editor/debugger/editor_debugger_server.cpp
@@ -76,7 +76,7 @@ Error EditorDebuggerServerTCP::start(const String &p_uri) {
 	int bind_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	// Optionally override
-	if (!p_uri.is_empty() && p_uri != "tcp://") {
+	if (!p_uri.is_empty_string() && p_uri != "tcp://") {
 		String scheme, path;
 		Error err = p_uri.parse_url(scheme, bind_host, bind_port, path);
 		ERR_FAIL_COND_V(err != OK, ERR_INVALID_PARAMETER);

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -265,7 +265,7 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 		} break;
 		case ITEM_MENU_COPY_NODE_PATH: {
 			String text = get_selected_path();
-			if (text.is_empty()) {
+			if (text.is_empty_string()) {
 				return;
 			} else if (text == "/root") {
 				text = ".";

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -81,7 +81,7 @@ void ScriptEditorDebugger::_put_msg(String p_message, Array p_data) {
 
 void ScriptEditorDebugger::debug_copy() {
 	String msg = reason->get_text();
-	if (msg.is_empty()) {
+	if (msg.is_empty_string()) {
 		return;
 	}
 	DisplayServer::get_singleton()->clipboard_set(msg);
@@ -315,7 +315,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		if (is_move_to_foreground()) {
 			DisplayServer::get_singleton()->window_move_to_foreground();
 		}
-		if (!error.is_empty()) {
+		if (!error.is_empty_string()) {
 			tabs->set_current_tab(0);
 		}
 		profiler->set_enabled(false);
@@ -512,17 +512,17 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		if (oe.callstack.size() > 0) {
 			// If available, use the script's stack in the error title.
 			error_title = oe.callstack[oe.callstack.size() - 1].func + ": ";
-		} else if (!oe.source_func.is_empty()) {
+		} else if (!oe.source_func.is_empty_string()) {
 			// Otherwise try to use the C++ source function.
 			error_title += oe.source_func + ": ";
 		}
 		// If we have a (custom) error message, use it as title, and add a C++ Error
 		// item with the original error condition.
-		error_title += oe.error_descr.is_empty() ? oe.error : oe.error_descr;
+		error_title += oe.error_descr.is_empty_string() ? oe.error : oe.error_descr;
 		error->set_text(1, error_title);
 		tooltip += " " + error_title + "\n";
 
-		if (!oe.error_descr.is_empty()) {
+		if (!oe.error_descr.is_empty_string()) {
 			// Add item for C++ error condition.
 			TreeItem *cpp_cond = error_tree->create_item(error);
 			cpp_cond->set_text(0, "<" + TTR("C++ Error") + ">");
@@ -538,7 +538,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 		// Source of the error.
 		String source_txt = (source_is_project_file ? oe.source_file.get_file() : oe.source_file) + ":" + itos(oe.source_line);
-		if (!oe.source_func.is_empty()) {
+		if (!oe.source_func.is_empty_string()) {
 			source_txt += " @ " + oe.source_func + "()";
 		}
 
@@ -1099,7 +1099,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 
 	Resource *res = Object::cast_to<Resource>(p_base);
 
-	if (res && !res->get_path().is_empty()) {
+	if (res && !res->get_path().is_empty_string()) {
 		String respath = res->get_path();
 		int pathid = _get_res_path_cache(respath);
 
@@ -1129,7 +1129,7 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 
 		if (p_value.is_ref_counted()) {
 			Ref<Resource> res = p_value;
-			if (res.is_valid() && !res->get_path().is_empty()) {
+			if (res.is_valid() && !res->get_path().is_empty_string()) {
 				Array msg;
 				msg.push_back(pathid);
 				msg.push_back(p_property);
@@ -1149,13 +1149,13 @@ void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p
 
 	Resource *res = Object::cast_to<Resource>(p_base);
 
-	if (res && !res->get_path().is_empty()) {
+	if (res && !res->get_path().is_empty_string()) {
 		String respath = res->get_path();
 		int pathid = _get_res_path_cache(respath);
 
 		if (p_value.is_ref_counted()) {
 			Ref<Resource> res2 = p_value;
-			if (res2.is_valid() && !res2->get_path().is_empty()) {
+			if (res2.is_valid() && !res2->get_path().is_empty_string()) {
 				Array msg;
 				msg.push_back(pathid);
 				msg.push_back(p_property);
@@ -1559,7 +1559,7 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 
 			// Construct a GitHub repository URL and open it in the user's default web browser.
 			// If the commit hash is available, use it for greater accuracy. Otherwise fall back to tagged release.
-			String git_ref = String(VERSION_HASH).is_empty() ? String(VERSION_NUMBER) + "-stable" : String(VERSION_HASH);
+			String git_ref = String(VERSION_HASH).is_empty_string() ? String(VERSION_NUMBER) + "-stable" : String(VERSION_HASH);
 			OS::get_singleton()->shell_open(vformat("https://github.com/godotengine/godot/blob/%s/%s#L%d",
 					git_ref, file, line_number));
 		} break;

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -81,7 +81,7 @@ void DependencyEditor::_fix_and_find(EditorFileSystemDirectory *efsd, HashMap<St
 		String path = efsd->get_file_path(i);
 
 		for (KeyValue<String, String> &E : candidates[file]) {
-			if (E.value.is_empty()) {
+			if (E.value.is_empty_string()) {
 				E.value = path;
 				continue;
 			}
@@ -141,7 +141,7 @@ void DependencyEditor::_fix_all() {
 
 	for (KeyValue<String, HashMap<String, String>> &E : candidates) {
 		for (const KeyValue<String, String> &F : E.value) {
-			if (!F.value.is_empty()) {
+			if (!F.value.is_empty_string()) {
 				remaps[F.key] = F.value;
 			}
 		}

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -109,8 +109,8 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 		String dependency_folder;
 
 		bool operator<(const RemovedDependency &p_other) const {
-			if (dependency_folder.is_empty() != p_other.dependency_folder.is_empty()) {
-				return p_other.dependency_folder.is_empty();
+			if (dependency_folder.is_empty_string() != p_other.dependency_folder.is_empty_string()) {
+				return p_other.dependency_folder.is_empty_string();
 			} else {
 				return dependency < p_other.dependency;
 			}

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -282,17 +282,17 @@ void DocTools::remove_from(const DocTools &p_data) {
 }
 
 void DocTools::add_doc(const DocData::ClassDoc &p_class_doc) {
-	ERR_FAIL_COND(p_class_doc.name.is_empty());
+	ERR_FAIL_COND(p_class_doc.name.is_empty_string());
 	class_list[p_class_doc.name] = p_class_doc;
 }
 
 void DocTools::remove_doc(const String &p_class_name) {
-	ERR_FAIL_COND(p_class_name.is_empty() || !class_list.has(p_class_name));
+	ERR_FAIL_COND(p_class_name.is_empty_string() || !class_list.has(p_class_name));
 	class_list.erase(p_class_name);
 }
 
 bool DocTools::has_doc(const String &p_class_name) {
-	if (p_class_name.is_empty()) {
+	if (p_class_name.is_empty_string()) {
 		return false;
 	}
 	return class_list.has(p_class_name);
@@ -470,7 +470,7 @@ void DocTools::generate(bool p_basic_types) {
 		method_list.sort();
 
 		for (const MethodInfo &E : method_list) {
-			if (E.name.is_empty() || (E.name[0] == '_' && !(E.flags & METHOD_FLAG_VIRTUAL))) {
+			if (E.name.is_empty_string() || (E.name[0] == '_' && !(E.flags & METHOD_FLAG_VIRTUAL))) {
 				continue; //hidden, don't count
 			}
 
@@ -492,21 +492,21 @@ void DocTools::generate(bool p_basic_types) {
 			}
 
 			if (E.flags & METHOD_FLAG_CONST) {
-				if (!method.qualifiers.is_empty()) {
+				if (!method.qualifiers.is_empty_string()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "const";
 			}
 
 			if (E.flags & METHOD_FLAG_VARARG) {
-				if (!method.qualifiers.is_empty()) {
+				if (!method.qualifiers.is_empty_string()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "vararg";
 			}
 
 			if (E.flags & METHOD_FLAG_STATIC) {
-				if (!method.qualifiers.is_empty()) {
+				if (!method.qualifiers.is_empty_string()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "static";
@@ -774,21 +774,21 @@ void DocTools::generate(bool p_basic_types) {
 			DocData::return_doc_from_retinfo(method, mi.return_val);
 
 			if (mi.flags & METHOD_FLAG_VARARG) {
-				if (!method.qualifiers.is_empty()) {
+				if (!method.qualifiers.is_empty_string()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "vararg";
 			}
 
 			if (mi.flags & METHOD_FLAG_CONST) {
-				if (!method.qualifiers.is_empty()) {
+				if (!method.qualifiers.is_empty_string()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "const";
 			}
 
 			if (mi.flags & METHOD_FLAG_STATIC) {
-				if (!method.qualifiers.is_empty()) {
+				if (!method.qualifiers.is_empty_string()) {
 					method.qualifiers += " ";
 				}
 				method.qualifiers += "static";
@@ -923,7 +923,7 @@ void DocTools::generate(bool p_basic_types) {
 				md.name = mi.name;
 
 				if (mi.flags & METHOD_FLAG_VARARG) {
-					if (!md.qualifiers.is_empty()) {
+					if (!md.qualifiers.is_empty_string()) {
 						md.qualifiers += " ";
 					}
 					md.qualifiers += "vararg";
@@ -1043,7 +1043,7 @@ Error DocTools::load_classes(const String &p_dir) {
 	da->list_dir_begin();
 	String path;
 	path = da->get_next();
-	while (!path.is_empty()) {
+	while (!path.is_empty_string()) {
 		if (!da->current_is_dir() && path.ends_with("xml")) {
 			Ref<XMLParser> parser = memnew(XMLParser);
 			Error err2 = parser->open(p_dir.plus_file(path));
@@ -1073,7 +1073,7 @@ Error DocTools::erase_classes(const String &p_dir) {
 	da->list_dir_begin();
 	String path;
 	path = da->get_next();
-	while (!path.is_empty()) {
+	while (!path.is_empty_string()) {
 		if (!da->current_is_dir() && path.ends_with("xml")) {
 			to_erase.push_back(path);
 		}
@@ -1274,7 +1274,7 @@ Error DocTools::_load(Ref<XMLParser> parser) {
 }
 
 static void _write_string(Ref<FileAccess> f, int p_tablevel, const String &p_string) {
-	if (p_string.is_empty()) {
+	if (p_string.is_empty_string()) {
 		return;
 	}
 	String tab;
@@ -1292,15 +1292,15 @@ static void _write_method_doc(Ref<FileAccess> f, const String &p_name, Vector<Do
 			const DocData::MethodDoc &m = p_method_docs[i];
 
 			String qualifiers;
-			if (!m.qualifiers.is_empty()) {
+			if (!m.qualifiers.is_empty_string()) {
 				qualifiers += " qualifiers=\"" + m.qualifiers.xml_escape() + "\"";
 			}
 
 			_write_string(f, 2, "<" + p_name + " name=\"" + m.name.xml_escape() + "\"" + qualifiers + ">");
 
-			if (!m.return_type.is_empty()) {
+			if (!m.return_type.is_empty_string()) {
 				String enum_text;
-				if (!m.return_enum.is_empty()) {
+				if (!m.return_enum.is_empty_string()) {
 					enum_text = " enum=\"" + m.return_enum + "\"";
 				}
 				_write_string(f, 3, "<return type=\"" + m.return_type + "\"" + enum_text + " />");
@@ -1315,11 +1315,11 @@ static void _write_method_doc(Ref<FileAccess> f, const String &p_name, Vector<Do
 				const DocData::ArgumentDoc &a = m.arguments[j];
 
 				String enum_text;
-				if (!a.enumeration.is_empty()) {
+				if (!a.enumeration.is_empty_string()) {
 					enum_text = " enum=\"" + a.enumeration + "\"";
 				}
 
-				if (!a.default_value.is_empty()) {
+				if (!a.default_value.is_empty_string()) {
 					_write_string(f, 3, "<argument index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape() + "\"" + enum_text + " default=\"" + a.default_value.xml_escape(true) + "\" />");
 				} else {
 					_write_string(f, 3, "<argument index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape() + "\"" + enum_text + " />");
@@ -1357,7 +1357,7 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 		_write_string(f, 0, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
 
 		String header = "<class name=\"" + c.name + "\"";
-		if (!c.inherits.is_empty()) {
+		if (!c.inherits.is_empty_string()) {
 			header += " inherits=\"" + c.inherits + "\"";
 		}
 		header += String(" version=\"") + VERSION_BRANCH + "\"";
@@ -1380,7 +1380,7 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 		_write_string(f, 1, "<tutorials>");
 		for (int i = 0; i < c.tutorials.size(); i++) {
 			DocData::TutorialDoc tutorial = c.tutorials.get(i);
-			String title_attribute = (!tutorial.title.is_empty()) ? " title=\"" + _translate_doc_string(tutorial.title).xml_escape() + "\"" : "";
+			String title_attribute = (!tutorial.title.is_empty_string()) ? " title=\"" + _translate_doc_string(tutorial.title).xml_escape() + "\"" : "";
 			_write_string(f, 2, "<link" + title_attribute + ">" + tutorial.link.xml_escape() + "</link>");
 		}
 		_write_string(f, 1, "</tutorials>");
@@ -1396,10 +1396,10 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 
 			for (int i = 0; i < c.properties.size(); i++) {
 				String additional_attributes;
-				if (!c.properties[i].enumeration.is_empty()) {
+				if (!c.properties[i].enumeration.is_empty_string()) {
 					additional_attributes += " enum=\"" + c.properties[i].enumeration + "\"";
 				}
-				if (!c.properties[i].default_value.is_empty()) {
+				if (!c.properties[i].default_value.is_empty_string()) {
 					additional_attributes += " default=\"" + c.properties[i].default_value.xml_escape(true) + "\"";
 				}
 
@@ -1423,13 +1423,13 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 			for (int i = 0; i < c.constants.size(); i++) {
 				const DocData::ConstantDoc &k = c.constants[i];
 				if (k.is_value_valid) {
-					if (!k.enumeration.is_empty()) {
+					if (!k.enumeration.is_empty_string()) {
 						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\" enum=\"" + k.enumeration + "\">");
 					} else {
 						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\">");
 					}
 				} else {
-					if (!k.enumeration.is_empty()) {
+					if (!k.enumeration.is_empty_string()) {
 						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"platform-dependent\" enum=\"" + k.enumeration + "\">");
 					} else {
 						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"platform-dependent\">");
@@ -1449,7 +1449,7 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 			for (int i = 0; i < c.theme_properties.size(); i++) {
 				const DocData::ThemeItemDoc &ti = c.theme_properties[i];
 
-				if (!ti.default_value.is_empty()) {
+				if (!ti.default_value.is_empty_string()) {
 					_write_string(f, 2, "<theme_item name=\"" + ti.name + "\" data_type=\"" + ti.data_type + "\" type=\"" + ti.type + "\" default=\"" + ti.default_value.xml_escape(true) + "\">");
 				} else {
 					_write_string(f, 2, "<theme_item name=\"" + ti.name + "\" data_type=\"" + ti.data_type + "\" type=\"" + ti.type + "\">");

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -168,7 +168,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 			depth--;
 		}
 
-		if (skip || path.is_empty()) {
+		if (skip || path.is_empty_string()) {
 			continue;
 		}
 
@@ -267,7 +267,7 @@ void EditorAssetInstaller::ok_pressed() {
 
 		if (status_map.has(name) && (status_map[name]->is_checked(0) || status_map[name]->is_indeterminate(0))) {
 			String path = status_map[name]->get_metadata(0);
-			if (path.is_empty()) { // a dir
+			if (path.is_empty_string()) { // a dir
 
 				String dirpath;
 				TreeItem *t = status_map[name];

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -157,7 +157,7 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 }
 
 void EditorAutoloadSettings::_autoload_add() {
-	if (autoload_add_path->get_text().is_empty()) {
+	if (autoload_add_path->get_text().is_empty_string()) {
 		ScriptCreateDialog *dialog = FileSystemDock::get_singleton()->get_script_create_dialog();
 		String fpath = path;
 		if (!fpath.ends_with("/")) {
@@ -381,7 +381,7 @@ void EditorAutoloadSettings::_autoload_file_callback(const String &p_path) {
 }
 
 void EditorAutoloadSettings::_autoload_text_submitted(const String p_name) {
-	if (!autoload_add_path->get_text().is_empty() && _autoload_name_is_valid(p_name, nullptr)) {
+	if (!autoload_add_path->get_text().is_empty_string() && _autoload_name_is_valid(p_name, nullptr)) {
 		_autoload_add();
 	}
 }
@@ -395,7 +395,7 @@ void EditorAutoloadSettings::_autoload_text_changed(const String p_name) {
 	bool is_name_valid = _autoload_name_is_valid(p_name, &error_string);
 	add_autoload->set_disabled(!is_name_valid);
 	error_message->set_text(error_string);
-	error_message->set_visible(!autoload_add_name->get_text().is_empty() && !is_name_valid);
+	error_message->set_visible(!autoload_add_name->get_text().is_empty_string() && !is_name_valid);
 }
 
 Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
@@ -454,7 +454,7 @@ void EditorAutoloadSettings::update_autoload() {
 		String name = pi.name.get_slice("/", 1);
 		String path = ProjectSettings::get_singleton()->get(pi.name);
 
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			continue;
 		}
 
@@ -830,7 +830,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 		String name = pi.name.get_slice("/", 1);
 		String path = ProjectSettings::get_singleton()->get(pi.name);
 
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			continue;
 		}
 

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -72,7 +72,7 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 		r.last_used = E.value.last_used;
 
 		if (search_text.is_subsequence_ofn(r.display_name)) {
-			if (!search_text.is_empty()) {
+			if (!search_text.is_empty_string()) {
 				r.score = _score_path(search_text, r.display_name.to_lower());
 			}
 
@@ -91,7 +91,7 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 		return;
 	}
 
-	if (!search_text.is_empty()) {
+	if (!search_text.is_empty_string()) {
 		SortArray<CommandEntry, CommandEntryComparator> sorter;
 		sorter.sort(entries.ptrw(), entries.size());
 	} else {
@@ -163,7 +163,7 @@ void EditorCommandPalette::_sbox_input(const Ref<InputEvent> &p_ie) {
 void EditorCommandPalette::_confirmed() {
 	TreeItem *selected_option = search_options->get_selected();
 	String command_key = selected_option != nullptr ? selected_option->get_metadata(0) : "";
-	if (!command_key.is_empty()) {
+	if (!command_key.is_empty_string()) {
 		hide();
 		execute_command(command_key);
 	}
@@ -323,7 +323,7 @@ EditorCommandPalette::EditorCommandPalette() {
 }
 
 Ref<Shortcut> ED_SHORTCUT_AND_COMMAND(const String &p_path, const String &p_name, Key p_keycode, String p_command_name) {
-	if (p_command_name.is_empty()) {
+	if (p_command_name.is_empty_string()) {
 		p_command_name = p_name;
 	}
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -95,7 +95,7 @@ void EditorSelectionHistory::add_object(ObjectID p_object, const String &p_prope
 	}
 
 	HistoryElement h;
-	if (!p_property.is_empty() && has_prev) {
+	if (!p_property.is_empty_string() && has_prev) {
 		// Add a sub property.
 		HistoryElement &prev_element = history.write[current_elem_idx];
 		h = prev_element;
@@ -542,7 +542,7 @@ void EditorData::remove_scene(int p_idx) {
 		current_edited_scene--;
 	}
 
-	if (!edited_scene[p_idx].path.is_empty()) {
+	if (!edited_scene[p_idx].path.is_empty_string()) {
 		ScriptEditor::get_singleton()->close_builtin_scripts_from_scene(edited_scene[p_idx].path);
 	}
 
@@ -554,7 +554,7 @@ bool EditorData::_find_updated_instances(Node *p_root, Node *p_node, HashSet<Str
 
 	if (p_node == p_root) {
 		ss = p_node->get_scene_inherited_state();
-	} else if (!p_node->get_scene_file_path().is_empty()) {
+	} else if (!p_node->get_scene_file_path().is_empty_string()) {
 		ss = p_node->get_scene_instance_state();
 	}
 
@@ -618,7 +618,7 @@ bool EditorData::check_and_update_scene(int p_idx) {
 
 		memdelete(edited_scene[p_idx].root);
 		edited_scene.write[p_idx].root = new_scene;
-		if (!new_scene->get_scene_file_path().is_empty()) {
+		if (!new_scene->get_scene_file_path().is_empty_string()) {
 			edited_scene.write[p_idx].path = new_scene->get_scene_file_path();
 		}
 		edited_scene.write[p_idx].selection = new_selection;
@@ -652,14 +652,14 @@ void EditorData::set_edited_scene_root(Node *p_root) {
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 	edited_scene.write[current_edited_scene].root = p_root;
 	if (p_root) {
-		if (!p_root->get_scene_file_path().is_empty()) {
+		if (!p_root->get_scene_file_path().is_empty_string()) {
 			edited_scene.write[current_edited_scene].path = p_root->get_scene_file_path();
 		} else {
 			p_root->set_scene_file_path(edited_scene[current_edited_scene].path);
 		}
 	}
 
-	if (!edited_scene[current_edited_scene].path.is_empty()) {
+	if (!edited_scene[current_edited_scene].path.is_empty_string()) {
 		edited_scene.write[current_edited_scene].file_modified_time = FileAccess::get_modified_time(edited_scene[current_edited_scene].path);
 	}
 }
@@ -734,7 +734,7 @@ Ref<Script> EditorData::get_scene_root_script(int p_idx) const {
 	Ref<Script> s = edited_scene[p_idx].root->get_script();
 	if (!s.is_valid() && edited_scene[p_idx].root->get_child_count()) {
 		Node *n = edited_scene[p_idx].root->get_child(0);
-		while (!s.is_valid() && n && n->get_scene_file_path().is_empty()) {
+		while (!s.is_valid() && n && n->get_scene_file_path().is_empty_string()) {
 			s = n->get_script();
 			n = n->get_parent();
 		}
@@ -747,7 +747,7 @@ String EditorData::get_scene_title(int p_idx, bool p_always_strip_extension) con
 	if (!edited_scene[p_idx].root) {
 		return TTR("[empty]");
 	}
-	if (edited_scene[p_idx].root->get_scene_file_path().is_empty()) {
+	if (edited_scene[p_idx].root->get_scene_file_path().is_empty_string()) {
 		return TTR("[unsaved]");
 	}
 
@@ -788,7 +788,7 @@ String EditorData::get_scene_path(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), String());
 
 	if (edited_scene[p_idx].root) {
-		if (edited_scene[p_idx].root->get_scene_file_path().is_empty()) {
+		if (edited_scene[p_idx].root->get_scene_file_path().is_empty_string()) {
 			edited_scene[p_idx].root->set_scene_file_path(edited_scene[p_idx].path);
 		} else {
 			return edited_scene[p_idx].root->get_scene_file_path();
@@ -925,7 +925,7 @@ String EditorData::script_class_get_icon_path(const String &p_class) const {
 
 	String current = p_class;
 	String ret = _script_class_icon_paths[current];
-	while (ret.is_empty()) {
+	while (ret.is_empty_string()) {
 		current = script_class_get_base(current);
 		if (!ScriptServer::is_global_class(current)) {
 			return String();

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -49,7 +49,7 @@ void EditorDirDialog::_update_dir(TreeItem *p_item, EditorFileSystemDirectory *p
 	if (!p_item->get_parent()) {
 		p_item->set_text(0, "res://");
 	} else {
-		if (!opened_paths.has(path) && (p_select_path.is_empty() || !p_select_path.begins_with(path))) {
+		if (!opened_paths.has(path) && (p_select_path.is_empty_string() || !p_select_path.begins_with(path))) {
 			p_item->set_collapsed(true);
 		}
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -343,7 +343,7 @@ void EditorExportPlatform::gen_debug_flags(Vector<String> &r_flags, int p_flags)
 		String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
 		r_flags.push_back("--remote-fs");
 		r_flags.push_back(host + ":" + itos(port));
-		if (!passwd.is_empty()) {
+		if (!passwd.is_empty_string()) {
 			r_flags.push_back("--remote-fs-password");
 			r_flags.push_back(passwd);
 		}
@@ -568,7 +568,7 @@ void EditorExportPlatform::_edit_files_with_filter(Ref<DirAccess> &da, const Vec
 
 	Vector<String> dirs;
 	String f = da->get_next();
-	while (!f.is_empty()) {
+	while (!f.is_empty_string()) {
 		if (da->current_is_dir()) {
 			dirs.push_back(f);
 		} else {
@@ -607,14 +607,14 @@ void EditorExportPlatform::_edit_files_with_filter(Ref<DirAccess> &da, const Vec
 }
 
 void EditorExportPlatform::_edit_filter_list(HashSet<String> &r_list, const String &p_filter, bool exclude) {
-	if (p_filter.is_empty()) {
+	if (p_filter.is_empty_string()) {
 		return;
 	}
 	Vector<String> split = p_filter.split(",");
 	Vector<String> filters;
 	for (int i = 0; i < split.size(); i++) {
 		String f = split[i].strip_edges();
-		if (f.is_empty()) {
+		if (f.is_empty_string()) {
 			continue;
 		}
 		filters.push_back(f);
@@ -777,12 +777,12 @@ EditorExportPlatform::FeatureContainers EditorExportPlatform::get_feature_contai
 		result.features_pv.push_back("release");
 	}
 
-	if (!p_preset->get_custom_features().is_empty()) {
+	if (!p_preset->get_custom_features().is_empty_string()) {
 		Vector<String> tmp_custom_list = p_preset->get_custom_features().split(",");
 
 		for (int i = 0; i < tmp_custom_list.size(); i++) {
 			String f = tmp_custom_list[i].strip_edges();
-			if (!f.is_empty()) {
+			if (!f.is_empty_string()) {
 				result.features.insert(f);
 				result.features_pv.push_back(f);
 			}
@@ -880,7 +880,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		Vector<String> enc_in_split = p_preset->get_enc_in_filter().split(",");
 		for (int i = 0; i < enc_in_split.size(); i++) {
 			String f = enc_in_split[i].strip_edges();
-			if (f.is_empty()) {
+			if (f.is_empty_string()) {
 				continue;
 			}
 			enc_in_filters.push_back(f);
@@ -889,7 +889,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		Vector<String> enc_ex_split = p_preset->get_enc_ex_filter().split(",");
 		for (int i = 0; i < enc_ex_split.size(); i++) {
 			String f = enc_ex_split[i].strip_edges();
-			if (f.is_empty()) {
+			if (f.is_empty_string()) {
 				continue;
 			}
 			enc_ex_filters.push_back(f);
@@ -1088,12 +1088,12 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 	Vector<String> custom_list;
 
-	if (!p_preset->get_custom_features().is_empty()) {
+	if (!p_preset->get_custom_features().is_empty_string()) {
 		Vector<String> tmp_custom_list = p_preset->get_custom_features().split(",");
 
 		for (int i = 0; i < tmp_custom_list.size(); i++) {
 			String f = tmp_custom_list[i].strip_edges();
-			if (!f.is_empty()) {
+			if (!f.is_empty_string()) {
 				custom_list.push_back(f);
 			}
 		}
@@ -1127,14 +1127,14 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	// Store icon and splash images directly, they need to bypass the import system and be loaded as images
 	String icon = ProjectSettings::get_singleton()->get("application/config/icon");
 	String splash = ProjectSettings::get_singleton()->get("application/boot_splash/image");
-	if (!icon.is_empty() && FileAccess::exists(icon)) {
+	if (!icon.is_empty_string() && FileAccess::exists(icon)) {
 		Vector<uint8_t> array = FileAccess::get_file_as_array(icon);
 		err = p_func(p_udata, icon, array, idx, total, enc_in_filters, enc_ex_filters, key);
 		if (err != OK) {
 			return err;
 		}
 	}
-	if (!splash.is_empty() && FileAccess::exists(splash) && icon != splash) {
+	if (!splash.is_empty_string() && FileAccess::exists(splash) && icon != splash) {
 		Vector<uint8_t> array = FileAccess::get_file_as_array(splash);
 		err = p_func(p_udata, splash, array, idx, total, enc_in_filters, enc_ex_filters, key);
 		if (err != OK) {
@@ -1465,7 +1465,7 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 		String passwd = EditorSettings::get_singleton()->get("filesystem/file_server/password");
 		r_flags.push_back("--remote-fs");
 		r_flags.push_back(host + ":" + itos(port));
-		if (!passwd.is_empty()) {
+		if (!passwd.is_empty_string()) {
 			r_flags.push_back("--remote-fs-password");
 			r_flags.push_back(passwd);
 		}
@@ -1903,7 +1903,7 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 	valid = dvalid || rvalid;
 	r_missing_templates = !valid;
 
-	if (!err.is_empty()) {
+	if (!err.is_empty_string()) {
 		r_error = err;
 	}
 	return valid;
@@ -1936,11 +1936,11 @@ Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_
 
 	template_path = template_path.strip_edges();
 
-	if (template_path.is_empty()) {
+	if (template_path.is_empty_string()) {
 		template_path = find_export_template(get_template_file_name(p_debug ? "debug" : "release", p_preset->get("binary_format/64_bits") ? "64" : "32"));
 	}
 
-	if (!template_path.is_empty() && !FileAccess::exists(template_path)) {
+	if (!template_path.is_empty_string() && !FileAccess::exists(template_path)) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Template"), vformat(TTR("Template file not found: \"%s\"."), template_path));
 		return ERR_FILE_NOT_FOUND;
 	}
@@ -1983,7 +1983,7 @@ Error EditorExportPlatformPC::export_project_data(const Ref<EditorExportPreset> 
 		for (int i = 0; i < so_files.size() && err == OK; i++) {
 			String src_path = ProjectSettings::get_singleton()->globalize_path(so_files[i].path);
 			String target_path;
-			if (so_files[i].target.is_empty()) {
+			if (so_files[i].target.is_empty_string()) {
 				target_path = p_path.get_base_dir().plus_file(src_path.get_file());
 			} else {
 				target_path = p_path.get_base_dir().plus_file(so_files[i].target).plus_file(src_path.get_file());

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -312,7 +312,7 @@ void EditorFeatureProfileManager::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
 			current_profile = EDITOR_GET("_default_feature_profile");
-			if (!current_profile.is_empty()) {
+			if (!current_profile.is_empty_string()) {
 				current.instantiate();
 				Error err = current->load_from_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(current_profile + ".profile"));
 				if (err != OK) {
@@ -337,7 +337,7 @@ String EditorFeatureProfileManager::_get_selected_profile() {
 
 void EditorFeatureProfileManager::_update_profile_list(const String &p_select_profile) {
 	String selected_profile;
-	if (p_select_profile.is_empty()) { //default, keep
+	if (p_select_profile.is_empty_string()) { //default, keep
 		if (profile_list->get_selected() >= 0) {
 			selected_profile = profile_list->get_item_metadata(profile_list->get_selected());
 			if (!FileAccess::exists(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(selected_profile + ".profile"))) {
@@ -355,7 +355,7 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 	d->list_dir_begin();
 	while (true) {
 		String f = d->get_next();
-		if (f.is_empty()) {
+		if (f.is_empty_string()) {
 			break;
 		}
 
@@ -374,7 +374,7 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 	for (int i = 0; i < profiles.size(); i++) {
 		String name = profiles[i];
 
-		if (i == 0 && selected_profile.is_empty()) {
+		if (i == 0 && selected_profile.is_empty_string()) {
 			selected_profile = name;
 		}
 
@@ -389,15 +389,15 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 		}
 	}
 
-	class_list_vbc->set_visible(!selected_profile.is_empty());
-	property_list_vbc->set_visible(!selected_profile.is_empty());
-	no_profile_selected_help->set_visible(selected_profile.is_empty());
-	profile_actions[PROFILE_CLEAR]->set_disabled(current_profile.is_empty());
-	profile_actions[PROFILE_ERASE]->set_disabled(selected_profile.is_empty());
-	profile_actions[PROFILE_EXPORT]->set_disabled(selected_profile.is_empty());
-	profile_actions[PROFILE_SET]->set_disabled(selected_profile.is_empty());
+	class_list_vbc->set_visible(!selected_profile.is_empty_string());
+	property_list_vbc->set_visible(!selected_profile.is_empty_string());
+	no_profile_selected_help->set_visible(selected_profile.is_empty_string());
+	profile_actions[PROFILE_CLEAR]->set_disabled(current_profile.is_empty_string());
+	profile_actions[PROFILE_ERASE]->set_disabled(selected_profile.is_empty_string());
+	profile_actions[PROFILE_EXPORT]->set_disabled(selected_profile.is_empty_string());
+	profile_actions[PROFILE_SET]->set_disabled(selected_profile.is_empty_string());
 
-	current_profile_name->set_text(!current_profile.is_empty() ? current_profile : TTR("(none)"));
+	current_profile_name->set_text(!current_profile.is_empty_string() ? current_profile : TTR("(none)"));
 
 	_update_selected_profile();
 }
@@ -415,7 +415,7 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 		} break;
 		case PROFILE_SET: {
 			String selected = _get_selected_profile();
-			ERR_FAIL_COND(selected.is_empty());
+			ERR_FAIL_COND(selected.is_empty_string());
 			if (selected == current_profile) {
 				return; // Nothing to do here.
 			}
@@ -441,7 +441,7 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 		} break;
 		case PROFILE_ERASE: {
 			String selected = _get_selected_profile();
-			ERR_FAIL_COND(selected.is_empty());
+			ERR_FAIL_COND(selected.is_empty_string());
 
 			erase_profile_dialog->set_text(vformat(TTR("Remove currently selected profile, '%s'? Cannot be undone."), selected));
 			erase_profile_dialog->popup_centered(Size2(240, 60) * EDSCALE);
@@ -451,7 +451,7 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 
 void EditorFeatureProfileManager::_erase_selected_profile() {
 	String selected = _get_selected_profile();
-	ERR_FAIL_COND(selected.is_empty());
+	ERR_FAIL_COND(selected.is_empty_string());
 	Ref<DirAccess> da = DirAccess::open(EditorSettings::get_singleton()->get_feature_profiles_dir());
 	ERR_FAIL_COND_MSG(da.is_null(), "Cannot open directory '" + EditorSettings::get_singleton()->get_feature_profiles_dir() + "'.");
 
@@ -736,7 +736,7 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 	class_list->clear();
 
 	String profile = _get_selected_profile();
-	if (profile.is_empty()) { //nothing selected, nothing edited
+	if (profile.is_empty_string()) { //nothing selected, nothing edited
 		property_list->clear();
 		edited.unref();
 		return;
@@ -840,7 +840,7 @@ void EditorFeatureProfileManager::_export_profile(const String &p_path) {
 
 void EditorFeatureProfileManager::_save_and_update() {
 	String edited_path = _get_selected_profile();
-	ERR_FAIL_COND(edited_path.is_empty());
+	ERR_FAIL_COND(edited_path.is_empty_string());
 	ERR_FAIL_COND(edited.is_null());
 
 	edited->save_to_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(edited_path + ".profile"));

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -283,7 +283,7 @@ void EditorFileDialog::_post_popup() {
 		file_box->set_visible(true);
 	}
 
-	if (is_visible() && !get_current_file().is_empty()) {
+	if (is_visible() && !get_current_file().is_empty_string()) {
 		_request_single_thumbnail(get_current_dir().plus_file(get_current_file()));
 	}
 
@@ -791,7 +791,7 @@ void EditorFileDialog::update_file_list() {
 
 	String item = dir_access->get_next();
 
-	while (!item.is_empty()) {
+	while (!item.is_empty_string()) {
 		if (item == "." || item == "..") {
 			item = dir_access->get_next();
 			continue;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -241,7 +241,7 @@ void EditorFileSystem::_scan_filesystem() {
 					first = false;
 					continue;
 				}
-				if (l.is_empty()) {
+				if (l.is_empty_string()) {
 					continue;
 				}
 
@@ -293,7 +293,7 @@ void EditorFileSystem::_scan_filesystem() {
 		{
 			Ref<FileAccess> f2 = FileAccess::open(update_cache, FileAccess::READ);
 			String l = f2->get_line().strip_edges();
-			while (!l.is_empty()) {
+			while (!l.is_empty_string()) {
 				file_cache.erase(l); //erase cache for this, so it gets updated
 				l = f2->get_line().strip_edges();
 			}
@@ -398,7 +398,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 			return false; //parse error, try reimport manually (Avoid reimport loop on broken file)
 		}
 
-		if (!assign.is_empty()) {
+		if (!assign.is_empty_string()) {
 			if (assign.begins_with("path")) {
 				to_check.push_back(value);
 			} else if (assign == "files") {
@@ -466,7 +466,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 			ERR_PRINT("ResourceFormatImporter::load - '" + p_path + ".import.md5:" + itos(lines) + "' error '" + error_text + "'.");
 			return false; // parse error
 		}
-		if (!assign.is_empty()) {
+		if (!assign.is_empty_string()) {
 			if (!p_only_imported_files) {
 				if (assign == "source_md5") {
 					source_md5 = value;
@@ -486,11 +486,11 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 
 	//check source md5 matching
 	if (!p_only_imported_files) {
-		if (!source_file.is_empty() && source_file != p_path) {
+		if (!source_file.is_empty_string() && source_file != p_path) {
 			return true; //file was moved, reimport
 		}
 
-		if (source_md5.is_empty()) {
+		if (source_md5.is_empty_string()) {
 			return true; //lacks md5, so just reimport
 		}
 
@@ -499,7 +499,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 			return true;
 		}
 
-		if (dest_files.size() && !dest_md5.is_empty()) {
+		if (dest_files.size() && !dest_md5.is_empty_string()) {
 			md5 = FileAccess::get_multiple_md5(dest_files);
 			if (md5 != dest_md5) {
 				return true;
@@ -743,7 +743,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, Ref<DirAc
 	da->list_dir_begin();
 	while (true) {
 		String f = da->get_next();
-		if (f.is_empty()) {
+		if (f.is_empty_string()) {
 			break;
 		}
 
@@ -853,7 +853,7 @@ void EditorFileSystem::_scan_new_dir(EditorFileSystemDirectory *p_dir, Ref<DirAc
 					scan_actions.push_back(ia);
 				}
 
-				if (fc->type.is_empty()) {
+				if (fc->type.is_empty_string()) {
 					fi->type = ResourceLoader::get_resource_type(path);
 					fi->import_group_file = ResourceLoader::get_import_group_file(path);
 					//there is also the chance that file type changed due to reimport, must probably check this somehow here (or kind of note it for next time in another file?)
@@ -965,7 +965,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 		da->list_dir_begin();
 		while (true) {
 			String f = da->get_next();
-			if (f.is_empty()) {
+			if (f.is_empty_string()) {
 				break;
 			}
 
@@ -1278,7 +1278,7 @@ void EditorFileSystem::_save_filesystem_cache(EditorFileSystemDirectory *p_dir, 
 	p_file->store_line("::" + p_dir->get_path() + "::" + String::num(p_dir->modified_time));
 
 	for (int i = 0; i < p_dir->files.size(); i++) {
-		if (!p_dir->files[i]->import_group_file.is_empty()) {
+		if (!p_dir->files[i]->import_group_file.is_empty_string()) {
 			group_file_cache.insert(p_dir->files[i]->import_group_file);
 		}
 		String s = p_dir->files[i]->file + "::" + p_dir->files[i]->type + "::" + itos(p_dir->files[i]->uid) + "::" + itos(p_dir->files[i]->modified_time) + "::" + itos(p_dir->files[i]->import_modified_time) + "::" + itos(p_dir->files[i]->import_valid) + "::" + p_dir->files[i]->import_group_file + "::" + p_dir->files[i]->script_class_name + "<>" + p_dir->files[i]->script_class_extends + "<>" + p_dir->files[i]->script_class_icon_path;
@@ -1418,7 +1418,7 @@ EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p
 
 	f = f.substr(6, f.length());
 	f = f.replace("\\", "/");
-	if (f.is_empty()) {
+	if (f.is_empty_string()) {
 		return filesystem;
 	}
 
@@ -1497,7 +1497,7 @@ void EditorFileSystem::_scan_script_classes(EditorFileSystemDirectory *p_dir) {
 	int filecount = p_dir->files.size();
 	const EditorFileSystemDirectory::FileInfo *const *files = p_dir->files.ptr();
 	for (int i = 0; i < filecount; i++) {
-		if (files[i]->script_class_name.is_empty()) {
+		if (files[i]->script_class_name.is_empty_string()) {
 			continue;
 		}
 
@@ -1577,7 +1577,7 @@ void EditorFileSystem::update_file(const String &p_file) {
 	}
 
 	String type = ResourceLoader::get_resource_type(p_file);
-	if (type.is_empty() && textfile_extensions.has(p_file.get_extension())) {
+	if (type.is_empty_string() && textfile_extensions.has(p_file.get_extension())) {
 		type = "TextFile";
 	}
 	ResourceUID::ID uid = ResourceLoader::get_resource_uid(p_file);
@@ -1652,9 +1652,9 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		ERR_CONTINUE(err != OK);
 		ERR_CONTINUE(!config->has_section_key("remap", "importer"));
 		String file_importer_name = config->get_value("remap", "importer");
-		ERR_CONTINUE(file_importer_name.is_empty());
+		ERR_CONTINUE(file_importer_name.is_empty_string());
 
-		if (!importer_name.is_empty() && importer_name != file_importer_name) {
+		if (!importer_name.is_empty_string() && importer_name != file_importer_name) {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("There are multiple importers for different types pointing to file %s, import aborted"), p_group_file));
 			ERR_FAIL_V(ERR_FILE_CORRUPT);
 		}
@@ -1692,7 +1692,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		return OK; // (do nothing)
 	}
 
-	ERR_FAIL_COND_V(importer_name.is_empty(), ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(importer_name.is_empty_string(), ERR_UNCONFIGURED);
 
 	Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 
@@ -1715,7 +1715,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 			if (version > 0) {
 				f->store_line("importer_version=" + itos(version));
 			}
-			if (!importer->get_resource_type().is_empty()) {
+			if (!importer->get_resource_type().is_empty_string()) {
 				f->store_line("type=\"" + importer->get_resource_type() + "\"");
 			}
 
@@ -1795,7 +1795,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		if (ResourceCache::has(file)) {
 			Resource *r = ResourceCache::get(file);
 
-			if (!r->get_import_path().is_empty()) {
+			if (!r->get_import_path().is_empty_string()) {
 				String dst_path = ResourceFormatImporter::get_singleton()->get_internal_resource_path(file);
 				r->set_import_path(dst_path);
 				r->set_import_last_modified_time(0);
@@ -1819,7 +1819,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const HashMap<String
 	HashMap<StringName, Variant> params;
 	String importer_name; //empty by default though
 
-	if (!p_custom_importer.is_empty()) {
+	if (!p_custom_importer.is_empty_string()) {
 		importer_name = p_custom_importer;
 	}
 	if (p_custom_options != nullptr) {
@@ -1844,7 +1844,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const HashMap<String
 				}
 
 				if (cf->has_section("remap")) {
-					if (p_custom_importer.is_empty()) {
+					if (p_custom_importer.is_empty_string()) {
 						importer_name = cf->get_value("remap", "importer");
 					}
 
@@ -1870,7 +1870,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const HashMap<String
 	Ref<ResourceImporter> importer;
 	bool load_default = false;
 	//find the importer
-	if (!importer_name.is_empty()) {
+	if (!importer_name.is_empty_string()) {
 		importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 	}
 
@@ -1932,7 +1932,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const HashMap<String
 		if (version > 0) {
 			f->store_line("importer_version=" + itos(version));
 		}
-		if (!importer->get_resource_type().is_empty()) {
+		if (!importer->get_resource_type().is_empty_string()) {
 			f->store_line("type=\"" + importer->get_resource_type() + "\"");
 		}
 
@@ -1943,7 +1943,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const HashMap<String
 		f->store_line("uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\""); //store in readable format
 
 		if (err == OK) {
-			if (importer->get_save_extension().is_empty()) {
+			if (importer->get_save_extension().is_empty_string()) {
 				//no path
 			} else if (import_variants.size()) {
 				//import with variants
@@ -2037,7 +2037,7 @@ void EditorFileSystem::_reimport_file(const String &p_file, const HashMap<String
 	if (ResourceCache::has(p_file)) {
 		Resource *r = ResourceCache::get(p_file);
 
-		if (!r->get_import_path().is_empty()) {
+		if (!r->get_import_path().is_empty_string()) {
 			String dst_path = ResourceFormatImporter::get_singleton()->get_internal_resource_path(p_file);
 			r->set_import_path(dst_path);
 			r->set_import_last_modified_time(0);
@@ -2096,7 +2096,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 			groups_to_reimport.insert(file);
 			//groups do not belong to grups
 			group_file = String();
-		} else if (!group_file.is_empty()) {
+		} else if (!group_file.is_empty_string()) {
 			//it's a group file, add group to import and skip this file
 			groups_to_reimport.insert(group_file);
 		} else {

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -113,7 +113,7 @@ void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p
 		if (E.usage & PROPERTY_USAGE_EDITOR) {
 			if (E.type == Variant::OBJECT) {
 				Ref<Resource> res = p_node->get(E.name);
-				if (res.is_valid() && !resources.has(res) && !res->get_path().is_empty() && !res->get_path().is_resource_file()) {
+				if (res.is_valid() && !resources.has(res) && !res->get_path().is_empty_string() && !res->get_path().is_resource_file()) {
 					Vector<String> res_unfolds = _get_unfolds(res.ptr());
 					resource_folds.push_back(res->get_path());
 					resource_folds.push_back(res_unfolds);
@@ -243,8 +243,8 @@ void EditorFolding::_do_object_unfolds(Object *p_object, HashSet<Ref<Resource>> 
 
 		//can unfold
 		if (E.usage & PROPERTY_USAGE_EDITOR) {
-			if (!group.is_empty()) { //group
-				if (group_base.is_empty() || E.name.begins_with(group_base)) {
+			if (!group.is_empty_string()) { //group
+				if (group_base.is_empty_string() || E.name.begins_with(group_base)) {
 					bool can_revert = EditorPropertyRevert::can_property_revert(p_object, E.name);
 					if (can_revert) {
 						unfold_group.insert(group);
@@ -262,7 +262,7 @@ void EditorFolding::_do_object_unfolds(Object *p_object, HashSet<Ref<Resource>> 
 
 			if (E.type == Variant::OBJECT) {
 				Ref<Resource> res = p_object->get(E.name);
-				if (res.is_valid() && !resources.has(res) && !res->get_path().is_empty() && !res->get_path().is_resource_file()) {
+				if (res.is_valid() && !resources.has(res) && !res->get_path().is_empty_string() && !res->get_path().is_resource_file()) {
 					resources.insert(res);
 					_do_object_unfolds(res.ptr(), resources);
 				}

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -95,7 +95,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (!m_variations.is_empty()) {                               \
+		if (!m_variations.is_empty_string()) {                        \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \
@@ -121,7 +121,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (!m_variations.is_empty()) {                               \
+		if (!m_variations.is_empty_string()) {                        \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \
@@ -148,7 +148,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (!m_variations.is_empty()) {                               \
+		if (!m_variations.is_empty_string()) {                        \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \
@@ -174,7 +174,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (!m_variations.is_empty()) {                               \
+		if (!m_variations.is_empty_string()) {                        \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \
@@ -200,7 +200,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (!m_variations.is_empty()) {                               \
+		if (!m_variations.is_empty_string()) {                        \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \
@@ -226,7 +226,7 @@
 	}                                                                 \
 	{                                                                 \
 		Dictionary variations;                                        \
-		if (!m_variations.is_empty()) {                               \
+		if (!m_variations.is_empty_string()) {                        \
 			Vector<String> variation_tags = m_variations.split(",");  \
 			for (int i = 0; i < variation_tags.size(); i++) {         \
 				Vector<String> tokens = variation_tags[i].split("="); \

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -195,12 +195,12 @@ void EditorHelp::_class_desc_resized(bool p_force_update_theme) {
 
 void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 	String t = p_type;
-	if (t.is_empty()) {
+	if (t.is_empty_string()) {
 		t = "void";
 	}
-	bool can_ref = (t != "void" && !t.contains("*")) || !p_enum.is_empty();
+	bool can_ref = (t != "void" && !t.contains("*")) || !p_enum.is_empty_string();
 
-	if (!p_enum.is_empty()) {
+	if (!p_enum.is_empty_string()) {
 		if (p_enum.get_slice_count(".") > 1) {
 			t = p_enum.get_slice(".", 1);
 		} else {
@@ -215,7 +215,7 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 			add_array = true;
 			t = t.replace("[]", "");
 		}
-		if (p_enum.is_empty()) {
+		if (p_enum.is_empty_string()) {
 			class_desc->push_meta("#" + t); //class
 		} else {
 			class_desc->push_meta("$" + p_enum); //class
@@ -272,7 +272,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		class_desc->add_text(" ");
 	}
 
-	if (p_overview && !p_method.description.is_empty()) {
+	if (p_overview && !p_method.description.is_empty_string()) {
 		class_desc->push_meta("@method " + p_method.name);
 	}
 
@@ -280,7 +280,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	_add_text(p_method.name);
 	class_desc->pop();
 
-	if (p_overview && !p_method.description.is_empty()) {
+	if (p_overview && !p_method.description.is_empty_string()) {
 		class_desc->pop(); //meta
 	}
 
@@ -297,7 +297,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		_add_text(p_method.arguments[j].name);
 		class_desc->add_text(": ");
 		_add_type(p_method.arguments[j].type, p_method.arguments[j].enumeration);
-		if (!p_method.arguments[j].default_value.is_empty()) {
+		if (!p_method.arguments[j].default_value.is_empty_string()) {
 			class_desc->push_color(symbol_color);
 			class_desc->add_text(" = ");
 			class_desc->pop();
@@ -323,7 +323,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	class_desc->push_color(symbol_color);
 	class_desc->add_text(")");
 	class_desc->pop();
-	if (!p_method.qualifiers.is_empty()) {
+	if (!p_method.qualifiers.is_empty_string()) {
 		class_desc->push_color(qualifier_color);
 		class_desc->add_text(" ");
 		_add_text(p_method.qualifiers);
@@ -397,7 +397,7 @@ void EditorHelp::_update_method_list(const Vector<DocData::MethodDoc> p_methods,
 			if (i < m.size() - 1 && new_prefix == m[i + 1].name.substr(0, 3) && new_prefix != group_prefix) {
 				is_new_group = i > 0;
 				group_prefix = new_prefix;
-			} else if (!group_prefix.is_empty() && new_prefix != group_prefix) {
+			} else if (!group_prefix.is_empty_string() && new_prefix != group_prefix) {
 				is_new_group = true;
 				group_prefix = "";
 			}
@@ -409,7 +409,7 @@ void EditorHelp::_update_method_list(const Vector<DocData::MethodDoc> p_methods,
 				class_desc->pop(); //cell
 			}
 
-			if (!m[i].description.is_empty() || m[i].errors_returned.size() > 0) {
+			if (!m[i].description.is_empty_string() || m[i].errors_returned.size() > 0) {
 				r_method_descrpitons = true;
 			}
 
@@ -483,7 +483,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc p_classdoc,
 				class_desc->add_newline();
 				class_desc->add_newline();
 			}
-			if (!methods_filtered[i].description.strip_edges().is_empty()) {
+			if (!methods_filtered[i].description.strip_edges().is_empty_string()) {
 				_add_text(DTR(methods_filtered[i].description));
 			} else {
 				class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
@@ -549,19 +549,19 @@ void EditorHelp::_update_doc() {
 	// Inheritance tree
 
 	// Ascendents
-	if (!cd.inherits.is_empty()) {
+	if (!cd.inherits.is_empty_string()) {
 		class_desc->push_color(title_color);
 		class_desc->push_font(doc_font);
 		class_desc->add_text(TTR("Inherits:") + " ");
 
 		String inherits = cd.inherits;
 
-		while (!inherits.is_empty()) {
+		while (!inherits.is_empty_string()) {
 			_add_type(inherits);
 
 			inherits = doc->class_list[inherits].inherits;
 
-			if (!inherits.is_empty()) {
+			if (!inherits.is_empty_string()) {
 				class_desc->add_text(" < ");
 			}
 		}
@@ -605,7 +605,7 @@ void EditorHelp::_update_doc() {
 	class_desc->add_newline();
 
 	// Brief description
-	if (!cd.brief_description.is_empty()) {
+	if (!cd.brief_description.is_empty_string()) {
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_bold_font);
 		class_desc->push_indent(1);
@@ -619,7 +619,7 @@ void EditorHelp::_update_doc() {
 	}
 
 	// Class description
-	if (!cd.description.is_empty()) {
+	if (!cd.description.is_empty_string()) {
 		section_line.push_back(Pair<String, int>(TTR("Description"), class_desc->get_paragraph_count() - 2));
 		description_line = class_desc->get_paragraph_count() - 2;
 		class_desc->push_color(title_color);
@@ -656,7 +656,7 @@ void EditorHelp::_update_doc() {
 
 		for (int i = 0; i < cd.tutorials.size(); i++) {
 			const String link = DTR(cd.tutorials[i].link);
-			String linktxt = (cd.tutorials[i].title.is_empty()) ? link : DTR(cd.tutorials[i].title);
+			String linktxt = (cd.tutorials[i].title.is_empty_string()) ? link : DTR(cd.tutorials[i].title);
 			const int seppos = linktxt.find("//");
 			if (seppos != -1) {
 				linktxt = link.substr(seppos + 2);
@@ -682,7 +682,7 @@ void EditorHelp::_update_doc() {
 	if (cd.is_script_doc) {
 		has_properties = false;
 		for (int i = 0; i < cd.properties.size(); i++) {
-			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.is_empty()) {
+			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.is_empty_string()) {
 				continue;
 			}
 			has_properties = true;
@@ -706,7 +706,7 @@ void EditorHelp::_update_doc() {
 
 		for (int i = 0; i < cd.properties.size(); i++) {
 			// Ignore undocumented private.
-			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.is_empty()) {
+			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.is_empty_string()) {
 				continue;
 			}
 			property_line[cd.properties[i].name] = class_desc->get_paragraph_count() - 2; //gets overridden if description
@@ -722,16 +722,16 @@ void EditorHelp::_update_doc() {
 
 			bool describe = false;
 
-			if (!cd.properties[i].setter.is_empty()) {
+			if (!cd.properties[i].setter.is_empty_string()) {
 				skip_methods.insert(cd.properties[i].setter);
 				describe = true;
 			}
-			if (!cd.properties[i].getter.is_empty()) {
+			if (!cd.properties[i].getter.is_empty_string()) {
 				skip_methods.insert(cd.properties[i].getter);
 				describe = true;
 			}
 
-			if (!cd.properties[i].description.is_empty()) {
+			if (!cd.properties[i].description.is_empty_string()) {
 				describe = true;
 			}
 
@@ -763,7 +763,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_cell();
 			class_desc->push_font(doc_code_font);
 
-			if (!cd.properties[i].default_value.is_empty()) {
+			if (!cd.properties[i].default_value.is_empty_string()) {
 				class_desc->push_color(symbol_color);
 				if (cd.properties[i].overridden) {
 					class_desc->add_text(" [");
@@ -792,18 +792,18 @@ void EditorHelp::_update_doc() {
 			class_desc->push_cell();
 			class_desc->push_font(doc_code_font);
 
-			if (cd.is_script_doc && (!cd.properties[i].setter.is_empty() || !cd.properties[i].getter.is_empty())) {
+			if (cd.is_script_doc && (!cd.properties[i].setter.is_empty_string() || !cd.properties[i].getter.is_empty_string())) {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("property:") + " ");
 				class_desc->pop(); // color
 
-				if (!cd.properties[i].setter.is_empty()) {
+				if (!cd.properties[i].setter.is_empty_string()) {
 					class_desc->push_color(value_color);
 					class_desc->add_text("setter");
 					class_desc->pop(); // color
 				}
-				if (!cd.properties[i].getter.is_empty()) {
-					if (!cd.properties[i].setter.is_empty()) {
+				if (!cd.properties[i].getter.is_empty_string()) {
+					if (!cd.properties[i].setter.is_empty_string()) {
 						class_desc->push_color(symbol_color);
 						class_desc->add_text(", ");
 						class_desc->pop(); // color
@@ -844,7 +844,7 @@ void EditorHelp::_update_doc() {
 			}
 		}
 		// Ignore undocumented non virtual private.
-		if (cd.methods[i].name.begins_with("_") && cd.methods[i].description.is_empty() && !cd.methods[i].qualifiers.contains("virtual")) {
+		if (cd.methods[i].name.begins_with("_") && cd.methods[i].description.is_empty_string() && !cd.methods[i].qualifiers.contains("virtual")) {
 			continue;
 		}
 		methods.push_back(cd.methods[i]);
@@ -942,7 +942,7 @@ void EditorHelp::_update_doc() {
 			class_desc->pop();
 
 			// Theme item default value.
-			if (!cd.theme_properties[i].default_value.is_empty()) {
+			if (!cd.theme_properties[i].default_value.is_empty_string()) {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("default:") + " ");
 				class_desc->pop();
@@ -957,7 +957,7 @@ void EditorHelp::_update_doc() {
 			class_desc->pop(); // monofont
 
 			// Theme item description.
-			if (!cd.theme_properties[i].description.is_empty()) {
+			if (!cd.theme_properties[i].description.is_empty_string()) {
 				class_desc->push_font(doc_font);
 				class_desc->push_color(comment_color);
 				class_desc->push_indent(1);
@@ -1013,7 +1013,7 @@ void EditorHelp::_update_doc() {
 				_add_text(cd.signals[i].arguments[j].name);
 				class_desc->add_text(": ");
 				_add_type(cd.signals[i].arguments[j].type);
-				if (!cd.signals[i].arguments[j].default_value.is_empty()) {
+				if (!cd.signals[i].arguments[j].default_value.is_empty_string()) {
 					class_desc->push_color(symbol_color);
 					class_desc->add_text(" = ");
 					class_desc->pop();
@@ -1027,7 +1027,7 @@ void EditorHelp::_update_doc() {
 			class_desc->add_text(")");
 			class_desc->pop();
 			class_desc->pop(); // end monofont
-			if (!cd.signals[i].description.is_empty()) {
+			if (!cd.signals[i].description.is_empty_string()) {
 				class_desc->push_font(doc_font);
 				class_desc->push_color(comment_color);
 				class_desc->push_indent(1);
@@ -1050,7 +1050,7 @@ void EditorHelp::_update_doc() {
 		Vector<DocData::ConstantDoc> constants;
 
 		for (int i = 0; i < cd.constants.size(); i++) {
-			if (!cd.constants[i].enumeration.is_empty()) {
+			if (!cd.constants[i].enumeration.is_empty_string()) {
 				if (!enums.has(cd.constants[i].enumeration)) {
 					enums[cd.constants[i].enumeration] = Vector<DocData::ConstantDoc>();
 				}
@@ -1058,7 +1058,7 @@ void EditorHelp::_update_doc() {
 				enums[cd.constants[i].enumeration].push_back(cd.constants[i]);
 			} else {
 				// Ignore undocumented private.
-				if (cd.constants[i].name.begins_with("_") && cd.constants[i].description.is_empty()) {
+				if (cd.constants[i].name.begins_with("_") && cd.constants[i].description.is_empty_string()) {
 					continue;
 				}
 				constants.push_back(cd.constants[i]);
@@ -1142,7 +1142,7 @@ void EditorHelp::_update_doc() {
 
 					class_desc->add_newline();
 
-					if (!enum_list[i].description.strip_edges().is_empty()) {
+					if (!enum_list[i].description.strip_edges().is_empty_string()) {
 						class_desc->push_font(doc_font);
 						class_desc->push_color(comment_color);
 						_add_text(DTR(enum_list[i].description));
@@ -1211,7 +1211,7 @@ void EditorHelp::_update_doc() {
 
 				class_desc->add_newline();
 
-				if (!constants[i].description.is_empty()) {
+				if (!constants[i].description.is_empty_string()) {
 					class_desc->push_font(doc_font);
 					class_desc->push_color(comment_color);
 					_add_text(DTR(constants[i].description));
@@ -1267,7 +1267,7 @@ void EditorHelp::_update_doc() {
 			_add_text(cd.properties[i].name);
 			class_desc->pop(); // color
 
-			if (!cd.properties[i].default_value.is_empty()) {
+			if (!cd.properties[i].default_value.is_empty_string()) {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("default:") + " ");
 				class_desc->pop(); // color
@@ -1281,18 +1281,18 @@ void EditorHelp::_update_doc() {
 				class_desc->pop(); // color
 			}
 
-			if (cd.is_script_doc && (!cd.properties[i].setter.is_empty() || !cd.properties[i].getter.is_empty())) {
+			if (cd.is_script_doc && (!cd.properties[i].setter.is_empty_string() || !cd.properties[i].getter.is_empty_string())) {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("property:") + " ");
 				class_desc->pop(); // color
 
-				if (!cd.properties[i].setter.is_empty()) {
+				if (!cd.properties[i].setter.is_empty_string()) {
 					class_desc->push_color(value_color);
 					class_desc->add_text("setter");
 					class_desc->pop(); // color
 				}
-				if (!cd.properties[i].getter.is_empty()) {
-					if (!cd.properties[i].setter.is_empty()) {
+				if (!cd.properties[i].getter.is_empty_string()) {
+					if (!cd.properties[i].setter.is_empty_string()) {
 						class_desc->push_color(symbol_color);
 						class_desc->add_text(", ");
 						class_desc->pop(); // color
@@ -1317,7 +1317,7 @@ void EditorHelp::_update_doc() {
 					method_map[methods[j].name] = methods[j];
 				}
 
-				if (!cd.properties[i].setter.is_empty()) {
+				if (!cd.properties[i].setter.is_empty_string()) {
 					class_desc->push_cell();
 					class_desc->pop(); // cell
 
@@ -1341,7 +1341,7 @@ void EditorHelp::_update_doc() {
 					method_line[cd.properties[i].setter] = property_line[cd.properties[i].name];
 				}
 
-				if (!cd.properties[i].getter.is_empty()) {
+				if (!cd.properties[i].getter.is_empty_string()) {
 					class_desc->push_cell();
 					class_desc->pop(); // cell
 
@@ -1374,7 +1374,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_color(text_color);
 			class_desc->push_font(doc_font);
 			class_desc->push_indent(1);
-			if (!cd.properties[i].description.strip_edges().is_empty()) {
+			if (!cd.properties[i].description.strip_edges().is_empty_string()) {
 				_add_text(DTR(cd.properties[i].description));
 			} else {
 				class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
@@ -2052,7 +2052,7 @@ void FindBar::popup_search() {
 		grabbed_focus = true;
 	}
 
-	if (!search_text->get_text().is_empty()) {
+	if (!search_text->get_text().is_empty_string()) {
 		search_text->select_all();
 		search_text->set_caret_column(search_text->get_text().length());
 		if (grabbed_focus) {
@@ -2118,7 +2118,7 @@ void FindBar::_update_results_count() {
 	results_count = 0;
 
 	String searched = search_text->get_text();
-	if (searched.is_empty()) {
+	if (searched.is_empty_string()) {
 		return;
 	}
 
@@ -2138,7 +2138,7 @@ void FindBar::_update_results_count() {
 }
 
 void FindBar::_update_matches_label() {
-	if (search_text->get_text().is_empty() || results_count == -1) {
+	if (search_text->get_text().is_empty_string() || results_count == -1) {
 		matches_label->hide();
 	} else {
 		matches_label->show();

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -163,7 +163,7 @@ void EditorHelpSearch::popup_dialog(const String &p_term) {
 		popup_centered_ratio(0.5F);
 	}
 
-	if (p_term.is_empty()) {
+	if (p_term.is_empty_string()) {
 		search_box->clear();
 	} else {
 		if (old_term == p_term) {
@@ -323,7 +323,7 @@ bool EditorHelpSearch::Runner::_phase_match_classes_init() {
 
 bool EditorHelpSearch::Runner::_phase_match_classes() {
 	DocData::ClassDoc &class_doc = iterator_doc->value;
-	if (class_doc.name.is_empty()) {
+	if (class_doc.name.is_empty_string()) {
 		return false;
 	}
 	if (!_is_class_disabled_by_feature_profile(class_doc.name)) {
@@ -335,7 +335,7 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 			// If the search term is empty, add any classes which are not script docs or which don't start with
 			// a double-quotation. This will ensure that only C++ classes and explicitly named classes will
 			// be added.
-			match.name = (term.is_empty() && (!class_doc.is_script_doc || class_doc.name[0] != '\"')) || _match_string(term, class_doc.name);
+			match.name = (term.is_empty_string() && (!class_doc.is_script_doc || class_doc.name[0] != '\"')) || _match_string(term, class_doc.name);
 		}
 
 		// Match members if the term is long enough.
@@ -452,7 +452,7 @@ bool EditorHelpSearch::Runner::_phase_member_items() {
 	if (!match.doc) {
 		return false;
 	}
-	if (match.doc->name.is_empty()) {
+	if (match.doc->name.is_empty_string()) {
 		return false;
 	}
 
@@ -523,7 +523,7 @@ void EditorHelpSearch::Runner::_match_item(TreeItem *p_item, const String &p_tex
 }
 
 TreeItem *EditorHelpSearch::Runner::_create_class_hierarchy(const ClassMatch &p_match) {
-	if (p_match.doc->name.is_empty()) {
+	if (p_match.doc->name.is_empty_string()) {
 		return nullptr;
 	}
 	if (class_items.has(p_match.doc->name)) {
@@ -532,7 +532,7 @@ TreeItem *EditorHelpSearch::Runner::_create_class_hierarchy(const ClassMatch &p_
 
 	// Ensure parent nodes are created first.
 	TreeItem *parent = root_item;
-	if (!p_match.doc->inherits.is_empty()) {
+	if (!p_match.doc->inherits.is_empty_string()) {
 		if (class_items.has(p_match.doc->inherits)) {
 			parent = class_items[p_match.doc->inherits];
 		} else {
@@ -579,7 +579,7 @@ TreeItem *EditorHelpSearch::Runner::_create_method_item(TreeItem *p_parent, cons
 	for (int i = 0; i < p_doc->arguments.size(); i++) {
 		const DocData::ArgumentDoc &arg = p_doc->arguments[i];
 		tooltip += arg.type + " " + arg.name;
-		if (!arg.default_value.is_empty()) {
+		if (!arg.default_value.is_empty_string()) {
 			tooltip += " = " + arg.default_value;
 		}
 		if (i < p_doc->arguments.size() - 1) {
@@ -595,7 +595,7 @@ TreeItem *EditorHelpSearch::Runner::_create_signal_item(TreeItem *p_parent, cons
 	for (int i = 0; i < p_doc->arguments.size(); i++) {
 		const DocData::ArgumentDoc &arg = p_doc->arguments[i];
 		tooltip += arg.type + " " + arg.name;
-		if (!arg.default_value.is_empty()) {
+		if (!arg.default_value.is_empty_string()) {
 			tooltip += " = " + arg.default_value;
 		}
 		if (i < p_doc->arguments.size() - 1) {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2333,7 +2333,7 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<Edit
 					ep->property_usage = 0;
 				}
 
-				if (!F.label.is_empty()) {
+				if (!F.label.is_empty_string()) {
 					ep->set_label(F.label);
 				}
 
@@ -2549,7 +2549,7 @@ void EditorInspector::update_tree() {
 				}
 			}
 			if (category->icon.is_null()) {
-				if (!type.is_empty()) { // Can happen for built-in scripts.
+				if (!type.is_empty_string()) { // Can happen for built-in scripts.
 					category->icon = EditorNode::get_singleton()->get_class_icon(type, "Object");
 				}
 			}
@@ -2570,7 +2570,7 @@ void EditorInspector::update_tree() {
 					class_descr_cache[type2] = descr;
 				}
 
-				category->set_tooltip(p.name + "::" + (class_descr_cache[type2].is_empty() ? "" : class_descr_cache[type2]));
+				category->set_tooltip(p.name + "::" + (class_descr_cache[type2].is_empty_string() ? "" : class_descr_cache[type2]));
 			}
 
 			// Add editors at the start of a category.
@@ -2613,7 +2613,7 @@ void EditorInspector::update_tree() {
 			}
 		}
 
-		if (!array_prefix.is_empty()) {
+		if (!array_prefix.is_empty_string()) {
 			// If we have an array element, find the according index in array.
 			String str = p.name.trim_prefix(array_prefix);
 			int to_char_index = 0;
@@ -2630,7 +2630,7 @@ void EditorInspector::update_tree() {
 			}
 		}
 
-		if (!array_prefix.is_empty()) {
+		if (!array_prefix.is_empty_string()) {
 			path = path.trim_prefix(array_prefix);
 			int char_index = path.find("/");
 			if (char_index >= 0) {
@@ -2640,7 +2640,7 @@ void EditorInspector::update_tree() {
 			}
 		} else {
 			// Check if we exit or not a subgroup. If there is a prefix, remove it from the property label string.
-			if (!subgroup.is_empty() && !subgroup_base.is_empty()) {
+			if (!subgroup.is_empty_string() && !subgroup_base.is_empty_string()) {
 				if (path.begins_with(subgroup_base)) {
 					path = path.trim_prefix(subgroup_base);
 				} else if (subgroup_base.begins_with(path)) {
@@ -2651,7 +2651,7 @@ void EditorInspector::update_tree() {
 			}
 
 			// Check if we exit or not a group. If there is a prefix, remove it from the property label string.
-			if (!group.is_empty() && !group_base.is_empty() && subgroup.is_empty()) {
+			if (!group.is_empty_string() && !group_base.is_empty_string() && subgroup.is_empty_string()) {
 				if (path.begins_with(group_base)) {
 					path = path.trim_prefix(group_base);
 				} else if (group_base.begins_with(path)) {
@@ -2663,10 +2663,10 @@ void EditorInspector::update_tree() {
 			}
 
 			// Add the group and subgroup to the path.
-			if (!subgroup.is_empty()) {
+			if (!subgroup.is_empty_string()) {
 				path = subgroup + "/" + path;
 			}
-			if (!group.is_empty()) {
+			if (!group.is_empty_string()) {
 				path = group + "/" + path;
 			}
 		}
@@ -2698,8 +2698,8 @@ void EditorInspector::update_tree() {
 		}
 
 		// Ignore properties that do not fit the filter.
-		if (use_filter && !filter.is_empty()) {
-			const String property_path = property_prefix + (path.is_empty() ? "" : path + "/") + name_override;
+		if (use_filter && !filter.is_empty_string()) {
+			const String property_path = property_prefix + (path.is_empty_string() ? "" : path + "/") + name_override;
 			if (!_property_path_matches(property_path, filter, property_name_style)) {
 				continue;
 			}
@@ -2712,7 +2712,7 @@ void EditorInspector::update_tree() {
 		}
 
 		// Find the correct section/vbox to add the property editor to.
-		VBoxContainer *root_vbox = array_prefix.is_empty() ? main_vbox : editor_inspector_array_per_prefix[array_prefix]->get_vbox(array_index);
+		VBoxContainer *root_vbox = array_prefix.is_empty_string() ? main_vbox : editor_inspector_array_per_prefix[array_prefix]->get_vbox(array_index);
 		if (!root_vbox) {
 			continue;
 		}
@@ -2842,7 +2842,7 @@ void EditorInspector::update_tree() {
 
 			// Get the class name.
 			StringName classname = object->get_class_name();
-			if (!object_class.is_empty()) {
+			if (!object_class.is_empty_string()) {
 				classname = object_class;
 			}
 
@@ -2864,7 +2864,7 @@ void EditorInspector::update_tree() {
 				// Build the property description String and add it to the cache.
 				DocTools *dd = EditorHelp::get_doc_data();
 				HashMap<String, DocData::ClassDoc>::Iterator F = dd->class_list.find(classname);
-				while (F && descr.is_empty()) {
+				while (F && descr.is_empty_string()) {
 					for (int i = 0; i < F->value.properties.size(); i++) {
 						if (F->value.properties[i].name == propname.operator String()) {
 							descr = DTR(F->value.properties[i].description);
@@ -2882,7 +2882,7 @@ void EditorInspector::update_tree() {
 						}
 					}
 
-					if (!F->value.inherits.is_empty()) {
+					if (!F->value.inherits.is_empty_string()) {
 						F = dd->class_list.find(F->value.inherits);
 					} else {
 						break;
@@ -2935,7 +2935,7 @@ void EditorInspector::update_tree() {
 						//and set label?
 					}
 
-					if (!editors[i].label.is_empty()) {
+					if (!editors[i].label.is_empty_string()) {
 						ep->set_label(editors[i].label);
 					} else {
 						// Use the existing one.
@@ -2974,7 +2974,7 @@ void EditorInspector::update_tree() {
 				ep->connect("multiple_properties_changed", callable_mp(this, &EditorInspector::_multiple_properties_changed));
 				ep->connect("resource_selected", callable_mp(this, &EditorInspector::_resource_selected), varray(), CONNECT_DEFERRED);
 				ep->connect("object_id_selected", callable_mp(this, &EditorInspector::_object_id_selected), varray(), CONNECT_DEFERRED);
-				if (!doc_hint.is_empty()) {
+				if (!doc_hint.is_empty_string()) {
 					ep->set_tooltip(property_prefix + p.name + "::" + doc_hint);
 				} else {
 					ep->set_tooltip(property_prefix + p.name);
@@ -3214,7 +3214,7 @@ void EditorInspector::_edit_request_change(Object *p_object, const String &p_pro
 		return;
 	}
 
-	if (p_property.is_empty()) {
+	if (p_property.is_empty_string()) {
 		update_tree_pending = true;
 	} else {
 		pending.insert(p_property);
@@ -3652,9 +3652,9 @@ void EditorInspector::_update_script_class_properties(const Object &p_object, Li
 	for (const Ref<Script> &s : classes) {
 		String path = s->get_path();
 		String name = EditorNode::get_editor_data().script_class_get_name(path);
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			if (s->is_built_in()) {
-				if (s->get_name().is_empty()) {
+				if (s->get_name().is_empty_string()) {
 					name = TTR("Built-in script");
 				} else {
 					name = vformat("%s (%s)", s->get_name(), TTR("Built-in"));

--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -74,7 +74,7 @@ void EditorLayoutsDialog::ok_pressed() {
 		for (int i = 0; i < selected_items.size(); ++i) {
 			emit_signal(SNAME("name_confirmed"), layout_names->get_item_text(selected_items[i]));
 		}
-	} else if (name->is_visible() && !name->get_text().is_empty()) {
+	} else if (name->is_visible() && !name->get_text().is_empty_string()) {
 		emit_signal(SNAME("name_confirmed"), name->get_text());
 	}
 }

--- a/editor/editor_locale_dialog.cpp
+++ b/editor/editor_locale_dialog.cpp
@@ -48,18 +48,18 @@ void EditorLocaleDialog::ok_pressed() {
 	}
 
 	String locale;
-	if (lang_code->get_text().is_empty()) {
+	if (lang_code->get_text().is_empty_string()) {
 		return; // Language code is required.
 	}
 	locale = lang_code->get_text();
 
-	if (!script_code->get_text().is_empty()) {
+	if (!script_code->get_text().is_empty_string()) {
 		locale += "_" + script_code->get_text();
 	}
-	if (!country_code->get_text().is_empty()) {
+	if (!country_code->get_text().is_empty_string()) {
 		locale += "_" + country_code->get_text();
 	}
-	if (!variant_code->get_text().is_empty()) {
+	if (!variant_code->get_text().is_empty_string()) {
 		locale += "_" + variant_code->get_text();
 	}
 
@@ -343,7 +343,7 @@ void EditorLocaleDialog::_update_tree() {
 
 void EditorLocaleDialog::set_locale(const String &p_locale) {
 	const String &locale = TranslationServer::get_singleton()->standardize_locale(p_locale);
-	if (locale.is_empty()) {
+	if (locale.is_empty_string()) {
 		locale_set = false;
 
 		lang_code->set_text("");

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -167,11 +167,11 @@ void EditorLog::_clear_request() {
 void EditorLog::_copy_request() {
 	String text = log->get_selected_text();
 
-	if (text.is_empty()) {
+	if (text.is_empty_string()) {
 		text = log->get_parsed_text();
 	}
 
-	if (!text.is_empty()) {
+	if (!text.is_empty_string()) {
 		DisplayServer::get_singleton()->clipboard_set(text);
 	}
 }
@@ -242,7 +242,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	// Only add the message to the log if it passes the filters.
 	bool filter_active = type_filter_map[p_message.type]->is_active();
 	String search_text = search_box->get_text();
-	bool search_match = search_text.is_empty() || p_message.text.findn(search_text) > -1;
+	bool search_match = search_text.is_empty_string() || p_message.text.findn(search_text) > -1;
 
 	if (!filter_active || !search_match) {
 		return;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -417,9 +417,9 @@ void EditorNode::_version_control_menu_option(int p_idx) {
 
 void EditorNode::_update_title() {
 	const String appname = ProjectSettings::get_singleton()->get("application/config/name");
-	String title = (appname.is_empty() ? TTR("Unnamed Project") : appname) + String(" - ") + VERSION_NAME;
+	String title = (appname.is_empty_string() ? TTR("Unnamed Project") : appname) + String(" - ") + VERSION_NAME;
 	const String edited = editor_data.get_edited_scene_root() ? editor_data.get_edited_scene_root()->get_scene_file_path() : String();
-	if (!edited.is_empty()) {
+	if (!edited.is_empty_string()) {
 		// Display the edited scene name before the program name so that it can be seen in the OS task bar.
 		title = vformat("%s - %s", edited.get_file(), title);
 	}
@@ -890,7 +890,7 @@ void EditorNode::_resources_changed(const Vector<String> &p_resources) {
 			continue;
 		}
 
-		if (!res->get_import_path().is_empty()) {
+		if (!res->get_import_path().is_empty_string()) {
 			// This is an imported resource, will be reloaded if reimported via the _resources_reimported() callback.
 			continue;
 		}
@@ -918,7 +918,7 @@ void EditorNode::_fs_changed() {
 
 	// FIXME: Move this to a cleaner location, it's hacky to do this in _fs_changed.
 	String export_error;
-	if (!export_defer.preset.is_empty() && !EditorFileSystem::get_singleton()->is_scanning()) {
+	if (!export_defer.preset.is_empty_string() && !EditorFileSystem::get_singleton()->is_scanning()) {
 		String preset_name = export_defer.preset;
 		// Ensures export_project does not loop infinitely, because notifications may
 		// come during the export.
@@ -947,8 +947,8 @@ void EditorNode::_fs_changed() {
 			}
 		} else {
 			Ref<EditorExportPlatform> platform = export_preset->get_platform();
-			const String export_path = export_defer.path.is_empty() ? export_preset->get_export_path() : export_defer.path;
-			if (export_path.is_empty()) {
+			const String export_path = export_defer.path.is_empty_string() ? export_preset->get_export_path() : export_defer.path;
+			if (export_path.is_empty_string()) {
 				export_error = vformat("Export preset \"%s\" doesn't have a default export path, and none was specified.", preset_name);
 			} else if (platform.is_null()) {
 				export_error = vformat("Export preset \"%s\" doesn't have a matching platform.", preset_name);
@@ -979,7 +979,7 @@ void EditorNode::_fs_changed() {
 			}
 		}
 
-		if (!export_error.is_empty()) {
+		if (!export_error.is_empty_string()) {
 			ERR_PRINT(export_error);
 			_exit_editor(EXIT_FAILURE);
 		} else {
@@ -1033,7 +1033,7 @@ void EditorNode::_sources_changed(bool p_exist) {
 
 		_load_docks();
 
-		if (!defer_load_scene.is_empty()) {
+		if (!defer_load_scene.is_empty_string()) {
 			load_scene(defer_load_scene);
 			defer_load_scene = "";
 		}
@@ -1268,7 +1268,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 		preferred.move_to_front(tres_element);
 	}
 
-	if (!p_at_path.is_empty()) {
+	if (!p_at_path.is_empty_string()) {
 		file->set_current_dir(p_at_path);
 		if (p_resource->get_path().is_resource_file()) {
 			file->set_current_file(p_resource->get_path().get_file());
@@ -1280,7 +1280,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 				file->set_current_file(String());
 			}
 		}
-	} else if (!p_resource->get_path().is_empty()) {
+	} else if (!p_resource->get_path().is_empty_string()) {
 		file->set_current_path(p_resource->get_path());
 		if (extensions.size()) {
 			String ext = p_resource->get_path().get_extension().to_lower();
@@ -1698,7 +1698,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
-	if (!scene->get_scene_file_path().is_empty() && _validate_scene_recursive(scene->get_scene_file_path(), scene)) {
+	if (!scene->get_scene_file_path().is_empty_string() && _validate_scene_recursive(scene->get_scene_file_path(), scene)) {
 		show_accept(TTR("This scene can't be saved because there is a cyclic instancing inclusion.\nPlease resolve it and then attempt to save again."), TTR("OK"));
 		return;
 	}
@@ -1806,7 +1806,7 @@ void EditorNode::restart_editor() {
 	args.push_back("--path");
 	args.push_back(ProjectSettings::get_singleton()->get_resource_path());
 	args.push_back("-e");
-	if (!to_reopen.is_empty()) {
+	if (!to_reopen.is_empty_string()) {
 		args.push_back(to_reopen);
 	}
 
@@ -1818,13 +1818,13 @@ void EditorNode::_save_all_scenes() {
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		Node *scene = editor_data.get_edited_scene_root(i);
 		if (scene) {
-			if (!scene->get_scene_file_path().is_empty() && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
+			if (!scene->get_scene_file_path().is_empty_string() && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
 				if (i != editor_data.get_edited_scene()) {
 					_save_scene(scene->get_scene_file_path(), i);
 				} else {
 					_save_scene_with_preview(scene->get_scene_file_path());
 				}
-			} else if (!scene->get_scene_file_path().is_empty()) {
+			} else if (!scene->get_scene_file_path().is_empty_string()) {
 				all_saved = false;
 			}
 		}
@@ -1844,7 +1844,7 @@ void EditorNode::_mark_unsaved_scenes() {
 		}
 
 		String path = node->get_scene_file_path();
-		if (!(path.is_empty() || FileAccess::exists(path))) {
+		if (!(path.is_empty_string() || FileAccess::exists(path))) {
 			if (i == editor_data.get_edited_scene()) {
 				set_current_version(-1);
 			} else {
@@ -1960,7 +1960,7 @@ void EditorNode::_dialog_action(String p_file) {
 			current_obj->notify_property_list_changed();
 		} break;
 		case SETTINGS_LAYOUT_SAVE: {
-			if (p_file.is_empty()) {
+			if (p_file.is_empty_string()) {
 				return;
 			}
 
@@ -1988,7 +1988,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 		} break;
 		case SETTINGS_LAYOUT_DELETE: {
-			if (p_file.is_empty()) {
+			if (p_file.is_empty_string()) {
 				return;
 			}
 
@@ -2107,7 +2107,7 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 	if (id != editor_history.get_current()) {
 		if (p_inspector_only) {
 			editor_history.add_object(id, String(), true);
-		} else if (p_property.is_empty()) {
+		} else if (p_property.is_empty_string()) {
 			editor_history.add_object(id);
 		} else {
 			editor_history.add_object(id, p_property);
@@ -2228,7 +2228,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 			InspectorDock::get_singleton()->update(nullptr);
 		}
 
-		if (get_edited_scene() && !get_edited_scene()->get_scene_file_path().is_empty()) {
+		if (get_edited_scene() && !get_edited_scene()->get_scene_file_path().is_empty_string()) {
 			String source_scene = get_edited_scene()->get_scene_file_path();
 			if (FileAccess::exists(source_scene + ".import")) {
 				editable_warning = TTR("This scene was imported, so changes to it won't be kept.\nInstancing it or inheriting will allow making changes to it.\nPlease read the documentation relevant to importing scenes to better understand this workflow.");
@@ -2364,7 +2364,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 
 	String run_filename;
 
-	if (p_current || (editor_data.get_edited_scene_root() && !p_custom.is_empty() && p_custom == editor_data.get_edited_scene_root()->get_scene_file_path())) {
+	if (p_current || (editor_data.get_edited_scene_root() && !p_custom.is_empty_string() && p_custom == editor_data.get_edited_scene_root()->get_scene_file_path())) {
 		Node *scene = editor_data.get_edited_scene_root();
 
 		if (!scene) {
@@ -2372,7 +2372,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 			return;
 		}
 
-		if (scene->get_scene_file_path().is_empty()) {
+		if (scene->get_scene_file_path().is_empty_string()) {
 			current_menu_option = -1;
 			_menu_option(FILE_SAVE_AS_SCENE);
 			// Set the option to save and run so when the dialog is accepted, the scene runs.
@@ -2382,11 +2382,11 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		}
 
 		run_filename = scene->get_scene_file_path();
-	} else if (!p_custom.is_empty()) {
+	} else if (!p_custom.is_empty_string()) {
 		run_filename = p_custom;
 	}
 
-	if (run_filename.is_empty()) {
+	if (run_filename.is_empty_string()) {
 		// Evidently, run the scene.
 		if (!ensure_main_scene(false)) {
 			return;
@@ -2397,7 +2397,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		if (unsaved_cache) {
 			Node *scene = editor_data.get_edited_scene_root();
 
-			if (scene && !scene->get_scene_file_path().is_empty()) { // Only autosave if there is a scene and if it has a path.
+			if (scene && !scene->get_scene_file_path().is_empty_string()) { // Only autosave if there is a scene and if it has a path.
 				_save_scene_with_preview(scene->get_scene_file_path());
 			}
 		}
@@ -2429,7 +2429,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	if (p_current) {
 		play_scene_button->set_pressed(true);
 		play_scene_button->set_icon(gui_base->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
-	} else if (!p_custom.is_empty()) {
+	} else if (!p_custom.is_empty_string()) {
 		run_custom_filename = p_custom;
 		play_custom_scene_button->set_pressed(true);
 		play_custom_scene_button->set_icon(gui_base->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
@@ -2551,10 +2551,10 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 						String scene_filename = scene_root->get_scene_file_path();
 						if (p_option == FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT) {
 							save_confirmation->get_ok_button()->set_text(TTR("Save & Reload"));
-							save_confirmation->set_text(vformat(TTR("Save changes to '%s' before reloading?"), !scene_filename.is_empty() ? scene_filename : "unsaved scene"));
+							save_confirmation->set_text(vformat(TTR("Save changes to '%s' before reloading?"), !scene_filename.is_empty_string() ? scene_filename : "unsaved scene"));
 						} else {
 							save_confirmation->get_ok_button()->set_text(TTR("Save & Quit"));
-							save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), !scene_filename.is_empty() ? scene_filename : "unsaved scene"));
+							save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), !scene_filename.is_empty_string() ? scene_filename : "unsaved scene"));
 						}
 						save_confirmation->popup_centered();
 						break;
@@ -2573,7 +2573,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_SAVE_SCENE: {
 			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing_idx;
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
-			if (scene && !scene->get_scene_file_path().is_empty()) {
+			if (scene && !scene->get_scene_file_path().is_empty_string()) {
 				if (DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
 					if (scene_idx != editor_data.get_edited_scene()) {
 						_save_scene_with_preview(scene->get_scene_file_path(), scene_idx);
@@ -2629,7 +2629,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				file->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 			}
 
-			if (!scene->get_scene_file_path().is_empty()) {
+			if (!scene->get_scene_file_path().is_empty_string()) {
 				String path = scene->get_scene_file_path();
 				file->set_current_path(path);
 				if (extensions.size()) {
@@ -2692,7 +2692,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 				if (!editor_data.get_undo_redo().undo()) {
 					log->add_message(TTR("Nothing to undo."), EditorLog::MSG_TYPE_EDITOR);
-				} else if (!action.is_empty()) {
+				} else if (!action.is_empty_string()) {
 					log->add_message(vformat(TTR("Undo: %s"), action), EditorLog::MSG_TYPE_EDITOR);
 				}
 			}
@@ -2719,7 +2719,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 			String filename = scene->get_scene_file_path();
 
-			if (filename.is_empty()) {
+			if (filename.is_empty_string()) {
 				show_warning(TTR("Can't reload a scene that was never saved."));
 				break;
 			}
@@ -2748,7 +2748,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case RUN_PLAY_CUSTOM_SCENE: {
-			if (run_custom_filename.is_empty() || editor_run.get_status() == EditorRun::STATUS_STOP) {
+			if (run_custom_filename.is_empty_string() || editor_run.get_status() == EditorRun::STATUS_STOP) {
 				_menu_option_confirm(RUN_STOP, true);
 				quick_run->popup_dialog("PackedScene", true);
 				quick_run->set_title(TTR("Quick Run Scene..."));
@@ -2789,7 +2789,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		case FILE_SHOW_IN_FILESYSTEM: {
 			String path = editor_data.get_scene_path(editor_data.get_edited_scene());
-			if (!path.is_empty()) {
+			if (!path.is_empty_string()) {
 				FileSystemDock::get_singleton()->navigate_to_path(path);
 			}
 		} break;
@@ -3033,7 +3033,7 @@ void EditorNode::_export_as_menu_option(int p_idx) {
 		file_export_lib->popup_file_dialog();
 		file_export_lib->set_title(TTR("Export Mesh Library"));
 	} else { // Custom menu options added by plugins
-		if (export_as_menu->get_item_submenu(p_idx).is_empty()) { // If not a submenu
+		if (export_as_menu->get_item_submenu(p_idx).is_empty_string()) { // If not a submenu
 			Callable callback = export_as_menu->get_item_metadata(p_idx);
 			Callable::CallError ce;
 			Variant result;
@@ -3089,7 +3089,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 			Node *scene = editor_data.get_edited_scene_root(tab_closing_idx);
 			if (scene != nullptr) {
 				String scene_filename = scene->get_scene_file_path();
-				if (!scene_filename.is_empty()) {
+				if (!scene_filename.is_empty_string()) {
 					previous_scenes.push_back(scene_filename);
 				}
 			}
@@ -3225,7 +3225,7 @@ void EditorNode::_editor_select(int p_which) {
 }
 
 void EditorNode::select_editor_by_name(const String &p_name) {
-	ERR_FAIL_COND(p_name.is_empty());
+	ERR_FAIL_COND(p_name.is_empty_string());
 
 	for (int i = 0; i < main_editor_buttons.size(); i++) {
 		if (main_editor_buttons[i]->get_text() == p_name) {
@@ -4135,7 +4135,7 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 }
 
 Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p_fallback) const {
-	ERR_FAIL_COND_V_MSG(p_class.is_empty(), nullptr, "Class name cannot be empty.");
+	ERR_FAIL_COND_V_MSG(p_class.is_empty_string(), nullptr, "Class name cannot be empty.");
 
 	if (ScriptServer::is_global_class(p_class)) {
 		String class_name = p_class;
@@ -4162,7 +4162,7 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 				}
 				script = base_script;
 				class_name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
-			} while (class_name.is_empty());
+			} while (class_name.is_empty_string());
 		}
 	}
 
@@ -4597,13 +4597,13 @@ void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p
 		String names;
 		for (int j = 0; j < dock_slot[i]->get_tab_count(); j++) {
 			String name = dock_slot[i]->get_tab_control(j)->get_name();
-			if (!names.is_empty()) {
+			if (!names.is_empty_string()) {
 				names += ",";
 			}
 			names += name;
 		}
 
-		if (!names.is_empty()) {
+		if (!names.is_empty_string()) {
 			p_layout->set_value(p_section, "dock_" + itos(i + 1), names);
 		}
 	}
@@ -4628,7 +4628,7 @@ void EditorNode::_save_open_scenes_to_config(Ref<ConfigFile> p_layout, const Str
 	Array scenes;
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		String path = editor_data.get_scene_path(i);
-		if (path.is_empty()) {
+		if (path.is_empty_string()) {
 			continue;
 		}
 		scenes.push_back(path);
@@ -4895,7 +4895,7 @@ bool EditorNode::ensure_main_scene(bool p_from_native) {
 	pick_main_scene->set_meta("from_native", p_from_native); // Whether from play button or native run.
 	String main_scene = GLOBAL_DEF_BASIC("application/run/main_scene", "");
 
-	if (main_scene.is_empty()) {
+	if (main_scene.is_empty_string()) {
 		current_menu_option = -1;
 		pick_main_scene->set_text(TTR("No main scene has ever been defined, select one?\nYou can change it later in \"Project Settings\" under the 'application' category."));
 		pick_main_scene->popup_centered();
@@ -4958,7 +4958,7 @@ bool EditorNode::is_run_playing() const {
 
 String EditorNode::get_run_playing_scene() const {
 	String run_filename = editor_run.get_running_scene();
-	if (run_filename.is_empty() && is_run_playing()) {
+	if (run_filename.is_empty_string() && is_run_playing()) {
 		run_filename = GLOBAL_DEF_BASIC("application/run/main_scene", ""); // Must be the main scene then.
 	}
 
@@ -5092,7 +5092,7 @@ void EditorNode::_scene_tab_closed(int p_tab, int option) {
 			: editor_data.get_scene_version(p_tab) != 0;
 	if (unsaved) {
 		save_confirmation->get_ok_button()->set_text(TTR("Save & Close"));
-		save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), !scene->get_scene_file_path().is_empty() ? scene->get_scene_file_path() : "unsaved scene"));
+		save_confirmation->set_text(vformat(TTR("Save changes to '%s' before closing?"), !scene->get_scene_file_path().is_empty_string() ? scene->get_scene_file_path() : "unsaved scene"));
 		save_confirmation->popup_centered();
 	} else {
 		_discard_changes();
@@ -5112,7 +5112,7 @@ void EditorNode::_scene_tab_hovered(int p_tab) {
 		tab_preview_panel->hide();
 	} else {
 		String path = editor_data.get_scene_path(p_tab);
-		if (!path.is_empty()) {
+		if (!path.is_empty_string()) {
 			EditorResourcePreview::get_singleton()->queue_resource_preview(path, this, "_thumbnail_done", p_tab);
 		}
 	}
@@ -5422,7 +5422,7 @@ Variant EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 	drag_control->add_child(drag_preview);
 	if (p_res->get_path().is_resource_file()) {
 		label->set_text(p_res->get_path().get_file());
-	} else if (!p_res->get_name().is_empty()) {
+	} else if (!p_res->get_name().is_empty_string()) {
 		label->set_text(p_res->get_name());
 	} else {
 		label->set_text(p_res->get_class());
@@ -5565,7 +5565,7 @@ void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, Str
 			sub_dir->list_dir_begin();
 
 			String next_file = sub_dir->get_next();
-			while (!next_file.is_empty()) {
+			while (!next_file.is_empty_string()) {
 				if (next_file == "." || next_file == "..") {
 					next_file = sub_dir->get_next();
 					continue;

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -131,14 +131,14 @@ void EditorPath::update_path() {
 					name = r->get_name();
 				}
 
-				if (name.is_empty()) {
+				if (name.is_empty_string()) {
 					name = r->get_class();
 				}
 			} else if (obj->is_class("EditorDebuggerRemoteObject")) {
 				name = obj->call("get_title");
 			} else if (Object::cast_to<Node>(obj)) {
 				name = Object::cast_to<Node>(obj)->get_name();
-			} else if (Object::cast_to<Resource>(obj) && !Object::cast_to<Resource>(obj)->get_name().is_empty()) {
+			} else if (Object::cast_to<Resource>(obj) && !Object::cast_to<Resource>(obj)->get_name().is_empty_string()) {
 				name = Object::cast_to<Resource>(obj)->get_name();
 			} else {
 				name = obj->get_class();

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -136,7 +136,7 @@ EditorPaths::EditorPaths() {
 		}
 	}
 
-	paths_valid = (!data_path.is_empty() && !config_path.is_empty() && !cache_path.is_empty());
+	paths_valid = (!data_path.is_empty_string() && !config_path.is_empty_string() && !cache_path.is_empty_string());
 	ERR_FAIL_COND_MSG(!paths_valid, "Editor data, config, or cache paths are invalid.");
 
 	// Validate or create each dir and its relevant subdirectories.

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -297,7 +297,7 @@ Error EditorInterface::save_scene() {
 	if (!get_edited_scene_root()) {
 		return ERR_CANT_CREATE;
 	}
-	if (get_edited_scene_root()->get_scene_file_path().is_empty()) {
+	if (get_edited_scene_root()->get_scene_file_path().is_empty_string()) {
 		return ERR_CANT_CREATE;
 	}
 

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -172,7 +172,7 @@ Vector<String> EditorPluginSettings::_get_plugins(const String &p_dir) {
 
 	Vector<String> plugins;
 	da->list_dir_begin();
-	for (String path = da->get_next(); !path.is_empty(); path = da->get_next()) {
+	for (String path = da->get_next(); !path.is_empty_string(); path = da->get_next()) {
 		if (path[0] == '.' || !da->current_is_dir()) {
 			continue;
 		}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -244,7 +244,7 @@ void EditorPropertyTextEnum::update_property() {
 		option_button->clear();
 
 		// Manually entered value.
-		if (default_option < 0 && !current_value.is_empty()) {
+		if (default_option < 0 && !current_value.is_empty_string()) {
 			option_button->add_item(current_value, options.size() + 1001);
 			option_button->select(0);
 
@@ -441,7 +441,7 @@ void EditorPropertyPath::_path_pressed() {
 		dialog->set_file_mode(save_mode ? EditorFileDialog::FILE_MODE_SAVE_FILE : EditorFileDialog::FILE_MODE_OPEN_FILE);
 		for (int i = 0; i < extensions.size(); i++) {
 			String e = extensions[i].strip_edges();
-			if (!e.is_empty()) {
+			if (!e.is_empty_string()) {
 				dialog->add_filter(extensions[i].strip_edges());
 			}
 		}
@@ -760,7 +760,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 	uint32_t current_val;
 	for (int i = 0; i < p_options.size(); i++) {
 		String option = p_options[i].strip_edges();
-		if (!option.is_empty()) {
+		if (!option.is_empty_string()) {
 			CheckBox *cb = memnew(CheckBox);
 			cb->set_text(option);
 			cb->set_clip_text(true);
@@ -1144,7 +1144,7 @@ void EditorPropertyLayers::setup(LayerType p_layer_type) {
 			name = ProjectSettings::get_singleton()->get(basename + vformat("/layer_%d", i + 1));
 		}
 
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			name = vformat(TTR("Layer %d"), i + 1);
 		}
 
@@ -1288,7 +1288,7 @@ void EditorPropertyObjectID::_edit_pressed() {
 
 void EditorPropertyObjectID::update_property() {
 	String type = base_type;
-	if (type.is_empty()) {
+	if (type.is_empty_string()) {
 		type = "Object";
 	}
 
@@ -3196,7 +3196,7 @@ void EditorPropertyResource::_set_read_only(bool p_read_only) {
 };
 
 void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource, bool p_edit) {
-	if (p_resource->is_built_in() && !p_resource->get_path().is_empty()) {
+	if (p_resource->is_built_in() && !p_resource->get_path().is_empty_string()) {
 		String parent = p_resource->get_path().get_slice("::", 0);
 		List<String> extensions;
 		ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
@@ -3620,7 +3620,7 @@ static EditorPropertyRangeHint _parse_range_hint(PropertyHint p_hint, const Stri
 		}
 	}
 
-	if ((hint.radians || degrees) && hint.suffix.is_empty()) {
+	if ((hint.radians || degrees) && hint.suffix.is_empty_string()) {
 		hint.suffix = U"\u00B0";
 	}
 
@@ -3911,10 +3911,10 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		} break;
 		case Variant::NODE_PATH: {
 			EditorPropertyNodePath *editor = memnew(EditorPropertyNodePath);
-			if (p_hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !p_hint_text.is_empty()) {
+			if (p_hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !p_hint_text.is_empty_string()) {
 				editor->setup(p_hint_text, Vector<StringName>(), (p_usage & PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT));
 			}
-			if (p_hint == PROPERTY_HINT_NODE_PATH_VALID_TYPES && !p_hint_text.is_empty()) {
+			if (p_hint == PROPERTY_HINT_NODE_PATH_VALID_TYPES && !p_hint_text.is_empty_string()) {
 				Vector<String> types = p_hint_text.split(",", false);
 				Vector<StringName> sn = Variant(types); //convert via variant
 				editor->setup(NodePath(), sn, (p_usage & PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT));

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -406,7 +406,7 @@ bool EditorPropertyArray::_is_drop_valid(const Dictionary &p_drag_data) const {
 
 	// When the subtype is of type Object, an additional subtype may be specified in the hint string
 	// (e.g. Resource, Texture2D, ShaderMaterial, etc). We want the allowed type to be that, not just "Object".
-	if (subtype == Variant::OBJECT && !subtype_hint_string.is_empty()) {
+	if (subtype == Variant::OBJECT && !subtype_hint_string.is_empty_string()) {
 		allowed_type = subtype_hint_string;
 	}
 
@@ -585,7 +585,7 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 
 	// The format of p_hint_string is:
 	// subType/subTypeHint:nextSubtype ... etc.
-	if (array_type == Variant::ARRAY && !p_hint_string.is_empty()) {
+	if (array_type == Variant::ARRAY && !p_hint_string.is_empty_string()) {
 		int hint_subtype_separator = p_hint_string.find(":");
 		if (hint_subtype_separator >= 0) {
 			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -57,7 +57,7 @@ void EditorResourcePicker::_update_resource() {
 	} else {
 		assign_button->set_icon(EditorNode::get_singleton()->get_object_icon(edited_resource.operator->(), "Object"));
 
-		if (!edited_resource->get_name().is_empty()) {
+		if (!edited_resource->get_name().is_empty_string()) {
 			assign_button->set_text(edited_resource->get_name());
 		} else if (edited_resource->get_path().is_resource_file()) {
 			assign_button->set_text(edited_resource->get_path().get_file());
@@ -120,7 +120,7 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 	Ref<Resource> loaded_resource = ResourceLoader::load(p_path);
 	ERR_FAIL_COND_MSG(loaded_resource.is_null(), "Cannot load resource from path '" + p_path + "'.");
 
-	if (!base_type.is_empty()) {
+	if (!base_type.is_empty_string()) {
 		bool any_type_matches = false;
 
 		for (int i = 0; i < base_type.get_slice_count(","); i++) {
@@ -187,7 +187,7 @@ void EditorResourcePicker::_update_menu_items() {
 	Ref<Resource> cb = EditorSettings::get_singleton()->get_resource_clipboard();
 	bool paste_valid = false;
 	if (cb.is_valid()) {
-		if (base_type.is_empty()) {
+		if (base_type.is_empty_string()) {
 			paste_valid = true;
 		} else {
 			for (int i = 0; i < base_type.get_slice_count(","); i++) {
@@ -406,7 +406,7 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 	}
 
 	// By default provide generic "New ..." options.
-	if (!base_type.is_empty()) {
+	if (!base_type.is_empty_string()) {
 		int idx = 0;
 
 		HashSet<String> allowed_types;
@@ -552,7 +552,7 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<Strin
 }
 
 bool EditorResourcePicker::_is_drop_valid(const Dictionary &p_drag_data) const {
-	if (base_type.is_empty()) {
+	if (base_type.is_empty_string()) {
 		return true;
 	}
 
@@ -589,7 +589,7 @@ bool EditorResourcePicker::_is_drop_valid(const Dictionary &p_drag_data) const {
 			String file = files[0];
 
 			String file_type = EditorFileSystem::get_singleton()->get_file_type(file);
-			if (!file_type.is_empty() && _is_type_valid(file_type, allowed_types)) {
+			if (!file_type.is_empty_string() && _is_type_valid(file_type, allowed_types)) {
 				return true;
 			}
 		}
@@ -767,7 +767,7 @@ void EditorResourcePicker::set_base_type(const String &p_base_type) {
 
 	// There is a possibility that the new base type is conflicting with the existing value.
 	// Keep the value, but warn the user that there is a potential mistake.
-	if (!base_type.is_empty() && edited_resource.is_valid()) {
+	if (!base_type.is_empty_string() && edited_resource.is_valid()) {
 		HashSet<String> allowed_types;
 		_get_allowed_types(true, &allowed_types);
 
@@ -817,7 +817,7 @@ void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
 		return;
 	}
 
-	if (!base_type.is_empty()) {
+	if (!base_type.is_empty_string()) {
 		HashSet<String> allowed_types;
 		_get_allowed_types(true, &allowed_types);
 

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -142,7 +142,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		type = ResourceLoader::get_resource_type(p_item.path);
 	}
 
-	if (type.is_empty()) {
+	if (type.is_empty_string()) {
 		r_texture = Ref<ImageTexture>();
 		r_small_texture = Ref<ImageTexture>();
 		return; //could not guess type

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -47,7 +47,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	List<String> args;
 
 	String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-	if (!resource_path.is_empty()) {
+	if (!resource_path.is_empty_string()) {
 		args.push_back("--path");
 		args.push_back(resource_path.replace(" ", "%20"));
 	}
@@ -203,14 +203,14 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		args.push_back("--skip-breakpoints");
 	}
 
-	if (!p_scene.is_empty()) {
+	if (!p_scene.is_empty_string()) {
 		args.push_back(p_scene);
 	}
 
 	String exec = OS::get_singleton()->get_executable_path();
 
 	const String raw_custom_args = ProjectSettings::get_singleton()->get("editor/run/main_run_args");
-	if (!raw_custom_args.is_empty()) {
+	if (!raw_custom_args.is_empty_string()) {
 		// Allow the user to specify a command to run, similar to Steam's launch options.
 		// In this case, Godot will no longer be run directly; it's up to the underlying command
 		// to run it. For instance, this can be used on Linux to force a running project
@@ -267,7 +267,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	}
 
 	status = STATUS_PLAY;
-	if (!p_scene.is_empty()) {
+	if (!p_scene.is_empty_string()) {
 		running_scene = p_scene;
 	}
 

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -61,7 +61,7 @@ class SectionedInspectorFilter : public Object {
 		}
 
 		String name = p_name;
-		if (!section.is_empty()) {
+		if (!section.is_empty_string()) {
 			name = section + "/" + name;
 		}
 
@@ -76,7 +76,7 @@ class SectionedInspectorFilter : public Object {
 		}
 
 		String name = p_name;
-		if (!section.is_empty()) {
+		if (!section.is_empty_string()) {
 			name = section + "/" + name;
 		}
 
@@ -171,7 +171,7 @@ String SectionedInspector::get_current_section() const {
 String SectionedInspector::get_full_item_path(const String &p_item) {
 	String base = get_current_section();
 
-	if (!base.is_empty()) {
+	if (!base.is_empty_string()) {
 		return base + "/" + p_item;
 	} else {
 		return p_item;
@@ -250,7 +250,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		if (!filter.is_empty() && !_property_path_matches(pi.name, filter, name_style)) {
+		if (!filter.is_empty_string() && !_property_path_matches(pi.name, filter, name_style)) {
 			continue;
 		}
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -930,7 +930,7 @@ void EditorSettings::setup_network() {
 		if (ip == current) {
 			selected = ip;
 		}
-		if (!hint.is_empty()) {
+		if (!hint.is_empty_string()) {
 			hint += ",";
 		}
 		hint += ip;
@@ -949,7 +949,7 @@ void EditorSettings::save() {
 		return;
 	}
 
-	if (singleton->config_file_path.is_empty()) {
+	if (singleton->config_file_path.is_empty_string()) {
 		ERR_PRINT("Cannot save EditorSettings config, no valid path");
 		return;
 	}
@@ -1202,7 +1202,7 @@ void EditorSettings::load_favorites_and_recent_dirs() {
 	Ref<FileAccess> f = FileAccess::open(favorites_file, FileAccess::READ);
 	if (f.is_valid()) {
 		String line = f->get_line().strip_edges();
-		while (!line.is_empty()) {
+		while (!line.is_empty_string()) {
 			favorites.push_back(line);
 			line = f->get_line().strip_edges();
 		}
@@ -1211,7 +1211,7 @@ void EditorSettings::load_favorites_and_recent_dirs() {
 	f = FileAccess::open(recent_dirs_file, FileAccess::READ);
 	if (f.is_valid()) {
 		String line = f->get_line().strip_edges();
-		while (!line.is_empty()) {
+		while (!line.is_empty_string()) {
 			recent_dirs.push_back(line);
 			line = f->get_line().strip_edges();
 		}
@@ -1234,7 +1234,7 @@ void EditorSettings::list_text_editor_themes() {
 		List<String> custom_themes;
 		d->list_dir_begin();
 		String file = d->get_next();
-		while (!file.is_empty()) {
+		while (!file.is_empty_string()) {
 			if (file.get_extension() == "tet" && !_is_default_text_editor_theme(file.get_basename().to_lower())) {
 				custom_themes.push_back(file.get_basename());
 			}
@@ -1344,14 +1344,14 @@ bool EditorSettings::is_default_text_editor_theme() {
 Vector<String> EditorSettings::get_script_templates(const String &p_extension, const String &p_custom_path) {
 	Vector<String> templates;
 	String template_dir = get_script_templates_dir();
-	if (!p_custom_path.is_empty()) {
+	if (!p_custom_path.is_empty_string()) {
 		template_dir = p_custom_path;
 	}
 	Ref<DirAccess> d = DirAccess::open(template_dir);
 	if (d.is_valid()) {
 		d->list_dir_begin();
 		String file = d->get_next();
-		while (!file.is_empty()) {
+		while (!file.is_empty_string()) {
 			if (file.get_extension() == p_extension) {
 				templates.push_back(file.get_basename());
 			}

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -158,7 +158,7 @@ void EditorSettingsDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 
 		if (ED_IS_SHORTCUT("ui_undo", p_event)) {
 			String action = undo_redo->get_current_action_name();
-			if (!action.is_empty()) {
+			if (!action.is_empty_string()) {
 				EditorNode::get_log()->add_message("Undo: " + action, EditorLog::MSG_TYPE_EDITOR);
 			}
 			undo_redo->undo();
@@ -168,7 +168,7 @@ void EditorSettingsDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 		if (ED_IS_SHORTCUT("ui_redo", p_event)) {
 			undo_redo->redo();
 			String action = undo_redo->get_current_action_name();
-			if (!action.is_empty()) {
+			if (!action.is_empty_string()) {
 				EditorNode::get_log()->add_message("Redo: " + action, EditorLog::MSG_TYPE_EDITOR);
 			}
 			handled = true;

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -261,9 +261,9 @@ void EditorSpinSlider::_update_value_input_stylebox() {
 	// The margin values below were determined by empirical testing.
 	if (is_layout_rtl()) {
 		stylebox->set_default_margin(SIDE_LEFT, 0);
-		stylebox->set_default_margin(SIDE_RIGHT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
+		stylebox->set_default_margin(SIDE_RIGHT, (!get_label().is_empty_string() ? 23 : 16) * EDSCALE);
 	} else {
-		stylebox->set_default_margin(SIDE_LEFT, (!get_label().is_empty() ? 23 : 16) * EDSCALE);
+		stylebox->set_default_margin(SIDE_LEFT, (!get_label().is_empty_string() ? 23 : 16) * EDSCALE);
 		stylebox->set_default_margin(SIDE_RIGHT, 0);
 	}
 
@@ -302,7 +302,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 	Color fc = get_theme_color(is_read_only() ? SNAME("font_uneditable_color") : SNAME("font_color"), SNAME("LineEdit"));
 	Color lc = get_theme_color(is_read_only() ? SNAME("read_only_label_color") : SNAME("label_color"));
 
-	if (flat && !label.is_empty()) {
+	if (flat && !label.is_empty_string()) {
 		Ref<StyleBox> label_bg = get_theme_stylebox(SNAME("label_bg"), SNAME("EditorSpinSlider"));
 		if (rtl) {
 			draw_style_box(label_bg, Rect2(Vector2(size.width - (sb->get_offset().x * 2 + label_width), 0), Vector2(sb->get_offset().x * 2 + label_width, size.height)));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1774,7 +1774,7 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 	Ref<Theme> theme = create_editor_theme(p_theme);
 
 	const String custom_theme_path = EditorSettings::get_singleton()->get("interface/theme/custom_theme");
-	if (!custom_theme_path.is_empty()) {
+	if (!custom_theme_path.is_empty_string()) {
 		Ref<Theme> custom_theme = ResourceLoader::load(custom_theme_path);
 		if (custom_theme.is_valid()) {
 			theme->merge_with(custom_theme);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -55,7 +55,7 @@ void ExportTemplateManager::_update_template_status() {
 	da->list_dir_begin();
 	if (err == OK) {
 		String c = da->get_next();
-		while (!c.is_empty()) {
+		while (!c.is_empty_string()) {
 			if (da->current_is_dir() && !c.begins_with(".")) {
 				templates.insert(c);
 			}
@@ -123,7 +123,7 @@ void ExportTemplateManager::_download_current() {
 
 	if (mirrors_available) {
 		String mirror_url = _get_selected_mirror();
-		if (mirror_url.is_empty()) {
+		if (mirror_url.is_empty_string()) {
 			_set_current_progress_status(TTR("There are no mirrors available."), true);
 			return;
 		}
@@ -289,7 +289,7 @@ void ExportTemplateManager::_refresh_mirrors_completed(int p_status, int p_code,
 
 	if (is_downloading_templates) {
 		String mirror_url = _get_selected_mirror();
-		if (mirror_url.is_empty()) {
+		if (mirror_url.is_empty_string()) {
 			_set_current_progress_status(TTR("There are no mirrors available."), true);
 			return;
 		}
@@ -432,7 +432,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 		ret = unzGoToNextFile(pkg);
 	}
 
-	if (version.is_empty()) {
+	if (version.is_empty_string()) {
 		EditorNode::get_singleton()->show_warning(TTR("No version.txt found inside the export templates file."));
 		unzClose(pkg);
 		return false;
@@ -573,7 +573,7 @@ void ExportTemplateManager::_mirror_options_button_cbk(int p_id) {
 	switch (p_id) {
 		case VISIT_WEB_MIRROR: {
 			String mirror_url = _get_selected_mirror();
-			if (mirror_url.is_empty()) {
+			if (mirror_url.is_empty_string()) {
 				EditorNode::get_singleton()->show_warning(TTR("There are no mirrors available."));
 				return;
 			}
@@ -583,7 +583,7 @@ void ExportTemplateManager::_mirror_options_button_cbk(int p_id) {
 
 		case COPY_MIRROR_URL: {
 			String mirror_url = _get_selected_mirror();
-			if (mirror_url.is_empty()) {
+			if (mirror_url.is_empty_string()) {
 				EditorNode::get_singleton()->show_warning(TTR("There are no mirrors available."));
 				return;
 			}

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -87,7 +87,7 @@ void EditorFileServer::_subthread_start(void *s) {
 			ERR_FAIL();
 		}
 	} else {
-		if (!cd->efs->password.is_empty()) {
+		if (!cd->efs->password.is_empty_string()) {
 			encode_uint32(ERR_INVALID_DATA, buf4);
 			cd->connection->put_data(buf4, 4);
 			OS::get_singleton()->delay_usec(1000000);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -68,7 +68,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 	// Create a tree item for the subdirectory.
 	TreeItem *subdirectory_item = tree->create_item(p_parent);
 	String dname = p_dir->get_name();
-	if (dname.is_empty()) {
+	if (dname.is_empty_string()) {
 		dname = "res://";
 	}
 
@@ -559,7 +559,7 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 	}
 
 	String file_name = p_path.get_file();
-	if (!file_name.is_empty()) {
+	if (!file_name.is_empty_string()) {
 		for (int i = 0; i < files->get_item_count(); i++) {
 			if (files->get_item_text(i) == file_name) {
 				files->select(i, true);
@@ -947,7 +947,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			files->select(item_index, false);
 		}
 
-		if (!p_keep_selection && !file.is_empty() && fname == file) {
+		if (!p_keep_selection && !file.is_empty_string() && fname == file) {
 			files->select(item_index, true);
 			files->ensure_current_is_visible();
 		}
@@ -1741,7 +1741,7 @@ Vector<String> FileSystemDock::_remove_self_included_paths(Vector<String> select
 		selected_strings.sort_custom<NaturalNoCaseComparator>();
 		String last_path = "";
 		for (int i = 0; i < selected_strings.size(); i++) {
-			if (!last_path.is_empty() && selected_strings[i].begins_with(last_path)) {
+			if (!last_path.is_empty_string() && selected_strings[i].begins_with(last_path)) {
 				selected_strings.remove_at(i);
 				i--;
 			}
@@ -2097,7 +2097,7 @@ void FileSystemDock::_search_changed(const String &p_text, const Control *p_from
 		tree_search_box->set_text(searched_string);
 	}
 
-	bool unfold_path = (p_text.is_empty() && !path.is_empty());
+	bool unfold_path = (p_text.is_empty_string() && !path.is_empty_string());
 	switch (display_mode) {
 		case DISPLAY_MODE_TREE_ONLY: {
 			_update_tree(searched_string.length() == 0 ? uncollapsed_paths_before_search : Vector<String>(), false, false, unfold_path);
@@ -2233,7 +2233,7 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
-		return !to_dir.is_empty();
+		return !to_dir.is_empty_string();
 	}
 
 	if (drag_data.has("type") && (String(drag_data["type"]) == "files" || String(drag_data["type"]) == "files_and_dirs")) {
@@ -2246,7 +2246,7 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 			return true;
 		}
 
-		if (to_dir.is_empty()) {
+		if (to_dir.is_empty_string()) {
 			return false;
 		}
 
@@ -2349,7 +2349,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
-		if (res.is_valid() && !to_dir.is_empty()) {
+		if (res.is_valid() && !to_dir.is_empty_string()) {
 			EditorNode::get_singleton()->push_item(res.ptr());
 			EditorNode::get_singleton()->save_resource_as(res, to_dir);
 		}
@@ -2360,7 +2360,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
-		if (!to_dir.is_empty()) {
+		if (!to_dir.is_empty_string()) {
 			Vector<String> fnames = drag_data["files"];
 			to_move.clear();
 			for (int i = 0; i < fnames.size(); i++) {
@@ -2883,7 +2883,7 @@ void FileSystemDock::_get_imported_files(const String &p_path, Vector<String> &f
 	Ref<DirAccess> da = DirAccess::open(p_path);
 	da->list_dir_begin();
 	String n = da->get_next();
-	while (!n.is_empty()) {
+	while (!n.is_empty_string()) {
 		if (n != "." && n != ".." && !n.ends_with(".import")) {
 			String npath = p_path + n + (da->current_is_dir() ? "/" : "");
 			_get_imported_files(npath, files);
@@ -2938,7 +2938,7 @@ void FileSystemDock::_update_import_dock() {
 		if (cf->has_section_key("remap", "type")) {
 			type = cf->get_value("remap", "type");
 		}
-		if (import_type.is_empty()) {
+		if (import_type.is_empty_string()) {
 			import_type = type;
 		} else if (import_type != type) {
 			// All should be the same type.

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -112,7 +112,7 @@ void FindInFiles::_notification(int p_what) {
 }
 
 void FindInFiles::start() {
-	if (_pattern.is_empty()) {
+	if (_pattern.is_empty_string()) {
 		print_verbose("Nothing to search, pattern is empty");
 		emit_signal(SNAME(SIGNAL_FINISHED));
 		return;
@@ -222,7 +222,7 @@ void FindInFiles::_scan_dir(String path, PackedStringArray &out_folders) {
 	for (int i = 0; i < 1000; ++i) {
 		String file = dir->get_next();
 
-		if (file.is_empty()) {
+		if (file.is_empty_string()) {
 			break;
 		}
 
@@ -504,8 +504,8 @@ void FindInFilesDialog::_on_search_text_modified(String text) {
 	ERR_FAIL_COND(!_find_button);
 	ERR_FAIL_COND(!_replace_button);
 
-	_find_button->set_disabled(get_search_text().is_empty());
-	_replace_button->set_disabled(get_search_text().is_empty());
+	_find_button->set_disabled(get_search_text().is_empty_string());
+	_replace_button->set_disabled(get_search_text().is_empty_string());
 }
 
 void FindInFilesDialog::_on_search_text_submitted(String text) {

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -199,7 +199,7 @@ void GroupDialog::_add_group(String p_name) {
 	}
 
 	String name = p_name.strip_edges();
-	if (name.is_empty() || groups->get_item_with_text(name)) {
+	if (name.is_empty_string() || groups->get_item_with_text(name)) {
 		return;
 	}
 
@@ -213,7 +213,7 @@ void GroupDialog::_add_group(String p_name) {
 }
 
 void GroupDialog::_add_group_text_changed(const String &p_new_text) {
-	add_group_button->set_disabled(p_new_text.strip_edges().is_empty());
+	add_group_button->set_disabled(p_new_text.strip_edges().is_empty_string());
 }
 
 void GroupDialog::_group_renamed() {
@@ -232,7 +232,7 @@ void GroupDialog::_group_renamed() {
 		}
 	}
 
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		renamed_group->set_text(0, selected_group);
 		error->set_text(TTR("Invalid group name."));
 		error->popup_centered();
@@ -581,7 +581,7 @@ void GroupsEditor::_add_group(const String &p_group) {
 	}
 
 	const String name = group_name->get_text().strip_edges();
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		return;
 	}
 
@@ -640,7 +640,7 @@ void GroupsEditor::_modify_group(Object *p_item, int p_column, int p_id, MouseBu
 }
 
 void GroupsEditor::_group_name_changed(const String &p_new_text) {
-	add->set_disabled(p_new_text.strip_edges().is_empty());
+	add->set_disabled(p_new_text.strip_edges().is_empty_string());
 }
 
 struct _GroupInfoComparator {

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -1337,7 +1337,7 @@ Collada::Node *Collada::_parse_visual_instance_geometry(XMLParser &parser) {
 			} else if (parser.get_node_name() == "skeleton") {
 				parser.read();
 				String uri = _uri_to_id(parser.get_node_data());
-				if (!uri.is_empty()) {
+				if (!uri.is_empty_string()) {
 					geom->skeletons.push_back(uri);
 				}
 			}
@@ -1439,7 +1439,7 @@ Collada::Node *Collada::_parse_visual_scene_node(XMLParser &parser) {
 
 	bool found_name = false;
 
-	if (id.is_empty()) {
+	if (id.is_empty_string()) {
 		id = "%NODEID%" + itos(Math::rand());
 
 	} else {
@@ -1454,7 +1454,7 @@ Collada::Node *Collada::_parse_visual_scene_node(XMLParser &parser) {
 	Node *node = nullptr;
 
 	name = parser.has_attribute("name") ? parser.get_attribute_value_safe("name") : parser.get_attribute_value_safe("id");
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		name = id;
 	} else {
 		found_name = true;
@@ -1474,7 +1474,7 @@ Collada::Node *Collada::_parse_visual_scene_node(XMLParser &parser) {
 			joint->sid = parser.get_attribute_value_safe("name");
 		}
 
-		if (!joint->sid.is_empty()) {
+		if (!joint->sid.is_empty_string()) {
 			state.sid_to_node_map[joint->sid] = id;
 		}
 
@@ -1671,16 +1671,16 @@ void Collada::_parse_animation(XMLParser &parser) {
 				source_param_types[current_source] = Vector<String>();
 
 			} else if (name == "float_array") {
-				if (!current_source.is_empty()) {
+				if (!current_source.is_empty_string()) {
 					float_sources[current_source] = _read_float_array(parser);
 				}
 
 			} else if (name == "Name_array") {
-				if (!current_source.is_empty()) {
+				if (!current_source.is_empty_string()) {
 					string_sources[current_source] = _read_string_array(parser);
 				}
 			} else if (name == "accessor") {
-				if (!current_source.is_empty() && parser.has_attribute("stride")) {
+				if (!current_source.is_empty_string() && parser.has_attribute("stride")) {
 					source_strides[current_source] = parser.get_attribute_value("stride").to_int();
 				}
 			} else if (name == "sampler") {
@@ -1700,7 +1700,7 @@ void Collada::_parse_animation(XMLParser &parser) {
 				}
 
 			} else if (name == "input") {
-				if (!current_sampler.is_empty()) {
+				if (!current_sampler.is_empty_string()) {
 					samplers[current_sampler][parser.get_attribute_value("semantic")] = parser.get_attribute_value("source");
 				}
 
@@ -1813,7 +1813,7 @@ void Collada::_parse_animation(XMLParser &parser) {
 					track.component = track.param.get_slice(".", 1).to_upper();
 				}
 				track.param = track.param.get_slice(".", 0);
-				if (names.size() > 1 && track.component.is_empty()) {
+				if (names.size() > 1 && track.component.is_empty_string()) {
 					//this is a guess because the collada spec is ambiguous here...
 					//i suppose if you have many names (outputs) you can't use a component and i should abide to that.
 					track.component = name;
@@ -1830,7 +1830,7 @@ void Collada::_parse_animation(XMLParser &parser) {
 
 			state.referenced_tracks[target].push_back(state.animation_tracks.size() - 1);
 
-			if (!id.is_empty()) {
+			if (!id.is_empty_string()) {
 				if (!state.by_id_tracks.has(id)) {
 					state.by_id_tracks[id] = Vector<int>();
 				}
@@ -1928,10 +1928,10 @@ void Collada::_parse_library(XMLParser &parser) {
 				while (parser.read() == OK) {
 					if (parser.get_node_type() == XMLParser::NODE_ELEMENT) {
 						if (parser.get_node_name() == "mesh") {
-							state.mesh_name_map[id] = (!name2.is_empty()) ? name2 : id;
+							state.mesh_name_map[id] = (!name2.is_empty_string()) ? name2 : id;
 							_parse_mesh_geometry(parser, id, name2);
 						} else if (parser.get_node_name() == "spline") {
-							state.mesh_name_map[id] = (!name2.is_empty()) ? name2 : id;
+							state.mesh_name_map[id] = (!name2.is_empty_string()) ? name2 : id;
 							_parse_curve_geometry(parser, id, name2);
 						} else if (!parser.is_empty()) {
 							parser.skip_section();
@@ -2261,7 +2261,7 @@ void Collada::_find_morph_nodes(VisualScene *p_vscene, Node *p_node) {
 		if (nj->controller) {
 			String base = nj->source;
 
-			while (!base.is_empty() && !state.mesh_data_map.has(base)) {
+			while (!base.is_empty_string() && !state.mesh_data_map.has(base)) {
 				if (state.skin_controller_data_map.has(base)) {
 					SkinControllerData &sk = state.skin_controller_data_map[base];
 					base = sk.base;

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -601,7 +601,7 @@ void DynamicFontImportSettings::_variations_validate() {
 			}
 		}
 	}
-	if (warn.is_empty()) {
+	if (warn.is_empty_string()) {
 		label_warn->set_text("");
 		label_warn->hide();
 	} else {
@@ -972,7 +972,7 @@ void DynamicFontImportSettings::_re_import() {
 		String name = vars_item->get_text(0);
 		variation += ("name=" + name);
 		for (const KeyValue<StringName, Variant> &E : import_variation_data->settings) {
-			if (!variation.is_empty()) {
+			if (!variation.is_empty_string()) {
 				variation += ",";
 			}
 			variation += (String(E.key) + "=" + String(E.value));
@@ -1072,7 +1072,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 			sample += sample_base[i];
 		}
 	}
-	if (sample.is_empty()) {
+	if (sample.is_empty_string()) {
 		sample = dfont_prev->get_supported_chars().substr(0, 6);
 	}
 	font_preview_label->set_text(sample);
@@ -1623,7 +1623,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	glyph_tree->connect("item_selected", callable_mp(this, &DynamicFontImportSettings::_range_selected));
 	glyph_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	glyph_root = glyph_tree->create_item();
-	for (int i = 0; !unicode_ranges[i].name.is_empty(); i++) {
+	for (int i = 0; !unicode_ranges[i].name.is_empty_string(); i++) {
 		_add_glyph_range_item(unicode_ranges[i].start, unicode_ranges[i].end, unicode_ranges[i].name);
 	}
 

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -303,7 +303,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 		} break;
 	}
 
-	if (!p_node->name.is_empty()) {
+	if (!p_node->name.is_empty_string()) {
 		node->set_name(p_node->name);
 	}
 	NodeMap nm;
@@ -317,7 +317,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 	p_parent->add_child(node, true);
 	node->set_owner(scene);
 
-	if (!p_node->empty_draw_type.is_empty()) {
+	if (!p_node->empty_draw_type.is_empty_string()) {
 		node->set_meta("empty_draw_type", Variant(p_node->empty_draw_type));
 	}
 
@@ -340,9 +340,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 	Ref<StandardMaterial3D> material = memnew(StandardMaterial3D);
 
 	String base_name;
-	if (!src_mat.name.is_empty()) {
+	if (!src_mat.name.is_empty_string()) {
 		base_name = src_mat.name;
-	} else if (!effect.name.is_empty()) {
+	} else if (!effect.name.is_empty_string()) {
 		base_name = effect.name;
 	} else {
 		base_name = "Material";
@@ -360,9 +360,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 
 	// DIFFUSE
 
-	if (!effect.diffuse.texture.is_empty()) {
+	if (!effect.diffuse.texture.is_empty_string()) {
 		String texfile = effect.get_texture_path(effect.diffuse.texture, collada);
-		if (!texfile.is_empty()) {
+		if (!texfile.is_empty_string()) {
 			if (texfile.begins_with("/")) {
 				texfile = texfile.replace_first("/", "res://");
 			}
@@ -381,9 +381,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 
 	// SPECULAR
 
-	if (!effect.specular.texture.is_empty()) {
+	if (!effect.specular.texture.is_empty_string()) {
 		String texfile = effect.get_texture_path(effect.specular.texture, collada);
-		if (!texfile.is_empty()) {
+		if (!texfile.is_empty_string()) {
 			if (texfile.begins_with("/")) {
 				texfile = texfile.replace_first("/", "res://");
 			}
@@ -406,9 +406,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 
 	// EMISSION
 
-	if (!effect.emission.texture.is_empty()) {
+	if (!effect.emission.texture.is_empty_string()) {
 		String texfile = effect.get_texture_path(effect.emission.texture, collada);
-		if (!texfile.is_empty()) {
+		if (!texfile.is_empty_string()) {
 			if (texfile.begins_with("/")) {
 				texfile = texfile.replace_first("/", "res://");
 			}
@@ -433,9 +433,9 @@ Error ColladaImport::_create_material(const String &p_target) {
 
 	// NORMAL
 
-	if (!effect.bump.texture.is_empty()) {
+	if (!effect.bump.texture.is_empty_string()) {
 		String texfile = effect.get_texture_path(effect.bump.texture, collada);
-		if (!texfile.is_empty()) {
+		if (!texfile.is_empty_string()) {
 			if (texfile.begins_with("/")) {
 				texfile = texfile.replace_first("/", "res://");
 			}
@@ -525,7 +525,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				normal_ofs = vertex_ofs;
 			}
 
-			if (!normal_source_id.is_empty()) {
+			if (!normal_source_id.is_empty_string()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(normal_source_id), ERR_INVALID_DATA);
 				normal_src = &meshdata.sources[normal_source_id];
 			}
@@ -545,7 +545,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				binormal_ofs = vertex_ofs;
 			}
 
-			if (!binormal_source_id.is_empty()) {
+			if (!binormal_source_id.is_empty_string()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(binormal_source_id), ERR_INVALID_DATA);
 				binormal_src = &meshdata.sources[binormal_source_id];
 			}
@@ -565,7 +565,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				tangent_ofs = vertex_ofs;
 			}
 
-			if (!tangent_source_id.is_empty()) {
+			if (!tangent_source_id.is_empty_string()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(tangent_source_id), ERR_INVALID_DATA);
 				tangent_src = &meshdata.sources[tangent_source_id];
 			}
@@ -585,7 +585,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				uv_ofs = vertex_ofs;
 			}
 
-			if (!uv_source_id.is_empty()) {
+			if (!uv_source_id.is_empty_string()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(uv_source_id), ERR_INVALID_DATA);
 				uv_src = &meshdata.sources[uv_source_id];
 			}
@@ -605,7 +605,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				uv2_ofs = vertex_ofs;
 			}
 
-			if (!uv2_source_id.is_empty()) {
+			if (!uv2_source_id.is_empty_string()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(uv2_source_id), ERR_INVALID_DATA);
 				uv2_src = &meshdata.sources[uv2_source_id];
 			}
@@ -625,7 +625,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				color_ofs = vertex_ofs;
 			}
 
-			if (!color_source_id.is_empty()) {
+			if (!color_source_id.is_empty_string()) {
 				ERR_FAIL_COND_V(!meshdata.sources.has(color_source_id), ERR_INVALID_DATA);
 				color_src = &meshdata.sources[color_source_id];
 			}
@@ -914,7 +914,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 						material = material_cache[target];
 					}
 
-				} else if (!p.material.is_empty()) {
+				} else if (!p.material.is_empty_string()) {
 					WARN_PRINT("Collada: Unreferenced material in geometry instance: " + p.material);
 				}
 			}
@@ -1197,7 +1197,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 					}
 				}
 
-				ERR_FAIL_COND_V_MSG(!ngsource.is_empty(), ERR_INVALID_DATA, "Controller instance source '" + ngsource + "' is neither skin or morph!");
+				ERR_FAIL_COND_V_MSG(!ngsource.is_empty_string(), ERR_INVALID_DATA, "Controller instance source '" + ngsource + "' is neither skin or morph!");
 
 			} else {
 				meshid = ng2->source;
@@ -1214,13 +1214,13 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 					mesh = Ref<ImporterMesh>(memnew(ImporterMesh));
 					const Collada::MeshData &meshdata = collada.state.mesh_data_map[meshid];
 					String name = meshdata.name;
-					if (name.is_empty()) {
+					if (name.is_empty_string()) {
 						name = "Mesh";
 					}
 					int counter = 2;
 					while (mesh_unique_names.has(name)) {
 						name = meshdata.name;
-						if (name.is_empty()) {
+						if (name.is_empty_string()) {
 							name = "Mesh";
 						}
 						name += itos(counter++);
@@ -1260,7 +1260,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 							}
 
 							mi->set_surface_material(i, material);
-						} else if (!matname.is_empty()) {
+						} else if (!matname.is_empty_string()) {
 							WARN_PRINT("Collada: Unreferenced material in geometry instance: " + matname);
 						}
 					}
@@ -1342,7 +1342,7 @@ void ColladaImport::_fix_param_animation_tracks() {
 				// test source(s)
 				String source = ng->source;
 
-				while (!source.is_empty()) {
+				while (!source.is_empty_string()) {
 					if (collada.state.skin_controller_data_map.has(source)) {
 						const Collada::SkinControllerData &skin = collada.state.skin_controller_data_map[source];
 
@@ -1795,7 +1795,7 @@ Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint3
 		AnimationPlayer *ap = memnew(AnimationPlayer);
 		for (int i = 0; i < state.animations.size(); i++) {
 			String name;
-			if (state.animations[i]->get_name().is_empty()) {
+			if (state.animations[i]->get_name().is_empty_string()) {
 				name = "default";
 			} else {
 				name = state.animations[i]->get_name();

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -111,7 +111,7 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 
 	while (line.size() == locales.size() + 1) {
 		String key = line[0];
-		if (!key.is_empty()) {
+		if (!key.is_empty_string()) {
 			for (int i = 1; i < line.size(); i++) {
 				translations.write[i - 1]->add_message(key, line[i].c_unescape());
 			}

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -235,7 +235,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 		while (l.length() && l[l.length() - 1] == '\\') {
 			String add = f->get_line().strip_edges();
 			l += add;
-			if (add.is_empty()) {
+			if (add.is_empty_string()) {
 				break;
 			}
 		}
@@ -301,7 +301,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 						surf_tool->set_normal(normals[norm]);
 					}
 
-					if (face[idx].size() >= 2 && !face[idx][1].is_empty()) {
+					if (face[idx].size() >= 2 && !face[idx][1].is_empty_string()) {
 						int uv = face[idx][1].to_int() - 1;
 						if (uv < 0) {
 							uv += uvs.size() + 1;
@@ -361,9 +361,9 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 
 				mesh = surf_tool->commit(mesh, mesh_flags);
 
-				if (!current_material.is_empty()) {
+				if (!current_material.is_empty_string()) {
 					mesh->surface_set_name(mesh->get_surface_count() - 1, current_material.get_basename());
-				} else if (!current_group.is_empty()) {
+				} else if (!current_group.is_empty_string()) {
 					mesh->surface_set_name(mesh->get_surface_count() - 1, current_group);
 				}
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -488,7 +488,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			fixed_name = _fixstr(name, "convcolonly");
 		}
 
-		ERR_FAIL_COND_V(fixed_name.is_empty(), nullptr);
+		ERR_FAIL_COND_V(fixed_name.is_empty_string(), nullptr);
 
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
 		if (mi) {
@@ -600,7 +600,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				fixed_name = _fixstr(name, "convcol");
 			}
 
-			if (!fixed_name.is_empty()) {
+			if (!fixed_name.is_empty_string()) {
 				if (mi->get_parent() && !mi->get_parent()->has_node(fixed_name)) {
 					mi->set_name(fixed_name);
 				}
@@ -647,7 +647,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				}
 				if (_teststr(name, "occ")) {
 					String fixed_name = _fixstr(name, "occ");
-					if (!fixed_name.is_empty()) {
+					if (!fixed_name.is_empty_string()) {
 						if (mi->get_parent() && !mi->get_parent()->has_node(fixed_name)) {
 							mi->set_name(fixed_name);
 						}
@@ -797,7 +797,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					if (mat.is_valid()) {
 						String mat_id = mat->get_meta("import_id", mat->get_name());
 
-						if (!mat_id.is_empty() && p_material_data.has(mat_id)) {
+						if (!mat_id.is_empty_string() && p_material_data.has(mat_id)) {
 							Dictionary matdata = p_material_data[mat_id];
 
 							for (int j = 0; j < post_importer_plugins.size(); j++) {
@@ -1558,7 +1558,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	String script_ext_hint;
 
 	for (const String &E : script_extentions) {
-		if (!script_ext_hint.is_empty()) {
+		if (!script_ext_hint.is_empty_string()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "*." + E;
@@ -1620,7 +1620,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 
 				String mesh_id = src_mesh_node->get_mesh()->get_meta("import_id", src_mesh_node->get_mesh()->get_name());
 
-				if (!mesh_id.is_empty() && p_mesh_data.has(mesh_id)) {
+				if (!mesh_id.is_empty_string() && p_mesh_data.has(mesh_id)) {
 					Dictionary mesh_settings = p_mesh_data[mesh_id];
 
 					if (mesh_settings.has("generate/shadow_meshes")) {
@@ -1710,7 +1710,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 					src_mesh_node->get_mesh()->create_shadow_mesh();
 				}
 
-				if (!save_to_file.is_empty()) {
+				if (!save_to_file.is_empty_string()) {
 					Ref<Mesh> existing = Ref<Resource>(ResourceCache::get(save_to_file));
 					if (existing.is_valid()) {
 						//if somehow an existing one is useful, create
@@ -2128,7 +2128,7 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	String post_import_script_path = p_options["import_script/path"];
 	Ref<EditorScenePostImport> post_import_script;
 
-	if (!post_import_script_path.is_empty()) {
+	if (!post_import_script_path.is_empty_string()) {
 		Ref<Script> scr = ResourceLoader::load(post_import_script_path);
 		if (!scr.is_valid()) {
 			EditorNode::add_io_error(TTR("Couldn't load post-import script:") + " " + post_import_script_path);

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -138,7 +138,7 @@ void SceneImportSettings::_fill_material(Tree *p_tree, const Ref<Material> &p_ma
 	if (p_material->has_meta("import_id")) {
 		import_id = p_material->get_meta("import_id");
 		has_import_id = true;
-	} else if (!p_material->get_name().is_empty()) {
+	} else if (!p_material->get_name().is_empty_string()) {
 		import_id = p_material->get_name();
 		has_import_id = true;
 	} else {
@@ -194,7 +194,7 @@ void SceneImportSettings::_fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, Tree
 	if (p_mesh->has_meta("import_id")) {
 		import_id = p_mesh->get_meta("import_id");
 		has_import_id = true;
-	} else if (!p_mesh->get_name().is_empty()) {
+	} else if (!p_mesh->get_name().is_empty_string()) {
 		import_id = p_mesh->get_name();
 		has_import_id = true;
 	} else {
@@ -467,7 +467,7 @@ void SceneImportSettings::_update_camera() {
 	float rot_y = cam_rot_y;
 	float zoom = cam_zoom;
 
-	if (selected_type == "Node" || selected_type.is_empty()) {
+	if (selected_type == "Node" || selected_type.is_empty_string()) {
 		camera_aabb = contents_aabb;
 	} else {
 		if (mesh_preview->get_mesh().is_valid()) {

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -536,7 +536,7 @@ void ImportDock::_reimport() {
 			Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
 			ERR_CONTINUE(!importer.is_valid());
 			String group_file_property = importer->get_option_group_file();
-			if (!group_file_property.is_empty()) {
+			if (!group_file_property.is_empty_string()) {
 				//can import from a group (as in, atlas)
 				ERR_CONTINUE(!params->values.has(group_file_property));
 				String group_file = params->values[group_file_property];

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -330,7 +330,7 @@ void InspectorDock::_prepare_history() {
 			Resource *r = Object::cast_to<Resource>(obj);
 			if (r->get_path().is_resource_file()) {
 				text = r->get_path().get_file();
-			} else if (!r->get_name().is_empty()) {
+			} else if (!r->get_name().is_empty_string()) {
 				text = r->get_name();
 			} else {
 				text = r->get_class();
@@ -466,7 +466,7 @@ void InspectorDock::open_resource(const String &p_type) {
 
 void InspectorDock::set_warning(const String &p_message) {
 	warning->hide();
-	if (!p_message.is_empty()) {
+	if (!p_message.is_empty_string()) {
 		warning->show();
 		warning_dialog->set_text(p_message);
 	}

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -75,7 +75,7 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 			ur->add_do_property(n, name, path);
 		} else {
 			Variant new_value;
-			if (p_field.is_empty()) {
+			if (p_field.is_empty_string()) {
 				// whole value
 				new_value = p_value;
 			} else {

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -58,8 +58,8 @@ void PluginConfigDialog::_on_confirmed() {
 
 	int lang_idx = script_option_edit->get_selected();
 	String ext = ScriptServer::get_language(lang_idx)->get_extension();
-	String script_name = script_edit->get_text().is_empty() ? _get_subfolder() : script_edit->get_text();
-	if (script_name.get_extension().is_empty()) {
+	String script_name = script_edit->get_text().is_empty_string() ? _get_subfolder() : script_edit->get_text();
+	if (script_name.get_extension().is_empty_string()) {
 		script_name += "." + ext;
 	}
 	String script_path = path.plus_file(script_name);
@@ -117,17 +117,17 @@ void PluginConfigDialog::_on_required_text_changed(const String &) {
 
 	// Change valid status to invalid depending on conditions.
 	Vector<String> errors;
-	if (name_edit->get_text().is_empty()) {
+	if (name_edit->get_text().is_empty_string()) {
 		is_valid = false;
 		name_validation->set_texture(invalid_icon);
 		name_validation->set_tooltip(TTR("Plugin name cannot be blank."));
 	}
-	if ((!script_edit->get_text().get_extension().is_empty() && script_edit->get_text().get_extension() != ext) || script_edit->get_text().ends_with(".")) {
+	if ((!script_edit->get_text().get_extension().is_empty_string() && script_edit->get_text().get_extension() != ext) || script_edit->get_text().ends_with(".")) {
 		is_valid = false;
 		script_validation->set_texture(invalid_icon);
 		script_validation->set_tooltip(vformat(TTR("Script extension must match chosen language extension (.%s)."), ext));
 	}
-	if (!subfolder_edit->get_text().is_empty() && !subfolder_edit->get_text().is_valid_filename()) {
+	if (!subfolder_edit->get_text().is_empty_string() && !subfolder_edit->get_text().is_valid_filename()) {
 		is_valid = false;
 		subfolder_validation->set_texture(invalid_icon);
 		subfolder_validation->set_tooltip(TTR("Subfolder name is not a valid folder name."));
@@ -144,7 +144,7 @@ void PluginConfigDialog::_on_required_text_changed(const String &) {
 }
 
 String PluginConfigDialog::_get_subfolder() {
-	return subfolder_edit->get_text().is_empty() ? name_edit->get_text().replace(" ", "_").to_lower() : subfolder_edit->get_text();
+	return subfolder_edit->get_text().is_empty_string() ? name_edit->get_text().replace(" ", "_").to_lower() : subfolder_edit->get_text();
 }
 
 String PluginConfigDialog::_to_absolute_plugin_path(const String &p_plugin_name) {

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -556,7 +556,7 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);
-				if (!error.is_empty()) {
+				if (!error.is_empty_string()) {
 					error_panel->show();
 				} else {
 					error_panel->hide();

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -766,7 +766,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);
-				if (!error.is_empty()) {
+				if (!error.is_empty_string()) {
 					error_panel->show();
 				} else {
 					error_panel->hide();

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -297,7 +297,7 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		anode = EditorSettings::get_singleton()->get_resource_clipboard();
 		ERR_FAIL_COND(!anode.is_valid());
 		base_name = anode->get_class();
-	} else if (!add_options[p_idx].type.is_empty()) {
+	} else if (!add_options[p_idx].type.is_empty_string()) {
 		AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate(add_options[p_idx].type));
 		ERR_FAIL_COND(!an);
 		anode = Ref<AnimationNode>(an);
@@ -318,7 +318,7 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		return;
 	}
 
-	if (!from_node.is_empty() && anode->get_input_count() == 0) {
+	if (!from_node.is_empty_string() && anode->get_input_count() == 0) {
 		from_node = "";
 		return;
 	}
@@ -343,11 +343,11 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 	undo_redo->add_do_method(blend_tree.ptr(), "add_node", name, anode, instance_pos / EDSCALE);
 	undo_redo->add_undo_method(blend_tree.ptr(), "remove_node", name);
 
-	if (!from_node.is_empty()) {
+	if (!from_node.is_empty_string()) {
 		undo_redo->add_do_method(blend_tree.ptr(), "connect_node", name, 0, from_node);
 		from_node = "";
 	}
-	if (!to_node.is_empty() && to_slot != -1) {
+	if (!to_node.is_empty_string() && to_slot != -1) {
 		undo_redo->add_do_method(blend_tree.ptr(), "connect_node", to_node, to_slot, name);
 		to_node = "";
 		to_slot = -1;
@@ -592,7 +592,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 					default: {
 					} break;
 				}
-				if (!track_type_name.is_empty()) {
+				if (!track_type_name.is_empty_string()) {
 					types[track_path].insert(track_type_name);
 				}
 			}
@@ -611,7 +611,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 		String accum;
 		for (int i = 0; i < path.get_name_count(); i++) {
 			String name = path.get_name(i);
-			if (!accum.is_empty()) {
+			if (!accum.is_empty_string()) {
 				accum += "/";
 			}
 			accum += name;
@@ -783,7 +783,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);
-				if (!error.is_empty()) {
+				if (!error.is_empty_string()) {
 					error_panel->show();
 				} else {
 					error_panel->hide();
@@ -853,13 +853,13 @@ AnimationNodeBlendTreeEditor *AnimationNodeBlendTreeEditor::singleton = nullptr;
 
 void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<AnimationNode> p_node) {
 	String prev_name = blend_tree->get_node_name(p_node);
-	ERR_FAIL_COND(prev_name.is_empty());
+	ERR_FAIL_COND(prev_name.is_empty_string());
 	GraphNode *gn = Object::cast_to<GraphNode>(graph->get_node(prev_name));
 	ERR_FAIL_COND(!gn);
 
 	const String &new_name = p_text;
 
-	ERR_FAIL_COND(new_name.is_empty() || new_name.contains(".") || new_name.contains("/"));
+	ERR_FAIL_COND(new_name.is_empty_string() || new_name.contains(".") || new_name.contains("/"));
 
 	if (new_name == prev_name) {
 		return; //nothing to do

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -194,7 +194,7 @@ void AnimationPlayerEditor::_autoplay_pressed() {
 void AnimationPlayerEditor::_play_pressed() {
 	String current = _get_current();
 
-	if (!current.is_empty()) {
+	if (!current.is_empty_string()) {
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
 		}
@@ -208,7 +208,7 @@ void AnimationPlayerEditor::_play_pressed() {
 void AnimationPlayerEditor::_play_from_pressed() {
 	String current = _get_current();
 
-	if (!current.is_empty()) {
+	if (!current.is_empty_string()) {
 		float time = player->get_current_animation_position();
 
 		if (current == player->get_assigned_animation() && player->is_playing()) {
@@ -232,7 +232,7 @@ String AnimationPlayerEditor::_get_current() const {
 }
 void AnimationPlayerEditor::_play_bw_pressed() {
 	String current = _get_current();
-	if (!current.is_empty()) {
+	if (!current.is_empty_string()) {
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
 		}
@@ -246,7 +246,7 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 void AnimationPlayerEditor::_play_bw_from_pressed() {
 	String current = _get_current();
 
-	if (!current.is_empty()) {
+	if (!current.is_empty_string()) {
 		float time = player->get_current_animation_position();
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
@@ -278,7 +278,7 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 	// ui-wise is that it should play/blend the next one if currently playing
 	String current = _get_current();
 
-	if (!current.is_empty()) {
+	if (!current.is_empty_string()) {
 		player->set_assigned_animation(current);
 
 		Ref<Animation> anim = player->get_animation(current);
@@ -726,7 +726,7 @@ void AnimationPlayerEditor::set_state(const Dictionary &p_state) {
 
 			if (p_state.has("animation")) {
 				String anim = p_state["animation"];
-				if (!anim.is_empty() && player->has_animation(anim)) {
+				if (!anim.is_empty_string() && player->has_animation(anim)) {
 					_select_anim_by_name(anim);
 					_animation_edit();
 				}
@@ -1083,7 +1083,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set, bool 
 
 	updating = true;
 	String current = player->get_assigned_animation();
-	if (current.is_empty() || !player->has_animation(current)) {
+	if (current.is_empty_string() || !player->has_animation(current)) {
 		updating = false;
 		current = "";
 		return;
@@ -1162,7 +1162,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 	String current = _get_current();
 
 	Ref<Animation> anim;
-	if (!current.is_empty()) {
+	if (!current.is_empty_string()) {
 		anim = player->get_animation(current);
 	}
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -987,7 +987,7 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 		return;
 	}
 
-	if (base_name.is_empty()) {
+	if (base_name.is_empty_string()) {
 		base_name = node->get_class().replace_first("AnimationNode", "");
 	}
 
@@ -1573,7 +1573,7 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);
-				if (!error.is_empty()) {
+				if (!error.is_empty_string()) {
 					error_panel->show();
 				} else {
 					error_panel->hide();
@@ -1706,7 +1706,7 @@ void AnimationNodeStateMachineEditor::_removed_from_graph() {
 void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 	const String &new_name = p_text;
 
-	ERR_FAIL_COND(new_name.is_empty() || new_name.contains(".") || new_name.contains("/"));
+	ERR_FAIL_COND(new_name.is_empty_string() || new_name.contains(".") || new_name.contains("/"));
 
 	if (new_name == prev_name) {
 		return; // Nothing to do.

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -358,7 +358,7 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 			if (p_code != 200) {
 				error_text = TTR("Request failed, return code:") + " " + itos(p_code);
 				status->set_text(TTR("Failed:") + " " + itos(p_code));
-			} else if (!sha256.is_empty()) {
+			} else if (!sha256.is_empty_string()) {
 				String download_sha256 = FileAccess::get_sha256(download->get_download_file());
 				if (sha256 != download_sha256) {
 					error_text = TTR("Bad download hash, assuming file has been tampered with.") + "\n";
@@ -369,7 +369,7 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 		} break;
 	}
 
-	if (!error_text.is_empty()) {
+	if (!error_text.is_empty_string()) {
 		download_error->set_text(TTR("Asset Download Error:") + "\n" + error_text);
 		download_error->popup_centered();
 		// Let the user retry the download.
@@ -946,7 +946,7 @@ void EditorAssetLibrary::_search(int p_page) {
 			support_list += String(support_key[i]) + "+";
 		}
 	}
-	if (!support_list.is_empty()) {
+	if (!support_list.is_empty_string()) {
 		args += "&support=" + support_list.substr(0, support_list.length() - 1);
 	}
 
@@ -959,7 +959,7 @@ void EditorAssetLibrary::_search(int p_page) {
 		args += "&reverse=true";
 	}
 
-	if (!filter->get_text().is_empty()) {
+	if (!filter->get_text().is_empty_string()) {
 		args += "&filter=" + filter->get_text().uri_encode();
 	}
 
@@ -1219,7 +1219,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 			library_vb->add_child(asset_bottom_page);
 
 			if (result.is_empty()) {
-				if (!filter->get_text().is_empty()) {
+				if (!filter->get_text().is_empty_string()) {
 					library_info->set_text(
 							vformat(TTR("No results for \"%s\"."), filter->get_text()));
 				} else {
@@ -1252,7 +1252,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				item->connect("author_selected", callable_mp(this, &EditorAssetLibrary::_select_author));
 				item->connect("category_selected", callable_mp(this, &EditorAssetLibrary::_select_category));
 
-				if (r.has("icon_url") && !r["icon_url"].operator String().is_empty()) {
+				if (r.has("icon_url") && !r["icon_url"].operator String().is_empty_string()) {
 					_request_image(item->get_instance_id(), r["icon_url"], IMAGE_QUEUE_ICON, 0);
 				}
 			}
@@ -1303,7 +1303,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				description->get_ok_button()->set_disabled(false);
 			}
 
-			if (r.has("icon_url") && !r["icon_url"].operator String().is_empty()) {
+			if (r.has("icon_url") && !r["icon_url"].operator String().is_empty_string()) {
 				_request_image(description->get_instance_id(), r["icon_url"], IMAGE_QUEUE_ICON, 0);
 			}
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1467,7 +1467,7 @@ bool CanvasItemEditor::_gui_input_open_scene_on_double_click(const Ref<InputEven
 		List<CanvasItem *> selection = _get_edited_canvas_items();
 		if (selection.size() == 1) {
 			CanvasItem *canvas_item = selection[0];
-			if (!canvas_item->get_scene_file_path().is_empty() && canvas_item != EditorNode::get_singleton()->get_edited_scene()) {
+			if (!canvas_item->get_scene_file_path().is_empty_string() && canvas_item != EditorNode::get_singleton()->get_edited_scene()) {
 				EditorNode::get_singleton()->open_request(canvas_item->get_scene_file_path());
 				return true;
 			}
@@ -5519,7 +5519,7 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 
 	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
 
-	if (!edited_scene->get_scene_file_path().is_empty()) { // cyclical instancing
+	if (!edited_scene->get_scene_file_path().is_empty_string()) { // cyclical instancing
 		if (_cyclical_dependency_exists(edited_scene->get_scene_file_path(), instantiated_scene)) {
 			memdelete(instantiated_scene);
 			return false;

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -440,7 +440,7 @@ bool EditorInspectorPluginControl::parse_property(Object *p_object, const Varian
 	if (p_path == "size_flags_horizontal" || p_path == "size_flags_vertical") {
 		EditorPropertySizeFlags *prop_editor = memnew(EditorPropertySizeFlags);
 		Vector<String> options;
-		if (!p_hint_text.is_empty()) {
+		if (!p_hint_text.is_empty_string()) {
 			options = p_hint_text.split(",");
 		}
 		prop_editor->setup(options, p_path == "size_flags_vertical");

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -474,7 +474,7 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const Ref<Resource> &p_from, 
 	}
 
 	String code = scr->get_source_code().strip_edges();
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return Ref<Texture2D>();
 	}
 
@@ -833,7 +833,7 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path,
 			sample += sample_base[i];
 		}
 	}
-	if (sample.is_empty()) {
+	if (sample.is_empty_string()) {
 		sample = sampled_font->get_supported_chars().substr(0, 6);
 	}
 	Vector2 size = sampled_font->get_string_size(sample, 50);

--- a/editor/plugins/font_editor_plugin.cpp
+++ b/editor/plugins/font_editor_plugin.cpp
@@ -65,7 +65,7 @@ void FontDataPreview::set_data(const Ref<FontData> &p_data) {
 				sample += sample_base[i];
 			}
 		}
-		if (sample.is_empty()) {
+		if (sample.is_empty_string()) {
 			sample = p_data->get_supported_chars().substr(0, 6);
 		}
 		line->add_string(sample, f, 72);

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -37,7 +37,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_bake() {
 	if (col_sdf) {
 		if (col_sdf->get_texture().is_null() || !col_sdf->get_texture()->get_path().is_resource_file()) {
 			String path = get_tree()->get_edited_scene_root()->get_scene_file_path();
-			if (path.is_empty()) {
+			if (path.is_empty_string()) {
 				path = "res://" + col_sdf->get_name() + "_data.exr";
 			} else {
 				String ext = path.get_extension();

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -48,10 +48,10 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 		switch (err) {
 			case LightmapGI::BAKE_ERROR_NO_SAVE_PATH: {
 				String scene_path = lightmap->get_scene_file_path();
-				if (scene_path.is_empty()) {
+				if (scene_path.is_empty_string()) {
 					scene_path = lightmap->get_owner()->get_scene_file_path();
 				}
-				if (scene_path.is_empty()) {
+				if (scene_path.is_empty_string()) {
 					EditorNode::get_singleton()->show_warning(TTR("Can't determine a save path for lightmap images.\nSave your scene and try again."));
 					break;
 				}

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -62,7 +62,7 @@ void MeshLibraryEditor::_menu_update_confirm(bool p_apply_xforms) {
 	cd_update->hide();
 	apply_xforms = p_apply_xforms;
 	String existing = mesh_library->get_meta("_editor_source_scene");
-	ERR_FAIL_COND(existing.is_empty());
+	ERR_FAIL_COND(existing.is_empty_string());
 	_import_scene_cbk(existing);
 }
 

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -50,7 +50,7 @@ void MultiMeshEditor::_populate() {
 
 	Ref<Mesh> mesh;
 
-	if (mesh_source->get_text().is_empty()) {
+	if (mesh_source->get_text().is_empty_string()) {
 		Ref<MultiMesh> multimesh;
 		multimesh = node->get_multimesh();
 		if (multimesh.is_null()) {
@@ -91,7 +91,7 @@ void MultiMeshEditor::_populate() {
 		}
 	}
 
-	if (surface_source->get_text().is_empty()) {
+	if (surface_source->get_text().is_empty_string()) {
 		err_dialog->set_text(TTR("No surface source specified."));
 		err_dialog->popup_centered();
 		return;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3881,7 +3881,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		return false;
 	}
 
-	if (!EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path().is_empty()) { // cyclical instancing
+	if (!EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path().is_empty_string()) { // cyclical instancing
 		if (_cyclical_dependency_exists(EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path(), instantiated_scene)) {
 			memdelete(instantiated_scene);
 			return false;

--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -45,10 +45,10 @@ void OccluderInstance3DEditorPlugin::_bake_select_file(const String &p_file) {
 		switch (err) {
 			case OccluderInstance3D::BAKE_ERROR_NO_SAVE_PATH: {
 				String scene_path = occluder_instance->get_scene_file_path();
-				if (scene_path.is_empty()) {
+				if (scene_path.is_empty_string()) {
 					scene_path = occluder_instance->get_owner()->get_scene_file_path();
 				}
-				if (scene_path.is_empty()) {
+				if (scene_path.is_empty_string()) {
 					EditorNode::get_singleton()->show_warning(TTR("Can't determine a save path for the occluder.\nSave your scene and try again."));
 					break;
 				}

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -92,7 +92,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 				int incr_value = node_type == "MenuButton" ? PopupMenu::ITEM_PROPERTY_SIZE : OptionButton::ITEM_PROPERTY_SIZE;
 				for (int k = 0; k < str_values.size(); k += incr_value) {
 					String desc = str_values[k].get_slice(";", 1).strip_edges();
-					if (!desc.is_empty()) {
+					if (!desc.is_empty_string()) {
 						parsed_strings.push_back(desc);
 					}
 				}
@@ -101,14 +101,14 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 				Vector<String> str_values = property_value;
 				for (int k = 0; k < str_values.size(); k++) {
 					String desc = str_values[k].get_slice(";", 1).strip_edges();
-					if (!desc.is_empty()) {
+					if (!desc.is_empty_string()) {
 						parsed_strings.push_back(desc);
 					}
 				}
 			} else if (property_value.get_type() == Variant::STRING) {
 				String str_value = String(property_value);
 				// Prevent reading text containing only spaces.
-				if (!str_value.strip_edges().is_empty()) {
+				if (!str_value.strip_edges().is_empty_string()) {
 					parsed_strings.push_back(str_value);
 				}
 			}

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -179,7 +179,7 @@ void Polygon2DEditor::_update_bone_list() {
 		if (np.get_name_count()) {
 			name = np.get_name(np.get_name_count() - 1);
 		}
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			name = "Bone " + itos(i);
 		}
 		cb->set_text(name);

--- a/editor/plugins/replication_editor_plugin.cpp
+++ b/editor/plugins/replication_editor_plugin.cpp
@@ -73,7 +73,7 @@ void ReplicationEditor::_pick_node_select_recursive(TreeItem *p_item, const Stri
 	NodePath np = p_item->get_metadata(0);
 	Node *node = get_node(np);
 
-	if (!p_filter.is_empty() && ((String)node->get_name()).findn(p_filter) != -1) {
+	if (!p_filter.is_empty_string() && ((String)node->get_name()).findn(p_filter) != -1) {
 		p_select_candidates.push_back(node);
 	}
 

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -108,7 +108,7 @@ void ResourcePreloaderEditor::_item_edited() {
 			return;
 		}
 
-		if (new_name.is_empty() || new_name.contains("\\") || new_name.contains("/") || preloader->has_resource(new_name)) {
+		if (new_name.is_empty_string() || new_name.contains("\\") || new_name.contains("/") || preloader->has_resource(new_name)) {
 			s->set_text(0, old_name);
 			return;
 		}
@@ -145,10 +145,10 @@ void ResourcePreloaderEditor::_paste_pressed() {
 	}
 
 	String name = r->get_name();
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		name = r->get_path().get_file();
 	}
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		name = r->get_class();
 	}
 
@@ -302,7 +302,7 @@ void ResourcePreloaderEditor::drop_data_fw(const Point2 &p_point, const Variant 
 
 		if (r.is_valid()) {
 			String basename;
-			if (!r->get_name().is_empty()) {
+			if (!r->get_name().is_empty_string()) {
 				basename = r->get_name();
 			} else if (r->get_path().is_resource_file()) {
 				basename = r->get_path().get_basename();

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -89,7 +89,7 @@ void EditorPropertyRootMotion::_node_assign() {
 		String accum;
 		for (int i = 0; i < path.get_name_count(); i++) {
 			String name = path.get_name(i);
-			if (!accum.is_empty()) {
+			if (!accum.is_empty_string()) {
 				accum += "/";
 			}
 			accum += name;
@@ -280,7 +280,7 @@ bool EditorInspectorRootMotionPlugin::can_handle(Object *p_object) {
 bool EditorInspectorRootMotionPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
 	if (p_path == "root_motion_track" && p_object->is_class("AnimationTree") && p_type == Variant::NODE_PATH) {
 		EditorPropertyRootMotion *editor = memnew(EditorPropertyRootMotion);
-		if (p_hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !p_hint_text.is_empty()) {
+		if (p_hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !p_hint_text.is_empty_string()) {
 			editor->setup(p_hint_text);
 		}
 		add_property_editor(p_path, editor);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -181,7 +181,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		for (const String &comment : comments) {
 			String beg = comment.get_slice(" ", 0);
 			String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
-			highlighter->add_color_region(beg, end, comment_color, end.is_empty());
+			highlighter->add_color_region(beg, end, comment_color, end.is_empty_string());
 		}
 
 		/* Strings */
@@ -191,7 +191,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		for (const String &string : strings) {
 			String beg = string.get_slice(" ", 0);
 			String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
-			highlighter->add_color_region(beg, end, string_color, end.is_empty());
+			highlighter->add_color_region(beg, end, string_color, end.is_empty_string());
 		}
 	}
 }
@@ -323,7 +323,7 @@ void ScriptEditorQuickOpen::_update_search() {
 
 	for (int i = 0; i < functions.size(); i++) {
 		String file = functions[i];
-		if ((search_box->get_text().is_empty() || file.findn(search_box->get_text()) != -1)) {
+		if ((search_box->get_text().is_empty_string() || file.findn(search_box->get_text()) != -1)) {
 			TreeItem *ti = search_options->create_item(root);
 			ti->set_text(0, file);
 			if (root->get_first_child() == ti) {
@@ -395,7 +395,7 @@ ScriptEditor *ScriptEditor::script_editor = nullptr;
 
 String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *_se) {
 	String val = EditorDebuggerNode::get_singleton()->get_var_value(p_text);
-	if (!val.is_empty()) {
+	if (!val.is_empty_string()) {
 		return p_text + ": " + val;
 	} else {
 		return String();
@@ -651,7 +651,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 }
 
 void ScriptEditor::_add_recent_script(String p_path) {
-	if (p_path.is_empty()) {
+	if (p_path.is_empty_string()) {
 		return;
 	}
 
@@ -767,7 +767,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save, bool p_history_back) {
 			}
 		}
 		if (file.is_valid()) {
-			if (!file->get_path().is_empty()) {
+			if (!file->get_path().is_empty_string()) {
 				// Only saved scripts can be restored.
 				previous_scripts.push_back(file->get_path());
 			}
@@ -1423,7 +1423,7 @@ void ScriptEditor::_menu_option(int p_option) {
 			case SHOW_IN_FILE_SYSTEM: {
 				const Ref<Resource> script = current->get_edited_resource();
 				String path = script->get_path();
-				if (!path.is_empty()) {
+				if (!path.is_empty_string()) {
 					if (script->is_built_in()) {
 						path = path.get_slice("::", 0); // Show the scene instead.
 					}
@@ -1729,7 +1729,7 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 
 		String base = script->get_path();
 		loaded_scripts.insert(base);
-		if (base.begins_with("local://") || base.is_empty()) {
+		if (base.begins_with("local://") || base.is_empty_string()) {
 			continue;
 		}
 
@@ -1882,7 +1882,7 @@ void ScriptEditor::_update_members_overview() {
 	for (int i = 0; i < functions.size(); i++) {
 		String filter = filter_methods->get_text();
 		String name = functions[i].get_slice(":", 0);
-		if (filter.is_empty() || filter.is_subsequence_ofn(name)) {
+		if (filter.is_empty_string() || filter.is_subsequence_ofn(name)) {
 			members_overview->add_item(name);
 			members_overview->set_item_metadata(-1, functions[i].get_slice(":", 1).to_int() - 1);
 		}
@@ -1998,7 +1998,7 @@ void ScriptEditor::_update_script_names() {
 		if (se) {
 			Ref<Texture2D> icon = se->get_theme_icon();
 			String path = se->get_edited_resource()->get_path();
-			bool saved = !path.is_empty();
+			bool saved = !path.is_empty_string();
 			if (saved) {
 				// The script might be deleted, moved, or renamed, so make sure
 				// to update original path to previously edited resource.
@@ -2036,7 +2036,7 @@ void ScriptEditor::_update_script_names() {
 					sd.name = name;
 				} break;
 				case DISPLAY_DIR_AND_NAME: {
-					if (!path.get_base_dir().get_file().is_empty()) {
+					if (!path.get_base_dir().get_file().is_empty_string()) {
 						sd.name = path.get_base_dir().get_file().plus_file(name);
 					} else {
 						sd.name = name;
@@ -2132,7 +2132,7 @@ void ScriptEditor::_update_script_names() {
 	Vector<_ScriptEditorItemData> sedata_filtered;
 	for (int i = 0; i < sedata.size(); i++) {
 		String filter = filter_scripts->get_text();
-		if (filter.is_empty() || filter.is_subsequence_ofn(sedata[i].name)) {
+		if (filter.is_empty_string() || filter.is_subsequence_ofn(sedata[i].name)) {
 			sedata_filtered.push_back(sedata[i]);
 		}
 	}
@@ -2478,7 +2478,7 @@ void ScriptEditor::save_current_script() {
 	if (resource->is_built_in()) {
 		// If built-in script, save the scene instead.
 		const String scene_path = resource->get_path().get_slice("::", 0);
-		if (!scene_path.is_empty()) {
+		if (!scene_path.is_empty_string()) {
 			Vector<String> scene_to_save;
 			scene_to_save.push_back(scene_path);
 			EditorNode::get_singleton()->save_scene_list(scene_to_save);
@@ -2707,7 +2707,7 @@ void ScriptEditor::_editor_settings_changed() {
 
 	_update_autosave_timer();
 
-	if (current_theme.is_empty()) {
+	if (current_theme.is_empty_string()) {
 		current_theme = EditorSettings::get_singleton()->get("text_editor/theme/color_theme");
 	} else if (current_theme != String(EditorSettings::get_singleton()->get("text_editor/theme/color_theme"))) {
 		current_theme = EditorSettings::get_singleton()->get("text_editor/theme/color_theme");
@@ -2900,7 +2900,7 @@ bool ScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 
 		for (int i = 0; i < files.size(); i++) {
 			String file = files[i];
-			if (file.is_empty() || !FileAccess::exists(file)) {
+			if (file.is_empty_string() || !FileAccess::exists(file)) {
 				continue;
 			}
 			if (ResourceLoader::exists(file, "Script")) {
@@ -2980,7 +2980,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 		int num_tabs_before = tab_container->get_tab_count();
 		for (int i = 0; i < files.size(); i++) {
 			String file = files[i];
-			if (file.is_empty() || !FileAccess::exists(file)) {
+			if (file.is_empty_string() || !FileAccess::exists(file)) {
 				continue;
 			}
 
@@ -3192,7 +3192,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 
 	for (int i = 0; i < helps.size(); i++) {
 		String path = helps[i];
-		if (path.is_empty()) { // invalid, skip
+		if (path.is_empty_string()) { // invalid, skip
 			continue;
 		}
 		_help_class_open(path);
@@ -3268,7 +3268,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 }
 
 void ScriptEditor::_help_class_open(const String &p_class) {
-	if (p_class.is_empty()) {
+	if (p_class.is_empty_string()) {
 		return;
 	}
 
@@ -3972,7 +3972,7 @@ void ScriptEditorPlugin::edit(Object *p_object) {
 		Script *p_script = Object::cast_to<Script>(p_object);
 		String res_path = p_script->get_path().get_slice("::", 0);
 
-		if (p_script->is_built_in() && !res_path.is_empty()) {
+		if (p_script->is_built_in() && !res_path.is_empty_string()) {
 			if (ResourceLoader::get_resource_type(res_path) == "PackedScene") {
 				if (!EditorNode::get_singleton()->is_scene_open(res_path)) {
 					EditorNode::get_singleton()->load_scene(res_path);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -206,10 +206,10 @@ void ScriptTextEditor::_set_theme_for_script() {
 		String beg = string.get_slice(" ", 0);
 		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
 		if (!text_edit->has_string_delimiter(beg)) {
-			text_edit->add_string_delimiter(beg, end, end.is_empty());
+			text_edit->add_string_delimiter(beg, end, end.is_empty_string());
 		}
 
-		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
+		if (!end.is_empty_string() && !text_edit->has_auto_brace_completion_open_key(beg)) {
 			text_edit->add_auto_brace_completion_pair(beg, end);
 		}
 	}
@@ -220,9 +220,9 @@ void ScriptTextEditor::_set_theme_for_script() {
 	for (const String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
-		text_edit->add_comment_delimiter(beg, end, end.is_empty());
+		text_edit->add_comment_delimiter(beg, end, end.is_empty_string());
 
-		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
+		if (!end.is_empty_string() && !text_edit->has_auto_brace_completion_open_key(beg)) {
 			text_edit->add_auto_brace_completion_pair(beg, end);
 		}
 	}
@@ -320,7 +320,7 @@ void ScriptTextEditor::update_settings() {
 bool ScriptTextEditor::is_unsaved() {
 	const bool unsaved =
 			code_editor->get_text_editor()->get_version() != code_editor->get_text_editor()->get_saved_version() ||
-			script->get_path().is_empty(); // In memory.
+			script->get_path().is_empty_string(); // In memory.
 	return unsaved;
 }
 
@@ -396,12 +396,12 @@ String ScriptTextEditor::get_name() {
 	String name;
 
 	name = script->get_path().get_file();
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		// This appears for newly created built-in scripts before saving the scene.
 		name = TTR("[unsaved]");
 	} else if (script->is_built_in()) {
 		const String &script_name = script->get_name();
-		if (!script_name.is_empty()) {
+		if (!script_name.is_empty_string()) {
 			// If the built-in script has a custom resource name defined,
 			// display the built-in script name as follows: `ResourceName (scene_file.tscn)`
 			name = vformat("%s (%s)", script_name, name.get_slice("::", 0));
@@ -575,7 +575,7 @@ void ScriptTextEditor::_update_errors() {
 			if (safe_lines.has(i + 1)) {
 				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 				last_is_safe = true;
-			} else if (last_is_safe && (te->is_in_comment(i) != -1 || te->get_line(i).strip_edges().is_empty())) {
+			} else if (last_is_safe && (te->is_in_comment(i) != -1 || te->get_line(i).strip_edges().is_empty_string())) {
 				te->set_line_gutter_item_color(i, line_number_gutter, safe_line_number_color);
 			} else {
 				te->set_line_gutter_item_color(i, line_number_gutter, default_line_number_color);
@@ -1050,7 +1050,7 @@ void ScriptTextEditor::_gutter_clicked(int p_line, int p_gutter) {
 	}
 
 	String method = code_editor->get_text_editor()->get_line_gutter_metadata(p_line, p_gutter);
-	if (method.is_empty()) {
+	if (method.is_empty_string()) {
 		return;
 	}
 
@@ -1197,7 +1197,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 				if (expression.parse(line) == OK) {
 					Variant result = expression.execute(Array(), Variant(), false);
-					if (expression.get_error_text().is_empty()) {
+					if (expression.get_error_text().is_empty_string()) {
 						results.push_back(whitespace + result.get_construct_string());
 					} else {
 						results.push_back(line);
@@ -1323,19 +1323,19 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case HELP_CONTEXTUAL: {
 			String text = tx->get_selected_text();
-			if (text.is_empty()) {
+			if (text.is_empty_string()) {
 				text = tx->get_word_under_caret();
 			}
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				emit_signal(SNAME("request_help"), text);
 			}
 		} break;
 		case LOOKUP_SYMBOL: {
 			String text = tx->get_word_under_caret();
-			if (text.is_empty()) {
+			if (text.is_empty_string()) {
 				text = tx->get_selected_text();
 			}
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				_lookup_symbol(text, tx->get_caret_line(), tx->get_caret_column());
 			}
 		} break;
@@ -1680,10 +1680,10 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		}
 
 		String word_at_pos = tx->get_word_at_pos(local_pos);
-		if (word_at_pos.is_empty()) {
+		if (word_at_pos.is_empty_string()) {
 			word_at_pos = tx->get_word_under_caret();
 		}
-		if (word_at_pos.is_empty()) {
+		if (word_at_pos.is_empty_string()) {
 			word_at_pos = tx->get_selected_text();
 		}
 

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -97,7 +97,7 @@ void ShaderFileEditor::_version_selected(int p_option) {
 
 	error_text->push_font(get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 
-	if (error.is_empty()) {
+	if (error.is_empty_string()) {
 		error_text->add_text(TTR("Shader stage compiled without errors."));
 	} else {
 		error_text->add_text(error);
@@ -107,7 +107,7 @@ void ShaderFileEditor::_version_selected(int p_option) {
 void ShaderFileEditor::_update_options() {
 	ERR_FAIL_COND(shader_file.is_null());
 
-	if (!shader_file->get_base_error().is_empty()) {
+	if (!shader_file->get_base_error().is_empty_string()) {
 		stage_hb->hide();
 		versions->hide();
 		error_text->clear();
@@ -136,7 +136,7 @@ void ShaderFileEditor::_update_options() {
 
 	for (int i = 0; i < version_list.size(); i++) {
 		String title = version_list[i];
-		if (title.is_empty()) {
+		if (title.is_empty_string()) {
 			title = "default";
 		}
 
@@ -148,7 +148,7 @@ void ShaderFileEditor::_update_options() {
 		bool failed = false;
 		for (int j = 0; j < RD::SHADER_STAGE_MAX; j++) {
 			String error = bytecode->get_stage_compile_error(RD::ShaderStage(j));
-			if (!error.is_empty()) {
+			if (!error.is_empty_string()) {
 				failed = true;
 			}
 		}
@@ -182,7 +182,7 @@ void ShaderFileEditor::_update_options() {
 	for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 		Vector<uint8_t> bc = bytecode->get_stage_bytecode(RD::ShaderStage(i));
 		String error = bytecode->get_stage_compile_error(RD::ShaderStage(i));
-		bool disable = error.is_empty() && bc.is_empty();
+		bool disable = error.is_empty_string() && bc.is_empty();
 		stages[i]->set_disabled(disable);
 		if (!disable) {
 			if (stages[i]->is_pressed()) {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -309,7 +309,7 @@ void Skeleton3DEditor::insert_keys(const bool p_all_bones) {
 	for (int i = 0; i < bone_len; i++) {
 		const String name = skeleton->get_bone_name(i);
 
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			continue;
 		}
 

--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -69,7 +69,7 @@ void TextControlEditor::_find_resources(EditorFileSystemDirectory *p_dir) {
 			if (fd.is_valid()) {
 				String name = fd->get_font_name();
 				String sty = fd->get_font_style_name();
-				if (sty.is_empty()) {
+				if (sty.is_empty_string()) {
 					sty = "Default";
 				}
 				fonts[name][sty] = p_dir->get_file_path(i);
@@ -309,7 +309,7 @@ void TextControlEditor::_set_font() {
 			// Load new font resource using selected name and style.
 			String name = font_list->get_item_text(font_list->get_selected());
 			String style = font_style_list->get_item_text(font_style_list->get_selected());
-			if (style.is_empty()) {
+			if (style.is_empty_string()) {
 				style = "Default";
 			}
 			if (fonts.has(name)) {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -66,12 +66,12 @@ String TextEditor::get_name() {
 	String name;
 
 	name = text_file->get_path().get_file();
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		// This appears for newly created built-in text_files before saving the scene.
 		name = TTR("[unsaved]");
 	} else if (text_file->is_built_in()) {
 		const String &text_file_name = text_file->get_name();
-		if (!text_file_name.is_empty()) {
+		if (!text_file_name.is_empty_string()) {
 			// If the built-in text_file has a custom resource name defined,
 			// display the built-in text_file name as follows: `ResourceName (scene_file.tscn)`
 			name = vformat("%s (%s)", text_file_name, name.get_slice("::", 0));
@@ -198,7 +198,7 @@ void TextEditor::apply_code() {
 bool TextEditor::is_unsaved() {
 	const bool unsaved =
 			code_editor->get_text_editor()->get_version() != code_editor->get_text_editor()->get_saved_version() ||
-			text_file->get_path().is_empty(); // In memory.
+			text_file->get_path().is_empty_string(); // In memory.
 	return unsaved;
 }
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -81,7 +81,7 @@ void ThemeItemImportTree::_update_items_tree() {
 		type_node->set_checked(IMPORT_ITEM_DATA, false);
 		type_node->set_editable(IMPORT_ITEM_DATA, true);
 
-		bool is_matching_filter = (filter_text.is_empty() || type_name.findn(filter_text) > -1);
+		bool is_matching_filter = (filter_text.is_empty_string() || type_name.findn(filter_text) > -1);
 		bool has_filtered_items = false;
 
 		for (int i = 0; i < Theme::DATA_TYPE_MAX; i++) {
@@ -96,12 +96,12 @@ void ThemeItemImportTree::_update_items_tree() {
 			for (const StringName &F : names) {
 				String item_name = (String)F;
 				bool is_item_matching_filter = (item_name.findn(filter_text) > -1);
-				if (!filter_text.is_empty() && !is_matching_filter && !is_item_matching_filter) {
+				if (!filter_text.is_empty_string() && !is_matching_filter && !is_item_matching_filter) {
 					continue;
 				}
 
 				// Only mark this if actual items match the filter and not just the type group.
-				if (!filter_text.is_empty() && is_item_matching_filter) {
+				if (!filter_text.is_empty_string() && is_item_matching_filter) {
 					has_filtered_items = true;
 					data_type_has_filtered_items = true;
 				}
@@ -206,7 +206,7 @@ void ThemeItemImportTree::_update_items_tree() {
 		}
 
 		// Show one level inside of a type group if there are matches in items.
-		if (!filter_text.is_empty() && has_filtered_items) {
+		if (!filter_text.is_empty_string() && has_filtered_items) {
 			type_node->set_collapsed(false);
 		}
 	}
@@ -2162,7 +2162,7 @@ void ThemeTypeDialog::_add_type_dialog_activated(int p_index) {
 
 void ThemeTypeDialog::_add_type_selected(const String &p_type_name) {
 	pre_submitted_value = p_type_name;
-	if (p_type_name.is_empty()) {
+	if (p_type_name.is_empty_string()) {
 		add_type_confirmation->popup_centered();
 		return;
 	}
@@ -2711,11 +2711,11 @@ void ThemeTypeEditor::_update_type_items() {
 	}
 
 	// Various type settings.
-	if (edited_type.is_empty() || ClassDB::class_exists(edited_type)) {
+	if (edited_type.is_empty_string() || ClassDB::class_exists(edited_type)) {
 		type_variation_edit->set_editable(false);
 		type_variation_edit->set_text("");
 		type_variation_button->hide();
-		type_variation_locked->set_visible(!edited_type.is_empty());
+		type_variation_locked->set_visible(!edited_type.is_empty_string());
 	} else {
 		type_variation_edit->set_editable(true);
 		type_variation_edit->set_text(edited_theme->get_type_variation_base(edited_type));
@@ -2822,7 +2822,7 @@ void ThemeTypeEditor::_add_default_type_items() {
 
 void ThemeTypeEditor::_item_add_cbk(int p_data_type, Control *p_control) {
 	LineEdit *le = Object::cast_to<LineEdit>(p_control);
-	if (le->get_text().strip_edges().is_empty()) {
+	if (le->get_text().strip_edges().is_empty_string()) {
 		return;
 	}
 
@@ -2979,7 +2979,7 @@ void ThemeTypeEditor::_item_rename_cbk(int p_data_type, String p_item_name, Cont
 
 void ThemeTypeEditor::_item_rename_confirmed(int p_data_type, String p_item_name, Control *p_control) {
 	LineEdit *le = Object::cast_to<LineEdit>(p_control->get_child(1));
-	if (le->get_text().strip_edges().is_empty()) {
+	if (le->get_text().strip_edges().is_empty_string()) {
 		return;
 	}
 
@@ -3255,7 +3255,7 @@ void ThemeTypeEditor::_type_variation_changed(const String p_value) {
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Set Theme Type Variation"));
 
-	if (p_value.is_empty()) {
+	if (p_value.is_empty_string()) {
 		ur->add_do_method(*edited_theme, "clear_type_variation", edited_type);
 	} else {
 		ur->add_do_method(*edited_theme, "set_type_variation", edited_type, StringName(p_value));

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -449,7 +449,7 @@ void SceneThemeEditorPreview::_reload_scene() {
 		return;
 	}
 
-	if (loaded_scene->get_path().is_empty() || !ResourceLoader::exists(loaded_scene->get_path())) {
+	if (loaded_scene->get_path().is_empty_string() || !ResourceLoader::exists(loaded_scene->get_path())) {
 		EditorNode::get_singleton()->show_warning(TTR("Invalid path, the PackedScene resource was probably moved or removed."));
 		emit_signal(SNAME("scene_invalidated"));
 		return;

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1122,7 +1122,7 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 }
 
 void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, String p_property, String p_label, Variant p_default_value) {
-	ERR_FAIL_COND_MSG(!property.is_empty(), "Cannot setup TileDataDefaultEditor twice");
+	ERR_FAIL_COND_MSG(!property.is_empty_string(), "Cannot setup TileDataDefaultEditor twice");
 	property = p_property;
 
 	// Update everything.
@@ -1146,7 +1146,7 @@ void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, String p
 	// Create and setup the property editor.
 	property_editor = EditorInspectorDefaultPlugin::get_editor_for_property(dummy_object, p_type, p_property, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT);
 	property_editor->set_object_and_property(dummy_object, p_property);
-	if (p_label.is_empty()) {
+	if (p_label.is_empty_string()) {
 		property_editor->set_label(EditorPropertyNameProcessor::get_singleton()->process_name(p_property, EditorPropertyNameProcessor::get_default_inspector_style()));
 	} else {
 		property_editor->set_label(p_label);
@@ -1605,7 +1605,7 @@ void TileDataTerrainsEditor::_update_terrain_selector() {
 		options.push_back(String(TTR("No terrain")) + String(":-1"));
 		for (int i = 0; i < tile_set->get_terrains_count(terrain_set); i++) {
 			String name = tile_set->get_terrain_name(terrain_set, i);
-			if (name.is_empty()) {
+			if (name.is_empty_string()) {
 				options.push_back(vformat("Terrain %d", i));
 			} else {
 				options.push_back(name);

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -153,7 +153,7 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		String item_text;
 
 		// Common to all type of sources.
-		if (!source->get_name().is_empty()) {
+		if (!source->get_name().is_empty_string()) {
 			item_text = vformat(TTR("%s (id:%d)"), source->get_name(), source_id);
 		}
 
@@ -161,7 +161,7 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 		if (atlas_source) {
 			texture = atlas_source->get_texture();
-			if (item_text.is_empty()) {
+			if (item_text.is_empty_string()) {
 				if (texture.is_valid()) {
 					item_text = vformat("%s (ID: %d)", texture->get_path().get_file(), source_id);
 				} else {
@@ -174,13 +174,13 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		TileSetScenesCollectionSource *scene_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 		if (scene_collection_source) {
 			texture = tiles_bottom_panel->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
-			if (item_text.is_empty()) {
+			if (item_text.is_empty_string()) {
 				item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
 			}
 		}
 
 		// Use default if not valid.
-		if (item_text.is_empty()) {
+		if (item_text.is_empty_string()) {
 			item_text = vformat(TTR("Unknown Type Source (ID: %d)"), source_id);
 		}
 		if (!texture.is_valid()) {
@@ -3679,7 +3679,7 @@ void TileMapEditor::_update_layers_selection() {
 		// Build the list of layers.
 		for (int i = 0; i < tile_map->get_layers_count(); i++) {
 			String name = tile_map->get_layer_name(i);
-			layers_selection_button->add_item(name.is_empty() ? vformat(TTR("Layer %d"), i) : name, i);
+			layers_selection_button->add_item(name.is_empty_string() ? vformat(TTR("Layer %d"), i) : name, i);
 			layers_selection_button->set_item_disabled(i, !tile_map->is_layer_enabled(i));
 		}
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -735,7 +735,7 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	// --- Custom Data ---
 	ADD_TILE_DATA_EDITOR_GROUP("Custom Data");
 	for (int i = 0; i < tile_set->get_custom_data_layers_count(); i++) {
-		if (tile_set->get_custom_data_name(i).is_empty()) {
+		if (tile_set->get_custom_data_name(i).is_empty_string()) {
 			ADD_TILE_DATA_EDITOR(group, vformat("Custom Data %d", i), vformat("custom_data_%d", i));
 		} else {
 			ADD_TILE_DATA_EDITOR(group, tile_set->get_custom_data_name(i), vformat("custom_data_%d", i));
@@ -788,7 +788,7 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 void TileSetAtlasSourceEditor::_update_current_tile_data_editor() {
 	// Find the property to use.
 	String property;
-	if (tools_button_group->get_pressed_button() == tool_select_button && tile_inspector->is_visible() && !tile_inspector->get_selected_path().is_empty()) {
+	if (tools_button_group->get_pressed_button() == tool_select_button && tile_inspector->is_visible() && !tile_inspector->get_selected_path().is_empty_string()) {
 		Vector<String> components = tile_inspector->get_selected_path().split("/");
 		if (components.size() >= 1) {
 			property = components[0];
@@ -2566,7 +2566,7 @@ void EditorPropertyTilePolygon::_add_focusable_children(Node *p_node) {
 }
 
 void EditorPropertyTilePolygon::_polygons_changed() {
-	if (String(count_property).is_empty()) {
+	if (String(count_property).is_empty_string()) {
 		if (base_type == "OccluderPolygon2D") {
 			// Single OccluderPolygon2D.
 			Ref<OccluderPolygon2D> occluder;
@@ -2588,7 +2588,7 @@ void EditorPropertyTilePolygon::_polygons_changed() {
 			emit_changed(get_edited_property(), navigation_polygon);
 		}
 	} else {
-		if (base_type.is_empty()) {
+		if (base_type.is_empty_string()) {
 			// Multiple array of vertices.
 			Vector<String> changed_properties;
 			Array values;
@@ -2621,7 +2621,7 @@ void EditorPropertyTilePolygon::update_property() {
 	// Reset the polygons.
 	generic_tile_polygon_editor->clear_polygons();
 
-	if (String(count_property).is_empty()) {
+	if (String(count_property).is_empty_string()) {
 		if (base_type == "OccluderPolygon2D") {
 			// Single OccluderPolygon2D.
 			Ref<OccluderPolygon2D> occluder = get_edited_object()->get(get_edited_property());
@@ -2641,7 +2641,7 @@ void EditorPropertyTilePolygon::update_property() {
 		}
 	} else {
 		int count = get_edited_object()->get(count_property);
-		if (base_type.is_empty()) {
+		if (base_type.is_empty_string()) {
 			// Multiple array of vertices.
 			generic_tile_polygon_editor->clear_polygons();
 			for (int i = 0; i < count; i++) {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -147,7 +147,7 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 		String item_text;
 
 		// Common to all type of sources.
-		if (!source->get_name().is_empty()) {
+		if (!source->get_name().is_empty_string()) {
 			item_text = vformat(TTR("%s (id:%d)"), source->get_name(), source_id);
 		}
 
@@ -155,7 +155,7 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 		TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 		if (atlas_source) {
 			texture = atlas_source->get_texture();
-			if (item_text.is_empty()) {
+			if (item_text.is_empty_string()) {
 				if (texture.is_valid()) {
 					item_text = vformat("%s (ID: %d)", texture->get_path().get_file(), source_id);
 				} else {
@@ -168,13 +168,13 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 		TileSetScenesCollectionSource *scene_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 		if (scene_collection_source) {
 			texture = get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
-			if (item_text.is_empty()) {
+			if (item_text.is_empty_string()) {
 				item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
 			}
 		}
 
 		// Use default if not valid.
-		if (item_text.is_empty()) {
+		if (item_text.is_empty_string()) {
 			item_text = vformat(TTR("Unknown Type Source (ID: %d)"), source_id);
 		}
 		if (!texture.is_valid()) {

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -299,19 +299,19 @@ bool TilesEditorPlugin::SourceNameComparator::operator()(const int &p_a, const i
 	{
 		TileSetSource *source = *tile_set->get_source(p_a);
 
-		if (!source->get_name().is_empty()) {
+		if (!source->get_name().is_empty_string()) {
 			name_a = source->get_name();
 		}
 
 		TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 		if (atlas_source) {
 			Ref<Texture2D> texture = atlas_source->get_texture();
-			if (name_a.is_empty() && texture.is_valid()) {
+			if (name_a.is_empty_string() && texture.is_valid()) {
 				name_a = texture->get_path().get_file();
 			}
 		}
 
-		if (name_a.is_empty()) {
+		if (name_a.is_empty_string()) {
 			name_a = itos(p_a);
 		}
 	}
@@ -319,19 +319,19 @@ bool TilesEditorPlugin::SourceNameComparator::operator()(const int &p_a, const i
 	{
 		TileSetSource *source = *tile_set->get_source(p_b);
 
-		if (!source->get_name().is_empty()) {
+		if (!source->get_name().is_empty_string()) {
 			name_b = source->get_name();
 		}
 
 		TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 		if (atlas_source) {
 			Ref<Texture2D> texture = atlas_source->get_texture();
-			if (name_b.is_empty() && texture.is_valid()) {
+			if (name_b.is_empty_string() && texture.is_valid()) {
 				name_b = texture->get_path().get_file();
 			}
 		}
 
-		if (name_b.is_empty()) {
+		if (name_b.is_empty_string()) {
 			name_b = itos(p_b);
 		}
 	}

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -266,7 +266,7 @@ void VersionControlEditorPlugin::_display_file_diff(String p_file_path) {
 
 void VersionControlEditorPlugin::_refresh_file_diff() {
 	String open_file = diff_file_name->get_text();
-	if (!open_file.is_empty()) {
+	if (!open_file.is_empty_string()) {
 		_display_file_diff(diff_file_name->get_text());
 	}
 }
@@ -299,14 +299,14 @@ void VersionControlEditorPlugin::_update_commit_status() {
 }
 
 void VersionControlEditorPlugin::_update_commit_button() {
-	commit_button->set_disabled(commit_message->get_text().strip_edges().is_empty());
+	commit_button->set_disabled(commit_message->get_text().strip_edges().is_empty_string());
 }
 
 void VersionControlEditorPlugin::_commit_message_gui_input(const Ref<InputEvent> &p_event) {
 	if (!commit_message->has_focus()) {
 		return;
 	}
-	if (commit_message->get_text().strip_edges().is_empty()) {
+	if (commit_message->get_text().strip_edges().is_empty_string()) {
 		// Do not allow empty commit messages.
 		return;
 	}

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -960,7 +960,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	}
 
 	String error = vsnode->get_warning(mode, p_type);
-	if (!error.is_empty()) {
+	if (!error.is_empty_string()) {
 		Label *error_label = memnew(Label);
 		error_label->add_theme_color_override("font_color", editor->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		error_label->set_text(error);
@@ -1274,7 +1274,7 @@ void VisualShaderEditor::_update_nodes() {
 			category = category.rstrip("/");
 			category = category.lstrip("/");
 			category = "Addons/" + category;
-			if (!subcategory.is_empty()) {
+			if (!subcategory.is_empty_string()) {
 				category += "/" + subcategory;
 			}
 
@@ -1340,7 +1340,7 @@ void VisualShaderEditor::_update_options_menu() {
 	TreeItem *root = members->create_item();
 
 	String filter = node_filter->get_text().strip_edges();
-	bool use_filter = !filter.is_empty();
+	bool use_filter = !filter.is_empty_string();
 
 	bool is_first_item = true;
 
@@ -1817,7 +1817,7 @@ void VisualShaderEditor::_change_input_port_name(const String &p_text, Object *p
 	ERR_FAIL_COND(!line_edit);
 
 	String validated_name = visual_shader->validate_port_name(p_text, node.ptr(), p_port_id, false);
-	if (validated_name.is_empty() || prev_name == validated_name) {
+	if (validated_name.is_empty_string() || prev_name == validated_name) {
 		line_edit->set_text(node->get_input_port_name(p_port_id));
 		return;
 	}
@@ -1843,7 +1843,7 @@ void VisualShaderEditor::_change_output_port_name(const String &p_text, Object *
 	ERR_FAIL_COND(!line_edit);
 
 	String validated_name = visual_shader->validate_port_name(p_text, node.ptr(), p_port_id, true);
-	if (validated_name.is_empty() || prev_name == validated_name) {
+	if (validated_name.is_empty_string() || prev_name == validated_name) {
 		line_edit->set_text(node->get_output_port_name(p_port_id));
 		return;
 	}
@@ -2638,7 +2638,7 @@ void VisualShaderEditor::_add_node(int p_idx, const Vector<Variant> &p_ops, Stri
 
 	bool is_custom = add_options[p_idx].is_custom;
 
-	if (!is_custom && !add_options[p_idx].type.is_empty()) {
+	if (!is_custom && !add_options[p_idx].type.is_empty_string()) {
 		VisualShaderNode *vsn = Object::cast_to<VisualShaderNode>(ClassDB::instantiate(add_options[p_idx].type));
 		ERR_FAIL_COND(!vsn);
 		if (!p_ops.is_empty()) {
@@ -2698,7 +2698,7 @@ void VisualShaderEditor::_add_node(int p_idx, const Vector<Variant> &p_ops, Stri
 
 	int id_to_use = visual_shader->get_valid_node_id(type);
 
-	if (p_resource_path.is_empty()) {
+	if (p_resource_path.is_empty_string()) {
 		undo_redo->create_action(TTR("Add Node to Visual Shader"));
 	} else {
 		id_to_use += p_node_idx;
@@ -2845,7 +2845,7 @@ void VisualShaderEditor::_add_node(int p_idx, const Vector<Variant> &p_ops, Stri
 		graph_plugin->call_deferred(SNAME("update_curve_xyz"), id_to_use);
 	}
 
-	if (p_resource_path.is_empty()) {
+	if (p_resource_path.is_empty_string()) {
 		undo_redo->commit_action();
 	} else {
 		//post-initialization

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -37,7 +37,7 @@ void VoxelGIEditorPlugin::_bake() {
 	if (voxel_gi) {
 		if (voxel_gi->get_probe_data().is_null()) {
 			String path = get_tree()->get_edited_scene_root()->get_scene_file_path();
-			if (path.is_empty()) {
+			if (path.is_empty_string()) {
 				path = "res://" + voxel_gi->get_name() + "_data.res";
 			} else {
 				String ext = path.get_extension();

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -138,7 +138,7 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			}
 
 			// Write context.
-			if (!context.is_empty()) {
+			if (!context.is_empty_string()) {
 				file->store_line("msgctxt \"" + context + "\"");
 			}
 
@@ -146,7 +146,7 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			_write_msgid(file, msgid, false);
 
 			// Write msgid_plural.
-			if (!plural.is_empty()) {
+			if (!plural.is_empty_string()) {
 				_write_msgid(file, plural, true);
 				file->store_line("msgstr[0] \"\"");
 				file->store_line("msgstr[1] \"\"");
@@ -186,7 +186,7 @@ void POTGenerator::_add_new_msgid(const String &p_msgid, const String &p_context
 		Vector<MsgidData> &v_mdata = all_translation_strings[p_msgid];
 		for (int i = 0; i < v_mdata.size(); i++) {
 			if (v_mdata[i].ctx == p_context) {
-				if (!v_mdata[i].plural.is_empty() && !p_plural.is_empty() && v_mdata[i].plural != p_plural) {
+				if (!v_mdata[i].plural.is_empty_string() && !p_plural.is_empty_string() && v_mdata[i].plural != p_plural) {
 					WARN_PRINT("Redefinition of plural message (msgid_plural), under the same message (msgid) and context (msgctxt)");
 				}
 				v_mdata.write[i].locations.insert(p_location);

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2362,7 +2362,7 @@ Vector<String> ProjectConverter3To4::parse_arguments(const String &line) {
 	Vector<String> clean_parts;
 	for (String &part : parts) {
 		part = part.strip_edges();
-		if (!part.is_empty()) {
+		if (!part.is_empty_string()) {
 			clean_parts.append(part);
 		}
 	}
@@ -2417,7 +2417,7 @@ String ProjectConverter3To4::get_starting_space(const String &line) const {
 	String empty_space;
 	int current_character = 0;
 
-	if (line.is_empty()) {
+	if (line.is_empty_string()) {
 		return empty_space;
 	}
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -183,7 +183,7 @@ void ProjectExportDialog::_update_export_all() {
 		Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_export_preset(i);
 		bool needs_templates;
 		String error;
-		if (preset->get_export_path().is_empty() || !preset->get_platform()->can_export(preset, error, needs_templates)) {
+		if (preset->get_export_path().is_empty_string() || !preset->get_platform()->can_export(preset, error, needs_templates)) {
 			can_export = false;
 			break;
 		}
@@ -249,7 +249,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	bool needs_templates;
 	String error;
 	if (!current->get_platform()->can_export(current, error, needs_templates)) {
-		if (!error.is_empty()) {
+		if (!error.is_empty_string()) {
 			Vector<String> items = error.split("\n", false);
 			error = "";
 			for (int i = 0; i < items.size(); i++) {
@@ -356,7 +356,7 @@ void ProjectExportDialog::_update_feature_list() {
 	Vector<String> custom_list = custom.split(",");
 	for (int i = 0; i < custom_list.size(); i++) {
 		String f = custom_list[i].strip_edges();
-		if (!f.is_empty()) {
+		if (!f.is_empty_string()) {
 			features.push_back(f);
 		}
 	}
@@ -544,7 +544,7 @@ void ProjectExportDialog::_script_encryption_key_changed(const String &p_key) {
 bool ProjectExportDialog::_validate_script_encryption_key(const String &p_key) {
 	bool is_valid = false;
 
-	if (!p_key.is_empty() && p_key.is_valid_hex_number(false) && p_key.length() == 64) {
+	if (!p_key.is_empty_string() && p_key.is_valid_hex_number(false) && p_key.length() == 64) {
 		is_valid = true;
 	}
 	return is_valid;
@@ -860,7 +860,7 @@ void ProjectExportDialog::_open_export_template_manager() {
 
 void ProjectExportDialog::_validate_export_path(const String &p_path) {
 	// Disable export via OK button or Enter key if LineEdit has an empty filename
-	bool invalid_path = (p_path.get_file().get_basename().is_empty());
+	bool invalid_path = (p_path.get_file().get_basename().is_empty_string());
 
 	// Check if state change before needlessly messing with signals
 	if (invalid_path && export_project->get_ok_button()->is_disabled()) {
@@ -894,7 +894,7 @@ void ProjectExportDialog::_export_project() {
 		export_project->add_filter(vformat("*.%s; %s", extension_list[i], vformat(TTR("%s Export"), platform->get_name())));
 	}
 
-	if (!current->get_export_path().is_empty()) {
+	if (!current->get_export_path().is_empty_string()) {
 		export_project->set_current_path(current->get_export_path());
 	} else {
 		if (extension_list.size() >= 1) {
@@ -1284,10 +1284,10 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	default_filename = EditorSettings::get_singleton()->get_project_metadata("export_options", "default_filename", "");
 	// If no default set, use project name
-	if (default_filename.is_empty()) {
+	if (default_filename.is_empty_string()) {
 		// If no project name defined, use a sane default
 		default_filename = ProjectSettings::get_singleton()->get("application/config/name");
-		if (default_filename.is_empty()) {
+		if (default_filename.is_empty_string()) {
 			default_filename = "UnnamedProject";
 		}
 	}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -163,7 +163,7 @@ private:
 			}
 		}
 
-		if (valid_path.is_empty()) {
+		if (valid_path.is_empty_string()) {
 			set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR);
 			get_ok_button()->set_disabled(true);
 			return "";
@@ -176,7 +176,7 @@ private:
 				valid_install_path = install_path->get_text().strip_edges();
 			}
 
-			if (valid_install_path.is_empty()) {
+			if (valid_install_path.is_empty_string()) {
 				set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR, INSTALL_PATH);
 				get_ok_button()->set_disabled(true);
 				return "";
@@ -184,7 +184,7 @@ private:
 		}
 
 		if (mode == MODE_IMPORT || mode == MODE_RENAME) {
-			if (!valid_path.is_empty() && !d->file_exists("project.godot")) {
+			if (!valid_path.is_empty_string() && !d->file_exists("project.godot")) {
 				if (valid_path.ends_with(".zip")) {
 					Ref<FileAccess> io_fa;
 					zlib_filefunc_def io = zipio_create_io(&io_fa);
@@ -226,7 +226,7 @@ private:
 					d->list_dir_begin();
 					is_folder_empty = true;
 					String n = d->get_next();
-					while (!n.is_empty()) {
+					while (!n.is_empty_string()) {
 						if (!n.begins_with(".")) {
 							// Allow `.`, `..` (reserved current/parent folder names)
 							// and hidden files/folders to be present.
@@ -263,7 +263,7 @@ private:
 			d->list_dir_begin();
 			is_folder_empty = true;
 			String n = d->get_next();
-			while (!n.is_empty()) {
+			while (!n.is_empty_string()) {
 				if (!n.begins_with(".")) {
 					// Allow `.`, `..` (reserved current/parent folder names)
 					// and hidden files/folders to be present.
@@ -291,16 +291,16 @@ private:
 
 	void _path_text_changed(const String &p_path) {
 		String sp = _test_path();
-		if (!sp.is_empty()) {
+		if (!sp.is_empty_string()) {
 			// If the project name is empty or default, infer the project name from the selected folder name
-			if (project_name->get_text().strip_edges().is_empty() || project_name->get_text().strip_edges() == TTR("New Game Project")) {
+			if (project_name->get_text().strip_edges().is_empty_string() || project_name->get_text().strip_edges() == TTR("New Game Project")) {
 				sp = sp.replace("\\", "/");
 				int lidx = sp.rfind("/");
 
 				if (lidx != -1) {
 					sp = sp.substr(lidx + 1, sp.length()).capitalize();
 				}
-				if (sp.is_empty() && mode == MODE_IMPORT) {
+				if (sp.is_empty_string() && mode == MODE_IMPORT) {
 					sp = TTR("Imported Project");
 				}
 
@@ -309,7 +309,7 @@ private:
 			}
 		}
 
-		if (!created_folder_path.is_empty() && created_folder_path != p_path) {
+		if (!created_folder_path.is_empty_string() && created_folder_path != p_path) {
 			_remove_created_folder();
 		}
 	}
@@ -378,7 +378,7 @@ private:
 
 	void _create_folder() {
 		const String project_name_no_edges = project_name->get_text().strip_edges();
-		if (project_name_no_edges.is_empty() || !created_folder_path.is_empty() || project_name_no_edges.ends_with(".")) {
+		if (project_name_no_edges.is_empty_string() || !created_folder_path.is_empty_string() || project_name_no_edges.ends_with(".")) {
 			set_message(TTR("Invalid project name."), MESSAGE_WARNING);
 			return;
 		}
@@ -411,7 +411,7 @@ private:
 
 		_test_path();
 
-		if (p_text.strip_edges().is_empty()) {
+		if (p_text.strip_edges().is_empty_string()) {
 			set_message(TTR("It would be a good idea to name your project."), MESSAGE_ERROR);
 		}
 	}
@@ -426,7 +426,7 @@ private:
 
 		if (mode == MODE_RENAME) {
 			String dir2 = _test_path();
-			if (dir2.is_empty()) {
+			if (dir2.is_empty_string()) {
 				set_message(TTR("Invalid project path (changed anything?)."), MESSAGE_ERROR);
 				return;
 			}
@@ -543,7 +543,7 @@ private:
 
 						String path = String::utf8(fname);
 
-						if (path.is_empty() || path == zip_root || !zip_root.is_subsequence_of(path)) {
+						if (path.is_empty_string() || path == zip_root || !zip_root.is_subsequence_of(path)) {
 							//
 						} else if (path.ends_with("/")) { // a dir
 							path = path.substr(0, path.length() - 1);
@@ -610,7 +610,7 @@ private:
 	}
 
 	void _remove_created_folder() {
-		if (!created_folder_path.is_empty()) {
+		if (!created_folder_path.is_empty_string()) {
 			Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			d->remove(created_folder_path);
 
@@ -711,7 +711,7 @@ public:
 
 		} else {
 			fav_dir = EditorSettings::get_singleton()->get("filesystem/directories/default_project_path");
-			if (!fav_dir.is_empty()) {
+			if (!fav_dir.is_empty_string()) {
 				project_path->set_text(fav_dir);
 				fdialog->set_current_dir(fav_dir);
 			} else {
@@ -1161,7 +1161,7 @@ void ProjectList::load_project_icon(int p_index) {
 
 	Ref<Texture2D> default_icon = get_theme_icon(SNAME("DefaultProjectIcon"), SNAME("EditorIcons"));
 	Ref<Texture2D> icon;
-	if (!item.icon.is_empty()) {
+	if (!item.icon.is_empty_string()) {
 		Ref<Image> img;
 		img.instantiate();
 		Error err = img->load(item.icon.replace_first("res://", item.path + "/"));
@@ -1194,7 +1194,7 @@ ProjectList::Item ProjectList::load_project_data(const String &p_property_key, b
 	String project_name = TTR("Unnamed Project");
 	if (cf_err == OK) {
 		String cf_project_name = static_cast<String>(cf->get_value("application", "config/name", ""));
-		if (!cf_project_name.is_empty()) {
+		if (!cf_project_name.is_empty_string()) {
 			project_name = cf_project_name.xml_unescape();
 		}
 		config_version = (int)cf->get_value("", "config_version", 0);
@@ -1476,7 +1476,7 @@ void ProjectList::sort_projects() {
 		Item &item = _projects.write[i];
 
 		bool visible = true;
-		if (!_search_term.is_empty()) {
+		if (!_search_term.is_empty_string()) {
 			String search_path;
 			if (_search_term.contains("/")) {
 				// Search path will match the whole path
@@ -1788,7 +1788,7 @@ void ProjectList::_panel_input(const Ref<InputEvent> &p_ev, Node *p_hb) {
 	const Item &clicked_project = _projects[clicked_index];
 
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		if (mb->is_shift_pressed() && _selected_project_keys.size() > 0 && !_last_clicked.is_empty() && clicked_project.project_key != _last_clicked) {
+		if (mb->is_shift_pressed() && _selected_project_keys.size() > 0 && !_last_clicked.is_empty_string() && clicked_project.project_key != _last_clicked) {
 			int anchor_index = -1;
 			for (int i = 0; i < _projects.size(); ++i) {
 				const Item &p = _projects[i];
@@ -2249,7 +2249,7 @@ void ProjectManager::_run_project_confirm() {
 
 	for (int i = 0; i < selected_list.size(); ++i) {
 		const String &selected_main = selected_list[i].main_scene;
-		if (selected_main.is_empty()) {
+		if (selected_main.is_empty_string()) {
 			run_error_diag->set_text(TTR("Can't run project: no main scene defined.\nPlease edit the project and set the main scene in the Project Settings under the \"Application\" category."));
 			run_error_diag->popup_centered();
 			continue;
@@ -2302,7 +2302,7 @@ void ProjectManager::_scan_dir(const String &path, List<String> *r_projects) {
 	ERR_FAIL_COND_MSG(error != OK, "Could not scan directory at: " + path);
 	da->list_dir_begin();
 	String n = da->get_next();
-	while (!n.is_empty()) {
+	while (!n.is_empty_string()) {
 		if (da->current_is_dir() && !n.begins_with(".")) {
 			_scan_dir(da->get_current_dir().plus_file(n), r_projects);
 		} else if (n == "project.godot") {
@@ -2443,7 +2443,7 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 			if (dir->change_dir(folders[0]) == OK) {
 				dir->list_dir_begin();
 				String file = dir->get_next();
-				while (confirm && !file.is_empty()) {
+				while (confirm && !file.is_empty_string()) {
 					if (!dir->current_is_dir() && file.ends_with("project.godot")) {
 						confirm = false;
 					}
@@ -2899,7 +2899,7 @@ ProjectManager::ProjectManager() {
 	}
 
 	String autoscan_path = EditorSettings::get_singleton()->get("filesystem/directories/autoscan_project_path");
-	if (!autoscan_path.is_empty()) {
+	if (!autoscan_path.is_empty_string()) {
 		if (dir_access->dir_exists(autoscan_path)) {
 			_scan_begin(autoscan_path);
 		} else {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -81,7 +81,7 @@ void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {
 }
 
 void ProjectSettingsEditor::_setting_selected(const String &p_path) {
-	if (p_path.is_empty()) {
+	if (p_path.is_empty_string()) {
 		return;
 	}
 
@@ -150,12 +150,12 @@ void ProjectSettingsEditor::_update_property_box() {
 	const Vector<String> t = setting.split(".", true, 1);
 	const String name = t[0];
 	const String feature = (t.size() == 2) ? t[1] : "";
-	bool feature_invalid = (t.size() == 2) && (t[1].is_empty());
+	bool feature_invalid = (t.size() == 2) && (t[1].is_empty_string());
 
 	add_button->set_disabled(true);
 	del_button->set_disabled(true);
 
-	if (!feature.is_empty()) {
+	if (!feature.is_empty_string()) {
 		feature_invalid = true;
 		for (int i = 1; i < feature_box->get_item_count(); i++) {
 			if (feature == feature_box->get_item_text(i)) {
@@ -166,11 +166,11 @@ void ProjectSettingsEditor::_update_property_box() {
 		}
 	}
 
-	if (feature.is_empty() || feature_invalid) {
+	if (feature.is_empty_string() || feature_invalid) {
 		feature_box->select(0);
 	}
 
-	if (property_box->get_text().is_empty()) {
+	if (property_box->get_text().is_empty_string()) {
 		return;
 	}
 
@@ -213,7 +213,7 @@ void ProjectSettingsEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 
 		if (ED_IS_SHORTCUT("ui_undo", p_event)) {
 			String action = undo_redo->get_current_action_name();
-			if (!action.is_empty()) {
+			if (!action.is_empty_string()) {
 				EditorNode::get_log()->add_message("Undo: " + action, EditorLog::MSG_TYPE_EDITOR);
 			}
 			undo_redo->undo();
@@ -223,7 +223,7 @@ void ProjectSettingsEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 		if (ED_IS_SHORTCUT("ui_redo", p_event)) {
 			undo_redo->redo();
 			String action = undo_redo->get_current_action_name();
-			if (!action.is_empty()) {
+			if (!action.is_empty_string()) {
 				EditorNode::get_log()->add_message("Redo: " + action, EditorLog::MSG_TYPE_EDITOR);
 			}
 			handled = true;
@@ -285,7 +285,7 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 		Vector<String> custom_list = custom.split(",");
 		for (int j = 0; j < custom_list.size(); j++) {
 			String f = custom_list[j].strip_edges();
-			if (!f.is_empty()) {
+			if (!f.is_empty_string()) {
 				presets.insert(f);
 			}
 		}

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -363,18 +363,18 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				int c = hint_text.get_slice_count(",");
 				float min = 0, max = 100, step = type == Variant::FLOAT ? .01 : 1;
 				if (c >= 1) {
-					if (!hint_text.get_slice(",", 0).is_empty()) {
+					if (!hint_text.get_slice(",", 0).is_empty_string()) {
 						min = hint_text.get_slice(",", 0).to_float();
 					}
 				}
 				if (c >= 2) {
-					if (!hint_text.get_slice(",", 1).is_empty()) {
+					if (!hint_text.get_slice(",", 1).is_empty_string()) {
 						max = hint_text.get_slice(",", 1).to_float();
 					}
 				}
 
 				if (c >= 3) {
-					if (!hint_text.get_slice(",", 2).is_empty()) {
+					if (!hint_text.get_slice(",", 2).is_empty_string()) {
 						step = hint_text.get_slice(",", 2).to_float();
 					}
 				}
@@ -567,7 +567,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 					add_child(create_dialog);
 				}
 
-				if (!hint_text.is_empty()) {
+				if (!hint_text.is_empty_string()) {
 					create_dialog->set_base_type(hint_text);
 				} else {
 					create_dialog->set_base_type("Object");
@@ -868,7 +868,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			if (p_name == "script" && hint_text == "Script" && Object::cast_to<Node>(owner)) {
 				menu->add_item(TTR("New Script"), OBJ_MENU_NEW_SCRIPT);
 				menu->add_separator();
-			} else if (!hint_text.is_empty()) {
+			} else if (!hint_text.is_empty_string()) {
 				int idx = 0;
 
 				Vector<EditorData::CustomType> custom_resources;
@@ -948,7 +948,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 			Ref<Resource> cb = EditorSettings::get_singleton()->get_resource_clipboard();
 			bool paste_valid = false;
 			if (cb.is_valid()) {
-				if (hint_text.is_empty()) {
+				if (hint_text.is_empty_string()) {
 					paste_valid = true;
 				} else {
 					for (int i = 0; i < hint_text.get_slice_count(","); i++) {
@@ -1133,7 +1133,7 @@ void CustomPropertyEditor::_node_path_selected(NodePath p_path) {
 		return;
 	}
 
-	if (hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !hint_text.is_empty()) {
+	if (hint == PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE && !hint_text.is_empty_string()) {
 		Node *node = get_node(hint_text);
 		if (node) {
 			Node *tonode = node->get_node(p_path);
@@ -1217,7 +1217,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 
 					file->clear_filters();
 
-					if (!hint_text.is_empty()) {
+					if (!hint_text.is_empty_string()) {
 						Vector<String> extensions = hint_text.split(",");
 						for (int i = 0; i < extensions.size(); i++) {
 							String filter = extensions[i];

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -181,7 +181,7 @@ void PropertySelector::_update_search() {
 				continue;
 			}
 
-			if (!search_box->get_text().is_empty() && E.name.findn(search_text) == -1) {
+			if (!search_box->get_text().is_empty_string() && E.name.findn(search_text) == -1) {
 				continue;
 			}
 
@@ -194,7 +194,7 @@ void PropertySelector::_update_search() {
 			item->set_metadata(0, E.name);
 			item->set_icon(0, type_icons[E.type]);
 
-			if (!found && !search_box->get_text().is_empty() && E.name.findn(search_text) != -1) {
+			if (!found && !search_box->get_text().is_empty_string() && E.name.findn(search_text) != -1) {
 				item->select(0);
 				found = true;
 			}
@@ -272,7 +272,7 @@ void PropertySelector::_update_search() {
 				continue;
 			}
 
-			if (!search_box->get_text().is_empty() && name.findn(search_text) == -1) {
+			if (!search_box->get_text().is_empty_string() && name.findn(search_text) == -1) {
 				continue;
 			}
 
@@ -321,7 +321,7 @@ void PropertySelector::_update_search() {
 			item->set_metadata(0, name);
 			item->set_selectable(0, true);
 
-			if (!found && !search_box->get_text().is_empty() && name.findn(search_text) != -1) {
+			if (!found && !search_box->get_text().is_empty_string() && name.findn(search_text) != -1) {
 				item->select(0);
 				found = true;
 			}
@@ -356,7 +356,7 @@ void PropertySelector::_item_selected() {
 	String class_type;
 	if (type != Variant::NIL) {
 		class_type = Variant::get_type_name(type);
-	} else if (!base_type.is_empty()) {
+	} else if (!base_type.is_empty_string()) {
 		class_type = base_type;
 	} else if (instance) {
 		class_type = instance->get_class();
@@ -365,7 +365,7 @@ void PropertySelector::_item_selected() {
 	DocTools *dd = EditorHelp::get_doc_data();
 	String text;
 	if (properties) {
-		while (!class_type.is_empty()) {
+		while (!class_type.is_empty_string()) {
 			HashMap<String, DocData::ClassDoc>::Iterator E = dd->class_list.find(class_type);
 			if (E) {
 				for (int i = 0; i < E->value.properties.size(); i++) {
@@ -376,7 +376,7 @@ void PropertySelector::_item_selected() {
 				}
 			}
 
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				break;
 			}
 
@@ -384,7 +384,7 @@ void PropertySelector::_item_selected() {
 			class_type = ClassDB::get_parent_class(class_type);
 		}
 	} else {
-		while (!class_type.is_empty()) {
+		while (!class_type.is_empty_string()) {
 			HashMap<String, DocData::ClassDoc>::Iterator E = dd->class_list.find(class_type);
 			if (E) {
 				for (int i = 0; i < E->value.methods.size(); i++) {
@@ -395,7 +395,7 @@ void PropertySelector::_item_selected() {
 				}
 			}
 
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				break;
 			}
 
@@ -404,7 +404,7 @@ void PropertySelector::_item_selected() {
 		}
 	}
 
-	if (!text.is_empty()) {
+	if (!text.is_empty_string()) {
 		// Display both property name and description, since the help bit may be displayed
 		// far away from the location (especially if the dialog was resized to be taller).
 		help_bit->set_text(vformat("[b]%s[/b]: %s", name, text));

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -79,7 +79,7 @@ void EditorQuickOpen::_build_search_cache(EditorFileSystemDirectory *p_efsd) {
 
 void EditorQuickOpen::_update_search() {
 	const String search_text = search_box->get_text();
-	const bool empty_search = search_text.is_empty();
+	const bool empty_search = search_text.is_empty_string();
 
 	// Filter possible candidates.
 	Vector<Entry> entries;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -200,7 +200,7 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 			break;
 		}
 
-		if (!edited_scene->get_scene_file_path().is_empty()) {
+		if (!edited_scene->get_scene_file_path().is_empty_string()) {
 			if (_cyclical_dependency_exists(edited_scene->get_scene_file_path(), instantiated_scene)) {
 				accept->set_text(vformat(TTR("Cannot instance the scene '%s' because the current scene exists within one of its nodes."), p_files[i]));
 				accept->popup_centered();
@@ -759,7 +759,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				return;
 			}
 
-			if (!node->get_scene_file_path().is_empty()) {
+			if (!node->get_scene_file_path().is_empty_string()) {
 				accept->set_text(TTR("Instantiated scenes can't become root"));
 				accept->popup_centered();
 				return;
@@ -838,7 +838,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					Node *node = remove_list[0];
 					if (node == editor_data->get_edited_scene_root()) {
 						msg = vformat(TTR("Delete the root node \"%s\"?"), node->get_name());
-					} else if (node->get_scene_file_path().is_empty() && node->get_child_count() > 0) {
+					} else if (node->get_scene_file_path().is_empty_string() && node->get_child_count() > 0) {
 						// Display this message only for non-instantiated scenes
 						msg = vformat(TTR("Delete node \"%s\" and its children?"), node->get_name());
 					} else {
@@ -885,7 +885,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
-			if (tocopy != editor_data->get_edited_scene_root() && !tocopy->get_scene_file_path().is_empty()) {
+			if (tocopy != editor_data->get_edited_scene_root() && !tocopy->get_scene_file_path().is_empty_string()) {
 				accept->set_text(TTR("Can't save the branch of an already instantiated scene.\nTo create a variation of a scene, you can make an inherited scene based on the instantiated scene using Scene > New Inherited Scene... instead."));
 				accept->popup_centered();
 				break;
@@ -1013,7 +1013,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						break;
 					}
 
-					ERR_FAIL_COND(node->get_scene_file_path().is_empty());
+					ERR_FAIL_COND(node->get_scene_file_path().is_empty_string());
 					undo_redo->create_action(TTR("Make Local"));
 					undo_redo->add_do_method(node, "set_scene_file_path", "");
 					undo_redo->add_undo_method(node, "set_scene_file_path", node->get_scene_file_path());
@@ -1716,7 +1716,7 @@ bool SceneTreeDock::_validate_no_instance() {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
 	for (Node *E : selection) {
-		if (E != edited_scene && !E->get_scene_file_path().is_empty()) {
+		if (E != edited_scene && !E->get_scene_file_path().is_empty_string()) {
 			accept->set_text(TTR("This operation can't be done on instantiated scenes."));
 			accept->popup_centered();
 			return false;
@@ -2764,7 +2764,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 		bool can_replace = true;
 		for (Node *E : selection) {
-			if (E != edited_scene && (E->get_owner() != edited_scene || !E->get_scene_file_path().is_empty())) {
+			if (E != edited_scene && (E->get_owner() != edited_scene || !E->get_scene_file_path().is_empty_string())) {
 				can_replace = false;
 				break;
 			}
@@ -2807,7 +2807,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->set_item_checked(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), selection[0]->is_unique_name_in_owner());
 		}
 
-		bool is_external = (!selection[0]->get_scene_file_path().is_empty());
+		bool is_external = (!selection[0]->get_scene_file_path().is_empty_string());
 		if (is_external) {
 			bool is_inherited = selection[0]->get_scene_inherited_state() != nullptr;
 			bool is_top_level = selection[0]->get_owner() == nullptr;
@@ -2913,9 +2913,9 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 	Ref<Script> existing = selected->get_script();
 
 	String path = selected->get_scene_file_path();
-	if (path.is_empty()) {
+	if (path.is_empty_string()) {
 		String root_path = editor_data->get_edited_scene_root()->get_scene_file_path();
-		if (root_path.is_empty()) {
+		if (root_path.is_empty_string()) {
 			path = String("res://").plus_file(selected->get_name());
 		} else {
 			path = root_path.get_base_dir().plus_file(selected->get_name());
@@ -2963,18 +2963,18 @@ void SceneTreeDock::attach_shader_to_selected(int p_preferred_mode) {
 	}
 
 	String path = selected_shader_material->get_path();
-	if (path.is_empty()) {
+	if (path.is_empty_string()) {
 		String root_path;
 		if (editor_data->get_edited_scene_root()) {
 			root_path = editor_data->get_edited_scene_root()->get_scene_file_path();
 		}
 		String shader_name;
-		if (selected_shader_material->get_name().is_empty()) {
+		if (selected_shader_material->get_name().is_empty_string()) {
 			shader_name = root_path.get_file();
 		} else {
 			shader_name = selected_shader_material->get_name();
 		}
-		if (root_path.is_empty()) {
+		if (root_path.is_empty_string()) {
 			path = String("res://").plus_file(shader_name);
 		} else {
 			path = root_path.get_base_dir().plus_file(shader_name);
@@ -3011,7 +3011,7 @@ List<Node *> SceneTreeDock::paste_nodes() {
 	}
 
 	bool has_cycle = false;
-	if (edited_scene && !edited_scene->get_scene_file_path().is_empty()) {
+	if (edited_scene && !edited_scene->get_scene_file_path().is_empty_string()) {
 		for (Node *E : node_clipboard) {
 			if (edited_scene->get_scene_file_path() == E->get_scene_file_path()) {
 				has_cycle = true;
@@ -3182,7 +3182,7 @@ void SceneTreeDock::_update_create_root_dialog() {
 			while (!f->eof_reached()) {
 				String l = f->get_line().strip_edges();
 
-				if (!l.is_empty()) {
+				if (!l.is_empty_string()) {
 					Button *button = memnew(Button);
 					favorite_nodes->add_child(button);
 					button->set_text(l);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -126,7 +126,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_WARNING) {
 		String config_err = n->get_configuration_warnings_as_string();
-		if (config_err.is_empty()) {
+		if (config_err.is_empty_string()) {
 			return;
 		}
 		config_err = config_err.word_wrap(80);
@@ -267,7 +267,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 	if (can_rename) { //should be can edit..
 
 		String warning = p_node->get_configuration_warnings_as_string();
-		if (!warning.is_empty()) {
+		if (!warning.is_empty_string()) {
 			item->add_button(0, get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")), BUTTON_WARNING, false, TTR("Node configuration warning:") + "\n" + warning);
 		}
 
@@ -327,16 +327,16 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
 
 		String tooltip = String(p_node->get_name()) + "\n" + TTR("Inherits:") + " " + p_node->get_scene_inherited_state()->get_path() + "\n" + TTR("Type:") + " " + p_node->get_class();
-		if (!p_node->get_editor_description().is_empty()) {
+		if (!p_node->get_editor_description().is_empty_string()) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
 		item->set_tooltip(0, tooltip);
-	} else if (p_node != get_scene_node() && !p_node->get_scene_file_path().is_empty() && can_open_instance) {
+	} else if (p_node != get_scene_node() && !p_node->get_scene_file_path().is_empty_string() && can_open_instance) {
 		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
 
 		String tooltip = String(p_node->get_name()) + "\n" + TTR("Instance:") + " " + p_node->get_scene_file_path() + "\n" + TTR("Type:") + " " + p_node->get_class();
-		if (!p_node->get_editor_description().is_empty()) {
+		if (!p_node->get_editor_description().is_empty_string()) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
@@ -348,7 +348,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		}
 
 		String tooltip = String(p_node->get_name()) + "\n" + TTR("Type:") + " " + type;
-		if (!p_node->get_editor_description().is_empty()) {
+		if (!p_node->get_editor_description().is_empty_string()) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
@@ -574,7 +574,7 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 	updating_tree = false;
 	tree_dirty = false;
 
-	if (!filter.is_empty()) {
+	if (!filter.is_empty_string()) {
 		_update_filter(nullptr, p_scroll_to_selected);
 	}
 }
@@ -841,7 +841,7 @@ void SceneTreeEditor::_renamed() {
 	ERR_FAIL_COND(!n);
 
 	// Empty node names are not allowed, so resets it to previous text and show warning
-	if (which->get_text(0).strip_edges().is_empty()) {
+	if (which->get_text(0).strip_edges().is_empty_string()) {
 		which->set_text(0, n->get_name());
 		EditorNode::get_singleton()->show_warning(TTR("No name provided."));
 		return;
@@ -854,7 +854,7 @@ void SceneTreeEditor::_renamed() {
 		error->set_text(TTR("Invalid node name, the following characters are not allowed:") + "\n" + String::invalid_node_name_characters);
 		error->popup_centered();
 
-		if (new_name.is_empty()) {
+		if (new_name.is_empty_string()) {
 			which->set_text(0, n->get_name());
 			return;
 		}
@@ -1019,7 +1019,7 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 		Node *n = get_node(np);
 		if (n) {
 			// Only allow selection if not part of an instantiated scene.
-			if (!n->get_owner() || n->get_owner() == get_scene_node() || n->get_owner()->get_scene_file_path().is_empty()) {
+			if (!n->get_owner() || n->get_owner() == get_scene_node() || n->get_owner()->get_scene_file_path().is_empty_string()) {
 				selected.push_back(n);
 				icons.push_back(next->get_icon(0));
 			}
@@ -1133,7 +1133,7 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		}
 	}
 
-	return String(d["type"]) == "nodes" && filter.is_empty();
+	return String(d["type"]) == "nodes" && filter.is_empty_string();
 }
 
 void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -60,7 +60,7 @@ static String _get_parent_class_of_script(String p_path) {
 
 	// Inherits from a script that has class_name.
 	class_name = script->get_language()->get_global_class_name(base->get_path());
-	if (!class_name.is_empty()) {
+	if (!class_name.is_empty_string()) {
 		return class_name;
 	}
 
@@ -108,7 +108,7 @@ void ScriptCreateDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			String last_language = EditorSettings::get_singleton()->get_project_metadata("script_setup", "last_selected_language", "");
-			if (!last_language.is_empty()) {
+			if (!last_language.is_empty_string()) {
 				for (int i = 0; i < language_menu->get_item_count(); i++) {
 					if (language_menu->get_item_text(i) == last_language) {
 						language_menu->select(i);
@@ -166,7 +166,7 @@ void ScriptCreateDialog::config(const String &p_base_name, const String &p_base_
 	parent_name->set_text(p_base_name);
 	parent_name->deselect();
 
-	if (!p_base_path.is_empty()) {
+	if (!p_base_path.is_empty_string()) {
 		initial_bp = p_base_path.get_basename();
 		file_path->set_text(initial_bp + "." + ScriptServer::get_language(language_menu->get_selected())->get_extension());
 		current_language = language_menu->get_selected();
@@ -229,10 +229,10 @@ bool ScriptCreateDialog::_validate_class(const String &p_string) {
 String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must_exist) {
 	String p = p_path.strip_edges();
 
-	if (p.is_empty()) {
+	if (p.is_empty_string()) {
 		return TTR("Path is empty.");
 	}
-	if (p.get_file().get_basename().is_empty()) {
+	if (p.get_file().get_basename().is_empty_string()) {
 		return TTR("Filename is empty.");
 	}
 
@@ -294,7 +294,7 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 
 	// Let ScriptLanguage do custom validation.
 	String path_error = ScriptServer::get_language(language_menu->get_selected())->validate_path(p);
-	if (!path_error.is_empty()) {
+	if (!path_error.is_empty_string()) {
 		return path_error;
 	}
 
@@ -344,7 +344,7 @@ void ScriptCreateDialog::_template_changed(int p_template) {
 	String template_info = String::utf8("•  ");
 	template_info += TTR("Template:");
 	template_info += " " + sinfo.name;
-	if (!sinfo.description.is_empty()) {
+	if (!sinfo.description.is_empty_string()) {
 		template_info += " - " + sinfo.description;
 	}
 	template_info_label->set_text(template_info);
@@ -422,7 +422,7 @@ void ScriptCreateDialog::_language_changed(int l) {
 	String selected_ext = "." + language->get_extension();
 	String path = file_path->get_text();
 	String extension = "";
-	if (!path.is_empty()) {
+	if (!path.is_empty_string()) {
 		if (path.contains(".")) {
 			extension = path.get_extension();
 		}
@@ -540,7 +540,7 @@ void ScriptCreateDialog::_path_changed(const String &p_path) {
 	is_new_script_created = true;
 
 	String path_error = _validate_path(p_path, false);
-	if (!path_error.is_empty()) {
+	if (!path_error.is_empty_string()) {
 		_msg_path_valid(false, path_error);
 		_update_dialog();
 		return;
@@ -775,14 +775,14 @@ void ScriptCreateDialog::_update_dialog() {
 	// Show templates list if needed.
 	if (is_using_templates) {
 		// Check if at least one suitable template has been found.
-		if (template_menu->get_item_count() == 0 && template_inactive_message.is_empty()) {
+		if (template_menu->get_item_count() == 0 && template_inactive_message.is_empty_string()) {
 			template_inactive_message = TTR("No suitable template.");
 		}
 	} else {
 		template_inactive_message = TTR("Empty");
 	}
 
-	if (!template_inactive_message.is_empty()) {
+	if (!template_inactive_message.is_empty_string()) {
 		template_menu->set_disabled(true);
 		template_menu->clear();
 		template_menu->add_item(template_inactive_message);

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -42,7 +42,7 @@ void ShaderCreateDialog::_notification(int p_what) {
 			_update_theme();
 
 			String last_lang = EditorSettings::get_singleton()->get_project_metadata("shader_setup", "last_selected_language", "");
-			if (!last_lang.is_empty()) {
+			if (!last_lang.is_empty_string()) {
 				for (int i = 0; i < language_menu->get_item_count(); i++) {
 					if (language_menu->get_item_text(i) == last_lang) {
 						language_menu->select(i);
@@ -223,7 +223,7 @@ void ShaderCreateDialog::_language_changed(int p_language) {
 	String path = file_path->get_text();
 	String extension = "";
 
-	if (!path.is_empty()) {
+	if (!path.is_empty_string()) {
 		if (path.contains(".")) {
 			extension = path.get_extension();
 		}
@@ -306,7 +306,7 @@ void ShaderCreateDialog::_path_changed(const String &p_path) {
 	is_new_shader_created = true;
 
 	String path_error = _validate_path(p_path);
-	if (!path_error.is_empty()) {
+	if (!path_error.is_empty_string()) {
 		_msg_path_valid(false, path_error);
 		_update_dialog();
 		return;
@@ -328,7 +328,7 @@ void ShaderCreateDialog::_path_submitted(const String &p_path) {
 }
 
 void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabled, bool p_load_enabled, int p_preferred_type, int p_preferred_mode) {
-	if (!p_base_path.is_empty()) {
+	if (!p_base_path.is_empty_string()) {
 		initial_base_path = p_base_path.get_basename();
 		file_path->set_text(initial_base_path + "." + language_data[language_menu->get_selected()].default_extension);
 		current_language = language_menu->get_selected();
@@ -358,10 +358,10 @@ void ShaderCreateDialog::config(const String &p_base_path, bool p_built_in_enabl
 String ShaderCreateDialog::_validate_path(const String &p_path) {
 	String p = p_path.strip_edges();
 
-	if (p.is_empty()) {
+	if (p.is_empty_string()) {
 		return TTR("Path is empty.");
 	}
-	if (p.get_file().get_basename().is_empty()) {
+	if (p.get_file().get_basename().is_empty_string()) {
 		return TTR("Filename is empty.");
 	}
 

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -375,7 +375,7 @@ static Variant create_var(RS::GlobalVariableType p_type) {
 
 void ShaderGlobalsEditor::_variable_added() {
 	String var = variable_name->get_text().strip_edges();
-	if (var.is_empty() || !var.is_valid_identifier()) {
+	if (var.is_empty_string() || !var.is_valid_identifier()) {
 		EditorNode::get_singleton()->show_warning(TTR("Please specify a valid variable identifier name."));
 		return;
 	}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -201,7 +201,7 @@ static String unescape_cmdline(const String &p_str) {
 
 static String get_full_version_string() {
 	String hash = String(VERSION_HASH);
-	if (!hash.is_empty()) {
+	if (!hash.is_empty_string()) {
 		hash = "." + hash.left(9);
 	}
 	return String(VERSION_FULL_BUILD) + hash;
@@ -429,7 +429,7 @@ Error Main::test_setup() {
 	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
 
 	translation_server->setup(); //register translations, load them, etc.
-	if (!locale.is_empty()) {
+	if (!locale.is_empty_string()) {
 		translation_server->set_locale(locale);
 	}
 	translation_server->load_translations();
@@ -1183,7 +1183,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// Network file system needs to be configured before globals, since globals are based on the
 	// 'project.godot' file which will only be available through the network if this is enabled
 	FileAccessNetwork::configure();
-	if (!remotefs.is_empty()) {
+	if (!remotefs.is_empty_string()) {
 		file_access_network_client = memnew(FileAccessNetworkClient);
 		int port;
 		if (remotefs.contains(":")) {
@@ -1352,12 +1352,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	// And OpenGL3 next, or first if Vulkan is disabled.
 #ifdef GLES3_ENABLED
-	if (!renderer_hints.is_empty()) {
+	if (!renderer_hints.is_empty_string()) {
 		renderer_hints += ",";
 	}
 	renderer_hints += "opengl3";
 #endif
-	if (renderer_hints.is_empty()) {
+	if (renderer_hints.is_empty_string()) {
 		ERR_PRINT("No rendering driver available.");
 	}
 
@@ -1370,7 +1370,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					PROPERTY_HINT_ENUM, renderer_hints));
 
 	// if not set on the command line
-	if (rendering_driver.is_empty()) {
+	if (rendering_driver.is_empty_string()) {
 		rendering_driver = GLOBAL_GET("rendering/driver/driver_name");
 	}
 
@@ -1471,7 +1471,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	OS::get_singleton()->set_display_driver_id(display_driver_idx);
 
 	GLOBAL_DEF_RST_NOVAL("audio/driver/driver", AudioDriverManager::get_driver(0)->get_name());
-	if (audio_driver.is_empty()) { // Specified in project.godot.
+	if (audio_driver.is_empty_string()) { // Specified in project.godot.
 		audio_driver = GLOBAL_GET("audio/driver/driver");
 	}
 
@@ -1724,9 +1724,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		ProjectSettings::get_singleton()->set_custom_property_info("input_devices/pen_tablet/driver.windows", PropertyInfo(Variant::STRING, "input_devices/pen_tablet/driver.windows", PROPERTY_HINT_ENUM, "wintab,winink"));
 	}
 
-	if (tablet_driver.is_empty()) { // specified in project.godot
+	if (tablet_driver.is_empty_string()) { // specified in project.godot
 		tablet_driver = GLOBAL_GET("input_devices/pen_tablet/driver");
-		if (tablet_driver.is_empty()) {
+		if (tablet_driver.is_empty_string()) {
 			tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
 		}
 	}
@@ -1738,7 +1738,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		}
 	}
 
-	if (DisplayServer::get_singleton()->tablet_get_current_driver().is_empty()) {
+	if (DisplayServer::get_singleton()->tablet_get_current_driver().is_empty_string()) {
 		DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(0));
 	}
 
@@ -1837,7 +1837,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		Ref<Image> boot_logo;
 
 		if (boot_logo_image) {
-			if (!boot_logo_path.is_empty()) {
+			if (!boot_logo_path.is_empty_string()) {
 				boot_logo.instantiate();
 				Error load_err = ImageLoader::load_image(boot_logo_path, boot_logo);
 				if (load_err) {
@@ -1879,7 +1879,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		}
 
 #ifdef TOOLS_ENABLED
-		if (OS::get_singleton()->get_bundle_icon_path().is_empty()) {
+		if (OS::get_singleton()->get_bundle_icon_path().is_empty_string()) {
 			Ref<Image> icon = memnew(Image(app_icon_png));
 			DisplayServer::get_singleton()->set_icon(icon);
 		}
@@ -1931,7 +1931,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	MAIN_PRINT("Main: Load Translations and Remaps");
 
 	translation_server->setup(); //register translations, load them, etc.
-	if (!locale.is_empty()) {
+	if (!locale.is_empty_string()) {
 		translation_server->set_locale(locale);
 	}
 	translation_server->load_translations();
@@ -1953,11 +1953,11 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	ProjectSettings::get_singleton()->set_custom_property_info("internationalization/rendering/text_driver", PropertyInfo(Variant::STRING, "internationalization/rendering/text_driver", PROPERTY_HINT_ENUM, text_driver_options));
 
 	/* Determine text driver */
-	if (text_driver.is_empty()) {
+	if (text_driver.is_empty_string()) {
 		text_driver = GLOBAL_GET("internationalization/rendering/text_driver");
 	}
 
-	if (!text_driver.is_empty()) {
+	if (!text_driver.is_empty_string()) {
 		/* Load user selected text server. */
 		for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
 			if (TextServerManager::get_singleton()->get_interface(i)->get_name() == text_driver) {
@@ -2117,7 +2117,7 @@ bool Main::start() {
 		} else if (args[i] == "-p" || args[i] == "--project-manager") {
 			project_manager = true;
 #endif
-		} else if (args[i].length() && args[i][0] != '-' && positional_arg.is_empty()) {
+		} else if (args[i].length() && args[i][0] != '-' && positional_arg.is_empty_string()) {
 			positional_arg = args[i];
 
 			if (args[i].ends_with(".scn") ||
@@ -2176,12 +2176,12 @@ bool Main::start() {
 	}
 
 #ifdef TOOLS_ENABLED
-	if (!doc_tool_path.is_empty()) {
+	if (!doc_tool_path.is_empty_string()) {
 		// Needed to instance editor-only classes for their default values
 		Engine::get_singleton()->set_editor_hint(true);
 
 		// Translate the class reference only when `-l LOCALE` parameter is given.
-		if (!locale.is_empty() && locale != "en") {
+		if (!locale.is_empty_string() && locale != "en") {
 			load_doc_translations(locale);
 		}
 
@@ -2279,12 +2279,12 @@ bool Main::start() {
 
 #endif
 
-	if (script.is_empty() && game_path.is_empty() && String(GLOBAL_GET("application/run/main_scene")) != "") {
+	if (script.is_empty_string() && game_path.is_empty_string() && String(GLOBAL_GET("application/run/main_scene")) != "") {
 		game_path = GLOBAL_GET("application/run/main_scene");
 	}
 
 #ifdef TOOLS_ENABLED
-	if (!editor && !project_manager && !cmdline_tool && script.is_empty() && game_path.is_empty()) {
+	if (!editor && !project_manager && !cmdline_tool && script.is_empty_string() && game_path.is_empty_string()) {
 		// If we end up here, it means we didn't manage to detect what we want to run.
 		// Let's throw an error gently. The code leading to this is pretty brittle so
 		// this might end up triggered by valid usage, in which case we'll have to
@@ -2300,7 +2300,7 @@ bool Main::start() {
 	}
 	String main_loop_type = GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
 
-	if (!script.is_empty()) {
+	if (!script.is_empty_string()) {
 		Ref<Script> script_res = ResourceLoader::load(script);
 		ERR_FAIL_COND_V_MSG(script_res.is_null(), false, "Can't load script: " + script);
 
@@ -2349,7 +2349,7 @@ bool Main::start() {
 		}
 	}
 
-	if (!main_loop && main_loop_type.is_empty()) {
+	if (!main_loop && main_loop_type.is_empty_string()) {
 		main_loop_type = "SceneTree";
 	}
 
@@ -2390,7 +2390,7 @@ bool Main::start() {
 		ResourceSaver::add_custom_savers();
 
 		if (!project_manager && !editor) { // game
-			if (!game_path.is_empty() || !script.is_empty()) {
+			if (!game_path.is_empty_string() || !script.is_empty_string()) {
 				//autoload
 				HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
 
@@ -2455,7 +2455,7 @@ bool Main::start() {
 			editor_node = memnew(EditorNode);
 			sml->get_root()->add_child(editor_node);
 
-			if (!_export_preset.is_empty()) {
+			if (!_export_preset.is_empty_string()) {
 				editor_node->export_preset(_export_preset, positional_arg, export_debug, export_pack_only);
 				game_path = ""; // Do not load anything.
 			}
@@ -2572,7 +2572,7 @@ bool Main::start() {
 #endif
 
 		String local_game_path;
-		if (!game_path.is_empty() && !project_manager) {
+		if (!game_path.is_empty_string() && !project_manager) {
 			local_game_path = game_path.replace("\\", "/");
 
 			if (!local_game_path.begins_with("res://")) {
@@ -2611,7 +2611,7 @@ bool Main::start() {
 					}
 				}
 				DisplayServer::get_singleton()->set_context(DisplayServer::CONTEXT_EDITOR);
-				if (!debug_server_uri.is_empty()) {
+				if (!debug_server_uri.is_empty_string()) {
 					EditorDebuggerNode::get_singleton()->start(debug_server_uri);
 				}
 			}
@@ -2626,7 +2626,7 @@ bool Main::start() {
 			// Load SSL Certificates from Project Settings (or builtin).
 			Crypto::load_default_certificates(GLOBAL_DEF("network/ssl/certificate_bundle_override", ""));
 
-			if (!game_path.is_empty()) {
+			if (!game_path.is_empty_string()) {
 				Node *scene = nullptr;
 				Ref<PackedScene> scenedata = ResourceLoader::load(local_game_path);
 				if (scenedata.is_valid()) {
@@ -2646,14 +2646,14 @@ bool Main::start() {
 
 #ifdef WINDOWS_ENABLED
 				String win_iconpath = GLOBAL_DEF("application/config/windows_native_icon", "Variant()");
-				if (!win_iconpath.is_empty()) {
+				if (!win_iconpath.is_empty_string()) {
 					DisplayServer::get_singleton()->set_native_icon(win_iconpath);
 					hasicon = true;
 				}
 #endif
 
 				String iconpath = GLOBAL_DEF("application/config/icon", "Variant()");
-				if ((!iconpath.is_empty()) && (!hasicon)) {
+				if ((!iconpath.is_empty_string()) && (!hasicon)) {
 					Ref<Image> icon;
 					icon.instantiate();
 					if (ImageLoader::load_image(iconpath, icon) == OK) {
@@ -2682,7 +2682,7 @@ bool Main::start() {
 #endif
 	}
 
-	if (!hasicon && OS::get_singleton()->get_bundle_icon_path().is_empty()) {
+	if (!hasicon && OS::get_singleton()->get_bundle_icon_path().is_empty_string()) {
 		Ref<Image> icon = memnew(Image(app_icon_png));
 		DisplayServer::get_singleton()->set_icon(icon);
 	}

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -452,7 +452,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 					previous_column = j;
 
 					// ignore if just whitespace
-					if (!text.is_empty()) {
+					if (!text.is_empty_string()) {
 						previous_text = text;
 					}
 				}
@@ -547,7 +547,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	for (const String &comment : comments) {
 		String beg = comment.get_slice(" ", 0);
 		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
-		add_color_region(beg, end, comment_color, end.is_empty());
+		add_color_region(beg, end, comment_color, end.is_empty_string());
 	}
 
 	/* Strings */
@@ -557,7 +557,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	for (const String &string : strings) {
 		String beg = string.get_slice(" ", 0);
 		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
-		add_color_region(beg, end, string_color, end.is_empty());
+		add_color_region(beg, end, string_color, end.is_empty_string());
 	}
 
 	const Ref<Script> script = _get_edited_resource();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -410,7 +410,7 @@ bool GDScript::instance_has(const Object *p_this) const {
 }
 
 bool GDScript::has_source_code() const {
-	return !source.is_empty();
+	return !source.is_empty_string();
 }
 
 String GDScript::get_source_code() const {
@@ -465,7 +465,7 @@ void GDScript::_update_doc() {
 	_clear_doc();
 
 	doc.script_path = "\"" + get_path().get_slice("://", 1) + "\"";
-	if (!name.is_empty()) {
+	if (!name.is_empty_string()) {
 		doc.name = name;
 	} else {
 		doc.name = doc.script_path;
@@ -479,7 +479,7 @@ void GDScript::_update_doc() {
 	doc.is_script_doc = true;
 
 	if (base.is_valid() && base->is_valid()) {
-		if (!base->doc.name.is_empty()) {
+		if (!base->doc.name.is_empty_string()) {
 			doc.inherits = base->doc.name;
 		} else {
 			doc.inherits = base->get_instance_base_type();
@@ -493,7 +493,7 @@ void GDScript::_update_doc() {
 	doc.tutorials = doc_tutorials;
 
 	for (const KeyValue<String, DocData::EnumDoc> &E : doc_enums) {
-		if (!E.value.description.is_empty()) {
+		if (!E.value.description.is_empty_string()) {
 			doc.enums[E.key] = E.value.description;
 		}
 	}
@@ -637,11 +637,11 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 
 		String basedir = path;
 
-		if (basedir.is_empty()) {
+		if (basedir.is_empty_string()) {
 			basedir = get_path();
 		}
 
-		if (!basedir.is_empty()) {
+		if (!basedir.is_empty_string()) {
 			basedir = basedir.get_base_dir();
 		}
 
@@ -663,7 +663,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 					path = c->extends_path;
 					if (path.is_relative_path()) {
 						String base = get_path();
-						if (base.is_empty() || base.is_relative_path()) {
+						if (base.is_empty_string() || base.is_relative_path()) {
 							ERR_PRINT(("Could not resolve relative path for parent class: " + path).utf8().get_data());
 						} else {
 							path = base.get_base_dir().plus_file(path);
@@ -677,7 +677,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 					}
 				}
 
-				if (!path.is_empty()) {
+				if (!path.is_empty_string()) {
 					if (path != get_path()) {
 						Ref<GDScript> bf = ResourceLoader::load(path);
 
@@ -811,7 +811,7 @@ void GDScript::_set_subclass_path(Ref<GDScript> &p_sc, const String &p_path) {
 }
 
 String GDScript::_get_debug_path() const {
-	if (is_built_in() && !get_name().is_empty()) {
+	if (is_built_in() && !get_name().is_empty_string()) {
 		return get_name() + " (" + get_path() + ")";
 	} else {
 		return get_path();
@@ -830,11 +830,11 @@ Error GDScript::reload(bool p_keep_state) {
 
 	String basedir = path;
 
-	if (basedir.is_empty()) {
+	if (basedir.is_empty_string()) {
 		basedir = get_path();
 	}
 
-	if (!basedir.is_empty()) {
+	if (!basedir.is_empty_string()) {
 		basedir = basedir.get_base_dir();
 	}
 
@@ -847,10 +847,10 @@ Error GDScript::reload(bool p_keep_state) {
 
 	{
 		String source_path = path;
-		if (source_path.is_empty()) {
+		if (source_path.is_empty_string()) {
 			source_path = get_path();
 		}
-		if (!source_path.is_empty()) {
+		if (!source_path.is_empty_string()) {
 			MutexLock lock(GDScriptCache::singleton->lock);
 			if (!GDScriptCache::singleton->shallow_gdscript_cache.has(source_path)) {
 				GDScriptCache::singleton->shallow_gdscript_cache[source_path] = this;
@@ -866,7 +866,7 @@ Error GDScript::reload(bool p_keep_state) {
 			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().line, "Parser Error: " + parser.get_errors().front()->get().message);
 		}
 		// TODO: Show all error messages.
-		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+		_err_print_error("GDScript::reload", path.is_empty_string() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		ERR_FAIL_V(ERR_PARSE_ERROR);
 	}
 
@@ -880,7 +880,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 		const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();
 		while (e != nullptr) {
-			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+			_err_print_error("GDScript::reload", path.is_empty_string() ? "built-in" : (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 			e = e->next();
 		}
 		ERR_FAIL_V(ERR_PARSE_ERROR);
@@ -900,7 +900,7 @@ Error GDScript::reload(bool p_keep_state) {
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), compiler.get_error_line(), "Parser Error: " + compiler.get_error());
 			}
-			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+			_err_print_error("GDScript::reload", path.is_empty_string() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 			ERR_FAIL_V(ERR_COMPILATION_FAILED);
 		} else {
 			return err;
@@ -1149,7 +1149,7 @@ String GDScript::_get_gdscript_reference_class_name(const GDScript *p_gdscript) 
 
 	String class_name;
 	while (p_gdscript) {
-		if (class_name.is_empty()) {
+		if (class_name.is_empty_string()) {
 			class_name = p_gdscript->get_script_class_name();
 		} else {
 			class_name = p_gdscript->get_script_class_name() + "." + class_name;
@@ -1466,7 +1466,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 					pinfo.type = Variant::Type(d["type"].operator int());
 					ERR_CONTINUE(pinfo.type < 0 || pinfo.type >= Variant::VARIANT_MAX);
 					pinfo.name = d["name"];
-					ERR_CONTINUE(pinfo.name.is_empty());
+					ERR_CONTINUE(pinfo.name.is_empty_string());
 					if (d.has("hint")) {
 						pinfo.hint = PropertyHint(d["hint"].operator int());
 					}
@@ -2121,7 +2121,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 	if (err == OK) {
 		const GDScriptParser::ClassNode *c = parser.get_tree();
 		if (r_icon_path) {
-			if (c->icon_path.is_empty() || c->icon_path.is_absolute_path()) {
+			if (c->icon_path.is_empty_string() || c->icon_path.is_absolute_path()) {
 				*r_icon_path = c->icon_path;
 			} else if (c->icon_path.is_relative_path()) {
 				*r_icon_path = p_path.get_base_dir().plus_file(c->icon_path).simplify_path();
@@ -2133,7 +2133,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 			GDScriptParser subparser;
 			while (subclass) {
 				if (subclass->extends_used) {
-					if (!subclass->extends_path.is_empty()) {
+					if (!subclass->extends_path.is_empty_string()) {
 						if (subclass->extends.size() == 0) {
 							get_global_class_name(subclass->extends_path, r_base_type);
 							subclass = nullptr;
@@ -2147,7 +2147,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 							}
 							String subsource = subfile->get_as_utf8_string();
 
-							if (subsource.is_empty()) {
+							if (subsource.is_empty_string()) {
 								break;
 							}
 							String subpath = subclass->extends_path;
@@ -2347,7 +2347,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 	ERR_FAIL_COND_MSG(file.is_null(), "Cannot open file '" + p_path + "'.");
 
 	String source = file->get_as_utf8_string();
-	if (source.is_empty()) {
+	if (source.is_empty_string()) {
 		return;
 	}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -258,7 +258,7 @@ Error GDScriptAnalyzer::resolve_inheritance(GDScriptParser::ClassNode *p_class, 
 
 		int extends_index = 0;
 
-		if (!p_class->extends_path.is_empty()) {
+		if (!p_class->extends_path.is_empty_string()) {
 			if (p_class->extends_path.is_relative_path()) {
 				p_class->extends_path = class_type.script_path.get_base_dir().plus_file(p_class->extends_path).simplify_path();
 			}

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -117,7 +117,7 @@ void GDScriptCache::remove_script(const String &p_path) {
 Ref<GDScriptParserRef> GDScriptCache::get_parser(const String &p_path, GDScriptParserRef::Status p_status, Error &r_error, const String &p_owner) {
 	MutexLock lock(singleton->lock);
 	Ref<GDScriptParserRef> ref;
-	if (!p_owner.is_empty()) {
+	if (!p_owner.is_empty_string()) {
 		singleton->dependencies[p_owner].insert(p_path);
 	}
 	if (singleton->parser_map.has(p_path)) {
@@ -165,7 +165,7 @@ String GDScriptCache::get_source_code(const String &p_path) {
 
 Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, const String &p_owner) {
 	MutexLock lock(singleton->lock);
-	if (!p_owner.is_empty()) {
+	if (!p_owner.is_empty_string()) {
 		singleton->dependencies[p_owner].insert(p_path);
 	}
 	if (singleton->full_gdscript_cache.has(p_path)) {
@@ -188,7 +188,7 @@ Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, const Stri
 Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_error, const String &p_owner) {
 	MutexLock lock(singleton->lock);
 
-	if (!p_owner.is_empty()) {
+	if (!p_owner.is_empty_string()) {
 		singleton->dependencies[p_owner].insert(p_path);
 	}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -66,7 +66,7 @@ bool GDScriptCompiler::_is_class_member_property(GDScript *owner, const StringNa
 }
 
 void GDScriptCompiler::_set_error(const String &p_error, const GDScriptParser::Node *p_node) {
-	if (!error.is_empty()) {
+	if (!error.is_empty_string()) {
 		return;
 	}
 
@@ -115,8 +115,8 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 				result.builtin_type = p_datatype.builtin_type;
 
 				String class_name = class_type->fqcn.split("::")[0];
-				const bool is_inner_by_path = (!main_script->path.is_empty()) && (class_name == main_script->path);
-				const bool is_inner_by_name = (!main_script->name.is_empty()) && (class_name == main_script->name);
+				const bool is_inner_by_path = (!main_script->path.is_empty_string()) && (class_name == main_script->path);
+				const bool is_inner_by_name = (!main_script->name.is_empty_string()) && (class_name == main_script->name);
 				if (is_inner_by_path || is_inner_by_name) {
 					// Local class.
 					List<StringName> names;
@@ -2079,7 +2079,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	if (EngineDebugger::is_active()) {
 		String signature;
 		// Path.
-		if (!p_script->get_path().is_empty()) {
+		if (!p_script->get_path().is_empty_string()) {
 			signature += p_script->get_path();
 		}
 		// Location.
@@ -2217,7 +2217,7 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 	p_script->tool = parser->is_tool();
 	p_script->name = p_class->identifier ? p_class->identifier->name : "";
 
-	if (!p_script->name.is_empty()) {
+	if (!p_script->name.is_empty_string()) {
 		if (ClassDB::class_exists(p_script->name) && ClassDB::is_class_exposed(p_script->name)) {
 			_set_error("The class '" + p_script->name + "' shadows a native class", p_class);
 			return ERR_ALREADY_EXISTS;
@@ -2346,7 +2346,7 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 				p_script->constants.insert(name, constant->initializer->reduced_value);
 #ifdef TOOLS_ENABLED
 				p_script->member_lines[name] = constant->start_line;
-				if (!constant->doc_description.is_empty()) {
+				if (!constant->doc_description.is_empty_string()) {
 					p_script->doc_constants[name] = constant->doc_description;
 				}
 #endif
@@ -2382,7 +2382,7 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 				}
 				p_script->_signals[name] = parameters_names;
 #ifdef TOOLS_ENABLED
-				if (!signal->doc_description.is_empty()) {
+				if (!signal->doc_description.is_empty_string()) {
 					p_script->doc_signals[name] = signal->doc_description;
 				}
 #endif

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -102,10 +102,10 @@ static void get_function_names_recursively(const GDScriptParser::ClassNode *p_cl
 	for (int i = 0; i < p_class->members.size(); i++) {
 		if (p_class->members[i].type == GDScriptParser::ClassNode::Member::FUNCTION) {
 			const GDScriptParser::FunctionNode *function = p_class->members[i].function;
-			r_funcs[function->start_line] = p_prefix.is_empty() ? String(function->identifier->name) : p_prefix + "." + String(function->identifier->name);
+			r_funcs[function->start_line] = p_prefix.is_empty_string() ? String(function->identifier->name) : p_prefix + "." + String(function->identifier->name);
 		} else if (p_class->members[i].type == GDScriptParser::ClassNode::Member::CLASS) {
 			String new_prefix = p_class->members[i].m_class->identifier->name;
-			get_function_names_recursively(p_class->members[i].m_class, p_prefix.is_empty() ? new_prefix : p_prefix + "." + new_prefix, r_funcs);
+			get_function_names_recursively(p_class->members[i].m_class, p_prefix.is_empty_string() ? new_prefix : p_prefix + "." + new_prefix, r_funcs);
 		}
 	}
 }
@@ -461,7 +461,7 @@ String GDScriptLanguage::make_function(const String &p_class, const String &p_na
 			s += p_args[i].get_slice(":", 0);
 			if (th) {
 				String type = p_args[i].get_slice(":", 1);
-				if (!type.is_empty() && type != "var") {
+				if (!type.is_empty_string() && type != "var") {
 					s += ": " + type;
 				}
 			}
@@ -1522,7 +1522,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 									String arg1 = args[0];
 									if (arg1.begins_with("/root/")) {
 										String which = arg1.get_slice("/", 2);
-										if (!which.is_empty()) {
+										if (!which.is_empty_string()) {
 											// Try singletons first
 											if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(which)) {
 												r_type = _type_from_variant(GDScriptLanguage::get_singleton()->get_named_globals_map()[which]);
@@ -2709,7 +2709,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				break;
 			}
 
-			if (!type.enumeration.is_empty()) {
+			if (!type.enumeration.is_empty_string()) {
 				_find_enumeration_candidates(completion_context, type.enumeration, options);
 				r_forced = options.size() > 0;
 			} else {
@@ -2960,7 +2960,7 @@ void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_t
 		}
 
 		String st = l.substr(tc, l.length()).strip_edges();
-		if (st.is_empty() || st.begins_with("#")) {
+		if (st.is_empty_string() || st.begins_with("#")) {
 			continue; //ignore!
 		}
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -171,16 +171,16 @@ void GDScriptParser::push_error(const String &p_message, const Node *p_origin) {
 void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_code, const String &p_symbol1, const String &p_symbol2, const String &p_symbol3, const String &p_symbol4) {
 	ERR_FAIL_COND(p_source == nullptr);
 	Vector<String> symbols;
-	if (!p_symbol1.is_empty()) {
+	if (!p_symbol1.is_empty_string()) {
 		symbols.push_back(p_symbol1);
 	}
-	if (!p_symbol2.is_empty()) {
+	if (!p_symbol2.is_empty_string()) {
 		symbols.push_back(p_symbol2);
 	}
-	if (!p_symbol3.is_empty()) {
+	if (!p_symbol3.is_empty_string()) {
 		symbols.push_back(p_symbol3);
 	}
-	if (!p_symbol4.is_empty()) {
+	if (!p_symbol4.is_empty_string()) {
 		symbols.push_back(p_symbol4);
 	}
 	push_warning(p_source, p_code, symbols);
@@ -756,7 +756,7 @@ void GDScriptParser::parse_class_member(T *(GDScriptParser::*p_parse_function)()
 #endif // TOOLS_ENABLED
 
 	if (member->identifier != nullptr) {
-		if (!((String)member->identifier->name).is_empty()) { // Enums may be unnamed.
+		if (!((String)member->identifier->name).is_empty_string()) { // Enums may be unnamed.
 
 #ifdef DEBUG_ENABLED
 			List<MethodInfo> gdscript_funcs;
@@ -3152,7 +3152,7 @@ String GDScriptParser::get_doc_comment(int p_line, bool p_single_line) {
 		}
 		String line_join = (in_codeblock) ? "\n" : " ";
 
-		doc = (doc.is_empty()) ? doc_line : doc + line_join + doc_line;
+		doc = (doc.is_empty_string()) ? doc_line : doc + line_join + doc_line;
 		line++;
 	}
 
@@ -3164,7 +3164,7 @@ void GDScriptParser::get_class_doc_comment(int p_line, String &p_brief, String &
 	if (!comments.has(p_line)) {
 		return;
 	}
-	ERR_FAIL_COND(!p_brief.is_empty() || !p_desc.is_empty() || p_tutorials.size() != 0);
+	ERR_FAIL_COND(!p_brief.is_empty_string() || !p_desc.is_empty_string() || p_tutorials.size() != 0);
 
 	int line = p_line;
 	bool in_codeblock = false;
@@ -3196,7 +3196,7 @@ void GDScriptParser::get_class_doc_comment(int p_line, String &p_brief, String &
 		String stripped_line = doc_line.strip_edges();
 
 		// Set the read mode.
-		if (stripped_line.is_empty() && mode == BRIEF && !p_brief.is_empty()) {
+		if (stripped_line.is_empty_string() && mode == BRIEF && !p_brief.is_empty_string()) {
 			mode = DESC;
 			continue;
 
@@ -3245,7 +3245,7 @@ void GDScriptParser::get_class_doc_comment(int p_line, String &p_brief, String &
 
 			mode = TUTORIALS;
 			in_codeblock = false;
-		} else if (stripped_line.is_empty()) {
+		} else if (stripped_line.is_empty_string()) {
 			continue;
 		} else {
 			// Tutorial docs are single line, we need a @tag after it.
@@ -3804,11 +3804,11 @@ String GDScriptParser::DataType::to_string() const {
 				return script_type->get_class_name().operator String();
 			}
 			String name = script_type->get_name();
-			if (!name.is_empty()) {
+			if (!name.is_empty_string()) {
 				return name;
 			}
 			name = script_path;
-			if (!name.is_empty()) {
+			if (!name.is_empty_string()) {
 				return name;
 			}
 			return native_type.operator String();
@@ -3884,7 +3884,7 @@ void GDScriptParser::TreePrinter::decrease_indent() {
 }
 
 void GDScriptParser::TreePrinter::push_line(const String &p_line) {
-	if (!p_line.is_empty()) {
+	if (!p_line.is_empty_string()) {
 		push_text(p_line);
 	}
 	printed += "\n";
@@ -4099,7 +4099,7 @@ void GDScriptParser::TreePrinter::print_class(ClassNode *p_class) {
 	if (p_class->extends_used) {
 		bool first = true;
 		push_text(" Extends ");
-		if (!p_class->extends_path.is_empty()) {
+		if (!p_class->extends_path.is_empty_string()) {
 			push_text(vformat(R"("%s")", p_class->extends_path));
 			first = false;
 		}
@@ -4702,7 +4702,7 @@ void GDScriptParser::TreePrinter::print_tree(const GDScriptParser &p_parser) {
 	if (p_parser.is_tool()) {
 		push_line("@tool");
 	}
-	if (!p_parser.get_tree()->icon_path.is_empty()) {
+	if (!p_parser.get_tree()->icon_path.is_empty_string()) {
 		push_text(R"(@icon (")");
 		push_text(p_parser.get_tree()->icon_path);
 		push_line("\")");

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -223,7 +223,7 @@ String GDScriptTokenizer::get_token_name(Token::Type p_token_type) {
 
 void GDScriptTokenizer::set_source_code(const String &p_source_code) {
 	source = p_source_code;
-	if (source.is_empty()) {
+	if (source.is_empty_string()) {
 		_source = U"";
 	} else {
 		_source = source.ptr();

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -73,7 +73,7 @@ static String _get_script_name(const Ref<Script> p_script) {
 	Ref<GDScript> gdscript = p_script;
 	if (gdscript.is_valid()) {
 		return gdscript->get_script_class_name();
-	} else if (p_script->get_name().is_empty()) {
+	} else if (p_script->get_name().is_empty_string()) {
 		return p_script->get_path().get_file();
 	} else {
 		return p_script->get_name();
@@ -793,7 +793,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = index->operator String();
-					if (!v.is_empty()) {
+					if (!v.is_empty_string()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -823,7 +823,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = index->operator String();
-					if (!v.is_empty()) {
+					if (!v.is_empty_string()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -855,7 +855,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (oob) {
 					String v = index->operator String();
-					if (!v.is_empty()) {
+					if (!v.is_empty_string()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -886,7 +886,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = index->operator String();
-					if (!v.is_empty()) {
+					if (!v.is_empty_string()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -922,7 +922,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (!valid) {
 					String v = key->operator String();
-					if (!v.is_empty()) {
+					if (!v.is_empty_string()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(key) + "'";
@@ -955,7 +955,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #ifdef DEBUG_ENABLED
 				if (oob) {
 					String v = index->operator String();
-					if (!v.is_empty()) {
+					if (!v.is_empty_string()) {
 						v = "'" + v + "'";
 					} else {
 						v = "of type '" + _get_var_type(index) + "'";
@@ -2763,7 +2763,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				VariantInternal::initialize(counter, Variant::INT);
 				*VariantInternal::get_int(counter) = 0;
 
-				if (!str->is_empty()) {
+				if (!str->is_empty_string()) {
 					GET_INSTRUCTION_ARG(iterator, 2);
 					VariantInternal::initialize(iterator, Variant::STRING);
 					*VariantInternal::get_string(iterator) = str->substr(0, 1);
@@ -3331,7 +3331,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						GET_INSTRUCTION_ARG(message, 1);
 						message_str = *message;
 					}
-					if (message_str.is_empty()) {
+					if (message_str.is_empty_string()) {
 						err_text = "Assertion failed.";
 					} else {
 						err_text = "Assertion failed: " + message_str;
@@ -3409,20 +3409,20 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		//error
 		// function, file, line, error, explanation
 		String err_file;
-		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->path.is_empty()) {
+		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->path.is_empty_string()) {
 			err_file = p_instance->script->path;
 		} else if (script) {
 			err_file = script->path;
 		}
-		if (err_file.is_empty()) {
+		if (err_file.is_empty_string()) {
 			err_file = "<built-in>";
 		}
 		String err_func = name;
-		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->name.is_empty()) {
+		if (p_instance && ObjectDB::get_instance(p_instance->owner_id) != nullptr && p_instance->script->is_valid() && !p_instance->script->name.is_empty_string()) {
 			err_func = p_instance->script->name + "." + err_func;
 		}
 		int err_line = line;
-		if (err_text.is_empty()) {
+		if (err_text.is_empty_string()) {
 			err_text = "Internal script error! Opcode: " + itos(last_opcode) + " (please report).";
 		}
 

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -145,7 +145,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 	r_symbol.script_path = path;
 	r_symbol.children.clear();
 	r_symbol.name = p_class->identifier != nullptr ? String(p_class->identifier->name) : String();
-	if (r_symbol.name.is_empty()) {
+	if (r_symbol.name.is_empty_string()) {
 		r_symbol.name = path.get_file();
 	}
 	r_symbol.kind = lsp::SymbolKind::Class;
@@ -213,9 +213,9 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				String value_text;
 				if (default_value.get_type() == Variant::OBJECT) {
 					Ref<Resource> res = default_value;
-					if (res.is_valid() && !res->get_path().is_empty()) {
+					if (res.is_valid() && !res->get_path().is_empty_string()) {
 						value_text = "preload(\"" + res->get_path() + "\")";
-						if (symbol.documentation.is_empty()) {
+						if (symbol.documentation.is_empty_string()) {
 							if (HashMap<String, ExtendGDScriptParser *>::Iterator S = GDScriptLanguageProtocol::get_singleton()->get_workspace()->scripts.find(res->get_path())) {
 								symbol.documentation = S->value->class_symbol.documentation;
 							}
@@ -226,7 +226,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				} else {
 					value_text = default_value.to_json_string();
 				}
-				if (!value_text.is_empty()) {
+				if (!value_text.is_empty_string()) {
 					symbol.detail += " = " + value_text;
 				}
 
@@ -499,7 +499,7 @@ String ExtendGDScriptParser::get_text_for_lookup_symbol(const lsp::Position &p_c
 			String line = lines[i];
 			String first_part = line.substr(0, p_cursor.character);
 			String last_part = line.substr(p_cursor.character + 1, lines[i].length());
-			if (!p_symbol.is_empty()) {
+			if (!p_symbol.is_empty_string()) {
 				String left_cursor_text;
 				for (int c = p_cursor.character - 1; c >= 0; c--) {
 					left_cursor_text = line.substr(c, p_cursor.character - c);
@@ -532,7 +532,7 @@ String ExtendGDScriptParser::get_text_for_lookup_symbol(const lsp::Position &p_c
 String ExtendGDScriptParser::get_identifier_under_position(const lsp::Position &p_position, Vector2i &p_offset) const {
 	ERR_FAIL_INDEX_V(p_position.line, lines.size(), "");
 	String line = lines[p_position.line];
-	if (line.is_empty()) {
+	if (line.is_empty_string()) {
 		return "";
 	}
 	ERR_FAIL_INDEX_V(p_position.character, line.size(), "");
@@ -638,7 +638,7 @@ const lsp::DocumentSymbol *ExtendGDScriptParser::get_symbol_defined_at_line(int 
 }
 
 const lsp::DocumentSymbol *ExtendGDScriptParser::get_member_symbol(const String &p_name, const String &p_subclass) const {
-	if (p_subclass.is_empty()) {
+	if (p_subclass.is_empty_string()) {
 		const lsp::DocumentSymbol *const *ptr = members.getptr(p_name);
 		if (ptr) {
 			return *ptr;

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -94,7 +94,7 @@ Error GDScriptLanguageProtocol::LSPeer::handle_data() {
 
 		// Response
 		String output = GDScriptLanguageProtocol::get_singleton()->process_message(msg);
-		if (!output.is_empty()) {
+		if (!output.is_empty_string()) {
 			res_queue.push_back(output.utf8());
 		}
 	}
@@ -139,7 +139,7 @@ void GDScriptLanguageProtocol::on_client_disconnected(const int &p_client_id) {
 
 String GDScriptLanguageProtocol::process_message(const String &p_text) {
 	String ret = process_string(p_text);
-	if (ret.is_empty()) {
+	if (ret.is_empty_string()) {
 		return ret;
 	} else {
 		return format_output(ret);

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -360,7 +360,7 @@ Variant GDScriptTextDocument::declaration(const Dictionary &p_params) {
 	params.load(p_params);
 	List<const lsp::DocumentSymbol *> symbols;
 	Array arr = this->find_symbols(params, symbols);
-	if (arr.is_empty() && !symbols.is_empty() && !symbols.front()->get()->native_class.is_empty()) { // Find a native symbol
+	if (arr.is_empty() && !symbols.is_empty() && !symbols.front()->get()->native_class.is_empty_string()) { // Find a native symbol
 		const lsp::DocumentSymbol *symbol = symbols.front()->get();
 		if (GDScriptLanguageProtocol::get_singleton()->is_goto_native_symbols_enabled()) {
 			String id;
@@ -449,7 +449,7 @@ Array GDScriptTextDocument::find_symbols(const lsp::TextDocumentPositionParams &
 		GDScriptLanguageProtocol::get_singleton()->get_workspace()->resolve_related_symbols(p_location, list);
 		for (const lsp::DocumentSymbol *&E : list) {
 			if (const lsp::DocumentSymbol *s = E) {
-				if (!s->uri.is_empty()) {
+				if (!s->uri.is_empty_string()) {
 					lsp::Location location;
 					location.uri = s->uri;
 					location.range = s->range;

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -144,7 +144,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::get_native_symbol(const String &p_
 		if (HashMap<StringName, lsp::DocumentSymbol>::ConstIterator E = native_symbols.find(class_name)) {
 			const lsp::DocumentSymbol &class_symbol = E->value;
 
-			if (p_member.is_empty()) {
+			if (p_member.is_empty_string()) {
 				return &class_symbol;
 			} else {
 				for (int i = 0; i < class_symbol.children.size(); i++) {
@@ -172,7 +172,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::get_script_symbol(const String &p_
 const lsp::DocumentSymbol *GDScriptWorkspace::get_parameter_symbol(const lsp::DocumentSymbol *p_parent, const String &symbol_identifier) {
 	for (int i = 0; i < p_parent->children.size(); ++i) {
 		const lsp::DocumentSymbol *parameter_symbol = &p_parent->children[i];
-		if (!parameter_symbol->detail.is_empty() && parameter_symbol->name == symbol_identifier) {
+		if (!parameter_symbol->detail.is_empty_string() && parameter_symbol->name == symbol_identifier) {
 			return parameter_symbol;
 		}
 	}
@@ -189,7 +189,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::get_local_symbol(const ExtendGDScr
 
 			for (int l = 0; l < function_symbol->children.size(); ++l) {
 				const lsp::DocumentSymbol *local = &function_symbol->children[l];
-				if (!local->detail.is_empty() && local->name == p_symbol_identifier) {
+				if (!local->detail.is_empty_string() && local->name == p_symbol_identifier) {
 					return local;
 				}
 			}
@@ -264,7 +264,7 @@ ExtendGDScriptParser *GDScriptWorkspace::get_parse_result(const String &p_path) 
 Array GDScriptWorkspace::symbol(const Dictionary &p_params) {
 	String query = p_params["query"];
 	Array arr;
-	if (!query.is_empty()) {
+	if (!query.is_empty_string()) {
 		for (const KeyValue<String, ExtendGDScriptParser *> &E : scripts) {
 			Vector<lsp::DocumentedSymbolInformation> script_symbols;
 			E.value->get_symbols().symbol_tree_as_list(E.key, script_symbols);
@@ -294,7 +294,7 @@ Error GDScriptWorkspace::initialize() {
 		class_symbol.native_class = class_name;
 		class_symbol.kind = lsp::SymbolKind::Class;
 		class_symbol.detail = String("<Native> class ") + class_name;
-		if (!class_data.inherits.is_empty()) {
+		if (!class_data.inherits.is_empty_string()) {
 			class_symbol.detail += " extends " + class_data.inherits;
 		}
 		class_symbol.documentation = class_data.brief_description + "\n" + class_data.description;
@@ -366,7 +366,7 @@ Error GDScriptWorkspace::initialize() {
 				symbol_arg.kind = lsp::SymbolKind::Variable;
 				symbol_arg.detail = arg.type;
 
-				if (!arg_default_value_started && !arg.default_value.is_empty()) {
+				if (!arg_default_value_started && !arg.default_value.is_empty_string()) {
 					arg_default_value_started = true;
 				}
 				String arg_str = arg.name + ": " + arg.type;
@@ -381,11 +381,11 @@ Error GDScriptWorkspace::initialize() {
 				symbol.children.push_back(symbol_arg);
 			}
 			if (data.qualifiers.contains("vararg")) {
-				params += params.is_empty() ? "..." : ", ...";
+				params += params.is_empty_string() ? "..." : ", ...";
 			}
 
 			String return_type = data.return_type;
-			if (return_type.is_empty()) {
+			if (return_type.is_empty_string()) {
 				return_type = "void";
 			}
 			symbol.detail = "func " + class_name + "." + data.name + "(" + params + ") -> " + return_type;
@@ -621,13 +621,13 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 		}
 
 		lsp::Position pos = p_doc_pos.position;
-		if (symbol_identifier.is_empty()) {
+		if (symbol_identifier.is_empty_string()) {
 			Vector2i offset;
 			symbol_identifier = parser->get_identifier_under_position(p_doc_pos.position, offset);
 			pos.character += offset.y;
 		}
 
-		if (!symbol_identifier.is_empty()) {
+		if (!symbol_identifier.is_empty_string()) {
 			if (ScriptServer::is_global_class(symbol_identifier)) {
 				String class_path = ScriptServer::get_global_class_path(symbol_identifier);
 				symbol = get_script_symbol(class_path);
@@ -642,7 +642,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 						String target_script_path = path;
 						if (!ret.script.is_null()) {
 							target_script_path = ret.script->get_path();
-						} else if (!ret.class_path.is_empty()) {
+						} else if (!ret.class_path.is_empty_string()) {
 							target_script_path = ret.class_path;
 						}
 
@@ -656,7 +656,7 @@ const lsp::DocumentSymbol *GDScriptWorkspace::resolve_symbol(const lsp::TextDocu
 
 					} else {
 						String member = ret.class_member;
-						if (member.is_empty() && symbol_identifier != ret.class_name) {
+						if (member.is_empty_string() && symbol_identifier != ret.class_name) {
 							member = symbol_identifier;
 						}
 						symbol = get_native_symbol(ret.class_name, member);
@@ -709,7 +709,7 @@ void GDScriptWorkspace::resolve_related_symbols(const lsp::TextDocumentPositionP
 const lsp::DocumentSymbol *GDScriptWorkspace::resolve_native_symbol(const lsp::NativeSymbolInspectParams &p_params) {
 	if (HashMap<StringName, lsp::DocumentSymbol>::Iterator E = native_symbols.find(p_params.native_class)) {
 		const lsp::DocumentSymbol &symbol = E->value;
-		if (p_params.symbol_name.is_empty() || p_params.symbol_name == symbol.name) {
+		if (p_params.symbol_name.is_empty_string() || p_params.symbol_name == symbol.name) {
 			return &symbol;
 		}
 

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -1257,7 +1257,7 @@ struct DocumentSymbol {
 
 	void symbol_tree_as_list(const String &p_uri, Vector<DocumentedSymbolInformation> &r_list, const String &p_container = "", bool p_join_name = false) const {
 		DocumentedSymbolInformation si;
-		if (p_join_name && !p_container.is_empty()) {
+		if (p_join_name && !p_container.is_empty_string()) {
 			si.name = p_container + ">" + name;
 		} else {
 			si.name = name;

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -240,7 +240,7 @@ bool GDScriptTestRunner::make_tests_for_dir(const String &p_dir) {
 	dir->list_dir_begin();
 	String next = dir->get_next();
 
-	while (!next.is_empty()) {
+	while (!next.is_empty_string()) {
 		if (dir->current_is_dir()) {
 			if (next == "." || next == "..") {
 				next = dir->get_next();
@@ -301,7 +301,7 @@ bool GDScriptTestRunner::generate_class_index() {
 		String base_type;
 
 		String class_name = GDScriptLanguage::get_singleton()->get_global_class_name(test.get_source_file(), &base_type);
-		if (class_name.is_empty()) {
+		if (class_name.is_empty_string()) {
 			continue;
 		}
 		ERR_FAIL_COND_V_MSG(ScriptServer::is_global_class(class_name), false,

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -102,7 +102,7 @@ void SceneExporterGLTFPlugin::convert_scene_to_gltf2() {
 		return;
 	}
 	String filename = String(root->get_scene_file_path().get_file().get_basename());
-	if (filename.is_empty()) {
+	if (filename.is_empty_string()) {
 		filename = root->get_name();
 	}
 	file_export_lib->set_current_file(filename + String(".gltf"));

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -249,7 +249,7 @@ Error GLTFDocument::_serialize_scenes(Ref<GLTFState> state) {
 
 	if (state->nodes.size()) {
 		Dictionary s;
-		if (!state->scene_name.is_empty()) {
+		if (!state->scene_name.is_empty_string()) {
 			s["name"] = state->scene_name;
 		}
 
@@ -408,7 +408,7 @@ Error GLTFDocument::_serialize_nodes(Ref<GLTFState> state) {
 		Ref<GLTFNode> n = state->nodes[i];
 		Dictionary extensions;
 		node["extensions"] = extensions;
-		if (!n->get_name().is_empty()) {
+		if (!n->get_name().is_empty_string()) {
 			node["name"] = n->get_name();
 		}
 		if (n->camera != -1) {
@@ -528,7 +528,7 @@ String GLTFDocument::_sanitize_bone_name(const String &p_name) {
 
 String GLTFDocument::_gen_unique_bone_name(Ref<GLTFState> state, const GLTFSkeletonIndex skel_i, const String &p_name) {
 	String s_name = _sanitize_bone_name(p_name);
-	if (s_name.is_empty()) {
+	if (s_name.is_empty_string()) {
 		s_name = "bone";
 	}
 	String name;
@@ -569,7 +569,7 @@ Error GLTFDocument::_parse_scenes(Ref<GLTFState> state) {
 			state->root_nodes.push_back(nodes[j]);
 		}
 
-		if (s.has("name") && !String(s["name"]).is_empty() && !((String)s["name"]).begins_with("Scene")) {
+		if (s.has("name") && !String(s["name"]).is_empty_string() && !((String)s["name"]).begins_with("Scene")) {
 			state->scene_name = _gen_unique_name(state, s["name"]);
 		} else {
 			state->scene_name = _gen_unique_name(state, state->filename);
@@ -788,7 +788,7 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> state, const String &p_base_pa
 					}
 					buffer_data = _parse_base64_uri(uri);
 				} else { // Relative path to an external image file.
-					ERR_FAIL_COND_V(p_base_path.is_empty(), ERR_INVALID_PARAMETER);
+					ERR_FAIL_COND_V(p_base_path.is_empty_string(), ERR_INVALID_PARAMETER);
 					uri = uri.uri_decode();
 					uri = p_base_path.plus_file(uri).replace("\\", "/"); // Fix for Windows.
 					buffer_data = FileAccess::get_file_as_array(uri);
@@ -2556,7 +2556,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> state) {
 		Ref<ImporterMesh> import_mesh;
 		import_mesh.instantiate();
 		String mesh_name = "mesh";
-		if (d.has("name") && !String(d["name"]).is_empty()) {
+		if (d.has("name") && !String(d["name"]).is_empty_string()) {
 			mesh_name = d["name"];
 		}
 		import_mesh->set_name(_gen_unique_name(state, vformat("%s_%s", state->scene_name, mesh_name)));
@@ -3000,7 +3000,7 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> state, const String &p_path
 		Ref<Image> image = state->images[i]->get_image();
 		ERR_CONTINUE(image.is_null());
 
-		if (p_path.to_lower().ends_with("glb") || p_path.is_empty()) {
+		if (p_path.to_lower().ends_with("glb") || p_path.is_empty_string()) {
 			GLTFBufferViewIndex bvi;
 
 			Ref<GLTFBufferView> bv;
@@ -3029,9 +3029,9 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> state, const String &p_path
 			d["bufferView"] = bvi;
 			d["mimeType"] = "image/png";
 		} else {
-			ERR_FAIL_COND_V(p_path.is_empty(), ERR_INVALID_PARAMETER);
+			ERR_FAIL_COND_V(p_path.is_empty_string(), ERR_INVALID_PARAMETER);
 			String name = state->images[i]->get_name();
-			if (name.is_empty()) {
+			if (name.is_empty_string()) {
 				name = itos(i);
 			}
 			name = _gen_unique_name(state, name);
@@ -3112,7 +3112,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> state, const String &p_base_pat
 				data_ptr = data.ptr();
 				data_size = data.size();
 				// mimeType is optional, but if we have it defined in the URI, let's use it.
-				if (mimetype.is_empty()) {
+				if (mimetype.is_empty_string()) {
 					if (uri.begins_with("data:image/png;base64")) {
 						mimetype = "image/png";
 					} else if (uri.begins_with("data:image/jpeg;base64")) {
@@ -3120,7 +3120,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> state, const String &p_base_pat
 					}
 				}
 			} else { // Relative path to an external image file.
-				ERR_FAIL_COND_V(p_base_path.is_empty(), ERR_INVALID_PARAMETER);
+				ERR_FAIL_COND_V(p_base_path.is_empty_string(), ERR_INVALID_PARAMETER);
 				uri = uri.uri_decode();
 				uri = p_base_path.plus_file(uri).replace("\\", "/"); // Fix for Windows.
 				// ResourceLoader will rely on the file extension to use the relevant loader.
@@ -3152,7 +3152,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> state, const String &p_base_pat
 			}
 		} else if (d.has("bufferView")) {
 			// Handles the third bullet point from the spec (bufferView).
-			ERR_FAIL_COND_V_MSG(mimetype.is_empty(), ERR_FILE_CORRUPT,
+			ERR_FAIL_COND_V_MSG(mimetype.is_empty_string(), ERR_FILE_CORRUPT,
 					vformat("glTF: Image index '%d' specifies 'bufferView' but no 'mimeType', which is invalid.", i));
 
 			const GLTFBufferViewIndex bvi = d["bufferView"];
@@ -3285,7 +3285,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> state) {
 			materials.push_back(d);
 			continue;
 		}
-		if (!material->get_name().is_empty()) {
+		if (!material->get_name().is_empty_string()) {
 			d["name"] = _gen_unique_name(state, material->get_name());
 		}
 		{
@@ -3546,7 +3546,7 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> state) {
 
 		Ref<StandardMaterial3D> material;
 		material.instantiate();
-		if (d.has("name") && !String(d["name"]).is_empty()) {
+		if (d.has("name") && !String(d["name"]).is_empty_string()) {
 			material->set_name(d["name"]);
 		} else {
 			material->set_name(vformat("material_%s", itos(i)));
@@ -4083,7 +4083,7 @@ Error GLTFDocument::_parse_skins(Ref<GLTFState> state) {
 			state->nodes.write[node]->joint = true;
 		}
 
-		if (d.has("name") && !String(d["name"]).is_empty()) {
+		if (d.has("name") && !String(d["name"]).is_empty_string()) {
 			skin->set_name(d["name"]);
 		} else {
 			skin->set_name(vformat("skin_%s", itos(i)));
@@ -4385,7 +4385,7 @@ Error GLTFDocument::_create_skeletons(Ref<GLTFState> state) {
 
 			const int bone_index = skeleton->get_bone_count();
 
-			if (node->get_name().is_empty()) {
+			if (node->get_name().is_empty_string()) {
 				node->set_name("bone");
 			}
 
@@ -4487,7 +4487,7 @@ Error GLTFDocument::_create_skins(Ref<GLTFState> state) {
 	// Create unique names now, after removing duplicates
 	for (GLTFSkinIndex skin_i = 0; skin_i < state->skins.size(); ++skin_i) {
 		Ref<Skin> skin = state->skins.write[skin_i]->godot_skin;
-		if (skin->get_name().is_empty()) {
+		if (skin->get_name().is_empty_string()) {
 			// Make a unique name, no gltf node represents this skin
 			skin->set_name(_gen_unique_name(state, "Skin"));
 		}
@@ -4757,7 +4757,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 			continue;
 		}
 
-		if (!gltf_animation->get_name().is_empty()) {
+		if (!gltf_animation->get_name().is_empty_string()) {
 			d["name"] = gltf_animation->get_name();
 		}
 		Array channels;
@@ -5068,7 +5068,7 @@ void GLTFDocument::_assign_scene_names(Ref<GLTFState> state) {
 			continue;
 		}
 
-		if (n->get_name().is_empty()) {
+		if (n->get_name().is_empty_string()) {
 			if (n->mesh >= 0) {
 				n->set_name(_gen_unique_name(state, "Mesh"));
 			} else if (n->camera >= 0) {
@@ -5892,7 +5892,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 	Ref<GLTFAnimation> anim = state->animations[index];
 
 	String name = anim->get_name();
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		// No node represent these, and they are not in the hierarchy, so just make a unique name
 		name = _gen_unique_name(state, "Animation");
 	}
@@ -6715,7 +6715,7 @@ Error GLTFDocument::_serialize_version(Ref<GLTFState> state) {
 	asset["version"] = version;
 
 	String hash = String(VERSION_HASH);
-	asset["generator"] = String(VERSION_FULL_NAME) + String("@") + (hash.is_empty() ? String("unknown") : hash);
+	asset["generator"] = String(VERSION_FULL_NAME) + String("@") + (hash.is_empty_string() ? String("unknown") : hash);
 	state->json["asset"] = asset;
 	ERR_FAIL_COND_V(!asset.has("version"), Error::FAILED);
 	ERR_FAIL_COND_V(!state->json.has("asset"), Error::FAILED);
@@ -7093,7 +7093,7 @@ Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> r_state, uint
 	ERR_FAIL_COND_V(err != OK, ERR_FILE_CANT_OPEN);
 	ERR_FAIL_NULL_V(f, ERR_FILE_CANT_OPEN);
 	String base_path = p_base_path;
-	if (base_path.is_empty()) {
+	if (base_path.is_empty_string()) {
 		base_path = p_path.get_base_dir();
 	}
 	r_state->base_path = base_path;

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -88,7 +88,7 @@ static void _editor_init() {
 			"filesystem/import/fbx/fbx2gltf_path", PROPERTY_HINT_GLOBAL_FILE));
 	if (fbx_enabled) {
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		if (fbx2gltf_path.is_empty()) {
+		if (fbx2gltf_path.is_empty_string()) {
 			WARN_PRINT("FBX file import is enabled, but no FBX2glTF path is configured. FBX files will not be imported.");
 		} else if (!da->file_exists(fbx2gltf_path)) {
 			WARN_PRINT("FBX file import is enabled, but the FBX2glTF path doesn't point to a valid FBX2glTF executable. FBX files will not be imported.");

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -876,11 +876,11 @@ void GridMapEditor::update_palette() {
 		String name = mesh_library->get_item_name(id);
 		Ref<Texture2D> preview = mesh_library->get_item_preview(id);
 
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			name = "#" + itos(id);
 		}
 
-		if (!filter.is_empty() && !filter.is_subsequence_ofn(name)) {
+		if (!filter.is_empty_string() && !filter.is_subsequence_ofn(name)) {
 			continue;
 		}
 

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -41,7 +41,7 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, bool p_f
 	while (true) {
 		String line = f->get_line();
 		ERR_FAIL_COND_V(f->eof_reached(), ERR_FILE_UNRECOGNIZED);
-		if (line.is_empty()) { // empty line indicates end of header
+		if (line.is_empty_string()) { // empty line indicates end of header
 			break;
 		}
 		if (line.begins_with("FORMAT=")) { // leave option to implement other commands

--- a/modules/jsonrpc/jsonrpc.cpp
+++ b/modules/jsonrpc/jsonrpc.cpp
@@ -152,7 +152,7 @@ Variant JSONRPC::process_action(const Variant &p_action, bool p_process_arr_elem
 }
 
 String JSONRPC::process_string(const String &p_input) {
-	if (p_input.is_empty()) {
+	if (p_input.is_empty_string()) {
 		return String();
 	}
 

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -304,7 +304,7 @@ void CryptoMbedTLS::load_default_certificates(String p_path) {
 	default_certs = memnew(X509CertificateMbedTLS);
 	ERR_FAIL_COND(default_certs == nullptr);
 
-	if (!p_path.is_empty()) {
+	if (!p_path.is_empty_string()) {
 		// Use certs defined in project settings.
 		default_certs->load(p_path);
 	}

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -64,7 +64,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 			for (const KeyValue<StringName, MethodBind *> &F : t->method_map) {
 				String name = F.key.operator String();
 
-				ERR_CONTINUE(name.is_empty());
+				ERR_CONTINUE(name.is_empty_string());
 
 				if (name[0] == '_') {
 					continue; // Ignore non-virtual methods that start with an underscore

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -407,7 +407,7 @@ bool CSharpLanguage::supports_builtin_mode() const {
 
 #ifdef TOOLS_ENABLED
 static String variant_type_to_managed_name(const String &p_var_type_name) {
-	if (p_var_type_name.is_empty()) {
+	if (p_var_type_name.is_empty_string()) {
 		return "object";
 	}
 
@@ -3130,7 +3130,7 @@ CSharpInstance *CSharpScript::_create_instance(const Variant **p_args, int p_arg
 		ERR_FAIL_COND_V_MSG(p_argcount == 0, nullptr,
 				"Cannot create script instance. The class '" + script_class->get_full_name() +
 						"' does not define a parameterless constructor." +
-						(get_path().is_empty() ? String() : " Path: '" + get_path() + "'."));
+						(get_path().is_empty_string() ? String() : " Path: '" + get_path() + "'."));
 
 		ERR_FAIL_V_MSG(nullptr, "Constructor not found.");
 	}
@@ -3284,7 +3284,7 @@ bool CSharpScript::instance_has(const Object *p_this) const {
 }
 
 bool CSharpScript::has_source_code() const {
-	return !source.is_empty();
+	return !source.is_empty_string();
 }
 
 String CSharpScript::get_source_code() const {
@@ -3541,7 +3541,7 @@ Error CSharpScript::load_source_code(const String &p_path) {
 void CSharpScript::_update_name() {
 	String path = get_path();
 
-	if (!path.is_empty()) {
+	if (!path.is_empty_string()) {
 		name = get_path().get_file().get_basename();
 	}
 }

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -155,7 +155,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 				dir_access->list_dir_begin();
 				String filename = dir_access->get_next();
 
-				while (!filename.is_empty()) {
+				while (!filename.is_empty_string()) {
 					if (filename == "." || filename == "..") {
 						filename = dir_access->get_next();
 						continue;

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -153,7 +153,7 @@ private:
 
 		String appname = ProjectSettings::get_singleton()->get("application/config/name");
 		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-		if (appname_safe.is_empty()) {
+		if (appname_safe.is_empty_string()) {
 			appname_safe = "UnnamedProject";
 		}
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -138,7 +138,7 @@ void gd_mono_debug_init() {
 	int da_timeout = GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
 
 	if (Engine::get_singleton()->is_editor_hint() ||
-			ProjectSettings::get_singleton()->get_resource_path().is_empty() ||
+			ProjectSettings::get_singleton()->get_resource_path().is_empty_string() ||
 			Engine::get_singleton()->is_project_manager_hint()) {
 		if (da_args.size() == 0) {
 			return;
@@ -295,7 +295,7 @@ void GDMono::determine_mono_dirs(String &r_assembly_rootdir, String &r_config_di
 	}
 
 #ifdef WINDOWS_ENABLED
-	if (r_assembly_rootdir.is_empty() || r_config_dir.is_empty()) {
+	if (r_assembly_rootdir.is_empty_string() || r_config_dir.is_empty_string()) {
 		ERR_PRINT("Cannot find Mono in the registry.");
 		// Assertion: if they are not set, then they weren't found in the registry
 		CRASH_COND(mono_reg_info.assembly_dir.length() > 0 || mono_reg_info.config_dir.length() > 0);
@@ -358,7 +358,7 @@ void GDMono::initialize() {
 #ifndef TOOLS_ENABLED
 	// Exported games that don't use C# must still work. They likely don't ship with mscorlib.
 	// We only initialize the Mono runtime if we can find mscorlib. Otherwise it would crash.
-	if (GDMonoAssembly::find_assembly("mscorlib.dll").is_empty()) {
+	if (GDMonoAssembly::find_assembly("mscorlib.dll").is_empty_string()) {
 		print_verbose("Mono: Skipping runtime initialization because 'mscorlib.dll' could not be found");
 		return;
 	}
@@ -937,7 +937,7 @@ void GDMono::_load_api_assemblies() {
 
 		// 2. Update the API assemblies
 		String update_error = update_api_assemblies_from_prebuilt("Debug", &core_api_assembly.out_of_sync, &editor_api_assembly.out_of_sync);
-		CRASH_COND_MSG(!update_error.is_empty(), update_error);
+		CRASH_COND_MSG(!update_error.is_empty_string(), update_error);
 
 		// 3. Load the scripts domain again
 		Error domain_load_err = _load_scripts_domain();
@@ -991,7 +991,7 @@ bool GDMono::_load_project_assembly() {
 
 	String appname = ProjectSettings::get_singleton()->get("application/config/name");
 	String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-	if (appname_safe.is_empty()) {
+	if (appname_safe.is_empty_string()) {
 		appname_safe = "UnnamedProject";
 	}
 

--- a/modules/mono/mono_gd/gd_mono_assembly.cpp
+++ b/modules/mono/mono_gd/gd_mono_assembly.cpp
@@ -48,20 +48,20 @@ Vector<String> GDMonoAssembly::search_dirs;
 void GDMonoAssembly::fill_search_dirs(Vector<String> &r_search_dirs, const String &p_custom_config, const String &p_custom_bcl_dir) {
 	String framework_dir;
 
-	if (!p_custom_bcl_dir.is_empty()) {
+	if (!p_custom_bcl_dir.is_empty_string()) {
 		framework_dir = p_custom_bcl_dir;
 	} else if (mono_assembly_getrootdir()) {
 		framework_dir = String::utf8(mono_assembly_getrootdir()).plus_file("mono").plus_file("4.5");
 	}
 
-	if (!framework_dir.is_empty()) {
+	if (!framework_dir.is_empty_string()) {
 		r_search_dirs.push_back(framework_dir);
 		r_search_dirs.push_back(framework_dir.plus_file("Facades"));
 	}
 
 #if !defined(TOOLS_ENABLED)
 	String data_game_assemblies_dir = GodotSharpDirs::get_data_game_assemblies_dir();
-	if (!data_game_assemblies_dir.is_empty()) {
+	if (!data_game_assemblies_dir.is_empty_string()) {
 		r_search_dirs.push_back(data_game_assemblies_dir);
 	}
 #endif
@@ -72,7 +72,7 @@ void GDMonoAssembly::fill_search_dirs(Vector<String> &r_search_dirs, const Strin
 		r_search_dirs.push_back(GodotSharpDirs::get_res_temp_assemblies_dir());
 	}
 
-	if (p_custom_config.is_empty()) {
+	if (p_custom_config.is_empty_string()) {
 		r_search_dirs.push_back(GodotSharpDirs::get_res_assemblies_dir());
 	} else {
 		String api_config = p_custom_config == "ExportRelease" ? "Release" : "Debug";

--- a/modules/mono/mono_gd/gd_mono_log.cpp
+++ b/modules/mono/mono_gd/gd_mono_log.cpp
@@ -119,7 +119,7 @@ void GDMonoLog::_delete_old_log_files(const String &p_logs_dir) {
 	ERR_FAIL_COND(da->list_dir_begin() != OK);
 
 	String current = da->get_next();
-	while (!current.is_empty()) {
+	while (!current.is_empty_string()) {
 		if (da->current_is_dir() || !current.ends_with(".txt")) {
 			current = da->get_next();
 			continue;

--- a/modules/mono/utils/mono_reg_utils.cpp
+++ b/modules/mono/utils/mono_reg_utils.cpp
@@ -198,7 +198,7 @@ String find_msbuild_tools_path() {
 				if (key == "installationPath") {
 					String val = line.substr(sep_idx + 1, line.length()).strip_edges();
 
-					ERR_BREAK(val.is_empty());
+					ERR_BREAK(val.is_empty_string());
 
 					if (!val.ends_with("\\")) {
 						val += "\\";

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -139,7 +139,7 @@ String realpath(const String &p_path) {
 }
 
 String join(const String &p_a, const String &p_b) {
-	if (p_a.is_empty()) {
+	if (p_a.is_empty_string()) {
 		return p_b;
 	}
 
@@ -168,7 +168,7 @@ String relative_to_impl(const String &p_path, const String &p_relative_to) {
 	} else {
 		String base_dir = p_relative_to.get_base_dir();
 
-		if (base_dir.length() <= 2 && (base_dir.is_empty() || base_dir.ends_with(":"))) {
+		if (base_dir.length() <= 2 && (base_dir.is_empty_string() || base_dir.ends_with(":"))) {
 			return p_path;
 		}
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -401,7 +401,7 @@ bool TextServerAdvanced::load_support_data(const String &p_filename) {
 	}
 #else
 	if (!icu_data_loaded) {
-		String filename = (p_filename.is_empty()) ? String("res://") + _MKSTR(ICU_DATA_NAME) : p_filename;
+		String filename = (p_filename.is_empty_string()) ? String("res://") + _MKSTR(ICU_DATA_NAME) : p_filename;
 
 		Ref<File> f;
 		f.instantiate();
@@ -3632,7 +3632,7 @@ bool TextServerAdvanced::shaped_text_add_string(const RID &p_shaped, const Strin
 		ERR_FAIL_COND_V(!font_owner.get_or_null(p_fonts[i]), false);
 	}
 
-	if (p_text.is_empty()) {
+	if (p_text.is_empty_string()) {
 		return true;
 	}
 
@@ -4873,7 +4873,7 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_star
 	}
 	hb_buffer_set_script(p_sd->hb_buffer, p_script);
 
-	if (!p_sd->spans[p_span].language.is_empty()) {
+	if (!p_sd->spans[p_span].language.is_empty_string()) {
 		hb_language_t lang = hb_language_from_string(p_sd->spans[p_span].language.ascii().get_data(), -1);
 		hb_buffer_set_language(p_sd->hb_buffer, lang);
 	}
@@ -5527,12 +5527,12 @@ void TextServerAdvanced::_insert_num_systems_lang() {
 }
 
 String TextServerAdvanced::format_number(const String &p_string, const String &p_language) const {
-	const StringName lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
+	const StringName lang = (p_language.is_empty_string()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 
 	String res = p_string;
 	for (int i = 0; i < num_systems.size(); i++) {
 		if (num_systems[i].lang.has(lang)) {
-			if (num_systems[i].digits.is_empty()) {
+			if (num_systems[i].digits.is_empty_string()) {
 				return p_string;
 			}
 			res.replace("e", num_systems[i].exp);
@@ -5552,12 +5552,12 @@ String TextServerAdvanced::format_number(const String &p_string, const String &p
 }
 
 String TextServerAdvanced::parse_number(const String &p_string, const String &p_language) const {
-	const StringName lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
+	const StringName lang = (p_language.is_empty_string()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 
 	String res = p_string;
 	for (int i = 0; i < num_systems.size(); i++) {
 		if (num_systems[i].lang.has(lang)) {
-			if (num_systems[i].digits.is_empty()) {
+			if (num_systems[i].digits.is_empty_string()) {
 				return p_string;
 			}
 			res.replace(num_systems[i].exp, "e");
@@ -5580,11 +5580,11 @@ String TextServerAdvanced::parse_number(const String &p_string, const String &p_
 }
 
 String TextServerAdvanced::percent_sign(const String &p_language) const {
-	const StringName lang = (p_language.is_empty()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
+	const StringName lang = (p_language.is_empty_string()) ? TranslationServer::get_singleton()->get_tool_locale() : p_language;
 
 	for (int i = 0; i < num_systems.size(); i++) {
 		if (num_systems[i].lang.has(lang)) {
-			if (num_systems[i].percent_sign.is_empty()) {
+			if (num_systems[i].percent_sign.is_empty_string()) {
 				return "%";
 			}
 			return num_systems[i].percent_sign;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -2678,7 +2678,7 @@ bool TextServerFallback::shaped_text_add_string(const RID &p_shaped, const Strin
 		ERR_FAIL_COND_V(!font_owner.get_or_null(p_fonts[i]), false);
 	}
 
-	if (p_text.is_empty()) {
+	if (p_text.is_empty_string()) {
 		return true;
 	}
 

--- a/modules/upnp/upnp.cpp
+++ b/modules/upnp/upnp.cpp
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 
 bool UPNP::is_common_device(const String &dev) const {
-	return dev.is_empty() ||
+	return dev.is_empty_string() ||
 			dev.find("InternetGatewayDevice") >= 0 ||
 			dev.find("WANIPConnection") >= 0 ||
 			dev.find("WANPPPConnection") >= 0 ||
@@ -78,7 +78,7 @@ int UPNP::discover(int timeout, int ttl, const String &device_filter) {
 	struct UPNPDev *dev = devlist;
 
 	while (dev) {
-		if (device_filter.is_empty() || strstr(dev->st, device_filter.utf8().get_data())) {
+		if (device_filter.is_empty_string() || strstr(dev->st, device_filter.utf8().get_data())) {
 			add_device_to_list(dev, devlist);
 		}
 

--- a/modules/upnp/upnp_device.cpp
+++ b/modules/upnp/upnp_device.cpp
@@ -65,7 +65,7 @@ int UPNPDevice::add_port_mapping(int port, int port_internal, String desc, Strin
 			itos(port).utf8().get_data(),
 			itos(port_internal).utf8().get_data(),
 			igd_our_addr.utf8().get_data(),
-			desc.is_empty() ? nullptr : desc.utf8().get_data(),
+			desc.is_empty_string() ? nullptr : desc.utf8().get_data(),
 			proto.utf8().get_data(),
 			nullptr, // Remote host, always nullptr as IGDs don't support it
 			duration > 0 ? itos(duration).utf8().get_data() : nullptr);

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -725,7 +725,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			line_edit->connect("text_changed", callable_mp(this, &VisualScriptEditor::_expression_text_changed), varray(E));
 		} else {
 			String text = node->get_text();
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				has_gnode_text = true;
 				Label *label = memnew(Label);
 				label->set_text(text);
@@ -1384,7 +1384,7 @@ void VisualScriptEditor::_create_function_dialog() {
 }
 
 void VisualScriptEditor::_create_function() {
-	String name = _validate_name((func_name_box->get_text().is_empty()) ? "new_func" : func_name_box->get_text());
+	String name = _validate_name((func_name_box->get_text().is_empty_string()) ? "new_func" : func_name_box->get_text());
 	selected = name;
 	Vector2 pos = _get_available_pos();
 
@@ -2166,7 +2166,7 @@ Variant VisualScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 
 		String type = it->get_metadata(0);
 
-		if (type.is_empty()) {
+		if (type.is_empty_string()) {
 			return Variant();
 		}
 
@@ -2689,12 +2689,12 @@ String VisualScriptEditor::get_name() {
 	String name;
 
 	name = script->get_path().get_file();
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		// This appears for newly created built-in scripts before saving the scene.
 		name = TTR("[unsaved]");
 	} else if (script->is_built_in()) {
 		const String &script_name = script->get_name();
-		if (!script_name.is_empty()) {
+		if (!script_name.is_empty_string()) {
 			// If the built-in script has a custom resource name defined,
 			// display the built-in script name as follows: `ResourceName (scene_file.tscn)`
 			name = vformat("%s (%s)", script_name, name.get_slice("::", 0));
@@ -2725,7 +2725,7 @@ bool VisualScriptEditor::is_unsaved() {
 	bool unsaved =
 			script->is_edited() ||
 			script->are_subnodes_edited() ||
-			script->get_path().is_empty(); // In memory.
+			script->get_path().is_empty_string(); // In memory.
 	return unsaved;
 }
 
@@ -2923,7 +2923,7 @@ void VisualScriptEditor::clear_edit_menu() {
 void VisualScriptEditor::_change_base_type_callback() {
 	String bt = select_base_type->get_selected_type();
 
-	ERR_FAIL_COND(bt.is_empty());
+	ERR_FAIL_COND(bt.is_empty_string());
 	undo_redo->create_action(TTR("Change Base Type"));
 	undo_redo->add_do_method(script.ptr(), "set_instance_base_type", bt);
 	undo_redo->add_undo_method(script.ptr(), "set_instance_base_type", script->get_instance_base_type());
@@ -3333,7 +3333,7 @@ void VisualScriptEditor::_port_action_menu(int p_option) {
 				property_info = script->get_node(port_action_node)->get_output_value_port_info(port_action_output);
 			}
 			if (tg.type == Variant::OBJECT) {
-				if (property_info.type == Variant::OBJECT && !property_info.hint_string.is_empty()) {
+				if (property_info.type == Variant::OBJECT && !property_info.hint_string.is_empty_string()) {
 					new_connect_node_select->select_from_action(property_info.hint_string);
 				} else {
 					new_connect_node_select->select_from_action("");
@@ -3603,7 +3603,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 					PropertyHint hint = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint;
 					String base_type = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint_string;
 
-					if (!base_type.is_empty() && hint == PROPERTY_HINT_TYPE_STRING) {
+					if (!base_type.is_empty_string() && hint == PROPERTY_HINT_TYPE_STRING) {
 						vsfc->set_base_type(base_type);
 					}
 					if (method_name == "call" || method_name == "call_deferred") {
@@ -3638,7 +3638,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 					PropertyHint hint = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint;
 					String base_type = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint_string;
 
-					if (!base_type.is_empty() && hint == PROPERTY_HINT_TYPE_STRING) {
+					if (!base_type.is_empty_string() && hint == PROPERTY_HINT_TYPE_STRING) {
 						vsp->set_base_type(base_type);
 					}
 				}
@@ -3667,7 +3667,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 				} else if (script->get_node(port_action_node).is_valid()) {
 					PropertyHint hint = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint;
 					String base_type = script->get_node(port_action_node)->get_output_value_port_info(port_action_output).hint_string;
-					if (!base_type.is_empty() && hint == PROPERTY_HINT_TYPE_STRING) {
+					if (!base_type.is_empty_string() && hint == PROPERTY_HINT_TYPE_STRING) {
 						vsp->set_base_type(base_type);
 					}
 				}

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1641,8 +1641,8 @@ Variant VisualScriptInstance::_call_internal(const StringName &p_method, void *p
 		String err_func = p_method;
 		int err_line = current_node_id; // Not a line but it works as one.
 
-		if (node && (r_error.error != Callable::CallError::CALL_ERROR_INVALID_METHOD || error_str.is_empty())) {
-			if (!error_str.is_empty()) {
+		if (node && (r_error.error != Callable::CallError::CALL_ERROR_INVALID_METHOD || error_str.is_empty_string())) {
+			if (!error_str.is_empty_string()) {
 				error_str += " ";
 			}
 
@@ -2345,7 +2345,7 @@ void VisualScriptLanguage::debug_get_stack_level_locals(int p_level, List<String
 
 	for (int i = 0; i < node->input_port_count; i++) {
 		String name = node->get_base_node()->get_input_value_port_info(i).name;
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			name = "in_" + itos(i);
 		}
 
@@ -2365,7 +2365,7 @@ void VisualScriptLanguage::debug_get_stack_level_locals(int p_level, List<String
 
 	for (int i = 0; i < node->output_port_count; i++) {
 		String name = node->get_base_node()->get_output_value_port_info(i).name;
-		if (name.is_empty()) {
+		if (name.is_empty_string()) {
 			name = "out_" + itos(i);
 		}
 

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -724,7 +724,7 @@ String VisualScriptTypeCast::get_caption() const {
 }
 
 String VisualScriptTypeCast::get_text() const {
-	if (!script.is_empty()) {
+	if (!script.is_empty_string()) {
 		return vformat(RTR("Is %s?"), script.get_file());
 	} else {
 		return vformat(RTR("Is %s?"), base_type);
@@ -762,7 +762,7 @@ String VisualScriptTypeCast::get_base_script() const {
 VisualScriptTypeCast::TypeGuess VisualScriptTypeCast::guess_output_type(TypeGuess *p_inputs, int p_output) const {
 	TypeGuess tg;
 	tg.type = Variant::OBJECT;
-	if (!script.is_empty()) {
+	if (!script.is_empty_string()) {
 		tg.script = ResourceLoader::load(script);
 	}
 	//if (!tg.script.is_valid()) {
@@ -793,7 +793,7 @@ public:
 			return 0;
 		}
 
-		if (!script.is_empty()) {
+		if (!script.is_empty_string()) {
 			Ref<Script> obj_script = obj->get_script();
 			if (!obj_script.is_valid()) {
 				return 1; //well, definitely not the script because object we got has no script.
@@ -853,7 +853,7 @@ void VisualScriptTypeCast::_bind_methods() {
 
 	String script_ext_hint;
 	for (const String &E : script_extensions) {
-		if (!script_ext_hint.is_empty()) {
+		if (!script_ext_hint.is_empty_string()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "*." + E;

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -371,7 +371,7 @@ void VisualScriptFunctionCall::_update_method_cache() {
 
 	} else if (call_mode == CALL_MODE_INSTANCE) {
 		type = base_type;
-		if (!base_script.is_empty()) {
+		if (!base_script.is_empty_string()) {
 			if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 				ScriptServer::edit_request_func(base_script); //make sure it's loaded
 			}
@@ -540,7 +540,7 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 			property.hint = PROPERTY_HINT_ENUM;
 			String sl;
 			for (const Engine::Singleton &E : names) {
-				if (!sl.is_empty()) {
+				if (!sl.is_empty_string()) {
 					sl += ",";
 				}
 				sl += E.name;
@@ -581,7 +581,7 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 			property.hint = PROPERTY_HINT_METHOD_OF_BASE_TYPE;
 			property.hint_string = base_type;
 
-			if (!base_script.is_empty()) {
+			if (!base_script.is_empty_string()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -685,7 +685,7 @@ void VisualScriptFunctionCall::_bind_methods() {
 
 	String script_ext_hint;
 	for (const String &E : script_extensions) {
-		if (!script_ext_hint.is_empty()) {
+		if (!script_ext_hint.is_empty_string()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "*." + E;
@@ -1172,7 +1172,7 @@ void VisualScriptPropertySet::_update_cache() {
 			}
 		} else if (call_mode == CALL_MODE_INSTANCE) {
 			type = base_type;
-			if (!base_script.is_empty()) {
+			if (!base_script.is_empty_string()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -1332,7 +1332,7 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
 			property.hint_string = base_type;
 
-			if (!base_script.is_empty()) {
+			if (!base_script.is_empty_string()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -1372,7 +1372,7 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 		property.hint = PROPERTY_HINT_ENUM;
 		property.hint_string = options;
 		property.type = Variant::STRING;
-		if (options.is_empty()) {
+		if (options.is_empty_string()) {
 			property.usage = PROPERTY_USAGE_NONE; //hide if type has no usable index
 		}
 	}
@@ -1422,7 +1422,7 @@ void VisualScriptPropertySet::_bind_methods() {
 
 	String script_ext_hint;
 	for (const String &E : script_extensions) {
-		if (!script_ext_hint.is_empty()) {
+		if (!script_ext_hint.is_empty_string()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "*." + E;
@@ -1858,7 +1858,7 @@ void VisualScriptPropertyGet::_update_cache() {
 			}
 		} else if (call_mode == CALL_MODE_INSTANCE) {
 			type = base_type;
-			if (!base_script.is_empty()) {
+			if (!base_script.is_empty_string()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -2038,7 +2038,7 @@ void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
 			property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
 			property.hint_string = base_type;
 
-			if (!base_script.is_empty()) {
+			if (!base_script.is_empty_string()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
 					ScriptServer::edit_request_func(base_script); //make sure it's loaded
 				}
@@ -2077,7 +2077,7 @@ void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
 		property.hint = PROPERTY_HINT_ENUM;
 		property.hint_string = options;
 		property.type = Variant::STRING;
-		if (options.is_empty()) {
+		if (options.is_empty_string()) {
 			property.usage = PROPERTY_USAGE_NONE; //hide if type has no usable index
 		}
 	}
@@ -2124,7 +2124,7 @@ void VisualScriptPropertyGet::_bind_methods() {
 
 	String script_ext_hint;
 	for (const String &E : script_extensions) {
-		if (!script_ext_hint.is_empty()) {
+		if (!script_ext_hint.is_empty_string()) {
 			script_ext_hint += ",";
 		}
 		script_ext_hint += "." + E;
@@ -2337,13 +2337,13 @@ void VisualScriptEmitSignal::_validate_property(PropertyInfo &property) const {
 
 		String ml;
 		for (const StringName &E : sigs) {
-			if (!ml.is_empty()) {
+			if (!ml.is_empty_string()) {
 				ml += ",";
 			}
 			ml += E;
 		}
 		for (const MethodInfo &E : base_sigs) {
-			if (!ml.is_empty()) {
+			if (!ml.is_empty_string()) {
 				ml += ",";
 			}
 			ml += E.name;

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1307,7 +1307,7 @@ void VisualScriptVariableGet::_validate_property(PropertyInfo &property) const {
 
 		String vhint;
 		for (const StringName &E : vars) {
-			if (!vhint.is_empty()) {
+			if (!vhint.is_empty_string()) {
 				vhint += ",";
 			}
 
@@ -1417,7 +1417,7 @@ void VisualScriptVariableSet::_validate_property(PropertyInfo &property) const {
 
 		String vhint;
 		for (const StringName &E : vars) {
-			if (!vhint.is_empty()) {
+			if (!vhint.is_empty_string()) {
 				vhint += ",";
 			}
 
@@ -1615,7 +1615,7 @@ PropertyInfo VisualScriptPreload::get_output_value_port_info(int p_idx) const {
 		pinfo.hint_string = preload->get_class();
 		if (preload->get_path().is_resource_file()) {
 			pinfo.name = preload->get_path();
-		} else if (!preload->get_name().is_empty()) {
+		} else if (!preload->get_name().is_empty_string()) {
 			pinfo.name = preload->get_name();
 		} else {
 			pinfo.name = preload->get_class();
@@ -1989,7 +1989,7 @@ void VisualScriptClassConstant::_validate_property(PropertyInfo &property) const
 
 		property.hint_string = "";
 		for (const String &E : constants) {
-			if (!property.hint_string.is_empty()) {
+			if (!property.hint_string.is_empty_string()) {
 				property.hint_string += ",";
 			}
 			property.hint_string += E;
@@ -2126,7 +2126,7 @@ void VisualScriptBasicTypeConstant::_validate_property(PropertyInfo &property) c
 		}
 		property.hint_string = "";
 		for (const StringName &E : constants) {
-			if (!property.hint_string.is_empty()) {
+			if (!property.hint_string.is_empty_string()) {
 				property.hint_string += ",";
 			}
 			property.hint_string += String(E);
@@ -2356,7 +2356,7 @@ void VisualScriptEngineSingleton::_validate_property(PropertyInfo &property) con
 			continue; //skip these, too simple named
 		}
 
-		if (!cc.is_empty()) {
+		if (!cc.is_empty_string()) {
 			cc += ",";
 		}
 		cc += E.name;
@@ -3140,7 +3140,7 @@ String VisualScriptSubCall::get_caption() const {
 String VisualScriptSubCall::get_text() const {
 	Ref<Script> script = get_script();
 	if (script.is_valid()) {
-		if (!script->get_name().is_empty()) {
+		if (!script->get_name().is_empty_string()) {
 			return script->get_name();
 		}
 		if (script->get_path().is_resource_file()) {
@@ -3779,7 +3779,7 @@ void VisualScriptInputAction::_validate_property(PropertyInfo &property) const {
 		al.sort();
 
 		for (int i = 0; i < al.size(); i++) {
-			if (!actions.is_empty()) {
+			if (!actions.is_empty_string()) {
 				actions += ",";
 			}
 			actions += al[i];

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -454,7 +454,7 @@ void VisualScriptYieldSignal::_validate_property(PropertyInfo &property) const {
 
 		String ml;
 		for (const String &E : mstring) {
-			if (!ml.is_empty()) {
+			if (!ml.is_empty_string()) {
 				ml += ",";
 			}
 			ml += E;

--- a/modules/websocket/editor/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor/editor_debugger_server_websocket.cpp
@@ -62,7 +62,7 @@ Error EditorDebuggerServerWebSocket::start(const String &p_uri) {
 	int bind_port = (int)EditorSettings::get_singleton()->get("network/debug/remote_port");
 
 	// Optionally override
-	if (!p_uri.is_empty() && p_uri != "ws://") {
+	if (!p_uri.is_empty_string() && p_uri != "ws://") {
 		String scheme, path;
 		Error err = p_uri.parse_url(scheme, bind_host, bind_port, path);
 		ERR_FAIL_COND_V(err != OK, ERR_INVALID_PARAMETER);

--- a/modules/websocket/websocket_client.cpp
+++ b/modules/websocket/websocket_client.cpp
@@ -55,7 +55,7 @@ Error WebSocketClient::connect_to_url(String p_url, const Vector<String> p_proto
 	if (port == 0) {
 		port = ssl ? 443 : 80;
 	}
-	if (path.is_empty()) {
+	if (path.is_empty_string()) {
 		path = "/";
 	}
 	return connect_to_host(host, path, port, ssl, p_protocols, p_custom_headers);

--- a/modules/websocket/wsl_client.cpp
+++ b/modules/websocket/wsl_client.cpp
@@ -163,7 +163,7 @@ bool WSLClient::_verify_headers(String &r_protocol) {
 
 Error WSLClient::connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, const Vector<String> p_protocols, const Vector<String> p_custom_headers) {
 	ERR_FAIL_COND_V(_connection.is_valid(), ERR_ALREADY_IN_USE);
-	ERR_FAIL_COND_V(p_path.is_empty(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_path.is_empty_string(), ERR_INVALID_PARAMETER);
 
 	_peer = Ref<WSLPeer>(memnew(WSLPeer));
 

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -83,11 +83,11 @@ bool WSLServer::PendingPeer::_parse_request(const Vector<String> p_protocols, St
 				break;
 			}
 			// Found a protocol
-			if (!protocol.is_empty()) {
+			if (!protocol.is_empty_string()) {
 				break;
 			}
 		}
-		if (protocol.is_empty()) { // Invalid protocol(s) requested
+		if (protocol.is_empty_string()) { // Invalid protocol(s) requested
 			return false;
 		}
 	} else if (p_protocols.size() > 0) { // No protocol requested, but we need one
@@ -138,7 +138,7 @@ Error WSLServer::PendingPeer::do_handshake(const Vector<String> p_protocols, uin
 				s += "Upgrade: websocket\r\n";
 				s += "Connection: Upgrade\r\n";
 				s += "Sec-WebSocket-Accept: " + WSLPeer::compute_key_response(key) + "\r\n";
-				if (!protocol.is_empty()) {
+				if (!protocol.is_empty_string()) {
 					s += "Sec-WebSocket-Protocol: " + protocol + "\r\n";
 				}
 				for (int i = 0; i < p_extra_headers.size(); i++) {

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -103,7 +103,7 @@ String DirAccessJAndroid::get_drive(int p_drive) {
 Error DirAccessJAndroid::change_dir(String p_dir) {
 	JNIEnv *env = get_jni_env();
 
-	if (p_dir.is_empty() || p_dir == "." || (p_dir == ".." && current_dir.is_empty())) {
+	if (p_dir.is_empty_string() || p_dir == "." || (p_dir == ".." && current_dir.is_empty_string())) {
 		return OK;
 	}
 
@@ -117,7 +117,7 @@ Error DirAccessJAndroid::change_dir(String p_dir) {
 		new_dir = p_dir.substr(1, p_dir.length());
 	} else if (p_dir.begins_with("res://")) {
 		new_dir = p_dir.substr(6, p_dir.length());
-	} else if (current_dir.is_empty()) {
+	} else if (current_dir.is_empty_string()) {
 		new_dir = p_dir;
 	} else {
 		new_dir = current_dir.plus_file(p_dir);
@@ -146,7 +146,7 @@ String DirAccessJAndroid::get_current_dir(bool p_include_drive) const {
 
 bool DirAccessJAndroid::file_exists(String p_file) {
 	String sd;
-	if (current_dir.is_empty()) {
+	if (current_dir.is_empty_string()) {
 		sd = p_file;
 	} else {
 		sd = current_dir.plus_file(p_file);
@@ -164,7 +164,7 @@ bool DirAccessJAndroid::dir_exists(String p_dir) {
 
 	String sd;
 
-	if (current_dir.is_empty()) {
+	if (current_dir.is_empty_string()) {
 		sd = p_dir;
 	} else {
 		if (p_dir.is_relative_path()) {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -327,7 +327,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 						}
 					}
 
-					if (d.description.is_empty()) {
+					if (d.description.is_empty_string()) {
 						//in the oven, request!
 						args.clear();
 						args.push_back("-s");
@@ -376,7 +376,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 						}
 
 						d.name = vendor + " " + device;
-						if (device.is_empty()) {
+						if (device.is_empty_string()) {
 							continue;
 						}
 					}
@@ -414,13 +414,13 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 
 String EditorExportPlatformAndroid::get_project_name(const String &p_name) const {
 	String aname;
-	if (!p_name.is_empty()) {
+	if (!p_name.is_empty_string()) {
 		aname = p_name;
 	} else {
 		aname = ProjectSettings::get_singleton()->get("application/config/name");
 	}
 
-	if (aname.is_empty()) {
+	if (aname.is_empty_string()) {
 		aname = VERSION_NAME;
 	}
 
@@ -444,7 +444,7 @@ String EditorExportPlatformAndroid::get_package_name(const String &p_package) co
 			first = false;
 		}
 	}
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		name = "noname";
 	}
 
@@ -601,7 +601,7 @@ Vector<String> EditorExportPlatformAndroid::list_gdap_files(const String &p_path
 		da->list_dir_begin();
 		while (true) {
 			String file = da->get_next();
-			if (file.is_empty()) {
+			if (file.is_empty_string()) {
 				break;
 			}
 
@@ -764,7 +764,7 @@ void EditorExportPlatformAndroid::_get_permissions(const Ref<EditorExportPreset>
 	PackedStringArray user_perms = p_preset->get("permissions/custom_permissions");
 	for (int i = 0; i < user_perms.size(); i++) {
 		String user_perm = user_perms[i].strip_edges();
-		if (!user_perm.is_empty()) {
+		if (!user_perm.is_empty_string()) {
 			r_permissions.push_back(user_perm);
 		}
 	}
@@ -1504,7 +1504,7 @@ String EditorExportPlatformAndroid::load_splash_refs(Ref<Image> &splash_image, R
 	bool apply_filter = ProjectSettings::get_singleton()->get("application/boot_splash/use_filter");
 	String project_splash_path = ProjectSettings::get_singleton()->get("application/boot_splash/image");
 
-	if (!project_splash_path.is_empty()) {
+	if (!project_splash_path.is_empty_string()) {
 		splash_image.instantiate();
 		print_verbose("Loading splash image: " + project_splash_path);
 		const Error err = ImageLoader::load_image(project_splash_path, splash_image);
@@ -1563,7 +1563,7 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	// Regular icon: user selection -> project icon -> default.
 	String path = static_cast<String>(p_preset->get(launcher_icon_option)).strip_edges();
 	print_verbose("Loading regular icon from " + path);
-	if (path.is_empty() || ImageLoader::load_image(path, icon) != OK) {
+	if (path.is_empty_string() || ImageLoader::load_image(path, icon) != OK) {
 		print_verbose("- falling back to project icon: " + project_icon_path);
 		ImageLoader::load_image(project_icon_path, icon);
 	}
@@ -1571,14 +1571,14 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	// Adaptive foreground: user selection -> regular icon (user selection -> project icon -> default).
 	path = static_cast<String>(p_preset->get(launcher_adaptive_icon_foreground_option)).strip_edges();
 	print_verbose("Loading adaptive foreground icon from " + path);
-	if (path.is_empty() || ImageLoader::load_image(path, foreground) != OK) {
+	if (path.is_empty_string() || ImageLoader::load_image(path, foreground) != OK) {
 		print_verbose("- falling back to using the regular icon");
 		foreground = icon;
 	}
 
 	// Adaptive background: user selection -> default.
 	path = static_cast<String>(p_preset->get(launcher_adaptive_icon_background_option)).strip_edges();
-	if (!path.is_empty()) {
+	if (!path.is_empty_string()) {
 		print_verbose("Loading adaptive background icon from " + path);
 		ImageLoader::load_image(path, background);
 	}
@@ -1601,7 +1601,7 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 		const Ref<Image> &foreground,
 		const Ref<Image> &background) {
 	// Store the splash configuration
-	if (!processed_splash_config_xml.is_empty()) {
+	if (!processed_splash_config_xml.is_empty_string()) {
 		print_verbose("Storing processed splash configuration: " + String("\n") + processed_splash_config_xml);
 		store_string_at_path(SPLASH_CONFIG_PATH, processed_splash_config_xml);
 	}
@@ -2016,7 +2016,7 @@ String EditorExportPlatformAndroid::get_apksigner_path() {
 	// There are additional versions directories we need to go through.
 	da->list_dir_begin();
 	String sub_dir = da->get_next();
-	while (!sub_dir.is_empty()) {
+	while (!sub_dir.is_empty_string()) {
 		if (!sub_dir.begins_with(".") && da->current_is_dir()) {
 			// Check if the tool is here.
 			String tool_path = build_tools_dir.plus_file(sub_dir).plus_file(apksigner_command_name);
@@ -2029,7 +2029,7 @@ String EditorExportPlatformAndroid::get_apksigner_path() {
 	}
 	da->list_dir_end();
 
-	if (apksigner_path.is_empty()) {
+	if (apksigner_path.is_empty_string()) {
 		print_error("Unable to find the 'apksigner' tool.");
 	}
 
@@ -2090,7 +2090,7 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 	String dk_user = p_preset->get("keystore/debug_user");
 	String dk_password = p_preset->get("keystore/debug_password");
 
-	if ((dk.is_empty() || dk_user.is_empty() || dk_password.is_empty()) && (!dk.is_empty() || !dk_user.is_empty() || !dk_password.is_empty())) {
+	if ((dk.is_empty_string() || dk_user.is_empty_string() || dk_password.is_empty_string()) && (!dk.is_empty_string() || !dk_user.is_empty_string() || !dk_password.is_empty_string())) {
 		valid = false;
 		err += TTR("Either Debug Keystore, Debug User AND Debug Password settings must be configured OR none of them.") + "\n";
 	}
@@ -2107,18 +2107,18 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 	String rk_user = p_preset->get("keystore/release_user");
 	String rk_password = p_preset->get("keystore/release_password");
 
-	if ((rk.is_empty() || rk_user.is_empty() || rk_password.is_empty()) && (!rk.is_empty() || !rk_user.is_empty() || !rk_password.is_empty())) {
+	if ((rk.is_empty_string() || rk_user.is_empty_string() || rk_password.is_empty_string()) && (!rk.is_empty_string() || !rk_user.is_empty_string() || !rk_password.is_empty_string())) {
 		valid = false;
 		err += TTR("Either Release Keystore, Release User AND Release Password settings must be configured OR none of them.") + "\n";
 	}
 
-	if (!rk.is_empty() && !FileAccess::exists(rk)) {
+	if (!rk.is_empty_string() && !FileAccess::exists(rk)) {
 		valid = false;
 		err += TTR("Release keystore incorrectly configured in the export preset.") + "\n";
 	}
 
 	String sdk_path = EditorSettings::get_singleton()->get("export/android/android_sdk_path");
-	if (sdk_path.is_empty()) {
+	if (sdk_path.is_empty_string()) {
 		err += TTR("A valid Android SDK path is required in Editor Settings.") + "\n";
 		valid = false;
 	} else {
@@ -2165,7 +2165,7 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 	if (apk_expansion) {
 		String apk_expansion_pkey = p_preset->get("apk_expansion/public_key");
 
-		if (apk_expansion_pkey.is_empty()) {
+		if (apk_expansion_pkey.is_empty_string()) {
 			valid = false;
 
 			err += TTR("Invalid public key for APK expansion.") + "\n";
@@ -2181,14 +2181,14 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 	}
 
 	String etc_error = test_etc2();
-	if (!etc_error.is_empty()) {
+	if (!etc_error.is_empty_string()) {
 		valid = false;
 		err += etc_error;
 	}
 
 	// Ensure that `Use Custom Build` is enabled if a plugin is selected.
 	String enabled_plugins_names = PluginConfigAndroid::get_plugins_names(get_enabled_plugins(p_preset));
-	if (!enabled_plugins_names.is_empty() && !custom_build_enabled) {
+	if (!enabled_plugins_names.is_empty_string() && !custom_build_enabled) {
 		valid = false;
 		err += TTR("\"Use Custom Build\" must be enabled to use the plugins.");
 		err += "\n";
@@ -2347,7 +2347,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 		password = p_preset->get("keystore/debug_password");
 		user = p_preset->get("keystore/debug_user");
 
-		if (keystore.is_empty()) {
+		if (keystore.is_empty_string()) {
 			keystore = EditorSettings::get_singleton()->get("export/android/debug_keystore");
 			password = EditorSettings::get_singleton()->get("export/android/debug_keystore_pass");
 			user = EditorSettings::get_singleton()->get("export/android/debug_keystore_user");
@@ -2452,7 +2452,7 @@ void EditorExportPlatformAndroid::_remove_copied_libs() {
 	print_verbose("Removing previously installed libraries...");
 	Error error;
 	String libs_json = FileAccess::get_file_as_string(GDNATIVE_LIBS_PATH, &error);
-	if (error || libs_json.is_empty()) {
+	if (error || libs_json.is_empty_string()) {
 		print_verbose("No previously installed libraries found");
 		return;
 	}
@@ -2564,7 +2564,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		}
 		const String assets_directory = get_assets_directory(p_preset, export_format);
 		String sdk_path = EDITOR_GET("export/android/android_sdk_path");
-		ERR_FAIL_COND_V_MSG(sdk_path.is_empty(), ERR_UNCONFIGURED, "Android SDK path must be configured in Editor Settings at 'export/android/android_sdk_path'.");
+		ERR_FAIL_COND_V_MSG(sdk_path.is_empty_string(), ERR_UNCONFIGURED, "Android SDK path must be configured in Editor Settings at 'export/android/android_sdk_path'.");
 		print_verbose("Android sdk path: " + sdk_path);
 
 		// TODO: should we use "package/name" or "application/config/name"?
@@ -2676,7 +2676,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 				String debug_password = p_preset->get("keystore/debug_password");
 				String debug_user = p_preset->get("keystore/debug_user");
 
-				if (debug_keystore.is_empty()) {
+				if (debug_keystore.is_empty_string()) {
 					debug_keystore = EditorSettings::get_singleton()->get("export/android/debug_keystore");
 					debug_password = EditorSettings::get_singleton()->get("export/android/debug_keystore_pass");
 					debug_user = EditorSettings::get_singleton()->get("export/android/debug_keystore_user");
@@ -2758,13 +2758,13 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		src_apk = p_preset->get("custom_template/release");
 	}
 	src_apk = src_apk.strip_edges();
-	if (src_apk.is_empty()) {
+	if (src_apk.is_empty_string()) {
 		if (p_debug) {
 			src_apk = find_export_template("android_debug.apk");
 		} else {
 			src_apk = find_export_template("android_release.apk");
 		}
-		if (src_apk.is_empty()) {
+		if (src_apk.is_empty_string()) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Package not found: \"%s\"."), src_apk));
 			return ERR_FILE_NOT_FOUND;
 		}

--- a/platform/android/export/godot_plugin_config.cpp
+++ b/platform/android/export/godot_plugin_config.cpp
@@ -46,7 +46,7 @@
 
 String PluginConfigAndroid::resolve_local_dependency_path(String plugin_config_dir, String dependency_path) {
 	String absolute_path;
-	if (!dependency_path.is_empty()) {
+	if (!dependency_path.is_empty_string()) {
 		if (dependency_path.is_absolute_path()) {
 			absolute_path = ProjectSettings::get_singleton()->globalize_path(dependency_path);
 		} else {
@@ -75,13 +75,13 @@ Vector<PluginConfigAndroid> PluginConfigAndroid::get_prebuilt_plugins(String plu
 }
 
 bool PluginConfigAndroid::is_plugin_config_valid(PluginConfigAndroid plugin_config) {
-	bool valid_name = !plugin_config.name.is_empty();
+	bool valid_name = !plugin_config.name.is_empty_string();
 	bool valid_binary_type = plugin_config.binary_type == PluginConfigAndroid::BINARY_TYPE_LOCAL ||
 			plugin_config.binary_type == PluginConfigAndroid::BINARY_TYPE_REMOTE;
 
 	bool valid_binary = false;
 	if (valid_binary_type) {
-		valid_binary = !plugin_config.binary.is_empty() &&
+		valid_binary = !plugin_config.binary.is_empty_string() &&
 				(plugin_config.binary_type == PluginConfigAndroid::BINARY_TYPE_REMOTE ||
 						FileAccess::exists(plugin_config.binary));
 	}

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -161,7 +161,7 @@ Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset
 	Dictionary appnames = ProjectSettings::get_singleton()->get("application/config/name_localized");
 	while (true) {
 		String file = da->get_next();
-		if (file.is_empty()) {
+		if (file.is_empty_string()) {
 			break;
 		}
 		if (!file.begins_with("values-")) {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -233,7 +233,7 @@ String OS_Android::get_resource_dir() const {
 
 String OS_Android::get_locale() const {
 	String locale = godot_io_java->get_locale();
-	if (!locale.is_empty()) {
+	if (!locale.is_empty_string()) {
 		return locale;
 	}
 
@@ -242,7 +242,7 @@ String OS_Android::get_locale() const {
 
 String OS_Android::get_model_name() const {
 	String model = godot_io_java->get_model();
-	if (!model.is_empty()) {
+	if (!model.is_empty_string()) {
 		return model;
 	}
 
@@ -262,12 +262,12 @@ String OS_Android::get_executable_path() const {
 }
 
 String OS_Android::get_user_data_dir() const {
-	if (!data_dir_cache.is_empty()) {
+	if (!data_dir_cache.is_empty_string()) {
 		return data_dir_cache;
 	}
 
 	String data_dir = godot_io_java->get_user_data_dir();
-	if (!data_dir.is_empty()) {
+	if (!data_dir.is_empty_string()) {
 		data_dir_cache = _remove_symlink(data_dir);
 		return data_dir_cache;
 	}
@@ -275,12 +275,12 @@ String OS_Android::get_user_data_dir() const {
 }
 
 String OS_Android::get_cache_path() const {
-	if (!cache_dir_cache.is_empty()) {
+	if (!cache_dir_cache.is_empty_string()) {
 		return cache_dir_cache;
 	}
 
 	String cache_dir = godot_io_java->get_cache_dir();
-	if (!cache_dir.is_empty()) {
+	if (!cache_dir.is_empty_string()) {
 		cache_dir_cache = _remove_symlink(cache_dir);
 		return cache_dir_cache;
 	}
@@ -289,7 +289,7 @@ String OS_Android::get_cache_path() const {
 
 String OS_Android::get_unique_id() const {
 	String unique_id = godot_io_java->get_unique_id();
-	if (!unique_id.is_empty()) {
+	if (!unique_id.is_empty_string()) {
 		return unique_id;
 	}
 

--- a/platform/android/tts_android.cpp
+++ b/platform/android/tts_android.cpp
@@ -139,7 +139,7 @@ void TTS_Android::speak(const String &p_text, const String &p_voice, int p_volum
 		stop();
 	}
 
-	if (p_text.is_empty()) {
+	if (p_text.is_empty_string()) {
 		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_CANCELED, p_utterance_id);
 		return;
 	}

--- a/platform/iphone/export/export_plugin.cpp
+++ b/platform/iphone/export/export_plugin.cpp
@@ -176,10 +176,10 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		"scaleAspectFill",
 		"scaleToFill"
 	};
-	String dbg_sign_id = p_preset->get("application/code_sign_identity_debug").operator String().is_empty() ? "iPhone Developer" : p_preset->get("application/code_sign_identity_debug");
-	String rel_sign_id = p_preset->get("application/code_sign_identity_release").operator String().is_empty() ? "iPhone Distribution" : p_preset->get("application/code_sign_identity_release");
-	bool dbg_manual = !p_preset->get("application/provisioning_profile_uuid_debug").operator String().is_empty() || (dbg_sign_id != "iPhone Developer");
-	bool rel_manual = !p_preset->get("application/provisioning_profile_uuid_release").operator String().is_empty() || (rel_sign_id != "iPhone Distribution");
+	String dbg_sign_id = p_preset->get("application/code_sign_identity_debug").operator String().is_empty_string() ? "iPhone Developer" : p_preset->get("application/code_sign_identity_debug");
+	String rel_sign_id = p_preset->get("application/code_sign_identity_release").operator String().is_empty_string() ? "iPhone Distribution" : p_preset->get("application/code_sign_identity_release");
+	bool dbg_manual = !p_preset->get("application/provisioning_profile_uuid_debug").operator String().is_empty_string() || (dbg_sign_id != "iPhone Developer");
+	bool rel_manual = !p_preset->get("application/provisioning_profile_uuid_release").operator String().is_empty_string() || (rel_sign_id != "iPhone Distribution");
 	String str;
 	String strnew;
 	str.parse_utf8((const char *)pfile.ptr(), pfile.size());
@@ -635,7 +635,7 @@ Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExpor
 
 		const String splash_path = ProjectSettings::get_singleton()->get("application/boot_splash/image");
 
-		if (!splash_path.is_empty()) {
+		if (!splash_path.is_empty_string()) {
 			splash.instantiate();
 			const Error err = splash->load(splash_path);
 			if (err) {
@@ -761,7 +761,7 @@ Error EditorExportPlatformIOS::_walk_dir_recursive(Ref<DirAccess> &p_da, FileHan
 	String current_dir = p_da->get_current_dir();
 	p_da->list_dir_begin();
 	String path = p_da->get_next();
-	while (!path.is_empty()) {
+	while (!path.is_empty_string()) {
 		if (p_da->current_is_dir()) {
 			if (path != "." && path != "..") {
 				dirs.push_back(path);
@@ -807,9 +807,9 @@ Error EditorExportPlatformIOS::_codesign(String p_file, void *p_userdata) {
 
 		String sign_id;
 		if (data->debug) {
-			sign_id = data->preset->get("application/code_sign_identity_debug").operator String().is_empty() ? "iPhone Developer" : data->preset->get("application/code_sign_identity_debug");
+			sign_id = data->preset->get("application/code_sign_identity_debug").operator String().is_empty_string() ? "iPhone Developer" : data->preset->get("application/code_sign_identity_debug");
 		} else {
-			sign_id = data->preset->get("application/code_sign_identity_release").operator String().is_empty() ? "iPhone Distribution" : data->preset->get("application/code_sign_identity_release");
+			sign_id = data->preset->get("application/code_sign_identity_release").operator String().is_empty_string() ? "iPhone Distribution" : data->preset->get("application/code_sign_identity_release");
 		}
 
 		List<String> codesign_args;
@@ -1277,7 +1277,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 					break;
 			}
 
-			if (key.is_empty() || value.is_empty()) {
+			if (key.is_empty_string() || value.is_empty_string()) {
 				continue;
 			}
 
@@ -1305,7 +1305,7 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 			String key = E.key;
 			String value = E.value;
 
-			if (key.is_empty() || value.is_empty()) {
+			if (key.is_empty_string() || value.is_empty_string()) {
 				continue;
 			}
 
@@ -1392,10 +1392,10 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 		src_pkg_name = p_preset->get("custom_template/release");
 	}
 
-	if (src_pkg_name.is_empty()) {
+	if (src_pkg_name.is_empty_string()) {
 		String err;
 		src_pkg_name = find_export_template("iphone.zip", &err);
-		if (src_pkg_name.is_empty()) {
+		if (src_pkg_name.is_empty_string()) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), TTR("Export template not found."));
 			return ERR_FILE_NOT_FOUND;
 		}
@@ -1825,12 +1825,12 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 	}
 
 	const String etc_error = test_etc2();
-	if (!etc_error.is_empty()) {
+	if (!etc_error.is_empty_string()) {
 		valid = false;
 		err += etc_error;
 	}
 
-	if (!err.is_empty()) {
+	if (!err.is_empty_string()) {
 		r_error = err;
 	}
 

--- a/platform/iphone/export/export_plugin.h
+++ b/platform/iphone/export/export_plugin.h
@@ -218,7 +218,7 @@ public:
 			da->list_dir_begin();
 			while (true) {
 				String file = da->get_next();
-				if (file.is_empty()) {
+				if (file.is_empty_string()) {
 					break;
 				}
 

--- a/platform/iphone/export/godot_plugin_config.cpp
+++ b/platform/iphone/export/godot_plugin_config.cpp
@@ -37,7 +37,7 @@
 String PluginConfigIOS::resolve_local_dependency_path(String plugin_config_dir, String dependency_path) {
 	String absolute_path;
 
-	if (dependency_path.is_empty()) {
+	if (dependency_path.is_empty_string()) {
 		return absolute_path;
 	}
 
@@ -54,7 +54,7 @@ String PluginConfigIOS::resolve_local_dependency_path(String plugin_config_dir, 
 String PluginConfigIOS::resolve_system_dependency_path(String dependency_path) {
 	String absolute_path;
 
-	if (dependency_path.is_empty()) {
+	if (dependency_path.is_empty_string()) {
 		return absolute_path;
 	}
 
@@ -73,7 +73,7 @@ Vector<String> PluginConfigIOS::resolve_local_dependencies(String plugin_config_
 	for (int i = 0; i < p_paths.size(); i++) {
 		String path = resolve_local_dependency_path(plugin_config_dir, p_paths[i]);
 
-		if (path.is_empty()) {
+		if (path.is_empty_string()) {
 			continue;
 		}
 
@@ -89,7 +89,7 @@ Vector<String> PluginConfigIOS::resolve_system_dependencies(Vector<String> p_pat
 	for (int i = 0; i < p_paths.size(); i++) {
 		String path = resolve_system_dependency_path(p_paths[i]);
 
-		if (path.is_empty()) {
+		if (path.is_empty_string()) {
 			continue;
 		}
 
@@ -100,10 +100,10 @@ Vector<String> PluginConfigIOS::resolve_system_dependencies(Vector<String> p_pat
 }
 
 bool PluginConfigIOS::validate_plugin(PluginConfigIOS &plugin_config) {
-	bool valid_name = !plugin_config.name.is_empty();
-	bool valid_binary_name = !plugin_config.binary.is_empty();
-	bool valid_initialize = !plugin_config.initialization_method.is_empty();
-	bool valid_deinitialize = !plugin_config.deinitialization_method.is_empty();
+	bool valid_name = !plugin_config.name.is_empty_string();
+	bool valid_binary_name = !plugin_config.binary.is_empty_string();
+	bool valid_initialize = !plugin_config.initialization_method.is_empty_string();
+	bool valid_deinitialize = !plugin_config.deinitialization_method.is_empty_string();
 
 	bool fields_value = valid_name && valid_binary_name && valid_initialize && valid_deinitialize;
 
@@ -236,7 +236,7 @@ PluginConfigIOS PluginConfigIOS::load_plugin_config(Ref<ConfigFile> config_file,
 				}
 			}
 
-			if (key_value.is_empty() || key_type == PluginConfigIOS::PlistItemType::UNKNOWN) {
+			if (key_value.is_empty_string() || key_type == PluginConfigIOS::PlistItemType::UNKNOWN) {
 				continue;
 			}
 

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -306,7 +306,7 @@ void DisplayServerJavaScript::tts_speak(const String &p_text, const String &p_vo
 		tts_stop();
 	}
 
-	if (p_text.is_empty()) {
+	if (p_text.is_empty_string()) {
 		tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_CANCELED, p_utterance_id);
 		return;
 	}

--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -164,7 +164,7 @@ Error EditorExportPlatformJavaScript::_add_manifest_icon(const String &p_path, c
 	const String icon_dest = p_path.get_base_dir().plus_file(icon_name);
 
 	Ref<Image> icon;
-	if (!p_icon.is_empty()) {
+	if (!p_icon.is_empty_string()) {
 		icon.instantiate();
 		const Error err = ImageLoader::load_image(p_icon, icon);
 		if (err != OK) {
@@ -193,7 +193,7 @@ Error EditorExportPlatformJavaScript::_add_manifest_icon(const String &p_path, c
 
 Error EditorExportPlatformJavaScript::_build_pwa(const Ref<EditorExportPreset> &p_preset, const String p_path, const Vector<SharedObject> &p_shared_objects) {
 	String proj_name = ProjectSettings::get_singleton()->get_setting("application/config/name");
-	if (proj_name.is_empty()) {
+	if (proj_name.is_empty_string()) {
 		proj_name = "Godot Game";
 	}
 
@@ -252,7 +252,7 @@ Error EditorExportPlatformJavaScript::_build_pwa(const Ref<EditorExportPreset> &
 
 	// Custom offline page
 	const String offline_page = p_preset->get("progressive_web_app/offline_page");
-	if (!offline_page.is_empty()) {
+	if (!offline_page.is_empty_string()) {
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		const String offline_dest = dir.plus_file(name + ".offline.html");
 		err = da->copy(ProjectSettings::get_singleton()->globalize_path(offline_page), offline_dest);
@@ -399,13 +399,13 @@ bool EditorExportPlatformJavaScript::can_export(const Ref<EditorExportPreset> &p
 
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
 		String etc_error = test_etc2();
-		if (!etc_error.is_empty()) {
+		if (!etc_error.is_empty_string()) {
 			valid = false;
 			err += etc_error;
 		}
 	}
 
-	if (!err.is_empty()) {
+	if (!err.is_empty_string()) {
 		r_error = err;
 	}
 
@@ -434,7 +434,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 	// Find the correct template
 	String template_path = p_debug ? custom_debug : custom_release;
 	template_path = template_path.strip_edges();
-	if (template_path.is_empty()) {
+	if (template_path.is_empty_string()) {
 		ExportMode mode = (ExportMode)(int)p_preset->get("variant/export_type");
 		template_path = find_export_template(_get_template_name(mode, p_debug));
 	}
@@ -443,7 +443,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 		return ERR_FILE_BAD_PATH;
 	}
 
-	if (!template_path.is_empty() && !FileAccess::exists(template_path)) {
+	if (!template_path.is_empty_string() && !FileAccess::exists(template_path)) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), vformat(TTR("Template file not found: \"%s\"."), template_path));
 		return ERR_FILE_NOT_FOUND;
 	}
@@ -487,7 +487,7 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 	}
 
 	// Read the HTML shell file (custom or from template).
-	const String html_path = custom_html.is_empty() ? base_path + ".html" : custom_html;
+	const String html_path = custom_html.is_empty_string() ? base_path + ".html" : custom_html;
 	Vector<uint8_t> html;
 	f = FileAccess::open(html_path, FileAccess::READ);
 	if (f.is_null()) {

--- a/platform/javascript/export/export_plugin.h
+++ b/platform/javascript/export/export_plugin.h
@@ -84,7 +84,7 @@ class EditorExportPlatformJavaScript : public EditorExportPlatform {
 		Ref<Image> icon;
 		icon.instantiate();
 		const String icon_path = String(GLOBAL_GET("application/config/icon")).strip_edges();
-		if (icon_path.is_empty() || ImageLoader::load_image(icon_path, icon) != OK) {
+		if (icon_path.is_empty_string() || ImageLoader::load_image(icon_path, icon) != OK) {
 			return EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("DefaultProjectIcon"), SNAME("EditorIcons"))->get_image();
 		}
 		return icon;
@@ -94,7 +94,7 @@ class EditorExportPlatformJavaScript : public EditorExportPlatform {
 		Ref<Image> splash;
 		splash.instantiate();
 		const String splash_path = String(GLOBAL_GET("application/boot_splash/image")).strip_edges();
-		if (splash_path.is_empty() || ImageLoader::load_image(splash_path, splash) != OK) {
+		if (splash_path.is_empty_string() || ImageLoader::load_image(splash_path, splash) != OK) {
 			return Ref<Image>(memnew(Image(boot_splash_png)));
 		}
 		return splash;

--- a/platform/javascript/export/export_server.h
+++ b/platform/javascript/export/export_server.h
@@ -106,7 +106,7 @@ public:
 			if (crypto.is_null()) {
 				return ERR_UNAVAILABLE;
 			}
-			if (!p_ssl_key.is_empty() && !p_ssl_cert.is_empty()) {
+			if (!p_ssl_key.is_empty_string() && !p_ssl_cert.is_empty_string()) {
 				key = Ref<CryptoKey>(CryptoKey::create());
 				Error err = key->load(p_ssl_key);
 				ERR_FAIL_COND_V(err != OK, err);

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -83,7 +83,7 @@ Error HTTPClientJavaScript::request(Method p_method, const String &p_url, const 
 	ERR_FAIL_INDEX_V(p_method, METHOD_MAX, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V_MSG(p_method == METHOD_TRACE || p_method == METHOD_CONNECT, ERR_UNAVAILABLE, "HTTP methods TRACE and CONNECT are not supported for the HTML5 platform.");
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V(host.is_empty(), ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(host.is_empty_string(), ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(port < 0, ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(!p_url.begins_with("/"), ERR_INVALID_PARAMETER);
 

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -72,7 +72,7 @@ static void handle_crash(int sig) {
 	print_error(vformat("%s: Program crashed with signal %d", __FUNCTION__, sig));
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
-	if (String(VERSION_HASH).is_empty()) {
+	if (String(VERSION_HASH).is_empty_string()) {
 		print_error(vformat("Engine version: %s", VERSION_FULL_NAME));
 	} else {
 		print_error(vformat("Engine version: %s (%s)", VERSION_FULL_NAME, VERSION_HASH));

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -450,7 +450,7 @@ void DisplayServerX11::clipboard_set(const String &p_text) {
 
 void DisplayServerX11::clipboard_set_primary(const String &p_text) {
 	_THREAD_SAFE_METHOD_
-	if (!p_text.is_empty()) {
+	if (!p_text.is_empty_string()) {
 		{
 			// The clipboard content can be accessed while polling for events.
 			MutexLock mutex_lock(events_mutex);
@@ -622,7 +622,7 @@ String DisplayServerX11::_clipboard_get(Atom p_source, Window x11_window) const 
 	if (utf8_atom != None) {
 		ret = _clipboard_get_impl(p_source, x11_window, utf8_atom);
 	}
-	if (ret.is_empty()) {
+	if (ret.is_empty_string()) {
 		ret = _clipboard_get_impl(p_source, x11_window, XA_STRING);
 	}
 	return ret;
@@ -634,7 +634,7 @@ String DisplayServerX11::clipboard_get() const {
 	String ret;
 	ret = _clipboard_get(XInternAtom(x11_display, "CLIPBOARD", 0), windows[MAIN_WINDOW_ID].x11_window);
 
-	if (ret.is_empty()) {
+	if (ret.is_empty_string()) {
 		ret = _clipboard_get(XA_PRIMARY, windows[MAIN_WINDOW_ID].x11_window);
 	}
 
@@ -647,7 +647,7 @@ String DisplayServerX11::clipboard_get_primary() const {
 	String ret;
 	ret = _clipboard_get(XInternAtom(x11_display, "PRIMARY", 0), windows[MAIN_WINDOW_ID].x11_window);
 
-	if (ret.is_empty()) {
+	if (ret.is_empty_string()) {
 		ret = _clipboard_get(XA_PRIMARY, windows[MAIN_WINDOW_ID].x11_window);
 	}
 

--- a/platform/linuxbsd/freedesktop_screensaver.cpp
+++ b/platform/linuxbsd/freedesktop_screensaver.cpp
@@ -57,7 +57,7 @@ void FreeDesktopScreenSaver::inhibit() {
 
 	String app_name_string = ProjectSettings::get_singleton()->get("application/config/name");
 	CharString app_name_utf8 = app_name_string.utf8();
-	const char *app_name = app_name_string.is_empty() ? "Godot Engine" : app_name_utf8.get_data();
+	const char *app_name = app_name_string.is_empty_string() ? "Godot Engine" : app_name_utf8.get_data();
 
 	const char *reason = "Running Godot Engine project";
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -130,10 +130,10 @@ void OS_LinuxBSD::initialize_joypads() {
 
 String OS_LinuxBSD::get_unique_id() const {
 	static String machine_id;
-	if (machine_id.is_empty()) {
+	if (machine_id.is_empty_string()) {
 		Ref<FileAccess> f = FileAccess::open("/etc/machine-id", FileAccess::READ);
 		if (f.is_valid()) {
-			while (machine_id.is_empty() && !f->eof_reached()) {
+			while (machine_id.is_empty_string() && !f->eof_reached()) {
 				machine_id = f->get_line().strip_edges();
 			}
 		}
@@ -520,7 +520,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	String mnt = get_mountpoint(path);
 
 	// If there is a directory "[Mountpoint]/.Trash-[UID], use it as the trash can.
-	if (!mnt.is_empty()) {
+	if (!mnt.is_empty_string()) {
 		String mountpoint_trash_path(mnt + "/.Trash-" + itos(getuid()));
 		struct stat s;
 		if (!stat(mountpoint_trash_path.utf8().get_data(), &s)) {
@@ -529,7 +529,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	}
 
 	// Otherwise, if ${XDG_DATA_HOME} is defined, use "${XDG_DATA_HOME}/Trash" as the trash can.
-	if (trash_path.is_empty()) {
+	if (trash_path.is_empty_string()) {
 		char *dhome = getenv("XDG_DATA_HOME");
 		if (dhome) {
 			trash_path = String::utf8(dhome) + "/Trash";
@@ -537,7 +537,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	}
 
 	// Otherwise, if ${HOME} is defined, use "${HOME}/.local/share/Trash" as the trash can.
-	if (trash_path.is_empty()) {
+	if (trash_path.is_empty_string()) {
 		char *home = getenv("HOME");
 		if (home) {
 			trash_path = String::utf8(home) + "/.local/share/Trash";
@@ -545,7 +545,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	}
 
 	// Issue an error if none of the previous locations is appropriate for the trash can.
-	ERR_FAIL_COND_V_MSG(trash_path.is_empty(), FAILED, "Could not determine the trash can location");
+	ERR_FAIL_COND_V_MSG(trash_path.is_empty_string(), FAILED, "Could not determine the trash can location");
 
 	// Create needed directories for decided trash can location.
 	{

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -184,7 +184,7 @@ void TTS_Linux::speak(const String &p_text, const String &p_voice, int p_volume,
 		stop();
 	}
 
-	if (p_text.is_empty()) {
+	if (p_text.is_empty_string()) {
 		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_CANCELED, p_utterance_id);
 		return;
 	}

--- a/platform/osx/export/codesign.cpp
+++ b/platform/osx/export/codesign.cpp
@@ -263,7 +263,7 @@ bool CodeSignCodeResources::add_nested_file(const String &p_root, const String &
 				}
 			}
 		}
-		if (req_string.is_empty()) {
+		if (req_string.is_empty_string()) {
 			req_string = "cdhash H\"" + String::hex_encode_buffer(hash.ptr(), hash.size()) + "\"";
 		}
 		print_verbose(vformat("CodeSign/CodeResources: Nested object %s (cputype: %d) cdhash:%s designated rq:%s", f.name, mh.get_cputype(), f.hash, req_string));
@@ -317,7 +317,7 @@ bool CodeSignCodeResources::add_folder_recursive(const String &p_root, const Str
 					main_exe = path;
 					bundle = true;
 				}
-				if (bundle && found == CRMatch::CR_MATCH_NESTED && !info_path.is_empty()) {
+				if (bundle && found == CRMatch::CR_MATCH_NESTED && !info_path.is_empty_string()) {
 					// Read Info.plist.
 					PList info_plist;
 					if (info_plist.load_file(info_path)) {
@@ -390,12 +390,12 @@ bool CodeSignCodeResources::save_to_file(const String &p_path) {
 	pl.get_root()->push_subnode(rules1_dict, "rules");
 	for (int i = 0; i < rules1.size(); i++) {
 		if (rules1[i].store) {
-			if (rules1[i].key.is_empty() && rules1[i].weight <= 0) {
+			if (rules1[i].key.is_empty_string() && rules1[i].weight <= 0) {
 				rules1_dict->push_subnode(PListNode::new_bool(true), rules1[i].file_pattern);
 			} else {
 				Ref<PListNode> rule_dict = PListNode::new_dict();
 				rules1_dict->push_subnode(rule_dict, rules1[i].file_pattern);
-				if (!rules1[i].key.is_empty()) {
+				if (!rules1[i].key.is_empty_string()) {
 					rule_dict->push_subnode(PListNode::new_bool(true), rules1[i].key);
 				}
 				if (rules1[i].weight != 1) {
@@ -410,12 +410,12 @@ bool CodeSignCodeResources::save_to_file(const String &p_path) {
 	pl.get_root()->push_subnode(rules2_dict, "rules2");
 	for (int i = 0; i < rules2.size(); i++) {
 		if (rules2[i].store) {
-			if (rules2[i].key.is_empty() && rules2[i].weight <= 0) {
+			if (rules2[i].key.is_empty_string() && rules2[i].weight <= 0) {
 				rules2_dict->push_subnode(PListNode::new_bool(true), rules2[i].file_pattern);
 			} else {
 				Ref<PListNode> rule_dict = PListNode::new_dict();
 				rules2_dict->push_subnode(rule_dict, rules2[i].file_pattern);
-				if (!rules2[i].key.is_empty()) {
+				if (!rules2[i].key.is_empty_string()) {
 					rule_dict->push_subnode(PListNode::new_bool(true), rules2[i].key);
 				}
 				if (rules2[i].weight != 1) {
@@ -425,7 +425,7 @@ bool CodeSignCodeResources::save_to_file(const String &p_path) {
 		}
 	}
 	String text = pl.save_text();
-	ERR_FAIL_COND_V_MSG(text.is_empty(), false, "CodeSign/CodeResources: Generating resources PList failed.");
+	ERR_FAIL_COND_V_MSG(text.is_empty_string(), false, "CodeSign/CodeResources: Generating resources PList failed.");
 
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("CodeSign/CodeResources: Can't open file: \"%s\".", p_path));
@@ -1210,7 +1210,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 	}
 
 	// Read Info.plist.
-	if (!p_info.is_empty()) {
+	if (!p_info.is_empty_string()) {
 		print_verbose(vformat("CodeSign: Reading bundle info..."));
 		PList info_plist;
 		if (info_plist.load_file(p_info)) {
@@ -1283,7 +1283,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 	}
 
 	// Generate core resources.
-	if (!p_bundle_path.is_empty()) {
+	if (!p_bundle_path.is_empty_string()) {
 		print_verbose(vformat("CodeSign: Generating bundle CodeResources..."));
 		CodeSignCodeResources cr;
 
@@ -1355,7 +1355,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 	}
 
 	// Generate common signature structures.
-	if (id.is_empty()) {
+	if (id.is_empty_string()) {
 		CryptoCore::RandomGenerator rng;
 		ERR_FAIL_COND_V_MSG(rng.init(), FAILED, "Failed to initialize random number generator.");
 		uint8_t uuid[16];
@@ -1370,9 +1370,9 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 
 	Ref<CodeSignEntitlementsText> cet;
 	Ref<CodeSignEntitlementsBinary> ceb;
-	if (!p_ent_path.is_empty()) {
+	if (!p_ent_path.is_empty_string()) {
 		String entitlements = FileAccess::get_file_as_string(p_ent_path);
-		if (entitlements.is_empty()) {
+		if (entitlements.is_empty_string()) {
 			CLEANUP();
 			r_error_msg = TTR("Invalid entitlements file.");
 			ERR_FAIL_V_MSG(FAILED, "CodeSign: Invalid entitlements file.");

--- a/platform/osx/export/export_plugin.cpp
+++ b/platform/osx/export/export_plugin.cpp
@@ -347,51 +347,51 @@ void EditorExportPlatformOSX::_fix_plist(const Ref<EditorExportPreset> &p_preset
 			strnew += lines[i].replace("$highres", p_preset->get("display/high_res") ? "\t<true/>" : "\t<false/>") + "\n";
 		} else if (lines[i].find("$usage_descriptions") != -1) {
 			String descriptions;
-			if (!((String)p_preset->get("privacy/microphone_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/microphone_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSMicrophoneUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/microphone_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/camera_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/camera_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSCameraUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/camera_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/location_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/location_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSLocationUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/location_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/address_book_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/address_book_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSContactsUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/address_book_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/calendar_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/calendar_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSCalendarsUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/calendar_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/photos_library_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/photos_library_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSPhotoLibraryUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/photos_library_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/desktop_folder_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/desktop_folder_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSDesktopFolderUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/desktop_folder_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/documents_folder_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/documents_folder_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSDocumentsFolderUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/documents_folder_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/downloads_folder_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/downloads_folder_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSDownloadsFolderUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/downloads_folder_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/network_volumes_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/network_volumes_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSNetworkVolumesUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/network_volumes_usage_description") + "</string>\n";
 			}
-			if (!((String)p_preset->get("privacy/removable_volumes_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/removable_volumes_usage_description")).is_empty_string()) {
 				descriptions += "\t<key>NSRemovableVolumesUsageDescription</key>\n";
 				descriptions += "\t<string>" + (String)p_preset->get("privacy/removable_volumes_usage_description") + "</string>\n";
 			}
-			if (!descriptions.is_empty()) {
+			if (!descriptions.is_empty_string()) {
 				strnew += lines[i].replace("$usage_descriptions", descriptions);
 			}
 		} else {
@@ -526,7 +526,7 @@ Error EditorExportPlatformOSX::_code_sign(const Ref<EditorExportPreset> &p_prese
 		PackedStringArray user_args = p_preset->get("codesign/custom_options");
 		for (int i = 0; i < user_args.size(); i++) {
 			String user_arg = user_args[i].strip_edges();
-			if (!user_arg.is_empty()) {
+			if (!user_arg.is_empty_string()) {
 				args.push_back(user_arg);
 			}
 		}
@@ -634,7 +634,7 @@ Error EditorExportPlatformOSX::_copy_and_sign_files(Ref<DirAccess> &dir_access, 
 		err = dir_access->copy(p_src_path, p_in_app_path);
 	}
 	if (err == OK && p_sign_enabled) {
-		if (dir_access->dir_exists(p_src_path) && p_src_path.get_extension().is_empty()) {
+		if (dir_access->dir_exists(p_src_path) && p_src_path.get_extension().is_empty_string()) {
 			// If it is a directory, find and sign all dynamic libraries.
 			err = _code_sign_directory(p_preset, p_in_app_path, p_ent_path, p_should_error_on_non_code_sign);
 		} else {
@@ -726,10 +726,10 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		src_pkg_name = p_preset->get("custom_template/release");
 	}
 
-	if (src_pkg_name.is_empty()) {
+	if (src_pkg_name.is_empty_string()) {
 		String err;
 		src_pkg_name = find_export_template("osx.zip", &err);
-		if (src_pkg_name.is_empty()) {
+		if (src_pkg_name.is_empty_string()) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), TTR("Export template not found."));
 			return ERR_FILE_NOT_FOUND;
 		}
@@ -870,37 +870,37 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			f->store_line("/* Localized versions of Info.plist keys */");
 			f->store_line("");
 			f->store_line("CFBundleDisplayName = \"" + ProjectSettings::get_singleton()->get("application/config/name").operator String() + "\";");
-			if (!((String)p_preset->get("privacy/microphone_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/microphone_usage_description")).is_empty_string()) {
 				f->store_line("NSMicrophoneUsageDescription = \"" + p_preset->get("privacy/microphone_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/camera_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/camera_usage_description")).is_empty_string()) {
 				f->store_line("NSCameraUsageDescription = \"" + p_preset->get("privacy/camera_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/location_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/location_usage_description")).is_empty_string()) {
 				f->store_line("NSLocationUsageDescription = \"" + p_preset->get("privacy/location_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/address_book_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/address_book_usage_description")).is_empty_string()) {
 				f->store_line("NSContactsUsageDescription = \"" + p_preset->get("privacy/address_book_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/calendar_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/calendar_usage_description")).is_empty_string()) {
 				f->store_line("NSCalendarsUsageDescription = \"" + p_preset->get("privacy/calendar_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/photos_library_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/photos_library_usage_description")).is_empty_string()) {
 				f->store_line("NSPhotoLibraryUsageDescription = \"" + p_preset->get("privacy/photos_library_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/desktop_folder_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/desktop_folder_usage_description")).is_empty_string()) {
 				f->store_line("NSDesktopFolderUsageDescription = \"" + p_preset->get("privacy/desktop_folder_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/documents_folder_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/documents_folder_usage_description")).is_empty_string()) {
 				f->store_line("NSDocumentsFolderUsageDescription = \"" + p_preset->get("privacy/documents_folder_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/downloads_folder_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/downloads_folder_usage_description")).is_empty_string()) {
 				f->store_line("NSDownloadsFolderUsageDescription = \"" + p_preset->get("privacy/downloads_folder_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/network_volumes_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/network_volumes_usage_description")).is_empty_string()) {
 				f->store_line("NSNetworkVolumesUsageDescription = \"" + p_preset->get("privacy/network_volumes_usage_description").operator String() + "\";");
 			}
-			if (!((String)p_preset->get("privacy/removable_volumes_usage_description")).is_empty()) {
+			if (!((String)p_preset->get("privacy/removable_volumes_usage_description")).is_empty_string()) {
 				f->store_line("NSRemovableVolumesUsageDescription = \"" + p_preset->get("privacy/removable_volumes_usage_description").operator String() + "\";");
 			}
 			f->store_line("NSHumanReadableCopyright = \"" + p_preset->get("application/copyright").operator String() + "\";");
@@ -1034,7 +1034,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 				iconpath = ProjectSettings::get_singleton()->get("application/config/icon");
 			}
 
-			if (!iconpath.is_empty()) {
+			if (!iconpath.is_empty_string()) {
 				if (iconpath.get_extension() == "icns") {
 					Ref<FileAccess> icon = FileAccess::open(iconpath, FileAccess::READ);
 					if (icon.is_valid()) {
@@ -1134,7 +1134,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 
 		String ent_path = p_preset->get("codesign/entitlements/custom_file");
 		String hlp_ent_path = EditorPaths::get_singleton()->get_cache_dir().plus_file(pkg_name + "_helper.entitlements");
-		if (sign_enabled && (ent_path.is_empty())) {
+		if (sign_enabled && (ent_path.is_empty_string())) {
 			ent_path = EditorPaths::get_singleton()->get_cache_dir().plus_file(pkg_name + ".entitlements");
 
 			Ref<FileAccess> ent_f = FileAccess::open(ent_path, FileAccess::WRITE);
@@ -1315,7 +1315,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			for (int i = 0; i < shared_objects.size(); i++) {
 				String src_path = ProjectSettings::get_singleton()->globalize_path(shared_objects[i].path);
-				if (shared_objects[i].target.is_empty()) {
+				if (shared_objects[i].target.is_empty_string()) {
 					String path_in_app = tmp_app_path_name + "/Contents/Frameworks/" + src_path.get_file();
 					err = _copy_and_sign_files(da, src_path, path_in_app, sign_enabled, p_preset, ent_path, true);
 				} else {
@@ -1420,12 +1420,12 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 }
 
 void EditorExportPlatformOSX::_zip_folder_recursive(zipFile &p_zip, const String &p_root_path, const String &p_folder, const String &p_pkg_name) {
-	String dir = p_folder.is_empty() ? p_root_path : p_root_path.plus_file(p_folder);
+	String dir = p_folder.is_empty_string() ? p_root_path : p_root_path.plus_file(p_folder);
 
 	Ref<DirAccess> da = DirAccess::open(dir);
 	da->list_dir_begin();
 	String f = da->get_next();
-	while (!f.is_empty()) {
+	while (!f.is_empty_string()) {
 		if (f == "." || f == "..") {
 			f = da->get_next();
 			continue;
@@ -1632,33 +1632,33 @@ bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset
 #endif
 
 	if (sign_enabled) {
-		if ((bool)p_preset->get("codesign/entitlements/audio_input") && ((String)p_preset->get("privacy/microphone_usage_description")).is_empty()) {
+		if ((bool)p_preset->get("codesign/entitlements/audio_input") && ((String)p_preset->get("privacy/microphone_usage_description")).is_empty_string()) {
 			err += TTR("Privacy: Microphone access is enabled, but usage description is not specified.") + "\n";
 			valid = false;
 		}
-		if ((bool)p_preset->get("codesign/entitlements/camera") && ((String)p_preset->get("privacy/camera_usage_description")).is_empty()) {
+		if ((bool)p_preset->get("codesign/entitlements/camera") && ((String)p_preset->get("privacy/camera_usage_description")).is_empty_string()) {
 			err += TTR("Privacy: Camera access is enabled, but usage description is not specified.") + "\n";
 			valid = false;
 		}
-		if ((bool)p_preset->get("codesign/entitlements/location") && ((String)p_preset->get("privacy/location_usage_description")).is_empty()) {
+		if ((bool)p_preset->get("codesign/entitlements/location") && ((String)p_preset->get("privacy/location_usage_description")).is_empty_string()) {
 			err += TTR("Privacy: Location information access is enabled, but usage description is not specified.") + "\n";
 			valid = false;
 		}
-		if ((bool)p_preset->get("codesign/entitlements/address_book") && ((String)p_preset->get("privacy/address_book_usage_description")).is_empty()) {
+		if ((bool)p_preset->get("codesign/entitlements/address_book") && ((String)p_preset->get("privacy/address_book_usage_description")).is_empty_string()) {
 			err += TTR("Privacy: Address book access is enabled, but usage description is not specified.") + "\n";
 			valid = false;
 		}
-		if ((bool)p_preset->get("codesign/entitlements/calendars") && ((String)p_preset->get("privacy/calendar_usage_description")).is_empty()) {
+		if ((bool)p_preset->get("codesign/entitlements/calendars") && ((String)p_preset->get("privacy/calendar_usage_description")).is_empty_string()) {
 			err += TTR("Privacy: Calendar access is enabled, but usage description is not specified.") + "\n";
 			valid = false;
 		}
-		if ((bool)p_preset->get("codesign/entitlements/photos_library") && ((String)p_preset->get("privacy/photos_library_usage_description")).is_empty()) {
+		if ((bool)p_preset->get("codesign/entitlements/photos_library") && ((String)p_preset->get("privacy/photos_library_usage_description")).is_empty_string()) {
 			err += TTR("Privacy: Photo library access is enabled, but usage description is not specified.") + "\n";
 			valid = false;
 		}
 	}
 
-	if (!err.is_empty()) {
+	if (!err.is_empty_string()) {
 		r_error = err;
 	}
 	return valid;

--- a/platform/osx/export/plist.cpp
+++ b/platform/osx/export/plist.cpp
@@ -99,7 +99,7 @@ Ref<PListNode> PListNode::new_real(float p_real) {
 bool PListNode::push_subnode(const Ref<PListNode> &p_node, const String &p_key) {
 	ERR_FAIL_COND_V(p_node.is_null(), false);
 	if (data_type == PList::PLNodeType::PL_NODE_TYPE_DICT) {
-		ERR_FAIL_COND_V(p_key.is_empty(), false);
+		ERR_FAIL_COND_V(p_key.is_empty_string(), false);
 		ERR_FAIL_COND_V(data_dict.has(p_key), false);
 		data_dict[p_key] = p_node;
 		return true;
@@ -383,7 +383,7 @@ bool PList::load_string(const String &p_string) {
 		pos = open_token_e;
 
 		String token = p_string.substr(open_token_s + 1, open_token_e - open_token_s - 1);
-		if (token.is_empty()) {
+		if (token.is_empty_string()) {
 			ERR_FAIL_V_MSG(false, "PList: Invalid token name.");
 		}
 		String value;

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -265,7 +265,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 
 	Platform arch = (Platform)(int)p_preset->get("architecture/target");
 
-	if (src_appx.is_empty()) {
+	if (src_appx.is_empty_string()) {
 		String err, infix;
 		switch (arch) {
 			case ARM: {
@@ -283,7 +283,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 		} else {
 			src_appx = find_export_template("uwp" + infix + "release.zip", &err);
 		}
-		if (src_appx.is_empty()) {
+		if (src_appx.is_empty_string()) {
 			EditorNode::add_io_error(err);
 			return ERR_FILE_NOT_FOUND;
 		}
@@ -442,7 +442,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 #ifdef WINDOWS_ENABLED
 	// Sign with signtool
 	String signtool_path = EditorSettings::get_singleton()->get("export/uwp/signtool");
-	if (signtool_path.is_empty()) {
+	if (signtool_path.is_empty_string()) {
 		return OK;
 	}
 
@@ -463,7 +463,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 		cert_alg = p_preset->get("signing/algorithm");
 	}
 
-	if (cert_path.is_empty()) {
+	if (cert_path.is_empty_string()) {
 		return OK; // Certificate missing, don't try to sign
 	}
 

--- a/platform/uwp/export/export_plugin.h
+++ b/platform/uwp/export/export_plugin.h
@@ -97,7 +97,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 	};
 
 	bool _valid_resource_name(const String &p_name) const {
-		if (p_name.is_empty()) {
+		if (p_name.is_empty_string()) {
 			return false;
 		}
 		if (p_name.ends_with(".")) {
@@ -143,7 +143,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 	}
 
 	bool _valid_bgcolor(const String &p_color) const {
-		if (p_color.is_empty()) {
+		if (p_color.is_empty_string()) {
 			return true;
 		}
 		if (p_color.begins_with("#") && p_color.is_valid_html_color()) {
@@ -219,7 +219,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		String architecture = arch == ARM ? "arm" : (arch == X86 ? "x86" : "x64");
 		result = result.replace("$architecture$", architecture);
 
-		result = result.replace("$display_name$", String(p_preset->get("package/display_name")).is_empty() ? (String)ProjectSettings::get_singleton()->get("application/config/name") : String(p_preset->get("package/display_name")));
+		result = result.replace("$display_name$", String(p_preset->get("package/display_name")).is_empty_string() ? (String)ProjectSettings::get_singleton()->get("application/config/name") : String(p_preset->get("package/display_name")));
 
 		result = result.replace("$publisher_display_name$", p_preset->get("package/publisher_display_name"));
 		result = result.replace("$app_description$", p_preset->get("package/description"));
@@ -238,7 +238,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		}
 
 		String show_name_on_tiles = "";
-		if (!name_on_tiles.is_empty()) {
+		if (!name_on_tiles.is_empty_string()) {
 			show_name_on_tiles = "<uap:ShowNameOnTiles>\n" + name_on_tiles + "        </uap:ShowNameOnTiles>";
 		}
 
@@ -259,7 +259,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		}
 
 		String rotation_preference = "";
-		if (!rotations.is_empty()) {
+		if (!rotations.is_empty_string()) {
 			rotation_preference = "<uap:InitialRotationPreference>\n" + rotations + "        </uap:InitialRotationPreference>";
 		}
 
@@ -293,7 +293,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		}
 
 		String capabilities_string = "<Capabilities />";
-		if (!capabilities_elements.is_empty()) {
+		if (!capabilities_elements.is_empty_string()) {
 			capabilities_string = "<Capabilities>\n" + capabilities_elements + "  </Capabilities>";
 		}
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1749,7 +1749,7 @@ String DisplayServerWindows::keyboard_get_layout_name(int p_index) const {
 	GetKeyboardLayoutList(layout_count, layouts);
 
 	String ret = _get_full_layout_name_from_registry(layouts[p_index]); // Try reading full name from Windows registry, fallback to locale name if failed (e.g. on Wine).
-	if (ret.is_empty()) {
+	if (ret.is_empty_string()) {
 		WCHAR buf[LOCALE_NAME_MAX_LENGTH];
 		memset(buf, 0, LOCALE_NAME_MAX_LENGTH * sizeof(WCHAR));
 		LCIDToLocaleName(MAKELCID(LOWORD(layouts[p_index]), SORT_DEFAULT), buf, LOCALE_NAME_MAX_LENGTH, 0);

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -161,12 +161,12 @@ Error EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset
 	// On non-Windows we need WINE to run rcedit
 	String wine_path = EditorSettings::get_singleton()->get("export/windows/wine");
 
-	if (!wine_path.is_empty() && !FileAccess::exists(wine_path)) {
+	if (!wine_path.is_empty_string() && !FileAccess::exists(wine_path)) {
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Resources Modification"), vformat(TTR("Could not find wine executable at \"%s\"."), wine_path));
 		return ERR_FILE_NOT_FOUND;
 	}
 
-	if (wine_path.is_empty()) {
+	if (wine_path.is_empty_string()) {
 		wine_path = "wine"; // try to run wine from PATH
 	}
 #endif
@@ -183,39 +183,39 @@ Error EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset
 
 	List<String> args;
 	args.push_back(p_path);
-	if (!icon_path.is_empty()) {
+	if (!icon_path.is_empty_string()) {
 		args.push_back("--set-icon");
 		args.push_back(icon_path);
 	}
-	if (!file_verion.is_empty()) {
+	if (!file_verion.is_empty_string()) {
 		args.push_back("--set-file-version");
 		args.push_back(file_verion);
 	}
-	if (!product_version.is_empty()) {
+	if (!product_version.is_empty_string()) {
 		args.push_back("--set-product-version");
 		args.push_back(product_version);
 	}
-	if (!company_name.is_empty()) {
+	if (!company_name.is_empty_string()) {
 		args.push_back("--set-version-string");
 		args.push_back("CompanyName");
 		args.push_back(company_name);
 	}
-	if (!product_name.is_empty()) {
+	if (!product_name.is_empty_string()) {
 		args.push_back("--set-version-string");
 		args.push_back("ProductName");
 		args.push_back(product_name);
 	}
-	if (!file_description.is_empty()) {
+	if (!file_description.is_empty_string()) {
 		args.push_back("--set-version-string");
 		args.push_back("FileDescription");
 		args.push_back(file_description);
 	}
-	if (!copyright.is_empty()) {
+	if (!copyright.is_empty_string()) {
 		args.push_back("--set-version-string");
 		args.push_back("LegalCopyright");
 		args.push_back(copyright);
 	}
-	if (!trademarks.is_empty()) {
+	if (!trademarks.is_empty_string()) {
 		args.push_back("--set-version-string");
 		args.push_back("LegalTrademarks");
 		args.push_back(trademarks);
@@ -248,20 +248,20 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 
 #ifdef WINDOWS_ENABLED
 	String signtool_path = EditorSettings::get_singleton()->get("export/windows/signtool");
-	if (!signtool_path.is_empty() && !FileAccess::exists(signtool_path)) {
+	if (!signtool_path.is_empty_string() && !FileAccess::exists(signtool_path)) {
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), vformat(TTR("Could not find signtool executable at \"%s\"."), signtool_path));
 		return ERR_FILE_NOT_FOUND;
 	}
-	if (signtool_path.is_empty()) {
+	if (signtool_path.is_empty_string()) {
 		signtool_path = "signtool"; // try to run signtool from PATH
 	}
 #else
 	String signtool_path = EditorSettings::get_singleton()->get("export/windows/osslsigncode");
-	if (!signtool_path.is_empty() && !FileAccess::exists(signtool_path)) {
+	if (!signtool_path.is_empty_string() && !FileAccess::exists(signtool_path)) {
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), vformat(TTR("Could not find osslsigncode executable at \"%s\"."), signtool_path));
 		return ERR_FILE_NOT_FOUND;
 	}
-	if (signtool_path.is_empty()) {
+	if (signtool_path.is_empty_string()) {
 		signtool_path = "osslsigncode"; // try to run signtool from PATH
 	}
 #endif
@@ -361,7 +361,7 @@ Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_p
 	PackedStringArray user_args = p_preset->get("codesign/custom_options");
 	for (int i = 0; i < user_args.size(); i++) {
 		String user_arg = user_args[i].strip_edges();
-		if (!user_arg.is_empty()) {
+		if (!user_arg.is_empty_string()) {
 			args.push_back(user_arg);
 		}
 	}
@@ -416,19 +416,19 @@ bool EditorExportPlatformWindows::can_export(const Ref<EditorExportPreset> &p_pr
 	bool valid = EditorExportPlatformPC::can_export(p_preset, err, r_missing_templates);
 
 	String rcedit_path = EditorSettings::get_singleton()->get("export/windows/rcedit");
-	if (p_preset->get("application/modify_resources") && rcedit_path.is_empty()) {
+	if (p_preset->get("application/modify_resources") && rcedit_path.is_empty_string()) {
 		err += TTR("The rcedit tool must be configured in the Editor Settings (Export > Windows > Rcedit) to change the icon or app information data.") + "\n";
 	}
 
 	String icon_path = ProjectSettings::get_singleton()->globalize_path(p_preset->get("application/icon"));
-	if (!icon_path.is_empty() && !FileAccess::exists(icon_path)) {
+	if (!icon_path.is_empty_string() && !FileAccess::exists(icon_path)) {
 		err += TTR("Invalid icon path:") + " " + icon_path + "\n";
 	}
 
 	// Only non-negative integers can exist in the version string.
 
 	String file_version = p_preset->get("application/file_version");
-	if (!file_version.is_empty()) {
+	if (!file_version.is_empty_string()) {
 		PackedStringArray version_array = file_version.split(".", false);
 		if (version_array.size() != 4 || !version_array[0].is_valid_int() ||
 				!version_array[1].is_valid_int() || !version_array[2].is_valid_int() ||
@@ -438,7 +438,7 @@ bool EditorExportPlatformWindows::can_export(const Ref<EditorExportPreset> &p_pr
 	}
 
 	String product_version = p_preset->get("application/product_version");
-	if (!product_version.is_empty()) {
+	if (!product_version.is_empty_string()) {
 		PackedStringArray version_array = product_version.split(".", false);
 		if (version_array.size() != 4 || !version_array[0].is_valid_int() ||
 				!version_array[1].is_valid_int() || !version_array[2].is_valid_int() ||
@@ -447,7 +447,7 @@ bool EditorExportPlatformWindows::can_export(const Ref<EditorExportPreset> &p_pr
 		}
 	}
 
-	if (!err.is_empty()) {
+	if (!err.is_empty_string()) {
 		r_error = err;
 	}
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -707,7 +707,7 @@ String OS_Windows::get_locale() const {
 		wl++;
 	}
 
-	if (!neutral.is_empty()) {
+	if (!neutral.is_empty_string()) {
 		return String(neutral).replace("-", "_");
 	}
 
@@ -867,7 +867,7 @@ String OS_Windows::get_data_path() const {
 
 String OS_Windows::get_cache_path() const {
 	static String cache_path_cache;
-	if (cache_path_cache.is_empty()) {
+	if (cache_path_cache.is_empty_string()) {
 		// The XDG Base Directory specification technically only applies on Linux/*BSD, but it doesn't hurt to support it on Windows as well.
 		if (has_environment("XDG_CACHE_HOME")) {
 			if (get_environment("XDG_CACHE_HOME").is_absolute_path()) {
@@ -876,13 +876,13 @@ String OS_Windows::get_cache_path() const {
 				WARN_PRINT_ONCE("`XDG_CACHE_HOME` is a relative path. Ignoring its value and falling back to `%LOCALAPPDATA%\\cache`, `%TEMP%` or `get_config_path()` per the XDG Base Directory specification.");
 			}
 		}
-		if (cache_path_cache.is_empty() && has_environment("LOCALAPPDATA")) {
+		if (cache_path_cache.is_empty_string() && has_environment("LOCALAPPDATA")) {
 			cache_path_cache = get_environment("LOCALAPPDATA").replace("\\", "/");
 		}
-		if (cache_path_cache.is_empty() && has_environment("TEMP")) {
+		if (cache_path_cache.is_empty_string() && has_environment("TEMP")) {
 			cache_path_cache = get_environment("TEMP").replace("\\", "/");
 		}
-		if (cache_path_cache.is_empty()) {
+		if (cache_path_cache.is_empty_string()) {
 			cache_path_cache = get_config_path();
 		}
 	}
@@ -934,11 +934,11 @@ String OS_Windows::get_system_dir(SystemDir p_dir, bool p_shared_storage) const 
 
 String OS_Windows::get_user_data_dir() const {
 	String appname = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/name"));
-	if (!appname.is_empty()) {
+	if (!appname.is_empty_string()) {
 		bool use_custom_dir = ProjectSettings::get_singleton()->get("application/config/use_custom_user_dir");
 		if (use_custom_dir) {
 			String custom_dir = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/custom_user_dir_name"), true);
-			if (custom_dir.is_empty()) {
+			if (custom_dir.is_empty_string()) {
 				custom_dir = appname;
 			}
 			return get_data_path().plus_file(custom_dir).replace("\\", "/");

--- a/platform/windows/tts_windows.cpp
+++ b/platform/windows/tts_windows.cpp
@@ -189,7 +189,7 @@ void TTS_Windows::speak(const String &p_text, const String &p_voice, int p_volum
 		stop();
 	}
 
-	if (p_text.is_empty()) {
+	if (p_text.is_empty_string()) {
 		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_CANCELED, p_utterance_id);
 		return;
 	}

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -128,7 +128,7 @@ void AnimatedSprite2D::_validate_property(PropertyInfo &property) const {
 		}
 
 		if (!current_found) {
-			if (property.hint_string.is_empty()) {
+			if (property.hint_string.is_empty_string()) {
 				property.hint_string = String(animation);
 			} else {
 				property.hint_string = String(animation) + "," + property.hint_string;

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -205,7 +205,7 @@ bool Joint2D::get_exclude_nodes_from_collision() const {
 TypedArray<String> Joint2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node2D::get_configuration_warnings();
 
-	if (!warning.is_empty()) {
+	if (!warning.is_empty_string()) {
 		warnings.push_back(warning);
 	}
 

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -91,7 +91,7 @@ void Joint3D::_update_joint(bool p_only_free) {
 
 	update_configuration_warnings();
 
-	if (!warning.is_empty()) {
+	if (!warning.is_empty_string()) {
 		PhysicsServer3D::get_singleton()->joint_clear(joint);
 		return;
 	}
@@ -201,7 +201,7 @@ bool Joint3D::get_exclude_nodes_from_collision() const {
 TypedArray<String> Joint3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node3D::get_configuration_warnings();
 
-	if (!warning.is_empty()) {
+	if (!warning.is_empty_string()) {
 		warnings.push_back(warning);
 	}
 

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -706,7 +706,7 @@ void LightmapGI::_gen_new_positions_from_octree(const GenProbesOctree *p_cell, f
 }
 
 LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_path, Lightmapper::BakeStepFunc p_bake_step, void *p_bake_userdata) {
-	if (p_image_data_path.is_empty()) {
+	if (p_image_data_path.is_empty_string()) {
 		if (get_light_data().is_null()) {
 			return BAKE_ERROR_NO_SAVE_PATH;
 		}

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -639,7 +639,7 @@ void OccluderInstance3D::bake_single_node(const Node3D *p_node, float p_simplifi
 }
 
 OccluderInstance3D::BakeError OccluderInstance3D::bake_scene(Node *p_from_node, String p_occluder_path) {
-	if (p_occluder_path.is_empty()) {
+	if (p_occluder_path.is_empty_string()) {
 		if (get_occluder().is_null()) {
 			return BAKE_ERROR_NO_SAVE_PATH;
 		}

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -496,7 +496,7 @@ int Skeleton3D::get_bone_axis_forward_enum(int p_bone) {
 // Skeleton creation api
 
 void Skeleton3D::add_bone(const String &p_name) {
-	ERR_FAIL_COND(p_name.is_empty() || p_name.contains(":") || p_name.contains("/"));
+	ERR_FAIL_COND(p_name.is_empty_string() || p_name.contains(":") || p_name.contains("/"));
 
 	for (int i = 0; i < bones.size(); i++) {
 		ERR_FAIL_COND(bones[i].name == p_name);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1024,7 +1024,7 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &property) const {
 		}
 
 		if (!current_found) {
-			if (property.hint_string.is_empty()) {
+			if (property.hint_string.is_empty_string()) {
 				property.hint_string = String(animation);
 			} else {
 				property.hint_string = String(animation) + "," + property.hint_string;

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -57,7 +57,7 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &property) const {
 			}
 			anims += String(names[i]);
 		}
-		if (!anims.is_empty()) {
+		if (!anims.is_empty_string()) {
 			property.hint = PROPERTY_HINT_ENUM;
 			property.hint_string = anims;
 		}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -52,7 +52,7 @@ void AnimationNodeStateMachineTransition::set_advance_condition(const StringName
 	String cs = p_condition;
 	ERR_FAIL_COND(cs.contains("/") || cs.contains(":"));
 	advance_condition = p_condition;
-	if (!cs.is_empty()) {
+	if (!cs.is_empty_string()) {
 		advance_condition_name = "conditions/" + cs;
 	} else {
 		advance_condition_name = StringName();

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1633,7 +1633,7 @@ bool AnimationPlayer::is_playing() const {
 }
 
 void AnimationPlayer::set_current_animation(const String &p_anim) {
-	if (p_anim == "[stop]" || p_anim.is_empty()) {
+	if (p_anim == "[stop]" || p_anim.is_empty_string()) {
 		stop();
 	} else if (!is_playing() || playback.assigned != p_anim) {
 		play(p_anim);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -139,7 +139,7 @@ double AnimationNode::_pre_process(const StringName &p_base_path, AnimationNode 
 void AnimationNode::make_invalid(const String &p_reason) {
 	ERR_FAIL_COND(!state);
 	state->valid = false;
-	if (!state->invalid_reasons.is_empty()) {
+	if (!state->invalid_reasons.is_empty_string()) {
 		state->invalid_reasons += "\n";
 	}
 	state->invalid_reasons += String::utf8("•  ") + p_reason;

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -334,7 +334,7 @@ void SceneDebugger::add_to_cache(const String &p_filename, Node *p_node) {
 		return;
 	}
 
-	if (EngineDebugger::get_script_debugger() && !p_filename.is_empty()) {
+	if (EngineDebugger::get_script_debugger() && !p_filename.is_empty_string()) {
 		debugger->live_scene_edit_cache[p_filename].insert(p_node);
 	}
 }
@@ -475,7 +475,7 @@ void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 
 		PropertyHint hint = pi.hint;
 		String hint_string = pi.hint_string;
-		if (!res.is_null() && !res->get_path().is_empty()) {
+		if (!res.is_null() && !res->get_path().is_empty_string()) {
 			var = res->get_path();
 		} else { //only send information that can be sent..
 			int len = 0; //test how big is this to encode

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -363,7 +363,7 @@ String BaseButton::get_tooltip(const Point2 &p_pos) const {
 	String tooltip = Control::get_tooltip(p_pos);
 	if (shortcut_in_tooltip && shortcut.is_valid() && shortcut->has_valid_event()) {
 		String text = shortcut->get_name() + " (" + shortcut->get_as_text() + ")";
-		if (!tooltip.is_empty() && shortcut->get_name().nocasecmp_to(tooltip) != 0) {
+		if (!tooltip.is_empty_string() && shortcut->get_name().nocasecmp_to(tooltip) != 0) {
 			text += "\n" + atr(tooltip);
 		}
 		tooltip = text;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -52,7 +52,7 @@ Size2 Button::get_minimum_size() const {
 
 			if (icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
 				minsize.width += _icon->get_width();
-				if (!xl_text.is_empty()) {
+				if (!xl_text.is_empty_string()) {
 					minsize.width += get_theme_constant(SNAME("h_separation"));
 				}
 			} else {
@@ -60,7 +60,7 @@ Size2 Button::get_minimum_size() const {
 			}
 		}
 	}
-	if (!xl_text.is_empty()) {
+	if (!xl_text.is_empty_string()) {
 		Ref<Font> font = get_theme_font(SNAME("font"));
 		float font_height = font->get_height(get_theme_font_size(SNAME("font_size")));
 		minsize.height = MAX(font_height, minsize.height);
@@ -258,7 +258,7 @@ void Button::_notification(int p_what) {
 
 				if (expand_icon) {
 					Size2 _size = get_size() - style->get_offset() * 2;
-					int icon_text_separation = text.is_empty() ? 0 : get_theme_constant(SNAME("h_separation"));
+					int icon_text_separation = text.is_empty_string() ? 0 : get_theme_constant(SNAME("h_separation"));
 					_size.width -= icon_text_separation + icon_ofs_region;
 					if (!clip_text && icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER) {
 						_size.width -= text_buf->get_size().width;
@@ -363,7 +363,7 @@ void Button::_shape() {
 	} else {
 		text_buf->set_direction((TextServer::Direction)text_direction);
 	}
-	text_buf->add_string(xl_text, font, font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
+	text_buf->add_string(xl_text, font, font_size, opentype_features, (!language.is_empty_string()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 	text_buf->set_text_overrun_behavior(overrun_behavior);
 }
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -192,7 +192,7 @@ void CodeEdit::_notification(int p_what) {
 			}
 
 			/* Code hint */
-			if (caret_visible && !code_hint.is_empty() && (!code_completion_active || (code_completion_below != code_hint_draw_below))) {
+			if (caret_visible && !code_hint.is_empty_string() && (!code_completion_active || (code_completion_below != code_hint_draw_below))) {
 				const int font_height = font->get_height(font_size);
 				Ref<StyleBox> sb = get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel"));
 				Color font_color = get_theme_color(SNAME("font_color"), SNAME("TooltipLabel"));
@@ -318,7 +318,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 		} else {
 			if (mb->get_button_index() == MouseButton::LEFT) {
-				if (mb->is_command_pressed() && !symbol_lookup_word.is_empty()) {
+				if (mb->is_command_pressed() && !symbol_lookup_word.is_empty_string()) {
 					Vector2i mpos = mb->get_position();
 					if (is_layout_rtl()) {
 						mpos.x = get_size().x - mpos.x;
@@ -477,7 +477,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	/* MISC */
-	if (!code_hint.is_empty() && k->is_action("ui_cancel", true)) {
+	if (!code_hint.is_empty_string() && k->is_action("ui_cancel", true)) {
 		set_code_hint("");
 		accept_event();
 		return;
@@ -538,7 +538,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 /* General overrides */
 Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
-	if (!symbol_lookup_word.is_empty()) {
+	if (!symbol_lookup_word.is_empty_string()) {
 		return CURSOR_POINTING_HAND;
 	}
 
@@ -596,7 +596,7 @@ void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode) {
 			insert_text_at_caret(chr);
 
 			String close_key = get_auto_brace_completion_close_key(chr);
-			if (!close_key.is_empty()) {
+			if (!close_key.is_empty_string()) {
 				insert_text_at_caret(selection_text + close_key);
 				set_caret_column(get_caret_column() - 1);
 			}
@@ -1009,7 +1009,7 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 			ins += indent_text;
 
 			String closing_pair = get_auto_brace_completion_close_key(String::chr(indent_char));
-			if (!closing_pair.is_empty() && line.find(closing_pair, cc) == cc) {
+			if (!closing_pair.is_empty_string() && line.find(closing_pair, cc) == cc) {
 				/* No need to move the brace below if we are not taking the text with us. */
 				if (p_split_current_line) {
 					brace_indent = true;
@@ -1072,8 +1072,8 @@ bool CodeEdit::is_highlight_matching_braces_enabled() const {
 }
 
 void CodeEdit::add_auto_brace_completion_pair(const String &p_open_key, const String &p_close_key) {
-	ERR_FAIL_COND_MSG(p_open_key.is_empty(), "auto brace completion open key cannot be empty");
-	ERR_FAIL_COND_MSG(p_close_key.is_empty(), "auto brace completion close key cannot be empty");
+	ERR_FAIL_COND_MSG(p_open_key.is_empty_string(), "auto brace completion open key cannot be empty");
+	ERR_FAIL_COND_MSG(p_close_key.is_empty_string(), "auto brace completion close key cannot be empty");
 
 	for (int i = 0; i < p_open_key.length(); i++) {
 		ERR_FAIL_COND_MSG(!is_symbol(p_open_key[i]), "auto brace completion open key must be a symbol");
@@ -1745,7 +1745,7 @@ void CodeEdit::set_code_completion_prefixes(const TypedArray<String> &p_prefixes
 	for (int i = 0; i < p_prefixes.size(); i++) {
 		const String prefix = p_prefixes[i];
 
-		ERR_CONTINUE_MSG(prefix.is_empty(), "Code completion prefix cannot be empty.");
+		ERR_CONTINUE_MSG(prefix.is_empty_string(), "Code completion prefix cannot be empty.");
 		code_completion_prefixes.insert(prefix[0]);
 	}
 }
@@ -2592,7 +2592,7 @@ int CodeEdit::_is_in_delimiter(int p_line, int p_column, DelimiterType p_type) c
 void CodeEdit::_add_delimiter(const String &p_start_key, const String &p_end_key, bool p_line_only, DelimiterType p_type) {
 	// If we are the editor allow "null" as a valid start key, otherwise users cannot add delimiters via the inspector.
 	if (!(Engine::get_singleton()->is_editor_hint() && p_start_key == "null")) {
-		ERR_FAIL_COND_MSG(p_start_key.is_empty(), "delimiter start key cannot be empty");
+		ERR_FAIL_COND_MSG(p_start_key.is_empty_string(), "delimiter start key cannot be empty");
 
 		for (int i = 0; i < p_start_key.length(); i++) {
 			ERR_FAIL_COND_MSG(!is_symbol(p_start_key[i]), "delimiter must start with a symbol");
@@ -2617,7 +2617,7 @@ void CodeEdit::_add_delimiter(const String &p_start_key, const String &p_end_key
 	delimiter.type = p_type;
 	delimiter.start_key = p_start_key;
 	delimiter.end_key = p_end_key;
-	delimiter.line_only = p_line_only || p_end_key.is_empty();
+	delimiter.line_only = p_line_only || p_end_key.is_empty_string();
 	delimiters.insert(at, delimiter);
 	if (!setting_delimiters) {
 		delimiter_cache.clear();
@@ -2660,14 +2660,14 @@ void CodeEdit::_set_delimiters(const TypedArray<String> &p_delimiters, Delimiter
 	for (int i = 0; i < p_delimiters.size(); i++) {
 		String key = p_delimiters[i];
 
-		if (key.is_empty()) {
+		if (key.is_empty_string()) {
 			continue;
 		}
 
 		const String start_key = key.get_slice(" ", 0);
 		const String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();
 
-		_add_delimiter(start_key, end_key, end_key.is_empty(), p_type);
+		_add_delimiter(start_key, end_key, end_key.is_empty_string(), p_type);
 	}
 	setting_delimiters = false;
 	_update_delimiter_cache();
@@ -2691,7 +2691,7 @@ TypedArray<String> CodeEdit::_get_delimiters(DelimiterType p_type) const {
 		if (delimiters[i].type != p_type) {
 			continue;
 		}
-		r_delimiters.push_back(delimiters[i].start_key + (delimiters[i].end_key.is_empty() ? "" : " " + delimiters[i].end_key));
+		r_delimiters.push_back(delimiters[i].start_key + (delimiters[i].end_key.is_empty_string() ? "" : " " + delimiters[i].end_key));
 	}
 	return r_delimiters;
 }
@@ -2815,7 +2815,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		prev_is_prefix = true;
 	}
 
-	if (!prev_is_word && string_to_complete.is_empty() && (cofs == 0 || !prev_is_prefix)) {
+	if (!prev_is_word && string_to_complete.is_empty_string() && (cofs == 0 || !prev_is_prefix)) {
 		cancel_code_completion();
 		return;
 	}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -524,25 +524,25 @@ void Control::_validate_property(PropertyInfo &property) const {
 				hint_string += "Fill:1";
 			}
 			if (size_flags.has(SIZE_EXPAND)) {
-				if (!hint_string.is_empty()) {
+				if (!hint_string.is_empty_string()) {
 					hint_string += ",";
 				}
 				hint_string += "Expand:2";
 			}
 			if (size_flags.has(SIZE_SHRINK_CENTER)) {
-				if (!hint_string.is_empty()) {
+				if (!hint_string.is_empty_string()) {
 					hint_string += ",";
 				}
 				hint_string += "Shrink Center:4";
 			}
 			if (size_flags.has(SIZE_SHRINK_END)) {
-				if (!hint_string.is_empty()) {
+				if (!hint_string.is_empty_string()) {
 					hint_string += ",";
 				}
 				hint_string += "Shrink End:8";
 			}
 
-			if (hint_string.is_empty()) {
+			if (hint_string.is_empty_string()) {
 				property.hint_string = "";
 				property.usage |= PROPERTY_USAGE_READ_ONLY;
 			} else {
@@ -3079,7 +3079,7 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 TypedArray<String> Control::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
-	if (data.mouse_filter == MOUSE_FILTER_IGNORE && !data.tooltip.is_empty()) {
+	if (data.mouse_filter == MOUSE_FILTER_IGNORE && !data.tooltip.is_empty_string()) {
 		warnings.push_back(RTR("The Hint Tooltip won't be displayed as the control's Mouse Filter is set to \"Ignore\". To solve this, set the Mouse Filter to \"Stop\" or \"Pass\"."));
 	}
 

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -171,7 +171,7 @@ void AcceptDialog::register_text_enter(Control *p_line_edit) {
 
 void AcceptDialog::_update_child_rects() {
 	Size2 label_size = label->get_minimum_size();
-	if (label->get_text().is_empty()) {
+	if (label->get_text().is_empty_string()) {
 		label_size.height = 0;
 	}
 	int margin = hbc->get_theme_constant(SNAME("margin"), SNAME("Dialogs"));
@@ -252,7 +252,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 		hbc->add_spacer(true);
 	}
 
-	if (!p_action.is_empty()) {
+	if (!p_action.is_empty_string()) {
 		button->connect("pressed", callable_mp(this, &AcceptDialog::_custom_action), varray(p_action));
 	}
 
@@ -261,7 +261,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 
 Button *AcceptDialog::add_cancel_button(const String &p_cancel) {
 	String c = p_cancel;
-	if (p_cancel.is_empty()) {
+	if (p_cancel.is_empty_string()) {
 		c = TTRC("Cancel");
 	}
 	Button *b = swap_cancel_ok ? add_button(c, true) : add_button(c);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -517,7 +517,7 @@ void FileDialog::update_file_list() {
 	bool is_hidden;
 	String item = dir_access->get_next();
 
-	while (!item.is_empty()) {
+	while (!item.is_empty_string()) {
 		if (item == "." || item == "..") {
 			item = dir_access->get_next();
 			continue;

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -471,7 +471,7 @@ void GraphNode::_shape() {
 	} else {
 		title_buf->set_direction((TextServer::Direction)text_direction);
 	}
-	title_buf->add_string(title, font, font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
+	title_buf->add_string(title, font, font_size, opentype_features, (!language.is_empty_string()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 #ifdef TOOLS_ENABLED

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -43,7 +43,7 @@ void ItemList::_shape(int p_idx) {
 	} else {
 		item.text_buf->set_direction((TextServer::Direction)item.text_direction);
 	}
-	item.text_buf->add_string(item.text, get_theme_font(SNAME("font")), get_theme_font_size(SNAME("font_size")), item.opentype_features, (!item.language.is_empty()) ? item.language : TranslationServer::get_singleton()->get_tool_locale());
+	item.text_buf->add_string(item.text, get_theme_font(SNAME("font")), get_theme_font_size(SNAME("font_size")), item.opentype_features, (!item.language.is_empty_string()) ? item.language : TranslationServer::get_singleton()->get_tool_locale());
 	if (icon_mode == ICON_MODE_TOP && max_text_lines > 0) {
 		item.text_buf->set_flags(TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::BREAK_GRAPHEME_BOUND);
 	} else {
@@ -696,7 +696,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (p_event->is_pressed() && items.size() > 0) {
 		if (p_event->is_action("ui_up")) {
-			if (!search_string.is_empty()) {
+			if (!search_string.is_empty_string()) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
 
@@ -734,7 +734,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				accept_event();
 			}
 		} else if (p_event->is_action("ui_down")) {
-			if (!search_string.is_empty()) {
+			if (!search_string.is_empty_string()) {
 				uint64_t now = OS::get_singleton()->get_ticks_msec();
 				uint64_t diff = now - search_time_msec;
 
@@ -1003,7 +1003,7 @@ void ItemList::_notification(int p_what) {
 							minsize = items[i].get_icon_size() * icon_scale;
 						}
 
-						if (!items[i].text.is_empty()) {
+						if (!items[i].text.is_empty_string()) {
 							if (icon_mode == ICON_MODE_TOP) {
 								minsize.y += icon_margin;
 							} else {
@@ -1012,7 +1012,7 @@ void ItemList::_notification(int p_what) {
 						}
 					}
 
-					if (!items[i].text.is_empty()) {
+					if (!items[i].text.is_empty_string()) {
 						int max_width = -1;
 						if (fixed_column_width) {
 							max_width = fixed_column_width;
@@ -1271,7 +1271,7 @@ void ItemList::_notification(int p_what) {
 					draw_texture(items[i].tag_icon, draw_pos + base_ofs);
 				}
 
-				if (!items[i].text.is_empty()) {
+				if (!items[i].text.is_empty_string()) {
 					int max_len = -1;
 
 					Vector2 size2 = items[i].text_buf->get_size();
@@ -1446,10 +1446,10 @@ String ItemList::get_tooltip(const Point2 &p_pos) const {
 		if (!items[closest].tooltip_enabled) {
 			return "";
 		}
-		if (!items[closest].tooltip.is_empty()) {
+		if (!items[closest].tooltip.is_empty_string()) {
 			return items[closest].tooltip;
 		}
-		if (!items[closest].text.is_empty()) {
+		if (!items[closest].text.is_empty_string()) {
 			return items[closest].text;
 		}
 	}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -83,7 +83,7 @@ void Label::_shape() {
 	int width = (get_size().width - style->get_minimum_size().width);
 
 	if (dirty || font_dirty) {
-		String lang = (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale();
+		String lang = (!language.is_empty_string()) ? language : TranslationServer::get_singleton()->get_tool_locale();
 		if (dirty) {
 			TS->shaped_text_clear(text_rid);
 		}

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -261,7 +261,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 			deselect();
 			set_caret_at_pixel_pos(b->get_position().x);
-			if (!paste_buffer.is_empty()) {
+			if (!paste_buffer.is_empty_string()) {
 				insert_text_at_caret(paste_buffer);
 
 				if (!text_changed_dirty) {
@@ -282,7 +282,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		_reset_caret_blink_timer();
 		if (b->is_pressed()) {
 			accept_event(); // don't pass event further when clicked on text field
-			if (!text.is_empty() && is_editable() && _is_over_clear_button(b->get_position())) {
+			if (!text.is_empty_string() && is_editable() && _is_over_clear_button(b->get_position())) {
 				clear_button_status.press_attempt = true;
 				clear_button_status.pressing_inside = true;
 				update();
@@ -354,7 +354,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (selection.enabled && !pass && b->get_button_index() == MouseButton::LEFT && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIPBOARD_PRIMARY)) {
 				DisplayServer::get_singleton()->clipboard_set_primary(text.substr(selection.begin, selection.end - selection.begin));
 			}
-			if (!text.is_empty() && is_editable() && clear_button_enabled) {
+			if (!text.is_empty_string() && is_editable() && clear_button_enabled) {
 				bool press_attempt = clear_button_status.press_attempt;
 				clear_button_status.press_attempt = false;
 				if (press_attempt && clear_button_status.pressing_inside && _is_over_clear_button(b->get_position())) {
@@ -381,7 +381,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseMotion> m = p_event;
 
 	if (m.is_valid()) {
-		if (!text.is_empty() && is_editable() && clear_button_enabled) {
+		if (!text.is_empty_string() && is_editable() && clear_button_enabled) {
 			bool last_press_inside = clear_button_status.pressing_inside;
 			clear_button_status.pressing_inside = clear_button_status.press_attempt && _is_over_clear_button(m->get_position());
 			if (last_press_inside != clear_button_status.pressing_inside) {
@@ -684,7 +684,7 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 }
 
 Control::CursorShape LineEdit::get_cursor_shape(const Point2 &p_pos) const {
-	if ((!text.is_empty() && is_editable() && _is_over_clear_button(p_pos)) || (!is_editable() && (!is_selecting_enabled() || text.is_empty()))) {
+	if ((!text.is_empty_string() && is_editable() && _is_over_clear_button(p_pos)) || (!is_editable() && (!is_selecting_enabled() || text.is_empty_string()))) {
 		return CURSOR_ARROW;
 	}
 	return Control::get_cursor_shape(p_pos);
@@ -774,7 +774,7 @@ void LineEdit::_notification(int p_what) {
 			}
 
 			int x_ofs = 0;
-			bool using_placeholder = text.is_empty() && ime_text.is_empty();
+			bool using_placeholder = text.is_empty_string() && ime_text.is_empty_string();
 			float text_width = TS->shaped_text_get_size(text_rid).x;
 			float text_height = TS->shaped_text_get_size(text_rid).y + font->get_spacing(TextServer::SPACING_TOP) + font->get_spacing(TextServer::SPACING_BOTTOM);
 
@@ -1086,7 +1086,7 @@ void LineEdit::paste_text() {
 	// Strip escape characters like \n and \t as they can't be displayed on LineEdit.
 	String paste_buffer = DisplayServer::get_singleton()->clipboard_get().strip_escapes();
 
-	if (!paste_buffer.is_empty()) {
+	if (!paste_buffer.is_empty_string()) {
 		int prev_len = text.length();
 		if (selection.enabled) {
 			selection_delete();
@@ -1209,7 +1209,7 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 		} break;
 	}
 
-	bool using_placeholder = text.is_empty() && ime_text.is_empty();
+	bool using_placeholder = text.is_empty_string() && ime_text.is_empty_string();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
@@ -1257,7 +1257,7 @@ Vector2i LineEdit::get_caret_pixel_pos() {
 		} break;
 	}
 
-	bool using_placeholder = text.is_empty() && ime_text.is_empty();
+	bool using_placeholder = text.is_empty_string() && ime_text.is_empty_string();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
@@ -1594,7 +1594,7 @@ void LineEdit::set_caret_column(int p_column) {
 	}
 
 	int ofs_max = get_size().width - style->get_margin(SIDE_RIGHT);
-	bool using_placeholder = text.is_empty() && ime_text.is_empty();
+	bool using_placeholder = text.is_empty_string() && ime_text.is_empty_string();
 	bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
@@ -2142,7 +2142,7 @@ void LineEdit::_shape() {
 	const Ref<Font> &font = get_theme_font(SNAME("font"));
 	int font_size = get_theme_font_size(SNAME("font_size"));
 	ERR_FAIL_COND(font.is_null());
-	TS->shaped_text_add_string(text_rid, t, font->get_rids(), font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
+	TS->shaped_text_add_string(text_rid, t, font->get_rids(), font_size, opentype_features, (!language.is_empty_string()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 	TS->shaped_text_set_bidi_override(text_rid, structured_text_parser(st_parser, st_args, t));
 
 	full_width = TS->shaped_text_get_size(text_rid).x;
@@ -2159,7 +2159,7 @@ void LineEdit::_fit_to_width() {
 	if (alignment == HORIZONTAL_ALIGNMENT_FILL) {
 		Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 		int t_width = get_size().width - style->get_margin(SIDE_RIGHT) - style->get_margin(SIDE_LEFT);
-		bool using_placeholder = text.is_empty() && ime_text.is_empty();
+		bool using_placeholder = text.is_empty_string() && ime_text.is_empty_string();
 		bool display_clear_icon = !using_placeholder && is_editable() && clear_button_enabled;
 		if (right_icon.is_valid() || display_clear_icon) {
 			Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -43,7 +43,7 @@ void LinkButton::_shape() {
 		text_buf->set_direction((TextServer::Direction)text_direction);
 	}
 	TS->shaped_text_set_bidi_override(text_buf->get_rid(), structured_text_parser(st_parser, st_args, xl_text));
-	text_buf->add_string(xl_text, font, font_size, opentype_features, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
+	text_buf->add_string(xl_text, font, font_size, opentype_features, (!language.is_empty_string()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 void LinkButton::set_text(const String &p_text) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -81,7 +81,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 			accel_max_w = MAX(accel_w, accel_max_w);
 		}
 
-		if (!items[i].submenu.is_empty()) {
+		if (!items[i].submenu.is_empty_string()) {
 			size.width += get_theme_icon(SNAME("submenu"))->get_width();
 		}
 
@@ -348,13 +348,13 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 			set_input_as_handled();
 		}
 	} else if (p_event->is_action("ui_right") && p_event->is_pressed()) {
-		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator && !items[mouse_over].submenu.is_empty() && submenu_over != mouse_over) {
+		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator && !items[mouse_over].submenu.is_empty_string() && submenu_over != mouse_over) {
 			_activate_submenu(mouse_over, true);
 			set_input_as_handled();
 		}
 	} else if (p_event->is_action("ui_accept") && p_event->is_pressed()) {
 		if (mouse_over >= 0 && mouse_over < items.size() && !items[mouse_over].separator) {
-			if (!items[mouse_over].submenu.is_empty() && submenu_over != mouse_over) {
+			if (!items[mouse_over].submenu.is_empty_string() && submenu_over != mouse_over) {
 				_activate_submenu(mouse_over, true);
 			} else {
 				activate_item(mouse_over);
@@ -409,7 +409,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 					return;
 				}
 
-				if (!items[over].submenu.is_empty()) {
+				if (!items[over].submenu.is_empty_string()) {
 					_activate_submenu(over);
 					return;
 				}
@@ -446,7 +446,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
-		if (!items[over].submenu.is_empty() && submenu_over != over) {
+		if (!items[over].submenu.is_empty_string() && submenu_over != over) {
 			submenu_over = over;
 			submenu_timer->start();
 		}
@@ -587,7 +587,7 @@ void PopupMenu::_draw_items() {
 		// Separator
 		item_ofs.x += items[i].h_ofs;
 		if (items[i].separator) {
-			if (!text.is_empty() || !items[i].icon.is_null()) {
+			if (!text.is_empty_string() || !items[i].icon.is_null()) {
 				int content_size = items[i].text_buf->get_size().width + hseparation * 2;
 				if (!items[i].icon.is_null()) {
 					content_size += icon_size.width + hseparation;
@@ -650,7 +650,7 @@ void PopupMenu::_draw_items() {
 		}
 
 		// Submenu arrow on right hand side.
-		if (!items[i].submenu.is_empty()) {
+		if (!items[i].submenu.is_empty_string()) {
 			if (rtl) {
 				submenu->draw(ci, Point2(scroll_width + style->get_margin(SIDE_LEFT) + item_end_padding, item_ofs.y + Math::floor(h - submenu->get_height()) / 2), icon_color);
 			} else {
@@ -666,7 +666,7 @@ void PopupMenu::_draw_items() {
 			Color font_separator_outline_color = get_theme_color(SNAME("font_separator_outline_color"));
 			int separator_outline_size = get_theme_constant(SNAME("separator_outline_size"));
 
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				Vector2 text_pos = Point2(separator_ofs, item_ofs.y + Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
 				if (!rtl && !items[i].icon.is_null()) {
 					text_pos.x += icon_size.width + hseparation;
@@ -760,7 +760,7 @@ void PopupMenu::_shape_item(int p_item) {
 		} else {
 			items.write[p_item].text_buf->set_direction((TextServer::Direction)items[p_item].text_direction);
 		}
-		items.write[p_item].text_buf->add_string(items.write[p_item].xl_text, font, font_size, items[p_item].opentype_features, !items[p_item].language.is_empty() ? items[p_item].language : TranslationServer::get_singleton()->get_tool_locale());
+		items.write[p_item].text_buf->add_string(items.write[p_item].xl_text, font, font_size, items[p_item].opentype_features, !items[p_item].language.is_empty_string() ? items[p_item].language : TranslationServer::get_singleton()->get_tool_locale());
 
 		items.write[p_item].accel_text_buf->clear();
 		items.write[p_item].accel_text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
@@ -798,7 +798,7 @@ void PopupMenu::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_WM_MOUSE_EXIT: {
-			if (mouse_over >= 0 && (items[mouse_over].submenu.is_empty() || submenu_over != -1)) {
+			if (mouse_over >= 0 && (items[mouse_over].submenu.is_empty_string() || submenu_over != -1)) {
 				mouse_over = -1;
 				control->update();
 			}
@@ -832,7 +832,7 @@ void PopupMenu::_notification(int p_what) {
 				}
 
 				for (int i = 0; i < items.size(); i++) {
-					if (items[i].submenu.is_empty()) {
+					if (items[i].submenu.is_empty_string()) {
 						continue;
 					}
 
@@ -1484,7 +1484,7 @@ bool PopupMenu::activate_item_by_event(const Ref<InputEvent> &p_event, bool p_fo
 			return true;
 		}
 
-		if (!items[i].submenu.is_empty()) {
+		if (!items[i].submenu.is_empty_string()) {
 			Node *n = get_node(items[i].submenu);
 			if (!n) {
 				continue;
@@ -1573,7 +1573,7 @@ void PopupMenu::add_separator(const String &p_text, int p_id) {
 	Item sep;
 	sep.separator = true;
 	sep.id = p_id;
-	if (!p_text.is_empty()) {
+	if (!p_text.is_empty_string()) {
 		sep.text = p_text;
 		sep.xl_text = atr(p_text);
 	}
@@ -1671,7 +1671,7 @@ void PopupMenu::set_parent_rect(const Rect2 &p_rect) {
 
 void PopupMenu::get_translatable_strings(List<String> *p_strings) const {
 	for (int i = 0; i < items.size(); i++) {
-		if (!items[i].xl_text.is_empty()) {
+		if (!items[i].xl_text.is_empty_string()) {
 			p_strings->push_back(items[i].xl_text);
 		}
 	}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -742,7 +742,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 			prefix = segment + prefix;
 		}
 	}
-	if (!prefix.is_empty()) {
+	if (!prefix.is_empty_string()) {
 		Ref<Font> font = _find_font(l.from);
 		if (font.is_null()) {
 			font = get_theme_font(SNAME("normal_font"));
@@ -1626,7 +1626,7 @@ void RichTextLabel::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 			_stop_thread();
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				set_text(text);
 			}
 
@@ -2876,7 +2876,7 @@ void RichTextLabel::push_dropcap(const String &p_string, const Ref<Font> &p_font
 	MutexLock data_lock(data_mutex);
 
 	ERR_FAIL_COND(current->type == ITEM_TABLE);
-	ERR_FAIL_COND(p_string.is_empty());
+	ERR_FAIL_COND(p_string.is_empty_string());
 	ERR_FAIL_COND(p_font.is_null());
 	ERR_FAIL_COND(p_size <= 0);
 
@@ -3419,11 +3419,11 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 		if (brk_pos == p_bbcode.length()) {
 			// For tags that are not properly closed.
-			if (text.is_empty() && after_list_open_tag) {
+			if (text.is_empty_string() && after_list_open_tag) {
 				text = "\n";
 			}
 
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				add_text(text);
 			}
 			break; //nothing else to add
@@ -3488,13 +3488,13 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				continue;
 			}
 
-			if (text.is_empty() && after_list_open_tag) {
+			if (text.is_empty_string() && after_list_open_tag) {
 				text = "\n"; // Make empty list have at least one item.
 			}
 			after_list_open_tag = false;
 
 			if (tag == "/ol" || tag == "/ul") {
-				if (!text.is_empty()) {
+				if (!text.is_empty_string()) {
 					// Make sure text ends with a newline character, that is, the last item
 					// will wrap at the end of block.
 					if (!text.ends_with("\n")) {
@@ -3508,7 +3508,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				after_list_close_tag = false;
 			}
 
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				add_text(text);
 			}
 
@@ -3521,14 +3521,14 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 		}
 
 		if (tag == "ol" || tag.begins_with("ol ") || tag == "ul" || tag.begins_with("ul ")) {
-			if (text.is_empty() && after_list_open_tag) {
+			if (text.is_empty_string() && after_list_open_tag) {
 				text = "\n"; // Make each list have at least one item at the beginning.
 			}
 			after_list_open_tag = true;
 		} else {
 			after_list_open_tag = false;
 		}
-		if (!text.is_empty()) {
+		if (!text.is_empty_string()) {
 			add_text(text);
 		}
 		after_list_close_tag = false;
@@ -3935,7 +3935,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 				int width = 0;
 				int height = 0;
-				if (!bbcode_value.is_empty()) {
+				if (!bbcode_value.is_empty_string()) {
 					int sep = bbcode_value.find("x");
 					if (sep == -1) {
 						width = bbcode_value.to_int();
@@ -4566,7 +4566,7 @@ void RichTextLabel::deselect() {
 void RichTextLabel::selection_copy() {
 	String text = get_selected_text();
 
-	if (!text.is_empty()) {
+	if (!text.is_empty_string()) {
 		DisplayServer::get_singleton()->clipboard_set(text);
 	}
 }
@@ -4792,7 +4792,7 @@ float RichTextLabel::get_percent_visible() const {
 
 void RichTextLabel::set_effects(Array p_effects) {
 	custom_effects = p_effects;
-	if ((!text.is_empty()) && use_bbcode) {
+	if ((!text.is_empty_string()) && use_bbcode) {
 		parse_bbcode(text);
 	}
 }
@@ -4807,7 +4807,7 @@ void RichTextLabel::install_effect(const Variant effect) {
 
 	if (rteffect.is_valid()) {
 		custom_effects.push_back(effect);
-		if ((!text.is_empty()) && use_bbcode) {
+		if ((!text.is_empty_string()) && use_bbcode) {
 			parse_bbcode(text);
 		}
 	}
@@ -4837,7 +4837,7 @@ int RichTextLabel::get_content_width() const {
 // People will be very angry, if their texts get erased, because of #39148. (3.x -> 4.0)
 // Although some people may not used bbcode_text, so we only overwrite, if bbcode_text is not empty.
 bool RichTextLabel::_set(const StringName &p_name, const Variant &p_value) {
-	if (p_name == "bbcode_text" && !((String)p_value).is_empty()) {
+	if (p_name == "bbcode_text" && !((String)p_value).is_empty_string()) {
 		set_text(p_value);
 		return true;
 	}

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -41,10 +41,10 @@ Size2 SpinBox::get_minimum_size() const {
 
 void SpinBox::_value_changed(double p_value) {
 	String value = TS->format_number(String::num(get_value(), Math::range_step_decimals(get_step())));
-	if (!prefix.is_empty()) {
+	if (!prefix.is_empty_string()) {
 		value = prefix + " " + value;
 	}
-	if (!suffix.is_empty()) {
+	if (!suffix.is_empty_string()) {
 		value += " " + suffix;
 	}
 	line_edit->set_text(value);

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -76,7 +76,7 @@ Size2 TabBar::get_minimum_size() const {
 			ms.width += tex->get_size().width + hseparation;
 		}
 
-		if (!tabs[i].text.is_empty()) {
+		if (!tabs[i].text.is_empty_string()) {
 			ms.width += tabs[i].size_text + hseparation;
 		}
 		ms.height = MAX(ms.height, tabs[i].text_buf->get_size().y + y_margin);
@@ -311,7 +311,7 @@ void TabBar::_shape(int p_tab) {
 		tabs.write[p_tab].text_buf->set_direction((TextServer::Direction)tabs[p_tab].text_direction);
 	}
 
-	tabs.write[p_tab].text_buf->add_string(tabs[p_tab].xl_text, font, font_size, tabs[p_tab].opentype_features, !tabs[p_tab].language.is_empty() ? tabs[p_tab].language : TranslationServer::get_singleton()->get_tool_locale());
+	tabs.write[p_tab].text_buf->add_string(tabs[p_tab].xl_text, font, font_size, tabs[p_tab].opentype_features, !tabs[p_tab].language.is_empty_string() ? tabs[p_tab].language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 void TabBar::_notification(int p_what) {
@@ -495,7 +495,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 	}
 
 	// Draw the text.
-	if (!tabs[p_index].text.is_empty()) {
+	if (!tabs[p_index].text.is_empty_string()) {
 		Point2i text_pos = Point2i(rtl ? p_x - tabs[p_index].size_text : p_x,
 				p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tabs[p_index].text_buf->get_size().y) / 2);
 
@@ -1291,7 +1291,7 @@ int TabBar::get_tab_width(int p_idx) const {
 		x += tex->get_width() + hseparation;
 	}
 
-	if (!tabs[p_idx].text.is_empty()) {
+	if (!tabs[p_idx].text.is_empty_string()) {
 		x += tabs[p_idx].size_text + hseparation;
 	}
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -754,7 +754,7 @@ void TabContainer::get_translatable_strings(List<String> *p_strings) const {
 		}
 
 		String name = c->get_meta("_tab_name");
-		if (!name.is_empty()) {
+		if (!name.is_empty_string()) {
 			p_strings->push_back(name);
 		}
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -689,7 +689,7 @@ void TextEdit::_notification(int p_what) {
 			String highlighted_text = get_selected_text();
 
 			// Check if highlighted words contain only whitespaces (tabs or spaces).
-			bool only_whitespaces_highlighted = highlighted_text.strip_edges().is_empty();
+			bool only_whitespaces_highlighted = highlighted_text.strip_edges().is_empty_string();
 
 			const int caret_wrap_index = get_caret_wrap_index();
 
@@ -1007,7 +1007,7 @@ void TextEdit::_notification(int p_what) {
 							switch (gutter.type) {
 								case GUTTER_TYPE_STRING: {
 									const String &text = get_line_gutter_text(line, g);
-									if (text.is_empty()) {
+									if (text.is_empty_string()) {
 										break;
 									}
 
@@ -1098,7 +1098,7 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					int start = TS->shaped_text_get_range(rid).x;
-					if (!clipped && !search_text.is_empty()) { // Search highhlight
+					if (!clipped && !search_text.is_empty_string()) { // Search highhlight
 						int search_text_col = _get_column_pos_of_word(search_text, str, search_flags, 0);
 						while (search_text_col != -1) {
 							Vector<Vector2> sel = TS->shaped_text_get_selection(rid, search_text_col + start, search_text_col + search_text.length() + start);
@@ -1121,7 +1121,7 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 
-					if (!clipped && highlight_all_occurrences && !only_whitespaces_highlighted && !highlighted_text.is_empty()) { // Highlight
+					if (!clipped && highlight_all_occurrences && !only_whitespaces_highlighted && !highlighted_text.is_empty_string()) { // Highlight
 						int highlighted_text_col = _get_column_pos_of_word(highlighted_text, str, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, 0);
 						while (highlighted_text_col != -1) {
 							Vector<Vector2> sel = TS->shaped_text_get_selection(rid, highlighted_text_col + start, highlighted_text_col + highlighted_text.length() + start);
@@ -1482,7 +1482,7 @@ void TextEdit::_notification(int p_what) {
 				DisplayServer::get_singleton()->window_set_ime_position(Point2(), get_viewport()->get_window_id());
 				DisplayServer::get_singleton()->window_set_ime_active(false, get_viewport()->get_window_id());
 			}
-			if (!ime_text.is_empty()) {
+			if (!ime_text.is_empty_string()) {
 				ime_text = "";
 				ime_selection = Point2();
 				text.invalidate_cache(caret.line, caret.column, true, ime_text);
@@ -2652,7 +2652,7 @@ void TextEdit::_update_caches() {
 	} else {
 		dir = (TextServer::Direction)text_direction;
 	}
-	text.set_direction_and_language(dir, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
+	text.set_direction_and_language(dir, (!language.is_empty_string()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 	text.set_font_features(opentype_features);
 	text.set_draw_control_chars(draw_control_chars);
 	text.set_font(font);
@@ -2806,7 +2806,7 @@ void TextEdit::set_tooltip_request_func(const Callable &p_tooltip_callback) {
 /* Text */
 // Text properties.
 bool TextEdit::has_ime_text() const {
-	return !ime_text.is_empty();
+	return !ime_text.is_empty_string();
 }
 
 void TextEdit::set_editable(const bool p_editable) {
@@ -2836,7 +2836,7 @@ void TextEdit::set_text_direction(Control::TextDirection p_text_direction) {
 		} else {
 			dir = (TextServer::Direction)text_direction;
 		}
-		text.set_direction_and_language(dir, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
+		text.set_direction_and_language(dir, (!language.is_empty_string()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 		text.invalidate_font();
 		_update_placeholder();
 
@@ -2890,7 +2890,7 @@ void TextEdit::set_language(const String &p_language) {
 		} else {
 			dir = (TextServer::Direction)text_direction;
 		}
-		text.set_direction_and_language(dir, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
+		text.set_direction_and_language(dir, (!language.is_empty_string()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 		text.invalidate_all();
 		_update_placeholder();
 		update();
@@ -5689,7 +5689,7 @@ void TextEdit::_paste_internal() {
 	begin_complex_operation();
 	if (has_selection()) {
 		delete_selection();
-	} else if (!cut_copy_line.is_empty() && cut_copy_line == clipboard) {
+	} else if (!cut_copy_line.is_empty_string() && cut_copy_line == clipboard) {
 		set_caret_column(0);
 		String ins = "\n";
 		clipboard += ins;
@@ -5710,7 +5710,7 @@ void TextEdit::_paste_primary_clipboard_internal() {
 	deselect();
 	set_caret_line(pos.y, true, false);
 	set_caret_column(pos.x);
-	if (!paste_buffer.is_empty()) {
+	if (!paste_buffer.is_empty_string()) {
 		insert_text_at_caret(paste_buffer);
 	}
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -268,7 +268,7 @@ void TreeItem::set_text(int p_column, String p_text) {
 		cells.write[p_column].max = INT_MIN;
 		for (int i = 0; i < strings.size(); i++) {
 			int value = i;
-			if (!strings[i].get_slicec(':', 1).is_empty()) {
+			if (!strings[i].get_slicec(':', 1).is_empty_string()) {
 				value = strings[i].get_slicec(':', 1).to_int();
 			}
 			cells.write[p_column].min = MIN(cells[p_column].min, value);
@@ -1175,7 +1175,7 @@ Size2 TreeItem::get_minimum_size(int p_column) {
 		Size2 size;
 
 		// Text.
-		if (!cell.text.is_empty()) {
+		if (!cell.text.is_empty_string()) {
 			if (cell.dirty) {
 				tree->update_item_cell(this, p_column);
 			}
@@ -1667,7 +1667,7 @@ void Tree::update_column(int p_col) {
 		columns.write[p_col].text_buf->set_direction((TextServer::Direction)columns[p_col].text_direction);
 	}
 
-	columns.write[p_col].text_buf->add_string(columns[p_col].title, cache.font, cache.font_size, columns[p_col].opentype_features, !columns[p_col].language.is_empty() ? columns[p_col].language : TranslationServer::get_singleton()->get_tool_locale());
+	columns.write[p_col].text_buf->add_string(columns[p_col].title, cache.font, cache.font_size, columns[p_col].opentype_features, !columns[p_col].language.is_empty_string() ? columns[p_col].language : TranslationServer::get_singleton()->get_tool_locale());
 }
 
 void Tree::update_item_cell(TreeItem *p_item, int p_col) {
@@ -1675,7 +1675,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 
 	p_item->cells.write[p_col].text_buf->clear();
 	if (p_item->cells[p_col].mode == TreeItem::CELL_MODE_RANGE) {
-		if (!p_item->cells[p_col].text.is_empty()) {
+		if (!p_item->cells[p_col].text.is_empty_string()) {
 			if (!p_item->cells[p_col].editable) {
 				return;
 			}
@@ -1686,7 +1686,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 			Vector<String> strings = p_item->cells[p_col].text.split(",");
 			for (int j = 0; j < strings.size(); j++) {
 				int value = j;
-				if (!strings[j].get_slicec(':', 1).is_empty()) {
+				if (!strings[j].get_slicec(':', 1).is_empty_string()) {
 					value = strings[j].get_slicec(':', 1).to_int();
 				}
 				if (option == value) {
@@ -1702,7 +1702,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 		valtext = p_item->cells[p_col].text;
 	}
 
-	if (!p_item->cells[p_col].suffix.is_empty()) {
+	if (!p_item->cells[p_col].suffix.is_empty_string()) {
 		valtext += " " + p_item->cells[p_col].suffix;
 	}
 
@@ -1725,7 +1725,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 	} else {
 		font_size = cache.font_size;
 	}
-	p_item->cells.write[p_col].text_buf->add_string(valtext, font, font_size, p_item->cells[p_col].opentype_features, !p_item->cells[p_col].language.is_empty() ? p_item->cells[p_col].language : TranslationServer::get_singleton()->get_tool_locale());
+	p_item->cells.write[p_col].text_buf->add_string(valtext, font, font_size, p_item->cells[p_col].opentype_features, !p_item->cells[p_col].language.is_empty_string() ? p_item->cells[p_col].language : TranslationServer::get_singleton()->get_tool_locale());
 	TS->shaped_text_set_bidi_override(p_item->cells[p_col].text_buf->get_rid(), structured_text_parser(p_item->cells[p_col].st_parser, p_item->cells[p_col].st_args, valtext));
 	p_item->cells.write[p_col].dirty = false;
 }
@@ -1794,7 +1794,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 			if (p_item->cells[i].expand_right) {
 				int plus = 1;
-				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text.is_empty() && p_item->cells[i + plus].icon.is_null()) {
+				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text.is_empty_string() && p_item->cells[i + plus].icon.is_null()) {
 					w += get_column_width(i + plus);
 					plus++;
 					skip2++;
@@ -1988,7 +1988,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 				} break;
 				case TreeItem::CELL_MODE_RANGE: {
-					if (!p_item->cells[i].text.is_empty()) {
+					if (!p_item->cells[i].text.is_empty_string()) {
 						if (!p_item->cells[i].editable) {
 							break;
 						}
@@ -2481,7 +2481,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 			if (p_item->cells[i].expand_right) {
 				int plus = 1;
-				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text.is_empty() && p_item->cells[i + plus].icon.is_null()) {
+				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text.is_empty_string() && p_item->cells[i + plus].icon.is_null()) {
 					col_width += cache.hseparation;
 					col_width += get_column_width(i + plus);
 					plus++;
@@ -2657,12 +2657,12 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 			} break;
 			case TreeItem::CELL_MODE_RANGE: {
-				if (!c.text.is_empty()) {
+				if (!c.text.is_empty_string()) {
 					//if (x >= (get_column_width(col)-item_h/2)) {
 					popup_menu->clear();
 					for (int i = 0; i < c.text.get_slice_count(","); i++) {
 						String s = c.text.get_slicec(',', i);
-						popup_menu->add_item(s.get_slicec(':', 0), s.get_slicec(':', 1).is_empty() ? i : s.get_slicec(':', 1).to_int());
+						popup_menu->add_item(s.get_slicec(':', 0), s.get_slicec(':', 1).is_empty_string() ? i : s.get_slicec(':', 1).to_int());
 					}
 
 					popup_menu->set_size(Size2(col_width, 0));
@@ -3583,11 +3583,11 @@ bool Tree::edit_selected() {
 		item_edited(col, s);
 
 		return true;
-	} else if (c.mode == TreeItem::CELL_MODE_RANGE && !c.text.is_empty()) {
+	} else if (c.mode == TreeItem::CELL_MODE_RANGE && !c.text.is_empty_string()) {
 		popup_menu->clear();
 		for (int i = 0; i < c.text.get_slice_count(","); i++) {
 			String s2 = c.text.get_slicec(',', i);
-			popup_menu->add_item(s2.get_slicec(':', 0), s2.get_slicec(':', 1).is_empty() ? i : s2.get_slicec(':', 1).to_int());
+			popup_menu->add_item(s2.get_slicec(':', 0), s2.get_slicec(':', 1).is_empty_string() ? i : s2.get_slicec(':', 1).to_int());
 		}
 
 		popup_menu->set_size(Size2(rect.size.width, 0));
@@ -4863,7 +4863,7 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 				Size2 size = b->get_size() + cache.button_pressed->get_minimum_size();
 				if (pos.x > col_width - size.width) {
 					String tooltip = c.buttons[j].tooltip;
-					if (!tooltip.is_empty()) {
+					if (!tooltip.is_empty_string()) {
 						return tooltip;
 					}
 				}

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -61,7 +61,7 @@ Error HTTPRequest::_parse_url(const String &p_url) {
 	if (port == 0) {
 		port = use_ssl ? 443 : 80;
 	}
-	if (request_string.is_empty()) {
+	if (request_string.is_empty_string()) {
 		request_string = "/";
 	}
 	return OK;
@@ -240,7 +240,7 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 			}
 		}
 
-		if (!new_request.is_empty()) {
+		if (!new_request.is_empty_string()) {
 			// Process redirect.
 			client->close();
 			int new_redirs = redirections + 1; // Because _request() will clear it.
@@ -360,7 +360,7 @@ bool HTTPRequest::_update_connection() {
 					return true;
 				}
 
-				if (!download_to_file.is_empty()) {
+				if (!download_to_file.is_empty_string()) {
 					file = FileAccess::open(download_to_file, FileAccess::WRITE);
 					if (file.is_null()) {
 						call_deferred(SNAME("_request_done"), RESULT_DOWNLOAD_FILE_CANT_OPEN, response_code, response_headers, PackedByteArray());

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -908,7 +908,7 @@ void Node::_set_name_nocheck(const StringName &p_name) {
 void Node::set_name(const String &p_name) {
 	String name = p_name.validate_node_name();
 
-	ERR_FAIL_COND(name.is_empty());
+	ERR_FAIL_COND(name.is_empty_string());
 
 	if (data.unique_name_in_owner && data.owner) {
 		_release_unique_name_in_owner();
@@ -1365,7 +1365,7 @@ bool Node::has_node(const NodePath &p_path) const {
 // Finds the first child node (in tree order) whose name matches the given pattern.
 // Can be recursive or not, and limited to owned nodes.
 Node *Node::find_child(const String &p_pattern, bool p_recursive, bool p_owned) const {
-	ERR_FAIL_COND_V(p_pattern.is_empty(), nullptr);
+	ERR_FAIL_COND_V(p_pattern.is_empty_string(), nullptr);
 
 	Node *const *cptr = data.children.ptr();
 	int ccount = data.children.size();
@@ -1394,7 +1394,7 @@ Node *Node::find_child(const String &p_pattern, bool p_recursive, bool p_owned) 
 // Can be recursive or not, and limited to owned nodes.
 TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_type, bool p_recursive, bool p_owned) const {
 	TypedArray<Node> ret;
-	ERR_FAIL_COND_V(p_pattern.is_empty() && p_type.is_empty(), ret);
+	ERR_FAIL_COND_V(p_pattern.is_empty_string() && p_type.is_empty_string(), ret);
 
 	Node *const *cptr = data.children.ptr();
 	int ccount = data.children.size();
@@ -1403,10 +1403,10 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 			continue;
 		}
 
-		if (!p_pattern.is_empty()) {
+		if (!p_pattern.is_empty_string()) {
 			if (!cptr[i]->data.name.operator String().match(p_pattern)) {
 				continue;
-			} else if (p_type.is_empty()) {
+			} else if (p_type.is_empty_string()) {
 				ret.append(cptr[i]);
 			}
 		}
@@ -2099,7 +2099,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 		nip->set_instance_path(ip->get_instance_path());
 		node = nip;
 
-	} else if ((p_flags & DUPLICATE_USE_INSTANCING) && !get_scene_file_path().is_empty()) {
+	} else if ((p_flags & DUPLICATE_USE_INSTANCING) && !get_scene_file_path().is_empty_string()) {
 		Ref<PackedScene> res = ResourceLoader::load(get_scene_file_path());
 		ERR_FAIL_COND_V(res.is_null(), nullptr);
 		PackedScene::GenEditState ges = PackedScene::GEN_EDIT_STATE_DISABLED;
@@ -2124,7 +2124,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 		ERR_FAIL_COND_V(!node, nullptr);
 	}
 
-	if (!get_scene_file_path().is_empty()) { //an instance
+	if (!get_scene_file_path().is_empty_string()) { //an instance
 		node->set_scene_file_path(get_scene_file_path());
 		node->data.editable_instance = data.editable_instance;
 	}
@@ -2156,7 +2156,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 
 				node_tree.push_back(descendant);
 
-				if (!descendant->get_scene_file_path().is_empty() && instance_roots.has(descendant->get_owner())) {
+				if (!descendant->get_scene_file_path().is_empty_string() && instance_roots.has(descendant->get_owner())) {
 					instance_roots.push_back(descendant);
 				}
 			}

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -510,7 +510,7 @@ bool SceneTree::process(double p_time) {
 			cpath = fallback->get_path();
 		}
 		if (cpath != env_path) {
-			if (!env_path.is_empty()) {
+			if (!env_path.is_empty_string()) {
 				fallback = ResourceLoader::load(env_path);
 				if (fallback.is_null()) {
 					//could not load fallback, set as empty
@@ -1320,7 +1320,7 @@ void SceneTree::get_argument_options(const StringName &p_function, int p_idx, Li
 			dir_access->list_dir_begin();
 			String filename = dir_access->get_next();
 
-			while (!filename.is_empty()) {
+			while (!filename.is_empty_string()) {
 				if (filename == "." || filename == "..") {
 					filename = dir_access->get_next();
 					continue;
@@ -1435,7 +1435,7 @@ SceneTree::SceneTree() {
 		ResourceLoader::get_recognized_extensions_for_type("Environment", &exts);
 		String ext_hint;
 		for (const String &E : exts) {
-			if (!ext_hint.is_empty()) {
+			if (!ext_hint.is_empty_string()) {
 				ext_hint += ",";
 			}
 			ext_hint += "*." + E;
@@ -1445,7 +1445,7 @@ SceneTree::SceneTree() {
 		// Setup property.
 		ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/defaults/default_environment", PropertyInfo(Variant::STRING, "rendering/viewport/default_environment", PROPERTY_HINT_FILE, ext_hint));
 		env_path = env_path.strip_edges();
-		if (!env_path.is_empty()) {
+		if (!env_path.is_empty_string()) {
 			Ref<Environment> env = ResourceLoader::load(env_path);
 			if (env.is_valid()) {
 				root->get_world_3d()->set_fallback_environment(env);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1148,7 +1148,7 @@ String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Cont
 		}
 
 		// If we found a tooltip, we stop here.
-		if (!tooltip.is_empty()) {
+		if (!tooltip.is_empty_string()) {
 			break;
 		}
 
@@ -1182,7 +1182,7 @@ void Viewport::_gui_show_tooltip() {
 			gui.tooltip_control->get_global_transform().xform_inv(gui.last_mouse_pos),
 			&tooltip_owner);
 	tooltip_text = tooltip_text.strip_edges();
-	if (tooltip_text.is_empty()) {
+	if (tooltip_text.is_empty_string()) {
 		return; // Nothing to show.
 	}
 

--- a/scene/multiplayer/multiplayer_spawner.cpp
+++ b/scene/multiplayer/multiplayer_spawner.cpp
@@ -76,7 +76,7 @@ void MultiplayerSpawner::_get_property_list(List<PropertyInfo> *p_list) const {
 	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &exts);
 	String ext_hint;
 	for (const String &E : exts) {
-		if (!ext_hint.is_empty()) {
+		if (!ext_hint.is_empty_string()) {
 			ext_hint += ",";
 		}
 		ext_hint += "*." + E;

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -200,7 +200,7 @@ Vector<SceneState::PackState> PropertyUtils::get_node_states_stack(const Node *p
 					}
 				}
 				break;
-			} else if (!n->get_scene_file_path().is_empty()) {
+			} else if (!n->get_scene_file_path().is_empty_string()) {
 				const Ref<SceneState> &state = n->get_scene_instance_state();
 				_collect_inheritance_chain(state, n->get_path_to(p_node), states_stack);
 			}

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1122,7 +1122,7 @@ void initialize_theme() {
 	const bool font_generate_mipmaps = GLOBAL_DEF_RST("gui/theme/default_font_generate_mipmaps", false);
 
 	Ref<Font> font;
-	if (!font_path.is_empty()) {
+	if (!font_path.is_empty_string()) {
 		font = ResourceLoader::load(font_path);
 		if (!font.is_valid()) {
 			ERR_PRINT("Error loading custom font '" + font_path + "'");
@@ -1134,7 +1134,7 @@ void initialize_theme() {
 		make_default_theme(default_theme_scale, font, font_subpixel_positioning, font_hinting, font_antialiased, font_msdf, font_generate_mipmaps);
 	}
 
-	if (!theme_path.is_empty()) {
+	if (!theme_path.is_empty_string()) {
 		Ref<Theme> theme = ResourceLoader::load(theme_path);
 		if (theme.is_valid()) {
 			Theme::set_project_default(theme);

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -31,7 +31,7 @@
 #include "animation_library.h"
 
 bool AnimationLibrary::is_valid_animation_name(const String &p_name) {
-	return !(p_name.is_empty() || p_name.contains("/") || p_name.contains(":") || p_name.contains(",") || p_name.contains("["));
+	return !(p_name.is_empty_string() || p_name.contains("/") || p_name.contains(":") || p_name.contains(",") || p_name.contains("["));
 }
 
 bool AnimationLibrary::is_valid_library_name(const String &p_name) {

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -657,7 +657,7 @@ Ref<ArrayMesh> ImporterMesh::get_mesh(const Ref<ArrayMesh> &p_base) {
 			if (surfaces[i].material.is_valid()) {
 				mesh->surface_set_material(mesh->get_surface_count() - 1, surfaces[i].material);
 			}
-			if (!surfaces[i].name.is_empty()) {
+			if (!surfaces[i].name.is_empty_string()) {
 				mesh->surface_set_name(mesh->get_surface_count() - 1, surfaces[i].name);
 			}
 		}
@@ -843,7 +843,7 @@ Dictionary ImporterMesh::_get_data() const {
 			d["material"] = surfaces[i].material;
 		}
 
-		if (!surfaces[i].name.is_empty()) {
+		if (!surfaces[i].name.is_empty_string()) {
 			d["name"] = surfaces[i].name;
 		}
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -960,7 +960,7 @@ void BaseMaterial3D::_update_shader() {
 		// On the other hand, albedo textures are almost always external to the scene.
 		if (textures[TEXTURE_ALBEDO].is_valid()) {
 			WARN_PRINT(vformat("%s (albedo %s): Height mapping is not supported on triplanar materials. Ignoring height mapping in favor of triplanar mapping.", get_path(), textures[TEXTURE_ALBEDO]->get_path()));
-		} else if (!get_path().is_empty()) {
+		} else if (!get_path().is_empty_string()) {
 			WARN_PRINT(vformat("%s: Height mapping is not supported on triplanar materials. Ignoring height mapping in favor of triplanar mapping.", get_path()));
 		} else {
 			// Resource wasn't saved yet.

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1354,7 +1354,7 @@ Array ArrayMesh::_get_surfaces() const {
 			data["material"] = surfaces[i].material;
 		}
 
-		if (!surfaces[i].name.is_empty()) {
+		if (!surfaces[i].name.is_empty_string()) {
 			data["name"] = surfaces[i].name;
 		}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -335,7 +335,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				}
 			}
 
-			if (!old_parent_path.is_empty()) {
+			if (!old_parent_path.is_empty_string()) {
 				node->_set_name_nocheck(old_parent_path + "@" + node->get_name());
 			}
 
@@ -465,7 +465,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	// save the child instantiated scenes that are chosen as editable, so they can be restored
 	// upon load back
-	if (p_node != p_owner && !p_node->get_scene_file_path().is_empty() && p_owner->is_editable_instance(p_node)) {
+	if (p_node != p_owner && !p_node->get_scene_file_path().is_empty_string() && p_owner->is_editable_instance(p_node)) {
 		editable_instances.push_back(p_owner->get_path_to(p_node));
 		// Node is the root of an editable instance.
 		is_editable_instance = true;
@@ -499,7 +499,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 	bool instantiated_by_owner = false;
 	Vector<SceneState::PackState> states_stack = PropertyUtils::get_node_states_stack(p_node, p_owner, &instantiated_by_owner);
 
-	if (!p_node->get_scene_file_path().is_empty() && p_node->get_owner() == p_owner && instantiated_by_owner) {
+	if (!p_node->get_scene_file_path().is_empty_string() && p_node->get_owner() == p_owner && instantiated_by_owner) {
 		if (p_node->get_scene_instance_load_placeholder()) {
 			//it's a placeholder, use the placeholder path
 			nd.instance = _vm_get_variant(p_node->get_scene_file_path(), variant_map);
@@ -731,7 +731,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 
 			ERR_CONTINUE(!common_parent);
 
-			if (common_parent != p_owner && common_parent->get_scene_file_path().is_empty()) {
+			if (common_parent != p_owner && common_parent->get_scene_file_path().is_empty_string()) {
 				common_parent = common_parent->get_owner();
 			}
 
@@ -791,7 +791,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 
 						nl = nullptr;
 					} else {
-						if (!nl->get_scene_file_path().is_empty()) {
+						if (!nl->get_scene_file_path().is_empty_string()) {
 							//is an instance
 							Ref<SceneState> state = nl->get_scene_instance_state();
 							if (state.is_valid()) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -277,12 +277,12 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 					}
 				}
 
-				if (!assign.is_empty()) {
+				if (!assign.is_empty_string()) {
 					int nameidx = packed_scene->get_state()->add_name(assign);
 					int valueidx = packed_scene->get_state()->add_value(value);
 					packed_scene->get_state()->add_node_property(node_id, nameidx, valueidx);
 					//it's assignment
-				} else if (!next_tag.name.is_empty()) {
+				} else if (!next_tag.name.is_empty_string()) {
 					break;
 				}
 			}
@@ -595,7 +595,7 @@ Error ResourceLoaderText::load() {
 				return error;
 			}
 
-			if (!assign.is_empty()) {
+			if (!assign.is_empty_string()) {
 				if (do_assign) {
 					bool set_valid = true;
 
@@ -616,7 +616,7 @@ Error ResourceLoaderText::load() {
 					}
 				}
 				//it's assignment
-			} else if (!next_tag.name.is_empty()) {
+			} else if (!next_tag.name.is_empty_string()) {
 				error = OK;
 				break;
 			} else {
@@ -714,7 +714,7 @@ Error ResourceLoaderText::load() {
 				return error;
 			}
 
-			if (!assign.is_empty()) {
+			if (!assign.is_empty_string()) {
 				bool set_valid = true;
 
 				if (value.get_type() == Variant::OBJECT && missing_resource != nullptr) {
@@ -733,7 +733,7 @@ Error ResourceLoaderText::load() {
 					resource->set(assign, value);
 				}
 				//it's assignment
-			} else if (!next_tag.name.is_empty()) {
+			} else if (!next_tag.name.is_empty_string()) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Extra tag found when parsing main resource file";
 				_printerr();
@@ -1231,13 +1231,13 @@ Error ResourceLoaderText::save_as_binary(Ref<FileAccess> p_f, const String &p_pa
 					return error;
 				}
 
-				if (!assign.is_empty()) {
+				if (!assign.is_empty_string()) {
 					HashMap<StringName, int> empty_string_map; //unused
 					bs_save_unicode_string(wf2, assign, true);
 					ResourceFormatSaverBinaryInstance::write_variant(wf2, value, dummy_read.resource_index_map, dummy_read.external_resources, empty_string_map);
 					prop_count++;
 
-				} else if (!next_tag.name.is_empty()) {
+				} else if (!next_tag.name.is_empty_string()) {
 					error = OK;
 					break;
 				} else {
@@ -1412,7 +1412,7 @@ Ref<Resource> ResourceFormatLoaderText::load(const String &p_path, const String 
 	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), "Cannot open file '" + p_path + "'.");
 
 	ResourceLoaderText loader;
-	String path = !p_original_path.is_empty() ? p_original_path : p_path;
+	String path = !p_original_path.is_empty_string() ? p_original_path : p_path;
 	loader.cache_mode = p_cache_mode;
 	loader.use_sub_threads = p_use_sub_threads;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(path);
@@ -1431,7 +1431,7 @@ Ref<Resource> ResourceFormatLoaderText::load(const String &p_path, const String 
 }
 
 void ResourceFormatLoaderText::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
-	if (p_type.is_empty()) {
+	if (p_type.is_empty_string()) {
 		get_recognized_extensions(p_extensions);
 		return;
 	}
@@ -1740,7 +1740,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	HashSet<String> cached_ids_found;
 	for (KeyValue<Ref<Resource>, String> &E : external_resources) {
 		String cached_id = E.key->get_id_for_path(local_path);
-		if (cached_id.is_empty() || cached_ids_found.has(cached_id)) {
+		if (cached_id.is_empty_string() || cached_ids_found.has(cached_id)) {
 			int sep_pos = E.value.find("_");
 			if (sep_pos != -1) {
 				E.value = E.value.substr(0, sep_pos + 1); // Keep the order found, for improved thread loading performance.
@@ -1814,7 +1814,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	for (List<Ref<Resource>>::Element *E = saved_resources.front(); E; E = E->next()) {
 		Ref<Resource> res = E->get();
 		if (E->next() && res->is_built_in()) {
-			if (!res->get_scene_unique_id().is_empty()) {
+			if (!res->get_scene_unique_id().is_empty_string()) {
 				if (used_unique_ids.has(res->get_scene_unique_id())) {
 					res->set_scene_unique_id(""); // Repeated.
 				} else {
@@ -1837,7 +1837,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			f->store_line("[resource]");
 		} else {
 			String line = "[sub_resource ";
-			if (res->get_scene_unique_id().is_empty()) {
+			if (res->get_scene_unique_id().is_empty_string()) {
 				String new_id;
 				while (true) {
 					new_id = _resource_get_class(res) + "_" + Resource::generate_scene_unique_id();
@@ -1965,7 +1965,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 			f->store_string(header);
 
-			if (!instance_placeholder.is_empty()) {
+			if (!instance_placeholder.is_empty_string()) {
 				String vars;
 				f->store_string(" instance_placeholder=");
 				VariantWriter::write_to_string(instance_placeholder, vars, _write_resources, this);

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -513,7 +513,7 @@ void CodeHighlighter::add_color_region(const String &p_start_key, const String &
 	color_region.color = p_color;
 	color_region.start_key = p_start_key;
 	color_region.end_key = p_end_key;
-	color_region.line_only = p_line_only || p_end_key.is_empty();
+	color_region.line_only = p_line_only || p_end_key.is_empty_string();
 	color_regions.insert(at, color_region);
 	clear_highlighting_cache();
 }
@@ -549,7 +549,7 @@ void CodeHighlighter::set_color_regions(const Dictionary &p_color_regions) {
 		String start_key = key.get_slice(" ", 0);
 		String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();
 
-		add_color_region(start_key, end_key, p_color_regions[key], end_key.is_empty());
+		add_color_region(start_key, end_key, p_color_regions[key], end_key.is_empty_string());
 	}
 	clear_highlighting_cache();
 }
@@ -563,7 +563,7 @@ Dictionary CodeHighlighter::get_color_regions() const {
 	Dictionary r_color_regions;
 	for (int i = 0; i < color_regions.size(); i++) {
 		ColorRegion region = color_regions[i];
-		r_color_regions[region.start_key + (region.end_key.is_empty() ? "" : " " + region.end_key)] = region.color;
+		r_color_regions[region.start_key + (region.end_key.is_empty_string() ? "" : " " + region.end_key)] = region.color;
 	}
 	return r_color_regions;
 }

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -33,7 +33,7 @@
 #include "core/io/file_access.h"
 
 bool TextFile::has_text() const {
-	return !text.is_empty();
+	return !text.is_empty_string();
 }
 
 String TextFile::get_text() const {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -890,7 +890,7 @@ Error CompressedTexture2D::load(const String &p_path) {
 	path_to_file = p_path;
 	format = image->get_format();
 
-	if (get_path().is_empty()) {
+	if (get_path().is_empty_string()) {
 		//temporarily set path if no path set for resource, helps find errors
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
@@ -1324,7 +1324,7 @@ Error CompressedTexture3D::load(const String &p_path) {
 
 	path_to_file = p_path;
 
-	if (get_path().is_empty()) {
+	if (get_path().is_empty_string()) {
 		//temporarily set path if no path set for resource, helps find errors
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
@@ -3147,7 +3147,7 @@ Error CompressedTextureLayered::load(const String &p_path) {
 
 	path_to_file = p_path;
 
-	if (get_path().is_empty()) {
+	if (get_path().is_empty_string()) {
 		//temporarily set path if no path set for resource, helps find errors
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -253,7 +253,7 @@ bool Theme::is_valid_type_name(const String &p_name) {
 }
 
 bool Theme::is_valid_item_name(const String &p_name) {
-	if (p_name.is_empty()) {
+	if (p_name.is_empty_string()) {
 		return false;
 	}
 	for (int i = 0; i < p_name.length(); i++) {

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -1052,7 +1052,7 @@ void TileSet::set_custom_data_name(int p_layer_id, String p_value) {
 	ERR_FAIL_INDEX(p_layer_id, custom_data_layers.size());
 
 	// Exit if another property has the same name.
-	if (!p_value.is_empty()) {
+	if (!p_value.is_empty_string()) {
 		for (int other_layer_id = 0; other_layer_id < get_custom_data_layers_count(); other_layer_id++) {
 			if (other_layer_id != p_layer_id && get_custom_data_name(other_layer_id) == p_value) {
 				ERR_FAIL_MSG(vformat("There is already a custom property named %s", p_value));
@@ -1060,7 +1060,7 @@ void TileSet::set_custom_data_name(int p_layer_id, String p_value) {
 		}
 	}
 
-	if (p_value.is_empty() && custom_data_layers_by_name.has(p_value)) {
+	if (p_value.is_empty_string() && custom_data_layers_by_name.has(p_value)) {
 		custom_data_layers_by_name.erase(p_value);
 	} else {
 		custom_data_layers_by_name[p_value] = p_layer_id;

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -594,7 +594,7 @@ void VisualShaderNodeCustom::_set_input_port_default_value(int p_port, const Var
 }
 
 bool VisualShaderNodeCustom::_is_valid_code(const String &p_code) const {
-	if (p_code.is_empty() || p_code == "null") {
+	if (p_code.is_empty_string() || p_code == "null") {
 		return false;
 	}
 	return true;
@@ -1225,7 +1225,7 @@ String VisualShader::generate_preview_shader(Type p_type, int p_node, int p_port
 String VisualShader::validate_port_name(const String &p_port_name, VisualShaderNode *p_node, int p_port_id, bool p_output) const {
 	String name = p_port_name;
 
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		return String();
 	}
 
@@ -1233,7 +1233,7 @@ String VisualShader::validate_port_name(const String &p_port_name, VisualShaderN
 		name = name.substr(1, name.length() - 1);
 	}
 
-	if (!name.is_empty()) {
+	if (!name.is_empty_string()) {
 		String valid_name;
 
 		for (int i = 0; i < name.length(); i++) {
@@ -1277,7 +1277,7 @@ String VisualShader::validate_uniform_name(const String &p_name, const Ref<Visua
 	while (name.length() && !is_ascii_char(name[0])) {
 		name = name.substr(1, name.length() - 1);
 	}
-	if (!name.is_empty()) {
+	if (!name.is_empty_string()) {
 		String valid_name;
 
 		for (int i = 0; i < name.length(); i++) {
@@ -1291,7 +1291,7 @@ String VisualShader::validate_uniform_name(const String &p_name, const Ref<Visua
 		name = valid_name;
 	}
 
-	if (name.is_empty()) {
+	if (name.is_empty_string()) {
 		name = p_uniform->get_caption();
 	}
 
@@ -1321,7 +1321,7 @@ String VisualShader::validate_uniform_name(const String &p_name, const Ref<Visua
 			while (name.length() && is_digit(name[name.length() - 1])) {
 				name = name.substr(0, name.length() - 1);
 			}
-			ERR_FAIL_COND_V(name.is_empty(), String());
+			ERR_FAIL_COND_V(name.is_empty_string(), String());
 			name += itos(attempt);
 		} else {
 			break;
@@ -1986,7 +1986,7 @@ Error VisualShader::_write_node(Type type, StringBuilder *global_code, StringBui
 	}
 
 	node_code += vsnode->generate_code(get_mode(), type, node, inputs, outputs, for_preview);
-	if (!node_code.is_empty()) {
+	if (!node_code.is_empty_string()) {
 		code += node_name;
 		code += node_code;
 	}
@@ -2063,7 +2063,7 @@ Error VisualShader::_write_node(Type type, StringBuilder *global_code, StringBui
 		}
 	}
 
-	if (!node_code.is_empty()) {
+	if (!node_code.is_empty_string()) {
 		code += "\n";
 	}
 
@@ -2117,7 +2117,7 @@ void VisualShader::_update_shader() const {
 
 			if (!info.options.is_empty()) {
 				if (modes.has(temp) && modes[temp] < info.options.size()) {
-					if (!render_mode.is_empty()) {
+					if (!render_mode.is_empty_string()) {
 						render_mode += ", ";
 					}
 					render_mode += temp + "_" + info.options[modes[temp]];
@@ -2129,14 +2129,14 @@ void VisualShader::_update_shader() const {
 
 		// Add flags afterward.
 		for (int i = 0; i < flag_names.size(); i++) {
-			if (!render_mode.is_empty()) {
+			if (!render_mode.is_empty_string()) {
 				render_mode += ", ";
 			}
 			render_mode += flag_names[i];
 		}
 	}
 
-	if (!render_mode.is_empty()) {
+	if (!render_mode.is_empty_string()) {
 		global_code += "render_mode " + render_mode + ";\n\n";
 	}
 
@@ -2352,11 +2352,11 @@ void VisualShader::_update_shader() const {
 	String global_compute_code;
 
 	if (shader_mode == Shader::MODE_PARTICLES) {
-		bool has_start = !code_map[TYPE_START].is_empty();
-		bool has_start_custom = !code_map[TYPE_START_CUSTOM].is_empty();
-		bool has_process = !code_map[TYPE_PROCESS].is_empty();
-		bool has_process_custom = !code_map[TYPE_PROCESS_CUSTOM].is_empty();
-		bool has_collide = !code_map[TYPE_COLLIDE].is_empty();
+		bool has_start = !code_map[TYPE_START].is_empty_string();
+		bool has_start_custom = !code_map[TYPE_START_CUSTOM].is_empty_string();
+		bool has_process = !code_map[TYPE_PROCESS].is_empty_string();
+		bool has_process_custom = !code_map[TYPE_PROCESS_CUSTOM].is_empty_string();
+		bool has_collide = !code_map[TYPE_COLLIDE].is_empty_string();
 
 		code += "void start() {\n";
 		if (has_start || has_start_custom) {
@@ -2491,7 +2491,7 @@ void VisualShader::_update_shader() const {
 			continue;
 		}
 		String func_code = global_code_per_func[Type(i)].as_string();
-		if (empty_funcs.has(Type(i)) && !func_code.is_empty()) {
+		if (empty_funcs.has(Type(i)) && !func_code.is_empty_string()) {
 			func_code = vformat("%s%s%s", String("\nvoid " + String(func_name[i]) + "() {\n"), func_code, "}\n");
 		}
 		tcode = tcode.insert(insertion_pos[i], func_code);
@@ -3003,7 +3003,7 @@ String VisualShaderNodeInput::generate_code(Shader::Mode p_mode, VisualShader::T
 			idx++;
 		}
 
-		if (code.is_empty()) {
+		if (code.is_empty_string()) {
 			switch (get_output_port_type(0)) {
 				case PORT_TYPE_SCALAR: {
 					code = "	" + p_output_vars[0] + " = 0.0;\n";
@@ -3043,7 +3043,7 @@ String VisualShaderNodeInput::generate_code(Shader::Mode p_mode, VisualShader::T
 			idx++;
 		}
 
-		if (code.is_empty()) {
+		if (code.is_empty_string()) {
 			code = "	" + p_output_vars[0] + " = 0.0;\n"; //default (none found) is scalar
 		}
 
@@ -3146,7 +3146,7 @@ void VisualShaderNodeInput::_validate_property(PropertyInfo &property) const {
 
 		while (ports[idx].mode != Shader::MODE_MAX) {
 			if (ports[idx].mode == shader_mode && ports[idx].shader_type == shader_type) {
-				if (!port_list.is_empty()) {
+				if (!port_list.is_empty_string()) {
 					port_list += ",";
 				}
 				port_list += ports[idx].name;
@@ -3154,7 +3154,7 @@ void VisualShaderNodeInput::_validate_property(PropertyInfo &property) const {
 			idx++;
 		}
 
-		if (port_list.is_empty()) {
+		if (port_list.is_empty_string()) {
 			port_list = RTR("None");
 		}
 		property.hint_string = port_list;
@@ -3618,7 +3618,7 @@ String VisualShaderNodeOutput::generate_code(Shader::Mode p_mode, VisualShader::
 	String code;
 	while (ports[idx].mode != Shader::MODE_MAX) {
 		if (ports[idx].mode == shader_mode && ports[idx].shader_type == shader_type) {
-			if (!p_input_vars[count].is_empty()) {
+			if (!p_input_vars[count].is_empty_string()) {
 				String s = ports[idx].string;
 				if (s.contains(":")) {
 					code += "	" + s.get_slicec(':', 0) + " = " + p_input_vars[count] + "." + s.get_slicec(':', 1) + ";\n";

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -725,13 +725,13 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	String code;
 	if (source == SOURCE_TEXTURE) {
 		String id = make_unique_id(p_type, p_id, "tex");
-		if (p_input_vars[0].is_empty()) { // Use UV by default.
-			if (p_input_vars[1].is_empty()) {
+		if (p_input_vars[0].is_empty_string()) { // Use UV by default.
+			if (p_input_vars[1].is_empty_string()) {
 				code += "	" + p_output_vars[0] + " = texture(" + id + ", " + default_uv + ");\n";
 			} else {
 				code += "	" + p_output_vars[0] + " = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + ");\n";
 			}
-		} else if (p_input_vars[1].is_empty()) {
+		} else if (p_input_vars[1].is_empty_string()) {
 			//no lod
 			code += "	" + p_output_vars[0] + " = texture(" + id + ", " + p_input_vars[0] + ");\n";
 		} else {
@@ -742,16 +742,16 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 	if (source == SOURCE_PORT) {
 		String id = p_input_vars[2];
-		if (id.is_empty()) {
+		if (id.is_empty_string()) {
 			code += "	" + p_output_vars[0] + " = vec4(0.0);\n";
 		} else {
-			if (p_input_vars[0].is_empty()) { // Use UV by default.
-				if (p_input_vars[1].is_empty()) {
+			if (p_input_vars[0].is_empty_string()) { // Use UV by default.
+				if (p_input_vars[1].is_empty_string()) {
 					code += "	" + p_output_vars[0] + " = texture(" + id + ", " + default_uv + ");\n";
 				} else {
 					code += "	" + p_output_vars[0] + " = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + ");\n";
 				}
-			} else if (p_input_vars[1].is_empty()) {
+			} else if (p_input_vars[1].is_empty_string()) {
 				//no lod
 				code += "	" + p_output_vars[0] + " = texture(" + id + ", " + p_input_vars[0] + ");\n";
 			} else {
@@ -762,13 +762,13 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	}
 
 	if (source == SOURCE_SCREEN && (p_mode == Shader::MODE_SPATIAL || p_mode == Shader::MODE_CANVAS_ITEM) && p_type == VisualShader::TYPE_FRAGMENT) {
-		if (p_input_vars[0].is_empty() || p_for_preview) { // Use UV by default.
-			if (p_input_vars[1].is_empty()) {
+		if (p_input_vars[0].is_empty_string() || p_for_preview) { // Use UV by default.
+			if (p_input_vars[1].is_empty_string()) {
 				code += "	" + p_output_vars[0] + " = textureLod(SCREEN_TEXTURE, " + default_uv + ", 0.0);\n";
 			} else {
 				code += "	" + p_output_vars[0] + " = textureLod(SCREEN_TEXTURE, " + default_uv + ", " + p_input_vars[1] + ");\n";
 			}
-		} else if (p_input_vars[1].is_empty()) {
+		} else if (p_input_vars[1].is_empty_string()) {
 			//no lod
 			code += "	" + p_output_vars[0] + " = textureLod(SCREEN_TEXTURE, " + p_input_vars[0] + ", 0.0);\n";
 		} else {
@@ -778,13 +778,13 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	}
 
 	if (source == SOURCE_2D_TEXTURE && p_mode == Shader::MODE_CANVAS_ITEM && p_type == VisualShader::TYPE_FRAGMENT) {
-		if (p_input_vars[0].is_empty()) { // Use UV by default.
-			if (p_input_vars[1].is_empty()) {
+		if (p_input_vars[0].is_empty_string()) { // Use UV by default.
+			if (p_input_vars[1].is_empty_string()) {
 				code += "	" + p_output_vars[0] + " = texture(TEXTURE, " + default_uv + ");\n";
 			} else {
 				code += "	" + p_output_vars[0] + " = textureLod(TEXTURE, " + default_uv + ", " + p_input_vars[1] + ");\n";
 			}
-		} else if (p_input_vars[1].is_empty()) {
+		} else if (p_input_vars[1].is_empty_string()) {
 			//no lod
 			code += "	" + p_output_vars[0] + " = texture(TEXTURE, " + p_input_vars[0] + ");\n";
 		} else {
@@ -794,13 +794,13 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	}
 
 	if (source == SOURCE_2D_NORMAL && p_mode == Shader::MODE_CANVAS_ITEM && p_type == VisualShader::TYPE_FRAGMENT) {
-		if (p_input_vars[0].is_empty()) { // Use UV by default.
-			if (p_input_vars[1].is_empty()) {
+		if (p_input_vars[0].is_empty_string()) { // Use UV by default.
+			if (p_input_vars[1].is_empty_string()) {
 				code += "	" + p_output_vars[0] + " = texture(NORMAL_TEXTURE, " + default_uv + ");\n";
 			} else {
 				code += "	" + p_output_vars[0] + " = textureLod(NORMAL_TEXTURE, " + default_uv + ", " + p_input_vars[1] + ");\n";
 			}
-		} else if (p_input_vars[1].is_empty()) {
+		} else if (p_input_vars[1].is_empty_string()) {
 			//no lod
 			code += "	" + p_output_vars[0] + " = texture(NORMAL_TEXTURE, " + p_input_vars[0] + ".xy);\n";
 		} else {
@@ -812,13 +812,13 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 	if (source == SOURCE_DEPTH) {
 		if (!p_for_preview && p_mode == Shader::MODE_SPATIAL && p_type == VisualShader::TYPE_FRAGMENT) {
 			code += "	{\n";
-			if (p_input_vars[0].is_empty()) { // Use UV by default.
-				if (p_input_vars[1].is_empty()) {
+			if (p_input_vars[0].is_empty_string()) { // Use UV by default.
+				if (p_input_vars[1].is_empty_string()) {
 					code += "		float _depth = texture(DEPTH_TEXTURE, " + default_uv + ").r;\n";
 				} else {
 					code += "		float _depth = textureLod(DEPTH_TEXTURE, " + default_uv + ", " + p_input_vars[1] + ").r;\n";
 				}
-			} else if (p_input_vars[1].is_empty()) {
+			} else if (p_input_vars[1].is_empty_string()) {
 				//no lod
 				code += "		float _depth = texture(DEPTH_TEXTURE, " + p_input_vars[0] + ".xy).r;\n";
 			} else {
@@ -1019,7 +1019,7 @@ String VisualShaderNodeCurveTexture::generate_global(Shader::Mode p_mode, Visual
 }
 
 String VisualShaderNodeCurveTexture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	if (p_input_vars[0].is_empty()) {
+	if (p_input_vars[0].is_empty_string()) {
 		return "	" + p_output_vars[0] + " = 0.0;\n";
 	}
 	String id = make_unique_id(p_type, p_id, "curve");
@@ -1104,7 +1104,7 @@ String VisualShaderNodeCurveXYZTexture::generate_global(Shader::Mode p_mode, Vis
 }
 
 String VisualShaderNodeCurveXYZTexture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	if (p_input_vars[0].is_empty()) {
+	if (p_input_vars[0].is_empty_string()) {
 		return "	" + p_output_vars[0] + " = vec3(0.0);\n";
 	}
 	String id = make_unique_id(p_type, p_id, "curve3d");
@@ -1213,14 +1213,14 @@ String VisualShaderNodeSample3D::generate_code(Shader::Mode p_mode, VisualShader
 		} else {
 			id = p_input_vars[2];
 		}
-		if (!id.is_empty()) {
-			if (p_input_vars[0].is_empty()) { // Use UV by default.
-				if (p_input_vars[1].is_empty()) {
+		if (!id.is_empty_string()) {
+			if (p_input_vars[0].is_empty_string()) { // Use UV by default.
+				if (p_input_vars[1].is_empty_string()) {
 					code += "	" + p_output_vars[0] + " = texture(" + id + ", " + default_uv + ");\n";
 				} else {
 					code += "	" + p_output_vars[0] + " = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + ");\n";
 				}
-			} else if (p_input_vars[1].is_empty()) {
+			} else if (p_input_vars[1].is_empty_string()) {
 				//no lod
 				code += "	" + p_output_vars[0] + " = texture(" + id + ", " + p_input_vars[0] + ");\n";
 			} else {
@@ -1494,20 +1494,20 @@ String VisualShaderNodeCubemap::generate_code(Shader::Mode p_mode, VisualShader:
 		return code;
 	}
 
-	if (id.is_empty()) {
+	if (id.is_empty_string()) {
 		code += "	" + p_output_vars[0] + " = vec4(0.0);\n";
 		return code;
 	}
 
-	if (p_input_vars[0].is_empty()) { // Use UV by default.
+	if (p_input_vars[0].is_empty_string()) { // Use UV by default.
 
-		if (p_input_vars[1].is_empty()) {
+		if (p_input_vars[1].is_empty_string()) {
 			code += "	" + p_output_vars[0] + " = texture(" + id + ", " + default_uv + ");\n";
 		} else {
 			code += "	" + p_output_vars[0] + " = textureLod(" + id + ", " + default_uv + ", " + p_input_vars[1] + ");\n";
 		}
 
-	} else if (p_input_vars[1].is_empty()) {
+	} else if (p_input_vars[1].is_empty_string()) {
 		//no lod
 		code += "	" + p_output_vars[0] + " = texture(" + id + ", " + p_input_vars[0] + ");\n";
 	} else {
@@ -3031,7 +3031,7 @@ String VisualShaderNodeUVFunc::generate_code(Shader::Mode p_mode, VisualShader::
 	String code;
 
 	String uv;
-	if (p_input_vars[0].is_empty()) {
+	if (p_input_vars[0].is_empty_string()) {
 		if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
 			uv = "UV";
 		} else {
@@ -5599,7 +5599,7 @@ String get_sampler_hint(VisualShaderNodeTextureUniform::TextureType p_texture_ty
 				break;
 		}
 
-		if (!type_code.is_empty()) {
+		if (!type_code.is_empty_string()) {
 			code += " : " + type_code;
 			has_colon = true;
 		}
@@ -5632,7 +5632,7 @@ String get_sampler_hint(VisualShaderNodeTextureUniform::TextureType p_texture_ty
 				break;
 		}
 
-		if (!filter_code.is_empty()) {
+		if (!filter_code.is_empty_string()) {
 			if (!has_colon) {
 				code += " : ";
 				has_colon = true;
@@ -5658,7 +5658,7 @@ String get_sampler_hint(VisualShaderNodeTextureUniform::TextureType p_texture_ty
 				break;
 		}
 
-		if (!repeat_code.is_empty()) {
+		if (!repeat_code.is_empty_string()) {
 			if (!has_colon) {
 				code += " : ";
 			} else {
@@ -5956,11 +5956,11 @@ String VisualShaderNodeTextureUniformTriplanar::generate_code(Shader::Mode p_mod
 	String id = get_uniform_name();
 
 	String code;
-	if (p_input_vars[0].is_empty() && p_input_vars[1].is_empty()) {
+	if (p_input_vars[0].is_empty_string() && p_input_vars[1].is_empty_string()) {
 		code += "	" + p_output_vars[0] + " = triplanar_texture(" + id + ", triplanar_power_normal, triplanar_pos);\n";
-	} else if (!p_input_vars[0].is_empty() && p_input_vars[1].is_empty()) {
+	} else if (!p_input_vars[0].is_empty_string() && p_input_vars[1].is_empty_string()) {
 		code += "	" + p_output_vars[0] + " = triplanar_texture(" + id + ", " + p_input_vars[0] + ", triplanar_pos);\n";
-	} else if (p_input_vars[0].is_empty() && !p_input_vars[1].is_empty()) {
+	} else if (p_input_vars[0].is_empty_string() && !p_input_vars[1].is_empty_string()) {
 		code += "	" + p_output_vars[0] + " = triplanar_texture(" + id + ", triplanar_power_normal, " + p_input_vars[1] + ");\n";
 	} else {
 		code += "	" + p_output_vars[0] + " = triplanar_texture(" + id + ", " + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
@@ -6353,7 +6353,7 @@ bool VisualShaderNodeFresnel::is_generate_input_var(int p_port) const {
 String VisualShaderNodeFresnel::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String normal;
 	String view;
-	if (p_input_vars[0].is_empty()) {
+	if (p_input_vars[0].is_empty_string()) {
 		if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
 			normal = "NORMAL";
 		} else {
@@ -6362,7 +6362,7 @@ String VisualShaderNodeFresnel::generate_code(Shader::Mode p_mode, VisualShader:
 	} else {
 		normal = p_input_vars[0];
 	}
-	if (p_input_vars[1].is_empty()) {
+	if (p_input_vars[1].is_empty_string()) {
 		if (p_mode == Shader::MODE_SPATIAL) {
 			view = "VIEW";
 		} else {

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -135,9 +135,9 @@ String VisualShaderNodeParticleSphereEmitter::generate_code(Shader::Mode p_mode,
 	String code;
 
 	if (mode_2d) {
-		code += "	" + p_output_vars[0] + " = __get_random_point_in_circle(__seed, " + (p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ", " + (p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ");\n";
+		code += "	" + p_output_vars[0] + " = __get_random_point_in_circle(__seed, " + (p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ", " + (p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ");\n";
 	} else {
-		code += "	" + p_output_vars[0] + " = __get_random_point_in_sphere(__seed, " + (p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ", " + (p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ");\n";
+		code += "	" + p_output_vars[0] + " = __get_random_point_in_sphere(__seed, " + (p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ", " + (p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ");\n";
 	}
 
 	return code;
@@ -207,9 +207,9 @@ String VisualShaderNodeParticleBoxEmitter::generate_global_per_node(Shader::Mode
 String VisualShaderNodeParticleBoxEmitter::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String code;
 	if (mode_2d) {
-		code += "	" + p_output_vars[0] + " = __get_random_point_in_box2d(__seed, " + (p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ");\n";
+		code += "	" + p_output_vars[0] + " = __get_random_point_in_box2d(__seed, " + (p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ");\n";
 	} else {
-		code += "	" + p_output_vars[0] + " = __get_random_point_in_box3d(__seed, " + (p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ");\n";
+		code += "	" + p_output_vars[0] + " = __get_random_point_in_box3d(__seed, " + (p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ");\n";
 	}
 	return code;
 }
@@ -265,9 +265,9 @@ String VisualShaderNodeParticleRingEmitter::generate_code(Shader::Mode p_mode, V
 	String code;
 
 	if (mode_2d) {
-		code = "	" + p_output_vars[0] + " = __get_random_point_on_ring2d(__seed, " + (p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ", " + (p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ");\n";
+		code = "	" + p_output_vars[0] + " = __get_random_point_on_ring2d(__seed, " + (p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ", " + (p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ");\n";
 	} else {
-		code = "	" + p_output_vars[0] + " = __get_random_point_on_ring3d(__seed, " + (p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ", " + (p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ", " + (p_input_vars[2].is_empty() ? (String)get_input_port_default_value(2) : p_input_vars[2]) + ");\n";
+		code = "	" + p_output_vars[0] + " = __get_random_point_on_ring3d(__seed, " + (p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0]) + ", " + (p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ", " + (p_input_vars[2].is_empty_string() ? (String)get_input_port_default_value(2) : p_input_vars[2]) + ");\n";
 	}
 
 	return code;
@@ -799,9 +799,9 @@ String VisualShaderNodeParticleMultiplyByAxisAngle::get_output_port_name(int p_p
 String VisualShaderNodeParticleMultiplyByAxisAngle::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String code;
 	if (degrees_mode) {
-		code += "	" + p_output_vars[0] + " = __build_rotation_mat3(" + (p_input_vars[1].is_empty() ? ("vec3" + (String)get_input_port_default_value(1)) : p_input_vars[1]) + ", radians(" + (p_input_vars[2].is_empty() ? (String)get_input_port_default_value(2) : p_input_vars[2]) + ")) * " + (p_input_vars[0].is_empty() ? "vec3(0.0)" : p_input_vars[0]) + ";\n";
+		code += "	" + p_output_vars[0] + " = __build_rotation_mat3(" + (p_input_vars[1].is_empty_string() ? ("vec3" + (String)get_input_port_default_value(1)) : p_input_vars[1]) + ", radians(" + (p_input_vars[2].is_empty_string() ? (String)get_input_port_default_value(2) : p_input_vars[2]) + ")) * " + (p_input_vars[0].is_empty_string() ? "vec3(0.0)" : p_input_vars[0]) + ";\n";
 	} else {
-		code += "	" + p_output_vars[0] + " = __build_rotation_mat3(" + (p_input_vars[1].is_empty() ? ("vec3" + (String)get_input_port_default_value(1)) : p_input_vars[1]) + ", " + (p_input_vars[2].is_empty() ? (String)get_input_port_default_value(2) : p_input_vars[2]) + ") * " + (p_input_vars[0].is_empty() ? "vec3(0.0)" : p_input_vars[0]) + ";\n";
+		code += "	" + p_output_vars[0] + " = __build_rotation_mat3(" + (p_input_vars[1].is_empty_string() ? ("vec3" + (String)get_input_port_default_value(1)) : p_input_vars[1]) + ", " + (p_input_vars[2].is_empty_string() ? (String)get_input_port_default_value(2) : p_input_vars[2]) + ") * " + (p_input_vars[0].is_empty_string() ? "vec3(0.0)" : p_input_vars[0]) + ";\n";
 	}
 	return code;
 }
@@ -879,10 +879,10 @@ bool VisualShaderNodeParticleConeVelocity::has_output_port_preview(int p_port) c
 
 String VisualShaderNodeParticleConeVelocity::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String code;
-	code += "	__radians = radians(" + (p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ");\n";
+	code += "	__radians = radians(" + (p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ");\n";
 	code += "	__scalar_buff1 = __rand_from_seed_m1_p1(__seed) * __radians;\n";
 	code += "	__scalar_buff2 = __rand_from_seed_m1_p1(__seed) * __radians;\n";
-	code += "	__vec3_buff1 = " + (p_input_vars[0].is_empty() ? "vec3" + (String)get_input_port_default_value(0) : p_input_vars[0]) + ";\n";
+	code += "	__vec3_buff1 = " + (p_input_vars[0].is_empty_string() ? "vec3" + (String)get_input_port_default_value(0) : p_input_vars[0]) + ";\n";
 	code += "	__scalar_buff1 += __vec3_buff1.z != 0.0 ? atan(__vec3_buff1.x, __vec3_buff1.z) : sign(__vec3_buff1.x) * (PI / 2.0);\n";
 	code += "	__scalar_buff2 += __vec3_buff1.z != 0.0 ? atan(__vec3_buff1.y, abs(__vec3_buff1.z)) : (__vec3_buff1.x != 0.0 ? atan(__vec3_buff1.y, abs(__vec3_buff1.x)) : sign(__vec3_buff1.y) * (PI / 2.0));\n";
 	code += "	__vec3_buff1 = vec3(sin(__scalar_buff1), 0.0, cos(__scalar_buff1));\n";
@@ -970,13 +970,13 @@ String VisualShaderNodeParticleRandomness::generate_code(Shader::Mode p_mode, Vi
 	String code;
 	switch (op_type) {
 		case OP_TYPE_SCALAR: {
-			code += vformat("	%s = __randf_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
+			code += vformat("	%s = __randf_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
 		} break;
 		case OP_TYPE_VECTOR_2D: {
-			code += vformat("	%s = __randv2_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
+			code += vformat("	%s = __randv2_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
 		} break;
 		case OP_TYPE_VECTOR_3D: {
-			code += vformat("	%s = __randv3_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
+			code += vformat("	%s = __randv3_range(__seed, %s, %s);\n", p_output_vars[0], p_input_vars[0].is_empty_string() ? (String)get_input_port_default_value(0) : p_input_vars[0], p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]);
 		} break;
 		default:
 			break;
@@ -1088,14 +1088,14 @@ String VisualShaderNodeParticleAccelerator::generate_code(Shader::Mode p_mode, V
 	String code;
 	switch (mode) {
 		case MODE_LINEAR:
-			code += "	" + p_output_vars[0] + " = length(VELOCITY) > 0.0 ? " + "normalize(VELOCITY) * " + (p_input_vars[0].is_empty() ? "vec3" + (String)get_input_port_default_value(0) : p_input_vars[0]) + " * mix(1.0, __rand_from_seed(__seed), " + (p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ") : vec3(0.0);\n";
+			code += "	" + p_output_vars[0] + " = length(VELOCITY) > 0.0 ? " + "normalize(VELOCITY) * " + (p_input_vars[0].is_empty_string() ? "vec3" + (String)get_input_port_default_value(0) : p_input_vars[0]) + " * mix(1.0, __rand_from_seed(__seed), " + (p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ") : vec3(0.0);\n";
 			break;
 		case MODE_RADIAL:
-			code += "	" + p_output_vars[0] + " = length(__diff) > 0.0 ? __ndiff * " + (p_input_vars[0].is_empty() ? "vec3" + (String)get_input_port_default_value(0) : p_input_vars[0]) + " * mix(1.0, __rand_from_seed(__seed), " + (p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ") : vec3(0.0);\n";
+			code += "	" + p_output_vars[0] + " = length(__diff) > 0.0 ? __ndiff * " + (p_input_vars[0].is_empty_string() ? "vec3" + (String)get_input_port_default_value(0) : p_input_vars[0]) + " * mix(1.0, __rand_from_seed(__seed), " + (p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ") : vec3(0.0);\n";
 			break;
 		case MODE_TANGENTIAL:
-			code += "	__vec3_buff1 = cross(__ndiff, normalize(" + (p_input_vars[2].is_empty() ? "vec3" + (String)get_input_port_default_value(2) : p_input_vars[2]) + "));\n";
-			code += "	" + p_output_vars[0] + " = length(__vec3_buff1) > 0.0 ? normalize(__vec3_buff1) * (" + (p_input_vars[0].is_empty() ? "vec3" + (String)get_input_port_default_value(0) : p_input_vars[0]) + " * mix(1.0, __rand_from_seed(__seed), " + (p_input_vars[1].is_empty() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ")) : vec3(0.0);\n";
+			code += "	__vec3_buff1 = cross(__ndiff, normalize(" + (p_input_vars[2].is_empty_string() ? "vec3" + (String)get_input_port_default_value(2) : p_input_vars[2]) + "));\n";
+			code += "	" + p_output_vars[0] + " = length(__vec3_buff1) > 0.0 ? normalize(__vec3_buff1) * (" + (p_input_vars[0].is_empty_string() ? "vec3" + (String)get_input_port_default_value(0) : p_input_vars[0]) + " * mix(1.0, __rand_from_seed(__seed), " + (p_input_vars[1].is_empty_string() ? (String)get_input_port_default_value(1) : p_input_vars[1]) + ")) : vec3(0.0);\n";
 			break;
 		default:
 			break;
@@ -1276,7 +1276,7 @@ String VisualShaderNodeParticleOutput::get_input_port_name(int p_port) const {
 		default:
 			break;
 	}
-	if (!port_name.is_empty()) {
+	if (!port_name.is_empty_string()) {
 		return port_name.capitalize();
 	}
 	return String();
@@ -1299,44 +1299,44 @@ String VisualShaderNodeParticleOutput::generate_code(Shader::Mode p_mode, Visual
 	String tab = "	";
 
 	if (shader_type == VisualShader::TYPE_START_CUSTOM || shader_type == VisualShader::TYPE_PROCESS_CUSTOM) {
-		if (!p_input_vars[0].is_empty()) { // custom.rgb
+		if (!p_input_vars[0].is_empty_string()) { // custom.rgb
 			code += tab + "CUSTOM.rgb = " + p_input_vars[0] + ";\n";
 		}
-		if (!p_input_vars[1].is_empty()) { // custom.a
+		if (!p_input_vars[1].is_empty_string()) { // custom.a
 			code += tab + "CUSTOM.a = " + p_input_vars[1] + ";\n";
 		}
-		if (!p_input_vars[2].is_empty()) { // velocity
+		if (!p_input_vars[2].is_empty_string()) { // velocity
 			code += tab + "VELOCITY = " + p_input_vars[2] + ";\n";
 		}
-		if (!p_input_vars[3].is_empty()) { // color.rgb
+		if (!p_input_vars[3].is_empty_string()) { // color.rgb
 			code += tab + "COLOR.rgb = " + p_input_vars[3] + ";\n";
 		}
-		if (!p_input_vars[4].is_empty()) { // color.a
+		if (!p_input_vars[4].is_empty_string()) { // color.a
 			code += tab + "COLOR.a = " + p_input_vars[4] + ";\n";
 		}
-		if (!p_input_vars[5].is_empty()) { // transform
+		if (!p_input_vars[5].is_empty_string()) { // transform
 			code += tab + "TRANSFORM = " + p_input_vars[5] + ";\n";
 		}
 	} else {
-		if (!p_input_vars[0].is_empty()) { // Active (begin).
+		if (!p_input_vars[0].is_empty_string()) { // Active (begin).
 			code += tab + "ACTIVE = " + p_input_vars[0] + ";\n";
 			code += tab + "if(ACTIVE) {\n";
 			tab += "	";
 		}
-		if (!p_input_vars[1].is_empty()) { // velocity
+		if (!p_input_vars[1].is_empty_string()) { // velocity
 			code += tab + "VELOCITY = " + p_input_vars[1] + ";\n";
 		}
-		if (!p_input_vars[2].is_empty()) { // color
+		if (!p_input_vars[2].is_empty_string()) { // color
 			code += tab + "COLOR.rgb = " + p_input_vars[2] + ";\n";
 		}
-		if (!p_input_vars[3].is_empty()) { // alpha
+		if (!p_input_vars[3].is_empty_string()) { // alpha
 			code += tab + "COLOR.a = " + p_input_vars[3] + ";\n";
 		}
 
 		// position
 		if (shader_type == VisualShader::TYPE_START) {
 			code += tab + "if (RESTART_POSITION) {\n";
-			if (!p_input_vars[4].is_empty()) {
+			if (!p_input_vars[4].is_empty_string()) {
 				code += tab + "	TRANSFORM = mat4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0), vec4(" + p_input_vars[4] + ", 1.0));\n";
 			} else {
 				code += tab + "	TRANSFORM = mat4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));\n";
@@ -1347,7 +1347,7 @@ String VisualShaderNodeParticleOutput::generate_code(Shader::Mode p_mode, Visual
 			code += tab + "	TRANSFORM = EMISSION_TRANSFORM * TRANSFORM;\n";
 			code += tab + "}\n";
 		} else if (shader_type == VisualShader::TYPE_COLLIDE) { // position
-			if (!p_input_vars[4].is_empty()) {
+			if (!p_input_vars[4].is_empty_string()) {
 				code += tab + "TRANSFORM = " + p_input_vars[4] + ";\n";
 			}
 		}
@@ -1368,20 +1368,20 @@ String VisualShaderNodeParticleOutput::generate_code(Shader::Mode p_mode, Visual
 				op = "=";
 			}
 
-			if (!p_input_vars[rotation].is_empty()) { // rotation_axis & angle_in_radians
+			if (!p_input_vars[rotation].is_empty_string()) { // rotation_axis & angle_in_radians
 				String axis;
-				if (p_input_vars[rotation_axis].is_empty()) {
+				if (p_input_vars[rotation_axis].is_empty_string()) {
 					axis = "vec3(0, 1, 0)";
 				} else {
 					axis = p_input_vars[rotation_axis];
 				}
 				code += tab + "TRANSFORM " + op + " __build_rotation_mat4(" + axis + ", " + p_input_vars[rotation] + ");\n";
 			}
-			if (!p_input_vars[scale].is_empty()) { // scale
+			if (!p_input_vars[scale].is_empty_string()) { // scale
 				code += tab + "TRANSFORM " + op + " mat4(vec4(" + p_input_vars[scale] + ", 0, 0, 0), vec4(0, " + p_input_vars[scale] + ", 0, 0), vec4(0, 0, " + p_input_vars[scale] + ", 0), vec4(0, 0, 0, 1));\n";
 			}
 		}
-		if (!p_input_vars[0].is_empty()) { // Active (end).
+		if (!p_input_vars[0].is_empty_string()) { // Active (end).
 			code += "	}\n";
 		}
 	}
@@ -1538,42 +1538,42 @@ String VisualShaderNodeParticleEmit::generate_code(Shader::Mode p_mode, VisualSh
 	}
 
 	String transform;
-	if (p_input_vars[1].is_empty()) {
+	if (p_input_vars[1].is_empty_string()) {
 		transform = "TRANSFORM";
 	} else {
 		transform = p_input_vars[1];
 	}
 
 	String velocity;
-	if (p_input_vars[2].is_empty()) {
+	if (p_input_vars[2].is_empty_string()) {
 		velocity = "VELOCITY";
 	} else {
 		velocity = p_input_vars[2];
 	}
 
 	String color;
-	if (p_input_vars[3].is_empty()) {
+	if (p_input_vars[3].is_empty_string()) {
 		color = "COLOR.rgb";
 	} else {
 		color = p_input_vars[3];
 	}
 
 	String alpha;
-	if (p_input_vars[4].is_empty()) {
+	if (p_input_vars[4].is_empty_string()) {
 		alpha = "COLOR.a";
 	} else {
 		alpha = p_input_vars[4];
 	}
 
 	String custom;
-	if (p_input_vars[5].is_empty()) {
+	if (p_input_vars[5].is_empty_string()) {
 		custom = "CUSTOM.rgb";
 	} else {
 		custom = p_input_vars[5];
 	}
 
 	String custom_alpha;
-	if (p_input_vars[6].is_empty()) {
+	if (p_input_vars[6].is_empty_string()) {
 		custom_alpha = "CUSTOM.a";
 	} else {
 		custom_alpha = p_input_vars[6];
@@ -1606,7 +1606,7 @@ String VisualShaderNodeParticleEmit::generate_code(Shader::Mode p_mode, VisualSh
 		flags += flags_arr[i];
 	}
 
-	if (flags.is_empty()) {
+	if (flags.is_empty_string()) {
 		flags = "uint(0)";
 	}
 

--- a/scene/resources/visual_shader_sdf_nodes.cpp
+++ b/scene/resources/visual_shader_sdf_nodes.cpp
@@ -61,7 +61,7 @@ String VisualShaderNodeSDFToScreenUV::get_output_port_name(int p_port) const {
 }
 
 String VisualShaderNodeSDFToScreenUV::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "		" + p_output_vars[0] + " = sdf_to_screen_uv(" + (p_input_vars[0].is_empty() ? "vec2(0.0)" : p_input_vars[0]) + ");\n";
+	return "		" + p_output_vars[0] + " = sdf_to_screen_uv(" + (p_input_vars[0].is_empty_string() ? "vec2(0.0)" : p_input_vars[0]) + ");\n";
 }
 
 VisualShaderNodeSDFToScreenUV::VisualShaderNodeSDFToScreenUV() {
@@ -105,7 +105,7 @@ bool VisualShaderNodeScreenUVToSDF::is_input_port_default(int p_port, Shader::Mo
 }
 
 String VisualShaderNodeScreenUVToSDF::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "		" + p_output_vars[0] + " = screen_uv_to_sdf(" + (p_input_vars[0].is_empty() ? "SCREEN_UV" : p_input_vars[0]) + ");\n";
+	return "		" + p_output_vars[0] + " = screen_uv_to_sdf(" + (p_input_vars[0].is_empty_string() ? "SCREEN_UV" : p_input_vars[0]) + ");\n";
 }
 
 VisualShaderNodeScreenUVToSDF::VisualShaderNodeScreenUVToSDF() {
@@ -142,7 +142,7 @@ String VisualShaderNodeTextureSDF::get_output_port_name(int p_port) const {
 }
 
 String VisualShaderNodeTextureSDF::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "		" + p_output_vars[0] + " = texture_sdf(" + (p_input_vars[0].is_empty() ? "vec2(0.0)" : p_input_vars[0]) + ");\n";
+	return "		" + p_output_vars[0] + " = texture_sdf(" + (p_input_vars[0].is_empty_string() ? "vec2(0.0)" : p_input_vars[0]) + ");\n";
 }
 
 VisualShaderNodeTextureSDF::VisualShaderNodeTextureSDF() {
@@ -179,7 +179,7 @@ String VisualShaderNodeTextureSDFNormal::get_output_port_name(int p_port) const 
 }
 
 String VisualShaderNodeTextureSDFNormal::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "		" + p_output_vars[0] + " = texture_sdf_normal(" + (p_input_vars[0].is_empty() ? "vec2(0.0)" : p_input_vars[0]) + ");\n";
+	return "		" + p_output_vars[0] + " = texture_sdf_normal(" + (p_input_vars[0].is_empty_string() ? "vec2(0.0)" : p_input_vars[0]) + ");\n";
 }
 
 VisualShaderNodeTextureSDFNormal::VisualShaderNodeTextureSDFNormal() {
@@ -242,13 +242,13 @@ String VisualShaderNodeSDFRaymarch::generate_code(Shader::Mode p_mode, VisualSha
 
 	code += "		{\n";
 
-	if (p_input_vars[0].is_empty()) {
+	if (p_input_vars[0].is_empty_string()) {
 		code += "				vec2 __from_pos = vec2(0.0f);\n";
 	} else {
 		code += "				vec2 __from_pos = " + p_input_vars[0] + ";\n";
 	}
 
-	if (p_input_vars[1].is_empty()) {
+	if (p_input_vars[1].is_empty_string()) {
 		code += "				vec2 __to_pos = vec2(0.0f);\n";
 	} else {
 		code += "				vec2 __to_pos = " + p_input_vars[1] + ";\n";

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -324,7 +324,7 @@ String DisplayServer::clipboard_get() const {
 }
 
 bool DisplayServer::clipboard_has() const {
-	return !clipboard_get().is_empty();
+	return !clipboard_get().is_empty_string();
 }
 
 void DisplayServer::clipboard_set_primary(const String &p_text) {

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -46,7 +46,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	uniforms.clear();
 	uses_screen_texture = false;
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -48,7 +48,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	uniforms.clear();
 	uses_screen_texture = false;
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1978,7 +1978,7 @@ void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code) {
 	uses_sdf = false;
 	uses_time = false;
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -250,7 +250,7 @@ RendererCompositorRD::RendererCompositorRD() {
 
 	{
 		String shader_cache_dir = Engine::get_singleton()->get_shader_cache_path();
-		if (shader_cache_dir.is_empty()) {
+		if (shader_cache_dir.is_empty_string()) {
 			shader_cache_dir = "user://";
 		}
 		Ref<DirAccess> da = DirAccess::open(shader_cache_dir);
@@ -271,7 +271,7 @@ RendererCompositorRD::RendererCompositorRD() {
 					shader_cache_dir = String(); //disable only if not editor
 				}
 
-				if (!shader_cache_dir.is_empty()) {
+				if (!shader_cache_dir.is_empty_string()) {
 					bool compress = GLOBAL_GET("rendering/shader_compiler/shader_cache/compress");
 					bool use_zstd = GLOBAL_GET("rendering/shader_compiler/shader_cache/use_zstd_compression");
 					bool strip_debug = GLOBAL_GET("rendering/shader_compiler/shader_cache/strip_debug");

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3979,7 +3979,7 @@ void RendererSceneRenderRD::FogShaderData::set_code(const String &p_code) {
 	ubo_size = 0;
 	uniforms.clear();
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -49,7 +49,7 @@ void RendererSceneSkyRD::SkyShaderData::set_code(const String &p_code) {
 	ubo_size = 0;
 	uniforms.clear();
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -79,7 +79,7 @@ void ShaderRD::_add_stage(const char *p_code, StageType p_stage_type) {
 		}
 
 		if (push_chunk) {
-			if (!text.is_empty()) {
+			if (!text.is_empty_string()) {
 				StageTemplate::Chunk text_chunk;
 				text_chunk.type = StageTemplate::Chunk::TYPE_TEXT;
 				text_chunk.text = text.utf8();
@@ -90,7 +90,7 @@ void ShaderRD::_add_stage(const char *p_code, StageType p_stage_type) {
 		}
 	}
 
-	if (!text.is_empty()) {
+	if (!text.is_empty_string()) {
 		StageTemplate::Chunk text_chunk;
 		text_chunk.type = StageTemplate::Chunk::TYPE_TEXT;
 		text_chunk.text = text.utf8();
@@ -636,7 +636,7 @@ void ShaderRD::initialize(const Vector<String> &p_variant_defines, const String 
 		variants_enabled.push_back(true);
 	}
 
-	if (!shader_cache_dir.is_empty()) {
+	if (!shader_cache_dir.is_empty_string()) {
 		StringBuilder hash_build;
 
 		hash_build.append("[base_hash]");

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1138,7 +1138,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 				}
 			}
 #ifdef TOOLS_ENABLED
-			if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
+			if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty_string()) {
 				roughness_detect_texture->detect_roughness_callback(roughness_detect_texture->detect_roughness_callback_ud, normal_detect_texture->path, roughness_channel);
 			}
 #endif
@@ -1178,7 +1178,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 					rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_WHITE);
 				}
 #ifdef TOOLS_ENABLED
-				if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
+				if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty_string()) {
 					roughness_detect_texture->detect_roughness_callback(roughness_detect_texture->detect_roughness_callback_ud, normal_detect_texture->path, roughness_channel);
 				}
 #endif

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1523,7 +1523,7 @@ void ParticlesStorage::ParticlesShaderData::set_code(const String &p_code) {
 	uniforms.clear();
 	uses_collision = false;
 
-	if (code.is_empty()) {
+	if (code.is_empty_string()) {
 		return; //just invalid, but no error
 	}
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -187,7 +187,7 @@ Ref<RDShaderSPIRV> RenderingDevice::_shader_compile_spirv_from_source(const Ref<
 		ShaderStage stage = ShaderStage(i);
 		String source = p_source->get_stage_source(stage);
 
-		if (!source.is_empty()) {
+		if (!source.is_empty_string()) {
 			Vector<uint8_t> spirv = shader_compile_spirv_from_source(stage, source, p_source->get_language(), &error, p_allow_cache);
 			bytecode->set_stage_bytecode(stage, spirv);
 			bytecode->set_stage_compile_error(stage, error);
@@ -205,7 +205,7 @@ Vector<uint8_t> RenderingDevice::_shader_compile_binary_from_spirv(const Ref<RDS
 		ShaderStageSPIRVData sd;
 		sd.shader_stage = stage;
 		String error = p_spirv->get_stage_compile_error(stage);
-		ERR_FAIL_COND_V_MSG(!error.is_empty(), Vector<uint8_t>(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
+		ERR_FAIL_COND_V_MSG(!error.is_empty_string(), Vector<uint8_t>(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
 		sd.spir_v = p_spirv->get_stage_bytecode(stage);
 		if (sd.spir_v.is_empty()) {
 			continue;
@@ -225,7 +225,7 @@ RID RenderingDevice::_shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv
 		ShaderStageSPIRVData sd;
 		sd.shader_stage = stage;
 		String error = p_spirv->get_stage_compile_error(stage);
-		ERR_FAIL_COND_V_MSG(!error.is_empty(), RID(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
+		ERR_FAIL_COND_V_MSG(!error.is_empty_string(), RID(), "Can't create a shader from an errored bytecode. Check errors in source bytecode.");
 		sd.spir_v = p_spirv->get_stage_bytecode(stage);
 		if (sd.spir_v.is_empty()) {
 			continue;

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -80,7 +80,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 						}
 					}
 
-					if (!base_error.is_empty()) {
+					if (!base_error.is_empty_string()) {
 						break;
 					}
 				}
@@ -89,7 +89,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 			}
 		}
 
-		if (stage == RD::SHADER_STAGE_MAX && !line.strip_edges().is_empty()) {
+		if (stage == RD::SHADER_STAGE_MAX && !line.strip_edges().is_empty_string()) {
 			line = line.strip_edges();
 			if (line.begins_with("//") || line.begins_with("/*")) {
 				continue; //assuming comment (single line)
@@ -98,7 +98,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 
 		if (reading_versions) {
 			String l = line.strip_edges();
-			if (!l.is_empty()) {
+			if (!l.is_empty_string()) {
 				if (!l.contains("=")) {
 					base_error = "Missing `=` in '" + l + "'. Version syntax is `version = \"<defines with C escaping>\";`.";
 					break;
@@ -124,7 +124,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 				version_texts[version] = define + "\n" + p_defines;
 			}
 		} else {
-			if (stage == RD::SHADER_STAGE_MAX && !line.strip_edges().is_empty()) {
+			if (stage == RD::SHADER_STAGE_MAX && !line.strip_edges().is_empty_string()) {
 				base_error = "Text was found that does not belong to a valid section: " + line;
 				break;
 			}
@@ -140,7 +140,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 						}
 						include = include.substr(1, include.length() - 2).strip_edges();
 						String include_text = p_include_func(include, p_include_func_userdata);
-						if (!include_text.is_empty()) {
+						if (!include_text.is_empty_string()) {
 							stage_code[stage] += "\n" + include_text + "\n";
 						} else {
 							base_error = "#include failed for file '" + include + "'";
@@ -158,7 +158,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 	Ref<RDShaderFile> shader_file;
 	shader_file.instantiate();
 
-	if (base_error.is_empty()) {
+	if (base_error.is_empty_string()) {
 		if (stage_found[RD::SHADER_STAGE_COMPUTE] && stages_found > 1) {
 			ERR_FAIL_V_MSG(ERR_PARSE_ERROR, "When writing compute shaders, [compute] mustbe the only stage present.");
 		}
@@ -177,14 +177,14 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 
 			for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 				String code = stage_code[i];
-				if (code.is_empty()) {
+				if (code.is_empty_string()) {
 					continue;
 				}
 				code = code.replace("VERSION_DEFINES", E.value);
 				String error;
 				Vector<uint8_t> spirv = RenderingDevice::get_singleton()->shader_compile_spirv_from_source(RD::ShaderStage(i), code, RD::SHADER_LANGUAGE_GLSL, &error, false);
 				bytecode->set_stage_bytecode(RD::ShaderStage(i), spirv);
-				if (!error.is_empty()) {
+				if (!error.is_empty_string()) {
 					error += String() + "\n\nStage '" + stage_str[i] + "' source code: \n\n";
 					Vector<String> sclines = code.split("\n");
 					for (int j = 0; j < sclines.size(); j++) {

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -368,13 +368,13 @@ public:
 	}
 
 	void print_errors(const String &p_file) {
-		if (!base_error.is_empty()) {
+		if (!base_error.is_empty_string()) {
 			ERR_PRINT("Error parsing shader '" + p_file + "':\n\n" + base_error);
 		} else {
 			for (KeyValue<StringName, Ref<RDShaderSPIRV>> &E : versions) {
 				for (int i = 0; i < RD::SHADER_STAGE_MAX; i++) {
 					String error = E.value->get_stage_compile_error(RD::ShaderStage(i));
-					if (!error.is_empty()) {
+					if (!error.is_empty_string()) {
 						static const char *stage_str[RD::SHADER_STAGE_MAX] = {
 							"vertex",
 							"fragment",

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3203,7 +3203,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 		}
 
 		FunctionNode *pfunc = shader->functions[i].function;
-		if (arg_list.is_empty()) {
+		if (arg_list.is_empty_string()) {
 			for (int j = 0; j < pfunc->arguments.size(); j++) {
 				if (j > 0) {
 					arg_list += ", ";
@@ -7449,7 +7449,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			if (tk.type == TK_SEMICOLON) {
 				//all is good
 				if (b->parent_function->return_type != TYPE_VOID) {
-					_set_error(vformat(RTR("Expected '%s' with an expression of type '%s'."), "return", (!return_struct_name.is_empty() ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string));
+					_set_error(vformat(RTR("Expected '%s' with an expression of type '%s'."), "return", (!return_struct_name.is_empty_string() ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string));
 					return ERR_PARSE_ERROR;
 				}
 			} else {
@@ -7467,7 +7467,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				}
 
 				if (b->parent_function->return_type != expr->get_datatype() || b->parent_function->return_array_size != expr->get_array_size() || return_struct_name != expr->get_datatype_name()) {
-					_set_error(vformat(RTR("Expected return with an expression of type '%s'."), (!return_struct_name.is_empty() ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string));
+					_set_error(vformat(RTR("Expected return with an expression of type '%s'."), (!return_struct_name.is_empty_string() ? return_struct_name : get_datatype_name(b->parent_function->return_type)) + array_size_string));
 					return ERR_PARSE_ERROR;
 				}
 
@@ -7636,7 +7636,7 @@ String ShaderLanguage::_get_shader_type_list(const HashSet<String> &p_shader_typ
 	// Return a list of shader types as an human-readable string
 	String valid_types;
 	for (const String &E : p_shader_types) {
-		if (!valid_types.is_empty()) {
+		if (!valid_types.is_empty_string()) {
 			valid_types += ", ";
 		}
 
@@ -9446,7 +9446,7 @@ String ShaderLanguage::get_shader_type(const String &p_code) {
 			break;
 
 		} else if (p_code[i] <= 32) {
-			if (!cur_identifier.is_empty()) {
+			if (!cur_identifier.is_empty_string()) {
 				if (!reading_type) {
 					if (cur_identifier != "shader_type") {
 						return String();
@@ -9942,7 +9942,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 						calltip += get_datatype_name(builtin_func_defs[idx].args[i]);
 
 						String arg_name = (String)builtin_func_defs[idx].args_names[i];
-						if (!arg_name.is_empty()) {
+						if (!arg_name.is_empty_string()) {
 							calltip += " ";
 							calltip += arg_name;
 						}

--- a/tests/core/io/test_file_access.h
+++ b/tests/core/io/test_file_access.h
@@ -53,7 +53,7 @@ TEST_CASE("[FileAccess] CSV read") {
 	REQUIRE(row2.size() == 3);
 	CHECK(row2[0] == "GOOD_EVENING");
 	CHECK(row2[1] == "Good Evening");
-	CHECK(row2[2].is_empty()); // Use case: not yet translated!
+	CHECK(row2[2].is_empty_string()); // Use case: not yet translated!
 	// https://github.com/godotengine/godot/issues/44269
 	CHECK_MESSAGE(row2[2] != "\"", "Should not parse empty string as a single double quote.");
 

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -413,7 +413,7 @@ void validate_method(const Context &p_context, const ExposedClass &p_class, cons
 			String type_error_msg;
 			bool arg_defval_assignable_to_type = arg_default_value_is_assignable_to_type(p_context, arg.defval, arg.type, &type_error_msg);
 			String err_msg = vformat("Invalid default value for parameter '%s' of method '%s.%s'.", arg.name, p_class.name, p_method.name);
-			if (!type_error_msg.is_empty()) {
+			if (!type_error_msg.is_empty_string()) {
 				err_msg += " " + type_error_msg;
 			}
 			TEST_COND(!arg_defval_assignable_to_type, err_msg.utf8().get_data());
@@ -559,7 +559,7 @@ void add_exposed_classes(Context &r_context) {
 
 			int argc = method_info.arguments.size();
 
-			if (method_info.name.is_empty()) {
+			if (method_info.name.is_empty_string()) {
 				continue;
 			}
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -158,10 +158,10 @@ TEST_CASE("[String] Invalid UTF8") {
 	String s;
 	bool err = s.parse_utf8((const char *)u8str);
 	CHECK(err);
-	CHECK(s.is_empty());
+	CHECK(s.is_empty_string());
 
 	CharString cs = (const char *)u8str;
-	CHECK(String::utf8(cs).is_empty());
+	CHECK(String::utf8(cs).is_empty_string());
 	ERR_PRINT_ON
 }
 
@@ -171,10 +171,10 @@ TEST_CASE("[String] Invalid UTF16") {
 	String s;
 	bool err = s.parse_utf16(u16str);
 	CHECK(err);
-	CHECK(s.is_empty());
+	CHECK(s.is_empty_string());
 
 	Char16String cs = u16str;
-	CHECK(String::utf16(cs).is_empty());
+	CHECK(String::utf16(cs).is_empty_string());
 	ERR_PRINT_ON
 }
 
@@ -238,11 +238,11 @@ TEST_CASE("[String] Testing size and length of string") {
 }
 
 TEST_CASE("[String] Testing for empty string") {
-	CHECK(!String("Mellon").is_empty());
+	CHECK(!String("Mellon").is_empty_string());
 	// do this more than once, to check for string corruption
-	CHECK(String("").is_empty());
-	CHECK(String("").is_empty());
-	CHECK(String("").is_empty());
+	CHECK(String("").is_empty_string());
+	CHECK(String("").is_empty_string());
+	CHECK(String("").is_empty_string());
 }
 
 TEST_CASE("[String] Contains") {
@@ -1536,7 +1536,7 @@ TEST_CASE("[String] Variant ptr indexed set") {
 TEST_CASE("[Stress][String] Empty via ' == String()'") {
 	for (int i = 0; i < 100000; ++i) {
 		String str = "Hello World!";
-		if (str.is_empty()) {
+		if (str.is_empty_string()) {
 			continue;
 		}
 	}
@@ -1545,7 +1545,7 @@ TEST_CASE("[Stress][String] Empty via ' == String()'") {
 TEST_CASE("[Stress][String] Empty via `is_empty()`") {
 	for (int i = 0; i < 100000; ++i) {
 		String str = "Hello World!";
-		if (str.is_empty()) {
+		if (str.is_empty_string()) {
 			continue;
 		}
 	}

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -1802,10 +1802,10 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->set_editable(false);
 
 		code_edit->do_indent();
-		CHECK(code_edit->get_line(0).is_empty());
+		CHECK(code_edit->get_line(0).is_empty_string());
 
 		code_edit->indent_lines();
-		CHECK(code_edit->get_line(0).is_empty());
+		CHECK(code_edit->get_line(0).is_empty_string());
 
 		code_edit->set_editable(true);
 
@@ -1875,10 +1875,10 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->set_editable(false);
 
 		code_edit->do_indent();
-		CHECK(code_edit->get_line(0).is_empty());
+		CHECK(code_edit->get_line(0).is_empty_string());
 
 		code_edit->indent_lines();
-		CHECK(code_edit->get_line(0).is_empty());
+		CHECK(code_edit->get_line(0).is_empty_string());
 
 		code_edit->set_editable(true);
 
@@ -2774,7 +2774,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		CHECK(code_edit->get_auto_brace_completion_close_key("'") == "'");
 		CHECK(code_edit->get_auto_brace_completion_close_key(";") == "'");
 		CHECK(code_edit->get_auto_brace_completion_close_key("'''") == "'''");
-		CHECK(code_edit->get_auto_brace_completion_close_key("(").is_empty());
+		CHECK(code_edit->get_auto_brace_completion_close_key("(").is_empty_string());
 
 		/* Check typing inserts closing pair. */
 		code_edit->clear();
@@ -2795,7 +2795,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Backspace should remove all. */
 		SEND_GUI_ACTION(code_edit, "ui_text_backspace");
-		CHECK(code_edit->get_line(0).is_empty());
+		CHECK(code_edit->get_line(0).is_empty_string());
 
 		/* If in between and typing close key should "skip". */
 		SEND_GUI_KEY_EVENT(code_edit, Key::BRACKETLEFT);
@@ -3325,7 +3325,7 @@ TEST_CASE("[SceneTree][CodeEdit] Backspace delete") {
 	code_edit->insert_text_at_caret("line 1\nline 2\nline 3");
 	code_edit->select_all();
 	code_edit->backspace();
-	CHECK(code_edit->get_text().is_empty());
+	CHECK(code_edit->get_text().is_empty_string());
 
 	/* Backspace at the beginning without selection has no effect. */
 	code_edit->set_text("");


### PR DESCRIPTION
The change in #43181 was done for the sake of improving performance, even
though it probably was not needed. As a result, code legibility for
string processing has become significantly more difficult. Code like

```C++
if (something != "")
// became
if (!something.is_empty())
```

Making it less obvious that "something" is a string (because is_empty is used with templated containers, and String is not really considered one).
The negation also makes it a bit more difficult to read, specially in long variables but at this point its too late to change.

This PR intends to make it clearer that the base type is a String and not a container when reading code. Another PR may follow up to get rid of the negation, but its probably not as urgent.

Supersedes #62294
