### PR TITLE
[4.x] Allow extending MultiplayerPeerExtension from GDScript

### DIFF
--- a/core/multiplayer/multiplayer_peer.cpp
+++ b/core/multiplayer/multiplayer_peer.cpp
@@ -130,6 +130,20 @@ Error MultiplayerPeerExtension::get_packet(const uint8_t **r_buffer, int &r_buff
 	if (GDVIRTUAL_CALL(_get_packet, r_buffer, &r_buffer_size, err)) {
 		return (Error)err;
 	}
+	if (GDVIRTUAL_IS_OVERRIDDEN(_get_packet_script)) {
+		if (!GDVIRTUAL_CALL(_get_packet_script, script_buffer)) {
+			return FAILED;
+		}
+
+		if (script_buffer.size() == 0) {
+			return Error::ERR_UNAVAILABLE;
+		}
+
+		*r_buffer = script_buffer.ptr();
+		r_buffer_size = script_buffer.size();
+
+		return Error::OK;
+	}
 	WARN_PRINT_ONCE("MultiplayerPeerExtension::_get_packet_native is unimplemented!");
 	return FAILED;
 }
@@ -137,6 +151,16 @@ Error MultiplayerPeerExtension::get_packet(const uint8_t **r_buffer, int &r_buff
 Error MultiplayerPeerExtension::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 	int err;
 	if (GDVIRTUAL_CALL(_put_packet, p_buffer, p_buffer_size, err)) {
+		return (Error)err;
+	}
+	if (GDVIRTUAL_IS_OVERRIDDEN(_put_packet_script)) {
+		PackedByteArray a;
+		a.resize(p_buffer_size);
+		memcpy(a.ptrw(), p_buffer, p_buffer_size);
+
+		if (!GDVIRTUAL_CALL(_put_packet_script, a, err)) {
+			return FAILED;
+		}
 		return (Error)err;
 	}
 	WARN_PRINT_ONCE("MultiplayerPeerExtension::_put_packet_native is unimplemented!");
@@ -253,6 +277,9 @@ void MultiplayerPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_put_packet, "p_buffer", "p_buffer_size");
 	GDVIRTUAL_BIND(_get_available_packet_count);
 	GDVIRTUAL_BIND(_get_max_packet_size);
+
+	GDVIRTUAL_BIND(_get_packet_script)
+	GDVIRTUAL_BIND(_put_packet_script, "p_buffer");
 
 	GDVIRTUAL_BIND(_set_transfer_channel, "p_channel");
 	GDVIRTUAL_BIND(_get_transfer_channel);

--- a/core/multiplayer/multiplayer_peer.h
+++ b/core/multiplayer/multiplayer_peer.h
@@ -93,6 +93,8 @@ class MultiplayerPeerExtension : public MultiplayerPeer {
 protected:
 	static void _bind_methods();
 
+	PackedByteArray script_buffer;
+
 public:
 	/* PacketPeer */
 	virtual int get_available_packet_count() const override;
@@ -125,6 +127,10 @@ public:
 	GDVIRTUAL2R(int, _get_packet, GDNativeConstPtr<const uint8_t *>, GDNativePtr<int>);
 	GDVIRTUAL2R(int, _put_packet, GDNativeConstPtr<const uint8_t>, int);
 	GDVIRTUAL0RC(int, _get_max_packet_size);
+
+	/* PacketPeer GDScript */
+	GDVIRTUAL0R(PackedByteArray, _get_packet_script);
+	GDVIRTUAL1R(int, _put_packet_script, PackedByteArray);
 
 	/* MultiplayerPeer GDExtension */
 	GDVIRTUAL1(_set_transfer_channel, int);

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -41,6 +41,12 @@
 				Called when the ID of the [MultiplayerPeer] who sent the most recent packet is requested (see [method MultiplayerPeer.get_packet_peer]).
 			</description>
 		</method>
+		<method name="_get_packet_script" qualifiers="virtual">
+			<return type="PackedByteArray" />
+			<description>
+				Called when a packet needs to be received by the [MultiplayerAPI], if [method _get_packet] isn't implemented. Use this when extending this class via GDScript.
+			</description>
+		</method>
 		<method name="_get_transfer_channel" qualifiers="virtual const">
 			<return type="int" />
 			<description>
@@ -83,6 +89,13 @@
 			<argument index="1" name="p_buffer_size" type="int" />
 			<description>
 				Called when a packet needs to be sent by the [MultiplayerAPI], with [code]p_buffer_size[/code] being the size of the binary [code]p_buffer[/code] in bytes.
+			</description>
+		</method>
+		<method name="_put_packet_script" qualifiers="virtual">
+			<return type="int" />
+			<argument index="0" name="p_buffer" type="PackedByteArray" />
+			<description>
+				Called when a packet needs to be sent by the [MultiplayerAPI], if [method _put_packet] isn't implemented. Use this when extending this class via GDScript.
 			</description>
 		</method>
 		<method name="_set_refuse_new_connections" qualifiers="virtual">


### PR DESCRIPTION
Godot 4 implementation of https://github.com/godotengine/godot-proposals/issues/4873

It looks like the 3.x version (PR https://github.com/godotengine/godot/pull/63163) was just merged!