### PR TITLE
Add `ShapeCast3D` node

### DIFF
--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ShapeCast3D" inherits="Node3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Node for physics collision sweep and immediate overlap queries. Similar to the [RayCast3D] node.
+	</brief_description>
+	<description>
+		Shape casting allows to detect collision objects by sweeping the [member shape] along the cast direction determined by [member target_position] (useful for things like beam weapons).
+		Immediate collision overlaps can be done with the [member target_position] set to [code]Vector3(0, 0, 0)[/code] and by calling [method force_shapecast_update] within the same [b]physics_frame[/b]. This also helps to overcome some limitations of [Area3D] when used as a continuous detection area, often requiring waiting a couple of frames before collision information is available to [Area3D] nodes, and when using the signals creates unnecessary complexity.
+		The node can detect multiple collision objects, but usually the first detected collision.
+		[b]Note:[/b] Shape casting is more computationally expensive compared to ray casting.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_exception">
+			<return type="void" />
+			<argument index="0" name="node" type="Object" />
+			<description>
+				Adds a collision exception so the shape does not report collisions with the specified [CollisionObject3D] node.
+			</description>
+		</method>
+		<method name="add_exception_rid">
+			<return type="void" />
+			<argument index="0" name="rid" type="RID" />
+			<description>
+				Adds a collision exception so the shape does not report collisions with the specified [RID].
+			</description>
+		</method>
+		<method name="clear_exceptions">
+			<return type="void" />
+			<description>
+				Removes all collision exceptions for this shape.
+			</description>
+		</method>
+		<method name="force_shapecast_update">
+			<return type="void" />
+			<description>
+				Updates the collision information for the shape. Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the shape or its parent has changed state.
+				[b]Note:[/b] [code]enabled == true[/code] is not required for this to work.
+			</description>
+		</method>
+		<method name="get_closest_collision_safe_fraction" qualifiers="const">
+			<return type="float" />
+			<description>
+				The fraction of the motion (between 0 and 1) of how far the shape can move without triggering a collision. The motion is determined by [member target_position].
+			</description>
+		</method>
+		<method name="get_closest_collision_unsafe_fraction" qualifiers="const">
+			<return type="float" />
+			<description>
+				The fraction of the motion (between 0 and 1) when the shape triggers a collision. The motion is determined by [member target_position].
+			</description>
+		</method>
+		<method name="get_collider" qualifiers="const">
+			<return type="Object" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+			</description>
+		</method>
+		<method name="get_collider_shape" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the shape ID of one of the multiple collisions at [code]index[/code] that the shape intersects, or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+			</description>
+		</method>
+		<method name="get_collision_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				The number of collisions detected at the point of impact. Use this to iterate over multiple collisions as provided by [method get_collider], [method get_collider_shape], [method get_collision_point], and [method get_collision_normal] methods.
+			</description>
+		</method>
+		<method name="get_collision_mask_value" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
+		<method name="get_collision_normal" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the normal containing one of the multiple collisions at [code]index[/code] of the intersecting object.
+			</description>
+		</method>
+		<method name="get_collision_point" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the collision point containing one of the multiple collisions at [code]index[/code] at which the shape intersects the object.
+				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
+			</description>
+		</method>
+		<method name="is_colliding" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether any object is intersecting with the shape's vector (considering the vector length).
+			</description>
+		</method>
+		<method name="remove_exception">
+			<return type="void" />
+			<argument index="0" name="node" type="Object" />
+			<description>
+				Removes a collision exception so the shape does report collisions with the specified [CollisionObject3D] node.
+			</description>
+		</method>
+		<method name="remove_exception_rid">
+			<return type="void" />
+			<argument index="0" name="rid" type="RID" />
+			<description>
+				Removes a collision exception so the shape does report collisions with the specified [RID].
+			</description>
+		</method>
+		<method name="resource_changed">
+			<return type="void" />
+			<argument index="0" name="resource" type="Resource" />
+			<description>
+				Used internally to update the debug gizmo in the editor. Any code placed in this function will be called whenever the [member shape] resource is modified.
+			</description>
+		</method>
+		<method name="set_collision_mask_value">
+			<return type="void" />
+			<argument index="0" name="layer_number" type="int" />
+			<argument index="1" name="value" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
+			If [code]true[/code], collision with [Area3D]s will be reported.
+		</member>
+		<member name="collide_with_bodies" type="bool" setter="set_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
+			If [code]true[/code], collision with [PhysicsBody3D]s will be reported.
+		</member>
+		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
+			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected.
+		</member>
+		<member name="collision_result" type="Array" setter="" getter="_get_collision_result" default="[]">
+			A complete collision information. The data returned is the same as in the [method PhysicsDirectSpaceState3D.get_rest_info] method.
+		</member>
+		<member name="debug_shape_custom_color" type="Color" setter="set_debug_shape_custom_color" getter="get_debug_shape_custom_color" default="Color(0, 0, 0, 1)">
+			The custom color to use to draw the shape in the editor and at run-time if [b]Visible Collision Shapes[/b] is enabled in the [b]Debug[/b] menu. This color will be highlighted at run-time if the [ShapeCast3D] is colliding with something.
+			If set to [code]Color(0.0, 0.0, 0.0)[/code] (by default), the color set in [member ProjectSettings.debug/shapes/collision/shape_color] is used.
+		</member>
+		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
+			If [code]true[/code], collisions will be reported.
+		</member>
+		<member name="exclude_parent" type="bool" setter="set_exclude_parent_body" getter="get_exclude_parent_body" default="true">
+			If [code]true[/code], the parent node will be excluded from collision detection.
+		</member>
+		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
+			The collision margin for the shape. A larger margin helps detecting collisions more consistently, at the cost of precision.
+		</member>
+		<member name="max_results" type="int" setter="set_max_results" getter="get_max_results" default="32">
+			The number of intersections can be limited with this parameter, to reduce the processing time.
+		</member>
+		<member name="shape" type="Shape3D" setter="set_shape" getter="get_shape">
+			Any [Shape3D] derived shape used for collision queries.
+		</member>
+		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3(0, -1, 0)">
+			The shape's destination point, relative to this node's [code]position[/code].
+		</member>
+	</members>
+</class>

