### PR TITLE
Use integer types in Image and ImageTexture methods

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2478,15 +2478,15 @@ Image::Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const V
 	create(p_width, p_height, p_mipmaps, p_format, p_data);
 }
 
-Rect2 Image::get_used_rect() const {
+Rect2i Image::get_used_rect() const {
 	if (format != FORMAT_LA8 && format != FORMAT_RGBA8 && format != FORMAT_RGBAF && format != FORMAT_RGBAH && format != FORMAT_RGBA4444 && format != FORMAT_RGB565) {
-		return Rect2(Point2(), Size2(width, height));
+		return Rect2i(0, 0, width, height);
 	}
 
 	int len = data.size();
 
 	if (len == 0) {
-		return Rect2();
+		return Rect2i();
 	}
 
 	int minx = 0xFFFFFF, miny = 0xFFFFFFF;
@@ -2512,15 +2512,15 @@ Rect2 Image::get_used_rect() const {
 	}
 
 	if (maxx == -1) {
-		return Rect2();
+		return Rect2i();
 	} else {
-		return Rect2(minx, miny, maxx - minx + 1, maxy - miny + 1);
+		return Rect2i(minx, miny, maxx - minx + 1, maxy - miny + 1);
 	}
 }
 
-Ref<Image> Image::get_rect(const Rect2 &p_area) const {
+Ref<Image> Image::get_rect(const Rect2i &p_area) const {
 	Ref<Image> img = memnew(Image(p_area.size.x, p_area.size.y, mipmaps, format));
-	img->blit_rect(Ref<Image>((Image *)this), p_area, Point2(0, 0));
+	img->blit_rect(Ref<Image>((Image *)this), p_area, Point2i(0, 0));
 	return img;
 }
 
@@ -2557,7 +2557,7 @@ void Image::_get_clipped_src_and_dest_rects(const Ref<Image> &p_src, const Rect2
 	r_clipped_dest_rect.size.y = r_clipped_src_rect.size.y;
 }
 
-void Image::blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Point2 &p_dest) {
+void Image::blit_rect(const Ref<Image> &p_src, const Rect2i &p_src_rect, const Point2i &p_dest) {
 	ERR_FAIL_COND_MSG(p_src.is_null(), "It's not a reference to a valid Image object.");
 	int dsize = data.size();
 	int srcdsize = p_src->data.size();
@@ -2599,7 +2599,7 @@ void Image::blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Po
 	}
 }
 
-void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest) {
+void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2i &p_src_rect, const Point2i &p_dest) {
 	ERR_FAIL_COND_MSG(p_src.is_null(), "It's not a reference to a valid Image object.");
 	ERR_FAIL_COND_MSG(p_mask.is_null(), "It's not a reference to a valid Image object.");
 	int dsize = data.size();
@@ -2649,7 +2649,7 @@ void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, co
 	}
 }
 
-void Image::blend_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Point2 &p_dest) {
+void Image::blend_rect(const Ref<Image> &p_src, const Rect2i &p_src_rect, const Point2i &p_dest) {
 	ERR_FAIL_COND_MSG(p_src.is_null(), "It's not a reference to a valid Image object.");
 	int dsize = data.size();
 	int srcdsize = p_src->data.size();
@@ -2684,7 +2684,7 @@ void Image::blend_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const P
 	}
 }
 
