### PR TITLE
Add debug instance index argument when running multiple instances

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -264,9 +264,19 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	printf("\n");
 
 	int instances = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_instances", 1);
+	bool add_instance_arg = instances > 1;
+	if (add_instance_arg) {
+		args.push_back("debug_instance_index");
+	}
 	for (int i = 0; i < instances; i++) {
+		if (add_instance_arg) {
+			args.push_back(itos(i));
+		}
 		OS::ProcessID pid = 0;
 		Error err = OS::get_singleton()->create_instance(args, &pid);
+		if (add_instance_arg) {
+			args.pop_back();
+		}
 		ERR_FAIL_COND_V(err, err);
 		pids.push_back(pid);
 	}


### PR DESCRIPTION
When running multiple instances (eg. Debug->Run Multiple Instances->Run 3 Instances), there is no automatic way to tell one instance to behave differently to the others (eg. you might want one instance to host a game and the others to join it).

When running more than one instance, this PR adds an argument accessible through OS.get_cmdline_args() for the index of the instance. Each instance will always be assigned a different number from 0 to n-1 for n instances.
![image](https://user-images.githubusercontent.com/14885846/177027570-fb888189-efa6-4ca1-aa52-c11c80855b90.png)
