### PR TITLE
Make tooltips be shown at different directions if there's not enough space

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1234,13 +1234,23 @@ void Viewport::_gui_show_tooltip() {
 	Rect2i vr = window->get_usable_parent_rect();
 
 	if (r.size.x + r.position.x > vr.size.x + vr.position.x) {
-		r.position.x = vr.position.x + vr.size.x - r.size.x;
+		// Place it in the opposite direction. If it fails, just hug the border.
+		r.position.x = gui.tooltip_pos.x - r.size.x - tooltip_offset.x;
+
+		if (r.position.x < vr.position.x) {
+			r.position.x = vr.position.x + vr.size.x - r.size.x;
+		}
 	} else if (r.position.x < vr.position.x) {
 		r.position.x = vr.position.x;
 	}
 
 	if (r.size.y + r.position.y > vr.size.y + vr.position.y) {
-		r.position.y = vr.position.y + vr.size.y - r.size.y;
+		// Same as above.
+		r.position.y = gui.tooltip_pos.y - r.size.y - tooltip_offset.y;
+
+		if (r.position.y < vr.position.y) {
+			r.position.y = vr.position.y + vr.size.y - r.size.y;
+		}
 	} else if (r.position.y < vr.position.y) {
 		r.position.y = vr.position.y;
 	}


### PR DESCRIPTION
Currently, if a tooltip doesn't have enough space, it will just hug the border. This can be problematic sometimes, as the tooltip can end up covering the hovered area.

This PR makes so that tooltips will first attempt to be placed at the opposite direction, and if that doesn't work, then fall back to the old behavior:

![image](https://user-images.githubusercontent.com/30739239/180617602-5e5e3a07-3fc5-4d0a-ba59-fa834e9eca86.png)