### PR TITLE
[macOS] Improve file association handling, and allow URL schema handling.

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -160,6 +160,7 @@ public:
 
 	virtual String get_name() const = 0;
 	virtual List<String> get_cmdline_args() const { return _cmdline; }
+	virtual List<String> get_cmdline_platform_args() const { return List<String>(); }
 	virtual String get_model_name() const;
 
 	bool is_layered_allowed() const { return _allow_layered; }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -621,9 +621,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	/* argument parsing and main creation */
 	List<String> args;
 	List<String> main_args;
+	List<String> platform_args = OS::get_singleton()->get_cmdline_platform_args();
 
+	// Add command line arguments.
 	for (int i = 0; i < argc; i++) {
 		args.push_back(String::utf8(argv[i]));
+	}
+
+	// Add arguments received from macOS LaunchService (URL schemas, file associations).
+	for (const String &arg : platform_args) {
+		args.push_back(arg);
 	}
 
 	List<String>::Element *I = args.front();

--- a/platform/osx/godot_application_delegate.h
+++ b/platform/osx/godot_application_delegate.h
@@ -40,6 +40,7 @@
 - (void)forceUnbundledWindowActivationHackStep1;
 - (void)forceUnbundledWindowActivationHackStep2;
 - (void)forceUnbundledWindowActivationHackStep3;
+- (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
 @end
 
 #endif // GODOT_APPLICATION_DELEGATE_H

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -74,14 +74,7 @@ int main(int argc, char **argv) {
 	// We must override main when testing is enabled.
 	TEST_MAIN_OVERRIDE
 
-	if (os.get_open_with_filename() != "") {
-		char *argv_c = (char *)malloc(os.get_open_with_filename().utf8().size());
-		memcpy(argv_c, os.get_open_with_filename().utf8().get_data(), os.get_open_with_filename().utf8().size());
-		err = Main::setup(argv[0], 1, &argv_c);
-		free(argv_c);
-	} else {
-		err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
-	}
+	err = Main::setup(argv[0], argc - first_arg, &argv[first_arg]);
 
 	if (err == ERR_HELP) { // Returned by --help and --version, so success.
 		return 0;

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -57,7 +57,7 @@ class OS_OSX : public OS_Unix {
 
 	MainLoop *main_loop = nullptr;
 
-	String open_with_filename;
+	List<String> launch_service_args;
 
 	static _FORCE_INLINE_ String get_framework_executable(const String &p_path);
 	static void pre_wait_observer_cb(CFRunLoopObserverRef p_observer, CFRunLoopActivity p_activiy, void *p_context);
@@ -73,8 +73,8 @@ protected:
 	virtual void delete_main_loop() override;
 
 public:
-	String get_open_with_filename() const;
-	void set_open_with_filename(const String &p_path);
+	virtual void set_cmdline_platform_args(const List<String> &p_args);
+	virtual List<String> get_cmdline_platform_args() const override;
 
 	virtual String get_name() const override;
 

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -121,12 +121,12 @@ void OS_OSX::delete_main_loop() {
 	main_loop = nullptr;
 }
 
-String OS_OSX::get_open_with_filename() const {
-	return open_with_filename;
+void OS_OSX::set_cmdline_platform_args(const List<String> &p_args) {
+	launch_service_args = p_args;
 }
 
-void OS_OSX::set_open_with_filename(const String &p_path) {
-	open_with_filename = p_path;
+List<String> OS_OSX::get_cmdline_platform_args() const {
+	return launch_service_args;
 }
 
 String OS_OSX::get_name() const {


### PR DESCRIPTION
Makes macOS app behavior similar to the other platforms, opening an associated file will start a new instance with file name as a command line argument.

These changes are also required for handling of the registered URL schemas (see #62788).