### PR TITLE
[3.5] Add safe defaults for async shader compilation

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1516,22 +1516,32 @@
 			At runtime, while that count is reached, other shaders that can be asynchronously compiled will just use their fallback, without their setup being started until the count gets lower.
 			This is a way to balance the CPU work between running the game and compiling the shaders. The goal is to have as many asynchronous compiles in flight as possible without impacting the responsiveness of the game, which beyond some point would destroy the benefits of asynchronous compilation. In other words, you may be able to afford that the FPS lowers a bit, and that will already be better than the stalling that synchronous compilation could cause.
 			The default value is a conservative one, so you are advised to tweak it according to the hardware you are targeting.
-			[b]Note:[/b] This setting is only meaningful if [code]rendering/gles3/shaders/shader_compilation_mode[/code] is [b]not[/b] [code]Synchronous[/code].
+			[b]Note:[/b] This setting is only meaningful if [member rendering/gles3/shaders/shader_compilation_mode] is [b]not[/b] [code]Synchronous[/code].
 		</member>
 		<member name="rendering/gles3/shaders/max_simultaneous_compiles.mobile" type="int" setter="" getter="" default="1">
-			The default is a very conservative override for [code]rendering/gles3/shaders/max_concurrent_compiles[/code].
+			The default is a very conservative override for [member rendering/gles3/shaders/max_simultaneous_compiles].
 			Depending on the specific devices you are targeting, you may want to raise it.
-			[b]Note:[/b] This setting is only meaningful if [code]rendering/gles3/shaders/shader_compilation_mode[/code] is [b]not[/b] [code]Synchronous[/code].
+			[b]Note:[/b] This setting is only meaningful if [member rendering/gles3/shaders/shader_compilation_mode] is [b]not[/b] [code]Synchronous[/code].
+		</member>
+		<member name="rendering/gles3/shaders/max_simultaneous_compiles.web" type="int" setter="" getter="" default="1">
+			The default is a very conservative override for [member rendering/gles3/shaders/max_simultaneous_compiles].
+			Depending on the specific browsers you are targeting, you may want to raise it.
+			[b]Note:[/b] This setting is only meaningful if [member rendering/gles3/shaders/shader_compilation_mode] is [b]not[/b] [code]Synchronous[/code].
 		</member>
 		<member name="rendering/gles3/shaders/shader_cache_size_mb" type="int" setter="" getter="" default="512">
 			The maximum size, in megabytes, that the ubershader cache can grow up to. On startup, the least recently used entries will be deleted until the total size is within bounds.
-			[b]Note:[/b] This setting is only meaningful if [code]rendering/gles3/shaders/shader_compilation_mode[/code] is set to [code]Asynchronous + Cache[/code].
+			[b]Note:[/b] This setting is only meaningful if [member rendering/gles3/shaders/shader_compilation_mode] is set to [code]Asynchronous + Cache[/code].
 		</member>
 		<member name="rendering/gles3/shaders/shader_cache_size_mb.mobile" type="int" setter="" getter="" default="128">
-			An override for [code]rendering/gles3/shaders/ubershader_cache_size_mb[/code], so a smaller maximum size can be configured for mobile platforms, where storage space is more limited.
-			[b]Note:[/b] This setting is only meaningful if [code]rendering/gles3/shaders/shader_compilation_mode[/code] is set to [code]Asynchronous + Cache[/code].
+			An override for [member rendering/gles3/shaders/shader_cache_size_mb], so a smaller maximum size can be configured for mobile platforms, where storage space is more limited.
+			[b]Note:[/b] This setting is only meaningful if [member rendering/gles3/shaders/shader_compilation_mode] is set to [code]Asynchronous + Cache[/code].
 		</member>
-		<member name="rendering/gles3/shaders/shader_compilation_mode" type="int" setter="" getter="" default="2">
+		<member name="rendering/gles3/shaders/shader_cache_size_mb.web" type="int" setter="" getter="" default="128">
+			An override for [member rendering/gles3/shaders/shader_cache_size_mb], so a smaller maximum size can be configured for web platforms, where storage space is more limited.
+			[b]Note:[/b] Currently, shader caching is generally unavailable on web platforms.
+			[b]Note:[/b] This setting is only meaningful if [member rendering/gles3/shaders/shader_compilation_mode] is set to [code]Asynchronous + Cache[/code].
+		</member>
+		<member name="rendering/gles3/shaders/shader_compilation_mode" type="int" setter="" getter="" default="0">
 			If set to [code]Asynchronous[/code] and available on the target device, asynchronous compilation of shaders is enabled (in contrast to [code]Asynchronous[/code]).
 			That means that when a shader is first used under some new rendering situation, the game won't stall while such shader is being compiled. Instead, a fallback will be used and the real shader will be compiled in the background. Once the actual shader is compiled, it will be used the next times it's used to draw a frame.
 			Depending on the async mode configured for a given material/shader, the fallback will be an "ubershader" (the default) or just skip rendering any item it is applied to.
