### PR TITLE
Fix haunted editor bug causing weird issues with mouse behaviour

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2382,7 +2382,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		}
 		case WM_MOUSELEAVE: {
 			old_invalid = true;
-			outside = true;
+			windows[window_id].mouse_outside = true;
 
 			_send_window_event(windows[window_id], WINDOW_EVENT_MOUSE_EXIT);
 
@@ -2612,7 +2612,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				}
 			}
 
-			if (outside) {
+			if (windows[window_id].mouse_outside) {
 				// Mouse enter.
 
 				if (mouse_mode != MOUSE_MODE_CAPTURED) {
@@ -2622,7 +2622,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				CursorShape c = cursor_shape;
 				cursor_shape = CURSOR_MAX;
 				cursor_set_shape(c);
-				outside = false;
+				windows[window_id].mouse_outside = false;
 
 				// Once-off notification, must call again.
 				track_mouse_leave_event(hWnd);
@@ -2713,7 +2713,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				}
 			}
 
-			if (outside) {
+			if (windows[window_id].mouse_outside) {
 				// Mouse enter.
 
 				if (mouse_mode != MOUSE_MODE_CAPTURED) {
@@ -2723,7 +2723,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				CursorShape c = cursor_shape;
 				cursor_shape = CURSOR_MAX;
 				cursor_set_shape(c);
-				outside = false;
+				windows[window_id].mouse_outside = false;
 
 				// Once-off notification, must call again.
 				track_mouse_leave_event(hWnd);
@@ -3607,8 +3607,6 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	pressrc = 0;
 	old_invalid = true;
 	mouse_mode = MOUSE_MODE_VISIBLE;
-
-	outside = true;
 
 	rendering_driver = p_rendering_driver;
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -313,7 +313,6 @@ class DisplayServerWindows : public DisplayServer {
 	int key_event_pos;
 
 	bool old_invalid;
-	bool outside;
 	int old_x, old_y;
 	Point2i center;
 
@@ -387,6 +386,7 @@ class DisplayServerWindows : public DisplayServer {
 
 		Size2 window_rect;
 		Point2 last_pos;
+		bool mouse_outside = true;
 
 		ObjectID instance_id;
 


### PR DESCRIPTION
Fixes #58609

After some investigating, I discovered that this *'haunted editor bug'* that goes away after alt-tabbing was caused by the Windows Display Server's `outside` field which was directly in the DisplayServerWindows class, thus being common to all windows. But since this field is supposed to indicate whether the mouse is inside or outside a **window**, it should be instanced once for every window of the engine.

This issue was caused by a regression from #58490