### PR TITLE
Restore the openexr grayscale property.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2324,11 +2324,11 @@ Error Image::save_exr(const String &p_path, bool p_grayscale) const {
 	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale);
 }
 
-Vector<uint8_t> Image::save_exr_to_buffer() const {
+Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale) const {
 	if (save_exr_buffer_func == nullptr) {
 		return Vector<uint8_t>();
 	}
-	return save_exr_buffer_func(Ref<Image>((Image *)this), false);
+	return save_exr_buffer_func(Ref<Image>((Image *)this), p_grayscale);
 }
 
 Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_quality) const {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -294,7 +294,7 @@ public:
 	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
 	Vector<uint8_t> save_png_to_buffer() const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
-	Vector<uint8_t> save_exr_to_buffer() const;
+	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale) const;
 	Error save_exr(const String &p_path, bool p_grayscale) const;
 	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
 	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -380,6 +380,14 @@
 				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
 			</description>
 		</method>
+		<method name="save_exr_to_buffer" qualifiers="const">
+			<return type="PackedByteArray" />
+			<argument index="0" name="grayscale" type="bool" default="false" />
+			<description>
+				Saves the image as an EXR file to a byte array. If [code]grayscale[/code] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return an empty byte array if Godot was compiled without the TinyEXR module.
+				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return an empty byte array when it is called from an exported project.
+			</description>
+		</method>
 		<method name="save_jpg" qualifiers="const">
 			<return type="int" enum="Error" />
 			<argument index="0" name="path" type="String" />


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/62367 🦊 