### PR TITLE
Fix editor dock layout not saving correctly

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4589,8 +4589,14 @@ void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p
 			names += name;
 		}
 
+		String config_key = "dock_" + itos(i + 1);
+
+		if (p_layout->has_section_key(p_section, config_key)) {
+			p_layout->erase_section_key(p_section, config_key);
+		}
+
 		if (!names.is_empty()) {
-			p_layout->set_value(p_section, "dock_" + itos(i + 1), names);
+			p_layout->set_value(p_section, config_key, names);
 		}
 	}
 


### PR DESCRIPTION
Fixes #57142

When saving the editor dock layout, the `dock_[...]` keys were never erased when `names` was empty, causing the config to keep the old values for these keys.

For example, if you had:
```properties
dock_1="Node"
dock_2="Inspector"
```
And you moved `Node` to `dock_2`, this was the result:
```properties
dock_1="Node"
dock_2="Inspector,Node"
```

It now makes sure the key is erased if `names` is empty *(it also erases it even if it's non-empty, so the keys are always ordered correctly in the config)*.

This issue was caused by a regression from #48466