### PR TITLE
Fix getting error message when switching window visibility in editor

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -305,7 +305,12 @@ void Viewport::_sub_window_grab_focus(Window *p_window) {
 	}
 
 	if (old_focus) {
-		_sub_window_update(old_focus);
+		Viewport *embedder = old_focus->_get_embedder();
+		if (embedder) {
+			embedder->_sub_window_update(old_focus);
+		} else {
+			old_focus->update_canvas_items();
+		}
 	}
 
 	_sub_window_update(p_window);
@@ -345,6 +350,23 @@ void Viewport::_sub_window_remove(Window *p_window) {
 	}
 
 	RenderingServer::get_singleton()->viewport_set_parent_viewport(p_window->viewport, p_window->parent ? p_window->parent->viewport : RID());
+}
+
+Viewport *Viewport::_get_embedder() const {
+	Viewport *vp = get_parent_viewport();
+
+	while (vp) {
+		if (vp->is_embedding_subwindows()) {
+			return vp;
+		}
+
+		if (vp->get_parent()) {
+			vp = vp->get_parent()->get_viewport();
+		} else {
+			vp = nullptr;
+		}
+	}
+	return nullptr;
 }
 
 void Viewport::_notification(int p_what) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -467,6 +467,7 @@ private:
 	uint64_t event_count = 0;
 
 protected:
+	Viewport *_get_embedder() const;
 	void _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, const Transform2D &p_stretch_transform, bool p_allocated);
 
 	Size2i _get_size() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -752,23 +752,6 @@ void Window::_update_window_callbacks() {
 	DisplayServer::get_singleton()->window_set_drop_files_callback(callable_mp(this, &Window::_window_drop_files), window_id);
 }
 
-Viewport *Window::_get_embedder() const {
-	Viewport *vp = get_parent_viewport();
-
-	while (vp) {
-		if (vp->is_embedding_subwindows()) {
-			return vp;
-		}
-
-		if (vp->get_parent()) {
-			vp = vp->get_parent()->get_viewport();
-		} else {
-			vp = nullptr;
-		}
-	}
-	return nullptr;
-}
-
 void Window::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -151,7 +151,6 @@ private:
 	virtual bool _can_consume_input_events() const override;
 
 protected:
-	Viewport *_get_embedder() const;
 	virtual Rect2i _popup_adjust_rect() const { return Rect2i(); }
 
 	virtual void _post_popup() {}


### PR DESCRIPTION
Previously, toggling window visibility in the editor gave the following error message:

```
ERROR: Condition "index == -1" is true.
   at: _sub_window_update (scene/main/viewport.cpp:201)
```

This is caused by `old_focus` possibly being the root window.

Move the function `_get_embedder()` from the `Window` class to the `Viewport` class

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
