### PR TITLE
Add rolling average option to `Engine.get_frames_per_second()`

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -115,6 +115,17 @@ void Engine::increment_frames_drawn() {
 	frames_drawn++;
 }
 
+double Engine::get_frames_per_second(FPSMetric p_metric) const {
+	switch (p_metric) {
+		case FPS_METRIC_AVERAGE:
+			return _fps_average;
+		case FPS_METRIC_ROLLING_AVERAGE:
+			return _fps_rolling_average;
+		default:
+			ERR_FAIL_V_MSG(1.0, "Invalid FPS metric: " + itos(p_metric));
+	}
+}
+
 uint64_t Engine::get_frames_drawn() {
 	return frames_drawn;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -53,6 +53,12 @@ public:
 		Singleton(const StringName &p_name = StringName(), Object *p_ptr = nullptr, const StringName &p_class_name = StringName());
 	};
 
+	enum FPSMetric {
+		FPS_METRIC_AVERAGE,
+		FPS_METRIC_ROLLING_AVERAGE,
+		FPS_METRIC_MAX,
+	};
+
 private:
 	friend class Main;
 
@@ -64,7 +70,12 @@ private:
 	int ips = 60;
 	int user_ips = 60;
 	double physics_jitter_fix = 0.5;
-	double _fps = 1;
+
+	// Assume to be rendering at 60 FPS at first, so that the FPS counters can
+	// smoothly interpolate from that value (which is more realistic than going up from 1 FPS).
+	double _fps_average = 60.0;
+	double _fps_rolling_average = 60.0;
+
 	int _max_fps = 0;
 	int _audio_output_latency = 0;
 	double _time_scale = 1.0;
@@ -131,7 +142,7 @@ public:
 	virtual void set_audio_output_latency(int p_msec);
 	virtual int get_audio_output_latency() const;
 
-	virtual double get_frames_per_second() const { return _fps; }
+	virtual double get_frames_per_second(FPSMetric p_metric = FPS_METRIC_AVERAGE) const;
 
 	uint64_t get_frames_drawn();
 

--- a/core/core_bind.compat.inc
+++ b/core/core_bind.compat.inc
@@ -59,6 +59,16 @@ void OS::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("execute_with_pipe", "path", "arguments"), &OS::_execute_with_pipe_bind_compat_94434);
 }
 
+// Engine
+
+double Engine::_get_frames_per_second_compat_63356() const {
+	return get_frames_per_second(Engine::FPS_METRIC_AVERAGE);
+}
+
+void Engine::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_frames_per_second"), &Engine::_get_frames_per_second_compat_63356);
+}
+
 } // namespace CoreBind
 
 #endif // DISABLE_DEPRECATED

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1916,8 +1916,8 @@ int Engine::get_max_fps() const {
 	return ::Engine::get_singleton()->get_max_fps();
 }
 
-double Engine::get_frames_per_second() const {
-	return ::Engine::get_singleton()->get_frames_per_second();
+double Engine::get_frames_per_second(FPSMetric p_metric) const {
+	return ::Engine::get_singleton()->get_frames_per_second((::Engine::FPSMetric)p_metric);
 }
 
 uint64_t Engine::get_physics_frames() const {
@@ -2097,7 +2097,7 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_time_scale"), &Engine::get_time_scale);
 
 	ClassDB::bind_method(D_METHOD("get_frames_drawn"), &Engine::get_frames_drawn);
-	ClassDB::bind_method(D_METHOD("get_frames_per_second"), &Engine::get_frames_per_second);
+	ClassDB::bind_method(D_METHOD("get_frames_per_second", "metric"), &Engine::get_frames_per_second, DEFVAL(FPS_METRIC_AVERAGE));
 	ClassDB::bind_method(D_METHOD("get_physics_frames"), &Engine::get_physics_frames);
 	ClassDB::bind_method(D_METHOD("get_process_frames"), &Engine::get_process_frames);
 
@@ -2145,6 +2145,10 @@ void Engine::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_fps"), "set_max_fps", "get_max_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_scale"), "set_time_scale", "get_time_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "physics_jitter_fix"), "set_physics_jitter_fix", "get_physics_jitter_fix");
+
+	BIND_ENUM_CONSTANT(FPS_METRIC_AVERAGE);
+	BIND_ENUM_CONSTANT(FPS_METRIC_ROLLING_AVERAGE);
+	BIND_ENUM_CONSTANT(FPS_METRIC_MAX);
 }
 
 ////// EngineDebugger //////

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -570,7 +570,18 @@ protected:
 	static void _bind_methods();
 	static inline Engine *singleton = nullptr;
 
