### PR TITLE
Compile Godot Engine as a library.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -133,7 +133,6 @@ env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
 
 env_base.__class__.add_shared_library = methods.add_shared_library
 env_base.__class__.add_library = methods.add_library
-env_base.__class__.add_program = methods.add_program
 env_base.__class__.CommandNoCache = methods.CommandNoCache
 env_base.__class__.Run = methods.Run
 env_base.__class__.disable_warnings = methods.disable_warnings
@@ -184,6 +183,14 @@ opts.Add(BoolVariable("custom_modules_recursive", "Detect custom modules recursi
 opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loader dynamically", True))
 
 # Advanced options
+opts.Add(
+    EnumVariable(
+        "library_type",
+        "Build library type",
+        "executable",
+        ("executable", "static_library", "shared_library"),
+    )
+)
 opts.Add(BoolVariable("dev", "If yes, alias for verbose=yes warnings=extra werror=yes", False))
 opts.Add(BoolVariable("tests", "Build the unit tests", False))
 opts.Add(BoolVariable("fast_unsafe", "Enable unsafe options for faster rebuilds", False))
@@ -245,6 +252,16 @@ opts.Update(env_base)
 # Platform selection: validate input, and add options.
 
 selected_platform = ""
+
+if env_base["library_type"] == "static_library":
+    env_base.__class__.add_program = methods.add_library
+    env_base.Append(CPPDEFINES=["LIBRARY_ENABLED"])
+elif env_base["library_type"] == "shared_library":
+    env_base.__class__.add_program = methods.add_shared_library
+    env_base.Append(CPPDEFINES=["LIBRARY_ENABLED"])
+    env_base.env_base(CCFLAGS=["-fPIC"])
+else:
+    env_base.__class__.add_program = methods.add_program
 
 if env_base["platform"] != "":
     selected_platform = env_base["platform"]

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -40,7 +40,11 @@
 #include "main/main.h"
 #include "os_linuxbsd.h"
 
+#if defined(LIBRARY_ENABLED)
+extern "C" int godot_main(int argc, char *argv[]) {
+#else
 int main(int argc, char *argv[]) {
+#endif
 #if defined(SANITIZERS_ENABLED)
 	// Note: Set stack size to be at least 30 MB (vs 8 MB default) to avoid overflow, address sanitizer can increase stack usage up to 3 times.
 	struct rlimit stack_lim = { 0x1E00000, 0x1E00000 };

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -39,7 +39,11 @@
 #include <sys/resource.h>
 #endif
 
+#if defined(LIBRARY_ENABLED)
+extern "C" int godot_main(int argc, char *argv[]) {
+#else
 int main(int argc, char **argv) {
+#endif
 #if defined(VULKAN_ENABLED)
 	// MoltenVK - enable full component swizzling support.
 	setenv("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1", 1);

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -204,7 +204,11 @@ int _main() {
 	return result;
 }
 
+#if defined(LIBRARY_ENABLED)
+extern "C" __declspec(dllexport) int godot_main(int argc, char *argv[]) {
+#else
 int main(int argc, char **argv) {
+#endif
 	// override the arguments for the test handler / if symbol is provided
 	// TEST_MAIN_OVERRIDE
 
@@ -223,7 +227,9 @@ int main(int argc, char **argv) {
 
 HINSTANCE godot_hinstance = nullptr;
 
+#if !defined(LIBRARY_ENABLED)
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
 	godot_hinstance = hInstance;
 	return main(0, nullptr);
 }
+#endif


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot-proposals/issues/4773

- [x] Replace the entry points of main of Windows and Linux.
- [x] Replace the entry points of osx.
- [ ] Replace the entry points of android.
- [ ] Replace the entry points of ios.
- [ ] Replace the entry points of uwp.
- [ ] Investigate the entry points of Javascript.
- [x] Cannot avoid 64k symbols limit on Windows dll format.
----

Part of the V-Sekai group. https://github.com/v-sekai
