### PR TITLE
Revert script resource on discard unsaved changes

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -831,8 +831,35 @@ void ScriptEditor::_close_current_tab(bool p_save) {
 }
 
 void ScriptEditor::_close_discard_current_tab(const String &p_str) {
+	_revert_discard_tab(tab_container->get_current_tab());
 	_close_tab(tab_container->get_current_tab(), false);
 	erase_tab_confirm->hide();
+}
+
+void ScriptEditor::_revert_discard_tab(int p_idx) {
+	if (p_idx < 0 || p_idx >= tab_container->get_tab_count()) {
+		return;
+	}
+
+	ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(p_idx));
+	if (!se) {
+		return;
+	}
+
+	Ref<Script> script = se->get_edited_resource();
+	if (script == nullptr || script->is_built_in()) {
+		return;
+	}
+
+	Ref<Script> rel_script = ResourceLoader::load(script->get_path(), script->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+	if (!rel_script.is_valid()) {
+		return;
+	}
+
+	script->set_source_code(rel_script->get_source_code());
+	script->set_last_modified_time(rel_script->get_last_modified_time());
+	script->reload(true);
+	se->reload_text();
 }
 
 void ScriptEditor::_close_docs_tab() {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -342,6 +342,7 @@ class ScriptEditor : public PanelContainer {
 
 	void _close_current_tab(bool p_save = true);
 	void _close_discard_current_tab(const String &p_str);
+	void _revert_discard_tab(int p_idx);
 	void _close_docs_tab();
 	void _close_other_tabs();
 	void _close_all_tabs();


### PR DESCRIPTION
Fixes #63151, fixes #50578

Currently, selecting "Discard" on the "Close and save changes?" dialog does not save the changes to disk. After the "Idle Parse Delay," and if the script is validated successfully, the contents of the editor are saved to the script resource. This is cached by ResourceLoader, so the unsaved changes remain loaded even after the file is 'closed' from the script editor. (This issue goes back since at least Godot 3.0.)

This PR uses the same approach as in ScriptEditor::_reload_scripts to clear the cache and reload the file from disk.

Currently, _reload_scripts is also broken because CACHE_MODE_IGNORE does not actually clear the cache from GDScriptCache, so #63224 must be merged first.