### PR TITLE
Implement `rotate_90/rotate_180` functions to `Image`

### DIFF
--- a/core/io/image.h
+++ b/core/io/image.h
@@ -254,6 +254,9 @@ public:
 	void crop_from_point(int p_x, int p_y, int p_width, int p_height);
 	void crop(int p_width, int p_height);
 
+	void rotate_90(ClockDirection p_direction);
+	void rotate_180();
+
 	void flip_x();
 	void flip_y();
 

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -378,6 +378,19 @@
 				Converts a standard RGBE (Red Green Blue Exponent) image to an sRGB image.
 			</description>
 		</method>
+		<method name="rotate_180">
+			<return type="void" />
+			<description>
+				Rotates the image by [code]180[/code] degrees. The width and height of the image must be greater than [code]1[/code].
+			</description>
+		</method>
+		<method name="rotate_90">
+			<return type="void" />
+			<argument index="0" name="direction" type="int" enum="ClockDirection" />
+			<description>
+				Rotates the image in the specified [code]direction[/code] by [code]90[/code] degrees. The width and height of the image must be greater than [code]1[/code]. If the width and height are not equal, the image will be resized.
+			</description>
+		</method>
 		<method name="save_exr" qualifiers="const">
 			<return type="int" enum="Error" />
 			<argument index="0" name="path" type="String" />


### PR DESCRIPTION
This PR adds `rotate_90` and `rotate_180` functions to `Image` class.

`rotate_90` accepts ClockDirection as a parameter to specify direction. If the width and height are unequal it will resize the image.
`rotate_180` simply apply combined flip operations to the image.

![image_rotate](https://user-images.githubusercontent.com/3036176/179075689-575c32a8-c250-4c8c-9981-bc74a13939a9.gif)

Closes https://github.com/godotengine/godot-proposals/issues/2428
