### PR TITLE
Portals - Fix invalid room hint when reconverting room graph

### DIFF
--- a/servers/visual/portals/portal_rooms_bsp.cpp
+++ b/servers/visual/portals/portal_rooms_bsp.cpp
@@ -102,19 +102,24 @@ int PortalRoomsBSP::find_room_within(const PortalRenderer &p_portal_renderer, co
 
 	// first try previous room
 	if (p_previous_room_id != -1) {
-		const VSRoom &prev_room = p_portal_renderer.get_room(p_previous_room_id);
+		if (p_previous_room_id < p_portal_renderer.get_num_rooms()) {
+			const VSRoom &prev_room = p_portal_renderer.get_room(p_previous_room_id);
 
-		// we can only use this shortcut if the room doesn't include internal rooms.
-		// otherwise the point may be inside more than one room, and we need to find the room of highest priority.
-		if (!prev_room._contains_internal_rooms) {
-			closest = prev_room.is_point_within(p_pos);
-			closest_room_id = p_previous_room_id;
+			// we can only use this shortcut if the room doesn't include internal rooms.
+			// otherwise the point may be inside more than one room, and we need to find the room of highest priority.
+			if (!prev_room._contains_internal_rooms) {
+				closest = prev_room.is_point_within(p_pos);
+				closest_room_id = p_previous_room_id;
 
-			if (closest < 0.0) {
-				return p_previous_room_id;
+				if (closest < 0.0) {
+					return p_previous_room_id;
+				}
+			} else {
+				// don't mark it as checked later, as we haven't done it because it contains internal rooms
+				p_previous_room_id = -1;
 			}
 		} else {
-			// don't mark it as checked later, as we haven't done it because it contains internal rooms
+			// previous room was out of range (perhaps due to reconverting room system and the number of rooms decreasing)
 			p_previous_room_id = -1;
 		}
 	}


### PR DESCRIPTION
In situations where rooms are converted multiple times, the previous room hint ID can reference a room number that is out of range of the new number of rooms. This fixes the bug by checking the room hint ID is within range.

Fixes #63375

## Notes
* Small oversight bug on my part. Partly because I had never envisaged users streaming in / out parts of portalled levels at runtime (this isn't really supported but they may just about get away with it as rooms convert is pretty fast). :grin: 
* Alternatives might include e.g. setting all room hints to -1 in the scene tree, but this is logistically difficult. Just checking the range should be fine for preventing crashes / errors, and if the room locations have changed then the code to test whether the point is within the previous room should detect this.
* I've marked as 3.5 only because this is super safe. But is fine to leave till 3.5.1 as well.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
