### PR TITLE
Clarify create_from_image() usage

### DIFF
--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -42,6 +42,14 @@
 				Returns the format of the texture, one of [enum Image.Format].
 			</description>
 		</method>
+		<method name="set_image">
+			<return type="void" />
+			<argument index="0" name="image" type="Image" />
+			<description>
+				Replaces the texture's data with a new [Image]. This will re-allocate new memory for the texture.
+				If you want to update the image, but don't need to change its paramters (format, size), use [method update] instead for better performance.
+			</description>
+		</method>
 		<method name="set_size_override">
 			<return type="void" />
 			<argument index="0" name="size" type="Vector2" />
@@ -54,8 +62,8 @@
 			<argument index="0" name="image" type="Image" />
 			<description>
 				Replaces the texture's data with a new [Image].
-				[b]Note:[/b] The texture has to be initialized first with the [method create_from_image] method before it can be updated. The new image dimensions, format, and mipmaps configuration should match the existing texture's image configuration, otherwise it has to be re-created with the [method create_from_image] method.
-				Use this method over [method create_from_image] if you need to update the texture frequently, which is faster than allocating additional memory for a new texture each time.
+				[b]Note:[/b] The texture has to be created using [method create_from_image] or initialized first with the [method set_image] method before it can be updated. The new image dimensions, format, and mipmaps configuration should match the existing texture's image configuration.
+				Use this method over [method set_image] if you need to update the texture frequently, which is faster than allocating additional memory for a new texture each time.
 			</description>
 		</method>
 	</methods>

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -323,6 +323,7 @@ void ImageTexture::_bind_methods() {
 	ClassDB::bind_static_method("ImageTexture", D_METHOD("create_from_image", "image"), &ImageTexture::create_from_image);
 	ClassDB::bind_method(D_METHOD("get_format"), &ImageTexture::get_format);
 
+	ClassDB::bind_method(D_METHOD("set_image", "image"), &ImageTexture::set_image);
 	ClassDB::bind_method(D_METHOD("update", "image"), &ImageTexture::update);
 	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &ImageTexture::set_size_override);
 }


### PR DESCRIPTION
`create_from_image()` should be always used to create ImageTexture and can no longer be used on existing ImageTexture. I don't know the internals exactly, but judging from the old descriptions *there is no point in reusing ImageTexture* as `create_from_image()` is the most expensive part of it anyway.

Resolves #63025
Closes #63131

EDIT:
Turns out there *is* some use case-case for updating ImageTexture, which is when you have multiple copies of it and want to update all of them, so I updated the PR to expose `set_image()`.