### PR TITLE
Code quality: Fix header guards consistency

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           bash ./misc/scripts/clang_format.sh
 
+      - name: Header guards formatting checks (header_guards.sh)
+        run: |
+          bash ./misc/scripts/header_guards.sh
+
       - name: Python style checks via black (black_format.sh)
         run: |
           bash ./misc/scripts/black_format.sh

--- a/core/core_constants.h
+++ b/core/core_constants.h
@@ -42,4 +42,4 @@ public:
 	static int64_t get_global_constant_value(int p_idx);
 };
 
-#endif // GLOBAL_CONSTANTS_H
+#endif // CORE_CONSTANTS_H

--- a/core/crypto/crypto_core.h
+++ b/core/crypto/crypto_core.h
@@ -115,4 +115,5 @@ public:
 	static Error sha1(const uint8_t *p_src, int p_src_len, unsigned char r_hash[20]);
 	static Error sha256(const uint8_t *p_src, int p_src_len, unsigned char r_hash[32]);
 };
+
 #endif // CRYPTO_CORE_H

--- a/core/debugger/debugger_marshalls.h
+++ b/core/debugger/debugger_marshalls.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef DEBUGGER_MARSHARLLS_H
-#define DEBUGGER_MARSHARLLS_H
+#ifndef DEBUGGER_MARSHALLS_H
+#define DEBUGGER_MARSHALLS_H
 
 #include "core/object/script_language.h"
 
@@ -69,4 +69,4 @@ struct DebuggerMarshalls {
 	};
 };
 
-#endif // DEBUGGER_MARSHARLLS_H
+#endif // DEBUGGER_MARSHALLS_H

--- a/core/extension/extension_api_dump.h
+++ b/core/extension/extension_api_dump.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef API_DUMP_H
-#define API_DUMP_H
+#ifndef EXTENSION_API_DUMP_H
+#define EXTENSION_API_DUMP_H
 
 #include "core/extension/native_extension.h"
 
@@ -42,4 +42,4 @@ public:
 };
 #endif
 
-#endif // API_DUMP_H
+#endif // EXTENSION_API_DUMP_H

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -582,4 +582,4 @@ typedef GDNativeBool (*GDNativeInitializationFunction)(const GDNativeInterface *
 }
 #endif
 
-#endif
+#endif // GDNATIVE_INTERFACE_H

--- a/core/extension/native_extension.h
+++ b/core/extension/native_extension.h
@@ -97,4 +97,4 @@ public:
 	virtual String get_resource_type(const String &p_path) const;
 };
 
-#endif // NATIVEEXTENSION_H
+#endif // NATIVE_EXTENSION_H

--- a/core/extension/native_extension_manager.h
+++ b/core/extension/native_extension_manager.h
@@ -71,4 +71,4 @@ public:
 
 VARIANT_ENUM_CAST(NativeExtensionManager::LoadStatus)
 
-#endif // NATIVEEXTENSIONMANAGER_H
+#endif // NATIVE_EXTENSION_MANAGER_H

--- a/core/input/shortcut.h
+++ b/core/input/shortcut.h
@@ -55,4 +55,5 @@ public:
 
 	static bool is_event_array_equal(const Array &p_event_array1, const Array &p_event_array2);
 };
+
 #endif // SHORTCUT_H

--- a/core/io/packet_peer.h
+++ b/core/io/packet_peer.h
@@ -127,4 +127,4 @@ public:
 	PacketPeerStream();
 };
 
-#endif // PACKET_STREAM_H
+#endif // PACKET_PEER_H

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RESOURCE_UUID_H
-#define RESOURCE_UUID_H
+#ifndef RESOURCE_UID_H
+#define RESOURCE_UID_H
 
 #include "core/object/ref_counted.h"
 #include "core/string/string_name.h"
@@ -85,4 +85,4 @@ public:
 	~ResourceUID();
 };
 
-#endif // RESOURCEUUID_H
+#endif // RESOURCE_UID_H

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CAMERA_MATRIX_H
-#define CAMERA_MATRIX_H
+#ifndef PROJECTION_H
+#define PROJECTION_H
 
 #include "core/math/math_defs.h"
 #include "core/math/vector3.h"
@@ -164,4 +164,4 @@ Vector3 Projection::xform(const Vector3 &p_vec3) const {
 	return ret / w;
 }
 
-#endif // CAMERA_MATRIX_H
+#endif // PROJECTION_H

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -272,4 +272,5 @@ _FORCE_INLINE_ Vector4 operator*(const int32_t p_scalar, const Vector4 &p_vec) {
 _FORCE_INLINE_ Vector4 operator*(const int64_t p_scalar, const Vector4 &p_vec) {
 	return p_vec * p_scalar;
 }
+
 #endif // VECTOR4_H

--- a/core/multiplayer/multiplayer_peer.h
+++ b/core/multiplayer/multiplayer_peer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NETWORKED_MULTIPLAYER_PEER_H
-#define NETWORKED_MULTIPLAYER_PEER_H
+#ifndef MULTIPLAYER_PEER_H
+#define MULTIPLAYER_PEER_H
 
 #include "core/io/packet_peer.h"
 #include "core/multiplayer/multiplayer.h"
@@ -147,4 +147,4 @@ public:
 	GDVIRTUAL0RC(int, _get_connection_status);
 };
 
-#endif // NETWORKED_MULTIPLAYER_PEER_H
+#endif // MULTIPLAYER_PEER_H

--- a/core/os/spin_lock.h
+++ b/core/os/spin_lock.h
@@ -48,4 +48,5 @@ public:
 		locked.clear(std::memory_order_release);
 	}
 };
+
 #endif // SPIN_LOCK_H

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -123,4 +123,5 @@ public:
 };
 
 #endif // THREAD_H
+
 #endif // PLATFORM_THREAD_OVERRIDE

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -28,9 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+// Note: _GODOT suffix added to avoid conflict with ICU header with the same guard.
+
 #ifndef USTRING_GODOT_H
 #define USTRING_GODOT_H
-// Note: Renamed to avoid conflict with ICU header with the same name.
 
 #include "core/string/char_utils.h"
 #include "core/templates/cowdata.h"

--- a/core/templates/bin_sorted_array.h
+++ b/core/templates/bin_sorted_array.h
@@ -178,4 +178,4 @@ public:
 	}
 };
 
-#endif //BIN_SORTED_ARRAY_H
+#endif // BIN_SORTED_ARRAY_H

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -124,4 +124,4 @@ public:
 	}
 };
 
-#endif
+#endif // LRU_H

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -758,4 +758,4 @@ public:
 	}
 };
 
-#endif // MAP_H
+#endif // RB_MAP_H

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -708,4 +708,4 @@ public:
 	}
 };
 
-#endif // SET_H
+#endif // RB_SET_H

--- a/core/templates/thread_work_pool.h
+++ b/core/templates/thread_work_pool.h
@@ -154,4 +154,4 @@ public:
 	~ThreadWorkPool();
 };
 
-#endif // THREAD_POOL_H
+#endif // THREAD_WORK_POOL_H

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef COREAUDIO_ENABLED
-
 #ifndef AUDIO_DRIVER_COREAUDIO_H
 #define AUDIO_DRIVER_COREAUDIO_H
+
+#ifdef COREAUDIO_ENABLED
 
 #include "servers/audio_server.h"
 
@@ -120,6 +120,6 @@ public:
 	~AudioDriverCoreAudio() {}
 };
 
-#endif
+#endif // COREAUDIO_ENABLED
 
-#endif
+#endif // AUDIO_DRIVER_COREAUDIO_H

--- a/drivers/coremidi/midi_driver_coremidi.h
+++ b/drivers/coremidi/midi_driver_coremidi.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef COREMIDI_ENABLED
-
 #ifndef MIDI_DRIVER_COREMIDI_H
 #define MIDI_DRIVER_COREMIDI_H
+
+#ifdef COREMIDI_ENABLED
 
 #include "core/os/midi_driver.h"
 #include "core/templates/vector.h"
@@ -57,5 +57,6 @@ public:
 	virtual ~MIDIDriverCoreMidi();
 };
 
-#endif // MIDI_DRIVER_COREMIDI_H
 #endif // COREMIDI_ENABLED
+
+#endif // MIDI_DRIVER_COREMIDI_H

--- a/drivers/gles3/effects/copy_effects.h
+++ b/drivers/gles3/effects/copy_effects.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef COPY_GL_H
-#define COPY_GL_H
+#ifndef COPY_EFFECTS_GLES3_H
+#define COPY_EFFECTS_GLES3_H
 
 #ifdef GLES3_ENABLED
 
@@ -70,4 +70,5 @@ public:
 } //namespace GLES3
 
 #endif // GLES3_ENABLED
-#endif // !COPY_GL_H
+
+#endif // COPY_EFFECTS_GLES3_H

--- a/drivers/gles3/environment/fog.h
+++ b/drivers/gles3/environment/fog.h
@@ -59,4 +59,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif // !FOG_GLES3_H
+#endif // FOG_GLES3_H

--- a/drivers/gles3/environment/gi.h
+++ b/drivers/gles3/environment/gi.h
@@ -93,4 +93,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif // !GI_GLES3_H
+#endif // GI_GLES3_H

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RASTERIZER_CANVAS_OPENGL_H
-#define RASTERIZER_CANVAS_OPENGL_H
+#ifndef RASTERIZER_CANVAS_GLES3_H
+#define RASTERIZER_CANVAS_GLES3_H
 
 #ifdef GLES3_ENABLED
 
@@ -262,4 +262,5 @@ public:
 };
 
 #endif // GLES3_ENABLED
-#endif // RASTERIZER_CANVAS_OPENGL_H
+
+#endif // RASTERIZER_CANVAS_GLES3_H

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RASTERIZER_OPENGL_H
-#define RASTERIZER_OPENGL_H
+#ifndef RASTERIZER_GLES3_H
+#define RASTERIZER_GLES3_H
 
 #ifdef GLES3_ENABLED
 
@@ -112,4 +112,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif
+#endif // RASTERIZER_GLES3_H

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RASTERIZER_SCENE_OPENGL_H
-#define RASTERIZER_SCENE_OPENGL_H
+#ifndef RASTERIZER_SCENE_GLES3_H
+#define RASTERIZER_SCENE_GLES3_H
 
 #ifdef GLES3_ENABLED
 
@@ -947,4 +947,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif // RASTERIZER_SCENE_OPENGL_H
+#endif // RASTERIZER_SCENE_GLES3_H

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SHADER_OPENGL_H
-#define SHADER_OPENGL_H
+#ifndef SHADER_GLES3_H
+#define SHADER_GLES3_H
 
 #include "core/math/projection.h"
 #include "core/os/mutex.h"
@@ -248,5 +248,6 @@ public:
 	virtual ~ShaderGLES3();
 };
 
-#endif // SHADER_OPENGL_H
-#endif
+#endif // GLES3_ENABLED
+
+#endif // SHADER_GLES3_H

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -90,4 +90,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif // !CONFIG_GLES3_H
+#endif // CONFIG_GLES3_H

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -342,6 +342,6 @@ public:
 
 } // namespace GLES3
 
-#endif // !GLES3_ENABLED
+#endif // GLES3_ENABLED
 
-#endif // !LIGHT_STORAGE_GLES3_H
+#endif // LIGHT_STORAGE_GLES3_H

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -599,4 +599,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif // !MATERIAL_STORAGE_GLES3_H
+#endif // MATERIAL_STORAGE_GLES3_H

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -543,4 +543,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif // !MESH_STORAGE_GLES3_H
+#endif // MESH_STORAGE_GLES3_H

--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -137,4 +137,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif // !PARTICLES_STORAGE_GLES3_H
+#endif // PARTICLES_STORAGE_GLES3_H

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -577,6 +577,6 @@ inline String TextureStorage::get_framebuffer_error(GLenum p_status) {
 
 } // namespace GLES3
 
-#endif // !GLES3_ENABLED
+#endif // GLES3_ENABLED
 
-#endif // !TEXTURE_STORAGE_GLES3_H
+#endif // TEXTURE_STORAGE_GLES3_H

--- a/drivers/gles3/storage/utilities.h
+++ b/drivers/gles3/storage/utilities.h
@@ -156,4 +156,4 @@ public:
 
 #endif // GLES3_ENABLED
 
-#endif // !UTILITIES_GLES3_H
+#endif // UTILITIES_GLES3_H

--- a/drivers/png/image_loader_png.h
+++ b/drivers/png/image_loader_png.h
@@ -45,4 +45,4 @@ public:
 	ImageLoaderPNG();
 };
 
-#endif
+#endif // IMAGE_LOADER_PNG_H

--- a/drivers/png/png_driver_common.h
+++ b/drivers/png/png_driver_common.h
@@ -43,4 +43,4 @@ Error png_to_image(const uint8_t *p_source, size_t p_size, bool p_force_linear, 
 Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer);
 } // namespace PNGDriverCommon
 
-#endif
+#endif // PNG_DRIVER_COMMON_H

--- a/drivers/register_driver_types.h
+++ b/drivers/register_driver_types.h
@@ -37,4 +37,4 @@ void unregister_core_driver_types();
 void register_driver_types();
 void unregister_driver_types();
 
-#endif
+#endif // REGISTER_DRIVER_TYPES_H

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -516,4 +516,4 @@ DirAccessUnix::~DirAccessUnix() {
 	list_dir_end();
 }
 
-#endif //posix_enabled
+#endif // UNIX_ENABLED || LIBC_FILEIO_ENABLED

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -90,5 +90,6 @@ public:
 	~DirAccessUnix();
 };
 
-#endif //UNIX ENABLED
-#endif
+#endif // UNIX_ENABLED || LIBC_FILEIO_ENABLED
+
+#endif // DIR_ACCESS_UNIX_H

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -339,4 +339,4 @@ FileAccessUnix::~FileAccessUnix() {
 	_close();
 }
 
-#endif
+#endif // UNIX_ENABLED || LIBC_FILEIO_ENABLED

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -86,5 +86,6 @@ public:
 	virtual ~FileAccessUnix();
 };
 
-#endif
-#endif
+#endif // UNIX_ENABLED || LIBC_FILEIO_ENABLED
+
+#endif // FILE_ACCESS_UNIX_H

--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -50,4 +50,5 @@ public:
 };
 
 #endif
+
 #endif // IP_UNIX_H

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NET_SOCKET_UNIX_H
-#define NET_SOCKET_UNIX_H
+#ifndef NET_SOCKET_POSIX_H
+#define NET_SOCKET_POSIX_H
 
 #include "core/io/net_socket.h"
 
@@ -104,4 +104,4 @@ public:
 	~NetSocketPosix();
 };
 
-#endif
+#endif // NET_SOCKET_POSIX_H

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -98,6 +98,6 @@ public:
 	virtual ~UnixTerminalLogger();
 };
 
-#endif
+#endif // UNIX_ENABLED
 
-#endif
+#endif // OS_UNIX_H

--- a/drivers/unix/syslog_logger.h
+++ b/drivers/unix/syslog_logger.h
@@ -43,6 +43,6 @@ public:
 	virtual ~SyslogLogger();
 };
 
-#endif
+#endif // UNIX_ENABLED
 
-#endif
+#endif // SYSLOG_LOGGER_H

--- a/drivers/unix/thread_posix.h
+++ b/drivers/unix/thread_posix.h
@@ -35,4 +35,4 @@
 void init_thread_posix();
 #endif
 
-#endif
+#endif // THREAD_POSIX_H

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -330,4 +330,4 @@ public:
 	virtual ~VulkanContext();
 };
 
-#endif // VULKAN_DEVICE_H
+#endif // VULKAN_CONTEXT_H

--- a/drivers/vulkan/vulkan_hooks.h
+++ b/drivers/vulkan/vulkan_hooks.h
@@ -45,4 +45,4 @@ public:
 	virtual ~VulkanHooks(){};
 };
 
-#endif
+#endif // VULKAN_HOOKS_H

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -120,4 +120,5 @@ public:
 };
 
 #endif // WASAPI_ENABLED
+
 #endif // AUDIO_DRIVER_WASAPI_H

--- a/drivers/winmidi/midi_driver_winmidi.h
+++ b/drivers/winmidi/midi_driver_winmidi.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef WINMIDI_ENABLED
-
 #ifndef MIDI_DRIVER_WINMIDI_H
 #define MIDI_DRIVER_WINMIDI_H
+
+#ifdef WINMIDI_ENABLED
 
 #include "core/os/midi_driver.h"
 #include "core/templates/vector.h"
@@ -57,5 +57,6 @@ public:
 	virtual ~MIDIDriverWinMidi();
 };
 
-#endif // MIDI_DRIVER_WINMIDI_H
 #endif // WINMIDI_ENABLED
+
+#endif // MIDI_DRIVER_WINMIDI_H

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -106,4 +106,4 @@ public:
 	~AudioDriverXAudio2() {}
 };
 
-#endif
+#endif // AUDIO_DRIVER_XAUDIO2_H

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -209,4 +209,4 @@ public:
 	ActionMapEditor();
 };
 
-#endif
+#endif // ACTION_MAP_EDITOR_H

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -125,4 +125,4 @@ public:
 	CreateDialog();
 };
 
-#endif
+#endif // CREATE_DIALOG_H

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -93,4 +93,4 @@ public:
 	Dictionary ev_breakpoint(const DAP::Breakpoint &p_breakpoint, const bool &p_enabled) const;
 };
 
-#endif
+#endif // DEBUG_ADAPTER_PARSER_H

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -152,4 +152,4 @@ public:
 	~DebugAdapterProtocol();
 };
 
-#endif
+#endif // DEBUG_ADAPTER_PROTOCOL_H

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -54,4 +54,4 @@ public:
 	void stop();
 };
 
-#endif
+#endif // DEBUG_ADAPTER_SERVER_H

--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -278,4 +278,4 @@ struct Variable {
 
 } // namespace DAP
 
-#endif
+#endif // DEBUG_ADAPTER_TYPES_H

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -30,6 +30,7 @@
 
 #ifndef EDITOR_DEBUGGER_INSPECTOR_H
 #define EDITOR_DEBUGGER_INSPECTOR_H
+
 #include "editor/editor_inspector.h"
 
 class EditorDebuggerRemoteObject : public Object {

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -205,4 +205,5 @@ public:
 	void add_debugger_plugin(const Ref<Script> &p_script);
 	void remove_debugger_plugin(const Ref<Script> &p_script);
 };
+
 #endif // EDITOR_DEBUGGER_NODE_H

--- a/editor/debugger/editor_debugger_server.h
+++ b/editor/debugger/editor_debugger_server.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITOR_DEBUGGER_CONNECTION_H
-#define EDITOR_DEBUGGER_CONNECTION_H
+#ifndef EDITOR_DEBUGGER_SERVER_H
+#define EDITOR_DEBUGGER_SERVER_H
 
 #include "core/debugger/remote_debugger_peer.h"
 #include "core/object/ref_counted.h"
@@ -57,4 +57,4 @@ public:
 	virtual Ref<RemoteDebuggerPeer> take_connection() = 0;
 };
 
-#endif // EDITOR_DEBUGGER_CONNECTION_H
+#endif // EDITOR_DEBUGGER_SERVER_H

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -71,4 +71,5 @@ public:
 	void update_scene_tree(const SceneDebuggerTree *p_tree, int p_debugger);
 	EditorDebuggerTree();
 };
+
 #endif // EDITOR_DEBUGGER_TREE_H

--- a/editor/debugger/editor_network_profiler.h
+++ b/editor/debugger/editor_network_profiler.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORNETWORKPROFILER_H
-#define EDITORNETWORKPROFILER_H
+#ifndef EDITOR_NETWORK_PROFILER_H
+#define EDITOR_NETWORK_PROFILER_H
 
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/box_container.h"
@@ -69,4 +69,4 @@ public:
 	EditorNetworkProfiler();
 };
 
-#endif //EDITORNETWORKPROFILER_H
+#endif // EDITOR_NETWORK_PROFILER_H

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORPROFILER_H
-#define EDITORPROFILER_H
+#ifndef EDITOR_PROFILER_H
+#define EDITOR_PROFILER_H
 
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -165,4 +165,4 @@ public:
 	EditorProfiler();
 };
 
-#endif // EDITORPROFILER_H
+#endif // EDITOR_PROFILER_H

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITOR_FRAME_PROFILER_H
-#define EDITOR_FRAME_PROFILER_H
+#ifndef EDITOR_VISUAL_PROFILER_H
+#define EDITOR_VISUAL_PROFILER_H
 
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -144,4 +144,4 @@ public:
 	EditorVisualProfiler();
 };
 
-#endif // EDITOR_FRAME_PROFILER_H
+#endif // EDITOR_VISUAL_PROFILER_H

--- a/editor/doc_tools.h
+++ b/editor/doc_tools.h
@@ -53,4 +53,4 @@ public:
 	Error load_compressed(const uint8_t *p_data, int p_compressed_size, int p_uncompressed_size);
 };
 
-#endif // DOC_DATA_H
+#endif // DOC_TOOLS_H

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -75,4 +75,4 @@ public:
 	~EditorAbout();
 };
 
-#endif
+#endif // EDITOR_ABOUT_H

--- a/editor/editor_asset_installer.h
+++ b/editor/editor_asset_installer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORASSETINSTALLER_H
-#define EDITORASSETINSTALLER_H
+#ifndef EDITOR_ASSET_INSTALLER_H
+#define EDITOR_ASSET_INSTALLER_H
 
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
@@ -59,4 +59,4 @@ public:
 	EditorAssetInstaller();
 };
 
-#endif // EDITORASSETINSTALLER_H
+#endif // EDITOR_ASSET_INSTALLER_H

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -112,4 +112,4 @@ public:
 	~EditorAutoloadSettings();
 };
 
-#endif
+#endif // EDITOR_AUTOLOAD_SETTINGS_H

--- a/editor/editor_command_palette.h
+++ b/editor/editor_command_palette.h
@@ -101,4 +101,4 @@ public:
 
 Ref<Shortcut> ED_SHORTCUT_AND_COMMAND(const String &p_path, const String &p_name, Key p_keycode = Key::NONE, String p_command = "");
 
-#endif //EDITOR_COMMAND_PALETTE_H
+#endif // EDITOR_COMMAND_PALETTE_H

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -529,4 +529,4 @@ public:
 	EditorExportTextSceneToBinaryPlugin();
 };
 
-#endif // EDITOR_IMPORT_EXPORT_H
+#endif // EDITOR_EXPORT_H

--- a/editor/editor_fonts.h
+++ b/editor/editor_fonts.h
@@ -35,4 +35,4 @@
 
 void editor_register_fonts(Ref<Theme> p_theme);
 
-#endif
+#endif // EDITOR_FONTS_H

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -602,4 +602,4 @@ public:
 	EditorInspector();
 };
 
-#endif // INSPECTOR_H
+#endif // EDITOR_INSPECTOR_H

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -91,6 +91,7 @@
 #include "editor/editor_plugin.h"
 #include "editor/editor_properties.h"
 #include "editor/editor_property_name_processor.h"
+#include "editor/editor_quick_open.h"
 #include "editor/editor_resource_picker.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_run.h"
@@ -200,7 +201,6 @@
 #include "editor/progress_dialog.h"
 #include "editor/project_export.h"
 #include "editor/project_settings_editor.h"
-#include "editor/quick_open.h"
 #include "editor/register_exporters.h"
 #include "editor/scene_tree_dock.h"
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -346,4 +346,4 @@ public:
 	}
 };
 
-#endif
+#endif // EDITOR_PLUGIN_H

--- a/editor/editor_plugin_settings.h
+++ b/editor/editor_plugin_settings.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORPLUGINSETTINGS_H
-#define EDITORPLUGINSETTINGS_H
+#ifndef EDITOR_PLUGIN_SETTINGS_H
+#define EDITOR_PLUGIN_SETTINGS_H
 
 #include "core/object/undo_redo.h"
 #include "editor/editor_data.h"
