### PR TITLE
Add missing Python type hints in doc/tools/make_rst.py

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -907,7 +907,7 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
     f.write(make_footer())
 
 
-def escape_rst(text, until_pos=-1):  # type: (str) -> str
+def escape_rst(text, until_pos=-1):  # type: (str, int) -> str
     # Escape \ character, otherwise it ends up as an escape character in rst
     pos = 0
     while True:
@@ -1301,7 +1301,7 @@ def rstize_text(text, state):  # type: (str, State) -> str
     return text
 
 
-def format_table(f, data, remove_empty_columns=False):  # type: (TextIO, Iterable[Tuple[str, ...]]) -> None
+def format_table(f, data, remove_empty_columns=False):  # type: (TextIO, Iterable[Tuple[str, ...]], bool) -> None
     if len(data) == 0:
         return
 


### PR DESCRIPTION
(This change is compatible with 3.x and can be cherry-picked.)
