### PR TITLE
[3.x][GDNative] Refactoring: add `const` to `has` and `join` methods of pooled arrays

### DIFF
--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -483,7 +483,7 @@ public:
 		return OK;
 	}
 
-	String join(String delimiter) {
+	String join(String delimiter) const {
 		String rs = "";
 		int s = size();
 		Read r = read();

--- a/modules/gdnative/gdnative/pool_arrays.cpp
+++ b/modules/gdnative/gdnative/pool_arrays.cpp
@@ -147,7 +147,7 @@ godot_bool GDAPI godot_pool_byte_array_empty(const godot_pool_byte_array *p_self
 	return self->empty();
 }
 
-godot_bool GDAPI godot_pool_byte_array_has(godot_pool_byte_array *p_self, const uint8_t p_data) {
+godot_bool GDAPI godot_pool_byte_array_has(const godot_pool_byte_array *p_self, const uint8_t p_data) {
 	const PoolVector<uint8_t> *self = (const PoolVector<uint8_t> *)p_self;
 	return self->has(p_data);
 }
@@ -251,7 +251,7 @@ godot_bool GDAPI godot_pool_int_array_empty(const godot_pool_int_array *p_self) 
 	return self->empty();
 }
 
-godot_bool GDAPI godot_pool_int_array_has(godot_pool_int_array *p_self, const godot_int p_data) {
+godot_bool GDAPI godot_pool_int_array_has(const godot_pool_int_array *p_self, const godot_int p_data) {
 	const PoolVector<godot_int> *self = (const PoolVector<godot_int> *)p_self;
 	return self->has(p_data);
 }
@@ -355,7 +355,7 @@ godot_bool GDAPI godot_pool_real_array_empty(const godot_pool_real_array *p_self
 	return self->empty();
 }
 
-godot_bool GDAPI godot_pool_real_array_has(godot_pool_real_array *p_self, const godot_real p_data) {
+godot_bool GDAPI godot_pool_real_array_has(const godot_pool_real_array *p_self, const godot_real p_data) {
 	const PoolVector<godot_real> *self = (const PoolVector<godot_real> *)p_self;
 	return self->has(p_data);
 }
@@ -411,8 +411,8 @@ void GDAPI godot_pool_string_array_invert(godot_pool_string_array *p_self) {
 	self->invert();
 }
 
-godot_string GDAPI godot_pool_string_array_join(godot_pool_string_array *p_self, const godot_string *p_delimiter) {
-	PoolVector<String> *self = (PoolVector<String> *)p_self;
+godot_string GDAPI godot_pool_string_array_join(const godot_pool_string_array *p_self, const godot_string *p_delimiter) {
+	const PoolVector<String> *self = (PoolVector<String> *)p_self;
 	String &delimiter = *(String *)p_delimiter;
 
 	godot_string str;
@@ -478,7 +478,7 @@ godot_bool GDAPI godot_pool_string_array_empty(const godot_pool_string_array *p_
 	return self->empty();
 }
 
-godot_bool GDAPI godot_pool_string_array_has(godot_pool_string_array *p_self, const godot_string *p_data) {
+godot_bool GDAPI godot_pool_string_array_has(const godot_pool_string_array *p_self, const godot_string *p_data) {
 	const PoolVector<String> *self = (const PoolVector<String> *)p_self;
 	String &s = *(String *)p_data;
 	return self->has(s);
@@ -590,7 +590,7 @@ godot_bool GDAPI godot_pool_vector2_array_empty(const godot_pool_vector2_array *
 	return self->empty();
 }
 
-godot_bool GDAPI godot_pool_vector2_array_has(godot_pool_vector2_array *p_self, const godot_vector2 *p_data) {
+godot_bool GDAPI godot_pool_vector2_array_has(const godot_pool_vector2_array *p_self, const godot_vector2 *p_data) {
 	const PoolVector<Vector2> *self = (const PoolVector<Vector2> *)p_self;
 	Vector2 &s = *(Vector2 *)p_data;
 	return self->has(s);
@@ -702,7 +702,7 @@ godot_bool GDAPI godot_pool_vector3_array_empty(const godot_pool_vector3_array *
 	return self->empty();
 }
 
-godot_bool GDAPI godot_pool_vector3_array_has(godot_pool_vector3_array *p_self, const godot_vector3 *p_data) {
+godot_bool GDAPI godot_pool_vector3_array_has(const godot_pool_vector3_array *p_self, const godot_vector3 *p_data) {
 	const PoolVector<Vector3> *self = (const PoolVector<Vector3> *)p_self;
 	Vector3 &s = *(Vector3 *)p_data;
 	return self->has(s);
@@ -814,7 +814,7 @@ godot_bool GDAPI godot_pool_color_array_empty(const godot_pool_color_array *p_se
 	return self->empty();
 }
 
-godot_bool GDAPI godot_pool_color_array_has(godot_pool_color_array *p_self, const godot_color *p_data) {
+godot_bool GDAPI godot_pool_color_array_has(const godot_pool_color_array *p_self, const godot_color *p_data) {
 	const PoolVector<Color> *self = (const PoolVector<Color> *)p_self;
 	Color &s = *(Color *)p_data;
 	return self->has(s);

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -29,7 +29,7 @@
               "name": "godot_pool_byte_array_has",
               "return_type": "godot_bool",
               "arguments": [
-                ["godot_pool_byte_array *", "p_self"],
+                ["const godot_pool_byte_array *", "p_self"],
                 ["const uint8_t", "p_data"]
               ]
             },
@@ -44,7 +44,7 @@
               "name": "godot_pool_int_array_has",
               "return_type": "godot_bool",
               "arguments": [
-                ["godot_pool_int_array *", "p_self"],
+                ["const godot_pool_int_array *", "p_self"],
                 ["const godot_int", "p_data"]
               ]
             },
@@ -59,7 +59,7 @@
               "name": "godot_pool_real_array_has",
               "return_type": "godot_bool",
               "arguments": [
-                ["godot_pool_real_array *", "p_self"],
+                ["const godot_pool_real_array *", "p_self"],
                 ["const godot_real", "p_data"]
               ]
             },
@@ -74,7 +74,7 @@
               "name": "godot_pool_string_array_has",
               "return_type": "godot_bool",
               "arguments": [
-                ["godot_pool_string_array *", "p_self"],
+                ["const godot_pool_string_array *", "p_self"],
                 ["const godot_string *", "p_data"]
               ]
             },
@@ -82,7 +82,7 @@
               "name": "godot_pool_string_array_join",
               "return_type": "godot_string",
               "arguments": [
-                ["godot_pool_string_array *", "p_self"],
+                ["const godot_pool_string_array *", "p_self"],
                 ["const godot_string *", "p_delimiter"]
               ]
             },
@@ -97,7 +97,7 @@
               "name": "godot_pool_vector2_array_has",
               "return_type": "godot_bool",
               "arguments": [
-                ["godot_pool_vector2_array *", "p_self"],
+                ["const godot_pool_vector2_array *", "p_self"],
                 ["const godot_vector2 *", "p_data"]
               ]
             },
@@ -112,7 +112,7 @@
               "name": "godot_pool_vector3_array_has",
               "return_type": "godot_bool",
               "arguments": [
-                ["godot_pool_vector3_array *", "p_self"],
+                ["const godot_pool_vector3_array *", "p_self"],
                 ["const godot_vector3 *", "p_data"]
               ]
             },
@@ -127,7 +127,7 @@
               "name": "godot_pool_color_array_has",
               "return_type": "godot_bool",
               "arguments": [
-                ["godot_pool_color_array *", "p_self"],
+                ["const godot_pool_color_array *", "p_self"],
                 ["const godot_color *", "p_data"]
               ]
             },

--- a/modules/gdnative/include/gdnative/pool_arrays.h
+++ b/modules/gdnative/include/gdnative/pool_arrays.h
@@ -195,7 +195,7 @@ godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_self);
 
 godot_bool GDAPI godot_pool_byte_array_empty(const godot_pool_byte_array *p_self);
 
-godot_bool GDAPI godot_pool_byte_array_has(godot_pool_byte_array *p_self, const uint8_t p_data);
+godot_bool GDAPI godot_pool_byte_array_has(const godot_pool_byte_array *p_self, const uint8_t p_data);
 
 void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_self);
 
@@ -232,7 +232,7 @@ godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_self);
 
 godot_bool GDAPI godot_pool_int_array_empty(const godot_pool_int_array *p_self);
 
-godot_bool GDAPI godot_pool_int_array_has(godot_pool_int_array *p_self, const godot_int p_data);
+godot_bool GDAPI godot_pool_int_array_has(const godot_pool_int_array *p_self, const godot_int p_data);
 
 void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_self);
 
@@ -269,7 +269,7 @@ godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_self);
 
 godot_bool GDAPI godot_pool_real_array_empty(const godot_pool_real_array *p_self);
 
-godot_bool GDAPI godot_pool_real_array_has(godot_pool_real_array *p_self, const godot_real p_data);
+godot_bool GDAPI godot_pool_real_array_has(const godot_pool_real_array *p_self, const godot_real p_data);
 
 void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_self);
 
