### PR TITLE
Enhanced locks with ownership and cleanup Mutex/RWLock

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -99,10 +99,10 @@ void RemoteDebuggerPeerTCP::_write_out() {
 			if (out_queue.size() == 0) {
 				break; // Nothing left to send
 			}
-			mutex.lock();
+			MutexLock m(mutex);
 			Variant var = out_queue[0];
 			out_queue.pop_front();
-			mutex.unlock();
+			m.unlock();
 			int size = 0;
 			Error err = encode_variant(var, nullptr, size);
 			ERR_CONTINUE(err != OK || size > out_buf.size() - 4); // 4 bytes separator.
@@ -144,9 +144,8 @@ void RemoteDebuggerPeerTCP::_read_in() {
 			Error err = decode_variant(var, buf, in_pos, &read);
 			ERR_CONTINUE(read != in_pos || err != OK);
 			ERR_CONTINUE_MSG(var.get_type() != Variant::ARRAY, "Malformed packet received, not an Array.");
-			mutex.lock();
+			MutexLock m(mutex);
 			in_queue.push_back(var);
-			mutex.unlock();
 		}
 	}
 }

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -381,13 +381,13 @@ uint64_t FileAccessNetwork::get_buffer(uint8_t *p_dst, uint64_t p_length) const 
 		int32_t page = pos / page_size;
 
 		if (page != last_page) {
-			buffer_mutex.lock();
+			MutexLock m(buffer_mutex);
 			if (pages[page].buffer.is_empty()) {
 				waiting_on_page = page;
 				for (int32_t j = 0; j < read_ahead; j++) {
 					_queue_page(page + j);
 				}
-				buffer_mutex.unlock();
+				m.unlock();
 				DEBUG_PRINT("wait");
 				page_sem.wait();
 				DEBUG_PRINT("done");
@@ -395,7 +395,7 @@ uint64_t FileAccessNetwork::get_buffer(uint8_t *p_dst, uint64_t p_length) const 
 				for (int32_t j = 0; j < read_ahead; j++) {
 					_queue_page(page + j);
 				}
-				buffer_mutex.unlock();
+				m.unlock();
 			}
 
 			buff = pages.write[page].buffer.ptrw();

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -56,7 +56,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 		p_take_over = false; // Can't take over an empty path
 	}
 
-	ResourceCache::lock.lock();
+	MutexLock m(ResourceCache::lock);
 
 	if (!path_cache.is_empty()) {
 		ResourceCache::resources.erase(path_cache);
@@ -71,7 +71,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 			existing->path_cache = String();
 			ResourceCache::resources.erase(p_path);
 		} else {
-			ResourceCache::lock.unlock();
+			m.unlock();
 			ERR_FAIL_MSG("Another resource is loaded from path '" + p_path + "' (possible cyclic resource inclusion).");
 		}
 	}
@@ -81,7 +81,7 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 	if (!path_cache.is_empty()) {
 		ResourceCache::resources[path_cache] = this;
 	}
-	ResourceCache::lock.unlock();
+	m.unlock();
 
 	_resource_path_changed();
 }
@@ -375,15 +375,13 @@ void Resource::set_as_translation_remapped(bool p_remapped) {
 		return;
 	}
 
-	ResourceCache::lock.lock();
+	MutexLock m(ResourceCache::lock);
 
 	if (p_remapped) {
 		ResourceLoader::remapped_list.add(&remapped_list);
 	} else {
 		ResourceLoader::remapped_list.remove(&remapped_list);
 	}
