### PR TITLE
Allow exporting PCK files without export templates installed

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -219,6 +219,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	export_path->show();
 	duplicate_preset->set_disabled(false);
 	delete_preset->set_disabled(false);
+	get_ok_button()->set_disabled(false);
 	name->set_text(current->get_name());
 
 	List<String> extension_list = current->get_platform()->get_binary_extensions(current);
@@ -265,7 +266,6 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 
 		export_warning->hide();
 		export_button->set_disabled(true);
-		get_ok_button()->set_disabled(true);
 	} else {
 		if (error != String()) {
 			Vector<String> items = error.split("\n", false);
@@ -285,7 +285,6 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		export_error->hide();
 		export_templates_error->hide();
 		export_button->set_disabled(false);
-		get_ok_button()->set_disabled(false);
 	}
 
 	custom_features->set_text(current->get_custom_features());


### PR DESCRIPTION
It's not necessary to have compiled export templates to export a PCK. When doing a quick test, the Godot editor executable can be used to run a PCK, no export template required. This PR un-disables the Export PCK button when export templates are missing.

This work was sponsored by The Mirror.