### PR TITLE
Fixup BVH debugging statements

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -302,7 +302,7 @@ public:
 		tree.update();
 		_check_for_collisions();
 #ifdef BVH_INTEGRITY_CHECKS
-		tree.integrity_check_all();
+		tree._integrity_check_all();
 #endif
 	}
 

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -2,7 +2,7 @@ public:
 BVHHandle item_add(T *p_userdata, bool p_active, const BOUNDS &p_aabb, int32_t p_subindex, uint32_t p_tree_id, uint32_t p_tree_collision_mask, bool p_invisible = false) {
 #ifdef BVH_VERBOSE_TREE
 	VERBOSE_PRINT("\nitem_add BEFORE");
-	_debug_recursive_print_tree(0);
+	_debug_recursive_print_tree(p_tree_id);
 	VERBOSE_PRINT("\n");
 #endif
 
@@ -78,8 +78,8 @@ BVHHandle item_add(T *p_userdata, bool p_active, const BOUNDS &p_aabb, int32_t p
 	mem += _nodes.estimate_memory_use();
 
 	String sz = _debug_aabb_to_string(abb);
-	VERBOSE_PRINT("\titem_add [" + itos(ref_id) + "] " + itos(_refs.size()) + " refs,\t" + itos(_nodes.size()) + " nodes " + sz);
-	VERBOSE_PRINT("mem use : " + itos(mem) + ", num nodes : " + itos(_nodes.size()));
+	VERBOSE_PRINT("\titem_add [" + itos(ref_id) + "] " + itos(_refs.used_size()) + " refs,\t" + itos(_nodes.used_size()) + " nodes " + sz);
+	VERBOSE_PRINT("mem use : " + itos(mem) + ", num nodes reserved : " + itos(_nodes.reserved_size()));
 
 #endif
 


### PR DESCRIPTION
Extra debugging output/checks for the BVH can be enabled by uncommenting the `#define`s here:

https://github.com/godotengine/godot/blob/ce959dc753c2245610e93e2f88eab4cc95bd7d9b/core/math/bvh_tree.h#L56-L66

Some of the code inside `#ifdef BVH_VERBOSE` and `#ifdef BVH_INTEGRITY_CHECKS` blocks got outdated; this PR makes the code compile again when those `#define`s are enabled.

cc @lawnjelly 