### PR TITLE
Print expected `os.arch` tuple for current platform in GDExtension error

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -181,6 +181,42 @@ String Engine::get_license_text() const {
 	return String(GODOT_LICENSE_TEXT);
 }
 
+String Engine::get_architecture_name() const {
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
+	return "x86_64";
+
+#elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
+	return "x86_32";
+
+#elif defined(__aarch64__) || defined(_M_ARM64)
+	return "arm64";
+
+#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7S__)
+	return "armv7";
+
+#elif defined(__riscv)
+#if __riscv_xlen == 8
+	return "rv64";
+#else
+	return "riscv";
+#endif
+
+#elif defined(__powerpc__)
+#if defined(__powerpc64__)
+	return "ppc64";
+#else
+	return "ppc";
+#endif
+
+#elif defined(__wasm__)
+#if defined(__wasm64__)
+	return "wasm64";
+#elif defined(__wasm32__)
+	return "wasm32";
+#endif
+#endif
+}
+
 bool Engine::is_abort_on_gpu_errors_enabled() const {
 	return abort_on_gpu_errors;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -142,6 +142,8 @@ public:
 	void set_write_movie_path(const String &p_path);
 	String get_write_movie_path() const;
 
+	String get_architecture_name() const;
+
 	void set_shader_cache_path(const String &p_path);
 	String get_shader_cache_path() const;
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2270,6 +2270,10 @@ String Engine::get_license_text() const {
 	return ::Engine::get_singleton()->get_license_text();
 }
 
+String Engine::get_architecture_name() const {
+	return ::Engine::get_singleton()->get_architecture_name();
+}
+
 bool Engine::is_in_physics_frame() const {
 	return ::Engine::get_singleton()->is_in_physics_frame();
 }
@@ -2366,6 +2370,8 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_donor_info"), &Engine::get_donor_info);
 	ClassDB::bind_method(D_METHOD("get_license_info"), &Engine::get_license_info);
 	ClassDB::bind_method(D_METHOD("get_license_text"), &Engine::get_license_text);
+
+	ClassDB::bind_method(D_METHOD("get_architecture_name"), &Engine::get_architecture_name);
 
 	ClassDB::bind_method(D_METHOD("is_in_physics_frame"), &Engine::is_in_physics_frame);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -666,6 +666,8 @@ public:
 	Dictionary get_license_info() const;
 	String get_license_text() const;
 
+	String get_architecture_name() const;
+
 	bool is_in_physics_frame() const;
 
 	bool has_singleton(const StringName &p_name) const;

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -372,7 +372,7 @@ Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const St
 	}
 
 	if (err != OK) {
-		ERR_PRINT("Error loading GDExtension config file: " + p_path);
+		ERR_PRINT("Error loading GDExtension configuration file: " + p_path);
 		return Ref<Resource>();
 	}
 
@@ -380,7 +380,7 @@ Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const St
 		if (r_error) {
 			*r_error = ERR_INVALID_DATA;
 		}
-		ERR_PRINT("GDExtension config file must contain 'configuration.entry_symbol' key: " + p_path);
+		ERR_PRINT("GDExtension configuration file must contain a \"configuration/entry_symbol\" key: " + p_path);
 		return Ref<Resource>();
 	}
 
@@ -413,7 +413,8 @@ Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const St
 		if (r_error) {
 			*r_error = ERR_FILE_NOT_FOUND;
 		}
-		ERR_PRINT("No GDExtension library found for current architecture; in config file " + p_path);
+		const String os_arch = OS::get_singleton()->get_name().to_lower() + "." + Engine::get_singleton()->get_architecture_name();
+		ERR_PRINT(vformat("No GDExtension library found for current OS and architecture (%s) in configuration file: %s", os_arch, p_path));
 		return Ref<Resource>();
 	}
 

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -9,6 +9,20 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_architecture_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name of the CPU architecture the Godot binary was built for. Possible return values are [code]x86_64[/code], [code]x86_32[/code], [code]arm64[/code], [code]armv7[/code], [code]rv64[/code], [code]riscv[/code], [code]ppc64[/code], [code]ppc[/code], [code]wasm64[/code] and [code]wasm32[/code].
+				To detect whether the current CPU architecture is 64-bit, you can use the fact that all 64-bit architecture names have [code]64[/code] in their name:
+				[codeblock]
+				if "64" in Engine.get_architecture_name():
+				    print("Running on 64-bit CPU.")
+				else:
+				    print("Running on 32-bit CPU.")
+				[/codeblock]
+				[b]Note:[/b] [method get_architecture_name] does [i]not[/i] return the name of the host CPU architecture. For example, if running an x86_32 Godot binary on a x86_64 system, the returned value will be [code]x86_32[/code].
+			</description>
+		</method>
 		<method name="get_author_info" qualifiers="const">
 			<return type="Dictionary" />
 			<description>


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/55778.

This also adds `Engine.get_architecture_name()` to get the name of the CPU architecture the Godot binary was built for.

I'm not 100% sure if this is a correct solution (and I don't have a GDExtension to test it), but it should help troubleshoot GDExtension setup problems.