### PR TITLE
Verify and record viewport visibility

### DIFF
--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -103,6 +103,7 @@ public:
 		float mesh_lod_threshold = 1.0;
 
 		uint64_t last_pass = 0;
+		bool visible = true;
 
 		RS::ViewportDebugDraw debug_draw;
 
@@ -210,6 +211,7 @@ private:
 	int occlusion_rays_per_thread = 512;
 
 	void _resize_occlusion_culling_buffer(const Size2i &p_size);
+	bool _check_viewport_visible(Viewport *p_viewport, const uint64_t p_pass, Ref<XRInterface> &p_xr_interface);
 
 public:
 	RID viewport_allocate();


### PR DESCRIPTION
Replaces the previous way of using sorted arrays. Use a simpler way to confirm the visibility of the viewport.

Fix #53776.
Fix #61034.

Supersedes #62938.
Supersedes #63091.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
**Edit:**
This patch mainly moves the viewport visibility confirmation logic into a separate function and caches the calculation results. The main part of the logic has not changed, recursion support has been added to support confirmation of parent visibility in the case of `update_mode == RS::VIEWPORT_UPDATE_WHEN_PARENT_VISIBLE`.