@@ -65,4 +65,4 @@ public:
 	EditorPluginSettings();
 };
 
-#endif // EDITORPLUGINSETTINGS_H
+#endif // EDITOR_PLUGIN_SETTINGS_H

--- a/editor/editor_quick_open.cpp
+++ b/editor/editor_quick_open.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  quick_open.cpp                                                       */
+/*  editor_quick_open.cpp                                                */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "quick_open.h"
+#include "editor_quick_open.h"
 
 #include "core/os/keyboard.h"
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -33,12 +33,12 @@
 #include "editor/audio_stream_preview.h"
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_node.h"
+#include "editor/editor_quick_open.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/filesystem_dock.h"
 #include "editor/plugins/script_editor_plugin.h"
-#include "editor/quick_open.h"
 #include "editor/scene_tree_dock.h"
 
 HashMap<StringName, List<StringName>> EditorResourcePicker::allowed_types_cache;

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORRESOURCEPREVIEW_H
-#define EDITORRESOURCEPREVIEW_H
+#ifndef EDITOR_RESOURCE_PREVIEW_H
+#define EDITOR_RESOURCE_PREVIEW_H
 
 #include "core/os/semaphore.h"
 #include "core/os/thread.h"
@@ -124,4 +124,4 @@ public:
 	~EditorResourcePreview();
 };
 
-#endif // EDITORRESOURCEPREVIEW_H
+#endif // EDITOR_RESOURCE_PREVIEW_H

--- a/editor/editor_scale.h
+++ b/editor/editor_scale.h
@@ -35,4 +35,5 @@ void editor_set_scale(float p_scale);
 float editor_get_scale();
 
 #define EDSCALE (editor_get_scale())
+
 #endif // EDITOR_SCALE_H

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -76,4 +76,5 @@ public:
 	SectionedInspector();
 	~SectionedInspector();
 };
+
 #endif // EDITOR_SECTIONED_INSPECTOR_H

--- a/editor/editor_themes.h
+++ b/editor/editor_themes.h
@@ -40,4 +40,4 @@ Ref<Theme> create_custom_theme(Ref<Theme> p_theme = nullptr);
 
 Ref<ImageTexture> create_unscaled_default_project_icon();
 
-#endif
+#endif // EDITOR_THEMES_H

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -85,4 +85,4 @@ public:
 	virtual ~EditorVCSInterface();
 };
 
-#endif // !EDITOR_VCS_INTERFACE_H
+#endif // EDITOR_VCS_INTERFACE_H

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -342,4 +342,4 @@ public:
 	~FileSystemDock();
 };
 
-#endif // SCENES_DOCK_H
+#endif // FILESYSTEM_DOCK_H

--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -144,4 +144,4 @@ public:
 	~GroupsEditor();
 };
 
-#endif
+#endif // GROUPS_EDITOR_H

--- a/editor/import/editor_import_collada.h
+++ b/editor/import/editor_import_collada.h
@@ -44,4 +44,4 @@ public:
 	EditorSceneFormatImporterCollada();
 };
 
-#endif
+#endif // EDITOR_IMPORT_COLLADA_H

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -68,4 +68,4 @@ public:
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata = nullptr) override;
 };
 
-#endif //EDITOR_IMPORT_PLUGIN_H
+#endif // EDITOR_IMPORT_PLUGIN_H

--- a/editor/import/resource_importer_bitmask.h
+++ b/editor/import/resource_importer_bitmask.h
@@ -53,4 +53,5 @@ public:
 	ResourceImporterBitMap();
 	~ResourceImporterBitMap();
 };
+
 #endif // RESOURCE_IMPORTER_BITMASK_H

--- a/editor/import/resource_importer_csv_translation.h
+++ b/editor/import/resource_importer_csv_translation.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RESOURCEIMPORTERCSVTRANSLATION_H
-#define RESOURCEIMPORTERCSVTRANSLATION_H
+#ifndef RESOURCE_IMPORTER_CSV_TRANSLATION_H
+#define RESOURCE_IMPORTER_CSV_TRANSLATION_H
 
 #include "core/io/resource_importer.h"
 
@@ -54,4 +54,4 @@ public:
 	ResourceImporterCSVTranslation();
 };
 
-#endif // RESOURCEIMPORTERCSVTRANSLATION_H
+#endif // RESOURCE_IMPORTER_CSV_TRANSLATION_H

--- a/editor/import/resource_importer_imagefont.h
+++ b/editor/import/resource_importer_imagefont.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RESOURCE_IMPORTER_IMAGE_FONT_H
-#define RESOURCE_IMPORTER_IMAGE_FONT_H
+#ifndef RESOURCE_IMPORTER_IMAGEFONT_H
+#define RESOURCE_IMPORTER_IMAGEFONT_H
 
 #include "core/io/resource_importer.h"
 #include "scene/resources/font.h"
@@ -55,4 +55,4 @@ public:
 	ResourceImporterImageFont();
 };
 
-#endif // RESOURCE_IMPORTER_IMAGE_FONT_H
+#endif // RESOURCE_IMPORTER_IMAGEFONT_H

--- a/editor/import/resource_importer_obj.h
+++ b/editor/import/resource_importer_obj.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RESOURCEIMPORTEROBJ_H
-#define RESOURCEIMPORTEROBJ_H
+#ifndef RESOURCE_IMPORTER_OBJ_H
+#define RESOURCE_IMPORTER_OBJ_H
 
 #include "resource_importer_scene.h"
 
@@ -69,4 +69,4 @@ public:
 	ResourceImporterOBJ();
 };
 
-#endif // RESOURCEIMPORTEROBJ_H
+#endif // RESOURCE_IMPORTER_OBJ_H

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RESOURCEIMPORTERSCENE_H
-#define RESOURCEIMPORTERSCENE_H
+#ifndef RESOURCE_IMPORTER_SCENE_H
+#define RESOURCE_IMPORTER_SCENE_H
 
 #include "core/error/error_macros.h"
 #include "core/io/resource_importer.h"
@@ -479,4 +479,4 @@ Transform3D ResourceImporterScene::get_collision_shapes_transform(const M &p_opt
 	return transform;
 }
 
-#endif // RESOURCEIMPORTERSCENE_H
+#endif // RESOURCE_IMPORTER_SCENE_H

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RESOURCEIMPORTTEXTURE_H
-#define RESOURCEIMPORTTEXTURE_H
+#ifndef RESOURCE_IMPORTER_TEXTURE_H
+#define RESOURCE_IMPORTER_TEXTURE_H
 
 #include "core/io/file_access.h"
 #include "core/io/image.h"
@@ -109,4 +109,4 @@ public:
 	~ResourceImporterTexture();
 };
 
-#endif // RESOURCEIMPORTTEXTURE_H
+#endif // RESOURCE_IMPORTER_TEXTURE_H

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef IMPORTDOCK_H
-#define IMPORTDOCK_H
+#ifndef IMPORT_DOCK_H
+#define IMPORT_DOCK_H
 
 #include "core/io/config_file.h"
 #include "core/io/resource_importer.h"
@@ -105,4 +105,4 @@ public:
 	~ImportDock();
 };
 
-#endif // IMPORTDOCK_H
+#endif // IMPORT_DOCK_H

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -153,4 +153,4 @@ public:
 	~InspectorDock();
 };
 
-#endif
+#endif // INSPECTOR_DOCK_H

--- a/editor/plugins/animation_library_editor.h
+++ b/editor/plugins/animation_library_editor.h
@@ -116,4 +116,4 @@ public:
 	AnimationLibraryEditor();
 };
 
-#endif // ANIMATIONPLAYERLIBRARYEDITOR_H
+#endif // ANIMATION_LIBRARY_EDITOR_H

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -338,4 +338,4 @@ public:
 	~AssetLibraryEditorPlugin();
 };
 
-#endif // EDITORASSETLIBRARY_H
+#endif // ASSET_LIBRARY_EDITOR_PLUGIN_H

--- a/editor/plugins/bit_map_editor_plugin.h
+++ b/editor/plugins/bit_map_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef BIT_MAP_PREVIEW_EDITOR_PLUGIN_H
-#define BIT_MAP_PREVIEW_EDITOR_PLUGIN_H
+#ifndef BIT_MAP_EDITOR_PLUGIN_H
+#define BIT_MAP_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/resources/bit_map.h"
@@ -61,4 +61,4 @@ public:
 	BitMapEditorPlugin();
 };
 
-#endif // BIT_MAP_PREVIEW_EDITOR_PLUGIN_H
+#endif // BIT_MAP_EDITOR_PLUGIN_H

--- a/editor/plugins/bone_map_editor_plugin.h
+++ b/editor/plugins/bone_map_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef BONE_MAP_EDITOR_H
-#define BONE_MAP_EDITOR_H
+#ifndef BONE_MAP_EDITOR_PLUGIN_H
+#define BONE_MAP_EDITOR_PLUGIN_H
 
 #include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
@@ -176,4 +176,4 @@ public:
 	BoneMapEditorPlugin();
 };
 
-#endif // BONE_MAP_EDITOR_H
+#endif // BONE_MAP_EDITOR_PLUGIN_H

--- a/editor/plugins/camera_3d_editor_plugin.h
+++ b/editor/plugins/camera_3d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CAMERA_EDITOR_PLUGIN_H
-#define CAMERA_EDITOR_PLUGIN_H
+#ifndef CAMERA_3D_EDITOR_PLUGIN_H
+#define CAMERA_3D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/camera_3d.h"
@@ -68,4 +68,4 @@ public:
 	~Camera3DEditorPlugin();
 };
 
-#endif // CAMERA_EDITOR_PLUGIN_H
+#endif // CAMERA_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -630,4 +630,4 @@ public:
 	~CanvasItemEditorViewport();
 };
 
-#endif //CANVAS_ITEM_EDITOR_PLUGIN_H
+#endif // CANVAS_ITEM_EDITOR_PLUGIN_H

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -112,4 +112,4 @@ public:
 	~CollisionShape2DEditorPlugin();
 };
 
-#endif //COLLISION_SHAPE_2D_EDITOR_PLUGIN_H
+#endif // COLLISION_SHAPE_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -247,4 +247,4 @@ public:
 	ControlEditorPlugin();
 };
 
-#endif //CONTROL_EDITOR_PLUGIN_H
+#endif // CONTROL_EDITOR_PLUGIN_H

--- a/editor/plugins/cpu_particles_3d_editor_plugin.h
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CPU_PARTICLES_EDITOR_PLUGIN_H
-#define CPU_PARTICLES_EDITOR_PLUGIN_H
+#ifndef CPU_PARTICLES_3D_EDITOR_PLUGIN_H
+#define CPU_PARTICLES_3D_EDITOR_PLUGIN_H
 
 #include "editor/plugins/gpu_particles_3d_editor_plugin.h"
 #include "scene/3d/cpu_particles_3d.h"
@@ -78,4 +78,4 @@ public:
 	~CPUParticles3DEditorPlugin();
 };
 
-#endif // CPU_PARTICLES_EDITOR_PLUGIN_H
+#endif // CPU_PARTICLES_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORPREVIEWPLUGINS_H
-#define EDITORPREVIEWPLUGINS_H
+#ifndef EDITOR_PREVIEW_PLUGINS_H
+#define EDITOR_PREVIEW_PLUGINS_H
 
 #include "core/templates/safe_refcount.h"
 #include "editor/editor_resource_preview.h"
@@ -193,4 +193,5 @@ public:
 
 	EditorGradientPreviewPlugin();
 };
-#endif // EDITORPREVIEWPLUGINS_H
+
+#endif // EDITOR_PREVIEW_PLUGINS_H

--- a/editor/plugins/font_config_plugin.h
+++ b/editor/plugins/font_config_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef OT_FEATURES_PLUGIN_H
-#define OT_FEATURES_PLUGIN_H
+#ifndef FONT_CONFIG_PLUGIN_H
+#define FONT_CONFIG_PLUGIN_H
 
 #include "core/io/marshalls.h"
 #include "editor/editor_plugin.h"
@@ -258,4 +258,4 @@ public:
 	virtual String get_name() const override { return "Font"; }
 };
 
-#endif // OT_FEATURES_PLUGIN_H
+#endif // FONT_CONFIG_PLUGIN_H

--- a/editor/plugins/gpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PARTICLES_2D_EDITOR_PLUGIN_H
-#define PARTICLES_2D_EDITOR_PLUGIN_H
+#ifndef GPU_PARTICLES_2D_EDITOR_PLUGIN_H
+#define GPU_PARTICLES_2D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/2d/collision_polygon_2d.h"
@@ -97,4 +97,4 @@ public:
 	~GPUParticles2DEditorPlugin();
 };
 
-#endif // PARTICLES_2D_EDITOR_PLUGIN_H
+#endif // GPU_PARTICLES_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/gpu_particles_3d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PARTICLES_EDITOR_PLUGIN_H
-#define PARTICLES_EDITOR_PLUGIN_H
+#ifndef GPU_PARTICLES_3D_EDITOR_PLUGIN_H
+#define GPU_PARTICLES_3D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/gpu_particles_3d.h"
@@ -114,4 +114,4 @@ public:
 	~GPUParticles3DEditorPlugin();
 };
 
-#endif // PARTICLES_EDITOR_PLUGIN_H
+#endif // GPU_PARTICLES_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/gradient_texture_2d_editor_plugin.h
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GRADIENT_TEXTURE_2D_EDITOR
-#define GRADIENT_TEXTURE_2D_EDITOR
+#ifndef GRADIENT_TEXTURE_2D_EDITOR_PLUGIN_H
+#define GRADIENT_TEXTURE_2D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "editor/editor_spin_slider.h"
@@ -109,4 +109,4 @@ public:
 	GradientTexture2DEditorPlugin();
 };
 
-#endif
+#endif // GRADIENT_TEXTURE_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/lightmap_gi_editor_plugin.h
+++ b/editor/plugins/lightmap_gi_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef BAKED_LIGHTMAP_EDITOR_PLUGIN_H
-#define BAKED_LIGHTMAP_EDITOR_PLUGIN_H
+#ifndef LIGHTMAP_GI_EDITOR_PLUGIN_H
+#define LIGHTMAP_GI_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/lightmap_gi.h"
@@ -67,4 +67,4 @@ public:
 	~LightmapGIEditorPlugin();
 };
 
-#endif
+#endif // LIGHTMAP_GI_EDITOR_PLUGIN_H

--- a/editor/plugins/mesh_editor_plugin.h
+++ b/editor/plugins/mesh_editor_plugin.h
@@ -87,4 +87,4 @@ public:
 	MeshEditorPlugin();
 };
 
-#endif
+#endif // MESH_EDITOR_PLUGIN_H

--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef MESH_INSTANCE_EDITOR_PLUGIN_H
-#define MESH_INSTANCE_EDITOR_PLUGIN_H
+#ifndef MESH_INSTANCE_3D_EDITOR_PLUGIN_H
+#define MESH_INSTANCE_3D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -97,4 +97,4 @@ public:
 	~MeshInstance3DEditorPlugin();
 };
 
-#endif // MESH_EDITOR_PLUGIN_H
+#endif // MESH_INSTANCE_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/navigation_polygon_editor_plugin.h
+++ b/editor/plugins/navigation_polygon_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NAVIGATIONPOLYGONEDITORPLUGIN_H
-#define NAVIGATIONPOLYGONEDITORPLUGIN_H
+#ifndef NAVIGATION_POLYGON_EDITOR_PLUGIN_H
+#define NAVIGATION_POLYGON_EDITOR_PLUGIN_H
 
 #include "editor/plugins/abstract_polygon_2d_editor.h"
 #include "scene/2d/navigation_region_2d.h"
@@ -67,4 +67,4 @@ public:
 	NavigationPolygonEditorPlugin();
 };
 
-#endif // NAVIGATIONPOLYGONEDITORPLUGIN_H
+#endif // NAVIGATION_POLYGON_EDITOR_PLUGIN_H

--- a/editor/plugins/occluder_instance_3d_editor_plugin.h
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.h
@@ -63,4 +63,4 @@ public:
 	~OccluderInstance3DEditorPlugin();
 };
 
-#endif
+#endif // OCCLUDER_INSTANCE_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PATH_EDITOR_PLUGIN_H
-#define PATH_EDITOR_PLUGIN_H
+#ifndef PATH_3D_EDITOR_PLUGIN_H
+#define PATH_3D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "editor/plugins/node_3d_editor_gizmos.h"
@@ -118,4 +118,4 @@ public:
 	~Path3DEditorPlugin();
 };
 
-#endif // PATH_EDITOR_PLUGIN_H
+#endif // PATH_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/physical_bone_3d_editor_plugin.h
+++ b/editor/plugins/physical_bone_3d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PHYSICAL_BONE_PLUGIN_H
-#define PHYSICAL_BONE_PLUGIN_H
+#ifndef PHYSICAL_BONE_3D_EDITOR_PLUGIN_H
+#define PHYSICAL_BONE_3D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/physics_body_3d.h"
@@ -76,4 +76,4 @@ public:
 	PhysicalBone3DEditorPlugin();
 };
 
-#endif
+#endif // PHYSICAL_BONE_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -252,4 +252,4 @@ public:
 	~ShaderEditorPlugin();
 };
 
-#endif
+#endif // SHADER_EDITOR_PLUGIN_H

--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SPRITE_EDITOR_PLUGIN_H
-#define SPRITE_EDITOR_PLUGIN_H
+#ifndef SPRITE_2D_EDITOR_PLUGIN_H
+#define SPRITE_2D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/2d/sprite_2d.h"
@@ -111,4 +111,4 @@ public:
 	~Sprite2DEditorPlugin();
 };
 
-#endif // SPRITE_EDITOR_PLUGIN_H
+#endif // SPRITE_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -91,4 +91,4 @@ public:
 	Texture3DEditorPlugin();
 };
 
-#endif // TEXTURE_EDITOR_PLUGIN_H
+#endif // TEXTURE_3D_EDITOR_PLUGIN_H

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -93,4 +93,4 @@ public:
 	TextureLayeredEditorPlugin();
 };
 
-#endif // TEXTURE_EDITOR_PLUGIN_H
+#endif // TEXTURE_LAYERED_EDITOR_PLUGIN_H

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -158,4 +158,4 @@ public:
 	TileAtlasView();
 };
 
-#endif // TILE_ATLAS_VIEW
+#endif // TILE_ATLAS_VIEW_H

--- a/editor/plugins/tiles/tile_map_editor.h
+++ b/editor/plugins/tiles/tile_map_editor.h
@@ -377,4 +377,4 @@ public:
 	static Vector<Vector2i> get_line(TileMap *p_tile_map, Vector2i p_from_cell, Vector2i p_to_cell);
 };
 
-#endif // TILE_MAP_EDITOR_PLUGIN_H
+#endif // TILE_MAP_EDITOR_H

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -108,4 +108,4 @@ public:
 	~TileSetEditor();
 };
 
-#endif // TILE_SET_EDITOR_PLUGIN_H
+#endif // TILE_SET_EDITOR_H

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
@@ -142,4 +142,4 @@ public:
 	~TileSetScenesCollectionSourceEditor();
 };
 
-#endif
+#endif // TILE_SET_SCENES_COLLECTION_SOURCE_EDITOR_H

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -148,4 +148,4 @@ public:
 
 VARIANT_ENUM_CAST(VersionControlEditorPlugin::ChangeType);
 
-#endif // !VERSION_CONTROL_EDITOR_PLUGIN_H
+#endif // VERSION_CONTROL_EDITOR_PLUGIN_H

--- a/editor/plugins/voxel_gi_editor_plugin.h
+++ b/editor/plugins/voxel_gi_editor_plugin.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VOXEL_GIEDITORPLUGIN_H
-#define VOXEL_GIEDITORPLUGIN_H
+#ifndef VOXEL_GI_EDITOR_PLUGIN_H
+#define VOXEL_GI_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/voxel_gi.h"
@@ -71,4 +71,4 @@ public:
 	~VoxelGIEditorPlugin();
 };
 
-#endif // VOXEL_GIEDITORPLUGIN_H
+#endif // VOXEL_GI_EDITOR_PLUGIN_H

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PROJECT_EXPORT_SETTINGS_H
-#define PROJECT_EXPORT_SETTINGS_H
+#ifndef PROJECT_EXPORT_H
+#define PROJECT_EXPORT_H
 
 #include "core/io/dir_access.h"
 #include "core/os/thread.h"
@@ -183,4 +183,4 @@ public:
 	~ProjectExportDialog();
 };
 
-#endif // PROJECT_EXPORT_SETTINGS_H
+#endif // PROJECT_EXPORT_H

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -181,4 +181,4 @@ public:
 	CustomPropertyEditor();
 };
 
-#endif
+#endif // PROPERTY_EDITOR_H

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PROPERTYSELECTOR_H
-#define PROPERTYSELECTOR_H
+#ifndef PROPERTY_SELECTOR_H
+#define PROPERTY_SELECTOR_H
 
 #include "editor/editor_help.h"
 #include "editor/property_editor.h"
@@ -80,4 +80,4 @@ public:
 	PropertySelector();
 };
 
-#endif // PROPERTYSELECTOR_H
+#endif // PROPERTY_SELECTOR_H

--- a/editor/register_exporters.h
+++ b/editor/register_exporters.h
@@ -33,4 +33,4 @@
 
 void register_exporters();
 
-#endif
+#endif // REGISTER_EXPORTERS_H

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -33,8 +33,8 @@
 
 #include "editor/create_dialog.h"
 #include "editor/editor_data.h"
+#include "editor/editor_quick_open.h"
 #include "editor/groups_editor.h"
-#include "editor/quick_open.h"
 #include "editor/reparent_dialog.h"
 #include "editor/script_create_dialog.h"
 #include "scene/animation/animation_player.h"

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -192,4 +192,4 @@ public:
 	~SceneTreeDialog();
 };
 
-#endif
+#endif // SCENE_TREE_EDITOR_H

--- a/editor/shader_create_dialog.h
+++ b/editor/shader_create_dialog.h
@@ -114,4 +114,4 @@ public:
 	ShaderCreateDialog();
 };
 
-#endif
+#endif // SHADER_CREATE_DIALOG_H

