### PR TITLE
LSP: Sanitizes protocol URI `file:///c%3A` in file path

### DIFF
--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -499,7 +499,9 @@ Error GDScriptWorkspace::parse_local_script(const String &p_path) {
 
 String GDScriptWorkspace::get_file_path(const String &p_uri) const {
 	String path = p_uri;
-	path = path.replace(root_uri + "/", "res://");
+	path = path.replace("///", "//");
+	path = path.replace("%3A", ":");
+	path = path.replacen(root_uri + "/", "res://");
 	path = path.uri_decode();
 	return path;
 }


### PR DESCRIPTION
Fix string formatting issues in get_file_path that caused sync_script_content() to always error. https://github.com/godotengine/godot/issues/63205

*Bugsquad edit:*
- Fixes #63205.