### PR TITLE
Fix getting an error when repeatedly opening the Advanced Import Settings dialog for fonts

### DIFF
--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -971,6 +971,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 	base_path = p_path;
 
 	inspector_vars->edit(nullptr);
+	inspector_text->edit(nullptr);
 	inspector_general->edit(nullptr);
 
 	text_settings_data.instantiate();


### PR DESCRIPTION
Fix #63471.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
