### PR TITLE
[3.x] `TileMapEditor` Fix interrupted erasing not being properly finished

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -1171,6 +1171,17 @@ bool TileMapEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 					return false; // Drag.
 				}
 
+				// Finish ongoing erasing.
+				if (tool == TOOL_ERASING || tool == TOOL_RECTANGLE_ERASE || tool == TOOL_LINE_ERASE) {
+					_finish_undo();
+
+					if (tool == TOOL_RECTANGLE_ERASE || tool == TOOL_LINE_ERASE) {
+						CanvasItemEditor::get_singleton()->update_viewport();
+					}
+
+					tool = TOOL_NONE;
+				}
+
 				if (tool == TOOL_NONE) {
 					if (mb->get_shift()) {
 						if (mb->get_command()) {


### PR DESCRIPTION
When in some erasing tool and LMB was pressed then the tool would be changed to non-erasing tool without properly finishing the ongoing erasing (specifically not finishing `UndoRedo` action could cause a crash). Proper finishing was handled only on RMB release. Added a check on LMB press to ensure ongoing erasing would be properly finished.
(Code handling all these tools feels spaghettish so... I just added some more pasta to it. :wink: Should be good enough for a hot-fix. Wouldn't be surprised if there were more unhandled hidden cases like this one in there though.)

Fixes #63160.

To make it clear, now:
1. Press and hold RMB -> erasing.
2. Click LMB (while holding RMB) -> finish erasing, place tile.
3. Still holding RMB -> nothing, erasing was finished. Would need to release and press RMB again to start a new erase.