### PR TITLE
Fix LineEdit text incorrectly trimmed due to rounding errors.

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -65,7 +65,7 @@
 			</description>
 		</method>
 		<method name="get_scroll_offset" qualifiers="const">
-			<return type="int" />
+			<return type="float" />
 			<description>
 				Returns the scroll offset due to [member caret_column], as a number of characters.
 			</description>

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -716,7 +716,7 @@ void LineEdit::_notification(int p_what) {
 
 		case NOTIFICATION_RESIZED: {
 			_fit_to_width();
-			scroll_offset = 0;
+			scroll_offset = 0.0;
 			set_caret_column(get_caret_column());
 		} break;
 
@@ -799,7 +799,7 @@ void LineEdit::_notification(int p_what) {
 					}
 				} break;
 				case HORIZONTAL_ALIGNMENT_CENTER: {
-					if (scroll_offset != 0) {
+					if (!Math::is_zero_approx(scroll_offset)) {
 						x_ofs = style->get_offset().x;
 					} else {
 						x_ofs = MAX(style->get_margin(SIDE_LEFT), int(size.width - (text_width)) / 2);
@@ -844,7 +844,7 @@ void LineEdit::_notification(int p_what) {
 				r_icon->draw(ci, Point2(width - r_icon->get_width() - style->get_margin(SIDE_RIGHT), height / 2 - r_icon->get_height() / 2), color_icon);
 
 				if (alignment == HORIZONTAL_ALIGNMENT_CENTER) {
-					if (scroll_offset == 0) {
+					if (Math::is_zero_approx(scroll_offset)) {
 						x_ofs = MAX(style->get_margin(SIDE_LEFT), int(size.width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 					}
 				} else {
@@ -1206,7 +1206,7 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 			}
 		} break;
 		case HORIZONTAL_ALIGNMENT_CENTER: {
-			if (scroll_offset != 0) {
+			if (!Math::is_zero_approx(scroll_offset)) {
 				x_ofs = style->get_offset().x;
 			} else {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - (text_width)) / 2);
@@ -1226,7 +1226,7 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 		if (alignment == HORIZONTAL_ALIGNMENT_CENTER) {
-			if (scroll_offset == 0) {
+			if (Math::is_zero_approx(scroll_offset)) {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
@@ -1234,11 +1234,11 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 		}
 	}
 
-	int ofs = TS->shaped_text_hit_test_position(text_rid, p_x - x_ofs - scroll_offset);
+	int ofs = ceil(TS->shaped_text_hit_test_position(text_rid, p_x - x_ofs - scroll_offset));
 	set_caret_column(ofs);
 }
 
-Vector2i LineEdit::get_caret_pixel_pos() {
+Vector2 LineEdit::get_caret_pixel_pos() {
 	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
 	bool rtl = is_layout_rtl();
 
@@ -1254,7 +1254,7 @@ Vector2i LineEdit::get_caret_pixel_pos() {
 			}
 		} break;
 		case HORIZONTAL_ALIGNMENT_CENTER: {
-			if (scroll_offset != 0) {
+			if (!Math::is_zero_approx(scroll_offset)) {
 				x_ofs = style->get_offset().x;
 			} else {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - (text_width)) / 2);
@@ -1274,7 +1274,7 @@ Vector2i LineEdit::get_caret_pixel_pos() {
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 		if (alignment == HORIZONTAL_ALIGNMENT_CENTER) {
-			if (scroll_offset == 0) {
+			if (Math::is_zero_approx(scroll_offset)) {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
@@ -1282,7 +1282,7 @@ Vector2i LineEdit::get_caret_pixel_pos() {
 		}
 	}
 
-	Vector2i ret;
+	Vector2 ret;
 	CaretInfo caret;
 	// Get position of the start of caret.
 	if (ime_text.length() != 0 && ime_selection.x != 0) {
@@ -1425,7 +1425,7 @@ void LineEdit::set_text(String p_text) {
 
 	update();
 	caret_column = 0;
-	scroll_offset = 0;
+	scroll_offset = 0.0;
 }
 
 void LineEdit::set_text_direction(Control::TextDirection p_text_direction) {
@@ -1549,7 +1549,7 @@ void LineEdit::set_caret_column(int p_column) {
 	// Fit to window.
 
 	if (!is_inside_tree()) {
-		scroll_offset = 0;
+		scroll_offset = 0.0;
 		return;
 	}
 
@@ -1568,7 +1568,7 @@ void LineEdit::set_caret_column(int p_column) {
 			}
 		} break;
 		case HORIZONTAL_ALIGNMENT_CENTER: {
-			if (scroll_offset != 0) {
+			if (!Math::is_zero_approx(scroll_offset)) {
 				x_ofs = style->get_offset().x;
 			} else {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - (text_width)) / 2);
@@ -1589,7 +1589,7 @@ void LineEdit::set_caret_column(int p_column) {
 	if (right_icon.is_valid() || display_clear_icon) {
 		Ref<Texture2D> r_icon = display_clear_icon ? Control::get_theme_icon(SNAME("clear")) : right_icon;
 		if (alignment == HORIZONTAL_ALIGNMENT_CENTER) {
-			if (scroll_offset == 0) {
+			if (Math::is_zero_approx(scroll_offset)) {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
@@ -1599,12 +1599,12 @@ void LineEdit::set_caret_column(int p_column) {
 	}
 
 	// Note: Use two coordinates to fit IME input range.
-	Vector2i primary_catret_offset = get_caret_pixel_pos();
+	Vector2 primary_caret_offset = get_caret_pixel_pos();
 
-	if (MIN(primary_catret_offset.x, primary_catret_offset.y) <= x_ofs) {
-		scroll_offset += (x_ofs - MIN(primary_catret_offset.x, primary_catret_offset.y));
-	} else if (MAX(primary_catret_offset.x, primary_catret_offset.y) >= ofs_max) {
-		scroll_offset += (ofs_max - MAX(primary_catret_offset.x, primary_catret_offset.y));
+	if (MIN(primary_caret_offset.x, primary_caret_offset.y) <= x_ofs) {
+		scroll_offset += x_ofs - MIN(primary_caret_offset.x, primary_caret_offset.y);
+	} else if (MAX(primary_caret_offset.x, primary_caret_offset.y) >= ofs_max) {
+		scroll_offset += ofs_max - MAX(primary_caret_offset.x, primary_caret_offset.y);
 	}
 	scroll_offset = MIN(0, scroll_offset);
 
@@ -1615,14 +1615,14 @@ int LineEdit::get_caret_column() const {
 	return caret_column;
 }
 
-void LineEdit::set_scroll_offset(int p_pos) {
+void LineEdit::set_scroll_offset(float p_pos) {
 	scroll_offset = p_pos;
-	if (scroll_offset < 0) {
-		scroll_offset = 0;
+	if (scroll_offset < 0.0) {
+		scroll_offset = 0.0;
 	}
 }
 
-int LineEdit::get_scroll_offset() const {
+float LineEdit::get_scroll_offset() const {
 	return scroll_offset;
 }
 
@@ -1650,7 +1650,7 @@ void LineEdit::clear_internal() {
 	deselect();
 	_clear_undo_stack();
 	caret_column = 0;
-	scroll_offset = 0;
+	scroll_offset = 0.0;
 	undo_text = "";
 	text = "";
 	_shape();

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -102,7 +102,7 @@ private:
 	bool caret_mid_grapheme_enabled = true;
 
 	int caret_column = 0;
-	int scroll_offset = 0;
+	float scroll_offset = 0.0;
 	int max_length = 0; // 0 for no maximum.
 
 	String language;
@@ -141,8 +141,7 @@ private:
 
 	struct TextOperation {
 		int caret_column = 0;
-		int scroll_offset = 0;
-		int cached_width = 0;
+		float scroll_offset = 0.0;
 		String text;
 	};
 	List<TextOperation> undo_stack;
@@ -180,11 +179,11 @@ private:
 	void shift_selection_check_post(bool);
 
 	void selection_fill_at_caret();
-	void set_scroll_offset(int p_pos);
-	int get_scroll_offset() const;
+	void set_scroll_offset(float p_pos);
+	float get_scroll_offset() const;
 
 	void set_caret_at_pixel_pos(int p_x);
-	Vector2i get_caret_pixel_pos();
+	Vector2 get_caret_pixel_pos();
 
 	void _reset_caret_blink_timer();
 	void _toggle_draw_caret();


### PR DESCRIPTION
Since text rendering now supports sub-pixel positioning, scroll offset and caret offset should also use float values to avoid rounding errors. (which was causing last char to be trimmed in some cases).