-void Image::blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest) {
+void Image::blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2i &p_src_rect, const Point2i &p_dest) {
 	ERR_FAIL_COND_MSG(p_src.is_null(), "It's not a reference to a valid Image object.");
 	ERR_FAIL_COND_MSG(p_mask.is_null(), "It's not a reference to a valid Image object.");
 	int dsize = data.size();
@@ -2756,7 +2756,7 @@ void Image::fill(const Color &p_color) {
 	_repeat_pixel_over_subsequent_memory(dst_data_ptr, pixel_size, width * height);
 }
 
-void Image::fill_rect(const Rect2 &p_rect, const Color &p_color) {
+void Image::fill_rect(const Rect2i &p_rect, const Color &p_color) {
 	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot fill rect in compressed or custom image formats.");
 
 	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect.abs());

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -370,15 +370,15 @@ public:
 	Ref<Image> get_image_from_mipmap(int p_mipamp) const;
 	void bump_map_to_normal_map(float bump_scale = 1.0);
 
-	void blit_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
-	void blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest);
-	void blend_rect(const Ref<Image> &p_src, const Rect2 &p_src_rect, const Point2 &p_dest);
-	void blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2 &p_src_rect, const Point2 &p_dest);
+	void blit_rect(const Ref<Image> &p_src, const Rect2i &p_src_rect, const Point2i &p_dest);
+	void blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2i &p_src_rect, const Point2i &p_dest);
+	void blend_rect(const Ref<Image> &p_src, const Rect2i &p_src_rect, const Point2i &p_dest);
+	void blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, const Rect2i &p_src_rect, const Point2i &p_dest);
 	void fill(const Color &p_color);
-	void fill_rect(const Rect2 &p_rect, const Color &p_color);
+	void fill_rect(const Rect2i &p_rect, const Color &p_color);
 
-	Rect2 get_used_rect() const;
-	Ref<Image> get_rect(const Rect2 &p_area) const;
+	Rect2i get_used_rect() const;
+	Ref<Image> get_rect(const Rect2i &p_area) const;
 
 	static void set_compress_bc_func(void (*p_compress_func)(Image *, float, UsedChannels));
 	static void set_compress_bptc_func(void (*p_compress_func)(Image *, float, UsedChannels));

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -23,8 +23,8 @@
 		<method name="blend_rect">
 			<return type="void" />
 			<argument index="0" name="src" type="Image" />
-			<argument index="1" name="src_rect" type="Rect2" />
-			<argument index="2" name="dst" type="Vector2" />
+			<argument index="1" name="src_rect" type="Rect2i" />
+			<argument index="2" name="dst" type="Vector2i" />
 			<description>
 				Alpha-blends [code]src_rect[/code] from [code]src[/code] image to this image at coordinates [code]dest[/code], clipped accordingly to both image bounds. This image and [code]src[/code] image [b]must[/b] have the same format. [code]src_rect[/code] with not positive size is treated as empty.
 			</description>
@@ -33,8 +33,8 @@
 			<return type="void" />
 			<argument index="0" name="src" type="Image" />
 			<argument index="1" name="mask" type="Image" />
-			<argument index="2" name="src_rect" type="Rect2" />
-			<argument index="3" name="dst" type="Vector2" />
+			<argument index="2" name="src_rect" type="Rect2i" />
+			<argument index="3" name="dst" type="Vector2i" />
 			<description>
 				Alpha-blends [code]src_rect[/code] from [code]src[/code] image to this image using [code]mask[/code] image at coordinates [code]dst[/code], clipped accordingly to both image bounds. Alpha channels are required for both [code]src[/code] and [code]mask[/code]. [code]dst[/code] pixels and [code]src[/code] pixels will blend if the corresponding mask pixel's alpha value is not 0. This image and [code]src[/code] image [b]must[/b] have the same format. [code]src[/code] image and [code]mask[/code] image [b]must[/b] have the same size (width and height) but they can have different formats. [code]src_rect[/code] with not positive size is treated as empty.
 			</description>
@@ -42,8 +42,8 @@
 		<method name="blit_rect">
 			<return type="void" />
 			<argument index="0" name="src" type="Image" />
-			<argument index="1" name="src_rect" type="Rect2" />
-			<argument index="2" name="dst" type="Vector2" />
+			<argument index="1" name="src_rect" type="Rect2i" />
+			<argument index="2" name="dst" type="Vector2i" />
 			<description>
 				Copies [code]src_rect[/code] from [code]src[/code] image to this image at coordinates [code]dst[/code], clipped accordingly to both image bounds. This image and [code]src[/code] image [b]must[/b] have the same format. [code]src_rect[/code] with not positive size is treated as empty.
 			</description>
