### PR TITLE
Prevent autoloads from being added or removed twice

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -529,8 +529,6 @@ void EditorAutoloadSettings::update_autoload() {
 			info.node->queue_delete();
 			info.node = nullptr;
 		}
-
-		ProjectSettings::get_singleton()->remove_autoload(info.name);
 	}
 
 	// Load new/changed autoloads
@@ -554,12 +552,6 @@ void EditorAutoloadSettings::update_autoload() {
 				ScriptServer::get_language(i)->add_named_global_constant(info->name, info->node);
 			}
 		}
-
-		ProjectSettings::AutoloadInfo prop_info;
-		prop_info.name = info->name;
-		prop_info.path = info->path;
-		prop_info.is_singleton = info->is_singleton;
-		ProjectSettings::get_singleton()->add_autoload(prop_info);
 
 		if (!info->in_editor && !info->is_singleton) {
 			// No reason to keep this node


### PR DESCRIPTION
Fixes: #63511

I'm not sure if this is the correct way to fix it, but it seems to be working.
I attached a project I used to test this pr. If you add the `test.gd` as an autoload with name `Test` then you can run the project and click the button. Then it prints `Test called!` to the output.

[autoload-pr-test.zip](https://github.com/godotengine/godot/files/9193390/autoload-pr-test.zip)

