### PR TITLE
Change (and rename) Quaternion cubic_slerp to perform component-wise cubic interpolation

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -109,33 +109,19 @@ Quaternion Quaternion::inverse() const {
 }
 
 Quaternion Quaternion::log() const {
-	Vector3 v = vector_part();
-	real_t vLength = v.length();
-#ifdef MATH_CHECKS
-	ERR_FAIL_COND_V_MSG(vLength == 0, Quaternion(), "Length of the vector part can't be zero.");
-#endif
-
-	real_t s = w;
-
-	real_t scalarPart = Math::log(length());
-	Vector3 vecPart = v / vLength * acos(s / length());
-
-	return Quaternion(vecPart.x, vecPart.y, vecPart.z, scalarPart);
+	Quaternion src = *this;
+	Vector3 src_v = src.get_axis() * src.get_angle();
+	return Quaternion(src_v.x, src_v.y, src_v.z, 0);
 }
 
 Quaternion Quaternion::exp() const {
-	Vector3 v = vector_part();
-	real_t vLength = v.length();
-#ifdef MATH_CHECKS
-	ERR_FAIL_COND_V_MSG(vLength == 0, Quaternion(), "Length of the vector part can't be zero.");
-#endif
-
-	real_t s = w;
-
-	real_t scalarPart = cos(vLength);
-	Vector3 vecPart = v / vLength * sin(vLength);
-
-	return Math::exp(s) * Quaternion(vecPart.x, vecPart.y, vecPart.z, scalarPart);
+	Quaternion src = *this;
+	Vector3 src_v = Vector3(src.x, src.y, src.z);
+	float theta = src_v.length();
+	if (theta < CMP_EPSILON) {
+		return Quaternion(0, 0, 0, 1);
+	}
+	return Quaternion(src_v.normalized(), theta);
 }
 
 Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) const {

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -195,25 +195,6 @@ Quaternion Quaternion::slerpni(const Quaternion &p_to, const real_t &p_weight) c
 			invFactor * from.w + newFactor * p_to.w);
 }
 
-static real_t cubic_interpolate_real(const real_t p_pre_a, const real_t p_a, const real_t p_b, const real_t p_post_b, real_t p_c) {
-	// This is cloned straight from animation.cpp
-
-	real_t p0 = p_pre_a;
-	real_t p1 = p_a;
-	real_t p2 = p_b;
-	real_t p3 = p_post_b;
-
-	real_t t = p_c;
-	real_t t2 = t * t;
-	real_t t3 = t2 * t;
-
-	return 0.5f *
-			((p1 * 2.0f) +
-					(-p0 + p2) * t +
-					(2.0f * p0 - 5.0f * p1 + 4.0f * p2 - p3) * t2 +
-					(-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
-}
-
 Quaternion Quaternion::cubic_interpolate(const Quaternion &p_q, const Quaternion &p_prep, const Quaternion &p_postq, const real_t &p_t, const bool flip_to_shortest_path) const {
 	Quaternion q0;
 	Quaternion q1;
@@ -254,10 +235,10 @@ Quaternion Quaternion::cubic_interpolate(const Quaternion &p_q, const Quaternion
 #endif
 
 	return Quaternion(
-			cubic_interpolate_real(q0.x, q1.x, q2.x, q3.x, p_t),
-			cubic_interpolate_real(q0.y, q1.y, q2.y, q3.y, p_t),
-			cubic_interpolate_real(q0.z, q1.z, q2.z, q3.z, p_t),
-			cubic_interpolate_real(q0.w, q1.w, q2.w, q3.w, p_t))
+			Math::cubic_interpolate(q1.x, q2.x, q0.x, q3.x, p_t),
+			Math::cubic_interpolate(q1.y, q2.y, q0.y, q3.y, p_t),
+			Math::cubic_interpolate(q1.z, q2.z, q0.z, q3.z, p_t),
+			Math::cubic_interpolate(q1.w, q2.w, q0.w, q3.w, p_t))
 			.normalized();
 }
 

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -162,10 +162,6 @@ struct _NO_DISCARD_ Quaternion {
 			w = s * 0.5f;
 		}
 	}
-
-	Vector3 vector_part() const {
-		return Vector3(x, y, z);
-	}
 };
 
 real_t Quaternion::dot(const Quaternion &p_q) const {

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -71,10 +71,10 @@ struct _NO_DISCARD_ Quaternion {
 
 	Quaternion slerp(const Quaternion &p_to, const real_t &p_weight) const;
 	Quaternion slerpni(const Quaternion &p_to, const real_t &p_weight) const;
-	Quaternion cubic_slerp(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight) const;
+	Quaternion cubic_interpolate(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight, const bool flip_to_shortest_path = true) const;
 
 	Vector3 get_axis() const;
-	float get_angle() const;
+	real_t get_angle() const;
 
 	_FORCE_INLINE_ void get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 		r_angle = 2 * Math::acos(w);
@@ -161,6 +161,10 @@ struct _NO_DISCARD_ Quaternion {
 			z = c.z * rs;
 			w = s * 0.5f;
 		}
+	}
+
+	Vector3 vector_part() const {
+		return Vector3(x, y, z);
 	}
 };
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1752,7 +1752,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Quaternion, dot, sarray("with"), varray());
 	bind_method(Quaternion, slerp, sarray("to", "weight"), varray());
 	bind_method(Quaternion, slerpni, sarray("to", "weight"), varray());
