### PR TITLE
Errors: Fallback to `fprintf` if `OS` singleton doesn't exist

### DIFF
--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -83,7 +83,13 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 
 // Main error printing function.
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, bool p_editor_notify, ErrorHandlerType p_type) {
-	OS::get_singleton()->print_error(p_function, p_file, p_line, p_error, p_message, p_editor_notify, (Logger::ErrorType)p_type);
+	if (OS::get_singleton()) {
+		OS::get_singleton()->print_error(p_function, p_file, p_line, p_error, p_message, p_editor_notify, (Logger::ErrorType)p_type);
+	} else {
+		// Fallback if errors happen before OS init or after it's destroyed.
+		const char *err_details = (p_message && *p_message) ? p_message : p_error;
+		fprintf(stderr, "ERROR: %s\n   at: %s (%s:%i)\n", err_details, p_function, p_file, p_line);
+	}
 
 	_global_lock();
 	ErrorHandlerList *l = error_handler_list;


### PR DESCRIPTION
Otherwise we would crash if something prints an error before init or
after destruction of the `OS` singleton which handles printing/logging.

Example of such crash, triggered with `VK_ICD_FILENAMES= godot` to run Godot on Linux without valid Vulkan driver.
```
Thread 1 "godot-git" received signal SIGSEGV, Segmentation fault.
0x00000000062e885d in OS::print_error (this=0x0, p_function=0x9558229 "unref", p_file=0x9558088 "core/string/string_name.cpp", p_line=131, p_code=0xa463e70 "BUG: Unreferenced static string to 0: interface_added", p_rationale=0x957e1e8 "", p_editor_notify=false, p_type=Logger::ERR_ERROR) at core/os/os.cpp:79
79              if (!_stderr_enabled) {
(gdb) bt
#0  0x00000000062e885d in OS::print_error (this=0x0, p_function=0x9558229 "unref", p_file=0x9558088 "core/string/string_name.cpp", p_line=131, 
    p_code=0xa463e70 "BUG: Unreferenced static string to 0: interface_added", p_rationale=0x957e1e8 "", p_editor_notify=false, p_type=Logger::ERR_ERROR) at core/os/os.cpp:79
#1  0x0000000006842493 in _err_print_error (p_function=0x9558229 "unref", p_file=0x9558088 "core/string/string_name.cpp", p_line=131, p_error=0xa463e70 "BUG: Unreferenced static string to 0: interface_added", 
    p_message=0x957e1e8 "", p_editor_notify=false, p_type=ERR_HANDLER_ERROR) at core/error/error_macros.cpp:86
#2  0x0000000006842411 in _err_print_error (p_function=0x9558229 "unref", p_file=0x9558088 "core/string/string_name.cpp", p_line=131, p_error=..., p_editor_notify=false, p_type=ERR_HANDLER_ERROR)
    at core/error/error_macros.cpp:81
#3  0x00000000067fae75 in StringName::unref (this=0xa043b40) at core/string/string_name.cpp:131
#4  0x000000000228d743 in StringName::~StringName (this=0xa043b40, __in_chrg=<optimized out>) at ./core/string/string_name.h:181
#5  0x00000000067a6896 in KeyValue<StringName, MethodInfo>::~KeyValue (this=0xa043b40, __in_chrg=<optimized out>) at ./core/templates/pair.h:82
#6  0x00000000067a68b6 in HashMapElement<StringName, MethodInfo>::~HashMapElement (this=0xa043b30, __in_chrg=<optimized out>) at ./core/templates/hash_map.h:55
#7  0x00000000067aaca3 in memdelete<HashMapElement<StringName, MethodInfo> > (p_class=0xa043b30) at ./core/os/memory.h:108
#8  0x00000000067a90e0 in DefaultTypedAllocator<HashMapElement<StringName, MethodInfo> >::delete_allocation (this=0xa04561c, p_allocation=0xa043b30) at ./core/os/memory.h:205
#9  0x00000000067a63f6 in HashMap<StringName, MethodInfo, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, MethodInfo> > >::clear (this=0xa045610)
    at ./core/templates/hash_map.h:265
#10 0x00000000067a443c in HashMap<StringName, MethodInfo, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, MethodInfo> > >::~HashMap (this=0xa045610, 
    __in_chrg=<optimized out>) at ./core/templates/hash_map.h:582
#11 0x00000000067a3ea6 in ClassDB::ClassInfo::~ClassInfo (this=0xa045548, __in_chrg=<optimized out>) at core/object/class_db.h:129
#12 0x00000000067a6e1c in KeyValue<StringName, ClassDB::ClassInfo>::~KeyValue (this=0xa045540, __in_chrg=<optimized out>) at ./core/templates/pair.h:82
#13 0x00000000067a6e48 in HashMapElement<StringName, ClassDB::ClassInfo>::~HashMapElement (this=0xa045530, __in_chrg=<optimized out>) at ./core/templates/hash_map.h:55
#14 0x00000000067aa72f in memdelete<HashMapElement<StringName, ClassDB::ClassInfo> > (p_class=0xa045530) at ./core/os/memory.h:108
#15 0x00000000067a8b46 in DefaultTypedAllocator<HashMapElement<StringName, ClassDB::ClassInfo> >::delete_allocation (this=0x9d7c60c <ClassDB::classes+12>, p_allocation=0xa045530) at ./core/os/memory.h:205
#16 0x00000000067a6120 in HashMap<StringName, ClassDB::ClassInfo, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, ClassDB::ClassInfo> > >::clear (
    this=0x9d7c600 <ClassDB::classes>) at ./core/templates/hash_map.h:265
#17 0x00000000067acac6 in HashMap<StringName, ClassDB::ClassInfo, HashMapHasherDefault, HashMapComparatorDefault<StringName>, DefaultTypedAllocator<HashMapElement<StringName, ClassDB::ClassInfo> > >::~HashMap (
    this=0x9d7c600 <ClassDB::classes>, __in_chrg=<optimized out>) at ./core/templates/hash_map.h:582
#18 0x00007ffff7a935e5 in __run_exit_handlers () from /lib64/libc.so.6
#19 0x00007ffff7a9375a in exit () from /lib64/libc.so.6
#20 0x00007ffff7a7e17e in __libc_start_call_main () from /lib64/libc.so.6
#21 0x00007ffff7a7e235 in __libc_start_main_impl () from /lib64/libc.so.6
#22 0x000000000228bd61 in _start ()
```