### PR TITLE
Validate AnimationNode name in AnimationStateMachine

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1018,7 +1018,7 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 
 	anim->set_animation(animations_to_add[p_index]);
 
-	String base_name = animations_to_add[p_index];
+	String base_name = animations_to_add[p_index].validate_node_name();
 	int base = 1;
 	String name = base_name;
 	while (state_machine->has_node(name)) {


### PR DESCRIPTION
fix [#60959 ](https://github.com/godotengine/godot/issues/60959)

Alternative variant [this ](https://github.com/godotengine/godot/pull/60960) PR. (This PR in one line is considered for more than ten days. And the problem prevents the implementation of LocomitonMovement)

This PR solves an issue with automatic names in AnimationNodeStateMachine. 
An AnimationPlayer containing an animation library creates animation names in the format `<animation_library_name>/<animation_name>`


In practice, the user still sets the custom node name to the AnimationNodeStateMachine.  For this reason, I think String.validate_node_name() is a good compromise.

This is what the tree looks like in practice. Almost all nodes have a custom name.
![image](https://user-images.githubusercontent.com/12483173/175311283-7b880ce9-6491-48b3-985e-5b19711cc331.png)


Result:
![image](https://user-images.githubusercontent.com/12483173/175311202-4d402d10-b187-42e4-9771-46e4fe02dcb9.png)
