### PR TITLE
DisplayServer: Don't fallback to headless

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1460,11 +1460,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	/* Determine audio and video drivers */
 
 	// Display driver, e.g. X11, Wayland.
-	// print_line("requested display driver : " + display_driver);
+	// Make sure that headless is the last one, which it is assumed to be by design.
+	DEV_ASSERT(String("headless") == DisplayServer::get_create_function_name(DisplayServer::get_create_function_count() - 1));
 	for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
 		String name = DisplayServer::get_create_function_name(i);
-		// print_line("\t" + itos(i) + " : " + name);
-
 		if (display_driver == name) {
 			display_driver_idx = i;
 			break;
@@ -1472,6 +1471,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (display_driver_idx < 0) {
+		// If the requested driver wasn't found, pick the first entry.
+		// If all else failed it would be the headless server.
 		display_driver_idx = 0;
 	}
 
@@ -1484,6 +1485,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		audio_driver = GLOBAL_GET("audio/driver/driver");
 	}
 
+	// Make sure that dummy is the last one, which it is assumed to be by design.
+	DEV_ASSERT(String("Dummy") == AudioDriverManager::get_driver(AudioDriverManager::get_driver_count() - 1)->get_name());
 	for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
 		if (audio_driver == AudioDriverManager::get_driver(i)->get_name()) {
 			audio_driver_idx = i;
@@ -1492,7 +1495,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	if (audio_driver_idx < 0) {
-		audio_driver_idx = 0; // 0 Is always available as the dummy driver (no sound)
+		// If the requested driver wasn't found, pick the first entry.
+		// If all else failed it would be the dummy driver (no sound).
+		audio_driver_idx = 0;
 	}
 
 	if (write_movie_path != String()) {
@@ -1685,10 +1690,12 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		Error err;
 		display_server = DisplayServer::create(display_driver_idx, rendering_driver, window_mode, window_vsync_mode, window_flags, window_size, err);
 		if (err != OK || display_server == nullptr) {
-			//ok i guess we can't use this display server, try other ones
-			for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
+			// We can't use this display server, try other ones as fallback.
+			// Skip headless (always last registered) because that's not what users
+			// would expect if they didn't request it explicitly.
+			for (int i = 0; i < DisplayServer::get_create_function_count() - 1; i++) {
 				if (i == display_driver_idx) {
-					continue; //don't try the same twice
+					continue; // Don't try the same twice.
 				}
 				display_server = DisplayServer::create(i, rendering_driver, window_mode, window_vsync_mode, window_flags, window_size, err);
 				if (err == OK && display_server != nullptr) {


### PR DESCRIPTION
Unless users requested the headless driver specifically, they expect to either
see a window, or that the process terminates if there's an error.

Currently it would fallback to headless so they'd unexpectedly get a valid headless
instance if their DisplayServer failed initializing (e.g. missing Vulkan support).

- Fixes #58414.
- Supersedes #59074.

---

Depends on #62555, otherwise it's crashing on exit in the case where it couldn't initialize a DisplayServer.
With #62555, it prints an error instead (which itself is likely a bug that could be fixed independently):
```
$ VK_ICD_FILENAMES= godot-git
Godot Engine v4.0.alpha.custom_build.e7197cb6f - https://godotengine.org
ERROR: No surface extension found, is a driver installed?
   at: _initialize_extensions (drivers/vulkan/vulkan_context.cpp:353)
ERROR: Could not initialize Vulkan
   at: DisplayServerX11 (platform/linuxbsd/display_server_x11.cpp:4684)
ERROR: Unable to create DisplayServer, all display drivers failed.
   at: setup2 (main/main.cpp:1700)
ERROR: BUG: Unreferenced static string to 0: interface_added
   at: unref (core/string/string_name.cpp:131)
```

The last `ERROR` here is printed using the fallback.