### PR TITLE
[3.x] Added grid scale property for the `HeightMapShape`

### DIFF
--- a/doc/classes/HeightMapShape.xml
+++ b/doc/classes/HeightMapShape.xml
@@ -20,6 +20,9 @@
 		<member name="map_width" type="int" setter="set_map_width" getter="get_map_width" default="2">
 			Number of vertices in the width of the height map. Changing this will resize the [member map_data].
 		</member>
+		<member name="grid_scale" type="Vector2" setter="set_grid_scale" getter="get_grid_scale" default="Vector2( 1, 1 )">
+			The vertices of the height map will be scaled by this scale.
+		</member>
 	</members>
 	<constants>
 	</constants>

--- a/doc/classes/HeightMapShape.xml
+++ b/doc/classes/HeightMapShape.xml
@@ -9,6 +9,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_grid_point">
+			<argument index="0" name="x" type="int" />
+			<argument index="1" name="y" type="int" />
+			<return type="Vector3" />
+			<description>
+				Returns the vertice position in the heightmap, with [code]x[/code] being the x index in the map data and [code]y[/code] being the y index in the map data. The returned [code]y[/code] axis of the vector is the height in the map data, and both [code]x[/code] and [code]z[/code] axes are scaled by [member grid_scale]
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="map_data" type="PoolRealArray" setter="set_map_data" getter="get_map_data" default="PoolRealArray( 0, 0, 0, 0 )">

--- a/doc/classes/HeightMapShape.xml
+++ b/doc/classes/HeightMapShape.xml
@@ -9,16 +9,19 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_grid_point">
+		<method name="get_grid_point" qualifiers="const">
+			<return type="Vector3" />
 			<argument index="0" name="x" type="int" />
 			<argument index="1" name="y" type="int" />
-			<return type="Vector3" />
 			<description>
 				Returns the vertice position in the heightmap, with [code]x[/code] being the x index in the map data and [code]y[/code] being the y index in the map data. The returned [code]y[/code] axis of the vector is the height in the map data, and both [code]x[/code] and [code]z[/code] axes are scaled by [member grid_scale]
 			</description>
 		</method>
 	</methods>
 	<members>
+		<member name="grid_scale" type="Vector2" setter="set_grid_scale" getter="get_grid_scale" default="Vector2( 1, 1 )">
+			The vertices of the height map will be scaled by this scale.
+		</member>
 		<member name="map_data" type="PoolRealArray" setter="set_map_data" getter="get_map_data" default="PoolRealArray( 0, 0, 0, 0 )">
 			Height map data, pool array must be of [member map_width] * [member map_depth] size.
 		</member>
@@ -27,9 +30,6 @@
 		</member>
 		<member name="map_width" type="int" setter="set_map_width" getter="get_map_width" default="2">
 			Number of vertices in the width of the height map. Changing this will resize the [member map_data].
-		</member>
-		<member name="grid_scale" type="Vector2" setter="set_grid_scale" getter="get_grid_scale" default="Vector2( 1, 1 )">
-			The vertices of the height map will be scaled by this scale.
 		</member>
 	</members>
 	<constants>

--- a/modules/bullet/shape_bullet.h
+++ b/modules/bullet/shape_bullet.h
@@ -215,6 +215,7 @@ public:
 	PoolVector<real_t> heights;
 	int width;
 	int depth;
+	Vector2 grid_scale;
 	real_t min_height;
 	real_t max_height;
 
@@ -226,7 +227,7 @@ public:
 	virtual btCollisionShape *create_bt_shape(const btVector3 &p_implicit_scale, real_t p_extra_edge = 0);
 
 private:
