### PR TITLE
Input: Re-enable input accumulation disabled by error in 3.4

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -400,7 +400,7 @@
 		<member name="use_accumulated_input" type="bool" setter="set_use_accumulated_input" getter="is_using_accumulated_input">
 			If [code]true[/code], similar input events sent by the operating system are accumulated. When input accumulation is enabled, all input events generated during a frame will be merged and emitted when the frame is done rendering. Therefore, this limits the number of input method calls per second to the rendering FPS.
 			Input accumulation can be disabled to get slightly more precise/reactive input at the cost of increased CPU usage. In applications where drawing freehand lines is required, input accumulation should generally be disabled while the user is drawing the line to get results that closely follow the actual input.
-			[b]Note:[/b] Input accumulation is [i]disabled[/i] by default for backward compatibility reasons. It is however recommended to enable it for games which don't require very reactive input, as this will decrease CPU usage.
+			[b]Note:[/b] Input accumulation is [i]enabled[/i] by default. It is recommended to keep it enabled for games which don't require very reactive input, as this will decrease CPU usage.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Contains mouse and pen motion information. Supports relative, absolute positions and speed. See [method Node._input].
-		[b]Note:[/b] By default, this event can be emitted multiple times per frame rendered, allowing for precise input reporting, at the expense of CPU usage. You can set [member Input.use_accumulated_input] to [code]true[/code] to let multiple events merge into a single emitted event per frame.
+		[b]Note:[/b] The behavior of this event is affected by the value of [member Input.use_accumulated_input]. When set to [code]true[/code] (default), mouse/pen motion events received from the OS will be merged to emit an accumulated event only once per frame rendered at most. When set to [code]false[/code], the events will be emitted as received, which means that they can be emitted multiple times per frame rendered, allowing for precise input reporting at the expense of CPU usage.
 		[b]Note:[/b] If you use InputEventMouseMotion to draw lines, consider implementing [url=https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm]Bresenham's line algorithm[/url] as well to avoid visible gaps in lines if the user is moving the mouse quickly.
 	</description>
 	<tutorials>

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -748,7 +748,7 @@ void InputDefault::release_pressed_events() {
 
 InputDefault::InputDefault() {
 	use_input_buffering = false;
-	use_accumulated_input = false;
+	use_accumulated_input = true;
 	mouse_button_mask = 0;
 	emulate_touch_from_mouse = false;
 	emulate_mouse_from_touch = false;


### PR DESCRIPTION
Input accumulation was implemented and enabled by default in 3.1, and
I don't recall major complaints around it (or bugs were fixed).

In 3.4, #42220 added input buffering and apparently toggled input
accumulation off by mistake.

This led to multiple bug reports about degraded performance on Windows,
or simply unexpected behavior change (see linked issues in #55037).

Fixes #55037.

----

We don't plan to cherry-pick this to `3.4` as this branch has been in use for too long already with input accumulation disabled, and this would be a breaking change unexpected in a patch release.

For `3.5`, we should point out this change clearly in the changelog so that users who need the precision of disabled input accumulation know to change it back when upgrading.