### PR TITLE
Fix SubViewport not rendering correctly

### DIFF
--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -21,7 +21,7 @@
 			The clear mode when the sub-viewport is used as a render target.
 			[b]Note:[/b] This property is intended for 2D usage.
 		</member>
-		<member name="render_target_update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="SubViewport.UpdateMode" default="2">
+		<member name="render_target_update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="SubViewport.UpdateMode" default="1">
 			The update mode when the sub-viewport is used as a render target.
 		</member>
 		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(512, 512)">

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -129,8 +129,6 @@ void SubViewportContainer::_notification(int p_what) {
 				} else {
 					c->set_update_mode(SubViewport::UPDATE_DISABLED);
 				}
-
-				c->set_handle_input_locally(false); //do not handle input locally here
 			}
 		} break;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4132,6 +4132,8 @@ void SubViewport::_bind_methods() {
 	BIND_ENUM_CONSTANT(UPDATE_ALWAYS);
 }
 
-SubViewport::SubViewport() {}
+SubViewport::SubViewport() {
+	set_size(get_size());
+}
 
 SubViewport::~SubViewport() {}

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -726,14 +726,14 @@ public:
 
 	enum UpdateMode {
 		UPDATE_DISABLED,
-		UPDATE_ONCE, //then goes to disabled
-		UPDATE_WHEN_VISIBLE, // default
+		UPDATE_ONCE, // Then goes to disabled, default value.
+		UPDATE_WHEN_VISIBLE, // It doesn't make sense, because SubViewport has no concept of visible.
 		UPDATE_WHEN_PARENT_VISIBLE,
 		UPDATE_ALWAYS
 	};
 
 private:
-	UpdateMode update_mode = UPDATE_WHEN_VISIBLE;
+	UpdateMode update_mode = UPDATE_ONCE;
 	ClearMode clear_mode = CLEAR_MODE_ALWAYS;
 	bool size_2d_override_stretch = false;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fix #55471.

Previously, the necessary steps in `_set_size` were not performed when the `SubViewport` was initialized, which caused rendering issues. There was no problem when changing the parameters (make `size`, `size_2d_override`, or `size_2d_override_stretch` not the default value) which caused `_set_size` to be called.

