### PR TITLE
Fix visual shader graph not correctly updating when multiple tabs opened

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -923,6 +923,15 @@ ShaderEditor *ShaderEditorPlugin::get_shader_editor(const Ref<Shader> &p_for_sha
 	return nullptr;
 }
 
+VisualShaderEditor *ShaderEditorPlugin::get_visual_shader_editor(const Ref<Shader> &p_for_shader) {
+	for (uint32_t i = 0; i < edited_shaders.size(); i++) {
+		if (edited_shaders[i].shader == p_for_shader) {
+			return edited_shaders[i].visual_shader_editor;
+		}
+	}
+	return nullptr;
+}
+
 void ShaderEditorPlugin::save_external_data() {
 	for (uint32_t i = 0; i < edited_shaders.size(); i++) {
 		if (edited_shaders[i].shader_editor) {
@@ -950,6 +959,7 @@ void ShaderEditorPlugin::_close_shader(int p_index) {
 	memdelete(c);
 	edited_shaders.remove_at(index);
 	_update_shader_list();
+	EditorNode::get_singleton()->get_undo_redo()->clear_history(); // To prevent undo on deleted graphs.
 }
 
 void ShaderEditorPlugin::_resource_saved(Object *obj) {

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -209,6 +209,7 @@ public:
 	virtual void selected_notify() override;
 
 	ShaderEditor *get_shader_editor(const Ref<Shader> &p_for_shader);
+	VisualShaderEditor *get_visual_shader_editor(const Ref<Shader> &p_for_shader);
 
 	virtual void save_external_data() override;
 	virtual void apply_changes() override;

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -42,8 +42,13 @@
 #include "scene/gui/tree.h"
 #include "scene/resources/visual_shader.h"
 
+class VisualShaderEditor;
+
 class VisualShaderNodePlugin : public RefCounted {
 	GDCLASS(VisualShaderNodePlugin, RefCounted);
+
+protected:
+	VisualShaderEditor *vseditor = nullptr;
 
 protected:
 	static void _bind_methods();
@@ -51,6 +56,7 @@ protected:
 	GDVIRTUAL2RC(Object *, _create_editor, Ref<Resource>, Ref<VisualShaderNode>)
 
 public:
+	void set_editor(VisualShaderEditor *p_editor);
 	virtual Control *create_editor(const Ref<Resource> &p_parent_resource, const Ref<VisualShaderNode> &p_node);
 };
 
@@ -58,6 +64,8 @@ class VisualShaderGraphPlugin : public RefCounted {
 	GDCLASS(VisualShaderGraphPlugin, RefCounted);
 
 private:
+	VisualShaderEditor *editor = nullptr;
+
 	struct InputPort {
 		Button *default_input_button = nullptr;
 	};
@@ -91,6 +99,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	void set_editor(VisualShaderEditor *p_editor);
 	void register_shader(VisualShader *p_visual_shader);
 	void set_connections(const List<VisualShader::Connection> &p_connections);
 	void register_link(VisualShader::Type p_type, int p_id, VisualShaderNode *p_visual_node, GraphNode *p_graph_node);
@@ -324,8 +333,6 @@ class VisualShaderEditor : public VBoxContainer {
 	void _update_preview();
 	String _get_description(int p_idx);
 
-	static VisualShaderEditor *singleton;
-
 	struct DragOp {
 		VisualShader::Type type = VisualShader::Type::TYPE_MAX;
 		int node = 0;
@@ -403,9 +410,9 @@ class VisualShaderEditor : public VBoxContainer {
 
 	void _duplicate_nodes();
 
-	Vector2 selection_center;
-	List<CopyItem> copy_items_buffer;
-	List<VisualShader::Connection> copy_connections_buffer;
+	static Vector2 selection_center;
+	static List<CopyItem> copy_items_buffer;
+	static List<VisualShader::Connection> copy_connections_buffer;
 
 	void _clear_copy_buffer();
 	void _copy_nodes(bool p_cut);
@@ -482,7 +489,6 @@ public:
 	void add_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 	void remove_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 
-	static VisualShaderEditor *get_singleton() { return singleton; }
 	VisualShaderGraphPlugin *get_graph_plugin() { return graph_plugin.ptr(); }
 
 	void clear_custom_types();

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -561,6 +561,7 @@ public:
 	};
 
 private:
+	RID shader_rid;
 	String uniform_name = "[None]";
 	UniformType uniform_type = UniformType::UNIFORM_TYPE_FLOAT;
 
@@ -568,9 +569,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	static void add_uniform(const String &p_name, UniformType p_type);
-	static void clear_uniforms();
-	static bool has_uniform(const String &p_name);
+	static void add_uniform(RID p_shader_rid, const String &p_name, UniformType p_type);
+	static void clear_uniforms(RID p_shader_rid);
+	static bool has_uniform(RID p_shader_rid, const String &p_name);
 
 public:
 	virtual String get_caption() const override;
@@ -583,8 +584,12 @@ public:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
+	void set_shader_rid(const RID &p_shader);
+
 	void set_uniform_name(const String &p_name);
 	String get_uniform_name() const;
+
+	void update_uniform_type();
 
 	void _set_uniform_type(int p_uniform_type);
 	int _get_uniform_type() const;


### PR DESCRIPTION
Currently if you open more than one instances of `VisualShaderEditor` its not correctly updating because singleton must be updated when you switch graphs:
![vs_bug](https://user-images.githubusercontent.com/3036176/179344080-c9cff140-a6fc-4b42-899d-fef57385af06.gif)

