### PR TITLE
Dependency Editor: Set current directory to closest existing directory

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -58,6 +58,9 @@ void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button, M
 
 	search->set_title(TTR("Search Replacement For:") + " " + replacing.get_file());
 
+	// Set directory to closest existing directory.
+	search->set_current_dir(replacing.get_base_dir());
+
 	search->clear_filters();
 	List<String> ext;
 	ResourceLoader::get_recognized_extensions_for_type(ti->get_metadata(0), &ext);


### PR DESCRIPTION
Source of "closest existing directory" is this code snippet here: https://github.com/godotengine/godot/blob/master/editor/editor_file_dialog.cpp#L263-L268

(And it works in testing)