### PR TITLE
Fix missing method qualifiers in script doc

### DIFF
--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -115,6 +115,31 @@ void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const Met
 	p_method.name = p_methodinfo.name;
 	p_method.description = p_desc;
 
+	if (p_methodinfo.flags & METHOD_FLAG_VIRTUAL) {
+		p_method.qualifiers = "virtual";
+	}
+
+	if (p_methodinfo.flags & METHOD_FLAG_CONST) {
+		if (!p_method.qualifiers.is_empty()) {
+			p_method.qualifiers += " ";
+		}
+		p_method.qualifiers += "const";
+	}
+
+	if (p_methodinfo.flags & METHOD_FLAG_VARARG) {
+		if (!p_method.qualifiers.is_empty()) {
+			p_method.qualifiers += " ";
+		}
+		p_method.qualifiers += "vararg";
+	}
+
+	if (p_methodinfo.flags & METHOD_FLAG_STATIC) {
+		if (!p_method.qualifiers.is_empty()) {
+			p_method.qualifiers += " ";
+		}
+		p_method.qualifiers += "static";
+	}
+
 	return_doc_from_retinfo(p_method, p_methodinfo.return_val);
 
 	for (int i = 0; i < p_methodinfo.arguments.size(); i++) {
@@ -123,7 +148,7 @@ void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const Met
 		int default_arg_index = i - (p_methodinfo.arguments.size() - p_methodinfo.default_arguments.size());
 		if (default_arg_index >= 0) {
 			Variant default_arg = p_methodinfo.default_arguments[default_arg_index];
-			argument.default_value = default_arg.get_construct_string();
+			argument.default_value = default_arg.get_construct_string().replace("\n", "");
 		}
 		p_method.arguments.push_back(argument);
 	}

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -498,53 +498,7 @@ void DocTools::generate(bool p_basic_types) {
 			}
 
 			DocData::MethodDoc method;
-
-			method.name = E.name;
-
-			if (E.flags & METHOD_FLAG_VIRTUAL) {
-				method.qualifiers = "virtual";
-			}
-
-			if (E.flags & METHOD_FLAG_CONST) {
-				if (!method.qualifiers.is_empty()) {
-					method.qualifiers += " ";
-				}
-				method.qualifiers += "const";
-			}
-
-			if (E.flags & METHOD_FLAG_VARARG) {
-				if (!method.qualifiers.is_empty()) {
-					method.qualifiers += " ";
-				}
-				method.qualifiers += "vararg";
-			}
-
-			if (E.flags & METHOD_FLAG_STATIC) {
-				if (!method.qualifiers.is_empty()) {
-					method.qualifiers += " ";
-				}
-				method.qualifiers += "static";
-			}
-
-			for (int i = -1; i < E.arguments.size(); i++) {
-				if (i == -1) {
-#ifdef DEBUG_METHODS_ENABLED
-					DocData::return_doc_from_retinfo(method, E.return_val);
-#endif
-				} else {
-					const PropertyInfo &arginfo = E.arguments[i];
-					DocData::ArgumentDoc argument;
-					DocData::argument_doc_from_arginfo(argument, arginfo);
-
-					int darg_idx = i - (E.arguments.size() - E.default_arguments.size());
-					if (darg_idx >= 0) {
-						Variant default_arg = E.default_arguments[darg_idx];
-						argument.default_value = default_arg.get_construct_string().replace("\n", " ");
-					}
-
-					method.arguments.push_back(argument);
-				}
-			}
+			DocData::method_doc_from_methodinfo(method, E, "");
 
 			Vector<Error> errs = ClassDB::get_method_error_return_values(name, E.name);
 			if (errs.size()) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -278,6 +278,11 @@ void GDScript::_get_script_method_list(List<MethodInfo> *r_list, bool p_include_
 			GDScriptFunction *func = E.value;
 			MethodInfo mi;
 			mi.name = E.key;
+
+			if (func->is_static()) {
+				mi.flags |= METHOD_FLAG_STATIC;
+			}
+
 			for (int i = 0; i < func->get_argument_count(); i++) {
 				PropertyInfo arginfo = func->get_argument_type(i);
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fix #63097