### PR TITLE
Set the changed field to empty (meaning all) if the link button is pressed

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1670,7 +1670,7 @@ void EditorPropertyVector2::_value_changed(double val, const String &p_name) {
 	Vector2 v2;
 	v2.x = spin[0]->get_value();
 	v2.y = spin[1]->get_value();
-	emit_changed(get_edited_property(), v2, p_name);
+	emit_changed(get_edited_property(), v2, linked->is_pressed() ? "" : p_name);
 }
 
 void EditorPropertyVector2::update_property() {
@@ -1917,7 +1917,7 @@ void EditorPropertyVector3::_value_changed(double val, const String &p_name) {
 		v3.y = Math::deg2rad(v3.y);
 		v3.z = Math::deg2rad(v3.z);
 	}
-	emit_changed(get_edited_property(), v3, p_name);
+	emit_changed(get_edited_property(), v3, linked->is_pressed() ? "" : p_name);
 }
 
 void EditorPropertyVector3::update_property() {
@@ -2083,7 +2083,7 @@ void EditorPropertyVector2i::_value_changed(double val, const String &p_name) {
 	Vector2i v2;
 	v2.x = spin[0]->get_value();
 	v2.y = spin[1]->get_value();
-	emit_changed(get_edited_property(), v2, p_name);
+	emit_changed(get_edited_property(), v2, linked->is_pressed() ? "" : p_name);
 }
 
 void EditorPropertyVector2i::update_property() {
@@ -2325,7 +2325,7 @@ void EditorPropertyVector3i::_value_changed(double val, const String &p_name) {
 	v3.x = spin[0]->get_value();
 	v3.y = spin[1]->get_value();
 	v3.z = spin[2]->get_value();
-	emit_changed(get_edited_property(), v3, p_name);
+	emit_changed(get_edited_property(), v3, linked->is_pressed() ? "" : p_name);
 }
 
 void EditorPropertyVector3i::update_property() {


### PR DESCRIPTION
Quick fix #62283.

This is due to the `p_field` in the `EditorProperty::emit_changed`. `p_field` only works for `MultiNodeEdit`, not for other objects.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
It feels like there is no need to make it a condition in `MultiNodeEdit` either.