### PR TITLE
Prevent possible crash when creating or deleting a mesh with armature

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -64,6 +64,8 @@ void MeshStorage::mesh_free(RID p_rid) {
 	mesh_clear(p_rid);
 	mesh_set_shadow_mesh(p_rid, RID());
 	Mesh *mesh = mesh_owner.get_or_null(p_rid);
+	ERR_FAIL_COND(!mesh);
+
 	mesh->dependency.deleted_notify(p_rid);
 	if (mesh->instances.size()) {
 		ERR_PRINT("deleting mesh with active instances");

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -210,6 +210,8 @@ void MeshStorage::mesh_free(RID p_rid) {
 	mesh_clear(p_rid);
 	mesh_set_shadow_mesh(p_rid, RID());
 	Mesh *mesh = mesh_owner.get_or_null(p_rid);
+	ERR_FAIL_COND(!mesh);
+
 	mesh->dependency.deleted_notify(p_rid);
 	if (mesh->instances.size()) {
 		ERR_PRINT("deleting mesh with active instances");


### PR DESCRIPTION
Currently I see the crash in my internal project with meshes (when `queue_free` is called on a base class with meshes with armatures), or It can be reproduced at the running of:
[TestModel.zip](https://github.com/godotengine/godot/files/9056546/TestModel.zip)

So I made a hotifx with nullchecking to prevent it. Seems like a recent regression.
```
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.0.alpha.custom_build (09e12ba9b46934c32ffc9e178b5c6f0348de809f)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[0] Dependency::deleted_notify (C:\GIT\godot\servers\rendering\storage\utilities.cpp:42)
[1] Dependency::deleted_notify (C:\GIT\godot\servers\rendering\storage\utilities.cpp:42)
[2] RendererRD::MeshStorage::mesh_free (C:\GIT\godot\servers\rendering\renderer_rd\storage_rd\mesh_storage.cpp:214)
[3] RendererSceneCull::_instance_update_mesh_instance (C:\GIT\godot\servers\rendering\renderer_scene_cull.cpp:474)
[4] RendererSceneCull::instance_attach_skeleton (C:\GIT\godot\servers\rendering\renderer_scene_cull.cpp:1012)
[5] RenderingServerDefault::instance_attach_skeleton (C:\GIT\godot\servers\rendering\rendering_server_default.h:751)
[6] VisualInstance3D::_notification (C:\GIT\godot\scene\3d\visual_instance_3d.cpp:71)
[7] VisualInstance3D::_notificationv (C:\GIT\godot\scene\3d\visual_instance_3d.h:37)
[8] GeometryInstance3D::_notificationv (C:\GIT\godot\scene\3d\visual_instance_3d.h:79)
[9] Object::notification (C:\GIT\godot\core\object\object.cpp:743)
[10] Node3D::_notification (C:\GIT\godot\scene\3d\node_3d.cpp:162)
[11] Node3D::_notificationv (C:\GIT\godot\scene\3d\node_3d.h:52)
[12] VisualInstance3D::_notificationv (C:\GIT\godot\scene\3d\visual_instance_3d.h:37)
[13] GeometryInstance3D::_notificationv (C:\GIT\godot\scene\3d\visual_instance_3d.h:79)
[14] Object::notification (C:\GIT\godot\core\object\object.cpp:743)
[15] Node::_propagate_exit_tree (C:\GIT\godot\scene\main\node.cpp:296)
[16] Node::_propagate_exit_tree (C:\GIT\godot\scene\main\node.cpp:285)
[17] Node::_propagate_exit_tree (C:\GIT\godot\scene\main\node.cpp:285)
[18] Node::_propagate_exit_tree (C:\GIT\godot\scene\main\node.cpp:285)
[19] Node::_propagate_exit_tree (C:\GIT\godot\scene\main\node.cpp:285)
[20] Node::remove_child (C:\GIT\godot\scene\main\node.cpp:1215)
[21] Node::_notification (C:\GIT\godot\scene\main\node.cpp:163)
[22] Node3D::_notificationv (C:\GIT\godot\scene\3d\node_3d.h:52)
[23] predelete_handler (C:\GIT\godot\core\object\object.cpp:1801)
[24] SceneTree::_flush_delete_queue (C:\GIT\godot\scene\main\scene_tree.cpp:1067)
[25] SceneTree::physics_process (C:\GIT\godot\scene\main\scene_tree.cpp:427)
[26] Main::iteration (C:\GIT\godot\main\main.cpp:2801)
[27] OS_Windows::run (C:\GIT\godot\platform\windows\os_windows.cpp:777)
[28] widechar_main (C:\GIT\godot\platform\windows\godot_windows.cpp:179)
[29] _main (C:\GIT\godot\platform\windows\godot_windows.cpp:203)
[30] main (C:\GIT\godot\platform\windows\godot_windows.cpp:215)
[31] __scrt_common_main_seh (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[32] BaseThreadInitThunk
-- END OF BACKTRACE --
```