### PR TITLE
[3.x] Fix `CanvasItem` not exiting its canvas group on canvas exit

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -530,16 +530,16 @@ void CanvasItem::_enter_canvas() {
 
 		VisualServer::get_singleton()->canvas_item_set_parent(canvas_item, canvas);
 
-		group = "root_canvas" + itos(canvas.get_id());
+		canvas_group = "root_canvas" + itos(canvas.get_id());
 
-		add_to_group(group);
+		add_to_group(canvas_group);
 		if (canvas_layer) {
 			canvas_layer->reset_sort_index();
 		} else {
 			get_viewport()->gui_reset_canvas_sort_index();
 		}
 
-		get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, group, "_toplevel_raise_self");
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, canvas_group, "_toplevel_raise_self");
 
 	} else {
 		CanvasItem *parent = get_parent_item();
@@ -558,7 +558,10 @@ void CanvasItem::_exit_canvas() {
 	notification(NOTIFICATION_EXIT_CANVAS, true); //reverse the notification
 	VisualServer::get_singleton()->canvas_item_set_parent(canvas_item, RID());
 	canvas_layer = nullptr;
-	group = "";
+	if (canvas_group != "") {
+		remove_from_group(canvas_group);
+		canvas_group = "";
+	}
 }
 
 void CanvasItem::_notification(int p_what) {
@@ -584,8 +587,8 @@ void CanvasItem::_notification(int p_what) {
 				break;
 			}
 
-			if (group != "") {
-				get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, group, "_toplevel_raise_self");
+			if (canvas_group != "") {
+				get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, canvas_group, "_toplevel_raise_self");
 			} else {
 				CanvasItem *p = get_parent_item();
 				ERR_FAIL_COND(!p);

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -179,7 +179,7 @@ private:
 	mutable SelfList<Node> xform_change;
 
 	RID canvas_item;
-	String group;
+	String canvas_group;
 
 	CanvasLayer *canvas_layer;
 


### PR DESCRIPTION
All `CanvasItem`s not parented to another `CanvasItem` within the given canvas are added to the group specific for this canvas (on entering the canvas). However, they were not removed from such group on canvas exit which could result in unexpected/strange state (and thus behavior) like: `CanvasItem` being a child of another `CanvasItem` could still belong to a canvas group, or `CanvasItem` could belong to many different canvas groups etc.
Now they should be correctly removed from the canvas group on exiting the canvas.

Fixes #63183.

In action (MRP from #63183):
Scene / after `ready()`:
![Godot_v3 5-rc6_win64_OD0wa8cuFN](https://user-images.githubusercontent.com/9283098/179961151-b752440d-88b4-475f-af02-4f7ec6d3e477.png) / ![Godot_v3 5-rc6_win64_qaSCgFu1Sk](https://user-images.githubusercontent.com/9283098/179961245-979febf7-0d19-4ea8-9794-22747ad8e2dd.png)

- `3.5.rc6`:
![Godot_v3 5-rc6_win64_qtbs0lgep9](https://user-images.githubusercontent.com/9283098/179963000-c15b4be5-c998-444a-b44d-883c4d964a3a.png)
Fixed behavior by manual removal from the group:
![52FAopsbdY](https://user-images.githubusercontent.com/9283098/179963059-c3c5031b-e2c6-4c65-87a2-82a21699d61e.png)

- This PR:
![v7dgQV7z7Q](https://user-images.githubusercontent.com/9283098/179963102-aa5cd28d-fdb0-41a1-a2a9-01645421ecf3.png)


