### PR TITLE
[WIP] [3.x] Add interactive music module by @DanielMatarov (GSoC 2019)

### DIFF
--- a/doc/classes/AudioStreamSample.xml
+++ b/doc/classes/AudioStreamSample.xml
@@ -20,6 +20,10 @@
 		</method>
 	</methods>
 	<members>
+		<member name="beats" type="int" setter="set_beat_count" getter="get_beat_count" default="0">
+		</member>
+		<member name="bpm" type="int" setter="set_bpm" getter="get_bpm" default="0">
+		</member>
 		<member name="data" type="PoolByteArray" setter="set_data" getter="get_data" default="PoolByteArray(  )">
 			Contains the audio data in bytes.
 			[b]Note:[/b] This property expects signed PCM8 data. To convert unsigned PCM8 to signed PCM8, subtract 128 from each byte.

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -88,6 +88,8 @@ void ResourceImporterWAV::get_import_options(List<ImportOption> *r_options, int 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "edit/loop_begin"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "edit/loop_end"), -1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/mode", PROPERTY_HINT_ENUM, "Disabled,RAM (Ima-ADPCM)"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "bpm"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "beats"), 0));
 }
 
 Error ResourceImporterWAV::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
@@ -521,6 +523,9 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 		}
 	}
 
+	int bpm = p_options["bpm"];
+	int beats = p_options["beats"];
+
 	Ref<AudioStreamSample> sample;
 	sample.instance();
 	sample->set_data(dst_data);
@@ -530,6 +535,8 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 	sample->set_loop_begin(loop_begin);
 	sample->set_loop_end(loop_end);
 	sample->set_stereo(format_channels == 2);
+	sample->set_bpm(bpm);
+	sample->set_beat_count(beats);
 
 	ResourceSaver::save(p_save_path + ".sample", sample);
 

