### PR TITLE
[3.x] Change X11 event timeout from 1 second to 100 milliseconds

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2457,8 +2457,8 @@ bool OS_X11::_wait_for_events() const {
 	FD_SET(x11_fd, &in_fds);
 
 	struct timeval tv;
-	tv.tv_usec = 0;
-	tv.tv_sec = 1;
+	tv.tv_usec = 100000;
+	tv.tv_sec = 0;
 
 	// Wait for next event or timeout.
 	int num_ready_fds = select(x11_fd + 1, &in_fds, nullptr, nullptr, &tv);


### PR DESCRIPTION
I couldn't easily cherry pick https://github.com/godotengine/godot/pull/63464 so I redid the change for 3.x