### PR TITLE
Load/update GDScript from disk on load if cache mode is CACHE_MODE_IGNORE

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2390,7 +2390,7 @@ Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const Str
 	}
 
 	Error err;
-	Ref<GDScript> script = GDScriptCache::get_full_script(p_path, err);
+	Ref<GDScript> script = GDScriptCache::get_full_script(p_path, err, "", p_cache_mode == CACHE_MODE_IGNORE);
 
 	// TODO: Reintroduce binary and encrypted scripts.
 

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -88,7 +88,7 @@ public:
 	static Ref<GDScriptParserRef> get_parser(const String &p_path, GDScriptParserRef::Status status, Error &r_error, const String &p_owner = String());
 	static String get_source_code(const String &p_path);
 	static Ref<GDScript> get_shallow_script(const String &p_path, const String &p_owner = String());
-	static Ref<GDScript> get_full_script(const String &p_path, Error &r_error, const String &p_owner = String());
+	static Ref<GDScript> get_full_script(const String &p_path, Error &r_error, const String &p_owner = String(), bool p_update_from_disk = false);
 	static Error finish_compiling(const String &p_owner);
 
 	GDScriptCache();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

`GDScript` has two caches, in `ResourceCache` and `GDScriptCache`.
Previously, it would not load/update from disk even if the cache mode was `CACHE_MODE_IGNORE`. Causes reloading `GDScript` to not work when externally changed.

[Peek 2022-07-18 22-04.webm](https://user-images.githubusercontent.com/30386067/179908456-9db2c488-7166-4bf1-b187-6bfc757ed80d.webm)

The left one is Alpha12


~~Fix #49298.~~

**Edit:**

I've found that external editing can be roughly divided into two cases:

1. External editing without _LSP_;
2. External editing via _LSP_ connection.

This PR is able to address the first case.
