### PR TITLE
Keep Perspective menu open after selecting an option

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4514,6 +4514,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	vbox->add_child(view_menu);
 
 	display_submenu = memnew(PopupMenu);
+	view_menu->get_popup()->set_hide_on_checkable_item_selection(false);
 	view_menu->get_popup()->add_child(display_submenu);
 
 	view_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/top_view"), VIEW_TOP);
@@ -4537,6 +4538,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_lighting", TTR("Display Lighting")), VIEW_DISPLAY_LIGHTING);
 	view_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_unshaded", TTR("Display Unshaded")), VIEW_DISPLAY_SHADELESS);
 	view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(VIEW_DISPLAY_NORMAL), true);
+	display_submenu->set_hide_on_checkable_item_selection(false);
 	display_submenu->add_radio_check_item(TTR("Directional Shadow Splits"), VIEW_DISPLAY_DEBUG_PSSM_SPLITS);
 	display_submenu->add_separator();
 	display_submenu->add_radio_check_item(TTR("Normal Buffer"), VIEW_DISPLAY_NORMAL_BUFFER);


### PR DESCRIPTION
Previously the menu closed after selecting an option, which made exploring view modes and debug options quite tedious.

This allows for quicker inspection of the scene, and makes missclicks more forgiving.

Also makes the Perspective menu consistent with the View menu in the 3D viewport.

**Demo:**

![ezgif-2-04c2e3ac71](https://user-images.githubusercontent.com/28286961/177046524-4f34bccb-337e-473a-a84a-a61ab90f8af9.gif)