--- a/misc/scripts/header_guards.sh
+++ b/misc/scripts/header_guards.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+if [ ! -f "version.py" ]; then
+  echo "Warning: This script is intended to be run from the root of the Godot repository."
+  echo "Some of the paths checks may not work as intended from a different folder."
+fi
+
+for file in $(find -name "thirdparty" -prune -o -name "*.h" -print); do
+  # Skip *.gen.h and *-so_wrap.h, they're generated.
+  if [[ "$file" == *".gen.h" || "$file" == *"-so_wrap.h" ]]; then continue; fi
+  # Has important define before normal header guards.
+  if [[ "$file" == *"thread.h" || "$file" == *"platform_config.h" ]]; then continue; fi
+
+  bname=$(basename $file .h)
+
+  # Add custom prefix or suffix for generic filenames with a well-defined namespace.
+
+  prefix=
+  if [[ "$file" == "./modules/"*"/register_types.h" ]]; then
+    module=$(echo $file | sed "s@.*modules/\([^/]*\).*@\1@")
+    prefix="${module^^}_"
+  fi
+  if [[ "$file" == "./platform/"*"/api/api.h" || "$file" == "./platform/"*"/export/"* ]]; then
+    platform=$(echo $file | sed "s@.*platform/\([^/]*\).*@\1@")
+    prefix="${platform^^}_"
+  fi
+  if [[ "$file" == "./modules/mono/utils/"* && "$bname" != *"mono"* ]]; then prefix="MONO_"; fi
+  if [[ "$file" == "./servers/rendering/storage/utilities.h" ]]; then prefix="RENDERER_"; fi
+
+  suffix=
+  if [[ "$file" == *"dummy"* && "$bname" != *"dummy"* ]]; then suffix="_DUMMY"; fi
+  if [[ "$file" == *"gles3"* && "$bname" != *"gles3"* ]]; then suffix="_GLES3"; fi
+  if [[ "$file" == *"renderer_rd"* && "$bname" != *"rd"* ]]; then suffix="_RD"; fi
+  if [[ "$file" == *"ustring.h" ]]; then suffix="_GODOT"; fi
+
+  # ^^ is bash builtin for UPPERCASE.
+  guard="${prefix}${bname^^}${suffix}_H"
+
+  # Replaces guards to use computed name.
+  # We also add some \n to make sure there's a proper separation.
+  sed -i $file -e "0,/ifndef/s/#ifndef.*/\n#ifndef $guard/"
+  sed -i $file -e "0,/define/s/#define.*/#define $guard\n/"
+  sed -i $file -e "$ s/#endif.*/\n#endif \/\/ $guard/"
+  # Removes redundant \n added before, if they weren't needed.
+  sed -i $file -e "/^$/N;/^\n$/D"
+done
+
+diff=$(git diff --color)
+
+# If no diff has been generated all is OK, clean up, and exit.
+if [ -z "$diff" ] ; then
+    printf "Files in this commit comply with the header guards formatting rules.\n"
+    exit 0
+fi
+
+# A diff has been created, notify the user, clean up, and exit.
+printf "\n*** The following differences were found between the code "
+printf "and the header guards formatting rules:\n\n"
+echo "$diff"
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+exit 1

--- a/modules/camera/camera_macos.h
+++ b/modules/camera/camera_macos.h
@@ -43,4 +43,4 @@ public:
 	void update_feeds();
 };
 
-#endif /* CAMERA_MACOS_H */
+#endif // CAMERA_MACOS_H

--- a/modules/camera/camera_win.h
+++ b/modules/camera/camera_win.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CAMERAWIN_H
-#define CAMERAWIN_H
+#ifndef CAMERA_WIN_H
+#define CAMERA_WIN_H
 
 #include "servers/camera/camera_feed.h"
 #include "servers/camera_server.h"
@@ -43,4 +43,4 @@ public:
 	~CameraWindows() {}
 };
 
-#endif /* CAMERAWIN_H */
+#endif // CAMERA_WIN_H

--- a/modules/enet/enet_multiplayer_peer.h
+++ b/modules/enet/enet_multiplayer_peer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NETWORKED_MULTIPLAYER_ENET_H
-#define NETWORKED_MULTIPLAYER_ENET_H
+#ifndef ENET_MULTIPLAYER_PEER_H
+#define ENET_MULTIPLAYER_PEER_H
 
 #include "core/crypto/crypto.h"
 #include "core/multiplayer/multiplayer_peer.h"
@@ -135,4 +135,4 @@ public:
 	~ENetMultiplayerPeer();
 };
 
-#endif // NETWORKED_MULTIPLAYER_ENET_H
+#endif // ENET_MULTIPLAYER_PEER_H

--- a/modules/freetype/uwpdef.h
+++ b/modules/freetype/uwpdef.h
@@ -28,6 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef UWPDEF_H
+#define UWPDEF_H
+
 // "generic" is a reserved keyword in C++/CX code
 // this avoids the errors in the variable name from Freetype code
 #define generic freetype_generic
+
+#endif // UWPDEF_H

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GDSCRIPT_BYTE_CODEGEN
-#define GDSCRIPT_BYTE_CODEGEN
+#ifndef GDSCRIPT_BYTE_CODEGEN_H
+#define GDSCRIPT_BYTE_CODEGEN_H
 
 #include "gdscript_codegen.h"
 
@@ -502,4 +502,4 @@ public:
 	virtual ~GDScriptByteCodeGenerator();
 };
 
-#endif // GDSCRIPT_BYTE_CODEGEN
+#endif // GDSCRIPT_BYTE_CODEGEN_H

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GDSCRIPT_CODEGEN
-#define GDSCRIPT_CODEGEN
+#ifndef GDSCRIPT_CODEGEN_H
+#define GDSCRIPT_CODEGEN_H
 
 #include "core/multiplayer/multiplayer.h"
 #include "core/string/string_name.h"
@@ -163,4 +163,4 @@ public:
 	virtual ~GDScriptCodeGenerator() {}
 };
 
-#endif // GDSCRIPT_CODEGEN
+#endif // GDSCRIPT_CODEGEN_H

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GDSCRIPT_LAMBDA_CALLABLE
-#define GDSCRIPT_LAMBDA_CALLABLE
+#ifndef GDSCRIPT_LAMBDA_CALLABLE_H
+#define GDSCRIPT_LAMBDA_CALLABLE_H
 
 #include "core/object/ref_counted.h"
 #include "core/templates/vector.h"
@@ -87,4 +87,4 @@ public:
 	virtual ~GDScriptLambdaSelfCallable() = default;
 };
 
-#endif // GDSCRIPT_LAMBDA_CALLABLE
+#endif // GDSCRIPT_LAMBDA_CALLABLE_H

--- a/modules/gdscript/gdscript_rpc_callable.h
+++ b/modules/gdscript/gdscript_rpc_callable.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GDSCRIPT_RPC_CALLABLE
-#define GDSCRIPT_RPC_CALLABLE
+#ifndef GDSCRIPT_RPC_CALLABLE_H
+#define GDSCRIPT_RPC_CALLABLE_H
 
 #include "core/variant/callable.h"
 #include "core/variant/variant.h"
@@ -58,4 +58,4 @@ public:
 	virtual ~GDScriptRPCCallable() = default;
 };
 
-#endif // GDSCRIPT_RPC_CALLABLE
+#endif // GDSCRIPT_RPC_CALLABLE_H

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -273,4 +273,4 @@ public:
 	GDScriptTokenizer();
 };
 
-#endif
+#endif // GDSCRIPT_TOKENIZER_H

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GDSCRIPT_WARNINGS
-#define GDSCRIPT_WARNINGS
+#ifndef GDSCRIPT_WARNING_H
+#define GDSCRIPT_WARNING_H
 
 #ifdef DEBUG_ENABLED
 
@@ -97,4 +97,4 @@ public:
 
 #endif // DEBUG_ENABLED
 
-#endif // GDSCRIPT_WARNINGS
+#endif // GDSCRIPT_WARNING_H

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -33,7 +33,7 @@
 
 #include "../gdscript_parser.h"
 #include "core/variant/variant.h"
-#include "lsp.hpp"
+#include "godot_lsp.h"
 
 #ifndef LINE_NUMBER_TO_INDEX
 #define LINE_NUMBER_TO_INDEX(p_line) ((p_line)-1)
@@ -99,4 +99,4 @@ public:
 	Error parse(const String &p_code, const String &p_path);
 };
 
-#endif
+#endif // GDSCRIPT_EXTEND_PARSER_H

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -36,7 +36,7 @@
 #include "core/io/tcp_server.h"
 #include "gdscript_text_document.h"
 #include "gdscript_workspace.h"
-#include "lsp.hpp"
+#include "godot_lsp.h"
 
 #include "modules/modules_enabled.gen.h" // For jsonrpc.
 #ifdef MODULE_JSONRPC_ENABLED

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -33,7 +33,7 @@
 
 #include "core/io/file_access.h"
 #include "core/object/ref_counted.h"
-#include "lsp.hpp"
+#include "godot_lsp.h"
 
 class GDScriptTextDocument : public RefCounted {
 	GDCLASS(GDScriptTextDocument, RefCounted)
@@ -77,4 +77,4 @@ public:
 	GDScriptTextDocument();
 };
 
-#endif
+#endif // GDSCRIPT_TEXT_DOCUMENT_H

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -35,7 +35,7 @@
 #include "core/variant/variant.h"
 #include "editor/editor_file_system.h"
 #include "gdscript_extend_parser.h"
-#include "lsp.hpp"
+#include "godot_lsp.h"
 
 class GDScriptWorkspace : public RefCounted {
 	GDCLASS(GDScriptWorkspace, RefCounted);
@@ -100,4 +100,4 @@ public:
 	~GDScriptWorkspace();
 };
 
-#endif
+#endif // GDSCRIPT_WORKSPACE_H

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  lsp.hpp                                                              */
+/*  godot_lsp.h                                                          */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -1975,4 +1975,4 @@ static String marked_documentation(const String &p_bbcode) {
 }
 } // namespace lsp
 
-#endif
+#endif // GODOT_LSP_H

--- a/modules/gdscript/tests/gdscript_test_runner.h
+++ b/modules/gdscript/tests/gdscript_test_runner.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GDSCRIPT_TEST_H
-#define GDSCRIPT_TEST_H
+#ifndef GDSCRIPT_TEST_RUNNER_H
+#define GDSCRIPT_TEST_RUNNER_H
 
 #include "../gdscript.h"
 #include "core/error/error_macros.h"
@@ -123,4 +123,4 @@ public:
 
 } // namespace GDScriptTests
 
-#endif // GDSCRIPT_TEST_H
+#endif // GDSCRIPT_TEST_RUNNER_H

--- a/modules/gltf/extensions/gltf_spec_gloss.h
+++ b/modules/gltf/extensions/gltf_spec_gloss.h
@@ -64,4 +64,5 @@ public:
 	Ref<Image> get_spec_gloss_img();
 	void set_spec_gloss_img(Ref<Image> p_spec_gloss_img);
 };
+
 #endif // GLTF_SPEC_GLOSS_H

--- a/modules/gltf/gltf_document_extension_convert_importer_mesh.h
+++ b/modules/gltf/gltf_document_extension_convert_importer_mesh.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GLTF_EXTENSION_EDITOR_H
-#define GLTF_EXTENSION_EDITOR_H
+#ifndef GLTF_DOCUMENT_EXTENSION_CONVERT_IMPORTER_MESH_H
+#define GLTF_DOCUMENT_EXTENSION_CONVERT_IMPORTER_MESH_H
 
 #include "gltf_document_extension.h"
 
@@ -46,4 +46,5 @@ protected:
 public:
 	Error import_post(Ref<GLTFState> p_state, Node *p_root) override;
 };
-#endif // GLTF_EXTENSION_EDITOR_H
+
+#endif // GLTF_DOCUMENT_EXTENSION_CONVERT_IMPORTER_MESH_H

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -192,4 +192,5 @@ public:
 	//	this->material_cache = p_material_cache;
 	//}
 };
+
 #endif // GLTF_STATE_H

--- a/modules/gltf/structures/gltf_accessor.h
+++ b/modules/gltf/structures/gltf_accessor.h
@@ -101,4 +101,5 @@ public:
 	int get_sparse_values_byte_offset();
 	void set_sparse_values_byte_offset(int p_sparse_values_byte_offset);
 };
+
 #endif // GLTF_ACCESSOR_H

--- a/modules/gltf/structures/gltf_animation.h
+++ b/modules/gltf/structures/gltf_animation.h
@@ -71,4 +71,5 @@ private:
 	bool loop = false;
 	HashMap<int, Track> tracks;
 };
+
 #endif // GLTF_ANIMATION_H

--- a/modules/gltf/structures/gltf_buffer_view.h
+++ b/modules/gltf/structures/gltf_buffer_view.h
@@ -65,4 +65,5 @@ public:
 	void set_indices(bool p_indices);
 	// matrices need to be transformed to this
 };
+
 #endif // GLTF_BUFFER_VIEW_H

--- a/modules/gltf/structures/gltf_camera.h
+++ b/modules/gltf/structures/gltf_camera.h
@@ -55,4 +55,5 @@ public:
 	float get_depth_near() const { return depth_near; }
 	void set_depth_near(float p_val) { depth_near = p_val; }
 };
+
 #endif // GLTF_CAMERA_H

--- a/modules/gltf/structures/gltf_node.h
+++ b/modules/gltf/structures/gltf_node.h
@@ -97,4 +97,5 @@ public:
 	GLTFLightIndex get_light();
 	void set_light(GLTFLightIndex p_light);
 };
+
 #endif // GLTF_NODE_H

--- a/modules/gltf/structures/gltf_skeleton.h
+++ b/modules/gltf/structures/gltf_skeleton.h
@@ -98,4 +98,5 @@ public:
 
 	int32_t get_bone_attachment_count();
 };
+
 #endif // GLTF_SKELETON_H

--- a/modules/gltf/structures/gltf_skin.h
+++ b/modules/gltf/structures/gltf_skin.h
@@ -106,4 +106,5 @@ public:
 	Ref<Skin> get_godot_skin();
 	void set_godot_skin(Ref<Skin> p_godot_skin);
 };
+
 #endif // GLTF_SKIN_H

--- a/modules/hdr/image_loader_hdr.h
+++ b/modules/hdr/image_loader_hdr.h
@@ -40,4 +40,4 @@ public:
 	ImageLoaderHDR();
 };
 
-#endif
+#endif // IMAGE_LOADER_HDR_H

--- a/modules/jpg/image_loader_jpegd.h
+++ b/modules/jpg/image_loader_jpegd.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef IMAGE_LOADER_JPG_H
-#define IMAGE_LOADER_JPG_H
+#ifndef IMAGE_LOADER_JPEGD_H
+#define IMAGE_LOADER_JPEGD_H
 
 #include "core/io/image_loader.h"
 
@@ -40,4 +40,4 @@ public:
 	ImageLoaderJPG();
 };
 
-#endif
+#endif // IMAGE_LOADER_JPEGD_H

--- a/modules/jsonrpc/jsonrpc.h
+++ b/modules/jsonrpc/jsonrpc.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_JSON_RPC_H
-#define GODOT_JSON_RPC_H
+#ifndef JSONRPC_H
+#define JSONRPC_H
 
 #include "core/object/class_db.h"
 #include "core/variant/variant.h"
@@ -67,4 +67,4 @@ public:
 
 VARIANT_ENUM_CAST(JSONRPC::ErrorCode);
 
-#endif
+#endif // JSONRPC_H

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -256,4 +256,4 @@ public:
 	LightmapperRD();
 };
 
-#endif // LIGHTMAPPER_H
+#endif // LIGHTMAPPER_RD_H

--- a/modules/lightmapper_rd/register_types.h
+++ b/modules/lightmapper_rd/register_types.h
@@ -36,4 +36,4 @@
 void initialize_lightmapper_rd_module(ModuleInitializationLevel p_level);
 void uninitialize_lightmapper_rd_module(ModuleInitializationLevel p_level);
 
-#endif // XATLAS_UNWRAP_REGISTER_TYPES_H
+#endif // LIGHTMAPPER_RD_REGISTER_TYPES_H

--- a/modules/mbedtls/dtls_server_mbedtls.h
+++ b/modules/mbedtls/dtls_server_mbedtls.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef MBED_DTLS_SERVER_H
-#define MBED_DTLS_SERVER_H
+#ifndef DTLS_SERVER_MBEDTLS_H
+#define DTLS_SERVER_MBEDTLS_H
 
 #include "core/io/dtls_server.h"
 #include "ssl_context_mbedtls.h"
@@ -54,4 +54,4 @@ public:
 	~DTLSServerMbedTLS();
 };
 
-#endif // MBED_DTLS_SERVER_H
+#endif // DTLS_SERVER_MBEDTLS_H

--- a/modules/mbedtls/ssl_context_mbedtls.h
+++ b/modules/mbedtls/ssl_context_mbedtls.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SSL_CONTEXT_MBED_TLS_H
-#define SSL_CONTEXT_MBED_TLS_H
+#ifndef SSL_CONTEXT_MBEDTLS_H
+#define SSL_CONTEXT_MBEDTLS_H
 
 #include "crypto_mbedtls.h"
 
@@ -90,4 +90,4 @@ public:
 	~SSLContextMbedTLS();
 };
 
-#endif // SSL_CONTEXT_MBED_TLS_H
+#endif // SSL_CONTEXT_MBEDTLS_H

--- a/modules/mbedtls/stream_peer_mbedtls.h
+++ b/modules/mbedtls/stream_peer_mbedtls.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef STREAM_PEER_OPEN_SSL_H
-#define STREAM_PEER_OPEN_SSL_H
+#ifndef STREAM_PEER_MBEDTLS_H
+#define STREAM_PEER_MBEDTLS_H
 
 #include "core/io/stream_peer_ssl.h"
 #include "ssl_context_mbedtls.h"
@@ -76,4 +76,4 @@ public:
 	~StreamPeerMbedTLS();
 };
 
-#endif // STREAM_PEER_SSL_H
+#endif // STREAM_PEER_MBEDTLS_H

--- a/modules/meshoptimizer/register_types.h
+++ b/modules/meshoptimizer/register_types.h
@@ -36,4 +36,4 @@
 void initialize_meshoptimizer_module(ModuleInitializationLevel p_level);
 void uninitialize_meshoptimizer_module(ModuleInitializationLevel p_level);
 
-#endif // PVR_REGISTER_TYPES_H
+#endif // MESHOPTIMIZER_REGISTER_TYPES_H

--- a/modules/mono/editor/editor_internal_calls.h
+++ b/modules/mono/editor/editor_internal_calls.h
@@ -28,9 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITOR_INTERNAL_CALL_H
-#define EDITOR_INTERNAL_CALL_H
+#ifndef EDITOR_INTERNAL_CALLS_H
+#define EDITOR_INTERNAL_CALLS_H
 
 void register_editor_internal_calls();
 
-#endif // EDITOR_INTERNAL_CALL_H
+#endif // EDITOR_INTERNAL_CALLS_H

--- a/modules/mono/glue/glue_header.h
+++ b/modules/mono/glue/glue_header.h
@@ -28,6 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef GLUE_HEADER_H
+#define GLUE_HEADER_H
+
 #ifdef MONO_GLUE_ENABLED
 
 #include "../mono_gd/gd_mono_marshal.h"
@@ -84,3 +87,5 @@ void godot_register_glue_header_icalls() {
 #include "arguments_vector.h"
 
 #endif // MONO_GLUE_ENABLED
+
+#endif // GLUE_HEADER_H

--- a/modules/mono/mono_gc_handle.h
+++ b/modules/mono/mono_gc_handle.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CSHARP_GC_HANDLE_H
-#define CSHARP_GC_HANDLE_H
+#ifndef MONO_GC_HANDLE_H
+#define MONO_GC_HANDLE_H
 
 #include <mono/jit/jit.h>
 
@@ -104,4 +104,4 @@ public:
 	~MonoGCHandleRef() { release(); }
 };
 
-#endif // CSHARP_GC_HANDLE_H
+#endif // MONO_GC_HANDLE_H

--- a/modules/mono/mono_gd/gd_mono_field.h
+++ b/modules/mono/mono_gd/gd_mono_field.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GDMONOFIELD_H
-#define GDMONOFIELD_H
+#ifndef GD_MONO_FIELD_H
+#define GD_MONO_FIELD_H
 
 #include "gd_mono.h"
 #include "gd_mono_header.h"
@@ -75,4 +75,4 @@ public:
 	~GDMonoField();
 };
 
-#endif // GDMONOFIELD_H
+#endif // GD_MONO_FIELD_H

--- a/modules/mono/mono_gd/gd_mono_marshal.h
+++ b/modules/mono/mono_gd/gd_mono_marshal.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GDMONOMARSHAL_H
-#define GDMONOMARSHAL_H
+#ifndef GD_MONO_MARSHAL_H
+#define GD_MONO_MARSHAL_H
 
 #include "core/variant/variant.h"
 
@@ -602,4 +602,4 @@ DECL_TYPE_MARSHAL_TEMPLATES(Plane)
 #define MARSHALLED_OUT(m_type, m_from) (GDMonoMarshal::marshalled_out_##m_type(m_from))
 } // namespace GDMonoMarshal
 
-#endif // GDMONOMARSHAL_H
+#endif // GD_MONO_MARSHAL_H

--- a/modules/mono/mono_gd/gd_mono_utils.h
+++ b/modules/mono/mono_gd/gd_mono_utils.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GD_MONOUTILS_H
-#define GD_MONOUTILS_H
+#ifndef GD_MONO_UTILS_H
+#define GD_MONO_UTILS_H
 
 #include <mono/metadata/threads.h>
 
@@ -202,4 +202,4 @@ void add_internal_call(const char *p_name, R (*p_func)(P...)) {
 #define GD_MONO_ASSERT_THREAD_ATTACHED ((void)0)
 #endif
 
-#endif // GD_MONOUTILS_H
+#endif // GD_MONO_UTILS_H

--- a/modules/mono/utils/macos_utils.h
+++ b/modules/mono/utils/macos_utils.h
@@ -30,8 +30,8 @@
 
 #include "core/string/ustring.h"
 
-#ifndef MACOS_UTILS_H
-#define MACOS_UTILS_H
+#ifndef MONO_MACOS_UTILS_H
+#define MONO_MACOS_UTILS_H
 
 #ifdef MACOS_ENABLED
 
@@ -39,4 +39,4 @@ bool macos_is_app_bundle_installed(const String &p_bundle_id);
 
 #endif
 
-#endif // MACOS_UTILS_H
+#endif // MONO_MACOS_UTILS_H

--- a/modules/mono/utils/macros.h
+++ b/modules/mono/utils/macros.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef UTIL_MACROS_H
-#define UTIL_MACROS_H
+#ifndef MONO_MACROS_H
+#define MONO_MACROS_H
 
 #define _GD_VARNAME_CONCAT_B_(m_ignore, m_name) m_name
 #define _GD_VARNAME_CONCAT_A_(m_a, m_b, m_c) _GD_VARNAME_CONCAT_B_(hello there, m_a##m_b##m_c)
@@ -69,4 +69,4 @@ public:
 #define SCOPE_EXIT \
 	auto GD_UNIQUE_NAME(gd_scope_exit) = gdmono::ScopeExitAux() + [=]() -> void
 
-#endif // UTIL_MACROS_H
+#endif // MONO_MACROS_H

--- a/modules/mono/utils/path_utils.h
+++ b/modules/mono/utils/path_utils.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PATH_UTILS_H
-#define PATH_UTILS_H
+#ifndef MONO_PATH_UTILS_H
+#define MONO_PATH_UTILS_H
 
 #include "core/string/string_builder.h"
 #include "core/string/ustring.h"
@@ -58,4 +58,4 @@ String realpath(const String &p_path);
 String relative_to(const String &p_path, const String &p_relative_to);
 } // namespace path
 
-#endif // PATH_UTILS_H
+#endif // MONO_PATH_UTILS_H

--- a/modules/mono/utils/string_utils.h
+++ b/modules/mono/utils/string_utils.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef STRING_FORMAT_H
-#define STRING_FORMAT_H
+#ifndef MONO_STRING_UTILS_H
+#define MONO_STRING_UTILS_H
 
 #include "core/string/ustring.h"
 #include "core/variant/variant.h"
@@ -59,4 +59,4 @@ String str_format(const char *p_format, va_list p_list) _PRINTF_FORMAT_ATTRIBUTE
 char *str_format_new(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_1_2;
 char *str_format_new(const char *p_format, va_list p_list) _PRINTF_FORMAT_ATTRIBUTE_1_0;
 
-#endif // STRING_FORMAT_H
+#endif // MONO_STRING_UTILS_H

--- a/modules/openxr/action_map/openxr_action.h
+++ b/modules/openxr/action_map/openxr_action.h
@@ -84,4 +84,4 @@ public:
 
 VARIANT_ENUM_CAST(OpenXRAction::ActionType);
 
-#endif // !OPENXR_ACTION_H
+#endif // OPENXR_ACTION_H

--- a/modules/openxr/action_map/openxr_action_map.h
+++ b/modules/openxr/action_map/openxr_action_map.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef OPENXR_ACTION_SETS_H
-#define OPENXR_ACTION_SETS_H
+#ifndef OPENXR_ACTION_MAP_H
+#define OPENXR_ACTION_MAP_H
 
 #include "core/io/resource.h"
 
@@ -79,4 +79,4 @@ public:
 	~OpenXRActionMap();
 };
 
