### PR TITLE
Expose `VisualServer.viewport_set_use_32_bpc_depth()` to the scripting API

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -294,7 +294,7 @@
 			The default exposure used for tonemapping.
 		</member>
 		<member name="tonemap_mode" type="int" setter="set_tonemapper" getter="get_tonemapper" enum="Environment.ToneMapper" default="0">
-			The tonemapping mode to use. Tonemapping is the process that "converts" HDR values to be suitable for rendering on a LDR display. (Godot doesn't support rendering on HDR displays yet.)
+			The tonemapping mode to use. Tonemapping is the process that "converts" HDR values to be suitable for rendering on a SDR display. (Godot doesn't support rendering on HDR displays yet.)
 		</member>
 		<member name="tonemap_white" type="float" setter="set_tonemap_white" getter="get_tonemap_white" default="1.0">
 			The white reference value for tonemapping. Only effective if the [member tonemap_mode] isn't set to [constant TONE_MAPPER_LINEAR].

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -3028,7 +3028,8 @@
 			<argument index="0" name="viewport" type="RID" />
 			<argument index="1" name="enabled" type="bool" />
 			<description>
-				If [code]true[/code], the viewport renders to hdr.
+				If [code]true[/code], the viewport renders to high dynamic range (HDR) instead of standard dynamic range (SDR). See also [method viewport_set_use_32_bpc_depth].
+				[b]Note:[/b] Only available on the GLES3 backend.
 			</description>
 		</method>
 		<method name="viewport_set_hide_canvas">
@@ -3136,6 +3137,15 @@
 			<argument index="1" name="usage" type="int" enum="VisualServer.ViewportUsage" />
 			<description>
 				Sets the viewport's 2D/3D mode. See [enum ViewportUsage] constants for options.
+			</description>
+		</method>
+		<method name="viewport_set_use_32_bpc_depth">
+			<return type="void" />
+			<argument index="0" name="viewport" type="RID" />
+			<argument index="1" name="enabled" type="bool" />
+			<description>
+				If [code]true[/code], allocates the viewport's framebuffer with full floating-point precision (32-bit) instead of half floating-point precision (16-bit). Only effective if [method viewport_set_use_32_bpc_depth] is used on the same [Viewport] to set HDR to [code]true[/code].
+				[b]Note:[/b] Only available on the GLES3 backend.
 			</description>
 		</method>
 		<method name="viewport_set_use_arvr">

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2095,6 +2095,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_use_debanding", "viewport", "debanding"), &VisualServer::viewport_set_use_debanding);
 	ClassDB::bind_method(D_METHOD("viewport_set_sharpen_intensity", "viewport", "intensity"), &VisualServer::viewport_set_sharpen_intensity);
 	ClassDB::bind_method(D_METHOD("viewport_set_hdr", "viewport", "enabled"), &VisualServer::viewport_set_hdr);
+	ClassDB::bind_method(D_METHOD("viewport_set_use_32_bpc_depth", "viewport", "enabled"), &VisualServer::viewport_set_use_32_bpc_depth);
 	ClassDB::bind_method(D_METHOD("viewport_set_usage", "viewport", "usage"), &VisualServer::viewport_set_usage);
 	ClassDB::bind_method(D_METHOD("viewport_get_render_info", "viewport", "info"), &VisualServer::viewport_get_render_info);
 	ClassDB::bind_method(D_METHOD("viewport_set_debug_draw", "viewport", "draw"), &VisualServer::viewport_set_debug_draw);


### PR DESCRIPTION
This fixes an oversight from https://github.com/godotengine/godot/pull/51708.

Previously, only the Viewport methods/properties were exposed to the scripting API.