### PR TITLE
Add peer visibility to MultiplayerSynchronizer.

### DIFF
--- a/core/multiplayer/multiplayer_api.cpp
+++ b/core/multiplayer/multiplayer_api.cpp
@@ -463,8 +463,12 @@ bool MultiplayerAPI::is_cache_confirmed(NodePath p_path, int p_peer) {
 	return cache->is_cache_confirmed(p_path, p_peer);
 }
 
-bool MultiplayerAPI::send_object_cache(Object *p_obj, NodePath p_path, int p_peer_id, int &r_id) {
-	return cache->send_object_cache(p_obj, p_path, p_peer_id, r_id);
+bool MultiplayerAPI::send_object_cache(Object *p_obj, int p_peer_id, int &r_id) {
+	return cache->send_object_cache(p_obj, p_peer_id, r_id);
+}
+
+int MultiplayerAPI::make_object_cache(Object *p_obj) {
+	return cache->make_object_cache(p_obj);
 }
 
 Object *MultiplayerAPI::get_cached_object(int p_from, uint32_t p_cache_id) {

--- a/core/multiplayer/multiplayer_api.h
+++ b/core/multiplayer/multiplayer_api.h
@@ -77,7 +77,8 @@ public:
 	virtual void process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len) {}
 
 	// Returns true if all peers have cached path.
-	virtual bool send_object_cache(Object *p_obj, NodePath p_path, int p_target, int &p_id) { return false; }
+	virtual bool send_object_cache(Object *p_obj, int p_target, int &r_id) { return false; }
+	virtual int make_object_cache(Object *p_obj) { return false; }
 	virtual Object *get_cached_object(int p_from, uint32_t p_cache_id) { return nullptr; }
 	virtual bool is_cache_confirmed(NodePath p_path, int p_peer) { return false; }
 
@@ -160,7 +161,8 @@ public:
 	Error replication_start(Object *p_object, Variant p_config);
 	Error replication_stop(Object *p_object, Variant p_config);
 	// Cache API
-	bool send_object_cache(Object *p_obj, NodePath p_path, int p_target, int &p_id);
+	bool send_object_cache(Object *p_obj, int p_target, int &r_id);
+	int make_object_cache(Object *p_obj);
 	Object *get_cached_object(int p_from, uint32_t p_cache_id);
 	bool is_cache_confirmed(NodePath p_path, int p_peer);
 

--- a/doc/classes/MultiplayerSpawner.xml
+++ b/doc/classes/MultiplayerSpawner.xml
@@ -43,8 +43,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="auto_spawn" type="bool" setter="set_auto_spawning" getter="is_auto_spawning" default="false">
-		</member>
 		<member name="spawn_limit" type="int" setter="set_spawn_limit" getter="get_spawn_limit" default="0">
 		</member>
 		<member name="spawn_path" type="NodePath" setter="set_spawn_path" getter="get_spawn_path" default="NodePath(&quot;&quot;)">

--- a/doc/classes/MultiplayerSynchronizer.xml
+++ b/doc/classes/MultiplayerSynchronizer.xml
@@ -6,12 +6,64 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="add_visibility_filter">
+			<return type="void" />
+			<argument index="0" name="filter" type="Callable" />
+			<description>
+			</description>
+		</method>
+		<method name="get_visibility_for" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="peer" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="remove_visibility_filter">
+			<return type="void" />
+			<argument index="0" name="filter" type="Callable" />
+			<description>
+			</description>
+		</method>
+		<method name="set_visibility_for">
+			<return type="void" />
+			<argument index="0" name="peer" type="int" />
+			<argument index="1" name="visible" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="update_visibility">
+			<return type="void" />
+			<argument index="0" name="for_peer" type="int" default="0" />
+			<description>
+			</description>
+		</method>
+	</methods>
 	<members>
+		<member name="public_visibility" type="bool" setter="set_visibility_public" getter="is_visibility_public" default="true">
+		</member>
 		<member name="replication_config" type="SceneReplicationConfig" setter="set_replication_config" getter="get_replication_config">
 		</member>
 		<member name="replication_interval" type="float" setter="set_replication_interval" getter="get_replication_interval" default="0.0">
 		</member>
 		<member name="root_path" type="NodePath" setter="set_root_path" getter="get_root_path" default="NodePath(&quot;..&quot;)">
 		</member>
+		<member name="visibility_update_mode" type="int" setter="set_visibility_update_mode" getter="get_visibility_update_mode" enum="MultiplayerSynchronizer.VisibilityUpdateMode" default="0">
+		</member>
 	</members>
+	<signals>
+		<signal name="visibility_changed">
+			<argument index="0" name="for_peer" type="int" />
+			<description>
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="VISIBILITY_PROCESS_IDLE" value="0" enum="VisibilityUpdateMode">
+		</constant>
+		<constant name="VISIBILITY_PROCESS_PHYSICS" value="1" enum="VisibilityUpdateMode">
+		</constant>
+		<constant name="VISIBILITY_PROCESS_NONE" value="2" enum="VisibilityUpdateMode">
+		</constant>
+	</constants>
 </class>

--- a/scene/multiplayer/multiplayer_spawner.h
+++ b/scene/multiplayer/multiplayer_spawner.h
@@ -69,7 +69,6 @@ private:
 
 	ObjectID spawn_node;
 	HashMap<ObjectID, SpawnInfo> tracked_nodes;
-	bool auto_spawn = false;
 	uint32_t spawn_limit = 0;
 
 	void _update_spawn_node();
@@ -102,8 +101,6 @@ public:
 	void set_spawn_path(const NodePath &p_path);
 	uint32_t get_spawn_limit() const { return spawn_limit; }
 	void set_spawn_limit(uint32_t p_limit) { spawn_limit = p_limit; }
-	bool is_auto_spawning() const;
-	void set_auto_spawning(bool p_enabled);
 
 	const Variant get_spawn_argument(const ObjectID &p_id) const;
 	int find_spawnable_scene_index_from_object(const ObjectID &p_id) const;

--- a/scene/multiplayer/multiplayer_synchronizer.h
+++ b/scene/multiplayer/multiplayer_synchronizer.h
@@ -38,14 +38,25 @@
 class MultiplayerSynchronizer : public Node {
 	GDCLASS(MultiplayerSynchronizer, Node);
 
+public:
+	enum VisibilityUpdateMode {
+		VISIBILITY_PROCESS_IDLE,
+		VISIBILITY_PROCESS_PHYSICS,
+		VISIBILITY_PROCESS_NONE,
+	};
+
 private:
 	Ref<SceneReplicationConfig> replication_config;
 	NodePath root_path = NodePath(".."); // Start with parent, like with AnimationPlayer.
 	uint64_t interval_msec = 0;
+	VisibilityUpdateMode visibility_update_mode = VISIBILITY_PROCESS_IDLE;
+	HashSet<Callable> visibility_filters;
+	HashSet<int> peer_visibility;
 
 	static Object *_get_prop_target(Object *p_obj, const NodePath &p_prop);
 	void _start();
 	void _stop();
+	void _update_process();
 
 protected:
 	static void _bind_methods();
@@ -66,7 +77,19 @@ public:
 	NodePath get_root_path() const;
 	virtual void set_multiplayer_authority(int p_peer_id, bool p_recursive = true) override;
 
-	MultiplayerSynchronizer() {}
+	bool is_visibility_public() const;
+	void set_visibility_public(bool p_public);
+	bool is_visible_to(int p_peer);
+	void set_visibility_for(int p_peer, bool p_visible);
+	bool get_visibility_for(int p_peer) const;
+	void update_visibility(int p_for_peer);
+	void set_visibility_update_mode(VisibilityUpdateMode p_mode);
+	void add_visibility_filter(Callable p_callback);
+	void remove_visibility_filter(Callable p_callback);
+	VisibilityUpdateMode get_visibility_update_mode() const;
+
+	MultiplayerSynchronizer();
 };
 
+VARIANT_ENUM_CAST(MultiplayerSynchronizer::VisibilityUpdateMode);
 #endif // MULTIPLAYER_SYNCHRONIZER_H

--- a/scene/multiplayer/scene_cache_interface.h
+++ b/scene/multiplayer/scene_cache_interface.h
@@ -72,7 +72,8 @@ public:
 	virtual void process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len) override;
 
 	// Returns true if all peers have cached path.
