### PR TITLE
Input: Document that accumulated input is disabled by default

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -400,6 +400,7 @@
 		<member name="use_accumulated_input" type="bool" setter="set_use_accumulated_input" getter="is_using_accumulated_input">
 			If [code]true[/code], similar input events sent by the operating system are accumulated. When input accumulation is enabled, all input events generated during a frame will be merged and emitted when the frame is done rendering. Therefore, this limits the number of input method calls per second to the rendering FPS.
 			Input accumulation can be disabled to get slightly more precise/reactive input at the cost of increased CPU usage. In applications where drawing freehand lines is required, input accumulation should generally be disabled while the user is drawing the line to get results that closely follow the actual input.
+			[b]Note:[/b] Input accumulation is [i]disabled[/i] by default for backward compatibility reasons. It is however recommended to enable it for games which don't require very reactive input, as this will decrease CPU usage.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -5,7 +5,8 @@
 	</brief_description>
 	<description>
 		Contains mouse and pen motion information. Supports relative, absolute positions and speed. See [method Node._input].
-		[b]Note:[/b] By default, this event is only emitted once per frame rendered at most. If you need more precise input reporting, set [member Input.use_accumulated_input] to [code]false[/code] to make events emitted as often as possible. If you use InputEventMouseMotion to draw lines, consider implementing [url=https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm]Bresenham's line algorithm[/url] as well to avoid visible gaps in lines if the user is moving the mouse quickly.
+		[b]Note:[/b] By default, this event can be emitted multiple times per frame rendered, allowing for precise input reporting, at the expense of CPU usage. You can set [member Input.use_accumulated_input] to [code]true[/code] to let multiple events merge into a single emitted event per frame.
+		[b]Note:[/b] If you use InputEventMouseMotion to draw lines, consider implementing [url=https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm]Bresenham's line algorithm[/url] as well to avoid visible gaps in lines if the user is moving the mouse quickly.
 	</description>
 	<tutorials>
 		<link title="Mouse and input coordinates">$DOCS_URL/tutorials/inputs/mouse_and_input_coordinates.html</link>


### PR DESCRIPTION
This was actually disabled by mistake in 3.4 causing a regression, but since
this issue survived the whole 3.4.x series and it's now very close to 3.5,
it's too late to change it again.

We might consider it for 3.6 after some beta testing.

- Fixes https://github.com/godotengine/godot/issues/55037.

---

Some more details on the defaults here:
- Accumulated input was implemented in a1e73dcc944627ab7185aec7cd4141fe4ebb97d7, off by default at runtime but enabled in the editor.
- 2 days later it was enabled by default always in ecd8795755095e5d8c002f030e51bb26892d7cbb. Those two changes were made for Godot 3.1.
- Then #42220 refactored things and added agile input flushing, and turned accumulated input off by mistake (still enabled in the editor by a call in `EditorNode`). This was changed in Godot 3.4.
- In `master` (which started diverging with `3.x` at Godot 3.2), #42220 was forward-ported by #51597 but accumulated input was not turned off then. On the other hand... I turned it off by error myself in #38697 while refactoring member initialization. #62665 should fix it.