### PR TITLE
SpriteFrames: Sort animations alphabetically

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -130,9 +130,4 @@
 			</description>
 		</method>
 	</methods>
-	<members>
-		<member name="frames" type="Array" setter="_set_frames" getter="_get_frames">
-			Compatibility property, always equals to an empty array.
-		</member>
-	</members>
 </class>

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -44,13 +44,8 @@ class SpriteFrames : public Resource {
 
 	HashMap<StringName, Anim> animations;
 
-	Array _get_frames() const;
-	void _set_frames(const Array &p_frames);
-
 	Array _get_animations() const;
 	void _set_animations(const Array &p_animations);
-
-	Vector<String> _get_animation_list() const;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
And finally remove the 'frames' property which was added for compatibility with 2.1
in bed3efb17ede58a2bfc177b47cb3a49091aea30a.
Fixes #21765, got to redo #21780 without even remembering it :)

The 'animations' property on the other hand is needed, contrarily to what its comment
said (copy-paste mistake probably).

Also removes unused '_get_animation_list' (as done in #49495).

`master` version of #62977.