### PR TITLE
[3.x] Update TextureRegion editor when NinePatchRect/StyleBoxTexture changes

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -925,6 +925,12 @@ void TextureRegionEditor::_changed_callback(Object *p_changed, const char *p_pro
 	if (p_prop == StringName("atlas") || p_prop == StringName("texture") || p_prop == StringName("region")) {
 		_edit_region();
 	}
+	if (Object::cast_to<NinePatchRect>(p_changed) && (p_prop == StringName("region_rect") || p_prop == StringName("patch_margin_left") || p_prop == StringName("patch_margin_right") || p_prop == StringName("patch_margin_top") || p_prop == StringName("patch_margin_bottom"))) {
+		_edit_region();
+	}
+	if (Object::cast_to<StyleBoxTexture>(p_changed) && (p_prop == StringName("content_margin_left") || p_prop == StringName("content_margin_right") || p_prop == StringName("content_margin_top") || p_prop == StringName("content_margin_bottom"))) {
+		_edit_region();
+	}
 }
 
 void TextureRegionEditor::_edit_region() {


### PR DESCRIPTION
Fixes #62694

Updates the editor when the region rect or margins change.

![Peek 2022-07-06 13-56](https://user-images.githubusercontent.com/372476/177480899-7a77677c-f2a1-4d4a-bab7-c55b5c80cb9c.gif)
![Peek 2022-07-06 13-55](https://user-images.githubusercontent.com/372476/177480909-d7641468-4221-492c-af42-0a5d3c662fb0.gif)

