### PR TITLE
Add missing fields to VkRenderPassCreateInfo2KHR struct

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4016,6 +4016,8 @@ RenderingDevice::FramebufferFormatID RenderingDeviceVulkan::framebuffer_format_c
 	render_pass_create_info.pSubpasses = &subpass;
 	render_pass_create_info.dependencyCount = 0;
 	render_pass_create_info.pDependencies = nullptr;
+	render_pass_create_info.correlatedViewMaskCount = 0;
+	render_pass_create_info.pCorrelatedViewMasks = nullptr;
 
 	VkRenderPass render_pass;
 	VkResult res = context->vkCreateRenderPass2KHR(device, &render_pass_create_info, nullptr, &render_pass);


### PR DESCRIPTION
Not all compilers clear structs resulting in unpredictable behavior (i.e. crashes), this PR clears 2 missing fields when calling `vkCreateRenderPass2KHR` when setting up our splash screen.

Should fix #63207
