### PR TITLE
[3.x] Prevent creating folders or files starting with a dot

### DIFF
--- a/editor/directory_create_dialog.cpp
+++ b/editor/directory_create_dialog.cpp
@@ -51,15 +51,22 @@ String DirectoryCreateDialog::_validate_path(const String &p_path) const {
 		return TTR("Folder name cannot be empty.");
 	}
 
+	if (p_path.find("\\") != -1 || p_path.find(":") != -1 || p_path.find("*") != -1 ||
+			p_path.find("|") != -1 || p_path.find(">") != -1) {
+		return TTR("Folder name contains invalid characters.");
+	}
+
 	const Vector<String> parts = p_path.split("/");
 	for (int i = 0; i < parts.size(); i++) {
 		const String part = parts[i];
 		if (part.empty()) {
 			return TTR("Folder name cannot be empty.");
 		}
-		if (p_path.find("\\") != -1 || p_path.find(":") != -1 || p_path.find("*") != -1 ||
-				p_path.find("|") != -1 || p_path.find(">") != -1 || p_path.ends_with(".") || p_path.ends_with(" ")) {
-			return TTR("Folder name contains invalid characters.");
+		if (part.ends_with(" ") || part[0] == ' ') {
+			return TTR("Folder name cannot begin or end with a space.");
+		}
+		if (part[0] == '.') {
+			return TTR("Folder name cannot begin with a dot.");
 		}
 	}
 

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -150,7 +150,15 @@ void EditorDirDialog::_make_dir_confirm() {
 
 	DirAccessRef d = DirAccess::open(dir);
 	ERR_FAIL_COND_MSG(!d, "Cannot open directory '" + dir + "'.");
-	Error err = d->make_dir(makedirname->get_text());
+
+	String dir_name = makedirname->get_text();
+	if (dir_name.begins_with(".")) {
+		mkdirerr->set_text(TTR("Could not use a name with a leading dot."));
+		mkdirerr->popup_centered_minsize(Size2(250, 80) * EDSCALE);
+		return;
+	}
+
+	Error err = d->make_dir(dir_name);
 
 	if (err != OK) {
 		mkdirerr->popup_centered_minsize(Size2(250, 80) * EDSCALE);

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1083,9 +1083,16 @@ EditorFileDialog::Access EditorFileDialog::get_access() const {
 }
 
 void EditorFileDialog::_make_dir_confirm() {
-	Error err = dir_access->make_dir(makedirname->get_text().strip_edges());
+	String dir_name = makedirname->get_text().strip_edges();
+	if (dir_name.begins_with(".")) {
+		mkdirerr->set_text(TTR("Could not use a name with a leading dot."));
+		mkdirerr->popup_centered_minsize(Size2(250, 50) * EDSCALE);
+		return;
+	}
+
+	Error err = dir_access->make_dir(dir_name);
 	if (err == OK) {
-		dir_access->change_dir(makedirname->get_text().strip_edges());
+		dir_access->change_dir(dir_name);
 		invalidate();
 		update_filters();
 		update_dir();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1797,6 +1797,11 @@ void EditorNode::_dialog_action(String p_file) {
 		case RESOURCE_SAVE:
 		case RESOURCE_SAVE_AS: {
 			ERR_FAIL_COND(saving_resource.is_null());
+			if (p_file.get_file().begins_with(".")) {
+				show_accept(TTR("Could not use a name with a leading dot."), TTR("OK"));
+				return;
+			}
+
 			save_resource_in_path(saving_resource, p_file);
 			saving_resource = Ref<Resource>();
 			ObjectID current = editor_history.get_current();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1394,6 +1394,9 @@ void FileSystemDock::_rename_operation_confirm() {
 	} else if (new_name.find("/") != -1 || new_name.find("\\") != -1 || new_name.find(":") != -1) {
 		EditorNode::get_singleton()->show_warning(TTR("Name contains invalid characters."));
 		return;
+	} else if (new_name[0] == '.') {
+		EditorNode::get_singleton()->show_warning(TTR("This filename begins with a dot rendering the file invisible to the editor.\nIf you want to rename it anyway, use your operating system's file manager."));
+		return;
 	} else if (to_rename.is_file && to_rename.path.get_extension() != new_name.get_extension()) {
 		if (!EditorFileSystem::get_singleton()->get_valid_extensions().find(new_name.get_extension())) {
 			EditorNode::get_singleton()->show_warning(TTR("This file extension is not recognized by the editor.\nIf you want to rename it anyway, use your operating system's file manager.\nAfter renaming to an unknown extension, the file won't be shown in the editor anymore."));
@@ -1455,6 +1458,9 @@ void FileSystemDock::_duplicate_operation_confirm() {
 		return;
 	} else if (new_name.find("/") != -1 || new_name.find("\\") != -1 || new_name.find(":") != -1) {
 		EditorNode::get_singleton()->show_warning(TTR("Name contains invalid characters."));
+		return;
+	} else if (new_name[0] == '.') {
+		EditorNode::get_singleton()->show_warning(TTR("Name begins with a dot."));
 		return;
 	}
 

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -110,6 +110,11 @@ void SceneCreateDialog::update_dialog(Variant p_discard) {
 		is_valid = false;
 	}
 
+	if (is_valid && scene_name[0] == '.') {
+		update_error(file_error_label, MSG_ERROR, TTR("File name begins with a dot."));
+		is_valid = false;
+	}
+
 	if (is_valid) {
 		scene_name = directory.plus_file(scene_name);
 		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -169,6 +169,9 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	if (p.get_file().get_basename() == "") {
 		return TTR("Filename is empty.");
 	}
+	if (p.get_file().begins_with(".")) {
+		return TTR("Name begins with a dot.");
+	}
 
 	p = ProjectSettings::get_singleton()->localize_path(p);
 	if (!p.begins_with("res://")) {


### PR DESCRIPTION
This PR is intended to fix #62497 on **3.x branch**.

It prevents the creation/renaming/duplication of a folder/scene/script/resource from the FileSystemDock while using a name with leading dot.
"_EditorDirDialog_" and "_EditorFileDialog_" were also modified to prevent creating such folder.

Also, as suggested, it prevents the creation of a scene like "a/my_scene.tscn". As a side-effect, this PR also avoid creating a scene as "res://my.tscn", which actually is rejected when you try to save the scene (_"res://res/ no longer exists! Please specify a new save location."_).

It introduce 2 new translations :
- "Could not use a name with a leading dot."
- "Could not create a scene for another folder.\nPlease select the target folder first."

I didn't modify "_scene\gui\FileDialog::_make_dir_confirm_" because I wasn't sure of possible side-effects