### PR TITLE
[3.x] X11: Properly check for fullscreen toggle made through the Window Manager

### DIFF
--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -247,6 +247,7 @@ protected:
 	void _window_changed(XEvent *event);
 
 	bool window_maximize_check(const char *p_atom_name) const;
+	bool window_fullscreen_check() const;
 	bool is_window_maximize_allowed() const;
 
 public:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #40007.

I'm unable to check if `master` is affected since the Editor does not open for me on that branch.

