### PR TITLE
Flush accumulated input events on iOS

### DIFF
--- a/platform/iphone/display_server_iphone.mm
+++ b/platform/iphone/display_server_iphone.mm
@@ -195,6 +195,7 @@ void DisplayServerIPhone::window_set_drop_files_callback(const Callable &p_calla
 }
 
 void DisplayServerIPhone::process_events() {
+	Input::get_singleton()->flush_buffered_events();
 }
 
 void DisplayServerIPhone::_dispatch_input_events(const Ref<InputEvent> &p_event) {


### PR DESCRIPTION
Version of #62842 for 4.0.