### PR TITLE
Fix incorrect indentation for class doc descriptions

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -601,19 +601,21 @@ void EditorHelp::_update_doc() {
 		}
 	}
 
-	class_desc->add_newline();
-	class_desc->add_newline();
-
 	// Brief description
 	if (!cd.brief_description.is_empty()) {
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_bold_font);
 		class_desc->push_indent(1);
+		class_desc->add_newline();
+		class_desc->add_newline();
 		_add_text(DTR(cd.brief_description));
 		class_desc->pop();
 		class_desc->pop();
 		class_desc->pop();
 		class_desc->add_newline();
+		class_desc->add_newline();
+		class_desc->add_newline();
+	} else {
 		class_desc->add_newline();
 		class_desc->add_newline();
 	}
@@ -628,11 +630,11 @@ void EditorHelp::_update_doc() {
 		class_desc->pop();
 		class_desc->pop();
 
+		class_desc->push_indent(1);
 		class_desc->add_newline();
 		class_desc->add_newline();
 		class_desc->push_color(text_color);
 		class_desc->push_font(doc_font);
-		class_desc->push_indent(1);
 		_add_text(DTR(cd.description));
 		class_desc->pop();
 		class_desc->pop();


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/3036176/176162747-484c911e-abcf-436e-8bdc-4145caf40bed.png)

After:

![image](https://user-images.githubusercontent.com/3036176/176160051-6b259f5c-9759-4d09-9b1c-8c248f17eedf.png)