@@ -1540,8 +1550,12 @@
 			[b]Note:[/b] Asynchronous compilation is currently only supported for spatial (3D) and particle materials/shaders. CanvasItem (2D) shaders will not use asynchronous compilation even if this setting is set to [code]Asynchronous[/code] or [code]Asynchronous + Cache[/code].
 		</member>
 		<member name="rendering/gles3/shaders/shader_compilation_mode.mobile" type="int" setter="" getter="" default="0">
-			An override for [code]rendering/gles3/shaders/shader_compilation_mode[/code], so asynchronous compilation can be disabled for mobile.
+			An override for [member rendering/gles3/shaders/shader_compilation_mode], so asynchronous compilation can be disabled on mobile platforms.
 			You may want to do that since mobile GPUs generally won't support ubershaders due to their complexity.
+		</member>
+		<member name="rendering/gles3/shaders/shader_compilation_mode.web" type="int" setter="" getter="" default="0">
+			An override for [member rendering/gles3/shaders/shader_compilation_mode], so asynchronous compilation can be disabled on web platforms.
+			You may want to do that since certain browsers (especially on mobile platforms) generally won't support ubershaders due to their complexity.
 		</member>
 		<member name="rendering/limits/buffers/blend_shape_max_buffer_size_kb" type="int" setter="" getter="" default="4096">
 			Max buffer size for blend shapes. Any blend shape bigger than this will not work.

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2735,16 +2735,19 @@ VisualServer::VisualServer() {
 		force_shader_fallbacks = GLOBAL_GET("rendering/gles3/shaders/debug_shader_fallbacks");
 	}
 #endif
-	GLOBAL_DEF("rendering/gles3/shaders/shader_compilation_mode", 2);
+	GLOBAL_DEF("rendering/gles3/shaders/shader_compilation_mode", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/gles3/shaders/shader_compilation_mode", PropertyInfo(Variant::INT, "rendering/gles3/shaders/shader_compilation_mode", PROPERTY_HINT_ENUM, "Synchronous,Asynchronous,Asynchronous + Cache"));
 	GLOBAL_DEF("rendering/gles3/shaders/shader_compilation_mode.mobile", 0);
+	GLOBAL_DEF("rendering/gles3/shaders/shader_compilation_mode.web", 0);
 	GLOBAL_DEF("rendering/gles3/shaders/max_simultaneous_compiles", 2);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/gles3/shaders/max_simultaneous_compiles", PropertyInfo(Variant::INT, "rendering/gles3/shaders/max_simultaneous_compiles", PROPERTY_HINT_RANGE, "1,8,1"));
 	GLOBAL_DEF("rendering/gles3/shaders/max_simultaneous_compiles.mobile", 1);
+	GLOBAL_DEF("rendering/gles3/shaders/max_simultaneous_compiles.web", 1);
 	GLOBAL_DEF("rendering/gles3/shaders/log_active_async_compiles_count", false);
 	GLOBAL_DEF("rendering/gles3/shaders/shader_cache_size_mb", 512);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/gles3/shaders/shader_cache_size_mb", PropertyInfo(Variant::INT, "rendering/gles3/shaders/shader_cache_size_mb", PROPERTY_HINT_RANGE, "128,4096,128"));
 	GLOBAL_DEF("rendering/gles3/shaders/shader_cache_size_mb.mobile", 128);
+	GLOBAL_DEF("rendering/gles3/shaders/shader_cache_size_mb.web", 128);
 }
 
 VisualServer::~VisualServer() {


### PR DESCRIPTION
Let's take the safe route for 3.5.

Fixes #62377.
Fixes #62443.
Related to #62450 (*Edit by Akien:* may not fix it, see https://github.com/godotengine/godot/issues/62450#issuecomment-1168468595).