### PR TITLE
Add C# resource export.

### DIFF
--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -130,6 +130,11 @@ private:
 	String source;
 	StringName name;
 
+	// For engine "Script Class" support, not affiliated with `GDMonoClass *script_class` property.
+	String script_class_name;
+	String script_class_base;
+	String script_class_icon_path;
+
 	SelfList<CSharpScript> script_list = this;
 
 	HashMap<StringName, Vector<SignalParameter>> _signals;
@@ -167,7 +172,7 @@ private:
 
 	bool _get_member_export(IMonoClassMember *p_member, bool p_inspect_export, PropertyInfo &r_prop_info, bool &r_exported);
 #ifdef TOOLS_ENABLED
-	static int _try_get_member_export_hint(IMonoClassMember *p_member, ManagedType p_type, Variant::Type p_variant_type, bool p_allow_generics, PropertyHint &r_hint, String &r_hint_string);
+	static int _try_get_member_export_hint(IMonoClassMember *p_member, ManagedType p_type, Variant::Type p_variant_type, PropertyHint p_given_hint, String p_given_hint_string, bool p_allow_generics, PropertyHint &r_hint, String &r_hint_string);
 #endif
 
 	CSharpInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_is_ref_counted, Callable::CallError &r_error);
@@ -241,6 +246,11 @@ public:
 #endif
 
 	Error load_source_code(const String &p_path);
+
+	String get_script_class_name() const { return script_class_name; }
+	String get_script_class_base() const { return script_class_base; }
+	String get_script_class_icon_path() const { return script_class_icon_path; }
+	void _update_global_script_class_settings();
 
 	CSharpScript();
 	~CSharpScript();
@@ -479,6 +489,10 @@ public:
 	virtual String _get_indentation() const;
 	/* TODO? */ void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override {}
 	/* TODO */ void add_global_constant(const StringName &p_variable, const Variant &p_value) override {}
+
+	/* SCRIPT CLASS FUNCTIONS */
+	virtual bool handles_global_class_type(const String &p_type) const;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = NULL, String *r_icon_path = NULL) const;
 
 	/* DEBUGGER FUNCTIONS */
 	String debug_get_error() const override;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
@@ -21,5 +21,16 @@ namespace Godot
             this.hint = hint;
             this.hintString = hintString;
         }
+
+        /// <summary>
+        /// Constructs a new ExportAttribute Instance. Allows properties to expose their data type as a non-C# Resource class in Godot.
+        /// </summary>
+        /// <param name="className">The name of a class by which to export the targeted property.</param>
+        public ExportAttribute(string className)
+        {
+            // Because `ScriptServer` is not exposed to the scripting API, there is no proper way of validating the passed in className.
+            this.hint = PropertyHint.ResourceType;
+            this.hintString = className;
+        }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Exposes the target class as a global script class to Godot Engine.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class GlobalAttribute : Attribute
+    {
+        private string name;
+        private string iconPath;
+
+        /// <summary>
+        /// Constructs a new GlobalAttribute Instance.
+        /// </summary>
+        /// <param name="name">The name under which to register the targeted class. Uses its typename by default.</param>
+        /// <param name="iconPath">An optional file path to a custom icon for representing this class in the Godot Editor.</param>
+        public GlobalAttribute(string name = "", string iconPath = "")
+        {
+            this.name = name ?? "";
+            this.iconPath = iconPath ?? "";
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -17,6 +17,7 @@
     <Compile Include="Core\Attributes\AssemblyHasScriptsAttribute.cs" />
     <Compile Include="Core\Attributes\DisableGodotGeneratorsAttribute.cs" />
     <Compile Include="Core\Attributes\ExportAttribute.cs" />
+    <Compile Include="Core\Attributes\GlobalAttribute.cs" />
     <Compile Include="Core\Attributes\GodotMethodAttribute.cs" />
     <Compile Include="Core\Attributes\RPCAttribute.cs" />
     <Compile Include="Core\Attributes\ScriptPathAttribute.cs" />

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -141,6 +141,9 @@ void CachedData::clear_godot_api_cache() {
 	class_ExportAttribute = nullptr;
 	field_ExportAttribute_hint = nullptr;
 	field_ExportAttribute_hintString = nullptr;
+	class_GlobalAttribute = nullptr;
+	field_GlobalAttribute_name = nullptr;
+	field_GlobalAttribute_iconPath = nullptr;
 	class_SignalAttribute = nullptr;
 	class_ToolAttribute = nullptr;
 	class_RPCAttribute = nullptr;
@@ -275,6 +278,9 @@ void update_godot_api_cache() {
 	CACHE_CLASS_AND_CHECK(ExportAttribute, GODOT_API_CLASS(ExportAttribute));
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hint, CACHED_CLASS(ExportAttribute)->get_field("hint"));
 	CACHE_FIELD_AND_CHECK(ExportAttribute, hintString, CACHED_CLASS(ExportAttribute)->get_field("hintString"));
+	CACHE_CLASS_AND_CHECK(GlobalAttribute, GODOT_API_CLASS(GlobalAttribute));
+	CACHE_FIELD_AND_CHECK(GlobalAttribute, name, CACHED_CLASS(GlobalAttribute)->get_field("name"));
+	CACHE_FIELD_AND_CHECK(GlobalAttribute, iconPath, CACHED_CLASS(GlobalAttribute)->get_field("iconPath"));
 	CACHE_CLASS_AND_CHECK(SignalAttribute, GODOT_API_CLASS(SignalAttribute));
 	CACHE_CLASS_AND_CHECK(ToolAttribute, GODOT_API_CLASS(ToolAttribute));
 	CACHE_CLASS_AND_CHECK(RPCAttribute, GODOT_API_CLASS(RPCAttribute));

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -112,6 +112,9 @@ struct CachedData {
 	GDMonoClass *class_ExportAttribute = nullptr;
 	GDMonoField *field_ExportAttribute_hint = nullptr;
 	GDMonoField *field_ExportAttribute_hintString = nullptr;
+	GDMonoClass *class_GlobalAttribute = nullptr;
+	GDMonoField *field_GlobalAttribute_name = nullptr;
+	GDMonoField *field_GlobalAttribute_iconPath = nullptr;
 	GDMonoClass *class_SignalAttribute = nullptr;
 	GDMonoClass *class_ToolAttribute = nullptr;
 	GDMonoClass *class_RPCAttribute = nullptr;


### PR DESCRIPTION
Adds support for C# to be able to define global types using a `[Global]` attribute and export global script class resource types using an `[Export]` attribute. The `[Export]` attribute has an optional single-string constructor which allows for you to specify non-C# types to be exported (they must extend `Resource`), but if you omit it, then it will simply use whatever data type the C# property type is (so the C# property must be a `Resource`-extending C# class with the `[Global]` attribute attached to it).

Related Issues:
- godotengine/godot-proposals#18

Related PRs:
- #48201 
    - implements the C# component

Sibling PRs:
- #62411
- #62413
- #62417

Considerations:
- Everything appears to be working properly.

