### PR TITLE
[3.6] Add alpha awareness to Multiply blend mode

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1765,9 +1765,9 @@ void RasterizerCanvasGLES2::_legacy_canvas_render_item(Item *p_ci, RenderItemSta
 			case RasterizerStorageGLES2::Shader::CanvasItem::BLEND_MODE_MUL: {
 				glBlendEquation(GL_FUNC_ADD);
 				if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {
-					glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+					glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ZERO);
 				} else {
-					glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_ZERO, GL_ONE);
+					glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 				}
 			} break;
 			case RasterizerStorageGLES2::Shader::CanvasItem::BLEND_MODE_PMALPHA: {
@@ -2130,9 +2130,9 @@ void RasterizerCanvasGLES2::render_joined_item(const BItemJoined &p_bij, RenderI
 			case RasterizerStorageGLES2::Shader::CanvasItem::BLEND_MODE_MUL: {
 				glBlendEquation(GL_FUNC_ADD);
 				if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {
-					glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+					glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ZERO);
 				} else {
-					glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_ZERO, GL_ONE);
+					glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 				}
 			} break;
 			case RasterizerStorageGLES2::Shader::CanvasItem::BLEND_MODE_PMALPHA: {

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -2411,9 +2411,9 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 					case RasterizerStorageGLES2::Shader::Spatial::BLEND_MODE_MUL: {
 						glBlendEquation(GL_FUNC_ADD);
 						if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {
-							glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+							glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ZERO);
 						} else {
-							glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_ZERO, GL_ONE);
+							glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 						}
 
 					} break;

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -290,9 +290,9 @@ void RasterizerCanvasGLES3::_legacy_canvas_render_item(Item *p_ci, RenderItemSta
 			case RasterizerStorageGLES3::Shader::CanvasItem::BLEND_MODE_MUL: {
 				glBlendEquation(GL_FUNC_ADD);
 				if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {
-					glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+					glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ZERO);
 				} else {
-					glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_ZERO, GL_ONE);
+					glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 				}
 
 			} break;
@@ -1373,9 +1373,9 @@ void RasterizerCanvasGLES3::render_joined_item(const BItemJoined &p_bij, RenderI
 			case RasterizerStorageGLES3::Shader::CanvasItem::BLEND_MODE_MUL: {
 				glBlendEquation(GL_FUNC_ADD);
 				if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {
-					glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+					glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ZERO);
 				} else {
-					glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_ZERO, GL_ONE);
+					glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 				}
 
 			} break;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2121,9 +2121,9 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 						case RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_MUL: {
 							glBlendEquation(GL_FUNC_ADD);
 							if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {
-								glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_DST_ALPHA, GL_ZERO);
+								glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_DST_ALPHA, GL_ZERO);
 							} else {
-								glBlendFuncSeparate(GL_DST_COLOR, GL_ZERO, GL_ZERO, GL_ONE);
+								glBlendFuncSeparate(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 							}
 
 						} break;


### PR DESCRIPTION
Fixes #29105.

This changes the Multiply blend equation to utilize `GL_ONE_MINUS_SRC_ALPHA` for the background value, allowing alpha to affect how much is being multiplied.

![image](https://user-images.githubusercontent.com/33995085/181117476-217aea77-6253-485f-9fe3-343fe95febe3.png)

The **current caveat** is that proper usage of this blend mode requires transparent textures to use _pre-multiplied alpha_, this also extends to Modulate usage as not multiplying it otherwise generates a pseudo-additive effect.

![image](https://user-images.githubusercontent.com/33995085/181117950-df2e445f-807e-4d4a-aa1d-d86a24b0a1d6.png)

I've not been able to find a proper way to modify Modulate usage to automatically do pre-multiplication if the blend mode being used is Multiply, so for now the next best thing is doing it yourself in a shader.

https://user-images.githubusercontent.com/33995085/181118285-dae5b3b5-9f5f-4be5-bc82-ee8833b89e68.mp4

`	vec4 modulate = MODULATE;
	modulate.rgb *= modulate.a;`

In spatial shaders, remember to multiply `ALBEDO` by `ALPHA`.

One observation is that automatically doing pre-multiplication for the Premultiplied Alpha blend mode would also get rid of its pseudo-additive behavior. Unfortunately since this is my first PR I am not aware at all of where I could change this, but the user should have a better multiply blend mode now. I've also made a `master` version of this PR. (#63630)

