### PR TITLE
Avoid crash when when the editor_property_map is empty.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3558,7 +3558,7 @@ void EditorInspector::_notification(int p_what) {
 				if (refresh_countdown <= 0) {
 					for (const KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {
 						for (EditorProperty *E : F.value) {
-							if (!E->is_cache_valid()) {
+							if (E && !E->is_cache_valid()) {
 								E->update_property();
 								E->update_revert_and_pin_status();
 								E->update_cache();


### PR DESCRIPTION
When the editor property bonemap is invalid, it passes an null EditorProperty and then Godot Engine crashes.