### PR TITLE
Round dimensions of SVG to work around floating point precision errors

### DIFF
--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -80,8 +80,8 @@ void ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, String p_strin
 	float fw, fh;
 	picture->size(&fw, &fh);
 
-	uint32_t width = MIN(fw * p_scale, 16 * 1024);
-	uint32_t height = MIN(fh * p_scale, 16 * 1024);
+	uint32_t width = MIN(round(fw * p_scale), 16 * 1024);
+	uint32_t height = MIN(round(fh * p_scale), 16 * 1024);
 	picture->size(width, height);
 
 	std::unique_ptr<tvg::SwCanvas> sw_canvas = tvg::SwCanvas::gen();


### PR DESCRIPTION
Inkscape shows 1600x1600:
![image](https://user-images.githubusercontent.com/14253836/180340582-aa23b183-4157-4b5f-9e47-acee7f877b94.png)

But Godot imports as 1599x1599:
![image](https://user-images.githubusercontent.com/14253836/180340513-8e0bb2c6-85cb-4764-9be9-974a949b6bcc.png)

\\/ Just an svg file :slightly_smiling_face: (public domain from thenounproject.com)
[settings.zip](https://github.com/godotengine/godot/files/9163695/settings.zip)

No longer reproducible after patch.