### PR TITLE
Clamp Decal's upper/lower fade to positive values

### DIFF
--- a/doc/classes/Decal.xml
+++ b/doc/classes/Decal.xml
@@ -79,7 +79,7 @@
 			Sets the size of the [AABB] used by the decal. The AABB goes from [code]-extents[/code] to [code]extents[/code].
 		</member>
 		<member name="lower_fade" type="float" setter="set_lower_fade" getter="get_lower_fade" default="0.3">
-			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB].
+			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB]. Only positive values are valid (negative values will be clamped to [code]0.0[/code]).
 		</member>
 		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 			Changes the [Color] of the Decal by multiplying it with this value.
@@ -100,7 +100,7 @@
 			[Texture2D] storing ambient occlusion, roughness, and metallic for the decal. Use this to add extra detail to decals.
 		</member>
 		<member name="upper_fade" type="float" setter="set_upper_fade" getter="get_upper_fade" default="0.3">
-			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB].
+			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB]. Only positive values are valid (negative values will be clamped to [code]0.0[/code]).
 		</member>
 	</members>
 	<constants>

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -72,7 +72,7 @@ real_t Decal::get_albedo_mix() const {
 }
 
 void Decal::set_upper_fade(real_t p_fade) {
-	upper_fade = p_fade;
+	upper_fade = MAX(p_fade, 0.0);
 	RS::get_singleton()->decal_set_fade(decal, upper_fade, lower_fade);
 }
 
@@ -81,7 +81,7 @@ real_t Decal::get_upper_fade() const {
 }
 
 void Decal::set_lower_fade(real_t p_fade) {
-	lower_fade = p_fade;
+	lower_fade = MAX(p_fade, 0.0);
 	RS::get_singleton()->decal_set_fade(decal, upper_fade, lower_fade);
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/53538 and https://github.com/godotengine/godot/pull/61492.

Negative easing values result in broken rendering.