-#endif // !OPENXR_ACTION_SETS_H
+#endif // OPENXR_ACTION_MAP_H

--- a/modules/openxr/action_map/openxr_action_set.h
+++ b/modules/openxr/action_map/openxr_action_set.h
@@ -72,4 +72,4 @@ public:
 	~OpenXRActionSet();
 };
 
-#endif // !OPENXR_ACTION_SET_H
+#endif // OPENXR_ACTION_SET_H

--- a/modules/openxr/action_map/openxr_defs.h
+++ b/modules/openxr/action_map/openxr_defs.h
@@ -121,4 +121,4 @@ public:
 	static PackedStringArray get_interaction_profile_paths();
 };
 
-#endif // !OPENXR_DEFS_H
+#endif // OPENXR_DEFS_H

--- a/modules/openxr/action_map/openxr_interaction_profile.h
+++ b/modules/openxr/action_map/openxr_interaction_profile.h
@@ -98,4 +98,4 @@ public:
 	~OpenXRInteractionProfile();
 };
 
-#endif // !OPENXR_INTERACTION_PROFILE_H
+#endif // OPENXR_INTERACTION_PROFILE_H

--- a/modules/openxr/editor/openxr_action_editor.h
+++ b/modules/openxr/editor/openxr_action_editor.h
@@ -64,4 +64,4 @@ public:
 	OpenXRActionEditor(Ref<OpenXRAction> p_action);
 };
 
-#endif // !OPENXR_ACTION_EDITOR_H
+#endif // OPENXR_ACTION_EDITOR_H

--- a/modules/openxr/editor/openxr_action_map_editor.h
+++ b/modules/openxr/editor/openxr_action_map_editor.h
@@ -97,4 +97,4 @@ public:
 	~OpenXRActionMapEditor();
 };
 
-#endif // !OPENXR_ACTION_MAP_EDITOR_H
+#endif // OPENXR_ACTION_MAP_EDITOR_H

--- a/modules/openxr/editor/openxr_action_set_editor.h
+++ b/modules/openxr/editor/openxr_action_set_editor.h
@@ -85,4 +85,4 @@ public:
 	OpenXRActionSetEditor(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRActionSet> p_action_set);
 };
 
-#endif // !OPENXR_ACTION_SET_EDITOR_H
+#endif // OPENXR_ACTION_SET_EDITOR_H

--- a/modules/openxr/editor/openxr_editor_plugin.h
+++ b/modules/openxr/editor/openxr_editor_plugin.h
@@ -50,4 +50,4 @@ public:
 	~OpenXREditorPlugin();
 };
 
-#endif // !OPENXR_EDITOR_PLUGIN_H
+#endif // OPENXR_EDITOR_PLUGIN_H

--- a/modules/openxr/editor/openxr_interaction_profile_editor.h
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.h
@@ -80,4 +80,4 @@ public:
 	OpenXRInteractionProfileEditor(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRInteractionProfile> p_interaction_profile);
 };
 
-#endif // !OPENXR_INTERACTION_PROFILE_EDITOR_H
+#endif // OPENXR_INTERACTION_PROFILE_EDITOR_H

--- a/modules/openxr/editor/openxr_select_action_dialog.h
+++ b/modules/openxr/editor/openxr_select_action_dialog.h
@@ -64,4 +64,4 @@ public:
 	OpenXRSelectActionDialog(Ref<OpenXRActionMap> p_action_map);
 };
 
-#endif // !OPENXR_SELECT_ACTION_DIALOG_H
+#endif // OPENXR_SELECT_ACTION_DIALOG_H

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.h
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.h
@@ -63,4 +63,4 @@ public:
 	OpenXRSelectInteractionProfileDialog();
 };
 
-#endif // !OPENXR_SELECT_INTERACTION_PROFILE_DIALOG_H
+#endif // OPENXR_SELECT_INTERACTION_PROFILE_DIALOG_H

--- a/modules/openxr/extensions/openxr_android_extension.h
+++ b/modules/openxr/extensions/openxr_android_extension.h
@@ -44,4 +44,4 @@ private:
 	static OpenXRAndroidExtension *singleton;
 };
 
-#endif // !OPENXR_ANDROID_EXTENSION_H
+#endif // OPENXR_ANDROID_EXTENSION_H

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -104,4 +104,4 @@ public:
 			OpenXRExtensionWrapper(p_openxr_api){};
 };
 
-#endif // ~OPENXR_EXTENSION_WRAPPER_H
+#endif // OPENXR_EXTENSION_WRAPPER_H

--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.h
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.h
@@ -49,4 +49,4 @@ private:
 	bool available = false;
 };
 
-#endif // !OPENXR_HTC_VIVE_TRACKER_EXTENSION_H
+#endif // OPENXR_HTC_VIVE_TRACKER_EXTENSION_H

--- a/modules/openxr/extensions/openxr_vulkan_extension.h
+++ b/modules/openxr/extensions/openxr_vulkan_extension.h
@@ -90,4 +90,4 @@ private:
 	XrResult xrCreateVulkanDeviceKHR(XrInstance p_instance, const XrVulkanDeviceCreateInfoKHR *p_create_info, VkDevice *r_device, VkResult *r_result);
 };
 
-#endif // !OPENXR_VULKAN_EXTENSION_H
+#endif // OPENXR_VULKAN_EXTENSION_H

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef OPENXR_DRIVER_H
-#define OPENXR_DRIVER_H
+#ifndef OPENXR_API_H
+#define OPENXR_API_H
 
 #include "core/error/error_macros.h"
 #include "core/math/projection.h"
@@ -292,4 +292,4 @@ public:
 	~OpenXRAPI();
 };
 
-#endif // !OPENXR_DRIVER_H
+#endif // OPENXR_API_H

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -140,4 +140,4 @@ public:
 	~OpenXRInterface();
 };
 
-#endif // !OPENXR_INTERFACE_H
+#endif // OPENXR_INTERFACE_H

--- a/modules/openxr/openxr_util.h
+++ b/modules/openxr/openxr_util.h
@@ -44,4 +44,4 @@ public:
 	static String make_xr_version_string(XrVersion p_version);
 };
 
-#endif // !OPENXR_UTIL_H
+#endif // OPENXR_UTIL_H

--- a/modules/raycast/lightmap_raycaster.h
+++ b/modules/raycast/lightmap_raycaster.h
@@ -74,4 +74,4 @@ public:
 	~LightmapRaycasterEmbree();
 };
 
-#endif
+#endif // LIGHTMAP_RAYCASTER_H

--- a/modules/raycast/raycast_occlusion_cull.h
+++ b/modules/raycast/raycast_occlusion_cull.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef OCCLUSION_CULL_RAYCASTER_H
-#define OCCLUSION_CULL_RAYCASTER_H
+#ifndef RAYCAST_OCCLUSION_CULL_H
+#define RAYCAST_OCCLUSION_CULL_H
 
 #include "core/io/image.h"
 #include "core/math/projection.h"
@@ -192,4 +192,4 @@ public:
 	~RaycastOcclusionCull();
 };
 
-#endif // OCCLUSION_CULL_RAYCASTER_H
+#endif // RAYCAST_OCCLUSION_CULL_H

--- a/modules/raycast/static_raycaster.h
+++ b/modules/raycast/static_raycaster.h
@@ -61,4 +61,4 @@ public:
 	~StaticRaycasterEmbree();
 };
 
-#endif
+#endif // STATIC_RAYCASTER_H

--- a/modules/text_server_adv/script_iterator.h
+++ b/modules/text_server_adv/script_iterator.h
@@ -75,4 +75,4 @@ public:
 	ScriptIterator(const String &p_string, int p_start, int p_length);
 };
 
-#endif //SCRIPT_ITERATOR_H
+#endif // SCRIPT_ITERATOR_H

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef TEXT_SERVER_FALLBACK_H
-#define TEXT_SERVER_FALLBACK_H
+#ifndef TEXT_SERVER_FB_H
+#define TEXT_SERVER_FB_H
 
 /*************************************************************************/
 /* Fallback Text Server provides simplified TS functionality, without    */
@@ -586,4 +586,4 @@ public:
 	~TextServerFallback();
 };
 
-#endif // TEXT_SERVER_FALLBACK_H
+#endif // TEXT_SERVER_FB_H

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -192,4 +192,4 @@ public:
 	virtual String get_resource_type(const String &p_path) const;
 };
 
-#endif
+#endif // VIDEO_STREAM_THEORA_H

--- a/modules/tinyexr/image_loader_tinyexr.h
+++ b/modules/tinyexr/image_loader_tinyexr.h
@@ -40,4 +40,4 @@ public:
 	ImageLoaderTinyEXR();
 };
 
-#endif
+#endif // IMAGE_LOADER_TINYEXR_H

--- a/modules/upnp/upnp.h
+++ b/modules/upnp/upnp.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_UPNP_H
-#define GODOT_UPNP_H
+#ifndef UPNP_H
+#define UPNP_H
 
 #include "core/object/ref_counted.h"
 
@@ -121,4 +121,4 @@ public:
 
 VARIANT_ENUM_CAST(UPNP::UPNPResult)
 
-#endif // GODOT_UPNP_H
+#endif // UPNP_H

--- a/modules/upnp/upnp_device.h
+++ b/modules/upnp/upnp_device.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_UPNP_DEVICE_H
-#define GODOT_UPNP_DEVICE_H
+#ifndef UPNP_DEVICE_H
+#define UPNP_DEVICE_H
 
 #include "core/object/ref_counted.h"
 
@@ -90,4 +90,4 @@ private:
 
 VARIANT_ENUM_CAST(UPNPDevice::IGDStatus)
 
-#endif // GODOT_UPNP_DEVICE_H
+#endif // UPNP_DEVICE_H

--- a/modules/visual_script/editor/visual_script_editor.h
+++ b/modules/visual_script/editor/visual_script_editor.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VISUALSCRIPT_EDITOR_H
-#define VISUALSCRIPT_EDITOR_H
+#ifndef VISUAL_SCRIPT_EDITOR_H
+#define VISUAL_SCRIPT_EDITOR_H
 
 #include "../visual_script.h"
 #include "editor/create_dialog.h"
@@ -374,4 +374,4 @@ public:
 
 #endif
 
-#endif // VISUALSCRIPT_EDITOR_H
+#endif // VISUAL_SCRIPT_EDITOR_H

--- a/modules/visual_script/editor/visual_script_property_selector.h
+++ b/modules/visual_script/editor/visual_script_property_selector.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VISUALSCRIPT_PROPERTYSELECTOR_H
-#define VISUALSCRIPT_PROPERTYSELECTOR_H
+#ifndef VISUAL_SCRIPT_PROPERTY_SELECTOR_H
+#define VISUAL_SCRIPT_PROPERTY_SELECTOR_H
 
 #include "../visual_script.h"
 #include "editor/editor_help.h"
@@ -226,4 +226,4 @@ public:
 	SearchRunner(VisualScriptPropertySelector *p_selector_ui, Tree *p_results_tree);
 };
 
-#endif // VISUALSCRIPT_PROPERTYSELECTOR_H
+#endif // VISUAL_SCRIPT_PROPERTY_SELECTOR_H

--- a/modules/visual_script/visual_script_expression.h
+++ b/modules/visual_script/visual_script_expression.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VISUALSCRIPTEXPRESSION_H
-#define VISUALSCRIPTEXPRESSION_H
+#ifndef VISUAL_SCRIPT_EXPRESSION_H
+#define VISUAL_SCRIPT_EXPRESSION_H
 
 #include "visual_script.h"
 #include "visual_script_builtin_funcs.h"
@@ -281,4 +281,4 @@ public:
 
 void register_visual_script_expression_node();
 
-#endif // VISUALSCRIPTEXPRESSION_H
+#endif // VISUAL_SCRIPT_EXPRESSION_H

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIO_STREAM_LIBVORBIS_H
-#define AUDIO_STREAM_LIBVORBIS_H
+#ifndef AUDIO_STREAM_OGG_VORBIS_H
+#define AUDIO_STREAM_OGG_VORBIS_H
 
 #include "core/variant/variant.h"
 #include "modules/ogg/ogg_packet_sequence.h"
@@ -153,4 +153,4 @@ public:
 	virtual ~AudioStreamOGGVorbis();
 };
 
-#endif // AUDIO_STREAM_LIBVORBIS_H
+#endif // AUDIO_STREAM_OGG_VORBIS_H

--- a/modules/webp/image_loader_webp.h
+++ b/modules/webp/image_loader_webp.h
@@ -40,4 +40,4 @@ public:
 	ImageLoaderWebP();
 };
 
-#endif
+#endif // IMAGE_LOADER_WEBP_H

--- a/modules/webrtc/webrtc_data_channel.h
+++ b/modules/webrtc/webrtc_data_channel.h
@@ -81,4 +81,5 @@ public:
 
 VARIANT_ENUM_CAST(WebRTCDataChannel::WriteMode);
 VARIANT_ENUM_CAST(WebRTCDataChannel::ChannelState);
+
 #endif // WEBRTC_DATA_CHANNEL_H

--- a/modules/webrtc/webrtc_multiplayer_peer.h
+++ b/modules/webrtc/webrtc_multiplayer_peer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef WEBRTC_MULTIPLAYER_H
-#define WEBRTC_MULTIPLAYER_H
+#ifndef WEBRTC_MULTIPLAYER_PEER_H
+#define WEBRTC_MULTIPLAYER_PEER_H
 
 #include "core/multiplayer/multiplayer_peer.h"
 #include "webrtc_peer_connection.h"
@@ -106,4 +106,4 @@ public:
 	ConnectionStatus get_connection_status() const override;
 };
 
-#endif // WEBRTC_MULTIPLAYER_H
+#endif // WEBRTC_MULTIPLAYER_PEER_H

--- a/modules/webrtc/webrtc_peer_connection.h
+++ b/modules/webrtc/webrtc_peer_connection.h
@@ -74,4 +74,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(WebRTCPeerConnection::ConnectionState);
+
 #endif // WEBRTC_PEER_CONNECTION_H

--- a/modules/websocket/emws_client.h
+++ b/modules/websocket/emws_client.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EMWSCLIENT_H
-#define EMWSCLIENT_H
+#ifndef EMWS_CLIENT_H
+#define EMWS_CLIENT_H
 
 #ifdef JAVASCRIPT_ENABLED
 
@@ -68,4 +68,4 @@ public:
 
 #endif // JAVASCRIPT_ENABLED
 
-#endif // EMWSCLIENT_H
+#endif // EMWS_CLIENT_H

--- a/modules/websocket/emws_peer.h
+++ b/modules/websocket/emws_peer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EMWSPEER_H
-#define EMWSPEER_H
+#ifndef EMWS_PEER_H
+#define EMWS_PEER_H
 
 #ifdef JAVASCRIPT_ENABLED
 
@@ -90,4 +90,4 @@ public:
 
 #endif // JAVASCRIPT_ENABLED
 
-#endif // LSWPEER_H
+#endif // EMWS_PEER_H

--- a/modules/websocket/emws_server.h
+++ b/modules/websocket/emws_server.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EMWSSERVER_H
-#define EMWSSERVER_H
+#ifndef EMWS_SERVER_H
+#define EMWS_SERVER_H
 
 #ifdef JAVASCRIPT_ENABLED
 
@@ -61,4 +61,4 @@ public:
 
 #endif
 
-#endif // LWSSERVER_H
+#endif // EMWS_SERVER_H

--- a/modules/websocket/websocket_peer.h
+++ b/modules/websocket/websocket_peer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef WEBSOCKETPEER_H
-#define WEBSOCKETPEER_H
+#ifndef WEBSOCKET_PEER_H
+#define WEBSOCKET_PEER_H
 
 #include "core/error/error_list.h"
 #include "core/io/packet_peer.h"
@@ -66,4 +66,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(WebSocketPeer::WriteMode);
-#endif // WEBSOCKETPEER_H
+
+#endif // WEBSOCKET_PEER_H

--- a/modules/websocket/websocket_server.h
+++ b/modules/websocket/websocket_server.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef WEBSOCKET_H
-#define WEBSOCKET_H
+#ifndef WEBSOCKET_SERVER_H
+#define WEBSOCKET_SERVER_H
 
 #include "core/crypto/crypto.h"
 #include "core/object/ref_counted.h"
@@ -87,4 +87,4 @@ public:
 	~WebSocketServer();
 };
 
-#endif // WEBSOCKET_H
+#endif // WEBSOCKET_SERVER_H

--- a/modules/websocket/wsl_client.h
+++ b/modules/websocket/wsl_client.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef WSLCLIENT_H
-#define WSLCLIENT_H
+#ifndef WSL_CLIENT_H
+#define WSL_CLIENT_H
 
 #ifndef JAVASCRIPT_ENABLED
 
@@ -88,4 +88,4 @@ public:
 
 #endif // JAVASCRIPT_ENABLED
 
-#endif // WSLCLIENT_H
+#endif // WSL_CLIENT_H

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef WSLPEER_H
-#define WSLPEER_H
+#ifndef WSL_PEER_H
+#define WSL_PEER_H
 
 #ifndef JAVASCRIPT_ENABLED
 
@@ -112,4 +112,4 @@ public:
 
 #endif // JAVASCRIPT_ENABLED
 
-#endif // LSWPEER_H
+#endif // WSL_PEER_H

--- a/modules/websocket/wsl_server.h
+++ b/modules/websocket/wsl_server.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef WSLSERVER_H
-#define WSLSERVER_H
+#ifndef WSL_SERVER_H
+#define WSL_SERVER_H
 
 #ifndef JAVASCRIPT_ENABLED
 
@@ -95,4 +95,4 @@ public:
 
 #endif // JAVASCRIPT_ENABLED
 
-#endif // WSLSERVER_H
+#endif // WSL_SERVER_H

--- a/modules/webxr/godot_webxr.h
+++ b/modules/webxr/godot_webxr.h
@@ -82,4 +82,4 @@ extern int *godot_webxr_get_bounds_geometry();
 }
 #endif
 
-#endif /* GODOT_WEBXR_H */
+#endif // GODOT_WEBXR_H

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_GRADLE_EXPORT_UTIL_H
-#define GODOT_GRADLE_EXPORT_UTIL_H
+#ifndef ANDROID_GRADLE_EXPORT_UTIL_H
+#define ANDROID_GRADLE_EXPORT_UTIL_H
 
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
@@ -106,4 +106,4 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset);
 
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_read_write_storage_permission);
 
-#endif // GODOT_GRADLE_EXPORT_UTIL_H
+#endif // ANDROID_GRADLE_EXPORT_UTIL_H

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_JAVA_GODOT_VIEW_WRAPPER_H
-#define GODOT_JAVA_GODOT_VIEW_WRAPPER_H
+#ifndef JAVA_GODOT_VIEW_WRAPPER_H
+#define JAVA_GODOT_VIEW_WRAPPER_H
 
 #include <android/log.h>
 #include <jni.h>
@@ -57,4 +57,4 @@ public:
 	~GodotJavaViewWrapper();
 };
 
-#endif // GODOT_JAVA_GODOT_VIEW_WRAPPER_H
+#endif // JAVA_GODOT_VIEW_WRAPPER_H

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef display_server_ios_h
-#define display_server_ios_h
+#ifndef DISPLAY_SERVER_IOS_H
+#define DISPLAY_SERVER_IOS_H
 
 #include "core/input/input.h"
 #include "servers/display_server.h"
@@ -214,4 +214,4 @@ public:
 	void resize_window(CGSize size);
 };
 
-#endif /* DISPLAY_SERVER_IOS_H */
+#endif // DISPLAY_SERVER_IOS_H

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -290,4 +290,4 @@ public:
 	}
 };
 
-#endif
+#endif // IOS_EXPORT_PLUGIN_H

--- a/platform/ios/export/godot_plugin_config.h
+++ b/platform/ios/export/godot_plugin_config.h
@@ -129,4 +129,4 @@ struct PluginConfigIOS {
 	static PluginConfigIOS load_plugin_config(Ref<ConfigFile> config_file, const String &path);
 };
 
-#endif // GODOT_PLUGIN_CONFIG_H
+#endif // IOS_GODOT_PLUGIN_CONFIG_H

--- a/platform/ios/ios.h
+++ b/platform/ios/ios.h
@@ -58,4 +58,4 @@ public:
 	iOS();
 };
 
-#endif
+#endif // IOS_H

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -121,4 +121,4 @@ public:
 
 #endif // OS_IOS_H
 
-#endif // IOS_ENABLED
+#endif // OS_IOS_H

--- a/platform/javascript/audio_driver_javascript.h
+++ b/platform/javascript/audio_driver_javascript.h
@@ -158,4 +158,4 @@ public:
 };
 #endif
 
-#endif
+#endif // AUDIO_DRIVER_JAVASCRIPT_H

--- a/platform/javascript/export/export.h
+++ b/platform/javascript/export/export.h
@@ -33,4 +33,4 @@
 
 void register_javascript_exporter();
 
-#endif
+#endif // JAVASCRIPT_EXPORT_H

--- a/platform/javascript/export/export_plugin.h
+++ b/platform/javascript/export/export_plugin.h
@@ -144,4 +144,4 @@ public:
 	~EditorExportPlatformJavaScript();
 };
 
-#endif
+#endif // JAVASCRIPT_EXPORT_PLUGIN_H

--- a/platform/javascript/export/export_server.h
+++ b/platform/javascript/export/export_server.h
@@ -248,4 +248,4 @@ public:
 	}
 };
 
-#endif
+#endif // JAVASCRIPT_EXPORT_SERVER_H

--- a/platform/javascript/godot_audio.h
+++ b/platform/javascript/godot_audio.h
@@ -63,4 +63,4 @@ extern void godot_audio_script_start(float *p_in_buf, int p_in_size, float *p_ou
 }
 #endif
 
-#endif /* GODOT_AUDIO_H */
+#endif // GODOT_AUDIO_H

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -127,4 +127,4 @@ extern void godot_js_display_vk_hide();
 }
 #endif
 
-#endif /* GODOT_JS_H */
+#endif // GODOT_JS_H

--- a/platform/javascript/godot_webgl2.h
+++ b/platform/javascript/godot_webgl2.h
@@ -34,4 +34,4 @@
 #include "GLES3/gl3.h"
 #include "webgl/webgl2.h"
 
-#endif
+#endif // GODOT_WEBGL2_H

--- a/platform/javascript/http_client_javascript.h
+++ b/platform/javascript/http_client_javascript.h
@@ -105,4 +105,5 @@ public:
 	HTTPClientJavaScript();
 	~HTTPClientJavaScript();
 };
+
 #endif // HTTP_CLIENT_JAVASCRIPT_H

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -107,4 +107,4 @@ public:
 	OS_JavaScript();
 };
 
-#endif
+#endif // OS_JAVASCRIPT_H

--- a/platform/linuxbsd/crash_handler_linuxbsd.h
+++ b/platform/linuxbsd/crash_handler_linuxbsd.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CRASH_HANDLER_X11_H
-#define CRASH_HANDLER_X11_H
+#ifndef CRASH_HANDLER_LINUXBSD_H
+#define CRASH_HANDLER_LINUXBSD_H
 
 class CrashHandler {
 	bool disabled;
@@ -44,4 +44,4 @@ public:
 	~CrashHandler();
 };
 
-#endif // CRASH_HANDLER_X11_H
+#endif // CRASH_HANDLER_LINUXBSD_H

--- a/platform/linuxbsd/detect_prime_x11.h
+++ b/platform/linuxbsd/detect_prime_x11.h
@@ -34,4 +34,5 @@
 int detect_prime();
 
 #endif
