### PR TITLE
Add classref documentation for AnimationLibrary

### DIFF
--- a/doc/classes/AnimationLibrary.xml
+++ b/doc/classes/AnimationLibrary.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationLibrary" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Container for [Animation] resources.
 	</brief_description>
 	<description>
+		An animation library stores a set of animations accessible through [StringName] keys, for use with [AnimationPlayer] nodes.
 	</description>
 	<tutorials>
+		<link title="Animation tutorial index">$DOCS_URL/tutorials/animation/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_animation">
@@ -12,29 +15,34 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="animation" type="Animation" />
 			<description>
+				Adds the [param animation] to the library, accesible by the key [param name].
 			</description>
 		</method>
 		<method name="get_animation" qualifiers="const">
 			<return type="Animation" />
 			<param index="0" name="name" type="StringName" />
 			<description>
+				Returns the [Animation] with the key [param name], or [code]null[/code] if none is found.
 			</description>
 		</method>
 		<method name="get_animation_list" qualifiers="const">
 			<return type="StringName[]" />
 			<description>
+				Returns the keys for the [Animation]s stored in the library.
 			</description>
 		</method>
 		<method name="has_animation" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
+				Returns [code]true[/code] if the library stores an [Animation] with [param name] as the key.
 			</description>
 		</method>
 		<method name="remove_animation">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
+				Removes the [Animation] with the key [param name].
 			</description>
 		</method>
 		<method name="rename_animation">
@@ -42,6 +50,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="newname" type="StringName" />
 			<description>
+				Changes the key of the [Animation] associated with the key [param name] to [param newname].
 			</description>
 		</method>
 	</methods>
@@ -53,17 +62,20 @@
 		<signal name="animation_added">
 			<param index="0" name="name" type="StringName" />
 			<description>
+				Emitted when an [Animation] is added, under the key [param name].
 			</description>
 		</signal>
 		<signal name="animation_removed">
 			<param index="0" name="name" type="StringName" />
 			<description>
+				Emitted when an [Animation] stored with the key [param name] is removed.
 			</description>
 		</signal>
 		<signal name="animation_renamed">
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="to_name" type="StringName" />
 			<description>
+				Emitted when the key for an [Animation] is changed, from [param name] to [param to_name].
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
Add class, method, and signal descriptions for AnimationLibrary, since it has none, as well as a tutorial link for the animation tutorial index (even though it doesn't actually cover animation libraries yet).
Writing this I noticed there's an entry for `_data` in the XML file. It doesn't actually show up in the docs, and running `--doctool` adds it back if it's removed. I don't know it that's an issue or if it's supposed to be there.
