### PR TITLE
Add minimum roughness project setting to improve VoxelGI/SDFGI performance

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2035,7 +2035,19 @@
 		</member>
 		<member name="rendering/global_illumination/sdfgi/frames_to_update_lights" type="int" setter="" getter="" default="2">
 		</member>
+		<member name="rendering/global_illumination/sdfgi/min_roughness" type="float" setter="" getter="" default="0.0">
+			If set to a value greater than [code]0.0[/code] (exclusive), clamps the minimum roughness used for SDFGI rendering (see [member Environment.sdfgi_enabled]). Higher values will improve performance in scenes with smooth materials (especially when set to [code]0.2[/code]), at the cost of less precise SDFGI reflections on smooth materials.
+			Clamping the roughness can also be useful to prevent bad interactions between [ReflectionProbe]s and SDFGI reflections, which may be noticeable in some scenes.
+			The minimum roughness defined here does [i]not[/i] affect other sources of reflections such as [ReflectionProbe]s or [Environment] sky reflections. See also [member rendering/global_illumination/voxel_gi/min_roughness].
+			[b]Note:[/b] This property is only read when the project starts. To set the minimum roughness for SDFGI reflections at run-time, call [method RenderingServer.environment_set_sdfgi_min_roughness] instead.
+		</member>
 		<member name="rendering/global_illumination/sdfgi/probe_ray_count" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="rendering/global_illumination/voxel_gi/min_roughness" type="float" setter="" getter="" default="0.0">
+			If set to a value greater than [code]0.0[/code] (exclusive), clamps the minimum roughness used for [VoxelGI] rendering. Higher values will improve performance in scenes with smooth materials, at the cost of less precise [VoxelGI] reflections on smooth materials.
+			Clamping the roughness can also be useful to prevent bad interactions between [ReflectionProbe]s and [VoxelGI] reflections, which may be noticeable in some scenes.
+			The minimum roughness defined here does [i]not[/i] affect other sources of reflections such as [ReflectionProbe]s or [Environment] sky reflections. See also [member rendering/global_illumination/sdfgi/min_roughness].
+			[b]Note:[/b] This property is only read when the project starts. To set the minimum roughness for [VoxelGI] reflections at run-time, call [method RenderingServer.voxel_gi_set_min_roughness] instead.
 		</member>
 		<member name="rendering/global_illumination/voxel_gi/quality" type="int" setter="" getter="" default="0">
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1080,6 +1080,15 @@
 			<description>
 			</description>
 		</method>
+		<method name="environment_set_sdfgi_min_roughness">
+			<return type="void" />
+			<argument index="0" name="roughness" type="float" />
+			<description>
+				If set to a value greater than [code]0.0[/code] (exclusive), clamps the minimum roughness used for SDFGI rendering (see [member Environment.sdfgi_enabled]). Higher values will improve performance in scenes with smooth materials (especially when set to [code]0.2[/code]), at the cost of less precise SDFGI reflections on smooth materials.
+				Clamping the roughness can also be useful to prevent bad interactions between [ReflectionProbe]s and SDFGI reflections, which may be noticeable in some scenes.
+				The minimum roughness defined here does [i]not[/i] affect other sources of reflections such as [ReflectionProbe]s or [Environment] sky reflections. See also [method voxel_gi_set_min_roughness] and [member ProjectSettings.rendering/global_illumination/sdfgi/min_roughness].
+			</description>
+		</method>
 		<method name="environment_set_sdfgi_ray_count">
 			<return type="void" />
 			<param index="0" name="ray_count" type="int" enum="RenderingServer.EnvironmentSDFGIRayCount" />
