### PR TITLE
Fix dead link in TAA resolve shader comment

### DIFF
--- a/servers/rendering/renderer_rd/shaders/taa_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/taa_resolve.glsl
@@ -29,7 +29,8 @@
 
 #VERSION_DEFINES
 
-// Based on Spartan Engine's TAA implementation https://github.com/PanosK92/SpartanEngine/blob/master/Data/shaders/temporal_antialiasing.hlsl
+// Based on Spartan Engine's TAA implementation (without TAA upscale).
+// <https://github.com/PanosK92/SpartanEngine/blob/a8338d0609b85dc32f3732a5c27fb4463816a3b9/Data/shaders/temporal_antialiasing.hlsl>
 
 #define USE_SUBGROUPS
 


### PR DESCRIPTION
Spartan Engine has recently removed its own internal TAA in favor of FSR 2.0. The link has been changed to point to a fixed commit, so the link will keep working as long as the repository exists.