### PR TITLE
Tree recursive folding (like Scene Tree Dock)

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -312,6 +312,9 @@
 			The drop mode as an OR combination of flags. See [enum DropModeFlags] constants. Once dropping is done, reverts to [constant DROP_MODE_DISABLED]. Setting this during [method Control._can_drop_data] is recommended.
 			This controls the drop sections, i.e. the decision and drawing of possible drop locations based on the mouse position.
 		</member>
+		<member name="enable_recursive_folding" type="bool" setter="set_enable_recursive_folding" getter="is_recursive_folding_enabled" default="true">
+			If [code]true[/code], recursive folding is enabled for this [Tree]. Holding down Shift while clicking the fold arrow collapses or uncollapses the [TreeItem] and all its descendants.
+		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="hide_folding" type="bool" setter="set_hide_folding" getter="is_folding_hidden" default="false">
 			If [code]true[/code], the folding arrow is hidden.

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -321,6 +321,14 @@
 				Returns the [Tree] that owns this TreeItem.
 			</description>
 		</method>
+		<method name="is_any_collapsed">
+			<return type="bool" />
+			<param index="0" name="only_visible" type="bool" default="false" />
+			<description>
+				Returns [code]true[/code] if this [TreeItem], or any of its descendants, is collapsed.
+				If [param only_visible] is [code]true[/code] it ignores non-visible [TreeItem]s.
+			</description>
+		</method>
 		<method name="is_button_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="column" type="int" />
@@ -440,6 +448,13 @@
 			<param index="1" name="checked" type="bool" />
 			<description>
 				If [code]true[/code], the given [param column] is checked. Clears column's indeterminate status.
+			</description>
+		</method>
+		<method name="set_collapsed_recursive">
+			<return type="void" />
+			<param index="0" name="enable" type="bool" />
+			<description>
+				Collapses or uncollapses this [TreeItem] and all the descendants of this item.
 			</description>
 		</method>
 		<method name="set_custom_as_button">

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1751,22 +1751,7 @@ void FileSystemDock::_tree_rmb_option(int p_option) {
 		case FOLDER_COLLAPSE_ALL: {
 			// Expand or collapse the folder
 			if (selected_strings.size() == 1) {
-				bool is_collapsed = (p_option == FOLDER_COLLAPSE_ALL);
-
-				Vector<TreeItem *> needs_check;
-				needs_check.push_back(tree->get_selected());
-
-				while (needs_check.size()) {
-					needs_check[0]->set_collapsed(is_collapsed);
-
-					TreeItem *child = needs_check[0]->get_first_child();
-					while (child) {
-						needs_check.push_back(child);
-						child = child->get_next();
-					}
-
-					needs_check.remove_at(0);
-				}
+				tree->get_selected()->set_collapsed_recursive(p_option == FOLDER_COLLAPSE_ALL);
 			}
 		} break;
 		default: {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -137,7 +137,6 @@ class SceneTreeDock : public VBoxContainer {
 	HBoxContainer *tool_hbc = nullptr;
 	void _tool_selected(int p_tool, bool p_confirm_override = false);
 	void _property_selected(int p_idx);
-	void _node_collapsed(Object *p_obj);
 
 	Node *property_drop_node = nullptr;
 	String resource_drop_path;
@@ -187,9 +186,6 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _node_reparent(NodePath p_path, bool p_keep_global_xform);
 	void _do_reparent(Node *p_new_parent, int p_position_in_parent, Vector<Node *> p_nodes, bool p_keep_global_xform);
-
-	bool _is_collapsed_recursive(TreeItem *p_item) const;
-	void _set_collapsed_recursive(TreeItem *p_item, bool p_collapsed);
 
 	void _set_owners(Node *p_owner, const Array &p_nodes);
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -173,6 +173,8 @@ private:
 		}
 	}
 
+	bool _is_any_collapsed(bool p_only_visible);
+
 protected:
 	static void _bind_methods();
 
@@ -271,6 +273,9 @@ public:
 
 	void set_collapsed(bool p_collapsed);
 	bool is_collapsed();
+
+	void set_collapsed_recursive(bool p_collapsed);
+	bool is_any_collapsed(bool p_only_visible = false);
 
 	void set_visible(bool p_visible);
 	bool is_visible();
@@ -613,6 +618,8 @@ private:
 
 	bool hide_folding = false;
 
+	bool enable_recursive_folding = true;
+
 	int _count_selected_items(TreeItem *p_from) const;
 	bool _is_branch_selected(TreeItem *p_from) const;
 	bool _is_sibling_branch_selected(TreeItem *p_from) const;
@@ -711,6 +718,9 @@ public:
 
 	void set_hide_folding(bool p_hide);
 	bool is_folding_hidden() const;
+
+	void set_enable_recursive_folding(bool p_enable);
+	bool is_recursive_folding_enabled() const;
 
 	void set_drop_mode_flags(int p_flags);
 	int get_drop_mode_flags() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Moves the behavior of Scene Tree Dock recursively folding of trees into TreeItem:
- Adds function `set_collapsed_recursive` to collapse/uncollapse a TreeItem and all its descendants
- Adds function `is_any_collapsed` to check if a TreeItem (with children) or any of its children (with children) are collapsed
- Shift clicking the fold collapses/uncollapses the entire tree under the TreeItem, depending on the fold state of the TreeItem
- Ads disable property for this input behavior to TreeItem

Replaced the functionality in Scene Tree Dock with this, and I haven't found anywhere else it is used but if anyone does please point it out and I can remove it there as well.

(The original approach in Scene Tree Dock was doing some redundant folding on shift click as it would fold the TreeItem and all descendants, but this would trigger each of those descendants to fold recursively on their own, not major and mostly unavoidable with the approach used, but it is a thing)

- Fixes https://github.com/godotengine/godot-proposals/issues/4791
- Fixes #35529