@@ -3582,6 +3591,15 @@
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
+			</description>
+		</method>
+		<method name="voxel_gi_set_min_roughness">
+			<return type="void" />
+			<argument index="0" name="roughness" type="float" />
+			<description>
+				If set to a value greater than [code]0.0[/code] (exclusive), clamps the minimum roughness used for SDFGI rendering (see [member Environment.sdfgi_enabled]). Higher values will improve performance in scenes with smooth materials (especially when set to [code]0.2[/code]), at the cost of less precise SDFGI reflections on smooth materials.
+				Clamping the roughness can also be useful to prevent bad interactions between [ReflectionProbe]s and SDFGI reflections, which may be noticeable in some scenes.
+				The minimum roughness defined here does [i]not[/i] affect other sources of reflections such as [ReflectionProbe]s or [Environment] sky reflections. See also [method environment_set_sdfgi_min_roughness] and [member ProjectSettings.rendering/global_illumination/voxel_gi/min_roughness].
 			</description>
 		</method>
 		<method name="voxel_gi_set_normal_bias">

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1088,6 +1088,9 @@ void RasterizerSceneGLES3::environment_set_sdfgi_frames_to_converge(RS::Environm
 void RasterizerSceneGLES3::environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) {
 }
 
+void RasterizerSceneGLES3::environment_set_sdfgi_min_roughness(float p_roughness) {
+}
+
 void RasterizerSceneGLES3::environment_set_volumetric_fog_volume_size(int p_size, int p_depth) {
 }
 
@@ -1137,6 +1140,9 @@ void RasterizerSceneGLES3::voxel_gi_update(RID p_probe, bool p_update_light_inst
 }
 
 void RasterizerSceneGLES3::voxel_gi_set_quality(RS::VoxelGIQuality) {
+}
+
+void RasterizerSceneGLES3::voxel_gi_set_min_roughness(float p_roughness) {
 }
 
 void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const RenderDataGLES3 *p_render_data, PassMode p_pass_mode, bool p_append) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -619,6 +619,7 @@ public:
 	void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) override;
 	void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) override;
 	void environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) override;
+	void environment_set_sdfgi_min_roughness(float p_roughness) override;
 
 	void environment_set_volumetric_fog_volume_size(int p_size, int p_depth) override;
 	void environment_set_volumetric_fog_filter_active(bool p_enable) override;
@@ -644,6 +645,7 @@ public:
 	void voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) override;
 
 	void voxel_gi_set_quality(RS::VoxelGIQuality) override;
+	void voxel_gi_set_min_roughness(float p_roughness) override;
 
 	void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingMethod::RenderInfo *r_render_info = nullptr) override;
 	void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -462,8 +462,12 @@ void EditorNode::_update_from_settings() {
 	RS::get_singleton()->environment_set_sdfgi_frames_to_converge(frames_to_converge);
 	RS::EnvironmentSDFGIRayCount ray_count = RS::EnvironmentSDFGIRayCount(int(GLOBAL_GET("rendering/global_illumination/sdfgi/probe_ray_count")));
 	RS::get_singleton()->environment_set_sdfgi_ray_count(ray_count);
+	float sdfgi_min_roughness = GLOBAL_DEF("rendering/global_illumination/sdfgi/min_roughness", 0.0);
+	RS::get_singleton()->environment_set_sdfgi_min_roughness(sdfgi_min_roughness);
 	RS::VoxelGIQuality voxel_gi_quality = RS::VoxelGIQuality(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/quality")));
 	RS::get_singleton()->voxel_gi_set_quality(voxel_gi_quality);
+	float voxel_gi_min_roughness = GLOBAL_DEF("rendering/global_illumination/voxel_gi/min_roughness", 0.0);
+	RS::get_singleton()->voxel_gi_set_min_roughness(voxel_gi_min_roughness);
 	RS::get_singleton()->environment_set_volumetric_fog_volume_size(GLOBAL_GET("rendering/environment/volumetric_fog/volume_size"), GLOBAL_GET("rendering/environment/volumetric_fog/volume_depth"));
 	RS::get_singleton()->environment_set_volumetric_fog_filter_active(bool(GLOBAL_GET("rendering/environment/volumetric_fog/use_filter")));
 	RS::get_singleton()->canvas_set_shadow_texture_size(GLOBAL_GET("rendering/2d/shadow_atlas/size"));

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -123,6 +123,7 @@ public:
 	void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) override {}
 	void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) override {}
 	void environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) override {}
