### PR TITLE
Fix issue causing the Android Editor port to crash when saving a scene

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -259,6 +259,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 			}
 		}
 
+#ifndef ANDROID_ENABLED
 		// Check for devices updates
 		String adb = get_adb_path();
 		if (FileAccess::exists(adb)) {
@@ -372,6 +373,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 
 			ea->device_lock.unlock();
 		}
+#endif
 
 		uint64_t sleep = 300'000;
 		uint64_t wait = 3'000'000;
@@ -384,6 +386,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 		}
 	}
 
+#ifndef ANDROID_ENABLED
 	if (EditorSettings::get_singleton()->get("export/android/shutdown_adb_on_exit")) {
 		String adb = get_adb_path();
 		if (!FileAccess::exists(adb)) {
@@ -394,6 +397,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 		args.push_back("kill-server");
 		OS::get_singleton()->execute(adb, args, true);
 	}
+#endif
 }
 
 String EditorExportPlatformAndroid::get_project_name(const String &p_name) const {

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -72,7 +72,14 @@ Error FileAccessFilesystemJAndroid::_open(const String &p_path, int p_mode_flags
 		env->DeleteLocalRef(js);
 
 		if (res <= 0) {
-			return ERR_FILE_CANT_OPEN;
+			switch (res) {
+				case 0:
+				default:
+					return ERR_FILE_CANT_OPEN;
+
+				case -1:
+					return ERR_FILE_NOT_FOUND;
+			}
 		}
 
 		id = res;

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
@@ -34,6 +34,7 @@ import android.content.Context
 import android.util.Log
 import android.util.SparseArray
 import org.godotengine.godot.io.StorageScope
+import java.io.FileNotFoundException
 import java.nio.ByteBuffer
 
 /**
@@ -44,6 +45,7 @@ class FileAccessHandler(val context: Context) {
 	companion object {
 		private val TAG = FileAccessHandler::class.java.simpleName
 
+		private const val FILE_NOT_FOUND_ERROR_ID = -1
 		private const val INVALID_FILE_ID = 0
 		private const val STARTING_FILE_ID = 1
 
@@ -104,6 +106,8 @@ class FileAccessHandler(val context: Context) {
 
 			files.put(++lastFileId, dataAccess)
 			return lastFileId
+		} catch (e: FileNotFoundException) {
+			return FILE_NOT_FOUND_ERROR_ID
 		} catch (e: Exception) {
 			Log.w(TAG, "Error while opening $path", e)
 			return INVALID_FILE_ID

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -538,6 +538,33 @@ String OS_Android::get_system_dir(SystemDir p_dir, bool p_shared_storage) const 
 	return godot_io_java->get_system_dir(p_dir, p_shared_storage);
 }
 
+Error OS_Android::move_to_trash(const String &p_path) {
+	DirAccessRef da_ref = DirAccess::create_for_path(p_path);
+	if (!da_ref) {
+		return FAILED;
+	}
+
+	// Check if it's a directory
+	if (da_ref->dir_exists(p_path)) {
+		Error err = da_ref->change_dir(p_path);
+		if (err) {
+			return err;
+		}
+		// This is directory, let's erase its contents
+		err = da_ref->erase_contents_recursive();
+		if (err) {
+			return err;
+		}
+		// Remove the top directory
+		return da_ref->remove(p_path);
+	} else if (da_ref->file_exists(p_path)) {
+		// This is a file, let's remove it.
+		return da_ref->remove(p_path);
+	} else {
+		return FAILED;
+	}
+}
+
 void OS_Android::set_offscreen_gl_available(bool p_available) {
 	secondary_gl_available = p_available;
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -165,6 +165,8 @@ public:
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const;
 
+	virtual Error move_to_trash(const String &p_path);
+
 	void process_accelerometer(const Vector3 &p_accelerometer);
 	void process_gravity(const Vector3 &p_gravity);
 	void process_magnetometer(const Vector3 &p_magnetometer);


### PR DESCRIPTION
The issue was caused because we were not returning a valid ERR_FILE_NOT_FOUND error when unable to find a file. 

In addition:
- Disable `adb devices` query (not supported when running the editor on Android devices)
- Add `move_to_trash` implementation for Android devices

Fixes https://github.com/godotengine/godot/issues/62488

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
