### PR TITLE
send FLAGS_TRANSPOSE_RECT to Vulkan

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -528,7 +528,7 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 					}
 
 					if (rect->flags & CANVAS_RECT_TRANSPOSE) {
-						dst_rect.size.x *= -1; // Encoding in the dst_rect.z uniform
+						push_constant.flags |= FLAGS_TRANSPOSE_RECT;
 					}
 
 					if (rect->flags & CANVAS_RECT_CLIP_UV) {


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/44365.

The FLAGS_TRANSPOSE_RECT flag is now passed through to Vulkan in order to render transposed canvas rects. I have tested it with the new TileMap system (see: https://github.com/godotengine/godot/issues/56390) and it seems to work perfectly for both square and non-square rects.

The only thing that concerns me about this PR is that I do not at all understand what the original line was *trying* to do, which makes me a little nervous about removing it a la Chesterton's Fence. Hopefully someone with more rendering experience can give it a look-over before merging.

*Bugsquad edit:*
- Fixes #44365.
- Fixes #56390.