### PR TITLE
Disable Expand by default in VideoStreamPlayer

### DIFF
--- a/doc/classes/VideoStreamPlayer.xml
+++ b/doc/classes/VideoStreamPlayer.xml
@@ -58,7 +58,7 @@
 		<member name="bus" type="StringName" setter="set_bus" getter="get_bus" default="&amp;&quot;Master&quot;">
 			Audio bus to use for sound playback.
 		</member>
-		<member name="expand" type="bool" setter="set_expand" getter="has_expand" default="true">
+		<member name="expand" type="bool" setter="set_expand" getter="has_expand" default="false">
 			If [code]true[/code], the video scales to the control size. Otherwise, the control minimum size will be automatically adjusted to match the video stream's dimensions.
 		</member>
 		<member name="paused" type="bool" setter="set_paused" getter="is_paused" default="false">

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -64,7 +64,7 @@ class VideoStreamPlayer : public Control {
 	bool autoplay = false;
 	float volume = 1.0;
 	double last_audio_time = 0.0;
-	bool expand = true;
+	bool expand = false;
 	bool loops = false;
 	int buffering_ms = 500;
 	int audio_track = 0;


### PR DESCRIPTION
This ensures videos are always visible as soon as a video file is specified in the VideoStreamPlayer node. The node will no longer be resized to 0×0 by default, making the video invisible in the process (even if the audio can still be heard).

This closes https://github.com/godotengine/godot/issues/36647.