### PR TITLE
SCons: Properly track codegen script dependency for generated GLSL headers

### DIFF
--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -10,7 +10,7 @@ if "GLES3_GLSL" in env["BUILDERS"]:
     glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
 
     # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files)
+    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#gles3_builders.py"])
 
     env.GLES3_GLSL("canvas.glsl")
     env.GLES3_GLSL("copy.glsl")

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -7,9 +7,7 @@ env_lightmapper_rd = env_modules.Clone()
 env_lightmapper_rd.GLSL_HEADER("lm_raster.glsl")
 env_lightmapper_rd.GLSL_HEADER("lm_compute.glsl")
 env_lightmapper_rd.GLSL_HEADER("lm_blendseams.glsl")
-env_lightmapper_rd.Depends("lm_raster.glsl.gen.h", "lm_common_inc.glsl")
-env_lightmapper_rd.Depends("lm_compute.glsl.gen.h", "lm_common_inc.glsl")
-env_lightmapper_rd.Depends("lm_blendseams.glsl.gen.h", "lm_common_inc.glsl")
+env_lightmapper_rd.Depends(Glob("*.glsl.gen.h"), ["lm_common_inc.glsl", "#glsl_builders.py"])
 
 # Godot source files
 env_lightmapper_rd.add_source_files(env.modules_sources, "*.cpp")

--- a/servers/rendering/renderer_rd/shaders/SCsub
+++ b/servers/rendering/renderer_rd/shaders/SCsub
@@ -10,7 +10,7 @@ if "RD_GLSL" in env["BUILDERS"]:
     glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
 
     # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files)
+    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
 
     # compile shaders
     for glsl_file in glsl_files:

--- a/servers/rendering/renderer_rd/shaders/effects/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/SCsub
@@ -10,7 +10,7 @@ if "RD_GLSL" in env["BUILDERS"]:
     glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
 
     # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files)
+    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
 
     # compile shaders
     for glsl_file in glsl_files:

--- a/servers/rendering/renderer_rd/shaders/environment/SCsub
+++ b/servers/rendering/renderer_rd/shaders/environment/SCsub
@@ -10,7 +10,7 @@ if "RD_GLSL" in env["BUILDERS"]:
     glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
 
     # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files)
+    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
 
     # compile shaders
     for glsl_file in glsl_files:


### PR DESCRIPTION
- `master` version of #62634

As a side note, the logic we have to handle the dependencies on `_inc.glsl` include shaders is a bit convoluted. This could likely all be refactored somewhat to reduce code duplication at least.