### PR TITLE
Patch the make_rst.py utility to handle specially operators with "<"

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1401,7 +1401,7 @@ def make_method_signature(
     if ref_type != "":
         if ref_type == "operator":
             out += ":ref:`{0}<class_{1}_{2}_{3}_{4}>` ".format(
-                method_def.name,
+                method_def.name.replace("<", "\\<"),  # So operator "<" gets correctly displayed.
                 class_def.name,
                 ref_type,
                 sanitize_operator_name(method_def.name, state),


### PR DESCRIPTION
When generating rst files from xml class reference, unknown references
to operators were generated, as something like:

:ref:`operator <<class_Vector2_operator_lt_bool>`

was rendered in html as:

operator ( Vector2 right )

-it just needed escaping.

The small addendum checks for operator names containing '<' and
substitutes it with '\<', escaping at rst level and generating
instead the right rendered html:

operator < ( Vector2 right )

This affected mostly the reference pages of the VectorX family of
classes. If in the future more types need escaping, a more
general solution will be needed.