-#endif
+
+#endif // DETECT_PRIME_X11_H

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -49,4 +49,4 @@ public:
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;
 };
 
-#endif
+#endif // LINUXBSD_EXPORT_PLUGIN_H

--- a/platform/linuxbsd/freedesktop_screensaver.h
+++ b/platform/linuxbsd/freedesktop_screensaver.h
@@ -28,6 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef FREEDESKTOP_SCREENSAVER_H
+#define FREEDESKTOP_SCREENSAVER_H
+
 #ifdef DBUS_ENABLED
 
 #include <dbus/dbus.h>
@@ -45,3 +48,5 @@ public:
 };
 
 #endif // DBUS_ENABLED
+
+#endif // FREEDESKTOP_SCREENSAVER_H

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -105,4 +105,4 @@ public:
 	OS_LinuxBSD();
 };
 
-#endif
+#endif // OS_LINUXBSD_H

--- a/platform/linuxbsd/vulkan_context_x11.h
+++ b/platform/linuxbsd/vulkan_context_x11.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VULKAN_DEVICE_X11_H
-#define VULKAN_DEVICE_X11_H
+#ifndef VULKAN_CONTEXT_X11_H
+#define VULKAN_CONTEXT_X11_H
 
 #include "drivers/vulkan/vulkan_context.h"
 #include <X11/Xlib.h>
@@ -44,4 +44,4 @@ public:
 	~VulkanContextX11();
 };
 
-#endif // VULKAN_DEVICE_X11_H
+#endif // VULKAN_CONTEXT_X11_H

--- a/platform/macos/dir_access_macos.h
+++ b/platform/macos/dir_access_macos.h
@@ -51,5 +51,6 @@ protected:
 	virtual bool is_hidden(const String &p_name);
 };
 
-#endif //UNIX ENABLED
-#endif
+#endif // UNIX ENABLED || LIBC_FILEIO_ENABLED
+
+#endif // DIR_ACCESS_MACOS_H

--- a/platform/macos/dir_access_macos.mm
+++ b/platform/macos/dir_access_macos.mm
@@ -78,4 +78,4 @@ bool DirAccessMacOS::is_hidden(const String &p_name) {
 	return [hidden boolValue];
 }
 
-#endif //posix_enabled
+#endif // UNIX_ENABLED || LIBC_FILEIO_ENABLED

--- a/platform/macos/export/codesign.h
+++ b/platform/macos/export/codesign.h
@@ -38,8 +38,8 @@
 //  - Requirements code generator is not implemented (only hard-coded requirements for the ad-hoc signing is supported).
 //  - RFC5652/CMS blob generation is not implemented, supports ad-hoc signing only.
 
-#ifndef CODESIGN_H
-#define CODESIGN_H
+#ifndef MACOS_CODESIGN_H
+#define MACOS_CODESIGN_H
 
 #include "core/crypto/crypto_core.h"
 #include "core/io/dir_access.h"
@@ -365,4 +365,4 @@ public:
 
 #endif // MODULE_REGEX_ENABLED
 
-#endif // CODESIGN_H
+#endif // MACOS_CODESIGN_H

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -134,4 +134,4 @@ public:
 	~EditorExportPlatformMacOS();
 };
 
-#endif
+#endif // MACOS_EXPORT_PLUGIN_H

--- a/platform/macos/export/lipo.h
+++ b/platform/macos/export/lipo.h
@@ -30,8 +30,8 @@
 
 // Universal / Universal 2 fat binary file creator and extractor.
 
-#ifndef LIPO_H
-#define LIPO_H
+#ifndef MACOS_LIPO_H
+#define MACOS_LIPO_H
 
 #include "core/io/file_access.h"
 #include "core/object/ref_counted.h"
@@ -73,4 +73,4 @@ public:
 
 #endif // MODULE_REGEX_ENABLED
 
-#endif // LIPO_H
+#endif // MACOS_LIPO_H

--- a/platform/macos/export/macho.h
+++ b/platform/macos/export/macho.h
@@ -30,8 +30,8 @@
 
 // Mach-O binary object file format parser and editor.
 
-#ifndef MACHO_H
-#define MACHO_H
+#ifndef MACOS_MACHO_H
+#define MACOS_MACHO_H
 
 #include "core/crypto/crypto.h"
 #include "core/crypto/crypto_core.h"
@@ -212,4 +212,4 @@ public:
 
 #endif // MODULE_REGEX_ENABLED
 
-#endif // MACHO_H
+#endif // MACOS_MACHO_H

--- a/platform/macos/export/plist.h
+++ b/platform/macos/export/plist.h
@@ -30,8 +30,8 @@
 
 // Property list file format (application/x-plist) parser, property list ASN-1 serialization.
 
-#ifndef PLIST_H
-#define PLIST_H
+#ifndef MACOS_PLIST_H
+#define MACOS_PLIST_H
 
 #include "core/crypto/crypto_core.h"
 #include "core/io/file_access.h"
@@ -113,4 +113,4 @@ public:
 
 #endif // MODULE_REGEX_ENABLED
 
-#endif // PLIST_H
+#endif // MACOS_PLIST_H

--- a/platform/macos/gl_manager_macos_legacy.h
+++ b/platform/macos/gl_manager_macos_legacy.h
@@ -94,4 +94,5 @@ public:
 };
 
 #endif // MACOS_ENABLED && GLES3_ENABLED
+
 #endif // GL_MANAGER_MACOS_LEGACY_H

--- a/platform/macos/godot_window.h
+++ b/platform/macos/godot_window.h
@@ -44,4 +44,4 @@
 
 @end
 
-#endif //GODOT_WINDOW_H
+#endif // GODOT_WINDOW_H

--- a/platform/macos/godot_window_delegate.h
+++ b/platform/macos/godot_window_delegate.h
@@ -44,4 +44,4 @@
 
 @end
 
-#endif //GODOT_WINDOW_DELEGATE_H
+#endif // GODOT_WINDOW_DELEGATE_H

--- a/platform/macos/macos_terminal_logger.h
+++ b/platform/macos/macos_terminal_logger.h
@@ -41,4 +41,5 @@ public:
 };
 
 #endif // MACOS_ENABLED
+
 #endif // MACOS_TERMINAL_LOGGER_H

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -117,4 +117,4 @@ public:
 	~OS_MacOS();
 };
 
-#endif
+#endif // OS_MACOS_H

--- a/platform/macos/vulkan_context_macos.h
+++ b/platform/macos/vulkan_context_macos.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VULKAN_DEVICE_MACOS_H
-#define VULKAN_DEVICE_MACOS_H
+#ifndef VULKAN_CONTEXT_MACOS_H
+#define VULKAN_CONTEXT_MACOS_H
 
 #include "drivers/vulkan/vulkan_context.h"
 #import <AppKit/AppKit.h>
@@ -44,4 +44,4 @@ public:
 	~VulkanContextMacOS();
 };
 
-#endif // VULKAN_DEVICE_MACOS_H
+#endif // VULKAN_CONTEXT_MACOS_H

--- a/platform/register_platform_apis.h
+++ b/platform/register_platform_apis.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef REGISTER_APIS_H
-#define REGISTER_APIS_H
+#ifndef REGISTER_PLATFORM_APIS_H
+#define REGISTER_PLATFORM_APIS_H
 
 void register_platform_apis();
 void unregister_platform_apis();
 
-#endif
+#endif // REGISTER_PLATFORM_APIS_H

--- a/platform/uwp/app_uwp.h
+++ b/platform/uwp/app_uwp.h
@@ -112,4 +112,5 @@ namespace GodotUWP
 }
 
 /* clang-format on */
+
 #endif // APP_UWP_H

--- a/platform/uwp/export/app_packager.h
+++ b/platform/uwp/export/app_packager.h
@@ -146,4 +146,4 @@ public:
 	~AppxPackager();
 };
 
-#endif
+#endif // UWP_APP_PACKAGER_H

--- a/platform/uwp/export/export_plugin.h
+++ b/platform/uwp/export/export_plugin.h
@@ -446,4 +446,4 @@ public:
 	EditorExportPlatformUWP();
 };
 
-#endif
+#endif // UWP_EXPORT_PLUGIN_H

--- a/platform/uwp/joypad_uwp.h
+++ b/platform/uwp/joypad_uwp.h
@@ -78,4 +78,4 @@ private:
 	void joypad_vibration_stop(int p_device, uint64_t p_timestamp);
 };
 
-#endif
+#endif // JOYPAD_UWP_H

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -252,4 +252,4 @@ public:
 	~OS_UWP();
 };
 
-#endif
+#endif // OS_UWP_H

--- a/platform/windows/export/export.h
+++ b/platform/windows/export/export.h
@@ -33,4 +33,4 @@
 
 void register_windows_exporter();
 
-#endif
+#endif // WINDOWS_EXPORT_H

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -54,4 +54,4 @@ public:
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;
 };
 
-#endif
+#endif // WINDOWS_EXPORT_PLUGIN_H

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -185,4 +185,4 @@ public:
 	~OS_Windows();
 };
 
-#endif
+#endif // OS_WINDOWS_H

--- a/platform/windows/vulkan_context_win.h
+++ b/platform/windows/vulkan_context_win.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VULKAN_DEVICE_WIN_H
-#define VULKAN_DEVICE_WIN_H
+#ifndef VULKAN_CONTEXT_WIN_H
+#define VULKAN_CONTEXT_WIN_H
 
 #include "drivers/vulkan/vulkan_context.h"
 
@@ -46,4 +46,4 @@ public:
 	~VulkanContextWindows();
 };
 
-#endif // VULKAN_DEVICE_WIN_H
+#endif // VULKAN_CONTEXT_WIN_H

--- a/platform/windows/windows_terminal_logger.h
+++ b/platform/windows/windows_terminal_logger.h
@@ -44,4 +44,4 @@ public:
 
 #endif
 
-#endif
+#endif // WINDOWS_TERMINAL_LOGGER_H

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -114,4 +114,4 @@ public:
 	AnimatedSprite2D();
 };
 
-#endif // ANIMATED_SPRITE_H
+#endif // ANIMATED_SPRITE_2D_H

--- a/scene/2d/audio_listener_2d.h
+++ b/scene/2d/audio_listener_2d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef LISTENER_2D_H
-#define LISTENER_2D_H
+#ifndef AUDIO_LISTENER_2D_H
+#define AUDIO_LISTENER_2D_H
 
 #include "scene/2d/node_2d.h"
 #include "scene/main/window.h"
@@ -56,4 +56,4 @@ public:
 	bool is_current() const;
 };
 
-#endif
+#endif // AUDIO_LISTENER_2D_H

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -135,4 +135,4 @@ public:
 	~AudioStreamPlayer2D();
 };
 
-#endif
+#endif // AUDIO_STREAM_PLAYER_2D_H

--- a/scene/2d/back_buffer_copy.h
+++ b/scene/2d/back_buffer_copy.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef BACKBUFFERCOPY_H
-#define BACKBUFFERCOPY_H
+#ifndef BACK_BUFFER_COPY_H
+#define BACK_BUFFER_COPY_H
 
 #include "scene/2d/node_2d.h"
 
@@ -71,4 +71,4 @@ public:
 
 VARIANT_ENUM_CAST(BackBufferCopy::CopyMode);
 
-#endif // BACKBUFFERCOPY_H
+#endif // BACK_BUFFER_COPY_H

--- a/scene/2d/canvas_group.h
+++ b/scene/2d/canvas_group.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CANVASGROUP_H
-#define CANVASGROUP_H
+#ifndef CANVAS_GROUP_H
+#define CANVAS_GROUP_H
 
 #include "scene/2d/node_2d.h"
 
@@ -56,4 +56,4 @@ public:
 	~CanvasGroup();
 };
 
-#endif // CANVASGROUP_H
+#endif // CANVAS_GROUP_H

--- a/scene/2d/canvas_modulate.h
+++ b/scene/2d/canvas_modulate.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CANVASMODULATE_H
-#define CANVASMODULATE_H
+#ifndef CANVAS_MODULATE_H
+#define CANVAS_MODULATE_H
 
 #include "scene/2d/node_2d.h"
 
@@ -52,4 +52,4 @@ public:
 	~CanvasModulate();
 };
 
-#endif // CANVASMODULATE_H
+#endif // CANVAS_MODULATE_H

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PARTICLES_2D_H
-#define PARTICLES_2D_H
+#ifndef GPU_PARTICLES_2D_H
+#define GPU_PARTICLES_2D_H
 
 #include "scene/2d/node_2d.h"
 
@@ -167,4 +167,4 @@ public:
 VARIANT_ENUM_CAST(GPUParticles2D::DrawOrder)
 VARIANT_ENUM_CAST(GPUParticles2D::EmitFlags)
 
-#endif // PARTICLES_2D_H
+#endif // GPU_PARTICLES_2D_H

--- a/scene/2d/light_occluder_2d.h
+++ b/scene/2d/light_occluder_2d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef LIGHTOCCLUDER2D_H
-#define LIGHTOCCLUDER2D_H
+#ifndef LIGHT_OCCLUDER_2D_H
+#define LIGHT_OCCLUDER_2D_H
 
 #include "scene/2d/node_2d.h"
 
@@ -111,4 +111,4 @@ public:
 	~LightOccluder2D();
 };
 
-#endif // LIGHTOCCLUDER2D_H
+#endif // LIGHT_OCCLUDER_2D_H

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef LINE2D_H
-#define LINE2D_H
+#ifndef LINE_2D_H
+#define LINE_2D_H
 
 #include "node_2d.h"
 
@@ -138,4 +138,4 @@ private:
 	bool _antialiased = false;
 };
 
-#endif // LINE2D_H
+#endif // LINE_2D_H

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -163,4 +163,4 @@ private:
 	void _check_distance_to_target();
 };
 
-#endif
+#endif // NAVIGATION_AGENT_2D_H

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -74,4 +74,4 @@ private:
 	real_t estimate_agent_radius() const;
 };
 
-#endif
+#endif // NAVIGATION_OBSTACLE_2D_H

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NODE2D_H
-#define NODE2D_H
+#ifndef NODE_2D_H
+#define NODE_2D_H
 
 #include "scene/main/canvas_item.h"
 
@@ -124,4 +124,4 @@ public:
 	Node2D() {}
 };
 
-#endif // NODE2D_H
+#endif // NODE_2D_H

--- a/scene/2d/shape_cast_2d.h
+++ b/scene/2d/shape_cast_2d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SHAPE_CAST_2D
-#define SHAPE_CAST_2D
+#ifndef SHAPE_CAST_2D_H
+#define SHAPE_CAST_2D_H
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/shape_2d.h"
@@ -120,4 +120,4 @@ public:
 	TypedArray<String> get_configuration_warnings() const override;
 };
 
-#endif
+#endif // SHAPE_CAST_2D_H

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -125,4 +125,4 @@ public:
 	~Sprite2D();
 };
 
-#endif // SPRITE_H
+#endif // SPRITE_2D_H

--- a/scene/2d/visible_on_screen_notifier_2d.h
+++ b/scene/2d/visible_on_screen_notifier_2d.h
@@ -102,4 +102,4 @@ public:
 
 VARIANT_ENUM_CAST(VisibleOnScreenEnabler2D::EnableMode);
 
-#endif // VISIBILITY_NOTIFIER_2D_H
+#endif // VISIBLE_ON_SCREEN_NOTIFIER_2D_H

--- a/scene/3d/audio_listener_3d.h
+++ b/scene/3d/audio_listener_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef LISTENER_3D_H
-#define LISTENER_3D_H
+#ifndef AUDIO_LISTENER_3D_H
+#define AUDIO_LISTENER_3D_H
 
 #include "scene/3d/node_3d.h"
 
@@ -67,4 +67,4 @@ public:
 	~AudioListener3D();
 };
 
-#endif
+#endif // AUDIO_LISTENER_3D_H

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -196,4 +196,5 @@ public:
 
 VARIANT_ENUM_CAST(AudioStreamPlayer3D::AttenuationModel)
 VARIANT_ENUM_CAST(AudioStreamPlayer3D::DopplerTracking)
+
 #endif // AUDIO_STREAM_PLAYER_3D_H

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef BONE_ATTACHMENT_H
-#define BONE_ATTACHMENT_H
+#ifndef BONE_ATTACHMENT_3D_H
+#define BONE_ATTACHMENT_3D_H
 
 #include "scene/3d/skeleton_3d.h"
 #ifdef TOOLS_ENABLED
@@ -99,4 +99,4 @@ public:
 	BoneAttachment3D();
 };
 
-#endif // BONE_ATTACHMENT_H
+#endif // BONE_ATTACHMENT_3D_H

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -185,4 +185,4 @@ VARIANT_ENUM_CAST(Camera3D::ProjectionType);
 VARIANT_ENUM_CAST(Camera3D::KeepAspect);
 VARIANT_ENUM_CAST(Camera3D::DopplerTracking);
 
-#endif
+#endif // CAMERA_3D_H

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -166,4 +166,4 @@ public:
 
 VARIANT_ENUM_CAST(CollisionObject3D::DisableMode);
 
-#endif // COLLISION_OBJECT__H
+#endif // COLLISION_OBJECT_3D_H

--- a/scene/3d/collision_polygon_3d.h
+++ b/scene/3d/collision_polygon_3d.h
@@ -79,4 +79,4 @@ public:
 	CollisionPolygon3D();
 };
 
-#endif // COLLISION_POLYGON_H
+#endif // COLLISION_POLYGON_3D_H

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef COLLISION_SHAPE_H
-#define COLLISION_SHAPE_H
+#ifndef COLLISION_SHAPE_3D_H
+#define COLLISION_SHAPE_3D_H
 
 #include "scene/3d/node_3d.h"
 #include "scene/resources/shape_3d.h"
@@ -68,4 +68,4 @@ public:
 	~CollisionShape3D();
 };
 
-#endif // BODY_VOLUME_H
+#endif // COLLISION_SHAPE_3D_H

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CPU_PARTICLES_H
-#define CPU_PARTICLES_H
+#ifndef CPU_PARTICLES_3D_H
+#define CPU_PARTICLES_3D_H
 
 #include "scene/3d/visual_instance_3d.h"
 
@@ -317,4 +317,4 @@ VARIANT_ENUM_CAST(CPUParticles3D::Parameter)
 VARIANT_ENUM_CAST(CPUParticles3D::ParticleFlags)
 VARIANT_ENUM_CAST(CPUParticles3D::EmissionShape)
 
-#endif // CPU_PARTICLES_H
+#endif // CPU_PARTICLES_3D_H

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PARTICLES_H
-#define PARTICLES_H
+#ifndef GPU_PARTICLES_3D_H
+#define GPU_PARTICLES_3D_H
 
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/skin.h"
@@ -179,4 +179,4 @@ VARIANT_ENUM_CAST(GPUParticles3D::DrawOrder)
 VARIANT_ENUM_CAST(GPUParticles3D::TransformAlign)
 VARIANT_ENUM_CAST(GPUParticles3D::EmitFlags)
 
-#endif // PARTICLES_H
+#endif // GPU_PARTICLES_3D_H

--- a/scene/3d/importer_mesh_instance_3d.h
+++ b/scene/3d/importer_mesh_instance_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SCENE_IMPORTER_MESH_INSTANCE_3D_H
-#define SCENE_IMPORTER_MESH_INSTANCE_3D_H
+#ifndef IMPORTER_MESH_INSTANCE_3D_H
+#define IMPORTER_MESH_INSTANCE_3D_H
 
 #include "scene/3d/node_3d.h"
 #include "scene/resources/immediate_mesh.h"
@@ -61,4 +61,5 @@ public:
 	void set_skeleton_path(const NodePath &p_path);
 	NodePath get_skeleton_path() const;
 };
-#endif
+
+#endif // IMPORTER_MESH_INSTANCE_3D_H

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -271,4 +271,4 @@ VARIANT_ENUM_CAST(LightmapGI::GenerateProbes);
 VARIANT_ENUM_CAST(LightmapGI::BakeError);
 VARIANT_ENUM_CAST(LightmapGI::EnvironmentMode);
 
-#endif // BAKED_LIGHTMAP_H
+#endif // LIGHTMAP_GI_H

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef MESH_INSTANCE_H
-#define MESH_INSTANCE_H
+#ifndef MESH_INSTANCE_3D_H
+#define MESH_INSTANCE_3D_H
 
 #include "core/templates/local_vector.h"
 #include "scene/3d/visual_instance_3d.h"
@@ -98,4 +98,4 @@ public:
 	~MeshInstance3D();
 };
 
-#endif
+#endif // MESH_INSTANCE_3D_H

--- a/scene/3d/multimesh_instance_3d.h
+++ b/scene/3d/multimesh_instance_3d.h
@@ -53,4 +53,4 @@ public:
 	~MultiMeshInstance3D();
 };
 
-#endif // MULTIMESH_INSTANCE_H
+#endif // MULTIMESH_INSTANCE_3D_H

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NAVIGATION_AGENT_H
-#define NAVIGATION_AGENT_H
+#ifndef NAVIGATION_AGENT_3D_H
+#define NAVIGATION_AGENT_3D_H
 
 #include "scene/main/node.h"
 
@@ -175,4 +175,4 @@ private:
 	void _check_distance_to_target();
 };
 
-#endif
+#endif // NAVIGATION_AGENT_3D_H

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NAVIGATION_OBSTACLE_H
-#define NAVIGATION_OBSTACLE_H
+#ifndef NAVIGATION_OBSTACLE_3D_H
+#define NAVIGATION_OBSTACLE_3D_H
 
 #include "scene/3d/node_3d.h"
 
@@ -73,4 +73,4 @@ private:
 	real_t estimate_agent_radius() const;
 };
 
-#endif
+#endif // NAVIGATION_OBSTACLE_3D_H

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef NAVIGATION_REGION_H
-#define NAVIGATION_REGION_H
+#ifndef NAVIGATION_REGION_3D_H
+#define NAVIGATION_REGION_3D_H
 
 #include "scene/3d/node_3d.h"
 #include "scene/resources/navigation_mesh.h"
@@ -85,4 +85,4 @@ public:
 	~NavigationRegion3D();
 };
 
-#endif // NAVIGATION_REGION_H
+#endif // NAVIGATION_REGION_3D_H

--- a/scene/3d/occluder_instance_3d.h
+++ b/scene/3d/occluder_instance_3d.h
@@ -211,4 +211,4 @@ public:
 	~OccluderInstance3D();
 };
 
-#endif
+#endif // OCCLUDER_INSTANCE_3D_H

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PATH_H
-#define PATH_H
+#ifndef PATH_3D_H
+#define PATH_3D_H
 
 #include "scene/3d/node_3d.h"
 #include "scene/resources/curve.h"
@@ -119,4 +119,4 @@ public:
 
 VARIANT_ENUM_CAST(PathFollow3D::RotationMode);
 
-#endif // PATH_H
+#endif // PATH_3D_H

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -784,4 +784,4 @@ private:
 VARIANT_ENUM_CAST(PhysicalBone3D::JointType);
 VARIANT_ENUM_CAST(PhysicalBone3D::DampMode);
 
-#endif // PHYSICS_BODY__H
+#endif // PHYSICS_BODY_3D_H

--- a/scene/3d/ray_cast_3d.h
+++ b/scene/3d/ray_cast_3d.h
@@ -126,4 +126,4 @@ public:
 	RayCast3D();
 };
 
-#endif // RAY_CAST_H
+#endif // RAY_CAST_3D_H

--- a/scene/3d/reflection_probe.h
+++ b/scene/3d/reflection_probe.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef REFLECTIONPROBE_H
-#define REFLECTIONPROBE_H
+#ifndef REFLECTION_PROBE_H
+#define REFLECTION_PROBE_H
 
 #include "scene/3d/visual_instance_3d.h"
 
