### PR TITLE
NavigationAgents - schedule pathfinds to prevent performance blips

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1213,6 +1213,11 @@
 		<member name="navigation/3d/default_map_up" type="Vector3" setter="" getter="" default="Vector3( 0, 1, 0 )">
 			Default map up vector for 3D navigation maps. See [method NavigationServer.map_set_up].
 		</member>
+		<member name="navigation/common/pathfinding/paths_per_tick" type="int" setter="" getter="" default="1">
+			Maximum amount of pathfinds allowed in each physics tick. A value of [code]0[/code] allows unlimited pathfinds. A negative value allows a pathfind every nth tick, e.g. [code]-2[/code] is every second tick.
+			This limit is useful because each pathfind is CPU intensive, and unconstrained pathfinds can result in dropped frames and other performance problems.
+			[b]Note:[/b] Limiting pathfinds can introduce some delay to agents, which can affect gameplay in some circumstances.
+		</member>
 		<member name="network/limits/debugger_stdout/max_chars_per_second" type="int" setter="" getter="" default="2048">
 			Maximum amount of characters allowed to send as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1267,6 +1267,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 #endif
 
+	GLOBAL_DEF("navigation/common/pathfinding/paths_per_tick", 1);
+	ProjectSettings::get_singleton()->set_custom_property_info("navigation/common/pathfinding/paths_per_tick",
+			PropertyInfo(Variant::INT,
+					"navigation/common/pathfinding/paths_per_tick",
+					PROPERTY_HINT_RANGE, "-128,128,1"));
+
 	message_queue = memnew(MessageQueue);
 
 	if (p_second_phase) {

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -34,6 +34,47 @@
 #include "scene/2d/navigation_2d.h"
 #include "servers/navigation_2d_server.h"
 
+uint32_t NavigationAgent2D::PathFindScheduler::_next_available_tick = 0;
+uint32_t NavigationAgent2D::PathFindScheduler::_paths_this_tick = 0;
+uint32_t NavigationAgent2D::PathFindScheduler::_paths_per_tick = 1;
+uint32_t NavigationAgent2D::PathFindScheduler::_tick_gap = 1;
+
+void NavigationAgent2D::PathFindScheduler::initialize() {
+	int ppt = GLOBAL_GET("navigation/common/pathfinding/paths_per_tick");
+	if (ppt >= 0) {
+		if (ppt == 0) {
+			// unlimited paths per tick, set to some high value
+			_paths_per_tick = 1 << 24;
+		} else {
+			_paths_per_tick = ppt;
+		}
+	} else {
+		_paths_per_tick = 1;
+		_tick_gap = -ppt;
+	}
+}
+
+uint32_t NavigationAgent2D::PathFindScheduler::request_path_tick() {
+	uint32_t tick = Engine::get_singleton()->get_physics_frames();
+
+	// see if we have caught up with the timer
+	if (tick > _next_available_tick) {
+		_next_available_tick = tick;
+		_paths_this_tick = 0;
+	}
+
+	_paths_this_tick++;
+
+	uint32_t scheduled_tick = _next_available_tick;
+
+	if (_paths_this_tick >= _paths_per_tick) {
+		_next_available_tick += _tick_gap;
+		_paths_this_tick = 0;
+	}
+
+	return scheduled_tick;
+}
+
 void NavigationAgent2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationAgent2D::get_rid);
 
