### PR TITLE
Add padding for code blocks in the editor help

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1844,6 +1844,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			p_rt->push_table(1);
 			p_rt->push_cell();
 			p_rt->set_cell_row_background_color(Color(0.5, 0.5, 0.5, 0.15), Color(0.5, 0.5, 0.5, 0.15));
+			p_rt->set_cell_padding(Rect2(10 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE));
 			p_rt->push_color(code_color);
 			codeblock_tag = true;
 			pos = brk_end + 1;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/62710.

This improves their appearance, making them look closer to code blocks in the online manual. Thanks @bruvzg for the suggestion :slightly_smiling_face:

## Preview

### Default theme

![2022-07-17_22 54 37](https://user-images.githubusercontent.com/180032/179424447-ba4bc368-98d5-4d9d-ae92-2a5537beeba4.png)

### Light theme

![2022-07-17_22 54 20](https://user-images.githubusercontent.com/180032/179424444-f3902b0f-98af-4140-a93e-85cea85618b9.png)