### PR TITLE
Improve antialiased line drawing sharpness and respect of original width

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -594,9 +594,13 @@ void RendererCanvasCull::canvas_item_add_line(RID p_item, const Point2 &p_from, 
 	}
 
 	if (p_antialiased) {
-		float border_size = 2.0;
-		if (p_width < border_size) {
-			border_size = p_width;
+		// Use the same antialiasing feather size as StyleBoxFlat's default
+		// (but doubled, as it's specified for both sides here).
+		// This value is empirically determined to provide good antialiasing quality
+		// while not making lines appear too soft.
+		float border_size = 1.25f;
+		if (p_width < 1.0f) {
+			border_size *= p_width;
 		}
 		Vector2 dir2 = diff.normalized();
 
@@ -763,9 +767,13 @@ void RendererCanvasCull::canvas_item_add_polyline(RID p_item, const Vector<Point
 	Color *colors_ptr = colors.ptrw();
 
 	if (p_antialiased) {
-		float border_size = 2.0;
-		if (p_width < border_size) {
-			border_size = p_width;
+		// Use the same antialiasing feather size as StyleBoxFlat's default
+		// (but doubled, as it's specified for both sides here).
+		// This value is empirically determined to provide good antialiasing quality
+		// while not making lines appear too soft.
+		float border_size = 1.25f;
+		if (p_width < 1.0f) {
+			border_size *= p_width;
 		}
 		Color color2 = Color(1, 1, 1, 0);
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/62638.

Antialiased lines with a width of 2 pixels or more now use a smaller feather width of 1.25 instead of 2.0. This makes them look sharper and better preserves their original shape while still having good antialiasing quality.

This also improves the appearance of thin antialiased lines by slightly increasing their feather size (from 1.0 to 1.25). It makes them appear a tad thicker, but the antialiasing quality is much improved by doing this.

## Preview

*Click to view at full size. 200% nearest-neighbor scaling is used to make the difference easier to notice.*

### Thin line

Before | After
-|-
![image](https://user-images.githubusercontent.com/180032/177009321-06d81172-7319-425e-926c-6a1955bbef9e.png) | ![image](https://user-images.githubusercontent.com/180032/177009325-0e0b2e9c-287a-47e4-ab13-1dc3668ea4ab.png)

### Thick line

Before | After
-|-
![2022-07-02_18 44 47](https://user-images.githubusercontent.com/180032/177009261-fb439811-cf9b-4ff2-adbe-99292b69a8fe.png) | ![2022-07-02_18 44 11](https://user-images.githubusercontent.com/180032/177009260-1318000d-533f-4597-b4e2-fe6bdc82fb79.png)