### PR TITLE
GDScript: Do not reset return value in release build

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3432,9 +3432,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			_err_print_error(err_func.utf8().get_data(), err_file.utf8().get_data(), err_line, err_text.utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		}
 
-#endif
 		// Get a default return type in case of failure
 		retvalue = _get_default_variant_for_data_type(return_type);
+#endif
 
 		OPCODE_OUT;
 	}


### PR DESCRIPTION
Fixes #59239

Reset return value on error only in debug builds. Right now there is no mechanism in release build to know if there was error or not.