### PR TITLE
Use single-precision floats in GradientEdit

### DIFF
--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -382,7 +382,7 @@ void GradientEdit::_color_changed(const Color &p_color) {
 	emit_signal(SNAME("ramp_changed"));
 }
 
-void GradientEdit::set_ramp(const Vector<real_t> &p_offsets, const Vector<Color> &p_colors) {
+void GradientEdit::set_ramp(const Vector<float> &p_offsets, const Vector<Color> &p_colors) {
 	ERR_FAIL_COND(p_offsets.size() != p_colors.size());
 	points.clear();
 	for (int i = 0; i < p_offsets.size(); i++) {
@@ -396,8 +396,8 @@ void GradientEdit::set_ramp(const Vector<real_t> &p_offsets, const Vector<Color>
 	update();
 }
 
-Vector<real_t> GradientEdit::get_offsets() const {
-	Vector<real_t> ret;
+Vector<float> GradientEdit::get_offsets() const {
+	Vector<float> ret;
 	for (int i = 0; i < points.size(); i++) {
 		ret.push_back(points[i].offset);
 	}

--- a/scene/gui/gradient_edit.h
+++ b/scene/gui/gradient_edit.h
@@ -67,8 +67,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_ramp(const Vector<real_t> &p_offsets, const Vector<Color> &p_colors);
-	Vector<real_t> get_offsets() const;
+	void set_ramp(const Vector<float> &p_offsets, const Vector<Color> &p_colors);
+	Vector<float> get_offsets() const;
 	Vector<Color> get_colors() const;
 	void set_points(Vector<Gradient::Point> &p_points);
 	Vector<Gradient::Point> &get_points();


### PR DESCRIPTION
Gradient itself only uses single-precision floats (https://github.com/godotengine/godot/pull/21922#discussion_r685571830), so using double-precision floats in GradientEdit is both unnecessary, and creates casting issues, as seen here when editing a Gradient in a binary compiled with `float=64`:
![image](https://user-images.githubusercontent.com/69441745/176252995-06b382d6-8b55-4925-903d-c5626c7012f1.png)
