### PR TITLE
Remove unnecessary ScrollContainer scrollbar logic

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6264,9 +6264,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scroll = memnew(ScrollContainer);
 	timeline_vbox->add_child(scroll);
 	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
-	VScrollBar *sb = scroll->get_v_scroll_bar();
-	scroll->remove_child(sb);
-	timeline_scroll->add_child(sb); // Move here so timeline and tracks are always aligned.
 	scroll->set_focus_mode(FOCUS_CLICK);
 	scroll->connect("gui_input", callable_mp(this, &AnimationTrackEditor::_scroll_input));
 	scroll->connect("focus_exited", callable_mp(panner.ptr(), &ViewPanner::release_pan_key));

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -271,11 +271,11 @@ void ScrollContainer::_update_dimensions() {
 	ofs += sb->get_offset();
 	bool rtl = is_layout_rtl();
 
-	if (h_scroll->is_visible_in_tree() && h_scroll->get_parent() == this) { //scrolls may have been moved out for reasons
+	if (h_scroll->is_visible_in_tree()) {
 		size.y -= h_scroll->get_minimum_size().y;
 	}
 
-	if (v_scroll->is_visible_in_tree() && v_scroll->get_parent() == this) { //scrolls may have been moved out for reasons
+	if (v_scroll->is_visible_in_tree()) {
 		size.x -= v_scroll->get_minimum_size().x;
 	}
 
@@ -312,7 +312,7 @@ void ScrollContainer::_update_dimensions() {
 			}
 		}
 		r.position += ofs;
-		if (rtl && v_scroll->is_visible_in_tree() && v_scroll->get_parent() == this) {
+		if (rtl && v_scroll->is_visible_in_tree()) {
 			r.position.x += v_scroll->get_minimum_size().x;
 		}
 		r.position = r.position.floor();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
See https://github.com/godotengine/godot/pull/63348#discussion_r928578860

I tried deleting the referenced code and the scroll bar still seems to be functioning as normal:

https://user-images.githubusercontent.com/50304111/180919152-76b3a7ed-9d22-47c6-b09b-1f7dc9b3027c.mp4

This code is as old as the animation editor itself: b659fd6d7442701284cbb8763fb712be36d17ed0, so my guess is something has changed since then or it wasn't needed in the first place?

In my opinion the scrollbars should always be children of the scroll container, because otherwise it introduces unnecessary complexity. 

It's still technically possible to access the scroll bars with `get_scroll_h/v()`, but there's already a warning in the documentation against tampering with them. I think maybe these methods could just be removed? The documentation makes it sound like the main purpose these is so you can hide them.

Edit: I'll just leave them for now, as if a user had code like:
https://github.com/godotengine/godot/blob/d995f127a79683053bde5e9efc7ba27d0fa99e91/scene/gui/popup_menu.cpp#L54
it would no longer work.