### PR TITLE
[3.x] Optimize `AudioServer::_driver_process()`

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -261,7 +261,14 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 
 		//master master, send to output
 		int cs = master->channels.size();
+
+		// take away 1 from the stride as we are manually incrementing one for stereo
+		uintptr_t stride_minus_one = (cs * 2) - 1;
+
 		for (int k = 0; k < cs; k++) {
+			// destination start for data will be the same in all cases
+			int32_t *dest = &p_buffer[(from_buf * (cs * 2)) + (k * 2)];
+
 			if (master->channels[k].active) {
 				const AudioFrame *buf = master->channels[k].buffer.ptr();
 
@@ -269,18 +276,25 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 					float l = CLAMP(buf[from + j].l, -1.0, 1.0);
 					int32_t vl = l * ((1 << 20) - 1);
 					int32_t vl2 = (vl < 0 ? -1 : 1) * (ABS(vl) << 11);
-					p_buffer[(from_buf + j) * (cs * 2) + k * 2 + 0] = vl2;
+					*dest = vl2;
+					dest++;
 
 					float r = CLAMP(buf[from + j].r, -1.0, 1.0);
 					int32_t vr = r * ((1 << 20) - 1);
 					int32_t vr2 = (vr < 0 ? -1 : 1) * (ABS(vr) << 11);
-					p_buffer[(from_buf + j) * (cs * 2) + k * 2 + 1] = vr2;
+					*dest = vr2;
+					dest += stride_minus_one;
 				}
 
 			} else {
+				// Bizarrely, profiling indicates that detecting the common case of cs == 1
+				// and k == 0, and using memset is SLOWER than setting individually.
+				// (Perhaps it gets optimized to a faster instruction than memset).
 				for (int j = 0; j < to_copy; j++) {
-					p_buffer[(from_buf + j) * (cs * 2) + k * 2 + 0] = 0;
-					p_buffer[(from_buf + j) * (cs * 2) + k * 2 + 1] = 0;
+					*dest = 0;
+					dest++;
+					*dest = 0;
+					dest += stride_minus_one;
 				}
 			}
 		}


### PR DESCRIPTION
Move expensive calculations outside inner hot loops.

## Notes
* Profiling reveals audio is now the biggest CPU user in the editor (when using `vital_redraws_only` mode). While turning off the audio processing completely is the most effective option for the editor, I noticed some low hanging fruit in the hot spots, which could also be useful in running games.
* This change is 8.69 / 2.61 = 3.3x faster for the `AudioServer::_driver_process()` in the empty case, and should also be significantly faster with active audio.
* I also tried using `memset()`, but bizarrely profiling revealed it was approximately equal in speed to the old code, and wasn't as fast as the new approach here. This may be system dependent, but without evidence of a benefit to using `memset()` I've left it out for now. It might be more advantageous with larger buffer sizes.
* Reducing audio processing cost means less load for batteries on mobile / laptops, and more CPU for other game processing on desktop, so seems well worth doing.
* Similar optimizations could be possible in 4.x, I haven't looked at the audio processing there yet.

## Further Discussion
As well as changes here, it looks like most important factor for reducing CPU in editor would either be to just turn off audio, or to sleep the `AudioDriver` (for longer, as it looks like it is slept for 1ms when there is no audio), or to close PulseAudio (or whatever platform equivalent) after some silence, as suggested here: https://github.com/godotengine/godot/pull/45948#issuecomment-779236872
The wider problem is that we can optimize the code in the audio threads as much as we want, but if they just spin, it will just do more iterations, so ultimately we probably need to sleep / sleep more / pause threads.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
