### PR TITLE
Improve visibility of code, kbd and clickable references in editor help

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1601,6 +1601,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 
 	List<String> tag_stack;
 	bool code_tag = false;
+	bool codeblock_tag = false;
 
 	int pos = 0;
 	while (pos < bbcode.length()) {
@@ -1612,7 +1613,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 
 		if (brk_pos > pos) {
 			String text = bbcode.substr(pos, brk_pos - pos);
-			if (!code_tag) {
+			if (!code_tag && !codeblock_tag) {
 				text = text.replace("\n", "\n\n");
 			}
 			p_rt->add_text(text);
@@ -1626,7 +1627,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 
 		if (brk_end == -1) {
 			String text = bbcode.substr(brk_pos, bbcode.length() - brk_pos);
-			if (!code_tag) {
+			if (!code_tag && !codeblock_tag) {
 				text = text.replace("\n", "\n\n");
 			}
 			p_rt->add_text(text);
@@ -1650,12 +1651,20 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			if (tag != "/img") {
 				p_rt->pop();
 				if (code_tag) {
+					// Pop both color and background color.
+					p_rt->pop();
+					p_rt->pop();
+				} else if (codeblock_tag) {
+					// Pop color, cell and table.
+					p_rt->pop();
+					p_rt->pop();
 					p_rt->pop();
 				}
 			}
 			code_tag = false;
+			codeblock_tag = false;
 
-		} else if (code_tag) {
+		} else if (code_tag || codeblock_tag) {
 			p_rt->add_text("[");
 			pos = brk_pos + 1;
 
@@ -1664,10 +1673,14 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			const String link_tag = tag.substr(0, tag_end);
 			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
 
+			// Use monospace font with translucent colored background color to make clickable references
+			// easier to distinguish from inline code and other text.
 			p_rt->push_font(doc_code_font);
 			p_rt->push_color(link_color);
+			p_rt->push_bgcolor(code_color * Color(1, 1, 1, 0.15));
 			p_rt->push_meta("@" + link_tag + " " + link_target);
 			p_rt->add_text(link_target + (tag.begins_with("method ") ? "()" : ""));
+			p_rt->pop();
 			p_rt->pop();
 			p_rt->pop();
 			p_rt->pop();
@@ -1675,10 +1688,14 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 
 		} else if (doc->class_list.has(tag)) {
 			// Class reference tag such as [Node2D] or [SceneTree].
+			// Use monospace font with translucent colored background color to make clickable references
+			// easier to distinguish from inline code and other text.
 			p_rt->push_font(doc_code_font);
 			p_rt->push_color(link_color);
+			p_rt->push_bgcolor(code_color * Color(1, 1, 1, 0.15));
 			p_rt->push_meta("#" + tag);
 			p_rt->add_text(tag);
+			p_rt->pop();
 			p_rt->pop();
 			p_rt->pop();
 			p_rt->pop();
@@ -1694,16 +1711,30 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			p_rt->push_font(doc_italic_font);
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
-		} else if (tag == "code" || tag == "codeblock") {
-			// Use monospace font.
+		} else if (tag == "code") {
+			// Use monospace font with translucent background color to make code easier to distinguish from other text.
 			p_rt->push_font(doc_code_font);
+			p_rt->push_bgcolor(Color(0.5, 0.5, 0.5, 0.15));
 			p_rt->push_color(code_color);
 			code_tag = true;
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
+		} else if (tag == "codeblock") {
+			// Use monospace font with translucent background color to make code easier to distinguish from other text.
+			// Use a single-column table with cell row background color instead of `[bgcolor]`.
+			// This makes the background color highlight cover the entire block, rather than individual lines.
+			p_rt->push_font(doc_code_font);
+			p_rt->push_table(1);
+			p_rt->push_cell();
+			p_rt->set_cell_row_background_color(Color(0.5, 0.5, 0.5, 0.15), Color(0.5, 0.5, 0.5, 0.15));
+			p_rt->push_color(code_color);
+			codeblock_tag = true;
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
 		} else if (tag == "kbd") {
-			// Use keyboard font with custom color.
+			// Use keyboard font with custom color and background color.
 			p_rt->push_font(doc_kbd_font);
+			p_rt->push_bgcolor(Color(0.5, 0.5, 0.5, 0.15));
 			p_rt->push_color(kbd_color);
 			code_tag = true; // Though not strictly a code tag, logic is similar.
 			pos = brk_end + 1;


### PR DESCRIPTION
This adds a background color for inline code, code blocks, keyboard shortcuts and clickable references (such as `[member something]`).

See https://github.com/godotengine/godot-proposals/discussions/4804.

**Note:** Not cherry-pickable to `3.x` unless [`[bgcolor]` is backported](https://github.com/godotengine/godot/pull/35608).

## Preview

*All descriptions are from the GraphNode class.*

![image](https://user-images.githubusercontent.com/180032/177384608-8a1da1a9-a656-4b19-8221-0bc0e32d5ada.png)

![2022-07-04_17 13 49](https://user-images.githubusercontent.com/180032/177182441-e24d856d-1911-4f98-b3e0-ba7254477613.png)

![2022-07-04_17 14 13](https://user-images.githubusercontent.com/180032/177182442-6030324e-7ab2-42a0-ba0d-f7bb5a9e8494.png)

![2022-07-04_17 14 26](https://user-images.githubusercontent.com/180032/177182444-afbafe80-4b9e-41fe-990a-8fe5e12ab1a3.png)

