### PR TITLE
Reduce contrast in inspector array element backgrounds

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2026,8 +2026,8 @@ void EditorInspectorArray::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			Color color = get_theme_color(SNAME("dark_color_1"), SNAME("Editor"));
-			odd_style->set_bg_color(color.lightened(0.15));
-			even_style->set_bg_color(color.darkened(0.15));
+			odd_style->set_bg_color(color.darkened(-0.08));
+			even_style->set_bg_color(color.darkened(0.08));
 
 			for (int i = 0; i < (int)array_elements.size(); i++) {
 				ArrayElement &ae = array_elements[i];


### PR DESCRIPTION
Split from https://github.com/godotengine/godot/pull/62896

Closes https://github.com/godotengine/godot/issues/62284

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/180613913-a8b773ec-5cb0-4105-9d02-f3c390c5de60.png) | ![image](https://user-images.githubusercontent.com/67974470/181175603-a102a744-df30-4e96-9e69-dfdea352f463.png) |