### PR TITLE
Implement loading and saving for floating docks

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -238,6 +238,11 @@ private:
 		Button *button = nullptr;
 	};
 
+	struct DockFindResult {
+		int dock_slot_index = -1;
+		Control *dock_control = nullptr;
+	};
+
 	struct ExportDefer {
 		String preset;
 		String path;
@@ -607,6 +612,7 @@ private:
 
 	void _update_dock_containers();
 
+	DockFindResult _find_dock_slot(const String &p_dock_name) const;
 	void _dock_select_input(const Ref<InputEvent> &p_input);
 	void _dock_move_left();
 	void _dock_move_right();
@@ -615,7 +621,8 @@ private:
 	void _dock_split_dragged(int ofs);
 	void _dock_popup_exit();
 	void _dock_floating_close_request(Control *p_control);
-	void _dock_make_float();
+	void _dock_make_selected_float();
+	void _dock_make_float(Control *p_control, int p_dock_index);
 	void _scene_tab_changed(int p_tab);
 	void _scene_tab_closed(int p_tab, int option = SCENE_TAB_CLOSE);
 	void _scene_tab_hovered(int p_tab);


### PR DESCRIPTION
As mentioned in https://github.com/godotengine/godot/issues/57142#issuecomment-1064021752, floating docks in the editor layout were not loaded nor saved, they were always reset back to their original dock slot.

Now, they are saved in the config with the key `dock_floating`, here's what it looks like in a config file:
```properties
dock_floating={
"Inspector": Rect2i(2319, 47, 688, 448),
"Node": Rect2i(3012, 48, 486, 933)
}
```