### PR TITLE
Make `BaseButton` Shortcut feedback togglable

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -68,6 +68,9 @@
 		<member name="shortcut" type="Shortcut" setter="set_shortcut" getter="get_shortcut">
 			[Shortcut] associated to the button.
 		</member>
+		<member name="shortcut_feedback" type="bool" setter="set_shortcut_feedback" getter="is_shortcut_feedback">
+			If [code]true[/code], the button will appear pressed when its shortcut is activated. If [code]false[/code] and [member toggle_mode] is [code]false[/code], the shortcut will activate the button without appearing to press the button.
+		</member>
 		<member name="shortcut_in_tooltip" type="bool" setter="set_shortcut_in_tooltip" getter="is_shortcut_in_tooltip_enabled">
 			If [code]true[/code], the button will add information about its shortcut in the tooltip.
 		</member>

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -53,6 +53,7 @@ private:
 	bool keep_pressed_outside = false;
 	Ref<Shortcut> shortcut;
 	ObjectID shortcut_context;
+	bool shortcut_feedback = true;
 
 	ActionMode action_mode = ACTION_MODE_BUTTON_RELEASE;
 	struct Status {
@@ -60,6 +61,7 @@ private:
 		bool hovering = false;
 		bool press_attempt = false;
 		bool pressing_inside = false;
+		bool shortcut_press = false;
 
 		bool disabled = false;
 
@@ -130,6 +132,9 @@ public:
 
 	void set_button_group(const Ref<ButtonGroup> &p_group);
 	Ref<ButtonGroup> get_button_group() const;
+
+	void set_shortcut_feedback(bool p_feedback);
+	bool is_shortcut_feedback() const;
 
 	BaseButton();
 	~BaseButton();


### PR DESCRIPTION
Fixes [#365](https://github.com/godotengine/godot-proposals/issues/365)

Makes `BaseButton::get_draw_mode` return `DRAW_NORMAL` when a shortcut activates the button if `toggle_mode` is false and `shortcut_feedback` is false.

## Exposed Additions
**BaseButton**:
```gdscript
@export
var shortcut_feedback : bool = true

func set_shortcut_feedback(value : bool)
func is_shortcut_feedback() -> bool
```

**Test Project**:
[ButtonShortcutFeedbackDisableTest.zip](https://github.com/godotengine/godot/files/9172711/ButtonShortcutFeedbackDisableTest.zip)