### PR TITLE
Make mouse wheel actions on EditorSpinSlider more user friendly

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -390,7 +390,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 
 		grabbing_spinner_mouse_pos = get_global_position() + grabber_rect.get_center();
 
-		bool display_grabber = (mouse_over_spin || mouse_over_grabber) && !grabbing_spinner && !(value_input_popup && value_input_popup->is_visible());
+		bool display_grabber = (grabbing_grabber || mouse_over_spin || mouse_over_grabber) && !grabbing_spinner && !(value_input_popup && value_input_popup->is_visible());
 		if (grabber->is_visible() != display_grabber) {
 			if (display_grabber) {
 				grabber->show();

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -49,7 +49,6 @@ class EditorSpinSlider : public Range {
 
 	bool mouse_over_spin = false;
 	bool mouse_over_grabber = false;
-	bool mousewheel_over_grabber = false;
 
 	bool grabbing_grabber = false;
 	int grabbing_from = 0;


### PR DESCRIPTION
As discussed [here](https://github.com/godotengine/godot/issues/63544) mouse grabbing on ``EditorSpinSlider``s is currently flawed, when moving the cursor out of the control element. This PR aims to fix this. The ``grabber`` TextureRect was hidden, which then caused a ``release`` event for the LeftMouse button, which then eventually released the grabbing action.

The second part of this PR aims to make the mouse wheel action more satisfiying. Currently the grabber must be grabbed with the left mouse button and simultaniously the mouse wheel must spinned. This seems somewhat inconveniant. Even then the behavior feels quite odd, because the cursor is getting adjusted after each spin, which feels (at least for me) very hacky.
I decided to push the mouse wheel action in the the actual control element and added 2 modified actions:
* holding cmd brings the value to the next integer value
* holding shift has more precise steps

Note: Both modifiers are already stated via tooltip.

In the end, that feels more comfortable.