### PR TITLE
Treat specular less than 0.02 as occlusion

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -241,7 +241,7 @@
 			A high value makes the material appear more like a metal. Non-metals use their albedo as the diffuse color and add diffuse to the specular reflection. With non-metals, the reflection appears on top of the albedo color. Metals use their albedo as a multiplier to the specular reflection and set the diffuse color to black resulting in a tinted reflection. Materials work better when fully metal or fully non-metal, values between [code]0[/code] and [code]1[/code] should only be used for blending between metal and non-metal sections. To alter the amount of reflection use [member roughness].
 		</member>
 		<member name="metallic_specular" type="float" setter="set_specular" getter="get_specular" default="0.5">
-			Sets the size of the specular lobe. The specular lobe is the bright spot that is reflected from light sources.
+			Adjusts the strength of specular reflections. Specular reflections are composed of scene reflections and the specular lobe which is the bright spot that is reflected from light sources. When set to [code]0.0[/code], no specular reflections will be visible. This differs from the [constant SPECULAR_DISABLED] [enum SpecularMode] as [constant SPECULAR_DISABLED] only applies to the specular lobe from the light source.
 			[b]Note:[/b] Unlike [member metallic], this is not energy-conserving, so it should be left at [code]0.5[/code] in most cases. See also [member roughness].
 		</member>
 		<member name="metallic_texture" type="Texture2D" setter="set_texture" getter="get_texture">

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -686,7 +686,10 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float atte
 #endif // LIGHT_ANISOTROPY_USED
 	   // F
 		float cLdotH5 = SchlickFresnel(cLdotH);
-		vec3 F = mix(vec3(cLdotH5), vec3(1.0), f0);
+		// Calculate Fresnel using cheap approximate specular occlusion term from Filament:
+		// https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion
+		float f90 = clamp(50.0 * f0.g, 0.0, 1.0);
+		vec3 F = f0 + (f90 - f0) * cLdotH5;
 
 		vec3 specular_brdf_NL = cNdotL * D * F * G;
 
@@ -1107,7 +1110,7 @@ void main() {
 
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
-		specular_light *= env.x * f0 + env.y;
+		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, 0.0, 1.0);
 #endif
 	}
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -1381,7 +1381,7 @@ void fragment_shader(in SceneData scene_data) {
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 
-		specular_light *= env.x * f0 + env.y;
+		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, 0.0, 1.0);
 #endif
 	}
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -199,7 +199,10 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, float atte
 #endif // LIGHT_ANISOTROPY_USED
 	   // F
 		float cLdotH5 = SchlickFresnel(cLdotH);
-		vec3 F = mix(vec3(cLdotH5), vec3(1.0), f0);
+		// Calculate Fresnel using specular occlusion term from Filament:
+		// https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion
+		float f90 = clamp(dot(f0, vec3(50.0 * 0.33)), 0.0, 1.0);
+		vec3 F = f0 + (f90 - f0) * cLdotH5;
 
 		vec3 specular_brdf_NL = cNdotL * D * F * G;
 


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/4818

This is a very common hack used in almost all PBR renderers to allow removing specular contribution in dielectric materials.

Filament calls it ["Pre-baked Specular Occlusion"](https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion). Essentially, a specular value of less than 0.02 is outside the realm of physical quantities, so that range is reused to signify occlusion. In effect, this makes the specular fade out when very low values are used and it does nothing when normal range values are used. 

Importantly, this PR matches the behaviour with Blender, Unreal, and Unity.

<details>
<summary><b>Specular = 1.0</b></summary>

_Before_

![Screenshot from 2022-07-28 11-23-59](https://user-images.githubusercontent.com/16521339/181612357-15fe5b7b-655e-4b51-883b-2fc71f3e664e.png)

_After_

![Screenshot from 2022-07-28 11-26-32](https://user-images.githubusercontent.com/16521339/181612461-70d0da4a-db27-4302-bd47-998495465c1c.png)

</details>

<details>
<summary><b>Specular = 0.5</b></summary>

_Before_

![Screenshot from 2022-07-28 11-23-56](https://user-images.githubusercontent.com/16521339/181612334-13b9c81f-ca78-4dd2-9eb0-1abab18cabdc.png)

_After_

![Screenshot from 2022-07-28 11-26-35](https://user-images.githubusercontent.com/16521339/181612477-6f042f04-e5ab-4702-b107-4b732a43ecd0.png)

</details>


<details>
<summary><b>Specular = 0.0</b></summary>

_Before_

![Screenshot from 2022-07-28 11-23-54](https://user-images.githubusercontent.com/16521339/182047200-2681f972-878d-4fb1-9aa1-326daa2f8117.png)

_After_

![Screenshot from 2022-07-28 11-26-39](https://user-images.githubusercontent.com/16521339/181612489-8e8af25c-7393-4335-b94a-7ff74ddda7da.png)

</details>


