### PR TITLE
Fix crash on mobile devices supporting S3TC for GLES3 renderer

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8072,6 +8072,13 @@ void RasterizerStorageGLES3::initialize() {
 	config.texture_float_linear_supported = config.extensions.has("GL_OES_texture_float_linear");
 	config.framebuffer_float_supported = config.extensions.has("GL_EXT_color_buffer_float");
 	config.framebuffer_half_float_supported = config.extensions.has("GL_EXT_color_buffer_half_float") || config.framebuffer_float_supported;
+
+	// If the desktop build is using S3TC, and you export / run from the IDE for android, if the device supports
+	// S3TC it will crash trying to load these textures, as they are not exported in the APK. This is a simple way
+	// to prevent Android devices trying to load S3TC, by faking lack of hardware support.
+#if defined(ANDROID_ENABLED) || defined(IPHONE_ENABLED)
+	config.s3tc_supported = false;
+#endif
 #endif
 
 	// not yet detected on GLES3 (is this mandated?)


### PR DESCRIPTION
Applies changes made in #32255 to `rasterizer_storage_gles3.cpp`, fixes https://github.com/godotengine/godot/issues/28308 for GLES3 builds.

The fix in that PR was only implemented for the GLES2 renderer. The same issue can however also occur on GLES3.
Mobile devices supporting S3TC compression will expect S3TC compressed files and crash if those are not found, complaining about missing `s3tc.stex` import files.

Since above PR was cherry picked for `3.4.3`, it may be sensible to include this in `3.x`. 
Not relevant for `master` as far as i am aware.