### PR TITLE
EditorFileDialog: disambiguate recent/favorite items

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -216,6 +216,8 @@ EditorNode *EditorNode::singleton = nullptr;
 static const String META_TEXT_TO_COPY = "text_to_copy";
 
 void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vector<String> &r_filenames) {
+	ERR_FAIL_COND_MSG(p_full_paths.size() != r_filenames.size(), vformat("disambiguate_filenames requires two string vectors of same length (%d != %d).", p_full_paths.size(), r_filenames.size()));
+
 	// Keep track of a list of "index sets," i.e. sets of indices
 	// within disambiguated_scene_names which contain the same name.
 	Vector<RBSet<int>> index_sets;
@@ -248,6 +250,13 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 				}
 				if (full_path.rfind(".") >= 0) {
 					full_path = full_path.substr(0, full_path.rfind("."));
+				}
+
+				// Normalize trailing slashes when normalizing directory names.
+				if (scene_name.rfind("/") == scene_name.length() - 1 && full_path.rfind("/") != full_path.length() - 1) {
+					full_path = full_path + "/";
+				} else if (scene_name.rfind("/") != scene_name.length() - 1 && full_path.rfind("/") == full_path.length() - 1) {
+					scene_name = scene_name + "/";
 				}
 
 				int scene_name_size = scene_name.size();


### PR DESCRIPTION
Implements part of https://github.com/godotengine/godot-proposals/issues/2876

Similar to the script editor, if two folders have the same name in any editor file dialog (e.g. Open Scene), they will now get a more descriptive name in the item list. Note that this is *not* showing the full path, it just adds the parent folder name where needed.

Also made the formatting more consistent by removing the trailing slash for both lists.

![image](https://user-images.githubusercontent.com/5117197/187459949-a1250b25-4b14-420c-876e-ac1c7a0d3d73.png)
