### PR TITLE
Fix AnimationTreeEditorPlugin editor selection on nodes with no tree root

### DIFF
--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -61,7 +61,7 @@ class AnimationTreeEditor : public VBoxContainer {
 	Vector<String> edited_path;
 	Vector<AnimationTreeNodeEditorPlugin *> editors;
 
-	void _update_path();
+	void _update_path(bool p_show_root);
 	ObjectID current_root;
 
 	void _path_button_pressed(int p_path);


### PR DESCRIPTION
Fixes an issue with the AnimationTreeEditorPlugin retaining the context of a previously selected AnimationTree node if the subsequent selection's tree_root is set to null.