### PR TITLE
Add `sync` to `NodeTransition` and `BlendSpace1D/2D` and refactor `sync` in `AnimationTree`

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -88,7 +88,7 @@
 			<argument index="3" name="seek_root" type="bool" />
 			<argument index="4" name="blend" type="float" />
 			<argument index="5" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
-			<argument index="6" name="optimize" type="bool" default="true" />
+			<argument index="6" name="sync" type="bool" default="true" />
 			<description>
 				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. The [code]time[/code] parameter is a relative delta, unless [code]seek[/code] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
 			</description>
@@ -102,7 +102,7 @@
 			<argument index="4" name="seek_root" type="bool" />
 			<argument index="5" name="blend" type="float" />
 			<argument index="6" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
-			<argument index="7" name="optimize" type="bool" default="true" />
+			<argument index="7" name="sync" type="bool" default="true" />
 			<description>
 				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
 			</description>

--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AnimationNodeAdd2" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AnimationNodeAdd2" inherits="AnimationNodeSync" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Blends two animations additively inside of an [AnimationNodeBlendTree].
 	</brief_description>
@@ -9,9 +9,4 @@
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
 	</tutorials>
-	<members>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
-		</member>
-	</members>
 </class>

--- a/doc/classes/AnimationNodeAdd3.xml
+++ b/doc/classes/AnimationNodeAdd3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AnimationNodeAdd3" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AnimationNodeAdd3" inherits="AnimationNodeSync" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Blends two of three animations additively inside of an [AnimationNodeBlendTree].
 	</brief_description>
@@ -14,9 +14,4 @@
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
-	<members>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
-		</member>
-	</members>
 </class>

--- a/doc/classes/AnimationNodeBlend2.xml
+++ b/doc/classes/AnimationNodeBlend2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AnimationNodeBlend2" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AnimationNodeBlend2" inherits="AnimationNodeSync" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Blends two animations linearly inside of an [AnimationNodeBlendTree].
 	</brief_description>
@@ -11,9 +11,4 @@
 		<link title="3D Platformer Demo">https://godotengine.org/asset-library/asset/125</link>
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
-	<members>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
-		</member>
-	</members>
 </class>

--- a/doc/classes/AnimationNodeBlend3.xml
+++ b/doc/classes/AnimationNodeBlend3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AnimationNodeBlend3" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AnimationNodeBlend3" inherits="AnimationNodeSync" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Blends two of three animations linearly inside of an [AnimationNodeBlendTree].
 	</brief_description>
@@ -13,9 +13,4 @@
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
 	</tutorials>
-	<members>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
-			If [code]true[/code], sets the [code]optimization[/code] to [code]false[/code] when calling [method AnimationNode.blend_input], forcing the blended animations to update every frame.
-		</member>
-	</members>
 </class>

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -76,6 +76,10 @@
 		<member name="snap" type="float" setter="set_snap" getter="get_snap" default="0.1">
 			Position increment to snap to when moving a point on the axis.
 		</member>
+		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
+			If [code]false[/code], the blended animations' frame are stopped when the blend value is [code]0[/code].
+			If [code]true[/code], forcing the blended animations to advance frame.
+		</member>
 		<member name="value_label" type="String" setter="set_value_label" getter="get_value_label" default="&quot;value&quot;">
 			Label of the virtual axis of the blend space.
 		</member>

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -113,6 +113,10 @@
 		<member name="snap" type="Vector2" setter="set_snap" getter="get_snap" default="Vector2(0.1, 0.1)">
 			Position increment to snap to when moving a point.
 		</member>
+		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
+			If [code]false[/code], the blended animations' frame are stopped when the blend value is [code]0[/code].
+			If [code]true[/code], forcing the blended animations to advance frame.
+		</member>
 		<member name="x_label" type="String" setter="set_x_label" getter="get_x_label" default="&quot;x&quot;">
 			Name of the blend space's X axis.
 		</member>

--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AnimationNodeOneShot" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AnimationNodeOneShot" inherits="AnimationNodeSync" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Plays an animation once in [AnimationNodeBlendTree].
 	</brief_description>
@@ -25,8 +25,6 @@
 		<member name="fadeout_time" type="float" setter="set_fadeout_time" getter="get_fadeout_time" default="0.0">
 		</member>
 		<member name="mix_mode" type="int" setter="set_mix_mode" getter="get_mix_mode" enum="AnimationNodeOneShot.MixMode" default="0">
-		</member>
-		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimationNodeSync.xml
+++ b/doc/classes/AnimationNodeSync.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodeSync" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="sync" type="bool" setter="set_use_sync" getter="is_using_sync" default="false">
+			If [code]false[/code], the blended animations' frame are stopped when the blend value is [code]0[/code].
+			If [code]true[/code], forcing the blended animations to advance frame.
+		</member>
+	</members>
+</class>

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AnimationNodeTransition" inherits="AnimationNode" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AnimationNodeTransition" inherits="AnimationNodeSync" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A generic animation transition node for [AnimationTree].
 	</brief_description>
