### PR TITLE
Implement XMLParser.get_current_line()

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -72,11 +72,11 @@ void XMLParser::_parse_closing_xml_element() {
 	node_empty = false;
 	attributes.clear();
 
-	++P;
+	next_char();
 	const char *pBeginClose = P;
 
 	while (*P && *P != '>') {
-		++P;
+		next_char();
 	}
 
 	node_name = String::utf8(pBeginClose, (int)(P - pBeginClose));
@@ -85,7 +85,7 @@ void XMLParser::_parse_closing_xml_element() {
 #endif
 
 	if (*P) {
-		++P;
+		next_char();
 	}
 }
 
@@ -95,12 +95,12 @@ void XMLParser::_ignore_definition() {
 	char *F = P;
 	// move until end marked with '>' reached
 	while (*P && *P != '>') {
-		++P;
+		next_char();
 	}
 	node_name.parse_utf8(F, P - F);
 
 	if (*P) {
-		++P;
+		next_char();
 	}
 }
 
@@ -114,7 +114,7 @@ bool XMLParser::_parse_cdata() {
 	// skip '<![CDATA['
 	int count = 0;
 	while (*P && count < 8) {
-		++P;
+		next_char();
 		++count;
 	}
 
@@ -134,7 +134,7 @@ bool XMLParser::_parse_cdata() {
 			cDataEnd = P - 2;
 		}
 
-		++P;
+		next_char();
 	}
 
 	if (cDataEnd) {
@@ -180,7 +180,7 @@ void XMLParser::_parse_comment() {
 			} else if (*P == '<') {
 				++count;
 			}
-			++P;
+			next_char();
 		}
 
 		if (count) {
@@ -206,7 +206,7 @@ void XMLParser::_parse_opening_xml_element() {
 
 	// find end of element
 	while (*P && *P != '>' && !_is_white_space(*P)) {
-		++P;
+		next_char();
 	}
 
 	const char *endName = P;
@@ -214,7 +214,7 @@ void XMLParser::_parse_opening_xml_element() {
 	// find attributes
 	while (*P && *P != '>') {
 		if (_is_white_space(*P)) {
-			++P;
+			next_char();
 		} else {
 			if (*P != '/') {
 				// we've got an attribute
@@ -223,7 +223,7 @@ void XMLParser::_parse_opening_xml_element() {
 				const char *attributeNameBegin = P;
 
 				while (*P && !_is_white_space(*P) && *P != '=') {
-					++P;
+					next_char();
 				}
 
 				if (!*P) {
@@ -231,12 +231,12 @@ void XMLParser::_parse_opening_xml_element() {
 				}
 
 				const char *attributeNameEnd = P;
-				++P;
+				next_char();
 
 				// read the attribute value
 				// check for quotes and single quotes, thx to murphy
 				while ((*P != '\"') && (*P != '\'') && *P) {
-					++P;
+					next_char();
 				}
 
 				if (!*P) { // malformatted xml file
@@ -245,16 +245,16 @@ void XMLParser::_parse_opening_xml_element() {
 
 				const char attributeQuoteChar = *P;
 
-				++P;
+				next_char();
 				const char *attributeValueBegin = P;
 
 				while (*P != attributeQuoteChar && *P) {
-					++P;
+					next_char();
 				}
 
 				const char *attributeValueEnd = P;
 				if (*P) {
-					++P;
+					next_char();
 				}
 
 				Attribute attr;
@@ -268,7 +268,7 @@ void XMLParser::_parse_opening_xml_element() {
 				attributes.push_back(attr);
 			} else {
 				// tag is closed directly
-				++P;
+				next_char();
 				node_empty = true;
 				break;
 			}
@@ -288,7 +288,7 @@ void XMLParser::_parse_opening_xml_element() {
 #endif
 
 	if (*P) {
-		++P;
+		next_char();
 	}
 }
 
@@ -298,7 +298,7 @@ void XMLParser::_parse_current_node() {
 
 	// more forward until '<' found
 	while (*P != '<' && *P) {
-		++P;
+		next_char();
 	}
 
 	if (P - start > 0) {
@@ -312,7 +312,7 @@ void XMLParser::_parse_current_node() {
 		return;
 	}
 
-	++P;
+	next_char();
 
 	// based on current token, parse and report next element
 	switch (*P) {
@@ -487,6 +487,7 @@ Error XMLParser::open(const String &p_path) {
 	file->get_buffer((uint8_t *)data, length);
 	data[length] = 0;
 	P = data;
+	current_line = 0;
 
 	return OK;
 }
@@ -523,10 +524,7 @@ void XMLParser::close() {
 }
 
 int XMLParser::get_current_line() const {
-	return 0;
-}
-
-XMLParser::XMLParser() {
+	return current_line;
 }
 
 XMLParser::~XMLParser() {

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -68,6 +68,7 @@ private:
 	char *data = nullptr;
 	char *P = nullptr;
 	uint64_t length = 0;
+	uint64_t current_line = 0;
 	String node_name;
 	bool node_empty = false;
 	NodeType node_type = NODE_NONE;
@@ -87,6 +88,13 @@ private:
 	void _parse_comment();
 	void _parse_opening_xml_element();
 	void _parse_current_node();
+
+	_FORCE_INLINE_ void next_char() {
+		if (*P == '\n') {
+			current_line++;
+		}
+		P++;
+	}
 
 	static void _bind_methods();
 
@@ -113,7 +121,6 @@ public:
 
 	void close();
 
-	XMLParser();
 	~XMLParser();
 };
 

--- a/doc/classes/XMLParser.xml
+++ b/doc/classes/XMLParser.xml
@@ -32,7 +32,7 @@
 		<method name="get_current_line" qualifiers="const">
 			<return type="int" />
 			<description>
-				Gets the current line in the parsed file (currently not implemented).
+				Gets the current line in the parsed file, counting from 0.
 			</description>
 		</method>
 		<method name="get_named_attribute_value" qualifiers="const">


### PR DESCRIPTION
I measured how it affects parsing speed (as this performs a comparison for each char in a file); I parsed `XMLParser.xml` 10 times in a loop and with this PR the parsing time went from 9-10ms to 10-11ms, so it's acceptable.