### PR TITLE
Don't process input in hidden EditorProperty.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -569,7 +569,7 @@ void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void EditorProperty::_unhandled_key_input(const Ref<InputEvent> &p_event) {
-	if (!selected) {
+	if (!selected || !is_visible_in_tree()) {
 		return;
 	}
 


### PR DESCRIPTION
This causes EditorProperty nodes to intercept input events even when the
Editor Properties dialog is not visible. This means that after closing
the dialog, ctrl+shift+c will still copy the last selected property
path.

Fixes #62866.

4.0 uses `shortcut_input` instead of `unhandled_input`, which does not have the same issue.
`shortcut_input` is not available in 3.x, so we have to work around it.
