### PR TITLE
Use projection matrix without offset

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1761,7 +1761,8 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 			CameraMatrix projection = correction * p_render_data->cam_projection;
 			sky.draw(env, can_continue_color, can_continue_depth, color_only_framebuffer, 1, &projection, p_render_data->cam_transform, time);
 		} else {
-			sky.draw(env, can_continue_color, can_continue_depth, color_only_framebuffer, p_render_data->view_count, p_render_data->view_projection, p_render_data->cam_transform, time);
+			// For the sky we want our projection without the eye offset or else our view vector will be incorrect.
+			sky.draw(env, can_continue_color, can_continue_depth, color_only_framebuffer, p_render_data->view_count, p_render_data->projection, p_render_data->cam_transform, time);
 		}
 		RD::get_singleton()->draw_command_end_label();
 	}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -765,7 +765,8 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 				CameraMatrix projection = correction * p_render_data->cam_projection;
 				sky.draw(draw_list, env, framebuffer, 1, &projection, p_render_data->cam_transform, time, _render_buffers_get_luminance_multiplier());
 			} else {
-				sky.draw(draw_list, env, framebuffer, p_render_data->view_count, p_render_data->view_projection, p_render_data->cam_transform, time, _render_buffers_get_luminance_multiplier());
+				// For the sky we want our projection without the eye offset or else our view vector will be incorrect.
+				sky.draw(draw_list, env, framebuffer, p_render_data->view_count, p_render_data->projection, p_render_data->cam_transform, time, _render_buffers_get_luminance_multiplier());
 			}
 
 			RD::get_singleton()->draw_command_end_label(); // Draw Sky Subpass

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -5121,6 +5121,7 @@ void RendererSceneRenderRD::render_scene(RID p_render_buffers, const CameraData 
 
 		render_data.view_count = p_camera_data->view_count;
 		for (uint32_t v = 0; v < p_camera_data->view_count; v++) {
+			render_data.projection[v] = p_camera_data->projection[v];
 			render_data.view_eye_offset[v] = p_camera_data->view_offset[v].origin;
 			render_data.view_projection[v] = p_camera_data->view_projection[v];
 		}

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -57,8 +57,9 @@ struct RenderDataRD {
 
 	// For stereo rendering
 	uint32_t view_count = 1;
-	Vector3 view_eye_offset[RendererSceneRender::MAX_RENDER_VIEWS];
-	CameraMatrix view_projection[RendererSceneRender::MAX_RENDER_VIEWS];
+	CameraMatrix projection[RendererSceneRender::MAX_RENDER_VIEWS]; // unaltered projection matrix
+	Vector3 view_eye_offset[RendererSceneRender::MAX_RENDER_VIEWS]; // eye offset for our view
+	CameraMatrix view_projection[RendererSceneRender::MAX_RENDER_VIEWS]; // projection matrix adjusted with our eye offset
 
 	Transform3D prev_cam_transform;
 	CameraMatrix prev_cam_projection;

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -38,6 +38,7 @@ void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, 
 	main_transform = p_transform;
 	main_projection = p_projection;
 
+	projection[0] = p_projection;
 	view_offset[0] = Transform3D();
 	view_projection[0] = p_projection;
 	taa_jitter = p_taa_jitter;
@@ -176,6 +177,7 @@ void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count
 	/////////////////////////////////////////////////////////////////////////////
 	// 3. Copy our view data
 	for (uint32_t v = 0; v < view_count; v++) {
+		projection[v] = p_projections[v];
 		view_offset[v] = main_transform_inv * p_transforms[v];
 		view_projection[v] = p_projections[v] * CameraMatrix(view_offset[v].inverse());
 	}

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -241,8 +241,9 @@ public:
 		Transform3D main_transform;
 		CameraMatrix main_projection;
 
-		Transform3D view_offset[RendererSceneRender::MAX_RENDER_VIEWS];
-		CameraMatrix view_projection[RendererSceneRender::MAX_RENDER_VIEWS];
+		CameraMatrix projection[RendererSceneRender::MAX_RENDER_VIEWS]; // Projection without eye offset applied
+		Transform3D view_offset[RendererSceneRender::MAX_RENDER_VIEWS]; // eye offset for this view
+		CameraMatrix view_projection[RendererSceneRender::MAX_RENDER_VIEWS]; // Projection with eye offset applied
 		Vector2 taa_jitter;
 
 		void set_camera(const Transform3D p_transform, const CameraMatrix p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2());


### PR DESCRIPTION
This should fix #62738 but it is a bit of a lengthy change.

We can probably clean this up further as part of the render reorganization where we plan to keep less copies of all these matrices and just have a structure that makes this information available to all render parts.

Anyway the problem here is that we now encode the eye_offset into the projection matrix. Not a big deal however the code in our sky shader:
```
	cube_normal.z = -1.0;
	cube_normal.x = (cube_normal.z * (-uv_interp.x - params.projections[ViewIndex].x)) / params.projections[ViewIndex].y;
	cube_normal.y = -(cube_normal.z * (-uv_interp.y - params.projections[ViewIndex].z)) / params.projections[ViewIndex].w;
```
doesn't work.

This simplified approach to un-projecting only works for normal projection matrices. As we've now combined our projection matrix with a translation, we would need to also reverse our translation.

Seeing we have the projection matrices without the translation available at the start of our rendering process. I'm just making them available to the sky shader.