### PR TITLE
Fix getting outdated tab controls

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -312,7 +312,7 @@ Vector<Control *> TabContainer::_get_tab_controls() const {
 	Vector<Control *> controls;
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *control = Object::cast_to<Control>(get_child(i));
-		if (!control || control->is_set_as_top_level() || control == tab_bar) {
+		if (!control || control->is_set_as_top_level() || control == tab_bar || control == child_removing) {
 			continue;
 		}
 
@@ -549,7 +549,12 @@ void TabContainer::remove_child_notify(Node *p_child) {
 		return;
 	}
 
-	tab_bar->remove_tab(get_tab_idx_from_control(c));
+	int idx = get_tab_idx_from_control(c);
+
+	// Before this, the tab control has not changed; after this, the tab control has changed.
+	child_removing = p_child;
+	tab_bar->remove_tab(idx);
+	child_removing = nullptr;
 
 	_update_margins();
 	if (get_tab_count() == 0) {

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -46,6 +46,7 @@ class TabContainer : public Container {
 	bool drag_to_rearrange_enabled = false;
 	bool use_hidden_tabs_for_min_size = false;
 	bool theme_changing = false;
+	Node *child_removing = nullptr;
 
 	int _get_top_margin() const;
 	Vector<Control *> _get_tab_controls() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Previously, removing the current tab control from the `TabContainer` would emit the `tab_changed` signal during the removal process. At this point, the internal `TabBar` has completed the change, but the tab controls have not (tab changed but tab controls not).

It is now logically synchronous, although still not removed, but the state is consistent (tab changed and tab controls changed).

~~Fix- #51174.~~
Fix #63061.

May fix #62503.
May fix #61689.
