### PR TITLE
Make code example in HTTPRequest classref working

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -15,7 +15,7 @@
 		    # Create an HTTP request node and connect its completion signal.
 		    var http_request = HTTPRequest.new()
 		    add_child(http_request)
-		    http_request.connect("request_completed", self, "_http_request_completed")
+		    http_request.request_completed.connect(self._http_request_completed)
 
 		    # Perform a GET request. The URL below returns JSON as of writing.
 		    var error = http_request.request("https://httpbin.org/get")
@@ -25,7 +25,7 @@
 		    # Perform a POST request. The URL below returns JSON as of writing.
 		    # Note: Don't make simultaneous requests using a single HTTPRequest node.
 		    # The snippet below is provided for reference only.
-		    var body = {"name": "Godette"}
+		    var body = JSON.new().stringify({"name": "Godette"})
 		    error = http_request.request("https://httpbin.org/post", [], true, HTTPClient.METHOD_POST, body)
 		    if error != OK:
 		        push_error("An error occurred in the HTTP request.")
@@ -33,7 +33,9 @@
 
 		# Called when the HTTP request is completed.
 		func _http_request_completed(result, response_code, headers, body):
-		    var response = parse_json(body.get_string_from_utf8())
+		    var json = JSON.new()
+		    json.parse(body.get_string_from_utf8())
+		    var response = json.get_data()
 
 		    # Will print the user agent string used by the HTTPRequest node (as recognized by httpbin.org).
 		    print(response.headers["User-Agent"])
@@ -44,7 +46,7 @@
 		    // Create an HTTP request node and connect its completion signal.
 		    var httpRequest = new HTTPRequest();
 		    AddChild(httpRequest);
-		    httpRequest.Connect("request_completed", this, nameof(HttpRequestCompleted));
+		    httpRequest.RequestCompleted += HttpRequestCompleted;
 
 		    // Perform a GET request. The URL below returns JSON as of writing.
 		    Error error = httpRequest.Request("https://httpbin.org/get");
@@ -56,21 +58,24 @@
 		    // Perform a POST request. The URL below returns JSON as of writing.
 		    // Note: Don't make simultaneous requests using a single HTTPRequest node.
 		    // The snippet below is provided for reference only.
-		    string[] body = { "name", "Godette" };
-		    // GDScript to_json is non existent, so we use JSON.Print() here.
-		    error = httpRequest.Request("https://httpbin.org/post", null, true, HTTPClient.Method.Post, JSON.Print(body));
+		    string body = new JSON().Stringify(new Godot.Collections.Dictionary
+		    {
+		        { "name", "Godette" }
+		    });
+		    error = httpRequest.Request("https://httpbin.org/post", null, true, HTTPClient.Method.Post, body);
 		    if (error != Error.Ok)
 		    {
 		        GD.PushError("An error occurred in the HTTP request.");
 		    }
 		}
 
-
 		// Called when the HTTP request is completed.
 		private void HttpRequestCompleted(int result, int response_code, string[] headers, byte[] body)
 		{
-		    // GDScript parse_json is non existent so we have to use JSON.parse, which has a slightly different syntax.
-		    var response = JSON.Parse(body.GetStringFromUTF8()).Result as Godot.Collections.Dictionary;
+		    var json = new JSON();
+		    json.Parse(body.GetStringFromUTF8());
+		    var response = json.GetData() as Godot.Collections.Dictionary;
+
 		    // Will print the user agent string used by the HTTPRequest node (as recognized by httpbin.org).
 		    GD.Print((response["headers"] as Godot.Collections.Dictionary)["User-Agent"]);
 		}
@@ -83,7 +88,7 @@
 		    # Create an HTTP request node and connect its completion signal.
 		    var http_request = HTTPRequest.new()
 		    add_child(http_request)
-		    http_request.connect("request_completed", self, "_http_request_completed")
+		    http_request.request_completed.connect(self._http_request_completed)
 
 		    # Perform the HTTP request. The URL below returns a PNG image as of writing.
 		    var error = http_request.request("https://via.placeholder.com/512")
@@ -115,7 +120,7 @@
 		    // Create an HTTP request node and connect its completion signal.
 		    var httpRequest = new HTTPRequest();
 		    AddChild(httpRequest);
-		    httpRequest.Connect("request_completed", this, nameof(HttpRequestCompleted));
+		    httpRequest.RequestCompleted += HttpRequestCompleted;
 
 		    // Perform the HTTP request. The URL below returns a PNG image as of writing.
 		    Error error = httpRequest.Request("https://via.placeholder.com/512");
@@ -124,7 +129,6 @@
 		        GD.PushError("An error occurred in the HTTP request.");
 		    }
 		}
-
 
 		// Called when the HTTP request is completed.
 		private void HttpRequestCompleted(int result, int response_code, string[] headers, byte[] body)


### PR DESCRIPTION
Fixes #53910

* The `body` argument of `HTTPRequest.request` should be a `String` instead of a `Dictionary`.
* Use 4.0 style signal connection.
* Use 4.0 style JSON parse/stringify.

**Note:** I'm not familiar with C#, so the C# code example is not touched.