### PR TITLE
Only include editor/SCsub when building the editor: tools=yes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -788,7 +788,8 @@ if selected_platform in platform_list:
     SConscript("core/SCsub")
     SConscript("servers/SCsub")
     SConscript("scene/SCsub")
-    SConscript("editor/SCsub")
+    if env["tools"]:
+        SConscript("editor/SCsub")
     SConscript("drivers/SCsub")
 
     SConscript("platform/SCsub")


### PR DESCRIPTION
Currently, when building Godot templates i.e. scons `tools=no`, SCons generates the following warning:
```
scons: warning: Calling missing SConscript without error is deprecated.
Transition by adding must_exist=False to SConscript calls.
Missing SConscript 'editor/SCsub'
File "/home/runner/work/godot/godot/SConstruct", line 791, in <module>
```

This PR excludes `editor/SCsub` when `tools=no`.

Can be cherry-picked onto 3.x.