### PR TITLE
Add read-only mode to AnimationTreeEditor plugins

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -221,6 +221,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="arrange_nodes_button_hidden" type="bool" setter="set_arrange_nodes_button_hidden" getter="is_arrange_nodes_button_hidden" default="false">
+			If [code]true[/code], the Arrange Nodes button is hidden.
+		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="connection_lines_antialiased" type="bool" setter="set_connection_lines_antialiased" getter="is_connection_lines_antialiased" default="true">
 			If [code]true[/code], the lines between nodes will use antialiasing.

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -156,7 +156,7 @@
 			<description>
 				Sets properties of the slot with ID [param idx].
 				If [param enable_left]/[param enable_right], a port will appear and the slot will be able to be connected from this side.
-				[param type_left]/[param type_right] is an arbitrary type of the port. Only ports with the same type values can be connected.
+				[param type_left]/[param type_right] is an arbitrary type of the port. Only ports with the same type values can be connected and negative values will disallow all connections to be made via user inputs.
 				[param color_left]/[param color_right] is the tint of the port's icon on this side.
 				[param custom_left]/[param custom_right] is a custom texture for this side's port.
 				[b]Note:[/b] This method only sets properties of the slot. To create the slot, add a [Control]-derived child to the GraphNode.
@@ -208,7 +208,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="type_left" type="int" />
 			<description>
-				Sets the left (input) type of the slot [param idx] to [param type_left].
+				Sets the left (input) type of the slot [param idx] to [param type_left]. If the value is negative, all connections will be disallowed to be created via user inputs.
 			</description>
 		</method>
 		<method name="set_slot_type_right">
@@ -216,13 +216,16 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="type_right" type="int" />
 			<description>
-				Sets the right (output) type of the slot [param idx] to [param type_right].
+				Sets the right (output) type of the slot [param idx] to [param type_right]. If the value is negative, all connections will be disallowed to be created via user inputs.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="comment" type="bool" setter="set_comment" getter="is_comment" default="false">
 			If [code]true[/code], the GraphNode is a comment node.
+		</member>
+		<member name="draggable" type="bool" setter="set_draggable" getter="is_draggable" default="true">
+			If [code]true[/code], the user can drag the GraphNode.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
@@ -238,6 +241,9 @@
 		<member name="resizable" type="bool" setter="set_resizable" getter="is_resizable" default="false">
 			If [code]true[/code], the user can resize the GraphNode.
 			[b]Note:[/b] Dragging the handle will only emit the [signal resize_request] signal, the GraphNode needs to be resized manually.
+		</member>
+		<member name="selectable" type="bool" setter="set_selectable" getter="is_selectable" default="true">
+			If [code]true[/code], the user can select the GraphNode.
 		</member>
 		<member name="selected" type="bool" setter="set_selected" getter="is_selected" default="false">
 			If [code]true[/code], the GraphNode is selected.

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -149,6 +149,10 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
+	if (read_only) {
+		return;
+	}
+
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (grabbing_grabber) {

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -46,6 +46,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendSpace1DEditor, AnimationTreeNodeEditorPlugin);
 
 	Ref<AnimationNodeBlendSpace1D> blend_space;
+	bool read_only = false;
 
 	HBoxContainer *goto_parent_hb = nullptr;
 	Button *goto_parent = nullptr;

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -46,6 +46,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendSpace2DEditor, AnimationTreeNodeEditorPlugin);
 
 	Ref<AnimationNodeBlendSpace2D> blend_space;
+	bool read_only = false;
 
 	PanelContainer *panel = nullptr;
 	Button *tool_blend = nullptr;

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -47,6 +47,9 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendTreeEditor, AnimationTreeNodeEditorPlugin);
 
 	Ref<AnimationNodeBlendTree> blend_tree;
+
+	bool read_only = false;
+
 	GraphEdit *graph = nullptr;
 	MenuButton *add_node = nullptr;
 	Vector2 position_from_popup_menu;
