### PR TITLE
Fix crash when selecting a non-imported material in Advanced Import Settings for Scene dialog

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -725,18 +725,24 @@ void SceneImportSettings::_select(Tree *p_from, String p_type, String p_id) {
 		mesh_preview->set_mesh(material_preview);
 
 		if (p_from != mesh_tree) {
-			md.mesh_node->uncollapse_tree();
-			md.mesh_node->select(0);
+			if (md.mesh_node) {
+				md.mesh_node->uncollapse_tree();
+				md.mesh_node->select(0);
+			}
 			mesh_tree->ensure_cursor_is_visible();
 		}
 		if (p_from != scene_tree) {
-			md.scene_node->uncollapse_tree();
-			md.scene_node->select(0);
+			if (md.scene_node) {
+				md.scene_node->uncollapse_tree();
+				md.scene_node->select(0);
+			}
 			scene_tree->ensure_cursor_is_visible();
 		}
 		if (p_from != material_tree) {
-			md.material_node->uncollapse_tree();
-			md.material_node->select(0);
+			if (md.material_node) {
+				md.material_node->uncollapse_tree();
+				md.material_node->select(0);
+			}
 			material_tree->ensure_cursor_is_visible();
 		}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Node may be `null`, so needs to do a check.

Fix #54807.