### PR TITLE
Default cursor fix for html5 export

### DIFF
--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -236,7 +236,7 @@ void DisplayServerJavaScript::mouse_move_callback(double p_x, double p_y, double
 const char *DisplayServerJavaScript::godot2dom_cursor(DisplayServer::CursorShape p_shape) {
 	switch (p_shape) {
 		case DisplayServer::CURSOR_ARROW:
-			return "auto";
+			return "default";
 		case DisplayServer::CURSOR_IBEAM:
 			return "text";
 		case DisplayServer::CURSOR_POINTING_HAND:
@@ -270,7 +270,7 @@ const char *DisplayServerJavaScript::godot2dom_cursor(DisplayServer::CursorShape
 		case DisplayServer::CURSOR_HELP:
 			return "help";
 		default:
-			return "auto";
+			return "default";
 	}
 }
 


### PR DESCRIPTION
To make the fix mentioned in #62606 possible, this change is neccessary as otherwise the css `auto` cursor will result in a text selection cursor.

As the intented behaviour of the "default" cursor is to have a "normal default" cursor and not leaving the decision to the browser, changing this to `default` will result in the correct cursor to be displayed.