### PR TITLE
Fixed bug in `GridContainer` with hidden children

### DIFF
--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -41,8 +41,6 @@ void GridContainer::_notification(int p_what) {
 
 			int hsep = get_theme_constant(SNAME("h_separation"));
 			int vsep = get_theme_constant(SNAME("v_separation"));
-			int max_col = MIN(get_child_count(), columns);
-			int max_row = ceil((float)get_child_count() / (float)columns);
 
 			// Compute the per-column/per-row data.
 			int valid_controls_index = 0;
@@ -78,6 +76,9 @@ void GridContainer::_notification(int p_what) {
 					row_expanded.insert(row);
 				}
 			}
+
+			int max_col = MIN(valid_controls_index, columns);
+			int max_row = ceil((float)valid_controls_index / (float)columns);
 
 			// Consider all empty columns expanded.
 			for (int i = valid_controls_index; i < columns; i++) {


### PR DESCRIPTION
Fix a bug that occour when there are hidden children in grid_container.
The visualization isn't correct due to a wrong calculation of max_col and max_row that mistakenly includes hidden children.
