### PR TITLE
Disable editing properties in foreign resources

### DIFF
--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -62,9 +62,9 @@
 		</signal>
 		<signal name="resource_selected">
 			<param index="0" name="resource" type="Resource" />
-			<param index="1" name="edit" type="bool" />
+			<param index="1" name="inspect" type="bool" />
 			<description>
-				Emitted when the resource value was set and user clicked to edit it. When [param edit] is [code]true[/code], the signal was caused by the context menu "Edit" option.
+				Emitted when the resource value was set and user clicked to edit it. When [param inspect] is [code]true[/code], the signal was caused by the context menu "Edit" or "Inspect" option.
 			</description>
 		</signal>
 	</signals>

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -60,7 +60,7 @@ public:
 		return true;
 	}
 
-	bool _read_only() {
+	bool _is_read_only() {
 		return animation_read_only;
 	}
 
@@ -70,7 +70,7 @@ public:
 		ClassDB::bind_method(D_METHOD("_hide_script_from_inspector"), &AnimationTrackKeyEdit::_hide_script_from_inspector);
 		ClassDB::bind_method(D_METHOD("get_root_path"), &AnimationTrackKeyEdit::get_root_path);
 		ClassDB::bind_method(D_METHOD("_dont_undo_redo"), &AnimationTrackKeyEdit::_dont_undo_redo);
-		ClassDB::bind_method(D_METHOD("_read_only"), &AnimationTrackKeyEdit::_read_only);
+		ClassDB::bind_method(D_METHOD("_is_read_only"), &AnimationTrackKeyEdit::_is_read_only);
 	}
 
 	void _fix_node_path(Variant &value) {
@@ -727,7 +727,7 @@ public:
 		return true;
 	}
 
-	bool _read_only() {
+	bool _is_read_only() {
 		return animation_read_only;
 	}
 
@@ -737,7 +737,7 @@ public:
 		ClassDB::bind_method(D_METHOD("_hide_script_from_inspector"), &AnimationMultiTrackKeyEdit::_hide_script_from_inspector);
 		ClassDB::bind_method(D_METHOD("get_root_path"), &AnimationMultiTrackKeyEdit::get_root_path);
 		ClassDB::bind_method(D_METHOD("_dont_undo_redo"), &AnimationMultiTrackKeyEdit::_dont_undo_redo);
-		ClassDB::bind_method(D_METHOD("_read_only"), &AnimationMultiTrackKeyEdit::_read_only);
+		ClassDB::bind_method(D_METHOD("_is_read_only"), &AnimationMultiTrackKeyEdit::_is_read_only);
 	}
 
 	void _fix_node_path(Variant &value, NodePath &base) {

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -85,6 +85,7 @@ void EditorDebuggerRemoteObject::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_variant"), &EditorDebuggerRemoteObject::get_variant);
 	ClassDB::bind_method(D_METHOD("clear"), &EditorDebuggerRemoteObject::clear);
 	ClassDB::bind_method(D_METHOD("get_remote_object_id"), &EditorDebuggerRemoteObject::get_remote_object_id);
+	ClassDB::bind_method(D_METHOD("_is_read_only"), &EditorDebuggerRemoteObject::_is_read_only);
 
 	ADD_SIGNAL(MethodInfo("value_edited", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "property"), PropertyInfo("value")));
 }

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -50,6 +50,7 @@ public:
 	HashMap<StringName, Variant> prop_values;
 
 	ObjectID get_remote_object_id() { return remote_object_id; };
+	bool _is_read_only() { return true; };
 	String get_title();
 
 	Variant get_variant(const StringName &p_name);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -776,6 +776,8 @@ public:
 	void open_request(const String &p_path);
 	void edit_foreign_resource(Ref<Resource> p_resource);
 
