### PR TITLE
Allow loading override.cfg from PCK files

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -511,8 +511,9 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		if (found) {
 			Error err = _load_settings_text_or_binary("res://project.godot", "res://project.binary");
 			if (err == OK && !p_ignore_override) {
-				// Load override from location of the executable.
-				// Optional, we don't mind if it fails.
+				// Load overrides from the PCK and the executable location.
+				// Optional, we don't mind if either fails.
+				_load_settings_text("res://override.cfg");
 				_load_settings_text(exec_path.get_base_dir().plus_file("override.cfg"));
 			}
 			return err;


### PR DESCRIPTION
Without this PR, `override.cfg` worked pre-export, but not post-export (at least inside the PCK, it could still work if it was instead next to the executable). This PR makes it so that it will be loaded properly in exported projects. I tested both embedded PCK and non-embedded PCK exports.

This work was sponsored by The Mirror.