### PR TITLE
Fix skeleton 2D stale bounding rect

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -483,6 +483,7 @@ public:
 	Transform skeleton_bone_get_transform(RID p_skeleton, int p_bone) const { return Transform(); }
 	void skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, const Transform2D &p_transform) {}
 	Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const { return Transform2D(); }
+	uint32_t skeleton_get_revision(RID p_skeleton) const { return 0; }
 
 	/* Light API */
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -3731,6 +3731,7 @@ void RasterizerStorageGLES2::skeleton_bone_set_transform_2d(RID p_skeleton, int 
 	if (!skeleton->update_list.in_list()) {
 		skeleton_update_list.add(&skeleton->update_list);
 	}
+	skeleton->revision++;
 }
 
 Transform2D RasterizerStorageGLES2::skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const {
@@ -3761,6 +3762,12 @@ void RasterizerStorageGLES2::skeleton_set_base_transform_2d(RID p_skeleton, cons
 	ERR_FAIL_COND(!skeleton);
 
 	skeleton->base_transform_2d = p_base_transform;
+}
+
+uint32_t RasterizerStorageGLES2::skeleton_get_revision(RID p_skeleton) const {
+	const Skeleton *skeleton = skeleton_owner.getornull(p_skeleton);
+	ERR_FAIL_COND_V(!skeleton, 0);
+	return skeleton->revision;
 }
 
 void RasterizerStorageGLES2::update_dirty_blend_shapes() {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -890,6 +890,7 @@ public:
 		bool use_2d;
 
 		int size;
+		uint32_t revision;
 
 		// TODO use float textures for storage
 
@@ -905,6 +906,7 @@ public:
 		Skeleton() :
 				use_2d(false),
 				size(0),
+				revision(1),
 				tex_id(0),
 				update_list(this) {
 		}
@@ -924,6 +926,7 @@ public:
 	virtual void skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, const Transform2D &p_transform);
 	virtual Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform);
+	virtual uint32_t skeleton_get_revision(RID p_skeleton) const;
 
 	void _update_skeleton_transform_buffer(const PoolVector<float> &p_data, size_t p_size);
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5277,6 +5277,8 @@ void RasterizerStorageGLES3::skeleton_bone_set_transform_2d(RID p_skeleton, int 
 	if (!skeleton->update_list.in_list()) {
 		skeleton_update_list.add(&skeleton->update_list);
 	}
+
+	skeleton->revision++;
 }
 Transform2D RasterizerStorageGLES3::skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const {
 	Skeleton *skeleton = skeleton_owner.getornull(p_skeleton);
@@ -5308,6 +5310,12 @@ void RasterizerStorageGLES3::skeleton_set_base_transform_2d(RID p_skeleton, cons
 	ERR_FAIL_COND(!skeleton->use_2d);
 
 	skeleton->base_transform_2d = p_base_transform;
+}
+
+uint32_t RasterizerStorageGLES3::skeleton_get_revision(RID p_skeleton) const {
+	const Skeleton *skeleton = skeleton_owner.getornull(p_skeleton);
+	ERR_FAIL_COND_V(!skeleton, 0);
+	return skeleton->revision;
 }
 
 void RasterizerStorageGLES3::update_dirty_skeletons() {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -920,6 +920,7 @@ public:
 	struct Skeleton : RID_Data {
 		bool use_2d;
 		int size;
+		uint32_t revision;
 		Vector<float> skel_texture;
 		GLuint texture;
 		SelfList<Skeleton> update_list;
@@ -929,6 +930,7 @@ public:
 		Skeleton() :
 				use_2d(false),
 				size(0),
+				revision(1),
 				texture(0),
 				update_list(this) {
 		}
@@ -948,6 +950,7 @@ public:
 	virtual void skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, const Transform2D &p_transform);
 	virtual Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform);
+	virtual uint32_t skeleton_get_revision(RID p_skeleton) const;
 
 	/* Light API */
 


### PR DESCRIPTION
Adds special logic for handling skeleton bounding rect updates. Previously these were never being updated because the canvas item is never set to "rect_dirty".

Fixes #63047

## Notes
* There are probably several ways of doing this. The PR may seem overcomplicated, but this whole area was an oversight and not implemented. Possibly at some point in the past it was set to always update the bounds, or perhaps it was always broken.
* You could alternatively try and set the `rect_dirty` on the canvas item from the scene side, but this will cause unnecessary server API calls as it can all be handled server side, so doing it as in the PR seems more efficient.
* This same problem / solution may also be present in 3D, I'll take a look.
* Using revisions rather than a dirty flag on the skeleton is probably necessary because more than one canvas item may be using the skeleton, and the canvas item may not be updated until many frames after the skeleton is updated.
* There's quite a bit of bloated data on the `Item` which I've reduced a bit using bitfields etc, which means the extra storage for the revision shouldn't be a problem.
* The `skeleton_get_revision()` doesn't need to be available externally as far as I can see, so is not added to the bindings.
* I don't know if similar bugs exist in 4.x - quite a bit has changed there, but it might be worth taking a look.

This is relevant to 3.5 (and earlier) but might make sense to cherry pick as we are so close to 3.5 stable. (If we go with this approach).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
