### PR TITLE
Clear `drag_selection` when drag ends

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1201,7 +1201,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 			}
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -1369,14 +1369,14 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 							drag_selection[0]->get_name(),
 							drag_selection[0]->_edit_get_pivot().x,
 							drag_selection[0]->_edit_get_pivot().y));
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			return true;
 		}
 
 		// Cancel a drag
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -1452,14 +1452,14 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 				_insert_animation_keys(false, true, false, true);
 			}
 
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			return true;
 		}
 
 		// Cancel a drag
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -1614,14 +1614,14 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 			_commit_canvas_item_state(
 					drag_selection,
 					vformat(TTR("Move CanvasItem \"%s\" Anchor"), drag_selection[0]->get_name()));
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			return true;
 		}
 
 		// Cancel a drag
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -1820,7 +1820,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -1830,7 +1830,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 			_restore_canvas_item_state(drag_selection);
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -1959,7 +1959,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 				_insert_animation_keys(false, false, true, true);
 			}
 
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -1967,7 +1967,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 		// Cancel a drag
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -2092,7 +2092,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
 
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -2102,7 +2102,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			_restore_canvas_item_state(drag_selection, true);
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -2209,7 +2209,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 								drag_selection[0]->_edit_get_position().y),
 						true);
 			}
-			drag_type = DRAG_NONE;
+			_reset_drag();
 		}
 		viewport->update();
 		return true;
@@ -2360,7 +2360,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 
 	if (drag_type == DRAG_QUEUED) {
 		if (b.is_valid() && !b->is_pressed()) {
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			return true;
 		}
 		if (m.is_valid()) {
@@ -2411,14 +2411,14 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				}
 			}
 
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
 
 		if (b.is_valid() && b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
 			// Cancel box selection
-			drag_type = DRAG_NONE;
+			_reset_drag();
 			viewport->update();
 			return true;
 		}
@@ -3981,7 +3981,7 @@ void CanvasItemEditor::_notification(int p_what) {
 
 void CanvasItemEditor::_selection_changed() {
 	if (!selected_from_canvas) {
-		drag_type = DRAG_NONE;
+		_reset_drag();
 	}
 	selected_from_canvas = false;
 }
@@ -3989,7 +3989,7 @@ void CanvasItemEditor::_selection_changed() {
 void CanvasItemEditor::edit(CanvasItem *p_canvas_item) {
 	Array selection = editor_selection->get_selected_nodes();
 	if (selection.size() != 1 || Object::cast_to<Node>(selection[0]) != p_canvas_item) {
-		drag_type = DRAG_NONE;
+		_reset_drag();
 
 		// Clear the selection
 		editor_selection->clear(); //_clear_canvas_items();
@@ -4699,6 +4699,11 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 			call_deferred(SNAME("_popup_callback"), VIEW_CENTER_TO_SELECTION);
 		}
 	}
+}
+
+void CanvasItemEditor::_reset_drag() {
+	drag_type = DRAG_NONE;
+	drag_selection.clear();
 }
 
 void CanvasItemEditor::_bind_methods() {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -455,8 +455,8 @@ private:
 	void _update_cursor();
 
 	void _selection_changed();
-
 	void _focus_selection(int p_op);
+	void _reset_drag();
 
 	SnapTarget snap_target[2];
 	Transform2D snap_transform;


### PR DESCRIPTION
Follow-up to #62993
I was going to open an issue, but came up with a solution before I finished writing it 🙃

`drag_selection` is a list of nodes dragged in the 2D editor. Previously it wasn't properly cleared when dragging stopped, which could result in invalid nodes (when scene is closed) or nodes not inside tree (when changing scene) being in the list. All methods that use `drag_selection` also check for a proper `drag_type`, but if such check is forgotten, using `drag_selection` might result in invalid behavior or a crash.

This PR ensures that `drag_selection` is properly cleared when drag ends. Checking if `drag_type` isn't NONE when using `drag_selection` could still be preferred, but missing such check will no longer cause a crash (unless there is a case where `drag_type` isn't set to NONE when it should...).