@@ -121,4 +121,4 @@ public:
 VARIANT_ENUM_CAST(ReflectionProbe::AmbientMode);
 VARIANT_ENUM_CAST(ReflectionProbe::UpdateMode);
 
-#endif // REFLECTIONPROBE_H
+#endif // REFLECTION_PROBE_H

--- a/scene/3d/remote_transform_3d.h
+++ b/scene/3d/remote_transform_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef REMOTETRANSFORM_H
-#define REMOTETRANSFORM_H
+#ifndef REMOTE_TRANSFORM_3D_H
+#define REMOTE_TRANSFORM_3D_H
 
 #include "scene/3d/node_3d.h"
 
@@ -75,4 +75,4 @@ public:
 	RemoteTransform3D();
 };
 
-#endif // REMOTETRANSFORM_H
+#endif // REMOTE_TRANSFORM_3D_H

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -288,4 +288,4 @@ public:
 	~Skeleton3D();
 };
 
-#endif
+#endif // SKELETON_3D_H

--- a/scene/3d/skeleton_ik_3d.h
+++ b/scene/3d/skeleton_ik_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETON_IK_H
-#define SKELETON_IK_H
+#ifndef SKELETON_IK_3D_H
+#define SKELETON_IK_3D_H
 
 #ifndef _3D_DISABLED
 
@@ -192,4 +192,4 @@ private:
 
 #endif // _3D_DISABLED
 
-#endif // SKELETON_IK_H
+#endif // SKELETON_IK_3D_H

--- a/scene/3d/soft_dynamic_body_3d.h
+++ b/scene/3d/soft_dynamic_body_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SOFT_DYNAMIC_BODY_H
-#define SOFT_DYNAMIC_BODY_H
+#ifndef SOFT_DYNAMIC_BODY_3D_H
+#define SOFT_DYNAMIC_BODY_3D_H
 
 #include "scene/3d/mesh_instance_3d.h"
 #include "servers/physics_server_3d.h"
@@ -199,4 +199,4 @@ private:
 
 VARIANT_ENUM_CAST(SoftDynamicBody3D::DisableMode);
 
-#endif // SOFT_DYNAMIC_BODY_H
+#endif // SOFT_DYNAMIC_BODY_3D_H

--- a/scene/3d/spring_arm_3d.h
+++ b/scene/3d/spring_arm_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SPRING_ARM_H
-#define SPRING_ARM_H
+#ifndef SPRING_ARM_3D_H
+#define SPRING_ARM_3D_H
 
 #include "scene/3d/node_3d.h"
 
@@ -68,4 +68,4 @@ private:
 	void process_spring();
 };
 
-#endif
+#endif // SPRING_ARM_3D_H

--- a/scene/3d/vehicle_body_3d.h
+++ b/scene/3d/vehicle_body_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VEHICLE_BODY_H
-#define VEHICLE_BODY_H
+#ifndef VEHICLE_BODY_3D_H
+#define VEHICLE_BODY_3D_H
 
 #include "scene/3d/physics_body_3d.h"
 
@@ -210,4 +210,4 @@ public:
 	VehicleBody3D();
 };
 
-#endif // VEHICLE_BODY_H
+#endif // VEHICLE_BODY_3D_H

--- a/scene/3d/velocity_tracker_3d.h
+++ b/scene/3d/velocity_tracker_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SPATIAL_VELOCITY_TRACKER_H
-#define SPATIAL_VELOCITY_TRACKER_H
+#ifndef VELOCITY_TRACKER_3D_H
+#define VELOCITY_TRACKER_3D_H
 
 #include "scene/3d/node_3d.h"
 
@@ -58,4 +58,4 @@ public:
 	VelocityTracker3D();
 };
 
-#endif // SPATIAL_VELOCITY_TRACKER_H
+#endif // VELOCITY_TRACKER_3D_H

--- a/scene/3d/visible_on_screen_notifier_3d.h
+++ b/scene/3d/visible_on_screen_notifier_3d.h
@@ -96,4 +96,4 @@ public:
 
 VARIANT_ENUM_CAST(VisibleOnScreenEnabler3D::EnableMode);
 
-#endif // VISIBILITY_NOTIFIER_H
+#endif // VISIBLE_ON_SCREEN_NOTIFIER_3D_H

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VISUAL_INSTANCE_H
-#define VISUAL_INSTANCE_H
+#ifndef VISUAL_INSTANCE_3D_H
+#define VISUAL_INSTANCE_3D_H
 
 #include "scene/3d/node_3d.h"
 
@@ -196,4 +196,4 @@ VARIANT_ENUM_CAST(GeometryInstance3D::LightmapScale);
 VARIANT_ENUM_CAST(GeometryInstance3D::GIMode);
 VARIANT_ENUM_CAST(GeometryInstance3D::VisibilityRangeFadeMode);
 
-#endif
+#endif // VISUAL_INSTANCE_3D_H

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VOXEL_LIGHT_BAKER_H
-#define VOXEL_LIGHT_BAKER_H
+#ifndef VOXELIZER_H
+#define VOXELIZER_H
 
 #include "scene/resources/multimesh.h"
 
@@ -129,4 +129,4 @@ public:
 	Voxelizer();
 };
 
-#endif // VOXEL_LIGHT_BAKER_H
+#endif // VOXELIZER_H

--- a/scene/3d/world_environment.h
+++ b/scene/3d/world_environment.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SCENARIO_FX_H
-#define SCENARIO_FX_H
+#ifndef WORLD_ENVIRONMENT_H
+#define WORLD_ENVIRONMENT_H
 
 #include "scene/main/node.h"
 #include "scene/resources/camera_effects.h"
@@ -60,4 +60,4 @@ public:
 	WorldEnvironment();
 };
 
-#endif
+#endif // WORLD_ENVIRONMENT_H

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -395,4 +395,4 @@ public:
 VARIANT_ENUM_CAST(AnimationPlayer::AnimationProcessCallback);
 VARIANT_ENUM_CAST(AnimationPlayer::AnimationMethodCallMode);
 
-#endif
+#endif // ANIMATION_PLAYER_H

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef ANIMATION_GRAPH_PLAYER_H
-#define ANIMATION_GRAPH_PLAYER_H
+#ifndef ANIMATION_TREE_H
+#define ANIMATION_TREE_H
 
 #include "animation_player.h"
 #include "scene/3d/node_3d.h"
@@ -359,4 +359,4 @@ public:
 
 VARIANT_ENUM_CAST(AnimationTree::AnimationProcessCallback)
 
-#endif // ANIMATION_GRAPH_PLAYER_H
+#endif // ANIMATION_TREE_H

--- a/scene/animation/easing_equations.h
+++ b/scene/animation/easing_equations.h
@@ -402,4 +402,4 @@ static real_t out_in(real_t t, real_t b, real_t c, real_t d) {
 }
 }; // namespace back
 
-#endif
+#endif // EASING_EQUATIONS_H

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -283,4 +283,4 @@ private:
 	Callable callback;
 };
 
-#endif
+#endif // TWEEN_H

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -174,4 +174,4 @@ public:
 };
 #endif
 
-#endif
+#endif // SCENE_DEBUGGER_H

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -155,4 +155,4 @@ public:
 	ButtonGroup();
 };
 
-#endif
+#endif // BASE_BUTTON_H

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -98,4 +98,4 @@ public:
 	~Button();
 };
 
-#endif
+#endif // BUTTON_H

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CODEEDIT_H
-#define CODEEDIT_H
+#ifndef CODE_EDIT_H
+#define CODE_EDIT_H
 
 #include "scene/gui/text_edit.h"
 
@@ -433,4 +433,4 @@ public:
 
 VARIANT_ENUM_CAST(CodeEdit::CodeCompletionKind);
 
-#endif // CODEEDIT_H
+#endif // CODE_EDIT_H

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -276,4 +276,5 @@ public:
 
 VARIANT_ENUM_CAST(ColorPicker::PickerShapeType);
 VARIANT_ENUM_CAST(ColorPicker::ColorModeType);
+
 #endif // COLOR_PICKER_H

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -574,4 +574,4 @@ VARIANT_ENUM_CAST(Control::LayoutMode);
 VARIANT_ENUM_CAST(Control::LayoutDirection);
 VARIANT_ENUM_CAST(Control::TextDirection);
 
-#endif
+#endif // CONTROL_H

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -120,4 +120,4 @@ public:
 	ConfirmationDialog();
 };
 
-#endif
+#endif // DIALOGS_H

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -196,4 +196,4 @@ public:
 VARIANT_ENUM_CAST(FileDialog::FileMode);
 VARIANT_ENUM_CAST(FileDialog::Access);
 
-#endif
+#endif // FILE_DIALOG_H

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -365,4 +365,4 @@ public:
 
 VARIANT_ENUM_CAST(GraphEdit::PanningScheme);
 
-#endif // GRAPHEdit_H
+#endif // GRAPH_EDIT_H

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef ITEMLIST_H
-#define ITEMLIST_H
+#ifndef ITEM_LIST_H
+#define ITEM_LIST_H
 
 #include "scene/gui/control.h"
 #include "scene/gui/scroll_bar.h"
@@ -259,4 +259,4 @@ public:
 VARIANT_ENUM_CAST(ItemList::SelectMode);
 VARIANT_ENUM_CAST(ItemList::IconMode);
 
-#endif // ITEMLIST_H
+#endif // ITEM_LIST_H

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -140,4 +140,4 @@ public:
 	~Label();
 };
 
-#endif
+#endif // LABEL_H

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -336,4 +336,4 @@ public:
 
 VARIANT_ENUM_CAST(LineEdit::MenuItems);
 
-#endif
+#endif // LINE_EDIT_H

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef LINKBUTTON_H
-#define LINKBUTTON_H
+#ifndef LINK_BUTTON_H
+#define LINK_BUTTON_H
 
 #include "scene/gui/base_button.h"
 #include "scene/resources/text_line.h"
@@ -86,4 +86,4 @@ public:
 
 VARIANT_ENUM_CAST(LinkButton::UnderlineMode);
 
-#endif // LINKBUTTON_H
+#endif // LINK_BUTTON_H

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -71,4 +71,4 @@ public:
 	~MenuButton();
 };
 
-#endif
+#endif // MENU_BUTTON_H

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -105,4 +105,4 @@ public:
 	~OptionButton();
 };
 
-#endif
+#endif // OPTION_BUTTON_H

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -79,4 +79,4 @@ public:
 	PopupPanel();
 };
 
-#endif
+#endif // POPUP_H

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -260,4 +260,4 @@ public:
 	~PopupMenu();
 };
 
-#endif
+#endif // POPUP_MENU_H

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -106,4 +106,4 @@ public:
 	~Range();
 };
 
-#endif
+#endif // RANGE_H

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -128,4 +128,4 @@ public:
 			ScrollBar(VERTICAL) { set_h_size_flags(0); }
 };
 
-#endif
+#endif // SCROLL_BAR_H

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -116,4 +116,4 @@ public:
 
 VARIANT_ENUM_CAST(ScrollContainer::ScrollMode);
 
-#endif
+#endif // SCROLL_CONTAINER_H

--- a/scene/gui/separator.h
+++ b/scene/gui/separator.h
@@ -60,4 +60,4 @@ public:
 	HSeparator();
 };
 
-#endif
+#endif // SEPARATOR_H

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VIEWPORTCONTAINER_H
-#define VIEWPORTCONTAINER_H
+#ifndef SUBVIEWPORT_CONTAINER_H
+#define SUBVIEWPORT_CONTAINER_H
 
 #include "scene/gui/container.h"
 
@@ -63,4 +63,4 @@ public:
 	SubViewportContainer();
 };
 
-#endif // VIEWPORTCONTAINER_H
+#endif // SUBVIEWPORT_CONTAINER_H

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -101,4 +101,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(TextureButton::StretchMode);
+
 #endif // TEXTURE_BUTTON_H

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -719,4 +719,5 @@ public:
 
 VARIANT_ENUM_CAST(Tree::SelectMode);
 VARIANT_ENUM_CAST(Tree::DropModeFlags);
-#endif
+
+#endif // TREE_H

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef HTTPREQUEST_H
-#define HTTPREQUEST_H
+#ifndef HTTP_REQUEST_H
+#define HTTP_REQUEST_H
 
 #include "core/io/http_client.h"
 #include "core/os/thread.h"
@@ -162,4 +162,4 @@ public:
 
 VARIANT_ENUM_CAST(HTTPRequest::Result);
 
-#endif // HTTPREQUEST_H
+#endif // HTTP_REQUEST_H

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -526,4 +526,4 @@ VARIANT_ENUM_CAST(Node::DuplicateFlags);
 
 typedef HashSet<Node *, Node::Comparator> NodeSet;
 
-#endif
+#endif // NODE_H

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -779,4 +779,4 @@ VARIANT_ENUM_CAST(Viewport::RenderInfoType);
 VARIANT_ENUM_CAST(Viewport::DefaultCanvasItemTextureFilter);
 VARIANT_ENUM_CAST(Viewport::DefaultCanvasItemTextureRepeat);
 
-#endif
+#endif // VIEWPORT_H

--- a/scene/multiplayer/multiplayer_synchronizer.h
+++ b/scene/multiplayer/multiplayer_synchronizer.h
@@ -92,4 +92,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(MultiplayerSynchronizer::VisibilityUpdateMode);
+
 #endif // MULTIPLAYER_SYNCHRONIZER_H

--- a/scene/multiplayer/scene_replication_interface.h
+++ b/scene/multiplayer/scene_replication_interface.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SCENE_TREE_REPLICATOR_INTERFACE_H
-#define SCENE_TREE_REPLICATOR_INTERFACE_H
+#ifndef SCENE_REPLICATION_INTERFACE_H
+#define SCENE_REPLICATION_INTERFACE_H
 
 #include "core/multiplayer/multiplayer_api.h"
 
@@ -84,4 +84,4 @@ public:
 	}
 };
 
-#endif // SCENE_TREE_REPLICATOR_INTERFACE_H
+#endif // SCENE_REPLICATION_INTERFACE_H

--- a/scene/multiplayer/scene_replication_state.h
+++ b/scene/multiplayer/scene_replication_state.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SCENE_REPLICATON_STATE_H
-#define SCENE_REPLICATON_STATE_H
+#ifndef SCENE_REPLICATION_STATE_H
+#define SCENE_REPLICATION_STATE_H
 
 #include "core/object/ref_counted.h"
 
@@ -129,4 +129,4 @@ public:
 	SceneReplicationState() {}
 };
 
-#endif // SCENE_REPLICATON_STATE_H
+#endif // SCENE_REPLICATION_STATE_H

--- a/scene/register_scene_types.h
+++ b/scene/register_scene_types.h
@@ -36,4 +36,4 @@ void unregister_scene_types();
 
 void initialize_theme();
 
-#endif
+#endif // REGISTER_SCENE_TYPES_H

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -488,4 +488,4 @@ VARIANT_ENUM_CAST(Animation::UpdateMode);
 VARIANT_ENUM_CAST(Animation::HandleMode);
 VARIANT_ENUM_CAST(Animation::LoopMode);
 
-#endif
+#endif // ANIMATION_H

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -63,4 +63,4 @@ public:
 	AnimationLibrary();
 };
 
-#endif // ANIMATIONLIBRARY_H
+#endif // ANIMATION_LIBRARY_H

--- a/scene/resources/box_shape_3d.h
+++ b/scene/resources/box_shape_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef BOX_SHAPE_H
-#define BOX_SHAPE_H
+#ifndef BOX_SHAPE_3D_H
+#define BOX_SHAPE_3D_H
 
 #include "scene/resources/shape_3d.h"
 
@@ -56,4 +56,4 @@ public:
 	BoxShape3D();
 };
 
-#endif // BOX_SHAPE_H
+#endif // BOX_SHAPE_3D_H

--- a/scene/resources/capsule_shape_3d.h
+++ b/scene/resources/capsule_shape_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CAPSULE_SHAPE_H
-#define CAPSULE_SHAPE_H
+#ifndef CAPSULE_SHAPE_3D_H
+#define CAPSULE_SHAPE_3D_H
 
 #include "scene/resources/shape_3d.h"
 
@@ -55,4 +55,4 @@ public:
 	CapsuleShape3D();
 };
 
-#endif // CAPSULE_SHAPE_H
+#endif // CAPSULE_SHAPE_3D_H

--- a/scene/resources/concave_polygon_shape_2d.h
+++ b/scene/resources/concave_polygon_shape_2d.h
@@ -52,4 +52,4 @@ public:
 	ConcavePolygonShape2D();
 };
 
-#endif
+#endif // CONCAVE_POLYGON_SHAPE_2D_H

--- a/scene/resources/concave_polygon_shape_3d.h
+++ b/scene/resources/concave_polygon_shape_3d.h
@@ -77,4 +77,4 @@ public:
 	ConcavePolygonShape3D();
 };
 
-#endif // CONCAVE_POLYGON_SHAPE_H
+#endif // CONCAVE_POLYGON_SHAPE_3D_H

--- a/scene/resources/convex_polygon_shape_3d.h
+++ b/scene/resources/convex_polygon_shape_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CONVEX_POLYGON_SHAPE_H
-#define CONVEX_POLYGON_SHAPE_H
+#ifndef CONVEX_POLYGON_SHAPE_3D_H
+#define CONVEX_POLYGON_SHAPE_3D_H
 
 #include "scene/resources/shape_3d.h"
 
@@ -52,4 +52,4 @@ public:
 	ConvexPolygonShape3D();
 };
 
-#endif // CONVEX_POLYGON_SHAPE_H
+#endif // CONVEX_POLYGON_SHAPE_3D_H

--- a/scene/resources/cylinder_shape_3d.h
+++ b/scene/resources/cylinder_shape_3d.h
@@ -54,4 +54,4 @@ public:
 	CylinderShape3D();
 };
 
-#endif // CYLINDER_SHAPE_H
+#endif // CYLINDER_SHAPE_3D_H

--- a/scene/resources/default_theme/default_theme.h
+++ b/scene/resources/default_theme/default_theme.h
@@ -39,4 +39,4 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 void make_default_theme(float p_scale, Ref<Font> p_font, TextServer::SubpixelPositioning p_font_subpixel = TextServer::SUBPIXEL_POSITIONING_AUTO, TextServer::Hinting p_font_hinting = TextServer::HINTING_LIGHT, bool p_font_antialiased = true, bool p_font_msdf = false, bool p_font_generate_mipmaps = false);
 void clear_default_theme();
 
-#endif
+#endif // DEFAULT_THEME_H

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -381,4 +381,4 @@ public:
 	~FontVariation();
 };
 
-#endif /* FONT_H */
+#endif // FONT_H

--- a/scene/resources/height_map_shape_3d.h
+++ b/scene/resources/height_map_shape_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef HEIGHT_MAP_SHAPE_H
-#define HEIGHT_MAP_SHAPE_H
+#ifndef HEIGHT_MAP_SHAPE_3D_H
+#define HEIGHT_MAP_SHAPE_3D_H
 
 #include "scene/resources/shape_3d.h"
 
@@ -60,4 +60,4 @@ public:
 	HeightMapShape3D();
 };
 
-#endif /* !HEIGHT_MAP_SHAPE_H */
+#endif // HEIGHT_MAP_SHAPE_3D_H

--- a/scene/resources/immediate_mesh.h
+++ b/scene/resources/immediate_mesh.h
@@ -115,4 +115,4 @@ public:
 	~ImmediateMesh();
 };
 
-#endif // IMMEDIATEMESH_H
+#endif // IMMEDIATE_MESH_H

--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SCENE_IMPORTER_MESH_H
-#define SCENE_IMPORTER_MESH_H
+#ifndef IMPORTER_MESH_H
+#define IMPORTER_MESH_H
 
 #include "core/io/resource.h"
 #include "core/templates/local_vector.h"
@@ -130,4 +130,5 @@ public:
 	Ref<ArrayMesh> get_mesh(const Ref<ArrayMesh> &p_base = Ref<ArrayMesh>());
 	void clear();
 };
-#endif // SCENE_IMPORTER_MESH_H
+
+#endif // IMPORTER_MESH_H

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -809,4 +809,4 @@ public:
 
 //////////////////////
 
-#endif
+#endif // MATERIAL_H

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -362,4 +362,4 @@ public:
 	~PlaceholderMesh();
 };
 
-#endif
+#endif // MESH_H

--- a/scene/resources/multimesh.h
+++ b/scene/resources/multimesh.h
@@ -113,4 +113,4 @@ public:
 
 VARIANT_ENUM_CAST(MultiMesh::TransformFormat);
 
-#endif // MULTI_MESH_H
+#endif // MULTIMESH_H

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -249,4 +249,4 @@ public:
 
 VARIANT_ENUM_CAST(PackedScene::GenEditState)
 
-#endif // SCENE_PRELOADER_H
+#endif // PACKED_SCENE_H

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -595,4 +595,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(RibbonTrailMesh::Shape)
-#endif
+
+#endif // PRIMITIVE_MESHES_H

--- a/scene/resources/separation_ray_shape_3d.h
+++ b/scene/resources/separation_ray_shape_3d.h
@@ -28,8 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SEPARATION_RAY_SHAPE_H
-#define SEPARATION_RAY_SHAPE_H
+#ifndef SEPARATION_RAY_SHAPE_3D_H
+#define SEPARATION_RAY_SHAPE_3D_H
+
 #include "scene/resources/shape_3d.h"
 
 class SeparationRayShape3D : public Shape3D {
@@ -53,4 +54,5 @@ public:
 
 	SeparationRayShape3D();
 };
-#endif // SEPARATION_RAY_SHAPE_H
+
+#endif // SEPARATION_RAY_SHAPE_3D_H

--- a/scene/resources/shape_3d.h
+++ b/scene/resources/shape_3d.h
@@ -73,4 +73,4 @@ public:
 	~Shape3D();
 };
 
-#endif // SHAPE_H
+#endif // SHAPE_3D_H

--- a/scene/resources/skeleton_modification_2d.h
+++ b/scene/resources/skeleton_modification_2d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION2D_H
-#define SKELETONMODIFICATION2D_H
+#ifndef SKELETON_MODIFICATION_2D_H
+#define SKELETON_MODIFICATION_2D_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_stack_2d.h"
@@ -86,4 +86,4 @@ public:
 	SkeletonModification2D();
 };
 
-#endif // SKELETONMODIFICATION2D_H
+#endif // SKELETON_MODIFICATION_2D_H

--- a/scene/resources/skeleton_modification_2d_ccdik.h
+++ b/scene/resources/skeleton_modification_2d_ccdik.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION2DCCDIK_H
-#define SKELETONMODIFICATION2DCCDIK_H
+#ifndef SKELETON_MODIFICATION_2D_CCDIK_H
+#define SKELETON_MODIFICATION_2D_CCDIK_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_2d.h"
@@ -113,4 +113,4 @@ public:
 	~SkeletonModification2DCCDIK();
 };
 
-#endif // SKELETONMODIFICATION2DCCDIK_H
+#endif // SKELETON_MODIFICATION_2D_CCDIK_H

--- a/scene/resources/skeleton_modification_2d_fabrik.h
+++ b/scene/resources/skeleton_modification_2d_fabrik.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION2DFABRIK_H
-#define SKELETONMODIFICATION2DFABRIK_H
+#ifndef SKELETON_MODIFICATION_2D_FABRIK_H
+#define SKELETON_MODIFICATION_2D_FABRIK_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_2d.h"
@@ -105,4 +105,4 @@ public:
 	~SkeletonModification2DFABRIK();
 };
 
-#endif // SKELETONMODIFICATION2DFABRIK_H
+#endif // SKELETON_MODIFICATION_2D_FABRIK_H

