### PR TITLE
Fix build console colored output issues in VS Code on Windows

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -460,7 +460,7 @@ def use_windows_spawn_fix(self, platform=None):
         rv = proc.wait()
         if rv:
             print("=====")
-            print(err)
+            print(err.decode("ascii"))
             print("=====")
         return rv
 
@@ -515,6 +515,7 @@ def save_active_platforms(apnames, ap):
 
 def no_verbose(sys, env):
 
+    os.system("")
     colors = {}
 
     # Colors are disabled in non-TTY environments such as pipes. This means


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
~~Added python module "colorama" to display ANSI color control character correctly.~~ Include a pseudo call to os.system() for the ANSI control characters to work properly. Some consoles tend to output raw character of it rather than changing the color as expected, in this case is Visual Studio Code.

Instead of printing build error directly, decode the error string as ASCII and print it. The subprocess communicate() function in 3.x has changed from returning a regular string to returning a byte string, which will cause special characters like newline (\n) to print raw character than actually going to the next line.