### PR TITLE
Fix grouping annotations displayed in script document

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -536,6 +536,9 @@ void GDScript::_update_doc() {
 	List<PropertyInfo> props;
 	_get_script_property_list(&props, false);
 	for (int i = 0; i < props.size(); i++) {
+		if (props[i].usage & PROPERTY_USAGE_CATEGORY || props[i].usage & PROPERTY_USAGE_GROUP || props[i].usage & PROPERTY_USAGE_SUBGROUP) {
+			continue;
+		}
 		ScriptMemberInfo scr_member_info;
 		scr_member_info.propinfo = props[i];
 		scr_member_info.propinfo.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fix #62953