### PR TITLE
Register missing WebRTCDataChannelJS type

### DIFF
--- a/modules/webrtc/webrtc_peer_connection_js.cpp
+++ b/modules/webrtc/webrtc_peer_connection_js.cpp
@@ -57,7 +57,7 @@ void WebRTCPeerConnectionJS::_on_error(void *p_obj) {
 
 void WebRTCPeerConnectionJS::_on_data_channel(void *p_obj, int p_id) {
 	WebRTCPeerConnectionJS *peer = static_cast<WebRTCPeerConnectionJS *>(p_obj);
-	peer->emit_signal(SNAME("data_channel_received"), Ref<WebRTCDataChannelJS>(new WebRTCDataChannelJS(p_id)));
+	peer->emit_signal(SNAME("data_channel_received"), Ref<WebRTCDataChannel>(memnew(WebRTCDataChannelJS(p_id))));
 }
 
 void WebRTCPeerConnectionJS::close() {

--- a/modules/webrtc/webrtc_peer_connection_js.h
+++ b/modules/webrtc/webrtc_peer_connection_js.h
@@ -52,6 +52,8 @@ extern int godot_js_rtc_pc_datachannel_create(int p_id, const char *p_label, con
 }
 
 class WebRTCPeerConnectionJS : public WebRTCPeerConnection {
+	GDCLASS(WebRTCPeerConnectionJS, WebRTCPeerConnection);
+
 private:
 	int _js_id;
 	ConnectionState _conn_state;


### PR DESCRIPTION
Rebased #55044 on the `master` branch as that PR was wrongly targeting `3.4`.