### PR TITLE
Highlight ^NodePath and &StringName differently

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -54,7 +54,9 @@ private:
 		NONE,
 		REGION,
 		NODE_PATH,
+		NODE_REF,
 		ANNOTATION,
+		STRING_NAME,
 		SYMBOL,
 		NUMBER,
 		FUNCTION,
@@ -74,7 +76,9 @@ private:
 	Color number_color;
 	Color member_color;
 	Color node_path_color;
+	Color node_ref_color;
 	Color annotation_color;
+	Color string_name_color;
 	Color type_color;
 
 	void add_color_region(const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only = false);


### PR DESCRIPTION
Part of https://github.com/godotengine/godot-proposals/issues/4721
![image](https://user-images.githubusercontent.com/2223172/175830897-90d1b8d1-7cc2-4a34-ab19-289a7e04de4f.png)

We already have a color for NodePath, for StringName I reused annotation color. I could make them unique if that's confusing.