### PR TITLE
Added animation synchronization

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -88,7 +88,6 @@
 			<argument index="3" name="seek_root" type="bool" />
 			<argument index="4" name="blend" type="float" />
 			<argument index="5" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
-			<argument index="6" name="optimize" type="bool" default="true" />
 			<description>
 				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. The [code]time[/code] parameter is a relative delta, unless [code]seek[/code] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
 			</description>
@@ -102,7 +101,6 @@
 			<argument index="4" name="seek_root" type="bool" />
 			<argument index="5" name="blend" type="float" />
 			<argument index="6" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
-			<argument index="7" name="optimize" type="bool" default="true" />
 			<description>
 				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>

--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -9,9 +9,4 @@
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
 	</tutorials>
-	<members>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
-		</member>
-	</members>
 </class>

--- a/doc/classes/AnimationNodeAdd3.xml
+++ b/doc/classes/AnimationNodeAdd3.xml
@@ -14,9 +14,4 @@
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
-	<members>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
-		</member>
-	</members>
 </class>

--- a/doc/classes/AnimationNodeAnimation.xml
+++ b/doc/classes/AnimationNodeAnimation.xml
@@ -18,6 +18,10 @@
 		<member name="play_mode" type="int" setter="set_play_mode" getter="get_play_mode" enum="AnimationNodeAnimation.PlayMode" default="0">
 			Determines the playback direction of the animation.
 		</member>
+		<member name="playback_speed" type="float" setter="set_playback_speed" getter="get_playback_speed" default="1.0">
+		</member>
+		<member name="sync_group" type="StringName" setter="set_sync_group" getter="get_sync_group" default="&amp;&quot;&quot;">
+		</member>
 	</members>
 	<constants>
 		<constant name="PLAY_MODE_FORWARD" value="0" enum="PlayMode">

--- a/doc/classes/AnimationNodeBlend2.xml
+++ b/doc/classes/AnimationNodeBlend2.xml
@@ -11,9 +11,4 @@
 		<link title="3D Platformer Demo">https://godotengine.org/asset-library/asset/125</link>
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
-	<members>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
-		</member>
-	</members>
 </class>

--- a/doc/classes/AnimationNodeBlend3.xml
+++ b/doc/classes/AnimationNodeBlend3.xml
@@ -13,9 +13,4 @@
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
 	</tutorials>
-	<members>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
-		</member>
-	</members>
 </class>

--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -26,8 +26,6 @@
 		</member>
 		<member name="mix_mode" type="int" setter="set_mix_mode" getter="get_mix_mode" enum="AnimationNodeOneShot.MixMode" default="0">
 		</member>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-		</member>
 	</members>
 	<constants>
 		<constant name="MIX_MODE_BLEND" value="0" enum="MixMode">

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -226,7 +226,7 @@ double AnimationNodeBlendSpace1D::process(double p_time, bool p_seek, bool p_see
 
 	if (blend_points_used == 1) {
 		// only one point available, just play that animation
-		return blend_node(blend_points[0].name, blend_points[0].node, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, false);
+		return blend_node(blend_points[0].name, blend_points[0].node, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE);
 	}
 
 	double blend_pos = get_parameter(blend_position);
@@ -295,7 +295,7 @@ double AnimationNodeBlendSpace1D::process(double p_time, bool p_seek, bool p_see
 	double max_time_remaining = 0.0;
 
 	for (int i = 0; i < blend_points_used; i++) {
-		double remaining = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, weights[i], FILTER_IGNORE, false);
+		double remaining = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, weights[i], FILTER_IGNORE);
 
 		max_time_remaining = MAX(max_time_remaining, remaining);
 	}

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -502,7 +502,7 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_see
 			for (int j = 0; j < 3; j++) {
 				if (i == triangle_points[j]) {
 					//blend with the given weight
-					double t = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, blend_weights[j], FILTER_IGNORE, false);
+					double t = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, blend_weights[j], FILTER_IGNORE);
 					if (first || t < mind) {
 						mind = t;
 						first = false;
@@ -514,7 +514,7 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_see
 
 			if (!found) {
 				//ignore
-				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, false);
+				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE);
 			}
 		}
 	} else {
@@ -539,16 +539,16 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek, bool p_see
 					na_n->set_backward(na_c->is_backward());
 				}
 				//see how much animation remains
-				from = length_internal - blend_node(blend_points[closest].name, blend_points[closest].node, p_time, false, p_seek_root, 0.0, FILTER_IGNORE, false);
+				from = length_internal - blend_node(blend_points[closest].name, blend_points[closest].node, p_time, false, p_seek_root, 0.0, FILTER_IGNORE);
 			}
 