@@ -40,6 +40,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="from_start" type="bool" setter="set_from_start" getter="is_from_start" default="true">
+			If [code]true[/code], the destination animation is played back from the beginning when switched.
+		</member>
 		<member name="input_count" type="int" setter="set_enabled_inputs" getter="get_enabled_inputs" default="0">
 			The number of available input ports for this node.
 		</member>

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -314,6 +314,8 @@ void AnimationNodeBlendSpace1DEditor::_update_space() {
 	max_value->set_value(blend_space->get_max_space());
 	min_value->set_value(blend_space->get_min_space());
 
+	sync->set_pressed(blend_space->is_using_sync());
+
 	label_value->set_text(blend_space->get_value_label());
 
 	snap_value->set_value(blend_space->get_snap());
@@ -329,13 +331,15 @@ void AnimationNodeBlendSpace1DEditor::_config_changed(double) {
 	}
 
 	updating = true;
-	undo_redo->create_action(TTR("Change BlendSpace1D Limits"));
+	undo_redo->create_action(TTR("Change BlendSpace1D Config"));
 	undo_redo->add_do_method(blend_space.ptr(), "set_max_space", max_value->get_value());
 	undo_redo->add_undo_method(blend_space.ptr(), "set_max_space", blend_space->get_max_space());
 	undo_redo->add_do_method(blend_space.ptr(), "set_min_space", min_value->get_value());
 	undo_redo->add_undo_method(blend_space.ptr(), "set_min_space", blend_space->get_min_space());
 	undo_redo->add_do_method(blend_space.ptr(), "set_snap", snap_value->get_value());
 	undo_redo->add_undo_method(blend_space.ptr(), "set_snap", blend_space->get_snap());
+	undo_redo->add_do_method(blend_space.ptr(), "set_use_sync", sync->is_pressed());
+	undo_redo->add_undo_method(blend_space.ptr(), "set_use_sync", blend_space->is_using_sync());
 	undo_redo->add_do_method(this, "_update_space");
 	undo_redo->add_undo_method(this, "_update_space");
 	undo_redo->commit_action();
@@ -649,6 +653,12 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	snap_value->set_min(0.01);
 	snap_value->set_step(0.01);
 	snap_value->set_max(1000);
+
+	top_hb->add_child(memnew(VSeparator));
+	top_hb->add_child(memnew(Label(TTR("Sync:"))));
+	sync = memnew(CheckBox);
+	top_hb->add_child(sync);
+	sync->connect("toggled", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_config_changed));
 
 	edit_hb = memnew(HBoxContainer);
 	top_hb->add_child(edit_hb);

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -61,6 +61,8 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	SpinBox *max_value = nullptr;
 	SpinBox *min_value = nullptr;
 
+	CheckBox *sync = nullptr;
+
 	HBoxContainer *edit_hb = nullptr;
 	SpinBox *edit_value = nullptr;
 	Button *open_editor = nullptr;

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -595,6 +595,7 @@ void AnimationNodeBlendSpace2DEditor::_update_space() {
 
 	auto_triangles->set_pressed(blend_space->get_auto_triangles());
 
+	sync->set_pressed(blend_space->is_using_sync());
 	interpolation->select(blend_space->get_blend_mode());
 
 	max_x_value->set_value(blend_space->get_max_space().x);
@@ -620,13 +621,15 @@ void AnimationNodeBlendSpace2DEditor::_config_changed(double) {
 	}
 
 	updating = true;
-	undo_redo->create_action(TTR("Change BlendSpace2D Limits"));
+	undo_redo->create_action(TTR("Change BlendSpace2D Config"));
 	undo_redo->add_do_method(blend_space.ptr(), "set_max_space", Vector2(max_x_value->get_value(), max_y_value->get_value()));
 	undo_redo->add_undo_method(blend_space.ptr(), "set_max_space", blend_space->get_max_space());
 	undo_redo->add_do_method(blend_space.ptr(), "set_min_space", Vector2(min_x_value->get_value(), min_y_value->get_value()));
 	undo_redo->add_undo_method(blend_space.ptr(), "set_min_space", blend_space->get_min_space());
 	undo_redo->add_do_method(blend_space.ptr(), "set_snap", Vector2(snap_x->get_value(), snap_y->get_value()));
 	undo_redo->add_undo_method(blend_space.ptr(), "set_snap", blend_space->get_snap());
+	undo_redo->add_do_method(blend_space.ptr(), "set_use_sync", sync->is_pressed());
+	undo_redo->add_undo_method(blend_space.ptr(), "set_use_sync", blend_space->is_using_sync());
 	undo_redo->add_do_method(blend_space.ptr(), "set_blend_mode", interpolation->get_selected());
 	undo_redo->add_undo_method(blend_space.ptr(), "set_blend_mode", blend_space->get_blend_mode());
 	undo_redo->add_do_method(this, "_update_space");
@@ -896,6 +899,13 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	snap_y->set_min(0.01);
 	snap_y->set_step(0.01);
 	snap_y->set_max(1000);
+
+	top_hb->add_child(memnew(VSeparator));
+
+	top_hb->add_child(memnew(Label(TTR("Sync:"))));
+	sync = memnew(CheckBox);
+	top_hb->add_child(sync);
+	sync->connect("toggled", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));
 
 	top_hb->add_child(memnew(VSeparator));
 

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -55,6 +55,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	Button *snap = nullptr;
 	SpinBox *snap_x = nullptr;
 	SpinBox *snap_y = nullptr;
