### PR TITLE
Fix editor re-focus on debugger break on Windows

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -43,6 +43,8 @@ HashMap<StringName, EngineDebugger::Profiler> EngineDebugger::profilers;
 HashMap<StringName, EngineDebugger::Capture> EngineDebugger::captures;
 HashMap<String, EngineDebugger::CreatePeerFunc> EngineDebugger::protocols;
 
+void (*EngineDebugger::allow_focus_steal_fn)();
+
 void EngineDebugger::register_profiler(const StringName &p_name, const Profiler &p_func) {
 	ERR_FAIL_COND_MSG(profilers.has(p_name), "Profiler already registered: " + p_name);
 	profilers.insert(p_name, p_func);
@@ -133,7 +135,7 @@ void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks,
 	singleton->poll_events(true);
 }
 
-void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Vector<String> p_breakpoints) {
+void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Vector<String> p_breakpoints, void (*p_allow_focus_steal_fn)()) {
 	register_uri_handler("tcp://", RemoteDebuggerPeerTCP::create); // TCP is the default protocol. Platforms/modules can add more.
 	if (p_uri.is_empty()) {
 		return;
@@ -174,6 +176,8 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Ve
 
 		singleton_script_debugger->insert_breakpoint(bp.substr(sp + 1, bp.length()).to_int(), bp.substr(0, sp));
 	}
+
+	allow_focus_steal_fn = p_allow_focus_steal_fn;
 }
 
 void EngineDebugger::deinitialize() {

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -100,13 +100,15 @@ protected:
 	static HashMap<StringName, Capture> captures;
 	static HashMap<String, CreatePeerFunc> protocols;
 
+	static void (*allow_focus_steal_fn)();
+
 public:
 	_FORCE_INLINE_ static EngineDebugger *get_singleton() { return singleton; }
 	_FORCE_INLINE_ static bool is_active() { return singleton != nullptr && script_debugger != nullptr; }
 
 	_FORCE_INLINE_ static ScriptDebugger *get_script_debugger() { return script_debugger; };
 
-	static void initialize(const String &p_uri, bool p_skip_breakpoints, Vector<String> p_breakpoints);
+	static void initialize(const String &p_uri, bool p_skip_breakpoints, Vector<String> p_breakpoints, void (*p_allow_focus_steal_fn)());
 	static void deinitialize();
 	static void register_profiler(const StringName &p_name, const Profiler &p_profiler);
 	static void unregister_profiler(const StringName &p_name);

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -452,6 +452,9 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	msg.push_back(error_str);
 	ERR_FAIL_COND(!script_lang);
 	msg.push_back(script_lang->debug_get_stack_level_count() > 0);
+	if (allow_focus_steal_fn) {
+		allow_focus_steal_fn();
+	}
 	send_message("debug_enter", msg);
 
 	Input::MouseMode mouse_mode = Input::get_singleton()->get_mouse_mode();

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -55,7 +55,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	args.push_back("--remote-debug");
 	args.push_back(EditorDebuggerNode::get_singleton()->get_server_uri());
 
-	args.push_back("--allow_focus_steal_pid");
+	args.push_back("--editor-pid");
 	args.push_back(itos(OS::get_singleton()->get_process_id()));
 
 	bool debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisons", false);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -148,7 +148,7 @@ static bool cmdline_tool = false;
 static String locale;
 static bool show_help = false;
 static bool auto_quit = false;
-static OS::ProcessID allow_focus_steal_pid = 0;
+static OS::ProcessID editor_pid = 0;
 #ifdef TOOLS_ENABLED
 static bool auto_build_solutions = false;
 static String debug_server_uri;
@@ -1141,9 +1141,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing remote debug host address, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--allow_focus_steal_pid") { // not exposed to user
+		} else if (I->get() == "--editor-pid") { // not exposed to user
 			if (I->next()) {
-				allow_focus_steal_pid = I->next()->get().to_int();
+				editor_pid = I->next()->get().to_int();
 				N = I->next()->next();
 			} else {
 				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
@@ -1273,7 +1273,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					PROPERTY_HINT_RANGE,
 					"0, 200, 1, or_greater"));
 
-	EngineDebugger::initialize(debug_uri, skip_breakpoints, breakpoints);
+	EngineDebugger::initialize(debug_uri, skip_breakpoints, breakpoints, []() {
+		if (editor_pid) {
+			DisplayServer::get_singleton()->enable_for_stealing_focus(editor_pid);
+		}
+	});
 
 #ifdef TOOLS_ENABLED
 	if (editor) {
@@ -1836,10 +1840,6 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	}
 	if (init_always_on_top) {
 		DisplayServer::get_singleton()->window_set_flag(DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP, true);
-	}
-
-	if (allow_focus_steal_pid) {
-		DisplayServer::get_singleton()->enable_for_stealing_focus(allow_focus_steal_pid);
 	}
 
 	MAIN_PRINT("Main: Load Boot Image");


### PR DESCRIPTION
This fixes the once more resurrected bug by which the editor can't claim focus on a debugger break. Repeat with me: **on Windows the permission to get focus stealed must be re-granted every time** (after new user input).

Quoting https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-allowsetforegroundwindow:
> The process specified by dwProcessId loses the ability to set the foreground window the next time the user generates input [...].

Additionally, the various cases of `(p_)allow_focus_steal_pid` are renamed to `(p_)editor_pid` and the relevant command-line option is hyphenated instead of "underscorated".