### PR TITLE
Fix CapsuleMesh height/radius setters

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -439,12 +439,15 @@ void CapsuleMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater,suffix:m"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_segments", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_radial_segments", "get_radial_segments");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_rings", "get_rings");
+
+	ADD_LINKED_PROPERTY("radius", "height");
+	ADD_LINKED_PROPERTY("height", "radius");
 }
 
 void CapsuleMesh::set_radius(const float p_radius) {
 	radius = p_radius;
 	if (radius > height * 0.5) {
-		radius = height * 0.5;
+		height = radius * 2.0;
 	}
 	_request_update();
 }
@@ -456,7 +459,7 @@ float CapsuleMesh::get_radius() const {
 void CapsuleMesh::set_height(const float p_height) {
 	height = p_height;
 	if (radius > height * 0.5) {
-		height = radius * 2;
+		radius = height * 0.5;
 	}
 	_request_update();
 }


### PR DESCRIPTION
Implements #51583 from CapsuleShape3D for CapsuleMesh. 

Limiting the radius in set_radius doesn't work because height isn't loaded yet causing a CapsuleMesh with a radius greater than 1 to get it's radius reset to 1:
![beforeReload](https://user-images.githubusercontent.com/69000267/175077312-f33d906f-bed3-4493-837d-27d30ad82561.png)
![afterReload](https://user-images.githubusercontent.com/69000267/175077340-bedaab7d-e88d-46b3-822b-71400589f237.png)
 
The same is true for height. Also linked radius and height for editor history (Ctrl Z otherwise not working)