### PR TITLE
Fix range slider in tree not updating text value

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2850,6 +2850,9 @@ void Tree::value_editor_changed(double p_value) {
 
 	TreeItem::Cell &c = popup_edited_item->cells.write[popup_edited_item_col];
 	c.val = p_value;
+
+	text_editor->set_text(String::num(c.val, Math::range_step_decimals(c.step)));
+
 	item_edited(popup_edited_item_col, popup_edited_item);
 	update();
 }


### PR DESCRIPTION
Fixes #39349

This fixes the tree range cell not updating the text value when using the slider.
This also fixes the field's value not being updated at all when using the slider, even when stopping the edit (unlike shown in the linked issue, probably a regression).