### PR TITLE
SCons: Prevent using `vsproj` option outside Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -834,6 +834,9 @@ if selected_platform in platform_list:
 
     # Microsoft Visual Studio Project Generation
     if env["vsproj"]:
+        if os.name != "nt":
+            print("Error: The `vsproj` option is only usable on Windows with Visual Studio.")
+            Exit(255)
         env["CPPPATH"] = [Dir(path) for path in env["CPPPATH"]]
         methods.generate_vs_project(env, GetOption("num_jobs"))
         methods.generate_cpp_hint_file("cpp.hint")


### PR DESCRIPTION
Fixes #63305.