### PR TITLE
Replace some TTRCs with RTRs

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -262,7 +262,7 @@ Button *AcceptDialog::add_button(const String &p_text, bool p_right, const Strin
 Button *AcceptDialog::add_cancel_button(const String &p_cancel) {
 	String c = p_cancel;
 	if (p_cancel.is_empty()) {
-		c = TTRC("Cancel");
+		c = RTR("Cancel");
 	}
 	Button *b = swap_cancel_ok ? add_button(c, true) : add_button(c);
 	b->connect("pressed", callable_mp(this, &AcceptDialog::_cancel_pressed));
@@ -349,7 +349,7 @@ AcceptDialog::AcceptDialog() {
 
 	hbc->add_spacer();
 	ok = memnew(Button);
-	ok->set_text(TTRC("OK"));
+	ok->set_text(RTR("OK"));
 	hbc->add_child(ok);
 	hbc->add_spacer();
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -337,7 +337,7 @@ void FileDialog::_action_pressed() {
 		}
 
 		if (dir_access->file_exists(f)) {
-			confirm_save->set_text(TTRC("File exists, overwrite?"));
+			confirm_save->set_text(RTR("File exists, overwrite?"));
 			confirm_save->popup_centered(Size2(200, 80));
 		} else {
 			emit_signal(SNAME("file_selected"), f);
@@ -423,10 +423,10 @@ void FileDialog::deselect_all() {
 		switch (mode) {
 			case FILE_MODE_OPEN_FILE:
 			case FILE_MODE_OPEN_FILES:
-				get_ok_button()->set_text(TTRC("Open"));
+				get_ok_button()->set_text(RTR("Open"));
 				break;
 			case FILE_MODE_OPEN_DIR:
-				get_ok_button()->set_text(TTRC("Select Current Folder"));
+				get_ok_button()->set_text(RTR("Select Current Folder"));
 				break;
 			case FILE_MODE_OPEN_ANY:
 			case FILE_MODE_SAVE_FILE:
@@ -450,7 +450,7 @@ void FileDialog::_tree_selected() {
 	if (!d["dir"]) {
 		file->set_text(d["name"]);
 	} else if (mode == FILE_MODE_OPEN_DIR) {
-		get_ok_button()->set_text(TTRC("Select This Folder"));
+		get_ok_button()->set_text(RTR("Select This Folder"));
 	}
 
 	get_ok_button()->set_disabled(_is_open_should_be_disabled());
@@ -502,7 +502,7 @@ void FileDialog::update_file_list() {
 	if (dir_access->is_readable(dir_access->get_current_dir().utf8().get_data())) {
 		message->hide();
 	} else {
-		message->set_text(TTRC("You don't have permission to access contents of this folder."));
+		message->set_text(RTR("You don't have permission to access contents of this folder."));
 		message->show();
 	}
 
@@ -746,35 +746,35 @@ void FileDialog::set_file_mode(FileMode p_mode) {
 	mode = p_mode;
 	switch (mode) {
 		case FILE_MODE_OPEN_FILE:
-			get_ok_button()->set_text(TTRC("Open"));
+			get_ok_button()->set_text(RTR("Open"));
 			if (mode_overrides_title) {
 				set_title(TTRC("Open a File"));
 			}
 			makedir->hide();
 			break;
 		case FILE_MODE_OPEN_FILES:
-			get_ok_button()->set_text(TTRC("Open"));
+			get_ok_button()->set_text(RTR("Open"));
 			if (mode_overrides_title) {
 				set_title(TTRC("Open File(s)"));
 			}
 			makedir->hide();
 			break;
 		case FILE_MODE_OPEN_DIR:
-			get_ok_button()->set_text(TTRC("Select Current Folder"));
+			get_ok_button()->set_text(RTR("Select Current Folder"));
 			if (mode_overrides_title) {
 				set_title(TTRC("Open a Directory"));
 			}
 			makedir->show();
 			break;
 		case FILE_MODE_OPEN_ANY:
-			get_ok_button()->set_text(TTRC("Open"));
+			get_ok_button()->set_text(RTR("Open"));
 			if (mode_overrides_title) {
 				set_title(TTRC("Open a File or Directory"));
 			}
 			makedir->show();
 			break;
 		case FILE_MODE_SAVE_FILE:
-			get_ok_button()->set_text(TTRC("Save"));
+			get_ok_button()->set_text(RTR("Save"));
 			if (mode_overrides_title) {
 				set_title(TTRC("Save a File"));
 			}
@@ -964,13 +964,13 @@ FileDialog::FileDialog() {
 
 	dir_prev = memnew(Button);
 	dir_prev->set_flat(true);
-	dir_prev->set_tooltip(TTRC("Go to previous folder."));
+	dir_prev->set_tooltip(RTR("Go to previous folder."));
 	dir_next = memnew(Button);
 	dir_next->set_flat(true);
-	dir_next->set_tooltip(TTRC("Go to next folder."));
+	dir_next->set_tooltip(RTR("Go to next folder."));
 	dir_up = memnew(Button);
 	dir_up->set_flat(true);
-	dir_up->set_tooltip(TTRC("Go to parent folder."));
+	dir_up->set_tooltip(RTR("Go to parent folder."));
 	hbc->add_child(dir_prev);
 	hbc->add_child(dir_next);
 	hbc->add_child(dir_up);
@@ -978,7 +978,7 @@ FileDialog::FileDialog() {
 	dir_next->connect("pressed", callable_mp(this, &FileDialog::_go_forward));
 	dir_up->connect("pressed", callable_mp(this, &FileDialog::_go_up));
 
-	hbc->add_child(memnew(Label(TTRC("Path:"))));
+	hbc->add_child(memnew(Label(RTR("Path:"))));
 
 	drives_container = memnew(HBoxContainer);
 	hbc->add_child(drives_container);
@@ -994,7 +994,7 @@ FileDialog::FileDialog() {
 
 	refresh = memnew(Button);
 	refresh->set_flat(true);
-	refresh->set_tooltip(TTRC("Refresh files."));
+	refresh->set_tooltip(RTR("Refresh files."));
 	refresh->connect("pressed", callable_mp(this, &FileDialog::update_file_list));
 	hbc->add_child(refresh);
 
@@ -1002,7 +1002,7 @@ FileDialog::FileDialog() {
 	show_hidden->set_flat(true);
 	show_hidden->set_toggle_mode(true);
 	show_hidden->set_pressed(is_showing_hidden_files());
-	show_hidden->set_tooltip(TTRC("Toggle the visibility of hidden files."));
+	show_hidden->set_tooltip(RTR("Toggle the visibility of hidden files."));
 	show_hidden->connect("toggled", callable_mp(this, &FileDialog::set_show_hidden_files));
 	hbc->add_child(show_hidden);
 
@@ -1010,14 +1010,14 @@ FileDialog::FileDialog() {
 	hbc->add_child(shortcuts_container);
 
 	makedir = memnew(Button);
-	makedir->set_text(TTRC("Create Folder"));
+	makedir->set_text(RTR("Create Folder"));
 	makedir->connect("pressed", callable_mp(this, &FileDialog::_make_dir));
 	hbc->add_child(makedir);
 	vbox->add_child(hbc);
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
-	vbox->add_margin_child(TTRC("Directories & Files:"), tree, true);
+	vbox->add_margin_child(RTR("Directories & Files:"), tree, true);
 
 	message = memnew(Label);
 	message->hide();
@@ -1027,7 +1027,7 @@ FileDialog::FileDialog() {
 	tree->add_child(message);
 
 	file_box = memnew(HBoxContainer);
-	file_box->add_child(memnew(Label(TTRC("File:"))));
+	file_box->add_child(memnew(Label(RTR("File:"))));
 	file = memnew(LineEdit);
 	file->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
 	file->set_stretch_ratio(4);
@@ -1058,22 +1058,22 @@ FileDialog::FileDialog() {
 	confirm_save->connect("confirmed", callable_mp(this, &FileDialog::_save_confirm_pressed));
 
 	makedialog = memnew(ConfirmationDialog);
-	makedialog->set_title(TTRC("Create Folder"));
+	makedialog->set_title(RTR("Create Folder"));
 	VBoxContainer *makevb = memnew(VBoxContainer);
 	makedialog->add_child(makevb);
 
 	makedirname = memnew(LineEdit);
 	makedirname->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
-	makevb->add_margin_child(TTRC("Name:"), makedirname);
+	makevb->add_margin_child(RTR("Name:"), makedirname);
 	add_child(makedialog, false, INTERNAL_MODE_FRONT);
 	makedialog->register_text_enter(makedirname);
 	makedialog->connect("confirmed", callable_mp(this, &FileDialog::_make_dir_confirm));
 	mkdirerr = memnew(AcceptDialog);
-	mkdirerr->set_text(TTRC("Could not create folder."));
+	mkdirerr->set_text(RTR("Could not create folder."));
 	add_child(mkdirerr, false, INTERNAL_MODE_FRONT);
 
 	exterr = memnew(AcceptDialog);
-	exterr->set_text(TTRC("Must use a valid extension."));
+	exterr->set_text(RTR("Must use a valid extension."));
 	add_child(exterr, false, INTERNAL_MODE_FRONT);
 
 	update_filters();


### PR DESCRIPTION
Addresses #50650
TTRC was not needed in the cases there, as none of this is saved in the scene, so it won't be causing problems (🤞).
Not sure if doing changes in FileDialog is necessary, as it's probably not used in the editor, idk.
~~Also I used TTR not RTR, as the strings are automatically runtime-translated anyway.~~

This doesn't fully fix the issue, because titles are still not translated. But changing them to `TTR()` would re-introduce translated property bug, so not sure how to solve this.