### PR TITLE
[3.5] Flush accumulated input events on iOS

### DIFF
--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -203,6 +203,8 @@ bool OSIPhone::iterate() {
 		return true;
 	}
 
+	input->flush_buffered_events();
+
 	return Main::iteration();
 };
 


### PR DESCRIPTION
Fixes #62833.

**UPDATE:** Version for 4.0 in #62843.