### PR TITLE
Fix unnamed arguments in XML docs

### DIFF
--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -14,8 +14,8 @@
 			<argument index="0" name="canvas_item" type="RID" />
 			<argument index="1" name="pos" type="Vector2" />
 			<argument index="2" name="char" type="int" />
-			<argument index="3" name="modulate" type="int" />
-			<argument index="4" name="arg4" type="Color" default="Color(1, 1, 1, 1)" />
+			<argument index="3" name="font_size" type="int" />
+			<argument index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
 				Draw a single Unicode character [code]char[/code] into a canvas item using the font, at a given position, with [code]modulate[/code] color. [code]position[/code] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 				[b]Note:[/b] Do not use this function to draw strings character by character, use [method draw_string] or [TextLine] instead.
@@ -26,9 +26,9 @@
 			<argument index="0" name="canvas_item" type="RID" />
 			<argument index="1" name="pos" type="Vector2" />
 			<argument index="2" name="char" type="int" />
-			<argument index="3" name="size" type="int" />
-			<argument index="4" name="modulate" type="int" default="-1" />
-			<argument index="5" name="arg5" type="Color" default="Color(1, 1, 1, 1)" />
+			<argument index="3" name="font_size" type="int" />
+			<argument index="4" name="size" type="int" default="-1" />
+			<argument index="5" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
 				Draw a single Unicode character [code]char[/code] outline into a canvas item using the font, at a given position, with [code]modulate[/code] color and [code]size[/code] outline size. [code]position[/code] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 				[b]Note:[/b] Do not use this function to draw strings character by character, use [method draw_string] or [TextLine] instead.
@@ -129,7 +129,7 @@
 		<method name="get_char_size" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="char" type="int" />
-			<argument index="1" name="arg1" type="int" />
+			<argument index="1" name="font_size" type="int" />
 			<description>
 				Returns the size of a character, optionally taking kerning into account if the next character is provided.
 				[b]Note:[/b] Do not use this function to calculate width of the string character by character, use [method get_string_size] or [TextLine] instead. The height returned is the font height (see also [method get_height]) and has no relation to the glyph height.

--- a/modules/openxr/action_map/openxr_interaction_profile.cpp
+++ b/modules/openxr/action_map/openxr_interaction_profile.cpp
@@ -40,7 +40,7 @@ void OpenXRIPBinding::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_paths"), &OpenXRIPBinding::get_paths);
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "paths", PROPERTY_HINT_ARRAY_TYPE, "STRING"), "set_paths", "get_paths");
 
-	ClassDB::bind_method(D_METHOD("has_path"), &OpenXRIPBinding::has_path);
+	ClassDB::bind_method(D_METHOD("has_path", "path"), &OpenXRIPBinding::has_path);
 	ClassDB::bind_method(D_METHOD("add_path", "path"), &OpenXRIPBinding::add_path);
 	ClassDB::bind_method(D_METHOD("remove_path", "path"), &OpenXRIPBinding::remove_path);
 }

--- a/modules/openxr/doc_classes/OpenXRIPBinding.xml
+++ b/modules/openxr/doc_classes/OpenXRIPBinding.xml
@@ -24,7 +24,7 @@
 		</method>
 		<method name="has_path" qualifiers="const">
 			<return type="bool" />
-			<argument index="0" name="arg0" type="String" />
+			<argument index="0" name="path" type="String" />
 			<description>
 				Returns [code]true[/code] if this input/output path is part of this binding.
 			</description>

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -79,9 +79,9 @@ void Font::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_multiline_string_outline", "canvas_item", "pos", "text", "alignment", "width", "font_size", "max_lines", "size", "modulate", "brk_flags", "jst_flags", "direction", "orientation"), &Font::draw_multiline_string_outline, DEFVAL(HORIZONTAL_ALIGNMENT_LEFT), DEFVAL(-1), DEFVAL(DEFAULT_FONT_SIZE), DEFVAL(-1), DEFVAL(1), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND), DEFVAL(TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND), DEFVAL(TextServer::DIRECTION_AUTO), DEFVAL(TextServer::ORIENTATION_HORIZONTAL));
 
 	// Drawing char.
-	ClassDB::bind_method(D_METHOD("get_char_size", "char"), &Font::get_char_size);
-	ClassDB::bind_method(D_METHOD("draw_char", "canvas_item", "pos", "char", "modulate"), &Font::draw_char, DEFVAL(Color(1.0, 1.0, 1.0)));
-	ClassDB::bind_method(D_METHOD("draw_char_outline", "canvas_item", "pos", "char", "size", "modulate"), &Font::draw_char_outline, DEFVAL(-1), DEFVAL(Color(1.0, 1.0, 1.0)));
+	ClassDB::bind_method(D_METHOD("get_char_size", "char", "font_size"), &Font::get_char_size);
+	ClassDB::bind_method(D_METHOD("draw_char", "canvas_item", "pos", "char", "font_size", "modulate"), &Font::draw_char, DEFVAL(Color(1.0, 1.0, 1.0)));
+	ClassDB::bind_method(D_METHOD("draw_char_outline", "canvas_item", "pos", "char", "font_size", "size", "modulate"), &Font::draw_char_outline, DEFVAL(-1), DEFVAL(Color(1.0, 1.0, 1.0)));
 
 	// Helper functions.
 	ClassDB::bind_method(D_METHOD("has_char", "char"), &Font::has_char);


### PR DESCRIPTION
Searched for `/"arg\d/` in all XML files, then adjusted names based on the method signatures.