### PR TITLE
Add generalized version of `wrap` function

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -267,6 +267,52 @@ struct VariantUtilityFunctions {
 		return Math::db2linear(db);
 	}
 
+	static inline Variant wrap(const Variant &p_x, const Variant &p_min, const Variant &p_max, Callable::CallError &r_error) {
+		Variant::Type x_type = p_x.get_type();
+		if (x_type != Variant::INT && x_type != Variant::FLOAT) {
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.argument = 0;
+			r_error.expected = x_type;
+			return Variant();
+		}
+
+		Variant::Type min_type = p_min.get_type();
+		if (min_type != Variant::INT && min_type != Variant::FLOAT) {
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.argument = 1;
+			r_error.expected = x_type;
+			return Variant();
+		}
+
+		Variant::Type max_type = p_max.get_type();
+		if (max_type != Variant::INT && max_type != Variant::FLOAT) {
+			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+			r_error.argument = 2;
+			r_error.expected = x_type;
+			return Variant();
+		}
+
+		Variant value;
+
+		switch (x_type) {
+			case Variant::INT: {
+				if (x_type != min_type || x_type != max_type) {
+					value = wrapf((double)p_x, (double)p_min, (double)p_max);
+				} else {
+					value = wrapi((int)p_x, (int)p_min, (int)p_max);
+				}
+			} break;
+			case Variant::FLOAT: {
+				value = wrapf((double)p_x, (double)p_min, (double)p_max);
+			} break;
+			default:
+				break;
+		}
+
+		r_error.error = Callable::CallError::CALL_OK;
+		return value;
+	}
+
 	static inline int64_t wrapi(int64_t value, int64_t min, int64_t max) {
 		return Math::wrapi(value, min, max);
 	}
@@ -1216,6 +1262,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(linear2db, sarray("lin"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(db2linear, sarray("db"), Variant::UTILITY_FUNC_TYPE_MATH);
 
+	FUNCBINDVR3(wrap, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(wrapi, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(wrapf, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1040,6 +1040,27 @@
 				A weak reference to an object is not enough to keep the object alive: when the only remaining references to a referent are weak references, garbage collection is free to destroy the referent and reuse its memory for something else. However, until the object is actually destroyed the weak reference may return the object even if there are no strong references to it.
 			</description>
 		</method>
+		<method name="wrap">
+			<return type="Variant" />
+			<argument index="0" name="value" type="Variant" />
+			<argument index="1" name="min" type="Variant" />
+			<argument index="2" name="max" type="Variant" />
+			<description>
+				Wraps the [Variant] [code]value[/code] between [code]min[/code] and [code]max[/code].
+				Usable for creating loop-alike behavior or infinite surfaces.
+				Variant types [int] and [float] (real) are supported. If any of the argument is [float] the result will be [float], otherwise it is [int].
+				[codeblock]
+				var a = wrap(4, 5, 10)
+				# a is 9 (int)
+
+				var a = wrap(7, 5, 10)
+				# a is 7 (int)
+
+				var a = wrap(10.5, 5, 10)
+				# a is 5.5 (float)
+				[/codeblock]
+			</description>
+		</method>
 		<method name="wrapf">
 			<return type="float" />
 			<argument index="0" name="value" type="float" />


### PR DESCRIPTION
Since other functions like `clamp` (`clampi` / `clampf`) or `max` (`maxi`, `maxf`) are exists then (`wrapi`/`wrapf`) lacks the generalized version to call for any float or integer argument - this small PR fixes it.