@@ -287,7 +287,7 @@ godot_error GDAPI godot_pool_string_array_insert(godot_pool_string_array *p_self
 
 void GDAPI godot_pool_string_array_invert(godot_pool_string_array *p_self);
 
-godot_string GDAPI godot_pool_string_array_join(godot_pool_string_array *p_self, const godot_string *p_delimiter);
+godot_string GDAPI godot_pool_string_array_join(const godot_pool_string_array *p_self, const godot_string *p_delimiter);
 
 void GDAPI godot_pool_string_array_push_back(godot_pool_string_array *p_self, const godot_string *p_data);
 
@@ -308,7 +308,7 @@ godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_se
 
 godot_bool GDAPI godot_pool_string_array_empty(const godot_pool_string_array *p_self);
 
-godot_bool GDAPI godot_pool_string_array_has(godot_pool_string_array *p_self, const godot_string *p_data);
+godot_bool GDAPI godot_pool_string_array_has(const godot_pool_string_array *p_self, const godot_string *p_data);
 
 void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_self);
 
@@ -345,7 +345,7 @@ godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_
 
 godot_bool GDAPI godot_pool_vector2_array_empty(const godot_pool_vector2_array *p_self);
 
-godot_bool GDAPI godot_pool_vector2_array_has(godot_pool_vector2_array *p_self, const godot_vector2 *p_data);
+godot_bool GDAPI godot_pool_vector2_array_has(const godot_pool_vector2_array *p_self, const godot_vector2 *p_data);
 
 void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_self);
 
@@ -382,7 +382,7 @@ godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_
 
 godot_bool GDAPI godot_pool_vector3_array_empty(const godot_pool_vector3_array *p_self);
 
-godot_bool GDAPI godot_pool_vector3_array_has(godot_pool_vector3_array *p_self, const godot_vector3 *p_data);
+godot_bool GDAPI godot_pool_vector3_array_has(const godot_pool_vector3_array *p_self, const godot_vector3 *p_data);
 
 void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_self);
 
@@ -419,7 +419,7 @@ godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_self
 
 godot_bool GDAPI godot_pool_color_array_empty(const godot_pool_color_array *p_self);
 
-godot_bool GDAPI godot_pool_color_array_has(godot_pool_color_array *p_self, const godot_color *p_data);
+godot_bool GDAPI godot_pool_color_array_has(const godot_pool_color_array *p_self, const godot_color *p_data);
 
 void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_self);
 


### PR DESCRIPTION
This PR has some minor refactoring related to the PR #55650 

It adds _const_-ness to the methods `has` and `join` of pooled array classes in GDNative CORE API v1.3.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
