### PR TITLE
Defer `tab_changed` signal when removing children from `TabContainer` nodes

### DIFF
--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -46,7 +46,6 @@ class TabContainer : public Container {
 	bool drag_to_rearrange_enabled = false;
 	bool use_hidden_tabs_for_min_size = false;
 	bool theme_changing = false;
-	Node *child_removing = nullptr;
 
 	struct ThemeCache {
 		int side_margin = 0;


### PR DESCRIPTION
Reverts #63145 by resolving the problem with a different approach.

While it still removes the tab immediately, the signal emission itself is deferred. This means functions that do operations which modify the tab bar still work correctly when called right after `remove_child(child)`, while stuff that relies on the signal also works as well.

This implementation also avoids a bug from the older version when doing a operation that affect the tab bar right when the `tab_changed` signal is called.

I tested it with the bugs closed by the previous PR and they seemed to remain fixed, but I remember also not being able to reproduce the bug even before the old fix, so more testing is required.