### PR TITLE
Flush buffered input events on UWP

### DIFF
--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -557,6 +557,7 @@ uint64_t OS_UWP::get_ticks_usec() const {
 void OS_UWP::process_events() {
 	joypad->process_controllers();
 	process_key_events();
+	input->flush_buffered_events();
 }
 
 void OS_UWP::process_key_events() {


### PR DESCRIPTION
I haven't tested it, but, given all the evidence and the experience in other platforms, this is likely the fix.

Also, I'm PRing for 4.0 since the UWP code there still has the 3.0 structure, which allows to add the call to 4.0 while being easily cherry-pickable.

Fixes #63322.