### PR TITLE
Add option to allow toggling XR from command line

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -240,6 +240,9 @@ public:
 
 	virtual bool is_single_window() const;
 
+	virtual void disable_xr() {}
+	virtual bool is_disable_xr() const { return false; }
+
 	virtual void disable_crash_handler() {}
 	virtual bool is_disable_crash_handler() const { return false; }
 	virtual void initialize_debugging() {}

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -109,6 +109,10 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		args.push_back("--disable-crash-handler");
 	}
 
+	if (OS::get_singleton()->is_disable_xr()) {
+		args.push_back("--disable-xr");
+	}
+
 	Rect2 screen_rect;
 	screen_rect.position = DisplayServer::get_singleton()->screen_get_position(screen);
 	screen_rect.size = DisplayServer::get_singleton()->screen_get_size(screen);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -331,6 +331,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --text-driver <driver>                       Text driver (Fonts, BiDi, shaping)\n");
 	OS::get_singleton()->print("  --tablet-driver <driver>                     Pen tablet input driver.\n");
 	OS::get_singleton()->print("  --headless                                   Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script.\n");
+	OS::get_singleton()->print("  --disable-xr                                 Force disabling of xr. Run the engine so that xr is disabled.\n");
 	OS::get_singleton()->print("  --write-movie <file>                         Run the engine in a way that a movie is written (by default .avi MJPEG). Fixed FPS is forced when enabled, but can be used to change movie FPS. Disabling vsync can speed up movie writing but makes interaction more difficult.\n");
 	OS::get_singleton()->print("  --disable-vsync                              Force disabling of vsync. Run the engine in a way that a movie is written (by default .avi MJPEG). Fixed FPS is forced when enabled, but can be used to change movie FPS.\n");
 
@@ -1164,6 +1165,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing write-movie argument, aborting.\n");
 				goto error;
 			}
+		} else if (I->get() == "--disable-xr") {
+			OS::get_singleton()->disable_xr();
 		} else if (I->get() == "--disable-vsync") {
 			disable_vsync = true;
 		} else if (I->get() == "--print-fps") {

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -57,7 +57,7 @@ OpenXRAPI *OpenXRAPI::singleton = nullptr;
 bool OpenXRAPI::openxr_is_enabled(bool p_check_run_in_editor) {
 	// @TODO we need an overrule switch so we can force enable openxr, i.e run "godot --openxr_enabled"
 
-	if (Engine::get_singleton()->is_editor_hint() && p_check_run_in_editor) {
+	if ((Engine::get_singleton()->is_editor_hint() && p_check_run_in_editor) || OS::get_singleton()->is_disable_xr()) {
 #ifdef TOOLS_ENABLED
 		// Disabled for now, using XR inside of the editor we'll be working on during the coming months.
 		return false;

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -446,6 +446,14 @@ void OS_LinuxBSD::run() {
 	main_loop->finalize();
 }
 
+void OS_LinuxBSD::disable_xr() {
+	force_disable_xr = true;
+}
+
+bool OS_LinuxBSD::is_disable_xr() const {
+	return force_disable_xr;
+}
+
 void OS_LinuxBSD::disable_crash_handler() {
 	crash_handler.disable();
 }

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -44,6 +44,7 @@ class OS_LinuxBSD : public OS_Unix {
 	virtual void delete_main_loop() override;
 
 	bool force_quit;
+	bool force_disable_xr = false;
 
 #ifdef JOYDEV_ENABLED
 	JoypadLinux *joypad = nullptr;
@@ -96,6 +97,9 @@ public:
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 
 	void run();
+
+	virtual void disable_xr() override;
+	virtual bool is_disable_xr() const override;
 
 	virtual void disable_crash_handler() override;
 	virtual bool is_disable_crash_handler() const override;

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -41,6 +41,7 @@
 
 class OS_OSX : public OS_Unix {
 	bool force_quit = false;
+	bool force_disable_xr = false;
 
 	JoypadOSX *joypad_osx = nullptr;
 
@@ -105,6 +106,9 @@ public:
 	virtual String get_processor_name() const override;
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
+
+	virtual void disable_xr() override;
+	virtual bool is_disable_xr() const override;
 
 	virtual void disable_crash_handler() override;
 	virtual bool is_disable_crash_handler() const override;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -416,6 +416,14 @@ bool OS_OSX::_check_internal_feature_support(const String &p_feature) {
 	return p_feature == "pc";
 }
 
+void OS_OSX::disable_xr() {
+	force_disable_xr = true;
+}
+
+bool OS_OSX::is_disable_xr() const {
+	return force_disable_xr;
+}
+
 void OS_OSX::disable_crash_handler() {
 	crash_handler.disable();
 }

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -960,6 +960,14 @@ bool OS_Windows::_check_internal_feature_support(const String &p_feature) {
 	return p_feature == "pc";
 }
 
+void OS_Windows::disable_xr() {
+	force_disable_xr = true;
+}
+
+bool OS_Windows::is_disable_xr() const {
+	return force_disable_xr;
+}
+
 void OS_Windows::disable_crash_handler() {
 	crash_handler.disable();
 }

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -91,6 +91,7 @@ class OS_Windows : public OS {
 #endif
 
 	bool force_quit;
+	bool force_disable_xr = false;
 	HWND main_window;
 
 	// functions used by main to initialize/deinitialize the OS
@@ -171,6 +172,9 @@ public:
 	void run();
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
+
+	virtual void disable_xr() override;
+	virtual bool is_disable_xr() const override;
 
 	virtual void disable_crash_handler() override;
 	virtual bool is_disable_crash_handler() const override;


### PR DESCRIPTION
Useful for debugging and for forcing desktop flat mode.

We are unable to disable XR early enough, so this is why it's in the os class. Let me know if there's a better place. I know @BastiaanOlij had a 1 page summary why Vulkan initializes xr so early.