### PR TITLE
Allow using separate amounts for near and far depth of field

### DIFF
--- a/doc/classes/CameraEffects.xml
+++ b/doc/classes/CameraEffects.xml
@@ -10,26 +10,35 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="dof_blur_amount" type="float" setter="set_dof_blur_amount" getter="get_dof_blur_amount" default="0.1">
-			The amount of blur for both near and far depth-of-field effects. The amount of blur increases the radius of the blur effect, making the affected area blurrier. However, If the amount is too high, you might start to see lines appearing, especially when using a low quality blur.
+		<member name="dof_blur_far_amount" type="float" setter="set_dof_blur_far_amount" getter="get_dof_blur_far_amount" default="0.1">
+			The amount of blur for far depth-of-field effects. The amount of blur increases the radius of the blur effect, making the affected area blurrier. However, If the amount is too high, you might start to see lines appearing, especially when using a low quality blur.
+			[b]Note:[/b] Blur amount is currently dependent on the viewport resolution. At higher resolutions, you need to increase the blur amount to keep the same amount of blur relative to the camera's view space.
+			[b]Note:[/b] If [member ProjectSettings.rendering/camera/depth_of_field/depth_of_field_bokeh_shape] is set to [b]Circle[/b], higher amounts are much slower to render compared to lower amounts. With [b]Box[/b] and [b]Hexagon[/b] bokeh shapes, blur amount doesn't affect performance significantly.
 		</member>
 		<member name="dof_blur_far_distance" type="float" setter="set_dof_blur_far_distance" getter="get_dof_blur_far_distance" default="10.0">
 			The distance from the camera where the far blur effect affects the rendering.
+			[b]Note:[/b] It's recommended to avoid having the near and far blurs "cross" each other. Otherwise, artifacts may appear, especially if different amounts are chosen for both blurs.
 		</member>
 		<member name="dof_blur_far_enabled" type="bool" setter="set_dof_blur_far_enabled" getter="is_dof_blur_far_enabled" default="false">
 			If [code]true[/code], enables the depth-of-field far blur effect. This has a significant performance cost. Consider disabling it in scenes where there are no far away objects.
 		</member>
 		<member name="dof_blur_far_transition" type="float" setter="set_dof_blur_far_transition" getter="get_dof_blur_far_transition" default="5.0">
-			The length of the transition between the no-blur area and far blur.
+			The length of the transition between the no-blur area and far blur. Higher values result in a smoother transition over distance.
+		</member>
+		<member name="dof_blur_near_amount" type="float" setter="set_dof_blur_near_amount" getter="get_dof_blur_near_amount" default="0.1">
+			The amount of blur for near depth-of-field effects. The amount of blur increases the radius of the blur effect, making the affected area blurrier. However, If the amount is too high, you might start to see lines appearing, especially when using a low quality blur.
+			[b]Note:[/b] Blur amount is currently dependent on the viewport resolution. At higher resolutions, you need to increase the blur amount to keep the same amount of blur relative to the camera's view space.
+			[b]Note:[/b] If [member ProjectSettings.rendering/camera/depth_of_field/depth_of_field_bokeh_shape] is set to [b]Circle[/b], higher amounts are much slower to render compared to lower amounts. With [b]Box[/b] and [b]Hexagon[/b] bokeh shapes, blur amount doesn't affect performance significantly.
 		</member>
 		<member name="dof_blur_near_distance" type="float" setter="set_dof_blur_near_distance" getter="get_dof_blur_near_distance" default="2.0">
 			Distance from the camera where the near blur effect affects the rendering.
+			[b]Note:[/b] It's recommended to avoid having the near and far blurs "cross" each other. Otherwise, artifacts may appear, especially if different amounts are chosen for both blurs.
 		</member>
 		<member name="dof_blur_near_enabled" type="bool" setter="set_dof_blur_near_enabled" getter="is_dof_blur_near_enabled" default="false">
 			If [code]true[/code], enables the depth-of-field near blur effect. This has a significant performance cost. Consider disabling it in scenes where there are no nearby objects.
 		</member>
 		<member name="dof_blur_near_transition" type="float" setter="set_dof_blur_near_transition" getter="get_dof_blur_near_transition" default="1.0">