+#ifndef DISABLE_DEPRECATED
+	double _get_frames_per_second_compat_63356() const;
+	static void _bind_compatibility_methods();
+#endif
+
 public:
+	enum FPSMetric {
+		FPS_METRIC_AVERAGE,
+		FPS_METRIC_ROLLING_AVERAGE,
+		FPS_METRIC_MAX,
+	};
+
 	static Engine *get_singleton() { return singleton; }
 	void set_physics_ticks_per_second(int p_ips);
 	int get_physics_ticks_per_second() const;
@@ -585,7 +596,7 @@ public:
 	void set_max_fps(int p_fps);
 	int get_max_fps() const;
 
-	double get_frames_per_second() const;
+	double get_frames_per_second(FPSMetric p_metric = FPS_METRIC_AVERAGE) const;
 	uint64_t get_physics_frames() const;
 	uint64_t get_process_frames() const;
 
@@ -709,3 +720,5 @@ VARIANT_ENUM_CAST(CoreBind::Geometry2D::PolyEndType);
 VARIANT_ENUM_CAST(CoreBind::Thread::Priority);
 
 VARIANT_ENUM_CAST(CoreBind::Special::ClassDB::APIType);
+
+VARIANT_ENUM_CAST(CoreBind::Engine::FPSMetric);

--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -65,7 +65,7 @@ inline constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
 #define UNIT_EPSILON 0.001
 #endif
 
