### PR TITLE
[3.x] Fix LineEdit caret after using arrow key to deselect

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -426,12 +426,12 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 					if (!k->get_alt())
 #endif
 					{
-						shift_selection_check_pre(k->get_shift());
 						if (selection.enabled && !k->get_shift()) {
 							set_cursor_position(selection.begin);
 							deselect();
 							break;
 						}
+						shift_selection_check_pre(k->get_shift());
 					}
 
 #ifdef APPLE_STYLE_KEYS
@@ -475,11 +475,15 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 					FALLTHROUGH;
 				}
 				case KEY_RIGHT: {
-					if (selection.enabled && !k->get_shift()) {
-						set_cursor_position(selection.end);
-						deselect();
-						break;
-					} else {
+#ifndef APPLE_STYLE_KEYS
+					if (!k->get_alt())
+#endif
+					{
+						if (selection.enabled && !k->get_shift()) {
+							set_cursor_position(selection.end);
+							deselect();
+							break;
+						}
 						shift_selection_check_pre(k->get_shift());
 					}
 #ifdef APPLE_STYLE_KEYS


### PR DESCRIPTION
The behavior is inconsistent when using left or right arrow keys to deselect text in LineEdit:

| Key | 3.x | 4.0 |
| ---- | ---- | ---- |
| ← | Move caret one character left |  Move caret to start of selection |
| → | Move caret to end of selection | Move caret to end of selection |
| Alt + ← | Nothing happens | Nothing happens |
| Alt + → | Move caret to end of selection | Nothing happens |

This PR makes it behave like `4.0`.

* Left arrow key did not move the caret to the start of selection: This seems to be a cherry-pick mistake in #52686. As its `master` version correctly calls `shift_selection_check_pre()` after the deselection logic.
* Alt right arrow key moves the caret: This also seems to be unintended. #5379 says LineEdit should no longer deselect text when Alt is pressed, but the alt check is only added for the left arrow key.