### PR TITLE
Fix various issues when function argument's default value is array/dictionary

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1160,7 +1160,11 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		if (p_function->parameters[i]->default_value) {
 			default_value_count++;
 
-			if (p_function->parameters[i]->default_value->is_constant) {
+			if (p_function->parameters[i]->default_value->type == GDScriptParser::Node::ARRAY || p_function->parameters[i]->default_value->type == GDScriptParser::Node::DICTIONARY) {
+				if (p_function->parameters[i]->default_value->reduced_value.get_type() != Variant::NIL) {
+					p_function->default_arg_values.push_back(p_function->parameters[i]->default_value->reduced_value);
+				}
+			} else if (p_function->parameters[i]->default_value->is_constant) {
 				p_function->default_arg_values.push_back(p_function->parameters[i]->default_value->reduced_value);
 			}
 		}
@@ -1724,6 +1728,13 @@ void GDScriptAnalyzer::resolve_parameter(GDScriptParser::ParameterNode *p_parame
 			result.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
 		} else {
 			result.type_source = GDScriptParser::DataType::INFERRED;
+		}
+		result.is_constant = false;
+
+		if (p_parameter->default_value->type == GDScriptParser::Node::ARRAY) {
+			parameter_fold_array(static_cast<GDScriptParser::ArrayNode *>(p_parameter->default_value));
+		} else if (p_parameter->default_value->type == GDScriptParser::Node::DICTIONARY) {
+			parameter_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(p_parameter->default_value));
 		}
 	}
 
@@ -3653,8 +3664,6 @@ void GDScriptAnalyzer::reduce_unary_op(GDScriptParser::UnaryOpNode *p_unary_op) 
 }
 
 void GDScriptAnalyzer::const_fold_array(GDScriptParser::ArrayNode *p_array) {
-	bool all_is_constant = true;
-
 	for (int i = 0; i < p_array->elements.size(); i++) {
 		GDScriptParser::ExpressionNode *element = p_array->elements[i];
 
@@ -3664,8 +3673,7 @@ void GDScriptAnalyzer::const_fold_array(GDScriptParser::ArrayNode *p_array) {
 			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(element));
 		}
 
-		all_is_constant = all_is_constant && element->is_constant;
-		if (!all_is_constant) {
+		if (!element->is_constant) {
 			return;
 		}
 	}
@@ -3680,8 +3688,6 @@ void GDScriptAnalyzer::const_fold_array(GDScriptParser::ArrayNode *p_array) {
 }
 
 void GDScriptAnalyzer::const_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary) {
-	bool all_is_constant = true;
-
 	for (int i = 0; i < p_dictionary->elements.size(); i++) {
 		const GDScriptParser::DictionaryNode::Pair &element = p_dictionary->elements[i];
 
@@ -3691,8 +3697,7 @@ void GDScriptAnalyzer::const_fold_dictionary(GDScriptParser::DictionaryNode *p_d
 			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(element.value));
 		}
 
-		all_is_constant = all_is_constant && element.key->is_constant && element.value->is_constant;
-		if (!all_is_constant) {
+		if (!element.key->is_constant || !element.value->is_constant) {
 			return;
 		}
 	}
@@ -3703,6 +3708,60 @@ void GDScriptAnalyzer::const_fold_dictionary(GDScriptParser::DictionaryNode *p_d
 		dict[element.key->reduced_value] = element.value->reduced_value;
 	}
 	p_dictionary->is_constant = true;
+	p_dictionary->reduced_value = dict;
+}
+
+void GDScriptAnalyzer::parameter_fold_array(GDScriptParser::ArrayNode *p_array) {
+	for (int i = 0; i < p_array->elements.size(); i++) {
+		GDScriptParser::ExpressionNode *element = p_array->elements[i];
+
+		if (element->type == GDScriptParser::Node::ARRAY) {
+			parameter_fold_array(static_cast<GDScriptParser::ArrayNode *>(element));
+			if (element->reduced_value.get_type() == Variant::NIL) {
+				return;
+			}
+		} else if (element->type == GDScriptParser::Node::DICTIONARY) {
+			parameter_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(element));
+			if (element->reduced_value.get_type() == Variant::NIL) {
+				return;
+			}
+		} else if (!element->is_constant) {
+			return;
+		}
+	}
+
+	Array array;
+	array.resize(p_array->elements.size());
+	for (int i = 0; i < p_array->elements.size(); i++) {
+		array[i] = p_array->elements[i]->reduced_value;
+	}
+	p_array->reduced_value = array;
+}
+
+void GDScriptAnalyzer::parameter_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary) {
+	for (int i = 0; i < p_dictionary->elements.size(); i++) {
+		const GDScriptParser::DictionaryNode::Pair &element = p_dictionary->elements[i];
+
+		if (element.value->type == GDScriptParser::Node::ARRAY) {
+			parameter_fold_array(static_cast<GDScriptParser::ArrayNode *>(element.value));
+			if (element.value->reduced_value.get_type() == Variant::NIL) {
+				return;
+			}
+		} else if (element.value->type == GDScriptParser::Node::DICTIONARY) {
+			parameter_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(element.value));
+			if (element.value->reduced_value.get_type() == Variant::NIL) {
+				return;
+			}
+		} else if (!element.key->is_constant || !element.value->is_constant) {
+			return;
+		}
+	}
+
+	Dictionary dict;
+	for (int i = 0; i < p_dictionary->elements.size(); i++) {
+		const GDScriptParser::DictionaryNode::Pair &element = p_dictionary->elements[i];
+		dict[element.key->reduced_value] = element.value->reduced_value;
+	}
 	p_dictionary->reduced_value = dict;
 }
 

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -100,6 +100,9 @@ class GDScriptAnalyzer {
 	void const_fold_array(GDScriptParser::ArrayNode *p_array);
 	void const_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary);
 
+	void parameter_fold_array(GDScriptParser::ArrayNode *p_array);
+	void parameter_fold_dictionary(GDScriptParser::DictionaryNode *p_dictionary);
+
 	// Helpers.
 	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source);
 	GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type) const;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -702,13 +702,13 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 				} break;
 				case GDScriptParser::Node::ARRAY: {
 					const GDScriptParser::ArrayNode *arr = static_cast<const GDScriptParser::ArrayNode *>(par->default_value);
-					if (arr->is_constant && arr->reduced) {
+					if (arr->reduced_value.get_type() != Variant::NIL && arr->reduced) {
 						def_val = arr->reduced_value.operator String();
 					}
 				} break;
 				case GDScriptParser::Node::DICTIONARY: {
 					const GDScriptParser::DictionaryNode *dict = static_cast<const GDScriptParser::DictionaryNode *>(par->default_value);
-					if (dict->is_constant && dict->reduced) {
+					if (dict->reduced_value.get_type() != Variant::NIL && dict->reduced) {
 						def_val = dict->reduced_value.operator String();
 					}
 				} break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
In the current version, if the default value of a GDScript function arguments is set to an array or dictionary, it will be null in tooltips and documentation. This PR fixes this issue.  

Fix #63018
  
It also probably fixes some other array and dictionary related issues, but I couldn't find it. Hope someone can test it