### PR TITLE
Corrected InputEventKey::as_text to return a non-empty string for physical keys.

### DIFF
--- a/core/os/input_event.cpp
+++ b/core/os/input_event.cpp
@@ -268,7 +268,14 @@ uint32_t InputEventKey::get_physical_scancode_with_modifiers() const {
 }
 
 String InputEventKey::as_text() const {
-	String kc = keycode_get_string(scancode);
+	String kc;
+
+	if (scancode == 0) {
+		kc = keycode_get_string(physical_scancode) + " (" + RTR("Physical") + ")";
+	} else {
+		kc = keycode_get_string(scancode);
+	}
+
 	if (kc == String()) {
 		return kc;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #61508.

After discussing with YuriSizov on the Godot Contributor Chat, I decided to backport a small part of dfe4c5f8e130b9c63a1a18ffdaf07c512e670e63 (only the part handling physical keys) in order to fix this issue. I didn't backport the whole commit to avoid breaking compatibility.