### PR TITLE
[3.x] Add options for sorting transparent objects

### DIFF
--- a/doc/classes/VisualInstance.xml
+++ b/doc/classes/VisualInstance.xml
@@ -62,6 +62,13 @@
 			The render layer(s) this [VisualInstance] is drawn on.
 			This object will only be visible for [Camera]s whose cull mask includes the render object this [VisualInstance] is set to.
 		</member>
+		<member name="sorting_offset" type="float" setter="set_sorting_offset" getter="get_sorting_offset" default="0.0">
+			The sorting offset used by this [VisualInstance]. Adjusting it to a higher value will make the [VisualInstance] reliably draw on top of other [VisualInstance]s that are otherwise positioned at the same spot.
+		</member>
+		<member name="sorting_use_aabb_center" type="bool" setter="set_sorting_use_aabb_center" getter="is_sorting_use_aabb_center" default="true">
+			If [code]true[/code], the object is sorted based on the [AABB] center. Sorted based on the global position otherwise.
+			The [AABB] center based sorting is generally more accurate for 3D models. The position based sorting instead allows to better control the drawing order when working with [Particles] and [CPUParticles].
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -180,6 +180,24 @@ bool VisualInstance::get_layer_mask_bit(int p_layer) const {
 	return (layers & (1 << p_layer));
 }
 
+void VisualInstance::set_sorting_offset(float p_offset) {
+	sorting_offset = p_offset;
+	VisualServer::get_singleton()->instance_set_pivot_data(instance, sorting_offset, sorting_use_aabb_center);
+}
+
+float VisualInstance::get_sorting_offset() {
+	return sorting_offset;
+}
+
+void VisualInstance::set_sorting_use_aabb_center(bool p_enabled) {
+	sorting_use_aabb_center = p_enabled;
+	VisualServer::get_singleton()->instance_set_pivot_data(instance, sorting_offset, sorting_use_aabb_center);
+}
+
+bool VisualInstance::is_sorting_use_aabb_center() {
+	return sorting_use_aabb_center;
+}
+
 void VisualInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_visual_instance_rid"), &VisualInstance::_get_visual_instance_rid);
 	ClassDB::bind_method(D_METHOD("set_base", "base"), &VisualInstance::set_base);
@@ -190,8 +208,16 @@ void VisualInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_layer_mask_bit", "layer", "enabled"), &VisualInstance::set_layer_mask_bit);
 	ClassDB::bind_method(D_METHOD("get_layer_mask_bit", "layer"), &VisualInstance::get_layer_mask_bit);
 	ClassDB::bind_method(D_METHOD("get_transformed_aabb"), &VisualInstance::get_transformed_aabb);
