### PR TITLE
Fix getting wrong focus neighbor when the control is in ScrollContainer

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -314,7 +314,7 @@ private:
 
 	// Focus.
 
-	void _window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, const Point2 *p_points, real_t p_min, real_t &r_closest_dist, Control **r_closest);
+	void _window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, const Rect2 &p_rect, const Rect2 &p_clamp, real_t p_min, real_t &r_closest_dist_squared, Control **r_closest);
 	Control *_get_focus_neighbor(Side p_side, int p_count = 0);
 
 	// Theming.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Now, navigating in a `ScrollContainer` without `follow_focus` enabled will not navigate to the shadow child control.
Then when navigating outside of a `ScrollContainer`, avoid unintended effects on navigation caused by the `ScrollContainer` with `follow_focus` enabled.


Fix #63067, fix #98445.




| Before | After |
| :------: | :------: |
| ![001](https://github.com/user-attachments/assets/0436abdc-0e50-4a8f-be8e-4c415d7416cd) | ![002](https://github.com/user-attachments/assets/f9608e16-9e89-4abf-bf3c-73e14ff8cf5e) |
| ![003](https://github.com/user-attachments/assets/ab0632e0-1d4a-4657-892d-f4145586812a) | ![004](https://github.com/user-attachments/assets/21ee77f8-5e51-4704-af4f-9094e95bbdb5) |



~~Works fine when `follow_focus` is enabled, when not enabled, there is still an issue. See #63067.~~

