### PR TITLE
Make sure the tile data clears its `terrain` field when said terrain is removed from the tileset.

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4924,6 +4924,10 @@ void TileData::move_terrain(int p_terrain_set, int p_from_index, int p_to_pos) {
 
 void TileData::remove_terrain(int p_terrain_set, int p_index) {
 	if (terrain_set == p_terrain_set) {
+		if (terrain == p_index) {
+			terrain = -1;
+		}
+
 		for (int i = 0; i < 16; i++) {
 			if (terrain_peering_bits[i] == p_index) {
 				terrain_peering_bits[i] = -1;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #62630 

I am not quite sure what the `TileData::terrain` field does, but this fixes the crash mentioned above when the tileset editor tries to generate the terrain previews.