### PR TITLE
Fix TileSet not loading correctly when embedded in a scene

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -226,14 +226,14 @@ void TilesEditorPlugin::synchronize_sources_list(Object *p_current_list, Object 
 	}
 
 	if (item_list->is_visible_in_tree()) {
+		// Make sure the selection is not overwritten after sorting.
+		int atlas_sources_lists_current_mem = atlas_sources_lists_current;
+		item_list->emit_signal(SNAME("sort_request"));
+		atlas_sources_lists_current = atlas_sources_lists_current_mem;
+
 		if (atlas_sources_lists_current < 0 || atlas_sources_lists_current >= item_list->get_item_count()) {
 			item_list->deselect_all();
 		} else {
-			// Make sure the selection is not overwritten after sorting.
-			int atlas_sources_lists_current_mem = atlas_sources_lists_current;
-			item_list->emit_signal(SNAME("sort_request"));
-			atlas_sources_lists_current = atlas_sources_lists_current_mem;
-
 			item_list->set_current(atlas_sources_lists_current);
 			item_list->ensure_current_is_visible();
 			item_list->emit_signal(SNAME("item_selected"), atlas_sources_lists_current);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -569,7 +569,7 @@ public:
 	virtual void add_custom_data_layer(int p_index){};
 	virtual void move_custom_data_layer(int p_from_index, int p_to_pos){};
 	virtual void remove_custom_data_layer(int p_index){};
-	virtual void reset_state() override{};
+	virtual void reset_state() override;
 
 	// Tiles.
 	virtual int get_tiles_count() const = 0;
@@ -847,7 +847,6 @@ public:
 	void add_custom_data_layer(int p_index);
 	void move_custom_data_layer(int p_from_index, int p_to_pos);
 	void remove_custom_data_layer(int p_index);
-	void reset_state();
 	void set_allow_transform(bool p_allow_transform);
 	bool is_allowing_transform() const;
 


### PR DESCRIPTION
Things were in fact saved correctly, but it was the loading that was not working. This was due to `reset_state()` not fully resetting resources correctly.

Fixes https://github.com/godotengine/godot/issues/58848
Maybe fixes - https://github.com/godotengine/godot/issues/54598 (to be tested)