### PR TITLE
Update export dialog to handle many architectures

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -428,7 +428,7 @@ void EditorExportPlatform::_edit_filter_list(HashSet<String> &r_list, const Stri
 	_edit_files_with_filter(da, filters, r_list, exclude);
 }
 
-EditorExportPlatform::FeatureContainers EditorExportPlatform::get_feature_containers(const Ref<EditorExportPreset> &p_preset, bool p_debug) {
+EditorExportPlatform::FeatureContainers EditorExportPlatform::get_feature_containers(const Ref<EditorExportPreset> &p_preset, bool p_debug) const {
 	Ref<EditorExportPlatform> platform = p_preset->get_platform();
 	List<String> feature_list;
 	platform->get_platform_features(&feature_list);

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -110,14 +110,14 @@ protected:
 		~ExportNotifier();
 	};
 
-	FeatureContainers get_feature_containers(const Ref<EditorExportPreset> &p_preset, bool p_debug);
+	FeatureContainers get_feature_containers(const Ref<EditorExportPreset> &p_preset, bool p_debug) const;
 
 	bool exists_export_template(String template_file_name, String *err) const;
 	String find_export_template(String template_file_name, String *err = nullptr) const;
 	void gen_export_flags(Vector<String> &r_flags, int p_flags);
 
 public:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) = 0;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const = 0;
 
 	struct ExportOption {
 		PropertyInfo option;
@@ -211,7 +211,7 @@ public:
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) = 0;
 	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
-	virtual void get_platform_features(List<String> *r_features) = 0;
+	virtual void get_platform_features(List<String> *r_features) const = 0;
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) = 0;
 	virtual String get_debug_protocol() const { return "tcp://"; }
 

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -32,7 +32,7 @@
 
 #include "core/config/project_settings.h"
 
-void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
+void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	if (p_preset->get("texture_format/s3tc")) {
 		r_features->push_back("s3tc");
 	}
@@ -224,7 +224,7 @@ void EditorExportPlatformPC::set_logo(const Ref<Texture2D> &p_logo) {
 	logo = p_logo;
 }
 
-void EditorExportPlatformPC::get_platform_features(List<String> *r_features) {
+void EditorExportPlatformPC::get_platform_features(List<String> *r_features) const {
 	r_features->push_back("pc"); //all pcs support "pc"
 	r_features->push_back("s3tc"); //all pcs support "s3tc" compression
 	r_features->push_back(get_os_name().to_lower()); //OS name is a feature

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -42,12 +42,9 @@ void EditorExportPlatformPC::get_preset_features(const Ref<EditorExportPreset> &
 	if (p_preset->get("texture_format/etc2")) {
 		r_features->push_back("etc2");
 	}
-
-	if (p_preset->get("binary_format/64_bits")) {
-		r_features->push_back("64");
-	} else {
-		r_features->push_back("32");
-	}
+	// PC platforms only have one architecture per export, since
+	// we export a single executable instead of a bundle.
+	r_features->push_back(p_preset->get("binary_format/architecture"));
 }
 
 void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) {
@@ -57,7 +54,6 @@ void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) {
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "debug/export_console_script", PROPERTY_HINT_ENUM, "No,Debug Only,Debug and Release"), 1));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "binary_format/64_bits"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "binary_format/embed_pck"), false));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "texture_format/bptc"), false));
@@ -84,10 +80,9 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 	bool valid = false;
 
 	// Look for export templates (first official, and if defined custom templates).
