### PR TITLE
Script-class-aware Inspector & related controls.

### DIFF
--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -91,6 +91,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _button_draw();
 	void _button_input(const Ref<InputEvent> &p_event);
 
+	String _get_resource_type(const Ref<Resource> &p_resource) const;
 	void _get_allowed_types(bool p_with_convert, HashSet<String> *p_vector) const;
 	bool _is_drop_valid(const Dictionary &p_drag_data) const;
 	bool _is_type_valid(const String p_type_name, HashSet<String> p_allowed_types) const;


### PR DESCRIPTION
Updates `EditorResourcePicker` so that global script classes are properly recognized and handled.

Related Issues:
- godotengine/godot-proposals#18

Related PRs:
- #48201 
    - implements the Editor / Inspector tooling

Sibling PRs:
- #62411
- #62417
- #63126

Considerations:
- None. Everything should work fine as far as I know. Have tested with regular properties, array properties, make unique, external resources, embedded resources, etc.

