### PR TITLE
Enable users to react to save/load operations globally.

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -60,9 +60,11 @@ protected:
 	GDVIRTUAL1RC(bool, _exists, String)
 
 	GDVIRTUAL4RC(Variant, _load, String, String, bool, int)
+	GDVIRTUAL3C(_on_load, Ref<Resource>, String, int);
 
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual void on_load(Ref<Resource> p_resource, const String &p_path, CacheMode p_cache_mode) const;
 	virtual bool exists(const String &p_path) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -50,6 +50,10 @@ Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p
 	return ERR_METHOD_NOT_FOUND;
 }
 
+void ResourceFormatSaver::on_save(Ref<Resource> p_resource, const String &p_path, uint32_t p_flags) const {
+	GDVIRTUAL_CALL(_on_save, p_resource, p_path, p_flags);
+}
+
 bool ResourceFormatSaver::recognize(const Ref<Resource> &p_resource) const {
 	bool success;
 	if (GDVIRTUAL_CALL(_recognize, p_resource, success)) {
@@ -71,6 +75,7 @@ void ResourceFormatSaver::get_recognized_extensions(const Ref<Resource> &p_resou
 
 void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_save, "path", "resource", "flags");
+	GDVIRTUAL_BIND(_on_save, "resource", "path", "flags");
 	GDVIRTUAL_BIND(_recognize, "resource");
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
 }
@@ -134,7 +139,13 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 				save_callback(p_resource, path);
 			}
 
-			return OK;
+			break;
+		}
+	}
+
+	if (err == OK) {
+		for (int i = 0; i < saver_count; i++) {
+			saver[i]->on_save(p_resource, path, p_flags);
 		}
 	}
 

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -42,11 +42,13 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL3R(int64_t, _save, Ref<Resource>, String, uint32_t)
+	GDVIRTUAL3C(_on_save, Ref<Resource>, String, uint32_t);
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
+	virtual void on_save(Ref<Resource> p_resource, const String &p_path, uint32_t p_flags) const;
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -71,6 +71,15 @@
 				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
 			</description>
 		</method>
+		<method name="_on_load" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="resource" type="Resource" />
+			<param index="1" name="path" type="String" />
+			<param index="2" name="cache_mode" type="int" />
+			<description>
+				Executes on every successfully loaded resource regardless of type or path. All arguments are the same as those from [method _load] except [code]path[/code] which uses [code]original_path[/code].
+			</description>
+		</method>
 		<method name="_rename_dependencies" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="path" type="String" />

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -17,6 +17,15 @@
 				Returns the list of extensions available for saving the resource object, provided it is recognized (see [method _recognize]).
 			</description>
 		</method>
+		<method name="_on_save" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="resource" type="Resource" />
+			<param index="1" name="path" type="String" />
+			<param index="2" name="flags" type="int" />
+			<description>
+				Executes on every successfully saved resource regardless of type or path. All arguments are the same as those from [method _save].
+			</description>
+		</method>
 		<method name="_recognize" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="resource" type="Resource" />


### PR DESCRIPTION
Closes godotengine/godot-proposals#3232.

Initially implemented as adding signals to `ResourceSaver` and `ResourceLoader`. Upon receiving feedback from reduz below, it has been rewritten as a new virtual callback associated with the `ResourceFormatSaver` and `ResourceFormatLoader`.