### PR TITLE
Tweak initial X11 window title to be more descriptive

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -4490,7 +4490,11 @@ DisplayServerX11::WindowID DisplayServerX11::_create_window(WindowMode p_mode, V
 		}
 
 		/* set the titlebar name */
-		XStoreName(x11_display, wd.x11_window, "Godot");
+#ifdef TOOLS_ENABLED
+		XStoreName(x11_display, wd.x11_window, "Godot Engine - Loading...");
+#else
+		XStoreName(x11_display, wd.x11_window, "Loading...");
+#endif
 		XSetWMProtocols(x11_display, wd.x11_window, &wm_delete, 1);
 		if (xdnd_aware != None) {
 			XChangeProperty(x11_display, wd.x11_window, xdnd_aware, XA_ATOM, 32, PropModeReplace, (unsigned char *)&xdnd_version, 1);


### PR DESCRIPTION
A "Loading" text is now added to the initial window title. This temporary window title is then replaced by the project manager, editor or running project once these are done initializing.

Exported projects will not refer to Godot by name during the initial loading.

## Preview

*Click to play.*

https://user-images.githubusercontent.com/180032/180839719-dad9b41a-fe25-4504-808f-14c7ca1ed753.mp4

## TODO

- [ ] Port to Windows (and macOS if possible/relevant).