### PR TITLE
Fix ProgressBar's minimum size not updating when toggling its percent_visible

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -126,7 +126,11 @@ int ProgressBar::get_fill_mode() {
 }
 
 void ProgressBar::set_percent_visible(bool p_visible) {
+	if (percent_visible == p_visible) {
+		return;
+	}
 	percent_visible = p_visible;
+	update_minimum_size();
 	update();
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->



| Before | After |
| :-------: | :-----: |
| ![1](https://user-images.githubusercontent.com/30386067/175764310-24f46117-c2ed-46e9-b597-14fe9b0e2632.gif) | ![2](https://user-images.githubusercontent.com/30386067/175764309-b1aaadd0-00ca-43e3-950d-0e286b264d0f.gif) |

