### PR TITLE
Add 'Make Local Recursively' command

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1028,6 +1028,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						break;
 					}
 
+					ERR_FAIL_COND(node->get_owner() != root);
 					ERR_FAIL_COND(node->get_scene_file_path().is_empty());
 					undo_redo->create_action(TTR("Make Local"));
 					undo_redo->add_do_method(node, "set_scene_file_path", "");
@@ -2899,7 +2900,9 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				if (profile_allow_editing) {
 					menu->add_check_item(TTR("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
 					menu->add_check_item(TTR("Load As Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
-					menu->add_item(TTR("Make Local"), TOOL_SCENE_MAKE_LOCAL);
+					if (selection[0]->get_owner() == EditorNode::get_singleton()->get_edited_scene()) {
+						menu->add_item(TTR("Make Local"), TOOL_SCENE_MAKE_LOCAL);
+					}
 				}
 				menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open in Editor"), TOOL_SCENE_OPEN);
 				if (profile_allow_editing) {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -83,6 +83,7 @@ class SceneTreeDock : public VBoxContainer {
 		TOOL_SCENE_EDITABLE_CHILDREN,
 		TOOL_SCENE_USE_PLACEHOLDER,
 		TOOL_SCENE_MAKE_LOCAL,
+		TOOL_SCENE_MAKE_LOCAL_RECURSIVELY,
 		TOOL_SCENE_OPEN,
 		TOOL_SCENE_CLEAR_INHERITANCE,
 		TOOL_SCENE_CLEAR_INHERITANCE_CONFIRM,
@@ -198,6 +199,9 @@ class SceneTreeDock : public VBoxContainer {
 	};
 
 	void _node_replace_owner(Node *p_base, Node *p_node, Node *p_root, ReplaceOwnerMode p_mode = MODE_BIDI);
+	void _node_make_local_recursively(Vector<Node *> p_bases, Node *p_node, Node *p_root);
+	void _node_make_local_recursively_inner(Vector<Node *> p_bases, Node *p_node, Node *p_root);
+
 	void _load_request(const String &p_path);
 	void _script_open_request(const Ref<Script> &p_script);
 	void _push_item(Object *p_object);


### PR DESCRIPTION
Fairly self-explanatory: Adds an additional command beneath the regular 'make local' command which both converts an instance to be local to the current scene, but also any recursive instances inside itself too.

![mzu8VRhziB](https://user-images.githubusercontent.com/12756047/180622950-6b686280-fbf8-4040-8433-d7d4d5f455b4.png)

Depends on #60160