-			The length of the transition between the near blur and no-blur area.
+			The length of the transition between the near blur and no-blur area. Higher values result in a smoother transition over distance.
 		</member>
 		<member name="override_exposure" type="float" setter="set_override_exposure" getter="get_override_exposure" default="1.0">
 			The exposure override value to use. Higher values will result in a brighter scene. Only effective if [member override_exposure_enabled] is [code]true[/code].

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -52,11 +52,13 @@
 			<argument index="1" name="far_enable" type="bool" />
 			<argument index="2" name="far_distance" type="float" />
 			<argument index="3" name="far_transition" type="float" />
-			<argument index="4" name="near_enable" type="bool" />
-			<argument index="5" name="near_distance" type="float" />
-			<argument index="6" name="near_transition" type="float" />
-			<argument index="7" name="amount" type="float" />
+			<argument index="4" name="far_amount" type="float" />
+			<argument index="5" name="near_enable" type="bool" />
+			<argument index="6" name="near_distance" type="float" />
+			<argument index="7" name="near_transition" type="float" />
+			<argument index="8" name="near_amount" type="float" />
 			<description>
+				Sets the depth of field blur on the given [CameraEffects] resource. See [CameraEffects] for documentation on individual depth of field properties.
 			</description>
 		</method>
 		<method name="camera_effects_set_dof_blur_bokeh_shape">

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1304,7 +1304,7 @@ void RasterizerSceneGLES3::camera_effects_set_dof_blur_quality(RS::DOFBlurQualit
 void RasterizerSceneGLES3::camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) {
 }
 
-void RasterizerSceneGLES3::camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) {
+void RasterizerSceneGLES3::camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, float p_far_amount, bool p_near_enable, float p_near_distance, float p_near_transition, float p_near_amount) {
 }
 
 void RasterizerSceneGLES3::camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -853,7 +853,7 @@ public:
 	void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) override;
 	void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) override;
 
-	void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) override;
+	void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, float p_far_amount, bool p_near_enable, float p_near_distance, float p_near_transition, float p_near_amount) override;
 	void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override;
 
 	void shadows_quality_set(RS::ShadowQuality p_quality) override;

--- a/scene/resources/camera_effects.cpp
+++ b/scene/resources/camera_effects.cpp
@@ -66,6 +66,15 @@ float CameraEffects::get_dof_blur_far_transition() const {
 	return dof_blur_far_transition;
 }
 
+void CameraEffects::set_dof_blur_far_amount(float p_amount) {
+	dof_blur_far_amount = p_amount;
+	_update_dof_blur();
+}
+
+float CameraEffects::get_dof_blur_far_amount() const {
+	return dof_blur_far_amount;
+}
+
 void CameraEffects::set_dof_blur_near_enabled(bool p_enabled) {
 	dof_blur_near_enabled = p_enabled;
 	_update_dof_blur();
@@ -94,13 +103,13 @@ float CameraEffects::get_dof_blur_near_transition() const {
 	return dof_blur_near_transition;
 }
 
-void CameraEffects::set_dof_blur_amount(float p_amount) {
-	dof_blur_amount = p_amount;
+void CameraEffects::set_dof_blur_near_amount(float p_amount) {
+	dof_blur_near_amount = p_amount;
 	_update_dof_blur();
 }
 
-float CameraEffects::get_dof_blur_amount() const {
-	return dof_blur_amount;
+float CameraEffects::get_dof_blur_near_amount() const {
+	return dof_blur_near_amount;
 }
 
 void CameraEffects::_update_dof_blur() {
@@ -109,10 +118,11 @@ void CameraEffects::_update_dof_blur() {
 			dof_blur_far_enabled,
 			dof_blur_far_distance,
 			dof_blur_far_transition,
+			dof_blur_far_amount,
 			dof_blur_near_enabled,
 			dof_blur_near_distance,
 			dof_blur_near_transition,
-			dof_blur_amount);
+			dof_blur_near_amount);
 }
 
 // Custom exposure
@@ -162,6 +172,8 @@ void CameraEffects::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_dof_blur_far_distance"), &CameraEffects::get_dof_blur_far_distance);
 	ClassDB::bind_method(D_METHOD("set_dof_blur_far_transition", "distance"), &CameraEffects::set_dof_blur_far_transition);
 	ClassDB::bind_method(D_METHOD("get_dof_blur_far_transition"), &CameraEffects::get_dof_blur_far_transition);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_far_amount", "amount"), &CameraEffects::set_dof_blur_far_amount);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_far_amount"), &CameraEffects::get_dof_blur_far_amount);
 
 	ClassDB::bind_method(D_METHOD("set_dof_blur_near_enabled", "enabled"), &CameraEffects::set_dof_blur_near_enabled);
 	ClassDB::bind_method(D_METHOD("is_dof_blur_near_enabled"), &CameraEffects::is_dof_blur_near_enabled);
