### PR TITLE
Fix Vector4 parse error

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -60,8 +60,8 @@ Variant::Type GDScriptParser::get_builtin_type(const StringName &p_type) {
 		builtin_types["Transform2D"] = Variant::TRANSFORM2D;
 		builtin_types["Vector3"] = Variant::VECTOR3;
 		builtin_types["Vector3i"] = Variant::VECTOR3I;
-		builtin_types["Vector4"] = Variant::VECTOR3;
-		builtin_types["Vector4i"] = Variant::VECTOR3I;
+		builtin_types["Vector4"] = Variant::VECTOR4;
+		builtin_types["Vector4i"] = Variant::VECTOR4I;
 		builtin_types["AABB"] = Variant::AABB;
 		builtin_types["Plane"] = Variant::PLANE;
 		builtin_types["Quaternion"] = Variant::QUATERNION;


### PR DESCRIPTION
Fixes this bug:
![](https://chat.godotengine.org/file-upload/6GySzsgxDuFPSNtsB/Clipboard%20-%2025%20lipca%202022%2022:43)

Thanks to @derammo for helping to find the cause.