### PR TITLE
[Core] Make ImageFormatLoader extensible.

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -32,6 +32,12 @@
 
 #include "core/string/print_string.h"
 
+void ImageFormatLoader::_bind_methods() {
+	BIND_BITFIELD_FLAG(FLAG_NONE);
+	BIND_BITFIELD_FLAG(FLAG_FORCE_LINEAR);
+	BIND_BITFIELD_FLAG(FLAG_CONVERT_COLORS);
+}
+
 bool ImageFormatLoader::recognize(const String &p_extension) const {
 	List<String> extensions;
 	get_recognized_extensions(&extensions);
@@ -44,7 +50,39 @@ bool ImageFormatLoader::recognize(const String &p_extension) const {
 	return false;
 }
 
-Error ImageLoader::load_image(String p_file, Ref<Image> p_image, Ref<FileAccess> p_custom, uint32_t p_flags, float p_scale) {
+Error ImageFormatLoaderExtension::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
+	Error err;
+	if (GDVIRTUAL_CALL(_load_image, p_image, p_fileaccess, p_flags, p_scale, err)) {
+		return err;
+	}
+	return ERR_UNAVAILABLE;
+}
+
+void ImageFormatLoaderExtension::get_recognized_extensions(List<String> *p_extension) const {
+	PackedStringArray ext;
+	if (GDVIRTUAL_CALL(_get_recognized_extensions, ext)) {
+		for (int i = 0; i < ext.size(); i++) {
+			p_extension->push_back(ext[i]);
+		}
+	}
+}
+
+void ImageFormatLoaderExtension::add_format_loader() {
+	ImageLoader::add_image_format_loader(this);
+}
+
+void ImageFormatLoaderExtension::remove_format_loader() {
+	ImageLoader::remove_image_format_loader(this);
+}
+
+void ImageFormatLoaderExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_get_recognized_extensions);
+	GDVIRTUAL_BIND(_load_image, "image", "fileaccess", "flags", "scale");
+	ClassDB::bind_method(D_METHOD("add_format_loader"), &ImageFormatLoaderExtension::add_format_loader);
+	ClassDB::bind_method(D_METHOD("remove_format_loader"), &ImageFormatLoaderExtension::remove_format_loader);
+}
+
+Error ImageLoader::load_image(String p_file, Ref<Image> p_image, Ref<FileAccess> p_custom, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	ERR_FAIL_COND_V_MSG(p_image.is_null(), ERR_INVALID_PARAMETER, "It's not a reference to a valid Image object.");
 
 	Ref<FileAccess> f = p_custom;
@@ -60,7 +98,7 @@ Error ImageLoader::load_image(String p_file, Ref<Image> p_image, Ref<FileAccess>
 		if (!loader[i]->recognize(extension)) {
 			continue;
 		}
-		Error err = loader[i]->load_image(p_image, f, p_flags, p_scale);
+		Error err = loader.write[i]->load_image(p_image, f, p_flags, p_scale);
 		if (err != OK) {
 			ERR_PRINT("Error loading image: " + p_file);
 		}
@@ -79,7 +117,7 @@ void ImageLoader::get_recognized_extensions(List<String> *p_extensions) {
 	}
 }
 
-ImageFormatLoader *ImageLoader::recognize(const String &p_extension) {
+Ref<ImageFormatLoader> ImageLoader::recognize(const String &p_extension) {
 	for (int i = 0; i < loader.size(); i++) {
 		if (loader[i]->recognize(p_extension)) {
 			return loader[i];
@@ -89,17 +127,17 @@ ImageFormatLoader *ImageLoader::recognize(const String &p_extension) {
 	return nullptr;
 }
 
-Vector<ImageFormatLoader *> ImageLoader::loader;
+Vector<Ref<ImageFormatLoader>> ImageLoader::loader;
 
-void ImageLoader::add_image_format_loader(ImageFormatLoader *p_loader) {
+void ImageLoader::add_image_format_loader(Ref<ImageFormatLoader> p_loader) {
 	loader.push_back(p_loader);
 }
 
-void ImageLoader::remove_image_format_loader(ImageFormatLoader *p_loader) {
+void ImageLoader::remove_image_format_loader(Ref<ImageFormatLoader> p_loader) {
 	loader.erase(p_loader);
 }
 
-const Vector<ImageFormatLoader *> &ImageLoader::get_image_format_loaders() {
+const Vector<Ref<ImageFormatLoader>> &ImageLoader::get_image_format_loaders() {
 	return loader;
 }
 
@@ -152,7 +190,7 @@ Ref<Resource> ResourceFormatLoaderImage::load(const String &p_path, const String
 	Ref<Image> image;
 	image.instantiate();
 
-	Error err = ImageLoader::loader[idx]->load_image(image, f);
+	Error err = ImageLoader::loader.write[idx]->load_image(image, f);
 
 	if (err != OK) {
 		if (r_error) {

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -31,22 +31,22 @@
 #ifndef IMAGE_LOADER_H
 #define IMAGE_LOADER_H
 
+#include "core/core_bind.h"
 #include "core/io/file_access.h"
 #include "core/io/image.h"
 #include "core/io/resource_loader.h"
+#include "core/object/gdvirtual.gen.inc"
 #include "core/string/ustring.h"
 #include "core/templates/list.h"
+#include "core/variant/binder_common.h"
 
 class ImageLoader;
 
-class ImageFormatLoader {
+class ImageFormatLoader : public RefCounted {
+	GDCLASS(ImageFormatLoader, RefCounted);
+
 	friend class ImageLoader;
 	friend class ResourceFormatLoaderImage;
-
-protected:
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, uint32_t p_flags = (uint32_t)FLAG_NONE, float p_scale = 1.0) = 0;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
-	bool recognize(const String &p_extension) const;
 
 public:
 	enum LoaderFlags {
@@ -55,23 +55,50 @@ public:
 		FLAG_CONVERT_COLORS = 2,
 	};
 
+protected:
+	static void _bind_methods();
+
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) = 0;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	bool recognize(const String &p_extension) const;
+
+public:
 	virtual ~ImageFormatLoader() {}
 };
 
+VARIANT_BITFIELD_CAST(ImageFormatLoader::LoaderFlags);
+
+class ImageFormatLoaderExtension : public ImageFormatLoader {
+	GDCLASS(ImageFormatLoaderExtension, ImageFormatLoader);
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) override;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+
+	void add_format_loader();
+	void remove_format_loader();
+
+	GDVIRTUAL0RC(PackedStringArray, _get_recognized_extensions);
+	GDVIRTUAL4R(Error, _load_image, Ref<Image>, Ref<FileAccess>, BitField<ImageFormatLoader::LoaderFlags>, float);
+};
+
 class ImageLoader {
-	static Vector<ImageFormatLoader *> loader;
+	static Vector<Ref<ImageFormatLoader>> loader;
 	friend class ResourceFormatLoaderImage;
 
 protected:
 public:
-	static Error load_image(String p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), uint32_t p_flags = (uint32_t)ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
+	static Error load_image(String p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), BitField<ImageFormatLoader::LoaderFlags> p_flags = ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
 	static void get_recognized_extensions(List<String> *p_extensions);
-	static ImageFormatLoader *recognize(const String &p_extension);
+	static Ref<ImageFormatLoader> recognize(const String &p_extension);
 
-	static void add_image_format_loader(ImageFormatLoader *p_loader);
-	static void remove_image_format_loader(ImageFormatLoader *p_loader);
+	static void add_image_format_loader(Ref<ImageFormatLoader> p_loader);
+	static void remove_image_format_loader(Ref<ImageFormatLoader> p_loader);
 
-	static const Vector<ImageFormatLoader *> &get_image_format_loaders();
+	static const Vector<Ref<ImageFormatLoader>> &get_image_format_loaders();
 
 	static void cleanup();
 };

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -249,6 +249,8 @@ void register_core_types() {
 	GDREGISTER_CLASS(EncodedObjectAsID);
 	GDREGISTER_CLASS(RandomNumberGenerator);
 
+	GDREGISTER_ABSTRACT_CLASS(ImageFormatLoader);
+	GDREGISTER_CLASS(ImageFormatLoaderExtension);
 	GDREGISTER_ABSTRACT_CLASS(ResourceImporter);
 
 	GDREGISTER_CLASS(NativeExtension);

--- a/doc/classes/ImageFormatLoader.xml
+++ b/doc/classes/ImageFormatLoader.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ImageFormatLoader" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base class to add support for specific image formats.
+	</brief_description>
+	<description>
+		The engine supports multiple image formats out of the box (PNG, SVG, JPEG, WebP to name a few), but you can choose to implement support for additional image formats by extending [ImageFormatLoaderExtension].
+	</description>
+	<tutorials>
+	</tutorials>
+	<constants>
+		<constant name="FLAG_NONE" value="0" enum="LoaderFlags" is_bitfield="true">
+		</constant>
+		<constant name="FLAG_FORCE_LINEAR" value="1" enum="LoaderFlags" is_bitfield="true">
+		</constant>
+		<constant name="FLAG_CONVERT_COLORS" value="2" enum="LoaderFlags" is_bitfield="true">
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/ImageFormatLoaderExtension.xml
+++ b/doc/classes/ImageFormatLoaderExtension.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ImageFormatLoaderExtension" inherits="ImageFormatLoader" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base class for creating [ImageFormatLoader] extensions (adding support for extra image formats).
+	</brief_description>
+	<description>
+		The engine supports multiple image formats out of the box (PNG, SVG, JPEG, WebP to name a few), but you can choose to implement support for additional image formats by extending this class.
+		Be sure to respect the documented return types and values. You should create an instance of it, and call [method add_format_loader] to register that loader during the initializaiton phase.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_get_recognized_extensions" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the list of file extensions for this image format. Files with the given extentions will be treated as image file and loaded using this class.
+			</description>
+		</method>
+		<method name="_load_image" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="image" type="Image" />
+			<param index="1" name="fileaccess" type="FileAccess" />
+			<param index="2" name="flags" type="int" enum="ImageFormatLoader.LoaderFlags" />
+			<param index="3" name="scale" type="float" />
+			<description>
+				Loads the content of [param fileaccess] into the provided [param image].
+			</description>
+		</method>
+		<method name="add_format_loader">
+			<return type="void" />
+			<description>
+				Add this format loader to the engine, allowing it to recognize the file extensions returned by [method _get_recognized_extensions].
+			</description>
+		</method>
+		<method name="remove_format_loader">
+			<return type="void" />
+			<description>
+				Remove this format loader from the engine.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -36,7 +36,7 @@
 
 #include <string.h>
 
-Error ImageLoaderPNG::load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale) {
+Error ImageLoaderPNG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	const uint64_t buffer_size = f->get_length();
 	Vector<uint8_t> file_buffer;
 	Error err = file_buffer.resize(buffer_size);

--- a/drivers/png/image_loader_png.h
+++ b/drivers/png/image_loader_png.h
@@ -40,7 +40,7 @@ private:
 	static Ref<Image> load_mem_png(const uint8_t *p_png, int p_size);
 
 public:
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale);
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	ImageLoaderPNG();
 };

--- a/drivers/register_driver_types.cpp
+++ b/drivers/register_driver_types.cpp
@@ -34,11 +34,11 @@
 #include "drivers/png/image_loader_png.h"
 #include "drivers/png/resource_saver_png.h"
 
-static ImageLoaderPNG *image_loader_png;
+static Ref<ImageLoaderPNG> image_loader_png;
 static Ref<ResourceSaverPNG> resource_saver_png;
 
 void register_core_driver_types() {
-	image_loader_png = memnew(ImageLoaderPNG);
+	image_loader_png.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_png);
 
 	resource_saver_png.instantiate();
@@ -46,9 +46,8 @@ void register_core_driver_types() {
 }
 
 void unregister_core_driver_types() {
-	if (image_loader_png) {
-		memdelete(image_loader_png);
-	}
+	ImageLoader::remove_image_format_loader(image_loader_png);
+	image_loader_png.unref();
 
 	ResourceSaver::remove_resource_format_saver(resource_saver_png);
 	resource_saver_png.unref();

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -200,7 +200,7 @@ Error ImageLoaderBMP::convert_to_image(Ref<Image> p_image,
 	return err;
 }
 
-Error ImageLoaderBMP::load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale) {
+Error ImageLoaderBMP::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	bmp_header_s bmp_header;
 	Error err = ERR_INVALID_DATA;
 

--- a/modules/bmp/image_loader_bmp.h
+++ b/modules/bmp/image_loader_bmp.h
@@ -83,7 +83,7 @@ protected:
 			const bmp_header_s &p_header);
 
 public:
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale);
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	ImageLoaderBMP();
 };

--- a/modules/bmp/register_types.cpp
+++ b/modules/bmp/register_types.cpp
@@ -32,14 +32,14 @@
 
 #include "image_loader_bmp.h"
 
-static ImageLoaderBMP *image_loader_bmp = nullptr;
+static Ref<ImageLoaderBMP> image_loader_bmp;
 
 void initialize_bmp_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
 
-	image_loader_bmp = memnew(ImageLoaderBMP);
+	image_loader_bmp.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_bmp);
 }
 
@@ -48,5 +48,6 @@ void uninitialize_bmp_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	memdelete(image_loader_bmp);
+	ImageLoader::remove_image_format_loader(image_loader_bmp);
+	image_loader_bmp.unref();
 }

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -33,7 +33,7 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
-Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale) {
+Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	String header = f->get_token();
 
 	ERR_FAIL_COND_V_MSG(header != "#?RADIANCE" && header != "#?RGBE", ERR_FILE_UNRECOGNIZED, "Unsupported header information in HDR: " + header + ".");

--- a/modules/hdr/image_loader_hdr.h
+++ b/modules/hdr/image_loader_hdr.h
@@ -35,7 +35,7 @@
 
 class ImageLoaderHDR : public ImageFormatLoader {
 public:
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale);
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	ImageLoaderHDR();
 };

--- a/modules/hdr/register_types.cpp
+++ b/modules/hdr/register_types.cpp
@@ -32,14 +32,14 @@
 
 #include "image_loader_hdr.h"
 
-static ImageLoaderHDR *image_loader_hdr = nullptr;
+static Ref<ImageLoaderHDR> image_loader_hdr;
 
 void initialize_hdr_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
 
-	image_loader_hdr = memnew(ImageLoaderHDR);
+	image_loader_hdr.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_hdr);
 }
 
