### PR TITLE
While the Script Editor Plugin is active, makes it optional to switch Editor Plugins when selecting Nodes in the Scene Tree

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2176,6 +2176,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 	Object *prev_inspected_object = InspectorDock::get_inspector_singleton()->get_edited_object();
 
 	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding"));
+	bool stay_in_script_editor_on_node_selected = bool(EDITOR_GET("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected"));
 	bool is_resource = current_obj->is_class("Resource");
 	bool is_node = current_obj->is_class("Node");
 
@@ -2214,6 +2215,9 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 			NodeDock::get_singleton()->set_node(current_node);
 			SceneTreeDock::get_singleton()->set_selected(current_node);
 			InspectorDock::get_singleton()->update(current_node);
+			if (!inspector_only) {
+				inspector_only = stay_in_script_editor_on_node_selected && ScriptEditor::get_singleton()->is_visible_in_tree();
+			}
 		} else {
 			NodeDock::get_singleton()->set_node(nullptr);
 			SceneTreeDock::get_singleton()->set_selected(nullptr);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -544,6 +544,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/navigation/smooth_scrolling", true);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/navigation/v_scroll_speed", 80, "1,10000,1")
 	_initial_set("text_editor/behavior/navigation/drag_and_drop_selection", true);
+	_initial_set("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected", true);
 
 	// Behavior: Indent
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/behavior/indent/type", 0, "Tabs,Spaces")


### PR DESCRIPTION
## Problem
- **While the Script editor is active, selecting a Node in the Scene Tree in order to inspect it, makes the `editor_plugin_screen` to be changed to the Node's main plugin**.
- The same happens when right-clicking a Node
- This makes it hard, and tiresome to **inspect and contextualize Nodes while writing Scripts**, because it **forcibly causes unintentional repetitive viewport and editor switching when interacting with Nodes while in the Script Editor**.
- It makes it even more cumbersome when dealing with long UI-centric Scene Trees, where it's necessary to gather Node Paths and adjust Inspector properties
- **The current behaviour is more than an annoyance than a desired effect** - I never faced any use case where I wanted to switch viewports when clicking a Node while in the Script Editor - **you end up FORCIBLY SWITCHING CONTEXTS back hundreds of times in a single day of work**. If I want to switch to the 2D or 3D viewports I can clearly click their toolbar buttons or use the switch hotkeys.
- It also makes the process of dragging and dropping Nodes into the Text Editor repetitive and tiresome, requiring 4 clicks: (1) click a Node, it switches to the 2D/3D viewport, (2) click to go back to Script, (3) click the Node again, (4) drag and drop it into the Text Editor to get the Node Path.
- Examples are reported in this [blog post](https://alfredbaudisch.com/blog/gamedev/godot-engine/godots-3d-confusing-workflow-inconsistencies-conflicting-behaviours-and-annoyances/), under "Inconsistent Viewport and Script Editor tab switching when clicking Nodes (2D/3D)".

https://user-images.githubusercontent.com/248383/180605492-0e974253-ec46-474d-b3cf-f9718fb3fa2f.mp4

## Solution
- **Make it optional to switch Editor Plugins when selecting Nodes** in the Scene tree **while the current active Editor Plugin is the Script Text Editor**. 
- It **works both with the Left Click** (PRIMARY EFFECT: to access the Node's Inspector) **and with Right Click** (SECONDARY EFFECT: to access the Node's Context Menu), both more than common and repetitive behaviors needed while writing Scripts.
- The feature is toggeable via `text_editor/behavior/navigation/node_select_toggles_inspector_only`.

https://user-images.githubusercontent.com/248383/180605429-7fa86418-e554-4386-afd7-fad42e3763d3.mp4

## Is it really needed?
- I make complex user interfaces with Godot, such as my project [Godello](https://github.com/alfredbaudisch/Godello) and [Dynamic Inventory System](https://github.com/alfredbaudisch/GodotDynamicInventorySystem), and this has always been in my way when scripting the complex UI Node trees.
- My tweet on this subject had a [few answers and retweets](https://twitter.com/AlfredBaudisch/status/1550770153066995712) regarding this to be a welcome addition, including [an answer](https://twitter.com/MagellanicGames/status/1550788937211416576) from the prolific Godot's developer MagellanicGames. Also [here](https://twitter.com/Saulcava1/status/1550837632179077126) and [here](https://twitter.com/pigdev/status/1550827749861908485).
- Update: many more public responses: [here](https://twitter.com/Jyve/status/1550869231838822400), [here](https://twitter.com/GreenMoonmoon/status/1550885913022054404), [here](https://twitter.com/fagnerln/status/1550914068529152001), [here](https://twitter.com/Seglectic/status/1550980186316865536), [here](https://twitter.com/coelhucass/status/1551021160598568960) (and other RTs, etc).