@@ -106,7 +109,7 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _delete_nodes_request(const TypedArray<StringName> &p_nodes);
 
 	bool _update_filters(const Ref<AnimationNode> &anode);
-	void _edit_filters(const String &p_which);
+	void _inspect_filters(const String &p_which);
 	void _filter_edited();
 	void _filter_toggled();
 	Ref<AnimationNode> _filter_edit;

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -47,6 +47,8 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	Ref<AnimationNodeStateMachine> state_machine;
 
+	bool read_only = false;
+
 	Button *tool_select = nullptr;
 	Button *tool_create = nullptr;
 	Button *tool_connect = nullptr;

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -607,13 +607,16 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 									connecting_color = Object::cast_to<GraphNode>(to)->get_connection_input_color(E.to_port);
 									connecting_target = false;
 									connecting_to = pos;
-									just_disconnected = true;
 
-									emit_signal(SNAME("disconnection_request"), E.from, E.from_port, E.to, E.to_port);
-									to = get_node(String(connecting_from)); //maybe it was erased
-									if (Object::cast_to<GraphNode>(to)) {
-										connecting = true;
-										emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, false);
+									if (connecting_type >= 0) {
+										just_disconnected = true;
+
+										emit_signal(SNAME("disconnection_request"), E.from, E.from_port, E.to, E.to_port);
+										to = get_node(String(connecting_from)); //maybe it was erased
+										if (Object::cast_to<GraphNode>(to)) {
+											connecting = true;
+											emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, false);
+										}
 									}
 									return;
 								}
@@ -621,7 +624,6 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 						}
 					}
 
-					connecting = true;
 					connecting_from = gn->get_name();
 					connecting_index = j;
 					connecting_out = true;
@@ -629,8 +631,11 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 					connecting_color = gn->get_connection_output_color(j);
 					connecting_target = false;
 					connecting_to = pos;
-					just_disconnected = false;
-					emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, true);
+					if (connecting_type >= 0) {
+						connecting = true;
+						just_disconnected = false;
+						emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, true);
+					}
 					return;
 				}
 			}
@@ -657,11 +662,13 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 									connecting_to = pos;
 									just_disconnected = true;
 
-									emit_signal(SNAME("disconnection_request"), E.from, E.from_port, E.to, E.to_port);
-									fr = get_node(String(connecting_from)); //maybe it was erased
-									if (Object::cast_to<GraphNode>(fr)) {
-										connecting = true;
-										emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, true);
+									if (connecting_type >= 0) {
+										emit_signal(SNAME("disconnection_request"), E.from, E.from_port, E.to, E.to_port);
+										fr = get_node(String(connecting_from)); //maybe it was erased
+										if (Object::cast_to<GraphNode>(fr)) {
+											connecting = true;
+											emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, true);
+										}
 									}
 									return;
 								}
@@ -669,7 +676,6 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 						}
 					}
 
-					connecting = true;
 					connecting_from = gn->get_name();
 					connecting_index = j;
 					connecting_out = false;
@@ -677,8 +683,11 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 					connecting_color = gn->get_connection_input_color(j);
 					connecting_target = false;
 					connecting_to = pos;
-					just_disconnected = false;
-					emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, false);
+					if (connecting_type >= 0) {
+						connecting = true;
+						just_disconnected = false;
+						emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, false);
+					}
 					return;
 				}
 			}
