### PR TITLE
Show errors from non-main threads in editor

### DIFF
--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -128,7 +128,7 @@ public:
 
 	virtual void poll_events(bool p_is_idle) {}
 	virtual void send_message(const String &p_msg, const Array &p_data) = 0;
-	virtual void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type) = 0;
+	virtual void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type, bool p_thread_safe = false) = 0;
 	virtual void debug(bool p_can_continue = true, bool p_is_error_breakpoint = false) = 0;
 
 	virtual ~EngineDebugger();

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -360,7 +360,7 @@ void LocalDebugger::send_message(const String &p_message, const Array &p_args) {
 	// print_line("MESSAGE: '" + p_message + "' - " + String(Variant(p_args)));
 }
 
-void LocalDebugger::send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type) {
+void LocalDebugger::send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type, bool p_thread_safe) {
 	print_line("ERROR: '" + (p_descr.is_empty() ? p_err : p_descr) + "'");
 }
 

--- a/core/debugger/local_debugger.h
+++ b/core/debugger/local_debugger.h
@@ -50,7 +50,7 @@ private:
 public:
 	void debug(bool p_can_continue, bool p_is_error_breakpoint);
 	void send_message(const String &p_message, const Array &p_args);
-	void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type);
+	void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type, bool p_thread_safe);
 
 	LocalDebugger();
 	~LocalDebugger();

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -79,8 +79,8 @@ private:
 
 	// Make handlers and send_message thread safe.
 	Mutex mutex;
-	bool flushing = false;
-	Thread::ID flush_thread = 0;
+	SafeFlag flushing;
+	SafeNumeric<Thread::ID> flush_thread;
 
 	PrintHandlerList phl;
 	static void _print_handler(void *p_this, const String &p_string, bool p_error, bool p_rich);
@@ -106,7 +106,7 @@ public:
 	// Overrides
 	void poll_events(bool p_is_idle);
 	void send_message(const String &p_message, const Array &p_args);
-	void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type);
+	void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type, bool p_thread_safe);
 	void debug(bool p_can_continue = true, bool p_is_error_breakpoint = false);
 
 	explicit RemoteDebugger(Ref<RemoteDebuggerPeer> p_peer);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3441,9 +3441,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 
 		if (!GDScriptLanguage::get_singleton()->debug_break(err_text, false)) {
-			// debugger break did not happen
-
+			// Debug break did not happen, usually because it is unsupported for additional threads.
 			_err_print_error(err_func.utf8().get_data(), err_file.utf8().get_data(), err_line, err_text.utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+
+			// Submit error to debugger also, which works for additional threads, even though debugging does not.
+			if (EngineDebugger::is_active()) {
+				EngineDebugger::get_singleton()->send_error(err_func, err_file, err_line, "Breakpoint could not be triggered due to engine limitations.", err_text, false, ERR_HANDLER_SCRIPT, true);
+			}
 		}
 
 		// Get a default return type in case of failure


### PR DESCRIPTION
The GDScript VM breaks out of the current function on error, such as assertion failures or general script errors.  These errors cause debug breakpoints when running under the debugger/editor.  However, threads that are not the main thread are not able to be debugged.  For any worker threads, these errors were just printed to stderr, and then the thread would silently exit the current frame, leading to unpredictable results.  There was no indication in the Editor itself.

This change submits such errors to the error reporting facility of the debugger also, so they can be displayed in the editor as Errors.  They still don't cause debug breakpoints, because that would require general support for thread debugging.  This is for notifications only.

Example program:

```
extends Node

var typed: int 

func _ready():
	var thread = Thread.new()
	thread.start(_thread_function)
	thread.wait_to_finish()
	
func _thread_function():
	assert(typed > 0, "this was only shown on stderr before, with no indication in the Editor")
```

![image](https://user-images.githubusercontent.com/817160/180123105-f1ce1a57-3286-4bc3-ab58-627ba60ccdaf.png)


