### PR TITLE
Allow drag-clicking before symbol lookup

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -371,12 +371,13 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		if (symbol_lookup_on_click_enabled) {
-			if (mm->is_command_or_control_pressed() && mm->get_button_mask() == MouseButton::NONE && !is_dragging_cursor()) {
+			if (mm->is_command_or_control_pressed() && mm->get_button_mask() == MouseButton::NONE) {
+				symbol_lookup_pos = get_line_column_at_pos(mpos);
 				symbol_lookup_new_word = get_word_at_pos(mpos);
 				if (symbol_lookup_new_word != symbol_lookup_word) {
 					emit_signal(SNAME("symbol_validate"), symbol_lookup_new_word);
 				}
-			} else {
+			} else if (!mm->is_command_or_control_pressed() || (mm->get_button_mask() != MouseButton::NONE && symbol_lookup_pos != get_line_column_at_pos(mpos))) {
 				set_symbol_lookup_word_as_valid(false);
 			}
 		}

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -235,6 +235,7 @@ private:
 
 	String symbol_lookup_new_word = "";
 	String symbol_lookup_word = "";
+	Point2i symbol_lookup_pos;
 
 	/* Visual */
 	Ref<StyleBox> style_normal;


### PR DESCRIPTION
This makes it possible for touch and graphics tablet users to do symbol lookups in the code editor by ctrl+clicking on a symbol. (Previously this wasn't possible because drag events invalidated the click).

~~As a consequence, starting a selection, hitting ctrl and releasing the mouse over a symbol triggers the lookup. Please let me know if this behavior is considered a bug, so that I can find a cleaner solution (probably involving some sort of maximum distance from the selection start).~~

<details>

![demonstration](https://user-images.githubusercontent.com/28286961/177043433-331d68e0-c285-423b-a5cd-990159603531.gif)

</details>