### PR TITLE
[3.x] Fixup BVH debugging statements

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -295,7 +295,7 @@ public:
 		tree.update();
 		_check_for_collisions();
 #ifdef BVH_INTEGRITY_CHECKS
-		tree.integrity_check_all();
+		tree._integrity_check_all();
 #endif
 	}
 
@@ -464,13 +464,6 @@ private:
 				if (ref_id == changed_item_ref_id) {
 					continue;
 				}
-
-#ifdef BVH_CHECKS
-				// if neither are pairable, they should ignore each other
-				// THIS SHOULD NEVER HAPPEN .. now we only test the pairable tree
-				// if the changed item is not pairable
-				CRASH_COND(params.test_pairable_only && !tree._extra[ref_id].pairable);
-#endif
 
 				// checkmasks is already done in the cull routine.
 				BVHHandle h_collidee;

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -2,7 +2,7 @@ public:
 BVHHandle item_add(T *p_userdata, bool p_active, const BOUNDS &p_aabb, int32_t p_subindex, uint32_t p_tree_id, uint32_t p_tree_collision_mask, bool p_invisible = false) {
 #ifdef BVH_VERBOSE_TREE
 	VERBOSE_PRINT("\nitem_add BEFORE");
-	_debug_recursive_print_tree(0);
+	_debug_recursive_print_tree(p_tree_id);
 	VERBOSE_PRINT("\n");
 #endif
 
@@ -78,8 +78,8 @@ BVHHandle item_add(T *p_userdata, bool p_active, const BOUNDS &p_aabb, int32_t p
 	mem += _nodes.estimate_memory_use();
 
 	String sz = _debug_aabb_to_string(abb);
-	VERBOSE_PRINT("\titem_add [" + itos(ref_id) + "] " + itos(_refs.size()) + " refs,\t" + itos(_nodes.size()) + " nodes " + sz);
-	VERBOSE_PRINT("mem use : " + itos(mem) + ", num nodes : " + itos(_nodes.size()));
+	VERBOSE_PRINT("\titem_add [" + itos(ref_id) + "] " + itos(_refs.used_size()) + " refs,\t" + itos(_nodes.used_size()) + " nodes " + sz);
+	VERBOSE_PRINT("mem use : " + itos(mem) + ", num nodes reserved : " + itos(_nodes.reserved_size()));
 
 #endif
 


### PR DESCRIPTION
This is the `3.x` version of https://github.com/godotengine/godot/pull/63443.

Removed an additional outdated check (that was already removed in `master`) because it is no longer applicable to the current implementation.