### PR TITLE
[3.x][GDNative] Expose `String::join()` over to GDNative Core API v1.3

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -1005,7 +1005,7 @@ Vector<int> String::split_ints_mk(const Vector<String> &p_splitters, bool p_allo
 	return ret;
 }
 
-String String::join(Vector<String> parts) {
+String String::join(const Vector<String> &parts) const {
 	String ret;
 	for (int i = 0; i < parts.size(); ++i) {
 		if (i > 0) {

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -274,7 +274,7 @@ public:
 	Vector<int> split_ints(const String &p_splitter, bool p_allow_empty = true) const;
 	Vector<int> split_ints_mk(const Vector<String> &p_splitters, bool p_allow_empty = true) const;
 
-	String join(Vector<String> parts);
+	String join(const Vector<String> &parts) const;
 
 	static CharType char_uppercase(CharType p_char);
 	static CharType char_lowercase(CharType p_char);

--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -846,6 +846,23 @@ godot_array GDAPI godot_string_split_spaces(const godot_string *p_self) {
 	return result;
 }
 
+godot_string GDAPI godot_string_join(const godot_string *p_self, const godot_array *p_parts) {
+	const String *self = (const String *)p_self;
+
+	const Array *parts_proxy = (const Array *)p_parts;
+	Vector<String> parts;
+	parts.resize(parts_proxy->size());
+	for (int i = 0; i < parts_proxy->size(); i++) {
+		parts.write[i] = (*parts_proxy)[i];
+	}
+
+	godot_string str;
+	String *s = (String *)&str;
+	memnew_placement(s, String);
+	*s = self->join(parts);
+	return str;
+}
+
 godot_int GDAPI godot_string_get_slice_count(const godot_string *p_self, godot_string p_splitter) {
 	const String *self = (const String *)p_self;
 	String *splitter = (String *)&p_splitter;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -137,6 +137,14 @@
               "arguments": [
                 ["godot_pool_color_array *", "p_self"]
               ]
+            },
+            {
+              "name": "godot_string_join",
+              "return_type": "godot_string",
+              "arguments": [
+                ["const godot_string *", "p_self"],
+                ["const godot_array *", "p_parts"]
+              ]
             }
           ]
         },

--- a/modules/gdnative/include/gdnative/string.h
+++ b/modules/gdnative/include/gdnative/string.h
@@ -179,6 +179,8 @@ godot_array GDAPI godot_string_split_ints_mk(const godot_string *p_self, const g
 godot_array GDAPI godot_string_split_ints_mk_allows_empty(const godot_string *p_self, const godot_array *p_splitters);
 godot_array GDAPI godot_string_split_spaces(const godot_string *p_self);
 
+godot_string GDAPI godot_string_join(const godot_string *p_self, const godot_array *p_parts);
+
 wchar_t GDAPI godot_string_char_lowercase(wchar_t p_char);
 wchar_t GDAPI godot_string_char_uppercase(wchar_t p_char);
 godot_string GDAPI godot_string_to_lower(const godot_string *p_self);


### PR DESCRIPTION
Expose method `join` of the class `String` to GDNative.

This method was already implemented before and it was exposed to GDScript in the PR #56369.

In this PR it's just exposed over to GDNative Core API v1.3.

This PR is logically related to #55826. The proposal for this specific change was discussed [here](https://github.com/godotengine/godot/pull/55826#issuecomment-1172970879)