### PR TITLE
Add/fix support for RID, Callable and Signal in editor properties

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1304,7 +1304,7 @@ void EditorPropertyObjectID::update_property() {
 
 	ObjectID id = get_edited_object()->get(get_edited_property());
 	if (id.is_valid()) {
-		edit->set_text(type + " ID: " + itos(id));
+		edit->set_text(type + " ID: " + uitos(id));
 		edit->set_disabled(false);
 		edit->set_icon(EditorNode::get_singleton()->get_class_icon(type));
 	} else {
@@ -1326,6 +1326,54 @@ EditorPropertyObjectID::EditorPropertyObjectID() {
 	add_child(edit);
 	add_focusable(edit);
 	edit->connect("pressed", callable_mp(this, &EditorPropertyObjectID::_edit_pressed));
+}
+
+///////////////////// SIGNAL /////////////////////////
+
+void EditorPropertySignal::_edit_pressed() {
+	Signal signal = get_edited_object()->get(get_edited_property());
+	emit_signal(SNAME("object_id_selected"), get_edited_property(), signal.get_object_id());
+}
+
+void EditorPropertySignal::update_property() {
+	String type = base_type;
+
+	Signal signal = get_edited_object()->get(get_edited_property());
+
+	edit->set_text("Signal: " + signal.get_name());
+	edit->set_disabled(false);
+	edit->set_icon(get_theme_icon(SNAME("Signals"), SNAME("EditorIcons")));
+}
+
+void EditorPropertySignal::_bind_methods() {
+}
+
+EditorPropertySignal::EditorPropertySignal() {
+	edit = memnew(Button);
+	add_child(edit);
+	add_focusable(edit);
+	edit->connect("pressed", callable_mp(this, &EditorPropertySignal::_edit_pressed));
+}
+
+///////////////////// CALLABLE /////////////////////////
+
+void EditorPropertyCallable::update_property() {
+	String type = base_type;
+
+	Callable callable = get_edited_object()->get(get_edited_property());
+
+	edit->set_text("Callable");
+	edit->set_disabled(true);
+	edit->set_icon(get_theme_icon(SNAME("Callable"), SNAME("EditorIcons")));
+}
+
+void EditorPropertyCallable::_bind_methods() {
+}
+
+EditorPropertyCallable::EditorPropertyCallable() {
+	edit = memnew(Button);
+	add_child(edit);
+	add_focusable(edit);
 }
 
 ///////////////////// FLOAT /////////////////////////
@@ -3222,8 +3270,8 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 void EditorPropertyRID::update_property() {
 	RID rid = get_edited_object()->get(get_edited_property());
 	if (rid.is_valid()) {
-		int id = rid.get_id();
-		label->set_text("RID: " + itos(id));
+		uint64_t id = rid.get_id();
+		label->set_text("RID: " + uitos(id));
 	} else {
 		label->set_text(TTR("Invalid RID"));
 	}
@@ -4001,6 +4049,14 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			}
 
+		} break;
+		case Variant::CALLABLE: {
+			EditorPropertyCallable *editor = memnew(EditorPropertyCallable);
+			return editor;
+		} break;
+		case Variant::SIGNAL: {
+			EditorPropertySignal *editor = memnew(EditorPropertySignal);
+			return editor;
 		} break;
 		case Variant::DICTIONARY: {
 			if (p_hint == PROPERTY_HINT_LOCALIZABLE_STRING) {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -389,6 +389,33 @@ public:
 	EditorPropertyObjectID();
 };
 
+class EditorPropertySignal : public EditorProperty {
+	GDCLASS(EditorPropertySignal, EditorProperty);
+	Button *edit = nullptr;
+	String base_type;
+	void _edit_pressed();
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual void update_property() override;
+	EditorPropertySignal();
+};
+
+class EditorPropertyCallable : public EditorProperty {
+	GDCLASS(EditorPropertyCallable, EditorProperty);
+	Button *edit = nullptr;
+	String base_type;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual void update_property() override;
+	EditorPropertyCallable();
+};
+
 class EditorPropertyFloat : public EditorProperty {
 	GDCLASS(EditorPropertyFloat, EditorProperty);
 	EditorSpinSlider *spin = nullptr;


### PR DESCRIPTION
Callable and Signal editor properties were missing, causing the editor to crash when expanding an array containing one of them. Also, the RID editor property was always showing "Invalid RID" due to missing of serialization.

So, I added serialization for RID and Signal (but not Callable, since it's not always serializable when using custom callables), but maybe it was not the best thing to do?

Then, I added missing editor properties for Signal and Callable, as seen below:
![Editor Properties](https://user-images.githubusercontent.com/13206601/176569755-179dd010-fca8-4b58-b5db-4f7ee1bceb6b.png)


Fixes #62171