### PR TITLE
Disable the OK button until a node is selected.

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1359,6 +1359,10 @@ void SceneTreeDialog::_select() {
 	}
 }
 
+void SceneTreeDialog::_selected_changed() {
+	get_ok_button()->set_disabled(!tree->get_selected());
+}
+
 void SceneTreeDialog::_filter_changed(const String &p_filter) {
 	tree->set_filter(p_filter);
 }
@@ -1386,6 +1390,10 @@ SceneTreeDialog::SceneTreeDialog() {
 	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &SceneTreeDialog::_select));
 	vbc->add_child(tree);
+
+	// Disable the OK button when no node is selected.
+	get_ok_button()->set_disabled(!tree->get_selected());
+	tree->connect("node_selected", callable_mp(this, &SceneTreeDialog::_selected_changed));
 }
 
 SceneTreeDialog::~SceneTreeDialog() {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -176,6 +176,7 @@ class SceneTreeDialog : public ConfirmationDialog {
 
 	void _select();
 	void _cancel();
+	void _selected_changed();
 	void _filter_changed(const String &p_filter);
 	void _update_theme();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #62893.
The OK button of SceneTreeDialog is disabled until a node is selected
![OK_Disabled](https://user-images.githubusercontent.com/88014292/178765942-f2ac9d84-35b9-4ee4-95b8-819ad0d29524.png)
![OK_Enabled](https://user-images.githubusercontent.com/88014292/178765946-7d72cb26-3b70-4560-93ac-9c38ed7538e0.png)
.