### PR TITLE
Solve discrepancy between code and class reference for Plane

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1730,7 +1730,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Plane, normalized, sarray(), varray());
 	bind_method(Plane, center, sarray(), varray());
 	bind_method(Plane, is_equal_approx, sarray("to_plane"), varray());
-	bind_method(Plane, is_point_over, sarray("plane"), varray());
+	bind_method(Plane, is_point_over, sarray("point"), varray());
 	bind_method(Plane, distance_to, sarray("point"), varray());
 	bind_method(Plane, has_point, sarray("point", "tolerance"), varray(CMP_EPSILON));
 	bind_method(Plane, project, sarray("point"), varray());

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -109,7 +109,7 @@
 			<argument index="0" name="from" type="Vector3" />
 			<argument index="1" name="to" type="Vector3" />
 			<description>
-				Returns the intersection point of a segment from position [code]begin[/code] to position [code]end[/code] with this plane. If no intersection is found, [code]null[/code] is returned.
+				Returns the intersection point of a segment from position [code]from[/code] to position [code]to[/code] with this plane. If no intersection is found, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="is_equal_approx" qualifiers="const">
@@ -121,7 +121,7 @@
 		</method>
 		<method name="is_point_over" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="plane" type="Vector3" />
+			<argument index="0" name="point" type="Vector3" />
 			<description>
 				Returns [code]true[/code] if [code]point[/code] is located above the plane.
 			</description>


### PR DESCRIPTION
On #43310, class reference was automatically updated from source,
causing xml documentation to disagree with parameter naming
description on Plane.intersects_segment().

The issue was a misleading binding argument name: while
Plane.is_point_over() is defined on math.Plane as
"const Vector3 &p_point", it was bound with the "plane"
argument indentifier.

* Update begin/end to from/to on Plane.intersects_segment(...)
  docs description to match source
* Change Plane.is_point_over(plane) to Plane.is_point_over(point)
  AND its description

Fixes godotengine/godot-docs#5976