### PR TITLE
Determine the visibility of the viewport when it is embedded

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -601,7 +601,11 @@ void RendererViewport::draw_viewports() {
 
 		if (vp->update_mode == RS::VIEWPORT_UPDATE_WHEN_PARENT_VISIBLE) {
 			Viewport *parent = viewport_owner.get_or_null(vp->parent);
-			if (parent && parent->last_pass == draw_viewports_pass) {
+			// The visibility is judged by comparing the pass count.
+			// If not embedded, the parent is drawn before the child, the condition for parent to be visible is
+			// parent->last_pass == draw_viewports_pass; But when embedded, the child is drawn before the parent,
+			// we estimate based on the visibility of the parent in the previous pass.
+			if (parent && ((parent->last_pass == draw_viewports_pass) || (parent->last_pass == draw_viewports_pass - 1))) {
 				visible = true;
 			}
 		}


### PR DESCRIPTION
Fix #61034.

When the update mode is set to `RS::VIEWPORT_UPDATE_WHEN_PARENT_VISIBLE`.
The visibility of child viewport will be set based on the visibility of the parent one, which is implemented to compare the pass count.
When embedded, the child is drawn before the parent, so judge by the count from the previous pass.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

This doesn't seem like a very good solution, there are still problems when switching window visibility in the editor. 

[1.webm](https://user-images.githubusercontent.com/30386067/178427812-c0f840d9-721f-4b3d-bcba-abb2c4720558.webm)


