### PR TITLE
StyleBox: Document correct methods to draw with a RID

### DIFF
--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -46,8 +46,8 @@
 			<argument index="0" name="canvas_item" type="RID" />
 			<argument index="1" name="rect" type="Rect2" />
 			<description>
-				Draws this stylebox using a [CanvasItem] with given [RID].
-				You can get a [RID] value using [method Object.get_instance_id] on a [CanvasItem]-derived node.
+				Draws this stylebox using a canvas item identified by the given [RID].
+				The [RID] value can either be the result of [method CanvasItem.get_canvas_item] called on an existing [CanvasItem]-derived node, or directly from creating a canvas item in the [RenderingServer] with [method RenderingServer.canvas_item_create].
 			</description>
 		</method>
 		<method name="get_center_size" qualifiers="const">


### PR DESCRIPTION
Object.get_instance_id returns an int, and it's not clear how this can be used to obtain an RID. The get_canvas_item method is the simplest way of obtaining a valid RID in this context.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
