### PR TITLE
Make Image.get_size() return a Vector2i instead of a Vector2

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -416,8 +416,8 @@ int Image::get_height() const {
 	return height;
 }
 
-Vector2 Image::get_size() const {
-	return Vector2(width, height);
+Vector2i Image::get_size() const {
+	return Vector2i(width, height);
 }
 
 bool Image::has_mipmaps() const {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -209,7 +209,7 @@ private:
 public:
 	int get_width() const; ///< Get image width
 	int get_height() const; ///< Get image height
-	Vector2 get_size() const;
+	Vector2i get_size() const;
 	bool has_mipmaps() const;
 	int get_mipmap_count() const;
 

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -250,7 +250,7 @@
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">
-			<return type="Vector2" />
+			<return type="Vector2i" />
 			<description>
 				Returns the image's size (width and height).
 			</description>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Closes #62856