### PR TITLE
Capitalize the SpriteFrames search bar placeholder text

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1169,7 +1169,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	anim_search_box = memnew(LineEdit);
 	hbc_animlist->add_child(anim_search_box);
 	anim_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	anim_search_box->set_placeholder(TTR("Filter animations"));
+	anim_search_box->set_placeholder(TTR("Filter Animations"));
 	anim_search_box->set_clear_button_enabled(true);
 	anim_search_box->connect("text_changed", callable_mp(this, &SpriteFramesEditor::_animation_search_text_changed));
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/49488

Capitalizes the placeholder text of the new SpriteFrames editor search bar. See https://github.com/godotengine/godot/pull/61488 where I did this for all other search bars across the editor.