### PR TITLE
[GDNative] Expose `Dictionary::merge()` over to GDNative CORE API v1.3

### DIFF
--- a/modules/gdnative/gdnative/dictionary.cpp
+++ b/modules/gdnative/gdnative/dictionary.cpp
@@ -186,6 +186,14 @@ godot_variant GDAPI godot_dictionary_get_with_default(const godot_dictionary *p_
 	return raw_dest;
 }
 
+// GDNative core 1.3
+
+void GDAPI godot_dictionary_merge(godot_dictionary *p_self, const godot_dictionary *p_dictionary, const godot_bool p_overwrite) {
+	Dictionary *self = (Dictionary *)p_self;
+	const Dictionary *dictionary = (const Dictionary *)p_dictionary;
+	self->merge(*dictionary, p_overwrite);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -26,6 +26,15 @@
           "next": null,
           "api": [
             {
+              "name": "godot_dictionary_merge",
+              "return_type": "void",
+              "arguments": [
+                ["godot_dictionary *", "p_self"],
+                ["const godot_dictionary *", "p_dictionary"],
+                ["const godot_bool", "p_overwrite"]
+              ]
+            },
+            {
               "name": "godot_pool_byte_array_has",
               "return_type": "godot_bool",
               "arguments": [

--- a/modules/gdnative/include/gdnative/dictionary.h
+++ b/modules/gdnative/include/gdnative/dictionary.h
@@ -102,6 +102,10 @@ godot_bool GDAPI godot_dictionary_erase_with_return(godot_dictionary *p_self, co
 
 godot_variant GDAPI godot_dictionary_get_with_default(const godot_dictionary *p_self, const godot_variant *p_key, const godot_variant *p_default);
 
+// GDNative core 1.3
+
+void GDAPI godot_dictionary_merge(godot_dictionary *p_self, const godot_dictionary *p_dictionary, const godot_bool p_overwrite);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Expose method `merge` of the class `Dictionary` to GDNative.

This method was already implemented before and it was exposed to GDScript in the PR #59883

In this PR it's just exposed over to GDNative Core API v1.3.

This PR is logically related to https://github.com/godotengine/godot/pull/55826. The proposal for this specific change was discussed https://github.com/godotengine/godot/pull/55826#issuecomment-1172970879