### PR TITLE
Fix regressions from Font refactor (2)

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1895,7 +1895,6 @@ CodeTextEditor::CodeTextEditor() {
 			} break;
 		}
 	}
-	text_editor->add_theme_font_override("font", fc);
 
 	text_editor->set_draw_line_numbers(true);
 	text_editor->set_highlight_matching_braces_enabled(true);

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -342,7 +342,11 @@ void Button::_notification(int p_what) {
 				} break;
 			}
 
-			text_buf->draw_outline(ci, text_ofs, get_theme_constant(SNAME("outline_size")), get_theme_color(SNAME("font_outline_color")));
+			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
+			if (outline_size > 0 && font_outline_color.a > 0) {
+				text_buf->draw_outline(ci, text_ofs, outline_size, font_outline_color);
+			}
 			text_buf->draw(ci, text_ofs, color);
 		} break;
 	}


### PR DESCRIPTION
Fixes few minor regressions from https://github.com/godotengine/godot/pull/62108

- Remove unnecessary font override
- Fixes button outline draw when it should not, causing button colors to be slightly off