### PR TITLE
Vulkan: Make `loader_get_json` "error" a verbose message on Windows

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -72,20 +72,20 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanContext::_debug_messenger_callback(
 			strstr(pCallbackData->pMessage, "must be a memory object") != nullptr) {
 		return VK_FALSE;
 	}
-	/*
-	// This is a valid warning because its illegal in Vulkan, but in practice it should work according to VK_KHR_maintenance2
-	if (strstr(pCallbackData->pMessage, "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT") != nullptr) {
-		return VK_FALSE;
-	}
 
-	if (strstr(pCallbackData->pMessage, "VK_FORMAT_R4G4B4A4_UNORM_PACK16 with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT") != nullptr) {
-		return VK_FALSE;
-	}
-*/
 	// Workaround for Vulkan-Loader usability bug: https://github.com/KhronosGroup/Vulkan-Loader/issues/262.
 	if (strstr(pCallbackData->pMessage, "wrong ELF class: ELFCLASS32") != nullptr) {
 		return VK_FALSE;
 	}
+
+#ifdef WINDOWS_ENABLED
+	// Some software installs Vulkan overlays in Windows registry and never cleans them up on uninstall.
+	// So we get spammy error level messages from the loader about those - make them verbose instead.
+	if (strstr(pCallbackData->pMessage, "loader_get_json: Failed to open JSON file") != nullptr) {
+		messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
+	}
+#endif
+
 	if (pCallbackData->pMessageIdName && strstr(pCallbackData->pMessageIdName, "UNASSIGNED-CoreValidation-DrawState-ClearCmdBeforeDraw") != nullptr) {
 		return VK_FALSE;
 	}


### PR DESCRIPTION
In far most cases it seems like it's going to message about bogus manifests
in the Windows registry which point to JSON files which have since been
uninstalled, but without clearing the registry.

This happens with bogus Vulkan overlays from Twitch, Epic Online Services,
NVIDIA Nsight Systems, OBS Studio, Rockstar Games... fix your mess folks.

- Fixes #56089.