### PR TITLE
Fix off-screen clipping bug with vulkan

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7647,9 +7647,6 @@ void RenderingDeviceVulkan::draw_list_enable_scissor(DrawListID p_list, const Re
 
 	rect = dl->viewport.intersection(rect);
 
-	if (rect.get_area() == 0) {
-		return;
-	}
 	VkRect2D scissor;
 	scissor.offset.x = rect.position.x;
 	scissor.offset.y = rect.position.y;


### PR DESCRIPTION
Fixes #56579

This fixes the bug that prevented canvas elements from being clipped when off-screen.

I'm not sure why this `if` was here, but since the `vkCmdSetScissor` method can accept an empty rect, I think we can safely remove it.