### PR TITLE
Prevent unnecessary additional parser error

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1646,8 +1646,9 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 				} else {
 					push_error(vformat(R"(Expected statement, found "%s" instead.)", previous.get_name()));
 				}
+			} else {
+				end_statement("expression");
 			}
-			end_statement("expression");
 			lambda_ended = lambda_ended || has_ended_lambda;
 			result = expression;
 


### PR DESCRIPTION
Fixes an aspect of #53345

Half of the errors in https://github.com/godotengine/godot/issues/53345#issuecomment-1172856468 are unnecessary, as the parser shouldn't expect the end of a statement if no statement was found in the first place.