### PR TITLE
Fix exit code of --help and --version, and test them in CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -127,6 +127,8 @@ jobs:
       - name: Unit tests
         if: ${{ matrix.tests }}
         run: |
+          ${{ matrix.bin }} --version
+          ${{ matrix.bin }} --help
           ${{ matrix.bin }} --test --headless
 
       # Check class reference

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Unit tests
         if: ${{ matrix.tests }}
         run: |
+          ${{ matrix.bin }} --version
+          ${{ matrix.bin }} --help
           ${{ matrix.bin }} --test
 
       - name: Prepare artifact

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Unit tests
         if: ${{ matrix.tests }}
         run: |
+          ${{ matrix.bin }} --version
+          ${{ matrix.bin }} --help
           ${{ matrix.bin }} --test
 
       - name: Prepare artifact

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -691,12 +691,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
 
 			show_help = true;
-			exit_code = OK;
+			exit_code = ERR_HELP; // Hack to force an early exit in `main()` with a success code.
 			goto error;
 
 		} else if (I->get() == "--version") {
 			print_line(get_full_version_string());
-			exit_code = OK;
+			exit_code = ERR_HELP; // Hack to force an early exit in `main()` with a success code.
 			goto error;
 
 		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -157,6 +157,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jc
 		memfree(cmdline);
 	}
 
+	// Note: --help and --version return ERR_HELP, but this should be translated to 0 if exit codes are propagated.
 	if (err != OK) {
 		return; // should exit instead and print the error
 	}

--- a/platform/iphone/godot_iphone.mm
+++ b/platform/iphone/godot_iphone.mm
@@ -112,7 +112,10 @@ int iphone_main(int argc, char **argv, String data_dir, String cache_dir) {
 
 	Error err = Main::setup(fargv[0], argc - 1, &fargv[1], false);
 	printf("setup %i\n", err);
-	if (err != OK) {
+
+	if (err == ERR_HELP) { // Returned by --help and --version, so success.
+		return 0;
+	} else if (err != OK) {
 		return 255;
 	}
 

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -61,6 +61,10 @@ int main(int argc, char *argv[]) {
 	Error err = Main::setup(argv[0], argc - 1, &argv[1]);
 	if (err != OK) {
 		free(cwd);
+
+		if (err == ERR_HELP) { // Returned by --help and --version, so success.
+			return 0;
+		}
 		return 255;
 	}
 

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -83,7 +83,9 @@ int main(int argc, char **argv) {
 		err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
 	}
 
-	if (err != OK) {
+	if (err == ERR_HELP) { // Returned by --help and --version, so success.
+		return 0;
+	} else if (err != OK) {
 		return 255;
 	}
 

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -166,6 +166,10 @@ int widechar_main(int argc, wchar_t **argv) {
 			delete[] argv_utf8[i];
 		}
 		delete[] argv_utf8;
+
+		if (err == ERR_HELP) { // Returned by --help and --version, so success.
+			return 0;
+		}
 		return 255;
 	}
 


### PR DESCRIPTION
Corrects prior regression from #62550, which caused `ERROR:` output and exit code 1.

Also invokes both `--help` and `--version` in GitHub Actions to ensure exit code 0.