--- a/editor/icons/ShapeCast3D.svg
+++ b/editor/icons/ShapeCast3D.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><g fill="#fc7f7f"><path d="m7 1v9h-3l4 5 4-5h-3v-9z"/><circle cx="7.990566" cy="4.8202" r="4.009434"/></g></svg>

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -57,6 +57,7 @@
 #include "scene/3d/position_3d.h"
 #include "scene/3d/ray_cast_3d.h"
 #include "scene/3d/reflection_probe.h"
+#include "scene/3d/shape_cast_3d.h"
 #include "scene/3d/soft_dynamic_body_3d.h"
 #include "scene/3d/spring_arm_3d.h"
 #include "scene/3d/sprite_3d.h"
@@ -2536,6 +2537,41 @@ void RayCast3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	p_gizmo->add_collision_segments(raycast->get_debug_line_vertices());
+}
+
+/////
+
+ShapeCast3DGizmoPlugin::ShapeCast3DGizmoPlugin() {
+	const Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	create_material("shape_material", gizmo_color);
+	const float gizmo_value = gizmo_color.get_v();
+	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
+	create_material("shape_material_disabled", gizmo_color_disabled);
+}
+
+bool ShapeCast3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
+	return Object::cast_to<ShapeCast3D>(p_spatial) != nullptr;
+}
+
+String ShapeCast3DGizmoPlugin::get_gizmo_name() const {
+	return "ShapeCast3D";
+}
+
+int ShapeCast3DGizmoPlugin::get_priority() const {
+	return -1;
+}
+
+void ShapeCast3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
+	ShapeCast3D *shapecast = Object::cast_to<ShapeCast3D>(p_gizmo->get_spatial_node());
+
+	p_gizmo->clear();
+
+	const Ref<StandardMaterial3D> material = shapecast->is_enabled() ? shapecast->get_debug_material() : get_material("shape_material_disabled");
+
+	p_gizmo->add_lines(shapecast->get_debug_shape_vertices(), material);
+	p_gizmo->add_lines(shapecast->get_debug_line_vertices(), material);
+
+	p_gizmo->add_collision_segments(shapecast->get_debug_line_vertices());
 }
 
 /////

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -373,6 +373,18 @@ public:
 	RayCast3DGizmoPlugin();
 };
 
