### PR TITLE
Use the right memory ordering in SafeNumeric operations

### DIFF
--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -111,7 +111,7 @@ public:
 			if (tmp >= p_value) {
 				return tmp; // already greater, or equal
 			}
-			if (value.compare_exchange_weak(tmp, p_value, std::memory_order_release)) {
+			if (value.compare_exchange_weak(tmp, p_value, std::memory_order_acq_rel)) {
 				return p_value;
 			}
 		}
@@ -123,7 +123,7 @@ public:
 			if (c == 0) {
 				return 0;
 			}
-			if (value.compare_exchange_weak(c, c + 1, std::memory_order_release)) {
+			if (value.compare_exchange_weak(c, c + 1, std::memory_order_acq_rel)) {
 				return c + 1;
 			}
 		}


### PR DESCRIPTION
`compare_exchange_weak` is a read-modify-write operation. With the former `std::memory_order_release` we were only imposing memory ordering on the write while keeping the read relaxed. In order for the operation to be trustworthy we need the read to use acquire ordering so it syncs with other threads properly. Therefore, `std::memory_order_acq_rel` is what we want.

(The load we make above ourselves already uses `std::memory_order_acquire`, but that doesn't mean we didn't have to use acquire again to —let's say— sync to whatever has happened between both.)