+	CheckBox *sync = nullptr;
 	OptionButton *interpolation = nullptr;
 
 	Button *auto_triangles = nullptr;

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -63,6 +63,8 @@ class AnimationNodeBlendSpace1D : public AnimationRootNode {
 	StringName blend_position = "blend_position";
 
 protected:
+	bool sync = false;
+
 	virtual void _validate_property(PropertyInfo &property) const override;
 	static void _bind_methods();
 
@@ -92,6 +94,9 @@ public:
 
 	void set_value_label(const String &p_label);
 	String get_value_label() const;
+
+	void set_use_sync(bool p_sync);
+	bool is_using_sync() const;
 
 	double process(double p_time, bool p_seek, bool p_seek_root) override;
 	String get_caption() const override;

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -88,6 +88,8 @@ protected:
 	void _tree_changed();
 
 protected:
+	bool sync = false;
+
 	virtual void _validate_property(PropertyInfo &property) const override;
 	static void _bind_methods();
 
@@ -136,6 +138,9 @@ public:
 
 	void set_blend_mode(BlendMode p_blend_mode);
 	BlendMode get_blend_mode() const;
+
+	void set_use_sync(bool p_sync);
+	bool is_using_sync() const;
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) override;
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -179,6 +179,26 @@ AnimationNodeAnimation::AnimationNodeAnimation() {
 
 ////////////////////////////////////////////////////////
 
+void AnimationNodeSync::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeSync::set_use_sync);
+	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeSync::is_using_sync);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
+}
+
+void AnimationNodeSync::set_use_sync(bool p_sync) {
+	sync = p_sync;
+}
+
+bool AnimationNodeSync::is_using_sync() const {
+	return sync;
+}
+
+AnimationNodeSync::AnimationNodeSync() {
+}
+
+////////////////////////////////////////////////////////
+
 void AnimationNodeOneShot::get_parameter_list(List<PropertyInfo> *r_list) const {
 	r_list->push_back(PropertyInfo(Variant::BOOL, active));
 	r_list->push_back(PropertyInfo(Variant::BOOL, prev_active, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
@@ -276,7 +296,7 @@ double AnimationNodeOneShot::process(double p_time, bool p_seek, bool p_seek_roo
 		}
 
 		if (!active) {
-			return blend_input(0, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, !sync);
+			return blend_input(0, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, sync);
 		}
 	}
 
@@ -313,12 +333,12 @@ double AnimationNodeOneShot::process(double p_time, bool p_seek, bool p_seek_roo
 
 	double main_rem;
 	if (mix == MIX_MODE_ADD) {
-		main_rem = blend_input(0, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, !sync);
+		main_rem = blend_input(0, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, sync);
 	} else {
-		main_rem = blend_input(0, p_time, p_seek, p_seek_root, 1.0 - blend, FILTER_BLEND, !sync);
+		main_rem = blend_input(0, p_time, p_seek, p_seek_root, 1.0 - blend, FILTER_BLEND, sync);
 	}
 
-	double os_rem = blend_input(1, os_seek ? time : p_time, os_seek, p_seek_root, blend, FILTER_PASS, false);
+	double os_rem = blend_input(1, os_seek ? time : p_time, os_seek, p_seek_root, blend, FILTER_PASS, true);
 
 	if (do_start) {
 		remaining = os_rem;
@@ -343,14 +363,6 @@ double AnimationNodeOneShot::process(double p_time, bool p_seek, bool p_seek_roo
 	return MAX(main_rem, remaining);
 }
 
-void AnimationNodeOneShot::set_use_sync(bool p_sync) {
-	sync = p_sync;
-}
-
-bool AnimationNodeOneShot::is_using_sync() const {
-	return sync;
-}
-
 void AnimationNodeOneShot::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fadein_time", "time"), &AnimationNodeOneShot::set_fadein_time);
 	ClassDB::bind_method(D_METHOD("get_fadein_time"), &AnimationNodeOneShot::get_fadein_time);
@@ -370,9 +382,6 @@ void AnimationNodeOneShot::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mix_mode", "mode"), &AnimationNodeOneShot::set_mix_mode);
 	ClassDB::bind_method(D_METHOD("get_mix_mode"), &AnimationNodeOneShot::get_mix_mode);
 
-	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeOneShot::set_use_sync);
-	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeOneShot::is_using_sync);
-
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mix_mode", PROPERTY_HINT_ENUM, "Blend,Add"), "set_mix_mode", "get_mix_mode");
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fadein_time", PROPERTY_HINT_RANGE, "0,60,0.01,or_greater,suffix:s"), "set_fadein_time", "get_fadein_time");
@@ -383,9 +392,6 @@ void AnimationNodeOneShot::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "autorestart_delay", PROPERTY_HINT_RANGE, "0,60,0.01,or_greater,suffix:s"), "set_autorestart_delay", "get_autorestart_delay");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "autorestart_random_delay", PROPERTY_HINT_RANGE, "0,60,0.01,or_greater,suffix:s"), "set_autorestart_random_delay", "get_autorestart_random_delay");
-
-	ADD_GROUP("", "");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
 
 	BIND_ENUM_CONSTANT(MIX_MODE_BLEND);
 	BIND_ENUM_CONSTANT(MIX_MODE_ADD);
