### PR TITLE
Fix CI OOM without disabling ASAN 

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -31,12 +31,12 @@ jobs:
             proj-conv: true
             artifact: true
 
-          - name: Editor with doubles and GCC sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=no, use_ubsan=yes)
+          - name: Editor with doubles and GCC sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=yes, use_ubsan=yes)
             cache-name: linux-editor-double-sanitizers
             target: debug
             tools: true
             tests: true
-            sconsflags: float=64 use_asan=no use_ubsan=yes
+            sconsflags: float=64 use_asan=yes use_ubsan=yes
             proj-test: true
             # Can be turned off for PRs that intentionally break compat with godot-cpp,
             # until both the upstream PR and the matching godot-cpp changes are merged.

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -216,7 +216,6 @@ def configure(env):
             env["AR"] = "gcc-ar"
 
     env.Append(CCFLAGS=["-pipe"])
-    env.Append(LINKFLAGS=["-pipe"])
 
     ## Dependencies
 


### PR DESCRIPTION
For some weird reason and according to my repeated testing, it looks like that we just have to remove `-pipe` from `LINKFLAGS` during `linuxbsd` building to not make the CI go OOM while running the GCC sanitized job.

Again, I'm not sure how it worked twice on my repo but I hope it works here too.