@@ -52,8 +52,8 @@
 			<return type="void" />
 			<argument index="0" name="src" type="Image" />
 			<argument index="1" name="mask" type="Image" />
-			<argument index="2" name="src_rect" type="Rect2" />
-			<argument index="3" name="dst" type="Vector2" />
+			<argument index="2" name="src_rect" type="Rect2i" />
+			<argument index="3" name="dst" type="Vector2i" />
 			<description>
 				Blits [code]src_rect[/code] area from [code]src[/code] image to this image at the coordinates given by [code]dst[/code], clipped accordingly to both image bounds. [code]src[/code] pixel is copied onto [code]dst[/code] if the corresponding [code]mask[/code] pixel's alpha value is not 0. This image and [code]src[/code] image [b]must[/b] have the same format. [code]src[/code] image and [code]mask[/code] image [b]must[/b] have the same size (width and height) but they can have different formats. [code]src_rect[/code] with not positive size is treated as empty.
 			</description>
@@ -168,7 +168,7 @@
 		</method>
 		<method name="fill_rect">
 			<return type="void" />
-			<argument index="0" name="rect" type="Rect2" />
+			<argument index="0" name="rect" type="Rect2i" />
 			<argument index="1" name="color" type="Color" />
 			<description>
 				Fills [code]rect[/code] with [code]color[/code].
@@ -244,7 +244,7 @@
 		</method>
 		<method name="get_rect" qualifiers="const">
 			<return type="Image" />
-			<argument index="0" name="rect" type="Rect2" />
+			<argument index="0" name="rect" type="Rect2i" />
 			<description>
 				Returns a new image that is a copy of the image's area specified with [code]rect[/code].
 			</description>
@@ -256,9 +256,9 @@
 			</description>
 		</method>
 		<method name="get_used_rect" qualifiers="const">
-			<return type="Rect2" />
+			<return type="Rect2i" />
 			<description>
-				Returns a [Rect2] enclosing the visible portion of the image, considering each pixel with a non-zero alpha channel as visible.
+				Returns a [Rect2i] enclosing the visible portion of the image, considering each pixel with a non-zero alpha channel as visible.
 			</description>
 		</method>
 		<method name="get_width" qualifiers="const">

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -44,7 +44,7 @@
 		</method>
 		<method name="set_size_override">
 			<return type="void" />
