### PR TITLE
Configure embedding per Window instead of per Viewport

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -295,11 +295,8 @@
 		<member name="gui_disable_input" type="bool" setter="set_disable_input" getter="is_input_disabled" default="false">
 			If [code]true[/code], the viewport will not receive input events.
 		</member>
-		<member name="gui_embedding_subwindows" type="bool" setter="set_embedding_subwindows" getter="is_embedding_subwindows" default="false">
-			Allow others windows to be embedded.
-		</member>
-		<member name="gui_force_embedding_subwindows" type="bool" setter="set_force_embedding_subwindows" getter="is_force_embedding_subwindows" default="false">
-			If [code]true[/code], children windows will ignore embedded variabile, and will to find parent viewport with embedding_windows, if it no viewport with embedding_windows will create a window.
+		<member name="gui_embed_subwindows" type="bool" setter="set_embedding_subwindows" getter="is_embedding_subwindows" default="false">
+			If [code]true[/code], sub-windows (popups and dialogs) will be embedded inside application window as control-like nodes. If [code]false[/code], they can appear as separate windows handled by the operating system.
 		</member>
 		<member name="gui_snap_controls_to_pixels" type="bool" setter="set_snap_controls_to_pixels" getter="is_snap_controls_to_pixels_enabled" default="true">
 			If [code]true[/code], the GUI controls on the viewport will lay pixel perfectly.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -295,8 +295,11 @@
 		<member name="gui_disable_input" type="bool" setter="set_disable_input" getter="is_input_disabled" default="false">
 			If [code]true[/code], the viewport will not receive input events.
 		</member>
-		<member name="gui_embed_subwindows" type="bool" setter="set_embedding_subwindows" getter="is_embedding_subwindows" default="false">
-			If [code]true[/code], sub-windows (popups and dialogs) will be embedded inside application window as control-like nodes. If [code]false[/code], they will appear as separate windows handled by the operating system.
+		<member name="gui_embedding_subwindows" type="bool" setter="set_embedding_subwindows" getter="is_embedding_subwindows" default="false">
+			Allow others windows to be embedded.
+		</member>
+		<member name="gui_force_embedding_subwindows" type="bool" setter="set_force_embedding_subwindows" getter="is_force_embedding_subwindows" default="false">
+			If [code]true[/code], children windows will ignore embedded variabile, and will to find parent viewport with embedding_windows, if it no viewport with embedding_windows will create a window.
 		</member>
 		<member name="gui_snap_controls_to_pixels" type="bool" setter="set_snap_controls_to_pixels" getter="is_snap_controls_to_pixels_enabled" default="true">
 			If [code]true[/code], the GUI controls on the viewport will lay pixel perfectly.

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -590,6 +590,9 @@
 			If [code]true[/code], the [Window] will be in exclusive mode. Exclusive windows are always on top of their parent and will block all input going to the parent [Window].
 			Needs [member transient] enabled to work.
 		</member>
+		<member name="native_hint" type="bool" setter="set_native_hint" getter="is_native_hint" default="true">
+			If [code]true[/code], the [Window] can be native if [member Viewport.gui_embed_subwindows] is [code]false[/code]
+		</member>
 		<member name="extend_to_title" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] contents is expanded to the full size of the window, window title bar is transparent.
 			[b]Note:[/b] This property is implemented only on macOS.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -976,12 +976,10 @@ void Viewport::update_canvas_items() {
 		return;
 	}
 
-	if (is_embedding_subwindows()) {
-		for (Viewport::SubWindow w : gui.sub_windows) {
-			if (w.window && !w.pending_window_update) {
-				w.pending_window_update = true;
-				callable_mp(this, &Viewport::_sub_window_update).call_deferred(w.window);
-			}
+	for (Viewport::SubWindow w : gui.sub_windows) {
+		if (w.window && !w.pending_window_update) {
+			w.pending_window_update = true;
+			callable_mp(this, &Viewport::_sub_window_update).call_deferred(w.window);
 		}
 	}
 	_update_canvas_items(this);
@@ -2926,7 +2924,7 @@ void Viewport::_update_mouse_over() {
 void Viewport::_update_mouse_over(Vector2 p_pos) {
 	gui.last_mouse_pos = p_pos; // Necessary, because mouse cursor can be over Viewports that are not reached by the InputEvent.
 	// Look for embedded windows at mouse position.
-	if (is_embedding_subwindows()) {
+	if (!gui.sub_windows.is_empty()) {
 		for (int i = gui.sub_windows.size() - 1; i >= 0; i--) {
 			Window *sw = gui.sub_windows[i].window;
 			Rect2 swrect = Rect2(sw->get_position(), sw->get_size());
@@ -3155,7 +3153,7 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 		_update_mouse_over();
 	}
 
-	if (is_embedding_subwindows() && _sub_windows_forward_input(ev)) {
+	if (_sub_windows_forward_input(ev)) {
 		set_input_as_handled();
 		return;
 	}

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -134,6 +134,7 @@ private:
 	bool transient = false;
 	bool transient_to_focused = false;
 	bool exclusive = false;
+	bool native_hint = true;
 	bool wrap_controls = false;
 	bool updating_child_controls = false;
 	bool updating_embedded_window = false;
@@ -151,6 +152,9 @@ private:
 	ContentScaleAspect content_scale_aspect = CONTENT_SCALE_ASPECT_IGNORE;
 	ContentScaleStretch content_scale_stretch = CONTENT_SCALE_STRETCH_FRACTIONAL;
 	real_t content_scale_factor = 1.0;
+
+	void _init_window();
+	void _deinit_window();
 
 	void _make_window();
 	void _clear_window();
@@ -331,6 +335,9 @@ public:
 
 	void set_exclusive(bool p_exclusive);
 	bool is_exclusive() const;
+
+	void set_native_hint(bool p_native);
+	bool is_native_hint() const;
 
 	void set_clamp_to_embedder(bool p_enable);
 	bool is_clamped_to_embedder() const;


### PR DESCRIPTION
_Closes https://github.com/godotengine/godot-proposals/issues/4741_

This adds `Window.native_hint` this makes undocking a window easier.
For that to work the `Viewport.gui_embed_subwindows` needs to be `false`.

Tested only for Arch Linux, KDE Plasma 6.2.3, Wayland