### PR TITLE
Add RelaxedFlag, the relaxed counterpart of SafeFlag

### DIFF
--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -161,6 +161,33 @@ public:
 	}
 };
 
+class RelaxedFlag {
+	std::atomic_bool flag;
+
+	static_assert(std::atomic_bool::is_always_lock_free);
+
+public:
+	_ALWAYS_INLINE_ bool is_set() const {
+		return flag.load(std::memory_order_relaxed);
+	}
+
+	_ALWAYS_INLINE_ void set() {
+		flag.store(true, std::memory_order_relaxed);
+	}
+
+	_ALWAYS_INLINE_ void clear() {
+		flag.store(false, std::memory_order_relaxed);
+	}
+
+	_ALWAYS_INLINE_ void set_to(bool p_value) {
+		flag.store(p_value, std::memory_order_relaxed);
+	}
+
+	_ALWAYS_INLINE_ explicit RelaxedFlag(bool p_value = false) {
+		set_to(p_value);
+	}
+};
+
 class SafeRefCount {
 	SafeNumeric<uint32_t> count;
 


### PR DESCRIPTION
This is useful for those cases in which there's already a synchronization mechanism (like a semaphore) and everything you need is to ensure the variable is correctly read/written without imposing any ordering constraints that may hinder performance.