+	void environment_set_sdfgi_min_roughness(float p_roughness) override {}
 
 	void environment_set_volumetric_fog_volume_size(int p_size, int p_depth) override {}
 	void environment_set_volumetric_fog_filter_active(bool p_enable) override {}
@@ -144,6 +145,7 @@ public:
 	void voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) override {}
 
 	void voxel_gi_set_quality(RS::VoxelGIQuality) override {}
+	void voxel_gi_set_min_roughness(float p_roughness) override {}
 
 	void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingMethod::RenderInfo *r_info = nullptr) override {}
 	void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override {}

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3360,7 +3360,6 @@ void GI::init(SkyRD *p_sky) {
 		voxel_gi_lights = memnew_arr(VoxelGILight, voxel_gi_max_lights);
 		voxel_gi_lights_uniform = RD::get_singleton()->uniform_buffer_create(voxel_gi_max_lights * sizeof(VoxelGILight));
 		voxel_gi_quality = RS::VoxelGIQuality(CLAMP(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/quality")), 0, 1));
-
 		String defines = "\n#define MAX_LIGHTS " + itos(voxel_gi_max_lights) + "\n";
 
 		Vector<String> versions;
@@ -3575,6 +3574,7 @@ void GI::init(SkyRD *p_sky) {
 	}
 	default_voxel_gi_buffer = RD::get_singleton()->uniform_buffer_create(sizeof(VoxelGIData) * MAX_VOXEL_GI_INSTANCES);
 	half_resolution = GLOBAL_GET("rendering/global_illumination/gi/use_half_resolution");
+	voxel_gi_min_roughness = GLOBAL_GET("rendering/global_illumination/gi/min_roughness");
 }
 
 void GI::free() {
@@ -3812,6 +3812,8 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 
 	push_constant.max_voxel_gi_instances = MIN((uint64_t)MAX_VOXEL_GI_INSTANCES, p_voxel_gi_instances.size());
 	push_constant.high_quality_vct = voxel_gi_quality == RS::VOXEL_GI_QUALITY_HIGH;
+	push_constant.voxel_gi_min_roughness = voxel_gi_min_roughness;
+	push_constant.sdfgi_min_roughness = sdfgi_min_roughness;
 
 	// these should be the same for all views
 	push_constant.orthogonal = p_projections[0].is_orthogonal();

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -540,6 +540,7 @@ public:
 	void voxel_gi_instance_free(RID p_rid);
 
 	RS::VoxelGIQuality voxel_gi_quality = RS::VOXEL_GI_QUALITY_LOW;
+	float voxel_gi_min_roughness = 0.0;
 
 	/* SDFGI */
 
@@ -695,6 +696,7 @@ public:
 	RS::EnvironmentSDFGIRayCount sdfgi_ray_count = RS::ENV_SDFGI_RAY_COUNT_16;
 	RS::EnvironmentSDFGIFramesToConverge sdfgi_frames_to_converge = RS::ENV_SDFGI_CONVERGE_IN_30_FRAMES;
 	RS::EnvironmentSDFGIFramesToUpdateLight sdfgi_frames_to_update_light = RS::ENV_SDFGI_UPDATE_LIGHT_IN_4_FRAMES;
+	float sdfgi_min_roughness = 0.0;
 
 	float sdfgi_solid_cell_ratio = 0.25;
 	Vector3 sdfgi_debug_probe_pos;
@@ -770,15 +772,15 @@ public:
 	struct PushConstant {
 		uint32_t max_voxel_gi_instances;
 		uint32_t high_quality_vct;
-		uint32_t orthogonal;
-		uint32_t view_index;
+		float voxel_gi_min_roughness;
+		float sdfgi_min_roughness;
 
 		float proj_info[4];
 
+		uint32_t view_index;
+		uint32_t orthogonal;
 		float z_near;
 		float z_far;
-		float pad2;
-		float pad3;
 	};
 
 	RID sdfgi_ubo;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -94,8 +94,13 @@ void RendererSceneRenderRD::environment_set_sdfgi_ray_count(RS::EnvironmentSDFGI
 void RendererSceneRenderRD::environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) {
 	gi.sdfgi_frames_to_converge = p_frames;
 }
+
 void RendererSceneRenderRD::environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) {
 	gi.sdfgi_frames_to_update_light = p_update;
+}
+
+void RendererSceneRenderRD::environment_set_sdfgi_min_roughness(float p_roughness) {
+	gi.sdfgi_min_roughness = p_roughness;
 }
 
 Ref<Image> RendererSceneRenderRD::environment_bake_panorama(RID p_env, bool p_bake_irradiance, const Size2i &p_size) {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -236,6 +236,7 @@ public:
 	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) override;
 	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) override;
 	virtual void environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) override;
