### PR TITLE
Show Resource type name in Array editor

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -211,7 +211,14 @@ void EditorPropertyArray::update_property() {
 
 	String array_type_name = Variant::get_type_name(array_type);
 	if (array_type == Variant::ARRAY && subtype != Variant::NIL) {
-		array_type_name = vformat("%s[%s]", array_type_name, Variant::get_type_name(subtype));
+		String type_name;
+		if (subtype == Variant::OBJECT && subtype_hint == PROPERTY_HINT_RESOURCE_TYPE) {
+			type_name = subtype_hint_string;
+		} else {
+			type_name = Variant::get_type_name(subtype);
+		}
+
+		array_type_name = vformat("%s[%s]", array_type_name, type_name);
 	}
 
 	if (array.get_type() == Variant::NIL) {


### PR DESCRIPTION
Follow-up to #60409

Makes the Array editor button show the Resource type name for typed arrays.

Example:
```gdscript
@export var gradient_array: Array[Gradient]
```

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/178807056-306e8d19-50ce-4bc0-b950-4d155280020b.png) | ![image](https://user-images.githubusercontent.com/67974470/178806700-b2247dba-b436-4b05-9d50-c345bb80754e.png) |