### PR TITLE
Ensure NuGet.config directory exists

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/NuGetUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/NuGetUtils.cs
@@ -99,7 +99,7 @@ namespace GodotTools.Build
             if (Utils.OS.IsWindows)
             {
                 // %APPDATA% for both
-                return new[] {Path.Combine(applicationData, "NuGet", "NuGet.Config")};
+                return new[] { Path.Combine(applicationData, "NuGet", "NuGet.Config") };
             }
 
             var paths = new string[2];
@@ -156,6 +156,7 @@ namespace GodotTools.Build
   </packageSources>
 </configuration>
 ";
+                    System.IO.Directory.CreateDirectory(Path.GetDirectoryName(nuGetConfigPath));
                     System.IO.File.WriteAllText(nuGetConfigPath, defaultConfig, Encoding.UTF8); // UTF-8 with BOM
                 }
 


### PR DESCRIPTION
Otherwise, creating the NuGet.config file may fail with error `ERROR: Failed to add Godot NuGet Offline Packages to NuGet.Config: Could not find a part of the path "/home/raulsntos/.config/NuGet/NuGet.Config".`.