### PR TITLE
Consistently use `double` in Slider and SpinBox

### DIFF
--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -96,15 +96,15 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 		if (grab.active) {
 			Size2i size = get_size();
 			Ref<Texture2D> grabber = get_theme_icon(SNAME("grabber"));
-			float motion = (orientation == VERTICAL ? mm->get_position().y : mm->get_position().x) - grab.pos;
+			double motion = (orientation == VERTICAL ? mm->get_position().y : mm->get_position().x) - grab.pos;
 			if (orientation == VERTICAL) {
 				motion = -motion;
 			}
-			float areasize = orientation == VERTICAL ? size.height - grabber->get_size().height : size.width - grabber->get_size().width;
+			double areasize = orientation == VERTICAL ? size.height - grabber->get_size().height : size.width - grabber->get_size().width;
 			if (areasize <= 0) {
 				return;
 			}
-			float umotion = motion / float(areasize);
+			double umotion = motion / double(areasize);
 			set_as_ratio(grab.uvalue + umotion);
 		}
 	}
@@ -180,7 +180,7 @@ void Slider::_notification(int p_what) {
 
 			if (orientation == VERTICAL) {
 				int widget_width = style->get_minimum_size().width + style->get_center_size().width;
-				float areasize = size.height - grabber->get_size().height;
+				double areasize = size.height - grabber->get_size().height;
 				style->draw(ci, Rect2i(Point2i(size.width / 2 - widget_width / 2, 0), Size2i(widget_width, size.height)));
 				grabber_area->draw(ci, Rect2i(Point2i((size.width - widget_width) / 2, size.height - areasize * ratio - grabber->get_size().height / 2), Size2i(widget_width, areasize * ratio + grabber->get_size().height / 2)));
 
@@ -197,7 +197,7 @@ void Slider::_notification(int p_what) {
 				grabber->draw(ci, Point2i(size.width / 2 - grabber->get_size().width / 2, size.height - ratio * areasize - grabber->get_size().height));
 			} else {
 				int widget_height = style->get_minimum_size().height + style->get_center_size().height;
-				float areasize = size.width - grabber->get_size().width;
+				double areasize = size.width - grabber->get_size().width;
 
 				style->draw(ci, Rect2i(Point2i(0, (size.height - widget_height) / 2), Size2i(size.width, widget_height)));
 				grabber_area->draw(ci, Rect2i(Point2i(0, (size.height - widget_height) / 2), Size2i(areasize * ratio + grabber->get_size().width / 2, widget_height)));
@@ -218,11 +218,11 @@ void Slider::_notification(int p_what) {
 	}
 }
 
-void Slider::set_custom_step(float p_custom_step) {
+void Slider::set_custom_step(double p_custom_step) {
 	custom_step = p_custom_step;
 }
 
-float Slider::get_custom_step() const {
+double Slider::get_custom_step() const {
 	return custom_step;
 }
 

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -38,14 +38,14 @@ class Slider : public Range {
 
 	struct Grab {
 		int pos = 0;
-		float uvalue = 0.0;
+		double uvalue = 0.0;
 		bool active = false;
 	} grab;
 
 	int ticks = 0;
 	bool mouse_inside = false;
 	Orientation orientation;
-	float custom_step = -1.0;
+	double custom_step = -1.0;
 	bool editable = true;
 	bool scrollable = true;
 
@@ -58,8 +58,8 @@ protected:
 public:
 	virtual Size2 get_minimum_size() const override;
 
-	void set_custom_step(float p_custom_step);
-	float get_custom_step() const;
+	void set_custom_step(double p_custom_step);
+	double get_custom_step() const;
 
 	void set_ticks(int p_count);
 	int get_ticks() const;

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -167,7 +167,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 	if (mm.is_valid() && (mm->get_button_mask() & MouseButton::MASK_LEFT) != MouseButton::NONE) {
 		if (drag.enabled) {
 			drag.diff_y += mm->get_relative().y;
-			float diff_y = -0.01 * Math::pow(ABS(drag.diff_y), 1.8f) * SIGN(drag.diff_y);
+			double diff_y = -0.01 * Math::pow(ABS(drag.diff_y), 1.8) * SIGN(drag.diff_y);
 			set_value(CLAMP(drag.base_val + get_step() * diff_y, get_min(), get_max()));
 		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2) {
 			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -56,11 +56,11 @@ class SpinBox : public Range {
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
 	struct Drag {
-		float base_val = 0.0;
+		double base_val = 0.0;
 		bool allowed = false;
 		bool enabled = false;
 		Vector2 capture_pos;
-		float diff_y = 0.0;
+		double diff_y = 0.0;
 	} drag;
 
 	void _line_edit_focus_exit();


### PR DESCRIPTION
(H/V)Slider and SpinBox mostly use `double`, and the parent class Range uses `double`, but there were a few places where there was precision loss because of a few parts that used `float`. This PR fixes this inconsistency.