-
-	ResourceCache::lock.unlock();
 }
 
 bool Resource::is_translation_remapped() const {
@@ -394,24 +392,20 @@ bool Resource::is_translation_remapped() const {
 //helps keep IDs same number when loading/saving scenes. -1 clears ID and it Returns -1 when no id stored
 void Resource::set_id_for_path(const String &p_path, const String &p_id) {
 	if (p_id.is_empty()) {
-		ResourceCache::path_cache_lock.write_lock();
+		RWLockWrite w(ResourceCache::path_cache_lock);
 		ResourceCache::resource_path_cache[p_path].erase(get_path());
-		ResourceCache::path_cache_lock.write_unlock();
 	} else {
-		ResourceCache::path_cache_lock.write_lock();
+		RWLockWrite w(ResourceCache::path_cache_lock);
 		ResourceCache::resource_path_cache[p_path][get_path()] = p_id;
-		ResourceCache::path_cache_lock.write_unlock();
 	}
 }
 
 String Resource::get_id_for_path(const String &p_path) const {
-	ResourceCache::path_cache_lock.read_lock();
+	RWLockRead r(ResourceCache::path_cache_lock);
 	if (ResourceCache::resource_path_cache[p_path].has(get_path())) {
 		String result = ResourceCache::resource_path_cache[p_path][get_path()];
-		ResourceCache::path_cache_lock.read_unlock();
 		return result;
 	} else {
-		ResourceCache::path_cache_lock.read_unlock();
 		return "";
 	}
 }
@@ -450,9 +444,8 @@ Resource::Resource() :
 
 Resource::~Resource() {
 	if (!path_cache.is_empty()) {
-		ResourceCache::lock.lock();
+		MutexLock m(ResourceCache::lock);
 		ResourceCache::resources.erase(path_cache);
-		ResourceCache::lock.unlock();
 	}
 	if (owners.size()) {
 		WARN_PRINT("Resource is still owned.");
@@ -486,7 +479,7 @@ void ResourceCache::reload_externals() {
 }
 
 bool ResourceCache::has(const String &p_path) {
-	lock.lock();
+	MutexLock m(lock);
 
 	Resource **res = resources.getptr(p_path);
 
@@ -497,8 +490,6 @@ bool ResourceCache::has(const String &p_path) {
 		res = nullptr;
 	}
 
-	lock.unlock();
-
 	if (!res) {
 		return false;
 	}
@@ -508,7 +499,7 @@ bool ResourceCache::has(const String &p_path) {
 
 Ref<Resource> ResourceCache::get_ref(const String &p_path) {
 	Ref<Resource> ref;
-	lock.lock();
+	MutexLock m(lock);
 
 	Resource **res = resources.getptr(p_path);
 
@@ -523,30 +514,26 @@ Ref<Resource> ResourceCache::get_ref(const String &p_path) {
 		res = nullptr;
 	}
 
-	lock.unlock();
-
 	return ref;
 }
 
 void ResourceCache::get_cached_resources(List<Ref<Resource>> *p_resources) {
-	lock.lock();
+	MutexLock m(lock);
 	for (KeyValue<String, Resource *> &E : resources) {
 		p_resources->push_back(Ref<Resource>(E.value));
 	}
-	lock.unlock();
 }
 
 int ResourceCache::get_cached_resource_count() {
-	lock.lock();
+	MutexLock m(lock);
 	int rc = resources.size();
-	lock.unlock();
 
 	return rc;
 }
 
 void ResourceCache::dump(const char *p_file, bool p_short) {
 #ifdef DEBUG_ENABLED
-	lock.lock();
+	MutexLock m(lock);
 
 	HashMap<String, int> type_count;
 
@@ -578,7 +565,6 @@ void ResourceCache::dump(const char *p_file, bool p_short) {
 		}
 	}
 
-	lock.unlock();
 #else
 	WARN_PRINT("ResourceCache::dump only with in debug builds.");
 #endif

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -890,9 +890,9 @@ void ClassDB::add_property_array(const StringName &p_class, const StringName &p_
 
 // NOTE: For implementation simplicity reasons, this method doesn't allow setters to have optional arguments at the end.
 void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter, int p_index) {
-	lock.read_lock();
+	RWLockRead r(lock);
 	ClassInfo *type = classes.getptr(p_class);
-	lock.read_unlock();
+	r.read_unlock();
 
 	ERR_FAIL_COND(!type);
 

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -210,7 +210,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 }
 
 void EditorResourcePreview::_iterate() {
-	preview_mutex.lock();
+	MutexLock m(preview_mutex);
 
 	if (queue.size()) {
 		QueueItem item = queue.front()->get();
@@ -224,10 +224,8 @@ void EditorResourcePreview::_iterate() {
 			}
 
 			_preview_ready(path, cache[item.path].preview, cache[item.path].small_preview, item.id, item.function, item.userdata);
-
-			preview_mutex.unlock();
 		} else {
-			preview_mutex.unlock();
+			m.unlock();
 
 			Ref<ImageTexture> texture;
 			Ref<ImageTexture> small_texture;
@@ -320,9 +318,6 @@ void EditorResourcePreview::_iterate() {
 				_preview_ready(item.path, texture, small_texture, item.id, item.function, item.userdata);
 			}
 		}
-
-	} else {
-		preview_mutex.unlock();
 	}
 }
 

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -280,15 +280,15 @@ void EditorFileServer::_thread_start(void *s) {
 			}
 		}
 
-		self->wait_mutex.lock();
+		MutexLock m(self->wait_mutex);
 		while (self->to_wait.size()) {
 			Thread *w = *self->to_wait.begin();
 			self->to_wait.erase(w);
-			self->wait_mutex.unlock();
+			m.unlock();
 			w->wait_to_finish();
-			self->wait_mutex.lock();
+			m.lock();
 		}
-		self->wait_mutex.unlock();
+		m.unlock();
 
 		OS::get_singleton()->delay_usec(100000);
 	}

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -65,11 +65,11 @@ void TilesEditorPlugin::_thread() {
 	while (!pattern_thread_exit.is_set()) {
 		pattern_preview_sem.wait();
 
-		pattern_preview_mutex.lock();
+		MutexLock m(pattern_preview_mutex);
 		if (pattern_preview_queue.size()) {
 			QueueItem item = pattern_preview_queue.front()->get();
 			pattern_preview_queue.pop_front();
-			pattern_preview_mutex.unlock();
+			m.unlock();
 
 			int thumbnail_size = EditorSettings::get_singleton()->get("filesystem/file_dialog/thumbnail_size");
 			thumbnail_size *= EDSCALE;
@@ -130,8 +130,6 @@ void TilesEditorPlugin::_thread() {
 				item.callback.call(args_ptr, 2, r, error);
 
 				viewport->queue_delete();
-			} else {
-				pattern_preview_mutex.unlock();
 			}
 		}
 	}

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -41,10 +41,11 @@ void AudioDriverOpenSL::_buffer_callback(
 		SLAndroidSimpleBufferQueueItf queueItf) {
 	bool mix = true;
 
+	MutexLock m(mutex, LOCK_MODE_DEFER);
 	if (pause) {
 		mix = false;
 	} else {
-		mix = mutex.try_lock() == OK;
+		mix = m.try_lock() == OK;
 	}
 
 	if (mix) {
@@ -57,7 +58,7 @@ void AudioDriverOpenSL::_buffer_callback(
 	}
 
 	if (mix) {
-		mutex.unlock();
+		m.unlock();
 	}
 
 	const int32_t *src_buff = mixdown_buffer;

--- a/scene/resources/fog_material.cpp
+++ b/scene/resources/fog_material.cpp
@@ -137,7 +137,7 @@ void FogMaterial::cleanup_shader() {
 }
 
 void FogMaterial::_update_shader() {
-	shader_mutex.lock();
+	MutexLock m(shader_mutex);
 	if (shader.is_null()) {
 		shader = RS::get_singleton()->shader_create();
 
@@ -164,7 +164,6 @@ void fog() {
 }
 )");
 	}
-	shader_mutex.unlock();
 }
 
 FogMaterial::FogMaterial() {

--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -240,7 +240,7 @@ void ProceduralSkyMaterial::cleanup_shader() {
 }
 
 void ProceduralSkyMaterial::_update_shader() {
-	shader_mutex.lock();
+	MutexLock m(shader_mutex);
 	if (shader.is_null()) {
 		shader = RS::get_singleton()->shader_create();
 
@@ -331,7 +331,6 @@ void sky() {
 }
 )");
 	}
-	shader_mutex.unlock();
 }
 
 ProceduralSkyMaterial::ProceduralSkyMaterial() {
@@ -423,7 +422,7 @@ void PanoramaSkyMaterial::cleanup_shader() {
 }
 
 void PanoramaSkyMaterial::_update_shader() {
-	shader_mutex.lock();
+	MutexLock m(shader_mutex);
 	if (shader_cache[0].is_null()) {
 		for (int i = 0; i < 2; i++) {
 			shader_cache[i] = RS::get_singleton()->shader_create();
@@ -443,8 +442,6 @@ void sky() {
 																		  i ? "filter_linear" : "filter_nearest"));
 		}
 	}
-
-	shader_mutex.unlock();
 }
 
 PanoramaSkyMaterial::PanoramaSkyMaterial() {
@@ -635,7 +632,7 @@ void PhysicalSkyMaterial::cleanup_shader() {
 }
 
 void PhysicalSkyMaterial::_update_shader() {
-	shader_mutex.lock();
+	MutexLock m(shader_mutex);
 	if (shader.is_null()) {
 		shader = RS::get_singleton()->shader_create();
 
@@ -738,8 +735,6 @@ void sky() {
 }
 )");
 	}
-
-	shader_mutex.unlock();
 }
 
 PhysicalSkyMaterial::PhysicalSkyMaterial() {


### PR DESCRIPTION
The goal was to clean up as much of `lock` and `unlock` as possible. I wanted to help improve code clarity and prevent mistakes. If the code does not look clearer with this change then it might not be worth merging.

To keep the change simple I added ownership for the different lock types: `MutexLock`, `RWLockRead` `RWLockWrite`. Ownership will help these different lock types to know if they need to unlock during destruction. This allows users to still unlock and relock mutex as needed. This affects some portions of the code but mostly helps due to not needing to manually control scope guards with braces or refactoring the code entirely.

I tried not to be too opinionated or overzealous when wrapping code with these locks. I tried to preserve as much of the original code's scope for each mutex if it made sense. Sometimes this meant keeping `unlock` where it might make sense for performance reasons like printing error logs. Not sure if that's worth it though due to error printing might be uncommon?

There is still a lot of `lock` and `unlock` in the code. Specifically with `SpinLock`. Additionally a lot of servers expose a `lock` and `unlock` function. There were also areas of the code with complex scenarios which would not be able to use the locks either.

Some details about the locks that know about ownership. There is an enum `LockMode` which allows users to specify how the lock should handle the mutex/rwlock on entry. There are 3 choices `lock`, `try_lock` or do nothing with `defer`. This is similar to how C++ works and give user as much flexibility as possible.