### PR TITLE
Add equal checks to Transform3D::looking_at and Transform3D::set_look_at, fixes misleading error.

### DIFF
--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -70,12 +70,18 @@ void Transform3D::rotate_basis(const Vector3 &p_axis, real_t p_angle) {
 }
 
 Transform3D Transform3D::looking_at(const Vector3 &p_target, const Vector3 &p_up) const {
+#ifdef MATH_CHECKS
+	ERR_FAIL_COND_V_MSG(origin.is_equal_approx(p_target), Transform3D(), "The transform's origin and target can't be equal.");
+#endif
 	Transform3D t = *this;
 	t.basis = Basis::looking_at(p_target - origin, p_up);
 	return t;
 }
 
 void Transform3D::set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up) {
+#ifdef MATH_CHECKS
+	ERR_FAIL_COND_MSG(p_eye.is_equal_approx(p_target), "The eye and target vectors can't be equal.");
+#endif
 	basis = Basis::looking_at(p_target - p_eye, p_up);
 	origin = p_eye;
 }


### PR DESCRIPTION
Code:
```gdscript
Transform3D().translated(Vector3(4, 0, 0)).looking_at(Vector3(4, 0, 0))
```

Before:
```
E 0:00:07:0161   _ready: The target vector can't be zero.
  <C++ Error>    Condition "p_target.is_equal_approx(Vector3())" is true. Returning: Basis()
  <C++ Source>   core/math/basis.cpp:1097 @ looking_at()
  <Stack Trace>  scene.gd:4 @ _ready()
```

After:
```
E 0:00:07:0230   _ready: The transform's origin and target can't be equal.
  <C++ Error>    Condition "origin.is_equal_approx(p_target)" is true. Returning: t
  <C++ Source>   core/math/transform_3d.cpp:75 @ looking_at()
  <Stack Trace>  scene.gd:4 @ _ready()
```

I am assuming this type of check would be useful elsewhere, if so let me know.