@@ -48,5 +48,6 @@ void uninitialize_hdr_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	memdelete(image_loader_hdr);
+	ImageLoader::remove_image_format_loader(image_loader_hdr);
+	image_loader_hdr.unref();
 }

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -104,7 +104,7 @@ Error jpeg_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 	return OK;
 }
 
-Error ImageLoaderJPG::load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale) {
+Error ImageLoaderJPG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	Vector<uint8_t> src_image;
 	uint64_t src_image_len = f->get_length();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);

--- a/modules/jpg/image_loader_jpegd.h
+++ b/modules/jpg/image_loader_jpegd.h
@@ -35,7 +35,7 @@
 
 class ImageLoaderJPG : public ImageFormatLoader {
 public:
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale);
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	ImageLoaderJPG();
 };

--- a/modules/jpg/register_types.cpp
+++ b/modules/jpg/register_types.cpp
@@ -32,14 +32,14 @@
 
 #include "image_loader_jpegd.h"
 
-static ImageLoaderJPG *image_loader_jpg = nullptr;
+static Ref<ImageLoaderJPG> image_loader_jpg;
 
 void initialize_jpg_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
 
-	image_loader_jpg = memnew(ImageLoaderJPG);
+	image_loader_jpg.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_jpg);
 }
 
@@ -48,5 +48,6 @@ void uninitialize_jpg_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	memdelete(image_loader_jpg);
+	ImageLoader::remove_image_format_loader(image_loader_jpg);
+	image_loader_jpg.unref();
 }

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -142,7 +142,7 @@ void ImageLoaderSVG::get_recognized_extensions(List<String> *p_extensions) const
 	p_extensions->push_back("svg");
 }
 
