### PR TITLE
Add NavigationPathQuery objects and NavigationServer query_path()

### DIFF
--- a/doc/classes/NavigationPathQueryParameters2D.xml
+++ b/doc/classes/NavigationPathQueryParameters2D.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationPathQueryParameters2D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Parameters to be sent to a 2D navigation path query.
+	</brief_description>
+	<description>
+		This class contains the start and target position and other parameters to be used with [method NavigationServer2D.query_path].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="map" type="RID" setter="set_map" getter="get_map">
+			The navigation [code]map[/code] [RID] used in the path query.
+		</member>
+		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
+			The navigation layers the query will use (as a bitmask).
+		</member>
+		<member name="path_postprocessing" type="int" setter="set_path_postprocessing" getter="get_path_postprocessing" enum="NavigationPathQueryParameters2D.PathPostProcessing" default="0">
+		</member>
+		<member name="pathfinding_algorithm" type="int" setter="set_pathfinding_algorithm" getter="get_pathfinding_algorithm" enum="NavigationPathQueryParameters2D.PathfindingAlgorithm" default="0">
+			The pathfinding algorithm used in the path query.
+		</member>
+		<member name="start_position" type="Vector2" setter="set_start_position" getter="get_start_position" default="Vector2(0, 0)">
+			The pathfinding start position in global coordinates.
+		</member>
+		<member name="target_position" type="Vector2" setter="set_target_position" getter="get_target_position" default="Vector2(0, 0)">
+			The pathfinding target position in global coordinates.
+		</member>
+	</members>
+	<constants>
+		<constant name="PATHFINDING_ALGORITHM_ASTAR" value="0" enum="PathfindingAlgorithm">
+			The path query uses the default A* pathfinding algorithm.
+		</constant>
+		<constant name="PATH_POSTPROCESSING_CORRIDORFUNNEL" value="0" enum="PathPostProcessing">
+			Applies a funnel algorithm to the raw path corridor found by the pathfinding algorithm. This will result in the shortest path possible inside the path corridor. This postprocessing very much depends on the navmesh polygon layout and the created corridor. Especially tile- or gridbased layouts can face artifical corners with diagonal movement due to a jagged path corridor imposed by the cell shapes.
+		</constant>
+		<constant name="PATH_POSTPROCESSING_EDGECENTERED" value="1" enum="PathPostProcessing">
+			Centers every path position in the middle of the traveled navmesh polygon edge. This creates better paths for tile- or gridbased layouts that restrict the movement to the cells center.
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/NavigationPathQueryParameters3D.xml
+++ b/doc/classes/NavigationPathQueryParameters3D.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationPathQueryParameters3D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Parameters to be sent to a 3D navigation path query.
+	</brief_description>
+	<description>
+		This class contains the start and target position and other parameters to be used with [method NavigationServer3D.query_path].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="map" type="RID" setter="set_map" getter="get_map">
+			The navigation [code]map[/code] [RID] used in the path query.
+		</member>
+		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
+			The navigation layers the query will use (as a bitmask).
+		</member>
+		<member name="path_postprocessing" type="int" setter="set_path_postprocessing" getter="get_path_postprocessing" enum="NavigationPathQueryParameters3D.PathPostProcessing" default="0">
+		</member>
+		<member name="pathfinding_algorithm" type="int" setter="set_pathfinding_algorithm" getter="get_pathfinding_algorithm" enum="NavigationPathQueryParameters3D.PathfindingAlgorithm" default="0">
+			The pathfinding algorithm used in the path query.
+		</member>
+		<member name="start_position" type="Vector3" setter="set_start_position" getter="get_start_position" default="Vector3(0, 0, 0)">
+			The pathfinding start position in global coordinates.
+		</member>
+		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3(0, 0, 0)">
+			The pathfinding target position in global coordinates.
+		</member>
+	</members>
+	<constants>
+		<constant name="PATHFINDING_ALGORITHM_ASTAR" value="0" enum="PathfindingAlgorithm">
+			The path query uses the default A* pathfinding algorithm.
+		</constant>
+		<constant name="PATH_POSTPROCESSING_CORRIDORFUNNEL" value="0" enum="PathPostProcessing">
+			Applies a funnel algorithm to the raw path corridor found by the pathfinding algorithm. This will result in the shortest path possible inside the path corridor. This postprocessing very much depends on the navmesh polygon layout and the created corridor. Especially tile- or gridbased layouts can face artifical corners with diagonal movement due to a jagged path corridor imposed by the cell shapes.
+		</constant>
+		<constant name="PATH_POSTPROCESSING_EDGECENTERED" value="1" enum="PathPostProcessing">
+			Centers every path position in the middle of the traveled navmesh polygon edge. This creates better paths for tile- or gridbased layouts that restrict the movement to the cells center.
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/NavigationPathQueryResult2D.xml
+++ b/doc/classes/NavigationPathQueryResult2D.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationPathQueryResult2D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Result from a [NavigationPathQueryParameters2D] navigation path query.
+	</brief_description>
+	<description>
+		This class contains the result of a navigation path query from [method NavigationServer2D.query_path].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="path" type="PackedVector2Array" setter="set_path" getter="get_path" default="PackedVector2Array()">
+			The resulting path array from the navigation query. All path array positions are in global coordinates. Without customized query parameters this is the same path as returned by [method NavigationServer2D.map_get_path].
+		</member>
+	</members>
+</class>

