### PR TITLE
Add enabled module names to the list of supported features for the project manager

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -46,6 +46,8 @@
 #include "core/version.h"
 
 #ifdef TOOLS_ENABLED
+#include "editor/editor_property_name_processor.h"
+#include "modules/module_names.gen.h"
 #include "modules/modules_enabled.gen.h" // For mono.
 #endif // TOOLS_ENABLED
 
@@ -91,6 +93,9 @@ const PackedStringArray ProjectSettings::_get_supported_features() {
 #ifdef MODULE_MONO_ENABLED
 	features.append("C#");
 #endif
+	for (const String &s : module_names) {
+		features.append(EditorPropertyNameProcessor::get_singleton()->process_name(s, EditorPropertyNameProcessor::Style::STYLE_CAPITALIZED));
+	}
 	// Allow pinning to a specific patch number or build type by marking
 	// them as supported. They're only used if the user adds them manually.
 	features.append(VERSION_BRANCH "." _MKSTR(VERSION_PATCH));

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -164,6 +164,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["bbcode"] = "BBCode";
 	capitalize_string_remaps["bg"] = "BG";
 	capitalize_string_remaps["bidi"] = "BiDi";
+	capitalize_string_remaps["bmp"] = "BMP";
 	capitalize_string_remaps["bp"] = "BP";
 	capitalize_string_remaps["bpc"] = "BPC";
 	capitalize_string_remaps["bpm"] = "BPM";
@@ -174,14 +175,18 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["cd"] = "CD";
 	capitalize_string_remaps["cpu"] = "CPU";
 	capitalize_string_remaps["csg"] = "CSG";
+	capitalize_string_remaps["cvtt"] = "CVTT";
 	capitalize_string_remaps["d3d12"] = "D3D12";
 	capitalize_string_remaps["db"] = "dB";
+	capitalize_string_remaps["dds"] = "DDS";
 	capitalize_string_remaps["dof"] = "DoF";
 	capitalize_string_remaps["dpi"] = "DPI";
 	capitalize_string_remaps["dtls"] = "DTLS";
+	capitalize_string_remaps["enet"] = "ENet";
 	capitalize_string_remaps["eol"] = "EOL";
 	capitalize_string_remaps["erp"] = "ERP";
 	capitalize_string_remaps["etc2"] = "ETC2";
+	capitalize_string_remaps["etcpak"] = "ETC Pak";
 	capitalize_string_remaps["fabrik"] = "FABRIK";
 	capitalize_string_remaps["fbx"] = "FBX";
 	capitalize_string_remaps["fbx2gltf"] = "FBX2glTF";
@@ -190,6 +195,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["filesystem"] = "FileSystem";
 	capitalize_string_remaps["fov"] = "FOV";
 	capitalize_string_remaps["fps"] = "FPS";
+	capitalize_string_remaps["freetype"] = "FreeType";
 	capitalize_string_remaps["fs"] = "FS";
 	capitalize_string_remaps["fsr"] = "FSR";
 	capitalize_string_remaps["fxaa"] = "FXAA";
@@ -201,8 +207,10 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["gles"] = "GLES";
 	capitalize_string_remaps["gles2"] = "GLES2";
 	capitalize_string_remaps["gles3"] = "GLES3";
+	capitalize_string_remaps["glslang"] = "GLSL";
 	capitalize_string_remaps["gltf"] = "glTF";
 	capitalize_string_remaps["gpu"] = "GPU";
+	capitalize_string_remaps["gridmap"] = "GridMap";
 	capitalize_string_remaps["gui"] = "GUI";
 	capitalize_string_remaps["guid"] = "GUID";
 	capitalize_string_remaps["hdr"] = "HDR";
@@ -227,6 +235,8 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["ir"] = "IR";
 	capitalize_string_remaps["itunes"] = "iTunes";
 	capitalize_string_remaps["jit"] = "JIT";
+	capitalize_string_remaps["jpg"] = "JPG";
+	capitalize_string_remaps["jsonrpc"] = "JSON RPC";
 	capitalize_string_remaps["k1"] = "K1";
 	capitalize_string_remaps["k2"] = "K2";
 	capitalize_string_remaps["kb"] = "(KB)"; // Unit.
@@ -239,11 +249,15 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["lowpass"] = "Low-pass";
 	capitalize_string_remaps["macos"] = "macOS";
 	capitalize_string_remaps["mb"] = "(MB)"; // Unit.
+	capitalize_string_remaps["mbedtls"] = "MbedTLS";
+	capitalize_string_remaps["meshoptimizer"] = "MeshOptimizer";
+	capitalize_string_remaps["minimp3"] = "MiniMP3";
 	capitalize_string_remaps["mjpeg"] = "MJPEG";
 	capitalize_string_remaps["mms"] = "MMS";
 	capitalize_string_remaps["ms"] = "(ms)"; // Unit
 	capitalize_string_remaps["msaa"] = "MSAA";
 	capitalize_string_remaps["msdf"] = "MSDF";
+	capitalize_string_remaps["msdfgen"] = "MSDF Gen";
 	// Not used for now as AudioEffectReverb has a `msec` property.
 	//capitalize_string_remaps["msec"] = "(msec)"; // Unit.
 	capitalize_string_remaps["navmesh"] = "NavMesh";
@@ -264,6 +278,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["pvs"] = "PVS";
 	capitalize_string_remaps["rcedit"] = "rcedit";
 	capitalize_string_remaps["rcodesign"] = "rcodesign";
+	capitalize_string_remaps["regex"] = "RegEx";
 	capitalize_string_remaps["rgb"] = "RGB";
 	capitalize_string_remaps["rid"] = "RID";
 	capitalize_string_remaps["rmb"] = "RMB";
@@ -290,9 +305,12 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["taa"] = "TAA";
 	capitalize_string_remaps["tcp"] = "TCP";
 	capitalize_string_remaps["textfile"] = "TextFile";
+	capitalize_string_remaps["tga"] = "TGA";
+	capitalize_string_remaps["tinyexr"] = "TinyEXR";
 	capitalize_string_remaps["tls"] = "TLS";
 	capitalize_string_remaps["tv"] = "TV";
 	capitalize_string_remaps["ui"] = "UI";
+	capitalize_string_remaps["upnp"] = "UPNP";
 	capitalize_string_remaps["uri"] = "URI";
 	capitalize_string_remaps["url"] = "URL";
 	capitalize_string_remaps["urls"] = "URLs";
@@ -304,7 +322,9 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["uv1"] = "UV1";
 	capitalize_string_remaps["uv2"] = "UV2";
 	capitalize_string_remaps["vector2"] = "Vector2";
+	capitalize_string_remaps["vhacd"] = "VHACD";
 	capitalize_string_remaps["vpn"] = "VPN";
+	capitalize_string_remaps["vr"] = "VR";
 	capitalize_string_remaps["vram"] = "VRAM";
 	capitalize_string_remaps["vrs"] = "VRS";
 	capitalize_string_remaps["vsync"] = "V-Sync";
@@ -312,11 +332,13 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["webp"] = "WebP";
 	capitalize_string_remaps["webrtc"] = "WebRTC";
 	capitalize_string_remaps["websocket"] = "WebSocket";
+	capitalize_string_remaps["webxr"] = "WebXR";
 	capitalize_string_remaps["wine"] = "wine";
 	capitalize_string_remaps["wifi"] = "Wi-Fi";
 	capitalize_string_remaps["x86"] = "x86";
 	capitalize_string_remaps["x86_32"] = "x86_32";
 	capitalize_string_remaps["x86_64"] = "x86_64";
+	capitalize_string_remaps["xatlas"] = "XAtlas";
 	capitalize_string_remaps["xr"] = "XR";
 	capitalize_string_remaps["xray"] = "X-Ray";
 	capitalize_string_remaps["xy"] = "XY";

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -38,6 +38,7 @@
 #include "core/os/os.h"
 #include "core/version.h"
 #include "editor/editor_about.h"
+#include "editor/editor_property_name_processor.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
 #include "editor/engine_update_label.h"
@@ -1074,6 +1075,8 @@ ProjectManager::ProjectManager() {
 
 	set_translation_domain("godot.editor");
 
+	EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);
+	add_child(epnp);
 	// Turn off some servers we aren't going to be using in the Project Manager.
 	NavigationServer3D::get_singleton()->set_active(false);
 	PhysicsServer3D::get_singleton()->set_active(false);

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -27,6 +27,23 @@ modules_enabled = env.CommandNoCache(
 )
 
 
+def generate_module_names(target, source, env):
+    with open(target[0].path, "w") as f:
+        f.write('#include "core/string/ustring.h"\n\n')
+        f.write("static const String module_names[] = {\n")
+        for module in env.module_list:
+            f.write('\t"' + module + '",\n')
+        f.write("};\n")
+
+# Header with a String array of module names.
+env.Depends("module_names.gen.h", Value(env.module_list))
+env.CommandNoCache(
+    "module_names.gen.h",
+    Value(env.module_list),
+    env.Run(generate_module_names),
+)
+
+
 def register_module_types_builder(target, source, env):
     modules = source[0].read()
     mod_inc = "\n".join([f'#include "{p}/register_types.h"' for p in modules.values()])


### PR DESCRIPTION
This PR enhances the project feature warning system in the project manager by listing all enabled modules as supported features. This allows people to manually list required modules in their projects, and does not require Godot to know about those modules at all - Godot only knows that the project asks for XYZ and it's missing.

As an example, I tested a project with this text in `project.godot`:

```ini
config/features=PackedStringArray("4.0", "GDScript", "WebP", "WebXR", "Voxel")
```

And this is what shows up in the project manager of Godot compiled with WebXR disabled:

<img width="860" alt="Screen Shot 2022-07-17 at 6 05 04 PM" src="https://user-images.githubusercontent.com/1646875/179429176-46e6c2f9-f1a0-4c37-b616-c5045adff486.png">

4.0, GDScript, and WebP are all supported, so they are not warned about. WebXR is disabled, and Voxel is not present, so they're not in the supported features list, and the project manager warns about them.