### PR TITLE
[FIXES] Fixed macro name in `vulkan_context.h` and use `bool` instead of numeric repr of `bool`.

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -210,19 +210,19 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanContext::_debug_report_callback(
 
 VkBool32 VulkanContext::_check_layers(uint32_t check_count, const char *const *check_names, uint32_t layer_count, VkLayerProperties *layers) {
 	for (uint32_t i = 0; i < check_count; i++) {
-		VkBool32 found = 0;
+		VkBool32 found = false;
 		for (uint32_t j = 0; j < layer_count; j++) {
 			if (!strcmp(check_names[i], layers[j].layerName)) {
-				found = 1;
+				found = true;
 				break;
 			}
 		}
 		if (!found) {
 			WARN_PRINT("Can't find layer: " + String(check_names[i]));
-			return 0;
+			return false;
 		}
 	}
-	return 1;
+	return true;
 }
 
 Error VulkanContext::_get_preferred_validation_layers(uint32_t *count, const char *const **names) {

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -44,7 +44,6 @@
 #include <string.h>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-#define APP_SHORT_NAME "GodotEngine"
 
 VulkanHooks *VulkanContext::vulkan_hooks = nullptr;
 

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -330,4 +330,4 @@ public:
 	virtual ~VulkanContext();
 };
 
-#endif // VULKAN_DEVICE_H
+#endif // VULKAN_CONTEXT_H


### PR DESCRIPTION
Note:
`VkBool32` is just an internal repr of `bool` type for the Vulkan API. Should be used `bool` type instead of unsafe numeric repr of `bool`.