### PR TITLE
Rename directory for export templates from `templates` to `export_templates`

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -491,7 +491,7 @@ Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
 
 String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
 	String current_version = VERSION_FULL_CONFIG;
-	String template_path = EditorSettings::get_singleton()->get_templates_dir().plus_file(current_version).plus_file(template_file_name);
+	String template_path = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(current_version).plus_file(template_file_name);
 
 	if (FileAccess::exists(template_path)) {
 		return template_path;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1105,8 +1105,8 @@ void EditorSettings::add_property_hint(const PropertyInfo &p_hint) {
 // Editor data and config directories
 // EditorPaths::create() is responsible for the creation of these directories.
 
-String EditorSettings::get_templates_dir() const {
-	return EditorPaths::get_singleton()->get_data_dir().plus_file("templates");
+String EditorSettings::get_export_templates_dir() const {
+	return EditorPaths::get_singleton()->get_data_dir().plus_file("export_templates");
 }
 
 String EditorSettings::get_project_settings_dir() const {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -151,7 +151,7 @@ public:
 	Ref<Resource> get_resource_clipboard() const { return clipboard; }
 
 	String get_data_dir() const;
-	String get_templates_dir() const;
+	String get_export_templates_dir() const;
 	String get_project_settings_dir() const;
 	String get_text_editor_themes_dir() const;
 	String get_script_templates_dir() const;

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -46,7 +46,7 @@
 void ExportTemplateManager::_update_template_status() {
 	// Fetch installed templates from the file system.
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	const String &templates_dir = EditorSettings::get_singleton()->get_templates_dir();
+	const String &templates_dir = EditorSettings::get_singleton()->get_export_templates_dir();
 
 	Error err = da->change_dir(templates_dir);
 	ERR_FAIL_COND_MSG(err != OK, "Could not access templates directory at '" + templates_dir + "'.");
@@ -439,7 +439,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 	}
 
 	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	String template_path = EditorSettings::get_singleton()->get_templates_dir().plus_file(version);
+	String template_path = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(version);
 	Error err = d->make_dir_recursive(template_path);
 	if (err != OK) {
 		EditorNode::get_singleton()->show_warning(TTR("Error creating path for extracting templates:") + "\n" + template_path);
@@ -538,7 +538,7 @@ void ExportTemplateManager::_uninstall_template(const String &p_version) {
 
 void ExportTemplateManager::_uninstall_template_confirmed() {
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	const String &templates_dir = EditorSettings::get_singleton()->get_templates_dir();
+	const String &templates_dir = EditorSettings::get_singleton()->get_export_templates_dir();
 
 	Error err = da->change_dir(templates_dir);
 	ERR_FAIL_COND_MSG(err != OK, "Could not access templates directory at '" + templates_dir + "'.");
@@ -616,7 +616,7 @@ void ExportTemplateManager::_installed_table_button_cbk(Object *p_item, int p_co
 }
 
 void ExportTemplateManager::_open_template_folder(const String &p_version) {
-	const String &templates_dir = EditorSettings::get_singleton()->get_templates_dir();
+	const String &templates_dir = EditorSettings::get_singleton()->get_export_templates_dir();
 	OS::get_singleton()->shell_open("file://" + templates_dir.plus_file(p_version));
 }
 
@@ -640,12 +640,12 @@ void ExportTemplateManager::_hide_dialog() {
 }
 
 bool ExportTemplateManager::can_install_android_template() {
-	const String templates_dir = EditorSettings::get_singleton()->get_templates_dir().plus_file(VERSION_FULL_CONFIG);
+	const String templates_dir = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
 	return FileAccess::exists(templates_dir.plus_file("android_source.zip"));
 }
 
 Error ExportTemplateManager::install_android_template() {
-	const String &templates_path = EditorSettings::get_singleton()->get_templates_dir().plus_file(VERSION_FULL_CONFIG);
+	const String &templates_path = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
 	const String &source_zip = templates_path.plus_file("android_source.zip");
 	ERR_FAIL_COND_V(!FileAccess::exists(source_zip), ERR_CANT_OPEN);
 	return install_android_template_from_file(source_zip);

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -339,7 +339,7 @@ MONO_AOT_MODE_LAST = 1000,
             string MonoLibFile(string libFileName) => libFileName + ".ios.fat.a";
 
             string MonoLibFromTemplate(string libFileName) =>
-                Path.Combine(Internal.FullTemplatesDir, "ios-mono-libs", MonoLibFile(libFileName));
+                Path.Combine(Internal.FullExportTemplatesDir, "ios-mono-libs", MonoLibFile(libFileName));
 
             exporter.AddIosProjectStaticLib(MonoLibFromTemplate("libmonosgen-2.0"));
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -337,7 +337,7 @@ namespace GodotTools.Export
 
             string TemplateDirName() => $"data.mono.{platform}.{bits}.{target}";
 
-            string templateDirPath = Path.Combine(Internal.FullTemplatesDir, TemplateDirName());
+            string templateDirPath = Path.Combine(Internal.FullExportTemplatesDir, TemplateDirName());
             bool validTemplatePathFound = true;
 
             if (!Directory.Exists(templateDirPath))
@@ -347,7 +347,7 @@ namespace GodotTools.Export
                 if (isDebug)
                 {
                     target = "debug"; // Support both 'release_debug' and 'debug' for the template data directory name
-                    templateDirPath = Path.Combine(Internal.FullTemplatesDir, TemplateDirName());
+                    templateDirPath = Path.Combine(Internal.FullExportTemplatesDir, TemplateDirName());
                     validTemplatePathFound = true;
 
                     if (!Directory.Exists(templateDirPath))
@@ -398,13 +398,13 @@ namespace GodotTools.Export
 
         private static string GetBclProfileDir(string profile)
         {
-            string templatesDir = Internal.FullTemplatesDir;
+            string templatesDir = Internal.FullExportTemplatesDir;
             return Path.Combine(templatesDir, "bcl", profile);
         }
 
         private static string DeterminePlatformBclDir(string platform)
         {
-            string templatesDir = Internal.FullTemplatesDir;
+            string templatesDir = Internal.FullExportTemplatesDir;
             string platformBclDir = Path.Combine(templatesDir, "bcl", platform);
 
             if (!File.Exists(Path.Combine(platformBclDir, "mscorlib.dll")))

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
@@ -12,8 +12,8 @@ namespace GodotTools.Internals
         public static string UpdateApiAssembliesFromPrebuilt(string config) =>
             internal_UpdateApiAssembliesFromPrebuilt(config);
 
-        public static string FullTemplatesDir =>
-            internal_FullTemplatesDir();
+        public static string FullExportTemplatesDir =>
+            internal_FullExportTemplatesDir();
 
         public static string SimplifyGodotPath(this string path) => internal_SimplifyGodotPath(path);
 
@@ -57,7 +57,7 @@ namespace GodotTools.Internals
         private static extern string internal_UpdateApiAssembliesFromPrebuilt(string config);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern string internal_FullTemplatesDir();
+        private static extern string internal_FullExportTemplatesDir();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_SimplifyGodotPath(this string path);

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -188,8 +188,8 @@ MonoString *godot_icall_Internal_UpdateApiAssembliesFromPrebuilt(MonoString *p_c
 	return GDMonoMarshal::mono_string_from_godot(error_str);
 }
 
-MonoString *godot_icall_Internal_FullTemplatesDir() {
-	String full_templates_dir = EditorSettings::get_singleton()->get_templates_dir().plus_file(VERSION_FULL_CONFIG);
+MonoString *godot_icall_Internal_FullExportTemplatesDir() {
+	String full_templates_dir = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
 	return GDMonoMarshal::mono_string_from_godot(full_templates_dir);
 }
 
@@ -364,7 +364,7 @@ void register_editor_internal_calls() {
 
 	// Internals
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Internal::internal_UpdateApiAssembliesFromPrebuilt", godot_icall_Internal_UpdateApiAssembliesFromPrebuilt);
-	GDMonoUtils::add_internal_call("GodotTools.Internals.Internal::internal_FullTemplatesDir", godot_icall_Internal_FullTemplatesDir);
+	GDMonoUtils::add_internal_call("GodotTools.Internals.Internal::internal_FullExportTemplatesDir", godot_icall_Internal_FullExportTemplatesDir);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Internal::internal_SimplifyGodotPath", godot_icall_Internal_SimplifyGodotPath);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Internal::internal_IsMacOSAppBundleInstalled", godot_icall_Internal_IsMacOSAppBundleInstalled);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.Internal::internal_GodotIs32Bits", godot_icall_Internal_GodotIs32Bits);


### PR DESCRIPTION
The editor's data directory also contains `script_templates`, so I think we should make the export templates folder less ambiguous by naming this folder `export_templates` instead of just `templates`.