### PR TITLE
Fix Curve{2D,3D} notifying property list changed

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -54,12 +54,12 @@ void Curve::set_point_count(int p_count) {
 	if (_points.size() >= p_count) {
 		_points.resize(p_count);
 		mark_dirty();
-		notify_property_list_changed();
 	} else {
 		for (int i = p_count - _points.size(); i > 0; i--) {
-			add_point(Vector2());
+			_add_point(Vector2());
 		}
 	}
+	notify_property_list_changed();
 }
 
 int Curve::_add_point(Vector2 p_position, real_t p_left_tangent, real_t p_right_tangent, TangentMode p_left_mode, TangentMode p_right_mode) {
@@ -650,16 +650,15 @@ void Curve2D::set_point_count(int p_count) {
 	if (points.size() >= p_count) {
 		points.resize(p_count);
 		mark_dirty();
-		baked_cache_dirty = true;
-		emit_signal(CoreStringNames::get_singleton()->changed);
 	} else {
 		for (int i = p_count - points.size(); i > 0; i--) {
-			add_point(Vector2());
+			_add_point(Vector2());
 		}
 	}
+	notify_property_list_changed();
 }
 
-void Curve2D::add_point(const Vector2 &p_position, const Vector2 &p_in, const Vector2 &p_out, int p_atpos) {
+void Curve2D::_add_point(const Vector2 &p_position, const Vector2 &p_in, const Vector2 &p_out, int p_atpos) {
 	Point n;
 	n.position = p_position;
 	n.in = p_in;
@@ -671,6 +670,11 @@ void Curve2D::add_point(const Vector2 &p_position, const Vector2 &p_in, const Ve
 	}
 
 	mark_dirty();
+}
+
+void Curve2D::add_point(const Vector2 &p_position, const Vector2 &p_in, const Vector2 &p_out, int p_atpos) {
+	_add_point(p_position, p_in, p_out, p_atpos);
+	notify_property_list_changed();
 }
 
 void Curve2D::set_point_position(int p_index, const Vector2 &p_position) {
@@ -709,16 +713,22 @@ Vector2 Curve2D::get_point_out(int p_index) const {
 	return points[p_index].out;
 }
 
-void Curve2D::remove_point(int p_index) {
+void Curve2D::_remove_point(int p_index) {
 	ERR_FAIL_INDEX(p_index, points.size());
 	points.remove_at(p_index);
 	mark_dirty();
+}
+
+void Curve2D::remove_point(int p_index) {
+	_remove_point(p_index);
+	notify_property_list_changed();
 }
 
 void Curve2D::clear_points() {
 	if (!points.is_empty()) {
 		points.clear();
 		mark_dirty();
+		notify_property_list_changed();
 	}
 }
 
@@ -753,7 +763,6 @@ Vector2 Curve2D::interpolatef(real_t p_findex) const {
 void Curve2D::mark_dirty() {
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
-	notify_property_list_changed();
 }
 
 void Curve2D::_bake_segment2d(RBMap<real_t, Vector2> &r_bake, real_t p_begin, real_t p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_max_depth, real_t p_tol) const {
@@ -1068,7 +1077,8 @@ void Curve2D::_set_data(const Dictionary &p_data) {
 		points.write[i].position = r[i * 3 + 2];
 	}
 
-	baked_cache_dirty = true;
+	mark_dirty();
+	notify_property_list_changed();
 }
 
 PackedVector2Array Curve2D::tessellate(int p_max_stages, real_t p_tolerance) const {
@@ -1219,12 +1229,13 @@ void Curve3D::set_point_count(int p_count) {
 		mark_dirty();
 	} else {
 		for (int i = p_count - points.size(); i > 0; i--) {
-			add_point(Vector3());
+			_add_point(Vector3());
 		}
 	}
+	notify_property_list_changed();
 }
 
-void Curve3D::add_point(const Vector3 &p_position, const Vector3 &p_in, const Vector3 &p_out, int p_atpos) {
+void Curve3D::_add_point(const Vector3 &p_position, const Vector3 &p_in, const Vector3 &p_out, int p_atpos) {
 	Point n;
 	n.position = p_position;
 	n.in = p_in;
@@ -1236,6 +1247,11 @@ void Curve3D::add_point(const Vector3 &p_position, const Vector3 &p_in, const Ve
 	}
 
 	mark_dirty();
+}
+
+void Curve3D::add_point(const Vector3 &p_position, const Vector3 &p_in, const Vector3 &p_out, int p_atpos) {
+	_add_point(p_position, p_in, p_out, p_atpos);
+	notify_property_list_changed();
 }
 
 void Curve3D::set_point_position(int p_index, const Vector3 &p_position) {
@@ -1286,16 +1302,22 @@ Vector3 Curve3D::get_point_out(int p_index) const {
 	return points[p_index].out;
 }
 
-void Curve3D::remove_point(int p_index) {
+void Curve3D::_remove_point(int p_index) {
 	ERR_FAIL_INDEX(p_index, points.size());
 	points.remove_at(p_index);
 	mark_dirty();
+}
+
+void Curve3D::remove_point(int p_index) {
+	_remove_point(p_index);
+	notify_property_list_changed();
 }
 
 void Curve3D::clear_points() {
 	if (!points.is_empty()) {
 		points.clear();
 		mark_dirty();
+		notify_property_list_changed();
 	}
 }
 
@@ -1330,7 +1352,6 @@ Vector3 Curve3D::interpolatef(real_t p_findex) const {
 void Curve3D::mark_dirty() {
 	baked_cache_dirty = true;
 	emit_signal(CoreStringNames::get_singleton()->changed);
-	notify_property_list_changed();
 }
 
 void Curve3D::_bake_segment3d(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const {
@@ -1853,7 +1874,8 @@ void Curve3D::_set_data(const Dictionary &p_data) {
 		points.write[i].tilt = rt[i];
 	}
 
-	baked_cache_dirty = true;
+	mark_dirty();
+	notify_property_list_changed();
 }
 
 PackedVector3Array Curve3D::tessellate(int p_max_stages, real_t p_tolerance) const {

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -189,6 +189,9 @@ class Curve2D : public Resource {
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+	void _add_point(const Vector2 &p_position, const Vector2 &p_in = Vector2(), const Vector2 &p_out = Vector2(), int p_atpos = -1);
+	void _remove_point(int p_index);
+
 protected:
 	static void _bind_methods();
 
@@ -260,6 +263,9 @@ class Curve3D : public Resource {
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	void _add_point(const Vector3 &p_position, const Vector3 &p_in = Vector3(), const Vector3 &p_out = Vector3(), int p_atpos = -1);
+	void _remove_point(int p_index);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Follow-up to #61628

Make `Curve2D` and `Curve3D` more consistent with `Curve` and avoid calling `notify_property_list_changed` when the list of points doesn't change.
