### PR TITLE
Fix typed array returns returning the incorrect contained type

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1596,7 +1596,7 @@ void GDScriptByteCodeGenerator::write_return(const Address &p_return_value) {
 				// Typed array.
 				const GDScriptDataType &element_type = function->return_type.get_container_element_type();
 
-				Variant script = function->return_type.script_type;
+				Variant script = element_type.script_type;
 				int script_idx = get_constant_pos(script) | (GDScriptFunction::ADDR_TYPE_CONSTANT << GDScriptFunction::ADDR_BITS);
 
 				append(GDScriptFunction::OPCODE_RETURN_TYPED_ARRAY, 2);


### PR DESCRIPTION
Fixes #59485 and fixes #60218

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
