### PR TITLE
[3.x] SCons: Properly track codegen script dependency for generated GLES headers

### DIFF
--- a/drivers/gles2/shaders/SCsub
+++ b/drivers/gles2/shaders/SCsub
@@ -12,3 +12,4 @@ if "GLES2_GLSL" in env["BUILDERS"]:
     env.GLES2_GLSL("effect_blur.glsl")
     env.GLES2_GLSL("tonemap.glsl")
     env.GLES2_GLSL("lens_distorted.glsl")
+    env.Depends(Glob("*.glsl.gen.h"), "#gles_builders.py")

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -21,3 +21,4 @@ if "GLES3_GLSL" in env["BUILDERS"]:
     env.GLES3_GLSL("tonemap.glsl")
     env.GLES3_GLSL("particles.glsl")
     env.GLES3_GLSL("lens_distorted.glsl")
+    env.Depends(Glob("*.glsl.gen.h"), "#gles_builders.py")


### PR DESCRIPTION
Needed for #62628 (and past changes that broke incremental compilation similarly).

- `3.x` version of #62636