### PR TITLE
Arrays: Zero new items of trivial types on resize() (bindings only)

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -158,6 +158,7 @@ public:
 		return _ptr[p_index];
 	}
 
+	template <bool p_ensure_zero = false>
 	Error resize(int p_size);
 
 	_FORCE_INLINE_ void remove_at(int p_index) {
@@ -257,6 +258,7 @@ uint32_t CowData<T>::_copy_on_write() {
 }
 
 template <class T>
+template <bool p_ensure_zero>
 Error CowData<T>::resize(int p_size) {
 	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
 
@@ -306,6 +308,8 @@ Error CowData<T>::resize(int p_size) {
 			for (int i = *_get_size(); i < p_size; i++) {
 				memnew_placement(&_ptr[i], T);
 			}
+		} else if (p_ensure_zero) {
+			memset((void *)(_ptr + current_size), 0, (p_size - current_size) * sizeof(T));
 		}
 
 		*_get_size() = p_size;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -89,6 +89,7 @@ public:
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
+	Error resize_zeroed(int p_size) { return _cowdata.template resize<true>(p_size); }
 	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
 	Error insert(int p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
 	int find(const T &p_val, int p_from = 0) const { return _cowdata.find(p_val, p_from); }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2060,7 +2060,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedByteArray, remove_at, sarray("index"), varray());
 	bind_method(PackedByteArray, insert, sarray("at_index", "value"), varray());
 	bind_method(PackedByteArray, fill, sarray("value"), varray());
-	bind_method(PackedByteArray, resize, sarray("new_size"), varray());
+	bind_methodv(PackedByteArray, resize, &PackedByteArray::resize_zeroed, sarray("new_size"), varray());
 	bind_method(PackedByteArray, has, sarray("value"), varray());
 	bind_method(PackedByteArray, reverse, sarray(), varray());
 	bind_method(PackedByteArray, slice, sarray("begin", "end"), varray(INT_MAX));
@@ -2124,7 +2124,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt32Array, remove_at, sarray("index"), varray());
 	bind_method(PackedInt32Array, insert, sarray("at_index", "value"), varray());
 	bind_method(PackedInt32Array, fill, sarray("value"), varray());
-	bind_method(PackedInt32Array, resize, sarray("new_size"), varray());
+	bind_methodv(PackedInt32Array, resize, &PackedInt32Array::resize_zeroed, sarray("new_size"), varray());
 	bind_method(PackedInt32Array, has, sarray("value"), varray());
 	bind_method(PackedInt32Array, reverse, sarray(), varray());
 	bind_method(PackedInt32Array, slice, sarray("begin", "end"), varray(INT_MAX));
@@ -2147,7 +2147,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt64Array, remove_at, sarray("index"), varray());
 	bind_method(PackedInt64Array, insert, sarray("at_index", "value"), varray());
 	bind_method(PackedInt64Array, fill, sarray("value"), varray());
-	bind_method(PackedInt64Array, resize, sarray("new_size"), varray());
+	bind_methodv(PackedInt64Array, resize, &PackedInt64Array::resize_zeroed, sarray("new_size"), varray());
 	bind_method(PackedInt64Array, has, sarray("value"), varray());
 	bind_method(PackedInt64Array, reverse, sarray(), varray());
 	bind_method(PackedInt64Array, slice, sarray("begin", "end"), varray(INT_MAX));
@@ -2170,7 +2170,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat32Array, remove_at, sarray("index"), varray());
 	bind_method(PackedFloat32Array, insert, sarray("at_index", "value"), varray());
 	bind_method(PackedFloat32Array, fill, sarray("value"), varray());
-	bind_method(PackedFloat32Array, resize, sarray("new_size"), varray());
+	bind_methodv(PackedFloat32Array, resize, &PackedFloat32Array::resize_zeroed, sarray("new_size"), varray());
 	bind_method(PackedFloat32Array, has, sarray("value"), varray());
 	bind_method(PackedFloat32Array, reverse, sarray(), varray());
 	bind_method(PackedFloat32Array, slice, sarray("begin", "end"), varray(INT_MAX));
