### PR TITLE
Fix `cubic_slerp()`

### DIFF
--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -74,7 +74,7 @@ struct _NO_DISCARD_ Quaternion {
 	Quaternion cubic_slerp(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight) const;
 
 	Vector3 get_axis() const;
-	float get_angle() const;
+	real_t get_angle() const;
 
 	_FORCE_INLINE_ void get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 		r_angle = 2 * Math::acos(w);


### PR DESCRIPTION
Co-authored-by: K. S. Ernest (iFire) Lee <ernest.lee@chibifire.com>
Co-authored-by: Pasi Nuutinmaki <gnssstylist@sci.fi>

If the angle is ~~very small or~~ very large, the interpolation is approximated by directly interpolating the quaternion elements, and in all other cases, ExpMap is used to interpolate more closely to the slerp.

This hybrid method is a tentative compromise since we could not solve the problem of incorrect flips in the ExpMap when the angle is large, but it allows the rotation path to use the shortest distance consistently and provides a much improved interpolation than the current broken `cubic_slerp()`.

Comparing the direct quaternion interpolation approximation with that using ExpMap, you can see in the video below that ExpMap correctly applies cubic interpolation to the rotation angles.

https://user-images.githubusercontent.com/61938263/180642977-574f1bc2-8323-4a0d-9bea-a2c7dacfb389.mp4

In the case of the sample project of [https://github.com/fire/godot-40592](https://github.com/fire/godot-40592), about 75% of the interpolation is done by ExpMax. I have not found any problems with switching between these interpolations so far.

## Bugsquad edit:

Fixes: #57951
Fixes: #40592
Supersedes: #63287, #59707.