### PR TITLE
[3.x] Tweak default sky appearance to avoid blue tint in shadows in new projects

### DIFF
--- a/doc/classes/ProceduralSky.xml
+++ b/doc/classes/ProceduralSky.xml
@@ -6,6 +6,7 @@
 	<description>
 		ProceduralSky provides a way to create an effective background quickly by defining procedural parameters for the sun, the sky and the ground. The sky and ground are very similar, they are defined by a color at the horizon, another color, and finally an easing curve to interpolate between these two colors. Similarly, the sun is described by a position in the sky, a color, and an easing curve. However, the sun also defines a minimum and maximum angle, these two values define at what distance the easing curve begins and ends from the sun, and thus end up defining the size of the sun in the sky.
 		The ProceduralSky is updated on the CPU after the parameters change. It is stored in a texture and then displayed as a background in the scene. This makes it relatively unsuitable for real-time updates during gameplay. However, with a small enough texture size, it can still be updated relatively frequently, as it is updated on a background thread when multi-threading is available.
+		[b]Note:[/b] The ProceduralSky appearance in projects created after Godot 3.6 is different from the defaults specified here. This is done to improve the appearance of new projects while preserving compatibility with existing projects. If you create a ProceduralSky resource in the editor or in a script, it will use the defaults specified here.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -481,9 +481,20 @@ private:
 						if (!f) {
 							set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 						} else {
+							// Store default environment file with some custom settings.
+							// This is done to improve the appearance of new projects
+							// (avoiding the notorious blue appearance of shaded areas),
+							// while keeping existing visuals in existing projects.
 							f->store_line("[gd_resource type=\"Environment\" load_steps=2 format=2]");
 							f->store_line("");
 							f->store_line("[sub_resource type=\"ProceduralSky\" id=1]");
+							f->store_line("sky_top_color = Color( 0.385, 0.454, 0.55, 1 )");
+							f->store_line("sky_horizon_color = Color( 0.646, 0.656, 0.67, 1 )");
+							f->store_line("sky_curve = 0.15");
+							f->store_line("ground_bottom_color = Color( 0.2, 0.169, 0.133, 1 )");
+							f->store_line("ground_horizon_color = Color( 0.646, 0.656, 0.67, 1 )");
+							f->store_line("sun_angle_max = 30.0");
+							f->store_line("sun_curve = 0.15");
 							f->store_line("");
 							f->store_line("[resource]");
 							f->store_line("background_mode = 2");


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/57993.

**This change only affects projects created after this PR is merged**, as only the initial `default_env.tres` file contains the new values. Creating a new ProceduralSky in the editor or via code will keep using the old defaults for compatibility reasons.

Given the above precaution is taken for backwards compatibility, I think this is safe to try out for 3.5. Performance should be identical compared to before, as we're only tweaking default colors. We can consider further changes to the default environment for 3.6 (such as using ACES Fitted by default like in https://github.com/godotengine/godot/pull/49736).

**Testing project:** [environment_tweaks_3.x.zip](https://github.com/godotengine/godot/files/9066927/environment_tweaks_3.x.zip)

## Applying to existing projects

If you wish to apply the new defaults in an existing project:

- Close the Godot editor.
- Open `default_env.tres` (located at the project root) with a text editor.
  - If you've changed the default environment project setting, the path may be different or nonexistent. In this case, create a new `default_env.tres` file. You can specify its path later in the Project Settings.
- Replace its *entire* contents with the following:

```ini
[gd_resource type="Environment" load_steps=2 format=2]

[sub_resource type="ProceduralSky" id=1]
sky_top_color = Color( 0.385, 0.454, 0.55, 1 )
sky_horizon_color = Color( 0.646, 0.656, 0.67, 1 )
sky_curve = 0.15
ground_bottom_color = Color( 0.2, 0.169, 0.133, 1 )
ground_horizon_color = Color( 0.646, 0.656, 0.67, 1 )
sun_angle_max = 30.0
sun_curve = 0.15

[resource]
background_mode = 2
background_sky = SubResource( 1 )
```

- Save the file and open the Godot editor.

## Preview

### GLES3, no GI, Linear tonemapping

Before | After
-|-
![2022-07-07_19 36 28_before_linear](https://user-images.githubusercontent.com/180032/177859440-67a7064b-9c6a-41af-ae3b-4192bce6d26f.png) | ![2022-07-07_19 39 38_after_linear](https://user-images.githubusercontent.com/180032/177859451-7e8b8ef8-2e1b-44bf-bf38-95bf9a4041d1.png)

### GLES2, no GI, Linear tonemapping

Before | After
-|-
![2022-07-07_19 40 10_before_gles2](https://user-images.githubusercontent.com/180032/177859420-031a95fc-94f7-4e66-ba44-01b532ce797e.png) | ![2022-07-07_19 40 21_after_gles2](https://user-images.githubusercontent.com/180032/177859427-7c8e5b9e-bac4-4419-b764-f0f123d397e9.png)

### GLES3, no GI, ACES Fitted tonemapping (whitepoint set to 6.0)

Before | After
-|-
![2022-07-07_19 35 38_before_aces_fitted_whitepoint_6](https://user-images.githubusercontent.com/180032/177859391-d05080a1-fd9a-491e-bd37-eca2ea438ce7.png) | ![2022-07-07_19 39 25_after_aces_fitted_whitepoint_6](https://user-images.githubusercontent.com/180032/177859399-e1761aef-7d01-428b-aab0-f78cc2f57f65.png)

### GLES3, GIProbe (propagation set to 0.0), Linear tonemapping

Before | After
-|-
![2022-07-07_21 41 04](https://user-images.githubusercontent.com/180032/177859472-21a77ac5-7ff4-4e3c-8e40-357e77382605.png) | ![2022-07-07_21 40 46](https://user-images.githubusercontent.com/180032/177859478-0214e8b8-2272-473a-bb25-d0ada4e60c5b.png)

## Comparison between 3.x and 4.0

*No GI and ACES Fitted tonemapping on both screenshots.
3.x appears brighter, as the [fallback material in 3.x is much brighter](https://github.com/godotengine/godot/issues/27082) than it is in 4.0. We could compensate for this by decreasing the default sky contribution to 0.6, but users would then have to set it back to 1.0 after loading a custom sky. We can also [tweak the fallback material appearance](https://github.com/godotengine/godot/pull/62756) instead.*

3.x | 4.0 | 3.x (sky contribution set to 0.6)
-|-|-
![2022-07-07_19 39 25_after_aces_fitted_whitepoint_6](https://user-images.githubusercontent.com/180032/177859399-e1761aef-7d01-428b-aab0-f78cc2f57f65.png) | ![2022-02-11_22 52 10](https://user-images.githubusercontent.com/180032/153681668-8ce0432d-9a69-489c-be7c-45c51fdc5158.png) | ![2022-07-07_21 56 40](https://user-images.githubusercontent.com/180032/177861228-56da1897-2b04-436d-b778-e35ce7a7646a.png)

