### PR TITLE
Enable FXAA by default on viewports

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1631,7 +1631,7 @@
 		<member name="rendering/anti_aliasing/quality/msaa" type="int" setter="" getter="" default="0">
 			Sets the number of MSAA samples to use (as a power of two). MSAA is used to reduce aliasing around the edges of polygons. A higher MSAA value results in smoother edges but can be significantly slower on some hardware. See also bilinear scaling 3d [member rendering/scaling_3d/mode] for supersampling, which provides higher quality but is much more expensive.
 		</member>
-		<member name="rendering/anti_aliasing/quality/screen_space_aa" type="int" setter="" getter="" default="0">
+		<member name="rendering/anti_aliasing/quality/screen_space_aa" type="int" setter="" getter="" default="1">
 			Sets the screen-space antialiasing mode for the default screen [Viewport]. Screen-space antialiasing works by selectively blurring edges in a post-process shader. It differs from MSAA which takes multiple coverage samples while rendering objects. Screen-space AA methods are typically faster than MSAA and will smooth out specular aliasing, but tend to make scenes appear blurry.
 			Another way to combat specular aliasing is to enable [member rendering/anti_aliasing/screen_space_roughness_limiter/enabled].
 		</member>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -259,7 +259,7 @@
 			When using FSR upscaling, AMD recommends exposing the following values as preset options to users "Ultra Quality: 0.77", "Quality: 0.67", "Balanced: 0.59", "Performance: 0.5" instead of exposing the entire scale.
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/scaling_3d/scale] project setting.
 		</member>
-		<member name="screen_space_aa" type="int" setter="set_screen_space_aa" getter="get_screen_space_aa" enum="Viewport.ScreenSpaceAA" default="0">
+		<member name="screen_space_aa" type="int" setter="set_screen_space_aa" getter="get_screen_space_aa" enum="Viewport.ScreenSpaceAA" default="1">
 			Sets the screen-space antialiasing method used. Screen-space antialiasing works by selectively blurring edges in a post-process shader. It differs from MSAA which takes multiple coverage samples while rendering objects. Screen-space AA methods are typically faster than MSAA and will smooth out specular aliasing, but tend to make scenes appear blurry.
 		</member>
 		<member name="sdf_oversize" type="int" setter="set_sdf_oversize" getter="get_sdf_oversize" enum="Viewport.SDFOversize" default="1">

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -528,7 +528,7 @@ protected:
 		int height = 0;
 		//float fsr_sharpness = 0.2f;
 		RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED;
-		//RS::ViewportScreenSpaceAA screen_space_aa = RS::VIEWPORT_SCREEN_SPACE_AA_DISABLED;
+		//RS::ViewportScreenSpaceAA screen_space_aa = RS::VIEWPORT_SCREEN_SPACE_AA_FXAA;
 		//bool use_debanding = false;
 		//uint32_t view_count = 1;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1424,7 +1424,7 @@ SceneTree::SceneTree() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/anti_aliasing/quality/msaa", PropertyInfo(Variant::INT, "rendering/anti_aliasing/quality/msaa", PROPERTY_HINT_ENUM, String::utf8("Disabled (Fastest),2× (Average),4× (Slow),8× (Slowest)")));
 	root->set_msaa(Viewport::MSAA(msaa_mode));
 
-	const int ssaa_mode = GLOBAL_DEF_BASIC("rendering/anti_aliasing/quality/screen_space_aa", 0);
+	const int ssaa_mode = GLOBAL_DEF_BASIC("rendering/anti_aliasing/quality/screen_space_aa", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/anti_aliasing/quality/screen_space_aa", PropertyInfo(Variant::INT, "rendering/anti_aliasing/quality/screen_space_aa", PROPERTY_HINT_ENUM, "Disabled (Fastest),FXAA (Fast)"));
 	root->set_screen_space_aa(Viewport::ScreenSpaceAA(ssaa_mode));
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -298,7 +298,7 @@ private:
 	PositionalShadowAtlasQuadrantSubdiv positional_shadow_atlas_quadrant_subdiv[4];
 
 	MSAA msaa = MSAA_DISABLED;
-	ScreenSpaceAA screen_space_aa = SCREEN_SPACE_AA_DISABLED;
+	ScreenSpaceAA screen_space_aa = SCREEN_SPACE_AA_FXAA;
 	bool use_taa = false;
 
 	Scaling3DMode scaling_3d_mode = SCALING_3D_MODE_BILINEAR;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -481,7 +481,7 @@ private:
 		int height = 0;
 		float fsr_sharpness = 0.2f;
 		RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED;
-		RS::ViewportScreenSpaceAA screen_space_aa = RS::VIEWPORT_SCREEN_SPACE_AA_DISABLED;
+		RS::ViewportScreenSpaceAA screen_space_aa = RS::VIEWPORT_SCREEN_SPACE_AA_FXAA;
 		bool use_taa = false;
 		bool use_debanding = false;
 		uint32_t view_count = 1;

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -157,7 +157,7 @@ public:
 
 			debug_draw = RS::VIEWPORT_DEBUG_DRAW_DISABLED;
 			msaa = RS::VIEWPORT_MSAA_DISABLED;
-			screen_space_aa = RS::VIEWPORT_SCREEN_SPACE_AA_DISABLED;
+			screen_space_aa = RS::VIEWPORT_SCREEN_SPACE_AA_FXAA;
 			use_debanding = false;
 			use_occlusion_culling = false;
 			occlusion_buffer_dirty = true;


### PR DESCRIPTION
This leads to higher-quality 3D visuals out of the box with a low performance impact. See https://github.com/godotengine/godot-proposals/issues/4832 for comparison screenshots.

This change only affects 3D rendering. I've tested 2D rendering in a simple scene and can confirm there is no performance impact whatsoever when no Camera3D is present and active in the scene.

This closes https://github.com/godotengine/godot-proposals/issues/4832 and partially addresses https://github.com/godotengine/godot/issues/53534.