### PR TITLE
Fix infinite recursion when guessing type of variable which is being assigned to in multiline statement

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1891,7 +1891,7 @@ static bool _guess_identifier_type(GDScriptParser::CompletionContext &p_context,
 		suite = suite->parent_block;
 	}
 
-	if (last_assigned_expression && last_assign_line != p_context.current_line) {
+	if (last_assigned_expression && last_assign_line < p_context.current_line) {
 		GDScriptParser::CompletionContext c = p_context;
 		c.current_line = last_assign_line;
 		r_type.assigned_expression = last_assigned_expression;


### PR DESCRIPTION
Fixes #62604

It was crashing because it wasn't foreseen that `last_assign_line` (4) could be greater than `current_line` (3).

```gdscript
func _ready():
	var x = Vector2()
	x = x.modify_me_in_editor \
	* 2

```