### PR TITLE
Fix the argcount when generating error message for CallableComparator

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -437,6 +437,6 @@ bool CallableComparator::operator()(const Variant &p_l, const Variant &p_r) cons
 	Variant res;
 	func.call(args, 2, res, err);
 	ERR_FAIL_COND_V_MSG(err.error != Callable::CallError::CALL_OK, false,
-			"Error calling compare method: " + Variant::get_callable_error_text(func, args, 1, err));
+			"Error calling compare method: " + Variant::get_callable_error_text(func, args, 2, err));
 	return res;
 }


### PR DESCRIPTION
Fixes #63046