### PR TITLE
Use menu icon for layers grid list button

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1088,6 +1088,17 @@ void EditorPropertyLayersGrid::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("rename_confirmed", PropertyInfo(Variant::INT, "layer_id"), PropertyInfo(Variant::STRING, "new_name")));
 }
 
+void EditorPropertyLayers::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			button->set_normal_texture(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
+			button->set_pressed_texture(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
+			button->set_disabled_texture(get_theme_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
+		} break;
+	}
+}
+
 void EditorPropertyLayers::_set_read_only(bool p_read_only) {
 	button->set_disabled(p_read_only);
 	grid->set_read_only(p_read_only);
@@ -1224,9 +1235,9 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	grid->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(grid);
 
-	button = memnew(Button);
+	button = memnew(TextureButton);
+	button->set_stretch_mode(TextureButton::STRETCH_KEEP_CENTERED);
 	button->set_toggle_mode(true);
-	button->set_text("...");
 	button->connect("pressed", callable_mp(this, &EditorPropertyLayers::_button_pressed));
 	hb->add_child(button);
 

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -340,13 +340,14 @@ private:
 	String basename;
 	LayerType layer_type;
 	PopupMenu *layers = nullptr;
-	Button *button = nullptr;
+	TextureButton *button = nullptr;
 
 	void _button_pressed();
 	void _menu_pressed(int p_menu);
 	void _refresh_names();
 
 protected:
+	void _notification(int p_what);
 	virtual void _set_read_only(bool p_read_only) override;
 	static void _bind_methods();
 


### PR DESCRIPTION
Changes the layers grid list button to a TextureButton with the menu icon.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/179635713-54da6a11-98fb-40c4-8546-a88a6131a140.png) | ![image](https://user-images.githubusercontent.com/67974470/179635519-e44282fc-38c1-4f0a-acf1-fcccdbb7341a.png) |