### PR TITLE
Fix initial value of TRS3DTrack cache in `AnimationPlayer`

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -109,6 +109,9 @@ private:
 		bool loc_used = false;
 		bool rot_used = false;
 		bool scale_used = false;
+		Vector3 init_loc = Vector3(0, 0, 0);
+		Quaternion init_rot = Quaternion(0, 0, 0, 1);
+		Vector3 init_scale = Vector3(1, 1, 1);
 
 		Vector3 loc_accum;
 		Quaternion rot_accum;


### PR DESCRIPTION
Fix a bug that caused Scale to be `Vector(0, 0, 0)` when switching between a track with an animation which has Scale track and an animation doesn't has Scale track on AnimationPlayer.

https://user-images.githubusercontent.com/61938263/180867846-0e140765-29ab-4f7e-a95b-14a3895c31cf.mp4

This bug is caused by the initial value of the accumulator in TrackCache being `Vector(0, 0, 0)` in AnimationPlayer. Also, since bone pose now includes bone rest in Godot 4, so its initial value should be set to the value of bone rest for consistency with AnimationTree.

---

#### Test model

Blender Chan! / CC by [SearKitchen](https://sketchfab.com/searkitchen)
https://sketchfab.com/3d-models/blender-chan-6835f0d60e0c4813812c0247e3b73da7