--- a/modules/interactive_music/SCsub
+++ b/modules/interactive_music/SCsub
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_modules")
+
+env_interactive_music = env_modules.Clone()
+
+# Godot's own source files
+env_interactive_music.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -1,0 +1,379 @@
+/*************************************************************************/
+/*  audio_stream_playlist.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "audio_stream_playlist.h"
+
+#include "core/math/math_funcs.h"
+#include "core/print_string.h"
+
+#include <iostream>
+#include <utility>
+
+AudioStreamPlaylist::AudioStreamPlaylist() {
+	bpm = 120;
+	stream_count = 1;
+	sample_rate = 44100;
+	stereo = true;
+	shuffle = false;
+	beat_count = 16;
+	length = 0;
+}
+
+Ref<AudioStreamPlayback> AudioStreamPlaylist::instance_playback() {
+	Ref<AudioStreamPlaybackPlaylist> playback_playlist;
+	playback_playlist.instance();
+	playback_playlist->playlist = Ref<AudioStreamPlaylist>(this);
+	playback_playlist->_update_playback_instances();
+	playbacks.insert(playback_playlist.operator->());
+	return playback_playlist;
+}
+
+String AudioStreamPlaylist::get_stream_name() const {
+	return "Playlist";
+}
+
+void AudioStreamPlaylist::reset() {
+	set_position(0);
+}
+
+void AudioStreamPlaylist::set_position(uint64_t p) {
+	pos = p;
+}
+
+void AudioStreamPlaylist::set_stream_beats(int beats) {
+	beat_count = beats;
+}
+
+int AudioStreamPlaylist::get_stream_beats() {
+	return beat_count;
+}
+
+void AudioStreamPlaylist::set_list_stream(int stream_number, Ref<AudioStream> p_stream) {
+	ERR_FAIL_COND(p_stream == this);
+	ERR_FAIL_INDEX(stream_number, MAX_STREAMS);
+
+	AudioServer::get_singleton()->lock();
+	audio_streams[stream_number] = p_stream;
+	for (Set<AudioStreamPlaybackPlaylist *>::Element *E = playbacks.front(); E; E = E->next()) {
+		E->get()->_update_playback_instances();
+	}
+	AudioServer::get_singleton()->unlock();
+}
+
+Ref<AudioStream> AudioStreamPlaylist::get_list_stream(int stream_number) {
+	ERR_FAIL_INDEX_V(stream_number, MAX_STREAMS, Ref<AudioStream>());
+
+	return audio_streams[stream_number];
+}
+
+void AudioStreamPlaylist::set_stream_count(int count) {
+	stream_count = count;
+}
+
+int AudioStreamPlaylist::get_stream_count() {
+	return stream_count;
+}
+
+void AudioStreamPlaylist::set_bpm(int beats_per_minute) {
+	bpm = beats_per_minute;
+}
+
+int AudioStreamPlaylist::get_bpm() const {
+	return bpm;
+}
+
+void AudioStreamPlaylist::set_shuffle(bool p_shuffle) {
+	shuffle = p_shuffle;
+}
+
+bool AudioStreamPlaylist::get_shuffle() {
+	return shuffle;
+}
+
+void AudioStreamPlaylist::set_loop(bool p_loop) {
+	loop = p_loop;
+}
+
+bool AudioStreamPlaylist::get_loop() {
+	return loop;
+}
+
+float AudioStreamPlaylist::get_length() const {
+	return length;
+}
+
+void AudioStreamPlaylist::_validate_property(PropertyInfo &property) const {
+	String prop = property.name;
+	if (prop.begins_with("stream_")) {
+		int stream = prop.get_slicec('/', 0).get_slicec('_', 1).to_int();
+		if (stream >= stream_count) {
+			property.usage = 0;
+		}
+	}
+}
+
+void AudioStreamPlaylist::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_stream_count", "stream_count"), &AudioStreamPlaylist::set_stream_count);
+	ClassDB::bind_method(D_METHOD("get_stream_count"), &AudioStreamPlaylist::get_stream_count);
+
+	ClassDB::bind_method(D_METHOD("set_bpm", "bpm"), &AudioStreamPlaylist::set_bpm);
+	ClassDB::bind_method(D_METHOD("get_bpm"), &AudioStreamPlaylist::get_bpm);
+
+	ClassDB::bind_method(D_METHOD("set_list_stream", "stream_number", "audio_stream"), &AudioStreamPlaylist::set_list_stream);
+	ClassDB::bind_method(D_METHOD("get_list_stream", "stream_number"), &AudioStreamPlaylist::get_list_stream);
+
+	ClassDB::bind_method(D_METHOD("set_stream_beats", "beat_count"), &AudioStreamPlaylist::set_stream_beats);
+	ClassDB::bind_method(D_METHOD("get_stream_beats"), &AudioStreamPlaylist::get_stream_beats);
+
+	ClassDB::bind_method(D_METHOD("set_shuffle", "shuffle"), &AudioStreamPlaylist::set_shuffle);
+	ClassDB::bind_method(D_METHOD("get_shuffle"), &AudioStreamPlaylist::get_shuffle);
+
+	ClassDB::bind_method(D_METHOD("set_loop", "loop"), &AudioStreamPlaylist::set_loop);
+	ClassDB::bind_method(D_METHOD("get_loop"), &AudioStreamPlaylist::get_loop);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stream_count", PROPERTY_HINT_RANGE, "1," + itos(MAX_STREAMS), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_stream_count", "get_stream_count");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bpm", PROPERTY_HINT_RANGE, "0,400"), "set_bpm", "get_bpm");
+	//ADD_PROPERTY(PropertyInfo(Variant::INT, "beat_count", PROPERTY_HINT_RANGE, "0,400"), "set_stream_beats", "get_stream_beats");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shuffle"), "set_shuffle", "get_shuffle");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "get_loop");
+
+	for (int i = 0; i < MAX_STREAMS; i++) {
+		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "stream_" + itos(i), PROPERTY_HINT_RESOURCE_TYPE, "AudioStream", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_list_stream", "get_list_stream", i);
+	}
+
+	BIND_CONSTANT(MAX_STREAMS);
+}
+
+//////////////////////
+//////////////////////
+
+AudioStreamPlaybackPlaylist::AudioStreamPlaybackPlaylist() :
+		active(false) {
+	current = 0;
+	fading = false;
+	fading_time = 1;
+	fading_samples = 0;
+}
+
+AudioStreamPlaybackPlaylist::~AudioStreamPlaybackPlaylist() {
+	playlist->playbacks.erase(this);
+}
+
+void AudioStreamPlaybackPlaylist::stop() {
+	active = false;
+	playlist->reset();
+}
+
+void AudioStreamPlaybackPlaylist::start(float p_from_pos) {
+	if (playlist->shuffle) {
+		for (int i = 0; i < playlist->stream_count; i++) {
+			std::swap(playback[i], playback[std::rand() % playlist->stream_count]);
+		}
+	} else {
+		for (int i = 0; i < playlist->stream_count; i++) {
+			if (playlist->audio_streams[i].is_valid()) {
+				playback[i] = playlist->audio_streams[i]->instance_playback();
+			} else {
+				playback[i].unref();
+			}
+		}
+	}
+
+	current = 0;
+
+	if (playlist->audio_streams[current].is_valid()) {
+		fading_samples_total = (fading_time * playlist->sample_rate) / 1000;
+		if (playlist->audio_streams[current]->get_bpm() == 0) {
+			beat_size = playlist->sample_rate * 60 / playlist->bpm;
+		} else {
+			beat_size = playlist->sample_rate * 60 / playlist->audio_streams[current]->get_bpm();
+		}
+		if (playlist->audio_streams[current]->get_beat_count() == 0) {
+			beat_amount_remaining = playlist->audio_streams[current]->get_length() * playlist->sample_rate;
+		} else {
+			beat_amount_remaining = playlist->audio_streams[current]->get_beat_count() * beat_size;
+		}
+
+		seek(p_from_pos);
+		active = true;
+		playback[current]->start();
+	} else {
+		active = false;
+	}
+}
+
+void AudioStreamPlaybackPlaylist::seek(float p_time) {
+	if (p_time < 0) {
+		p_time = 0;
+	}
+	playlist->set_position(uint64_t(p_time * playlist->sample_rate) << MIX_FRAC_BITS);
+}
+
+void AudioStreamPlaybackPlaylist::add_stream_to_buffer(Ref<AudioStreamPlayback> playback, int samples, float p_rate_scale, float initial_volume, float final_volume) {
+	playback->mix(aux_buffer, p_rate_scale, samples);
+	for (int i = 0; i < samples; i++) {
+		float c = float(i) / samples;
+		float volume = initial_volume * (1.0 - c) + final_volume * c;
+		pcm_buffer[i] += aux_buffer[i] * volume;
+	}
+}
+
+void AudioStreamPlaybackPlaylist::clear_buffer(int samples) {
+	for (int i = 0; i < samples; i++) {
+		pcm_buffer[i] = AudioFrame(0.0, 0.0);
+	}
+}
+
+void AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
+	if (active != true) {
+		for (int i = 0; i < p_frames; i++) {
+			p_buffer[i] = AudioFrame(0.0, 0.0);
+		}
+		stop();
+		return;
+
+	} else {
+		int dst_offset = 0;
+
+		while (p_frames > 0) {
+			if (beat_amount_remaining == 0) {
+				fading = true;
+				if ((current + 1) < playlist->stream_count) {
+					current = (current + 1) % playlist->stream_count;
+				} else {
+					if (playlist->loop) {
+						current = 0;
+						if (playlist->shuffle) {
+							for (int i = 0; i < playlist->stream_count; i++) {
+								std::swap(playback[i], playback[std::rand() % playlist->stream_count]);
+							}
+						}
+					} else {
+						stop();
+					}
+				}
+				playback[current]->start();
+				fading_samples = fading_samples_total;
+				if (playlist->audio_streams[current]->get_bpm() == 0) {
+					beat_size = playlist->sample_rate * 60 / playlist->bpm;
+				} else {
+					beat_size = playlist->sample_rate * 60 / playlist->audio_streams[current]->get_bpm();
+				}
+				if (playlist->audio_streams[current]->get_beat_count() == 0) {
+					beat_amount_remaining = playlist->audio_streams[current]->get_length() * beat_size;
+				} else {
+					beat_amount_remaining = playlist->audio_streams[current]->get_beat_count() * beat_size;
+				}
+			}
+
+			int to_mix = MIN(MIX_BUFFER_SIZE, MIN(p_frames, beat_amount_remaining));
+			if (to_mix < 0) {
+				to_mix = MIX_BUFFER_SIZE;
+			}
+
+			clear_buffer(to_mix);
+
+			if (fading) {
+				int to_fade = MIN(fading_samples, to_mix);
+				float from_volume = 1.0 - float(fading_samples_total - fading_samples) / fading_samples_total;
+				float to_volume = 1.0 - float(fading_samples_total - (fading_samples - to_fade)) / fading_samples_total;
+				if (to_volume < 0.0)
+					to_volume = 0.0;
+				if (playlist->loop && current == 0) {
+					add_stream_to_buffer(playback[playlist->stream_count - 1], to_fade, p_rate_scale, from_volume, to_volume);
+				} else {
+					add_stream_to_buffer(playback[current - 1], to_fade, p_rate_scale, from_volume, to_volume);
+				}
+				add_stream_to_buffer(playback[current], to_fade, p_rate_scale, (1.0 - from_volume), (1.0 - to_volume));
+				fading_samples -= to_fade;
+				if (fading_samples == 0) {
+					fading = false;
+					if (playlist->loop && current == 0) {
+						playback[playlist->stream_count - 1]->stop();
+					} else {
+						playback[current - 1]->stop();
+					}
+				}
+			} else {
+				add_stream_to_buffer(playback[current], to_mix, p_rate_scale, 1.0, 1.0);
+			}
+			for (int i = 0; i < to_mix; i++) {
+				p_buffer[i + dst_offset] = pcm_buffer[i];
+			}
+			dst_offset += to_mix;
+			p_frames -= to_mix;
+			beat_amount_remaining -= to_mix;
+		}
+	}
+}
+
+int AudioStreamPlaybackPlaylist::get_loop_count() const {
+	return 0;
+}
+
+float AudioStreamPlaybackPlaylist::get_playback_position() const {
+	return 0.0;
+}
+
+float AudioStreamPlaybackPlaylist::get_length() const {
+	return 0.0;
+}
+
+bool AudioStreamPlaybackPlaylist::is_playing() const {
+	return active;
+}
+
+void AudioStreamPlaybackPlaylist::_update_playback_instances() {
+	stop();
+
+	for (int i = 0; i < playlist->stream_count; i++) {
+		if (playlist->audio_streams[i].is_valid()) {
+			playback[i] = playlist->audio_streams[i]->instance_playback();
+		} else {
+			playback[i].unref();
+		}
+	}
+}
+
+void AudioStreamPlaybackPlaylist::_update_bpm_info() {
+	for (int i = 0; i < AudioStreamPlaylist::MAX_STREAMS; i++) {
+		if (playlist->audio_streams[i]->get_bpm() == 0) {
+			bpm_list[i] = playlist->bpm;
+		} else {
+			bpm_list[i] = playlist->audio_streams[i]->get_bpm();
+		}
+
+		if (playlist->audio_streams[i]->get_beat_count() == 0) {
+			beats_list[i] = playlist->beat_count;
+		} else {
+			beats_list[i] = playlist->audio_streams[i]->get_beat_count();
+		}
+	}
+}

--- a/modules/interactive_music/audio_stream_playlist.h
+++ b/modules/interactive_music/audio_stream_playlist.h
@@ -1,0 +1,144 @@
+/*************************************************************************/
+/*  audio_stream_playlist.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef AUDIO_STREAM_PLAYLIST_H
+#define AUDIO_STREAM_PLAYLIST_H
+
+#include "core/reference.h"
+#include "core/resource.h"
+#include "servers/audio/audio_stream.h"
+
+class AudioStreamPlaybackPlaylist;
+
+class AudioStreamPlaylist : public AudioStream {
+	GDCLASS(AudioStreamPlaylist, AudioStream)
+	OBJ_SAVE_TYPE(AudioStream)
+
+private:
+	friend class AudioStreamPlaybackPlaylist;
+	uint64_t pos;
+	int sample_rate;
+	bool stereo;
+	int stream_count;
+	int bpm;
+	float length;
+
+	double time;
+
+	enum {
+		MAX_STREAMS = 64
+	};
+
+	int beat_count;
+	bool shuffle;
+	bool loop;
+
+	Ref<AudioStream> audio_streams[MAX_STREAMS];
+	Set<AudioStreamPlaybackPlaylist *> playbacks;
+
+public:
+	void reset();
+	void set_position(uint64_t pos);
+
+	void set_stream_beats(int beats);
+	int get_stream_beats();
+	void set_bpm(int beats_per_minute);
+	virtual int get_bpm() const;
+	void set_stream_count(int count);
+	int get_stream_count();
+	void set_shuffle(bool p_shuffle);
+	bool get_shuffle();
+	void set_loop(bool p_loop);
+	bool get_loop();
+	void set_list_stream(int stream_number, Ref<AudioStream> p_stream);
+	Ref<AudioStream> get_list_stream(int stream_number);
+
+	virtual Ref<AudioStreamPlayback> instance_playback();
+	virtual String get_stream_name() const;
+	virtual float get_length() const;
+	AudioStreamPlaylist();
+
+protected:
+	static void _bind_methods();
+	void _validate_property(PropertyInfo &property) const;
+};
+
+///////////////////////////////////////
+
+class AudioStreamPlaybackPlaylist : public AudioStreamPlayback {
+	GDCLASS(AudioStreamPlaybackPlaylist, AudioStreamPlayback)
+	friend class AudioStreamPlaylist;
+
+private:
+	enum {
+		MIX_BUFFER_SIZE = 128
+	};
+	enum {
+		MIX_FRAC_BITS = 13,
+		MIX_FRAC_LEN = (1 << MIX_FRAC_BITS),
+		MIX_FRAC_MASK = MIX_FRAC_LEN - 1,
+	};
+	AudioFrame pcm_buffer[MIX_BUFFER_SIZE];
+	AudioFrame aux_buffer[MIX_BUFFER_SIZE];
+
+	Ref<AudioStreamPlaylist> playlist;
+	Ref<AudioStreamPlayback> playback[AudioStreamPlaylist::MAX_STREAMS];
+	int bpm_list[AudioStreamPlaylist::MAX_STREAMS];
+	int beats_list[AudioStreamPlaylist::MAX_STREAMS];
+
+	int current;
+	bool fading;
+	int fading_samples_total;
+	int fading_time;
+	int fading_samples;
+	float beat_size;
+	int beat_amount_remaining;
+
+	bool active;
+
+	virtual void _update_playback_instances();
+	virtual void _update_bpm_info();
+
+public:
+	virtual void start(float p_from_pos = 0.0);
+	virtual void stop();
+	virtual bool is_playing() const;
+	void clear_buffer(int samples);
+	virtual int get_loop_count() const; // times it looped
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
+	void add_stream_to_buffer(Ref<AudioStreamPlayback> playback, int samples, float p_rate_scale, float initial_volume, float final_volume);
+	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
+	virtual float get_length() const;
+	AudioStreamPlaybackPlaylist();
+	~AudioStreamPlaybackPlaylist();
+};
+
+#endif // AUDIO_STREAM_PLAYLIST_H

--- a/modules/interactive_music/audio_stream_transitioner.cpp
+++ b/modules/interactive_music/audio_stream_transitioner.cpp
@@ -1,0 +1,527 @@
+/*************************************************************************/
+/*  audio_stream_transitioner.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "audio_stream_transitioner.h"
+
+#include "core/math/math_funcs.h"
+#include "core/print_string.h"
+
+#include <iostream>
+
+AudioStreamTransitioner::AudioStreamTransitioner() {
+	bpm = 120;
+	transition_count = 1;
+	clip_count = 1;
+	sample_rate = 44100;
+	stereo = true;
+	active_transition.t_active = false;
+	active_clip_number = 0;
+	t_clip_active = false;
+	for (int i = 0; i < transition_count; i++) {
+		transitions[i].t_active = false;
+		transitions[i].fade_in_beats = 0;
+		transitions[i].fade_out_beats = 0;
+	}
+}
+
+Ref<AudioStreamPlayback> AudioStreamTransitioner::instance_playback() {
+	Ref<AudioStreamPlaybackTransitioner> playback_transitioner;
+	playback_transitioner.instance();
+	playback_transitioner->transitioner = Ref<AudioStreamTransitioner>(this);
+	playback_transitioner->_update_playback_instances();
+	playbacks.insert(playback_transitioner.operator->());
+	return playback_transitioner;
+}
+
+String AudioStreamTransitioner::get_stream_name() const {
+	return "Transitioner";
+}
+
+void AudioStreamTransitioner::reset() {
+	set_position(0);
+}
+
+void AudioStreamTransitioner::set_position(uint64_t p) {
+	pos = p;
+}
+
+void AudioStreamTransitioner::set_bpm(int p_bpm) {
+	ERR_FAIL_COND(p_bpm < 40 || p_bpm > 300);
+
+	bpm = p_bpm;
+}
+
+int AudioStreamTransitioner::get_bpm() const {
+	return bpm;
+}
+
+void AudioStreamTransitioner::set_transition_count(int t_count) {
+	ERR_FAIL_COND(t_count < 0 || t_count > MAX_TRANSITIONS);
+
+	transition_count = t_count;
+}
+
+int AudioStreamTransitioner::get_transition_count() {
+	return transition_count;
+}
+
+void AudioStreamTransitioner::set_clip_count(int p_clip_count) {
+	ERR_FAIL_COND(p_clip_count < 0 || p_clip_count > MAX_STREAMS);
+
+	clip_count = p_clip_count;
+}
+
+int AudioStreamTransitioner::get_clip_count() {
+	return clip_count;
+}
+
+void AudioStreamTransitioner::set_t_clip_active(bool active) {
+	t_clip_active = active;
+}
+
+bool AudioStreamTransitioner::get_t_clip_active() {
+	return t_clip_active;
+}
+
+void AudioStreamTransitioner::add_transition_clip(Ref<AudioStream> transition_clip) {
+	ERR_FAIL_COND(transition_clip == this);
+
+	t_clip = transition_clip;
+	for (Set<AudioStreamPlaybackTransitioner *>::Element *E = playbacks.front(); E; E = E->next()) {
+		E->get()->_update_playback_instances();
+	}
+}
+
+Ref<AudioStream> AudioStreamTransitioner::get_transition_clip() {
+	return t_clip;
+}
+
+void AudioStreamTransitioner::set_transition_fade_in(int t_number, int f_in) {
+	ERR_FAIL_COND(t_number < 0 || t_number > MAX_TRANSITIONS);
+	ERR_FAIL_COND(f_in < 0 || f_in > 64);
+
+	transitions[t_number].fade_in_beats = f_in;
+}
+
+int AudioStreamTransitioner::get_transition_fade_in(int t_number) {
+	return transitions[t_number].fade_in_beats;
+}
+
+void AudioStreamTransitioner::set_transition_fade_out(int t_number, int f_out) {
+	ERR_FAIL_COND(t_number < 0 || t_number > MAX_TRANSITIONS);
+	ERR_FAIL_COND(f_out < 0 || f_out > 64);
+
+	transitions[t_number].fade_out_beats = f_out;
+}
+
+int AudioStreamTransitioner::get_transition_fade_out(int t_number) {
+	return transitions[t_number].fade_out_beats;
+}
+
+void AudioStreamTransitioner::set_list_clip(int clip_number, Ref<AudioStream> p_clip) {
+	ERR_FAIL_COND(p_clip == this);
+	ERR_FAIL_INDEX(clip_number, MAX_STREAMS);
+
+	AudioServer::get_singleton()->lock();
+	clips[clip_number] = p_clip;
+	for (Set<AudioStreamPlaybackTransitioner *>::Element *E = playbacks.front(); E; E = E->next()) {
+		E->get()->_update_playback_instances();
+	}
+	AudioServer::get_singleton()->unlock();
+}
+
+Ref<AudioStream> AudioStreamTransitioner::get_list_clip(int clip_number) {
+	ERR_FAIL_INDEX_V(clip_number, MAX_STREAMS, Ref<AudioStream>());
+
+	return clips[clip_number];
+}
+
+void AudioStreamTransitioner::set_active_transition(int t_number, bool trigger) {
+	ERR_FAIL_COND(t_number < 0 || t_number > MAX_TRANSITIONS);
+	for (int i = 0; i < transition_count; i++) {
+		transitions[i].t_active = false;
+		_change_notify();
+	}
+	transitions[t_number].t_active = trigger;
+	active_transition = transitions[t_number];
+}
+
+bool AudioStreamTransitioner::get_transition_state(int transition_number) {
+	return transitions[transition_number].t_active;
+}
+
+void AudioStreamTransitioner::set_active_clip_number(int clip_number) {
+	ERR_FAIL_COND(clip_number < 0 || clip_number > MAX_STREAMS);
+	fading_clip_number = active_clip_number;
+	active_clip_number = clip_number;
+}
+
+int AudioStreamTransitioner::get_active_clip_number() {
+	return active_clip_number;
+}
+
+void AudioStreamTransitioner::go_to_clip(int clip_number, int transition_number) {
+	active_clip_number = clip_number;
+	set_active_transition(transition_number, true);
+}
+
+void AudioStreamTransitioner::_validate_property(PropertyInfo &property) const {
+	String prop = property.name;
+	if (prop.begins_with("clip_")) {
+		int clip = prop.get_slicec('_', 1).to_int();
+		if (clip >= clip_count) {
+			property.usage = 0;
+		}
+	}
+	if (prop.begins_with("transition_")) {
+		int transition = prop.get_slicec('/', 0).get_slicec('_', 1).to_int();
+		if (transition >= transition_count) {
+			property.usage = 0;
+		}
+	}
+}
+
+void AudioStreamTransitioner::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_bpm", "bpm"), &AudioStreamTransitioner::set_bpm);
+	ClassDB::bind_method(D_METHOD("get_bpm"), &AudioStreamTransitioner::get_bpm);
+
+	ClassDB::bind_method(D_METHOD("set_transition_count", "transition_count"), &AudioStreamTransitioner::set_transition_count);
+	ClassDB::bind_method(D_METHOD("get_transition_count"), &AudioStreamTransitioner::get_transition_count);
+
+	ClassDB::bind_method(D_METHOD("set_clip_count", "clip_count"), &AudioStreamTransitioner::set_clip_count);
+	ClassDB::bind_method(D_METHOD("get_clip_count"), &AudioStreamTransitioner::get_clip_count);
+
+	ClassDB::bind_method(D_METHOD("set_transition_fade_in", "transition_number", "fade_in_beats"), &AudioStreamTransitioner::set_transition_fade_in);
+	ClassDB::bind_method(D_METHOD("get_transition_fade_in", "transition_number"), &AudioStreamTransitioner::get_transition_fade_in);
+
+	ClassDB::bind_method(D_METHOD("set_transition_fade_out", "transition_number", "fade_out_beats"), &AudioStreamTransitioner::set_transition_fade_out);
+	ClassDB::bind_method(D_METHOD("get_transition_fade_out", "transition_number"), &AudioStreamTransitioner::get_transition_fade_out);
+
+	ClassDB::bind_method(D_METHOD("set_active_transition", "transition_number", "trigger"), &AudioStreamTransitioner::set_active_transition);
+	ClassDB::bind_method(D_METHOD("get_transition_state", "transition_number"), &AudioStreamTransitioner::get_transition_state);
+
+	ClassDB::bind_method(D_METHOD("set_active_clip_number", "clip_number"), &AudioStreamTransitioner::set_active_clip_number);
+	ClassDB::bind_method(D_METHOD("get_active_clip_number"), &AudioStreamTransitioner::get_active_clip_number);
+
+	ClassDB::bind_method(D_METHOD("set_list_clip", "clip_number", "clip"), &AudioStreamTransitioner::set_list_clip);
+	ClassDB::bind_method(D_METHOD("get_list_clip", "clip_number"), &AudioStreamTransitioner::get_list_clip);
+
+	ClassDB::bind_method(D_METHOD("set_t_clip_active", "transition_active"), &AudioStreamTransitioner::set_t_clip_active);
+	ClassDB::bind_method(D_METHOD("get_t_clip_active"), &AudioStreamTransitioner::get_t_clip_active);
+
+	ClassDB::bind_method(D_METHOD("add_transition_clip", "transition_clip"), &AudioStreamTransitioner::add_transition_clip);
+	ClassDB::bind_method(D_METHOD("get_transition_clip"), &AudioStreamTransitioner::get_transition_clip);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "clip_count", PROPERTY_HINT_RANGE, "1," + itos(MAX_STREAMS), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_clip_count", "get_clip_count");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "transition_count", PROPERTY_HINT_RANGE, "1," + itos(MAX_TRANSITIONS), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_transition_count", "get_transition_count");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bpm", PROPERTY_HINT_RANGE, "0,400"), "set_bpm", "get_bpm");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "active_clip", PROPERTY_HINT_RANGE, "0,64"), "set_active_clip_number", "get_active_clip_number");
+
+	ADD_GROUP("Transition Clip", "t_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "t_clip_active"), "set_t_clip_active", "get_t_clip_active");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "t_clip", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "add_transition_clip", "get_transition_clip");
+
+	ADD_GROUP("Clips", "clip_");
+	for (int i = 0; i < MAX_STREAMS; i++) {
+		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "clip_" + itos(i), PROPERTY_HINT_RESOURCE_TYPE, "AudioStream", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_list_clip", "get_list_clip", i);
+	}
+	ADD_GROUP("Transitions", "transition_");
+	for (int i = 0; i < MAX_TRANSITIONS; i++) {
+		ADD_PROPERTYI(PropertyInfo(Variant::INT, "transition_" + itos(i) + "/fade_in_beats", PROPERTY_HINT_RANGE, "0,64", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_transition_fade_in", "get_transition_fade_in", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::INT, "transition_" + itos(i) + "/fade_out_beats", PROPERTY_HINT_RANGE, "0,64", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_transition_fade_out", "get_transition_fade_out", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "transition_" + itos(i) + "/active"), "set_active_transition", "get_transition_state", i);
+	}
+
+	BIND_CONSTANT(MAX_STREAMS);
+	BIND_CONSTANT(MAX_TRANSITIONS);
+}
+
+///////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////
+AudioStreamPlaybackTransitioner::AudioStreamPlaybackTransitioner() :
+		active(false) {
+	current = 0;
+	fading = false;
+}
+
+AudioStreamPlaybackTransitioner::~AudioStreamPlaybackTransitioner() {
+	transitioner->playbacks.erase(this);
+}
+
+void AudioStreamPlaybackTransitioner::stop() {
+	active = false;
+	transitioner->reset();
+}
+
+void AudioStreamPlaybackTransitioner::start(float p_from_pos) {
+	current = transitioner->active_clip_number;
+
+	if (transitioner->clips[current].is_valid()) {
+		clip_samples_total = transitioner->clips[current]->get_length() * transitioner->sample_rate;
+		if (transitioner->clips[current]->get_bpm() == 0) {
+			beat_size = transitioner->sample_rate * 60 / transitioner->bpm;
+		} else {
+			beat_size = transitioner->sample_rate * 60 / transitioner->clips[current]->get_bpm();
+		}
+		seek(p_from_pos);
+		active = true;
+		playbacks[current]->start();
+	} else {
+		active = false;
+	}
+}
+
+void AudioStreamPlaybackTransitioner::seek(float p_time) {
+	if (p_time < 0) {
+		p_time = 0;
+	}
+	transitioner->set_position(uint64_t(p_time * transitioner->sample_rate) << MIX_FRAC_BITS);
+}
+
+void AudioStreamPlaybackTransitioner::add_stream_to_buffer(Ref<AudioStreamPlayback> playback, int samples, float p_rate_scale, float initial_volume, float final_volume) {
+	if (playback.is_valid()) {
+		playback->mix(aux_buffer, p_rate_scale, samples);
+		for (int i = 0; i < samples; i++) {
+			float c = float(i) / samples;
+			float volume = initial_volume * (1.0 - c) + final_volume * c;
+			pcm_buffer[i] += aux_buffer[i] * volume;
+		}
+	} else {
+		return;
+	}
+}
+
+void AudioStreamPlaybackTransitioner::clear_buffer(int samples) {
+	for (int i = 0; i < samples; i++) {
+		pcm_buffer[i] = AudioFrame(0.0, 0.0);
+	}
+}
+
+void AudioStreamPlaybackTransitioner::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
+	if (active != true) {
+		for (int i = 0; i < p_frames; i++) {
+			p_buffer[i] = AudioFrame(0.0, 0.0);
+		}
+		stop();
+		return;
+
+	} else {
+		if (transitioner->clips[current].is_valid()) {
+			int dst_offset = 0;
+			if (clip_samples_total <= 0) {
+				playbacks[current]->stop();
+				playbacks[current]->start();
+				clip_samples_total = transitioner->clips[current]->get_length() * transitioner->sample_rate;
+			}
+
+			while (p_frames > 0) {
+				if (transitioner->active_transition.t_active) {
+					current = transitioner->active_clip_number;
+					previous = transitioner->fading_clip_number;
+
+					fading = true;
+					clip_samples_total = transitioner->clips[current]->get_length() * transitioner->sample_rate;
+					if (transitioner->clips[current]->get_bpm() == 0) {
+						beat_size = transitioner->sample_rate * 60 / transitioner->bpm;
+					} else {
+						beat_size = transitioner->sample_rate * 60 / transitioner->clips[current]->get_bpm();
+					}
+					if (transitioner->clips[previous].is_valid()) {
+						if (transitioner->clips[previous]->get_bpm() == 0) {
+							fading_beat_size = transitioner->sample_rate * 60 / transitioner->bpm;
+						} else {
+							fading_beat_size = transitioner->sample_rate * 60 / transitioner->clips[previous]->get_bpm();
+						}
+					}
+					fade_out_samples_total = transitioner->active_transition.fade_out_beats * fading_beat_size;
+					fade_in_samples_total = transitioner->active_transition.fade_in_beats * beat_size;
+					if (transitioner->t_clip_active && transitioner->t_clip.is_valid()) {
+						if (transitioner->t_clip->get_bpm() == 0) {
+							t_clip_beat_size = transitioner->sample_rate * 60 / transitioner->bpm;
+						} else {
+							t_clip_beat_size = transitioner->sample_rate * 60 / transitioner->t_clip->get_bpm();
+						}
+						fade_in_t_clip_samples_total = transitioner->active_transition.fade_in_beats * t_clip_beat_size;
+						fade_out_t_clip_samples_total = transitioner->active_transition.fade_out_beats * t_clip_beat_size;
+						if (transitioner->t_clip->get_beat_count() == 0) {
+							t_clip_samples_total = transitioner->t_clip->get_length() * transitioner->sample_rate;
+						} else {
+							t_clip_samples_total = transitioner->t_clip->get_beat_count() * t_clip_beat_size;
+						}
+						int fading_total = MAX(fade_out_samples_total, fade_in_t_clip_samples_total) + MAX(fade_in_samples_total, fade_out_t_clip_samples_total);
+						transition_samples_total = fading_total + MAX(t_clip_samples_total - fading_total, 0);
+						fade_in_t_clip_samples = fade_in_t_clip_samples_total;
+						fade_out_t_clip_samples = fade_out_t_clip_samples_total;
+						t_clip_samples = t_clip_samples_total;
+						t_playback->start();
+					} else {
+						transition_samples_total = MAX(fade_in_samples_total, fade_out_samples_total);
+						playbacks[current]->start();
+					}
+					transition_samples = transition_samples_total;
+					fade_in_samples = fade_in_samples_total;
+					fade_out_samples = fade_out_samples_total;
+					transitioner->active_transition.t_active = false;
+				}
+
+				int to_mix = MIN(MIX_BUFFER_SIZE, p_frames);
+				clear_buffer(to_mix);
+
+				if (fading) {
+					if (transition_samples <= 0) {
+						fading = false;
+					} else {
+						if (playbacks[current].is_valid() && playbacks[previous].is_valid()) {
+							int to_fade_out = MIN(to_mix, fade_out_samples);
+							int to_fade_in = MIN(to_mix, fade_in_samples);
+							float fade_out_start_volume = 1.0 - float(fade_out_samples_total - fade_out_samples) / fade_out_samples_total;
+							float fade_out_end_volume = 1.0 - float(fade_out_samples_total - (fade_out_samples - to_fade_out)) / fade_out_samples_total;
+							float fade_in_start_volume = 1.0 - float(fade_in_samples) / fade_in_samples_total;
+							float fade_in_end_volume = 1.0 - float(fade_in_samples - to_fade_in) / fade_in_samples_total;
+							if (transitioner->t_clip_active && transitioner->t_clip.is_valid()) {
+								int to_fade_out_t_clip = MIN(to_mix, fade_out_t_clip_samples);
+								int to_fade_in_t_clip = MIN(to_mix, fade_in_t_clip_samples);
+								float fade_out_start_volume_t_samples = 1.0 - float(fade_out_t_clip_samples_total - fade_out_t_clip_samples) / fade_out_t_clip_samples_total;
+								float fade_out_end_volume_t_samples = 1.0 - float(fade_out_t_clip_samples_total - (fade_out_t_clip_samples - to_fade_out_t_clip)) / fade_out_t_clip_samples_total;
+								float fade_in_start_volume_t_samples = 1.0 - float(fade_in_t_clip_samples) / fade_in_t_clip_samples_total;
+								float fade_in_end_volume_t_samples = 1.0 - float(fade_in_t_clip_samples - to_fade_out_t_clip) / fade_in_t_clip_samples_total;
+								if (fade_out_samples > 0) {
+									add_stream_to_buffer(playbacks[previous], to_fade_out, p_rate_scale, fade_out_start_volume, fade_out_end_volume);
+									fade_out_samples -= to_fade_out;
+								} else {
+									playbacks[previous]->stop();
+								}
+								if (fade_in_t_clip_samples > 0 && transitioner->t_clip.is_valid()) {
+									add_stream_to_buffer(t_playback, to_fade_in_t_clip, p_rate_scale, fade_in_start_volume_t_samples, fade_in_end_volume_t_samples);
+									fade_in_t_clip_samples -= to_fade_in_t_clip;
+									t_clip_samples -= to_fade_in_t_clip;
+								} else {
+									if (t_clip_samples >= fade_out_t_clip_samples_total) {
+										add_stream_to_buffer(t_playback, to_mix, p_rate_scale, 1.0, 1.0);
+										t_clip_samples -= to_mix;
+									} else {
+										if (fade_in_samples == fade_in_samples_total) {
+											playbacks[current]->start();
+										}
+										if (fade_in_samples > 0) {
+											add_stream_to_buffer(playbacks[current], to_fade_in, p_rate_scale, fade_in_start_volume, fade_in_end_volume);
+											fade_in_samples -= to_fade_in;
+										} else {
+											add_stream_to_buffer(playbacks[current], to_mix, p_rate_scale, 1.0, 1.0);
+										}
+										if (fade_out_t_clip_samples > 0) {
+											add_stream_to_buffer(t_playback, to_fade_out_t_clip, p_rate_scale, fade_out_start_volume_t_samples, fade_out_end_volume_t_samples);
+											fade_out_t_clip_samples -= to_fade_out_t_clip;
+											t_clip_samples -= to_fade_out_t_clip;
+										} else {
+											t_playback->stop();
+										}
+									}
+								}
+
+							} else {
+								if (fade_out_samples > 0) {
+									add_stream_to_buffer(playbacks[previous], to_fade_out, p_rate_scale, fade_out_start_volume, fade_out_end_volume);
+								} else {
+									playbacks[previous]->stop();
+								}
+								if (fade_in_samples > 0) {
+									add_stream_to_buffer(playbacks[current], to_fade_in, p_rate_scale, fade_in_start_volume, fade_in_end_volume);
+								} else {
+									add_stream_to_buffer(playbacks[current], to_mix, p_rate_scale, 1.0, 1.0);
+								}
+
+								fade_out_samples -= to_fade_out;
+								fade_in_samples -= to_fade_in;
+							}
+							transition_samples -= to_mix;
+							if (transition_samples <= 0)
+								fading = false;
+						}
+					}
+				} else {
+					add_stream_to_buffer(playbacks[current], to_mix, p_rate_scale, 1.0, 1.0);
+				}
+				if (transition_samples < 0) {
+					for (int i = 0; i < transition_samples + to_mix; i++) {
+						p_buffer[i + dst_offset] = pcm_buffer[i];
+					}
+					dst_offset += transition_samples + to_mix;
+					p_frames -= transition_samples + to_mix;
+					clip_samples_total -= transition_samples + to_mix;
+					transition_samples = 0;
+
+				} else {
+					for (int i = 0; i < to_mix; i++) {
+						p_buffer[i + dst_offset] = pcm_buffer[i];
+					}
+					dst_offset += to_mix;
+					p_frames -= to_mix;
+					clip_samples_total -= to_mix;
+				}
+			}
+		}
+	}
+}
+
+int AudioStreamPlaybackTransitioner::get_loop_count() const {
+	return 0;
+}
+
+float AudioStreamPlaybackTransitioner::get_playback_position() const {
+	return 0.0;
+}
+
+float AudioStreamPlaybackTransitioner::get_length() const {
+	return 0.0;
+}
+
+bool AudioStreamPlaybackTransitioner::is_playing() const {
+	return active;
+}
+
+void AudioStreamPlaybackTransitioner::_update_playback_instances() {
+	stop();
+
+	for (int i = 0; i < transitioner->clip_count; i++) {
+		if (transitioner->clips[i].is_valid()) {
+			playbacks[i] = transitioner->clips[i]->instance_playback();
+		} else {
+			playbacks[i].unref();
+		}
+	}
+
+	if (transitioner->t_clip.is_valid()) {
+		t_playback = transitioner->t_clip->instance_playback();
+	} else {
+		t_playback.unref();
+	}
+}

--- a/modules/interactive_music/audio_stream_transitioner.h
+++ b/modules/interactive_music/audio_stream_transitioner.h
@@ -1,0 +1,183 @@
+/*************************************************************************/
+/*  audio_stream_transitioner.h                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef AUDIO_STREAM_TRANSITIONER_H
+#define AUDIO_STREAM_TRANSITIONER_H
+
+#include "core/reference.h"
+#include "core/resource.h"
+#include "servers/audio/audio_stream.h"
+
+class AudioStreamPlaybackTransitioner;
+
+class AudioStreamTransitioner : public AudioStream {
+	GDCLASS(AudioStreamTransitioner, AudioStream)
+	OBJ_SAVE_TYPE(AudioStream)
+
+private:
+	friend class AudioStreamPlaybackTransitioner;
+	uint64_t pos;
+	int sample_rate;
+	bool stereo;
+	int clip_count;
+	int transition_count;
+	int bpm;
+	double time;
+
+	enum {
+		MAX_STREAMS = 64,
+		MAX_TRANSITIONS = 48
+	};
+
+	struct Transition {
+		bool t_active;
+		int fade_in_beats;
+		int fade_out_beats;
+	};
+
+	Transition transitions[MAX_TRANSITIONS];
+	Transition active_transition;
+
+	Ref<AudioStream> clips[MAX_STREAMS];
+	Ref<AudioStream> t_clip;
+	bool t_clip_active;
+	int active_clip_number;
+	int fading_clip_number;
+	Set<AudioStreamPlaybackTransitioner *> playbacks;
+
+public:
+	void reset();
+	void set_position(uint64_t pos);
+
+	void set_bpm(int p_bpm);
+	virtual int get_bpm() const;
+
+	void set_list_clip(int clip_number, Ref<AudioStream> p_clip);
+	Ref<AudioStream> get_list_clip(int clip_number);
+
+	void set_transition_count(int p_transition_count);
+	int get_transition_count();
+
+	void set_clip_count(int p_clip_count);
+	int get_clip_count();
+
+	void set_t_clip_active(bool active);
+	bool get_t_clip_active();
+
+	void add_transition_clip(Ref<AudioStream> transition_clip);
+	Ref<AudioStream> get_transition_clip();
+
+	void set_transition_fade_in(int transition_number, int fade_in);
+	int get_transition_fade_in(int transition_number);
+
+	void set_transition_fade_out(int transition_number, int fade_out);
+	int get_transition_fade_out(int transition_number);
+
+	void set_active_transition(int transition_number, bool trigger);
+	bool get_transition_state(int transition_number);
+
+	void set_active_clip_number(int clip_number);
+	int get_active_clip_number();
+
+	void go_to_clip(int clip_number, int transition_number);
+
+	virtual Ref<AudioStreamPlayback> instance_playback();
+	virtual String get_stream_name() const;
+	virtual float get_length() const { return 0; }
+	AudioStreamTransitioner();
+
+protected:
+	static void _bind_methods();
+	void _validate_property(PropertyInfo &property) const;
+};
+
+class AudioStreamPlaybackTransitioner : public AudioStreamPlayback {
+	GDCLASS(AudioStreamPlaybackTransitioner, AudioStreamPlayback)
+	friend class AudioStreamTransitioner;
+
+private:
+	enum {
+		MIX_BUFFER_SIZE = 256
+	};
+	enum {
+		MIX_FRAC_BITS = 13,
+		MIX_FRAC_LEN = (1 << MIX_FRAC_BITS),
+		MIX_FRAC_MASK = MIX_FRAC_LEN - 1,
+	};
+	AudioFrame pcm_buffer[MIX_BUFFER_SIZE];
+	AudioFrame aux_buffer[MIX_BUFFER_SIZE];
+
+	Ref<AudioStreamTransitioner> transitioner;
+	Ref<AudioStreamPlayback> playbacks[AudioStreamTransitioner::MAX_STREAMS];
+	Ref<AudioStreamPlayback> t_playback;
+
+	int current;
+	int previous;
+	int fade_in_samples_total;
+	int fade_out_samples_total;
+	int fade_in_t_clip_samples_total;
+	int fade_out_t_clip_samples_total;
+	int transition_samples_total;
+	int clip_samples_total;
+	int t_clip_samples_total;
+
+	int transition_samples;
+	int fade_in_samples;
+	int fade_out_samples;
+	int fade_in_t_clip_samples;
+	int fade_out_t_clip_samples;
+	int t_clip_samples;
+
+	int beat_size;
+	int fading_beat_size;
+	int t_clip_beat_size;
+
+	bool fading;
+
+	bool active;
+
+	virtual void _update_playback_instances();
+
+public:
+	virtual void start(float p_from_pos = 0.0);
+	virtual void stop();
+	virtual bool is_playing() const;
+	void clear_buffer(int samples);
+	virtual int get_loop_count() const; // times it looped
+	virtual float get_playback_position() const;
+	virtual void seek(float p_time);
+	void add_stream_to_buffer(Ref<AudioStreamPlayback> playback, int samples, float p_rate_scale, float initial_volume, float final_volume);
+	virtual void mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
+	virtual float get_length() const;
+	AudioStreamPlaybackTransitioner();
+	~AudioStreamPlaybackTransitioner();
+};
+
+#endif // AUDIO_STREAM_TRANSITIONER_H

--- a/modules/interactive_music/config.py
+++ b/modules/interactive_music/config.py
@@ -1,0 +1,19 @@
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return [
+        "AudioStreamPlaylist",
+        "AudioStreamPlaybackPlaylist",
+        "AudioStreamPlaybackTransitioner",
+        "AudioStreamTransitioner",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackPlaylist.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackPlaylist.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioStreamPlaybackPlaylist" inherits="AudioStreamPlayback" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackTransitioner.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackTransitioner.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioStreamPlaybackTransitioner" inherits="AudioStreamPlayback" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/modules/interactive_music/doc_classes/AudioStreamPlaylist.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaylist.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioStreamPlaylist" inherits="AudioStream" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A class for playing multiple audio clips in a sequence
+	</brief_description>
+	<description>
+		A class for playing multiple audio clips in a sequence, based on their tempo and length in beats. Clips can be added either through drag and drop into inspector or through script.
+		BPM and beats information is imported into clips, however if a clip does not have this it will use the class' default BPM and calculate the beats automatically.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_list_stream">
+			<return type="AudioStream" />
+			<argument index="0" name="stream_number" type="int" />
+			<description>
+				Returns a stream based on its number
+			</description>
+		</method>
+		<method name="get_stream_beats">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="set_list_stream">
+			<return type="void" />
+			<argument index="0" name="stream_number" type="int" />
+			<argument index="1" name="audio_stream" type="AudioStream" />
+			<description>
+				Sets a stream based on its number
+			</description>
+		</method>
+		<method name="set_stream_beats">
+			<return type="void" />
+			<argument index="0" name="beat_count" type="int" />
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="bpm" type="int" setter="set_bpm" getter="get_bpm" default="120">
+			Sets default BPM for the playlist
+		</member>
+		<member name="loop" type="bool" setter="set_loop" getter="get_loop" default="false">
+			Enables looping
+		</member>
+		<member name="shuffle" type="bool" setter="set_shuffle" getter="get_shuffle" default="false">
+			Shuffles the order of the clips
+		</member>
+		<member name="stream_count" type="int" setter="set_stream_count" getter="get_stream_count" default="1">
+			Sets the amount of clips playlist can take, with a maximum of 64
+		</member>
+	</members>
+	<constants>
+		<constant name="MAX_STREAMS" value="64">
+		</constant>
+	</constants>
+</class>

--- a/modules/interactive_music/doc_classes/AudioStreamTransitioner.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamTransitioner.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioStreamTransitioner" inherits="AudioStream" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Class for playing audio clips based on events which activate transitions.
+	</brief_description>
+	<description>
+		Class for playing audio clips based on events which activate transitions. When a transition is activated it starts a crossfade between the previous and next clip, based on the fade in and fade out times in beats for the activated transition. The fades are both calculated based on each clip's BPM info.
+		An option for having a transition clip is also available, which allows for a clip to be played in between the previous and next clip.
+		The class can be used by musicians simply by using the inspector and by programmers in implementation through script.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_transition_clip">
+			<return type="void" />
+			<argument index="0" name="transition_clip" type="AudioStream" />
+			<description>
+				Adds a transition clip
+			</description>
+		</method>
+		<method name="get_list_clip">
+			<return type="AudioStream" />
+			<argument index="0" name="clip_number" type="int" />
+			<description>
+				Returns a clip based on its number
+			</description>
+		</method>
+		<method name="get_transition_clip">
+			<return type="AudioStream" />
+			<description>
+				Returns the transition clip
+			</description>
+		</method>
+		<method name="get_transition_fade_in">
+			<return type="int" />
+			<argument index="0" name="transition_number" type="int" />
+			<description>
+				Returns a transition's fade in beats.
+			</description>
+		</method>
+		<method name="get_transition_fade_out">
+			<return type="int" />
+			<argument index="0" name="transition_number" type="int" />
+			<description>
+				Returns a transition's fade out beats.
+			</description>
+		</method>
+		<method name="get_transition_state">
+			<return type="bool" />
+			<argument index="0" name="transition_number" type="int" />
+			<description>
+				Returns a transition's active member.
+			</description>
+		</method>
+		<method name="set_active_transition">
+			<return type="void" />
+			<argument index="0" name="transition_number" type="int" />
+			<argument index="1" name="trigger" type="bool" />
+			<description>
+				Sets a transition based on its number to active.
+			</description>
+		</method>
+		<method name="set_list_clip">
+			<return type="void" />
+			<argument index="0" name="clip_number" type="int" />
+			<argument index="1" name="clip" type="AudioStream" />
+			<description>
+				Adds a clip to transitioner based on its number.
+			</description>
+		</method>
+		<method name="set_transition_fade_in">
+			<return type="void" />
+			<argument index="0" name="transition_number" type="int" />
+			<argument index="1" name="fade_in_beats" type="int" />
+			<description>
+				Sets a transition's fade in beats
+			</description>
+		</method>
+		<method name="set_transition_fade_out">
+			<return type="void" />
+			<argument index="0" name="transition_number" type="int" />
+			<argument index="1" name="fade_out_beats" type="int" />
+			<description>
+				Sets a transition's fade out beats
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="active_clip" type="int" setter="set_active_clip_number" getter="get_active_clip_number" default="0">
+			Sets the next clip that will be faded in once a transition is activated
+		</member>
+		<member name="bpm" type="int" setter="set_bpm" getter="get_bpm" default="120">
+			Sets default BPM for the class
+		</member>
+		<member name="clip_count" type="int" setter="set_clip_count" getter="get_clip_count" default="1">
+			Sets the number of clips transitioner will take, with a maximum of 64.
+		</member>
+		<member name="t_clip_active" type="bool" setter="set_t_clip_active" getter="get_t_clip_active" default="false">
+		</member>
+		<member name="transition_0/active" type="bool" setter="set_active_transition" getter="get_transition_state" default="false">
+			Activates a transition
+		</member>
+		<member name="transition_1/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_10/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_11/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_12/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_13/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_14/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_15/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_16/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_17/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_18/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_19/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_2/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_20/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_21/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_22/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_23/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_24/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_25/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_26/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_27/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_28/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_29/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_3/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_30/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_31/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_32/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_33/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_34/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_35/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_36/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_37/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_38/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_39/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_4/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_40/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_41/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_42/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_43/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_44/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_45/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_46/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_47/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_5/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_6/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_7/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_8/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_9/active" type="bool" setter="set_active_transition" getter="get_transition_state">
+		</member>
+		<member name="transition_count" type="int" setter="set_transition_count" getter="get_transition_count" default="1">
+			Sets how many transitions the class will have, with a maximum of 48.
+		</member>
+	</members>
+	<constants>
+		<constant name="MAX_STREAMS" value="64">
+		</constant>
+		<constant name="MAX_TRANSITIONS" value="48">
+		</constant>
+	</constants>
+</class>

--- a/modules/interactive_music/register_types.cpp
+++ b/modules/interactive_music/register_types.cpp
@@ -1,0 +1,46 @@
+/*************************************************************************/
+/*  register_types.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "register_types.h"
+
+#include "audio_stream_playlist.h"
+#include "audio_stream_transitioner.h"
+#include "core/class_db.h"
+
+void register_interactive_music_types() {
+	ClassDB::register_class<AudioStreamPlaylist>();
+	ClassDB::register_class<AudioStreamPlaybackPlaylist>();
+	ClassDB::register_class<AudioStreamTransitioner>();
+	ClassDB::register_class<AudioStreamPlaybackTransitioner>();
+}
+
+void unregister_interactive_music_types() {
+	// Nothing to do here.
+}

--- a/modules/interactive_music/register_types.h
+++ b/modules/interactive_music/register_types.h
@@ -1,0 +1,37 @@
+/*************************************************************************/
+/*  register_types.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef INTERACTIVE_MUSIC_REGISTER_TYPES_H
+#define INTERACTIVE_MUSIC_REGISTER_TYPES_H
+
+void register_interactive_music_types();
+void unregister_interactive_music_types();
+
+#endif // INTERACTIVE_MUSIC_REGISTER_TYPES_H

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -246,6 +246,22 @@ float AudioStreamOGGVorbis::get_length() const {
 	return length;
 }
 
+void AudioStreamOGGVorbis::set_bpm(int p_bpm) {
+	bpm = p_bpm;
+}
+
+int AudioStreamOGGVorbis::get_bpm() const {
+	return bpm;
+}
+
+void AudioStreamOGGVorbis::set_beat_count(int p_beats) {
+	beats = p_beats;
+}
+
+int AudioStreamOGGVorbis::get_beat_count() const {
+	return beats;
+}
+
 void AudioStreamOGGVorbis::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_data", "data"), &AudioStreamOGGVorbis::set_data);
 	ClassDB::bind_method(D_METHOD("get_data"), &AudioStreamOGGVorbis::get_data);
@@ -256,9 +272,17 @@ void AudioStreamOGGVorbis::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_loop_offset", "seconds"), &AudioStreamOGGVorbis::set_loop_offset);
 	ClassDB::bind_method(D_METHOD("get_loop_offset"), &AudioStreamOGGVorbis::get_loop_offset);
 
+	ClassDB::bind_method(D_METHOD("set_bpm", "bpm"), &AudioStreamOGGVorbis::set_bpm);
+	ClassDB::bind_method(D_METHOD("get_bpm"), &AudioStreamOGGVorbis::get_bpm);
+
+	ClassDB::bind_method(D_METHOD("set_beat_count", "beats"), &AudioStreamOGGVorbis::set_beat_count);
+	ClassDB::bind_method(D_METHOD("get_beat_count"), &AudioStreamOGGVorbis::get_beat_count);
+
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_data", "get_data");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "loop_offset"), "set_loop_offset", "get_loop_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bpm"), "set_bpm", "get_bpm");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "beats"), "set_beat_count", "get_beat_count");
 }
 
 AudioStreamOGGVorbis::AudioStreamOGGVorbis() {
@@ -270,6 +294,8 @@ AudioStreamOGGVorbis::AudioStreamOGGVorbis() {
 	loop_offset = 0;
 	decode_mem_size = 0;
 	loop = false;
+	bpm = 0;
+	beats = 0;
 }
 
 AudioStreamOGGVorbis::~AudioStreamOGGVorbis() {

--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.h
@@ -85,6 +85,9 @@ class AudioStreamOGGVorbis : public AudioStream {
 	float length;
 	bool loop;
 	float loop_offset;
+	int bpm;
+	int beats;
+
 	void clear_data();
 
 protected:
@@ -96,6 +99,12 @@ public:
 
 	void set_loop_offset(float p_seconds);
 	float get_loop_offset() const;
+
+	void set_bpm(int p_bpm);
+	virtual int get_bpm() const;
+
+	void set_beat_count(int p_beats);
+	virtual int get_beat_count() const;
 
 	virtual Ref<AudioStreamPlayback> instance_playback();
 	virtual String get_stream_name() const;

--- a/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml
+++ b/modules/stb_vorbis/doc_classes/AudioStreamOGGVorbis.xml
@@ -11,6 +11,10 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="beats" type="int" setter="set_beat_count" getter="get_beat_count" default="0">
+		</member>
+		<member name="bpm" type="int" setter="set_bpm" getter="get_bpm" default="0">
+		</member>
 		<member name="data" type="PoolByteArray" setter="set_data" getter="get_data" default="PoolByteArray(  )">
 			Contains the audio data in bytes.
 		</member>

--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -67,11 +67,15 @@ String ResourceImporterOGGVorbis::get_preset_name(int p_idx) const {
 void ResourceImporterOGGVorbis::get_import_options(List<ImportOption> *r_options, int p_preset) const {
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "loop_offset"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "bpm"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::REAL, "beats"), 0));
 }
 
 Error ResourceImporterOGGVorbis::import(const String &p_source_file, const String &p_save_path, const Map<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	bool loop = p_options["loop"];
 	float loop_offset = p_options["loop_offset"];
+	int bpm = p_options["bpm"];
+	int beats = p_options["beats"];
 
 	FileAccess *f = FileAccess::open(p_source_file, FileAccess::READ);
 
@@ -94,6 +98,8 @@ Error ResourceImporterOGGVorbis::import(const String &p_source_file, const Strin
 	ERR_FAIL_COND_V_MSG(!ogg_stream->get_data().size(), ERR_FILE_CORRUPT, "Couldn't import file as AudioStreamOGGVorbis: " + p_source_file);
 	ogg_stream->set_loop(loop);
 	ogg_stream->set_loop_offset(loop_offset);
+	ogg_stream->set_bpm(bpm);
+	ogg_stream->set_beat_count(beats);
 
 	return ResourceSaver::save(p_save_path + ".oggstr", ogg_stream);
 }

--- a/scene/resources/audio_stream_sample.cpp
+++ b/scene/resources/audio_stream_sample.cpp
@@ -453,6 +453,22 @@ bool AudioStreamSample::is_stereo() const {
 	return stereo;
 }
 
+void AudioStreamSample::set_bpm(int p_bpm) {
+	bpm = p_bpm;
+}
+
+int AudioStreamSample::get_bpm() const {
+	return bpm;
+}
+
+void AudioStreamSample::set_beat_count(int p_beats) {
+	beats = p_beats;
+}
+
+int AudioStreamSample::get_beat_count() const {
+	return beats;
+}
+
 float AudioStreamSample::get_length() const {
 	int len = data_bytes;
 	switch (format) {
@@ -623,6 +639,12 @@ void AudioStreamSample::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stereo", "stereo"), &AudioStreamSample::set_stereo);
 	ClassDB::bind_method(D_METHOD("is_stereo"), &AudioStreamSample::is_stereo);
 
+	ClassDB::bind_method(D_METHOD("set_bpm", "bpm"), &AudioStreamSample::set_bpm);
+	ClassDB::bind_method(D_METHOD("get_bpm"), &AudioStreamSample::get_bpm);
+
+	ClassDB::bind_method(D_METHOD("set_beat_count", "beats"), &AudioStreamSample::set_beat_count);
+	ClassDB::bind_method(D_METHOD("get_beat_count"), &AudioStreamSample::get_beat_count);
+
 	ClassDB::bind_method(D_METHOD("save_to_wav", "path"), &AudioStreamSample::save_to_wav);
 
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR), "set_data", "get_data");
@@ -632,6 +654,8 @@ void AudioStreamSample::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_end"), "set_loop_end", "get_loop_end");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mix_rate"), "set_mix_rate", "get_mix_rate");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stereo"), "set_stereo", "is_stereo");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bpm"), "set_bpm", "get_bpm");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "beats"), "set_beat_count", "get_beat_count");
 
 	BIND_ENUM_CONSTANT(FORMAT_8_BITS);
 	BIND_ENUM_CONSTANT(FORMAT_16_BITS);
@@ -652,6 +676,8 @@ AudioStreamSample::AudioStreamSample() {
 	mix_rate = 44100;
 	data = nullptr;
 	data_bytes = 0;
+	bpm = 0;
+	beats = 0;
 }
 
 AudioStreamSample::~AudioStreamSample() {

--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -112,6 +112,8 @@ private:
 	int mix_rate;
 	void *data;
 	uint32_t data_bytes;
+	int bpm;
+	int beats;
 
 protected:
 	static void _bind_methods();
@@ -134,6 +136,12 @@ public:
 
 	void set_stereo(bool p_enable);
 	bool is_stereo() const;
+
+	void set_bpm(int p_bpm);
+	virtual int get_bpm() const;
+
+	void set_beat_count(int p_beats);
+	virtual int get_beat_count() const;
 
 	virtual float get_length() const; //if supported, otherwise return 0
 

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -92,6 +92,14 @@ void AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale,
 
 ////////////////////////////////
 
+int AudioStream::get_bpm() const {
+	return 0;
+}
+
+int AudioStream::get_beat_count() const {
+	return 0;
+}
+
 void AudioStream::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_length"), &AudioStream::get_length);
 }

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -89,6 +89,9 @@ public:
 	virtual String get_stream_name() const = 0;
 
 	virtual float get_length() const = 0; //if supported, otherwise return 0
+
+	virtual int get_bpm() const;
+	virtual int get_beat_count() const;
 };
 
 // Microphone


### PR DESCRIPTION
This is a redo of #32769 by @DanielMatarov targeting the `3.x` branch.

Squashing the commits in #32769 and doing a subsequent rebase was near impossible, so instead I just copied the changes over to latest `3.x` (as this dates back to 2019 so it's easier to compile on `3.x`, it will need further work to compile on `master`), and fixed various style issues.

I don't intend to work on this myself, I just ported it to help @reduz who's trying to bring this in latest `master` in a clean way. I didn't test if the feature still works, just that it compiles.

This might or might not eventually be backported to the `3.x` branch again for 3.6, but for now this is just targeting `3.x` as the branch closest to 2019's `master`.