### PR TITLE
Allow null object variants to be casted into any Object-derived classes.

### DIFF
--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -107,7 +107,9 @@ public:
 
 				Object *obj = p_variant.get_validated_object();
 				if (!obj) {
-					return false;
+					// Any Object-derived instance can be null, so a null object can be
+					// cast into any Object-derived type.
+					return true;
 				}
 
 				if (!ClassDB::is_parent_class(obj->get_class_name(), native_type)) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fixes #62658.

I'm not sure if this is the right way to fix this bug, but since any `Object`-derived classes can be null I don't see why a null object cannot be cast into any class.