-	bind_method(Quaternion, cubic_slerp, sarray("b", "pre_a", "post_b", "weight"), varray());
+	bind_method(Quaternion, cubic_interpolate, sarray("b", "pre_a", "post_b", "weight", "flip_to_shortest_path"), varray(true));
 	bind_method(Quaternion, get_euler, sarray(), varray());
 	bind_method(Quaternion, get_axis, sarray(), varray());
 	bind_method(Quaternion, get_angle, sarray(), varray());

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -74,14 +74,17 @@
 				[b]Note:[/b] This method has an abnormally high amount of floating-point error, so methods such as [code]is_zero_approx[/code] will not work reliably.
 			</description>
 		</method>
-		<method name="cubic_slerp" qualifiers="const">
+		<method name="cubic_interpolate" qualifiers="const">
 			<return type="Quaternion" />
 			<argument index="0" name="b" type="Quaternion" />
 			<argument index="1" name="pre_a" type="Quaternion" />
 			<argument index="2" name="post_b" type="Quaternion" />
 			<argument index="3" name="weight" type="float" />
+			<argument index="4" name="flip_to_shortest_path" type="bool" default="true" />
 			<description>
-				Performs a cubic spherical interpolation between quaternions [code]pre_a[/code], this vector, [code]b[/code], and [code]post_b[/code], by the given amount [code]weight[/code].
+				Performs a component-wise cubic interpolation between quaternions [code]pre_a[/code], this quaternion, [code]b[/code], and [code]post_b[/code], by the given amount [code]weight[/code].
+				Optional parameter [code]flip_to_shortest_path[/code] enables/disables automatic flipping of the subsequent quaternions to follow the shortest path. This quaternion is used as a reference (will not be flipped).
+				[b]Note:[/b] Automatic flipping of subsequent quaternions will introduce "sign-flips" (quaternion suddenly changing it's sign) when interpolation interval on a series of quaternions changes (like in an animation). Usually this is not a problem, though, since quaternion's sign-flip does not change the corresponding orientation in 3D-space.
 			</description>
 		</method>
 		<method name="dot" qualifiers="const">

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2302,7 +2302,7 @@ Vector3 Animation::_cubic_interpolate(const Vector3 &p_pre_a, const Vector3 &p_a
 }
 
 Quaternion Animation::_cubic_interpolate(const Quaternion &p_pre_a, const Quaternion &p_a, const Quaternion &p_b, const Quaternion &p_post_b, real_t p_c) const {
-	return p_a.cubic_slerp(p_b, p_pre_a, p_post_b, p_c);
+	return p_a.cubic_interpolate(p_b, p_pre_a, p_post_b, p_c);
 }
 
 Variant Animation::_cubic_interpolate(const Variant &p_pre_a, const Variant &p_a, const Variant &p_b, const Variant &p_post_b, real_t p_c) const {
@@ -2363,7 +2363,7 @@ Variant Animation::_cubic_interpolate(const Variant &p_pre_a, const Variant &p_a
 			Quaternion pa = p_pre_a;
 			Quaternion pb = p_post_b;
 
-			return a.cubic_slerp(b, pa, pb, p_c);
+			return a.cubic_interpolate(b, pa, pb, p_c);
 		}
 		case Variant::AABB: {
 			AABB a = p_a;


### PR DESCRIPTION
Fixes #57951

- Function cubic_slerp changed to perform component-wise cubic interpolation and renamed to cubic_interpolate.
- Rewrote log and exp-functions based on https://users.aalto.fi/~ssarkka/pub/quat.pdf
- Added a new optional parameter to cubic_slerp that can be used to flip (or not) the quaternions to the shorter path. Default is to flip. "Base" quaternion is used as a reference (never flipped). This might be used for blending using pre-flipped (or "cached") quaternions in animation.

This breaks compatibility as cubic_slerp is renamed to cubic_interpolate.

Didn't update doc yet. I can try to do that if this pull request looks ok otherwise(?)