-			<argument index="0" name="size" type="Vector2" />
+			<argument index="0" name="size" type="Vector2i" />
 			<description>
 				Resizes the texture to the specified dimensions.
 			</description>

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -367,7 +367,7 @@ Error ResourceImporterLayeredTexture::import(const String &p_source_file, const 
 		for (int j = 0; j < hslices; j++) {
 			int x = slice_w * j;
 			int y = slice_h * i;
-			Ref<Image> slice = image->get_rect(Rect2(x, y, slice_w, slice_h));
+			Ref<Image> slice = image->get_rect(Rect2i(x, y, slice_w, slice_h));
 			ERR_CONTINUE(slice.is_null() || slice->is_empty());
 			if (slice->get_width() != slice_w || slice->get_height() != slice_h) {
 				slice->resize(slice_w, slice_h);

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -212,7 +212,7 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 
 			EditorAtlasPacker::Chart chart;
 
-			Rect2 used_rect = Rect2(Vector2(), image->get_size());
+			Rect2i used_rect = Rect2i(Vector2i(), image->get_size());
 			if (trim_alpha_border_from_region) {
 				// Clip a region from the image.
 				used_rect = image->get_used_rect();
@@ -220,9 +220,9 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 			pack_data.region = used_rect;
 
 			chart.vertices.push_back(used_rect.position);
-			chart.vertices.push_back(used_rect.position + Vector2(used_rect.size.x, 0));
-			chart.vertices.push_back(used_rect.position + Vector2(used_rect.size.x, used_rect.size.y));
-			chart.vertices.push_back(used_rect.position + Vector2(0, used_rect.size.y));
+			chart.vertices.push_back(used_rect.position + Vector2i(used_rect.size.x, 0));
+			chart.vertices.push_back(used_rect.position + Vector2i(used_rect.size.x, used_rect.size.y));
+			chart.vertices.push_back(used_rect.position + Vector2i(0, used_rect.size.y));
 			EditorAtlasPacker::Chart::Face f;
 			f.vertex[0] = 0;
 			f.vertex[1] = 1;

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -132,8 +132,8 @@ void AnimationPlayerEditor::_notification(int p_what) {
 				Size2 icon_size = autoplay_img->get_size();
 				autoplay_reset_img.instantiate();
 				autoplay_reset_img->create(icon_size.x * 2, icon_size.y, false, autoplay_img->get_format());
-				autoplay_reset_img->blit_rect(autoplay_img, Rect2(Point2(), icon_size), Point2());
-				autoplay_reset_img->blit_rect(reset_img, Rect2(Point2(), icon_size), Point2(icon_size.x, 0));
+				autoplay_reset_img->blit_rect(autoplay_img, Rect2i(Point2i(), icon_size), Point2i());
+				autoplay_reset_img->blit_rect(reset_img, Rect2i(Point2i(), icon_size), Point2i(icon_size.x, 0));
 				autoplay_reset_icon.instantiate();
 				autoplay_reset_icon->set_image(autoplay_reset_img);
 			}

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -161,7 +161,7 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 						Ref<Image> overlay = previews->get_theme_icon(SNAME("PlayOverlay"), SNAME("EditorIcons"))->get_image();
 						Ref<Image> thumbnail = p_image->get_image();
 						thumbnail = thumbnail->duplicate();
-						Point2 overlay_pos = Point2((thumbnail->get_width() - overlay->get_width()) / 2, (thumbnail->get_height() - overlay->get_height()) / 2);
+						Point2i overlay_pos = Point2i((thumbnail->get_width() - overlay->get_width()) / 2, (thumbnail->get_height() - overlay->get_height()) / 2);
 
 						// Overlay and thumbnail need the same format for `blend_rect` to work.
 						thumbnail->convert(Image::FORMAT_RGBA8);

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -271,8 +271,8 @@ Lightmapper::BakeError LightmapperRD::_blit_meshes_into_atlas(int p_max_texture_
 		mi.offset.x = best_atlas_offsets[m_i].x;
 		mi.offset.y = best_atlas_offsets[m_i].y;
 		mi.slice = best_atlas_offsets[m_i].z;
-		albedo_images.write[mi.slice]->blit_rect(mi.data.albedo_on_uv2, Rect2(Vector2(), Size2i(mi.data.albedo_on_uv2->get_width(), mi.data.albedo_on_uv2->get_height())), mi.offset);
-		emission_images.write[mi.slice]->blit_rect(mi.data.emission_on_uv2, Rect2(Vector2(), Size2i(mi.data.emission_on_uv2->get_width(), mi.data.emission_on_uv2->get_height())), mi.offset);
+		albedo_images.write[mi.slice]->blit_rect(mi.data.albedo_on_uv2, Rect2i(Vector2i(), mi.data.albedo_on_uv2->get_size()), mi.offset);
+		emission_images.write[mi.slice]->blit_rect(mi.data.emission_on_uv2, Rect2(Vector2i(), mi.data.emission_on_uv2->get_size()), mi.offset);
 	}
 
 	return BAKE_OK;
@@ -1420,7 +1420,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			img2.instantiate();
 			img2->create(2, 2, false, Image::FORMAT_RGBAF, s);
 			img2->convert(Image::FORMAT_RGB8);
-			img->blit_rect(img2, Rect2(0, 0, 2, 2), Point2((j % 3) * 2, (j / 3) * 2));
+			img->blit_rect(img2, Rect2i(0, 0, 2, 2), Point2i((j % 3) * 2, (j / 3) * 2));
 		}
 		img->save_png("res://3_light_probe_" + itos(i) + ".png");
 	}

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -146,7 +146,7 @@ Array LightmapGIData::_get_light_textures_data() const {
 		texture_image->create(slice_width, slice_height * texture_slice_count, false, images[0]->get_format());
 
 		for (int j = 0; j < texture_slice_count; j++) {
-			texture_image->blit_rect(images[i * slices_per_texture + j], Rect2(0, 0, slice_width, slice_height), Point2(0, slice_height * j));
+			texture_image->blit_rect(images[i * slices_per_texture + j], Rect2i(0, 0, slice_width, slice_height), Point2i(0, slice_height * j));
 		}
 
 		String texture_path = texture_count > 1 ? base_name + "_" + itos(i) + ".exr" : base_name + ".exr";

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -300,8 +300,8 @@ bool ImageTexture::is_pixel_opaque(int p_x, int p_y) const {
 	return true;
 }
 
-void ImageTexture::set_size_override(const Size2 &p_size) {
-	Size2 s = p_size;
+void ImageTexture::set_size_override(const Size2i &p_size) {
+	Size2i s = p_size;
 	if (s.x != 0) {
 		w = s.x;
 	}

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -130,7 +130,7 @@ public:
 
 	bool is_pixel_opaque(int p_x, int p_y) const override;
 
-	void set_size_override(const Size2 &p_size);
+	void set_size_override(const Size2i &p_size);
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -1801,9 +1801,9 @@ Vector<Vector<Ref<Texture2D>>> TileSet::generate_terrains_icons(Size2i p_size) {
 			if (counts[terrain_set][terrain].count > 0) {
 				// Get the best tile.
 				Ref<Texture2D> texture = counts[terrain_set][terrain].texture;
-				Rect2 region = counts[terrain_set][terrain].region;
+				Rect2i region = counts[terrain_set][terrain].region;
 				image->create(region.size.x, region.size.y, false, Image::FORMAT_RGBA8);
-				image->blit_rect(texture->get_image(), region, Point2());
+				image->blit_rect(texture->get_image(), region, Point2i());
 				image->resize(p_size.x, p_size.y, Image::INTERPOLATE_NEAREST);
 			} else {
 				image->create(1, 1, false, Image::FORMAT_RGBA8);

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -161,8 +161,8 @@ TEST_CASE("[Image] Basic getters") {
 	CHECK(image->get_height() == 4);
 	CHECK(image->get_size() == Vector2(8, 4));
 	CHECK(image->get_format() == Image::FORMAT_LA8);
-	CHECK(image->get_used_rect() == Rect2(0, 0, 0, 0));
-	Ref<Image> image_get_rect = image->get_rect(Rect2(0, 0, 2, 1));
+	CHECK(image->get_used_rect() == Rect2i(0, 0, 0, 0));
+	Ref<Image> image_get_rect = image->get_rect(Rect2i(0, 0, 2, 1));
 	CHECK(image_get_rect->get_size() == Vector2(2, 1));
 }
 
@@ -213,8 +213,8 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 			image->get_pixelv(Vector2(0, 0)).is_equal_approx(Color(1, 1, 1, 1)),
 			"Image's get_pixel() should return the same color value as the one being set with set_pixel() in the same position.");
 	CHECK_MESSAGE(
-			image->get_used_rect() == Rect2(0, 0, 1, 1),
-			"Image's get_used_rect should return the expected value, larger than Rect2(0, 0, 0, 0) if it's visible.");
+			image->get_used_rect() == Rect2i(0, 0, 1, 1),
+			"Image's get_used_rect should return the expected value, larger than Rect2i(0, 0, 0, 0) if it's visible.");
 
 	image->set_pixelv(Vector2(0, 0), Color(0.5, 0.5, 0.5, 0.5));
 	Ref<Image> image2 = memnew(Image(3, 3, false, Image::FORMAT_RGBA8));
@@ -233,19 +233,19 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 	{
 		const int img_width = 3;
 		const int img_height = 3;
-		Vector<Rect2> rects;
-		rects.push_back(Rect2());
-		rects.push_back(Rect2(-5, -5, 3, 3));
-		rects.push_back(Rect2(img_width, 0, 12, 12));
-		rects.push_back(Rect2(0, img_height, 12, 12));
-		rects.push_back(Rect2(img_width + 1, img_height + 2, 12, 12));
-		rects.push_back(Rect2(1, 1, 1, 1));
-		rects.push_back(Rect2(0, 1, 2, 3));
-		rects.push_back(Rect2(-5, 0, img_width + 10, 2));
-		rects.push_back(Rect2(0, -5, 2, img_height + 10));
-		rects.push_back(Rect2(-1, -1, img_width + 1, img_height + 1));
+		Vector<Rect2i> rects;
+		rects.push_back(Rect2i());
+		rects.push_back(Rect2i(-5, -5, 3, 3));
+		rects.push_back(Rect2i(img_width, 0, 12, 12));
+		rects.push_back(Rect2i(0, img_height, 12, 12));
+		rects.push_back(Rect2i(img_width + 1, img_height + 2, 12, 12));
+		rects.push_back(Rect2i(1, 1, 1, 1));
+		rects.push_back(Rect2i(0, 1, 2, 3));
+		rects.push_back(Rect2i(-5, 0, img_width + 10, 2));
+		rects.push_back(Rect2i(0, -5, 2, img_height + 10));
+		rects.push_back(Rect2i(-1, -1, img_width + 1, img_height + 1));
 
-		for (const Rect2 &rect : rects) {
+		for (const Rect2i &rect : rects) {
 			Ref<Image> img = memnew(Image(img_width, img_height, false, Image::FORMAT_RGBA8));
 			CHECK_NOTHROW_MESSAGE(
 					img->fill_rect(rect, Color(1, 1, 1, 1)),
@@ -267,7 +267,7 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 	}
 
 	// Blend two images together
-	image->blend_rect(image2, Rect2(Vector2(0, 0), image2->get_size()), Vector2(0, 0));
+	image->blend_rect(image2, Rect2i(Vector2i(0, 0), image2->get_size()), Vector2i(0, 0));
 	CHECK_MESSAGE(
 			image->get_pixel(0, 0).a > 0.7,
 			"blend_rect() should blend the alpha values of the two images.");
@@ -279,7 +279,7 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 	image3->set_pixel(0, 0, Color(0, 1, 0, 1));
 
 	//blit_rect() two images together
-	image->blit_rect(image3, Rect2(Vector2(0, 0), image3->get_size()), Vector2(0, 0));
+	image->blit_rect(image3, Rect2i(Vector2i(0, 0), image3->get_size()), Vector2i(0, 0));
 	CHECK_MESSAGE(
 			image->get_pixel(0, 0).is_equal_approx(Color(0, 1, 0, 1)),
 			"blit_rect() should replace old colors and not blend them.");


### PR DESCRIPTION
Replaces some `Vector2` and `Rect2` method arguments and return values with `Vector2i` and `Rect2i`. All of these methods already convert the float values to integers internally, so the behavior of these methods doesn't change.

- `Image.blit_rect()`
- `Image.blit_rect_mask()`
- `Image.blend_rect()`
- `Image.blend_rect_mask()`
- `Image.fill_rect()`
- `Image.get_used_rect()`
- `Image.get_rect()`
- `ImageTexture.set_size_override()`

`Image.get_size()` is done by https://github.com/godotengine/godot/pull/62861