### PR TITLE
Conditionally hide button's icon-related property when icon is null

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -449,6 +449,7 @@ void Button::set_icon(const Ref<Texture2D> &p_icon) {
 		icon = p_icon;
 		update();
 		update_minimum_size();
+		notify_property_list_changed();
 	}
 }
 
@@ -560,6 +561,11 @@ void Button::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::INT, "opentype_features/" + name));
 	}
 	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+
+	if (icon.is_null()) {
+		p_list->erase(PropertyInfo(Variant::INT, "icon_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"));
+		p_list->erase(PropertyInfo(Variant::BOOL, "expand_icon"));
+	}
 }
 
 void Button::_bind_methods() {


### PR DESCRIPTION
Showing properties that don't affect anything is confusing for the user so therefore the icon-related properties should be hidden when the icon is null.

No icon:
![image](https://user-images.githubusercontent.com/19669673/175803664-86998c39-10a2-4aa8-b2a4-9d9b87792d6a.png)

Icon:
![image](https://user-images.githubusercontent.com/19669673/175803671-e3e9187b-b0cd-40c0-8a9b-2648f13e1527.png)