### PR TITLE
Fix parser stuck in an error loop

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1644,6 +1644,7 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 					lambda_ended = true;
 					has_ended_lambda = true;
 				} else {
+					advance();
 					push_error(vformat(R"(Expected statement, found "%s" instead.)", previous.get_name()));
 				}
 			}


### PR DESCRIPTION
Fixes (4.0) #53345

Using the repro from this comment https://github.com/godotengine/godot/issues/53345#issuecomment-1172856468 because I couldn't reproduce it with the code in the initial comment.

When lambda functions were added to GDScript, the behavior of `parse_precedence` had to be changed to not consume a token if a valid prefix rule didn't exist.
https://github.com/godotengine/godot/blob/d26442e709f6361af9ac755ec9291bb43f2cd69b/modules/gdscript/gdscript_parser.cpp#L2140

However, this can cause the parser to be stuck in an infinite loop in certain cases, since it never consumes the token causing the error.

With the assumption that this only happens with expression statements, I added an `advance()` call there, which will be called alongside the parser error.

_Bugsquad edit: This closes #53345._