### PR TITLE
Fixed pingpong animation get snaging on the edge in AnimationTree

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -104,11 +104,11 @@ double AnimationNodeAnimation::process(double p_time, bool p_seek, bool p_seek_r
 	if (anim->get_loop_mode() == Animation::LOOP_PINGPONG) {
 		if (!Math::is_zero_approx(anim_size)) {
 			if ((int)Math::floor(abs(time - prev_time) / anim_size) % 2 == 0) {
-				if (prev_time > 0 && time <= 0) {
+				if (prev_time >= 0 && time < 0) {
 					backward = !backward;
 					pingponged = -1;
 				}
-				if (prev_time < anim_size && time >= anim_size) {
+				if (prev_time <= anim_size && time > anim_size) {
 					backward = !backward;
 					pingponged = 1;
 				}


### PR DESCRIPTION
There was a possibility of pingpong animation getting stuck just after playback from the 0 position, so I fixed.

Before:

https://user-images.githubusercontent.com/61938263/176322839-a260edc0-c274-4873-a245-1bc74cd73026.mp4