@@ -410,31 +416,19 @@ String AnimationNodeAdd2::get_caption() const {
 	return "Add2";
 }
 
-void AnimationNodeAdd2::set_use_sync(bool p_sync) {
-	sync = p_sync;
-}
-
-bool AnimationNodeAdd2::is_using_sync() const {
-	return sync;
-}
-
 bool AnimationNodeAdd2::has_filter() const {
 	return true;
 }
 
 double AnimationNodeAdd2::process(double p_time, bool p_seek, bool p_seek_root) {
 	double amount = get_parameter(add_amount);
-	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, !sync);
-	blend_input(1, p_time, p_seek, p_seek_root, amount, FILTER_PASS, !sync);
+	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, sync);
+	blend_input(1, p_time, p_seek, p_seek_root, amount, FILTER_PASS, sync);
 
 	return rem0;
 }
 
 void AnimationNodeAdd2::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeAdd2::set_use_sync);
-	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeAdd2::is_using_sync);
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
 }
 
 AnimationNodeAdd2::AnimationNodeAdd2() {
@@ -456,32 +450,20 @@ String AnimationNodeAdd3::get_caption() const {
 	return "Add3";
 }
 
-void AnimationNodeAdd3::set_use_sync(bool p_sync) {
-	sync = p_sync;
-}
-
-bool AnimationNodeAdd3::is_using_sync() const {
-	return sync;
-}
-
 bool AnimationNodeAdd3::has_filter() const {
 	return true;
 }
 
 double AnimationNodeAdd3::process(double p_time, bool p_seek, bool p_seek_root) {
 	double amount = get_parameter(add_amount);
-	blend_input(0, p_time, p_seek, p_seek_root, MAX(0, -amount), FILTER_PASS, !sync);
-	double rem0 = blend_input(1, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, !sync);
-	blend_input(2, p_time, p_seek, p_seek_root, MAX(0, amount), FILTER_PASS, !sync);
+	blend_input(0, p_time, p_seek, p_seek_root, MAX(0, -amount), FILTER_PASS, sync);
+	double rem0 = blend_input(1, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, sync);
+	blend_input(2, p_time, p_seek, p_seek_root, MAX(0, amount), FILTER_PASS, sync);
 
 	return rem0;
 }
 
 void AnimationNodeAdd3::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeAdd3::set_use_sync);
-	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeAdd3::is_using_sync);
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
 }
 
 AnimationNodeAdd3::AnimationNodeAdd3() {
@@ -507,18 +489,10 @@ String AnimationNodeBlend2::get_caption() const {
 double AnimationNodeBlend2::process(double p_time, bool p_seek, bool p_seek_root) {
 	double amount = get_parameter(blend_amount);
 
-	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, 1.0 - amount, FILTER_BLEND, !sync);
-	double rem1 = blend_input(1, p_time, p_seek, p_seek_root, amount, FILTER_PASS, !sync);
+	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, 1.0 - amount, FILTER_BLEND, sync);
+	double rem1 = blend_input(1, p_time, p_seek, p_seek_root, amount, FILTER_PASS, sync);
 
 	return amount > 0.5 ? rem1 : rem0; //hacky but good enough
-}
-
-void AnimationNodeBlend2::set_use_sync(bool p_sync) {
-	sync = p_sync;
-}
-
-bool AnimationNodeBlend2::is_using_sync() const {
-	return sync;
 }
 
 bool AnimationNodeBlend2::has_filter() const {
@@ -526,10 +500,6 @@ bool AnimationNodeBlend2::has_filter() const {
 }
 
 void AnimationNodeBlend2::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeBlend2::set_use_sync);