+	bool is_resource_read_only(Ref<Resource> p_resource);
+
 	bool is_changing_scene() const;
 
 	Control *get_main_control();

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -835,7 +835,7 @@ class EditorPropertyResource : public EditorProperty {
 	bool updating_theme = false;
 	bool opened_editor = false;
 
-	void _resource_selected(const Ref<Resource> &p_resource, bool p_edit);
+	void _resource_selected(const Ref<Resource> &p_resource, bool p_inspect);
 	void _resource_changed(const Ref<Resource> &p_resource);
 
 	void _viewport_selected(const NodePath &p_path);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -81,6 +81,8 @@ void EditorResourcePicker::_update_resource() {
 	} else if (edited_resource.is_valid()) {
 		assign_button->set_tooltip(resource_path + TTR("Type:") + " " + edited_resource->get_class());
 	}
+
+	assign_button->set_disabled(!editable && !edited_resource.is_valid());
 }
 
 void EditorResourcePicker::_update_resource_preview(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, ObjectID p_obj) {
@@ -171,35 +173,50 @@ void EditorResourcePicker::_update_menu_items() {
 	edit_menu->clear();
 
 	// Add options for creating specific subtypes of the base resource type.
-	set_create_options(edit_menu);
+	if (is_editable()) {
+		set_create_options(edit_menu);
 
-	// Add an option to load a resource from a file using the QuickOpen dialog.
-	edit_menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Quick Load"), OBJ_MENU_QUICKLOAD);
+		// Add an option to load a resource from a file using the QuickOpen dialog.
+		edit_menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Quick Load"), OBJ_MENU_QUICKLOAD);
 
-	// Add an option to load a resource from a file using the regular file dialog.
-	edit_menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Load"), OBJ_MENU_LOAD);
+		// Add an option to load a resource from a file using the regular file dialog.
+		edit_menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Load"), OBJ_MENU_LOAD);
+	}
 
 	// Add options for changing existing value of the resource.
 	if (edited_resource.is_valid()) {
-		edit_menu->add_icon_item(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), TTR("Edit"), OBJ_MENU_EDIT);
-		edit_menu->add_icon_item(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), TTR("Clear"), OBJ_MENU_CLEAR);
-		edit_menu->add_icon_item(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), TTR("Make Unique"), OBJ_MENU_MAKE_UNIQUE);
+		// Determine if the edited resource is part of another scene (foreign) which was imported
+		bool is_edited_resource_foreign_import = EditorNode::get_singleton()->is_resource_read_only(edited_resource);
 