-	virtual bool send_object_cache(Object *p_obj, NodePath p_path, int p_target, int &p_id) override;
+	virtual bool send_object_cache(Object *p_obj, int p_target, int &p_id) override;
+	virtual int make_object_cache(Object *p_obj) override;
 	virtual Object *get_cached_object(int p_from, uint32_t p_cache_id) override;
 	virtual bool is_cache_confirmed(NodePath p_path, int p_peer) override;
 

--- a/scene/multiplayer/scene_replication_interface.h
+++ b/scene/multiplayer/scene_replication_interface.h
@@ -40,10 +40,13 @@ class SceneReplicationInterface : public MultiplayerReplicationInterface {
 
 private:
 	void _send_sync(int p_peer, uint64_t p_msec);
-	Error _send_spawn(Node *p_node, MultiplayerSpawner *p_spawner, int p_peer);
-	Error _send_despawn(Node *p_node, int p_peer);
+	Error _make_spawn_packet(Node *p_node, int &r_len);
+	Error _make_despawn_packet(Node *p_node, int &r_len);
 	Error _send_raw(const uint8_t *p_buffer, int p_size, int p_peer, bool p_reliable);
 
+	void _visibility_changed(int p_peer, ObjectID p_oid);
+	Error _update_sync_visibility(int p_peer, const ObjectID &p_oid);
+	Error _update_spawn_visibility(int p_peer, const ObjectID &p_oid);
 	void _free_remotes(int p_peer);
 
 	Ref<SceneReplicationState> rep_state;

--- a/scene/multiplayer/scene_replication_state.h
+++ b/scene/multiplayer/scene_replication_state.h
@@ -62,7 +62,8 @@ private:
 	};
 
 	struct PeerInfo {
-		HashSet<ObjectID> known_nodes;
+		HashSet<ObjectID> sync_nodes;
+		HashSet<ObjectID> spawn_nodes;
 		HashMap<uint32_t, ObjectID> recv_nodes;
 		uint16_t last_sent_sync = 0;
 		uint16_t last_recv_sync = 0;
@@ -73,7 +74,7 @@ private:
 	HashMap<ObjectID, TrackedNode> tracked_nodes;
 	HashMap<int, PeerInfo> peers_info;
 	HashSet<ObjectID> spawned_nodes;
-	HashSet<ObjectID> path_only_nodes;
+	HashSet<ObjectID> synced_nodes;
 
 	TrackedNode &_track(const ObjectID &p_id);
 	void _untrack(const ObjectID &p_id);
@@ -82,7 +83,9 @@ private:
 public:
 	const HashSet<int> get_peers() const { return known_peers; }
 	const HashSet<ObjectID> &get_spawned_nodes() const { return spawned_nodes; }
-	const HashSet<ObjectID> &get_path_only_nodes() const { return path_only_nodes; }
+	bool is_spawned_node(const ObjectID &p_id) const { return spawned_nodes.has(p_id); }
+	const HashSet<ObjectID> &get_synced_nodes() const { return synced_nodes; }
+	bool is_synced_node(const ObjectID &p_id) const { return synced_nodes.has(p_id); }
 
 	MultiplayerSynchronizer *get_synchronizer(const ObjectID &p_id) { return tracked_nodes.has(p_id) ? tracked_nodes[p_id].get_synchronizer() : nullptr; }
 	MultiplayerSpawner *get_spawner(const ObjectID &p_id) { return tracked_nodes.has(p_id) ? tracked_nodes[p_id].get_spawner() : nullptr; }
@@ -90,7 +93,6 @@ public:
 	bool update_last_node_sync(const ObjectID &p_id, uint16_t p_time);
 	bool update_sync_time(const ObjectID &p_id, uint64_t p_msec);
 
-	const HashSet<ObjectID> get_known_nodes(int p_peer);
 	uint32_t get_net_id(const ObjectID &p_id) const;
 	void set_net_id(const ObjectID &p_id, uint32_t p_net_id);
 	uint32_t ensure_net_id(const ObjectID &p_id);
@@ -104,8 +106,17 @@ public:
 	Error config_add_sync(Node *p_node, MultiplayerSynchronizer *p_sync);
 	Error config_del_sync(Node *p_node, MultiplayerSynchronizer *p_sync);
 
-	Error peer_add_node(int p_peer, const ObjectID &p_id);
-	Error peer_del_node(int p_peer, const ObjectID &p_id);
+	Error peer_add_sync(int p_peer, const ObjectID &p_id);
+	Error peer_del_sync(int p_peer, const ObjectID &p_id);
+
+	const HashSet<ObjectID> get_peer_sync_nodes(int p_peer);
+	bool is_peer_sync(int p_peer, const ObjectID &p_id) const;
+
+	Error peer_add_spawn(int p_peer, const ObjectID &p_id);
+	Error peer_del_spawn(int p_peer, const ObjectID &p_id);
+
+	const HashSet<ObjectID> get_peer_spawn_nodes(int p_peer);
+	bool is_peer_spawn(int p_peer, const ObjectID &p_id) const;
 
 	const HashMap<uint32_t, ObjectID> peer_get_remotes(int p_peer) const;
 	Node *peer_get_remote(int p_peer, uint32_t p_net_id);

--- a/scene/multiplayer/scene_rpc_interface.cpp
+++ b/scene/multiplayer/scene_rpc_interface.cpp
@@ -302,12 +302,9 @@ void SceneRPCInterface::_send_rpc(Node *p_from, int p_to, uint16_t p_rpc_id, con
 		ERR_FAIL_MSG("Attempt to call RPC with unknown peer ID: " + itos(p_to) + ".");
 	}
 
-	NodePath from_path = multiplayer->get_root_path().rel_path_to(p_from->get_path());
-	ERR_FAIL_COND_MSG(from_path.is_empty(), "Unable to send RPC. Relative path is empty. THIS IS LIKELY A BUG IN THE ENGINE!");
-
 	// See if all peers have cached path (if so, call can be fast).
 	int psc_id;
-	const bool has_all_peers = multiplayer->send_object_cache(p_from, from_path, p_to, psc_id);
+	const bool has_all_peers = multiplayer->send_object_cache(p_from, p_to, psc_id);
 
 	// Create base packet, lots of hardcode because it must be tight.
 
@@ -414,6 +411,7 @@ void SceneRPCInterface::_send_rpc(Node *p_from, int p_to, uint16_t p_rpc_id, con
 		// Not all verified path, so send one by one.
 
 		// Append path at the end, since we will need it for some packets.
+		NodePath from_path = multiplayer->get_root_path().rel_path_to(p_from->get_path());
 		CharString pname = String(from_path).utf8();
 		int path_len = encode_cstring(pname.get_data(), nullptr);
 		MAKE_ROOM(ofs + path_len);


### PR DESCRIPTION
TL;DR;
---

Sets visibility for synchronized objects: `$MultiplayerSynchronizer.set_visibility_for(peer_id, visible)`

**or**

```gdscript
extends MultiplayerSynchronizer

func _enter_tree():
	add_visibility_filter(self._is_visible_to)

func _is_visible_to(peer) -> bool:
	return false # Hidden
```

The visibility is updated on every frame (default), physics frame, or manually.
You can further notify visibility changes by calling `$MultiplayerSynchronizer.update_visibility(peer:=0)` (where `0` means for all peers).

This also allows players to join mid-game (with some quirks).

Description
--

`MultiplayerSynchronizer`s can now be configured to limit their visibility to a subset of the connected peers, if the synchronized node was spawned by a `MultiplayerSpawner` (either automatically or via custom spawn) the given node will also be de-spawned remotely.

The replication system doesn't have the logic to handle sub-spawn directly, but it is possible to handle them appropriately by manually updating the visibility of the parent before changing the one of the nested spawns via the "update_visibility" function.

The visibility of each `MultiplayerSynchronizer` can specified by overriding `MultiplayerSynchronizer._is_visible_to(peer)`.

To further optimize the network code, visibility can be configured to be automatically updated during idle or physics, or set to always require manual update (`update_visibility` function).

See attached project:

![limited_visibility](https://user-images.githubusercontent.com/1687918/178558760-d369909e-056f-4e42-8e8c-49aaad8adb55.png)

~[proj_mp_interest.zip](https://github.com/godotengine/godot/files/9095533/proj_mp_interest.zip)~

~*Edit: updated* [proj_mp_interest2.zip](https://github.com/godotengine/godot/files/9106215/proj_mp_interest2.zip)~

*Edit: updated again* [proj_mp_interest3.zip](https://github.com/godotengine/godot/files/9113981/proj_mp_interest3.zip)


I also updated the tests in #62870 to work correctly with one notable hack (delaying world spawning players by one frame, so spawns get replicated in the correct order).

[test8.zip](https://github.com/godotengine/godot/files/9095584/test8.zip)

Note: this PR also adds basic support for **peers joining mid-game** (see demo above) although some more work is likely needed to improve cleanup, and potentially support single-player to multi-player transition.

Note for reviewers:

- MultiplayerSpawner `auto_spawn` property is removed, simply auto spawn whatever is in the "auto spawn list", if `_spawn_custom` is not overridden.
- I don't like having to change MultiplayerAPI, but that's needed for this PR. We should probably do more work and clean it up simplifying the interfaces and modularizing the default implementation as suggested in #62870, but I wanted to keep this PR light.
- There is still some work needed to cleanup the editor plugins, and make sure it shows a warning when the root paths are missing or unreachable for easier debugging.

Fixes https://github.com/godotengine/godot/issues/61711
Fixes https://github.com/godotengine/godot/issues/62320
Closes https://github.com/godotengine/godot-proposals/issues/3904