### PR TITLE
Make `-q` to silence header, and `stdout` if specified twice

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -713,7 +713,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			OS::get_singleton()->_verbose_stdout = true;
 		} else if (I->get() == "-q" || I->get() == "--quiet") { // quieter output
-			if quiet_header {
+			if (quiet_header) {
 				// the option is specified twice
 				quiet_stdout = true;
 			} else {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -116,6 +116,7 @@ static ZipArchive *zip_packed_data = nullptr;
 #endif
 static FileAccessNetworkClient *file_access_network_client = nullptr;
 static MessageQueue *message_queue = nullptr;
+static bool quiet_header = false;
 
 // Initialized in setup2()
 static AudioServer *audio_server = nullptr;
@@ -649,7 +650,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String debug_uri = "";
 	bool skip_breakpoints = false;
 	String main_pack;
-	bool quiet_header = false;
 	bool quiet_stdout = false;
 	int rtm = -1;
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -719,6 +719,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				quiet_header = true;
 			}
+		} else if (I->get() == "-qq") {
+			quiet_header = true;
+			quiet_stdout = true;
 
 		} else if (I->get() == "--audio-driver") { // audio driver
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -281,7 +281,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -h, --help                                   Display this help message.\n");
 	OS::get_singleton()->print("  --version                                    Display the version string.\n");
 	OS::get_singleton()->print("  -v, --verbose                                Use verbose stdout mode.\n");
-	OS::get_singleton()->print("  -q, --quiet                                  Quiet mode, silences stdout messages. Errors are still displayed.\n");
+	OS::get_singleton()->print("  -q, --quiet                                  Be quiet. Silences header if specified once, and all stdout messages if present twice. Errors are still displayed.\n");
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Run options:\n");
@@ -649,6 +649,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String debug_uri = "";
 	bool skip_breakpoints = false;
 	String main_pack;
+	bool quiet_header = false;
 	bool quiet_stdout = false;
 	int rtm = -1;
 
@@ -712,8 +713,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 			OS::get_singleton()->_verbose_stdout = true;
 		} else if (I->get() == "-q" || I->get() == "--quiet") { // quieter output
-
-			quiet_stdout = true;
+			if quiet_header {
+				// the option is specified twice
+				quiet_stdout = true;
+			} else {
+				quiet_header = true;
+			}
 
 		} else if (I->get() == "--audio-driver") { // audio driver
 
@@ -1694,7 +1699,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
 
 	// Print engine name and version
-	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
+	if (!quiet_header) {
+		print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
+	}
 
 #if !defined(NO_THREADS)
 	if (p_main_tid_override) {


### PR DESCRIPTION
I am not sure it works, because `quiet_header` is defined in `Main::setup` and probably is not available in `Main::setup2`.

I'd like to silence the header, because I use some `.gd` scripts from command line, and need to pipe their output without extra lines from `godot`.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/4998.*