### PR TITLE
[3.x] Fix code example of `String.is_valid_integer()`

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -488,11 +488,11 @@
 			<description>
 				Returns [code]true[/code] if this string contains a valid integer.
 				[codeblock]
-				print("7".is_valid_int()) # Prints "True"
-				print("14.6".is_valid_int()) # Prints "False"
-				print("L".is_valid_int()) # Prints "False"
-				print("+3".is_valid_int()) # Prints "True"
-				print("-12".is_valid_int()) # Prints "True"
+				print("7".is_valid_integer()) # Prints "True"
+				print("14.6".is_valid_integer()) # Prints "False"
+				print("L".is_valid_integer()) # Prints "False"
+				print("+3".is_valid_integer()) # Prints "True"
+				print("-12".is_valid_integer()) # Prints "True"
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
The current code example uses `is_valid_int()` instead of `is_valid_integer()`. It's only renamed on master.