### PR TITLE
fix switching RAW mode to RGB mode issue

### DIFF
--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -99,7 +99,7 @@ public:
 class ColorModeRAW : public ColorMode {
 public:
 	String labels[3] = { "R", "G", "B" };
-	float slider_max[4] = { 100, 100, 100, 1 };
+	float slider_max[4] = { 1, 1, 1, 1 };
 
 	virtual String get_name() const override { return "RAW"; }
 


### PR DESCRIPTION
fixes #62894

```
return next_power_of_2(MAX(255, color.components[idx] * 255.0)) - 1;
```
when result of ```color.components[idx] * 255.0 ```  beyond 255, this issue will happen, so i modified this function as other mode

