### PR TITLE
Update export template names for Windows, Mac, and Linux

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1884,8 +1884,8 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 	// Look for export templates (first official, and if defined custom templates).
 
 	bool use64 = p_preset->get("binary_format/64_bits");
-	bool dvalid = exists_export_template(get_template_file_name("debug", use64 ? "64" : "32"), &err);
-	bool rvalid = exists_export_template(get_template_file_name("release", use64 ? "64" : "32"), &err);
+	bool dvalid = exists_export_template(get_template_file_name("debug", use64 ? "x86_64" : "x86_32"), &err);
+	bool rvalid = exists_export_template(get_template_file_name("release", use64 ? "x86_64" : "x86_32"), &err);
 
 	if (p_preset->get("custom_template/debug") != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -84,7 +84,7 @@ void EditorExportPlatformLinuxBSD::set_extension(const String &p_extension, cons
 }
 
 String EditorExportPlatformLinuxBSD::get_template_file_name(const String &p_target, const String &p_arch) const {
-	return "linux_x11_" + p_arch + "_" + p_target;
+	return "linux_" + p_target + "." + p_arch;
 }
 
 List<String> EditorExportPlatformLinuxBSD::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -766,7 +766,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 	int ret = unzGoToFirstFile(src_pkg_zip);
 
-	String binary_to_use = "godot_macos_" + String(p_debug ? "debug" : "release") + ".64";
+	String binary_to_use = "godot_macos_" + String(p_debug ? "debug" : "release") + ".universal";
 
 	String pkg_name;
 	if (String(ProjectSettings::get_singleton()->get("application/config/name")) != "") {
@@ -1064,19 +1064,19 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		if (data.size() > 0) {
-			if (file.find("/data.mono.macos.64.release_debug/") != -1) {
+			if (file.find("/data.mono.macos.release_debug.universal/") != -1) {
 				if (!p_debug) {
 					ret = unzGoToNextFile(src_pkg_zip);
 					continue; // skip
 				}
-				file = file.replace("/data.mono.macos.64.release_debug/", "/GodotSharp/");
+				file = file.replace("/data.mono.macos.release_debug.universal/", "/GodotSharp/");
 			}
-			if (file.find("/data.mono.macos.64.release/") != -1) {
+			if (file.find("/data.mono.macos.release.universal/") != -1) {
 				if (p_debug) {
 					ret = unzGoToNextFile(src_pkg_zip);
 					continue; // skip
 				}
-				file = file.replace("/data.mono.macos.64.release/", "/GodotSharp/");
+				file = file.replace("/data.mono.macos.release.universal/", "/GodotSharp/");
 			}
 
 			if (file.ends_with(".dylib")) {

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -104,7 +104,7 @@ Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> 
 }
 
 String EditorExportPlatformWindows::get_template_file_name(const String &p_target, const String &p_arch) const {
-	return "windows_" + p_arch + "_" + p_target + ".exe";
+	return "windows_" + p_target + "_" + p_arch + ".exe";
 }
 
 List<String> EditorExportPlatformWindows::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {


### PR DESCRIPTION
Should be merged alongside https://github.com/godotengine/godot-build-scripts/pull/57

Name changes:
```
linux_x11_64_release   -> linux_release.x86_64
linux_x11_64_debug     -> linux_debug.x86_64
linux_x11_32_release   -> linux_release.x86_32
linux_x11_32_debug     -> linux_debug.x86_32
windows_64_release.exe -> windows_release_x86_64.exe
windows_64_debug.exe   -> windows_debug_x86_64.exe
windows_32_release.exe -> windows_release_x86_32.exe
windows_32_debug.exe   -> windows_debug_x86_32.exe
godot_macos_release.64 -> godot_macos_release.universal
godot_macos_debug.64   -> godot_macos_debug.universal
```

For Linux, remove `_x11`, and put the architecture at the end with a dot so it matches the pattern used for exported games. For Windows, originally I was going to have the names end in `.x86_64.exe` etc instead of `_x86_64.exe`, but it was discussed that double extensions are not desired.