### PR TITLE
[3.x] Add `ios` and `macos` platform name aliases.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -232,6 +232,16 @@ else:
     if selected_platform != "":
         print("Automatically detected platform: " + selected_platform)
 
+if selected_platform == "macos":
+    # Alias for forward compatibility.
+    print('Platform "macos" is still called "osx" in Godot 3.x. Building for platform "osx".')
+    selected_platform = "osx"
+
+if selected_platform == "ios":
+    # Alias for forward compatibility.
+    print('Platform "ios" is still called "iphone" in Godot 3.x. Building for platform "iphone".')
+    selected_platform = "iphone"
+
 if selected_platform in ["linux", "bsd", "linuxbsd"]:
     if selected_platform == "linuxbsd":
         # Alias for forward compatibility.


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/63225

Adds new platform name aliases to the 3.x build config.