### PR TITLE
C#: Enable exporting nodes to the inspector

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2866,6 +2866,12 @@ int CSharpScript::_try_get_member_export_hint(IMonoClassMember *p_member, Manage
 
 		r_hint = PROPERTY_HINT_RESOURCE_TYPE;
 		r_hint_string = String(NATIVE_GDMONOCLASS_NAME(field_native_class));
+	} else if (p_variant_type == Variant::OBJECT && CACHED_CLASS(Node)->is_assignable_from(p_type.type_class)) {
+		GDMonoClass *field_native_class = GDMonoUtils::get_class_native_base(p_type.type_class);
+		CRASH_COND(field_native_class == nullptr);
+
+		r_hint = PROPERTY_HINT_NODE_TYPE;
+		r_hint_string = String(NATIVE_GDMONOCLASS_NAME(field_native_class));
 	} else if (p_allow_generics && p_variant_type == Variant::ARRAY) {
 		// Nested arrays are not supported in the inspector
 


### PR DESCRIPTION
Follow-up to #62185 that implements godotengine/godot-proposals#1048 for C#.

We may want to wait for the `dotnet6` branch to be merged first, in which case I can remake this PR.
For the `dotnet6` branch, the implementation would have to be moved to:

https://github.com/godotengine/godot/blob/56fd0b869d05c32e4637e3e1457cd8b91ad0da24/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs#L395-L404