### PR TITLE
[3.x] Change Node3D Gizmo to call group in realtime.

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -199,8 +199,7 @@ void Spatial::_notification(int p_what) {
 			}
 #ifdef TOOLS_ENABLED
 			if (Engine::get_singleton()->is_editor_hint() && get_tree()->is_node_being_edited(this)) {
-				//get_scene()->call_group(SceneMainLoop::GROUP_CALL_REALTIME,SceneStringNames::get_singleton()->_spatial_editor_group,SceneStringNames::get_singleton()->_request_gizmo,this);
-				get_tree()->call_group_flags(0, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
+				get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
 				if (!data.gizmo_disabled) {
 					if (data.gizmo.is_valid()) {
 						data.gizmo->create();


### PR DESCRIPTION
3.x backport of #54990: Averts godot crash which occurs if a node is added and then removed from the edited scene within one frame.
(note that #54990 was closed without merge because the default flags were changed in 4.x, leading to the same effect.)

This was apparently tried once before Godot was open sourced in 2014, as that is the source of the commented version I am removing. I have no idea why it would have been bad, but a lot has changed since then.

I'm submitting this PR because @Calinou suggested that this change could be useful for 3.6. That said, my project is now based on godot master and I was unsuccessful at finding an open bug relating to this.