-	void setup(PoolVector<real_t> &p_heights, int p_width, int p_depth, real_t p_min_height, real_t p_max_height);
+	void setup(PoolVector<real_t> &p_heights, int p_width, int p_depth, real_t p_min_height, real_t p_max_height, Vector2 p_grid_scale);
 };
 
 class RayShapeBullet : public ShapeBullet {

--- a/scene/resources/height_map_shape.cpp
+++ b/scene/resources/height_map_shape.cpp
@@ -201,6 +201,10 @@ Vector2 HeightMapShape::get_grid_scale() const {
 }
 
 Vector3 HeightMapShape::get_grid_point(int p_ix, int p_iy) const {
+	// Assert invalid point indexes
+	ERR_FAIL_COND_V(p_ix < 0 || p_ix >= map_width, Vector3());
+	ERR_FAIL_COND_V(p_iy < 0 || p_iy >= map_depth, Vector3());
+
 	PoolRealArray::Read r = map_data.read();
 
 	return Vector3(

--- a/scene/resources/height_map_shape.cpp
+++ b/scene/resources/height_map_shape.cpp
@@ -82,7 +82,7 @@ Vector<Vector3> HeightMapShape::get_debug_mesh_lines() {
 }
 
 real_t HeightMapShape::get_enclosing_radius() const {
-	return Vector3(real_t(map_width), max_height - min_height, real_t(map_depth)).length();
+	return Vector3(real_t(map_width) * grid_scale.x, max_height - min_height, real_t(map_depth) * grid_scale.y).length();
 }
 
 void HeightMapShape::_update_shape() {
@@ -92,6 +92,7 @@ void HeightMapShape::_update_shape() {
 	d["heights"] = map_data;
 	d["min_height"] = min_height;
 	d["max_height"] = max_height;
+	d["grid_scale"] = grid_scale;
 	PhysicsServer::get_singleton()->shape_set_data(get_shape(), d);
 	Shape::_update_shape();
 }
@@ -184,6 +185,19 @@ PoolRealArray HeightMapShape::get_map_data() const {
 	return map_data;
 }
 
+void HeightMapShape::set_grid_scale(Vector2 p_new) {
+	if (grid_scale != p_new) {
+		grid_scale = p_new;
+
+		_update_shape();
+		notify_change_to_owners();
+		_change_notify("grid_scale");
+	}
+}
+
+Vector2 HeightMapShape::get_grid_scale() const {
+	return grid_scale;
+}
 void HeightMapShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_map_width", "width"), &HeightMapShape::set_map_width);
 	ClassDB::bind_method(D_METHOD("get_map_width"), &HeightMapShape::get_map_width);
@@ -191,10 +205,13 @@ void HeightMapShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_map_depth"), &HeightMapShape::get_map_depth);
 	ClassDB::bind_method(D_METHOD("set_map_data", "data"), &HeightMapShape::set_map_data);
 	ClassDB::bind_method(D_METHOD("get_map_data"), &HeightMapShape::get_map_data);
+	ClassDB::bind_method(D_METHOD("set_grid_scale", "grid_scale"), &HeightMapShape::set_grid_scale);
+	ClassDB::bind_method(D_METHOD("get_grid_scale"), &HeightMapShape::get_grid_scale);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "map_width", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), "set_map_width", "get_map_width");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "map_depth", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), "set_map_depth", "get_map_depth");
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_REAL_ARRAY, "map_data"), "set_map_data", "get_map_data");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "grid_scale"), "set_grid_scale", "get_grid_scale");
 }
 
 HeightMapShape::HeightMapShape() :

--- a/scene/resources/height_map_shape.cpp
+++ b/scene/resources/height_map_shape.cpp
@@ -208,9 +208,9 @@ Vector3 HeightMapShape::get_grid_point(int p_ix, int p_iy) const {
 	PoolRealArray::Read r = map_data.read();
 
 	return Vector3(
-		(p_ix - (map_width - 1) * 0.5) * grid_scale.x,
-		r[p_ix + p_iy * map_width],
-		(p_iy - (map_depth - 1) * 0.5) * grid_scale.y);
+			(p_ix - (map_width - 1) * 0.5) * grid_scale.x,
+			r[p_ix + p_iy * map_width],
+			(p_iy - (map_depth - 1) * 0.5) * grid_scale.y);
 }
 
 void HeightMapShape::_bind_methods() {

--- a/scene/resources/height_map_shape.cpp
+++ b/scene/resources/height_map_shape.cpp
@@ -198,6 +198,16 @@ void HeightMapShape::set_grid_scale(Vector2 p_new) {
 Vector2 HeightMapShape::get_grid_scale() const {
 	return grid_scale;
 }
+
+Vector3 HeightMapShape::get_grid_point(int p_ix, int p_iy) const {
+	PoolRealArray::Read r = map_data.read();
+
+	return Vector3(
+		(p_ix - (map_width - 1) * 0.5) * grid_scale.x,
+		r[p_ix + p_iy * map_width],
+		(p_iy - (map_depth - 1) * 0.5) * grid_scale.y);
+}
+
 void HeightMapShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_map_width", "width"), &HeightMapShape::set_map_width);
 	ClassDB::bind_method(D_METHOD("get_map_width"), &HeightMapShape::get_map_width);
@@ -207,6 +217,7 @@ void HeightMapShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_map_data"), &HeightMapShape::get_map_data);
 	ClassDB::bind_method(D_METHOD("set_grid_scale", "grid_scale"), &HeightMapShape::set_grid_scale);
 	ClassDB::bind_method(D_METHOD("get_grid_scale"), &HeightMapShape::get_grid_scale);
+	ClassDB::bind_method(D_METHOD("get_grid_point", "x", "y"), &HeightMapShape::get_grid_point);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "map_width", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), "set_map_width", "get_map_width");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "map_depth", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), "set_map_depth", "get_map_depth");

