### PR TITLE
Rename and unify notation for spherical interpolation

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -183,7 +183,7 @@ Quaternion Quaternion::slerpni(const Quaternion &p_to, const real_t &p_weight) c
 			invFactor * from.w + newFactor * p_to.w);
 }
 
-Quaternion Quaternion::cubic_slerp(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight) const {
+Quaternion Quaternion::spherical_cubic_interpolate(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quaternion(), "The start quaternion must be normalized.");
 	ERR_FAIL_COND_V_MSG(!p_b.is_normalized(), Quaternion(), "The end quaternion must be normalized.");

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -71,7 +71,7 @@ struct _NO_DISCARD_ Quaternion {
 
 	Quaternion slerp(const Quaternion &p_to, const real_t &p_weight) const;
 	Quaternion slerpni(const Quaternion &p_to, const real_t &p_weight) const;
-	Quaternion cubic_slerp(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight) const;
+	Quaternion spherical_cubic_interpolate(const Quaternion &p_b, const Quaternion &p_pre_a, const Quaternion &p_post_b, const real_t &p_weight) const;
 
 	Vector3 get_axis() const;
 	real_t get_angle() const;

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -80,7 +80,7 @@ void Transform3D::set_look_at(const Vector3 &p_eye, const Vector3 &p_target, con
 	origin = p_eye;
 }
 
-Transform3D Transform3D::sphere_interpolate_with(const Transform3D &p_transform, real_t p_c) const {
+Transform3D Transform3D::spherical_interpolate_with(const Transform3D &p_transform, real_t p_c) const {
 	/* not sure if very "efficient" but good enough? */
 
 	Transform3D interp;

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -100,7 +100,7 @@ struct _NO_DISCARD_ Transform3D {
 	void operator*=(const real_t p_val);
 	Transform3D operator*(const real_t p_val) const;
 
-	Transform3D sphere_interpolate_with(const Transform3D &p_transform, real_t p_c) const;
+	Transform3D spherical_interpolate_with(const Transform3D &p_transform, real_t p_c) const;
 	Transform3D interpolate_with(const Transform3D &p_transform, real_t p_c) const;
 
 	_FORCE_INLINE_ Transform3D inverse_xform(const Transform3D &t) const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1781,7 +1781,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Quaternion, dot, sarray("with"), varray());
 	bind_method(Quaternion, slerp, sarray("to", "weight"), varray());
 	bind_method(Quaternion, slerpni, sarray("to", "weight"), varray());
-	bind_method(Quaternion, cubic_slerp, sarray("b", "pre_a", "post_b", "weight"), varray());
+	bind_method(Quaternion, spherical_cubic_interpolate, sarray("b", "pre_a", "post_b", "weight"), varray());
 	bind_method(Quaternion, get_euler, sarray(), varray());
 	bind_method(Quaternion, get_axis, sarray(), varray());
 	bind_method(Quaternion, get_angle, sarray(), varray());
@@ -1950,7 +1950,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform3D, scaled, sarray("scale"), varray());
 	bind_method(Transform3D, translated, sarray("offset"), varray());
 	bind_method(Transform3D, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
-	bind_method(Transform3D, sphere_interpolate_with, sarray("xform", "weight"), varray());
+	bind_method(Transform3D, spherical_interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, is_equal_approx, sarray("xform"), varray());
 

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -74,16 +74,6 @@
 				[b]Note:[/b] This method has an abnormally high amount of floating-point error, so methods such as [code]is_zero_approx[/code] will not work reliably.
 			</description>
 		</method>
-		<method name="cubic_slerp" qualifiers="const">
-			<return type="Quaternion" />
-			<argument index="0" name="b" type="Quaternion" />
-			<argument index="1" name="pre_a" type="Quaternion" />
-			<argument index="2" name="post_b" type="Quaternion" />
-			<argument index="3" name="weight" type="float" />
-			<description>
-				Performs a cubic spherical interpolation between quaternions [code]pre_a[/code], this vector, [code]b[/code], and [code]post_b[/code], by the given amount [code]weight[/code].
-			</description>
-		</method>
 		<method name="dot" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="with" type="Quaternion" />
@@ -169,6 +159,16 @@
 			<argument index="1" name="weight" type="float" />
 			<description>
 				Returns the result of the spherical linear interpolation between this quaternion and [code]to[/code] by amount [code]weight[/code], but without checking if the rotation path is not bigger than 90 degrees.
+			</description>
+		</method>
+		<method name="spherical_cubic_interpolate" qualifiers="const">
+			<return type="Quaternion" />
+			<argument index="0" name="b" type="Quaternion" />
+			<argument index="1" name="pre_a" type="Quaternion" />
+			<argument index="2" name="post_b" type="Quaternion" />
+			<argument index="3" name="weight" type="float" />
+			<description>
+				Performs a spherical cubic interpolation between quaternions [code]pre_a[/code], this vector, [code]b[/code], and [code]post_b[/code], by the given amount [code]weight[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -112,7 +112,7 @@
 				Returns a copy of the transform with its basis and origin scaled by the given [code]scale[/code] factor, using matrix multiplication.
 			</description>
 		</method>
-		<method name="sphere_interpolate_with" qualifiers="const">
+		<method name="spherical_interpolate_with" qualifiers="const">
 			<return type="Transform3D" />
 			<argument index="0" name="xform" type="Transform3D" />
 			<argument index="1" name="weight" type="float" />

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2302,7 +2302,7 @@ Vector3 Animation::_cubic_interpolate(const Vector3 &p_pre_a, const Vector3 &p_a
 }
 
 Quaternion Animation::_cubic_interpolate(const Quaternion &p_pre_a, const Quaternion &p_a, const Quaternion &p_b, const Quaternion &p_post_b, real_t p_c) const {
-	return p_a.cubic_slerp(p_b, p_pre_a, p_post_b, p_c);
+	return p_a.spherical_cubic_interpolate(p_b, p_pre_a, p_post_b, p_c);
 }
 
 Variant Animation::_cubic_interpolate(const Variant &p_pre_a, const Variant &p_a, const Variant &p_b, const Variant &p_post_b, real_t p_c) const {
@@ -2363,7 +2363,7 @@ Variant Animation::_cubic_interpolate(const Variant &p_pre_a, const Variant &p_a
 			Quaternion pa = p_pre_a;
 			Quaternion pb = p_post_b;
 
-			return a.cubic_slerp(b, pa, pb, p_c);
+			return a.spherical_cubic_interpolate(b, pa, pb, p_c);
 		}
 		case Variant::AABB: {
 			AABB a = p_a;


### PR DESCRIPTION
Cubic interpolation was implemented some correctly by #63380.

The name `cubic_slerp()` has a contradictory meaning, "cubic spherical linear interpolation", so it is renamed `spherical_cubic_interpolate()` to correspond to `slerp()`. I felt that `scerp()` is odd.

`Transform3D::sphere_interpolate_with()` is also renamed to `Transform3D::spherical_interpolate_with()` to accommodate this.