### PR TITLE
Fix heap-use-after-free when closing a scene with its builtin script open

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -534,6 +534,7 @@ void EditorData::remove_scene(int p_idx) {
 		}
 
 		memdelete(edited_scene[p_idx].root);
+		edited_scene.write[p_idx].root = nullptr;
 	}
 
 	if (current_edited_scene > p_idx) {


### PR DESCRIPTION
Make `edited_scene.write[p_idx].root` null after calling `memdelete` on it. Otherwise later calls will be using the wild pointer, and null checks won't help.

To reproduce the issue, do this in a debug/sanitizer build:
1. Create an empty scene.
2. Add a node and attach a builtin script to it.
3. Make sure the builtin script is open (appear in script editor's tab list).
4. Close current scene. The sanitizer build will complain and crash.

<details><summary>Address Sanitizer output</summary>

```
=================================================================
==3082517==ERROR: AddressSanitizer: heap-use-after-free on address 0x61a00059cb30 at pc 0x56288a31ac8f bp 0x7ffd7a197650 sp 0x7ffd7a197640
READ of size 8 at 0x61a00059cb30 thread T0
    #0 0x56288a31ac8e in Object::get_script_instance() const core/object/object.h:810
    #1 0x56288eb279c7 in ScriptEditor::_find_scripts(Node*, Node*, HashSet<Ref<Script>, HashMapHasherDefault, HashMapComparatorDefault<Ref<Script> > >&) editor/plugins/script_editor_plugin.cpp:1808
    #2 0x56288eb2b29a in ScriptEditor::_update_script_names() editor/plugins/script_editor_plugin.cpp:1986
    #3 0x56288eb4b617 in ScriptEditor::_update_history_pos(int) editor/plugins/script_editor_plugin.cpp:3410
    #4 0x56288eb4b8c5 in ScriptEditor::_history_back() editor/plugins/script_editor_plugin.cpp:3423
    #5 0x56288eb10f94 in ScriptEditor::_close_tab(int, bool, bool) editor/plugins/script_editor_plugin.cpp:784
    #6 0x56288eb2509f in ScriptEditor::close_builtin_scripts_from_scene(String const&) editor/plugins/script_editor_plugin.cpp:1698
    #7 0x56288d63b972 in EditorData::remove_scene(int) editor/editor_data.cpp:546
    #8 0x56288d942b4d in EditorNode::_remove_edited_scene(bool) editor/editor_node.cpp:3415
    #9 0x56288d942bdb in EditorNode::_remove_scene(int, bool) editor/editor_node.cpp:3427
    #10 0x56288d939b91 in EditorNode::_discard_changes(String const&) editor/editor_node.cpp:3090
    #11 0x56288d966bd2 in EditorNode::_scene_tab_closed(int, int) editor/editor_node.cpp:5091
    #12 0x56288da2c611 in void call_with_variant_args_helper<EditorNode, int, int, 0ul, 1ul>(EditorNode*, void (EditorNode::*)(int, int), Variant const**, Callable::CallError&, IndexSequence<0ul, 1ul>) core/variant/binder_common.h:236
    #13 0x56288da2690a in void call_with_variant_args<EditorNode, int, int>(EditorNode*, void (EditorNode::*)(int, int), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:350
    #14 0x56288da1b021 in CallableCustomMethodPointer<EditorNode, int, int>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #15 0x5628942af54d in Callable::call(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #16 0x562894973eef in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1013
    #17 0x56288a2a7a16 in Error Object::emit_signal<int>(StringName const&, int) core/object/object.h:824
    #18 0x562890597ac3 in TabBar::gui_input(Ref<InputEvent> const&) scene/gui/tab_bar.cpp:206
    #19 0x56289014c037 in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:952
    #20 0x56288fead318 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1278
    #21 0x56288feb0d64 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1589
    #22 0x56288fec28a7 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:2720
    #23 0x56288ff5f1c4 in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1020
    #24 0x56288ffacd58 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:236
    #25 0x56288ffa2166 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:350
    #26 0x56288ff9606b in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #27 0x5628942af54d in Callable::call(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #28 0x562889587384 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/display_server_x11.cpp:3184
    #29 0x562889586dae in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/display_server_x11.cpp:3155
    #30 0x5628941ce59a in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:663
    #31 0x5628941d24ca in Input::flush_buffered_events() core/input/input.cpp:888
    #32 0x562889594749 in DisplayServerX11::process_events() platform/linuxbsd/display_server_x11.cpp:4173
    #33 0x5628895469cb in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:437
    #34 0x56288953b8e1 in main platform/linuxbsd/godot_linuxbsd.cpp:72
    #35 0x7f437d62928f  (/usr/lib/libc.so.6+0x2928f)
    #36 0x7f437d629349 in __libc_start_main (/usr/lib/libc.so.6+0x29349)
    #37 0x56288953b4d4 in _start (/home/timothy/repos/godot-master/bin/godot.linuxbsd.tools.64.san+0x382f4d4)

0x61a00059cb30 is located 176 bytes inside of 1280-byte region [0x61a00059ca80,0x61a00059cf80)
freed by thread T0 here:
    #0 0x7f437dabe672 in __interceptor_free /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x562893d52c66 in Memory::free_static(void*, bool) core/os/memory.cpp:168
    #2 0x56288a826fb3 in void memdelete<Node>(Node*) core/os/memory.h:111
    #3 0x56288d63b825 in EditorData::remove_scene(int) editor/editor_data.cpp:536
    #4 0x56288d942b4d in EditorNode::_remove_edited_scene(bool) editor/editor_node.cpp:3415
    #5 0x56288d942bdb in EditorNode::_remove_scene(int, bool) editor/editor_node.cpp:3427
    #6 0x56288d939b91 in EditorNode::_discard_changes(String const&) editor/editor_node.cpp:3090
    #7 0x56288d966bd2 in EditorNode::_scene_tab_closed(int, int) editor/editor_node.cpp:5091
    #8 0x56288da2c611 in void call_with_variant_args_helper<EditorNode, int, int, 0ul, 1ul>(EditorNode*, void (EditorNode::*)(int, int), Variant const**, Callable::CallError&, IndexSequence<0ul, 1ul>) core/variant/binder_common.h:236
    #9 0x56288da2690a in void call_with_variant_args<EditorNode, int, int>(EditorNode*, void (EditorNode::*)(int, int), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:350
    #10 0x56288da1b021 in CallableCustomMethodPointer<EditorNode, int, int>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #11 0x5628942af54d in Callable::call(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #12 0x562894973eef in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1013
    #13 0x56288a2a7a16 in Error Object::emit_signal<int>(StringName const&, int) core/object/object.h:824
    #14 0x562890597ac3 in TabBar::gui_input(Ref<InputEvent> const&) scene/gui/tab_bar.cpp:206
    #15 0x56289014c037 in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:952
    #16 0x56288fead318 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1278
    #17 0x56288feb0d64 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1589
    #18 0x56288fec28a7 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:2720
    #19 0x56288ff5f1c4 in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1020
    #20 0x56288ffacd58 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:236
    #21 0x56288ffa2166 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:350
    #22 0x56288ff9606b in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #23 0x5628942af54d in Callable::call(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #24 0x562889587384 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/display_server_x11.cpp:3184
    #25 0x562889586dae in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/display_server_x11.cpp:3155
    #26 0x5628941ce59a in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:663
    #27 0x5628941d24ca in Input::flush_buffered_events() core/input/input.cpp:888
    #28 0x562889594749 in DisplayServerX11::process_events() platform/linuxbsd/display_server_x11.cpp:4173
    #29 0x5628895469cb in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:437

previously allocated by thread T0 here:
    #0 0x7f437dabfa89 in __interceptor_malloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x562893d52090 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:75
    #2 0x562893d51fae in operator new(unsigned long, char const*) core/os/memory.cpp:40
    #3 0x56288fcee488 in Object* ClassDB::creator<Node2D>() (/home/timothy/repos/godot-master/bin/godot.linuxbsd.tools.64.san+0x9fe2488)
    #4 0x56289492b5a0 in ClassDB::instantiate(StringName const&) core/object/class_db.cpp:331
    #5 0x5628918c947d in SceneState::instantiate(SceneState::GenEditState) const scene/resources/packed_scene.cpp:184
    #6 0x5628918e491f in PackedScene::instantiate(PackedScene::GenEditState) const scene/resources/packed_scene.cpp:1734
    #7 0x56288d9475d8 in EditorNode::load_scene(String const&, bool, bool, bool, bool, bool) editor/editor_node.cpp:3718
    #8 0x56288d94877c in EditorNode::open_request(String const&) editor/editor_node.cpp:3778
    #9 0x56288ddd9526 in FileSystemDock::_select_file(String const&, bool) editor/filesystem_dock.cpp:1006
    #10 0x56288ddda469 in FileSystemDock::_tree_activate_file() editor/filesystem_dock.cpp:1046
    #11 0x56288de41074 in void call_with_variant_args_helper<FileSystemDock>(FileSystemDock*, void (FileSystemDock::*)(), Variant const**, Callable::CallError&, IndexSequence<>) core/variant/binder_common.h:236
    #12 0x56288de3e4a9 in void call_with_variant_args<FileSystemDock>(FileSystemDock*, void (FileSystemDock::*)(), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:350
    #13 0x56288de3bb61 in CallableCustomMethodPointer<FileSystemDock>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #14 0x5628942af54d in Callable::call(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #15 0x562894973eef in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1013
    #16 0x56288a292e46 in Error Object::emit_signal<>(StringName const&) core/object/object.h:824
    #17 0x56289073cde5 in Tree::gui_input(Ref<InputEvent> const&) scene/gui/tree.cpp:3513
    #18 0x56289014c037 in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:952
    #19 0x56288fead318 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1278
    #20 0x56288feb0268 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1516
    #21 0x56288fec28a7 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:2720
    #22 0x56288ff5f1c4 in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1020
    #23 0x56288ffacd58 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:236
    #24 0x56288ffa2166 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:350
    #25 0x56288ff9606b in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #26 0x5628942af54d in Callable::call(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #27 0x562889587384 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/display_server_x11.cpp:3184
    #28 0x562889586dae in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/display_server_x11.cpp:3155
    #29 0x5628941ce59a in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:663

SUMMARY: AddressSanitizer: heap-use-after-free core/object/object.h:810 in Object::get_script_instance() const
Shadow bytes around the buggy address:
  0x0c34800ab910: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c34800ab920: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c34800ab930: fd fd fd fd fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c34800ab940: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c34800ab950: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c34800ab960: fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd fd
  0x0c34800ab970: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c34800ab980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c34800ab990: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c34800ab9a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c34800ab9b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==3082517==ABORTING
```

</details>