### PR TITLE
[3.x] Remove redundant checkbox check

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -104,7 +104,7 @@ void Button::_notification(int p_what) {
 					}
 				} break;
 				case DRAW_HOVER_PRESSED: {
-					if (has_stylebox("hover_pressed") && has_stylebox_override("hover_pressed")) {
+					if (has_stylebox("hover_pressed")) {
 						style = get_stylebox("hover_pressed");
 						if (!flat) {
 							style->draw(ci, Rect2(Point2(0, 0), size));


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/62642

![image](https://user-images.githubusercontent.com/48352564/177014036-2b0c1d7a-fee4-4ea4-bf5e-a638d63036c6.gif)

master is not relevant here.