+	virtual void environment_set_sdfgi_min_roughness(float p_roughness) override;
 
 	virtual Ref<Image> environment_bake_panorama(RID p_env, bool p_bake_irradiance, const Size2i &p_size) override;
 
@@ -266,6 +267,7 @@ public:
 	virtual bool voxel_gi_needs_update(RID p_probe) const override;
 	virtual void voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) override;
 	virtual void voxel_gi_set_quality(RS::VoxelGIQuality p_quality) override { gi.voxel_gi_quality = p_quality; }
+	virtual void voxel_gi_set_min_roughness(float p_roughness) override { gi.voxel_gi_min_roughness = p_roughness; }
 
 	/* render buffers */
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_gi_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_gi_inc.glsl
@@ -98,6 +98,7 @@ void voxel_gi_compute(uint index, vec3 position, vec3 normal, vec3 ref_vec, mat3
 	out_diff += vec4(light * blend, blend);
 
 	//irradiance
+	// TODO: This part isn't used?
 	vec4 irr_light = voxel_cone_trace(voxel_gi_textures[index], cell_size, position, ref_vec, tan(roughness * 0.5 * M_PI * 0.99), max_distance, voxel_gi_instances.data[index].bias);
 	if (voxel_gi_instances.data[index].blend_ambient) {
 		irr_light.rgb = mix(environment, irr_light.rgb, min(1.0, irr_light.a / 0.95));

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1082,6 +1082,7 @@ public:
 #define PASSBASE scene_render
 
 	PASS1(voxel_gi_set_quality, RS::VoxelGIQuality)
+	PASS1(voxel_gi_set_min_roughness, float)
 
 	/* SKY API */
 
@@ -1234,6 +1235,7 @@ public:
 	PASS1(environment_set_sdfgi_ray_count, RS::EnvironmentSDFGIRayCount)
 	PASS1(environment_set_sdfgi_frames_to_converge, RS::EnvironmentSDFGIFramesToConverge)
 	PASS1(environment_set_sdfgi_frames_to_update_light, RS::EnvironmentSDFGIFramesToUpdateLight)
+	PASS1(environment_set_sdfgi_min_roughness, float)
 
 	// Adjustment
 	PASS7(environment_set_adjustment, RID, bool, float, float, float, bool, RID)

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -213,6 +213,7 @@ public:
 	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) = 0;
 	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) = 0;
 	virtual void environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) = 0;
+	virtual void environment_set_sdfgi_min_roughness(float p_roughness) = 0;
 
 	// Adjustment
 	void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, bool p_use_1d_color_correction, RID p_color_correction);
@@ -240,6 +241,7 @@ public:
 	virtual void voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) = 0;
 
 	virtual void voxel_gi_set_quality(RS::VoxelGIQuality) = 0;
+	virtual void voxel_gi_set_min_roughness(float p_roughness) = 0;
 
 	struct RenderShadowData {
 		RID light;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -261,6 +261,7 @@ public:
 	virtual void environment_set_sdfgi_ray_count(RS::EnvironmentSDFGIRayCount p_ray_count) = 0;
 	virtual void environment_set_sdfgi_frames_to_converge(RS::EnvironmentSDFGIFramesToConverge p_frames) = 0;
 	virtual void environment_set_sdfgi_frames_to_update_light(RS::EnvironmentSDFGIFramesToUpdateLight p_update) = 0;
+	virtual void environment_set_sdfgi_min_roughness(float p_roughness) = 0;
 
 	virtual void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, bool p_use_1d_color_correction, RID p_color_correction) = 0;
 