@@ -169,18 +181,18 @@ void CameraEffects::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_dof_blur_near_distance"), &CameraEffects::get_dof_blur_near_distance);
 	ClassDB::bind_method(D_METHOD("set_dof_blur_near_transition", "distance"), &CameraEffects::set_dof_blur_near_transition);
 	ClassDB::bind_method(D_METHOD("get_dof_blur_near_transition"), &CameraEffects::get_dof_blur_near_transition);
-
-	ClassDB::bind_method(D_METHOD("set_dof_blur_amount", "amount"), &CameraEffects::set_dof_blur_amount);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_amount"), &CameraEffects::get_dof_blur_amount);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_near_amount", "amount"), &CameraEffects::set_dof_blur_near_amount);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_near_amount"), &CameraEffects::get_dof_blur_near_amount);
 
 	ADD_GROUP("DOF Blur", "dof_blur_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dof_blur_far_enabled"), "set_dof_blur_far_enabled", "is_dof_blur_far_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_far_distance", PROPERTY_HINT_RANGE, "0.01,8192,0.01,exp,suffix:m"), "set_dof_blur_far_distance", "get_dof_blur_far_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_far_transition", PROPERTY_HINT_RANGE, "0.01,8192,0.01,exp"), "set_dof_blur_far_transition", "get_dof_blur_far_transition");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_far_amount", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_dof_blur_far_amount", "get_dof_blur_far_amount");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dof_blur_near_enabled"), "set_dof_blur_near_enabled", "is_dof_blur_near_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_distance", PROPERTY_HINT_RANGE, "0.01,8192,0.01,exp,suffix:m"), "set_dof_blur_near_distance", "get_dof_blur_near_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_transition", PROPERTY_HINT_RANGE, "0.01,8192,0.01,exp"), "set_dof_blur_near_transition", "get_dof_blur_near_transition");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dof_blur_amount", "get_dof_blur_amount");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dof_blur_near_amount", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_dof_blur_near_amount", "get_dof_blur_near_amount");
 
 	// Override exposure
 

--- a/scene/resources/camera_effects.h
+++ b/scene/resources/camera_effects.h
@@ -44,12 +44,13 @@ private:
 	bool dof_blur_far_enabled = false;
 	float dof_blur_far_distance = 10.0;
 	float dof_blur_far_transition = 5.0;
+	float dof_blur_far_amount = 0.1;
 
 	bool dof_blur_near_enabled = false;
 	float dof_blur_near_distance = 2.0;
 	float dof_blur_near_transition = 1.0;
+	float dof_blur_near_amount = 0.1;
 
-	float dof_blur_amount = 0.1;
 	void _update_dof_blur();
 
 	// Override exposure
@@ -71,6 +72,8 @@ public:
 	float get_dof_blur_far_distance() const;
 	void set_dof_blur_far_transition(float p_distance);
 	float get_dof_blur_far_transition() const;
+	void set_dof_blur_far_amount(float p_amount);
+	float get_dof_blur_far_amount() const;
 
 	void set_dof_blur_near_enabled(bool p_enabled);
 	bool is_dof_blur_near_enabled() const;
@@ -78,9 +81,8 @@ public:
 	float get_dof_blur_near_distance() const;
 	void set_dof_blur_near_transition(float p_distance);
 	float get_dof_blur_near_transition() const;
-
-	void set_dof_blur_amount(float p_amount);
-	float get_dof_blur_amount() const;
+	void set_dof_blur_near_amount(float p_amount);
+	float get_dof_blur_near_amount() const;
 
 	// Override exposure
 	void set_override_exposure_enabled(bool p_enabled);

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -140,7 +140,7 @@ public:
 	void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) override {}
 	void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) override {}
 
-	void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) override {}
+	void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, float p_far_amount, bool p_near_enable, float p_near_distance, float p_near_transition, float p_near_amount) override {}
 	void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override {}
 
 	void shadows_quality_set(RS::ShadowQuality p_quality) override {}

--- a/servers/rendering/renderer_rd/effects/bokeh_dof.h
+++ b/servers/rendering/renderer_rd/effects/bokeh_dof.h
@@ -50,23 +50,24 @@ private:
 		float z_near;
 
 		uint32_t orthogonal;
