### PR TITLE
Download Vulkan SDK disk image to a temporary folder in the script

### DIFF
--- a/misc/scripts/install_vulkan_sdk_macos.sh
+++ b/misc/scripts/install_vulkan_sdk_macos.sh
@@ -4,10 +4,11 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Download and install the Vulkan SDK.
-curl -LO "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg"
-hdiutil attach vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
+curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/vulkan-sdk.dmg
+hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
 /Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
     --accept-licenses --default-answer --confirm-command install
 hdiutil detach /Volumes/vulkan-sdk
+rm -f /tmp/vulkan-sdk.dmg
 
 echo 'Vulkan SDK installed successfully! You can now build Godot by running "scons".'


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/54555.

This prevents a `vulkan-sdk.dmg` file from lingering in the current working directory after installing the Vulkan SDK.

The file is also removed after the disk image is detached, as it won't be needed anymore.

I haven't tested this on an actual macOS device – could someone give it a try?