-Error ImageLoaderSVG::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, uint32_t p_flags, float p_scale) {
+Error ImageLoaderSVG::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	String svg = p_fileaccess->get_as_utf8_string();
 
 	if (p_flags & FLAG_CONVERT_COLORS) {

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -43,7 +43,7 @@ public:
 
 	void create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, const HashMap<Color, Color> &p_color_map);
 
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, uint32_t p_flags, float p_scale) override;
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 };
 

--- a/modules/svg/register_types.cpp
+++ b/modules/svg/register_types.cpp
@@ -34,7 +34,7 @@
 
 #include <thorvg.h>
 
-static ImageLoaderSVG *image_loader_svg = nullptr;
+static Ref<ImageLoaderSVG> image_loader_svg;
 
 void initialize_svg_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
@@ -45,7 +45,8 @@ void initialize_svg_module(ModuleInitializationLevel p_level) {
 	if (tvg::Initializer::init(tvgEngine, 1) != tvg::Result::Success) {
 		return;
 	}
-	image_loader_svg = memnew(ImageLoaderSVG);
+
+	image_loader_svg.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_svg);
 }
 
@@ -54,9 +55,12 @@ void uninitialize_svg_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	if (!image_loader_svg) {
+	if (image_loader_svg.is_null()) {
+		// It failed to initialize so it was not added.
 		return;
 	}
-	memdelete(image_loader_svg);
+
+	ImageLoader::remove_image_format_loader(image_loader_svg);
+	image_loader_svg.unref();
 	tvg::Initializer::term(tvg::CanvasEngine::Sw);
 }

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -230,7 +230,7 @@ Error ImageLoaderTGA::convert_to_image(Ref<Image> p_image, const uint8_t *p_buff
 	return OK;
 }
 
