### PR TITLE
Fixed `set_position()` in Node3D

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -324,7 +324,7 @@ Transform3D Node3D::get_relative_transform(const Node *p_parent) const {
 }
 
 void Node3D::set_position(const Vector3 &p_position) {
-	get_transform().origin = p_position;
+	data.local_transform.origin = p_position;
 	_propagate_transform_changed(this);
 	if (data.notify_local_transform) {
 		notification(NOTIFICATION_LOCAL_TRANSFORM_CHANGED);


### PR DESCRIPTION
Fixed #62386. Self follow up of #62227.

My mistake, sorry. It seems I replaced it that I didn't need to.