### PR TITLE
[Export, Windows] Improve console wrapper script to handle stdin and child processes.

### DIFF
--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -49,8 +49,8 @@ Error EditorExportPlatformWindows::_export_debug_script(const Ref<EditorExportPr
 	}
 
 	f->store_line("@echo off");
-	f->store_line("title \"" + p_app_name + "\"");
-	f->store_line("\"%~dp0" + p_pkg_name + "\" \"%*\"");
+	f->store_line("title " + p_app_name + "");
+	f->store_line("powershell -command \"Start-Process -FilePath %~dp0" + p_pkg_name + " -ArgumentList \\\" %* \\\" -Wait\"");
 	f->store_line("pause > nul");
 
 	return OK;


### PR DESCRIPTION
Changes generated script to use PowerShell `Start-Process` cmdlet to start and wait for the Godot editor process, which:

- Correctly passes stdin input to the Godot process.
- Unlike cmd, it waits for the all child processes as well.

Same changes for the editor script - https://github.com/godotengine/godot-build-scripts/pull/59