@@ -292,6 +293,7 @@ public:
 
 	virtual TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) = 0;
 	virtual void voxel_gi_set_quality(RS::VoxelGIQuality) = 0;
+	virtual void voxel_gi_set_min_roughness(float p_roughness) = 0;
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -663,6 +663,7 @@ public:
 #define server_name RSG::scene
 
 	FUNC1(voxel_gi_set_quality, VoxelGIQuality)
+	FUNC1(voxel_gi_set_min_roughness, float)
 
 	/* SKY API */
 
@@ -713,6 +714,7 @@ public:
 	FUNC1(environment_set_sdfgi_ray_count, EnvironmentSDFGIRayCount)
 	FUNC1(environment_set_sdfgi_frames_to_converge, EnvironmentSDFGIFramesToConverge)
 	FUNC1(environment_set_sdfgi_frames_to_update_light, EnvironmentSDFGIFramesToUpdateLight)
+	FUNC1(environment_set_sdfgi_min_roughness, float)
 
 	FUNC3R(Ref<Image>, environment_bake_panorama, RID, bool, const Size2i &)
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2037,6 +2037,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("voxel_gi_set_use_two_bounces", "voxel_gi", "enable"), &RenderingServer::voxel_gi_set_use_two_bounces);
 
 	ClassDB::bind_method(D_METHOD("voxel_gi_set_quality", "quality"), &RenderingServer::voxel_gi_set_quality);
+	ClassDB::bind_method(D_METHOD("voxel_gi_set_min_roughness", "roughness"), &RenderingServer::voxel_gi_set_min_roughness);
 
 	BIND_ENUM_CONSTANT(VOXEL_GI_QUALITY_LOW);
 	BIND_ENUM_CONSTANT(VOXEL_GI_QUALITY_HIGH);
@@ -2361,6 +2362,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_ray_count", "ray_count"), &RenderingServer::environment_set_sdfgi_ray_count);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_frames_to_converge", "frames"), &RenderingServer::environment_set_sdfgi_frames_to_converge);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_frames_to_update_light", "frames"), &RenderingServer::environment_set_sdfgi_frames_to_update_light);
+	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_min_roughness", "roughness"), &RenderingServer::environment_set_sdfgi_min_roughness);
 	ClassDB::bind_method(D_METHOD("environment_set_volumetric_fog_volume_size", "size", "depth"), &RenderingServer::environment_set_volumetric_fog_volume_size);
 	ClassDB::bind_method(D_METHOD("environment_set_volumetric_fog_filter_active", "active"), &RenderingServer::environment_set_volumetric_fog_filter_active);
 
@@ -2896,6 +2898,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/global_illumination/gi/use_half_resolution", false);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/quality", PROPERTY_HINT_ENUM, "Low (4 Cones - Fast),High (6 Cones - Slow)"), 0);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/global_illumination/voxel_gi/min_roughness", PROPERTY_HINT_RANGE, "0,1,0.001"), 0.0);
 
 	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading", false);
 	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading.mobile", true);
@@ -2956,6 +2959,8 @@ void RenderingServer::init() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/probe_ray_count", PROPERTY_HINT_ENUM, "8 (Fastest),16,32,64,96,128 (Slowest)"), 1);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/frames_to_converge", PROPERTY_HINT_ENUM, "5 (Less Latency but Lower Quality),10,15,20,25,30 (More Latency but Higher Quality)"), 5);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/frames_to_update_lights", PROPERTY_HINT_ENUM, "1 (Slower),2,4,8,16 (Faster)"), 2);
+	// Unlike VoxelGI, minimum roughness above 0.2 doesn't improve performance for SDFGI.
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/global_illumination/sdfgi/min_roughness", PROPERTY_HINT_RANGE, "0,0.2,0.001"), 0.0);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/environment/volumetric_fog/volume_size", PROPERTY_HINT_RANGE, "16,512,1"), 64);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/environment/volumetric_fog/volume_depth", PROPERTY_HINT_RANGE, "16,512,1"), 64);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -611,6 +611,7 @@ public:
 	};
 
 	virtual void voxel_gi_set_quality(VoxelGIQuality) = 0;
