### PR TITLE
Simplify alignment preset, fixing icon for full rect

### DIFF
--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -173,7 +173,7 @@ void EditorPropertyAnchorsPreset::setup(const Vector<String> &p_options) {
 
 	Vector<String> split_after;
 	split_after.append("Custom");
-	split_after.append("PresetWide");
+	split_after.append("PresetFullRect");
 	split_after.append("PresetBottomLeft");
 	split_after.append("PresetCenter");
 
@@ -181,24 +181,18 @@ void EditorPropertyAnchorsPreset::setup(const Vector<String> &p_options) {
 		Vector<String> text_split = p_options[i].split(":");
 		int64_t current_val = text_split[1].to_int();
 
-		String humanized_name = text_split[0];
-		if (humanized_name.begins_with("Preset")) {
-			if (humanized_name == "PresetWide") {
-				humanized_name = "Full Rect";
-			} else {
-				humanized_name = humanized_name.trim_prefix("Preset");
-				humanized_name = humanized_name.capitalize();
-			}
-
-			String icon_name = text_split[0].trim_prefix("Preset");
-			icon_name = "ControlAlign" + icon_name;
+		String option_name = text_split[0];
+		if (option_name.begins_with("Preset")) {
+			String preset_name = option_name.trim_prefix("Preset");
+			String humanized_name = preset_name.capitalize();
+			String icon_name = "ControlAlign" + preset_name;
 			options->add_icon_item(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(icon_name, "EditorIcons"), humanized_name);
 		} else {
-			options->add_item(humanized_name);
+			options->add_item(option_name);
 		}
 
 		options->set_item_metadata(j, current_val);
-		if (split_after.has(text_split[0])) {
+		if (split_after.has(option_name)) {
 			options->add_separator();
 			j++;
 		}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3300,7 +3300,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_mode", PROPERTY_HINT_ENUM, "Position,Anchors,Container,Uncontrolled", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_layout_mode", "_get_layout_mode");
 	ADD_PROPERTY_DEFAULT("layout_mode", LayoutMode::LAYOUT_MODE_POSITION);
 
-	const String anchors_presets_options = "Custom:-1,PresetWide:15,"
+	const String anchors_presets_options = "Custom:-1,PresetFullRect:15,"
 										   "PresetTopLeft:0,PresetTopRight:1,PresetBottomRight:3,PresetBottomLeft:2,"
 										   "PresetCenterLeft:4,PresetCenterTop:5,PresetCenterRight:6,PresetCenterBottom:7,PresetCenter:8,"
 										   "PresetLeftWide:9,PresetTopWide:10,PresetRightWide:11,PresetBottomWide:12,PresetVCenterWide:13,PresetHCenterWide:14";


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/59301

Fixes this:
![image](https://user-images.githubusercontent.com/14253836/179958439-b561abe5-989a-46f7-bbff-16bfca88ba33.png)
