### PR TITLE
Fix find_next_valid_focus() freeze

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2422,7 +2422,7 @@ Control *Control::find_next_valid_focus() const {
 			}
 		}
 
-		if (next_child == from) { // No next control.
+		if (next_child == from || next_child == this) { // No next control.
 			return (get_focus_mode() == FOCUS_ALL) ? next_child : nullptr;
 		}
 		if (next_child) {
@@ -2506,7 +2506,7 @@ Control *Control::find_prev_valid_focus() const {
 			}
 		}
 
-		if (prev_child == from) { // No prev control.
+		if (prev_child == from || prev_child == this) { // No prev control.
 			return (get_focus_mode() == FOCUS_ALL) ? prev_child : nullptr;
 		}
 


### PR DESCRIPTION
Fixes #62564

`find_next_valid_focus()` will search for a focusable child and will go higher if it doesn't find one. What happened in #62564 was that the loop was going down and then back up, creating a weird cyclic loop. Turns out the original condition made sense, so now there's both of them :v

The new issue occurred in a dialog, which might explain why it wasn't triggered in master. But the fix is likely relevant for both branches.