### PR TITLE
Expose `Node` child manipulation callbacks

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -22,6 +22,14 @@
 		<link title="All Demos">https://github.com/godotengine/godot-demo-projects/</link>
 	</tutorials>
 	<methods>
+		<method name="_add_child_notify" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="child" type="Node" />
+			<description>
+				Called after a node is added as a child.
+				[b]Note:[/b] This method is called on application start for every node already in the tree as well.
+			</description>
+		</method>
 		<method name="_enter_tree" qualifiers="virtual">
 			<return type="void" />
 			<description>
@@ -55,6 +63,13 @@
 				[b]Note:[/b] This method is only called if the node is present in the scene tree (i.e. if it's not an orphan).
 			</description>
 		</method>
+		<method name="_move_child_notify" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="child" type="Node" />
+			<description>
+				Called after a child is moved within the node.
+			</description>
+		</method>
 		<method name="_physics_process" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
@@ -82,6 +97,13 @@
 				Corresponds to the [constant NOTIFICATION_READY] notification in [method Object._notification]. See also the [code]@onready[/code] annotation for variables.
 				Usually used for initialization. For even earlier initialization, [method Object._init] may be used. See also [method _enter_tree].
 				[b]Note:[/b] [method _ready] may be called only once for each node. After removing a node from the scene tree and adding it again, [code]_ready[/code] will not be called a second time. This can be bypassed by requesting another call with [method request_ready], which may be called anywhere before adding the node again.
+			</description>
+		</method>
+		<method name="_remove_child_notify" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="child" type="Node" />
+			<description>
+				Called when a child is removed within the node.
 			</description>
 		</method>
 		<method name="_shortcut_input" qualifiers="virtual">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -411,15 +411,18 @@ void Node::_propagate_groups_dirty() {
 }
 
 void Node::add_child_notify(Node *p_child) {
-	// to be used when not wanted
+	// Called when a node is added as a child to this one.
+	GDVIRTUAL_CALL(_add_child_notify, p_child);
 }
 
 void Node::remove_child_notify(Node *p_child) {
-	// to be used when not wanted
+	// Called when a child is removed from this node.
+	GDVIRTUAL_CALL(_remove_child_notify, p_child);
 }
 
 void Node::move_child_notify(Node *p_child) {
-	// to be used when not wanted
+	// Called when a child is moved inside this node.
+	GDVIRTUAL_CALL(_move_child_notify, p_child);
 }
 
 void Node::owner_changed_notify() {
@@ -2956,6 +2959,9 @@ void Node::_bind_methods() {
 	GDVIRTUAL_BIND(_shortcut_input, "event");
 	GDVIRTUAL_BIND(_unhandled_input, "event");
 	GDVIRTUAL_BIND(_unhandled_key_input, "event");
+	GDVIRTUAL_BIND(_add_child_notify, "child");
+	GDVIRTUAL_BIND(_remove_child_notify, "child");
+	GDVIRTUAL_BIND(_move_child_notify, "child");
 }
 
 String Node::_get_name_num_separator() {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -246,6 +246,10 @@ protected:
 	GDVIRTUAL1(_unhandled_input, Ref<InputEvent>)
 	GDVIRTUAL1(_unhandled_key_input, Ref<InputEvent>)
 
+	GDVIRTUAL1(_add_child_notify, Node *)
+	GDVIRTUAL1(_remove_child_notify, Node *)
+	GDVIRTUAL1(_move_child_notify, Node *)
+
 public:
 	enum {
 		// you can make your own, but don't use the same numbers as other notifications in other nodes

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1284,12 +1284,16 @@ Rect2i Window::get_usable_parent_rect() const {
 }
 
 void Window::add_child_notify(Node *p_child) {
+	Viewport::add_child_notify(p_child);
+
 	if (is_inside_tree() && wrap_controls) {
 		child_controls_changed();
 	}
 }
 
 void Window::remove_child_notify(Node *p_child) {
+	Viewport::remove_child_notify(p_child);
+
 	if (is_inside_tree() && wrap_controls) {
 		child_controls_changed();
 	}


### PR DESCRIPTION
Based on #43729, ported to 4.0, thank Xrayez for doing most of the work.

While #57541 solves godotengine/godot-proposals#724 and godotengine/godot-proposals#2544 using signals, it was suggested at https://github.com/godotengine/godot/pull/43729#issuecomment-1029793093 this was still being considered had it been ported to 4.0. I took a bit of liberty with the original PR and kept it more in line with the other virtual methods.

This does slightly diverge in function from #57541 in that it is called with every call to `add_child`, `move_child`, and `remove_child` that succeeds regardless of the scene tree. While in GDScript you may be capable to override the add, move, and remove child methods, (whether that should be commonly recommended aside, by itself it does reduce this PR's value in GDScript only) but in a more static language like C# this would only work if the method was virtual, otherwise you'd only hide it when you cast to your known class. 

## Exposed Additions 
```gdscript
virtual void _add_child_notify(child: Node)
virtual void _move_child_notify(child: Node)
virtual void _remove_child_notify(child: Node)
```

## Usage
```gdscript
extends Node

func _add_child_notify(child): print("child was added")
func _move_child_notify(child): print("child was moved")
func _remove_child_notify(child): print("child was removed")
```

Also corrects Control and Window not calling the base `add_child_notify` and `remove_child_notify` methods.

### Potential Considerations
* (This has since been addressed, TabContainer is currently consistent with other nodes) ~~`TabContainer` is the only Node that hides an internal node, its `TabBar` internal node, from the `add_child_notify`, `remove_child_notify`, and `move_child_notify` methods resulting in inconsistent behavior compared to all other internal nodes including its own. Can be corrected by adding either to the internal TabBar if branch:~~
    1. ~~Calling the CanvasItem `add_child_notify`, `remove_child_notify`, and `move_child_notify` so as to be consistent with previous function of not otherwise calling the Control base for the internal TabBar~~
    2. ~~Directly calling the respective `_add_child_notify`, `_remove_child_notify`, `_move_child_notify` virtual methods~~
* Documentation may optimally need to note that `_add_child_notify`, `_remove_child_notify`, and `_move_child_notify` will otherwise include internal nodes.

**Test Project**:
[NodeChildNotifyTestProject.zip](https://github.com/godotengine/godot/files/9034409/NodeChildNotifyTestProject.zip)