### PR TITLE
[3.4] Android: Only warn when Target SDK is non default

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6995,6 +6995,8 @@ EditorNode::EditorNode() {
 	execute_output_dialog = memnew(AcceptDialog);
 	execute_output_dialog->add_child(execute_outputs);
 	execute_output_dialog->set_title("");
+	// Prevent closing too fast and missing important information.
+	execute_output_dialog->set_exclusive(true);
 	gui_base->add_child(execute_output_dialog);
 
 	EditorFileSystem::get_singleton()->connect("sources_changed", this, "_sources_changed");

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -246,12 +246,12 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 				}
 				error += " - " + items[i];
 			}
-
 			export_error->set_text(error);
 			export_error->show();
 		} else {
 			export_error->hide();
 		}
+		export_warning->hide();
 		if (needs_templates) {
 			export_templates_error->show();
 		} else {
@@ -262,6 +262,20 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		get_ok()->set_disabled(true);
 
 	} else {
+		if (error != String()) {
+			Vector<String> items = error.split("\n", false);
+			error = "";
+			for (int i = 0; i < items.size(); i++) {
+				if (i > 0) {
+					error += "\n";
+				}
+				error += " - " + items[i];
+			}
+			export_warning->set_text(error);
+			export_warning->show();
+		} else {
+			export_warning->hide();
+		}
 		export_error->hide();
 		export_templates_error->hide();
 		export_button->set_disabled(false);
@@ -1143,6 +1157,11 @@ ProjectExportDialog::ProjectExportDialog() {
 	main_vb->add_child(export_error);
 	export_error->hide();
 	export_error->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("error_color", "Editor"));
+
+	export_warning = memnew(Label);
+	main_vb->add_child(export_warning);
+	export_warning->hide();
+	export_warning->add_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_color("warning_color", "Editor"));
 
 	export_templates_error = memnew(HBoxContainer);
 	main_vb->add_child(export_templates_error);

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -99,6 +99,7 @@ private:
 	Label *script_key_error;
 
 	Label *export_error;
+	Label *export_warning;
 	HBoxContainer *export_templates_error;
 
 	String default_filename;


### PR DESCRIPTION
The validation logic for Min Sdk and Target Sdk was flawed as it triggers
errors for users not using Custom Build even if they never modified the
values themselves.

The default values for those settings get saved in `export_presets.cfg` and
thus the error gets triggered when moving from 3.4.4 or earlier to 3.4.5, as
the target SDK changed from 30 to 31.

So instead we just raise a warning to make users aware of this non-default
Min Sdk or mostly Target Sdk that might be in their preset.

We also warn when they do use Custom Build as the target SDK 30 would likely
still be an upgrade issue and not an intentional choice, especially given
that Google Play will now require SDK 31.

The export info dialog is now exclusive so that when it doesn't auto-close,
i.e. when it errors, you don't close it by mistake by clicking outside.

The valid range for both options is no longer limited to Godot's own default
target SDK, but can accept higher values (they are not guaranteed to work,
but they might).

- Fixes #62465 without breaking compatibility for 3.4.5.