--- a/scene/resources/skeleton_modification_2d_jiggle.h
+++ b/scene/resources/skeleton_modification_2d_jiggle.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION2DJIGGLE_H
-#define SKELETONMODIFICATION2DJIGGLE_H
+#ifndef SKELETON_MODIFICATION_2D_JIGGLE_H
+#define SKELETON_MODIFICATION_2D_JIGGLE_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_2d.h"
@@ -136,4 +136,4 @@ public:
 	~SkeletonModification2DJiggle();
 };
 
-#endif // SKELETONMODIFICATION2DJIGGLE_H
+#endif // SKELETON_MODIFICATION_2D_JIGGLE_H

--- a/scene/resources/skeleton_modification_2d_lookat.h
+++ b/scene/resources/skeleton_modification_2d_lookat.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION2DLOOKAT_H
-#define SKELETONMODIFICATION2DLOOKAT_H
+#ifndef SKELETON_MODIFICATION_2D_LOOKAT_H
+#define SKELETON_MODIFICATION_2D_LOOKAT_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_2d.h"
@@ -97,4 +97,4 @@ public:
 	~SkeletonModification2DLookAt();
 };
 
-#endif // SKELETONMODIFICATION2DLOOKAT_H
+#endif // SKELETON_MODIFICATION_2D_LOOKAT_H

--- a/scene/resources/skeleton_modification_2d_physicalbones.h
+++ b/scene/resources/skeleton_modification_2d_physicalbones.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION2DPHYSICALBONES_H
-#define SKELETONMODIFICATION2DPHYSICALBONES_H
+#ifndef SKELETON_MODIFICATION_2D_PHYSICALBONES_H
+#define SKELETON_MODIFICATION_2D_PHYSICALBONES_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_2d.h"
@@ -79,4 +79,4 @@ public:
 	~SkeletonModification2DPhysicalBones();
 };
 
-#endif // SKELETONMODIFICATION2DPHYSICALBONES_H
+#endif // SKELETON_MODIFICATION_2D_PHYSICALBONES_H

--- a/scene/resources/skeleton_modification_2d_stackholder.h
+++ b/scene/resources/skeleton_modification_2d_stackholder.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION2DSTACKHOLDER_H
-#define SKELETONMODIFICATION2DSTACKHOLDER_H
+#ifndef SKELETON_MODIFICATION_2D_STACKHOLDER_H
+#define SKELETON_MODIFICATION_2D_STACKHOLDER_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_2d.h"
@@ -61,4 +61,4 @@ public:
 	~SkeletonModification2DStackHolder();
 };
 
-#endif // SKELETONMODIFICATION2DSTACKHOLDER_H
+#endif // SKELETON_MODIFICATION_2D_STACKHOLDER_H

--- a/scene/resources/skeleton_modification_2d_twoboneik.h
+++ b/scene/resources/skeleton_modification_2d_twoboneik.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION2DTWOBONEIK_H
-#define SKELETONMODIFICATION2DTWOBONEIK_H
+#ifndef SKELETON_MODIFICATION_2D_TWOBONEIK_H
+#define SKELETON_MODIFICATION_2D_TWOBONEIK_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_2d.h"
@@ -104,4 +104,4 @@ public:
 	~SkeletonModification2DTwoBoneIK();
 };
 
-#endif // SKELETONMODIFICATION2DTWOBONEIK_H
+#endif // SKELETON_MODIFICATION_2D_TWOBONEIK_H

--- a/scene/resources/skeleton_modification_3d.h
+++ b/scene/resources/skeleton_modification_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATION3D_H
-#define SKELETONMODIFICATION3D_H
+#ifndef SKELETON_MODIFICATION_3D_H
+#define SKELETON_MODIFICATION_3D_H
 
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/skeleton_modification_stack_3d.h"
@@ -76,4 +76,4 @@ public:
 	SkeletonModification3D();
 };
 
-#endif // SKELETONMODIFICATION3D_H
+#endif // SKELETON_MODIFICATION_3D_H

--- a/scene/resources/skeleton_modification_3d_ccdik.h
+++ b/scene/resources/skeleton_modification_3d_ccdik.h
@@ -32,8 +32,8 @@
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/skeleton_modification_3d.h"
 
-#ifndef SKELETONMODIFICATION3DCCDIK_H
-#define SKELETONMODIFICATION3DCCDIK_H
+#ifndef SKELETON_MODIFICATION_3D_CCDIK_H
+#define SKELETON_MODIFICATION_3D_CCDIK_H
 
 class SkeletonModification3DCCDIK : public SkeletonModification3D {
 	GDCLASS(SkeletonModification3DCCDIK, SkeletonModification3D);
@@ -111,4 +111,4 @@ public:
 	~SkeletonModification3DCCDIK();
 };
 
-#endif //SKELETONMODIFICATION3DCCDIK_H
+#endif // SKELETON_MODIFICATION_3D_CCDIK_H

--- a/scene/resources/skeleton_modification_3d_fabrik.h
+++ b/scene/resources/skeleton_modification_3d_fabrik.h
@@ -32,8 +32,8 @@
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/skeleton_modification_3d.h"
 
-#ifndef SKELETONMODIFICATION3DFABRIK_H
-#define SKELETONMODIFICATION3DFABRIK_H
+#ifndef SKELETON_MODIFICATION_3D_FABRIK_H
+#define SKELETON_MODIFICATION_3D_FABRIK_H
 
 class SkeletonModification3DFABRIK : public SkeletonModification3D {
 	GDCLASS(SkeletonModification3DFABRIK, SkeletonModification3D);
@@ -121,4 +121,4 @@ public:
 	~SkeletonModification3DFABRIK();
 };
 
-#endif //SKELETONMODIFICATION3DFABRIK_H
+#endif // SKELETON_MODIFICATION_3D_FABRIK_H

--- a/scene/resources/skeleton_modification_3d_jiggle.h
+++ b/scene/resources/skeleton_modification_3d_jiggle.h
@@ -32,8 +32,8 @@
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/skeleton_modification_3d.h"
 
-#ifndef SKELETONMODIFICATION3DJIGGLE_H
-#define SKELETONMODIFICATION3DJIGGLE_H
+#ifndef SKELETON_MODIFICATION_3D_JIGGLE_H
+#define SKELETON_MODIFICATION_3D_JIGGLE_H
 
 class SkeletonModification3DJiggle : public SkeletonModification3D {
 	GDCLASS(SkeletonModification3DJiggle, SkeletonModification3D);
@@ -135,4 +135,4 @@ public:
 	~SkeletonModification3DJiggle();
 };
 
-#endif //SKELETONMODIFICATION3DJIGGLE_H
+#endif // SKELETON_MODIFICATION_3D_JIGGLE_H

--- a/scene/resources/skeleton_modification_3d_lookat.h
+++ b/scene/resources/skeleton_modification_3d_lookat.h
@@ -31,8 +31,8 @@
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/skeleton_modification_3d.h"
 
-#ifndef SKELETONMODIFICATION3DLOOKAT_H
-#define SKELETONMODIFICATION3DLOOKAT_H
+#ifndef SKELETON_MODIFICATION_3D_LOOKAT_H
+#define SKELETON_MODIFICATION_3D_LOOKAT_H
 
 class SkeletonModification3DLookAt : public SkeletonModification3D {
 	GDCLASS(SkeletonModification3DLookAt, SkeletonModification3D);
@@ -86,4 +86,4 @@ public:
 	~SkeletonModification3DLookAt();
 };
 
-#endif //SKELETONMODIFICATION3DLOOKAT_H
+#endif // SKELETON_MODIFICATION_3D_LOOKAT_H

--- a/scene/resources/skeleton_modification_3d_stackholder.h
+++ b/scene/resources/skeleton_modification_3d_stackholder.h
@@ -31,8 +31,8 @@
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/skeleton_modification_3d.h"
 
-#ifndef SKELETONMODIFICATION3DSTACKHOLDER_H
-#define SKELETONMODIFICATION3DSTACKHOLDER_H
+#ifndef SKELETON_MODIFICATION_3D_STACKHOLDER_H
+#define SKELETON_MODIFICATION_3D_STACKHOLDER_H
 
 class SkeletonModification3DStackHolder : public SkeletonModification3D {
 	GDCLASS(SkeletonModification3DStackHolder, SkeletonModification3D);
@@ -56,4 +56,4 @@ public:
 	~SkeletonModification3DStackHolder();
 };
 
-#endif //SKELETONMODIFICATION3DSTACKHOLDER_H
+#endif // SKELETON_MODIFICATION_3D_STACKHOLDER_H

--- a/scene/resources/skeleton_modification_3d_twoboneik.h
+++ b/scene/resources/skeleton_modification_3d_twoboneik.h
@@ -31,8 +31,8 @@
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/skeleton_modification_3d.h"
 
-#ifndef SKELETONMODIFICATION3DTWOBONEIK_H
-#define SKELETONMODIFICATION3DTWOBONEIK_H
+#ifndef SKELETON_MODIFICATION_3D_TWOBONEIK_H
+#define SKELETON_MODIFICATION_3D_TWOBONEIK_H
 
 class SkeletonModification3DTwoBoneIK : public SkeletonModification3D {
 	GDCLASS(SkeletonModification3DTwoBoneIK, SkeletonModification3D);
@@ -115,4 +115,4 @@ public:
 	~SkeletonModification3DTwoBoneIK();
 };
 
-#endif //SKELETONMODIFICATION3DTWOBONEIK_H
+#endif // SKELETON_MODIFICATION_3D_TWOBONEIK_H

--- a/scene/resources/skeleton_modification_stack_2d.h
+++ b/scene/resources/skeleton_modification_stack_2d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATIONSTACK2D_H
-#define SKELETONMODIFICATIONSTACK2D_H
+#ifndef SKELETON_MODIFICATION_STACK_2D_H
+#define SKELETON_MODIFICATION_STACK_2D_H
 
 #include "scene/2d/skeleton_2d.h"
 #include "scene/resources/skeleton_modification_2d.h"
@@ -96,4 +96,4 @@ public:
 	SkeletonModificationStack2D();
 };
 
-#endif // SKELETONMODIFICATION2D_H
+#endif // SKELETON_MODIFICATION_STACK_2D_H

--- a/scene/resources/skeleton_modification_stack_3d.h
+++ b/scene/resources/skeleton_modification_stack_3d.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SKELETONMODIFICATIONSTACK3D_H
-#define SKELETONMODIFICATIONSTACK3D_H
+#ifndef SKELETON_MODIFICATION_STACK_3D_H
+#define SKELETON_MODIFICATION_STACK_3D_H
 
 #include "core/templates/local_vector.h"
 #include "scene/3d/skeleton_3d.h"
@@ -88,4 +88,4 @@ public:
 	SkeletonModificationStack3D();
 };
 
-#endif // SKELETONMODIFICATIONSTACK3D_H
+#endif // SKELETON_MODIFICATION_STACK_3D_H

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -219,4 +219,4 @@ public:
 	~PhysicalSkyMaterial();
 };
 
-#endif /* !SKY_MATERIAL_H */
+#endif // SKY_MATERIAL_H

--- a/scene/resources/sphere_shape_3d.h
+++ b/scene/resources/sphere_shape_3d.h
@@ -52,4 +52,4 @@ public:
 	SphereShape3D();
 };
 
-#endif // SPHERE_SHAPE_H
+#endif // SPHERE_SHAPE_3D_H

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -264,4 +264,4 @@ public:
 	~StyleBoxLine();
 };
 
-#endif
+#endif // STYLE_BOX_H

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -207,4 +207,4 @@ public:
 VARIANT_ENUM_CAST(SurfaceTool::CustomFormat)
 VARIANT_ENUM_CAST(SurfaceTool::SkinWeightCount)
 
-#endif
+#endif // SURFACE_TOOL_H

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -142,4 +142,4 @@ public:
 	Color get_member_variable_color() const;
 };
 
-#endif
+#endif // SYNTAX_HIGHLIGHTER_H

--- a/scene/resources/text_file.h
+++ b/scene/resources/text_file.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef TEXTFILE_H
-#define TEXTFILE_H
+#ifndef TEXT_FILE_H
+#define TEXT_FILE_H
 
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
@@ -51,4 +51,4 @@ public:
 	Error load_text(const String &p_path);
 };
 
-#endif // TEXTFILE_H
+#endif // TEXT_FILE_H

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -1106,4 +1106,4 @@ public:
 			PlaceholderTextureLayered(LAYERED_TYPE_CUBEMAP_ARRAY) {}
 };
 
-#endif
+#endif // TEXTURE_H

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -256,4 +256,4 @@ public:
 
 VARIANT_ENUM_CAST(Theme::DataType);
 
-#endif
+#endif // THEME_H

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -75,4 +75,4 @@ public:
 	virtual Ref<VideoStreamPlayback> instantiate_playback() = 0;
 };
 
-#endif
+#endif // VIDEO_STREAM_H

--- a/scene/resources/visual_shader_particle_nodes.h
+++ b/scene/resources/visual_shader_particle_nodes.h
@@ -352,4 +352,4 @@ public:
 
 VARIANT_ENUM_CAST(VisualShaderNodeParticleEmit::EmitFlags)
 
-#endif
+#endif // VISUAL_SHADER_PARTICLE_NODES_H

--- a/scene/resources/world_boundary_shape_3d.h
+++ b/scene/resources/world_boundary_shape_3d.h
@@ -53,4 +53,5 @@ public:
 
 	WorldBoundaryShape3D();
 };
-#endif // WORLD_BOUNDARY_SHAPE_H
+
+#endif // WORLD_BOUNDARY_SHAPE_3D_H

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -85,4 +85,4 @@ public:
 	~AudioDriverDummy() {}
 };
 
-#endif
+#endif // AUDIO_DRIVER_DUMMY_H

--- a/servers/audio/audio_effect.h
+++ b/servers/audio/audio_effect.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECT_H
-#define AUDIOEFFECT_H
+#ifndef AUDIO_EFFECT_H
+#define AUDIO_EFFECT_H
 
 #include "core/io/resource.h"
 #include "core/math/audio_frame.h"
@@ -62,4 +62,4 @@ public:
 	AudioEffect();
 };
 
-#endif // AUDIOEFFECT_H
+#endif // AUDIO_EFFECT_H

--- a/servers/audio/effects/audio_effect_amplify.h
+++ b/servers/audio/effects/audio_effect_amplify.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTAMPLIFY_H
-#define AUDIOEFFECTAMPLIFY_H
+#ifndef AUDIO_EFFECT_AMPLIFY_H
+#define AUDIO_EFFECT_AMPLIFY_H
 
 #include "servers/audio/audio_effect.h"
 
@@ -63,4 +63,4 @@ public:
 	AudioEffectAmplify();
 };
 
-#endif // AUDIOEFFECTAMPLIFY_H
+#endif // AUDIO_EFFECT_AMPLIFY_H

--- a/servers/audio/effects/audio_effect_chorus.h
+++ b/servers/audio/effects/audio_effect_chorus.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTCHORUS_H
-#define AUDIOEFFECTCHORUS_H
+#ifndef AUDIO_EFFECT_CHORUS_H
+#define AUDIO_EFFECT_CHORUS_H
 
 #include "servers/audio/audio_effect.h"
 
@@ -133,4 +133,4 @@ public:
 	AudioEffectChorus();
 };
 
-#endif // AUDIOEFFECTCHORUS_H
+#endif // AUDIO_EFFECT_CHORUS_H

--- a/servers/audio/effects/audio_effect_compressor.h
+++ b/servers/audio/effects/audio_effect_compressor.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTCOMPRESSOR_H
-#define AUDIOEFFECTCOMPRESSOR_H
+#ifndef AUDIO_EFFECT_COMPRESSOR_H
+#define AUDIO_EFFECT_COMPRESSOR_H
 
 #include "servers/audio/audio_effect.h"
 
@@ -91,4 +91,4 @@ public:
 	AudioEffectCompressor();
 };
 
-#endif // AUDIOEFFECTCOMPRESSOR_H
+#endif // AUDIO_EFFECT_COMPRESSOR_H

--- a/servers/audio/effects/audio_effect_delay.h
+++ b/servers/audio/effects/audio_effect_delay.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTDELAY_H
-#define AUDIOEFFECTDELAY_H
+#ifndef AUDIO_EFFECT_DELAY_H
+#define AUDIO_EFFECT_DELAY_H
 
 #include "servers/audio/audio_effect.h"
 
@@ -131,4 +131,4 @@ public:
 	AudioEffectDelay();
 };
 
-#endif // AUDIOEFFECTDELAY_H
+#endif // AUDIO_EFFECT_DELAY_H

--- a/servers/audio/effects/audio_effect_distortion.h
+++ b/servers/audio/effects/audio_effect_distortion.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTDISTORTION_H
-#define AUDIOEFFECTDISTORTION_H
+#ifndef AUDIO_EFFECT_DISTORTION_H
+#define AUDIO_EFFECT_DISTORTION_H
 
 #include "servers/audio/audio_effect.h"
 
@@ -90,4 +90,4 @@ public:
 
 VARIANT_ENUM_CAST(AudioEffectDistortion::Mode)
 
-#endif // AUDIOEFFECTDISTORTION_H
+#endif // AUDIO_EFFECT_DISTORTION_H

--- a/servers/audio/effects/audio_effect_eq.cpp
+++ b/servers/audio/effects/audio_effect_eq.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "audio_effect_eq.h"
+
 #include "servers/audio_server.h"
 
 void AudioEffectEQInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {

--- a/servers/audio/effects/audio_effect_eq.h
+++ b/servers/audio/effects/audio_effect_eq.h
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTEQ_H
-#define AUDIOEFFECTEQ_H
+#ifndef AUDIO_EFFECT_EQ_H
+#define AUDIO_EFFECT_EQ_H
 
 #include "servers/audio/audio_effect.h"
-#include "servers/audio/effects/eq.h"
+#include "servers/audio/effects/eq_filter.h"
 
 class AudioEffectEQ;
 
@@ -98,4 +98,4 @@ public:
 			AudioEffectEQ(EQ::PRESET_21_BANDS) {}
 };
 
-#endif // AUDIOEFFECTEQ_H
+#endif // AUDIO_EFFECT_EQ_H

--- a/servers/audio/effects/audio_effect_filter.h
+++ b/servers/audio/effects/audio_effect_filter.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTFILTER_H
-#define AUDIOEFFECTFILTER_H
+#ifndef AUDIO_EFFECT_FILTER_H
+#define AUDIO_EFFECT_FILTER_H
 
 #include "servers/audio/audio_effect.h"
 #include "servers/audio/audio_filter_sw.h"
@@ -167,4 +167,4 @@ public:
 			AudioEffectFilter(AudioFilterSW::HIGHSHELF) {}
 };
 
-#endif // AUDIOEFFECTFILTER_H
+#endif // AUDIO_EFFECT_FILTER_H

--- a/servers/audio/effects/audio_effect_panner.h
+++ b/servers/audio/effects/audio_effect_panner.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTPANNER_H
-#define AUDIOEFFECTPANNER_H
+#ifndef AUDIO_EFFECT_PANNER_H
+#define AUDIO_EFFECT_PANNER_H
 
 #include "servers/audio/audio_effect.h"
 
@@ -61,4 +61,4 @@ public:
 	AudioEffectPanner();
 };
 
-#endif // AUDIOEFFECTPANNER_H
+#endif // AUDIO_EFFECT_PANNER_H

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTRECORD_H
-#define AUDIOEFFECTRECORD_H
+#ifndef AUDIO_EFFECT_RECORD_H
+#define AUDIO_EFFECT_RECORD_H
 
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
@@ -103,4 +103,4 @@ public:
 	AudioEffectRecord();
 };
 
-#endif // AUDIOEFFECTRECORD_H
+#endif // AUDIO_EFFECT_RECORD_H

--- a/servers/audio/effects/audio_effect_reverb.h
+++ b/servers/audio/effects/audio_effect_reverb.h
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTREVERB_H
-#define AUDIOEFFECTREVERB_H
+#ifndef AUDIO_EFFECT_REVERB_H
+#define AUDIO_EFFECT_REVERB_H
 
 #include "servers/audio/audio_effect.h"
-#include "servers/audio/effects/reverb.h"
+#include "servers/audio/effects/reverb_filter.h"
 
 class AudioEffectReverb;
 
@@ -94,4 +94,4 @@ public:
 	AudioEffectReverb();
 };
 
-#endif // AUDIOEFFECTREVERB_H
+#endif // AUDIO_EFFECT_REVERB_H

--- a/servers/audio/effects/audio_stream_generator.h
+++ b/servers/audio/effects/audio_stream_generator.h
@@ -95,4 +95,5 @@ public:
 
 	AudioStreamGeneratorPlayback();
 };
+
 #endif // AUDIO_STREAM_GENERATOR_H

