### PR TITLE
Allow setting scroll_container.scroll_vertical in call_deferred instead of waiting for a notif_draw

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -312,6 +312,7 @@ void ScrollContainer::_update_dimensions() {
 		fit_child_in_rect(c, r);
 	}
 
+	update_scrollbars();
 	update();
 }
 


### PR DESCRIPTION
master version of https://github.com/godotengine/godot/pull/63294


Users cannot scroll a newly created scroll container until NOTIF_DRAW has computed the scroll max and min.

eg) 

```
add_children_to_scroll_container(scroll_container)

# this line does nothing
scroll_container.scroll_vertical = compute_initial_scroll()
```
This doesnt work because `scroll_container->v_scroll->shared->max/min` are not computed until NOTIF_DRAW calls 'update_scrollbars()`.

This PR calls update_scrollbars() in sort_children() so the max is set properly so you can set scroll_container.scroll_vertical instantly after adding children to a scroll container.


This commit seemed to try to fix it but has no impact because scroll_container.ready is too early to compute the max and min. The max and min values should be computed in `sort_children`.
https://github.com/godotengine/godot/commit/ae9e523025795afc9e3f3128f080919296fb3f2c

*Bugsquad edit: Follow-up to https://github.com/godotengine/godot/pull/61346.*

EDIT:


eg) this works now:

```
extends Control

onready var scroll_container := $ScrollContainer as ScrollContainer
onready var vbox := $ScrollContainer/VBoxContainer as VBoxContainer

const num_rows := 200
const initial_scroll_target := 0.5

func _ready():
	create_rows()
	# old code needed to wait for NOTIF_DRAW
	# which would require something like
	# yield(get_tree().create_timer(0.5), "timeout")
	# scroll_to_normalized_position(initial_scroll_target)
	
	# new code can work like this:
	call_deferred("scroll_to_normalized_position", 0.5)

func create_rows():
	for i in num_rows:
		var label := Label.new()
		vbox.add_child(label)
		label.text = "Row %s" % [i+1]

func scroll_to_normalized_position(normalized_position:float):
	var scroll_destination := normalized_position * vbox.rect_size.y
	print("scroll_to_normalized_position(%s) applying scroll_destination %s" % [normalized_position, scroll_destination])
	scroll_container.scroll_vertical = int(scroll_destination)
```