--- a/doc/classes/NavigationPathQueryResult3D.xml
+++ b/doc/classes/NavigationPathQueryResult3D.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationPathQueryResult3D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Result from a [NavigationPathQueryParameters3D] navigation path query.
+	</brief_description>
+	<description>
+		This class contains the result of a navigation path query from [method NavigationServer3D.query_path].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="path" type="PackedVector3Array" setter="set_path" getter="get_path" default="PackedVector3Array()">
+			The resulting path array from the navigation query. All path array positions are in global coordinates. Without customized query parameters this is the same path as returned by [method NavigationServer3D.map_get_path].
+		</member>
+	</members>
+</class>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -368,6 +368,14 @@
 				Set the map's link connection radius used to connect links to navigation polygons.
 			</description>
 		</method>
+		<method name="query_path" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="parameters" type="NavigationPathQueryParameters2D" />
+			<param index="1" name="result" type="NavigationPathQueryResult2D" />
+			<description>
+				Queries a path in a given navigation map. Start and target position and other parameters are defined through [NavigationPathQueryParameters2D]. Updates the provided [NavigationPathQueryResult2D] result object with the path among other results requested by the query.
+			</description>
+		</method>
 		<method name="region_create" qualifiers="const">
 			<return type="RID" />
 			<description>

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -410,6 +410,14 @@
 				[b]Note:[/b] This function is not thread safe.
 			</description>
 		</method>
+		<method name="query_path" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="parameters" type="NavigationPathQueryParameters3D" />
+			<param index="1" name="result" type="NavigationPathQueryResult3D" />
+			<description>
+				Queries a path in a given navigation map. Start and target position and other parameters are defined through [NavigationPathQueryParameters3D]. Updates the provided [NavigationPathQueryResult3D] result object with the path among other results requested by the query.
+			</description>
+		</method>
 		<method name="region_bake_navmesh" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="mesh" type="NavigationMesh" />

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -810,6 +810,32 @@ void GodotNavigationServer::process(real_t p_delta_time) {
 	}
 }
 
+NavigationUtilities::PathQueryResult GodotNavigationServer::_query_path(const NavigationUtilities::PathQueryParameters &p_parameters) const {
+	NavigationUtilities::PathQueryResult r_query_result;
+
+	const NavMap *map = map_owner.get_or_null(p_parameters.map);
+	ERR_FAIL_COND_V(map == nullptr, r_query_result);
+
+	// run the pathfinding
+
+	if (p_parameters.pathfinding_algorithm == NavigationUtilities::PathfindingAlgorithm::PATHFINDING_ALGORITHM_ASTAR) {
+		// while postprocessing is still part of map.get_path() need to check and route it here for the correct "optimize" post-processing
+		if (p_parameters.path_postprocessing == NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_CORRIDORFUNNEL) {
+			r_query_result.path = map->get_path(p_parameters.start_position, p_parameters.target_position, true, p_parameters.navigation_layers);
+		} else if (p_parameters.path_postprocessing == NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_EDGECENTERED) {
+			r_query_result.path = map->get_path(p_parameters.start_position, p_parameters.target_position, false, p_parameters.navigation_layers);
+		}
+	} else {
+		return r_query_result;
+	}
+
+	// add path postprocessing
+
+	// add path stats
+
+	return r_query_result;
+}
+
 #undef COMMAND_1
 #undef COMMAND_2
 #undef COMMAND_4

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -175,6 +175,8 @@ public:
 
 	void flush_queries();
 	virtual void process(real_t p_delta_time) override;
+
+	virtual NavigationUtilities::PathQueryResult _query_path(const NavigationUtilities::PathQueryParameters &p_parameters) const override;
 };
 
 #undef COMMAND_1

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -15,6 +15,7 @@ SConscript("text/SCsub")
 SConscript("debugger/SCsub")
 SConscript("extensions/SCsub")
 SConscript("movie_writer/SCsub")
+SConscript("navigation/SCsub")
 
 lib = env.add_library("servers", env.servers_sources)
 

