### PR TITLE
Implement registering protocols on Windows, Mac, and Linux

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -252,6 +252,14 @@ Error OS::shell_open(String p_uri) {
 	return ::OS::get_singleton()->shell_open(p_uri);
 }
 
+Error OS::register_protocol(String p_protocol) {
+	return ::OS::get_singleton()->register_protocol(p_protocol);
+}
+
+Error OS::unregister_protocol(String p_protocol) {
+	return ::OS::get_singleton()->unregister_protocol(p_protocol);
+}
+
 int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr, bool p_open_console) {
 	List<String> args;
 	for (int i = 0; i < p_arguments.size(); i++) {
@@ -638,6 +646,8 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_instance", "arguments"), &OS::create_instance);
 	ClassDB::bind_method(D_METHOD("kill", "pid"), &OS::kill);
 	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &OS::shell_open);
+	ClassDB::bind_method(D_METHOD("register_protocol", "protocol"), &OS::register_protocol);
+	ClassDB::bind_method(D_METHOD("unregister_protocol", "protocol"), &OS::unregister_protocol);
 	ClassDB::bind_method(D_METHOD("is_process_running", "pid"), &OS::is_process_running);
 	ClassDB::bind_method(D_METHOD("get_process_id"), &OS::get_process_id);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -178,6 +178,8 @@ public:
 	int create_instance(const Vector<String> &p_arguments);
 	Error kill(int p_pid);
 	Error shell_open(String p_uri);
+	Error register_protocol(String p_protocol);
+	Error unregister_protocol(String p_protocol);
 
 	bool is_process_running(int p_pid) const;
 	int get_process_id() const;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -326,6 +326,40 @@ Error OS::shell_open(String p_uri) {
 	return ERR_UNAVAILABLE;
 }
 
+bool OS::_validate_protocol(const String &p_protocol) {
+#ifdef TOOLS_ENABLED
+	// This warning should be shared between platforms, so putting it here.
+	// However, it's not technically related to validation.
+	WARN_PRINT("Registering protocols in the editor likely won't work as expected, since it will point to the editor binary. Consider only doing this in exported projects.");
+#endif
+	// https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1
+	// Protocols can't be empty, must be lowercase, must start with a letter,
+	// can only contain letters, numbers, '+', '-', and '.' characters.
+	if (p_protocol.is_empty()) {
+		return false;
+	}
+	if (p_protocol[0] < 'a' || p_protocol[0] > 'z') {
+		ERR_PRINT("Invalid protocol character: " + String::chr(p_protocol[0]) + ". Protocols must start with a lowercase letter.");
+		return false;
+	}
+	for (int i = 1; i < p_protocol.length(); i++) {
+		char32_t c = p_protocol[i];
+		if (c != '+' && c != '-' && c != '.' && !(c >= 'a' && c <= 'z') && !(c >= '0' && c <= '9')) {
+			ERR_PRINT("Invalid protocol character: " + String::chr(c) + ". Protocols must be lowercase, must start with a letter, can only contain letters, numbers, '+', '-', and '.' characters.");
+			return false;
+		}
+	}
+	return true;
+}
+
+Error OS::register_protocol(String p_protocol) {
+	return ERR_UNAVAILABLE;
+}
+
+Error OS::unregister_protocol(String p_protocol) {
+	return ERR_UNAVAILABLE;
+}
+
 // implement these with the canvas?
 
 uint64_t OS::get_static_memory_usage() const {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -111,6 +111,8 @@ protected:
 
 	virtual bool _check_internal_feature_support(const String &p_feature) = 0;
 
+	bool _validate_protocol(const String &p_protocol);
+
 public:
 	typedef int64_t ProcessID;
 
@@ -156,6 +158,10 @@ public:
 
 	virtual Error shell_open(String p_uri);
 	virtual Error set_cwd(const String &p_cwd);
+
+	// E.g. register_protocol("myapp") will redirect links like myapp://uri to the executable
+	virtual Error register_protocol(String p_protocol);
+	virtual Error unregister_protocol(String p_protocol);
 
 	virtual bool has_environment(const String &p_var) const = 0;
 	virtual String get_environment(const String &p_var) const = 0;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -561,6 +561,16 @@
 				Shows all resources currently used by the game.
 			</description>
 		</method>
+		<method name="register_protocol">
+			<return type="int" enum="Error" />
+			<argument index="0" name="protocol" type="String" />
+			<description>
+				Associates links that look like [code]protocol://uri[/code] with this executable.
+				When the OS opens a link like this, such as when the user clicks on a button in their web browser, the executable will launch with the given [code]uri[/code] as the [code]--uri[/code] command line argument, such as [code]myapp://launch/12345[/code] running [code]myapp.exe --uri="myapp://launch/12345"[/code].
+				Returns one of the [enum Error] code constants ([code]OK[/code] on success, [code]ERR_INVALID_PARAMETER[/code] if the given protocol is invalid).
+				[b]Note:[/b] This method is implemented on Linux and Windows, but on macOS you need to use the export dialog to register a protocol.
+			</description>
+		</method>
 		<method name="request_permission">
 			<return type="bool" />
 			<argument index="0" name="name" type="String" />
@@ -619,6 +629,15 @@
 				- [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://datatracker.ietf.org/doc/html/rfc2368]RFC 2368 - The [code]mailto[/code] URL scheme[/url] for a list of fields that can be added.
 				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
 				[b]Note:[/b] This method is implemented on Android, iOS, HTML5, Linux, macOS and Windows.
+			</description>
+		</method>
+		<method name="unregister_protocol">
+			<return type="int" enum="Error" />
+			<argument index="0" name="protocol" type="String" />
+			<description>
+				Removes the association between links that look like [code]protocol://uri[/code] and this game's executable.
+				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
+				[b]Note:[/b] This will remove any protocol with this name registered on the user level, whether or not it was registered by your game. For example, it can unregister protocols registered by other Godot games.
 			</description>
 		</method>
 	</methods>

--- a/misc/dist/macos_template.app/Contents/Info.plist
+++ b/misc/dist/macos_template.app/Contents/Info.plist
@@ -22,6 +22,7 @@
 	<string>$short_version</string>
 	<key>CFBundleSignature</key>
 	<string>$signature</string>
+$registered_protocols
 	<key>CFBundleVersion</key>
 	<string>$version</string>
 $usage_descriptions

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -94,6 +94,8 @@ public:
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
 
 	virtual Error shell_open(String p_uri) override;
+	virtual Error register_protocol(String p_protocol) override;
+	virtual Error unregister_protocol(String p_protocol) override;
 
 	virtual String get_unique_id() const override;
 	virtual String get_processor_name() const override;

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -82,6 +82,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version"), "1.0"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "application/copyright_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/protocol"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "display/high_res"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "privacy/microphone_usage_description", PROPERTY_HINT_PLACEHOLDER_TEXT, "Provide a message if you need to use the microphone"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "privacy/microphone_usage_description_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
@@ -346,6 +347,17 @@ void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_pres
 			strnew += lines[i].replace("$copyright", p_preset->get("application/copyright")) + "\n";
 		} else if (lines[i].find("$highres") != -1) {
 			strnew += lines[i].replace("$highres", p_preset->get("display/high_res") ? "\t<true/>" : "\t<false/>") + "\n";
+		} else if (lines[i].find("$registered_protocols") != -1) {
+			String protocol = p_preset->get("application/protocol");
+			if (!protocol.is_empty()) {
+				String s = "\t<key>CFBundleURLTypes</key>\n\t<array>\n";
+				s += "\t\t<dict>\n\t\t\t<key>CFBundleURLName</key>\n";
+				s += "\t\t\t<string>org.godot.URLSchema" + protocol.to_upper() + "</string>\n";
+				s += "\t\t\t<key>CFBundleURLSchemes</key>\n\t\t\t<array>\n";
+				s += "\t\t\t\t<string>" + protocol + "</string>\n";
+				s += "\t\t\t</array>\n\t\t</dict>\n\t</array>\n";
+				strnew += lines[i].replace("$registered_protocols", s);
+			}
 		} else if (lines[i].find("$usage_descriptions") != -1) {
 			String descriptions;
 			if (!((String)p_preset->get("privacy/microphone_usage_description")).is_empty()) {

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -94,6 +94,8 @@ public:
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
 
 	virtual Error shell_open(String p_uri) override;
+	virtual Error register_protocol(String p_protocol) override;
+	virtual Error unregister_protocol(String p_protocol) override;
 
 	virtual String get_locale() const override;
 

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -298,6 +298,16 @@ Error OS_MacOS::shell_open(String p_uri) {
 	return OK;
 }
 
+Error OS_MacOS::register_protocol(String p_protocol) {
+	WARN_PRINT("Registering protocols on macOS is done via the export dialog, not using the OS.register_protocol() method. This is because protocols are registered in the app bundle.");
+	return ERR_UNAVAILABLE;
+}
+
+Error OS_MacOS::unregister_protocol(String p_protocol) {
+	WARN_PRINT("Registering protocols on macOS is done via the export dialog, not using the OS.unregister_protocol() method. This is because protocols are registered in the app bundle.");
+	return ERR_UNAVAILABLE;
+}
+
 String OS_MacOS::get_locale() const {
 	NSString *locale_code = [[NSLocale preferredLanguages] objectAtIndex:0];
 	return String([locale_code UTF8String]).replace("-", "_");

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -191,6 +191,9 @@ public:
 
 	virtual Error shell_open(String p_uri) override;
 
+	virtual Error register_protocol(String p_protocol) override;
+	virtual Error unregister_protocol(String p_protocol) override;
+
 	void run();
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;


### PR DESCRIPTION
This PR implements this proposal https://github.com/godotengine/godot-proposals/issues/4665 on Windows, macOS, and Linux.

On Windows and Linux, we register protocols at runtime using the new OS method `register_protocol`, and there's also `unregister_protocol` so you can undo it. I did not implement `is_protocol_registered`.

On macOS, protocols are registered in the app bundle manifest, so it must be done at export time, not at runtime (there is a new field in the export dialog). Also, I have no idea how we are supposed to receive the information in the URL on macOS, since it's not a command line argument - but hey, at least the app opens.

This was built on top of code from Facade / @marc-weber1, who wrote the Windows code, and then I tweaked it and made the Linux and macOS code. My work on this was sponsored by The Mirror. If you want to take a look at the original Git history before I squashed it, here's a link: https://github.com/godotengine/godot/compare/master...marc-weber1:godot:protocol-registration 