--- a/servers/audio/effects/eq_filter.cpp
+++ b/servers/audio/effects/eq_filter.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  eq.cpp                                                               */
+/*  eq_filter.cpp                                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-// Author: reduzio@gmail.com (C) 2006
+#include "eq_filter.h"
 
-#include "eq.h"
 #include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
+
 #include <math.h>
 
 #define POW2(v) ((v) * (v))

--- a/servers/audio/effects/reverb_filter.cpp
+++ b/servers/audio/effects/reverb_filter.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  reverb.cpp                                                           */
+/*  reverb_filter.cpp                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "reverb.h"
+#include "reverb_filter.h"
 
 #include "core/math/math_funcs.h"
 

--- a/servers/debugger/servers_debugger.h
+++ b/servers/debugger/servers_debugger.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SERVER_DEBUGGER_H
-#define SERVER_DEBUGGER_H
+#ifndef SERVERS_DEBUGGER_H
+#define SERVERS_DEBUGGER_H
 
 #include "core/debugger/debugger_marshalls.h"
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -545,4 +545,4 @@ public:
 	~PhysicsServer3DExtension();
 };
 
-#endif // PHYSICSSERVER3DEXTENSION_H
+#endif // PHYSICS_SERVER_3D_EXTENSION_H

--- a/servers/physics_3d/gjk_epa.h
+++ b/servers/physics_3d/gjk_epa.h
@@ -37,4 +37,4 @@
 bool gjk_epa_calculate_penetration(const GodotShape3D *p_shape_A, const Transform3D &p_transform_A, const GodotShape3D *p_shape_B, const Transform3D &p_transform_B, GodotCollisionSolver3D::CallbackResult p_result_callback, void *p_userdata, bool p_swap = false, real_t p_margin_A = 0.0, real_t p_margin_B = 0.0);
 bool gjk_epa_calculate_distance(const GodotShape3D *p_shape_A, const Transform3D &p_transform_A, const GodotShape3D *p_shape_B, const Transform3D &p_transform_B, Vector3 &r_result_A, Vector3 &r_result_B);
 
-#endif
+#endif // GJK_EPA_H

--- a/servers/physics_3d/godot_collision_solver_3d_sat.h
+++ b/servers/physics_3d/godot_collision_solver_3d_sat.h
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_COLLISION_SOLVER_SAT_H
-#define GODOT_COLLISION_SOLVER_SAT_H
+#ifndef GODOT_COLLISION_SOLVER_3D_SAT_H
+#define GODOT_COLLISION_SOLVER_3D_SAT_H
 
 #include "godot_collision_solver_3d.h"
 
 bool sat_calculate_penetration(const GodotShape3D *p_shape_A, const Transform3D &p_transform_A, const GodotShape3D *p_shape_B, const Transform3D &p_transform_B, GodotCollisionSolver3D::CallbackResult p_result_callback, void *p_userdata, bool p_swap = false, Vector3 *r_prev_axis = nullptr, real_t p_margin_a = 0, real_t p_margin_b = 0);
 
-#endif // GODOT_COLLISION_SOLVER_SAT_H
+#endif // GODOT_COLLISION_SOLVER_3D_SAT_H

--- a/servers/rendering/dummy/environment/fog.h
+++ b/servers/rendering/dummy/environment/fog.h
@@ -52,4 +52,4 @@ public:
 
 } // namespace RendererDummy
 
-#endif // !FOG_DUMMY_H
+#endif // FOG_DUMMY_H

--- a/servers/rendering/dummy/environment/gi.h
+++ b/servers/rendering/dummy/environment/gi.h
@@ -79,4 +79,4 @@ public:
 
 } // namespace RendererDummy
 
-#endif // !GI_DUMMY_H
+#endif // GI_DUMMY_H

--- a/servers/rendering/dummy/rasterizer_canvas_dummy.h
+++ b/servers/rendering/dummy/rasterizer_canvas_dummy.h
@@ -60,4 +60,4 @@ public:
 	~RasterizerCanvasDummy() {}
 };
 
-#endif // !RASTERIZER_CANVAS_DUMMY_H
+#endif // RASTERIZER_CANVAS_DUMMY_H

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -214,4 +214,4 @@ public:
 	~RasterizerSceneDummy() {}
 };
 
-#endif // !RASTERIZER_SCENE_DUMMY_H
+#endif // RASTERIZER_SCENE_DUMMY_H

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -132,4 +132,4 @@ public:
 
 } // namespace RendererDummy
 
-#endif // !LIGHT_STORAGE_DUMMY_H
+#endif // LIGHT_STORAGE_DUMMY_H

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -95,4 +95,4 @@ public:
 
 } // namespace RendererDummy
 
-#endif // !MATERIAL_STORAGE_DUMMY_H
+#endif // MATERIAL_STORAGE_DUMMY_H

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -131,4 +131,4 @@ public:
 
 } // namespace RendererDummy
 
-#endif // !MESH_STORAGE_DUMMY_H
+#endif // MESH_STORAGE_DUMMY_H

--- a/servers/rendering/dummy/storage/particles_storage.h
+++ b/servers/rendering/dummy/storage/particles_storage.h
@@ -123,4 +123,4 @@ public:
 
 } // namespace RendererDummy
 
-#endif // !PARTICLES_STORAGE_DUMMY_H
+#endif // PARTICLES_STORAGE_DUMMY_H

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -176,4 +176,4 @@ public:
 
 } // namespace RendererDummy
 
-#endif // !TEXTURE_STORAGE_DUMMY_H
+#endif // TEXTURE_STORAGE_DUMMY_H

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -95,4 +95,4 @@ public:
 
 } // namespace RendererDummy
 
-#endif // !UTILITIES_DUMMY_H
+#endif // UTILITIES_DUMMY_H

--- a/servers/rendering/environment/renderer_fog.h
+++ b/servers/rendering/environment/renderer_fog.h
@@ -50,4 +50,4 @@ public:
 	virtual RS::FogVolumeShape fog_volume_get_shape(RID p_fog_volume) const = 0;
 };
 
-#endif // !RENDERER_FOG_H
+#endif // RENDERER_FOG_H

--- a/servers/rendering/environment/renderer_gi.h
+++ b/servers/rendering/environment/renderer_gi.h
@@ -78,4 +78,4 @@ public:
 	virtual uint32_t voxel_gi_get_version(RID p_probe) const = 0;
 };
 
-#endif // !RENDERER_GI_H
+#endif // RENDERER_GI_H

--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_CANVAS_CULL_H
-#define RENDERING_SERVER_CANVAS_CULL_H
+#ifndef RENDERER_CANVAS_CULL_H
+#define RENDERER_CANVAS_CULL_H
 
 #include "core/templates/paged_allocator.h"
 #include "renderer_compositor.h"
@@ -317,4 +317,4 @@ public:
 	~RendererCanvasCull();
 };
 
-#endif // RENDERING_SERVER_CANVAS_CULL_H
+#endif // RENDERER_CANVAS_CULL_H

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERINGSERVERCANVASRENDER_H
-#define RENDERINGSERVERCANVASRENDER_H
+#ifndef RENDERER_CANVAS_RENDER_H
+#define RENDERER_CANVAS_RENDER_H
 
 #include "servers/rendering_server.h"
 
@@ -520,4 +520,4 @@ public:
 	virtual ~RendererCanvasRender() {}
 };
 
-#endif // RENDERINGSERVERCANVASRENDER_H
+#endif // RENDERER_CANVAS_RENDER_H

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_COMPOSITOR_H
-#define RENDERING_SERVER_COMPOSITOR_H
+#ifndef RENDERER_COMPOSITOR_H
+#define RENDERER_COMPOSITOR_H
 
 #include "servers/rendering/environment/renderer_fog.h"
 #include "servers/rendering/environment/renderer_gi.h"
@@ -109,4 +109,4 @@ public:
 	virtual ~RendererCompositor() {}
 };
 
-#endif // RASTERIZER_H
+#endif // RENDERER_COMPOSITOR_H

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -375,4 +375,4 @@ public:
 	~ClusterBuilderRD();
 };
 
-#endif // CLUSTER_BUILDER_H
+#endif // CLUSTER_BUILDER_RD_H

--- a/servers/rendering/renderer_rd/effects/bokeh_dof.h
+++ b/servers/rendering/renderer_rd/effects/bokeh_dof.h
@@ -117,4 +117,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !BOKEH_DOF_RD_H
+#endif // BOKEH_DOF_RD_H

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef COPY_RD_H
-#define COPY_RD_H
+#ifndef COPY_EFFECTS_RD_H
+#define COPY_EFFECTS_RD_H
 
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
 #include "servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl.gen.h"
@@ -343,4 +343,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !COPY_RD_H
+#endif // COPY_EFFECTS_RD_H

--- a/servers/rendering/renderer_rd/effects/resolve.h
+++ b/servers/rendering/renderer_rd/effects/resolve.h
@@ -71,4 +71,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !RESOLVE_RD_H
+#endif // RESOLVE_RD_H

--- a/servers/rendering/renderer_rd/effects/ss_effects.h
+++ b/servers/rendering/renderer_rd/effects/ss_effects.h
@@ -505,4 +505,4 @@ private:
 
 } // namespace RendererRD
 
-#endif // !SS_EFFECTS_RD_H
+#endif // SS_EFFECTS_RD_H

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -149,4 +149,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !TONE_MAPPER_RD_H
+#endif // TONE_MAPPER_RD_H

--- a/servers/rendering/renderer_rd/effects/vrs.h
+++ b/servers/rendering/renderer_rd/effects/vrs.h
@@ -72,4 +72,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !VRS_RD_H
+#endif // VRS_RD_H

--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -246,4 +246,4 @@ public:
 	~EffectsRD();
 };
 
-#endif // !RASTERIZER_EFFECTS_RD_H
+#endif // EFFECTS_RD_H

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -80,4 +80,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !FOG_RD_H
+#endif // FOG_RD_H

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -786,4 +786,4 @@ public:
 
 } // namespace RendererRD
 
-#endif /* !GI_RD_H */
+#endif // GI_RD_H

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_SCENE_RENDER_FORWARD_CLUSTERED_H
-#define RENDERING_SERVER_SCENE_RENDER_FORWARD_CLUSTERED_H
+#ifndef RENDER_FORWARD_CLUSTERED_H
+#define RENDER_FORWARD_CLUSTERED_H
 
 #include "core/templates/paged_allocator.h"
 #include "servers/rendering/renderer_rd/effects/resolve.h"
@@ -693,4 +693,5 @@ public:
 	~RenderForwardClustered();
 };
 } // namespace RendererSceneRenderImplementation
-#endif // !RENDERING_SERVER_SCENE_RENDER_FORWARD_CLUSTERED_H
+
+#endif // RENDER_FORWARD_CLUSTERED_H

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RSSR_SCENE_SHADER_FC_H
-#define RSSR_SCENE_SHADER_FC_H
+#ifndef SCENE_SHADER_FORWARD_CLUSTERED_H
+#define SCENE_SHADER_FORWARD_CLUSTERED_H
 
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl.gen.h"
@@ -252,4 +252,5 @@ public:
 };
 
 } // namespace RendererSceneRenderImplementation
-#endif // !RSSR_SCENE_SHADER_FM_H
+
+#endif // SCENE_SHADER_FORWARD_CLUSTERED_H

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_SCENE_RENDER_FORWARD_MOBILE_H
-#define RENDERING_SERVER_SCENE_RENDER_FORWARD_MOBILE_H
+#ifndef RENDER_FORWARD_MOBILE_H
+#define RENDER_FORWARD_MOBILE_H
 
 #include "core/templates/paged_allocator.h"
 #include "servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h"
@@ -674,4 +674,5 @@ public:
 	~RenderForwardMobile();
 };
 } // namespace RendererSceneRenderImplementation
-#endif // !RENDERING_SERVER_SCENE_RENDER_FORWARD_MOBILE_H
+
+#endif // RENDER_FORWARD_MOBILE_H

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RSSR_SCENE_SHADER_FM_H
-#define RSSR_SCENE_SHADER_FM_H
+#ifndef SCENE_SHADER_FORWARD_MOBILE_H
+#define SCENE_SHADER_FORWARD_MOBILE_H
 
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl.gen.h"
@@ -212,4 +212,5 @@ public:
 };
 
 } // namespace RendererSceneRenderImplementation
-#endif // !RSSR_SCENE_SHADER_FM_H
+
+#endif // SCENE_SHADER_FORWARD_MOBILE_H

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.h
@@ -97,4 +97,4 @@ public:
 	~PipelineCacheRD();
 };
 
-#endif // RENDER_PIPELINE_CACHE_RD_H
+#endif // PIPELINE_CACHE_RD_H

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_CANVAS_RENDER_RD_H
-#define RENDERING_SERVER_CANVAS_RENDER_RD_H
+#ifndef RENDERER_CANVAS_RENDER_RD_H
+#define RENDERER_CANVAS_RENDER_RD_H
 
 #include "servers/rendering/renderer_canvas_render.h"
 #include "servers/rendering/renderer_compositor.h"
@@ -465,4 +465,4 @@ public:
 	~RendererCanvasRenderRD();
 };
 
-#endif // RASTERIZER_CANVAS_RD_H
+#endif // RENDERER_CANVAS_RENDER_RD_H

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_COMPOSITOR_RD_H
-#define RENDERING_SERVER_COMPOSITOR_RD_H
+#ifndef RENDERER_COMPOSITOR_RD_H
+#define RENDERER_COMPOSITOR_RD_H
 
 #include "core/os/os.h"
 #include "core/templates/thread_work_pool.h"
@@ -148,4 +148,5 @@ public:
 	RendererCompositorRD();
 	~RendererCompositorRD();
 };
-#endif // RASTERIZER_RD_H
+
+#endif // RENDERER_COMPOSITOR_RD_H

--- a/servers/rendering/renderer_rd/renderer_scene_environment_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_environment_rd.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_SCENE_ENVIRONMENT_RD_H
-#define RENDERING_SERVER_SCENE_ENVIRONMENT_RD_H
+#ifndef RENDERER_SCENE_ENVIRONMENT_RD_H
+#define RENDERER_SCENE_ENVIRONMENT_RD_H
 
 #include "servers/rendering/renderer_scene_render.h"
 #include "servers/rendering/rendering_device.h"
@@ -164,4 +164,4 @@ public:
 	void set_ssao(bool p_enable, float p_radius, float p_intensity, float p_power, float p_detail, float p_horizon, float p_sharpness, float p_light_affect, float p_ao_channel_affect);
 };
 
-#endif /* !RENDERING_SERVER_SCENE_ENVIRONMENT_RD_H */
+#endif // RENDERER_SCENE_ENVIRONMENT_RD_H

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_SCENE_RENDER_RD_H
-#define RENDERING_SERVER_SCENE_RENDER_RD_H
+#ifndef RENDERER_SCENE_RENDER_RD_H
+#define RENDERER_SCENE_RENDER_RD_H
 
 #include "core/templates/local_vector.h"
 #include "core/templates/rid_owner.h"
@@ -1489,4 +1489,4 @@ public:
 	~RendererSceneRenderRD();
 };
 
-#endif // RASTERIZER_SCENE_RD_H
+#endif // RENDERER_SCENE_RENDER_RD_H

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_SCENE_SKY_RD_H
-#define RENDERING_SERVER_SCENE_SKY_RD_H
+#ifndef RENDERER_SCENE_SKY_RD_H
+#define RENDERER_SCENE_SKY_RD_H
 
 #include "core/templates/rid_owner.h"
 #include "servers/rendering/renderer_compositor.h"
@@ -318,4 +318,4 @@ public:
 	RID sky_get_radiance_texture_rd(RID p_sky) const;
 };
 
-#endif /* RENDERING_SERVER_SCENE_SKY_RD_H */
+#endif // RENDERER_SCENE_SKY_RD_H

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -368,4 +368,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !LIGHT_STORAGE_RD_H
+#endif // LIGHT_STORAGE_RD_H

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -424,4 +424,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !MATERIAL_STORAGE_RD_H
+#endif // MATERIAL_STORAGE_RD_H

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -703,4 +703,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !MESH_STORAGE_RD_H
+#endif // MESH_STORAGE_RD_H

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -562,4 +562,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !PARTICLES_STORAGE_RD_H
+#endif // PARTICLES_STORAGE_RD_H

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -576,4 +576,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !_TEXTURE_STORAGE_RD_H
+#endif // TEXTURE_STORAGE_RD_H

--- a/servers/rendering/renderer_rd/storage_rd/utilities.h
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.h
@@ -119,4 +119,4 @@ public:
 
 } // namespace RendererRD
 
-#endif // !UTILITIES_RD_H
+#endif // UTILITIES_RD_H

--- a/servers/rendering/renderer_rd/uniform_set_cache_rd.h
+++ b/servers/rendering/renderer_rd/uniform_set_cache_rd.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef UNIFORM_SET_CACHE_H
-#define UNIFORM_SET_CACHE_H
+#ifndef UNIFORM_SET_CACHE_RD_H
+#define UNIFORM_SET_CACHE_RD_H
 
 #include "core/templates/local_vector.h"
 #include "core/templates/paged_allocator.h"
@@ -220,4 +220,4 @@ public:
 	~UniformSetCacheRD();
 };
 
-#endif // UNIFORMSETCACHE_H
+#endif // UNIFORM_SET_CACHE_RD_H

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERINGSERVERSCENE_H
-#define RENDERINGSERVERSCENE_H
+#ifndef RENDERER_SCENE_H
+#define RENDERER_SCENE_H
 
 #include "servers/rendering_server.h"
 #include "servers/xr/xr_interface.h"
@@ -226,4 +226,4 @@ public:
 	virtual ~RendererScene();
 };
 
-#endif // RENDERINGSERVERSCENE_H
+#endif // RENDERER_SCENE_H

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERING_SERVER_SCENE_CULL_H
-#define RENDERING_SERVER_SCENE_CULL_H
+#ifndef RENDERER_SCENE_CULL_H
+#define RENDERER_SCENE_CULL_H
 
 #include "core/math/dynamic_bvh.h"
 #include "core/templates/bin_sorted_array.h"
@@ -1183,4 +1183,4 @@ public:
 	virtual ~RendererSceneCull();
 };
 
-#endif // RENDERING_SERVER_SCENE_CULL_H
+#endif // RENDERER_SCENE_CULL_H

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -200,4 +200,4 @@ public:
 	};
 };
 
-#endif //RENDERER_SCENE_OCCLUSION_CULL_H
+#endif // RENDERER_SCENE_OCCLUSION_CULL_H

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERINGSERVERSCENERENDER_H
-#define RENDERINGSERVERSCENERENDER_H
+#ifndef RENDERER_SCENE_RENDER_H
+#define RENDERER_SCENE_RENDER_H
 
 #include "core/math/projection.h"
 #include "core/templates/paged_array.h"
@@ -281,4 +281,4 @@ public:
 	virtual ~RendererSceneRender() {}
 };
 
-#endif // RENDERINGSERVERSCENERENDER_H
+#endif // RENDERER_SCENE_RENDER_H

--- a/servers/rendering/renderer_thread_pool.h
+++ b/servers/rendering/renderer_thread_pool.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RENDERERTHREADPOOL_H
-#define RENDERERTHREADPOOL_H
+#ifndef RENDERER_THREAD_POOL_H
+#define RENDERER_THREAD_POOL_H
 
 #include "core/templates/thread_work_pool.h"
 
@@ -42,4 +42,4 @@ public:
 	~RendererThreadPool();
 };
 
-#endif // RENDERERTHREADPOOL_H
+#endif // RENDERER_THREAD_POOL_H

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -981,4 +981,4 @@ public:
 	~RenderingServerDefault();
 };
 
-#endif
+#endif // RENDERING_SERVER_DEFAULT_H

--- a/servers/rendering/shader_types.h
+++ b/servers/rendering/shader_types.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SHADERTYPES_H
-#define SHADERTYPES_H
+#ifndef SHADER_TYPES_H
+#define SHADER_TYPES_H
 
 #include "core/templates/rb_map.h"
 #include "servers/rendering_server.h"
@@ -59,4 +59,4 @@ public:
 	ShaderTypes();
 };
 
-#endif // SHADERTYPES_H
+#endif // SHADER_TYPES_H

--- a/servers/rendering/shader_warnings.h
+++ b/servers/rendering/shader_warnings.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SHADER_WARNINGS
-#define SHADER_WARNINGS
+#ifndef SHADER_WARNINGS_H
+#define SHADER_WARNINGS_H
 
 #ifdef DEBUG_ENABLED
 
@@ -90,4 +90,4 @@ public:
 
 #endif // DEBUG_ENABLED
 
-#endif // SHADER_WARNINGS
+#endif // SHADER_WARNINGS_H

--- a/servers/rendering/storage/light_storage.h
+++ b/servers/rendering/storage/light_storage.h
@@ -135,4 +135,4 @@ public:
 	virtual float lightmap_get_probe_capture_update_speed() const = 0;
 };
 
-#endif // !LIGHT_STORAGE_H
+#endif // LIGHT_STORAGE_H

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -99,4 +99,4 @@ public:
 	virtual void material_update_dependency(RID p_material, DependencyTracker *p_instance) = 0;
 };
 
-#endif // !MATERIAL_STORAGE_H
+#endif // MATERIAL_STORAGE_H

--- a/servers/rendering/storage/mesh_storage.h
+++ b/servers/rendering/storage/mesh_storage.h
@@ -133,4 +133,4 @@ public:
 	virtual void skeleton_update_dependency(RID p_base, DependencyTracker *p_instance) = 0;
 };
 
-#endif // !MESH_STORAGE_H
+#endif // MESH_STORAGE_H

--- a/servers/rendering/storage/particles_storage.h
+++ b/servers/rendering/storage/particles_storage.h
@@ -125,4 +125,4 @@ public:
 	virtual void particles_collision_instance_set_active(RID p_collision_instance, bool p_active) = 0;
 };
 
-#endif // !PARTICLES_STORAGE_H
+#endif // PARTICLES_STORAGE_H

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -148,4 +148,4 @@ public:
 	virtual void render_target_set_vrs_texture(RID p_render_target, RID p_texture) = 0;
 };
 
-#endif // !TEXTURE_STORAGE_H
+#endif // TEXTURE_STORAGE_H

--- a/servers/rendering/storage/utilities.h
+++ b/servers/rendering/storage/utilities.h
@@ -183,4 +183,4 @@ public:
 	virtual String get_video_adapter_api_version() const = 0;
 };
 
-#endif // !RENDERER_UTILITIES_H
+#endif // RENDERER_UTILITIES_H

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -28,6 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef SERVER_WRAP_MT_COMMON_H
+#define SERVER_WRAP_MT_COMMON_H
+
 #define FUNC0R(m_r, m_type)                                                     \
 	virtual m_r m_type() override {                                             \
 		if (Thread::get_caller_id() != server_thread) {                         \
@@ -762,3 +765,5 @@
 			server_name->m_type(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);                                                                                                                  \
 		}                                                                                                                                                                                                           \
 	}
+
+#endif // SERVER_WRAP_MT_COMMON_H

--- a/servers/xr/xr_interface_extension.h
+++ b/servers/xr/xr_interface_extension.h
@@ -132,4 +132,4 @@ public:
 	// RID get_render_target_depth(RID p_render_target);
 };
 
-#endif // !XR_INTERFACE_EXTENSION_H
+#endif // XR_INTERFACE_EXTENSION_H

--- a/servers/xr/xr_pose.h
+++ b/servers/xr/xr_pose.h
@@ -78,4 +78,4 @@ public:
 
 VARIANT_ENUM_CAST(XRPose::TrackingConfidence);
 
-#endif
+#endif // XR_POSE_H

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -300,4 +300,5 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 			"flip_y() should not leave old pixels behind.");
 }
 } // namespace TestImage
+
 #endif // TEST_IMAGE_H

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef TEST_RESOURCE
-#define TEST_RESOURCE
+#ifndef TEST_RESOURCE_H
+#define TEST_RESOURCE_H
 
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
@@ -111,4 +111,4 @@ TEST_CASE("[Resource] Saving and loading") {
 }
 } // namespace TestResource
 
-#endif // TEST_RESOURCE
+#endif // TEST_RESOURCE_H

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -283,4 +283,4 @@ TEST_CASE("[Stress][Basis] Euler conversions") {
 }
 } // namespace TestBasis
 
-#endif
+#endif // TEST_BASIS_H

--- a/tests/core/templates/test_hash_set.h
+++ b/tests/core/templates/test_hash_set.h
@@ -225,4 +225,4 @@ TEST_CASE("[HashSet] Copy") {
 
 } // namespace TestHashSet
 
-#endif // TEST_HASH_MAP_H
+#endif // TEST_HASH_SET_H

--- a/tests/scene/test_path_3d.h
+++ b/tests/scene/test_path_3d.h
@@ -81,4 +81,4 @@ TEST_CASE("[Path3D] Curve setter and getter") {
 
 } // namespace TestPath3D
 
-#endif // TEST_PATH_3D
+#endif // TEST_PATH_3D_H

--- a/tests/servers/test_text_server.h
+++ b/tests/servers/test_text_server.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef TOOLS_ENABLED
-
 #ifndef TEST_TEXT_SERVER_H
 #define TEST_TEXT_SERVER_H
+
+#ifdef TOOLS_ENABLED
 
 #include "editor/builtin_fonts.gen.h"
 #include "servers/text_server.h"
@@ -561,5 +561,6 @@ TEST_SUITE("[[TextServer]") {
 }
 }; // namespace TestTextServer
 
-#endif // TEST_TEXT_SERVER_H
 #endif // TOOLS_ENABLED
+
+#endif // TEST_TEXT_SERVER_H


### PR DESCRIPTION
Adds `header_guards.sh` bash script, used in CI to validate future
changes. Can be run locally to fix invalid header guards.

Finally took the time to address this pet peeve of mine with a proper script.

The expected style is, for a file named `some_class.h`:
```cpp
// License block.

#ifndef SOME_CLASS_H
#define SOME_CLASS_H

// Includes.

// Class declaration(s).

#endif // SOME_CLASS_H
```

See https://docs.godotengine.org/en/latest/community/contributing/code_style_guidelines.html#header-includes

There are some exceptions for files which exist multiple time in the codebase where either a prefix or a suffix is added:
- Module `register_types.h`
- Platform `export/` and `api/` headers
- Renderer implementation for effects

Check `misc/scripts/header_guards.sh` for details.

Renames `servers/audio/effects/{eq,reverb}.*` to have a `_filter` suffix, as the names were a bit confusing next to the `audio_effect_{eq,reverb}.*` that use them.

Renames `modules/gdscript/language_server/lsp.hpp` to `godot_lsp.h`, this was the only Godot C++ header using `.hpp` extension outside thirdparty code.