### PR TITLE
Made ScriptTextEditor::clear_edit_menu to set the `edit_hb` pointer to nullptr to avoid use-after-free crashes.

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1593,7 +1593,11 @@ void ScriptEditor::_prepare_file_menu() {
 }
 
 void ScriptEditor::_tab_changed(int p_which) {
-	ensure_select_current();
+	// defer the call since this function might be called after a tab is removed,
+	// and in that case `tab_container->get_tab_controls()` still contains the
+	// removed tab because the ScriptEditor is notified of the removal before
+	// the node is removed from the tree. See #62657 for more info.
+	call_deferred(SNAME("ensure_select_current"));
 }
 
 void ScriptEditor::_notification(int p_what) {
@@ -3636,6 +3640,8 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_current_script"), &ScriptEditor::_get_current_script);
 	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
+	
+	ClassDB::bind_method(D_METHOD("ensure_select_current"), &ScriptEditor::ensure_select_current);
 
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1418,6 +1418,7 @@ Control *ScriptTextEditor::get_edit_menu() {
 
 void ScriptTextEditor::clear_edit_menu() {
 	memdelete(edit_hb);
+	edit_hb = nullptr;
 }
 
 void ScriptTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #61689.

The generating the crash in the above issue was already checking for null pointers, so this indeed fixes the crash but the behaviour is still broken : 
1. There is an error `Condition "!is_inside_tre()" is true` being generated from `ScriptEditor::_tab_changed` : 
```
#0  Control::grab_focus (this=0x5555788e9270) at scene/gui/control.cpp:2534
#1  0x00005555597244c5 in ScriptTextEditor::ensure_focus (this=0x5555788dd6e0) at editor/plugins/script_text_editor.cpp:392
#2  0x00005555596e7231 in ScriptEditor::ensure_select_current (this=0x55556ca6d570) at editor/plugins/script_editor_plugin.cpp:1794
#3  0x00005555596e35c9 in ScriptEditor::_tab_changed (this=0x55556ca6d570, p_which=0) at editor/plugins/script_editor_plugin.cpp:1596
```
2. The script list is has a broken display afterward : 

https://user-images.githubusercontent.com/2700596/177029986-a4cfc180-8722-4fd6-8923-4e8b83bac737.mp4

 I'll try investigating both issues but I am open to any advice or pointer regarding it as I don't really know how that part of the engine works.