### PR TITLE
Remove unused anisotropy setter/getter methods in VoxelGI

### DIFF
--- a/drivers/gles3/environment/gi.cpp
+++ b/drivers/gles3/environment/gi.cpp
@@ -126,13 +126,6 @@ bool GI::voxel_gi_is_using_two_bounces(RID p_voxel_gi) const {
 	return false;
 }
 
-void GI::voxel_gi_set_anisotropy_strength(RID p_voxel_gi, float p_strength) {
-}
-
-float GI::voxel_gi_get_anisotropy_strength(RID p_voxel_gi) const {
-	return 0;
-}
-
 uint32_t GI::voxel_gi_get_version(RID p_voxel_gi) const {
 	return 0;
 }

--- a/drivers/gles3/environment/gi.h
+++ b/drivers/gles3/environment/gi.h
@@ -86,9 +86,6 @@ public:
 	virtual void voxel_gi_set_use_two_bounces(RID p_voxel_gi, bool p_enable) override;
 	virtual bool voxel_gi_is_using_two_bounces(RID p_voxel_gi) const override;
 
-	virtual void voxel_gi_set_anisotropy_strength(RID p_voxel_gi, float p_strength) override;
-	virtual float voxel_gi_get_anisotropy_strength(RID p_voxel_gi) const override;
-
 	virtual uint32_t voxel_gi_get_version(RID p_voxel_gi) const override;
 };
 

--- a/servers/rendering/dummy/environment/gi.h
+++ b/servers/rendering/dummy/environment/gi.h
@@ -74,9 +74,6 @@ public:
 	virtual void voxel_gi_set_use_two_bounces(RID p_voxel_gi, bool p_enable) override {}
 	virtual bool voxel_gi_is_using_two_bounces(RID p_voxel_gi) const override { return false; }
 
-	virtual void voxel_gi_set_anisotropy_strength(RID p_voxel_gi, float p_strength) override {}
-	virtual float voxel_gi_get_anisotropy_strength(RID p_voxel_gi) const override { return 0; }
-
 	virtual uint32_t voxel_gi_get_version(RID p_voxel_gi) const override { return 0; }
 };
 

--- a/servers/rendering/environment/renderer_gi.h
+++ b/servers/rendering/environment/renderer_gi.h
@@ -76,9 +76,6 @@ public:
 	virtual void voxel_gi_set_use_two_bounces(RID p_voxel_gi, bool p_enable) = 0;
 	virtual bool voxel_gi_is_using_two_bounces(RID p_voxel_gi) const = 0;
 
-	virtual void voxel_gi_set_anisotropy_strength(RID p_voxel_gi, float p_strength) = 0;
-	virtual float voxel_gi_get_anisotropy_strength(RID p_voxel_gi) const = 0;
-
 	virtual uint32_t voxel_gi_get_version(RID p_probe) const = 0;
 };
 

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -312,19 +312,6 @@ float GI::voxel_gi_get_normal_bias(RID p_voxel_gi) const {
 	return voxel_gi->normal_bias;
 }
 
-void GI::voxel_gi_set_anisotropy_strength(RID p_voxel_gi, float p_strength) {
-	VoxelGI *voxel_gi = voxel_gi_owner.get_or_null(p_voxel_gi);
-	ERR_FAIL_COND(!voxel_gi);
-
-	voxel_gi->anisotropy_strength = p_strength;
-}
-
-float GI::voxel_gi_get_anisotropy_strength(RID p_voxel_gi) const {
-	VoxelGI *voxel_gi = voxel_gi_owner.get_or_null(p_voxel_gi);
-	ERR_FAIL_COND_V(!voxel_gi, 0);
-	return voxel_gi->anisotropy_strength;
-}
-
 void GI::voxel_gi_set_interior(RID p_voxel_gi, bool p_enable) {
 	VoxelGI *voxel_gi = voxel_gi_owner.get_or_null(p_voxel_gi);
 	ERR_FAIL_COND(!voxel_gi);

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -84,8 +84,6 @@ public:
 		bool interior = false;
 		bool use_two_bounces = false;
 
-		float anisotropy_strength = 0.5;
-
 		uint32_t version = 1;
 		uint32_t data_version = 1;
 
@@ -417,9 +415,6 @@ public:
 
 	virtual void voxel_gi_set_use_two_bounces(RID p_voxel_gi, bool p_enable) override;
 	virtual bool voxel_gi_is_using_two_bounces(RID p_voxel_gi) const override;
-
-	virtual void voxel_gi_set_anisotropy_strength(RID p_voxel_gi, float p_strength) override;
-	virtual float voxel_gi_get_anisotropy_strength(RID p_voxel_gi) const override;
 
 	virtual uint32_t voxel_gi_get_version(RID p_probe) const override;
 	uint32_t voxel_gi_get_data_version(RID p_probe);


### PR DESCRIPTION
These methods weren't exposed to the scripting API.

Anisotropy was used in earlier iterations of VoxelGI, but it was removed as it was too expensive.

I tested VoxelGI again and made sure it still works as expected.