### PR TITLE
Improve `linuxbsd` headless building, cleanup build scripts

### DIFF
--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -17,7 +17,7 @@ if env["platform"] == "android":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_ANDROID_KHR"])
 elif env["platform"] == "iphone":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_IOS_MVK"])
-elif env["platform"] == "linuxbsd":
+elif env["platform"] == "linuxbsd" and env["x11"]:
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_XLIB_KHR"])
 elif env["platform"] == "osx":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_MACOS_MVK"])

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -35,7 +35,11 @@ if env["platform"] == "android":
 
     # may need to include java parts of the openxr loader
 elif env["platform"] == "linuxbsd":
-    env_thirdparty.AppendUnique(CPPDEFINES=["XR_OS_LINUX", "XR_USE_PLATFORM_XLIB"])
+    env_thirdparty.AppendUnique(CPPDEFINES=["XR_OS_LINUX"])
+
+    if env["x11"]:
+        env_thirdparty.AppendUnique(CPPDEFINES=["XR_USE_PLATFORM_XLIB"])
+
     # FIXME: Review what needs to be set for Android and macOS.
     env_thirdparty.AppendUnique(CPPDEFINES=["HAVE_SECURE_GETENV"])
 elif env["platform"] == "windows":

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -12,7 +12,7 @@ common_linuxbsd = [
     "freedesktop_screensaver.cpp",
 ]
 
-if "x11" in env and env["x11"]:
+if env["x11"]:
     common_linuxbsd += [
         "gl_manager_x11.cpp",
         "detect_prime_x11.cpp",
@@ -20,13 +20,13 @@ if "x11" in env and env["x11"]:
         "key_mapping_x11.cpp",
     ]
 
-if "speechd" in env and env["speechd"]:
+    if env["vulkan"]:
+        common_linuxbsd.append("vulkan_context_x11.cpp")
+
+if env["speechd"]:
     common_linuxbsd.append(["speechd-so_wrap.c", "tts_linux.cpp"])
 
-if "vulkan" in env and env["vulkan"]:
-    common_linuxbsd.append("vulkan_context_x11.cpp")
-
-if "udev" in env and env["udev"]:
+if env["udev"]:
     common_linuxbsd.append("libudev-so_wrap.c")
 
 prog = env.add_program("#bin/godot", ["godot_linuxbsd.cpp"] + common_linuxbsd)

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -15,45 +15,9 @@ def can_build():
     if os.name != "posix" or sys.platform == "darwin":
         return False
 
-    # Check the minimal dependencies
-    x11_error = os.system("pkg-config --version > /dev/null")
-    if x11_error:
+    pkgconf_error = os.system("pkg-config --version > /dev/null")
+    if pkgconf_error:
         print("Error: pkg-config not found. Aborting.")
-        return False
-
-    x11_error = os.system("pkg-config x11 --modversion > /dev/null")
-    if x11_error:
-        print("Error: X11 libraries not found. Aborting.")
-        return False
-
-    x11_error = os.system("pkg-config xcursor --modversion > /dev/null")
-    if x11_error:
-        print("Error: Xcursor library not found. Aborting.")
-        return False
-
-    x11_error = os.system("pkg-config xinerama --modversion > /dev/null")
-    if x11_error:
-        print("Error: Xinerama library not found. Aborting.")
-        return False
-
-    x11_error = os.system("pkg-config xext --modversion > /dev/null")
-    if x11_error:
-        print("Error: Xext library not found. Aborting.")
-        return False
-
-    x11_error = os.system("pkg-config xrandr --modversion > /dev/null")
-    if x11_error:
-        print("Error: XrandR library not found. Aborting.")
-        return False
-
-    x11_error = os.system("pkg-config xrender --modversion > /dev/null")
-    if x11_error:
-        print("Error: XRender library not found. Aborting.")
-        return False
-
-    x11_error = os.system("pkg-config xi --modversion > /dev/null")
-    if x11_error:
-        print("Error: Xi library not found. Aborting.")
         return False
 
     return True
@@ -219,13 +183,14 @@ def configure(env):
 
     ## Dependencies
 
-    env.ParseConfig("pkg-config x11 --cflags --libs")
-    env.ParseConfig("pkg-config xcursor --cflags --libs")
-    env.ParseConfig("pkg-config xinerama --cflags --libs")
-    env.ParseConfig("pkg-config xext --cflags --libs")
-    env.ParseConfig("pkg-config xrandr --cflags --libs")
-    env.ParseConfig("pkg-config xrender --cflags --libs")
-    env.ParseConfig("pkg-config xi --cflags --libs")
+    if env["x11"]:
+        env.ParseConfig("pkg-config x11 --cflags --libs")
+        env.ParseConfig("pkg-config xcursor --cflags --libs")
+        env.ParseConfig("pkg-config xinerama --cflags --libs")
+        env.ParseConfig("pkg-config xext --cflags --libs")
+        env.ParseConfig("pkg-config xrandr --cflags --libs")
+        env.ParseConfig("pkg-config xrender --cflags --libs")
+        env.ParseConfig("pkg-config xi --cflags --libs")
 
     if env["touch"]:
         env.Append(CPPDEFINES=["TOUCH_ENABLED"])
@@ -381,8 +346,9 @@ def configure(env):
             # No pkgconfig file so far, hardcode expected lib name.
             env.Append(LIBS=["glslang", "SPIRV"])
 
-    env.Append(CPPDEFINES=["GLES3_ENABLED"])
-    env.ParseConfig("pkg-config gl --cflags --libs")
+    if env["opengl3"]:
+        env.Append(CPPDEFINES=["GLES3_ENABLED"])
+        env.ParseConfig("pkg-config gl --cflags --libs")
 
     env.Append(LIBS=["pthread"])
 


### PR DESCRIPTION
Now the `linuxbsd` platform can be built headlessly (e.g. without X11 development libraries).

I also cleaned up some weird (old?) usages of the `env` variable which seem to make no difference and are used nowhere else.

I couldn't test this with everything and still for some reason [ALSA gets forced on](https://github.com/godotengine/godot/blob/e44a2f16805b09a9a858ba5e8ebec7e598feb4d8/platform/linuxbsd/detect.py#L320-L325), but I decided to ignore this behaviour for now (feel free to ask me to fix it).

This PR also paves the way for a proper Wayland integration in the build system, as X11 library checking was forced into `can_build` without being able to be disabled from the user, which caused lots of problems (like the one this PR fixes).