### PR TITLE
Define bold, italics and mono fonts in editor log for `print_rich()`

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -311,6 +311,24 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 		mono_other_fc->set_opentype_features(ftrs);
 	}
 
+	// Use fake bold/italics to style the editor log's `print_rich()` output.
+	// Use stronger embolden strength to make bold easier to distinguish from regular text.
+	Ref<FontVariation> mono_other_fc_bold = mono_other_fc->duplicate();
+	mono_other_fc_bold->set_variation_embolden(0.8);
+
+	Ref<FontVariation> mono_other_fc_italic = mono_other_fc->duplicate();
+	mono_other_fc_italic->set_variation_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
+
+	Ref<FontVariation> mono_other_fc_bold_italic = mono_other_fc->duplicate();
+	mono_other_fc_bold_italic->set_variation_embolden(0.8);
+	mono_other_fc_bold_italic->set_variation_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
+
+	Ref<FontVariation> mono_other_fc_mono = mono_other_fc->duplicate();
+	// Use a different font style to distinguish `[code]` in rich prints.
+	// This emulates the "faint" styling used in ANSI escape codes by using a slightly thinner font.
+	mono_other_fc_mono->set_variation_embolden(-0.25);
+	mono_other_fc_mono->set_variation_transform(Transform2D(1.0, 0.1, 0.0, 1.0, 0.0, 0.0));
+
 	Ref<FontVariation> italic_fc = default_fc->duplicate();
 	italic_fc->set_variation_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
 
@@ -380,6 +398,10 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	p_theme->set_font_size("output_source_size", "EditorFonts", int(EDITOR_GET("run/output/font_size")) * EDSCALE);
 	p_theme->set_font("output_source", "EditorFonts", mono_other_fc);
+	p_theme->set_font("output_source_bold", "EditorFonts", mono_other_fc_bold);
+	p_theme->set_font("output_source_italic", "EditorFonts", mono_other_fc_italic);
+	p_theme->set_font("output_source_bold_italic", "EditorFonts", mono_other_fc_bold_italic);
+	p_theme->set_font("output_source_mono", "EditorFonts", mono_other_fc_mono);
 
 	p_theme->set_font_size("status_source_size", "EditorFonts", default_font_size);
 	p_theme->set_font("status_source", "EditorFonts", mono_other_fc);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -62,18 +62,33 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 }
 
 void EditorLog::_update_theme() {
-	Ref<Font> normal_font = get_theme_font(SNAME("output_source"), SNAME("EditorFonts"));
+	const Ref<Font> normal_font = get_theme_font(SNAME("output_source"), SNAME("EditorFonts"));
 	if (normal_font.is_valid()) {
 		log->add_theme_font_override("normal_font", normal_font);
 	}
 
-	log->add_theme_font_size_override("normal_font_size", get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts")));
-	log->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
-
-	Ref<Font> bold_font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
+	const Ref<Font> bold_font = get_theme_font(SNAME("output_source_bold"), SNAME("EditorFonts"));
 	if (bold_font.is_valid()) {
 		log->add_theme_font_override("bold_font", bold_font);
 	}
+
+	const Ref<Font> italics_font = get_theme_font(SNAME("output_source_italic"), SNAME("EditorFonts"));
+	if (italics_font.is_valid()) {
+		log->add_theme_font_override("italics_font", italics_font);
+	}
+
+	const Ref<Font> bold_italics_font = get_theme_font(SNAME("output_source_bold_italic"), SNAME("EditorFonts"));
+	if (bold_italics_font.is_valid()) {
+		log->add_theme_font_override("bold_italics_font", bold_italics_font);
+	}
+
+	const Ref<Font> mono_font = get_theme_font(SNAME("output_source_mono"), SNAME("EditorFonts"));
+	if (mono_font.is_valid()) {
+		log->add_theme_font_override("mono_font", mono_font);
+	}
+
+	log->add_theme_font_size_override("normal_font_size", get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts")));
+	log->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 
 	type_filter_map[MSG_TYPE_STD]->toggle_button->set_icon(get_theme_icon(SNAME("Popup"), SNAME("EditorIcons")));
 	type_filter_map[MSG_TYPE_ERROR]->toggle_button->set_icon(get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/60675.

This is also used by the number indicator for message grouping, as it uses a bold font.

Mono font does not actually turn proportional fonts into monospace. Instead, it's a more faint version of the regular font, intended to emulate the look of the "faint" ANSI escape code (and make `[code]` distinguishable from regular text).

The custom code font will be used to generate the bold/italic/mono variants if specified in the Editor Settings.

**Testing project:** [test_print_rich.zip](https://github.com/godotengine/godot/files/9077585/test_print_rich.zip)

## Preview

*The font used here is Recursive Mono Casual, but this also works with the default editor code font.*

### Editor log

![2022-07-09_19 15 13](https://user-images.githubusercontent.com/180032/178116182-0da6b66a-6c4f-4451-8060-1b3453615031.png)

### Editor log (custom font, Recursive Mono Casual Regular)

![2022-07-09_19 16 31](https://user-images.githubusercontent.com/180032/178116183-359ef8f3-f701-4a2d-8e41-dacd77cc537e.png)

### Terminal (VS Code)

*Uses ANSI escape codes instead of BBCode.*

![2022-07-09_19 14 55](https://user-images.githubusercontent.com/180032/178116181-4b220642-e282-42a1-922d-0074707647c8.png)