### PR TITLE
GDNative: Expose `String::num_uint64`, and use bool in `capitalized` versions

### DIFF
--- a/modules/gdnative/gdnative/string.cpp
+++ b/modules/gdnative/gdnative/string.cpp
@@ -399,7 +399,21 @@ godot_string GDAPI godot_string_num_int64(int64_t p_num, godot_int p_base) {
 
 godot_string GDAPI godot_string_num_int64_capitalized(int64_t p_num, godot_int p_base, godot_bool p_capitalize_hex) {
 	godot_string result;
-	memnew_placement(&result, String(String::num_int64(p_num, p_base, true)));
+	memnew_placement(&result, String(String::num_int64(p_num, p_base, p_capitalize_hex)));
+
+	return result;
+}
+
+godot_string GDAPI godot_string_num_uint64(uint64_t p_num, godot_int p_base) {
+	godot_string result;
+	memnew_placement(&result, String(String::num_uint64(p_num, p_base)));
+
+	return result;
+}
+
+godot_string GDAPI godot_string_num_uint64_capitalized(uint64_t p_num, godot_int p_base, godot_bool p_capitalize_hex) {
+	godot_string result;
+	memnew_placement(&result, String(String::num_uint64(p_num, p_base, p_capitalize_hex)));
 
 	return result;
 }

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -154,6 +154,23 @@
                 ["const godot_string *", "p_self"],
                 ["const godot_array *", "p_parts"]
               ]
+            },
+            {
+              "name": "godot_string_num_uint64",
+              "return_type": "godot_string",
+              "arguments": [
+                ["uint64_t", "p_num"],
+                ["godot_int", "p_base"]
+              ]
+            },
+            {
+              "name": "godot_string_num_uint64_capitalized",
+              "return_type": "godot_string",
+              "arguments": [
+                ["uint64_t", "p_num"],
+                ["godot_int", "p_base"],
+                ["godot_bool", "p_capitalize_hex"]
+              ]
             }
           ]
         },

--- a/modules/gdnative/include/gdnative/string.h
+++ b/modules/gdnative/include/gdnative/string.h
@@ -129,6 +129,8 @@ godot_string GDAPI godot_string_md5(const uint8_t *p_md5);
 godot_string GDAPI godot_string_num(double p_num);
 godot_string GDAPI godot_string_num_int64(int64_t p_num, godot_int p_base);
 godot_string GDAPI godot_string_num_int64_capitalized(int64_t p_num, godot_int p_base, godot_bool p_capitalize_hex);
+godot_string GDAPI godot_string_num_uint64(uint64_t p_num, godot_int p_base);
+godot_string GDAPI godot_string_num_uint64_capitalized(uint64_t p_num, godot_int p_base, godot_bool p_capitalize_hex);
 godot_string GDAPI godot_string_num_real(double p_num);
 godot_string GDAPI godot_string_num_scientific(double p_num);
 godot_string GDAPI godot_string_num_with_decimals(double p_num, godot_int p_decimals);


### PR DESCRIPTION
Exposed in Core API 1.3 added in 3.5.

Supersedes #50806.