@@ -2193,7 +2193,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat64Array, remove_at, sarray("index"), varray());
 	bind_method(PackedFloat64Array, insert, sarray("at_index", "value"), varray());
 	bind_method(PackedFloat64Array, fill, sarray("value"), varray());
-	bind_method(PackedFloat64Array, resize, sarray("new_size"), varray());
+	bind_methodv(PackedFloat64Array, resize, &PackedFloat64Array::resize_zeroed, sarray("new_size"), varray());
 	bind_method(PackedFloat64Array, has, sarray("value"), varray());
 	bind_method(PackedFloat64Array, reverse, sarray(), varray());
 	bind_method(PackedFloat64Array, slice, sarray("begin", "end"), varray(INT_MAX));


### PR DESCRIPTION
This is not enabled by default in the core version for performance reasons,
as Vector/CowData are used in critical code paths where not zero'ing memory
which is going to be set later on can be important.

But for bindings / the scripting API, we make zero the new items by default
(which already happened for built types like Vector3, etc., but not for
trivial types like int, float).

Fixes #43033.

Co-authored-by: @Demindiro

---

Draft as I couldn't yet figure out how to make it work for `TypedArray`, my template-fu is not very advanced. Suggestions welcome.

Testing script:
```
var a = Array([5, 23, 12])
a.resize(12)
print(a)
print(typeof(a[10]))

a = PackedByteArray([5, 23, 12])
a.resize(12)
print(a)
print(typeof(a[10]))

a = PackedInt32Array([5, 23, 12])
a.resize(12)
print(a)
print(typeof(a[10]))

a = PackedInt64Array([5, 23, 12])
a.resize(12)
print(a)
print(typeof(a[10]))

a = PackedFloat32Array([5, 23, 12])
a.resize(12)
print(a)
print(typeof(a[10]))

a = PackedFloat64Array([5, 23, 12])
a.resize(12)
print(a)
print(typeof(a[10]))

var ai : Array[int] = [5, 23, 12]
ai.resize(12)
print(ai)
print(typeof(ai[10]))

var af : Array[float] = [5.0, 23.0, 12.0]
af.resize(12)
print(af)
print(typeof(af[10]))

var ab : Array[bool] = [true, false, true]
ab.resize(12)
print(ab)
print(typeof(ab[10]))
```

Results in current `master` (debug build, GCC):
```
[5, 23, 12, null, null, null, null, null, null, null, null, null]
0
[5, 23, 12, 0, 0, 0, 0, 0, 71, 105, 10, 71]
2
[5, 23, 12, 0, 0, 0, 44, 32, 49, 50, 44, 32]
2
[5, 23, 12, 1, 0, 432721992375206234, 80, 4294967298, 96, 96, 166760336, 0]
2
[5, 23, 12, 0, 0, 0, 3840589.25, 0.00001468074788, 0, 0, 0, 0]
3
[5, 23, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0]
3
[5, 23, 12, null, null, null, null, null, null, null, null, null]
0
[5, 23, 12, null, null, null, null, null, null, null, null, null]
0
[true, false, true, null, null, null, null, null, null, null, null, null]
0
```

Results from this PR (debug build, GCC):
```
[5, 23, 12, null, null, null, null, null, null, null, null, null]
0
[5, 23, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0]
2
[5, 23, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0]
2
[5, 23, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0]
2
[5, 23, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0]
3
[5, 23, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0]
3
[5, 23, 12, null, null, null, null, null, null, null, null, null]
0
[5, 23, 12, null, null, null, null, null, null, null, null, null]
0
[true, false, true, null, null, null, null, null, null, null, null, null]
0
```

The last three are wrong, they should be properly initalized to 0 (int and float) and `false` (bool).