### PR TITLE
SCons: Default `num_jobs` to max CPUs minus 1 if not specified

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -35,5 +35,5 @@ runs:
       run: |
         echo "Building with flags:" ${{ env.SCONSFLAGS }}
         if ! ${{ inputs.tools }}; then rm -rf editor; fi  # Ensure we don't include editor code.
-        scons p=${{ inputs.platform }} target=${{ inputs.target }} tools=${{ inputs.tools }} tests=${{ inputs.tests }} --jobs=2 ${{ env.SCONSFLAGS }}
+        scons p=${{ inputs.platform }} target=${{ inputs.target }} tools=${{ inputs.tools }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
         ls -l bin/

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -212,7 +212,7 @@ jobs:
         if: ${{ matrix.godot-cpp-test }}
         run: |
           cd godot-cpp/test
-          scons target=${{ matrix.target }} -j2
+          scons target=${{ matrix.target }}
           cd ../..
 
       - name: Prepare artifact


### PR DESCRIPTION
This doesn't change the behavior when `--jobs`/`-j` is specified as a
command-line argument or in `SCONSFLAGS`.

The SCons hack used to know if `num_jobs` was set by the user is derived
from the MongoDB setup.

~We use `os.sched_getaffinity` to respect potential limits set by the user
or system administrator.~

We use `os.cpu_count()` for portability (available since Python 3.4).

With 4 CPUs or less, we use the max. With more than 4 we use max - 1 to
preserve some bandwidth for the user's other programs.

*Edit:* godot-cpp equivalent: https://github.com/godotengine/godot-cpp/pull/788

---

Redo of #9972, 5 years later I've warmed up to the idea (CC @capnm).

It's up for discussion though. I think some modern buildsystems are now doing this automatically so users are used to it just using all the available capacity. Notably I saw [this recent example](https://twitter.com/ShawnWhite/status/1547249149845950470) of someone mistakenly building with one core. It's still possible to specify `-j1` when you want to compile sequentially (useful to check a build error without the noise of other jobs).

This change would enable us to simplify the compiling documentation (e.g. [here](https://docs.godotengine.org/en/latest/development/compiling/compiling_for_macos.html#compiling)) a bit so we don't have to drag along system-specific instructions to get the number of CPU cores. And I noticed that GitHub CI runners for macOS actually have 3-core CPUs so removing our `--jobs=2` should speed up CI significantly: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

*Edit:* CI build logs on this PR confirm 3 CPUs for macOS and 2 CPUs for Windows/Linux runners.