### PR TITLE
[3.x] When Camera2D enters tree, ensure first update is not lost

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -436,7 +436,9 @@ void Camera2D::clear_current() {
 void Camera2D::set_limit(Margin p_margin, int p_limit) {
 	ERR_FAIL_INDEX((int)p_margin, 4);
 	limit[p_margin] = p_limit;
+	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
+	smoothed_camera_pos = old_smoothed_camera_pos;
 }
 
 int Camera2D::get_limit(Margin p_margin) const {

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -254,9 +254,8 @@ void Camera2D::_notification(int p_what) {
 			// if a camera enters the tree that is set to current,
 			// it should take over as the current camera, and mark
 			// all other cameras as non current
-			_set_current(current);
-
 			first = true;
+			_set_current(current);
 
 		} break;
 		case NOTIFICATION_EXIT_TREE: {


### PR DESCRIPTION
3.x version of #63580.
