### PR TITLE
Add the ability to drag the code completion scrollbar using the mouse click

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -592,6 +592,9 @@
 		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.29)">
 			[Color] of the scrollbar in the code completion popup.
 		</theme_item>
+		<theme_item name="completion_scroll_hovered_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.4)">
+			[Color] of the scrollbar in the code completion popup when hovered.
+		</theme_item>
 		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color(0.26, 0.26, 0.27, 1)">
 			Background highlight [Color] for the current selected option item in the code completion popup.
 		</theme_item>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -763,6 +763,7 @@ void EditorSettings::_load_godot2_text_editor_theme() {
 	_initial_set("text_editor/theme/highlighting/completion_selected_color", Color(0.26, 0.26, 0.27));
 	_initial_set("text_editor/theme/highlighting/completion_existing_color", Color(0.87, 0.87, 0.87, 0.13));
 	_initial_set("text_editor/theme/highlighting/completion_scroll_color", Color(1, 1, 1, 0.29));
+	_initial_set("text_editor/theme/highlighting/completion_scroll_hovered_color", Color(1, 1, 1, 0.4));
 	_initial_set("text_editor/theme/highlighting/completion_font_color", Color(0.67, 0.67, 0.67));
 	_initial_set("text_editor/theme/highlighting/text_color", Color(0.67, 0.67, 0.67));
 	_initial_set("text_editor/theme/highlighting/line_number_color", Color(0.67, 0.67, 0.67, 0.4));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1683,6 +1683,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color completion_existing_color = alpha2;
 	// Same opacity as the scroll grabber editor icon.
 	const Color completion_scroll_color = Color(mono_value, mono_value, mono_value, 0.29);
+	const Color completion_scroll_hovered_color = Color(mono_value, mono_value, mono_value, 0.4);
 	const Color completion_font_color = font_color;
 	const Color text_color = font_color;
 	const Color line_number_color = dim_color;
@@ -1721,6 +1722,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		setting->set_initial_value("text_editor/theme/highlighting/completion_selected_color", completion_selected_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/completion_existing_color", completion_existing_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/completion_scroll_color", completion_scroll_color, true);
+		setting->set_initial_value("text_editor/theme/highlighting/completion_scroll_hovered_color", completion_scroll_hovered_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/completion_font_color", completion_font_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/text_color", text_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/line_number_color", line_number_color, true);
@@ -1766,6 +1768,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("completion_selected_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_selected_color"));
 	theme->set_color("completion_existing_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_existing_color"));
 	theme->set_color("completion_scroll_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_scroll_color"));
+	theme->set_color("completion_scroll_hovered_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_scroll_hovered_color"));
 	theme->set_color("completion_font_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_font_color"));
 	theme->set_color("font_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/text_color"));
 	theme->set_color("line_number_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/line_number_color"));

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -203,22 +203,27 @@ private:
 	int code_completion_max_lines = 7;
 	int code_completion_scroll_width = 0;
 	Color code_completion_scroll_color = Color(0, 0, 0, 0);
+	Color code_completion_scroll_hovered_color = Color(0, 0, 0, 0);
 	Color code_completion_background_color = Color(0, 0, 0, 0);
 	Color code_completion_selected_color = Color(0, 0, 0, 0);
 	Color code_completion_existing_color = Color(0, 0, 0, 0);
 
 	bool code_completion_active = false;
+	bool is_code_completion_scroll_hovered = false;
+	bool is_code_completion_scroll_pressed = false;
 	Vector<ScriptLanguage::CodeCompletionOption> code_completion_options;
 	int code_completion_line_ofs = 0;
 	int code_completion_current_selected = 0;
 	int code_completion_longest_line = 0;
 	Rect2i code_completion_rect;
+	Rect2i code_completion_scroll_rect;
 
 	HashSet<char32_t> code_completion_prefixes;
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_submitted;
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_sources;
 	String code_completion_base;
 
+	void _update_scroll_selected_line(float p_mouse_y);
 	void _filter_code_completion_candidates_impl();
 
 	/* Line length guidelines */

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -467,6 +467,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("completion_selected_color", "CodeEdit", Color(0.26, 0.26, 0.27));
 	theme->set_color("completion_existing_color", "CodeEdit", Color(0.87, 0.87, 0.87, 0.13));
 	theme->set_color("completion_scroll_color", "CodeEdit", control_font_pressed_color * Color(1, 1, 1, 0.29));
+	theme->set_color("completion_scroll_hovered_color", "CodeEdit", control_font_pressed_color * Color(1, 1, 1, 0.4));
 	theme->set_color("completion_font_color", "CodeEdit", Color(0.67, 0.67, 0.67));
 	theme->set_color("font_color", "CodeEdit", control_font_color);
 	theme->set_color("font_selected_color", "CodeEdit", Color(0, 0, 0));


### PR DESCRIPTION
It is now possible to drag the code completion scrollbar using the mouse click, thus allowing easier navigation within code completions.

![Demo of the feature](https://user-images.githubusercontent.com/13206601/175909089-3ba2a90c-c510-4443-a3cd-dd45cb067392.gif)