+	ClassDB::bind_method(D_METHOD("set_sorting_offset", "offset"), &VisualInstance::set_sorting_offset);
+	ClassDB::bind_method(D_METHOD("get_sorting_offset"), &VisualInstance::get_sorting_offset);
+	ClassDB::bind_method(D_METHOD("set_sorting_use_aabb_center", "enabled"), &VisualInstance::set_sorting_use_aabb_center);
+	ClassDB::bind_method(D_METHOD("is_sorting_use_aabb_center"), &VisualInstance::is_sorting_use_aabb_center);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_3D_RENDER), "set_layer_mask", "get_layer_mask");
+
+	ADD_GROUP("Sorting", "sorting_");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "sorting_offset"), "set_sorting_offset", "get_sorting_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sorting_use_aabb_center"), "set_sorting_use_aabb_center", "is_sorting_use_aabb_center");
 }
 
 void VisualInstance::set_base(const RID &p_base) {
@@ -207,6 +233,8 @@ VisualInstance::VisualInstance() {
 	instance = RID_PRIME(VisualServer::get_singleton()->instance_create());
 	VisualServer::get_singleton()->instance_attach_object_instance_id(instance, get_instance_id());
 	layers = 1;
+	sorting_offset = 0.0f;
+	sorting_use_aabb_center = true;
 	set_notify_transform(true);
 }
 

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -43,6 +43,8 @@ class VisualInstance : public CullInstance {
 	RID base;
 	RID instance;
 	uint32_t layers;
+	float sorting_offset;
+	bool sorting_use_aabb_center;
 
 	RID _get_visual_instance_rid() const;
 
@@ -76,6 +78,12 @@ public:
 
 	void set_layer_mask_bit(int p_layer, bool p_enable);
 	bool get_layer_mask_bit(int p_layer) const;
+
+	void set_sorting_offset(float p_offset);
+	float get_sorting_offset();
+
+	void set_sorting_use_aabb_center(bool p_enabled);
+	bool is_sorting_use_aabb_center();
 
 	VisualInstance();
 	~VisualInstance();

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -579,6 +579,7 @@ public:
 	BIND2(instance_set_base, RID, RID)
 	BIND2(instance_set_scenario, RID, RID)
 	BIND2(instance_set_layer_mask, RID, uint32_t)
+	BIND3(instance_set_pivot_data, RID, float, bool)
 	BIND2(instance_set_transform, RID, const Transform &)
 	BIND2(instance_set_interpolated, RID, bool)
 	BIND1(instance_reset_physics_interpolation, RID)

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -311,6 +311,8 @@ public:
 		AABB aabb;
 		AABB transformed_aabb;
 		AABB *custom_aabb; // <Zylann> would using aabb directly with a bool be better?
+		float sorting_offset;
+		bool use_aabb_center;
 		float extra_margin;
 		uint32_t object_id;
 
@@ -371,6 +373,8 @@ public:
 			base_data = nullptr;
 
 			custom_aabb = nullptr;
+			sorting_offset = 0.0f;
+			use_aabb_center = false;
 		}
 
 		~Instance() {
@@ -614,6 +618,7 @@ public:
 	virtual void instance_set_base(RID p_instance, RID p_base);
 	virtual void instance_set_scenario(RID p_instance, RID p_scenario);
 	virtual void instance_set_layer_mask(RID p_instance, uint32_t p_mask);
+	virtual void instance_set_pivot_data(RID p_instance, float p_sorting_offset, bool p_use_aabb_center);
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform);
 	virtual void instance_set_interpolated(RID p_instance, bool p_interpolated);
 	virtual void instance_reset_physics_interpolation(RID p_instance);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -484,6 +484,7 @@ public:
 	FUNC2(instance_set_base, RID, RID)
 	FUNC2(instance_set_scenario, RID, RID)
 	FUNC2(instance_set_layer_mask, RID, uint32_t)
+	FUNC3(instance_set_pivot_data, RID, float, bool)
 	FUNC2(instance_set_transform, RID, const Transform &)
 	FUNC2(instance_set_interpolated, RID, bool)
 	FUNC1(instance_reset_physics_interpolation, RID)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -866,6 +866,7 @@ public:
 	virtual void instance_set_base(RID p_instance, RID p_base) = 0;
 	virtual void instance_set_scenario(RID p_instance, RID p_scenario) = 0;
 	virtual void instance_set_layer_mask(RID p_instance, uint32_t p_mask) = 0;
+	virtual void instance_set_pivot_data(RID p_instance, float p_sorting_offset, bool p_use_aabb_center) = 0;
 	virtual void instance_set_transform(RID p_instance, const Transform &p_transform) = 0;
 	virtual void instance_set_interpolated(RID p_instance, bool p_interpolated) = 0;
 	virtual void instance_reset_physics_interpolation(RID p_instance) = 0;


### PR DESCRIPTION
This commit adds two properties to visual instance:
- `sorting_use_aabb_center` default to true, use the aabb center for sorting. if set to false, it uses the origin (pivot) of the object insted.
- `sorting_offset` a float value that will change the depth that is assigned to the object in the transparent queue.

This is especially useful for VFX where there are a lot of particle systems on top of each other, giving artists the full control over the ordering of particles within the same vfx, since godot has no concept of a vfx. (this can't be done with render priority, see: https://github.com/godotengine/godot-proposals/issues/4099 )

I'd love to port this to 4.x but I will need someone's help to figure out where i should touch the renderer.

Video of the new behaviour [https/giant.gfycat.com/MetallicTenderFlounder.mp4](https://giant.gfycat.com/MetallicTenderFlounder.mp4)


This work was kindly sponsored by [Pahdo Labs](https://www.pahdolabs.com/)