### PR TITLE
Fix regressions from Font refactor.

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1638,37 +1638,34 @@ void CodeTextEditor::_apply_settings_change() {
 	font_size = EditorSettings::get_singleton()->get("interface/editor/code_font_size");
 	int ot_mode = EditorSettings::get_singleton()->get("interface/editor/code_font_contextual_ligatures");
 
-	Ref<Font> fb = text_editor->get_theme_font(SNAME("font"));
-	Ref<FontVariation> fc = fb;
-	if (fc.is_null()) {
-		fc.instantiate();
-		fc->set_base_font(fb);
-	}
-
-	switch (ot_mode) {
-		case 1: { // Disable ligatures.
-			fc->set_opentype_features(Dictionary());
-		} break;
-		case 2: { // Custom.
-			Vector<String> subtag = String(EditorSettings::get_singleton()->get("interface/editor/code_font_custom_opentype_features")).split(",");
-			Dictionary ftrs;
-			for (int i = 0; i < subtag.size(); i++) {
-				Vector<String> subtag_a = subtag[i].split("=");
-				if (subtag_a.size() == 2) {
-					ftrs[TS->name_to_tag(subtag_a[0])] = subtag_a[1].to_int();
-				} else if (subtag_a.size() == 1) {
-					ftrs[TS->name_to_tag(subtag_a[0])] = 1;
+	Ref<FontVariation> fc = text_editor->get_theme_font(SNAME("font"));
+	if (fc.is_valid()) {
+		switch (ot_mode) {
+			case 1: { // Disable ligatures.
+				Dictionary ftrs;
+				ftrs[TS->name_to_tag("calt")] = 0;
+				fc->set_opentype_features(ftrs);
+			} break;
+			case 2: { // Custom.
+				Vector<String> subtag = String(EditorSettings::get_singleton()->get("interface/editor/code_font_custom_opentype_features")).split(",");
+				Dictionary ftrs;
+				for (int i = 0; i < subtag.size(); i++) {
+					Vector<String> subtag_a = subtag[i].split("=");
+					if (subtag_a.size() == 2) {
+						ftrs[TS->name_to_tag(subtag_a[0])] = subtag_a[1].to_int();
+					} else if (subtag_a.size() == 1) {
+						ftrs[TS->name_to_tag(subtag_a[0])] = 1;
+					}
 				}
-			}
-			fc->set_opentype_features(ftrs);
-		} break;
-		default: { // Default.
-			Dictionary ftrs;
-			ftrs[TS->name_to_tag("calt")] = 1;
-			fc->set_opentype_features(ftrs);
-		} break;
+				fc->set_opentype_features(ftrs);
+			} break;
+			default: { // Default.
+				Dictionary ftrs;
+				ftrs[TS->name_to_tag("calt")] = 1;
+				fc->set_opentype_features(ftrs);
+			} break;
+		}
 	}
-	text_editor->add_theme_font_override("font", fc);
 
 	text_editor->set_code_hint_draw_below(EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"));
 
@@ -1870,34 +1867,33 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	int ot_mode = EditorSettings::get_singleton()->get("interface/editor/code_font_contextual_ligatures");
-	Ref<Font> fb = text_editor->get_theme_font(SNAME("font"));
-	Ref<FontVariation> fc = fb;
-	if (fc.is_null()) {
-		fc.instantiate();
-		fc->set_base_font(fb);
-	}
-	switch (ot_mode) {
-		case 1: { // Disable ligatures.
-			fc->set_opentype_features(Dictionary());
-		} break;
-		case 2: { // Custom.
-			Vector<String> subtag = String(EditorSettings::get_singleton()->get("interface/editor/code_font_custom_opentype_features")).split(",");
-			Dictionary ftrs;
-			for (int i = 0; i < subtag.size(); i++) {
-				Vector<String> subtag_a = subtag[i].split("=");
-				if (subtag_a.size() == 2) {
-					ftrs[TS->name_to_tag(subtag_a[0])] = subtag_a[1].to_int();
-				} else if (subtag_a.size() == 1) {
-					ftrs[TS->name_to_tag(subtag_a[0])] = 1;
+	Ref<FontVariation> fc = text_editor->get_theme_font(SNAME("font"));
+	if (fc.is_valid()) {
+		switch (ot_mode) {
+			case 1: { // Disable ligatures.
+				Dictionary ftrs;
+				ftrs[TS->name_to_tag("calt")] = 0;
+				fc->set_opentype_features(ftrs);
+			} break;
+			case 2: { // Custom.
+				Vector<String> subtag = String(EditorSettings::get_singleton()->get("interface/editor/code_font_custom_opentype_features")).split(",");
+				Dictionary ftrs;
+				for (int i = 0; i < subtag.size(); i++) {
+					Vector<String> subtag_a = subtag[i].split("=");
+					if (subtag_a.size() == 2) {
+						ftrs[TS->name_to_tag(subtag_a[0])] = subtag_a[1].to_int();
+					} else if (subtag_a.size() == 1) {
+						ftrs[TS->name_to_tag(subtag_a[0])] = 1;
+					}
 				}
-			}
-			fc->set_opentype_features(ftrs);
-		} break;
-		default: { // Default.
-			Dictionary ftrs;
-			ftrs[TS->name_to_tag("calt")] = 1;
-			fc->set_opentype_features(ftrs);
-		} break;
+				fc->set_opentype_features(ftrs);
+			} break;
+			default: { // Default.
+				Dictionary ftrs;
+				ftrs[TS->name_to_tag("calt")] = 1;
+				fc->set_opentype_features(ftrs);
+			} break;
+		}
 	}
 	text_editor->add_theme_font_override("font", fc);
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3697,7 +3697,7 @@ void CanvasItemEditor::_draw_transform_message() {
 		return;
 	}
 
-	Ref<FontFile> font = get_theme_font(SNAME("font"), SNAME("Label"));
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 	Point2 msgpos = Point2(RULER_WIDTH + 5 * EDSCALE, viewport->get_size().y - 20 * EDSCALE);
 	viewport->draw_string(font, msgpos + Point2(1, 1), transform_message, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(0, 0, 0, 0.8));

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2081,7 +2081,7 @@ Ref<Font> RichTextLabel::_find_font(Item *p_item) {
 		fontitem = fontitem->parent;
 	}
 
-	return Ref<FontFile>();
+	return Ref<Font>();
 }
 
 int RichTextLabel::_find_font_size(Item *p_item) {
@@ -4002,7 +4002,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				if (subtag_a.size() == 2) {
 					if (subtag_a[0] == "name" || subtag_a[0] == "n") {
 						String fnt = subtag_a[1];
-						Ref<Font> font_data = ResourceLoader::load(fnt, "FontFile");
+						Ref<Font> font_data = ResourceLoader::load(fnt, "Font");
 						if (font_data.is_valid()) {
 							fc->set_base_font(font_data);
 						}


### PR DESCRIPTION
Fixes regressions from #62108

- Fixes `p_font.is_null()` errors due to incorrect resource type used.
- Fixes code editor font not set correctly, and OpenType features applied to the wrong font.