-		// Check whether the resource has subresources.
-		List<PropertyInfo> property_list;
-		edited_resource->get_property_list(&property_list);
-		bool has_subresources = false;
-		for (PropertyInfo &p : property_list) {
-			if ((p.type == Variant::OBJECT) && (p.hint == PROPERTY_HINT_RESOURCE_TYPE) && (p.name != "script")) {
-				has_subresources = true;
-				break;
+		// If the resource is determined to be foreign and imported, change the menu entry's description to 'inspect' rather than 'edit'
+		// since will only be able to view its properties in read-only mode.
+		if (is_edited_resource_foreign_import) {
+			// The 'Search' icon is a magnifying glass, which seems appropriate, but maybe a bespoke icon is preferred here.
+			edit_menu->add_icon_item(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")), TTR("Inspect"), OBJ_MENU_INSPECT);
+		} else {
+			edit_menu->add_icon_item(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), TTR("Edit"), OBJ_MENU_INSPECT);
+		}
+
+		if (is_editable()) {
+			edit_menu->add_icon_item(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")), TTR("Clear"), OBJ_MENU_CLEAR);
+			edit_menu->add_icon_item(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), TTR("Make Unique"), OBJ_MENU_MAKE_UNIQUE);
+
+			// Check whether the resource has subresources.
+			List<PropertyInfo> property_list;
+			edited_resource->get_property_list(&property_list);
+			bool has_subresources = false;
+			for (PropertyInfo &p : property_list) {
+				if ((p.type == Variant::OBJECT) && (p.hint == PROPERTY_HINT_RESOURCE_TYPE) && (p.name != "script")) {
+					has_subresources = true;
+					break;
+				}
 			}
-		}
-		if (has_subresources) {
-			edit_menu->add_icon_item(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), TTR("Make Unique (Recursive)"), OBJ_MENU_MAKE_UNIQUE_RECURSIVE);
-		}
+			if (has_subresources) {
+				edit_menu->add_icon_item(get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")), TTR("Make Unique (Recursive)"), OBJ_MENU_MAKE_UNIQUE_RECURSIVE);
+			}
 
-		edit_menu->add_icon_item(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")), TTR("Save"), OBJ_MENU_SAVE);
+			edit_menu->add_icon_item(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")), TTR("Save"), OBJ_MENU_SAVE);
+		}
 
 		if (edited_resource->get_path().is_resource_file()) {
 			edit_menu->add_separator();
@@ -210,14 +227,16 @@ void EditorResourcePicker::_update_menu_items() {
 	// Add options to copy/paste resource.
 	Ref<Resource> cb = EditorSettings::get_singleton()->get_resource_clipboard();
 	bool paste_valid = false;
-	if (cb.is_valid()) {
-		if (base_type.is_empty()) {
-			paste_valid = true;
-		} else {
-			for (int i = 0; i < base_type.get_slice_count(","); i++) {
-				if (ClassDB::is_parent_class(cb->get_class(), base_type.get_slice(",", i))) {
-					paste_valid = true;
-					break;
+	if (is_editable()) {
+		if (cb.is_valid()) {
+			if (base_type.is_empty()) {
+				paste_valid = true;
+			} else {
+				for (int i = 0; i < base_type.get_slice_count(","); i++) {
+					if (ClassDB::is_parent_class(cb->get_class(), base_type.get_slice(",", i))) {
+						paste_valid = true;
+						break;
+					}
 				}
 			}
 		}
@@ -236,7 +255,7 @@ void EditorResourcePicker::_update_menu_items() {
 	}
 
 	// Add options to convert existing resource to another type of resource.
-	if (edited_resource.is_valid()) {
+	if (is_editable() && edited_resource.is_valid()) {
 		Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(edited_resource);
 		if (conversions.size()) {
 			edit_menu->add_separator();
@@ -295,7 +314,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			quick_open->set_title(TTR("Resource"));
 		} break;
 
-		case OBJ_MENU_EDIT: {
+		case OBJ_MENU_INSPECT: {
 			if (edited_resource.is_valid()) {
 				emit_signal(SNAME("resource_selected"), edited_resource, true);
 			}
@@ -491,20 +510,21 @@ void EditorResourcePicker::_button_draw() {
 }
 
 void EditorResourcePicker::_button_input(const Ref<InputEvent> &p_event) {
-	if (!editable) {
-		return;
-	}
-
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (mb.is_valid()) {
 		if (mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
-			_update_menu_items();
+			// Only attempt to update and show the menu if we have
+			// a valid resource or the Picker is editable, as
+			// there will otherwise be nothing to display.
+			if (edited_resource.is_valid() || is_editable()) {
+				_update_menu_items();
 
-			Vector2 pos = get_screen_position() + mb->get_position();
-			edit_menu->reset_size();
-			edit_menu->set_position(pos);
-			edit_menu->popup();
+				Vector2 pos = get_screen_position() + mb->get_position();
+				edit_menu->reset_size();
+				edit_menu->set_position(pos);
+				edit_menu->popup();
+			}
 		}
 	}
 }
@@ -734,7 +754,7 @@ void EditorResourcePicker::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 
-	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource"), PropertyInfo(Variant::BOOL, "edit")));
+	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource"), PropertyInfo(Variant::BOOL, "inspect")));
 	ADD_SIGNAL(MethodInfo("resource_changed", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
 }
 
@@ -866,7 +886,7 @@ void EditorResourcePicker::set_toggle_pressed(bool p_pressed) {
 
 void EditorResourcePicker::set_editable(bool p_editable) {
 	editable = p_editable;
-	assign_button->set_disabled(!editable);
+	assign_button->set_disabled(!editable && !edited_resource.is_valid());
 	edit_button->set_visible(editable);
 }
 

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -63,7 +63,7 @@ class EditorResourcePicker : public HBoxContainer {
 	enum MenuOption {
 		OBJ_MENU_LOAD,
 		OBJ_MENU_QUICKLOAD,
-		OBJ_MENU_EDIT,
+		OBJ_MENU_INSPECT,
 		OBJ_MENU_CLEAR,
 		OBJ_MENU_MAKE_UNIQUE,
 		OBJ_MENU_MAKE_UNIQUE_RECURSIVE,

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -518,8 +518,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Color warning_color = Color(1, 0.87, 0.4);
 	Color error_color = Color(1, 0.47, 0.42);
 	Color property_color = font_color.lerp(Color(0.5, 0.5, 0.5), 0.5);
-	Color readonly_color = property_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
-	Color readonly_warning_color = error_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.5);
+	Color readonly_color = property_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
+	Color readonly_warning_color = error_color.lerp(dark_theme ? Color(0, 0, 0) : Color(1, 1, 1), 0.25);
 
 	if (!dark_theme) {
 		// Darken some colors to be readable on a light background

--- a/editor/icons/NodeInfo.svg
+++ b/editor/icons/NodeInfo.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m8 1a7 7 0 0 0 -7 7 7 7 0 0 0 7 7 7 7 0 0 0 7-7 7 7 0 0 0 -7-7zm-1 3h2v2h-2zm0 3h2v5h-2z" fill="#fff"/></svg>

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -247,7 +247,7 @@ void InspectorDock::_resource_file_selected(String p_file) {
 	}
 
 	if (res.is_null()) {
-		warning_dialog->set_text(TTR("Failed to load resource."));
+		info_dialog->set_text(TTR("Failed to load resource."));
 		return;
 	};
 
@@ -409,8 +409,8 @@ void InspectorDock::_menu_expand_revertable() {
 	inspector->expand_revertable();
 }
 
-void InspectorDock::_warning_pressed() {
-	warning_dialog->popup_centered();
+void InspectorDock::_info_pressed() {
+	info_dialog->popup_centered();
 }
 
 Container *InspectorDock::get_addon_area() {
@@ -446,8 +446,13 @@ void InspectorDock::_notification(int p_what) {
 			history_menu->set_icon(get_theme_icon(SNAME("History"), SNAME("EditorIcons")));
 			object_menu->set_icon(get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 			search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
-			warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
-			warning->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			if (info_is_warning) {
+				info->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
+				info->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			} else {
+				info->set_icon(get_theme_icon(SNAME("NodeInfo"), SNAME("EditorIcons")));
+				info->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("Editor")));
+			}
 		} break;
 	}
 }
@@ -476,11 +481,22 @@ void InspectorDock::open_resource(const String &p_type) {
 	_load_resource(p_type);
 }
 
-void InspectorDock::set_warning(const String &p_message) {
-	warning->hide();
-	if (!p_message.is_empty()) {
-		warning->show();
-		warning_dialog->set_text(p_message);
+void InspectorDock::set_info(const String &p_button_text, const String &p_message, bool p_is_warning) {
+	info->hide();
+	info_is_warning = p_is_warning;
+
+	if (info_is_warning) {
+		info->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
+		info->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+	} else {
+		info->set_icon(get_theme_icon(SNAME("NodeInfo"), SNAME("EditorIcons")));
+		info->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("Editor")));
+	}
+
+	if (!p_button_text.is_empty() && !p_message.is_empty()) {
+		info->show();
+		info->set_text(p_button_text);
+		info_dialog->set_text(p_message);
 	}
 }
 
@@ -515,7 +531,7 @@ void InspectorDock::update(Object *p_object) {
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_MAKE_BUILT_IN), !is_resource || is_text_file);
 
 	if (!is_object || is_text_file) {
-		warning->hide();
+		info->hide();
 		editor_path->clear_path();
 		return;
 	}
@@ -707,12 +723,11 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	object_menu->get_popup()->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_menu));
 	object_menu->get_popup()->connect("id_pressed", callable_mp(this, &InspectorDock::_menu_option));
 
-	warning = memnew(Button);
-	add_child(warning);
-	warning->set_text(TTR("Changes may be lost!"));
-	warning->set_clip_text(true);
-	warning->hide();
-	warning->connect("pressed", callable_mp(this, &InspectorDock::_warning_pressed));
+	info = memnew(Button);
+	add_child(info);
+	info->set_clip_text(true);
+	info->hide();
+	info->connect("pressed", callable_mp(this, &InspectorDock::_info_pressed));
 
 	unique_resources_confirmation = memnew(ConfirmationDialog);
 	add_child(unique_resources_confirmation);
@@ -737,8 +752,8 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 
 	unique_resources_confirmation->connect("confirmed", callable_mp(this, &InspectorDock::_menu_confirm_current));
 
-	warning_dialog = memnew(AcceptDialog);
-	EditorNode::get_singleton()->get_gui_base()->add_child(warning_dialog);
+	info_dialog = memnew(AcceptDialog);
+	EditorNode::get_singleton()->get_gui_base()->add_child(info_dialog);
 
 	load_resource_dialog = memnew(EditorFileDialog);
 	add_child(load_resource_dialog);

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -93,8 +93,9 @@ class InspectorDock : public VBoxContainer {
 	MenuButton *object_menu = nullptr;
 	EditorPath *editor_path = nullptr;
 
-	Button *warning = nullptr;
-	AcceptDialog *warning_dialog = nullptr;
+	bool info_is_warning = false; // Display in yellow and use warning icon if true.
+	Button *info = nullptr;
+	AcceptDialog *info_dialog = nullptr;
 
 	int current_option = -1;
 	ConfirmationDialog *unique_resources_confirmation = nullptr;
@@ -118,7 +119,7 @@ class InspectorDock : public VBoxContainer {
 	void _paste_resource();
 	void _prepare_resource_extra_popup();
 
-	void _warning_pressed();
+	void _info_pressed();
 	void _resource_created();
 	void _resource_selected(const Ref<Resource> &p_res, const String &p_property);
 	void _edit_forward();
@@ -145,7 +146,7 @@ public:
 	void edit_resource(const Ref<Resource> &p_resource);
 	void open_resource(const String &p_type);
 	void clear();
-	void set_warning(const String &p_message);
+	void set_info(const String &p_button_text, const String &p_message, bool p_is_warning);
 	void update(Object *p_object);
 	Container *get_addon_area();
 	EditorInspector *get_inspector() { return inspector; }


### PR DESCRIPTION
This PR adds new behaviour to the inspector to prevent the user from accidentally editing properties of resources embedded in other scenes (foreign resources) since these will not be saved and can lead to changes accidentally being lost the user assumes will be persistent. Editing these resources can still be possible by right-clicking on them and selecting 'edit', which will follow the pre-existing behaviour of opening up the corresponding scene and displaying it in the inspector. For resources which are embedded inside of imported scenes (those derived from imported formats such as GLTF) however, the 'edit' option will be replaced by an inspect option which will still switch the inspector this resource, but will not change the scene and instead display it in a 'read-only' fashion.

The InspectorDock warning button has also been changed to provide clarity when inspecting read-only objects. It is also now considered a more general info button due to considering the displaying of a read-only state to be more informative than warning-worthy, which also includes a new icon when displaying something considered information rather than a warning (flipping an existing exclamation mark vector and putting it inside a circle, a true stroke of genius! Clearly, I must be made Godot's new resident graphics designer)

![godot windows opt tools 64_qvOUfoCQTJ](https://user-images.githubusercontent.com/12756047/180202354-0698dba6-7e38-482f-b3af-cacff57f724e.png)

![godot windows opt tools 64_UEw3tz2iGZ](https://user-images.githubusercontent.com/12756047/180202901-d19fee9b-34a5-46d4-828a-53c9325a943b.png)


Furthermore, read-only mode is also applied to remote debug inspector objects with its own contextual information.

![godot windows opt tools 64_oKSCa31LQQ](https://user-images.githubusercontent.com/12756047/180202788-b64793e3-243b-4423-8c00-254326cf0a03.png)

Intended to compliment similar changes to bespoke editor plugins in:
#63249 #63245 #63253 #63252 #63251