### PR TITLE
Make asset library's column count dynamic

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -624,6 +624,10 @@ void EditorAssetLibrary::_notification(int p_what) {
 
 		} break;
 
+		case NOTIFICATION_RESIZED: {
+			_update_asset_items_columns();
+		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			_update_repository_options();
 			setup_http_request(request);
@@ -1213,7 +1217,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 			library_vb->add_child(asset_top_page);
 
 			asset_items = memnew(GridContainer);
-			asset_items->set_columns(2);
+			_update_asset_items_columns();
 			asset_items->add_theme_constant_override("h_separation", 10 * EDSCALE);
 			asset_items->add_theme_constant_override("v_separation", 10 * EDSCALE);
 
@@ -1379,12 +1383,17 @@ void EditorAssetLibrary::_install_external_asset(String p_zip_path, String p_tit
 	emit_signal(SNAME("install_asset"), p_zip_path, p_title);
 }
 
-void EditorAssetLibrary::disable_community_support() {
-	support->get_popup()->set_item_checked(SUPPORT_COMMUNITY, false);
+void EditorAssetLibrary::_update_asset_items_columns() {
+	int new_columns = get_size().x / (450.0 * EDSCALE);
+	new_columns = MAX(1, new_columns);
+
+	if (new_columns != asset_items->get_columns()) {
+		asset_items->set_columns(new_columns);
+	}
 }
 
-void EditorAssetLibrary::set_columns(const int p_columns) {
-	asset_items->set_columns(p_columns);
+void EditorAssetLibrary::disable_community_support() {
+	support->get_popup()->set_item_checked(SUPPORT_COMMUNITY, false);
 }
 
 void EditorAssetLibrary::_bind_methods() {
@@ -1542,7 +1551,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	library_vb->add_child(asset_top_page);
 
 	asset_items = memnew(GridContainer);
-	asset_items->set_columns(2);
+	_update_asset_items_columns();
 	asset_items->add_theme_constant_override("h_separation", 10 * EDSCALE);
 	asset_items->add_theme_constant_override("v_separation", 10 * EDSCALE);
 

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -301,6 +301,8 @@ class EditorAssetLibrary : public PanelContainer {
 
 	void _install_external_asset(String p_zip_path, String p_title);
 
+	void _update_asset_items_columns();
+
 	friend class EditorAssetLibraryItemDescription;
 	friend class EditorAssetLibraryItem;
 
@@ -311,7 +313,6 @@ protected:
 
 public:
 	void disable_community_support();
-	void set_columns(int p_columns);
 
 	EditorAssetLibrary(bool p_templates_only = false);
 };

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1895,7 +1895,6 @@ void ProjectManager::_notification(int p_what) {
 			}
 			if (asset_library) {
 				real_t size = get_size().x / EDSCALE;
-				asset_library->set_columns(size < 1000 ? 1 : 2);
 				// Adjust names of tabs to fit the new size.
 				if (size < 650) {
 					local_projects_hb->set_name(TTR("Local"));


### PR DESCRIPTION
Currently it's 1-2 columns, so a lot of space is wasted on bigger screens. I made the number dynamic based on width
![](https://user-images.githubusercontent.com/3097956/177015162-3afd2ff7-2a7d-4820-9b32-36c166fd5b6f.png)
