### PR TITLE
[3.x] Add forwards-compatible aliases for pool/packed arrays

### DIFF
--- a/core/variant_parser.cpp
+++ b/core/variant_parser.cpp
@@ -1022,7 +1022,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 			value = ie;
 #endif
-		} else if (id == "PoolByteArray" || id == "ByteArray") {
+		} else if (id == "PoolByteArray" || id == "PackedByteArray" || id == "ByteArray") {
 			Vector<uint8_t> args;
 			Error err = _parse_construct<uint8_t>(p_stream, args, line, r_err_str);
 			if (err) {
@@ -1040,8 +1040,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			value = arr;
-
-		} else if (id == "PoolIntArray" || id == "IntArray") {
+		} else if (id == "PoolIntArray" || id == "PackedInt32Array" || id == "PackedInt64Array" || id == "IntArray") {
 			Vector<int> args;
 			Error err = _parse_construct<int>(p_stream, args, line, r_err_str);
 			if (err) {
@@ -1059,8 +1058,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			value = arr;
-
-		} else if (id == "PoolRealArray" || id == "FloatArray") {
+		} else if (id == "PoolRealArray" || id == "PackedFloat32Array" || id == "PackedFloat64Array" || id == "FloatArray") {
 			Vector<float> args;
 			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);
 			if (err) {
@@ -1078,8 +1076,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			value = arr;
-
-		} else if (id == "PoolStringArray" || id == "StringArray") {
+		} else if (id == "PoolStringArray" || id == "PackedStringArray" || id == "StringArray") {
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_PARENTHESIS_OPEN) {
 				r_err_str = "Expected '('";
@@ -1125,8 +1122,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			value = arr;
-
-		} else if (id == "PoolVector2Array" || id == "Vector2Array") {
+		} else if (id == "PoolVector2Array" || id == "PackedVector2Array" || id == "Vector2Array") {
 			Vector<float> args;
 			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);
 			if (err) {
@@ -1144,8 +1140,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			value = arr;
-
-		} else if (id == "PoolVector3Array" || id == "Vector3Array") {
+		} else if (id == "PoolVector3Array" || id == "PackedVector3Array" || id == "Vector3Array") {
 			Vector<float> args;
 			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);
 			if (err) {
@@ -1163,8 +1158,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			value = arr;
-
-		} else if (id == "PoolColorArray" || id == "ColorArray") {
+		} else if (id == "PoolColorArray" || id == "PackedColorArray" || id == "ColorArray") {
 			Vector<float> args;
 			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);
 			if (err) {


### PR DESCRIPTION
When 4.0 projects are viewed in the project manager of Godot 3.x, a lot of ConfigFile parse errors are printed in the terminal. This PR eliminates most of those. Well, in particular I was concerned about `PackedStringArray`, but I figured I would alias the rest of these pool/packed array types for completeness.

I'm classifying this as an enhancement, since viewing 4.0 projects in 3.x probably isn't a "supported" use case anyway. However, this could easily be classified as a bug fix, feel free to change the labels if you disagree.