-Error ImageLoaderTGA::load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale) {
+Error ImageLoaderTGA::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	Vector<uint8_t> src_image;
 	uint64_t src_image_len = f->get_length();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);

--- a/modules/tga/image_loader_tga.h
+++ b/modules/tga/image_loader_tga.h
@@ -73,7 +73,7 @@ class ImageLoaderTGA : public ImageFormatLoader {
 	static Error convert_to_image(Ref<Image> p_image, const uint8_t *p_buffer, const tga_header_s &p_header, const uint8_t *p_palette, const bool p_is_monochrome, size_t p_input_size);
 
 public:
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale);
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	ImageLoaderTGA();
 };

--- a/modules/tga/register_types.cpp
+++ b/modules/tga/register_types.cpp
@@ -32,14 +32,14 @@
 
 #include "image_loader_tga.h"
 
-static ImageLoaderTGA *image_loader_tga = nullptr;
+static Ref<ImageLoaderTGA> image_loader_tga;
 
 void initialize_tga_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
 
-	image_loader_tga = memnew(ImageLoaderTGA);
+	image_loader_tga.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_tga);
 }
 
@@ -48,5 +48,6 @@ void uninitialize_tga_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	memdelete(image_loader_tga);
+	ImageLoader::remove_image_format_loader(image_loader_tga);
+	image_loader_tga.unref();
 }

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -37,7 +37,7 @@
 
 #include "thirdparty/tinyexr/tinyexr.h"
 
-Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale) {
+Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	Vector<uint8_t> src_image;
 	uint64_t src_image_len = f->get_length();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);

--- a/modules/tinyexr/image_loader_tinyexr.h
+++ b/modules/tinyexr/image_loader_tinyexr.h
@@ -35,7 +35,7 @@
 
 class ImageLoaderTinyEXR : public ImageFormatLoader {
 public:
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale);
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	ImageLoaderTinyEXR();
 };

--- a/modules/tinyexr/register_types.cpp
+++ b/modules/tinyexr/register_types.cpp
@@ -33,14 +33,14 @@
 #include "image_loader_tinyexr.h"
 #include "image_saver_tinyexr.h"
 
-static ImageLoaderTinyEXR *image_loader_tinyexr = nullptr;
+static Ref<ImageLoaderTinyEXR> image_loader_tinyexr;
 
 void initialize_tinyexr_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
 
-	image_loader_tinyexr = memnew(ImageLoaderTinyEXR);
+	image_loader_tinyexr.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_tinyexr);
 
 	Image::save_exr_func = save_exr;
@@ -52,7 +52,8 @@ void uninitialize_tinyexr_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	memdelete(image_loader_tinyexr);
+	ImageLoader::remove_image_format_loader(image_loader_tinyexr);
+	image_loader_tinyexr.unref();
 
 	Image::save_exr_func = nullptr;
 }

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -48,7 +48,7 @@ static Ref<Image> _webp_mem_loader_func(const uint8_t *p_png, int p_size) {
 	return img;
 }
 
