### PR TITLE
Fix return statement in set_drag_preview doc.

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -856,7 +856,7 @@
 				    cpb.color = color
 				    cpb.size = Vector2(50, 50)
 				    set_drag_preview(cpb)
-				    return color
+				    return cpb
 				[/gdscript]
 				[csharp]
 				[Export]
@@ -869,7 +869,7 @@
 				    cpb.Color = Color;
 				    cpb.RectSize = new Vector2(50, 50);
 				    SetDragPreview(cpb);
-				    return Color;
+				    return cpb;
 				}
 				[/csharp]
 				[/codeblocks]


### PR DESCRIPTION
The function should return a Control, not a Color.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
