### PR TITLE
Expose TileMap methods related to the name of custom data layers

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -117,6 +117,27 @@
 				If the TileSet has no proxy for the given identifiers, returns an empty Array.
 			</description>
 		</method>
+		<method name="get_custom_data_layer_by_name" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="layer_name" type="String" />
+			<description>
+				Returns the index of the custom data layer identified by the given name.
+			</description>
+		</method>
+		<method name="get_custom_data_layer_name" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="layer_index" type="int" />
+			<description>
+				Returns the name of the custom data layer identified by the given index.
+			</description>
+		</method>
+		<method name="get_custom_data_layer_type" qualifiers="const">
+			<return type="int" enum="Variant.Type" />
+			<argument index="0" name="layer_index" type="int" />
+			<description>
+				Returns the type of the custom data layer identified by the given index.
+			</description>
+		</method>
 		<method name="get_custom_data_layers_count" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -462,6 +483,22 @@
 				Creates a coordinates-level proxy for the given identifiers. A proxy will map set of tile identifiers to another set of identifiers. The alternative tile ID is kept the same when using coordinates-level proxies.
 				This can be used to replace a tile in all TileMaps using this TileSet, as TileMap nodes will find and use the proxy's target tile when one is available.
 				Proxied tiles can be automatically replaced in TileMap nodes using the editor.
