### PR TITLE
Prevent hard crash in GDScriptVM when a named global can not be found.

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3280,6 +3280,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				int globalname_idx = _code_ptr[ip + 2];
 				GD_ERR_BREAK(globalname_idx < 0 || globalname_idx >= _global_names_count);
 				const StringName *globalname = &_global_names_ptr[globalname_idx];
+				GD_ERR_BREAK(!GDScriptLanguage::get_singleton()->get_named_globals_map().has(*globalname));
 
 				GET_INSTRUCTION_ARG(dst, 0);
 				*dst = GDScriptLanguage::get_singleton()->get_named_globals_map()[*globalname];


### PR DESCRIPTION
Closes #63559
Provides a check in the VM for OPCODE_STORE_NAMED_GLOBAL. Fixes the issue, but wonder if concerned about potential overhead.