### PR TITLE
CI: Bump Linux cache key to force clean build

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.
-  GODOT_BASE_BRANCH: master-v2
+  GODOT_BASE_BRANCH: master-v3
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
 
 concurrency:


### PR DESCRIPTION
Sanitizers build started crashing on linking, let's see if this solves it.