### PR TITLE
Add Navigation function to get all navigation maps

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -127,6 +127,12 @@
 				Destroys the given RID.
 			</description>
 		</method>
+		<method name="get_maps" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns all created navigation map [RID]s on the NavigationServer. This returns both 2D and 3D created navigation maps as there is technically no distinction between them.
+			</description>
+		</method>
 		<method name="map_create" qualifiers="const">
 			<return type="RID" />
 			<description>

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -127,6 +127,12 @@
 				Destroys the given RID.
 			</description>
 		</method>
+		<method name="get_maps" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns all created navigation map [RID]s on the NavigationServer. This returns both 2D and 3D created navigation maps as there is technically no distinction between them.
+			</description>
+		</method>
 		<method name="map_create" qualifiers="const">
 			<return type="RID" />
 			<description>

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -123,6 +123,18 @@ void GodotNavigationServer::add_command(SetCommand *command) const {
 	}
 }
 
+Array GodotNavigationServer::get_maps() const {
+	Array all_map_rids;
+	List<RID> maps_owned;
+	map_owner.get_owned_list(&maps_owned);
+	if (maps_owned.size()) {
+		for (const RID &E : maps_owned) {
+			all_map_rids.push_back(E);
+		}
+	}
+	return all_map_rids;
+}
+
 RID GodotNavigationServer::map_create() const {
 	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -85,6 +85,8 @@ public:
 
 	void add_command(SetCommand *command) const;
 
+	virtual Array get_maps() const override;
+
 	virtual RID map_create() const override;
 	COMMAND_2(map_set_active, RID, p_map, bool, p_active);
 	virtual bool map_is_active(RID p_map) const override;

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -159,6 +159,8 @@ void NavigationServer2D::_emit_map_changed(RID p_map) {
 }
 
 void NavigationServer2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_maps"), &NavigationServer2D::get_maps);
+
 	ClassDB::bind_method(D_METHOD("map_create"), &NavigationServer2D::map_create);
 	ClassDB::bind_method(D_METHOD("map_set_active", "map", "active"), &NavigationServer2D::map_set_active);
 	ClassDB::bind_method(D_METHOD("map_is_active", "nap"), &NavigationServer2D::map_is_active);
@@ -216,6 +218,8 @@ NavigationServer2D::NavigationServer2D() {
 NavigationServer2D::~NavigationServer2D() {
 	singleton = nullptr;
 }
+
+Array FORWARD_0_C(get_maps);
 
 Array FORWARD_1_C(map_get_regions, RID, p_map, rid_to_rid);
 

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -53,6 +53,8 @@ public:
 	/// MUST be used in single thread!
 	static NavigationServer2D *get_singleton_mut() { return singleton; }
 
+	virtual Array get_maps() const;
+
 	/// Create a new map.
 	virtual RID map_create() const;
 

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -33,6 +33,8 @@
 NavigationServer3D *NavigationServer3D::singleton = nullptr;
 
 void NavigationServer3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_maps"), &NavigationServer3D::get_maps);
+
 	ClassDB::bind_method(D_METHOD("map_create"), &NavigationServer3D::map_create);
 	ClassDB::bind_method(D_METHOD("map_set_active", "map", "active"), &NavigationServer3D::map_set_active);
 	ClassDB::bind_method(D_METHOD("map_is_active", "nap"), &NavigationServer3D::map_is_active);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -56,6 +56,8 @@ public:
 	/// MUST be used in single thread!
 	static NavigationServer3D *get_singleton_mut();
 
+	virtual Array get_maps() const = 0;
+
 	/// Create a new map.
 	virtual RID map_create() const = 0;
 


### PR DESCRIPTION
Added new `get_maps()` function that returns all created navigation map RIDs from the NavigationServer. The function returns both 2D and 3D created navigation maps as technically there is no distinction between them.

Currently there is no way to know which navigation maps have been created and how many are currently active. With this functions the amount is available as well as the option to loop through the maps and check them, e.g. if they are set active.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
