### PR TITLE
Add error for invalid RichTextLabel.install_effect

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4883,11 +4883,10 @@ void RichTextLabel::install_effect(const Variant effect) {
 	Ref<RichTextEffect> rteffect;
 	rteffect = effect;
 
-	if (rteffect.is_valid()) {
-		custom_effects.push_back(effect);
-		if ((!text.is_empty()) && use_bbcode) {
-			parse_bbcode(text);
-		}
+	ERR_FAIL_COND_MSG(rteffect.is_null(), "Invalid RichTextEffect resource.");
+	custom_effects.push_back(effect);
+	if ((!text.is_empty()) && use_bbcode) {
+		parse_bbcode(text);
 	}
 }
 


### PR DESCRIPTION
Currently, `RichTextLabel.install_effect` silently fails when its argument is not a `RichTextEffect`.

This can cause confusion for "almost correct code" like `install_effect(load("res://my_effect.gd"))` which seems like it should work, but ends up doing nothing because of the missing `.new()`. This will now show an error instead.