### PR TITLE
Improve EditorInspector wide mode and make Editor Settings, Project Settings, and Import Defaults use wide mode

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -312,9 +312,11 @@ void EditorPropertyTextEnum::_notification(int p_what) {
 
 EditorPropertyTextEnum::EditorPropertyTextEnum() {
 	default_layout = memnew(HBoxContainer);
+	default_layout->add_theme_constant_override("separation", 0);
 	add_child(default_layout);
 
 	edit_custom_layout = memnew(HBoxContainer);
+	edit_custom_layout->add_theme_constant_override("separation", 0);
 	edit_custom_layout->hide();
 	add_child(edit_custom_layout);
 
@@ -1727,26 +1729,28 @@ void EditorPropertyVector2::setup(double p_min, double p_max, double p_step, boo
 	}
 }
 
-EditorPropertyVector2::EditorPropertyVector2(bool p_force_wide) {
-	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector2_editing"));
+EditorPropertyVector2::EditorPropertyVector2(bool p_wide) {
+	bool horizontal = bool(EDITOR_GET("interface/inspector/horizontal_vector2_editing"));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
+	hb->add_theme_constant_override("separation", 0);
 
 	BoxContainer *bc;
 
-	if (p_force_wide) {
+	if (horizontal) {
 		bc = memnew(HBoxContainer);
+		bc->add_theme_constant_override("separation", 0);
 		hb->add_child(bc);
-	} else if (horizontal) {
-		bc = memnew(HBoxContainer);
-		hb->add_child(bc);
-		set_bottom_editor(hb);
 	} else {
 		bc = memnew(VBoxContainer);
 		hb->add_child(bc);
 	}
 	bc->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(hb);
+	}
 
 	static const char *desc[2] = { "x", "y" };
 	for (int i = 0; i < 2; i++) {
@@ -1831,25 +1835,29 @@ void EditorPropertyRect2::setup(double p_min, double p_max, double p_step, bool 
 	}
 }
 
-EditorPropertyRect2::EditorPropertyRect2(bool p_force_wide) {
-	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
+EditorPropertyRect2::EditorPropertyRect2(bool p_wide) {
+	bool horizontal = bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 	bool grid = false;
 	BoxContainer *bc;
 
-	if (p_force_wide) {
-		bc = memnew(HBoxContainer);
-		add_child(bc);
-	} else if (horizontal) {
+	if (horizontal) {
 		bc = memnew(VBoxContainer);
 		add_child(bc);
-		set_bottom_editor(bc);
 
-		bc->add_child(memnew(HBoxContainer));
-		bc->add_child(memnew(HBoxContainer));
+		for (int i = 0; i < 2; i++) {
+			HBoxContainer *hbox = memnew(HBoxContainer);
+			hbox->add_theme_constant_override("separation", 0);
+			bc->add_child(hbox);
+		}
+
 		grid = true;
 	} else {
 		bc = memnew(VBoxContainer);
 		add_child(bc);
+	}
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(bc);
 	}
 
 	static const char *desc[4] = { "x", "y", "w", "h" };
@@ -1871,8 +1879,8 @@ EditorPropertyRect2::EditorPropertyRect2(bool p_force_wide) {
 		}
 	}
 
-	if (!horizontal) {
-		set_label_reference(spin[0]); //show text and buttons around this
+	if (!horizontal || p_wide) {
+		set_label_reference(spin[0]); // Show text and buttons around this.
 	}
 }
 
@@ -2009,26 +2017,28 @@ void EditorPropertyVector3::setup(double p_min, double p_max, double p_step, boo
 	}
 }
 
-EditorPropertyVector3::EditorPropertyVector3(bool p_force_wide) {
-	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
+EditorPropertyVector3::EditorPropertyVector3(bool p_wide) {
+	bool horizontal = bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
+	hb->add_theme_constant_override("separation", 0);
 
 	BoxContainer *bc;
 
-	if (p_force_wide) {
+	if (horizontal) {
 		bc = memnew(HBoxContainer);
+		bc->add_theme_constant_override("separation", 0);
 		hb->add_child(bc);
-	} else if (horizontal) {
-		bc = memnew(HBoxContainer);
-		hb->add_child(bc);
-		set_bottom_editor(hb);
 	} else {
 		bc = memnew(VBoxContainer);
 		hb->add_child(bc);
 	}
 	bc->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(hb);
+	}
 
 	static const char *desc[3] = { "x", "y", "z" };
 	for (int i = 0; i < 3; i++) {
@@ -2140,26 +2150,28 @@ void EditorPropertyVector2i::setup(int p_min, int p_max, bool p_no_slider, bool 
 	}
 }
 
-EditorPropertyVector2i::EditorPropertyVector2i(bool p_force_wide) {
-	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector2_editing"));
+EditorPropertyVector2i::EditorPropertyVector2i(bool p_wide) {
+	bool horizontal = bool(EDITOR_GET("interface/inspector/horizontal_vector2_editing"));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
+	hb->add_theme_constant_override("separation", 0);
 
 	BoxContainer *bc;
 
-	if (p_force_wide) {
+	if (horizontal) {
 		bc = memnew(HBoxContainer);
+		bc->add_theme_constant_override("separation", 0);
 		hb->add_child(bc);
-	} else if (horizontal) {
-		bc = memnew(HBoxContainer);
-		hb->add_child(bc);
-		set_bottom_editor(hb);
 	} else {
 		bc = memnew(VBoxContainer);
 		hb->add_child(bc);
 	}
 	bc->set_h_size_flags(SIZE_EXPAND_FILL);
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(hb);
+	}
 
 	static const char *desc[2] = { "x", "y" };
 	for (int i = 0; i < 2; i++) {
@@ -2244,25 +2256,29 @@ void EditorPropertyRect2i::setup(int p_min, int p_max, bool p_no_slider, const S
 	}
 }
 
-EditorPropertyRect2i::EditorPropertyRect2i(bool p_force_wide) {
-	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
+EditorPropertyRect2i::EditorPropertyRect2i(bool p_wide) {
+	bool horizontal = bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 	bool grid = false;
 	BoxContainer *bc;
 
-	if (p_force_wide) {
-		bc = memnew(HBoxContainer);
-		add_child(bc);
-	} else if (horizontal) {
+	if (horizontal) {
 		bc = memnew(VBoxContainer);
 		add_child(bc);
-		set_bottom_editor(bc);
 
-		bc->add_child(memnew(HBoxContainer));
-		bc->add_child(memnew(HBoxContainer));
+		for (int i = 0; i < 2; i++) {
+			HBoxContainer *hbox = memnew(HBoxContainer);
+			hbox->add_theme_constant_override("separation", 0);
+			bc->add_child(hbox);
+		}
+
 		grid = true;
 	} else {
 		bc = memnew(VBoxContainer);
 		add_child(bc);
+	}
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(bc);
 	}
 
 	static const char *desc[4] = { "x", "y", "w", "h" };
@@ -2284,8 +2300,8 @@ EditorPropertyRect2i::EditorPropertyRect2i(bool p_force_wide) {
 		}
 	}
 
-	if (!horizontal) {
-		set_label_reference(spin[0]); //show text and buttons around this
+	if (!horizontal || p_wide) {
+		set_label_reference(spin[0]); // Show text and buttons around this.
 	}
 }
 
@@ -2394,23 +2410,25 @@ void EditorPropertyVector3i::setup(int p_min, int p_max, bool p_no_slider, bool 
 	}
 }
 
-EditorPropertyVector3i::EditorPropertyVector3i(bool p_force_wide) {
-	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
+EditorPropertyVector3i::EditorPropertyVector3i(bool p_wide) {
+	bool horizontal = bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
+	hb->add_theme_constant_override("separation", 0);
 
 	BoxContainer *bc;
-	if (p_force_wide) {
+	if (horizontal) {
 		bc = memnew(HBoxContainer);
+		bc->add_theme_constant_override("separation", 0);
 		hb->add_child(bc);
-	} else if (horizontal) {
-		bc = memnew(HBoxContainer);
-		hb->add_child(bc);
-		set_bottom_editor(hb);
 	} else {
 		bc = memnew(VBoxContainer);
 		hb->add_child(bc);
+	}
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(hb);
 	}
 
 	static const char *desc[3] = { "x", "y", "z" };
@@ -2497,21 +2515,22 @@ void EditorPropertyPlane::setup(double p_min, double p_max, double p_step, bool 
 	spin[3]->set_suffix(p_suffix);
 }
 
-EditorPropertyPlane::EditorPropertyPlane(bool p_force_wide) {
-	bool horizontal = p_force_wide || bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
+EditorPropertyPlane::EditorPropertyPlane(bool p_wide) {
+	bool horizontal = bool(EDITOR_GET("interface/inspector/horizontal_vector_types_editing"));
 
 	BoxContainer *bc;
 
-	if (p_force_wide) {
+	if (horizontal) {
 		bc = memnew(HBoxContainer);
+		bc->add_theme_constant_override("separation", 0);
 		add_child(bc);
-	} else if (horizontal) {
-		bc = memnew(HBoxContainer);
-		add_child(bc);
-		set_bottom_editor(bc);
 	} else {
 		bc = memnew(VBoxContainer);
 		add_child(bc);
+	}
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(bc);
 	}
 
 	static const char *desc[4] = { "x", "y", "z", "d" };
@@ -2592,18 +2611,22 @@ void EditorPropertyQuaternion::setup(double p_min, double p_max, double p_step, 
 	}
 }
 
-EditorPropertyQuaternion::EditorPropertyQuaternion() {
+EditorPropertyQuaternion::EditorPropertyQuaternion(bool p_wide) {
 	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
 
 	BoxContainer *bc;
 
 	if (horizontal) {
 		bc = memnew(HBoxContainer);
+		bc->add_theme_constant_override("separation", 0);
 		add_child(bc);
-		set_bottom_editor(bc);
 	} else {
 		bc = memnew(VBoxContainer);
 		add_child(bc);
+	}
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(bc);
 	}
 
 	static const char *desc[4] = { "x", "y", "z", "w" };
@@ -2623,6 +2646,7 @@ EditorPropertyQuaternion::EditorPropertyQuaternion() {
 		set_label_reference(spin[0]); //show text and buttons around this
 	}
 }
+
 ///////////////////// VECTOR4 /////////////////////////
 
 void EditorPropertyVector4::_set_read_only(bool p_read_only) {
@@ -2683,18 +2707,22 @@ void EditorPropertyVector4::setup(double p_min, double p_max, double p_step, boo
 	}
 }
 
-EditorPropertyVector4::EditorPropertyVector4() {
+EditorPropertyVector4::EditorPropertyVector4(bool p_wide) {
 	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
 
 	BoxContainer *bc;
 
 	if (horizontal) {
 		bc = memnew(HBoxContainer);
+		bc->add_theme_constant_override("separation", 0);
 		add_child(bc);
-		set_bottom_editor(bc);
 	} else {
 		bc = memnew(VBoxContainer);
 		add_child(bc);
+	}
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(bc);
 	}
 
 	static const char *desc[4] = { "x", "y", "z", "w" };
@@ -2772,18 +2800,22 @@ void EditorPropertyVector4i::setup(double p_min, double p_max, bool p_no_slider,
 	}
 }
 
-EditorPropertyVector4i::EditorPropertyVector4i() {
+EditorPropertyVector4i::EditorPropertyVector4i(bool p_wide) {
 	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
 
 	BoxContainer *bc;
 
 	if (horizontal) {
 		bc = memnew(HBoxContainer);
+		bc->add_theme_constant_override("separation", 0);
 		add_child(bc);
-		set_bottom_editor(bc);
 	} else {
 		bc = memnew(VBoxContainer);
 		add_child(bc);
+	}
+
+	if (horizontal && !p_wide) {
+		set_bottom_editor(bc);
 	}
 
 	static const char *desc[4] = { "x", "y", "z", "w" };
@@ -2868,9 +2900,10 @@ void EditorPropertyAABB::setup(double p_min, double p_max, double p_step, bool p
 	}
 }
 
-EditorPropertyAABB::EditorPropertyAABB() {
+EditorPropertyAABB::EditorPropertyAABB(bool p_wide) {
 	GridContainer *g = memnew(GridContainer);
 	g->set_columns(3);
+	g->add_theme_constant_override("h_separation", 0);
 	add_child(g);
 
 	static const char *desc[6] = { "x", "y", "z", "w", "h", "d" };
@@ -2884,7 +2917,12 @@ EditorPropertyAABB::EditorPropertyAABB() {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyAABB::_value_changed), varray(desc[i]));
 	}
-	set_bottom_editor(g);
+
+	if (p_wide) {
+		set_label_reference(spin[0]);
+	} else {
+		set_bottom_editor(g);
+	}
 }
 
 ///////////////////// TRANSFORM2D /////////////////////////
@@ -2958,9 +2996,10 @@ void EditorPropertyTransform2D::setup(double p_min, double p_max, double p_step,
 	}
 }
 
-EditorPropertyTransform2D::EditorPropertyTransform2D(bool p_include_origin) {
+EditorPropertyTransform2D::EditorPropertyTransform2D(bool p_wide) {
 	GridContainer *g = memnew(GridContainer);
-	g->set_columns(p_include_origin ? 3 : 2);
+	g->set_columns(3);
+	g->add_theme_constant_override("h_separation", 0);
 	add_child(g);
 
 	static const char *desc[6] = { "xx", "xy", "xo", "yx", "yy", "yo" };
@@ -2968,14 +3007,17 @@ EditorPropertyTransform2D::EditorPropertyTransform2D(bool p_include_origin) {
 		spin[i] = memnew(EditorSpinSlider);
 		spin[i]->set_label(desc[i]);
 		spin[i]->set_flat(true);
-		if (p_include_origin || i % 3 != 2) {
-			g->add_child(spin[i]);
-		}
 		spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+		g->add_child(spin[i]);
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform2D::_value_changed), varray(desc[i]));
 	}
-	set_bottom_editor(g);
+
+	if (p_wide) {
+		set_label_reference(spin[0]);
+	} else {
+		set_bottom_editor(g);
+	}
 }
 
 ///////////////////// BASIS /////////////////////////
@@ -3050,9 +3092,10 @@ void EditorPropertyBasis::setup(double p_min, double p_max, double p_step, bool 
 	}
 }
 
-EditorPropertyBasis::EditorPropertyBasis() {
+EditorPropertyBasis::EditorPropertyBasis(bool p_wide) {
 	GridContainer *g = memnew(GridContainer);
 	g->set_columns(3);
+	g->add_theme_constant_override("h_separation", 0);
 	add_child(g);
 
 	static const char *desc[9] = { "xx", "xy", "xz", "yx", "yy", "yz", "zx", "zy", "zz" };
@@ -3065,7 +3108,12 @@ EditorPropertyBasis::EditorPropertyBasis() {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyBasis::_value_changed), varray(desc[i]));
 	}
-	set_bottom_editor(g);
+
+	if (p_wide) {
+		set_label_reference(spin[0]);
+	} else {
+		set_bottom_editor(g);
+	}
 }
 
 ///////////////////// TRANSFORM3D /////////////////////////
@@ -3148,9 +3196,10 @@ void EditorPropertyTransform3D::setup(double p_min, double p_max, double p_step,
 	}
 }
 
-EditorPropertyTransform3D::EditorPropertyTransform3D() {
+EditorPropertyTransform3D::EditorPropertyTransform3D(bool p_wide) {
 	GridContainer *g = memnew(GridContainer);
 	g->set_columns(4);
+	g->add_theme_constant_override("h_separation", 0);
 	add_child(g);
 
 	static const char *desc[12] = { "xx", "xy", "xz", "xo", "yx", "yy", "yz", "yo", "zx", "zy", "zz", "zo" };
@@ -3163,7 +3212,12 @@ EditorPropertyTransform3D::EditorPropertyTransform3D() {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyTransform3D::_value_changed), varray(desc[i]));
 	}
-	set_bottom_editor(g);
+
+	if (p_wide) {
+		set_label_reference(spin[0]);
+	} else {
+		set_bottom_editor(g);
+	}
 }
 
 ///////////////////// PROJECTION /////////////////////////
@@ -3254,9 +3308,10 @@ void EditorPropertyProjection::setup(double p_min, double p_max, double p_step, 
 	}
 }
 
-EditorPropertyProjection::EditorPropertyProjection() {
+EditorPropertyProjection::EditorPropertyProjection(bool p_wide) {
 	GridContainer *g = memnew(GridContainer);
 	g->set_columns(4);
+	g->add_theme_constant_override("h_separation", 0);
 	add_child(g);
 
 	static const char *desc[16] = { "xx", "xy", "xz", "xw", "yx", "yy", "yz", "yw", "zx", "zy", "zz", "zw", "wx", "wy", "wz", "ww" };
@@ -3269,8 +3324,14 @@ EditorPropertyProjection::EditorPropertyProjection() {
 		add_focusable(spin[i]);
 		spin[i]->connect("value_changed", callable_mp(this, &EditorPropertyProjection::_value_changed), varray(desc[i]));
 	}
-	set_bottom_editor(g);
+
+	if (p_wide) {
+		set_label_reference(spin[0]);
+	} else {
+		set_bottom_editor(g);
+	}
 }
+
 ////////////// COLOR PICKER //////////////////////
 
 void EditorPropertyColor::_set_read_only(bool p_read_only) {
@@ -3845,6 +3906,7 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_keying(is_keying());
 				sub_inspector->set_read_only(is_read_only());
 				sub_inspector->set_use_folding(is_using_folding());
+				sub_inspector->set_use_wide_editors(wide);
 				sub_inspector->set_undo_redo(EditorNode::get_undo_redo());
 
 				sub_inspector_vbox = memnew(VBoxContainer);
@@ -3930,8 +3992,9 @@ void EditorPropertyResource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_fold_other_editors"), &EditorPropertyResource::_fold_other_editors);
 }
 
-EditorPropertyResource::EditorPropertyResource() {
+EditorPropertyResource::EditorPropertyResource(bool p_wide) {
 	use_sub_inspector = bool(EDITOR_GET("interface/inspector/open_resources_in_current_inspector"));
+	wide = p_wide;
 
 	add_to_group("_editor_resource_properties");
 }
@@ -4240,21 +4303,21 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 
 		} break;
 		case Variant::VECTOR4: {
-			EditorPropertyVector4 *editor = memnew(EditorPropertyVector4);
+			EditorPropertyVector4 *editor = memnew(EditorPropertyVector4(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::VECTOR4I: {
-			EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i);
+			EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1);
 			editor->setup(hint.min, hint.max, hint.hide_slider, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::TRANSFORM2D: {
-			EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
+			EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;
@@ -4266,32 +4329,32 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 			return editor;
 		} break;
 		case Variant::QUATERNION: {
-			EditorPropertyQuaternion *editor = memnew(EditorPropertyQuaternion);
+			EditorPropertyQuaternion *editor = memnew(EditorPropertyQuaternion(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;
 		} break;
 		case Variant::AABB: {
-			EditorPropertyAABB *editor = memnew(EditorPropertyAABB);
+			EditorPropertyAABB *editor = memnew(EditorPropertyAABB(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;
 		} break;
 		case Variant::BASIS: {
-			EditorPropertyBasis *editor = memnew(EditorPropertyBasis);
+			EditorPropertyBasis *editor = memnew(EditorPropertyBasis(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;
 		} break;
 		case Variant::TRANSFORM3D: {
-			EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D);
+			EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::PROJECTION: {
-			EditorPropertyProjection *editor = memnew(EditorPropertyProjection);
+			EditorPropertyProjection *editor = memnew(EditorPropertyProjection(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.suffix);
 			return editor;
@@ -4344,7 +4407,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				editor->setup(NodePath(), sn, false, true);
 				return editor;
 			} else {
-				EditorPropertyResource *editor = memnew(EditorPropertyResource);
+				EditorPropertyResource *editor = memnew(EditorPropertyResource(p_wide));
 				editor->setup(p_object, p_path, p_hint == PROPERTY_HINT_RESOURCE_TYPE ? p_hint_text : "Resource");
 
 				if (p_hint == PROPERTY_HINT_RESOURCE_TYPE) {
@@ -4377,57 +4440,57 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				EditorPropertyLocalizableString *editor = memnew(EditorPropertyLocalizableString);
 				return editor;
 			} else {
-				EditorPropertyDictionary *editor = memnew(EditorPropertyDictionary);
+				EditorPropertyDictionary *editor = memnew(EditorPropertyDictionary(p_wide));
 				return editor;
 			}
 		} break;
 		case Variant::ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::ARRAY, p_hint_text);
 			return editor;
 		} break;
 		case Variant::PACKED_BYTE_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_BYTE_ARRAY);
 			return editor;
 		} break;
 		case Variant::PACKED_INT32_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_INT32_ARRAY);
 			return editor;
 		} break;
 		case Variant::PACKED_INT64_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_INT64_ARRAY);
 			return editor;
 		} break;
 		case Variant::PACKED_FLOAT32_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_FLOAT32_ARRAY);
 			return editor;
 		} break;
 		case Variant::PACKED_FLOAT64_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_FLOAT64_ARRAY);
 			return editor;
 		} break;
 		case Variant::PACKED_STRING_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_STRING_ARRAY);
 			return editor;
 		} break;
 		case Variant::PACKED_VECTOR2_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_VECTOR2_ARRAY);
 			return editor;
 		} break;
 		case Variant::PACKED_VECTOR3_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_VECTOR3_ARRAY);
 			return editor;
 		} break;
 		case Variant::PACKED_COLOR_ARRAY: {
-			EditorPropertyArray *editor = memnew(EditorPropertyArray);
+			EditorPropertyArray *editor = memnew(EditorPropertyArray(p_wide));
 			editor->setup(Variant::PACKED_COLOR_ARRAY);
 			return editor;
 		} break;

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -492,7 +492,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, bool p_link = false, const String &p_suffix = String());
-	EditorPropertyVector2(bool p_force_wide = false);
+	EditorPropertyVector2(bool p_wide = false);
 };
 
 class EditorPropertyRect2 : public EditorProperty {
@@ -509,7 +509,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyRect2(bool p_force_wide = false);
+	EditorPropertyRect2(bool p_wide = false);
 };
 
 class EditorPropertyVector3 : public EditorProperty {
@@ -537,7 +537,7 @@ public:
 	virtual void update_using_vector(Vector3 p_vector);
 	virtual Vector3 get_vector();
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, bool p_link = false, const String &p_suffix = String(), bool p_angle_in_radians = false);
-	EditorPropertyVector3(bool p_force_wide = false);
+	EditorPropertyVector3(bool p_wide = false);
 };
 
 class EditorPropertyVector2i : public EditorProperty {
@@ -557,7 +557,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(int p_min, int p_max, bool p_no_slider, bool p_link = false, const String &p_suffix = String());
-	EditorPropertyVector2i(bool p_force_wide = false);
+	EditorPropertyVector2i(bool p_wide = false);
 };
 
 class EditorPropertyRect2i : public EditorProperty {
@@ -574,7 +574,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(int p_min, int p_max, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyRect2i(bool p_force_wide = false);
+	EditorPropertyRect2i(bool p_wide = false);
 };
 
 class EditorPropertyVector3i : public EditorProperty {
@@ -599,7 +599,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(int p_min, int p_max, bool p_no_slider, bool p_link = false, const String &p_suffix = String());
-	EditorPropertyVector3i(bool p_force_wide = false);
+	EditorPropertyVector3i(bool p_wide = false);
 };
 
 class EditorPropertyPlane : public EditorProperty {
@@ -616,7 +616,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyPlane(bool p_force_wide = false);
+	EditorPropertyPlane(bool p_wide = false);
 };
 
 class EditorPropertyQuaternion : public EditorProperty {
@@ -633,7 +633,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyQuaternion();
+	EditorPropertyQuaternion(bool p_wide = false);
 };
 
 class EditorPropertyVector4 : public EditorProperty {
@@ -650,7 +650,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyVector4();
+	EditorPropertyVector4(bool p_wide = false);
 };
 
 class EditorPropertyVector4i : public EditorProperty {
@@ -667,7 +667,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyVector4i();
+	EditorPropertyVector4i(bool p_wide = false);
 };
 
 class EditorPropertyAABB : public EditorProperty {
@@ -684,7 +684,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyAABB();
+	EditorPropertyAABB(bool p_wide = false);
 };
 
 class EditorPropertyTransform2D : public EditorProperty {
@@ -701,7 +701,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyTransform2D(bool p_include_origin = true);
+	EditorPropertyTransform2D(bool p_wide = false);
 };
 
 class EditorPropertyBasis : public EditorProperty {
@@ -718,7 +718,7 @@ protected:
 public:
 	virtual void update_property() override;
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyBasis();
+	EditorPropertyBasis(bool p_wide = false);
 };
 
 class EditorPropertyTransform3D : public EditorProperty {
@@ -736,7 +736,7 @@ public:
 	virtual void update_property() override;
 	virtual void update_using_transform(Transform3D p_transform);
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyTransform3D();
+	EditorPropertyTransform3D(bool p_wide = false);
 };
 
 class EditorPropertyProjection : public EditorProperty {
@@ -754,7 +754,7 @@ public:
 	virtual void update_property() override;
 	virtual void update_using_transform(Projection p_transform);
 	void setup(double p_min, double p_max, double p_step, bool p_no_slider, const String &p_suffix = String());
-	EditorPropertyProjection();
+	EditorPropertyProjection(bool p_wide = false);
 };
 
 class EditorPropertyColor : public EditorProperty {
@@ -830,6 +830,7 @@ class EditorPropertyResource : public EditorProperty {
 	VBoxContainer *sub_inspector_vbox = nullptr;
 	bool updating_theme = false;
 	bool opened_editor = false;
+	bool wide = false;
 
 	void _resource_selected(const Ref<Resource> &p_resource, bool p_edit);
 	void _resource_changed(const Ref<Resource> &p_resource);
@@ -859,7 +860,7 @@ public:
 
 	void set_use_sub_inspector(bool p_enable);
 
-	EditorPropertyResource();
+	EditorPropertyResource(bool p_wide = false);
 };
 
 ///////////////////////////////////////////////////

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -348,7 +348,7 @@ void EditorPropertyArray::update_property() {
 				editor->setup("Object");
 				prop = editor;
 			} else {
-				prop = EditorInspector::instantiate_property_editor(nullptr, value_type, "", subtype_hint, subtype_hint_string, PROPERTY_USAGE_NONE);
+				prop = EditorInspector::instantiate_property_editor(nullptr, value_type, "", subtype_hint, subtype_hint_string, PROPERTY_USAGE_NONE, wide);
 			}
 
 			prop->set_object_and_property(object.ptr(), prop_name);
@@ -685,7 +685,7 @@ void EditorPropertyArray::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_drop_data_fw"), &EditorPropertyArray::drop_data_fw);
 }
 
-EditorPropertyArray::EditorPropertyArray() {
+EditorPropertyArray::EditorPropertyArray(bool p_wide) {
 	object.instantiate();
 	page_length = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
 
@@ -712,6 +712,7 @@ EditorPropertyArray::EditorPropertyArray() {
 	subtype = Variant::NIL;
 	subtype_hint = PROPERTY_HINT_NONE;
 	subtype_hint_string = "";
+	wide = p_wide;
 }
 
 ///////////////////// DICTIONARY ///////////////////////////
@@ -914,91 +915,91 @@ void EditorPropertyDictionary::update_property() {
 
 				// Math types.
 				case Variant::VECTOR2: {
-					EditorPropertyVector2 *editor = memnew(EditorPropertyVector2);
+					EditorPropertyVector2 *editor = memnew(EditorPropertyVector2(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR2I: {
-					EditorPropertyVector2i *editor = memnew(EditorPropertyVector2i);
+					EditorPropertyVector2i *editor = memnew(EditorPropertyVector2i(wide));
 					editor->setup(-100000, 100000, true);
 					prop = editor;
 
 				} break;
 				case Variant::RECT2: {
-					EditorPropertyRect2 *editor = memnew(EditorPropertyRect2);
+					EditorPropertyRect2 *editor = memnew(EditorPropertyRect2(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::RECT2I: {
-					EditorPropertyRect2i *editor = memnew(EditorPropertyRect2i);
+					EditorPropertyRect2i *editor = memnew(EditorPropertyRect2i(wide));
 					editor->setup(-100000, 100000, true);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR3: {
-					EditorPropertyVector3 *editor = memnew(EditorPropertyVector3);
+					EditorPropertyVector3 *editor = memnew(EditorPropertyVector3(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR3I: {
-					EditorPropertyVector3i *editor = memnew(EditorPropertyVector3i);
+					EditorPropertyVector3i *editor = memnew(EditorPropertyVector3i(wide));
 					editor->setup(-100000, 100000, true);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR4: {
-					EditorPropertyVector4 *editor = memnew(EditorPropertyVector4);
+					EditorPropertyVector4 *editor = memnew(EditorPropertyVector4(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::VECTOR4I: {
-					EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i);
+					EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i(wide));
 					editor->setup(-100000, 100000, true);
 					prop = editor;
 
 				} break;
 				case Variant::TRANSFORM2D: {
-					EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
+					EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::PLANE: {
-					EditorPropertyPlane *editor = memnew(EditorPropertyPlane);
+					EditorPropertyPlane *editor = memnew(EditorPropertyPlane(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::QUATERNION: {
-					EditorPropertyQuaternion *editor = memnew(EditorPropertyQuaternion);
+					EditorPropertyQuaternion *editor = memnew(EditorPropertyQuaternion(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::AABB: {
-					EditorPropertyAABB *editor = memnew(EditorPropertyAABB);
+					EditorPropertyAABB *editor = memnew(EditorPropertyAABB(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::BASIS: {
-					EditorPropertyBasis *editor = memnew(EditorPropertyBasis);
+					EditorPropertyBasis *editor = memnew(EditorPropertyBasis(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::TRANSFORM3D: {
-					EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D);
+					EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
 				} break;
 				case Variant::PROJECTION: {
-					EditorPropertyProjection *editor = memnew(EditorPropertyProjection);
+					EditorPropertyProjection *editor = memnew(EditorPropertyProjection(wide));
 					editor->setup(-100000, 100000, default_float_step, true);
 					prop = editor;
 
@@ -1030,7 +1031,7 @@ void EditorPropertyDictionary::update_property() {
 						prop = editor;
 
 					} else {
-						EditorPropertyResource *editor = memnew(EditorPropertyResource);
+						EditorPropertyResource *editor = memnew(EditorPropertyResource(wide));
 						editor->setup(object.ptr(), prop_name, "Resource");
 						editor->set_use_folding(is_using_folding());
 						prop = editor;
@@ -1038,58 +1039,58 @@ void EditorPropertyDictionary::update_property() {
 
 				} break;
 				case Variant::DICTIONARY: {
-					prop = memnew(EditorPropertyDictionary);
+					prop = memnew(EditorPropertyDictionary(wide));
 
 				} break;
 				case Variant::ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::ARRAY);
 					prop = editor;
 				} break;
 
 				// Arrays.
 				case Variant::PACKED_BYTE_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_BYTE_ARRAY);
 					prop = editor;
 				} break;
 				case Variant::PACKED_INT32_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_INT32_ARRAY);
 					prop = editor;
 				} break;
 				case Variant::PACKED_FLOAT32_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_FLOAT32_ARRAY);
 					prop = editor;
 				} break;
 				case Variant::PACKED_INT64_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_INT64_ARRAY);
 					prop = editor;
 				} break;
 				case Variant::PACKED_FLOAT64_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_FLOAT64_ARRAY);
 					prop = editor;
 				} break;
 				case Variant::PACKED_STRING_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_STRING_ARRAY);
 					prop = editor;
 				} break;
 				case Variant::PACKED_VECTOR2_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_VECTOR2_ARRAY);
 					prop = editor;
 				} break;
 				case Variant::PACKED_VECTOR3_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_VECTOR3_ARRAY);
 					prop = editor;
 				} break;
 				case Variant::PACKED_COLOR_ARRAY: {
-					EditorPropertyArray *editor = memnew(EditorPropertyArray);
+					EditorPropertyArray *editor = memnew(EditorPropertyArray(wide));
 					editor->setup(Variant::PACKED_COLOR_ARRAY);
 					prop = editor;
 				} break;
@@ -1211,7 +1212,7 @@ void EditorPropertyDictionary::_page_changed(int p_page) {
 void EditorPropertyDictionary::_bind_methods() {
 }
 
-EditorPropertyDictionary::EditorPropertyDictionary() {
+EditorPropertyDictionary::EditorPropertyDictionary(bool p_wide) {
 	object.instantiate();
 	page_length = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
 
@@ -1230,6 +1231,8 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	add_child(change_type);
 	change_type->connect("id_pressed", callable_mp(this, &EditorPropertyDictionary::_change_type_menu));
 	changing_type_index = -1;
+
+	wide = p_wide;
 }
 
 ///////////////////// LOCALIZABLE STRING ///////////////////////////

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -98,6 +98,7 @@ class EditorPropertyArray : public EditorProperty {
 	Variant::Type subtype;
 	PropertyHint subtype_hint;
 	String subtype_hint_string;
+	bool wide = false;
 
 	int reorder_from_index = -1;
 	int reorder_to_index = -1;
@@ -132,7 +133,7 @@ protected:
 public:
 	void setup(Variant::Type p_array_type, const String &p_hint_string = "");
 	virtual void update_property() override;
-	EditorPropertyArray();
+	EditorPropertyArray(bool p_wide = false);
 };
 
 class EditorPropertyDictionary : public EditorProperty {
@@ -151,6 +152,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	EditorSpinSlider *size_sliderv;
 	Button *button_add_item = nullptr;
 	EditorPaginator *paginator = nullptr;
+	bool wide = false;
 
 	void _page_changed(int p_page);
 	void _edit_pressed();
@@ -167,7 +169,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	EditorPropertyDictionary();
+	EditorPropertyDictionary(bool p_wide = false);
 };
 
 class EditorPropertyLocalizableString : public EditorProperty {

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -354,6 +354,7 @@ SectionedInspector::SectionedInspector() :
 	right_vb->add_child(inspector, true);
 	inspector->set_use_doc_hints(true);
 	inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+	inspector->set_use_wide_editors(true);
 
 	sections->connect("cell_selected", callable_mp(this, &SectionedInspector::_section_selected));
 }

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -218,6 +218,7 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	inspector = memnew(EditorInspector);
 	add_child(inspector);
 	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	inspector->set_use_wide_editors(true);
 	CenterContainer *cc = memnew(CenterContainer);
 	save_defaults = memnew(Button);
 	save_defaults->set_text(TTR("Save"));


### PR DESCRIPTION
- Adds wide mode support to more property types: Quaternion, Vector4, Vector4i, AABB, Basis, Transform2D, Transform3D, and Projection.
- Makes Project Settings, Editor Settings, and Import Defaults inspectors use wide mode.
- Makes vector type properties respect the `interface/inspector/horizontal_vector2_editing` and `interface/inspector/horizontal_vector_types_editing` editor settings in wide mode for a more consistent experience throughout the editor.
- Makes properties inside of resource sub-inspectors, arrays, or dictionaries use the wide mode state from the parent inspector.
- Changes horizontal spacing to 0 in numerical EditorProperty types.
- Removes the unused `p_include_origin` mode from EditorPropertyTransform2D.

### Screenshots:

**Before** (`horizontal_vector_types_editing = true`, `horizontal_vector2_editing = false`): all properties are horizontal regardless of settings and some properties are under instead of to the side.
![image](https://user-images.githubusercontent.com/67974470/181160818-da901e0e-4b46-4303-bd91-21562ff2c395.png)

**After** (`horizontal_vector_types_editing = true`, `horizontal_vector2_editing = false`):
![image](https://user-images.githubusercontent.com/67974470/181169019-e7eb8c26-c935-485a-b97e-3afc26ca1f93.png)

**After** (`horizontal_vector_types_editing = false`, `horizontal_vector2_editing = false`):
![image](https://user-images.githubusercontent.com/67974470/181169104-549866fc-d1fd-45a3-aa1b-e9772e0fffa5.png)

**After** (`horizontal_vector_types_editing = true`, `horizontal_vector2_editing = true`):
![image](https://user-images.githubusercontent.com/67974470/181170139-35177ec1-f86a-4ca5-9020-948e87e9d821.png)