-		float blur_size;
 		float blur_scale;
 		uint32_t steps;
-
 		uint32_t blur_near_active;
+
 		float blur_near_begin;
 		float blur_near_end;
+		float blur_near_size;
 		uint32_t blur_far_active;
 
 		float blur_far_begin;
 		float blur_far_end;
+		float blur_far_size;
 		uint32_t second_pass;
-		uint32_t half_size;
 
+		uint32_t half_size;
 		uint32_t use_jitter;
 		float jitter_seed;
-		uint32_t pad[2];
+		uint32_t pad;
 	};
 
 	enum BokehMode {
@@ -111,8 +112,8 @@ public:
 	BokehDOF(bool p_prefer_raster_effects);
 	~BokehDOF();
 
-	void bokeh_dof_compute(const BokehBuffers &p_buffers, bool p_dof_far, float p_dof_far_begin, float p_dof_far_size, bool p_dof_near, float p_dof_near_begin, float p_dof_near_size, float p_bokeh_size, RS::DOFBokehShape p_bokeh_shape, RS::DOFBlurQuality p_quality, bool p_use_jitter, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
-	void bokeh_dof_raster(const BokehBuffers &p_buffers, bool p_dof_far, float p_dof_far_begin, float p_dof_far_size, bool p_dof_near, float p_dof_near_begin, float p_dof_near_size, float p_dof_blur_amount, RenderingServer::DOFBokehShape p_bokeh_shape, RS::DOFBlurQuality p_quality, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
+	void bokeh_dof_compute(const BokehBuffers &p_buffers, bool p_dof_far, float p_dof_far_begin, float p_dof_far_size, float p_far_bokeh_size, bool p_dof_near, float p_dof_near_begin, float p_dof_near_size, float p_near_bokeh_size, RS::DOFBokehShape p_bokeh_shape, RS::DOFBlurQuality p_quality, bool p_use_jitter, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
+	void bokeh_dof_raster(const BokehBuffers &p_buffers, bool p_dof_far, float p_dof_far_begin, float p_dof_far_size, float p_dof_far_blur_amount, bool p_dof_near, float p_dof_near_begin, float p_dof_near_size, float p_dof_near_blur_amount, RenderingServer::DOFBokehShape p_bokeh_shape, RS::DOFBlurQuality p_quality, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1377,19 +1377,19 @@ void RendererSceneRenderRD::camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokeh
 	dof_blur_bokeh_shape = p_shape;
 }
 
-void RendererSceneRenderRD::camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) {
+void RendererSceneRenderRD::camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, float p_far_amount, bool p_near_enable, float p_near_distance, float p_near_transition, float p_near_amount) {
 	CameraEffects *camfx = camera_effects_owner.get_or_null(p_camera_effects);
 	ERR_FAIL_COND(!camfx);
 
 	camfx->dof_blur_far_enabled = p_far_enable;
 	camfx->dof_blur_far_distance = p_far_distance;
 	camfx->dof_blur_far_transition = p_far_transition;
+	camfx->dof_blur_far_amount = p_far_amount;
 
 	camfx->dof_blur_near_enabled = p_near_enable;
 	camfx->dof_blur_near_distance = p_near_distance;
 	camfx->dof_blur_near_transition = p_near_transition;
-
-	camfx->dof_blur_amount = p_amount;
+	camfx->dof_blur_near_amount = p_near_amount;
 }
 
 void RendererSceneRenderRD::camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) {
@@ -2427,7 +2427,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 	bool can_use_effects = rb->width >= 8 && rb->height >= 8;
 	bool can_use_storage = _render_buffers_can_be_storage();
 
-	if (can_use_effects && camfx && (camfx->dof_blur_near_enabled || camfx->dof_blur_far_enabled) && camfx->dof_blur_amount > 0.0) {
+	if (can_use_effects && camfx && (camfx->dof_blur_near_enabled || camfx->dof_blur_far_enabled) && (camfx->dof_blur_near_amount > 0.0 || camfx->dof_blur_far_amount > 0.0)) {
 		RENDER_TIMESTAMP("Depth of Field");
 		RD::get_singleton()->draw_command_begin_label("DOF");
 		if (rb->blur[0].texture.is_null()) {
@@ -2442,7 +2442,8 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 		buffers.half_texture[0] = rb->blur[1].layers[0].mipmaps[0].texture;
 		buffers.half_texture[1] = rb->blur[0].layers[0].mipmaps[1].texture;
 
-		float bokeh_size = camfx->dof_blur_amount * 64.0;
+		const float far_bokeh_size = camfx->dof_blur_far_amount * 64.0;
+		const float near_bokeh_size = camfx->dof_blur_near_amount * 64.0;
 		if (can_use_storage) {
 			for (uint32_t i = 0; i < rb->view_count; i++) {
 				buffers.base_texture = rb->views[i].view_texture;
@@ -2451,7 +2452,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				// In stereo p_render_data->z_near and p_render_data->z_far can be offset for our combined frustrum
 				float z_near = p_render_data->view_projection[i].get_z_near();
 				float z_far = p_render_data->view_projection[i].get_z_far();
-				bokeh_dof->bokeh_dof_compute(buffers, camfx->dof_blur_far_enabled, camfx->dof_blur_far_distance, camfx->dof_blur_far_transition, camfx->dof_blur_near_enabled, camfx->dof_blur_near_distance, camfx->dof_blur_near_transition, bokeh_size, dof_blur_bokeh_shape, dof_blur_quality, dof_blur_use_jitter, z_near, z_far, p_render_data->cam_orthogonal);
+				bokeh_dof->bokeh_dof_compute(buffers, camfx->dof_blur_far_enabled, camfx->dof_blur_far_distance, camfx->dof_blur_far_transition, far_bokeh_size, camfx->dof_blur_near_enabled, camfx->dof_blur_near_distance, camfx->dof_blur_near_transition, near_bokeh_size, dof_blur_bokeh_shape, dof_blur_quality, dof_blur_use_jitter, z_near, z_far, p_render_data->cam_orthogonal);
 			};
 		} else {
 			// Set framebuffers.
@@ -2474,7 +2475,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				// In stereo p_render_data->z_near and p_render_data->z_far can be offset for our combined frustrum
 				float z_near = p_render_data->view_projection[i].get_z_near();
 				float z_far = p_render_data->view_projection[i].get_z_far();
-				bokeh_dof->bokeh_dof_raster(buffers, camfx->dof_blur_far_enabled, camfx->dof_blur_far_distance, camfx->dof_blur_far_transition, camfx->dof_blur_near_enabled, camfx->dof_blur_near_distance, camfx->dof_blur_near_transition, bokeh_size, dof_blur_bokeh_shape, dof_blur_quality, z_near, z_far, p_render_data->cam_orthogonal);
+				bokeh_dof->bokeh_dof_raster(buffers, camfx->dof_blur_far_enabled, camfx->dof_blur_far_distance, camfx->dof_blur_far_transition, far_bokeh_size, camfx->dof_blur_near_enabled, camfx->dof_blur_near_distance, camfx->dof_blur_near_transition, near_bokeh_size, dof_blur_bokeh_shape, dof_blur_quality, z_near, z_far, p_render_data->cam_orthogonal);
 			}
 		}
 		RD::get_singleton()->draw_command_end_label();

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -444,12 +444,12 @@ private:
 		bool dof_blur_far_enabled = false;
 		float dof_blur_far_distance = 10;
 		float dof_blur_far_transition = 5;
+		float dof_blur_far_amount = 0.1;
 
 		bool dof_blur_near_enabled = false;
 		float dof_blur_near_distance = 2;
 		float dof_blur_near_transition = 1;
-
-		float dof_blur_amount = 0.1;
+		float dof_blur_near_amount = 0.1;
 
 		bool override_exposure_enabled = false;
 		float override_exposure = 1;
@@ -1134,13 +1134,13 @@ public:
 	virtual void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) override;
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) override;
 
-	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) override;
+	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, float p_far_amount, bool p_near_enable, float p_near_distance, float p_near_transition, float p_near_amount) override;
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override;
 
 	bool camera_effects_uses_dof(RID p_camera_effects) {
 		CameraEffects *camfx = camera_effects_owner.get_or_null(p_camera_effects);
 
-		return camfx && (camfx->dof_blur_near_enabled || camfx->dof_blur_far_enabled) && camfx->dof_blur_amount > 0.0;
+		return camfx && (camfx->dof_blur_near_enabled || camfx->dof_blur_far_enabled) && (camfx->dof_blur_near_amount > 0.0 || camfx->dof_blur_far_amount > 0.0);
 	}
 
 	/* LIGHT INSTANCE API */

--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof.glsl
@@ -41,11 +41,11 @@ float get_depth_at_pos(vec2 uv) {
 
 float get_blur_size(float depth) {
 	if (params.blur_near_active && depth < params.blur_near_begin) {
-		return -(1.0 - smoothstep(params.blur_near_end, params.blur_near_begin, depth)) * params.blur_size - DEPTH_GAP; //near blur is negative
+		return -(1.0 - smoothstep(params.blur_near_end, params.blur_near_begin, depth)) * params.blur_near_size - DEPTH_GAP; //near blur is negative
 	}
 
 	if (params.blur_far_active && depth > params.blur_far_begin) {
-		return smoothstep(params.blur_far_begin, params.blur_far_end, depth) * params.blur_size + DEPTH_GAP;
+		return smoothstep(params.blur_far_begin, params.blur_far_end, depth) * params.blur_far_size + DEPTH_GAP;
 	}
 
 	return 0.0;
@@ -62,7 +62,7 @@ vec4 weighted_filter_dir(vec2 dir, vec2 uv, vec2 pixel_size) {
 	vec4 accum = color;
 	float total = 1.0;
 
-	float blur_scale = params.blur_size / float(params.blur_steps);
+	float blur_scale = max(params.blur_near_size, params.blur_far_size) / float(params.blur_steps);
 
 	if (params.use_jitter) {
 		uv += dir * (hash12n(uv + params.jitter_seed) - 0.5);
@@ -175,7 +175,7 @@ void main() {
 	float accum = 1.0;
 	float radius = params.blur_scale;
 
-	for (float ang = 0.0; radius < params.blur_size; ang += GOLDEN_ANGLE) {
+	for (float ang = 0.0; radius < max(params.blur_near_size, params.blur_far_size); ang += GOLDEN_ANGLE) {
 		vec2 suv = uv + vec2(cos(ang), sin(ang)) * pixel_size * radius;
 		vec4 sample_color = texture(color_texture, suv);
 		float sample_size = abs(sample_color.a);

--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_inc.glsl
@@ -4,23 +4,24 @@ layout(push_constant, std430) uniform Params {
 	float z_near;
 
 	bool orthogonal;
-	float blur_size;
 	float blur_scale;
 	int blur_steps;
-
 	bool blur_near_active;
+
 	float blur_near_begin;
 	float blur_near_end;
+	float blur_near_size;
 	bool blur_far_active;
 
 	float blur_far_begin;
 	float blur_far_end;
+	float blur_far_size;
 	bool second_pass;
-	bool half_size;
 
+	bool half_size;
 	bool use_jitter;
 	float jitter_seed;
-	uint pad[2];
+	uint pad;
 }
 params;
 

--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_raster.glsl
@@ -63,11 +63,11 @@ float get_depth_at_pos(vec2 uv) {
 
 float get_blur_size(float depth) {
 	if (params.blur_near_active && depth < params.blur_near_begin) {
-		return -(1.0 - smoothstep(params.blur_near_end, params.blur_near_begin, depth)) * params.blur_size - DEPTH_GAP; //near blur is negative
+		return -(1.0 - smoothstep(params.blur_near_end, params.blur_near_begin, depth)) * params.blur_near_size - DEPTH_GAP; //near blur is negative
 	}
 
 	if (params.blur_far_active && depth > params.blur_far_begin) {
-		return smoothstep(params.blur_far_begin, params.blur_far_end, depth) * params.blur_size + DEPTH_GAP;
+		return smoothstep(params.blur_far_begin, params.blur_far_end, depth) * params.blur_far_size + DEPTH_GAP;
 	}
 
 	return 0.0;
@@ -85,7 +85,7 @@ vec4 weighted_filter_dir(vec2 dir, vec2 uv, vec2 pixel_size) {
 	vec4 accum = color;
 	float total = 1.0;
 
-	float blur_scale = params.blur_size / float(params.blur_steps);
+	float blur_scale = max(params.blur_near_size, params.blur_far_size) / float(params.blur_steps);
 
 	if (params.use_jitter) {
 		uv += dir * (hash12n(uv + params.jitter_seed) - 0.5);
@@ -201,7 +201,7 @@ void main() {
 	float accum = 1.0;
 
 	float radius = params.blur_scale;
-	for (float ang = 0.0; radius < params.blur_size; ang += GOLDEN_ANGLE) {
+	for (float ang = 0.0; radius < max(params.blur_near_size, params.blur_far_size); ang += GOLDEN_ANGLE) {
 		vec2 uv_adj = uv + vec2(cos(ang), sin(ang)) * pixel_size * radius;
 
 		vec4 sample_color = texture(source_color, uv_adj);

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -180,7 +180,7 @@ public:
 	virtual void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) = 0;
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) = 0;
 
-	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) = 0;
+	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, float p_far_amount, bool p_near_enable, float p_near_distance, float p_near_transition, float p_near_amount) = 0;
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) = 0;
 
 	virtual void shadows_quality_set(RS::ShadowQuality p_quality) = 0;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1147,7 +1147,7 @@ public:
 	PASS2(camera_effects_set_dof_blur_quality, RS::DOFBlurQuality, bool)
 	PASS1(camera_effects_set_dof_blur_bokeh_shape, RS::DOFBokehShape)
 
-	PASS8(camera_effects_set_dof_blur, RID, bool, float, float, bool, float, float, float)
+	PASS9(camera_effects_set_dof_blur, RID, bool, float, float, float, bool, float, float, float)
 	PASS3(camera_effects_set_custom_exposure, RID, bool, float)
 
 	PASS1(shadows_quality_set, RS::ShadowQuality)

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -163,7 +163,7 @@ public:
 	virtual void camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) = 0;
 	virtual void camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokehShape p_shape) = 0;
 
-	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) = 0;
+	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, float p_far_amount, bool p_near_enable, float p_near_distance, float p_near_transition, float p_near_amount) = 0;
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) = 0;
 
 	virtual void shadows_quality_set(RS::ShadowQuality p_quality) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -707,7 +707,7 @@ public:
 	FUNC2(camera_effects_set_dof_blur_quality, DOFBlurQuality, bool)
 	FUNC1(camera_effects_set_dof_blur_bokeh_shape, DOFBokehShape)
 
-	FUNC8(camera_effects_set_dof_blur, RID, bool, float, float, bool, float, float, float)
+	FUNC9(camera_effects_set_dof_blur, RID, bool, float, float, float, bool, float, float, float)
 	FUNC3(camera_effects_set_custom_exposure, RID, bool, float)
 
 	FUNC1(shadows_quality_set, ShadowQuality);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2435,7 +2435,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_effects_set_dof_blur_quality", "quality", "use_jitter"), &RenderingServer::camera_effects_set_dof_blur_quality);
 	ClassDB::bind_method(D_METHOD("camera_effects_set_dof_blur_bokeh_shape", "shape"), &RenderingServer::camera_effects_set_dof_blur_bokeh_shape);
 
-	ClassDB::bind_method(D_METHOD("camera_effects_set_dof_blur", "camera_effects", "far_enable", "far_distance", "far_transition", "near_enable", "near_distance", "near_transition", "amount"), &RenderingServer::camera_effects_set_dof_blur);
+	ClassDB::bind_method(D_METHOD("camera_effects_set_dof_blur", "camera_effects", "far_enable", "far_distance", "far_transition", "far_amount", "near_enable", "near_distance", "near_transition", "near_amount"), &RenderingServer::camera_effects_set_dof_blur);
 	ClassDB::bind_method(D_METHOD("camera_effects_set_custom_exposure", "camera_effects", "enable", "exposure"), &RenderingServer::camera_effects_set_custom_exposure);
 
 	BIND_ENUM_CONSTANT(DOF_BOKEH_BOX);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1140,7 +1140,7 @@ public:
 
 	virtual void camera_effects_set_dof_blur_bokeh_shape(DOFBokehShape p_shape) = 0;
 
-	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) = 0;
+	virtual void camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, float p_far_amount, bool p_near_enable, float p_near_distance, float p_near_transition, float p_near_amount) = 0;
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) = 0;
 
 	/* SCENARIO API */


### PR DESCRIPTION
This restores functionality that was available in Godot 3.x's depth of field.

Tested on the Vulkan Clustered and Vulkan Mobile backends, with all combinations of bokeh shapes and bokeh qualities. It works :slightly_smiling_face: 

The only quirk I noticed is that near blur's amount will appear to change if you also change the far blur amount (and vice versa). I'm not sure how this can be fixed.

**Testing project:** [test_dof_blur_separate_near_far_amount.zip](https://github.com/godotengine/godot/files/9005806/test_dof_blur_separate_near_far_amount.zip)

This closes https://github.com/godotengine/godot/issues/62473.