-
-	bool use64 = p_preset->get("binary_format/64_bits");
-	bool dvalid = exists_export_template(get_template_file_name("debug", use64 ? "x86_64" : "x86_32"), &err);
-	bool rvalid = exists_export_template(get_template_file_name("release", use64 ? "x86_64" : "x86_32"), &err);
+	String arch = p_preset->get("binary_format/architecture");
+	bool dvalid = exists_export_template(get_template_file_name("debug", arch), &err);
+	bool rvalid = exists_export_template(get_template_file_name("release", arch), &err);
 
 	if (p_preset->get("custom_template/debug") != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
@@ -139,7 +134,7 @@ Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_
 	template_path = template_path.strip_edges();
 
 	if (template_path.is_empty()) {
-		template_path = find_export_template(get_template_file_name(p_debug ? "debug" : "release", p_preset->get("binary_format/64_bits") ? "x86_64" : "x86_32"));
+		template_path = find_export_template(get_template_file_name(p_debug ? "debug" : "release", p_preset->get("binary_format/architecture")));
 	}
 
 	if (!template_path.is_empty() && !FileAccess::exists(template_path)) {
@@ -171,7 +166,7 @@ Error EditorExportPlatformPC::export_project_data(const Ref<EditorExportPreset> 
 	int64_t embedded_size;
 	Error err = save_pack(p_preset, p_debug, pck_path, &so_files, p_preset->get("binary_format/embed_pck"), &embedded_pos, &embedded_size);
 	if (err == OK && p_preset->get("binary_format/embed_pck")) {
-		if (embedded_size >= 0x100000000 && !p_preset->get("binary_format/64_bits")) {
+		if (embedded_size >= 0x100000000 && String(p_preset->get("binary_format/architecture")).contains("32")) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("PCK Embedding"), TTR("On 32-bit exports the embedded PCK cannot be bigger than 4 GiB."));
 			return ERR_INVALID_PARAMETER;
 		}

--- a/editor/export/editor_export_platform_pc.h
+++ b/editor/export/editor_export_platform_pc.h
@@ -44,7 +44,7 @@ private:
 	int chmod_flags = -1;
 
 public:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 
@@ -68,7 +68,7 @@ public:
 	void set_logo(const Ref<Texture2D> &p_logo);
 
 	void add_platform_feature(const String &p_feature);
-	virtual void get_platform_features(List<String> *r_features) override;
+	virtual void get_platform_features(List<String> *r_features) const override;
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override;
 
 	int get_chmod_flags() const;

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1671,7 +1671,7 @@ Vector<String> EditorExportPlatformAndroid::get_enabled_abis(const Ref<EditorExp
 	return enabled_abis;
 }
 
-void EditorExportPlatformAndroid::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
+void EditorExportPlatformAndroid::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	String driver = ProjectSettings::get_singleton()->get("rendering/driver/driver_name");
 	if (driver == "opengl3") {
 		r_features->push_back("etc");
@@ -3109,7 +3109,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	CLEANUP_AND_RETURN(OK);
 }
 
-void EditorExportPlatformAndroid::get_platform_features(List<String> *r_features) {
+void EditorExportPlatformAndroid::get_platform_features(List<String> *r_features) const {
 	r_features->push_back("mobile");
 	r_features->push_back("android");
 }

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1705,6 +1705,8 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	}
 	plugins_changed.clear();
 
+	// Android supports multiple architectures in an app bundle, so
+	// we expose each option as a checkbox in the export dialog.
 	const Vector<String> abis = get_abis();
 	for (int i = 0; i < abis.size(); ++i) {
 		const String abi = abis[i];

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -156,7 +156,7 @@ public:
 	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
 
 public:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 
@@ -231,7 +231,7 @@ public:
 
 	Error export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int export_format, bool should_sign, int p_flags);
 
-	virtual void get_platform_features(List<String> *r_features) override;
+	virtual void get_platform_features(List<String> *r_features) const override;
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override;
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -32,7 +32,7 @@
 
 #include "editor/editor_node.h"
 
-void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
+void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	String driver = ProjectSettings::get_singleton()->get("rendering/driver/driver_name");
 	// Vulkan and OpenGL ES 3.0 both mandate ETC2 support.
 	r_features->push_back("etc2");
@@ -43,7 +43,7 @@ void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> 
 	}
 }
 
-Vector<EditorExportPlatformIOS::ExportArchitecture> EditorExportPlatformIOS::_get_supported_architectures() {
+Vector<EditorExportPlatformIOS::ExportArchitecture> EditorExportPlatformIOS::_get_supported_architectures() const {
 	Vector<ExportArchitecture> archs;
 	archs.push_back(ExportArchitecture("arm64", true));
 	return archs;
@@ -1155,7 +1155,7 @@ Error EditorExportPlatformIOS::_export_additional_assets(const String &p_out_dir
 	return OK;
 }
 
-Vector<String> EditorExportPlatformIOS::_get_preset_architectures(const Ref<EditorExportPreset> &p_preset) {
+Vector<String> EditorExportPlatformIOS::_get_preset_architectures(const Ref<EditorExportPreset> &p_preset) const {
 	Vector<ExportArchitecture> all_archs = _get_supported_architectures();
 	Vector<String> enabled_archs;
 	for (int i = 0; i < all_archs.size(); ++i) {

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -106,8 +106,8 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 	Error _export_loading_screen_file(const Ref<EditorExportPreset> &p_preset, const String &p_dest_dir);
 	Error _export_icons(const Ref<EditorExportPreset> &p_preset, const String &p_iconset_dir);
 
-	Vector<ExportArchitecture> _get_supported_architectures();
-	Vector<String> _get_preset_architectures(const Ref<EditorExportPreset> &p_preset);
+	Vector<ExportArchitecture> _get_supported_architectures() const;
+	Vector<String> _get_preset_architectures(const Ref<EditorExportPreset> &p_preset) const;
 
 	void _add_assets_to_project(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_project_data, const Vector<IOSExportAsset> &p_additional_assets);
 	Error _export_additional_assets(const String &p_out_dir, const Vector<String> &p_assets, bool p_is_framework, bool p_should_embed, Vector<IOSExportAsset> &r_exported_assets);
@@ -173,7 +173,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 	}
 
 protected:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 
 public:
@@ -199,7 +199,7 @@ public:
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
 
-	virtual void get_platform_features(List<String> *r_features) override {
+	virtual void get_platform_features(List<String> *r_features) const override {
 		r_features->push_back("mobile");
 		r_features->push_back("ios");
 	}

--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -302,7 +302,7 @@ Error EditorExportPlatformJavaScript::_build_pwa(const Ref<EditorExportPreset> &
 	return OK;
 }
 
-void EditorExportPlatformJavaScript::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
+void EditorExportPlatformJavaScript::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	if (p_preset->get("vram_texture_compression/for_desktop")) {
 		r_features->push_back("s3tc");
 	}

--- a/platform/javascript/export/export_plugin.h
+++ b/platform/javascript/export/export_plugin.h
@@ -110,7 +110,7 @@ class EditorExportPlatformJavaScript : public EditorExportPlatform {
 	static void _server_thread_poll(void *data);
 
 public:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 
@@ -130,7 +130,7 @@ public:
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_option, int p_debug_flags) override;
 	virtual Ref<Texture2D> get_run_icon() const override;
 
-	virtual void get_platform_features(List<String> *r_features) override {
+	virtual void get_platform_features(List<String> *r_features) const override {
 		r_features->push_back("web");
 		r_features->push_back(get_os_name().to_lower());
 	}

--- a/platform/linuxbsd/export/export.cpp
+++ b/platform/linuxbsd/export/export.cpp
@@ -38,8 +38,6 @@ void register_linuxbsd_exporter() {
 	platform.instantiate();
 	platform->set_logo(ImageTexture::create_from_image(memnew(Image(_linuxbsd_logo))));
 	platform->set_name("Linux/X11");
-	platform->set_extension("x86_32");
-	platform->set_extension("x86_64", "binary_format/64_bits");
 	platform->set_os_name("Linux");
 	platform->set_chmod_flags(0755);
 

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -79,29 +79,19 @@ Error EditorExportPlatformLinuxBSD::export_project(const Ref<EditorExportPreset>
 	return err;
 }
 
-void EditorExportPlatformLinuxBSD::set_extension(const String &p_extension, const String &p_feature_key) {
-	extensions[p_feature_key] = p_extension;
-}
-
 String EditorExportPlatformLinuxBSD::get_template_file_name(const String &p_target, const String &p_arch) const {
 	return "linux_" + p_target + "." + p_arch;
 }
 
 List<String> EditorExportPlatformLinuxBSD::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
 	List<String> list;
-	for (const KeyValue<String, String> &E : extensions) {
-		if (p_preset->get(E.key)) {
-			list.push_back(extensions[E.key]);
-			return list;
-		}
-	}
-
-	if (extensions.has("default")) {
-		list.push_back(extensions["default"]);
-		return list;
-	}
-
+	list.push_back(p_preset->get("binary_format/architecture"));
 	return list;
+}
+
+void EditorExportPlatformLinuxBSD::get_export_options(List<ExportOption> *r_options) {
+	EditorExportPlatformPC::get_export_options(r_options);
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm64,arm32,rv64,ppc64,ppc32"), "x86_64"));
 }
 
 Error EditorExportPlatformLinuxBSD::fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) {

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -38,12 +38,12 @@
 #include "scene/resources/texture.h"
 
 class EditorExportPlatformLinuxBSD : public EditorExportPlatformPC {
-	HashMap<String, String> extensions;
 	Error _export_debug_script(const Ref<EditorExportPreset> &p_preset, const String &p_app_name, const String &p_pkg_name, const String &p_path);
 
 public:
 	void set_extension(const String &p_extension, const String &p_feature_key = "default");
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
+	virtual void get_export_options(List<ExportOption> *r_options) override;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
 	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -47,8 +47,7 @@ void EditorExportPlatformMacOS::get_preset_features(const Ref<EditorExportPreset
 	if (p_preset->get("texture_format/etc2")) {
 		r_features->push_back("etc2");
 	}
-
-	r_features->push_back("64");
+	r_features->push_back(p_preset->get("binary_format/architecture"));
 }
 
 bool EditorExportPlatformMacOS::get_export_option_visibility(const String &p_option, const HashMap<StringName, Variant> &p_options) const {
@@ -69,6 +68,7 @@ bool EditorExportPlatformMacOS::get_export_option_visibility(const String &p_opt
 }
 
 void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options) {
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "universal,x86_64,arm64", PROPERTY_USAGE_STORAGE), "universal"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 
@@ -766,7 +766,8 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 	int ret = unzGoToFirstFile(src_pkg_zip);
 
-	String binary_to_use = "godot_macos_" + String(p_debug ? "debug" : "release") + ".universal";
+	String architecture = p_preset->get("binary_format/architecture");
+	String binary_to_use = "godot_macos_" + String(p_debug ? "debug" : "release") + "." + architecture;
 
 	String pkg_name;
 	if (String(ProjectSettings::get_singleton()->get("application/config/name")) != "") {
@@ -1064,19 +1065,19 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		if (data.size() > 0) {
-			if (file.find("/data.mono.macos.release_debug.universal/") != -1) {
+			if (file.find("/data.mono.macos.release_debug." + architecture + "/") != -1) {
 				if (!p_debug) {
 					ret = unzGoToNextFile(src_pkg_zip);
 					continue; // skip
 				}
-				file = file.replace("/data.mono.macos.release_debug.universal/", "/GodotSharp/");
+				file = file.replace("/data.mono.macos.release_debug." + architecture + "/", "/GodotSharp/");
 			}
-			if (file.find("/data.mono.macos.release.universal/") != -1) {
+			if (file.find("/data.mono.macos.release." + architecture + "/") != -1) {
 				if (p_debug) {
 					ret = unzGoToNextFile(src_pkg_zip);
 					continue; // skip
 				}
-				file = file.replace("/data.mono.macos.release.universal/", "/GodotSharp/");
+				file = file.replace("/data.mono.macos.release." + architecture + "/", "/GodotSharp/");
 			}
 
 			if (file.ends_with(".dylib")) {

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -37,7 +37,7 @@
 
 #include "modules/modules_enabled.gen.h" // For regex.
 
-void EditorExportPlatformMacOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
+void EditorExportPlatformMacOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	if (p_preset->get("texture_format/s3tc")) {
 		r_features->push_back("s3tc");
 	}

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -99,7 +99,7 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	}
 
 protected:
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 	virtual bool get_export_option_visibility(const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
@@ -121,7 +121,7 @@ public:
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
 
-	virtual void get_platform_features(List<String> *r_features) override {
+	virtual void get_platform_features(List<String> *r_features) const override {
 		r_features->push_back("pc");
 		r_features->push_back("s3tc");
 		r_features->push_back("macos");

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -49,7 +49,7 @@ Ref<Texture2D> EditorExportPlatformUWP::get_logo() const {
 	return logo;
 }
 
-void EditorExportPlatformUWP::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) {
+void EditorExportPlatformUWP::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	r_features->push_back("s3tc");
 	r_features->push_back("etc");
 	switch ((int)p_preset->get("architecture/target")) {
@@ -494,7 +494,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 	return OK;
 }
 
-void EditorExportPlatformUWP::get_platform_features(List<String> *r_features) {
+void EditorExportPlatformUWP::get_platform_features(List<String> *r_features) const {
 	r_features->push_back("pc");
 	r_features->push_back("uwp");
 }

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -52,24 +52,14 @@ Ref<Texture2D> EditorExportPlatformUWP::get_logo() const {
 void EditorExportPlatformUWP::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	r_features->push_back("s3tc");
 	r_features->push_back("etc");
-	switch ((int)p_preset->get("architecture/target")) {
-		case EditorExportPlatformUWP::ARM: {
-			r_features->push_back("arm");
-		} break;
-		case EditorExportPlatformUWP::X86: {
-			r_features->push_back("32");
-		} break;
-		case EditorExportPlatformUWP::X64: {
-			r_features->push_back("64");
-		} break;
-	}
+	r_features->push_back(p_preset->get("binary_format/architecture"));
 }
 
 void EditorExportPlatformUWP::get_export_options(List<ExportOption> *r_options) {
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "architecture/target", PROPERTY_HINT_ENUM, "arm,x86,x64"), 1));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm32"), "x86_64"));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "command_line/extra_args"), ""));
 
@@ -143,23 +133,18 @@ bool EditorExportPlatformUWP::can_export(const Ref<EditorExportPreset> &p_preset
 	bool valid = false;
 
 	// Look for export templates (first official, and if defined custom templates).
-
-	Platform arch = (Platform)(int)(p_preset->get("architecture/target"));
-	String platform_infix;
-	switch (arch) {
-		case EditorExportPlatformUWP::ARM: {
-			platform_infix = "arm";
-		} break;
-		case EditorExportPlatformUWP::X86: {
-			platform_infix = "x86";
-		} break;
-		case EditorExportPlatformUWP::X64: {
-			platform_infix = "x64";
-		} break;
+	String arch = p_preset->get("binary_format/architecture");
+	String arch_infix;
+	if (arch == "arm32") {
+		arch_infix = "arm";
+	} else if (arch == "x86_32") {
+		arch_infix = "x86";
+	} else if (arch == "x86_64") {
+		arch_infix = "x64";
 	}
 
-	bool dvalid = exists_export_template("uwp_" + platform_infix + "_debug.zip", &err);
-	bool rvalid = exists_export_template("uwp_" + platform_infix + "_release.zip", &err);
+	bool dvalid = exists_export_template("uwp_" + arch_infix + "_debug.zip", &err);
+	bool rvalid = exists_export_template("uwp_" + arch_infix + "_release.zip", &err);
 
 	if (p_preset->get("custom_template/debug") != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
@@ -263,25 +248,21 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 
 	src_appx = src_appx.strip_edges();
 
-	Platform arch = (Platform)(int)p_preset->get("architecture/target");
+	String arch = p_preset->get("binary_format/architecture");
 
 	if (src_appx.is_empty()) {
-		String err, infix;
-		switch (arch) {
-			case ARM: {
-				infix = "_arm_";
-			} break;
-			case X86: {
-				infix = "_x86_";
-			} break;
-			case X64: {
-				infix = "_x64_";
-			} break;
+		String err, arch_infix;
+		if (arch == "arm32") {
+			arch_infix = "arm";
+		} else if (arch == "x86_32") {
+			arch_infix = "x86";
+		} else if (arch == "x86_64") {
+			arch_infix = "x64";
 		}
 		if (p_debug) {
-			src_appx = find_export_template("uwp" + infix + "debug.zip", &err);
+			src_appx = find_export_template("uwp_" + arch_infix + "_debug.zip", &err);
 		} else {
-			src_appx = find_export_template("uwp" + infix + "release.zip", &err);
+			src_appx = find_export_template("uwp_" + arch_infix + "_release.zip", &err);
 		}
 		if (src_appx.is_empty()) {
 			EditorNode::add_io_error(err);

--- a/platform/uwp/export/export_plugin.h
+++ b/platform/uwp/export/export_plugin.h
@@ -431,7 +431,7 @@ public:
 
 	virtual Ref<Texture2D> get_logo() const override;
 
-	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) override;
+	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 
@@ -439,7 +439,7 @@ public:
 
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
 
-	virtual void get_platform_features(List<String> *r_features) override;
+	virtual void get_platform_features(List<String> *r_features) const override;
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override;
 

--- a/platform/uwp/export/export_plugin.h
+++ b/platform/uwp/export/export_plugin.h
@@ -90,12 +90,6 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 
 	Ref<ImageTexture> logo;
 
-	enum Platform {
-		ARM,
-		X86,
-		X64
-	};
-
 	bool _valid_resource_name(const String &p_name) const {
 		if (p_name.is_empty()) {
 			return false;
@@ -215,8 +209,8 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		String version = itos(p_preset->get("version/major")) + "." + itos(p_preset->get("version/minor")) + "." + itos(p_preset->get("version/build")) + "." + itos(p_preset->get("version/revision"));
 		result = result.replace("$version_string$", version);
 
-		Platform arch = (Platform)(int)p_preset->get("architecture/target");
-		String architecture = arch == ARM ? "arm" : (arch == X86 ? "x86" : "x64");
+		String arch = p_preset->get("binary_format/architecture");
+		String architecture = arch == "arm32" ? "arm" : (arch == "x86_32" ? "x86" : "x64");
 		result = result.replace("$architecture$", architecture);
 
 		result = result.replace("$display_name$", String(p_preset->get("package/display_name")).is_empty() ? (String)ProjectSettings::get_singleton()->get("application/config/name") : String(p_preset->get("package/display_name")));

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -123,6 +123,7 @@ bool EditorExportPlatformWindows::get_export_option_visibility(const String &p_o
 
 void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_options) {
 	EditorExportPlatformPC::get_export_options(r_options);
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32"), "x86_64"));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/enable"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/identity_type", PROPERTY_HINT_ENUM, "Select automatically,Use PKCS12 file (specify *.PFX/*.P12 file),Use certificate store (specify SHA1 hash)"), 0));


### PR DESCRIPTION
This PR has two commits. The first commit adds `const` to a few places, to make it clear that these methods do not modify anything in the class.

The second commit is the bulk of this PR, it updates the export dialog to handle many architectures. This is fully compatible with the new export template names in https://github.com/godotengine/godot/pull/63096

* For Windows, Linux, and UWP, they get a dropdown menu called `binary_format/architecture`.
  * This means that `binary_format/64_bits` is now gone! (not to be confused with `bits=` in the build system)
  * UWP already had a dropdown before, but this PR makes it more consistent with the others.
  * Windows, Linux, and UWP all default to x86_64.
  * The only options for Windows are x86_64 and x86_32. When it's possible to build Godot for Windows for ARM, we'll add arm64 (and maybe arm32?) to the list.
* For macOS, it will use "universal", which is both x86_64 and arm64 at the same time.
* For Android and iOS, I did not touch them, except I added a comment for Android. These platforms already have checkboxes for which architectures to include in the app bundle.
* For the last platform we support, web, I did not touch it. When 64-bit WebAssembly inevitably starts existing and we want to support it, we will need to modify the web platform's code.

I will note that most users will not need to change the architecture, since most desktops are x86_64, and for macOS the universal architecture will work on all supported systems. But it's good to have this "properly" supported.

Here is a screenshot of what the dropdown looks like for Linux (which has the most options by *far*, and to be clear, it's not at all expected that the Godot organization provides all of these officially):

<img src="https://user-images.githubusercontent.com/1646875/181395798-898dfc45-cee6-4e53-9e6d-c5c0c1fb1c83.png" data-canonical-src="https://user-images.githubusercontent.com/1646875/181395798-898dfc45-cee6-4e53-9e6d-c5c0c1fb1c83.png" width="450" height="451" />