### PR TITLE
Fix Camera 2D position not updating correctly

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -439,7 +439,7 @@ void Camera2D::clear_current() {
 void Camera2D::set_limit(Side p_side, int p_limit) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	limit[p_side] = p_limit;
-	update();
+	_update_scroll();
 }
 
 int Camera2D::get_limit(Side p_side) const {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -90,8 +90,8 @@ private:
 	Window *root = nullptr;
 
 	uint64_t tree_version = 1;
-	double physics_process_time = 1.0;
-	double process_time = 1.0;
+	double physics_process_time = 0.0;
+	double process_time = 0.0;
 	bool accept_quit = true;
 	bool quit_on_go_back = true;
 

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -3139,7 +3139,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	v_scroll = text_edit->get_v_scroll();
 	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_DOWN, MouseButton::WHEEL_DOWN, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
-	CHECK(text_edit->get_v_scroll() > v_scroll);
+	CHECK(text_edit->get_v_scroll() >= v_scroll);
 	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_UP, MouseButton::WHEEL_UP, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() == v_scroll);
@@ -3148,7 +3148,7 @@ TEST_CASE("[SceneTree][TextEdit] viewport") {
 	text_edit->set_v_scroll_speed(10000);
 	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_DOWN, MouseButton::WHEEL_DOWN, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
-	CHECK(text_edit->get_v_scroll() > v_scroll);
+	CHECK(text_edit->get_v_scroll() >= v_scroll);
 	SEND_GUI_MOUSE_BUTTON_EVENT(text_edit, Point2i(10, 10), MouseButton::WHEEL_UP, MouseButton::WHEEL_UP, Key::NONE);
 	text_edit->notification(TextEdit::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	CHECK(text_edit->get_v_scroll() == v_scroll);


### PR DESCRIPTION
Currently, `SceneTree`'s initial `physics_process_time` and `process_time` are set to `1` second. So early calls to `get_process_delta_time()` or `get_physics_process_delta_time()` return unreasonably large values, which causes incorrect calculations. Most notably in `Camera2D`'s initial position when smoothing is enabled:
https://github.com/godotengine/godot/blob/5a6b13b8bb128a0e10cccab8f212b1ed15cea425/scene/2d/camera_2d.cpp#L158-L161

In addition, when a `Camera2D`'s limits are updated, the camera's position is not updated. This is requiring users to unnecessarily, manually call the hidden `_update_scroll()` method.

This PR fixes both these issues by setting `SceneTree`'s initial process times to `0` and calling `_update_scroll()` when setting limits. It also fixes `scene_tree.h`'s clang formatting, required to make changes to `scene_tree.h` and a `TestEdit` test that depends on `SceneTree`'s initial process times being arbitrarily greater than `0`.

Fixes #56336
Fixes #56913
