### PR TITLE
Remove debugging print following GI reorganization

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3633,8 +3633,6 @@ void GI::process_gi(RID p_render_buffers, RID *p_normal_roughness_views, RID p_v
 			RD::get_singleton()->free(rb->rbgi.reflection_buffer);
 		}
 
-		print_line("Allocating GI buffers"); // TESTING REMOVE BEFORE MERGING
-
 		// Remember the view count we're using
 		rb->rbgi.view_count = p_view_count;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->