-			mind = blend_node(blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_seek_root, 1.0, FILTER_IGNORE, false);
+			mind = blend_node(blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_seek_root, 1.0, FILTER_IGNORE);
 			length_internal = from + mind;
 
 			closest = new_closest;
 
 		} else {
-			mind = blend_node(blend_points[closest].name, blend_points[closest].node, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, false);
+			mind = blend_node(blend_points[closest].name, blend_points[closest].node, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE);
 		}
 	}
 

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -38,9 +38,13 @@ class AnimationNodeAnimation : public AnimationRootNode {
 
 	StringName animation;
 	StringName time = "time";
+	StringName sync_group;
 
 	uint64_t last_version = 0;
 	bool skip = false;
+
+	double playback_speed = 1.0;
+	double sync_group_playback_speed = 1.0;
 
 public:
 	enum PlayMode {
@@ -58,11 +62,18 @@ public:
 	void set_animation(const StringName &p_name);
 	StringName get_animation() const;
 
+	void set_sync_group(const StringName &p_name);
+	StringName get_sync_group() const;
+
 	void set_play_mode(PlayMode p_play_mode);
 	PlayMode get_play_mode() const;
 
 	void set_backward(bool p_backward);
 	bool is_backward() const;
+
+	void set_sync_group_playback_speed(double speed);
+	void set_playback_speed(double speed);
+	double get_playback_speed() const;
 
 	AnimationNodeAnimation();
 
@@ -94,8 +105,6 @@ private:
 	float autorestart_delay = 1.0;
 	float autorestart_random_delay = 0.0;
 	MixMode mix = MIX_MODE_BLEND;
-
-	bool sync = false;
 
 	/*	bool active;
 	bool do_start;
@@ -134,9 +143,6 @@ public:
 	void set_mix_mode(MixMode p_mix);
 	MixMode get_mix_mode() const;
 
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
-
 	virtual bool has_filter() const override;
 	virtual double process(double p_time, bool p_seek, bool p_seek_root) override;
 
@@ -149,7 +155,6 @@ class AnimationNodeAdd2 : public AnimationNode {
 	GDCLASS(AnimationNodeAdd2, AnimationNode);
 
 	StringName add_amount = PNAME("add_amount");
-	bool sync = false;
 
 protected:
 	static void _bind_methods();
@@ -159,9 +164,6 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
 
 	virtual bool has_filter() const override;
 	virtual double process(double p_time, bool p_seek, bool p_seek_root) override;
@@ -173,7 +175,6 @@ class AnimationNodeAdd3 : public AnimationNode {
 	GDCLASS(AnimationNodeAdd3, AnimationNode);
 
 	StringName add_amount = PNAME("add_amount");
-	bool sync = false;
 
 protected:
 	static void _bind_methods();
@@ -183,9 +184,6 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
 
 	virtual bool has_filter() const override;
 	virtual double process(double p_time, bool p_seek, bool p_seek_root) override;
@@ -197,7 +195,6 @@ class AnimationNodeBlend2 : public AnimationNode {
 	GDCLASS(AnimationNodeBlend2, AnimationNode);
 
 	StringName blend_amount = PNAME("blend_amount");
-	bool sync = false;
 
 protected:
 	static void _bind_methods();
@@ -209,9 +206,6 @@ public:
 	virtual String get_caption() const override;
 	virtual double process(double p_time, bool p_seek, bool p_seek_root) override;
 
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
-
 	virtual bool has_filter() const override;
 	AnimationNodeBlend2();
 };
@@ -220,7 +214,6 @@ class AnimationNodeBlend3 : public AnimationNode {
 	GDCLASS(AnimationNodeBlend3, AnimationNode);
 
 	StringName blend_amount = PNAME("blend_amount");
-	bool sync;
 
 protected:
 	static void _bind_methods();
@@ -230,9 +223,6 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
 
 	double process(double p_time, bool p_seek, bool p_seek_root) override;
 	AnimationNodeBlend3();

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -356,7 +356,7 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 			current = p_state_machine->start_node;
 		}
 
-		len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 1.0, AnimationNode::FILTER_IGNORE, false);
+		len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 1.0, AnimationNode::FILTER_IGNORE);
 		pos_current = 0;
 	}
 
@@ -381,10 +381,10 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 		}
 	}
 
-	float rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, p_seek_root, fade_blend, AnimationNode::FILTER_IGNORE, false);
+	float rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, p_seek_root, fade_blend, AnimationNode::FILTER_IGNORE);
 
 	if (fading_from != StringName()) {
-		p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_seek_root, 1.0 - fade_blend, AnimationNode::FILTER_IGNORE, false);
+		p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_seek_root, 1.0 - fade_blend, AnimationNode::FILTER_IGNORE);
 	}
 
 	//guess playback position
@@ -538,12 +538,12 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 			}
 			current = next;
 			if (switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_SYNC) {
-				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, false);
+				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE);
 				pos_current = MIN(pos_current, len_current);
-				p_state_machine->blend_node(current, p_state_machine->states[current].node, pos_current, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, false);
+				p_state_machine->blend_node(current, p_state_machine->states[current].node, pos_current, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE);
 
 			} else {
-				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, false);
+				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE);
 				pos_current = 0;
 			}
 


### PR DESCRIPTION
Fixes #23414

This PR adds the ability to synchronize the playback speeds of animations that are blended together in an animation tree. It keeps animations in sync even when they have different lengths.

Without synchronization, animations used in BlendSpace1D/2D or connected to Blend2/3 become desynchronized when their lengths don't match:

https://user-images.githubusercontent.com/8700280/175804524-03866bd2-ce51-45ee-b008-3ac8033dc45c.mp4

With synchronization, they stay in sync, depending on the current lead animation:

https://user-images.githubusercontent.com/8700280/175804529-bd098858-fb82-40d5-9358-de1db15e4ae5.mp4

## Background

I was looking for a way to implement #23414 as a necessary feature for third-person character animation. My original goal was to make this feature work without any extra steps required from devs, but that proved impractical and in some situations even undesired. I eventually went with a system similar to how it works in [Unreal Engine](https://docs.unrealengine.com/5.0/en-US/AnimatingObjects/SkeletalMeshAnimation/SyncGroups/).

The current implementation uses the concept of **Sync Groups** to decide which animations belong together. `AnimationNodeAnimation`s have a new `Sync Group` property that is set by developers to a StringName of their choosing. Based on the final blend weights of all the animations in a sync group, a leader is determined and the other animations in that group are timescaled to match the leader's playback length. Here are two videos demonstrating the feature in the editor and at runtime:

https://user-images.githubusercontent.com/8700280/175804537-5d6776ca-a7d2-4665-b9ae-1b39cc775b07.mp4

https://user-images.githubusercontent.com/8700280/175804547-7f25cbfe-bbc2-49c5-828d-d9a857231c0e.mp4

## Limitations & Improvements

The feature as-is works for the vast majority of cases where such synchronization is desired: locomotion state machines and blend spaces dealing with walk and aim cycles. There are ways to make it even better, but they come with more significant changes to animation nodes, which is why I didn't implement them in this first draft.

### TimeScale Node

The first limitation has to do with the TimeScale node. The system works as expected as long as any TimeScale node in the graph affects all animations in a Sync Group equally. That is, the picture on the left works, the one on the right doesn't:

![timescale](https://user-images.githubusercontent.com/8700280/175804585-97d5d72e-b25b-487c-8f58-8a68426c2350.PNG)

This has to do with the way the TimeScale node works internally. It's a limitation that probably won't be a very big problem in practice, but still might be nice to make it work. The thing is, the only way that I know how to do it would make the TimeScale node effectively obsolete. Instead, there would be a new `Playback Speed` property on *every* node to control a branch's playback speed directly on that node. This would allow us to accumulate the playback speed and pass it down to the leaf node in a way that the Sync Group system can handle it properly.

An advantage would be that it declutters the animation tree, but a disadvantage might be that the playback speed property would exist for every node even if it wouldn't really make sense for that particular node. We can work around that by exposing the variable as a property only for those nodes where it makes sense. For now, I added the playback speed property to the `AnimationNodeAnimation` class only. This allows us to scale an individual animation up or down without breaking synchronization.

![playback](https://user-images.githubusercontent.com/8700280/175805020-986b854c-22c2-4181-959c-05c83ac56ec2.PNG)

### Blend Logic

Another thing that would improve the end result at the cost of slightly complexer blend logic is changing the way that the final animation length is calculated. Right now, all animations in a group are scaled to the length of the leader. This is good enough, but it can produce notable speed pops when the group's leader changes. 

Given two animations of different lengths:

![Concept1](https://user-images.githubusercontent.com/8700280/175804720-db4ee86c-b36d-4b2f-89fe-e1d9492ee9ac.png)

This is what happens in Unreal Engine and what this PR is currently doing:

![Concept2](https://user-images.githubusercontent.com/8700280/175804738-01fbcc27-69cb-4e04-a178-989f8d4e7063.png)

What I have in mind instead is this:

![Concept4](https://user-images.githubusercontent.com/8700280/175804928-58c998b3-141c-46ed-9126-6370439708c1.png)

The animations are not merely scaled to match the leader, but all of them - including the leader - are scaled according to their weight. This would prevent any popping and would make leader switches buttery smooth.

### Desynchronization

There are still instances when the animations desynchronize. Most notably, while assigning sync groups in the editor. Restarting the animation tree fixes that, so I don't know if this is something that needs to be addressed necessarily. Still, it might be desirable to add some resynchronization logic as a response to properties being changed.

## Testing

I invite everyone to throw their animation trees at this to stake out where the current implementation breaks. Things I haven't tested yet include:
- Root motion
- BlendSpace2D (I am currently setting up animations for a proper test case)