### PR TITLE
Fix light intensity and attenuation import from GLTF

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5176,19 +5176,16 @@ Node3D *GLTFDocument::_generate_light(Ref<GLTFState> state, const GLTFNodeIndex 
 	}
 
 	const float range = CLAMP(l->range, 0, 4096);
-	// Doubling the range will double the effective brightness, so we need double attenuation (half brightness).
-	// We want to have double intensity give double brightness, so we need half the attenuation.
-	const float attenuation = range / (intensity * 2048);
 	if (l->light_type == "point") {
 		OmniLight3D *light = memnew(OmniLight3D);
-		light->set_param(OmniLight3D::PARAM_ATTENUATION, attenuation);
+		light->set_param(OmniLight3D::PARAM_ENERGY, intensity);
 		light->set_param(OmniLight3D::PARAM_RANGE, range);
 		light->set_color(l->color);
 		return light;
 	}
 	if (l->light_type == "spot") {
 		SpotLight3D *light = memnew(SpotLight3D);
-		light->set_param(SpotLight3D::PARAM_ATTENUATION, attenuation);
+		light->set_param(SpotLight3D::PARAM_ENERGY, intensity);
 		light->set_param(SpotLight3D::PARAM_RANGE, range);
 		light->set_param(SpotLight3D::PARAM_SPOT_ANGLE, Math::rad2deg(l->outer_cone_angle));
 		light->set_color(l->color);
@@ -5253,14 +5250,12 @@ GLTFLightIndex GLTFDocument::_convert_light(Ref<GLTFState> state, Light3D *p_lig
 		l->light_type = "point";
 		OmniLight3D *light = cast_to<OmniLight3D>(p_light);
 		l->range = light->get_param(OmniLight3D::PARAM_RANGE);
-		float attenuation = p_light->get_param(OmniLight3D::PARAM_ATTENUATION);
-		l->intensity = l->range / (attenuation * 2048);
+		l->intensity = light->get_param(OmniLight3D::PARAM_ENERGY);
 	} else if (cast_to<SpotLight3D>(p_light)) {
 		l->light_type = "spot";
 		SpotLight3D *light = cast_to<SpotLight3D>(p_light);
 		l->range = light->get_param(SpotLight3D::PARAM_RANGE);
-		float attenuation = light->get_param(SpotLight3D::PARAM_ATTENUATION);
-		l->intensity = l->range / (attenuation * 2048);
+		l->intensity = light->get_param(SpotLight3D::PARAM_ENERGY);
 		l->outer_cone_angle = Math::deg2rad(light->get_param(SpotLight3D::PARAM_SPOT_ANGLE));
 
 		// This equation is the inverse of the import equation (which has a desmos link).


### PR DESCRIPTION
When importing a GLTF scene, Omni and Spot lights calculated an **Attenuation** factor that could be set to infinity when the **Intensity** was 0. Also the **intensity** was never directly stored.

As discussed in rocket-chat, the **Attenuation** is used for artistic control, so lets just default it to 1 and use the **Intensity** properly instead.

Please note, the user can still set the attenuation to a big value and generate infinities in [this](https://github.com/godotengine/godot/blob/3a2b409c5a62b2b7fbaae36f536abf6a798a4b9d/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl#L390) line of the light shader, so a proper range should be added too somehow. I think **PROPERTY_HINT_EXP_EASING** [here](https://github.com/godotengine/godot/blob/master/scene/3d/light_3d.cpp#L516) can't have a min and max, so maybe we can change it to **PROPERTY_HINT_RANGE**?

Noticed after loading the new [Sponza](https://www.intel.com/content/www/us/en/developer/topic-technology/graphics-research/samples.html) scene where lights are stored with intensity 0:

**Before (intensity = 1, attenuation = inf)**
![before](https://user-images.githubusercontent.com/8772233/177390580-939be262-96a6-4313-87c6-af24f5cd6e63.png)

**After (intensity = 0, attenuation = 1)**
![after](https://user-images.githubusercontent.com/8772233/177390592-d711ca04-3549-48f3-9489-59ac7d489b2a.png)

