### PR TITLE
[3.x] Faster queue free

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -510,6 +510,7 @@
 			<description>
 				Queues a node for deletion at the end of the current frame. When deleted, all of its child nodes will be deleted as well. This method ensures it's safe to delete the node, contrary to [method Object.free]. Use [method Object.is_queued_for_deletion] to check whether a node will be deleted at the end of the frame.
 				[b]Important:[/b] If you have a variable pointing to a node, it will [i]not[/i] be assigned to [code]null[/code] once the node is freed. Instead, it will point to a [i]previously freed instance[/i] and you should validate it with [method @GDScript.is_instance_valid] before attempting to call its methods or access its properties.
+				[b]Note:[/b] For efficiency reasons, the final order of deletion is not guaranteed.
 			</description>
 		</method>
 		<method name="raise">

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -163,7 +163,11 @@ private:
 	void _update_font_oversampling(float p_ratio);
 	void _update_root_rect();
 
-	List<ObjectID> delete_queue;
+	struct DeleteQueueElement {
+		ObjectID id;
+		int32_t child_list_id;
+	};
+	LocalVector<DeleteQueueElement> delete_queue;
 
 	Map<UGCall, Vector<Variant>> unique_group_calls;
 	bool ugc_locked;


### PR DESCRIPTION
Calling `queue_free()` for large numbers of siblings could previously be very slow, with the time taken rising exponentially with number of children. This looked partly due to ordered_remove from the child list and notifications.

This PR identifies objects that are nodes, and sorts the deletion queue so that children are deleted in reverse child order. This minimizes the costs of reordering.

Fixes #61929
Supercedes #61932

## Performance testing, number of child nodes deleted
**50000 nodes** before 137017 ms, after 422 ms seconds (**325x** faster)
**20000 nodes** before 19425 ms, after 250 ms seconds (**78x** faster)
**5000 nodes** before 1228 ms, after 169 ms seconds (**7.3x** faster)
**1000 nodes** before 194 ms, after 150 ms seconds (**1.3x** faster)

(at lower node numbers the measurement from the MRP in #61929 becomes less useful as there are some fixed delays, however the pattern is that the benefit really starts to show with a decent number of children)

## Notes
* On further research, it turned out the child id _is_ already stored in nodes, in `data->pos`, and sorting by child id is a superior approach. It achieves the same upside of deleting in reverse order, but eliminates the possible downside of deleting small numbers of children from a parent that has a large number of children.
* Compared to the previous PR, the technique can now be employed in all cases (rather than having an arbitrary cutoff), and will always yield some benefit (though exponentially more benefit as the number of children rises), and effectively should have negligible cost.
* Uses an additional bit twiddling technique to combine the child id with a "group", to ensure that in most cases, the children of the same parent will be sorted together in the list. This could make things more cache friendly, and is super cheap to do, so why not.
* I also evaluated using a dirty flag for `NOTIFICATION_MOVED_IN_PARENT`. While this increased performance over baseline, it wasn't nearly as effective as the reverse ordering in this PR.
* Same principle can be applied in 4.x as the code is similar.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
