### PR TITLE
[3.x] Address remaining scoped storage regressions

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2091,16 +2091,10 @@ PoolVector<uint8_t> _File::get_buffer(int64_t p_length) const {
 String _File::get_as_text() const {
 	ERR_FAIL_COND_V_MSG(!f, String(), "File must be opened before use.");
 
-	String text;
 	uint64_t original_pos = f->get_position();
 	f->seek(0);
 
-	String l = get_line();
-	while (!eof_reached()) {
-		text += l + "\n";
-		l = get_line();
-	}
-	text += l;
+	String text = f->get_as_utf8_string();
 
 	f->seek(original_pos);
 

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -73,6 +73,7 @@ public:
 	virtual bool eof_reached() const override; ///< reading passed EOF
 
 	virtual uint8_t get_8() const override; ///< get a byte
+	virtual String get_line() const override; ///< get a line
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
 
 	virtual Error get_error() const override; ///< get last error

--- a/platform/android/java/lib/src/org/godotengine/godot/io/directory/FilesystemDirectoryAccess.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/directory/FilesystemDirectoryAccess.kt
@@ -54,6 +54,7 @@ internal class FilesystemDirectoryAccess(private val context: Context):
 
 	private data class DirData(val dirFile: File, val files: Array<File>, var current: Int = 0)
 
+	private val storageScopeIdentifier = StorageScope.Identifier(context)
 	private val storageManager = context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
 	private var lastDirId = STARTING_DIR_ID
 	private val dirs = SparseArray<DirData>()
@@ -62,7 +63,7 @@ internal class FilesystemDirectoryAccess(private val context: Context):
 		// Directory access is available for shared storage on Android 11+
 		// On Android 10, access is also available as long as the `requestLegacyExternalStorage`
 		// tag is available.
-		return StorageScope.getStorageScope(context, path) != StorageScope.UNKNOWN
+		return storageScopeIdentifier.identifyStorageScope(path) != StorageScope.UNKNOWN
 	}
 
 	override fun hasDirId(dirId: Int) = dirs.indexOfKey(dirId) >= 0
@@ -102,7 +103,7 @@ internal class FilesystemDirectoryAccess(private val context: Context):
 		}
 	}
 
-	override fun fileExists(path: String) = FileAccessHandler.fileExists(context, path)
+	override fun fileExists(path: String) = FileAccessHandler.fileExists(context, storageScopeIdentifier, path)
 
 	override fun dirNext(dirId: Int): String {
 		val dirData = dirs[dirId]
@@ -199,7 +200,7 @@ internal class FilesystemDirectoryAccess(private val context: Context):
 			if (fromFile.isDirectory) {
 				fromFile.renameTo(File(to))
 			} else {
-				FileAccessHandler.renameFile(context, from, to)
+				FileAccessHandler.renameFile(context, storageScopeIdentifier, from, to)
 			}
 		} catch (e: SecurityException) {
 			false
@@ -218,7 +219,7 @@ internal class FilesystemDirectoryAccess(private val context: Context):
 				if (deleteFile.isDirectory) {
 					deleteFile.delete()
 				} else {
-					FileAccessHandler.removeFile(context, filename)
+					FileAccessHandler.removeFile(context, storageScopeIdentifier, filename)
 				}
 			} else {
 				true

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/DataAccess.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/DataAccess.kt
@@ -161,8 +161,9 @@ internal abstract class DataAccess(private val filePath: String) {
 	fun read(buffer: ByteBuffer): Int {
 		return try {
 			val readBytes = fileChannel.read(buffer)
+			endOfFile = readBytes == -1
+					|| (fileChannel.position() >= fileChannel.size() && fileChannel.size() > 0)
 			if (readBytes == -1) {
-				endOfFile = true
 				0
 			} else {
 				readBytes

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/FileAccessHandler.kt
@@ -49,8 +49,8 @@ class FileAccessHandler(val context: Context) {
 		private const val INVALID_FILE_ID = 0
 		private const val STARTING_FILE_ID = 1
 
-		fun fileExists(context: Context, path: String?): Boolean {
-			val storageScope = StorageScope.getStorageScope(context, path)
+		internal fun fileExists(context: Context, storageScopeIdentifier: StorageScope.Identifier, path: String?): Boolean {
+			val storageScope = storageScopeIdentifier.identifyStorageScope(path)
 			if (storageScope == StorageScope.UNKNOWN) {
 				return false
 			}
@@ -62,8 +62,8 @@ class FileAccessHandler(val context: Context) {
 			}
 		}
 
-		fun removeFile(context: Context, path: String?): Boolean {
-			val storageScope = StorageScope.getStorageScope(context, path)
+		internal fun removeFile(context: Context, storageScopeIdentifier: StorageScope.Identifier, path: String?): Boolean {
+			val storageScope = storageScopeIdentifier.identifyStorageScope(path)
 			if (storageScope == StorageScope.UNKNOWN) {
 				return false
 			}
@@ -75,8 +75,8 @@ class FileAccessHandler(val context: Context) {
 			}
 		}
 
-		fun renameFile(context: Context, from: String?, to: String?): Boolean {
-			val storageScope = StorageScope.getStorageScope(context, from)
+		internal fun renameFile(context: Context, storageScopeIdentifier: StorageScope.Identifier, from: String?, to: String?): Boolean {
+			val storageScope = storageScopeIdentifier.identifyStorageScope(from)
 			if (storageScope == StorageScope.UNKNOWN) {
 				return false
 			}
@@ -89,13 +89,14 @@ class FileAccessHandler(val context: Context) {
 		}
 	}
 
+	private val storageScopeIdentifier = StorageScope.Identifier(context)
 	private val files = SparseArray<DataAccess>()
 	private var lastFileId = STARTING_FILE_ID
 
 	private fun hasFileId(fileId: Int) = files.indexOfKey(fileId) >= 0
 
 	fun fileOpen(path: String?, modeFlags: Int): Int {
-		val storageScope = StorageScope.getStorageScope(context, path)
+		val storageScope = storageScopeIdentifier.identifyStorageScope(path)
 		if (storageScope == StorageScope.UNKNOWN) {
 			return INVALID_FILE_ID
 		}
@@ -162,10 +163,10 @@ class FileAccessHandler(val context: Context) {
 		files[fileId].flush()
 	}
 
-	fun fileExists(path: String?) = Companion.fileExists(context, path)
+	fun fileExists(path: String?) = Companion.fileExists(context, storageScopeIdentifier, path)
 
 	fun fileLastModified(filepath: String?): Long {
-		val storageScope = StorageScope.getStorageScope(context, filepath)
+		val storageScope = storageScopeIdentifier.identifyStorageScope(filepath)
 		if (storageScope == StorageScope.UNKNOWN) {
 			return 0L
 		}


### PR DESCRIPTION
- Accelerate common path used to check the storage scope for a given path
- Update the logic for the `get_as_text()` method - previous logic loads the content of a text file one byte at a time

Fixes https://github.com/godotengine/godot/issues/63434

Validated the fix and the rest of the implementation with [ScopedStorageTests.zip](https://github.com/godotengine/godot/files/9187548/ScopedStorageTests.zip)
