### PR TITLE
Split ceil(), floor() and round() method

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -99,16 +99,103 @@ struct VariantUtilityFunctions {
 		return Math::posmod(b, r);
 	}
 
-	static inline double floor(double x) {
+	static inline Variant floor(Variant x, Callable::CallError &r_error) {
+		r_error.error = Callable::CallError::CALL_OK;
+		switch (x.get_type()) {
+			case Variant::INT: {
+				return VariantInternalAccessor<int64_t>::get(&x);
+			} break;
+			case Variant::FLOAT: {
+				return Math::floor(VariantInternalAccessor<double>::get(&x));
+			} break;
+			case Variant::VECTOR2: {
+				return VariantInternalAccessor<Vector2>::get(&x).floor();
+			} break;
+			case Variant::VECTOR3: {
+				return VariantInternalAccessor<Vector3>::get(&x).floor();
+			} break;
+			case Variant::VECTOR4: {
+				return VariantInternalAccessor<Vector4>::get(&x).floor();
+			} break;
+			default: {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+				return Variant();
+			}
+		}
+	}
+
+	static inline double floorf(double x) {
 		return Math::floor(x);
 	}
 
-	static inline double ceil(double x) {
+	static inline int floori(double x) {
+		return int(x);
+	}
+
+	static inline Variant ceil(Variant x, Callable::CallError &r_error) {
+		r_error.error = Callable::CallError::CALL_OK;
+		switch (x.get_type()) {
+			case Variant::INT: {
+				return VariantInternalAccessor<int64_t>::get(&x);
+			} break;
+			case Variant::FLOAT: {
+				return Math::ceil(VariantInternalAccessor<double>::get(&x));
+			} break;
+			case Variant::VECTOR2: {
+				return VariantInternalAccessor<Vector2>::get(&x).ceil();
+			} break;
+			case Variant::VECTOR3: {
+				return VariantInternalAccessor<Vector3>::get(&x).ceil();
+			} break;
+			case Variant::VECTOR4: {
+				return VariantInternalAccessor<Vector4>::get(&x).ceil();
+			} break;
+			default: {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+				return Variant();
+			}
+		}
+	}
+
+	static inline double ceilf(double x) {
 		return Math::ceil(x);
 	}
 
-	static inline double round(double x) {
+	static inline int ceili(double x) {
+		return int(Math::ceil(x));
+	}
+
+	static inline Variant round(Variant x, Callable::CallError &r_error) {
+		r_error.error = Callable::CallError::CALL_OK;
+		switch (x.get_type()) {
+			case Variant::INT: {
+				return VariantInternalAccessor<int64_t>::get(&x);
+			} break;
+			case Variant::FLOAT: {
+				return Math::round(VariantInternalAccessor<double>::get(&x));
+			} break;
+			case Variant::VECTOR2: {
+				return VariantInternalAccessor<Vector2>::get(&x).round();
+			} break;
+			case Variant::VECTOR3: {
+				return VariantInternalAccessor<Vector3>::get(&x).round();
+			} break;
+			case Variant::VECTOR4: {
+				return VariantInternalAccessor<Vector4>::get(&x).round();
+			} break;
+			default: {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+				return Variant();
+			}
+		}
+	}
+
+	static inline double roundf(double x) {
 		return Math::round(x);
+	}
+
+	static inline int roundi(double x) {
+		return int(Math::round(x));
 	}
 
 	static inline Variant abs(const Variant &x, Callable::CallError &r_error) {
@@ -1252,17 +1339,24 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(fmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(fposmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(posmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(floor, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(ceil, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(round, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+
+	FUNCBINDVR(floor, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(floorf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(floori, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+
+	FUNCBINDVR(ceil, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(ceilf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(ceili, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+
+	FUNCBINDVR(round, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(roundf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(roundi, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR(abs, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-
 	FUNCBINDR(absf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(absi, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR(sign, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-
 	FUNCBINDR(signf, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(signi, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
@@ -1300,12 +1394,10 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(wrapf, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVARARG(max, sarray(), Variant::UTILITY_FUNC_TYPE_MATH);
-
 	FUNCBINDR(maxi, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(maxf, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVARARG(min, sarray(), Variant::UTILITY_FUNC_TYPE_MATH);
-
 	FUNCBINDR(mini, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(minf, sarray("a", "b"), Variant::UTILITY_FUNC_TYPE_MATH);
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -134,15 +134,32 @@
 			</description>
 		</method>
 		<method name="ceil">
-			<return type="float" />
-			<argument index="0" name="x" type="float" />
+			<return type="Variant" />
+			<argument index="0" name="x" type="Variant" />
 			<description>
-				Rounds [code]x[/code] upward (towards positive infinity), returning the smallest whole number that is not less than [code]x[/code].
+				Rounds [code]x[/code] upward (towards positive infinity), returning the smallest whole number that is not less than [code]x[/code]. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
 				[codeblock]
 				var i = ceil(1.45) # i is 2.0
 				i = ceil(1.001)    # i is 2.0
 				[/codeblock]
 				See also [method floor], [method round], and [method snapped].
+				[b]Note:[/b] For better type safety, you can use [method ceilf], [method ceili], [method Vector2.ceil], [method Vector3.ceil] or [method Vector4.ceil] instead.
+			</description>
+		</method>
+		<method name="ceilf">
+			<return type="float" />
+			<argument index="0" name="x" type="float" />
+			<description>
+				Rounds [code]x[/code] upward (towards positive infinity), returning the smallest whole number that is not less than [code]x[/code].
+				A type-safe version of [method ceil], specialzied in floats.
+			</description>
+		</method>
+		<method name="ceili">
+			<return type="int" />
+			<argument index="0" name="x" type="float" />
+			<description>
+				Rounds [code]x[/code] upward (towards positive infinity), returning the smallest whole number that is not less than [code]x[/code].
+				A type-safe version of [method ceil] that returns integer.
 			</description>
 		</method>
 		<method name="clamp">
@@ -300,10 +317,10 @@
 			</description>
 		</method>
 		<method name="floor">
-			<return type="float" />
-			<argument index="0" name="x" type="float" />
+			<return type="Variant" />
+			<argument index="0" name="x" type="Variant" />
 			<description>
-				Rounds [code]x[/code] downward (towards negative infinity), returning the largest whole number that is not more than [code]x[/code].
+				Rounds [code]x[/code] downward (towards negative infinity), returning the largest whole number that is not more than [code]x[/code]. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
 				[codeblock]
 				# a is 2.0
 				var a = floor(2.99)
@@ -311,7 +328,23 @@
 				a = floor(-2.99)
 				[/codeblock]
 				See also [method ceil], [method round], and [method snapped].
-				[b]Note:[/b] This method returns a float. If you need an integer, you can use [code]int(x)[/code] directly.
+				[b]Note:[/b] For better type safety, you can use [method floorf], [method floori], [method Vector2.floor], [method Vector3.floor] or [method Vector4.floor] instead.
+			</description>
+		</method>
+		<method name="floorf">
+			<return type="float" />
+			<argument index="0" name="x" type="float" />
+			<description>
+				Rounds [code]x[/code] downward (towards negative infinity), returning the largest whole number that is not more than [code]x[/code].
+				A type-safe version of [method floor], specialzied in floats.
+			</description>
+		</method>
+		<method name="floori">
+			<return type="int" />
+			<argument index="0" name="x" type="float" />
+			<description>
+				Rounds [code]x[/code] downward (towards negative infinity), returning the largest whole number that is not more than [code]x[/code].
+				Equivalent of doing [code]int(x)[/code].
 			</description>
 		</method>
 		<method name="fmod">
@@ -827,14 +860,33 @@
 			</description>
 		</method>
 		<method name="round">
+			<return type="Variant" />
+			<argument index="0" name="x" type="Variant" />
+			<description>
+				Rounds [code]x[/code] to the nearest whole number, with halfway cases rounded away from zero. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
+				[codeblock]
+				round(2.4) # Returns 2
+				round(2.5) # Returns 3
+				round(2.6) # Returns 3
+				[/codeblock]
+				See also [method floor], [method ceil], and [method snapped].
+				[b]Note:[/b] For better type safety, you can use [method roundf], [method roundi], [method Vector2.round], [method Vector3.round] or [method Vector4.round] instead.
+			</description>
+		</method>
+		<method name="roundf">
 			<return type="float" />
 			<argument index="0" name="x" type="float" />
 			<description>
 				Rounds [code]x[/code] to the nearest whole number, with halfway cases rounded away from zero.
-				[codeblock]
-				round(2.6) # Returns 3
-				[/codeblock]
-				See also [method floor], [method ceil], and [method snapped].
+				A type-safe version of [method round], specialzied in floats.
+			</description>
+		</method>
+		<method name="roundi">
+			<return type="int" />
+			<argument index="0" name="x" type="float" />
+			<description>
+				Rounds [code]x[/code] to the nearest whole number, with halfway cases rounded away from zero.
+				A type-safe version of [method round] that returns integer.
 			</description>
 		</method>
 		<method name="seed">


### PR DESCRIPTION
This PR splits `ceil` `floor` and `round` into `ceilf`, `ceili`, `floorf`, `floori`, `roundf` and `roundi` methods. The original methods now take Variant, supporting int, float, Vector2 and Vector3.

We do the same for `abs`, `sign`, `max`, `min` and `clamp`, so it makes sense.

Resolves #19262
See also #60924, which does the same for `lerp()`.