### PR TITLE
Change window title in Movie Maker mode to display useful information

### DIFF
--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -42,6 +42,8 @@ class MovieWriter : public Object {
 	uint64_t mix_rate = 0;
 	uint32_t audio_channels = 0;
 
+	String project_name;
+
 	LocalVector<int32_t> audio_mix_buffer;
 
 	enum {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/62414.

The frame number and movie time is now displayed in the window title. This way, you can see how quickly the video recording is advancing in real-time (and perhaps tweak your settings if it's going too slow).

The window title changes fairly often, but this doesn't impact recording performance noticeably from my testing (even at 720p).

**Testing project:** [test_movie_maker_quit_on_finish.zip](https://github.com/godotengine/godot/files/8985733/test_movie_maker_quit_on_finish.zip)

## Preview

https://user-images.githubusercontent.com/180032/175794230-fbb18472-201c-41f1-86e3-8c07a6fd1748.mp4