@@ -1127,7 +1136,7 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 		drag_accum += mm->get_relative();
 		for (int i = get_child_count() - 1; i >= 0; i--) {
 			GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
-			if (gn && gn->is_selected()) {
+			if (gn && gn->is_selected() && gn->is_draggable()) {
 				Vector2 pos = (gn->get_drag_from() * zoom + drag_accum) / zoom;
 
 				// Snapping can be toggled temporarily by holding down Ctrl.
@@ -1166,7 +1175,9 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 				} else if (gn->is_selected() && !box_selection_mode_additive) {
 					emit_signal(SNAME("node_deselected"), gn);
 				}
-				gn->set_selected(box_selection_mode_additive);
+				if (gn->is_selectable()) {
+					gn->set_selected(box_selection_mode_additive);
+				}
 			} else {
 				bool select = (previous_selected.find(gn) != nullptr);
 				if (gn->is_selected() && !select) {
@@ -1174,7 +1185,9 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 				} else if (!gn->is_selected() && select) {
 					emit_signal(SNAME("node_selected"), gn);
 				}
-				gn->set_selected(select);
+				if (gn->is_selectable()) {
+					gn->set_selected(select);
+				}
 			}
 		}
 
@@ -1193,7 +1206,7 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 						continue;
 					}
 
