### PR TITLE
Don't print redundant errors when parsing GDScript

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -870,7 +870,7 @@ Error GDScript::reload(bool p_keep_state) {
 		}
 		// TODO: Show all error messages.
 		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
-		ERR_FAIL_V(ERR_PARSE_ERROR);
+		return ERR_PARSE_ERROR;
 	}
 
 	GDScriptAnalyzer analyzer(&parser);
@@ -886,7 +886,7 @@ Error GDScript::reload(bool p_keep_state) {
 			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), e->get().line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 			e = e->next();
 		}
-		ERR_FAIL_V(ERR_PARSE_ERROR);
+		return ERR_PARSE_ERROR;
 	}
 
 	bool can_run = ScriptServer::is_scripting_enabled() || parser.is_tool();
@@ -904,7 +904,7 @@ Error GDScript::reload(bool p_keep_state) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), compiler.get_error_line(), "Parser Error: " + compiler.get_error());
 			}
 			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
-			ERR_FAIL_V(ERR_COMPILATION_FAILED);
+			return ERR_COMPILATION_FAILED;
 		} else {
 			return err;
 		}


### PR DESCRIPTION
See the proposal where I reported this: https://github.com/godotengine/godot-proposals/issues/4945

Before: 

![image](https://user-images.githubusercontent.com/346300/180462031-417770e0-1422-4d56-946a-e212c3d7aebb.png)

The second error line is not only redundant, as the actual error is printed above, but is confusing and intimidating for new users who don't want to be thinking about `.cpp` files or the 873rd line of _any_ file.

After:

![image](https://user-images.githubusercontent.com/346300/180462050-5e2b20c4-abb3-4bd7-9fc5-1e6a76fd88af.png)

Only the GDScript error prints!

This would work in `3.x` as well; the only change is that 3.x doesn't have an Analyzer step.