+class ShapeCast3DGizmoPlugin : public EditorNode3DGizmoPlugin {
+	GDCLASS(ShapeCast3DGizmoPlugin, EditorNode3DGizmoPlugin);
+
+public:
+	bool has_gizmo(Node3D *p_spatial) override;
+	String get_gizmo_name() const override;
+	int get_priority() const override;
+	void redraw(EditorNode3DGizmo *p_gizmo) override;
+
+	ShapeCast3DGizmoPlugin();
+};
+
 class SpringArm3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(SpringArm3DGizmoPlugin, EditorNode3DGizmoPlugin);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7313,6 +7313,7 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<Label3DGizmoPlugin>(memnew(Label3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<Position3DGizmoPlugin>(memnew(Position3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<RayCast3DGizmoPlugin>(memnew(RayCast3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<ShapeCast3DGizmoPlugin>(memnew(ShapeCast3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<SpringArm3DGizmoPlugin>(memnew(SpringArm3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<VehicleWheel3DGizmoPlugin>(memnew(VehicleWheel3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<VisibleOnScreenNotifier3DGizmoPlugin>(memnew(VisibleOnScreenNotifier3DGizmoPlugin)));

--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -1,0 +1,630 @@
+/*************************************************************************/
+/*  shape_cast_3d.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "shape_cast_3d.h"
+
+#include "collision_object_3d.h"
+#include "mesh_instance_3d.h"
+#include "scene/resources/concave_polygon_shape_3d.h"
+
+void ShapeCast3D::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				_update_debug_shape_vertices();
+			}
+			if (enabled && !Engine::get_singleton()->is_editor_hint()) {
+				set_physics_process_internal(true);
+			} else {
+				set_physics_process_internal(false);
+			}
+
+			if (get_tree()->is_debugging_collisions_hint()) {
+				_update_debug_shape();
+			}
+
+			if (Object::cast_to<CollisionObject3D>(get_parent())) {
+				if (exclude_parent_body) {
+					exclude.insert(Object::cast_to<CollisionObject3D>(get_parent())->get_rid());
+				} else {
+					exclude.erase(Object::cast_to<CollisionObject3D>(get_parent())->get_rid());
+				}
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (enabled) {
+				set_physics_process_internal(false);
+			}
+
+			if (debug_shape) {
+				_clear_debug_shape();
+			}
+		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (!enabled) {
+				break;
+			}
+
+			bool prev_collision_state = collided;
+			_update_shapecast_state();
+			if (get_tree()->is_debugging_collisions_hint()) {
+				if (prev_collision_state != collided) {
+					_update_debug_shape_material(true);
+				}
+				if (collided) {
+					_update_debug_shape();
+				}
+				if (prev_collision_state == collided && !collided) {
+					_update_debug_shape();
+				}
+			}
+		} break;
+	}
+}
+
+void ShapeCast3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("resource_changed", "resource"), &ShapeCast3D::resource_changed);
+
+	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &ShapeCast3D::set_enabled);
+	ClassDB::bind_method(D_METHOD("is_enabled"), &ShapeCast3D::is_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &ShapeCast3D::set_shape);
+	ClassDB::bind_method(D_METHOD("get_shape"), &ShapeCast3D::get_shape);
+
+	ClassDB::bind_method(D_METHOD("set_target_position", "local_point"), &ShapeCast3D::set_target_position);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &ShapeCast3D::get_target_position);
+
+	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &ShapeCast3D::set_margin);
+	ClassDB::bind_method(D_METHOD("get_margin"), &ShapeCast3D::get_margin);
+
+	ClassDB::bind_method(D_METHOD("set_max_results", "max_results"), &ShapeCast3D::set_max_results);
+	ClassDB::bind_method(D_METHOD("get_max_results"), &ShapeCast3D::get_max_results);
+
+	ClassDB::bind_method(D_METHOD("is_colliding"), &ShapeCast3D::is_colliding);
+	ClassDB::bind_method(D_METHOD("get_collision_count"), &ShapeCast3D::get_collision_count);
+
+	ClassDB::bind_method(D_METHOD("force_shapecast_update"), &ShapeCast3D::force_shapecast_update);
+
+	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast3D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider_shape", "index"), &ShapeCast3D::get_collider_shape);
+	ClassDB::bind_method(D_METHOD("get_collision_point", "index"), &ShapeCast3D::get_collision_point);
+	ClassDB::bind_method(D_METHOD("get_collision_normal", "index"), &ShapeCast3D::get_collision_normal);
+
+	ClassDB::bind_method(D_METHOD("get_closest_collision_safe_fraction"), &ShapeCast3D::get_closest_collision_safe_fraction);
+	ClassDB::bind_method(D_METHOD("get_closest_collision_unsafe_fraction"), &ShapeCast3D::get_closest_collision_unsafe_fraction);
+
+	ClassDB::bind_method(D_METHOD("add_exception_rid", "rid"), &ShapeCast3D::add_exception_rid);
+	ClassDB::bind_method(D_METHOD("add_exception", "node"), &ShapeCast3D::add_exception);
+
+	ClassDB::bind_method(D_METHOD("remove_exception_rid", "rid"), &ShapeCast3D::remove_exception_rid);
+	ClassDB::bind_method(D_METHOD("remove_exception", "node"), &ShapeCast3D::remove_exception);
+
+	ClassDB::bind_method(D_METHOD("clear_exceptions"), &ShapeCast3D::clear_exceptions);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &ShapeCast3D::set_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &ShapeCast3D::get_collision_mask);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask_value", "layer_number", "value"), &ShapeCast3D::set_collision_mask_value);
+	ClassDB::bind_method(D_METHOD("get_collision_mask_value", "layer_number"), &ShapeCast3D::get_collision_mask_value);
+
+	ClassDB::bind_method(D_METHOD("set_exclude_parent_body", "mask"), &ShapeCast3D::set_exclude_parent_body);
+	ClassDB::bind_method(D_METHOD("get_exclude_parent_body"), &ShapeCast3D::get_exclude_parent_body);
+
+	ClassDB::bind_method(D_METHOD("set_collide_with_areas", "enable"), &ShapeCast3D::set_collide_with_areas);
+	ClassDB::bind_method(D_METHOD("is_collide_with_areas_enabled"), &ShapeCast3D::is_collide_with_areas_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &ShapeCast3D::set_collide_with_bodies);
+	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &ShapeCast3D::is_collide_with_bodies_enabled);
+
+	ClassDB::bind_method(D_METHOD("_get_collision_result"), &ShapeCast3D::_get_collision_result);
+
+	ClassDB::bind_method(D_METHOD("set_debug_shape_custom_color", "debug_shape_custom_color"), &ShapeCast3D::set_debug_shape_custom_color);
+	ClassDB::bind_method(D_METHOD("get_debug_shape_custom_color"), &ShapeCast3D::get_debug_shape_custom_color);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape3D"), "set_shape", "get_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_parent"), "set_exclude_parent_body", "get_exclude_parent_body");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_position", PROPERTY_HINT_NONE, "suffix:m"), "set_target_position", "get_target_position");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_results"), "set_max_results", "get_max_results");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "collision_result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "", "_get_collision_result");
+
+	ADD_GROUP("Collide With", "collide_with");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_areas", "is_collide_with_areas_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
+
+	ADD_GROUP("Debug Shape", "debug_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_shape_custom_color"), "set_debug_shape_custom_color", "get_debug_shape_custom_color");
+}
+
+TypedArray<String> ShapeCast3D::get_configuration_warnings() const {
+	TypedArray<String> warnings = Node3D::get_configuration_warnings();
+
+	if (shape.is_null()) {
+		warnings.push_back(RTR("This node cannot interact with other objects unless a Shape3D is assigned."));
+	}
+	if (shape.is_valid() && Object::cast_to<ConcavePolygonShape3D>(*shape)) {
+		warnings.push_back(RTR("ShapeCast3D does not support ConcavePolygonShape3Ds. Collisions will not be reported."));
+	}
+	return warnings;
+}
+
+void ShapeCast3D::set_enabled(bool p_enabled) {
+	enabled = p_enabled;
+	update_gizmos();
+
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
+		set_physics_process_internal(p_enabled);
+	}
+	if (!p_enabled) {
+		collided = false;
+	}
+
+	if (is_inside_tree() && get_tree()->is_debugging_collisions_hint()) {
+		if (p_enabled) {
+			_update_debug_shape();
+		} else {
+			_clear_debug_shape();
+		}
+	}
+}
+
+bool ShapeCast3D::is_enabled() const {
+	return enabled;
+}
+
+void ShapeCast3D::set_target_position(const Vector3 &p_point) {
+	target_position = p_point;
+	if (is_inside_tree()) {
+		_update_debug_shape();
+	}
+	update_gizmos();
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		if (is_inside_tree()) {
+			_update_debug_shape_vertices();
+		}
+	} else if (debug_shape) {
+		_update_debug_shape();
+	}
+}
+
+Vector3 ShapeCast3D::get_target_position() const {
+	return target_position;
+}
+
+void ShapeCast3D::set_margin(real_t p_margin) {
+	margin = p_margin;
+}
+
+real_t ShapeCast3D::get_margin() const {
+	return margin;
+}
+
+void ShapeCast3D::set_max_results(int p_max_results) {
+	max_results = p_max_results;
+}
+
+int ShapeCast3D::get_max_results() const {
+	return max_results;
+}
+
+void ShapeCast3D::set_collision_mask(uint32_t p_mask) {
+	collision_mask = p_mask;
+}
+
+uint32_t ShapeCast3D::get_collision_mask() const {
+	return collision_mask;
+}
+
+void ShapeCast3D::set_collision_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
+	uint32_t mask = get_collision_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_collision_mask(mask);
+}
+
+bool ShapeCast3D::get_collision_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
+	return get_collision_mask() & (1 << (p_layer_number - 1));
+}
+
+int ShapeCast3D::get_collision_count() const {
+	return result.size();
+}
+
+bool ShapeCast3D::is_colliding() const {
+	return collided;
+}
+
+Object *ShapeCast3D::get_collider(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), nullptr, "No collider found.");
+
+	if (result[p_idx].collider_id.is_null()) {
+		return nullptr;
+	}
+	return ObjectDB::get_instance(result[p_idx].collider_id);
+}
+
+int ShapeCast3D::get_collider_shape(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), -1, "No collider shape found.");
+	return result[p_idx].shape;
+}
+
+Vector3 ShapeCast3D::get_collision_point(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), Vector3(), "No collision point found.");
+	return result[p_idx].point;
+}
+
+Vector3 ShapeCast3D::get_collision_normal(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), Vector3(), "No collision normal found.");
+	return result[p_idx].normal;
+}
+
+real_t ShapeCast3D::get_closest_collision_safe_fraction() const {
+	return collision_safe_fraction;
+}
+
+real_t ShapeCast3D::get_closest_collision_unsafe_fraction() const {
+	return collision_unsafe_fraction;
+}
+
+void ShapeCast3D::resource_changed(Ref<Resource> p_res) {
+	if (is_inside_tree()) {
+		_update_debug_shape();
+	}
+	update_gizmos();
+}
+
+void ShapeCast3D::set_shape(const Ref<Shape3D> &p_shape) {
+	if (p_shape == shape) {
+		return;
+	}
+	if (!shape.is_null()) {
+		shape->unregister_owner(this);
+	}
+	shape = p_shape;
+	if (!shape.is_null()) {
+		shape->register_owner(this);
+	}
+	if (p_shape.is_valid()) {
+		shape_rid = shape->get_rid();
+	}
+
+	if (is_inside_tree()) {
+		_update_debug_shape();
+	}
+
+	update_gizmos();
+	update_configuration_warnings();
+}
+
+Ref<Shape3D> ShapeCast3D::get_shape() const {
+	return shape;
+}
+
+void ShapeCast3D::set_exclude_parent_body(bool p_exclude_parent_body) {
+	if (exclude_parent_body == p_exclude_parent_body) {
+		return;
+	}
+	exclude_parent_body = p_exclude_parent_body;
+
+	if (!is_inside_tree()) {
+		return;
+	}
+	if (Object::cast_to<CollisionObject3D>(get_parent())) {
+		if (exclude_parent_body) {
+			exclude.insert(Object::cast_to<CollisionObject3D>(get_parent())->get_rid());
+		} else {
+			exclude.erase(Object::cast_to<CollisionObject3D>(get_parent())->get_rid());
+		}
+	}
+}
+
+bool ShapeCast3D::get_exclude_parent_body() const {
+	return exclude_parent_body;
+}
+
+void ShapeCast3D::_update_shapecast_state() {
+	result.clear();
+
+	ERR_FAIL_COND_MSG(shape.is_null(), "Null reference to shape. ShapeCast3D requires a Shape3D to sweep for collisions.");
+
+	Ref<World3D> w3d = get_world_3d();
+	ERR_FAIL_COND(w3d.is_null());
+
+	PhysicsDirectSpaceState3D *dss = PhysicsServer3D::get_singleton()->space_get_direct_state(w3d->get_space());
+	ERR_FAIL_COND(!dss);
+
+	Transform3D gt = get_global_transform();
+
+	PhysicsDirectSpaceState3D::ShapeParameters params;
+	params.shape_rid = shape_rid;
+	params.transform = gt;
+	params.motion = gt.basis.xform(target_position);
+	params.margin = margin;
+	params.exclude = exclude;
+	params.collision_mask = collision_mask;
+	params.collide_with_bodies = collide_with_bodies;
+	params.collide_with_areas = collide_with_areas;
+
+	collision_safe_fraction = 0.0;
+	collision_unsafe_fraction = 0.0;
+
+	if (target_position != Vector3()) {
+		dss->cast_motion(params, collision_safe_fraction, collision_unsafe_fraction);
+		if (collision_unsafe_fraction < 1.0) {
+			// Move shape transform to the point of impact,
+			// so we can collect contact info at that point.
+			gt.set_origin(gt.get_origin() + params.motion * (collision_unsafe_fraction + CMP_EPSILON));
+			params.transform = gt;
+		}
+	}
+	// Regardless of whether the shape is stuck or it's moved along
+	// the motion vector, we'll only consider static collisions from now on.
+	params.motion = Vector3();
+
+	bool intersected = true;
+	while (intersected && result.size() < max_results) {
+		PhysicsDirectSpaceState3D::ShapeRestInfo info;
+		intersected = dss->rest_info(params, &info);
+		if (intersected) {
+			result.push_back(info);
+			params.exclude.insert(info.rid);
+		}
+	}
+	collided = !result.is_empty();
+}
+
+void ShapeCast3D::force_shapecast_update() {
+	_update_shapecast_state();
+}
+
+void ShapeCast3D::add_exception_rid(const RID &p_rid) {
+	exclude.insert(p_rid);
+}
+
+void ShapeCast3D::add_exception(const Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	const CollisionObject3D *co = Object::cast_to<CollisionObject3D>(p_object);
+	if (!co) {
+		return;
+	}
+	add_exception_rid(co->get_rid());
+}
+
+void ShapeCast3D::remove_exception_rid(const RID &p_rid) {
+	exclude.erase(p_rid);
+}
+
+void ShapeCast3D::remove_exception(const Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	const CollisionObject3D *co = Object::cast_to<CollisionObject3D>(p_object);
+	if (!co) {
+		return;
+	}
+	remove_exception_rid(co->get_rid());
+}
+
+void ShapeCast3D::clear_exceptions() {
+	exclude.clear();
+}
+
+void ShapeCast3D::set_collide_with_areas(bool p_clip) {
+	collide_with_areas = p_clip;
+}
+
+bool ShapeCast3D::is_collide_with_areas_enabled() const {
+	return collide_with_areas;
+}
+
+void ShapeCast3D::set_collide_with_bodies(bool p_clip) {
+	collide_with_bodies = p_clip;
+}
+
+bool ShapeCast3D::is_collide_with_bodies_enabled() const {
+	return collide_with_bodies;
+}
+
+Array ShapeCast3D::_get_collision_result() const {
+	Array ret;
+
+	for (int i = 0; i < result.size(); ++i) {
+		const PhysicsDirectSpaceState3D::ShapeRestInfo &sri = result[i];
+
+		Dictionary col;
+		col["point"] = sri.point;
+		col["normal"] = sri.normal;
+		col["rid"] = sri.rid;
+		col["collider"] = ObjectDB::get_instance(sri.collider_id);
+		col["collider_id"] = sri.collider_id;
+		col["shape"] = sri.shape;
+		col["linear_velocity"] = sri.linear_velocity;
+
+		ret.push_back(col);
+	}
+	return ret;
+}
+
+void ShapeCast3D::_update_debug_shape_vertices() {
+	debug_shape_vertices.clear();
+	debug_line_vertices.clear();
+
+	if (!shape.is_null()) {
+		debug_shape_vertices.append_array(shape->get_debug_mesh_lines());
+		for (int i = 0; i < debug_shape_vertices.size(); i++) {
+			debug_shape_vertices.set(i, debug_shape_vertices[i] + Vector3(target_position * get_closest_collision_safe_fraction()));
+		}
+	}
+
+	if (target_position == Vector3()) {
+		return;
+	}
+
+	debug_line_vertices.push_back(Vector3());
+	debug_line_vertices.push_back(target_position);
+}
+
+const Vector<Vector3> &ShapeCast3D::get_debug_shape_vertices() const {
+	return debug_shape_vertices;
+}
+
+const Vector<Vector3> &ShapeCast3D::get_debug_line_vertices() const {
+	return debug_line_vertices;
+}
+
+void ShapeCast3D::set_debug_shape_custom_color(const Color &p_color) {
+	debug_shape_custom_color = p_color;
+	if (debug_material.is_valid()) {
+		_update_debug_shape_material();
+	}
+}
+
+Ref<StandardMaterial3D> ShapeCast3D::get_debug_material() {
+	_update_debug_shape_material();
+	return debug_material;
+}
+
+const Color &ShapeCast3D::get_debug_shape_custom_color() const {
+	return debug_shape_custom_color;
+}
+
+void ShapeCast3D::_create_debug_shape() {
+	_update_debug_shape_material();
+
+	Ref<ArrayMesh> mesh = memnew(ArrayMesh);
+
+	MeshInstance3D *mi = memnew(MeshInstance3D);
+	mi->set_mesh(mesh);
+
+	add_child(mi);
+	debug_shape = mi;
+}
+
+void ShapeCast3D::_update_debug_shape_material(bool p_check_collision) {
+	if (!debug_material.is_valid()) {
+		Ref<StandardMaterial3D> material = memnew(StandardMaterial3D);
+		debug_material = material;
+
+		material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+		// Use double-sided rendering so that the RayCast can be seen if the camera is inside.
+		material->set_cull_mode(BaseMaterial3D::CULL_DISABLED);
+		material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
+	}
+
+	Color color = debug_shape_custom_color;
+	if (color == Color(0.0, 0.0, 0.0)) {
+		// Use the default debug shape color defined in the Project Settings.
+		color = get_tree()->get_debug_collisions_color();
+	}
+
+	if (p_check_collision && collided) {
+		if ((color.get_h() < 0.055 || color.get_h() > 0.945) && color.get_s() > 0.5 && color.get_v() > 0.5) {
+			// If base color is already quite reddish, highlight collision with green color
+			color = Color(0.0, 1.0, 0.0, color.a);
+		} else {
+			// Else, highlight collision with red color
+			color = Color(1.0, 0, 0, color.a);
+		}
+	}
+
+	Ref<StandardMaterial3D> material = static_cast<Ref<StandardMaterial3D>>(debug_material);
+	material->set_albedo(color);
+}
+
+void ShapeCast3D::_update_debug_shape() {
+	if (!enabled) {
+		return;
+	}
+
+	if (!debug_shape) {
+		_create_debug_shape();
+	}
+
+	MeshInstance3D *mi = static_cast<MeshInstance3D *>(debug_shape);
+	Ref<ArrayMesh> mesh = mi->get_mesh();
+	if (!mesh.is_valid()) {
+		return;
+	}
+
+	_update_debug_shape_vertices();
+
+	mesh->clear_surfaces();
+
+	Array a;
+	a.resize(Mesh::ARRAY_MAX);
+
+	uint32_t flags = 0;
+	int surface_count = 0;
+
+	if (!debug_shape_vertices.is_empty()) {
+		a[Mesh::ARRAY_VERTEX] = debug_shape_vertices;
+		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, a, Array(), Dictionary(), flags);
+		mesh->surface_set_material(surface_count, debug_material);
+		++surface_count;
+	}
+
+	if (!debug_line_vertices.is_empty()) {
+		a[Mesh::ARRAY_VERTEX] = debug_line_vertices;
+		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, a, Array(), Dictionary(), flags);
+		mesh->surface_set_material(surface_count, debug_material);
+		++surface_count;
+	}
+}
+
+void ShapeCast3D::_clear_debug_shape() {
+	if (!debug_shape) {
+		return;
+	}
+
+	MeshInstance3D *mi = static_cast<MeshInstance3D *>(debug_shape);
+	if (mi->is_inside_tree()) {
+		mi->queue_delete();
+	} else {
+		memdelete(mi);
+	}
+
+	debug_shape = nullptr;
+}
+
+ShapeCast3D::~ShapeCast3D() {
+	if (!shape.is_null()) {
+		shape->unregister_owner(this);
+	}
+}

--- a/scene/3d/shape_cast_3d.h
+++ b/scene/3d/shape_cast_3d.h
@@ -1,0 +1,142 @@
+/*************************************************************************/
+/*  shape_cast_3d.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SHAPE_CAST_3D_H
+#define SHAPE_CAST_3D_H
+
+#include "scene/3d/node_3d.h"
+#include "scene/resources/shape_3d.h"
+
+class ShapeCast3D : public Node3D {
+	GDCLASS(ShapeCast3D, Node3D);
+
+	bool enabled = true;
+	void resource_changed(Ref<Resource> p_res);
+
+	Ref<Shape3D> shape;
+	RID shape_rid;
+	Vector3 target_position = Vector3(0, -1, 0);
+
+	HashSet<RID> exclude;
+	real_t margin = 0.0;
+	uint32_t collision_mask = 1;
+	bool exclude_parent_body = true;
+	bool collide_with_areas = false;
+	bool collide_with_bodies = true;
+
+	Node *debug_shape = nullptr;
+	Ref<Material> debug_material;
+	Color debug_shape_custom_color = Color(0.0, 0.0, 0.0);
+	Vector<Vector3> debug_shape_vertices;
+	Vector<Vector3> debug_line_vertices;
+
+	void _create_debug_shape();
+	void _update_debug_shape();
+	void _update_debug_shape_material(bool p_check_collision = false);
+	void _update_debug_shape_vertices();
+	void _clear_debug_shape();
+
+	// Result
+	int max_results = 32;
+	Vector<PhysicsDirectSpaceState3D::ShapeRestInfo> result;
+	bool collided = false;
+	real_t collision_safe_fraction = 1.0;
+	real_t collision_unsafe_fraction = 1.0;
+
+	Array _get_collision_result() const;
+
+	~ShapeCast3D();
+
+protected:
+	void _notification(int p_what);
+	void _update_shapecast_state();
+	static void _bind_methods();
+
+public:
+	void set_collide_with_areas(bool p_clip);
+	bool is_collide_with_areas_enabled() const;
+
+	void set_collide_with_bodies(bool p_clip);
+	bool is_collide_with_bodies_enabled() const;
+
+	void set_enabled(bool p_enabled);
+	bool is_enabled() const;
+
+	void set_shape(const Ref<Shape3D> &p_shape);
+	Ref<Shape3D> get_shape() const;
+
+	void set_target_position(const Vector3 &p_point);
+	Vector3 get_target_position() const;
+
+	void set_margin(real_t p_margin);
+	real_t get_margin() const;
+
+	void set_max_results(int p_max_results);
+	int get_max_results() const;
+
+	void set_collision_mask(uint32_t p_mask);
+	uint32_t get_collision_mask() const;
+
+	void set_collision_mask_value(int p_layer_number, bool p_value);
+	bool get_collision_mask_value(int p_layer_number) const;
+
+	void set_exclude_parent_body(bool p_exclude_parent_body);
+	bool get_exclude_parent_body() const;
+
+	const Color &get_debug_shape_custom_color() const;
+	void set_debug_shape_custom_color(const Color &p_color);
+
+	const Vector<Vector3> &get_debug_shape_vertices() const;
+	const Vector<Vector3> &get_debug_line_vertices() const;
+
+	Ref<StandardMaterial3D> get_debug_material();
+
+	int get_collision_count() const;
+	Object *get_collider(int p_idx) const;
+	int get_collider_shape(int p_idx) const;
+	Vector3 get_collision_point(int p_idx) const;
+	Vector3 get_collision_normal(int p_idx) const;
+
+	real_t get_closest_collision_safe_fraction() const;
+	real_t get_closest_collision_unsafe_fraction() const;
+
+	void force_shapecast_update();
+	bool is_colliding() const;
+
+	void add_exception_rid(const RID &p_rid);
+	void add_exception(const Object *p_object);
+	void remove_exception_rid(const RID &p_rid);
+	void remove_exception(const Object *p_object);
+	void clear_exceptions();
+
+	virtual TypedArray<String> get_configuration_warnings() const override;
+};
+
+#endif // SHAPE_CAST_3D_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -246,6 +246,7 @@
 #include "scene/3d/ray_cast_3d.h"
 #include "scene/3d/reflection_probe.h"
 #include "scene/3d/remote_transform_3d.h"
+#include "scene/3d/shape_cast_3d.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/3d/skeleton_ik_3d.h"
 #include "scene/3d/soft_dynamic_body_3d.h"
@@ -538,6 +539,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CollisionShape3D);
 	GDREGISTER_CLASS(CollisionPolygon3D);
 	GDREGISTER_CLASS(RayCast3D);
+	GDREGISTER_CLASS(ShapeCast3D);
 	GDREGISTER_CLASS(MultiMeshInstance3D);
 
 	GDREGISTER_CLASS(Curve3D);


### PR DESCRIPTION
Implements the 3D part of https://github.com/godotengine/godot-proposals/issues/710.

![image](https://user-images.githubusercontent.com/89754713/179579912-9ac4cb33-c7e0-453e-a972-5d34a46b906d.png)

Finishes [#56470](https://github.com/godotengine/godot/pull/56470#issue-1092801194)
3D counterpart of https://github.com/godotengine/godot/pull/54803#issue-1048640872

The `ShapeCast3D` node aims to add a much more user-friendly wrapper on top of the `PhysicsDirectSpaceState3D` shape casting calls. It works very similar to the `ShapeCast2D` node. 3D debugging exists as a line similar to that of the `RayCast3D` node.

![image](https://user-images.githubusercontent.com/89754713/179580704-6058878d-9345-4627-adef-88ce70cf709a.png)

Test project: [ShapeCast3DTest.zip](https://github.com/godotengine/godot/files/9134480/ShapeCast3DTest.zip)

***
Note: This is my very first pull request, and the first time I've attempted to contribute to Godot Engine's source code. I'm fairly new to C++. If I did something wrong, please let me know. 