--- a/scene/resources/height_map_shape.cpp
+++ b/scene/resources/height_map_shape.cpp
@@ -224,6 +224,7 @@ HeightMapShape::HeightMapShape() :
 	w[1] = 0.0;
 	w[2] = 0.0;
 	w[3] = 0.0;
+	grid_scale = Vector2(1.0, 1.0);
 	min_height = 0.0;
 	max_height = 0.0;
 

--- a/scene/resources/height_map_shape.cpp
+++ b/scene/resources/height_map_shape.cpp
@@ -34,6 +34,7 @@
 
 Vector<Vector3> HeightMapShape::get_debug_mesh_lines() {
 	Vector<Vector3> points;
+	Vector3 s(grid_scale.x, 1.0, grid_scale.y);
 
 	if ((map_width != 0) && (map_depth != 0)) {
 		// This will be slow for large maps...
@@ -57,18 +58,18 @@ Vector<Vector3> HeightMapShape::get_debug_mesh_lines() {
 				height.y = r[r_offset++];
 
 				if (w != map_width - 1) {
-					points.write[w_offset++] = height;
-					points.write[w_offset++] = Vector3(height.x + 1.0, r[r_offset], height.z);
+					points.write[w_offset++] = height * s;
+					points.write[w_offset++] = Vector3(height.x + 1.0, r[r_offset], height.z) * s;
 				}
 
 				if (d != map_depth - 1) {
-					points.write[w_offset++] = height;
-					points.write[w_offset++] = Vector3(height.x, r[r_offset + map_width - 1], height.z + 1.0);
+					points.write[w_offset++] = height * s;
+					points.write[w_offset++] = Vector3(height.x, r[r_offset + map_width - 1], height.z + 1.0) * s;
 				}
 
 				if ((w != map_width - 1) && (d != map_depth - 1)) {
-					points.write[w_offset++] = Vector3(height.x + 1.0, r[r_offset], height.z);
-					points.write[w_offset++] = Vector3(height.x, r[r_offset + map_width - 1], height.z + 1.0);
+					points.write[w_offset++] = Vector3(height.x + 1.0, r[r_offset], height.z) * s;
+					points.write[w_offset++] = Vector3(height.x, r[r_offset + map_width - 1], height.z + 1.0) * s;
 				}
 
 				height.x += 1.0;

--- a/scene/resources/height_map_shape.h
+++ b/scene/resources/height_map_shape.h
@@ -57,6 +57,8 @@ public:
 	void set_grid_scale(Vector2 p_new);
 	Vector2 get_grid_scale() const;
 
+	Vector3 get_grid_point(int p_ix, int p_iy) const;
+
 	virtual Vector<Vector3> get_debug_mesh_lines();
 	virtual real_t get_enclosing_radius() const;
 

--- a/scene/resources/height_map_shape.h
+++ b/scene/resources/height_map_shape.h
@@ -39,6 +39,7 @@ class HeightMapShape : public Shape {
 	int map_width;
 	int map_depth;
 	PoolRealArray map_data;
+	Vector2 grid_scale;
 	float min_height;
 	float max_height;
 
@@ -53,6 +54,8 @@ public:
 	int get_map_depth() const;
 	void set_map_data(PoolRealArray p_new);
 	PoolRealArray get_map_data() const;
+	void set_grid_scale(Vector2 p_new);
+	Vector2 get_grid_scale() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines();
 	virtual real_t get_enclosing_radius() const;


### PR DESCRIPTION
This PR adds two features for the `HeightMapShape`:
- A property called `grid_scale` which scales the shape's vertices in both X and Z axes, using X and Y axes of the property respectively;
- A method called `get_grid_point` to get the point in the HeightMap using X and Y indexes, the indexes are used to get the height from the `map_data` and properly return X and Z axes using the `grid_scale`.

I was only able to implement in the Bullet physics server, that's why I'm targeting `3.x` branch (it seens bullet isn't implemented in the master branch yet). So the property is ignored when `physics/3d/physics_engine` is set to `GodotPhysics`.
So I'll try to implement this feature into Godot Physics in another PR, targetting `master` branch, then try to backport to `3.x`.