### PR TITLE
HTML5: Make locale string match other platforms

### DIFF
--- a/platform/javascript/js/engine/config.js
+++ b/platform/javascript/js/engine/config.js
@@ -334,6 +334,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 			locale = navigator.languages ? navigator.languages[0] : navigator.language;
 			locale = locale.split('.')[0];
 		}
+		locale = locale.replace('-', '_');
 		const onExit = this.onExit;
 
 		// Godot configuration.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #63029.
Tested on 3.x as I couldn't get master to work with HTML5 exports.