-	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeBlend2::is_using_sync);
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
 }
 
 AnimationNodeBlend2::AnimationNodeBlend2() {
@@ -551,35 +521,22 @@ String AnimationNodeBlend3::get_caption() const {
 	return "Blend3";
 }
 
-void AnimationNodeBlend3::set_use_sync(bool p_sync) {
-	sync = p_sync;
-}
-
-bool AnimationNodeBlend3::is_using_sync() const {
-	return sync;
-}
-
 double AnimationNodeBlend3::process(double p_time, bool p_seek, bool p_seek_root) {
 	double amount = get_parameter(blend_amount);
-	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, MAX(0, -amount), FILTER_IGNORE, !sync);
-	double rem1 = blend_input(1, p_time, p_seek, p_seek_root, 1.0 - ABS(amount), FILTER_IGNORE, !sync);
-	double rem2 = blend_input(2, p_time, p_seek, p_seek_root, MAX(0, amount), FILTER_IGNORE, !sync);
+	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, MAX(0, -amount), FILTER_IGNORE, sync);
+	double rem1 = blend_input(1, p_time, p_seek, p_seek_root, 1.0 - ABS(amount), FILTER_IGNORE, sync);
+	double rem2 = blend_input(2, p_time, p_seek, p_seek_root, MAX(0, amount), FILTER_IGNORE, sync);
 
 	return amount > 0.5 ? rem2 : (amount < -0.5 ? rem0 : rem1); //hacky but good enough
 }
 
 void AnimationNodeBlend3::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_use_sync", "enable"), &AnimationNodeBlend3::set_use_sync);
-	ClassDB::bind_method(D_METHOD("is_using_sync"), &AnimationNodeBlend3::is_using_sync);
-
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync"), "set_use_sync", "is_using_sync");
 }
 
 AnimationNodeBlend3::AnimationNodeBlend3() {
 	add_input("-blend");
 	add_input("in");
 	add_input("+blend");
-	sync = false;
 }
 
 /////////////////////////////////
