### PR TITLE
Abort running if --path does not exist

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1044,10 +1044,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			if (I->next()) {
 				String p = I->next()->get();
-				if (OS::get_singleton()->set_cwd(p) == OK) {
-					//nothing
-				} else {
-					project_path = I->next()->get(); //use project_path instead
+				if (OS::get_singleton()->set_cwd(p) != OK) {
+					OS::get_singleton()->print("Invalid project path specified: \"%s\", aborting.\n", p.utf8().get_data());
+					goto error;
 				}
 				N = I->next()->next();
 			} else {


### PR DESCRIPTION
Fixes #57194

The original behavior seems to have been intended, but it made no sense.