### PR TITLE
Input: Re-enable input accumulation by default

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -110,7 +110,7 @@ private:
 	bool emulate_touch_from_mouse = false;
 	bool emulate_mouse_from_touch = false;
 	bool use_input_buffering = false;
-	bool use_accumulated_input = false;
+	bool use_accumulated_input = true;
 
 	int mouse_from_touch_index = -1;
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -375,6 +375,7 @@
 		<member name="use_accumulated_input" type="bool" setter="set_use_accumulated_input" getter="is_using_accumulated_input">
 			If [code]true[/code], similar input events sent by the operating system are accumulated. When input accumulation is enabled, all input events generated during a frame will be merged and emitted when the frame is done rendering. Therefore, this limits the number of input method calls per second to the rendering FPS.
 			Input accumulation can be disabled to get slightly more precise/reactive input at the cost of increased CPU usage. In applications where drawing freehand lines is required, input accumulation should generally be disabled while the user is drawing the line to get results that closely follow the actual input.
+			[b]Note:[/b] Input accumulation is [i]enabled[/i] by default.
 		</member>
 	</members>
 	<signals>


### PR DESCRIPTION
I turned it off by mistake in #38697.
See also #62664 for details on this boolean's complex history :)

---

BTW I don't know why doctool isn't picking up the default value for this member. Maybe it doesn't properly support singletons.