### PR TITLE
Fix errors when opening font import settings multiple times

### DIFF
--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -972,6 +972,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 
 	inspector_vars->edit(nullptr);
 	inspector_general->edit(nullptr);
+	inspector_text->edit(nullptr);
 
 	text_settings_data.instantiate();
 	ERR_FAIL_NULL(text_settings_data);


### PR DESCRIPTION
Fixes #63471

Resetting `inspector_text` was missing before re-instantiate `text_settings_data`. So the inspector would be accessing a wild pointer.