@@ -599,9 +556,9 @@ String AnimationNodeTimeScale::get_caption() const {
 double AnimationNodeTimeScale::process(double p_time, bool p_seek, bool p_seek_root) {
 	double scale = get_parameter(this->scale);
 	if (p_seek) {
-		return blend_input(0, p_time, true, p_seek_root, 1.0, FILTER_IGNORE, false);
+		return blend_input(0, p_time, true, p_seek_root, 1.0, FILTER_IGNORE, true);
 	} else {
-		return blend_input(0, p_time * scale, false, p_seek_root, 1.0, FILTER_IGNORE, false);
+		return blend_input(0, p_time * scale, false, p_seek_root, 1.0, FILTER_IGNORE, true);
 	}
 }
 
@@ -629,13 +586,13 @@ String AnimationNodeTimeSeek::get_caption() const {
 double AnimationNodeTimeSeek::process(double p_time, bool p_seek, bool p_seek_root) {
 	double seek_pos = get_parameter(this->seek_pos);
 	if (p_seek) {
-		return blend_input(0, p_time, true, p_seek_root, 1.0, FILTER_IGNORE, false);
+		return blend_input(0, p_time, true, p_seek_root, 1.0, FILTER_IGNORE, true);
 	} else if (seek_pos >= 0) {
-		double ret = blend_input(0, seek_pos, true, true, 1.0, FILTER_IGNORE, false);
+		double ret = blend_input(0, seek_pos, true, true, 1.0, FILTER_IGNORE, true);
 		set_parameter(this->seek_pos, -1.0); //reset
 		return ret;
 	} else {
-		return blend_input(0, p_time, false, p_seek_root, 1.0, FILTER_IGNORE, false);
+		return blend_input(0, p_time, false, p_seek_root, 1.0, FILTER_IGNORE, true);
 	}
 }
 
@@ -727,6 +684,14 @@ float AnimationNodeTransition::get_cross_fade_time() const {
 	return xfade;
 }
 
+void AnimationNodeTransition::set_from_start(bool p_from_start) {
+	from_start = p_from_start;
+}
+
+bool AnimationNodeTransition::is_from_start() const {
+	return from_start;
+}
+
 double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_seek_root) {
 	int current = get_parameter(this->current);
 	int prev = get_parameter(this->prev);
@@ -753,9 +718,15 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_seek_
 
 	double rem = 0.0;
 
+	for (int i = 0; i < enabled_inputs; i++) {
+		if (i != current && i != prev) {
+			blend_input(i, p_time, p_seek, p_seek_root, 0, FILTER_IGNORE, sync);
+		}
+	}
+
 	if (prev < 0) { // process current animation, check for transition
 
-		rem = blend_input(current, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, false);
+		rem = blend_input(current, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, true);
 
 		if (p_seek) {
 			time = p_time;
@@ -771,18 +742,18 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_seek_
 
 		float blend = xfade == 0 ? 0 : (prev_xfading / xfade);
 
-		if (!p_seek && switched) { //just switched, seek to start of current
+		if (from_start && !p_seek && switched) { //just switched, seek to start of current
 
-			rem = blend_input(current, 0, true, p_seek_root, 1.0 - blend, FILTER_IGNORE, false);
+			rem = blend_input(current, 0, true, p_seek_root, 1.0 - blend, FILTER_IGNORE, true);
 		} else {
-			rem = blend_input(current, p_time, p_seek, p_seek_root, 1.0 - blend, FILTER_IGNORE, false);
+			rem = blend_input(current, p_time, p_seek, p_seek_root, 1.0 - blend, FILTER_IGNORE, true);
 		}
 
-		if (p_seek) { // don't seek prev animation
-			blend_input(prev, 0, false, p_seek_root, blend, FILTER_IGNORE, false);
+		if (p_seek) {
+			blend_input(prev, p_time, true, p_seek_root, blend, FILTER_IGNORE, true);
 			time = p_time;
 		} else {
-			blend_input(prev, p_time, false, p_seek_root, blend, FILTER_IGNORE, false);
+			blend_input(prev, p_time, false, p_seek_root, blend, FILTER_IGNORE, true);
 			time += p_time;
 			prev_xfading -= p_time;
 			if (prev_xfading < 0) {
@@ -824,8 +795,12 @@ void AnimationNodeTransition::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_cross_fade_time", "time"), &AnimationNodeTransition::set_cross_fade_time);
 	ClassDB::bind_method(D_METHOD("get_cross_fade_time"), &AnimationNodeTransition::get_cross_fade_time);
 
+	ClassDB::bind_method(D_METHOD("set_from_start", "from_start"), &AnimationNodeTransition::set_from_start);
+	ClassDB::bind_method(D_METHOD("is_from_start"), &AnimationNodeTransition::is_from_start);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "input_count", PROPERTY_HINT_RANGE, "0,64,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_enabled_inputs", "get_enabled_inputs");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "xfade_time", PROPERTY_HINT_RANGE, "0,120,0.01,suffix:s"), "set_cross_fade_time", "get_cross_fade_time");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "from_start"), "set_from_start", "is_from_start");
 
 	for (int i = 0; i < MAX_INPUTS; i++) {
 		ADD_PROPERTYI(PropertyInfo(Variant::STRING, "input_" + itos(i) + "/name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_input_caption", "get_input_caption", i);
@@ -846,7 +821,7 @@ String AnimationNodeOutput::get_caption() const {
 }
 
 double AnimationNodeOutput::process(double p_time, bool p_seek, bool p_seek_root) {
-	return blend_input(0, p_time, p_seek, p_seek_root, 1.0);
+	return blend_input(0, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, true);
 }
 
 AnimationNodeOutput::AnimationNodeOutput() {
@@ -1060,7 +1035,7 @@ String AnimationNodeBlendTree::get_caption() const {
 
 double AnimationNodeBlendTree::process(double p_time, bool p_seek, bool p_seek_root) {
 	Ref<AnimationNodeOutput> output = nodes[SceneStringNames::get_singleton()->output].node;
-	return _blend_node("output", nodes[SceneStringNames::get_singleton()->output].connections, this, output, p_time, p_seek, p_seek_root, 1.0);
+	return _blend_node("output", nodes[SceneStringNames::get_singleton()->output].connections, this, output, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, true);
 }
 
 void AnimationNodeBlendTree::get_node_list(List<StringName> *r_list) {

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -77,8 +77,23 @@ private:
 
 VARIANT_ENUM_CAST(AnimationNodeAnimation::PlayMode)
 
-class AnimationNodeOneShot : public AnimationNode {
-	GDCLASS(AnimationNodeOneShot, AnimationNode);
+class AnimationNodeSync : public AnimationNode {
+	GDCLASS(AnimationNodeSync, AnimationNode);
+
+protected:
+	bool sync = false;
+
+	static void _bind_methods();
+
+public:
+	void set_use_sync(bool p_sync);
+	bool is_using_sync() const;
+
+	AnimationNodeSync();
+};
+
+class AnimationNodeOneShot : public AnimationNodeSync {
+	GDCLASS(AnimationNodeOneShot, AnimationNodeSync);
 
 public:
 	enum MixMode {
@@ -94,8 +109,6 @@ private:
 	float autorestart_delay = 1.0;
 	float autorestart_random_delay = 0.0;
 	MixMode mix = MIX_MODE_BLEND;
-
-	bool sync = false;
 
 	/*	bool active;
 	bool do_start;
@@ -134,9 +147,6 @@ public:
 	void set_mix_mode(MixMode p_mix);
 	MixMode get_mix_mode() const;
 
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
-
 	virtual bool has_filter() const override;
 	virtual double process(double p_time, bool p_seek, bool p_seek_root) override;
 
@@ -145,11 +155,10 @@ public:
 
 VARIANT_ENUM_CAST(AnimationNodeOneShot::MixMode)
 
-class AnimationNodeAdd2 : public AnimationNode {
-	GDCLASS(AnimationNodeAdd2, AnimationNode);
+class AnimationNodeAdd2 : public AnimationNodeSync {
+	GDCLASS(AnimationNodeAdd2, AnimationNodeSync);
 
 	StringName add_amount = PNAME("add_amount");
-	bool sync = false;
 
 protected:
 	static void _bind_methods();
@@ -159,9 +168,6 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
 
 	virtual bool has_filter() const override;
 	virtual double process(double p_time, bool p_seek, bool p_seek_root) override;
@@ -169,11 +175,10 @@ public:
 	AnimationNodeAdd2();
 };
 
-class AnimationNodeAdd3 : public AnimationNode {
-	GDCLASS(AnimationNodeAdd3, AnimationNode);
+class AnimationNodeAdd3 : public AnimationNodeSync {
+	GDCLASS(AnimationNodeAdd3, AnimationNodeSync);
 
 	StringName add_amount = PNAME("add_amount");
-	bool sync = false;
 
 protected:
 	static void _bind_methods();
@@ -184,20 +189,16 @@ public:
 
 	virtual String get_caption() const override;
 
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
-
 	virtual bool has_filter() const override;
 	virtual double process(double p_time, bool p_seek, bool p_seek_root) override;
 
 	AnimationNodeAdd3();
 };
 
-class AnimationNodeBlend2 : public AnimationNode {
-	GDCLASS(AnimationNodeBlend2, AnimationNode);
+class AnimationNodeBlend2 : public AnimationNodeSync {
+	GDCLASS(AnimationNodeBlend2, AnimationNodeSync);
 
 	StringName blend_amount = PNAME("blend_amount");
-	bool sync = false;
 
 protected:
 	static void _bind_methods();
@@ -209,18 +210,14 @@ public:
 	virtual String get_caption() const override;
 	virtual double process(double p_time, bool p_seek, bool p_seek_root) override;
 
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
-
 	virtual bool has_filter() const override;
 	AnimationNodeBlend2();
 };
 
-class AnimationNodeBlend3 : public AnimationNode {
-	GDCLASS(AnimationNodeBlend3, AnimationNode);
+class AnimationNodeBlend3 : public AnimationNodeSync {
+	GDCLASS(AnimationNodeBlend3, AnimationNodeSync);
 
 	StringName blend_amount = PNAME("blend_amount");
-	bool sync;
 
 protected:
 	static void _bind_methods();
@@ -230,9 +227,6 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-
-	void set_use_sync(bool p_sync);
-	bool is_using_sync() const;
 
 	double process(double p_time, bool p_seek, bool p_seek_root) override;
 	AnimationNodeBlend3();
@@ -276,8 +270,8 @@ public:
 	AnimationNodeTimeSeek();
 };
 
-class AnimationNodeTransition : public AnimationNode {
-	GDCLASS(AnimationNodeTransition, AnimationNode);
+class AnimationNodeTransition : public AnimationNodeSync {
+	GDCLASS(AnimationNodeTransition, AnimationNodeSync);
 
 	enum {
 		MAX_INPUTS = 32
@@ -304,6 +298,7 @@ class AnimationNodeTransition : public AnimationNode {
 	StringName prev_current = "prev_current";
 
 	float xfade = 0.0;
+	bool from_start = true;
 
 	void _update_inputs();
 
@@ -328,6 +323,9 @@ public:
 
 	void set_cross_fade_time(float p_fade);
 	float get_cross_fade_time() const;
+
+	void set_from_start(bool p_from_start);
+	bool is_from_start() const;
 
 	double process(double p_time, bool p_seek, bool p_seek_root) override;
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -395,7 +395,7 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 			current = p_state_machine->start_node;
 		}
 
-		len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 1.0, AnimationNode::FILTER_IGNORE, false);
+		len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 1.0, AnimationNode::FILTER_IGNORE, true);
 		pos_current = 0;
 	}
 
@@ -420,10 +420,10 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 		}
 	}
 
-	float rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, p_seek_root, fade_blend, AnimationNode::FILTER_IGNORE, false);
+	float rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, p_seek_root, fade_blend, AnimationNode::FILTER_IGNORE, true);
 
 	if (fading_from != StringName()) {
-		p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_seek_root, 1.0 - fade_blend, AnimationNode::FILTER_IGNORE, false);
+		p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_seek_root, 1.0 - fade_blend, AnimationNode::FILTER_IGNORE, true);
 	}
 
 	//guess playback position
@@ -577,12 +577,12 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 			}
 			current = next;
 			if (switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_SYNC) {
-				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, false);
+				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, true);
 				pos_current = MIN(pos_current, len_current);
-				p_state_machine->blend_node(current, p_state_machine->states[current].node, pos_current, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, false);
+				p_state_machine->blend_node(current, p_state_machine->states[current].node, pos_current, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, true);
 
 			} else {
-				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, false);
+				len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_seek_root, 0, AnimationNode::FILTER_IGNORE, true);
 				pos_current = 0;
 			}
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -99,12 +99,12 @@ public:
 	Array _get_filters() const;
 	void _set_filters(const Array &p_filters);
 	friend class AnimationNodeBlendTree;
-	double _blend_node(const StringName &p_subpath, const Vector<StringName> &p_connections, AnimationNode *p_new_parent, Ref<AnimationNode> p_node, double p_time, bool p_seek, bool p_seek_root, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true, real_t *r_max = nullptr);
+	double _blend_node(const StringName &p_subpath, const Vector<StringName> &p_connections, AnimationNode *p_new_parent, Ref<AnimationNode> p_node, double p_time, bool p_seek, bool p_seek_root, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, real_t *r_max = nullptr);
 
 protected:
 	void blend_animation(const StringName &p_animation, double p_time, double p_delta, bool p_seeked, bool p_seek_root, real_t p_blend, int p_pingponged = 0);
-	double blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, double p_time, bool p_seek, bool p_seek_root, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
-	double blend_input(int p_input, double p_time, bool p_seek, bool p_seek_root, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_optimize = true);
+	double blend_node(const StringName &p_sub_path, Ref<AnimationNode> p_node, double p_time, bool p_seek, bool p_seek_root, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true);
+	double blend_input(int p_input, double p_time, bool p_seek, bool p_seek_root, real_t p_blend, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true);
 
 	void make_invalid(const String &p_reason);
 	AnimationTree *get_animation_tree() const;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -439,6 +439,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationNodeStateMachine);
 	GDREGISTER_CLASS(AnimationNodeStateMachinePlayback);
 
+	GDREGISTER_CLASS(AnimationNodeSync);
 	GDREGISTER_CLASS(AnimationNodeStateMachineTransition);
 	GDREGISTER_CLASS(AnimationNodeOutput);
 	GDREGISTER_CLASS(AnimationNodeOneShot);


### PR DESCRIPTION
Added `AnimationSyncNode` with the `sync` option as a base class and made any `AnimationNode` that may branch in the `AnimationTree` inherit from it.

Thus, `AnimationTransitionNode` is now has `sync`.

![image](https://user-images.githubusercontent.com/61938263/176984783-cb170f66-e30d-4a96-aa93-fb7933f66a8d.png)

However, if the animation is played from the beginning after switching state, `sync` will be broken. To prevent this, the option `from_start` is added in `AnimationTransitionNode`.

Also, `BlendSpace1D/2D` now has `sync`. This allows animations in multiple directions to be blended without breaking sync.

![image](https://user-images.githubusercontent.com/61938263/176984815-4feb3977-84cc-4abe-a637-7c32de4eb2f4.png)

----

In order to blend animations of different lengths neatly, the `TimeScale` must be changed depending on the actual animation blend value.

If the `AnimationTree` is not too complex, the actual blend value can be pre-computed from user input, etc., and this can be solved by adding a few lines of code in GDScript like below:

```GDScript
# Blend Walk and Run
_animtree["parameters/TimeScaleRun/scale"] = lerp(ANIMATION_LENGTH_RUN / ANIMATION_LENGTH_WALK, 1, _dash)
_animtree["parameters/TimeScaleWalk/scale"] = lerp(1, ANIMATION_LENGTH_WALK / ANIMATION_LENGTH_RUN, _dash)
_animtree["parameters/BlendDash/blend_amount"] = _dash
```

This process could be automated in some way, but it is quite complex. It requires recognizing chains between `NodeAnimations` and recognizing the actual blend values from the blends that exist in between.

In the past, #34179 has tried to solve this, but it still had the strong limitation that auto-adjustment would only occur between `NodeAnimation`s that were directly chained in `BlendSpace1D/2D`.

More recently, there is an approach of #62424, but so far this completely corrupts the blending process and makes it inconsistent.

In my opinion, if #62424 is to be implemented correctly, an *iterating process that only calculates the blend values for adjusting time scale* needs to be added before the *iterating process that calculates the actual track values* without changing blend process. However, even if this were done, there would still be inconsistencies due to `TimeScale` and `Seek`.

----

In summary, now all we need to do for `AnimationTree` is to add `sync` correctly in some nodes which lacks it.

**After all, when we create a game, we need a process to calculate the blend values depending on inputs and other factors. If we want to synchronize animations of different lengths, we should calculate the TimeScale properly in there.** It can be solved with a few lines of code in GDScript and it is not difficult.

With this PR, the [synchronization methods](https://github.com/godotengine/godot/issues/23414#issuecomment-474955147) mentioned by @David-Ochoa in #23414 should now work perfectly correctly. No longer needed the [hack](https://github.com/godotengine/godot/issues/23414#issuecomment-757587611) for sync.

Fixed #23414.

#34179 and #62424 may be possible to keep it as a proposal, but perhaps it should be transferred to a [godot-proposals](https://github.com/godotengine/godot-proposals) for discussion so that we can reach a consensus. At least this PR reduce what is needed to implement them.

----

https://user-images.githubusercontent.com/61938263/176985177-d2d8b51d-62bc-4d85-87d4-1d33f50ca969.mp4

There is a sample project for TPS-Lock-on movement. 

[character_controller_3d_sample.zip](https://github.com/godotengine/godot/files/9033610/character_controller_3d_sample.zip)

When rotating the hips in that TPS-Lock-on movement, the minimum number of animations required is high and blending can be complex, but the fixed `AnimationTree` uses `sync` to solve this problem with a tree of a certain size.