-Error ImageLoaderWebP::load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale) {
+Error ImageLoaderWebP::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	Vector<uint8_t> src_image;
 	uint64_t src_image_len = f->get_length();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);

--- a/modules/webp/image_loader_webp.h
+++ b/modules/webp/image_loader_webp.h
@@ -35,7 +35,7 @@
 
 class ImageLoaderWebP : public ImageFormatLoader {
 public:
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, uint32_t p_flags, float p_scale);
+	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	ImageLoaderWebP();
 };

--- a/modules/webp/register_types.cpp
+++ b/modules/webp/register_types.cpp
@@ -33,7 +33,7 @@
 #include "image_loader_webp.h"
 #include "resource_saver_webp.h"
 
-static ImageLoaderWebP *image_loader_webp = nullptr;
+static Ref<ImageLoaderWebP> image_loader_webp;
 static Ref<ResourceSaverWebP> resource_saver_webp;
 
 void initialize_webp_module(ModuleInitializationLevel p_level) {
@@ -41,9 +41,10 @@ void initialize_webp_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	image_loader_webp = memnew(ImageLoaderWebP);
-	resource_saver_webp.instantiate();
+	image_loader_webp.instantiate();
 	ImageLoader::add_image_format_loader(image_loader_webp);
+
+	resource_saver_webp.instantiate();
 	ResourceSaver::add_resource_format_saver(resource_saver_webp);
 }
 
@@ -52,7 +53,9 @@ void uninitialize_webp_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	memdelete(image_loader_webp);
+	ImageLoader::remove_image_format_loader(image_loader_webp);
+	image_loader_webp.unref();
+
 	ResourceSaver::remove_resource_format_saver(resource_saver_webp);
 	resource_saver_webp.unref();
 }


### PR DESCRIPTION
Make `ImageFormatLoader` `RefCounted`, expose it to extensions via `ImageFormatLoaderExtension`.
There is an AVIF implementation (WIP) here: https://github.com/Faless/gd-avif/tree/spike/initial

![spicy](https://user-images.githubusercontent.com/1687918/181634341-f19293b2-8a09-491f-b060-dece48ef7c84.png)

Proposals to support esoteric image format: godotengine/godot-proposals#2461 godotengine/godot-proposals#3726 

Draft status:
- Is `loader.add_format_loader` okay?
- Should we add `class_name` scripts like done in `ResourceFormatLoader`?
- Should we add `ResourceFormatLoader.add_custom_image_format_loader(String script_path);`/`ResourceFormatLoader.add_custom_image_format_loader_class(StringName p_class);` (class_names and extensions?)