### PR TITLE
Fix crash when drawing invalid tiles

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -884,6 +884,9 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 						if (atlas_source) {
 							// Get tile data.
 							TileData *tile_data = atlas_source->get_tile_data(E.value.get_atlas_coords(), E.value.alternative_tile);
+							if (!tile_data) {
+								continue;
+							}
 
 							// Compute the offset
 							Rect2i source_rect = atlas_source->get_tile_texture_region(E.value.get_atlas_coords());


### PR DESCRIPTION
Fixes #61198

The tiles will just not draw the preview:
![godot windows tools 64_40fmND9Ezs](https://user-images.githubusercontent.com/2223172/175299628-6468acb3-1373-4069-bc0d-38b4b4ff1520.gif)
