### PR TITLE
Fix GDScript parser sometimes crashing when issuing warning for unreachable pattern

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1829,7 +1829,7 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 		}
 
 #ifdef DEBUG_ENABLED
-		if (have_wildcard_without_continue) {
+		if (have_wildcard_without_continue && !branch->patterns.is_empty()) {
 			push_warning(branch->patterns[0], GDScriptWarning::UNREACHABLE_PATTERN);
 		}
 


### PR DESCRIPTION
Fix parser crashing when trying to issue a warning for an "unreachable pattern" of a match branch with no pattern (this can happen when the pattern has a parse error).
Fixes #62409