### PR TITLE
[3.x] HTML5: Add support for `Input.vibrate_handheld()`

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -187,7 +187,7 @@ int OS::get_process_id() const {
 };
 
 void OS::vibrate_handheld(int p_duration_ms) {
-	WARN_PRINT("vibrate_handheld() only works with Android and iOS");
+	WARN_PRINT("vibrate_handheld() only works with Android, iOS and HTML5");
 }
 
 bool OS::is_stdout_verbose() const {

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -379,9 +379,11 @@
 			<return type="void" />
 			<argument index="0" name="duration_ms" type="int" default="500" />
 			<description>
-				Vibrate Android and iOS devices.
+				Vibrate handheld devices.
+				[b]Note:[/b] This method is implemented on Android, iOS, and HTML5.
 				[b]Note:[/b] For Android, it requires enabling the [code]VIBRATE[/code] permission in the export preset.
 				[b]Note:[/b] For iOS, specifying the duration is supported in iOS 13 and later.
+				[b]Note:[/b] Some web browsers such as Safari and Firefox for Android do not support this method.
 			</description>
 		</method>
 		<method name="warp_mouse_position">

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -58,6 +58,7 @@ extern void godot_js_input_mouse_move_cb(void (*p_callback)(double p_x, double p
 extern void godot_js_input_mouse_wheel_cb(int (*p_callback)(double p_delta_x, double p_delta_y));
 extern void godot_js_input_touch_cb(void (*p_callback)(int p_type, int p_count), uint32_t *r_identifiers, double *r_coords);
 extern void godot_js_input_key_cb(void (*p_callback)(int p_type, int p_repeat, int p_modifiers), char r_code[32], char r_key[32]);
+extern void godot_js_input_vibrate_handheld(int p_duration_ms);
 
 // Input gamepad
 extern void godot_js_input_gamepad_cb(void (*p_on_change)(int p_index, int p_connected, const char *p_id, const char *p_guid));

--- a/platform/javascript/js/libs/library_godot_input.js
+++ b/platform/javascript/js/libs/library_godot_input.js
@@ -534,6 +534,15 @@ const GodotInput = {
 			GodotRuntime.free(ptr);
 		}, false);
 	},
+
+	godot_js_input_vibrate_handheld__sig: 'vi',
+	godot_js_input_vibrate_handheld: function (p_duration_ms) {
+		if (typeof navigator.vibrate !== 'function') {
+			GodotRuntime.print('This browser does not support vibration.');
+		} else {
+			navigator.vibrate(p_duration_ms);
+		}
+	},
 };
 
 autoAddDeps(GodotInput, '$GodotInput');

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -992,6 +992,10 @@ bool OS_JavaScript::can_draw() const {
 	return true; // Always?
 }
 
+void OS_JavaScript::vibrate_handheld(int p_duration_ms) {
+	godot_js_input_vibrate_handheld(p_duration_ms);
+}
+
 String OS_JavaScript::get_user_data_dir() const {
 	return "/userfs";
 };

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -186,6 +186,7 @@ public:
 	virtual String get_name() const;
 	virtual void add_frame_delay(bool p_can_draw) {}
 	virtual bool can_draw() const;
+	virtual void vibrate_handheld(int p_duration_ms);
 
 	virtual String get_cache_path() const;
 	virtual String get_config_path() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
`3.x` version of #63548 