### PR TITLE
Evaluate specular reflections using specular dominant direction

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1049,6 +1049,7 @@ void main() {
 #else
 		vec3 ref_vec = reflect(-view, normal);
 #endif
+		ref_vec = mix(ref_vec, normal, roughness * roughness);
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
 		specular_light = textureLod(radiance_map, ref_vec, roughness * RADIANCE_MAX_LOD).rgb;

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -869,15 +869,13 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			diffuse_light, specular_light);
 }
 
-void reflection_process(uint ref_index, vec3 view, vec3 vertex, vec3 normal, float roughness, vec3 ambient_light, vec3 specular_light, inout vec4 ambient_accum, inout vec4 reflection_accum) {
+void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, float roughness, vec3 ambient_light, vec3 specular_light, inout vec4 ambient_accum, inout vec4 reflection_accum) {
 	vec3 box_extents = reflections.data[ref_index].box_extents;
 	vec3 local_pos = (reflections.data[ref_index].local_matrix * vec4(vertex, 1.0)).xyz;
 
 	if (any(greaterThan(abs(local_pos), box_extents))) { //out of the reflection box
 		return;
 	}
-
-	vec3 ref_vec = normalize(reflect(-view, normal));
 
 	vec3 inner_pos = abs(local_pos / box_extents);
 	float blend = max(inner_pos.x, max(inner_pos.y, inner_pos.z));

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -889,8 +889,10 @@ void main() {
 		vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
 		vec3 ref_vec = reflect(-view, bent_normal);
+		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
 #else
 		vec3 ref_vec = reflect(-view, normal);
+		ref_vec = mix(ref_vec, normal, roughness * roughness);
 #endif
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
@@ -940,6 +942,7 @@ void main() {
 		vec3 n = normalize(normal_interp); // We want to use geometric normal, not normal_map
 		float NoV = max(dot(n, view), 0.0001);
 		vec3 ref_vec = reflect(-view, n);
+		ref_vec = mix(ref_vec, n, clearcoat_roughness * clearcoat_roughness);
 		// The clear coat layer assumes an IOR of 1.5 (4% reflectance)
 		float Fc = clearcoat * (0.04 + 0.96 * SchlickFresnel(NoV));
 		float attenuation = 1.0 - Fc;
@@ -1036,6 +1039,19 @@ void main() {
 		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
 
 		uint reflection_indices = draw_call.reflection_probes.x;
+
+#ifdef LIGHT_ANISOTROPY_USED
+		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
+		vec3 anisotropic_direction = anisotropy >= 0.0 ? binormal : tangent;
+		vec3 anisotropic_tangent = cross(anisotropic_direction, view);
+		vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
+		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
+#else
+		vec3 bent_normal = normal;
+#endif
+		vec3 ref_vec = normalize(reflect(-view, bent_normal));
+		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
+
 		for (uint i = 0; i < 8; i++) {
 			uint reflection_index = reflection_indices & 0xFF;
 			if (i == 4) {
@@ -1047,16 +1063,8 @@ void main() {
 			if (reflection_index == 0xFF) {
 				break;
 			}
-#ifdef LIGHT_ANISOTROPY_USED
-			// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
-			vec3 anisotropic_direction = anisotropy >= 0.0 ? binormal : tangent;
-			vec3 anisotropic_tangent = cross(anisotropic_direction, view);
-			vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
-			vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
-#else
-			vec3 bent_normal = normal;
-#endif
-			reflection_process(reflection_index, view, vertex, bent_normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
+
+			reflection_process(reflection_index, vertex, ref_vec, bent_normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
 		}
 
 		if (reflection_accum.a > 0.0) {


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/62359

Specular BRDFs should be evaluated based on their dominant direction which lies somewhere between the surface normal and the reflection vector (generally tends towards normal with an increase in roughness. Currently in Godot, we always assume that the dominant direction lies along the reflection vector. Accordingly, when looking up reflections, we end up treating rough metals like perfect mirrors. This results in an improper specular color.

See page 69 of the [Moving Frostbite to PBR course notes](https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf) for more details. The author recommends a simple linear fitted model. [Filament ](https://github.com/google/filament/blob/05792fa5f47964887f68476c5e2f0a7d5f4bb434/shaders/src/light_indirect.fs#L118-L120)simplifies as: reflection = mix(reflection, normal, roughness * roughness);

The examples below use a ReflectionProbe and Spheres with metallic and roughness of 1 to highlight the problem/solution.

_Before: notice the black patch at the bottom of the sphere_
![Screenshot from 2022-06-29 23-41-37](https://user-images.githubusercontent.com/16521339/176610231-e25b8513-3e31-47f4-9952-c98956dbee1a.png)

_After: black patch is gone_
![Screenshot from 2022-06-29 23-42-05](https://user-images.githubusercontent.com/16521339/176610229-b56587e2-3c10-4401-af40-b76efb251994.png)

_Before: Notice how the emissive box reflection appears to wrap around the sphere_
![Screenshot from 2022-06-29 23-42-49](https://user-images.githubusercontent.com/16521339/176610222-959414ba-4be5-4616-9b31-a02c45b8496e.png)

_After: the Color from the emissive box no longer wraps around_
![Screenshot from 2022-06-29 23-42-16](https://user-images.githubusercontent.com/16521339/176610224-543711ac-dc9e-4bcf-b74e-17ae5b1ba5ab.png)


