### PR TITLE
Hide Material Override/Overlay if no surface material is set

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -337,6 +337,8 @@ void MeshInstance3D::set_surface_override_material(int p_surface, const Ref<Mate
 	} else {
 		RS::get_singleton()->instance_set_surface_override_material(get_instance(), p_surface, RID());
 	}
+
+	notify_property_list_changed();
 }
 
 Ref<Material> MeshInstance3D::get_surface_override_material(int p_surface) const {
@@ -460,6 +462,28 @@ void MeshInstance3D::create_debug_tangents() {
 		}
 #endif
 	}
+}
+
+void MeshInstance3D::_validate_property(PropertyInfo &property) const {
+	if (property.name.begins_with("material_override") && !get_material_override().is_valid() && (get_surface_override_material_count() == 0 || get_active_material(0).is_null())) {
+		// To avoid choice paralysis with material assignment, hide material override
+		// if no material is defined on the mesh resource itself or as a surface override.
+		// However, only hide material override if there is none currently set.
+		// Using material override on a mesh with no materials via script is still valid.
+		property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	if (property.name.begins_with("material_overlay") && !get_material_overlay().is_valid() && (get_surface_override_material_count() == 0 || get_active_material(0).is_null())) {
+		// To avoid choice paralysis with material assignment, hide material overlay
+		// if no material is defined on the mesh resource itself or as a surface override.
+		// However, only hide material overlay if there is none currently set.
+		// Using material overlay on a mesh with no materials via script is still valid.
+		property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	GeometryInstance3D::_validate_property(property);
 }
 
 void MeshInstance3D::_bind_methods() {

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -60,6 +60,7 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual void _validate_property(PropertyInfo &property) const override;
 
 public:
 	void set_mesh(const Ref<Mesh> &p_mesh);

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -149,6 +149,10 @@ VisualInstance3D::~VisualInstance3D() {
 void GeometryInstance3D::set_material_override(const Ref<Material> &p_material) {
 	material_override = p_material;
 	RS::get_singleton()->instance_geometry_set_material_override(get_instance(), p_material.is_valid() ? p_material->get_rid() : RID());
+
+	// Not used within GeometryInstance, but used by MeshInstance3D's `_validate_property()`
+	// to only display material override/overlay if relevant.
+	notify_property_list_changed();
 }
 
 Ref<Material> GeometryInstance3D::get_material_override() const {
@@ -158,6 +162,10 @@ Ref<Material> GeometryInstance3D::get_material_override() const {
 void GeometryInstance3D::set_material_overlay(const Ref<Material> &p_material) {
 	material_overlay = p_material;
 	RS::get_singleton()->instance_geometry_set_material_overlay(get_instance(), p_material.is_valid() ? p_material->get_rid() : RID());
+
+	// Not used within GeometryInstance, but used by MeshInstance3D's `_validate_property()`
+	// to only display material override/overlay if relevant.
+	notify_property_list_changed();
 }
 
 Ref<Material> GeometryInstance3D::get_material_overlay() const {


### PR DESCRIPTION
This avoids choice paralysis when assigning materials to meshes.

There are still 2 ways to set materials on a newly created mesh (either inside or outside the Mesh resource depending on your use cases). Still, 2 ways to set materials is much less confusing than 4 :slightly_smiling_face: 

**Testing project:** [test_material_override_editor.zip](https://github.com/godotengine/godot/files/9176294/test_material_override_editor.zip)

This closes https://github.com/godotengine/godot-proposals/issues/4967.

## TODO

- [ ] Listen to Mesh resource changes and call `notify_property_list_changed()` when a material is added to the mesh or removed from it. This is required to update material override/overlay property visibility in this case.