### PR TITLE
Document changing the Decal and Light3D projector texture filter modes

### DIFF
--- a/doc/classes/Decal.xml
+++ b/doc/classes/Decal.xml
@@ -89,15 +89,19 @@
 		</member>
 		<member name="texture_albedo" type="Texture2D" setter="set_texture" getter="get_texture">
 			[Texture2D] with the base [Color] of the Decal. Either this or the [member texture_emission] must be set for the Decal to be visible. Use the alpha channel like a mask to smoothly blend the edges of the decal with the underlying object.
+			[b]Note:[/b] Unlike [BaseMaterial3D] whose filter mode can be adjusted on a per-material basis, the filter mode for [Decal] textures is set globally with [member ProjectSettings.rendering/textures/decals/filter].
 		</member>
 		<member name="texture_emission" type="Texture2D" setter="set_texture" getter="get_texture">
 			[Texture2D] with the emission [Color] of the Decal. Either this or the [member texture_emission] must be set for the Decal to be visible. Use the alpha channel like a mask to smoothly blend the edges of the decal with the underlying object.
+			[b]Note:[/b] Unlike [BaseMaterial3D] whose filter mode can be adjusted on a per-material basis, the filter mode for [Decal] textures is set globally with [member ProjectSettings.rendering/textures/decals/filter].
 		</member>
 		<member name="texture_normal" type="Texture2D" setter="set_texture" getter="get_texture">
 			[Texture2D] with the per-pixel normal map for the decal. Use this to add extra detail to decals.
+			[b]Note:[/b] Unlike [BaseMaterial3D] whose filter mode can be adjusted on a per-material basis, the filter mode for [Decal] textures is set globally with [member ProjectSettings.rendering/textures/decals/filter].
 		</member>
 		<member name="texture_orm" type="Texture2D" setter="set_texture" getter="get_texture">
 			[Texture2D] storing ambient occlusion, roughness, and metallic for the decal. Use this to add extra detail to decals.
+			[b]Note:[/b] Unlike [BaseMaterial3D] whose filter mode can be adjusted on a per-material basis, the filter mode for [Decal] textures is set globally with [member ProjectSettings.rendering/textures/decals/filter].
 		</member>
 		<member name="upper_fade" type="float" setter="set_upper_fade" getter="get_upper_fade" default="0.3">
 			Sets the curve over which the decal will fade as the surface gets further from the center of the [AABB]. Only positive values are valid (negative values will be clamped to [code]0.0[/code]).

--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -73,6 +73,7 @@
 		</member>
 		<member name="light_projector" type="Texture2D" setter="set_projector" getter="get_projector">
 			[Texture2D] projected by light. [member shadow_enabled] must be on for the projector to work. Light projectors make the light appear as if it is shining through a colored but transparent object, almost like light shining through stained-glass.
+			[b]Note:[/b] Unlike [BaseMaterial3D] whose filter mode can be adjusted on a per-material basis, the filter mode for light projector textures is set globally with [member ProjectSettings.rendering/textures/light_projectors/filter].
 		</member>
 		<member name="light_size" type="float" setter="set_param" getter="get_param" default="0.0">
 			The size of the light in Godot units. Only available for [OmniLight3D]s and [SpotLight3D]s. Increasing this value will make the light fade out slower and shadows appear blurrier. This can be used to simulate area lights to an extent.


### PR DESCRIPTION
I've chosen to duplicate the note several times in Decal, so that it appears when hovering any of the texture properties. It would be easier to miss if it's only added to the class description.

See https://github.com/godotengine/godot-proposals/issues/4809.