### PR TITLE
Disable polygon editing on foreign resources

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -118,6 +118,10 @@ bool AbstractPolygon2DEditor::_has_resource() const {
 	return true;
 }
 
+bool AbstractPolygon2DEditor::_resource_is_foreign() const {
+	return false;
+}
+
 void AbstractPolygon2DEditor::_create_resource() {
 }
 
@@ -259,6 +263,14 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 			create_resource->popup_centered();
 		}
 		return (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT);
+	} else {
+		if (_resource_is_foreign()) {
+			if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
+				foreign_resource_warning->set_text(String("Polygon resource cannot be edited because does not belong to the edited scene. Make it unique first."));
+				foreign_resource_warning->popup_centered();
+			}
+			return (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT);
+		}
 	}
 
 	CanvasItemEditor::Tool tool = CanvasItemEditor::get_singleton()->get_current_tool();
@@ -734,6 +746,10 @@ AbstractPolygon2DEditor::AbstractPolygon2DEditor(bool p_wip_destructive) {
 	create_resource = memnew(ConfirmationDialog);
 	add_child(create_resource);
 	create_resource->set_ok_button_text(TTR("Create"));
+
+	foreign_resource_warning = memnew(AcceptDialog);
+	add_child(foreign_resource_warning);
+	foreign_resource_warning->get_ok_button()->set_text(TTR("Warning"));
 }
 
 void AbstractPolygon2DEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -88,6 +88,7 @@ class AbstractPolygon2DEditor : public HBoxContainer {
 	CanvasItemEditor *canvas_item_editor = nullptr;
 	Panel *panel = nullptr;
 	ConfirmationDialog *create_resource = nullptr;
+	AcceptDialog *foreign_resource_warning = nullptr;
 
 protected:
 	enum {
@@ -134,6 +135,7 @@ protected:
 	virtual void _commit_action();
 
 	virtual bool _has_resource() const;
+	virtual bool _resource_is_foreign() const;
 	virtual void _create_resource();
 
 public:

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -89,6 +89,35 @@ bool LightOccluder2DEditor::_has_resource() const {
 	return node && node->get_occluder_polygon().is_valid();
 }
 
+bool LightOccluder2DEditor::_resource_is_foreign() const {
+	if (node) {
+		Ref<OccluderPolygon2D> occuluder_polygon = node->get_occluder_polygon();
+		if (occuluder_polygon.is_valid()) {
+			String path = occuluder_polygon->get_path();
+			if (!path.is_resource_file()) {
+				int srpos = path.find("::");
+				if (srpos != -1) {
+					String base = path.substr(0, srpos);
+					if (ResourceLoader::get_resource_type(base) == "PackedScene") {
+						if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
+							return true;
+						}
+					} else {
+						if (FileAccess::exists(base + ".import")) {
+							return true;
+						}
+					}
+				}
+			} else {
+				if (FileAccess::exists(occuluder_polygon->get_path() + ".import")) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
 void LightOccluder2DEditor::_create_resource() {
 	if (!node) {
 		return;

--- a/editor/plugins/light_occluder_2d_editor_plugin.h
+++ b/editor/plugins/light_occluder_2d_editor_plugin.h
@@ -53,6 +53,7 @@ protected:
 	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) override;
 
 	virtual bool _has_resource() const override;
+	virtual bool _resource_is_foreign() const override;
 	virtual void _create_resource() override;
 
 public:

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -99,6 +99,35 @@ bool NavigationPolygonEditor::_has_resource() const {
 	return node && node->get_navigation_polygon().is_valid();
 }
 
+bool NavigationPolygonEditor::_resource_is_foreign() const {
+	if (node) {
+		Ref<NavigationPolygon> navigation_polygon = node->get_navigation_polygon();
+		if (navigation_polygon.is_valid()) {
+			String path = navigation_polygon->get_path();
+			if (!path.is_resource_file()) {
+				int srpos = path.find("::");
+				if (srpos != -1) {
+					String base = path.substr(0, srpos);
+					if (ResourceLoader::get_resource_type(base) == "PackedScene") {
+						if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
+							return true;
+						}
+					} else {
+						if (FileAccess::exists(base + ".import")) {
+							return true;
+						}
+					}
+				}
+			} else {
+				if (FileAccess::exists(navigation_polygon->get_path() + ".import")) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
 void NavigationPolygonEditor::_create_resource() {
 	if (!node) {
 		return;

--- a/editor/plugins/navigation_polygon_editor_plugin.h
+++ b/editor/plugins/navigation_polygon_editor_plugin.h
@@ -54,6 +54,7 @@ protected:
 	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) override;
 
 	virtual bool _has_resource() const override;
+	virtual bool _resource_is_foreign() const override;
 	virtual void _create_resource() override;
 
 public:


### PR DESCRIPTION
Disables polygon edits on foreign resources since the results will not be saved.