### PR TITLE
Implement Floating Script Editor Window

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -200,6 +200,7 @@ class ScriptEditor : public PanelContainer {
 		FILE_THEME,
 		FILE_RUN,
 		FILE_CLOSE,
+		FLOAT_WINDOW,
 		CLOSE_DOCS,
 		CLOSE_ALL,
 		CLOSE_OTHER_TABS,
@@ -254,6 +255,7 @@ class ScriptEditor : public PanelContainer {
 	PopupMenu *theme_submenu = nullptr;
 
 	Button *help_search = nullptr;
+	Button *float_window = nullptr;
 	Button *site_search = nullptr;
 	EditorHelpSearch *help_search_dialog = nullptr;
 
@@ -448,6 +450,8 @@ class ScriptEditor : public PanelContainer {
 	void _update_modified_scripts_for_external_editor(Ref<Script> p_for_script = Ref<Script>());
 
 	void _script_changed();
+	void _on_float_window_requested();
+	void _script_floating_close_request(Control *p_control);
 	int file_dialog_option;
 	void _file_dialog_action(String p_file);
 


### PR DESCRIPTION
I've been working on a solution to make the script editor a floating window. This addresses https://github.com/godotengine/godot-proposals/issues/28

Here's a working prototype:

https://user-images.githubusercontent.com/62965063/175501663-eb2a883d-a638-4f7b-9fe6-2aa1411e93ca.mp4

It's not perfect, still has some bugs, but it works quite well nevertheless.