@@ -439,16 +480,29 @@ void NavigationAgent2D::update_navigation() {
 	}
 
 	if (reload_path) {
-		if (map_override.is_valid()) {
-			navigation_path = Navigation2DServer::get_singleton()->map_get_path(map_override, o, target_location, true, navigation_layers);
-		} else if (navigation != nullptr) {
-			navigation_path = Navigation2DServer::get_singleton()->map_get_path(navigation->get_rid(), o, target_location, true, navigation_layers);
-		} else {
-			navigation_path = Navigation2DServer::get_singleton()->map_get_path(agent_parent->get_world_2d()->get_navigation_map(), o, target_location, true, navigation_layers);
+		if (!scheduled_pathfind) {
+			scheduled_pathfind = true;
+			scheduled_pathfind_tick = PathFindScheduler::request_path_tick();
 		}
-		navigation_finished = false;
-		nav_path_index = 0;
-		emit_signal("path_changed");
+
+		if (Engine::get_singleton()->get_physics_frames() >= scheduled_pathfind_tick) {
+			scheduled_pathfind = false;
+
+			if (map_override.is_valid()) {
+				navigation_path = Navigation2DServer::get_singleton()->map_get_path(map_override, o, target_location, true, navigation_layers);
+			} else if (navigation != nullptr) {
+				navigation_path = Navigation2DServer::get_singleton()->map_get_path(navigation->get_rid(), o, target_location, true, navigation_layers);
+			} else {
+				navigation_path = Navigation2DServer::get_singleton()->map_get_path(agent_parent->get_world_2d()->get_navigation_map(), o, target_location, true, navigation_layers);
+			}
+			navigation_finished = false;
+			nav_path_index = 0;
+			emit_signal("path_changed");
+
+		} else {
+			// can't pathfind yet
+			return;
+		}
 	}
 
 	if (navigation_path.size() == 0) {
@@ -485,4 +539,8 @@ void NavigationAgent2D::_check_distance_to_target() {
 			target_reached = true;
 		}
 	}
+}
+
+void NavigationAgent2D::_initialize() {
+	NavigationAgent2D::PathFindScheduler::initialize();
 }

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -40,6 +40,19 @@ class Navigation2D;
 class NavigationAgent2D : public Node {
 	GDCLASS(NavigationAgent2D, Node);
 
+	// Simple way of preventing too many pathfinds on each tick,
+	// which could cause a performance blip.
+	class PathFindScheduler {
+		static uint32_t _next_available_tick;
+		static uint32_t _paths_this_tick;
+		static uint32_t _paths_per_tick;
+		static uint32_t _tick_gap;
+
+	public:
+		static uint32_t request_path_tick();
+		static void initialize();
+	};
+
 	Node2D *agent_parent = nullptr;
 	Navigation2D *navigation = nullptr;
 
@@ -71,6 +84,8 @@ class NavigationAgent2D : public Node {
 	bool navigation_finished = true;
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
+	uint32_t scheduled_pathfind_tick = 0;
+	bool scheduled_pathfind = false;
 
 protected:
 	static void _bind_methods();
@@ -164,6 +179,8 @@ public:
 	void _avoidance_done(Vector3 p_new_velocity);
 
 	virtual String get_configuration_warning() const;
+
+	static void _initialize();
 
 private:
 	void update_navigation();

--- a/scene/3d/navigation_agent.h
+++ b/scene/3d/navigation_agent.h
@@ -40,6 +40,19 @@ class Navigation;
 class NavigationAgent : public Node {
 	GDCLASS(NavigationAgent, Node);
 
+	// Simple way of preventing too many pathfinds on each tick,
+	// which could cause a performance blip.
+	class PathFindScheduler {
+		static uint32_t _next_available_tick;
+		static uint32_t _paths_this_tick;
+		static uint32_t _paths_per_tick;
+		static uint32_t _tick_gap;
+
+	public:
+		static uint32_t request_path_tick();
+		static void initialize();
+	};
+
 	Spatial *agent_parent = nullptr;
 	Navigation *navigation = nullptr;
 
@@ -73,6 +86,8 @@ class NavigationAgent : public Node {
 	bool navigation_finished = true;
 	// No initialized on purpose
 	uint32_t update_frame_id = 0;
+	uint32_t scheduled_pathfind_tick = 0;
+	bool scheduled_pathfind = false;
 
 protected:
 	static void _bind_methods();
@@ -176,6 +191,8 @@ public:
 	void _avoidance_done(Vector3 p_new_velocity);
 
 	virtual String get_configuration_warning() const;
+
+	static void _initialize();
 
 private:
 	void update_navigation();

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -510,6 +510,7 @@ void register_scene_types() {
 	ClassDB::register_class<Navigation>();
 	ClassDB::register_class<NavigationMeshInstance>();
 	ClassDB::register_class<NavigationAgent>();
+	NavigationAgent::_initialize();
 	ClassDB::register_class<NavigationObstacle>();
 
 	OS::get_singleton()->yield(); //may take time to init
@@ -768,6 +769,7 @@ void register_scene_types() {
 	ClassDB::register_class<NavigationPolygon>();
 	ClassDB::register_class<NavigationPolygonInstance>();
 	ClassDB::register_class<NavigationAgent2D>();
+	NavigationAgent2D::_initialize();
 	ClassDB::register_class<NavigationObstacle2D>();
 
 	OS::get_singleton()->yield(); //may take time to init


### PR DESCRIPTION
Adds a simple method to limit pathfinds per physics tick.

Pathfinds in the navigation server are currently synchronous, and can cause performance blips and dropped frames if several agents do a pathfind simultaneously. This PR enables simply limiting the number of pathfinds per physics tick.

## Notes
* Adds a project setting `navigation/common/pathfinding/paths_per_tick`. This can either be positive, 0 (unlimited), or negative, indicating a single pathfind every nth tick.
* Overall it is usually better (especially with large navmeshes) to distribute single pathfinds over several frames. But this would require major changes to the current design, so this PR is a reasonable compromise to get started managing performance.
* Duplicates some code in 2D and 3D versions. Could be moved out into a separate class if desired, am initially following the preference for local solutions (even if duplication occurs). See https://docs.godotengine.org/en/stable/community/contributing/best_practices_for_engine_contributors.html#prefer-local-solutions 
* Also relevant to 4.x.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
