### PR TITLE
[3.x] Build javascript+GDNative export template with -s WASM_BIGINT

### DIFF
--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -49,6 +49,8 @@ if env["gdnative_enabled"]:
     sys_env.Append(CCFLAGS=["-s", "EXPORT_ALL=1"])
     sys_env.Append(LINKFLAGS=["-s", "EXPORT_ALL=1"])
     sys_env.Append(LINKFLAGS=["-s", "WARN_ON_UNDEFINED_SYMBOLS=0"])
+    sys_env.Append(LINKFLAGS=["-s", "WASM_BIGINT=1"])
+
     # Force exporting the standard library (printf, malloc, etc.)
     sys_env["ENV"]["EMCC_FORCE_STDLIBS"] = "libc,libc++,libc++abi"
     # The main emscripten runtime, with exported standard libraries.
@@ -59,6 +61,7 @@ if env["gdnative_enabled"]:
     wasm_env.Append(CPPDEFINES=["WASM_GDNATIVE"])  # So that OS knows it can run GDNative libraries.
     wasm_env.Append(CCFLAGS=["-s", "SIDE_MODULE=2"])
     wasm_env.Append(LINKFLAGS=["-s", "SIDE_MODULE=2"])
+    wasm_env.Append(LINKFLAGS=["-s", "WASM_BIGINT=1"])
     wasm = wasm_env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", javascript_files)
     build = sys + [wasm[0]]
 else:


### PR DESCRIPTION
This tells emscripten to pass i64 values from WebAssembly to JavaScript as BigInt instead of as two i32s, which could lead to crashes when GDNative modules are used.

@hoodmane wrote about it [here](https://blog.pyodide.org/posts/rust-pyo3-support-in-pyodide/#error-handling-64-bit-integers-and-dynamic-linking). The gist of it (as I understand it) is that without this patch, emscripten generates custom wrapper functions per function signature to do the (i32, i32) -> i64 conversion, and if a GDNative module has to call a function with a signature not present in the Godot main module, an error is thrown. For my godot-rust project, this patch fixes an immediate crash on launch.

Note that this does reduce browser compatibility a bit for GDNative exports (to browsers supporting [BigInt64Array](https://caniuse.com/?search=BigInt64Array), although https://github.com/emscripten-core/emscripten/pull/17103 if merged would relax that requirement to just [BigInt](https://caniuse.com/?search=BigInt)).
