### PR TITLE
[3.5] Remove documentation that mentions 2D navigation mesh baking

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -135,7 +135,7 @@
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="10.0">
 			The radius of the avoidance agent. This is the "body" of the avoidance agent and not the avoidance maneuver starting radius (which is controlled by [member neighbor_dist]).
-			Does not affect normal pathfinding. To change an actor's pathfinding radius bake [NavigationMesh] resources with a different [member NavigationMesh.agent_radius] property and use different navigation maps for each actor size.
+			Does not affect normal pathfinding.
 		</member>
 		<member name="target_desired_distance" type="float" setter="set_target_desired_distance" getter="get_target_desired_distance" default="1.0">
 			The distance threshold before the final target point is considered to be reached. This will allow an agent to not have to hit the point of the final target exactly, but only the area. If this value is set to low the NavigationAgent will be stuck in a repath loop cause it will constantly overshoot or undershoot the distance to the final target point on each physics frame update.


### PR DESCRIPTION
Cherrypick mentions 2D navigation mesh baking which does only exist very hidden in Godot 3.5 with intermediate steps.

Navmesh baking for 2D is a drafted feature in Godot 4.0. The NavigationServer API already supports upload of NavigationMesh resource for use in 2D navigation maps but the current workflow has no helper functions and users need to use the NavigationServer3D API instead of the NavigationServer2D API so better remove it from the 3.5 docs to avoid all that jazz and confusion until it is more refined and supported with a real gui and 2D geometry parse.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
