### PR TITLE
Parser: Properly set node extents

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1301,6 +1301,12 @@ private:
 	};
 	static ParseRule *get_rule(GDScriptTokenizer::Token::Type p_token_type);
 
+	List<Node *> nodes_in_progress;
+	void complete_extents(Node *p_node);
+	void update_extents(Node *p_node);
+	void reset_extents(Node *p_node, GDScriptTokenizer::Token p_token);
+	void reset_extents(Node *p_node, Node *p_from);
+
 	template <class T>
 	T *alloc_node() {
 		T *node = memnew(T);
@@ -1308,13 +1314,8 @@ private:
 		node->next = list;
 		list = node;
 
-		// TODO: Properly set positions for all nodes.
-		node->start_line = previous.start_line;
-		node->end_line = previous.end_line;
-		node->start_column = previous.start_column;
-		node->end_column = previous.end_column;
-		node->leftmost_column = previous.leftmost_column;
-		node->rightmost_column = previous.rightmost_column;
+		reset_extents(node, previous);
+		nodes_in_progress.push_back(node);
 
 		return node;
 	}


### PR DESCRIPTION
Fixes (4.0) #38851
Fixes (4.0) #43286

The fix in #62690 was correct, but it still didn't work for these cases. The reason is that `GDScriptParser::Node`'s `end_line` member (and a few more) wasn't set properly / was TODO. This PR sets them to expectable values, which fixes (in 4.0) the aforementioned bugs (in combination with #62690).

This would also allow for more precise error/warning highlights in the future.