### PR TITLE
Allow non-constant string message for assert

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1590,8 +1590,8 @@ void GDScriptAnalyzer::resolve_assert(GDScriptParser::AssertNode *p_assert) {
 	reduce_expression(p_assert->condition);
 	if (p_assert->message != nullptr) {
 		reduce_expression(p_assert->message);
-		if (!p_assert->message->is_constant || p_assert->message->reduced_value.get_type() != Variant::STRING) {
-			push_error(R"(Expected constant string for assert error message.)", p_assert->message);
+		if (!p_assert->message->get_datatype().has_no_type() && (p_assert->message->get_datatype().kind != GDScriptParser::DataType::BUILTIN || p_assert->message->get_datatype().builtin_type != Variant::STRING)) {
+			push_error(R"(Expected string for assert error message.)", p_assert->message);
 		}
 	}
 


### PR DESCRIPTION
Fixes #47157
Based on #47165 reimplemented with modifications suggested from https://github.com/godotengine/godot/pull/47165#discussion_r633921302

Removes constant string requirement for assert message, analyzer does not account for some dynamic assignment.

## Original Behavior
```gdscript
assert(false, "Constant String")

var _testDynamicString = "test"
assert(false, _testDynamicString) # Errors: Expected constant string for assert error message

var _testExplicitString : String = "test"
assert(false, _testExplicitString) # Errors: Expected constant string for assert error message

var _testImplicitString := "test"
assert(false, _testImplicitString) # Errors: Expected constant string for assert error message

var _testExplicitHint : int = 1
assert(false, _testExplicitHint) # Errors: Expected constant string for assert error message

var _testImplicitHint := 1
assert(false, _testImplicitHint) # Errors: Expected constant string for assert error message

var _testDynamicAssign = 1
assert(false, _testDynamicAssign) # Errors: Expected constant string for assert error message
_testDynamicAssign = "test"
assert(false, _testDynamicAssign) # Errors: Expected constant string for assert error message
_testDynamicAssign = 1
assert(false, _testDynamicAssign) # Errors: Expected constant string for assert error message
```

## New Behavior
```gdscript
assert(false, "Constant String")

var _testDynamicString = "test"
assert(false, _testDynamicString)

var _testExplicitString : String = "test"
assert(false, _testExplicitString)

var _testImplicitString := "test"
assert(false, _testImplicitString)

var _testExplicitHint : int = 1
assert(false, _testExplicitHint) # Errors: Expected string for assert error message

var _testImplicitHint := 1
assert(false, _testImplicitHint) # Errors: Expected string for assert error message

var _testDynamicAssign = 1
assert(false, _testDynamicAssign) # Errors: Expected string for assert error message
_testDynamicAssign = "test"
assert(false, _testDynamicAssign)
_testDynamicAssign = 1
assert(false, _testDynamicAssign)
```

### Potential Considerations
Since there is the capacity for non-string assert messages to escape the error here, as was suggested at https://github.com/godotengine/godot/issues/47157#issuecomment-1012258542 a warning may be suitable in place of the original error. I was unsure whether that was desirable to put here or not so I have left any attempt out.