### PR TITLE
fix(gdscript): Fix out of bounds crash after reloading member variables

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1636,8 +1636,6 @@ const Vector<Multiplayer::RPCConfig> GDScriptInstance::get_rpc_methods() const {
 void GDScriptInstance::reload_members() {
 #ifdef DEBUG_ENABLED
 
-	members.resize(script->member_indices.size()); //resize
-
 	Vector<Variant> new_members;
 	new_members.resize(script->member_indices.size());
 
@@ -1648,6 +1646,8 @@ void GDScriptInstance::reload_members() {
 			new_members.write[E.value.index] = value;
 		}
 	}
+
+	members.resize(new_members.size()); //resize
 
 	//apply
 	members = new_members;


### PR DESCRIPTION
The crash happens because the members Vector is resized, while the member_indices_cache still has the old indices saved.
On deleting a member from the script this can result to a cached index of 1 while the members Vector size is only 1.

Solves #63455 