### PR TITLE
Fix drag_selection crash on scene close

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3645,7 +3645,7 @@ void CanvasItemEditor::_draw_hover() {
 }
 
 void CanvasItemEditor::_draw_transform_message() {
-	if (drag_selection.is_empty() || !drag_selection.front()->get()) {
+	if (drag_type == DRAG_NONE || drag_selection.is_empty() || !drag_selection.front()->get()) {
 		return;
 	}
 	String transform_message;


### PR DESCRIPTION
Fixes #62964

It's a bit worrying that `drag_selection` nodes can get invalidated, but I couldn't find an easy solution for that.