### PR TITLE
GDScript: Enable exporting nodes to the inspector

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3026,13 +3026,17 @@ String EditorPropertyNodePath::_get_meta_pointer_property() const {
 Variant EditorPropertyNodePath::_get_cache_value(const StringName &p_prop, bool &r_valid) const {
 	if (p_prop == get_edited_property()) {
 		r_valid = true;
-		return const_cast<EditorPropertyNodePath *>(this)->get_edited_object()->get(_get_meta_pointer_property(), &r_valid);
+		return const_cast<EditorPropertyNodePath *>(this)->get_edited_object()->get(pointer_mode ? StringName(_get_meta_pointer_property()) : get_edited_property(), &r_valid);
 	}
 	return Variant();
 }
 
 StringName EditorPropertyNodePath::_get_revert_property() const {
-	return _get_meta_pointer_property();
+	if (pointer_mode) {
+		return _get_meta_pointer_property();
+	} else {
+		return get_edited_property();
+	}
 }
 
 void EditorPropertyNodePath::_node_selected(const NodePath &p_path) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3605,8 +3605,12 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 					variable->export_info.type = Variant::OBJECT;
 					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
 					variable->export_info.hint_string = export_type.native_type;
+				} else if (ClassDB::is_parent_class(export_type.native_type, SNAME("Node"))) {
+					variable->export_info.type = Variant::OBJECT;
+					variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
+					variable->export_info.hint_string = export_type.native_type;
 				} else {
-					push_error(R"(Export type can only be built-in, a resource, or an enum.)", variable);
+					push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", variable);
 					return false;
 				}
 				break;


### PR DESCRIPTION
Use the addition from #62185 to allow exporting node types as well. Also fixed a small issue with it.

I notice one bug here that I can't revert it. The revert button is always active and clicking it does nothing, even if the path is cleared. I'm not familiar with the inspector code so I'll leave to someone else to figure it out.

<i>Bugsquad edit:</i>
- Fix #62461
- Implements https://github.com/godotengine/godot-proposals/issues/1048