### PR TITLE
Fixing print_rich() which only displays correctly in terminal - Fixes #62560

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -297,6 +297,14 @@ void RemoteDebugger::flush_output() {
 				}
 				strings.push_back(output_string.message);
 				types.push_back(MESSAGE_TYPE_ERROR);
+			} else if (output_string.type == MESSAGE_TYPE_LOG_RICH) {
+				if (!joined_log_strings.is_empty()) {
+					strings.push_back(String("\n").join(joined_log_strings));
+					types.push_back(MESSAGE_TYPE_LOG_RICH);
+					joined_log_strings.clear();
+				}
+				strings.push_back(output_string.message);
+				types.push_back(MESSAGE_TYPE_LOG_RICH);
 			} else {
 				joined_log_strings.push_back(output_string.message);
 			}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -428,6 +428,9 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 				case RemoteDebugger::MESSAGE_TYPE_LOG: {
 					msg_type = EditorLog::MSG_TYPE_STD;
 				} break;
+				case RemoteDebugger::MESSAGE_TYPE_LOG_RICH: {
+					msg_type = EditorLog::MSG_TYPE_STD_RICH;
+				} break;
 				case RemoteDebugger::MESSAGE_TYPE_ERROR: {
 					msg_type = EditorLog::MSG_TYPE_ERROR;
 				} break;


### PR DESCRIPTION
There was an issue that the type was not passed through correctly. These couple of lines fix this issue and make print_rich work as expected.

It was printing fine in the terminal, but not in the output inside of the engine itself.

This fixes issue #62560

Edit:
Picture to show that it is working correctly again:

![Screenshot from 2022-07-01 04-39-13](https://user-images.githubusercontent.com/56970759/176763500-d5995890-996b-4b71-98bf-6f55c203c6f2.png)
