### PR TITLE
fix 'Comparison result is always the same' warnings

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -815,10 +815,8 @@ void RasterizerCanvasGLES3::_render_item(RID p_render_target, const Item *p_item
 				_bind_canvas_texture(texture, current_filter, current_repeat, r_index);
 				if (instance_count == 1) {
 					GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_ATTRIBUTES);
-				} else if (instance_count > 1) {
-					GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_INSTANCED);
 				} else {
-					ERR_PRINT("Must have at least one mesh instance to draw mesh");
+					GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_INSTANCED);
 				}
 
 				uint32_t surf_count = mesh_storage->mesh_get_surface_count(mesh);
@@ -882,7 +880,7 @@ void RasterizerCanvasGLES3::_render_item(RID p_render_target, const Item *p_item
 						} else {
 							glDrawArrays(primitive_gl, 0, mesh_storage->mesh_surface_get_vertices_drawn_count(surface));
 						}
-					} else if (instance_count > 1) {
+					} else {
 						if (use_index_buffer) {
 							glDrawElementsInstanced(primitive_gl, mesh_storage->mesh_surface_get_vertices_drawn_count(surface), mesh_storage->mesh_surface_get_index_type(surface), 0, instance_count);
 						} else {

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -180,10 +180,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 2 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -210,10 +206,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 3 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -242,10 +234,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 4 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -298,10 +286,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 2 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -328,10 +312,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 3 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -360,10 +340,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 4 * p_array_size;
 
 				const int *r = iv.ptr();

--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -223,9 +223,6 @@ bool SceneCacheInterface::send_object_cache(Object *p_obj, int p_peer_id, int &r
 			if (p_peer_id < 0 && E == -p_peer_id) {
 				continue; // Continue, excluded.
 			}
-			if (p_peer_id > 0 && E != p_peer_id) {
-				continue; // Continue, not for this peer.
-			}
 
 			HashMap<int, bool>::Iterator F = psc->confirmed_peers.find(E);
 			if (!F) {

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -176,10 +176,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 2 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -205,10 +201,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 3 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -236,10 +228,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 4 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -292,10 +280,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 2 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -321,10 +305,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 3 * p_array_size;
 
 				const int *r = iv.ptr();
@@ -352,10 +332,6 @@ _FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataTy
 			if (p_array_size > 0) {
 				Vector<int> iv = value;
 				int s = iv.size();
-
-				if (p_array_size <= 0) {
-					p_array_size = 1;
-				}
 				int count = 4 * p_array_size;
 
 				const int *r = iv.ptr();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

According to [lgtm alerts](https://lgtm.com/projects/g/godotengine/godot/alerts?mode=tree&id=cpp%2Fconstant-comparison&ruleFocus=2154840804), there are some warnings in the codebase for if statements that are always true or false.
This pr removes them while behaviour should be the same (though I didn't check logic so condition might be wrong).