### PR TITLE
Fix error about transient window when running a custom scene

### DIFF
--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -146,8 +146,8 @@ void EditorQuickOpen::_confirmed() {
 		return;
 	}
 	_cleanup();
-	emit_signal(SNAME("quick_open"));
 	hide();
+	emit_signal(SNAME("quick_open"));
 }
 
 void EditorQuickOpen::cancel_pressed() {


### PR DESCRIPTION
When running a scene via the "Play Custom Scene" button, this error will appear:
```
Transient parent has another exclusive child
```

It's generally not noticeable because the output section is cleaned right after that, but if the run state is prevented by something (e.g. Movie Maker being enabled without a path defined), it's more obvious.