### PR TITLE
Consider uniform writability part of the interface of the set

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -544,12 +544,13 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 	struct UniformInfo {
 		UniformType type = UniformType::UNIFORM_TYPE_MAX;
+		bool writable = false;
 		int binding = 0;
 		uint32_t stages = 0;
 		int length = 0; //size of arrays (in total elements), or ubos (in bytes * total elements)
 
 		bool operator!=(const UniformInfo &p_info) const {
-			return (binding != p_info.binding || type != p_info.type || stages != p_info.stages || length != p_info.length);
+			return (binding != p_info.binding || type != p_info.type || writable != p_info.writable || stages != p_info.stages || length != p_info.length);
 		}
 
 		bool operator<(const UniformInfo &p_info) const {
@@ -558,6 +559,9 @@ class RenderingDeviceVulkan : public RenderingDevice {
 			}
 			if (type != p_info.type) {
 				return type < p_info.type;
+			}
+			if (writable != p_info.writable) {
+				return writable < p_info.writable;
 			}
 			if (stages != p_info.stages) {
 				return stages < p_info.stages;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -799,6 +799,7 @@ private:
 
 		RID fog_uniform_set;
 		RID copy_uniform_set;
+		RID process_uniform_set_density;
 		RID process_uniform_set;
 		RID process_uniform_set2;
 		RID sdfgi_uniform_set;

--- a/servers/rendering/renderer_rd/shaders/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/volumetric_fog_process.glsl
@@ -53,7 +53,6 @@ layout(set = 0, binding = 7) uniform sampler linear_sampler;
 
 #ifdef MODE_DENSITY
 layout(rgba16f, set = 0, binding = 8) uniform restrict writeonly image3D density_map;
-layout(rgba16f, set = 0, binding = 9) uniform restrict readonly image3D fog_map; //unused
 #endif
 
 #ifdef MODE_FOG


### PR DESCRIPTION
In SPIR-V/Vulkan one can create a descriptor set with bindings with different writabilities than those in another version of the shader and, as long as everything else matches, it can be bound.

In other modern rendering APIs that's not possible. Therefore, this PR adds an artificial restriction about that to achieve uniformity across rendering drivers. Namely, descriptor set formats now are different if different writabilities are found across its uniforms.

Finally, the only case we currently have where that new constraint is violated (volumetric fog) is adapted to this new policy.