### PR TITLE
Rework content scale to provide more options, add integer scaling

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2500,6 +2500,7 @@ bool Main::start() {
 
 			String stretch_mode = GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
 			String stretch_aspect = GLOBAL_DEF_BASIC("display/window/stretch/aspect", "keep");
+			String stretch_stretch = GLOBAL_DEF_BASIC("display/window/stretch/stretch", "fractional");
 			Size2i stretch_size = Size2i(GLOBAL_DEF_BASIC("display/window/size/viewport_width", 0),
 					GLOBAL_DEF_BASIC("display/window/size/viewport_height", 0));
 			real_t stretch_scale = GLOBAL_DEF_BASIC("display/window/stretch/scale", 1.0);
@@ -2522,8 +2523,16 @@ bool Main::start() {
 				cs_aspect = Window::CONTENT_SCALE_ASPECT_EXPAND;
 			}
 
+			Window::ContentScaleStretch cs_stretch = Window::CONTENT_SCALE_STRETCH_FRACTIONAL;
+			if (stretch_stretch == "integer") {
+				cs_stretch = Window::CONTENT_SCALE_STRETCH_INTEGER;
+			} else if (stretch_stretch == "hybrid") {
+				cs_stretch = Window::CONTENT_SCALE_STRETCH_HYBRID;
+			}
+
 			sml->get_root()->set_content_scale_mode(cs_sm);
 			sml->get_root()->set_content_scale_aspect(cs_aspect);
+			sml->get_root()->set_content_scale_stretch(cs_stretch);
 			sml->get_root()->set_content_scale_size(stretch_size);
 			sml->get_root()->set_content_scale_factor(stretch_scale);
 
@@ -2564,18 +2573,28 @@ bool Main::start() {
 							"display/window/stretch/mode",
 							PROPERTY_HINT_ENUM,
 							"disabled,canvas_items,viewport"));
+
 			GLOBAL_DEF_BASIC("display/window/stretch/aspect", "keep");
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/aspect",
 					PropertyInfo(Variant::STRING,
 							"display/window/stretch/aspect",
 							PROPERTY_HINT_ENUM,
 							"ignore,keep,keep_width,keep_height,expand"));
+
+			GLOBAL_DEF_BASIC("display/window/stretch/stretch", "fractional");
+			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/stretch",
+					PropertyInfo(Variant::STRING,
+							"display/window/stretch/stretch",
+							PROPERTY_HINT_ENUM,
+							"fractional,integer,hybrid"));
+
 			GLOBAL_DEF_BASIC("display/window/stretch/scale", 1.0);
 			ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/scale",
 					PropertyInfo(Variant::FLOAT,
 							"display/window/stretch/scale",
 							PROPERTY_HINT_RANGE,
-							"1.0,8.0,0.1"));
+							"0.5,8.0,0.01"));
+
 			sml->set_auto_accept_quit(GLOBAL_DEF("application/config/auto_accept_quit", true));
 			sml->set_quit_on_go_back(GLOBAL_DEF("application/config/quit_on_go_back", true));
 			GLOBAL_DEF_BASIC("gui/common/snap_controls_to_pixels", true);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -73,6 +73,12 @@ public:
 		CONTENT_SCALE_ASPECT_EXPAND,
 	};
 
+	enum ContentScaleStretch {
+		CONTENT_SCALE_STRETCH_FRACTIONAL,
+		CONTENT_SCALE_STRETCH_INTEGER,
+		CONTENT_SCALE_STRETCH_HYBRID,
+	};
+
 	enum LayoutDirection {
 		LAYOUT_DIRECTION_INHERITED,
 		LAYOUT_DIRECTION_LOCALE,
@@ -114,6 +120,7 @@ private:
 	Size2i content_scale_size;
 	ContentScaleMode content_scale_mode = CONTENT_SCALE_MODE_DISABLED;
 	ContentScaleAspect content_scale_aspect = CONTENT_SCALE_ASPECT_IGNORE;
+	ContentScaleStretch content_scale_stretch = CONTENT_SCALE_STRETCH_FRACTIONAL;
 	real_t content_scale_factor = 1.0;
 
 	void _make_window();
@@ -233,6 +240,9 @@ public:
 	void set_content_scale_aspect(ContentScaleAspect p_aspect);
 	ContentScaleAspect get_content_scale_aspect() const;
 
+	void set_content_scale_stretch(ContentScaleStretch p_stretch);
+	ContentScaleStretch get_content_scale_stretch() const;
+
 	void set_content_scale_factor(real_t p_factor);
 	real_t get_content_scale_factor() const;
 
@@ -304,6 +314,7 @@ VARIANT_ENUM_CAST(Window::Mode);
 VARIANT_ENUM_CAST(Window::Flags);
 VARIANT_ENUM_CAST(Window::ContentScaleMode);
 VARIANT_ENUM_CAST(Window::ContentScaleAspect);
+VARIANT_ENUM_CAST(Window::ContentScaleStretch);
 VARIANT_ENUM_CAST(Window::LayoutDirection);
 
 #endif // WINDOW_H


### PR DESCRIPTION
**I need help to finish this feature.** If you want to see this for 4.0, please lend a hand :slightly_smiling_face:

cc @yukitty, @starry-abyss

- Add content stretch modes Fractional (default), Integer and Hybrid.
  - All modes work with any stretch mode and aspect.
  - Fractional behaves as Godot currently does when scaling viewports. Pixel art will only look good when the window is scaled at an integer multiple of the original size.
  - Integer enforces an integer scale for the final display (rounded down from the automatically computed fractional scale). This provides crisp pixel art appearance.
    - Black bars may be displayed on all sides when using the `viewport` stretch mode. When using the `canvas_items` stretch mode, no black bars are displayed (unless the stretch aspect requires it), but the game's viewable area will change in 2D. 
  - *(Not implemented yet)*: Hybrid enforces an integer scale on the internal rendering resolution (rounding up), but the viewport will be stretched down to the final display with linear filtering. This provides good pixel art appearance, though not as crisp as the Integer mode. This is known as Sharp Bilinear in some other apps, though I think we should go for a shader-less approach.

- Tweak project setting for stretch scale to allow values as low as 0.5 (values below 1 are valid, and can be useful for UI testing purposes).

**Testing project:** [test_stretch_master.zip](https://github.com/godotengine/godot/files/9143781/test_stretch_master.zip)

## TODO

- [ ] Make UI anchors work properly when using integer scaling mode.
- [ ] Implement hybrid scaling mode.

This closes https://github.com/godotengine/godot-proposals/issues/1666.