### PR TITLE
Add an underscore to internal group names as per engine policy

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -439,9 +439,9 @@ void Node::set_physics_process(bool p_process) {
 	data.physics_process = p_process;
 
 	if (data.physics_process) {
-		add_to_group("physics_process", false);
+		add_to_group(SNAME("_physics_process"), false);
 	} else {
-		remove_from_group("physics_process");
+		remove_from_group(SNAME("_physics_process"));
 	}
 }
 
@@ -457,9 +457,9 @@ void Node::set_physics_process_internal(bool p_process_internal) {
 	data.physics_process_internal = p_process_internal;
 
 	if (data.physics_process_internal) {
-		add_to_group("physics_process_internal", false);
+		add_to_group(SNAME("_physics_process_internal"), false);
 	} else {
-		remove_from_group("physics_process_internal");
+		remove_from_group(SNAME("_physics_process_internal"));
 	}
 }
 
@@ -770,9 +770,9 @@ void Node::set_process(bool p_process) {
 	data.process = p_process;
 
 	if (data.process) {
-		add_to_group("process", false);
+		add_to_group(SNAME("_process"), false);
 	} else {
-		remove_from_group("process");
+		remove_from_group(SNAME("_process"));
 	}
 }
 
@@ -788,9 +788,9 @@ void Node::set_process_internal(bool p_process_internal) {
 	data.process_internal = p_process_internal;
 
 	if (data.process_internal) {
-		add_to_group("process_internal", false);
+		add_to_group(SNAME("_process_internal"), false);
 	} else {
-		remove_from_group("process_internal");
+		remove_from_group(SNAME("_process_internal"));
 	}
 }
 
@@ -807,19 +807,19 @@ void Node::set_process_priority(int p_priority) {
 	}
 
 	if (is_processing()) {
-		data.tree->make_group_changed("process");
+		data.tree->make_group_changed(SNAME("_process"));
 	}
 
 	if (is_processing_internal()) {
-		data.tree->make_group_changed("process_internal");
+		data.tree->make_group_changed(SNAME("_process_internal"));
 	}
 
 	if (is_physics_processing()) {
-		data.tree->make_group_changed("physics_process");
+		data.tree->make_group_changed(SNAME("_physics_process"));
 	}
 
 	if (is_physics_processing_internal()) {
-		data.tree->make_group_changed("physics_process_internal");
+		data.tree->make_group_changed(SNAME("_physics_process_internal"));
 	}
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -412,9 +412,9 @@ bool SceneTree::physics_process(double p_time) {
 
 	emit_signal(SNAME("physics_frame"));
 
-	_notify_group_pause(SNAME("physics_process_internal"), Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
+	_notify_group_pause(SNAME("_physics_process_internal"), Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	call_group(SNAME("_picking_viewports"), SNAME("_process_picking"));
-	_notify_group_pause(SNAME("physics_process"), Node::NOTIFICATION_PHYSICS_PROCESS);
+	_notify_group_pause(SNAME("_physics_process"), Node::NOTIFICATION_PHYSICS_PROCESS);
 	_flush_ugc();
 	MessageQueue::get_singleton()->flush(); //small little hack
 
@@ -449,8 +449,8 @@ bool SceneTree::process(double p_time) {
 
 	flush_transform_notifications();
 
-	_notify_group_pause(SNAME("process_internal"), Node::NOTIFICATION_INTERNAL_PROCESS);
-	_notify_group_pause(SNAME("process"), Node::NOTIFICATION_PROCESS);
+	_notify_group_pause(SNAME("_process_internal"), Node::NOTIFICATION_INTERNAL_PROCESS);
+	_notify_group_pause(SNAME("_process"), Node::NOTIFICATION_PROCESS);
 
 	_flush_ugc();
 	MessageQueue::get_singleton()->flush(); //small little hack


### PR DESCRIPTION
This also adds `SNAME()` macros where relevant to improve performance.

This closes https://github.com/godotengine/godot/issues/43738.