### PR TITLE
GDNative: fix StringName equal and less operators

### DIFF
--- a/modules/gdnative/gdnative/string_name.cpp
+++ b/modules/gdnative/gdnative/string_name.cpp
@@ -72,13 +72,13 @@ const void GDAPI *godot_string_name_get_data_unique_pointer(const godot_string_n
 godot_bool GDAPI godot_string_name_operator_equal(const godot_string_name *p_self, const godot_string_name *p_other) {
 	const StringName *self = (const StringName *)p_self;
 	const StringName *other = (const StringName *)p_other;
-	return self == other;
+	return *self == *other;
 }
 
 godot_bool GDAPI godot_string_name_operator_less(const godot_string_name *p_self, const godot_string_name *p_other) {
 	const StringName *self = (const StringName *)p_self;
 	const StringName *other = (const StringName *)p_other;
-	return self < other;
+	return *self < *other;
 }
 
 void GDAPI godot_string_name_destroy(godot_string_name *p_self) {


### PR DESCRIPTION
The `new` function accepts a pointer, where it constructs a `StringName` in-place:
```cpp
void GDAPI godot_string_name_new(godot_string_name *r_dest, const godot_string *p_name) {
	StringName *dest = (StringName *)r_dest;
	const String *name = (const String *)p_name;
	memnew_placement(dest, StringName(*name));
}
```
This means that it's possible to have _different pointers_ to the same `StringName`.

However, the `equal` and `less` methods only compare that pointer:
```cpp
godot_bool GDAPI godot_string_name_operator_equal(const godot_string_name *p_self, const godot_string_name *p_other) {
	const StringName *self = (const StringName *)p_self;
	const StringName *other = (const StringName *)p_other;
	return self == other;
}

godot_bool GDAPI godot_string_name_operator_less(const godot_string_name *p_self, const godot_string_name *p_other) {
	const StringName *self = (const StringName *)p_self;
	const StringName *other = (const StringName *)p_other;
	return self < other;
}
```

And to do that, they wouldn't need to first cast to `StringName*`. It looks like forgotten dereferencing.