### PR TITLE
NavigationAgent2D - robust waypoint detection

### DIFF
--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -60,6 +60,8 @@ class NavigationAgent2D : public Node {
 
 	real_t path_max_distance = 3.0;
 
+	Vector2 agent_pos_curr;
+	Vector2 agent_pos_prev;
 	Vector2 target_location;
 	Vector<Vector2> navigation_path;
 	int nav_path_index = 0;
@@ -169,6 +171,7 @@ private:
 	void update_navigation();
 	void _request_repath();
 	void _check_distance_to_target();
+	bool _has_reached_waypoint(const Vector2 &p_agent_pos, const Vector2 &p_waypoint_pos, real_t p_threshold_dist);
 };
 
 #endif


### PR DESCRIPTION
Keeps a record of the previous position of agents, and detects reaching a waypoint as the distance from the closest point on the agent path to the waypoint.

Helps address #62532

Fast moving agents, or agents moving at low tick rates may often overshoot waypoints. This currently results in oscillations around waypoints. It is possible to increase the `path_desired_distance` to compensate for this, but the more robust approach in this PR is to take a CCD (continuous collision detection) type approach to the problem, and consider the distance of the waypoint from the path travelled by the agent in the previous tick.

## Notes
* The line segment check can be more efficient, this is reusing existing code for brevity.
* Agents that have overshot should usually be able to progress to the next waypoint, producing a more natural result than backtracking.
* This same technique (if agreed) can be applied for 3D navigation, and applied in 4.x to keep both in sync.
* There are several other areas that could be improved such as using squared distances but these are omitted to make the PR simpler.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
