### PR TITLE
Change code folding behavior to include terminal indented comments

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6341,7 +6341,8 @@ void TextEdit::fold_line(int p_line) {
 	int last_line = start_indent;
 	for (int i = p_line + 1; i < text.size(); i++) {
 		if (text[i].strip_edges().size() != 0) {
-			if (is_line_comment(i)) {
+			if (is_line_comment(i) && get_indent_level(i) <= start_indent) {
+				// Checked indent to make sure indented comments that finish a code block are folded.
 				continue;
 			} else if (get_indent_level(i) > start_indent) {
 				last_line = i;


### PR DESCRIPTION
Fixes #62944

Previously, when folding a block of code that finished with an indented comment (i.e. one indented as much as or more than the starting indent of the code), that comment would be left out of the fold. Change the behavior to include such comments, but still leave less-indented ones out.

![image](https://user-images.githubusercontent.com/61291296/179415879-85f8d763-98ea-4a5c-90f9-98f9538571d2.png)