### PR TITLE
Request attention on the editor window when done recording a movie

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -152,6 +152,12 @@
 				Shows the given property on the given [code]object[/code] in the editor's Inspector dock. If [code]inspector_only[/code] is [code]true[/code], plugins will not attempt to edit [code]object[/code].
 			</description>
 		</method>
+		<method name="is_movie_maker_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if Movie Maker mode is enabled in the editor. See also [method set_movie_maker_enabled]. See [MovieWriter] for more information.
+			</description>
+		</method>
 		<method name="is_playing_scene" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -232,6 +238,13 @@
 			<argument index="0" name="name" type="String" />
 			<description>
 				Sets the editor's current main screen to the one specified in [code]name[/code]. [code]name[/code] must match the text of the tab in question exactly ([code]2D[/code], [code]3D[/code], [code]Script[/code], [code]AssetLib[/code]).
+			</description>
+		</method>
+		<method name="set_movie_maker_enabled">
+			<return type="void" />
+			<argument index="0" name="enabled" type="bool" />
+			<description>
+				Sets whether Movie Maker mode is enabled in the editor. See also [method is_movie_maker_enabled]. See [MovieWriter] for more information.
 			</description>
 		</method>
 		<method name="set_plugin_enabled">

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -224,6 +224,12 @@ void EditorDebuggerNode::stop() {
 	if (server.is_valid()) {
 		server->stop();
 		EditorNode::get_log()->add_message("--- Debugging process stopped ---", EditorLog::MSG_TYPE_EDITOR);
+
+		if (EditorNode::get_singleton()->is_movie_maker_enabled()) {
+			// Request attention in case the user was doing something else when movie recording is finished.
+			DisplayServer::get_singleton()->window_request_attention();
+		}
+
 		server.unref();
 	}
 	// Also close all debugging sessions.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3409,6 +3409,14 @@ bool EditorNode::is_addon_plugin_enabled(const String &p_addon) const {
 	return addon_name_to_plugin.has("res://addons/" + p_addon + "/plugin.cfg");
 }
 
+void EditorNode::set_movie_maker_enabled(bool p_enabled) {
+	write_movie_button->set_pressed(p_enabled);
+}
+
+bool EditorNode::is_movie_maker_enabled() const {
+	return write_movie_button->is_pressed();
+}
+
 void EditorNode::_remove_edited_scene(bool p_change_tab) {
 	int new_index = editor_data.get_edited_scene();
 	int old_index = new_index;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -747,6 +747,9 @@ public:
 	void set_addon_plugin_enabled(const String &p_addon, bool p_enabled, bool p_config_changed = false);
 	bool is_addon_plugin_enabled(const String &p_addon) const;
 
+	void set_movie_maker_enabled(bool p_enabled);
+	bool is_movie_maker_enabled() const;
+
 	void edit_node(Node *p_node);
 	void edit_resource(const Ref<Resource> &p_resource) { InspectorDock::get_singleton()->edit_resource(p_resource); };
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -289,6 +289,14 @@ bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {
 	return EditorNode::get_singleton()->is_addon_plugin_enabled(p_plugin);
 }
 
+void EditorInterface::set_movie_maker_enabled(bool p_enabled) {
+	EditorNode::get_singleton()->set_movie_maker_enabled(p_enabled);
+}
+
+bool EditorInterface::is_movie_maker_enabled() const {
+	return EditorNode::get_singleton()->is_movie_maker_enabled();
+}
+
 EditorInspector *EditorInterface::get_inspector() const {
 	return InspectorDock::get_inspector_singleton();
 }
@@ -356,6 +364,9 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
 	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_movie_maker_enabled", "enabled"), &EditorInterface::set_movie_maker_enabled);
+	ClassDB::bind_method(D_METHOD("is_movie_maker_enabled"), &EditorInterface::is_movie_maker_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_inspector"), &EditorInterface::get_inspector);
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -112,6 +112,9 @@ public:
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;
 
+	void set_movie_maker_enabled(bool p_enabled);
+	bool is_movie_maker_enabled() const;
+
 	EditorInspector *get_inspector() const;
 
 	Error save_scene();


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/62415 and https://github.com/godotengine/godot/pull/56367 (which does the same for lightmap baking).

Recording a movie can take a long time, so the user may not be paying attention to the editor while leaving a movie rendering in the background.

This also allows editor plugins to access the state of Movie Maker mode within the editor (and set it).