### PR TITLE
Improve DisplayServer.window_set_current_screen

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -1489,8 +1489,8 @@ void DisplayServerX11::window_set_current_screen(int p_screen, WindowID p_window
 		XMoveResizeWindow(x11_display, wd.x11_window, position.x, position.y, size.x, size.y);
 	} else {
 		if (p_screen != window_get_current_screen(p_window)) {
-			Point2i position = screen_get_position(p_screen);
-			XMoveWindow(x11_display, wd.x11_window, position.x, position.y);
+			Vector2 ofs = window_get_position(p_window) - screen_get_position(window_get_current_screen(p_window));
+			window_set_position(ofs + screen_get_position(p_screen), p_window);
 		}
 	}
 }

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -2008,6 +2008,10 @@ void DisplayServerOSX::window_set_current_screen(int p_screen, WindowID p_window
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
+	if (window_get_current_screen(p_window) == p_screen) {
+		return;
+	}
+
 	bool was_fullscreen = false;
 	if (wd.fullscreen) {
 		// Temporary exit fullscreen mode to move window.


### PR DESCRIPTION
- Prevent unnecessary fullscreen toggle animation on macOS, when screen is not changed
- Fix window position on Linux/X11