### PR TITLE
[3.x] Fix documentation for `print_debug`

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -716,7 +716,12 @@
 		<method name="print_debug" qualifiers="vararg">
 			<return type="void" />
 			<description>
-				Like [method print], but prints only when used in debug mode.
+				Like [method print], but includes the current stack frame when running with the debugger turned on.
+				Output in the console would look something like this:
+				[codeblock]
+				Test print
+				   At: res://test.gd:15:_process()
+				[/codeblock]
 			</description>
 		</method>
 		<method name="print_stack">


### PR DESCRIPTION
Closes #48068

`print_debug` was introduced by #18966 for printing file name & line number along with the message. When adding documetation for it in #24804, it's mistaken as debug mode only.

The documetation is correct on the current `master`.