### PR TITLE
Tweak the fallback 3D material's appearance

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This provides a default material with a wide variety of rendering features and properties without the need to write shader code. See the tutorial below for details.
+		[b]Fallback material:[/b] Meshes which don't have any material assigned will use a [i]fallback material[/i]. This material uses an [member albedo_color] set to [code]Color(0.5, 0.5, 0.5)[/code] and [member roughness] set to [code]0.5[/code]. All other parameters are identical to the defaults here. In contrast, newly created [BaseMaterial3D]s will use an [member albedo_color] of [code]Color(1.0, 1.0, 1.0)[/code] and [member roughness] of [code]1.0[/code], so they will appear brighter and less reflective.
 	</description>
 	<tutorials>
 		<link title="Standard Material 3D">$DOCS_URL/tutorials/3d/standard_material_3d.html</link>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2723,13 +2723,13 @@ RasterizerSceneGLES3::RasterizerSceneGLES3(RasterizerStorageGLES3 *p_storage) {
 shader_type spatial;
 
 void vertex() {
-	ROUGHNESS = 0.8;
+	ROUGHNESS = 0.5;
 }
 
 void fragment() {
-	ALBEDO = vec3(0.6);
-	ROUGHNESS = 0.8;
-	METALLIC = 0.2;
+	ALBEDO = vec3(0.5);
+	ROUGHNESS = 0.5;
+	METALLIC = 0.0;
 }
 )");
 		scene_globals.default_material = material_storage->material_allocate();

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -786,13 +786,13 @@ void SceneShaderForwardClustered::init(RendererStorageRD *p_storage, const Strin
 shader_type spatial;
 
 void vertex() {
-	ROUGHNESS = 0.8;
+	ROUGHNESS = 0.5;
 }
 
 void fragment() {
-	ALBEDO = vec3(0.6);
-	ROUGHNESS = 0.8;
-	METALLIC = 0.2;
+	ALBEDO = vec3(0.5);
+	ROUGHNESS = 0.5;
+	METALLIC = 0.0;
 }
 )");
 		default_material = material_storage->material_allocate();

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -685,13 +685,13 @@ void SceneShaderForwardMobile::init(RendererStorageRD *p_storage, const String p
 shader_type spatial;
 
 void vertex() {
-	ROUGHNESS = 0.8;
+	ROUGHNESS = 0.5;
 }
 
 void fragment() {
-	ALBEDO = vec3(0.6);
-	ROUGHNESS = 0.8;
-	METALLIC = 0.2;
+	ALBEDO = vec3(0.5);
+	ROUGHNESS = 0.5;
+	METALLIC = 0.0;
 }
 )");
 		default_material = material_storage->material_allocate();


### PR DESCRIPTION
- Decrease roughness from 0.8 to 0.5 to match Blender's default.
- Decrease metallic from 0.2 to 0.0.
  - In real life, materials are either fully dielectric or fully metallic.
- Darken albedo from `Color(0.6, 0.6, 0.6)` to `Color(0.5, 0.5, 0.5)`.
  - This compensates for the roughness/metallic change, but also makes the fallback material a tad darker overall. It now better corresponds to materials that are typically used in scenes, leading to a more accurate lighting preview (especially when the Debug Lighting draw mode is used).

**Testing project:** [test_fallback_material.zip](https://github.com/godotengine/godot/files/9050331/test_fallback_material.zip)

## Preview

### No GI

Before | After
-|-
![2022-07-06_01 05 17](https://user-images.githubusercontent.com/180032/177435662-781e5eff-6f5e-4ad3-a187-485adf17d8e2.png) | ![2022-07-20_22 43 12](https://user-images.githubusercontent.com/180032/180078423-b9d70d3d-fba7-456d-8742-04074c33c8f6.png)

### VoxelGI

Before | After
-|-
![2022-07-06_01 05 04](https://user-images.githubusercontent.com/180032/177435684-3d9bb181-560d-4bbd-8e1d-1e3decc1f16c.png) | ![2022-07-20_22 43 18](https://user-images.githubusercontent.com/180032/180078429-f25fa46f-5f08-42cf-b2fa-c9051c738b56.png)

### SDFGI

Before | After
-|-
![2022-07-06_01 06 04](https://user-images.githubusercontent.com/180032/177435672-748cac26-94cd-4502-88cb-63710c4816bb.png) | ![2022-07-20_22 43 26](https://user-images.githubusercontent.com/180032/180078431-3b48183f-3922-4671-b3e3-521c5c46f35a.png)

The fallback material's default appearance was already changed from 3.x, so this isn't a compatibility-breaking change (not any more than it previously was, at least).