+	virtual void voxel_gi_set_min_roughness(float p_roughness) = 0;
 
 	/* LIGHTMAP */
 
@@ -1128,6 +1129,8 @@ public:
 	};
 
 	virtual void environment_set_sdfgi_frames_to_update_light(EnvironmentSDFGIFramesToUpdateLight p_update) = 0;
+
+	virtual void environment_set_sdfgi_min_roughness(float p_roughness) = 0;
 
 	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect) = 0;
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/56804.

The roughness will be clamped for the purposes of VoxelGI and SDFGI rendering. This avoids rendering sharp reflections, which are very demanding when taking significant portions of the screen.

Other sources of reflection such as ReflectionProbes and environment sky aren't affected.

This closes https://github.com/godotengine/godot-proposals/issues/4811 and partially addresses https://github.com/godotengine/godot-proposals/issues/3012.

**Testing project:** [test_gi_opt.zip](https://github.com/godotengine/godot/files/9185373/test_gi_opt.zip)

## Benchmark (using testing project)

Note that the test scene only uses smooth materials, so the performance gain demonstrated here is greater than it would be in a typical real world scene.

**OS:** Fedora 36
**GPU:** GeForce GTX 1080 (NVIDIA 510.68.02)
**Resolution:** 2560×1440

### No GI

*For reference purposes.*

**306 FPS (3.27 mspf)**

### VoxelGI only

VoxelGI min. roughness | Performance
-:|:-
0.0 | **170 FPS (5.88 mspf)**
0.1 | 171 FPS (5.84 mspf)
0.2 | 181 FPS (5.52 mspf)
0.3 | 186 FPS (5.37 mspf)
0.4 | 195 FPS (5.12 mspf)
0.5 | 198 FPS (5.05 mspf)
0.6 | 200 FPS (5.00 mspf)
0.7 | 202 FPS (4.95 mspf)
0.8 | 204 FPS (4.90 mspf)
0.9 | 206 FPS (4.85 mspf)
1.0 | **208 FPS (4.81 mspf)**

### SDFGI only

***Note:** The sudden increase in performance at 0.2 is due to **all** sharp reflections being disabled within the SDFGI shader.*

SDFGI min. roughness | Performance
-:|:-
0.00 | **122 FPS (8.20 mspf)**
0.02 | 124 FPS (8.06 mspf)
0.04 | 125 FPS (8.00 mspf)
0.06 | 127 FPS (7.87 mspf)
0.08 | 128 FPS (7.81 mspf)
0.10 | 130 FPS (7.69 mspf)
0.12 | 132 FPS (7.58 mspf)
0.14 | 134 FPS (7.46 mspf)
0.16 | 135 FPS (7.41 mspf)
0.18 | 136 FPS (7.35 mspf)
0.20 | **166 FPS (6.02 mspf)**

### VoxelGI + SDFGI

Min. roughnesses | Performance
-:|:-
VoxelGI: 0.0, SDFGI: 0.00 | **96 FPS (10.42 mspf)**
VoxelGI: 0.1, SDFGI: 0.02 | 97 FPS (10.31 mspf)
VoxelGI: 0.2, SDFGI: 0.04 | 101 FPS (9.90 mspf)
VoxelGI: 0.3, SDFGI: 0.06 | 105 FPS (9.52 mspf)
VoxelGI: 0.4, SDFGI: 0.08 | 108 FPS (9.26 mspf)
VoxelGI: 0.5, SDFGI: 0.10 | 110 FPS (9.09 mspf)
VoxelGI: 0.6, SDFGI: 0.12 | 111 FPS (9.00 mspf)
VoxelGI: 0.7, SDFGI: 0.14 | 113 FPS (8.85 mspf)
VoxelGI: 0.8, SDFGI: 0.16 | 115 FPS (8.70 mspf)
VoxelGI: 0.9, SDFGI: 0.18 | 117 FPS (8.55 mspf)
VoxelGI: 1.0, SDFGI: 0.20 | **138 FPS (7.25 mspf)**