### PR TITLE
Introduce `appCategory` attribute of android to set category

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -865,7 +865,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 	int hand_tracking_frequency_index = p_preset->get("xr_features/hand_tracking_frequency");
 
 	bool backup_allowed = p_preset->get("user_data_backup/allow");
-	bool classify_as_game = p_preset->get("package/classify_as_game");
+	int app_category = p_preset->get("package/app_category");
 	bool retain_data_on_uninstall = p_preset->get("package/retain_data_on_uninstall");
 	bool exclude_from_recents = p_preset->get("package/exclude_from_recents");
 	bool is_resizeable = bool(GLOBAL_GET("display/window/size/resizable"));
@@ -964,8 +964,12 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 						encode_uint32(backup_allowed, &p_manifest.write[iofs + 16]);
 					}
 
+					if (tname == "application" && attrname == "appCategory") {
+						encode_uint32(_get_app_category_value(app_category), &p_manifest.write[iofs + 16]);
+					}
+
 					if (tname == "application" && attrname == "isGame") {
-						encode_uint32(classify_as_game, &p_manifest.write[iofs + 16]);
+						encode_uint32(app_category == APP_CATEGORY_GAME, &p_manifest.write[iofs + 16]);
 					}
 
 					if (tname == "application" && attrname == "hasFragileUserData") {
@@ -1727,7 +1731,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/unique_name", PROPERTY_HINT_PLACEHOLDER_TEXT, "ext.domain.name"), "org.godotengine.$genname"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name [default if blank]"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/signed"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/classify_as_game"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "package/app_category", PROPERTY_HINT_ENUM, "Accessibility,Audio,Game,Image,Maps,News,Productivity,Social,Video"), APP_CATEGORY_GAME));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/retain_data_on_uninstall"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/exclude_from_recents"), false));
 

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -72,6 +72,54 @@ String _get_android_orientation_label(DisplayServer::ScreenOrientation screen_or
 	}
 }
 
+int _get_app_category_value(int category_index) {
+	switch (category_index) {
+		case APP_CATEGORY_ACCESSIBILITY:
+			return 8;
+		case APP_CATEGORY_AUDIO:
+			return 1;
+		case APP_CATEGORY_IMAGE:
+			return 3;
+		case APP_CATEGORY_MAPS:
+			return 6;
+		case APP_CATEGORY_NEWS:
+			return 5;
+		case APP_CATEGORY_PRODUCTIVITY:
+			return 7;
+		case APP_CATEGORY_SOCIAL:
+			return 4;
+		case APP_CATEGORY_VIDEO:
+			return 2;
+		case APP_CATEGORY_GAME:
+		default:
+			return 0;
+	}
+}
+
+String _get_app_category_label(int category_index) {
+	switch (category_index) {
+		case APP_CATEGORY_ACCESSIBILITY:
+			return "accessibility";
+		case APP_CATEGORY_AUDIO:
+			return "audio";
+		case APP_CATEGORY_IMAGE:
+			return "image";
+		case APP_CATEGORY_MAPS:
+			return "maps";
+		case APP_CATEGORY_NEWS:
+			return "news";
+		case APP_CATEGORY_PRODUCTIVITY:
+			return "productivity";
+		case APP_CATEGORY_SOCIAL:
+			return "social";
+		case APP_CATEGORY_VIDEO:
+			return "video";
+		case APP_CATEGORY_GAME:
+		default:
+			return "game";
+	}
+}
+
 // Utility method used to create a directory.
 Error create_directory(const String &p_dir) {
 	if (!DirAccess::exists(p_dir)) {
@@ -255,21 +303,27 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 }
 
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_read_write_storage_permission) {
+	int app_category_index = (int)(p_preset->get("package/app_category"));
+	bool is_game = app_category_index == APP_CATEGORY_GAME;
+
 	int xr_mode_index = (int)(p_preset->get("xr_features/xr_mode"));
 	bool uses_xr = xr_mode_index == XR_MODE_OPENXR;
+
 	String manifest_application_text = vformat(
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"%s\"\n"
 			"        android:icon=\"@mipmap/icon\"\n"
+			"        android:appCategory=\"%s\"\n"
 			"        android:isGame=\"%s\"\n"
 			"        android:hasFragileUserData=\"%s\"\n"
 			"        android:requestLegacyExternalStorage=\"%s\"\n"
-			"        tools:replace=\"android:allowBackup,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n"
+			"        tools:replace=\"android:allowBackup,android:appCategory,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n"
 			"        tools:ignore=\"GoogleAppIndexingWarning\">\n\n"
 			"        <meta-data tools:node=\"remove\" android:name=\"xr_hand_tracking_version_name\" />\n"
 			"        <meta-data tools:node=\"remove\" android:name=\"xr_hand_tracking_metadata_name\" />\n",
 			bool_to_string(p_preset->get("user_data_backup/allow")),
-			bool_to_string(p_preset->get("package/classify_as_game")),
+			_get_app_category_label(app_category_index),
+			bool_to_string(is_game),
 			bool_to_string(p_preset->get("package/retain_data_on_uninstall")),
 			bool_to_string(p_has_read_write_storage_permission));
 

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -44,6 +44,18 @@ const String godot_project_name_xml_string = R"(<?xml version="1.0" encoding="ut
 </resources>
 )";
 
+// Application category.
+// See https://developer.android.com/guide/topics/manifest/application-element#appCategory for standards
+static const int APP_CATEGORY_ACCESSIBILITY = 0;
+static const int APP_CATEGORY_AUDIO = 1;
+static const int APP_CATEGORY_GAME = 2;
+static const int APP_CATEGORY_IMAGE = 3;
+static const int APP_CATEGORY_MAPS = 4;
+static const int APP_CATEGORY_NEWS = 5;
+static const int APP_CATEGORY_PRODUCTIVITY = 6;
+static const int APP_CATEGORY_SOCIAL = 7;
+static const int APP_CATEGORY_VIDEO = 8;
+
 // Supported XR modes.
 // This should match the entries in 'platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java'
 static const int XR_MODE_REGULAR = 0;
@@ -72,6 +84,10 @@ struct CustomExportData {
 int _get_android_orientation_value(DisplayServer::ScreenOrientation screen_orientation);
 
 String _get_android_orientation_label(DisplayServer::ScreenOrientation screen_orientation);
+
+int _get_app_category_value(int category_index);
+
+String _get_app_category_label(int category_index);
 
 // Utility method used to create a directory.
 Error create_directory(const String &p_dir);

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -20,6 +20,7 @@
         android:label="@string/godot_project_name_string"
         android:allowBackup="false"
         android:icon="@mipmap/icon"
+        android:appCategory="game"
         android:isGame="true"
         android:hasFragileUserData="false"
         android:requestLegacyExternalStorage="false"


### PR DESCRIPTION
According to android documentation (https://developer.android.com/guide/topics/manifest/application-element#isGame), `android:isGame` is deprecated.
To accommodate this change, use the `appCategory` attribute set to game.

: )

Considering that godot may also run on a lower version of android (because of minSDK), so the `isGame` attribute not delete.

Personally think: the change is compatible with `3.x`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
