### PR TITLE
Portals - Allow more logging to be disabled

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -463,23 +463,18 @@ bool RoomManager::get_merge_meshes() const {
 	return _settings_merge_meshes;
 }
 
-void RoomManager::show_warning(const String &p_string, const String &p_extra_string, bool p_alert) {
-	if (p_extra_string != "") {
-		WARN_PRINT(p_string + " " + p_extra_string);
-#ifdef TOOLS_ENABLED
-		if (p_alert && Engine::get_singleton()->is_editor_hint()) {
-			EditorNode::get_singleton()->show_warning(TTRGET(p_string) + "\n" + TTRGET(p_extra_string));
-		}
-#endif
-	} else {
-		WARN_PRINT(p_string);
-		// OS::get_singleton()->alert(p_string, p_title);
-#ifdef TOOLS_ENABLED
-		if (p_alert && Engine::get_singleton()->is_editor_hint()) {
-			EditorNode::get_singleton()->show_warning(TTRGET(p_string));
-		}
-#endif
+void RoomManager::show_warning(const String &p_string, bool p_skippable, bool p_alert) {
+	if (p_skippable && !Engine::get_singleton()->is_editor_hint() && !_show_debug) {
+		return;
 	}
+
+	WARN_PRINT(p_string);
+	// OS::get_singleton()->alert(p_string, p_title);
+#ifdef TOOLS_ENABLED
+	if (p_alert && Engine::get_singleton()->is_editor_hint()) {
+		EditorNode::get_singleton()->show_warning(TTRGET(p_string));
+	}
+#endif
 }
 
 void RoomManager::debug_print_line(String p_string, int p_priority) {
@@ -657,15 +652,15 @@ void RoomManager::rooms_convert() {
 	}
 
 	if (_warning_portal_link_room_not_found) {
-		show_warning(TTR("Portal link room not found, check output log for details."));
+		show_warning(TTR("Portal link room not found, check output log for details."), true);
 	}
 
 	if (_warning_portal_autolink_failed) {
-		show_warning(TTR("Portal autolink failed, check output log for details.\nCheck the portal is facing outwards from the source room."));
+		show_warning(TTR("Portal autolink failed, check output log for details.\nCheck the portal is facing outwards from the source room."), true);
 	}
 
 	if (_warning_room_overlap_detected) {
-		show_warning(TTR("Room overlap detected, cameras may work incorrectly in overlapping area.\nCheck output log for details."));
+		show_warning(TTR("Room overlap detected, cameras may work incorrectly in overlapping area.\nCheck output log for details."), true);
 	}
 }
 
@@ -1026,7 +1021,9 @@ void RoomManager::_autolink_portals(Spatial *p_roomlist, LocalVector<Portal *> &
 
 		// error condition
 		if (!autolink_found) {
-			WARN_PRINT("Portal AUTOLINK failed for " + portal->get_name() + " from " + source_room->get_name());
+			if (_show_debug) {
+				WARN_PRINT("Portal AUTOLINK failed for " + portal->get_name() + " from " + source_room->get_name());
+			}
 			_warning_portal_autolink_failed = true;
 
 #ifdef TOOLS_ENABLED

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -208,10 +208,10 @@ private:
 	// only prints when user has set 'debug' in the room manager inspector
 	// also does not show in non editor builds
 	void debug_print_line(String p_string, int p_priority = 0);
+	void show_warning(const String &p_string, bool p_skippable = false, bool p_alert = true);
 
 public:
 	static String _find_name_before(Node *p_node, String p_postfix, bool p_allow_no_postfix = false);
-	static void show_warning(const String &p_string, const String &p_extra_string = "", bool p_alert = true);
 	static real_t _get_default_portal_margin() { return _default_portal_margin; }
 
 private:

--- a/servers/visual/portals/portal_renderer.cpp
+++ b/servers/visual/portals/portal_renderer.cpp
@@ -152,12 +152,14 @@ void PortalRenderer::_debug_print_global_list() {
 }
 
 void PortalRenderer::_log(String p_string, int p_priority) {
-	// change this for more debug output ..
-	// not selectable at runtime yet.
-	if (p_priority >= 1) {
-		print_line(p_string);
-	} else {
-		print_verbose(p_string);
+	if (_show_debug) {
+		// change this for more debug output ..
+		// not selectable at runtime yet.
+		if (p_priority >= 1) {
+			print_line(p_string);
+		} else {
+			print_verbose(p_string);
+		}
 	}
 }
 
@@ -861,7 +863,7 @@ void PortalRenderer::rooms_finalize(bool p_generate_pvs, bool p_cull_using_pvs, 
 	// as this will worst case give wrong result for a frame
 	Engine::get_singleton()->set_portals_active(true);
 
-	print_line("Room conversion complete. " + itos(_room_pool_ids.size()) + " rooms, " + itos(_portal_pool_ids.size()) + " portals.");
+	_log("Room conversion complete. " + itos(_room_pool_ids.size()) + " rooms, " + itos(_portal_pool_ids.size()) + " portals.", 1);
 }
 
 bool PortalRenderer::sprawl_static_geometry(int p_static_id, const VSStatic &p_static, int p_room_id, const Vector<Vector3> &p_object_pts) {
@@ -1197,4 +1199,8 @@ String PortalRenderer::_rid_to_string(RID p_rid) {
 
 String PortalRenderer::_addr_to_string(const void *p_addr) {
 	return String::num_uint64((uint64_t)p_addr, 16);
+}
+
+PortalRenderer::PortalRenderer() {
+	_show_debug = GLOBAL_GET("rendering/portals/debug/logging");
 }

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -329,6 +329,7 @@ private:
 	bool _active = true;
 	bool _loaded = false;
 	bool _debug_sprawl = false;
+	bool _show_debug = true;
 
 	// if the pvs is generated, we can either cull using dynamic portals or PVS
 	bool _cull_using_pvs = false;
@@ -357,6 +358,8 @@ public:
 	void occluder_ensure_up_to_date_sphere(const PortalResources &p_resources, VSOccluder_Instance &r_occluder);
 	void occluder_ensure_up_to_date_polys(const PortalResources &p_resources, VSOccluder_Instance &r_occluder);
 	void occluder_refresh_room_within(uint32_t p_occluder_pool_id);
+
+	PortalRenderer();
 };
 
 inline void PortalRenderer::occluder_ensure_up_to_date_sphere(const PortalResources &p_resources, VSOccluder_Instance &r_occluder) {


### PR DESCRIPTION
Some logging messages were still being issued when portals/debug/logging was false. This could be annoying in games that stream in parts of levels and repeatedly call `rooms_convert()`.

This PR allows all but essential logging to be disabled.

## Notes
* I noticed in the MRP for #63375 that when using Portals with streaming, a number of warning messages were being issued that could be annoying, and there were no ways to turn these off.
* This makes it so that all but the essential messages can be turned off using the project setting `rendering/portals/debug/logging`.
* No changes to functionality, just quality of life improvement.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
