### PR TITLE
Fix `InputEventAction`'s `is_match` method ignoring `exact_match` parameter

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1309,7 +1309,7 @@ bool InputEventAction::is_match(const Ref<InputEvent> &p_event, bool p_exact_mat
 		return false;
 	}
 
-	return p_event->is_action(action);
+	return p_event->is_action(action, p_exact_match);
 }
 
 bool InputEventAction::is_action(const StringName &p_action) const {


### PR DESCRIPTION
Fixes #63108.

I tested it on the linked issue's minimal reproduction project and it seems to be working. I haven't tested it for 3.x, but if this PR gets accepted, I will open a new one for 3.x. I am slightly worried about this change because `InputEventAction`'s `is_action` doesn't take an `exact_match` parameter at all, but I didn't encounter any issues while testing this.