+			</description>
+		</method>
+		<method name="set_custom_data_layer_name">
+			<return type="void" />
+			<argument index="0" name="layer_index" type="int" />
+			<argument index="1" name="layer_name" type="String" />
+			<description>
+				Sets the name of the custom data layer identified by the given index. Names are identifiers of the layer therefore if the name is already taken it will fail and raise an error.
+			</description>
+		</method>
+		<method name="set_custom_data_layer_type">
+			<return type="void" />
+			<argument index="0" name="layer_index" type="int" />
+			<argument index="1" name="layer_type" type="int" enum="Variant.Type" />
+			<description>
+				Sets the type of the custom data layer identified by the given index.
 			</description>
 		</method>
 		<method name="set_navigation_layer_layers">

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -735,15 +735,15 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	// --- Custom Data ---
 	ADD_TILE_DATA_EDITOR_GROUP("Custom Data");
 	for (int i = 0; i < tile_set->get_custom_data_layers_count(); i++) {
-		if (tile_set->get_custom_data_name(i).is_empty()) {
+		if (tile_set->get_custom_data_layer_name(i).is_empty()) {
 			ADD_TILE_DATA_EDITOR(group, vformat("Custom Data %d", i), vformat("custom_data_%d", i));
 		} else {
-			ADD_TILE_DATA_EDITOR(group, tile_set->get_custom_data_name(i), vformat("custom_data_%d", i));
+			ADD_TILE_DATA_EDITOR(group, tile_set->get_custom_data_layer_name(i), vformat("custom_data_%d", i));
 		}
 		if (!tile_data_editors.has(vformat("custom_data_%d", i))) {
 			TileDataDefaultEditor *tile_data_custom_data_editor = memnew(TileDataDefaultEditor());
 			tile_data_custom_data_editor->hide();
-			tile_data_custom_data_editor->setup_property_editor(tile_set->get_custom_data_type(i), vformat("custom_data_%d", i), tile_set->get_custom_data_name(i));
+			tile_data_custom_data_editor->setup_property_editor(tile_set->get_custom_data_layer_type(i), vformat("custom_data_%d", i), tile_set->get_custom_data_layer_name(i));
 			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
 			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
 			tile_data_editors[vformat("custom_data_%d", i)] = tile_data_custom_data_editor;

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -1048,13 +1048,13 @@ int TileSet::get_custom_data_layer_by_name(String p_value) const {
 	}
 }
 
-void TileSet::set_custom_data_name(int p_layer_id, String p_value) {
+void TileSet::set_custom_data_layer_name(int p_layer_id, String p_value) {
 	ERR_FAIL_INDEX(p_layer_id, custom_data_layers.size());
 
 	// Exit if another property has the same name.
 	if (!p_value.is_empty()) {
 		for (int other_layer_id = 0; other_layer_id < get_custom_data_layers_count(); other_layer_id++) {
-			if (other_layer_id != p_layer_id && get_custom_data_name(other_layer_id) == p_value) {
+			if (other_layer_id != p_layer_id && get_custom_data_layer_name(other_layer_id) == p_value) {
 				ERR_FAIL_MSG(vformat("There is already a custom property named %s", p_value));
 			}
 		}
@@ -1070,12 +1070,12 @@ void TileSet::set_custom_data_name(int p_layer_id, String p_value) {
 	emit_changed();
 }
 
-String TileSet::get_custom_data_name(int p_layer_id) const {
+String TileSet::get_custom_data_layer_name(int p_layer_id) const {
 	ERR_FAIL_INDEX_V(p_layer_id, custom_data_layers.size(), "");
 	return custom_data_layers[p_layer_id].name;
 }
 
-void TileSet::set_custom_data_type(int p_layer_id, Variant::Type p_value) {
+void TileSet::set_custom_data_layer_type(int p_layer_id, Variant::Type p_value) {
 	ERR_FAIL_INDEX(p_layer_id, custom_data_layers.size());
 	custom_data_layers.write[p_layer_id].type = p_value;
 
@@ -1086,7 +1086,7 @@ void TileSet::set_custom_data_type(int p_layer_id, Variant::Type p_value) {
 	emit_changed();
 }
 
-Variant::Type TileSet::get_custom_data_type(int p_layer_id) const {
+Variant::Type TileSet::get_custom_data_layer_type(int p_layer_id) const {
 	ERR_FAIL_INDEX_V(p_layer_id, custom_data_layers.size(), Variant::NIL);
 	return custom_data_layers[p_layer_id].type;
 }
@@ -3003,14 +3003,14 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 				while (index >= custom_data_layers.size()) {
 					add_custom_data_layer();
 				}
-				set_custom_data_name(index, p_value);
+				set_custom_data_layer_name(index, p_value);
 				return true;
 			} else if (components[1] == "type") {
 				ERR_FAIL_COND_V(p_value.get_type() != Variant::INT, false);
 				while (index >= custom_data_layers.size()) {
 					add_custom_data_layer();
 				}
-				set_custom_data_type(index, Variant::Type(int(p_value)));
+				set_custom_data_layer_type(index, Variant::Type(int(p_value)));
 				return true;
 			}
 		} else if (components.size() == 2 && components[0] == "sources" && components[1].is_valid_int()) {
@@ -3132,10 +3132,10 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 			return false;
 		}
 		if (components[1] == "name") {
-			r_ret = get_custom_data_name(index);
+			r_ret = get_custom_data_layer_name(index);
 			return true;
 		} else if (components[1] == "type") {
-			r_ret = get_custom_data_type(index);
+			r_ret = get_custom_data_layer_type(index);
 			return true;
 		}
 	} else if (components.size() == 2 && components[0] == "sources" && components[1].is_valid_int()) {
@@ -3358,6 +3358,11 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_custom_data_layer", "to_position"), &TileSet::add_custom_data_layer, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("move_custom_data_layer", "layer_index", "to_position"), &TileSet::move_custom_data_layer);
 	ClassDB::bind_method(D_METHOD("remove_custom_data_layer", "layer_index"), &TileSet::remove_custom_data_layer);
+	ClassDB::bind_method(D_METHOD("get_custom_data_layer_by_name", "layer_name"), &TileSet::get_custom_data_layer_by_name);
+	ClassDB::bind_method(D_METHOD("set_custom_data_layer_name", "layer_index", "layer_name"), &TileSet::set_custom_data_layer_name);
+	ClassDB::bind_method(D_METHOD("get_custom_data_layer_name", "layer_index"), &TileSet::get_custom_data_layer_name);
+	ClassDB::bind_method(D_METHOD("set_custom_data_layer_type", "layer_index", "layer_type"), &TileSet::set_custom_data_layer_type);
+	ClassDB::bind_method(D_METHOD("get_custom_data_layer_type", "layer_index"), &TileSet::get_custom_data_layer_type);
 
 	// Tile proxies
 	ClassDB::bind_method(D_METHOD("set_source_level_tile_proxy", "source_from", "source_to"), &TileSet::set_source_level_tile_proxy);
@@ -4805,14 +4810,14 @@ void TileData::notify_tile_data_properties_should_change() {
 	// Convert custom data to the new type.
 	custom_data.resize(tile_set->get_custom_data_layers_count());
 	for (int i = 0; i < custom_data.size(); i++) {
-		if (custom_data[i].get_type() != tile_set->get_custom_data_type(i)) {
+		if (custom_data[i].get_type() != tile_set->get_custom_data_layer_type(i)) {
 			Variant new_val;
 			Callable::CallError error;
-			if (Variant::can_convert(custom_data[i].get_type(), tile_set->get_custom_data_type(i))) {
+			if (Variant::can_convert(custom_data[i].get_type(), tile_set->get_custom_data_layer_type(i))) {
 				const Variant *args[] = { &custom_data[i] };
-				Variant::construct(tile_set->get_custom_data_type(i), new_val, args, 1, error);
+				Variant::construct(tile_set->get_custom_data_layer_type(i), new_val, args, 1, error);
 			} else {
-				Variant::construct(tile_set->get_custom_data_type(i), new_val, nullptr, 0, error);
+				Variant::construct(tile_set->get_custom_data_layer_type(i), new_val, nullptr, 0, error);
 			}
 			custom_data.write[i] = new_val;
 		}
@@ -5626,7 +5631,7 @@ void TileData::_get_property_list(List<PropertyInfo> *p_list) const {
 			Variant default_val;
 			Callable::CallError error;
 			Variant::construct(custom_data[i].get_type(), default_val, nullptr, 0, error);
-			property_info = PropertyInfo(tile_set->get_custom_data_type(i), vformat("custom_data_%d", i), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
+			property_info = PropertyInfo(tile_set->get_custom_data_layer_type(i), vformat("custom_data_%d", i), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 			if (custom_data[i] == default_val) {
 				property_info.usage ^= PROPERTY_USAGE_STORAGE;
 			}

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -479,10 +479,10 @@ public:
 	void move_custom_data_layer(int p_from_index, int p_to_pos);
 	void remove_custom_data_layer(int p_index);
 	int get_custom_data_layer_by_name(String p_value) const;
-	void set_custom_data_name(int p_layer_id, String p_value);
-	String get_custom_data_name(int p_layer_id) const;
-	void set_custom_data_type(int p_layer_id, Variant::Type p_value);
-	Variant::Type get_custom_data_type(int p_layer_id) const;
+	void set_custom_data_layer_name(int p_layer_id, String p_value);
+	String get_custom_data_layer_name(int p_layer_id) const;
+	void set_custom_data_layer_type(int p_layer_id, Variant::Type p_value);
+	Variant::Type get_custom_data_layer_type(int p_layer_id) const;
 
 	// Tiles proxies.
 	void set_source_level_tile_proxy(int p_source_from, int p_source_to);


### PR DESCRIPTION
Fixes #63276 

Exposes TileMap methods that are related to the name of custom data layers and add docs description for them.