-					bool select = (previous_selected.find(gn) != nullptr);
+					bool select = (gn->is_selectable() && previous_selected.find(gn) != nullptr);
 					if (gn->is_selected() && !select) {
 						emit_signal(SNAME("node_deselected"), gn);
 					} else if (!gn->is_selected() && select) {
@@ -1285,7 +1298,7 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 						GraphNode *o_gn = Object::cast_to<GraphNode>(get_child(i));
 						if (o_gn) {
 							if (o_gn == gn) {
-								o_gn->set_selected(true);
+								o_gn->set_selected(o_gn->is_selectable());
 							} else {
 								if (o_gn->is_selected()) {
 									emit_signal(SNAME("node_deselected"), o_gn);
@@ -1296,7 +1309,7 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 					}
 				}
 
-				gn->set_selected(true);
+				gn->set_selected(gn->is_selectable());
 				for (int i = 0; i < get_child_count(); i++) {
 					GraphNode *o_gn = Object::cast_to<GraphNode>(get_child(i));
 					if (!o_gn) {
@@ -1709,6 +1722,19 @@ void GraphEdit::set_minimap_enabled(bool p_enable) {
 
 bool GraphEdit::is_minimap_enabled() const {
 	return minimap_button->is_pressed();
+}
+
+void GraphEdit::set_arrange_nodes_button_hidden(bool p_enable) {
+	arrange_nodes_button_hidden = p_enable;
+	if (arrange_nodes_button_hidden) {
+		layout_button->hide();
+	} else {
+		layout_button->show();
+	}
+}
+
+bool GraphEdit::is_arrange_nodes_button_hidden() const {
+	return arrange_nodes_button_hidden;
 }
 
 void GraphEdit::_minimap_toggled() {
@@ -2343,6 +2369,9 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_minimap_enabled", "enable"), &GraphEdit::set_minimap_enabled);
 	ClassDB::bind_method(D_METHOD("is_minimap_enabled"), &GraphEdit::is_minimap_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_arrange_nodes_button_hidden", "enable"), &GraphEdit::set_arrange_nodes_button_hidden);
+	ClassDB::bind_method(D_METHOD("is_arrange_nodes_button_hidden"), &GraphEdit::is_arrange_nodes_button_hidden);
+
 	ClassDB::bind_method(D_METHOD("set_right_disconnects", "enable"), &GraphEdit::set_right_disconnects);
 	ClassDB::bind_method(D_METHOD("is_right_disconnects_enabled"), &GraphEdit::is_right_disconnects_enabled);
 
@@ -2381,6 +2410,9 @@ void GraphEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_enabled"), "set_minimap_enabled", "is_minimap_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "minimap_size", PROPERTY_HINT_NONE, "suffix:px"), "set_minimap_size", "get_minimap_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "minimap_opacity"), "set_minimap_opacity", "get_minimap_opacity");
+
+	ADD_GROUP("UI", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "arrange_nodes_button_hidden"), "set_arrange_nodes_button_hidden", "is_arrange_nodes_button_hidden");
 
 	ADD_SIGNAL(MethodInfo("connection_request", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_slot")));
 	ADD_SIGNAL(MethodInfo("disconnection_request", PropertyInfo(Variant::STRING_NAME, "from"), PropertyInfo(Variant::INT, "from_slot"), PropertyInfo(Variant::STRING_NAME, "to"), PropertyInfo(Variant::INT, "to_slot")));

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -133,6 +133,8 @@ private:
 	void _pan_callback(Vector2 p_scroll_vec);
 	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
+	bool arrange_nodes_button_hidden = false;
+
 	bool connecting = false;
 	String connecting_from;
 	bool connecting_out = false;
@@ -322,6 +324,9 @@ public:
 
 	void set_minimap_enabled(bool p_enable);
 	bool is_minimap_enabled() const;
+
+	void set_arrange_nodes_button_hidden(bool p_enable);
+	bool is_arrange_nodes_button_hidden() const;
 
 	GraphEditFilter *get_top_layer() const { return top_layer; }
 	GraphEditMinimap *get_minimap() const { return minimap; }

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -1005,6 +1005,22 @@ bool GraphNode::is_resizable() const {
 	return resizable;
 }
 
+void GraphNode::set_draggable(bool p_draggable) {
+	draggable = p_draggable;
+}
+
+bool GraphNode::is_draggable() {
+	return draggable;
+}
+
+void GraphNode::set_selectable(bool p_selectable) {
+	selectable = p_selectable;
+}
+
+bool GraphNode::is_selectable() {
+	return selectable;
+}
+
 Vector<int> GraphNode::get_allowed_size_flags_horizontal() const {
 	Vector<int> flags;
 	flags.append(SIZE_FILL);
@@ -1066,6 +1082,12 @@ void GraphNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_resizable", "resizable"), &GraphNode::set_resizable);
 	ClassDB::bind_method(D_METHOD("is_resizable"), &GraphNode::is_resizable);
 
+	ClassDB::bind_method(D_METHOD("set_draggable", "draggable"), &GraphNode::set_draggable);
+	ClassDB::bind_method(D_METHOD("is_draggable"), &GraphNode::is_draggable);
+
+	ClassDB::bind_method(D_METHOD("set_selectable", "selectable"), &GraphNode::set_selectable);
+	ClassDB::bind_method(D_METHOD("is_selectable"), &GraphNode::is_selectable);
+
 	ClassDB::bind_method(D_METHOD("set_selected", "selected"), &GraphNode::set_selected);
 	ClassDB::bind_method(D_METHOD("is_selected"), &GraphNode::is_selected);
 
@@ -1091,6 +1113,8 @@ void GraphNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_position_offset", "get_position_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_close"), "set_show_close_button", "is_close_button_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resizable"), "set_resizable", "is_resizable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draggable"), "set_draggable", "is_draggable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selectable"), "set_selectable", "is_selectable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selected"), "set_selected", "is_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "comment"), "set_comment", "is_comment");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "overlay", PROPERTY_HINT_ENUM, "Disabled,Breakpoint,Position"), "set_overlay", "get_overlay");

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -67,6 +67,8 @@ private:
 	Vector2 position_offset;
 	bool comment = false;
 	bool resizable = false;
+	bool draggable = true;
+	bool selectable = true;
 
 	bool resizing = false;
 	Vector2 resizing_from;
@@ -182,6 +184,12 @@ public:
 
 	void set_resizable(bool p_enable);
 	bool is_resizable() const;
+
+	void set_draggable(bool p_draggable);
+	bool is_draggable();
+
+	void set_selectable(bool p_selectable);
+	bool is_selectable();
 
 	virtual Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
Adds a read-only mode to the AnimationTreeEditor plugin when operating on resources embedded in foreign scenes. Currently only covers state machines, blend 1D, and blend 2D editors. Blend trees do not currently support a read-only mode due to their reliance on the built-in GraphEdit control which does not yet have the required read-only state needed to prevent edits.

Complementary PR to #63245