### PR TITLE
When Camera2D enters tree, ensure first update is not lost

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -439,7 +439,9 @@ void Camera2D::clear_current() {
 void Camera2D::set_limit(Side p_side, int p_limit) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	limit[p_side] = p_limit;
+	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
+	smoothed_camera_pos = old_smoothed_camera_pos;
 }
 
 int Camera2D::get_limit(Side p_side) const {

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -247,8 +247,8 @@ void Camera2D::_notification(int p_what) {
 			add_to_group(canvas_group_name);
 
 			_update_process_callback();
-			_update_scroll();
 			first = true;
+			_update_scroll();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {


### PR DESCRIPTION
Currently, after initialising `Camera2D`, the camera is set to uninitialised again. The result is, the first call to `_update_scroll()` is used to initialise the camera and not used to update the scroll. This PR ensures that the camera is set to uninitialised before initialising the camera not after.

In addition, this PR ensures that changes to Camera2D's limits don't affect `smoothed_camera_pos` i.e. applies the #39567 and #2764 fix to 4c23fe602b7be8103bc611e2558f9bcfc6a3a57e included in #63083.

Fixes #63330.