-#define USEC_TO_SEC(m_usec) ((m_usec) / 1000000.0)
+#define USEC_TO_SEC(m_usec) ((m_usec) * 0.000'001)
 
 enum ClockDirection {
 	CLOCKWISE,

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -59,8 +59,10 @@
 		</method>
 		<method name="get_frames_per_second" qualifiers="const">
 			<return type="float" />
+			<param index="0" name="metric" type="int" enum="Engine.FPSMetric" default="0" />
 			<description>
-				Returns the average frames rendered every second (FPS), also known as the framerate.
+				Returns the average frames rendered every second (FPS), also known as the framerate. [param metric] can optionally be specified to customize the metric being reported.
+				[b]Note:[/b] Comparing performance is usually better done using [i]milliseconds per frame[/i] (mspf) instead of [i]frames per second[/i], as mspf measurements are linear across the entire spectrum of values. To get the milliseconds per frame, use [code]1000.0 / Engine.get_frames_per_second()[/code].
 			</description>
 		</method>
 		<method name="get_license_info" qualifiers="const">
@@ -353,4 +355,15 @@
 			[b]Note:[/b] This does not automatically adjust [member physics_ticks_per_second]. With values above [code]1.0[/code] physics simulation may become less precise, as each physics tick will stretch over a larger period of engine time. If you're modifying [member Engine.time_scale] to speed up simulation by a large factor, consider also increasing [member physics_ticks_per_second] to make the simulation more reliable.
 		</member>
 	</members>
+	<constants>
+		<constant name="FPS_METRIC_AVERAGE" value="0" enum="FPSMetric">
+			Number of frames rendered in the last second. This makes momentary frame drops easier to spot, but sudden value changes make the value harder to read. The value reported is always a whole number.
+		</constant>
+		<constant name="FPS_METRIC_ROLLING_AVERAGE" value="1" enum="FPSMetric">
+			Rolling average of the number of frames rendered in the last second. This provides a more stable FPS reading that is less affected by momentary frame drops, but it can make it harder to spot momentary drops in performance. The value reported may have a decimal fraction.
+		</constant>
+		<constant name="FPS_METRIC_MAX" value="2" enum="FPSMetric">
+			Represents the size of the [enum FPSMetric] enum.
+		</constant>
+	</constants>
 </class>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4995,7 +4995,13 @@ bool Main::iteration() {
 	frames++;
 	Engine::get_singleton()->_process_frames++;
 
-	if (frame > 1000000) {
+	// Smoothly update FPS over time, while ensuring the speed at which FPS stabilizes is not dependent on FPS.
+	// The FPS smooth factor is tuned to always *mostly* converge within a second.
+	constexpr int FPS_SMOOTH_FACTOR = 5;
+	const double ratio = MIN(1.0, FPS_SMOOTH_FACTOR * USEC_TO_SEC(ticks_elapsed));
+	Engine::get_singleton()->_fps_rolling_average = Engine::get_singleton()->_fps_rolling_average * (1 - ratio) + ratio * 1'000'000.0 / ticks_elapsed;
+
+	if (frame > 1'000'000) {
 		// Wait a few seconds before printing FPS, as FPS reporting just after the engine has started is inaccurate.
 		if (hide_print_fps_attempts == 0) {
 			if (editor || project_manager) {
@@ -5009,7 +5015,7 @@ bool Main::iteration() {
 			hide_print_fps_attempts--;
 		}
 
-		Engine::get_singleton()->_fps = frames;
+		Engine::get_singleton()->_fps_average = frames;
 		performance->set_process_time(USEC_TO_SEC(process_max));
 		performance->set_physics_process_time(USEC_TO_SEC(physics_process_max));
 		performance->set_navigation_process_time(USEC_TO_SEC(navigation_process_max));
@@ -5017,7 +5023,7 @@ bool Main::iteration() {
 		physics_process_max = 0;
 		navigation_process_max = 0;
 
-		frame %= 1000000;
+		frame %= 1'000'000;
 		frames = 0;
 	}
 

--- a/misc/extension_api_validation/4.6-stable/GH-63356.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-63356.txt
@@ -1,0 +1,5 @@
+GH-63356
+---------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Engine/methods/get_frames_per_second': arguments
+
+Optional argument added. Compatibility method registered.


### PR DESCRIPTION
This uses an averaging algorithm to smooth out the FPS counter. To opt into this new behavior, call `Engine.get_frames_per_second(Engine.FPS_METRIC_ROLLING_AVERAGE)`.

The existing behavior is preserved (average over the last second) if no parameter is passed to `Engine.get_frames_per_second()`.

This also improves the documentation a bit.

See also https://github.com/godotengine/godot/pull/18998, which is an earlier attempt at providing something like this (with a different formula). The same formula is included in the MRP (but commented out) for reference.

**Testing project:** [test_fps_counter.zip](https://github.com/user-attachments/files/25429189/test_fps_counter.zip)
*Press <kbd>Space</kbd> to toggle between core and script-based FPS reporting. Use core-based reporting to test this PR (or the current behavior, with a vanilla `master` build).*
*Press <kbd>Up</kbd>/<kbd>Down</kbd> arrows to increase/decrease maximum FPS. Note that it's capped by V-Sync for testing purposes, but you can disable V-Sync in the project settings or run with `--disable-vsync` CLI argument if needed.*

## TODO

- [x] Fix the reported value being higher than it should be, especially when a FPS cap below the monitor refresh rate is used. This is likely related to what `frame_time` actually defines (I've also tried `process_ticks` to no avail).  - For comparison, the script approach in the MRP does not have this issue.
  - Thanks @CaelusV for assistance in fixing this :slightly_smiling_face: 