### PR TITLE
Command line argument '--version' returns exit code 0 instead of 255

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -673,6 +673,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	packed_data->add_pack_source(zip_packed_data);
 #endif
 
+	// Default exit code, can be modified for certain errors.
+	Error exit_code = ERR_INVALID_PARAMETER;
+
 	I = args.front();
 	while (I) {
 #ifdef OSX_ENABLED
@@ -688,10 +691,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
 
 			show_help = true;
+			exit_code = OK;
 			goto error;
 
 		} else if (I->get() == "--version") {
 			print_line(get_full_version_string());
+			exit_code = OK;
 			goto error;
 
 		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output
@@ -1636,7 +1641,7 @@ error:
 	OS::get_singleton()->finalize_core();
 	locale = String();
 
-	return ERR_INVALID_PARAMETER;
+	return exit_code;
 }
 
 Error Main::setup2(Thread::ID p_main_tid_override) {


### PR DESCRIPTION
Allows to detect whether printing the version was successful and makes integration with shell scripts straightforward.

Minor thing: `--version` is usually read by tools (CI, shell scripts, bindings) and at the moment, an extra newline is being printed, which requires trimming. On the other hand, it makes things a bit more readable for humans. Let me know if the current behavior is good as it is.