### PR TITLE
Fix negative search result match number

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -332,7 +332,7 @@ void FindReplaceBar::_update_results_count() {
 
 		if (results_count_to_current > results_count) {
 			results_count_to_current = results_count_to_current - results_count;
-		} else if (results_count_to_current == 0) {
+		} else if (results_count_to_current <= 0) {
 			results_count_to_current = results_count;
 		}
 


### PR DESCRIPTION
Fixes #62949

When iterating over matches in the text editor's search/replace field, the upper bound is handled correctly, but the lower bound check is incomplete, leading to circumstances where the current match index can become negative. This is just a quick fix to prevent that.