### PR TITLE
X11: Properly check for fullscreen toggle made through the Window Manager

### DIFF
--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -265,6 +265,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	void _update_real_mouse_position(const WindowData &wd);
 	bool _window_maximize_check(WindowID p_window, const char *p_atom_name) const;
+	bool _window_fullscreen_check(WindowID p_window) const;
 	void _update_size_hints(WindowID p_window);
 	void _set_wm_fullscreen(WindowID p_window, bool p_enabled);
 	void _set_wm_maximized(WindowID p_window, bool p_enabled);


### PR DESCRIPTION
Fixes #40007.

`master` port of #62543.

As a side note, there's quite some code duplication in the checks for WM properties, we could maybe figure out a way to make a common helper method to simplify the code (for fullscreen, maximized and minimized checks done currently, maybe more).