### PR TITLE
Clamp VoxelGI extents to reasonable values to avoid breaking baking

### DIFF
--- a/doc/classes/VoxelGI.xml
+++ b/doc/classes/VoxelGI.xml
@@ -37,6 +37,7 @@
 		</member>
 		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(10, 10, 10)">
 			The size of the area covered by the [VoxelGI]. If you make the extents larger without increasing the subdivisions with [member subdiv], the size of each cell will increase and result in lower detailed lighting.
+			[b]Note:[/b] Extents are clamped to 1.0 unit or more on each axis.
 		</member>
 		<member name="subdiv" type="int" setter="set_subdiv" getter="get_subdiv" enum="VoxelGI.Subdiv" default="1">
 			Number of times to subdivide the grid that the [VoxelGI] operates on. A higher number results in finer detail and thus higher visual quality, while lower numbers result in better performance.

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -272,7 +272,8 @@ VoxelGI::Subdiv VoxelGI::get_subdiv() const {
 }
 
 void VoxelGI::set_extents(const Vector3 &p_extents) {
-	extents = p_extents;
+	// Prevent very small extents as these break baking if other extents are set very high.
+	extents = Vector3(MAX(1.0, p_extents.x), MAX(1.0, p_extents.y), MAX(1.0, p_extents.z));
 	update_gizmos();
 }
 


### PR DESCRIPTION
This also prevents crashes when resizing a VoxelGI's extents to 0 on any axis.

This closes https://github.com/godotengine/godot/issues/36702 and closes https://github.com/godotengine/godot/issues/59941. (The latter may still occur in extreme situations, but I've tried all kinds of fancy clamping solutions and this is the only one I've gotten to work.)