### PR TITLE
Enable QuickOpen to see scripted resources

### DIFF
--- a/editor/editor_quick_open.h
+++ b/editor/editor_quick_open.h
@@ -43,6 +43,7 @@ class EditorQuickOpen : public ConfirmationDialog {
 	Tree *search_options = nullptr;
 	StringName base_type;
 	bool allow_multi_select = false;
+	bool _load_resources = true;
 
 	Vector<String> files;
 	OAHashMap<String, Ref<Texture2D>> icons;


### PR DESCRIPTION
Updates `EditorQuickOpen` so that resources with global script classes attached to them are properly recognized and handled.

Related Issues:
- godotengine/godot-proposals#18

Related PRs:
- #48201 
    - implements the Editor / Inspector tooling (specifically, the `QuickLoad` option in `EditorResourcePicker`)
- #60606 (**dependency**)
    - builds on top of a squashed version of this PR's commits. Once it is merged, I can rebase so that @Atlinx's commit(s) won't be present in my PR.
    Without this, teaching `EditorQuickOpen` to display applicable resource files would be prohibitively expensive since *every* file with the same native base type would need to be fully loaded just to check 1) if it has a script attached, 2) whether the script is a global class, and 3) whether the script class matches the exported property's type constraints.

Sibling PRs:
- #62411
- #62413
- #63126

Considerations:
- None.