--- a/servers/navigation/SCsub
+++ b/servers/navigation/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/navigation/navigation_path_query_parameters_2d.cpp
+++ b/servers/navigation/navigation_path_query_parameters_2d.cpp
@@ -1,0 +1,144 @@
+/*************************************************************************/
+/*  navigation_path_query_parameters_2d.cpp                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "navigation_path_query_parameters_2d.h"
+
+void NavigationPathQueryParameters2D::set_pathfinding_algorithm(const NavigationPathQueryParameters2D::PathfindingAlgorithm p_pathfinding_algorithm) {
+	switch (p_pathfinding_algorithm) {
+		case PATHFINDING_ALGORITHM_ASTAR: {
+			parameters.pathfinding_algorithm = NavigationUtilities::PathfindingAlgorithm::PATHFINDING_ALGORITHM_ASTAR;
+		} break;
+		default: {
+			WARN_PRINT_ONCE("No match for used PathfindingAlgorithm - fallback to default");
+			parameters.pathfinding_algorithm = NavigationUtilities::PathfindingAlgorithm::PATHFINDING_ALGORITHM_ASTAR;
+		} break;
+	}
+}
+
+NavigationPathQueryParameters2D::PathfindingAlgorithm NavigationPathQueryParameters2D::get_pathfinding_algorithm() const {
+	switch (parameters.pathfinding_algorithm) {
+		case NavigationUtilities::PathfindingAlgorithm::PATHFINDING_ALGORITHM_ASTAR:
+			return PATHFINDING_ALGORITHM_ASTAR;
+		default:
+			WARN_PRINT_ONCE("No match for used PathfindingAlgorithm - fallback to default");
+			return PATHFINDING_ALGORITHM_ASTAR;
+	}
+}
+
+void NavigationPathQueryParameters2D::set_path_postprocessing(const NavigationPathQueryParameters2D::PathPostProcessing p_path_postprocessing) {
+	switch (p_path_postprocessing) {
+		case PATH_POSTPROCESSING_CORRIDORFUNNEL: {
+			parameters.path_postprocessing = NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_CORRIDORFUNNEL;
+		} break;
+		case PATH_POSTPROCESSING_EDGECENTERED: {
+			parameters.path_postprocessing = NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_EDGECENTERED;
+		} break;
+		default: {
+			WARN_PRINT_ONCE("No match for used PathPostProcessing - fallback to default");
+			parameters.path_postprocessing = NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_CORRIDORFUNNEL;
+		} break;
+	}
+}
+
+NavigationPathQueryParameters2D::PathPostProcessing NavigationPathQueryParameters2D::get_path_postprocessing() const {
+	switch (parameters.path_postprocessing) {
+		case NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_CORRIDORFUNNEL:
+			return PATH_POSTPROCESSING_CORRIDORFUNNEL;
+		case NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_EDGECENTERED:
+			return PATH_POSTPROCESSING_EDGECENTERED;
+		default:
+			WARN_PRINT_ONCE("No match for used PathPostProcessing - fallback to default");
+			return PATH_POSTPROCESSING_CORRIDORFUNNEL;
+	}
+}
+
+void NavigationPathQueryParameters2D::set_map(const RID &p_map) {
+	parameters.map = p_map;
+}
+
+const RID &NavigationPathQueryParameters2D::get_map() const {
+	return parameters.map;
+}
+
+void NavigationPathQueryParameters2D::set_start_position(const Vector2 p_start_position) {
+	parameters.start_position = Vector3(p_start_position.x, 0.0, p_start_position.y);
+}
+
+Vector2 NavigationPathQueryParameters2D::get_start_position() const {
+	return Vector2(parameters.start_position.x, parameters.start_position.z);
+}
+
+void NavigationPathQueryParameters2D::set_target_position(const Vector2 p_target_position) {
+	parameters.target_position = Vector3(p_target_position.x, 0.0, p_target_position.y);
+}
+
+Vector2 NavigationPathQueryParameters2D::get_target_position() const {
+	return Vector2(parameters.target_position.x, parameters.target_position.z);
+}
+
+void NavigationPathQueryParameters2D::set_navigation_layers(uint32_t p_navigation_layers) {
+	parameters.navigation_layers = p_navigation_layers;
+};
+
+uint32_t NavigationPathQueryParameters2D::get_navigation_layers() const {
+	return parameters.navigation_layers;
+};
+
+void NavigationPathQueryParameters2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_pathfinding_algorithm", "pathfinding_algorithm"), &NavigationPathQueryParameters2D::set_pathfinding_algorithm);
+	ClassDB::bind_method(D_METHOD("get_pathfinding_algorithm"), &NavigationPathQueryParameters2D::get_pathfinding_algorithm);
+
+	ClassDB::bind_method(D_METHOD("set_path_postprocessing", "path_postprocessing"), &NavigationPathQueryParameters2D::set_path_postprocessing);
+	ClassDB::bind_method(D_METHOD("get_path_postprocessing"), &NavigationPathQueryParameters2D::get_path_postprocessing);
+
+	ClassDB::bind_method(D_METHOD("set_map", "map"), &NavigationPathQueryParameters2D::set_map);
+	ClassDB::bind_method(D_METHOD("get_map"), &NavigationPathQueryParameters2D::get_map);
+
+	ClassDB::bind_method(D_METHOD("set_start_position", "start_position"), &NavigationPathQueryParameters2D::set_start_position);
+	ClassDB::bind_method(D_METHOD("get_start_position"), &NavigationPathQueryParameters2D::get_start_position);
+
+	ClassDB::bind_method(D_METHOD("set_target_position", "target_position"), &NavigationPathQueryParameters2D::set_target_position);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &NavigationPathQueryParameters2D::get_target_position);
+
+	ClassDB::bind_method(D_METHOD("set_navigation_layers", "navigation_layers"), &NavigationPathQueryParameters2D::set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_navigation_layers"), &NavigationPathQueryParameters2D::get_navigation_layers);
+
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "map"), "set_map", "get_map");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "start_position"), "set_start_position", "get_start_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "target_position"), "set_target_position", "get_target_position");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_2D_NAVIGATION), "set_navigation_layers", "get_navigation_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "pathfinding_algorithm", PROPERTY_HINT_ENUM, "AStar"), "set_pathfinding_algorithm", "get_pathfinding_algorithm");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "path_postprocessing", PROPERTY_HINT_ENUM, "Corridorfunnel,Edgecentered"), "set_path_postprocessing", "get_path_postprocessing");
+
+	BIND_ENUM_CONSTANT(PATHFINDING_ALGORITHM_ASTAR);
+
+	BIND_ENUM_CONSTANT(PATH_POSTPROCESSING_CORRIDORFUNNEL);
+	BIND_ENUM_CONSTANT(PATH_POSTPROCESSING_EDGECENTERED);
+}

--- a/servers/navigation/navigation_path_query_parameters_2d.h
+++ b/servers/navigation/navigation_path_query_parameters_2d.h
@@ -1,0 +1,79 @@
+/*************************************************************************/
+/*  navigation_path_query_parameters_2d.h                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef NAVIGATION_PATH_QUERY_PARAMETERS_2D_H
+#define NAVIGATION_PATH_QUERY_PARAMETERS_2D_H
+
+#include "core/object/ref_counted.h"
+#include "servers/navigation/navigation_utilities.h"
+
+class NavigationPathQueryParameters2D : public RefCounted {
+	GDCLASS(NavigationPathQueryParameters2D, RefCounted);
+
+	NavigationUtilities::PathQueryParameters parameters;
+
+protected:
+	static void _bind_methods();
+
+public:
+	enum PathfindingAlgorithm {
+		PATHFINDING_ALGORITHM_ASTAR = 0,
+	};
+
+	enum PathPostProcessing {
+		PATH_POSTPROCESSING_CORRIDORFUNNEL = 0,
+		PATH_POSTPROCESSING_EDGECENTERED,
+	};
+
+	const NavigationUtilities::PathQueryParameters &get_parameters() const { return parameters; }
+
+	void set_pathfinding_algorithm(const PathfindingAlgorithm p_pathfinding_algorithm);
+	PathfindingAlgorithm get_pathfinding_algorithm() const;
+
+	void set_path_postprocessing(const PathPostProcessing p_path_postprocessing);
+	PathPostProcessing get_path_postprocessing() const;
+
+	void set_map(const RID &p_map);
+	const RID &get_map() const;
+
+	void set_start_position(const Vector2 p_start_position);
+	Vector2 get_start_position() const;
+
+	void set_target_position(const Vector2 p_target_position);
+	Vector2 get_target_position() const;
+
+	void set_navigation_layers(uint32_t p_navigation_layers);
+	uint32_t get_navigation_layers() const;
+};
+
+VARIANT_ENUM_CAST(NavigationPathQueryParameters2D::PathfindingAlgorithm);
+VARIANT_ENUM_CAST(NavigationPathQueryParameters2D::PathPostProcessing);
+
+#endif // NAVIGATION_PATH_QUERY_PARAMETERS_2D_H

--- a/servers/navigation/navigation_path_query_parameters_3d.cpp
+++ b/servers/navigation/navigation_path_query_parameters_3d.cpp
@@ -1,0 +1,144 @@
+/*************************************************************************/
+/*  navigation_path_query_parameters_3d.cpp                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "navigation_path_query_parameters_3d.h"
+
+void NavigationPathQueryParameters3D::set_pathfinding_algorithm(const NavigationPathQueryParameters3D::PathfindingAlgorithm p_pathfinding_algorithm) {
+	switch (p_pathfinding_algorithm) {
+		case PATHFINDING_ALGORITHM_ASTAR: {
+			parameters.pathfinding_algorithm = NavigationUtilities::PathfindingAlgorithm::PATHFINDING_ALGORITHM_ASTAR;
+		} break;
+		default: {
+			WARN_PRINT_ONCE("No match for used PathfindingAlgorithm - fallback to default");
+			parameters.pathfinding_algorithm = NavigationUtilities::PathfindingAlgorithm::PATHFINDING_ALGORITHM_ASTAR;
+		} break;
+	}
+}
+
+NavigationPathQueryParameters3D::PathfindingAlgorithm NavigationPathQueryParameters3D::get_pathfinding_algorithm() const {
+	switch (parameters.pathfinding_algorithm) {
+		case NavigationUtilities::PathfindingAlgorithm::PATHFINDING_ALGORITHM_ASTAR:
+			return PATHFINDING_ALGORITHM_ASTAR;
+		default:
+			WARN_PRINT_ONCE("No match for used PathfindingAlgorithm - fallback to default");
+			return PATHFINDING_ALGORITHM_ASTAR;
+	}
+}
+
+void NavigationPathQueryParameters3D::set_path_postprocessing(const NavigationPathQueryParameters3D::PathPostProcessing p_path_postprocessing) {
+	switch (p_path_postprocessing) {
+		case PATH_POSTPROCESSING_CORRIDORFUNNEL: {
+			parameters.path_postprocessing = NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_CORRIDORFUNNEL;
+		} break;
+		case PATH_POSTPROCESSING_EDGECENTERED: {
+			parameters.path_postprocessing = NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_EDGECENTERED;
+		} break;
+		default: {
+			WARN_PRINT_ONCE("No match for used PathPostProcessing - fallback to default");
+			parameters.path_postprocessing = NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_CORRIDORFUNNEL;
+		} break;
+	}
+}
+
+NavigationPathQueryParameters3D::PathPostProcessing NavigationPathQueryParameters3D::get_path_postprocessing() const {
+	switch (parameters.path_postprocessing) {
+		case NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_CORRIDORFUNNEL:
+			return PATH_POSTPROCESSING_CORRIDORFUNNEL;
+		case NavigationUtilities::PathPostProcessing::PATH_POSTPROCESSING_EDGECENTERED:
+			return PATH_POSTPROCESSING_EDGECENTERED;
+		default:
+			WARN_PRINT_ONCE("No match for used PathPostProcessing - fallback to default");
+			return PATH_POSTPROCESSING_CORRIDORFUNNEL;
+	}
+}
+
+void NavigationPathQueryParameters3D::set_map(const RID &p_map) {
+	parameters.map = p_map;
+}
+
+const RID &NavigationPathQueryParameters3D::get_map() const {
+	return parameters.map;
+}
+
+void NavigationPathQueryParameters3D::set_start_position(const Vector3 &p_start_position) {
+	parameters.start_position = p_start_position;
+}
+
+const Vector3 &NavigationPathQueryParameters3D::get_start_position() const {
+	return parameters.start_position;
+}
+
+void NavigationPathQueryParameters3D::set_target_position(const Vector3 &p_target_position) {
+	parameters.target_position = p_target_position;
+}
+
+const Vector3 &NavigationPathQueryParameters3D::get_target_position() const {
+	return parameters.target_position;
+}
+
+void NavigationPathQueryParameters3D::set_navigation_layers(uint32_t p_navigation_layers) {
+	parameters.navigation_layers = p_navigation_layers;
+}
+
+uint32_t NavigationPathQueryParameters3D::get_navigation_layers() const {
+	return parameters.navigation_layers;
+}
+
+void NavigationPathQueryParameters3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_pathfinding_algorithm", "pathfinding_algorithm"), &NavigationPathQueryParameters3D::set_pathfinding_algorithm);
+	ClassDB::bind_method(D_METHOD("get_pathfinding_algorithm"), &NavigationPathQueryParameters3D::get_pathfinding_algorithm);
+
+	ClassDB::bind_method(D_METHOD("set_path_postprocessing", "path_postprocessing"), &NavigationPathQueryParameters3D::set_path_postprocessing);
+	ClassDB::bind_method(D_METHOD("get_path_postprocessing"), &NavigationPathQueryParameters3D::get_path_postprocessing);
+
+	ClassDB::bind_method(D_METHOD("set_map", "map"), &NavigationPathQueryParameters3D::set_map);
+	ClassDB::bind_method(D_METHOD("get_map"), &NavigationPathQueryParameters3D::get_map);
+
+	ClassDB::bind_method(D_METHOD("set_start_position", "start_position"), &NavigationPathQueryParameters3D::set_start_position);
+	ClassDB::bind_method(D_METHOD("get_start_position"), &NavigationPathQueryParameters3D::get_start_position);
+
+	ClassDB::bind_method(D_METHOD("set_target_position", "target_position"), &NavigationPathQueryParameters3D::set_target_position);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &NavigationPathQueryParameters3D::get_target_position);
+
+	ClassDB::bind_method(D_METHOD("set_navigation_layers", "navigation_layers"), &NavigationPathQueryParameters3D::set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_navigation_layers"), &NavigationPathQueryParameters3D::get_navigation_layers);
+
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "map"), "set_map", "get_map");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "start_position"), "set_start_position", "get_start_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_position"), "set_target_position", "get_target_position");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_navigation_layers", "get_navigation_layers");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "pathfinding_algorithm", PROPERTY_HINT_ENUM, "AStar"), "set_pathfinding_algorithm", "get_pathfinding_algorithm");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "path_postprocessing", PROPERTY_HINT_ENUM, "Corridorfunnel,Edgecentered"), "set_path_postprocessing", "get_path_postprocessing");
+
+	BIND_ENUM_CONSTANT(PATHFINDING_ALGORITHM_ASTAR);
+
+	BIND_ENUM_CONSTANT(PATH_POSTPROCESSING_CORRIDORFUNNEL);
+	BIND_ENUM_CONSTANT(PATH_POSTPROCESSING_EDGECENTERED);
+}

--- a/servers/navigation/navigation_path_query_parameters_3d.h
+++ b/servers/navigation/navigation_path_query_parameters_3d.h
@@ -1,0 +1,79 @@
+/*************************************************************************/
+/*  navigation_path_query_parameters_3d.h                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef NAVIGATION_PATH_QUERY_PARAMETERS_3D_H
+#define NAVIGATION_PATH_QUERY_PARAMETERS_3D_H
+
+#include "core/object/ref_counted.h"
+#include "servers/navigation/navigation_utilities.h"
+
+class NavigationPathQueryParameters3D : public RefCounted {
+	GDCLASS(NavigationPathQueryParameters3D, RefCounted);
+
+	NavigationUtilities::PathQueryParameters parameters;
+
+protected:
+	static void _bind_methods();
+
+public:
+	enum PathfindingAlgorithm {
+		PATHFINDING_ALGORITHM_ASTAR = 0,
+	};
+
+	enum PathPostProcessing {
+		PATH_POSTPROCESSING_CORRIDORFUNNEL = 0,
+		PATH_POSTPROCESSING_EDGECENTERED,
+	};
+
+	const NavigationUtilities::PathQueryParameters &get_parameters() const { return parameters; }
+
+	void set_pathfinding_algorithm(const PathfindingAlgorithm p_pathfinding_algorithm);
+	PathfindingAlgorithm get_pathfinding_algorithm() const;
+
+	void set_path_postprocessing(const PathPostProcessing p_path_postprocessing);
+	PathPostProcessing get_path_postprocessing() const;
+
+	void set_map(const RID &p_map);
+	const RID &get_map() const;
+
+	void set_start_position(const Vector3 &p_start_position);
+	const Vector3 &get_start_position() const;
+
+	void set_target_position(const Vector3 &p_target_position);
+	const Vector3 &get_target_position() const;
+
+	void set_navigation_layers(uint32_t p_navigation_layers);
+	uint32_t get_navigation_layers() const;
+};
+
+VARIANT_ENUM_CAST(NavigationPathQueryParameters3D::PathfindingAlgorithm);
+VARIANT_ENUM_CAST(NavigationPathQueryParameters3D::PathPostProcessing);
+
+#endif // NAVIGATION_PATH_QUERY_PARAMETERS_3D_H

--- a/servers/navigation/navigation_path_query_result_2d.cpp
+++ b/servers/navigation/navigation_path_query_result_2d.cpp
@@ -1,0 +1,46 @@
+/*************************************************************************/
+/*  navigation_path_query_result_2d.cpp                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "navigation_path_query_result_2d.h"
+
+void NavigationPathQueryResult2D::set_path(const Vector<Vector2> &p_path) {
+	path = p_path;
+}
+
+const Vector<Vector2> &NavigationPathQueryResult2D::get_path() const {
+	return path;
+}
+
+void NavigationPathQueryResult2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_path", "path"), &NavigationPathQueryResult2D::set_path);
+	ClassDB::bind_method(D_METHOD("get_path"), &NavigationPathQueryResult2D::get_path);
+
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "path"), "set_path", "get_path");
+}

--- a/servers/navigation/navigation_path_query_result_2d.h
+++ b/servers/navigation/navigation_path_query_result_2d.h
@@ -1,0 +1,50 @@
+/*************************************************************************/
+/*  navigation_path_query_result_2d.h                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef NAVIGATION_PATH_QUERY_RESULT_2D_H
+#define NAVIGATION_PATH_QUERY_RESULT_2D_H
+
+#include "core/object/ref_counted.h"
+#include "servers/navigation/navigation_utilities.h"
+
+class NavigationPathQueryResult2D : public RefCounted {
+	GDCLASS(NavigationPathQueryResult2D, RefCounted);
+
+	Vector<Vector2> path;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_path(const Vector<Vector2> &p_path);
+	const Vector<Vector2> &get_path() const;
+};
+
+#endif // NAVIGATION_PATH_QUERY_RESULT_2D_H

--- a/servers/navigation/navigation_path_query_result_3d.cpp
+++ b/servers/navigation/navigation_path_query_result_3d.cpp
@@ -1,0 +1,46 @@
+/*************************************************************************/
+/*  navigation_path_query_result_3d.cpp                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "navigation_path_query_result_3d.h"
+
+void NavigationPathQueryResult3D::set_path(const Vector<Vector3> &p_path) {
+	path = p_path;
+}
+
+const Vector<Vector3> &NavigationPathQueryResult3D::get_path() const {
+	return path;
+}
+
+void NavigationPathQueryResult3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_path", "path"), &NavigationPathQueryResult3D::set_path);
+	ClassDB::bind_method(D_METHOD("get_path"), &NavigationPathQueryResult3D::get_path);
+
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "path"), "set_path", "get_path");
+}

--- a/servers/navigation/navigation_path_query_result_3d.h
+++ b/servers/navigation/navigation_path_query_result_3d.h
@@ -1,0 +1,50 @@
+/*************************************************************************/
+/*  navigation_path_query_result_3d.h                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef NAVIGATION_PATH_QUERY_RESULT_3D_H
+#define NAVIGATION_PATH_QUERY_RESULT_3D_H
+
+#include "core/object/ref_counted.h"
+#include "servers/navigation/navigation_utilities.h"
+
+class NavigationPathQueryResult3D : public RefCounted {
+	GDCLASS(NavigationPathQueryResult3D, RefCounted);
+
+	Vector<Vector3> path;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_path(const Vector<Vector3> &p_path);
+	const Vector<Vector3> &get_path() const;
+};
+
+#endif // NAVIGATION_PATH_QUERY_RESULT_3D_H

--- a/servers/navigation/navigation_utilities.h
+++ b/servers/navigation/navigation_utilities.h
@@ -1,0 +1,62 @@
+/*************************************************************************/
+/*  navigation_utilities.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef NAVIGATION_UTILITIES_H
+#define NAVIGATION_UTILITIES_H
+
+#include "core/math/vector3.h"
+
+namespace NavigationUtilities {
+
+enum PathfindingAlgorithm {
+	PATHFINDING_ALGORITHM_ASTAR = 0,
+};
+
+enum PathPostProcessing {
+	PATH_POSTPROCESSING_CORRIDORFUNNEL = 0,
+	PATH_POSTPROCESSING_EDGECENTERED,
+};
+
+struct PathQueryParameters {
+	PathfindingAlgorithm pathfinding_algorithm = PATHFINDING_ALGORITHM_ASTAR;
+	PathPostProcessing path_postprocessing = PATH_POSTPROCESSING_CORRIDORFUNNEL;
+	RID map;
+	Vector3 start_position = Vector3();
+	Vector3 target_position = Vector3();
+	uint32_t navigation_layers = 1;
+};
+
+struct PathQueryResult {
+	Vector<Vector3> path;
+};
+
+} //namespace NavigationUtilities
+
+#endif // NAVIGATION_UTILITIES_H

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -243,6 +243,8 @@ void NavigationServer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("map_force_update", "map"), &NavigationServer2D::map_force_update);
 
+	ClassDB::bind_method(D_METHOD("query_path", "parameters", "result"), &NavigationServer2D::query_path);
+
 	ClassDB::bind_method(D_METHOD("region_create"), &NavigationServer2D::region_create);
 	ClassDB::bind_method(D_METHOD("region_set_enter_cost", "region", "enter_cost"), &NavigationServer2D::region_set_enter_cost);
 	ClassDB::bind_method(D_METHOD("region_get_enter_cost", "region"), &NavigationServer2D::region_get_enter_cost);
@@ -409,3 +411,12 @@ bool FORWARD_1_C(agent_is_map_changed, RID, p_agent, rid_to_rid);
 void FORWARD_4_C(agent_set_callback, RID, p_agent, Object *, p_receiver, StringName, p_method, Variant, p_udata, rid_to_rid, obj_to_obj, sn_to_sn, var_to_var);
 
 void FORWARD_1_C(free, RID, p_object, rid_to_rid);
+
+void NavigationServer2D::query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const {
+	ERR_FAIL_COND(!p_query_parameters.is_valid());
+	ERR_FAIL_COND(!p_query_result.is_valid());
+
+	const NavigationUtilities::PathQueryResult _query_result = NavigationServer3D::get_singleton()->_query_path(p_query_parameters->get_parameters());
+
+	p_query_result->set_path(vector_v3_to_v2(_query_result.path));
+}

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -33,7 +33,10 @@
 
 #include "core/object/class_db.h"
 #include "core/templates/rid.h"
+
 #include "scene/2d/navigation_region_2d.h"
+#include "servers/navigation/navigation_path_query_parameters_2d.h"
+#include "servers/navigation/navigation_path_query_result_2d.h"
 
 // This server exposes the `NavigationServer3D` features in the 2D world.
 class NavigationServer2D : public Object {
@@ -216,6 +219,8 @@ public:
 
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_callback(RID p_agent, Object *p_receiver, StringName p_method, Variant p_udata = Variant()) const;
+
+	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const;
 
 	/// Destroy the `RID`
 	virtual void free(RID p_object) const;

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -62,6 +62,8 @@ void NavigationServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("map_force_update", "map"), &NavigationServer3D::map_force_update);
 
+	ClassDB::bind_method(D_METHOD("query_path", "parameters", "result"), &NavigationServer3D::query_path);
+
 	ClassDB::bind_method(D_METHOD("region_create"), &NavigationServer3D::region_create);
 	ClassDB::bind_method(D_METHOD("region_set_enter_cost", "region", "enter_cost"), &NavigationServer3D::region_set_enter_cost);
 	ClassDB::bind_method(D_METHOD("region_get_enter_cost", "region"), &NavigationServer3D::region_get_enter_cost);
@@ -485,3 +487,14 @@ bool NavigationServer3D::get_debug_enabled() const {
 	return debug_enabled;
 }
 #endif // DEBUG_ENABLED
+
+///////////////////////////////////////////////////////
+
+void NavigationServer3D::query_path(const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result) const {
+	ERR_FAIL_COND(!p_query_parameters.is_valid());
+	ERR_FAIL_COND(!p_query_result.is_valid());
+
+	const NavigationUtilities::PathQueryResult _query_result = _query_path(p_query_parameters->get_parameters());
+
+	p_query_result->set_path(_query_result.path);
+}

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -33,7 +33,10 @@
 
 #include "core/object/class_db.h"
 #include "core/templates/rid.h"
+
 #include "scene/3d/navigation_region_3d.h"
+#include "servers/navigation/navigation_path_query_parameters_3d.h"
+#include "servers/navigation/navigation_path_query_result_3d.h"
 
 /// This server uses the concept of internal mutability.
 /// All the constant functions can be called in multithread because internally
@@ -41,6 +44,7 @@
 ///
 /// Note: All the `set` functions are commands executed during the `sync` phase,
 /// don't expect that a change is immediately propagated.
+
 class NavigationServer3D : public Object {
 	GDCLASS(NavigationServer3D, Object);
 
@@ -242,6 +246,11 @@ public:
 	/// so this must be called in the main thread.
 	/// Note: This function is not thread safe.
 	virtual void process(real_t delta_time) = 0;
+
+	/// Returns a customized navigation path using a query parameters object
+	void query_path(const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result) const;
+
+	virtual NavigationUtilities::PathQueryResult _query_path(const NavigationUtilities::PathQueryParameters &p_parameters) const = 0;
 
 	NavigationServer3D();
 	virtual ~NavigationServer3D();

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -165,6 +165,11 @@ void register_server_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
+	GDREGISTER_CLASS(NavigationPathQueryParameters2D);
+	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
+	GDREGISTER_CLASS(NavigationPathQueryResult2D);
+	GDREGISTER_CLASS(NavigationPathQueryResult3D);
+
 	GDREGISTER_CLASS(XRServer);
 	GDREGISTER_CLASS(CameraServer);
 


### PR DESCRIPTION
Adds `NavigationPathQueryParameters` and `NavigationPathQueryResult` objects in 2D and 3D similar to e.g. physics query parameters and results.

Can be used with 2D or 3D NavigationServer `query_path()` to get a customized navigation path considering additional options.

Does not affect the normal pathfinding with NavigationAgent nodes or NavigationServer.map_get_path() at all. Without customized options returns the same path as map_get_path() for now.

Removed for this pr most other options that are still developed and not finished yet (like [#2527](https://github.com/godotengine/godot-proposals/issues/2527) or [#3812](https://github.com/godotengine/godot-proposals/issues/3812)). If there is only a single function or an enum has only a single value that is why. This is basically only the core left as many other pr's and features will depend on this. This query can be used as a base to fix issues #19011 and #60277 in the future by adding a property that controls how the pathfinding adds points or a simplifying method in path postprocessing.

This pr is also a prerequisite for #62115 or any other issue that is related to the currently used pathfinding algorithm and forced path post-processing. Since Godot seems that it wants to support both 2D and 3D pathfinding as free-form as well as tile / grid based with TileMap and GridMap (#61293) it is impossible to have just one pathfinding algorithm and one out of two forced path post-processing for everything like it is rightnow.

Usage is to create both objects first and store them into a var for reuse.
Then use query_path() for updating the content of the result.

Example:

```gdscript
var query_parameters : NavigationPathQueryParameters3D = NavigationPathQueryParameters3D.new()
var query_result  : NavigationPathQueryResult3D = NavigationPathQueryResult3D.new()

# fill in parameters...

NavigationServer3D.query_path(query_parameters, query_result)
var path = query_result.get_path()
```
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
