### PR TITLE
GDScript: Fix brief/long description documentation comments

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3422,7 +3422,16 @@ void GDScriptParser::get_class_doc_comment(int p_line, String &p_brief, String &
 				p_tutorials.append(Pair<String, String>(title, link));
 				break;
 			case DONE:
-				return;
+				break;
+		}
+	}
+	if (current_class->members.size() > 0) {
+		const ClassNode::Member &m = current_class->members[0];
+		int first_member_line = m.get_line();
+		if (first_member_line == line) {
+			p_brief = "";
+			p_desc = "";
+			p_tutorials.clear();
 		}
 	}
 }


### PR DESCRIPTION
[Issue](https://github.com/godotengine/godot/issues/63032)

It doesn't look nice but fixes the issue. Not sure if there are any side-effects I missed 🤔 

_Bugsquad edit: Fix #63032_