### PR TITLE
GDScript: Fix autocompletetion showing class names with an underscore

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1838,6 +1838,9 @@ static void _find_enumeration_candidates(const String p_enum_hint, Map<String, S
 		ClassDB::get_enum_constants(class_name, enum_name, &enum_constants);
 		for (List<StringName>::Element *E = enum_constants.front(); E; E = E->next()) {
 			String candidate = class_name + "." + E->get();
+			if (candidate[0] == '_') { // Trim leading underscore.
+				candidate = candidate.substr(1);
+			}
 			ScriptCodeCompletionOption option(candidate, ScriptCodeCompletionOption::KIND_ENUM);
 			r_result.insert(option.display, option);
 		}


### PR DESCRIPTION
- Fixes #35469.
- Rebased version of #35739.
