### PR TITLE
[3.x] Check duplicate keys in dictionary literals: enums and const variables

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -607,6 +607,7 @@ private:
 	Node *_reduce_expression(Node *p_node, bool p_to_const = false);
 	Node *_parse_and_reduce_expression(Node *p_parent, bool p_static, bool p_reduce_const = false, bool p_allow_assign = false);
 	bool _reduce_export_var_type(Variant &p_value, int p_line = 0);
+	const Variant *_try_to_find_constant_value_for_expression(const Node *p_expr) const;
 
 	PatternNode *_parse_pattern(bool p_static);
 	void _parse_pattern_block(BlockNode *p_block, Vector<PatternBranchNode *> &p_branches, bool p_static);


### PR DESCRIPTION
**Implement checking of identifiers (const variables and unnamed enums) and named enums when parsing dictionary literals whether the keys are not duplicated.**

In case of duplicate key is encountered, highlight the line with it and print error message:
`Duplicate key "foo" found in Dictionary literal`

This commit is a logical continuation of the commit https://github.com/godotengine/godot/commit/dab73c701a9785be443977a613e57600d1e136c8 which implemented such checks only for literal keys and fixed #7034.

Apart from that, this commit also fixes the issue that the line below the duplicated key was highlighted with the error in case it was the last one in the dictionary literal and there was no hanging comma. That is, in the following example:
```gdscript
var foo = {
	1: "1",
	2: "2",
	1: "3"
}
```
the last line (with the `}`) was highlighted as the error instead of the line abobe with `1: "3"`. Now it's fixed.

Also, the format of the error message has been changed so that now the error message also contains the value of the key which is duplicated. Instead of:
`Duplicate key found in Dictionary literal`
now it prints
`Duplicate key "<value>" found in Dictionary literal`

Fixes #50971

Some of the tests for this PR are in [this Gist](https://gist.github.com/kdiduk/af087ee60eed0290cad19f6d281b08d6)