### PR TITLE
Fixed incorrect type display of function arguments in GDScript editor tooltips

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -671,7 +671,11 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 			arghint += String::chr(0xFFFF);
 		}
 		const GDScriptParser::ParameterNode *par = p_function->parameters[i];
-		arghint += par->identifier->name.operator String() + ": " + par->get_datatype().to_string();
+		if (!par->get_datatype().is_hard_type()) {
+			arghint += par->identifier->name.operator String() + ": Variant";
+		} else {
+			arghint += par->identifier->name.operator String() + ": " + par->get_datatype().to_string();
+		}
 
 		if (par->default_value) {
 			String def_val = "<unknown>";


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
For function arguments without a defined type but with a default value set, the arguments type will be displayed as the type of the default value in the editor tooltip (should be Variant)  

Fix #63017

Before this PR:
![image](https://user-images.githubusercontent.com/44023235/179137340-31ec4957-8d51-41ff-8714-b3f0c5fac5ba.png)

After:
![image](https://user-images.githubusercontent.com/44023235/179136753-1cc28d9f-b158-4935-8205-7f5309640f90.png)