### PR TITLE
Remove userdata from Thread.start()

### DIFF
--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -551,7 +551,6 @@ class Thread : public RefCounted {
 
 protected:
 	Variant ret;
-	Variant userdata;
 	SafeFlag running;
 	Callable target_callable;
 	::Thread thread;
@@ -566,7 +565,7 @@ public:
 		PRIORITY_MAX
 	};
 
-	Error start(const Callable &p_callable, const Variant &p_userdata = Variant(), Priority p_priority = PRIORITY_NORMAL);
+	Error start(const Callable &p_callable, Priority p_priority = PRIORITY_NORMAL);
 	String get_id() const;
 	bool is_started() const;
 	bool is_alive() const;

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -35,10 +35,11 @@
 		<method name="start">
 			<return type="int" enum="Error" />
 			<argument index="0" name="callable" type="Callable" />
-			<argument index="1" name="userdata" type="Variant" default="null" />
-			<argument index="2" name="priority" type="int" enum="Thread.Priority" default="1" />
+			<argument index="1" name="priority" type="int" enum="Thread.Priority" default="1" />
 			<description>
-				Starts a new [Thread] that calls [code]callable[/code] with [code]userdata[/code] passed as an argument. Even if no userdata is passed, [code]callable[/code] must accept one argument and it will be null. The [code]priority[/code] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
+				Starts a new [Thread] that calls [code]callable[/code].
+				If the method takes some arguments, you can pass them using [method Callable.bind].
+				The [code]priority[/code] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
 				Returns [constant OK] on success, or [constant ERR_CANT_CREATE] on failure.
 			</description>
 		</method>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4691

Seems like the called method was forced to take 1 argument and there was lots of useless code to handle that. Now the method can take 0 arguments or just any number.

Some test code:
```GDScript
func _ready() -> void:
	var th = Thread.new()
	th.start(test.bind("hello thread", 8))
	th.wait_to_finish()

func test(val, value2):
	print(val)
	print(value2)
```