### PR TITLE
Rename Object.get_indexed() to Object.get_by_path()

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -391,7 +391,7 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 	}
 }
 
-void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid) {
+void Object::set_by_path(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid) {
 	if (p_names.is_empty()) {
 		if (r_valid) {
 			*r_valid = false;
@@ -450,7 +450,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	ERR_FAIL_COND(!value_stack.is_empty());
 }
 
-Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) const {
+Variant Object::get_by_path(const Vector<StringName> &p_names, bool *r_valid) const {
 	if (p_names.is_empty()) {
 		if (r_valid) {
 			*r_valid = false;
@@ -1324,12 +1324,12 @@ Variant Object::_get_bind(const StringName &p_name) const {
 	return get(p_name);
 }
 
-void Object::_set_indexed_bind(const NodePath &p_name, const Variant &p_value) {
-	set_indexed(p_name.get_as_property_path().get_subnames(), p_value);
+void Object::_set_by_path_bind(const NodePath &p_name, const Variant &p_value) {
+	set_by_path(p_name.get_as_property_path().get_subnames(), p_value);
 }
 
-Variant Object::_get_indexed_bind(const NodePath &p_name) const {
-	return get_indexed(p_name.get_as_property_path().get_subnames());
+Variant Object::_get_by_path_bind(const NodePath &p_name) const {
+	return get_by_path(p_name.get_as_property_path().get_subnames());
 }
 
 void Object::initialize_class() {
@@ -1437,8 +1437,8 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
 	ClassDB::bind_method(D_METHOD("set", "property", "value"), &Object::_set_bind);
 	ClassDB::bind_method(D_METHOD("get", "property"), &Object::_get_bind);
-	ClassDB::bind_method(D_METHOD("set_indexed", "property", "value"), &Object::_set_indexed_bind);
-	ClassDB::bind_method(D_METHOD("get_indexed", "property"), &Object::_get_indexed_bind);
+	ClassDB::bind_method(D_METHOD("set_by_path", "property", "value"), &Object::_set_by_path_bind);
+	ClassDB::bind_method(D_METHOD("get_by_path", "property"), &Object::_get_by_path_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);
 	ClassDB::bind_method(D_METHOD("get_method_list"), &Object::_get_method_list_bind);
 	ClassDB::bind_method(D_METHOD("notification", "what", "reversed"), &Object::notification, DEFVAL(false));

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -577,8 +577,8 @@ private:
 	Array _get_incoming_connections() const;
 	void _set_bind(const StringName &p_set, const Variant &p_value);
 	Variant _get_bind(const StringName &p_name) const;
-	void _set_indexed_bind(const NodePath &p_name, const Variant &p_value);
-	Variant _get_indexed_bind(const NodePath &p_name) const;
+	void _set_by_path_bind(const NodePath &p_name, const Variant &p_value);
+	Variant _get_by_path_bind(const NodePath &p_name) const;
 
 	_FORCE_INLINE_ void _construct_object(bool p_reference);
 
@@ -759,8 +759,8 @@ public:
 
 	void set(const StringName &p_name, const Variant &p_value, bool *r_valid = nullptr);
 	Variant get(const StringName &p_name, bool *r_valid = nullptr) const;
-	void set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid = nullptr);
-	Variant get_indexed(const Vector<StringName> &p_names, bool *r_valid = nullptr) const;
+	void set_by_path(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid = nullptr);
+	Variant get_by_path(const Vector<StringName> &p_names, bool *r_valid = nullptr) const;
 
 	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
 

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -348,7 +348,7 @@
 				- [code]method_name[/code] is the name of the method to which the signal is connected.
 			</description>
 		</method>
-		<method name="get_indexed" qualifiers="const">
+		<method name="get_by_path" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="property" type="NodePath" />
 			<description>
@@ -513,7 +513,7 @@
 				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
 			</description>
 		</method>
-		<method name="set_indexed">
+		<method name="set_by_path">
 			<return type="void" />
 			<argument index="0" name="property" type="NodePath" />
 			<argument index="1" name="value" type="Variant" />

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -331,6 +331,14 @@
 				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
 			</description>
 		</method>
+		<method name="get_by_path" qualifiers="const">
+			<return type="Variant" />
+			<argument index="0" name="property" type="NodePath" />
+			<description>
+				Gets the object's property indexed by the given [NodePath]. The node path should be relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Examples: [code]"position:x"[/code] or [code]"material:next_pass:blend_mode"[/code].
+				[b]Note:[/b] Even though the method takes [NodePath] argument, it doesn't support actual paths to [Node]s in the scene tree, only colon-separated sub-property paths. For the purpose of nodes, use [method Node.get_node_and_resource] instead.
+			</description>
+		</method>
 		<method name="get_class" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -346,14 +354,6 @@
 				- [code]source[/code] is a reference to the signal emitter.
 				- [code]signal_name[/code] is the name of the connected signal.
 				- [code]method_name[/code] is the name of the method to which the signal is connected.
-			</description>
-		</method>
-		<method name="get_by_path" qualifiers="const">
-			<return type="Variant" />
-			<argument index="0" name="property" type="NodePath" />
-			<description>
-				Gets the object's property indexed by the given [NodePath]. The node path should be relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Examples: [code]"position:x"[/code] or [code]"material:next_pass:blend_mode"[/code].
-				[b]Note:[/b] Even though the method takes [NodePath] argument, it doesn't support actual paths to [Node]s in the scene tree, only colon-separated sub-property paths. For the purpose of nodes, use [method Node.get_node_and_resource] instead.
 			</description>
 		</method>
 		<method name="get_instance_id" qualifiers="const">
@@ -504,15 +504,6 @@
 				If set to [code]true[/code], signal emission is blocked.
 			</description>
 		</method>
-		<method name="set_deferred">
-			<return type="void" />
-			<argument index="0" name="property" type="StringName" />
-			<argument index="1" name="value" type="Variant" />
-			<description>
-				Assigns a new value to the given property, after the current frame's physics step. This is equivalent to calling [method set] via [method call_deferred], i.e. [code]call_deferred("set", property, value)[/code].
-				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
-			</description>
-		</method>
 		<method name="set_by_path">
 			<return type="void" />
 			<argument index="0" name="property" type="NodePath" />
@@ -533,6 +524,15 @@
 				GD.Print(node.Position); // (42, -10)
 				[/csharp]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="set_deferred">
+			<return type="void" />
+			<argument index="0" name="property" type="StringName" />
+			<argument index="1" name="value" type="Variant" />
+			<description>
+				Assigns a new value to the given property, after the current frame's physics step. This is equivalent to calling [method set] via [method call_deferred], i.e. [code]call_deferred("set", property, value)[/code].
+				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
 			</description>
 		</method>
 		<method name="set_message_translation">

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4132,12 +4132,12 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 	if (res.is_valid()) {
 		property_info_base = res;
 		if (r_current_val) {
-			*r_current_val = res->get_indexed(leftover_path);
+			*r_current_val = res->get_by_path(leftover_path);
 		}
 	} else if (node) {
 		property_info_base = node;
 		if (r_current_val) {
-			*r_current_val = node->get_indexed(leftover_path);
+			*r_current_val = node->get_by_path(leftover_path);
 		}
 	}
 

--- a/modules/visual_script/doc_classes/VisualScriptPropertyGet.xml
+++ b/modules/visual_script/doc_classes/VisualScriptPropertyGet.xml
@@ -19,7 +19,7 @@
 			The type to be used when [member set_mode] is set to [constant CALL_MODE_BASIC_TYPE].
 		</member>
 		<member name="index" type="StringName" setter="set_index" getter="get_index">
-			The indexed name of the property to retrieve. See [method Object.get_indexed] for details.
+			The indexed name of the property to retrieve. See [method Object.get_by_path] for details.
 		</member>
 		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path">
 			The node path to use when [member set_mode] is set to [constant CALL_MODE_NODE_PATH].

--- a/modules/visual_script/doc_classes/VisualScriptPropertySet.xml
+++ b/modules/visual_script/doc_classes/VisualScriptPropertySet.xml
@@ -22,7 +22,7 @@
 			The type to be used when [member set_mode] is set to [constant CALL_MODE_BASIC_TYPE].
 		</member>
 		<member name="index" type="StringName" setter="set_index" getter="get_index">
-			The indexed name of the property to set. See [method Object.set_indexed] for details.
+			The indexed name of the property to set. See [method Object.set_by_path] for details.
 		</member>
 		<member name="node_path" type="NodePath" setter="set_base_path" getter="get_base_path">
 			The node path to use when [member set_mode] is set to [constant CALL_MODE_NODE_PATH].

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -58,7 +58,7 @@ void AnimatedValuesBackup::restore() const {
 	for (int i = 0; i < entries.size(); i++) {
 		const AnimatedValuesBackup::Entry *entry = &entries[i];
 		if (entry->bone_idx == -1) {
-			entry->object->set_indexed(entry->subpath, entry->value);
+			entry->object->set_by_path(entry->subpath, entry->value);
 		} else {
 			Array arr = entry->value;
 			if (arr.size() == 3) {
@@ -602,7 +602,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 
 				if (update_mode == Animation::UPDATE_CAPTURE) {
 					if (p_started || pa->capture == Variant()) {
-						pa->capture = pa->object->get_indexed(pa->subpath);
+						pa->capture = pa->object->get_by_path(pa->subpath);
 					}
 
 					int key_count = a->track_get_key_count(i);
@@ -668,7 +668,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 						switch (pa->special) {
 							case SP_NONE: {
 								bool valid;
-								pa->object->set_indexed(pa->subpath, value, &valid); //you are not speshul
+								pa->object->set_by_path(pa->subpath, value, &valid); //you are not speshul
 #ifdef DEBUG_ENABLED
 								if (!valid) {
 									ERR_PRINT("Failed setting track value '" + String(pa->owner->path) + "'. Check if the property exists or the type of key is valid. Animation '" + a->get_name() + "' at node '" + get_path() + "'.");
@@ -1087,7 +1087,7 @@ void AnimationPlayer::_animation_update_transforms() {
 		switch (pa->special) {
 			case SP_NONE: {
 				bool valid;
-				pa->object->set_indexed(pa->subpath, pa->value_accum, &valid); //you are not speshul
+				pa->object->set_by_path(pa->subpath, pa->value_accum, &valid); //you are not speshul
 #ifdef DEBUG_ENABLED
 
 				if (!valid) {
@@ -1146,7 +1146,7 @@ void AnimationPlayer::_animation_update_transforms() {
 		TrackNodeCache::BezierAnim *ba = cache_update_bezier[i];
 
 		ERR_CONTINUE(ba->accum_pass != accum_pass);
-		ba->object->set_indexed(ba->bezier_property, ba->bezier_accum);
+		ba->object->set_by_path(ba->bezier_property, ba->bezier_accum);
 	}
 
 	cache_update_bezier_size = 0;
@@ -1969,7 +1969,7 @@ Ref<AnimatedValuesBackup> AnimationPlayer::backup_animated_values(Node *p_root_o
 					entry.object = E.value.object;
 					entry.subpath = E.value.subpath;
 					bool valid;
-					entry.value = E.value.object->get_indexed(E.value.subpath, &valid);
+					entry.value = E.value.object->get_by_path(E.value.subpath, &valid);
 					entry.bone_idx = -1;
 					if (valid) {
 						backup->entries.push_back(entry);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1342,13 +1342,13 @@ void AnimationTree::_process_graph(double p_delta) {
 									continue;
 								}
 								Variant value = a->track_get_key_value(i, idx);
-								t->object->set_indexed(t->subpath, value);
+								t->object->set_by_path(t->subpath, value);
 							} else {
 								List<int> indices;
 								a->value_track_get_key_indices(i, time, delta, &indices, pingponged);
 								for (int &F : indices) {
 									Variant value = a->track_get_key_value(i, F);
-									t->object->set_indexed(t->subpath, value);
+									t->object->set_by_path(t->subpath, value);
 								}
 							}
 						}
@@ -1645,13 +1645,13 @@ void AnimationTree::_process_graph(double p_delta) {
 				case Animation::TYPE_VALUE: {
 					TrackCacheValue *t = static_cast<TrackCacheValue *>(track);
 
-					t->object->set_indexed(t->subpath, t->value);
+					t->object->set_by_path(t->subpath, t->value);
 
 				} break;
 				case Animation::TYPE_BEZIER: {
 					TrackCacheBezier *t = static_cast<TrackCacheBezier *>(track);
 
-					t->object->set_indexed(t->subpath, t->value);
+					t->object->set_by_path(t->subpath, t->value);
 
 				} break;
 				default: {

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -76,7 +76,7 @@ Ref<PropertyTweener> Tween::tween_property(Object *p_target, NodePath p_property
 	ERR_FAIL_COND_V_MSG(started, nullptr, "Can't append to a Tween that has started. Use stop() first.");
 
 #ifdef DEBUG_ENABLED
-	Variant::Type property_type = p_target->get_indexed(p_property.get_as_property_path().get_subnames()).get_type();
+	Variant::Type property_type = p_target->get_by_path(p_property.get_as_property_path().get_subnames()).get_type();
 	ERR_FAIL_COND_V_MSG(property_type != p_to.get_type(), Ref<PropertyTweener>(), "Type mismatch between property and final value: " + Variant::get_type_name(property_type) + " and " + Variant::get_type_name(p_to.get_type()));
 #endif
 
@@ -730,7 +730,7 @@ void PropertyTweener::start() {
 	}
 
 	if (do_continue) {
-		initial_val = target_instance->get_indexed(property);
+		initial_val = target_instance->get_by_path(property);
 	}
 
 	if (relative) {
@@ -759,11 +759,11 @@ bool PropertyTweener::step(float &r_delta) {
 
 	float time = MIN(elapsed_time - delay, duration);
 	if (time < duration) {
-		target_instance->set_indexed(property, tween->interpolate_variant(initial_val, delta_val, time, duration, trans_type, ease_type));
+		target_instance->set_by_path(property, tween->interpolate_variant(initial_val, delta_val, time, duration, trans_type, ease_type));
 		r_delta = 0;
 		return true;
 	} else {
-		target_instance->set_indexed(property, final_val);
+		target_instance->set_by_path(property, final_val);
 		finished = true;
 		r_delta = elapsed_time - delay - duration;
 		emit_signal(SNAME("finished"));
@@ -793,7 +793,7 @@ void PropertyTweener::_bind_methods() {
 PropertyTweener::PropertyTweener(Object *p_target, NodePath p_property, Variant p_to, float p_duration) {
 	target = p_target->get_instance_id();
 	property = p_property.get_as_property_path().get_subnames();
-	initial_val = p_target->get_indexed(property);
+	initial_val = p_target->get_by_path(property);
 	base_final_val = p_to;
 	final_val = base_final_val;
 	duration = p_duration;


### PR DESCRIPTION
Rename Object.get_indexed() to Object.get_by_path()
and Object.set_indexed() also renamed to Object.set_by_path()

resolve https://github.com/godotengine/godot-proposals/issues/4727.