### PR TITLE
[macOS export] Unref FileAccess to ensure chmod is successful.

### DIFF
--- a/platform/osx/export/export_plugin.cpp
+++ b/platform/osx/export/export_plugin.cpp
@@ -1086,6 +1086,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 				Ref<FileAccess> f = FileAccess::open(file, FileAccess::WRITE);
 				if (f.is_valid()) {
 					f->store_buffer(data.ptr(), data.size());
+					f.unref();
 					if (is_execute) {
 						// chmod with 0755 if the file is executable.
 						FileAccess::set_unix_permissions(file, 0755);


### PR DESCRIPTION
Fixes macOS DMG/APP export sometimes failing to set `executable` flag.
