### PR TITLE
Improve appearance of the material editor preview

### DIFF
--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -155,7 +155,9 @@ MaterialEditor::MaterialEditor() {
 
 	camera = memnew(Camera3D);
 	camera->set_transform(Transform3D(Basis(), Vector3(0, 0, 3)));
-	camera->set_perspective(45, 0.1, 10);
+	// Use low field of view so the sphere/box is fully encompassed within the preview,
+	// without much distortion.
+	camera->set_perspective(20, 0.1, 10);
 	camera->make_current();
 	viewport->add_child(camera);
 
@@ -177,8 +179,8 @@ MaterialEditor::MaterialEditor() {
 	Transform3D box_xform;
 	box_xform.basis.rotate(Vector3(1, 0, 0), Math::deg2rad(25.0));
 	box_xform.basis = box_xform.basis * Basis().rotated(Vector3(0, 1, 0), Math::deg2rad(-25.0));
-	box_xform.basis.scale(Vector3(0.8, 0.8, 0.8));
-	box_xform.origin.y = 0.2;
+	box_xform.basis.scale(Vector3(0.7, 0.7, 0.7));
+	box_xform.origin.y = 0.05;
 	box_instance->set_transform(box_xform);
 
 	sphere_mesh.instantiate();


### PR DESCRIPTION
- Use lower camera FOV to show more of the sphere/box, while still fully displaying the meshes in question.

Once https://github.com/godotengine/godot/pull/61953 is merged, this is a good opportunity to use a negative mipmap LOD bias for the material preview.

**Testing project:** [test_material_preview.zip](https://github.com/godotengine/godot/files/9079458/test_material_preview.zip)

## Preview

![2022-07-10_18 46 39](https://user-images.githubusercontent.com/180032/178154019-1603663e-404c-4bfe-8a27-ec7659feee1f.png)

![2022-07-10_18 46 44](https://user-images.githubusercontent.com/180032/178154021-1f19f8c6-a16d-4923-b10b-4387619d1067.png)