### PR TITLE
[Windows] Set fullscreen flags on window creation.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3458,6 +3458,12 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			windows.erase(id);
 			ERR_FAIL_V_MSG(INVALID_WINDOW_ID, "Failed to create Windows OS window.");
 		}
+		if (p_mode == WINDOW_MODE_FULLSCREEN || p_mode == WINDOW_MODE_EXCLUSIVE_FULLSCREEN) {
+			wd.fullscreen = true;
+			if (p_mode == WINDOW_MODE_FULLSCREEN) {
+				wd.multiwindow_fs = true;
+			}
+		}
 		if (p_mode != WINDOW_MODE_FULLSCREEN && p_mode != WINDOW_MODE_EXCLUSIVE_FULLSCREEN) {
 			wd.pre_fs_valid = true;
 		}


### PR DESCRIPTION
Fixes issue https://github.com/godotengine/godot/issues/54065 (on Windows only).