### PR TITLE
Update the window title when the project settings were changed

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -553,8 +553,6 @@ void EditorNode::_update_from_settings() {
 	tree->set_debug_collision_contact_color(GLOBAL_GET("debug/shapes/collision/contact_color"));
 	tree->set_debug_navigation_color(GLOBAL_GET("debug/shapes/navigation/geometry_color"));
 	tree->set_debug_navigation_disabled_color(GLOBAL_GET("debug/shapes/navigation/disabled_geometry_color"));
-
-	_update_title();
 }
 
 void EditorNode::_select_default_main_screen_plugin() {
@@ -584,7 +582,11 @@ void EditorNode::_notification(int p_what) {
 				opening_prev = false;
 			}
 
-			unsaved_cache = saved_version != editor_data.get_undo_redo().get_version();
+			bool unsaved_cache_changed = false;
+			if (unsaved_cache != (saved_version != editor_data.get_undo_redo().get_version())) {
+				unsaved_cache = (saved_version != editor_data.get_undo_redo().get_version());
+				unsaved_cache_changed = true;
+			}
 
 			if (last_checked_version != editor_data.get_undo_redo().get_version()) {
 				_update_scene_tabs();
@@ -613,6 +615,10 @@ void EditorNode::_notification(int p_what) {
 			editor_selection->update();
 
 			ResourceImporterTexture::get_singleton()->update_imports();
+
+			if (settings_changed || unsaved_cache_changed) {
+				_update_title();
+			}
 
 			if (settings_changed) {
 				_update_from_settings();


### PR DESCRIPTION
My PR here https://github.com/godotengine/godot/pull/62252 contains a small regression.
The window title was not always correctly updated when making changes in the editor, e.g. the '(*)' was not displayed to mark unsaved data now.
Now we always update the title when data was changed/saved(like before) or when the projects settings were changed (as done in https://github.com/godotengine/godot/pull/62252).

https://user-images.githubusercontent.com/66004280/175160923-853da1c5-baeb-49c3-9149-953f28e7b242.mp4


