### PR TITLE
Move editor paths into the EditorPaths class

### DIFF
--- a/doc/classes/EditorPaths.xml
+++ b/doc/classes/EditorPaths.xml
@@ -48,6 +48,12 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="get_project_settings_dir" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the project-specific editor settings path. Projects all have a unique subdirectory inside the settings path where project-specific editor settings are saved.
+			</description>
+		</method>
 		<method name="get_self_contained_file" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -105,12 +105,6 @@
 				Returns project-specific metadata for the [code]section[/code] and [code]key[/code] specified. If the metadata doesn't exist, [code]default[/code] will be returned instead. See also [method set_project_metadata].
 			</description>
 		</method>
-		<method name="get_project_settings_dir" qualifiers="const">
-			<return type="String" />
-			<description>
-				Returns the project-specific settings path. Projects all have a unique subdirectory inside the settings path where project-specific settings are saved.
-			</description>
-		</method>
 		<method name="get_recent_dirs" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -34,6 +34,7 @@
 #include "core/os/keyboard.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 
@@ -378,7 +379,7 @@ void CreateDialog::_confirmed() {
 	}
 
 	{
-		Ref<FileAccess> f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("create_recent." + base_type), FileAccess::WRITE);
+		Ref<FileAccess> f = FileAccess::open(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("create_recent." + base_type), FileAccess::WRITE);
 		if (f.is_valid()) {
 			f->store_line(selected_item);
 
@@ -655,7 +656,7 @@ void CreateDialog::_save_and_update_favorite_list() {
 	TreeItem *root = favorites->create_item();
 
 	{
-		Ref<FileAccess> f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("favorites." + base_type), FileAccess::WRITE);
+		Ref<FileAccess> f = FileAccess::open(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("favorites." + base_type), FileAccess::WRITE);
 		if (f.is_valid()) {
 			for (int i = 0; i < favorite_list.size(); i++) {
 				String l = favorite_list[i];
@@ -680,7 +681,7 @@ void CreateDialog::_save_and_update_favorite_list() {
 }
 
 void CreateDialog::_load_favorites_and_history() {
-	String dir = EditorSettings::get_singleton()->get_project_settings_dir();
+	String dir = EditorPaths::get_singleton()->get_project_settings_dir();
 	Ref<FileAccess> f = FileAccess::open(dir.plus_file("create_recent." + base_type), FileAccess::READ);
 	if (f.is_valid()) {
 		while (!f->eof_reached()) {

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -34,6 +34,7 @@
 #include "core/io/json.h"
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
 #include "editor/editor_property_name_processor.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
@@ -314,7 +315,7 @@ void EditorFeatureProfileManager::_notification(int p_what) {
 			current_profile = EDITOR_GET("_default_feature_profile");
 			if (!current_profile.is_empty()) {
 				current.instantiate();
-				Error err = current->load_from_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(current_profile + ".profile"));
+				Error err = current->load_from_file(EditorPaths::get_singleton()->get_feature_profiles_dir().plus_file(current_profile + ".profile"));
 				if (err != OK) {
 					ERR_PRINT("Error loading default feature profile: " + current_profile);
 					current_profile = String();
@@ -340,7 +341,7 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 	if (p_select_profile.is_empty()) { //default, keep
 		if (profile_list->get_selected() >= 0) {
 			selected_profile = profile_list->get_item_metadata(profile_list->get_selected());
-			if (!FileAccess::exists(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(selected_profile + ".profile"))) {
+			if (!FileAccess::exists(EditorPaths::get_singleton()->get_feature_profiles_dir().plus_file(selected_profile + ".profile"))) {
 				selected_profile = String(); //does not exist
 			}
 		}
@@ -349,8 +350,8 @@ void EditorFeatureProfileManager::_update_profile_list(const String &p_select_pr
 	}
 
 	Vector<String> profiles;
-	Ref<DirAccess> d = DirAccess::open(EditorSettings::get_singleton()->get_feature_profiles_dir());
-	ERR_FAIL_COND_MSG(d.is_null(), "Cannot open directory '" + EditorSettings::get_singleton()->get_feature_profiles_dir() + "'.");
+	Ref<DirAccess> d = DirAccess::open(EditorPaths::get_singleton()->get_feature_profiles_dir());
+	ERR_FAIL_COND_MSG(d.is_null(), "Cannot open directory '" + EditorPaths::get_singleton()->get_feature_profiles_dir() + "'.");
 
 	d->list_dir_begin();
 	while (true) {
@@ -452,8 +453,8 @@ void EditorFeatureProfileManager::_profile_action(int p_action) {
 void EditorFeatureProfileManager::_erase_selected_profile() {
 	String selected = _get_selected_profile();
 	ERR_FAIL_COND(selected.is_empty());
-	Ref<DirAccess> da = DirAccess::open(EditorSettings::get_singleton()->get_feature_profiles_dir());
-	ERR_FAIL_COND_MSG(da.is_null(), "Cannot open directory '" + EditorSettings::get_singleton()->get_feature_profiles_dir() + "'.");
+	Ref<DirAccess> da = DirAccess::open(EditorPaths::get_singleton()->get_feature_profiles_dir());
+	ERR_FAIL_COND_MSG(da.is_null(), "Cannot open directory '" + EditorPaths::get_singleton()->get_feature_profiles_dir() + "'.");
 
 	da->remove(selected + ".profile");
 	if (selected == current_profile) {
@@ -469,7 +470,7 @@ void EditorFeatureProfileManager::_create_new_profile() {
 		EditorNode::get_singleton()->show_warning(TTR("Profile must be a valid filename and must not contain '.'"));
 		return;
 	}
-	String file = EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(name + ".profile");
+	String file = EditorPaths::get_singleton()->get_feature_profiles_dir().plus_file(name + ".profile");
 	if (FileAccess::exists(file)) {
 		EditorNode::get_singleton()->show_warning(TTR("Profile with this name already exists."));
 		return;
@@ -748,8 +749,8 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 	} else {
 		//reload edited, if different from current
 		edited.instantiate();
-		Error err = edited->load_from_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(profile + ".profile"));
-		ERR_FAIL_COND_MSG(err != OK, "Error when loading EditorSettings from file '" + EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(profile + ".profile") + "'.");
+		Error err = edited->load_from_file(EditorPaths::get_singleton()->get_feature_profiles_dir().plus_file(profile + ".profile"));
+		ERR_FAIL_COND_MSG(err != OK, "Error when loading editor feature profile from file '" + EditorPaths::get_singleton()->get_feature_profiles_dir().plus_file(profile + ".profile") + "'.");
 	}
 
 	updating_features = true;
@@ -804,7 +805,7 @@ void EditorFeatureProfileManager::_import_profiles(const Vector<String> &p_paths
 			return;
 		}
 
-		String dst_file = EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(basefile);
+		String dst_file = EditorPaths::get_singleton()->get_feature_profiles_dir().plus_file(basefile);
 
 		if (FileAccess::exists(dst_file)) {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("Profile '%s' already exists. Remove it first before importing, import aborted."), basefile.get_basename()));
@@ -819,7 +820,7 @@ void EditorFeatureProfileManager::_import_profiles(const Vector<String> &p_paths
 		Error err = profile->load_from_file(p_paths[i]);
 		ERR_CONTINUE(err != OK);
 		String basefile = p_paths[i].get_file();
-		String dst_file = EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(basefile);
+		String dst_file = EditorPaths::get_singleton()->get_feature_profiles_dir().plus_file(basefile);
 		profile->save_to_file(dst_file);
 	}
 
@@ -843,7 +844,7 @@ void EditorFeatureProfileManager::_save_and_update() {
 	ERR_FAIL_COND(edited_path.is_empty());
 	ERR_FAIL_COND(edited.is_null());
 
-	edited->save_to_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(edited_path + ".profile"));
+	edited->save_to_file(EditorPaths::get_singleton()->get_feature_profiles_dir().plus_file(edited_path + ".profile"));
 
 	if (edited == current) {
 		update_timer->start();

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -40,6 +40,7 @@
 #include "core/os/os.h"
 #include "core/variant/variant_parser.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_settings.h"
 
@@ -218,7 +219,7 @@ void EditorFileSystem::_scan_filesystem() {
 
 	String project = ProjectSettings::get_singleton()->get_resource_path();
 
-	String fscache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(CACHE_FILE_NAME);
+	String fscache = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(CACHE_FILE_NAME);
 	{
 		Ref<FileAccess> f = FileAccess::open(fscache, FileAccess::READ);
 
@@ -288,7 +289,7 @@ void EditorFileSystem::_scan_filesystem() {
 		}
 	}
 
-	String update_cache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file("filesystem_update4");
+	String update_cache = EditorPaths::get_singleton()->get_project_settings_dir().plus_file("filesystem_update4");
 
 	if (FileAccess::exists(update_cache)) {
 		{
@@ -331,7 +332,7 @@ void EditorFileSystem::_scan_filesystem() {
 void EditorFileSystem::_save_filesystem_cache() {
 	group_file_cache.clear();
 
-	String fscache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(CACHE_FILE_NAME);
+	String fscache = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(CACHE_FILE_NAME);
 
 	Ref<FileAccess> f = FileAccess::open(fscache, FileAccess::WRITE);
 	ERR_FAIL_COND_MSG(f.is_null(), "Cannot create file '" + fscache + "'. Check user write permissions.");
@@ -1456,7 +1457,7 @@ EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p
 
 void EditorFileSystem::_save_late_updated_files() {
 	//files that already existed, and were modified, need re-scanning for dependencies upon project restart. This is done via saving this special file
-	String fscache = EditorSettings::get_singleton()->get_project_settings_dir().plus_file("filesystem_update4");
+	String fscache = EditorPaths::get_singleton()->get_project_settings_dir().plus_file("filesystem_update4");
 	Ref<FileAccess> f = FileAccess::open(fscache, FileAccess::WRITE);
 	ERR_FAIL_COND_MSG(f.is_null(), "Cannot create file '" + fscache + "'. Check user write permissions.");
 	for (const String &E : late_update_files) {

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -30,9 +30,10 @@
 
 #include "editor_folding.h"
 
+#include "core/io/config_file.h"
 #include "core/io/file_access.h"
 #include "editor/editor_inspector.h"
-#include "editor/editor_settings.h"
+#include "editor/editor_paths.h"
 
 Vector<String> EditorFolding::_get_unfolds(const Object *p_object) {
 	Vector<String> sections;
@@ -55,7 +56,7 @@ void EditorFolding::save_resource_folding(const Ref<Resource> &p_resource, const
 	config->set_value("folding", "sections_unfolded", unfolds);
 
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
-	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
+	file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(file);
 	config->save(file);
 }
 
@@ -73,7 +74,7 @@ void EditorFolding::load_resource_folding(Ref<Resource> p_resource, const String
 	config.instantiate();
 
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
-	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
+	file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(file);
 
 	if (config->load(file) != OK) {
 		return;
@@ -149,7 +150,7 @@ void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path
 	config->set_value("folding", "nodes_folded", nodes_folded);
 
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
-	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
+	file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(file);
 	config->save(file);
 }
 
@@ -157,9 +158,9 @@ void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {
 	Ref<ConfigFile> config;
 	config.instantiate();
 
-	String path = EditorSettings::get_singleton()->get_project_settings_dir();
+	String path = EditorPaths::get_singleton()->get_project_settings_dir();
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
-	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
+	file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(file);
 
 	if (config->load(file) != OK) {
 		return;
@@ -213,7 +214,7 @@ void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {
 
 bool EditorFolding::has_folding_data(const String &p_path) {
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
-	file = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(file);
+	file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(file);
 	return FileAccess::exists(file);
 }
 

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -33,6 +33,7 @@
 #include "core/os/keyboard.h"
 #include "core/version.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "scene/gui/center_container.h"
 #include "scene/resources/font.h"
@@ -122,7 +123,7 @@ void EditorLog::_save_state() {
 	Ref<ConfigFile> config;
 	config.instantiate();
 	// Load and amend existing config if it exists.
-	config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	config->load(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 
 	const String section = "editor_log";
 	for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map) {
@@ -132,7 +133,7 @@ void EditorLog::_save_state() {
 	config->set_value(section, "collapse", collapse);
 	config->set_value(section, "show_search", search_box->is_visible());
 
-	config->save(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	config->save(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 }
 
 void EditorLog::_load_state() {
@@ -140,7 +141,7 @@ void EditorLog::_load_state() {
 
 	Ref<ConfigFile> config;
 	config.instantiate();
-	config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	config->load(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 
 	// Run the below code even if config->load returns an error, since we want the defaults to be set even if the file does not exist yet.
 	const String section = "editor_log";

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1376,7 +1376,7 @@ void EditorNode::_get_scene_metadata(const String &p_file) {
 		return;
 	}
 
-	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
+	String path = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
 
 	Ref<ConfigFile> cf;
 	cf.instantiate();
@@ -1408,7 +1408,7 @@ void EditorNode::_set_scene_metadata(const String &p_file, int p_idx) {
 		return;
 	}
 
-	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
+	String path = EditorPaths::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
 
 	Ref<ConfigFile> cf;
 	cf.instantiate();
@@ -4608,13 +4608,13 @@ void EditorNode::_save_docks() {
 	Ref<ConfigFile> config;
 	config.instantiate();
 	// Load and amend existing config if it exists.
-	config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	config->load(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 
 	_save_docks_to_config(config, "docks");
 	_save_open_scenes_to_config(config, "EditorNode");
 	editor_data.get_plugin_window_layout(config);
 
-	config->save(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	config->save(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 }
 
 void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) {
@@ -4678,7 +4678,7 @@ void EditorNode::_dock_split_dragged(int ofs) {
 void EditorNode::_load_docks() {
 	Ref<ConfigFile> config;
 	config.instantiate();
-	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	Error err = config->load(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 	if (err != OK) {
 		// No config.
 		if (overridden_default_layout >= 0) {
@@ -4911,7 +4911,7 @@ bool EditorNode::has_scenes_in_session() {
 	}
 	Ref<ConfigFile> config;
 	config.instantiate();
-	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
+	Error err = config->load(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 	if (err != OK) {
 		return false;
 	}

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -66,6 +66,30 @@ String EditorPaths::get_self_contained_file() const {
 	return self_contained_file;
 }
 
+String EditorPaths::get_export_templates_dir() const {
+	return get_data_dir().plus_file(export_templates_folder);
+}
+
+String EditorPaths::get_project_settings_dir() const {
+	return get_project_data_dir().plus_file("editor");
+}
+
+String EditorPaths::get_text_editor_themes_dir() const {
+	return get_config_dir().plus_file(text_editor_themes_folder);
+}
+
+String EditorPaths::get_script_templates_dir() const {
+	return get_config_dir().plus_file(script_templates_folder);
+}
+
+String EditorPaths::get_project_script_templates_dir() const {
+	return ProjectSettings::get_singleton()->get("editor/script/templates_search_path");
+}
+
+String EditorPaths::get_feature_profiles_dir() const {
+	return get_config_dir().plus_file(feature_profiles_folder);
+}
+
 void EditorPaths::create() {
 	ERR_FAIL_COND(singleton != nullptr);
 	memnew(EditorPaths());
@@ -82,6 +106,8 @@ void EditorPaths::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cache_dir"), &EditorPaths::get_cache_dir);
 	ClassDB::bind_method(D_METHOD("is_self_contained"), &EditorPaths::is_self_contained);
 	ClassDB::bind_method(D_METHOD("get_self_contained_file"), &EditorPaths::get_self_contained_file);
+
+	ClassDB::bind_method(D_METHOD("get_project_settings_dir"), &EditorPaths::get_project_settings_dir);
 }
 
 EditorPaths::EditorPaths() {
@@ -153,8 +179,8 @@ EditorPaths::EditorPaths() {
 			}
 		}
 
-		if (!dir->dir_exists("export_templates")) {
-			dir->make_dir("export_templates");
+		if (!dir->dir_exists(export_templates_folder)) {
+			dir->make_dir(export_templates_folder);
 		}
 	}
 
@@ -168,14 +194,14 @@ EditorPaths::EditorPaths() {
 			}
 		}
 
-		if (!dir->dir_exists("text_editor_themes")) {
-			dir->make_dir("text_editor_themes");
+		if (!dir->dir_exists(text_editor_themes_folder)) {
+			dir->make_dir(text_editor_themes_folder);
 		}
-		if (!dir->dir_exists("script_templates")) {
-			dir->make_dir("script_templates");
+		if (!dir->dir_exists(script_templates_folder)) {
+			dir->make_dir(script_templates_folder);
 		}
-		if (!dir->dir_exists("feature_profiles")) {
-			dir->make_dir("feature_profiles");
+		if (!dir->dir_exists(feature_profiles_folder)) {
+			dir->make_dir(feature_profiles_folder);
 		}
 	}
 
@@ -192,7 +218,6 @@ EditorPaths::EditorPaths() {
 
 	// Validate or create project-specific editor data dir,
 	// including shader cache subdir.
-
 	if (Engine::get_singleton()->is_project_manager_hint() || Main::is_cmdline_tool()) {
 		// Nothing to create, use shared editor data dir for shader cache.
 		Engine::get_singleton()->set_shader_cache_path(data_dir);

--- a/editor/editor_paths.h
+++ b/editor/editor_paths.h
@@ -45,6 +45,10 @@ class EditorPaths : public Object {
 	String project_data_dir; // Project-specific data (metadata, shader cache, etc.).
 	bool self_contained = false; // Self-contained means everything goes to `editor_data` dir.
 	String self_contained_file; // Self-contained file with configuration.
+	String export_templates_folder = "export_templates";
+	String text_editor_themes_folder = "text_editor_themes";
+	String script_templates_folder = "script_templates";
+	String feature_profiles_folder = "feature_profiles";
 
 	static EditorPaths *singleton;
 
@@ -58,6 +62,12 @@ public:
 	String get_config_dir() const;
 	String get_cache_dir() const;
 	String get_project_data_dir() const;
+	String get_export_templates_dir() const;
+	String get_project_settings_dir() const;
+	String get_text_editor_themes_dir() const;
+	String get_script_templates_dir() const;
+	String get_project_script_templates_dir() const;
+	String get_feature_profiles_dir() const;
 
 	bool is_self_contained() const;
 	String get_self_contained_file() const;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1103,38 +1103,11 @@ void EditorSettings::add_property_hint(const PropertyInfo &p_hint) {
 	hints[p_hint.name] = p_hint;
 }
 
-// Editor data and config directories
-// EditorPaths::create() is responsible for the creation of these directories.
-
-String EditorSettings::get_export_templates_dir() const {
-	return EditorPaths::get_singleton()->get_data_dir().plus_file("export_templates");
-}
-
-String EditorSettings::get_project_settings_dir() const {
-	return EditorPaths::get_singleton()->get_project_data_dir().plus_file("editor");
-}
-
-String EditorSettings::get_text_editor_themes_dir() const {
-	return EditorPaths::get_singleton()->get_config_dir().plus_file("text_editor_themes");
-}
-
-String EditorSettings::get_script_templates_dir() const {
-	return EditorPaths::get_singleton()->get_config_dir().plus_file("script_templates");
-}
-
-String EditorSettings::get_project_script_templates_dir() const {
-	return ProjectSettings::get_singleton()->get("editor/script/templates_search_path");
-}
-
-String EditorSettings::get_feature_profiles_dir() const {
-	return EditorPaths::get_singleton()->get_config_dir().plus_file("feature_profiles");
-}
-
 // Metadata
 
 void EditorSettings::set_project_metadata(const String &p_section, const String &p_key, Variant p_data) {
 	Ref<ConfigFile> cf = memnew(ConfigFile);
-	String path = get_project_settings_dir().plus_file("project_metadata.cfg");
+	String path = EditorPaths::get_singleton()->get_project_settings_dir().plus_file("project_metadata.cfg");
 	Error err;
 	err = cf->load(path);
 	ERR_FAIL_COND_MSG(err != OK && err != ERR_FILE_NOT_FOUND, "Cannot load editor settings from file '" + path + "'.");
@@ -1145,7 +1118,7 @@ void EditorSettings::set_project_metadata(const String &p_section, const String 
 
 Variant EditorSettings::get_project_metadata(const String &p_section, const String &p_key, Variant p_default) const {
 	Ref<ConfigFile> cf = memnew(ConfigFile);
-	String path = get_project_settings_dir().plus_file("project_metadata.cfg");
+	String path = EditorPaths::get_singleton()->get_project_settings_dir().plus_file("project_metadata.cfg");
 	Error err = cf->load(path);
 	if (err != OK) {
 		return p_default;
@@ -1159,7 +1132,7 @@ void EditorSettings::set_favorites(const Vector<String> &p_favorites) {
 	if (Engine::get_singleton()->is_project_manager_hint()) {
 		favorites_file = EditorPaths::get_singleton()->get_config_dir().plus_file("favorite_dirs");
 	} else {
-		favorites_file = get_project_settings_dir().plus_file("favorites");
+		favorites_file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file("favorites");
 	}
 	Ref<FileAccess> f = FileAccess::open(favorites_file, FileAccess::WRITE);
 	if (f.is_valid()) {
@@ -1179,7 +1152,7 @@ void EditorSettings::set_recent_dirs(const Vector<String> &p_recent_dirs) {
 	if (Engine::get_singleton()->is_project_manager_hint()) {
 		recent_dirs_file = EditorPaths::get_singleton()->get_config_dir().plus_file("recent_dirs");
 	} else {
-		recent_dirs_file = get_project_settings_dir().plus_file("recent_dirs");
+		recent_dirs_file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file("recent_dirs");
 	}
 	Ref<FileAccess> f = FileAccess::open(recent_dirs_file, FileAccess::WRITE);
 	if (f.is_valid()) {
@@ -1200,8 +1173,8 @@ void EditorSettings::load_favorites_and_recent_dirs() {
 		favorites_file = EditorPaths::get_singleton()->get_config_dir().plus_file("favorite_dirs");
 		recent_dirs_file = EditorPaths::get_singleton()->get_config_dir().plus_file("recent_dirs");
 	} else {
-		favorites_file = get_project_settings_dir().plus_file("favorites");
-		recent_dirs_file = get_project_settings_dir().plus_file("recent_dirs");
+		favorites_file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file("favorites");
+		recent_dirs_file = EditorPaths::get_singleton()->get_project_settings_dir().plus_file("recent_dirs");
 	}
 	Ref<FileAccess> f = FileAccess::open(favorites_file, FileAccess::READ);
 	if (f.is_valid()) {
@@ -1233,7 +1206,7 @@ bool EditorSettings::is_dark_theme() {
 void EditorSettings::list_text_editor_themes() {
 	String themes = "Default,Godot 2,Custom";
 
-	Ref<DirAccess> d = DirAccess::open(get_text_editor_themes_dir());
+	Ref<DirAccess> d = DirAccess::open(EditorPaths::get_singleton()->get_text_editor_themes_dir());
 	if (d.is_valid()) {
 		List<String> custom_themes;
 		d->list_dir_begin();
@@ -1264,7 +1237,7 @@ void EditorSettings::load_text_editor_theme() {
 		return; // sorry for "Settings changed" console spam
 	}
 
-	String theme_path = get_text_editor_themes_dir().plus_file(p_file + ".tet");
+	String theme_path = EditorPaths::get_singleton()->get_text_editor_themes_dir().plus_file(p_file + ".tet");
 
 	Ref<ConfigFile> cf = memnew(ConfigFile);
 	Error err = cf->load(theme_path);
@@ -1299,9 +1272,9 @@ bool EditorSettings::import_text_editor_theme(String p_file) {
 			return false;
 		}
 
-		Ref<DirAccess> d = DirAccess::open(get_text_editor_themes_dir());
+		Ref<DirAccess> d = DirAccess::open(EditorPaths::get_singleton()->get_text_editor_themes_dir());
 		if (d.is_valid()) {
-			d->copy(p_file, get_text_editor_themes_dir().plus_file(p_file.get_file()));
+			d->copy(p_file, EditorPaths::get_singleton()->get_text_editor_themes_dir().plus_file(p_file.get_file()));
 			return true;
 		}
 	}
@@ -1314,7 +1287,7 @@ bool EditorSettings::save_text_editor_theme() {
 	if (_is_default_text_editor_theme(p_file.get_file().to_lower())) {
 		return false;
 	}
-	String theme_path = get_text_editor_themes_dir().plus_file(p_file + ".tet");
+	String theme_path = EditorPaths::get_singleton()->get_text_editor_themes_dir().plus_file(p_file + ".tet");
 	return _save_text_editor_theme(theme_path);
 }
 
@@ -1331,7 +1304,7 @@ bool EditorSettings::save_text_editor_theme_as(String p_file) {
 		list_text_editor_themes();
 		String theme_name = p_file.substr(0, p_file.length() - 4).get_file();
 
-		if (p_file.get_base_dir() == get_text_editor_themes_dir()) {
+		if (p_file.get_base_dir() == EditorPaths::get_singleton()->get_text_editor_themes_dir()) {
 			_initial_set("text_editor/theme/color_theme", theme_name);
 			load_text_editor_theme();
 		}
@@ -1347,7 +1320,7 @@ bool EditorSettings::is_default_text_editor_theme() {
 
 Vector<String> EditorSettings::get_script_templates(const String &p_extension, const String &p_custom_path) {
 	Vector<String> templates;
-	String template_dir = get_script_templates_dir();
+	String template_dir = EditorPaths::get_singleton()->get_script_templates_dir();
 	if (!p_custom_path.is_empty()) {
 		template_dir = p_custom_path;
 	}
@@ -1653,8 +1626,6 @@ void EditorSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &EditorSettings::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &EditorSettings::property_get_revert);
 	ClassDB::bind_method(D_METHOD("add_property_info", "info"), &EditorSettings::_add_property_info_bind);
-
-	ClassDB::bind_method(D_METHOD("get_project_settings_dir"), &EditorSettings::get_project_settings_dir);
 
 	ClassDB::bind_method(D_METHOD("set_project_metadata", "section", "key", "data"), &EditorSettings::set_project_metadata);
 	ClassDB::bind_method(D_METHOD("get_project_metadata", "section", "key", "default"), &EditorSettings::get_project_metadata, DEFVAL(Variant()));

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -150,14 +150,6 @@ public:
 	void set_resource_clipboard(const Ref<Resource> &p_resource) { clipboard = p_resource; }
 	Ref<Resource> get_resource_clipboard() const { return clipboard; }
 
-	String get_data_dir() const;
-	String get_export_templates_dir() const;
-	String get_project_settings_dir() const;
-	String get_text_editor_themes_dir() const;
-	String get_script_templates_dir() const;
-	String get_project_script_templates_dir() const;
-	String get_feature_profiles_dir() const;
-
 	void set_project_metadata(const String &p_section, const String &p_key, Variant p_data);
 	Variant get_project_metadata(const String &p_section, const String &p_key, Variant p_default) const;
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -294,7 +294,7 @@ Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
 
 String EditorExportPlatform::find_export_template(String template_file_name, String *err) const {
 	String current_version = VERSION_FULL_CONFIG;
-	String template_path = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(current_version).plus_file(template_file_name);
+	String template_path = EditorPaths::get_singleton()->get_export_templates_dir().plus_file(current_version).plus_file(template_file_name);
 
 	if (FileAccess::exists(template_path)) {
 		return template_path;

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -45,7 +45,7 @@
 void ExportTemplateManager::_update_template_status() {
 	// Fetch installed templates from the file system.
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	const String &templates_dir = EditorSettings::get_singleton()->get_export_templates_dir();
+	const String &templates_dir = EditorPaths::get_singleton()->get_export_templates_dir();
 
 	Error err = da->change_dir(templates_dir);
 	ERR_FAIL_COND_MSG(err != OK, "Could not access templates directory at '" + templates_dir + "'.");
@@ -438,7 +438,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 	}
 
 	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	String template_path = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(version);
+	String template_path = EditorPaths::get_singleton()->get_export_templates_dir().plus_file(version);
 	Error err = d->make_dir_recursive(template_path);
 	if (err != OK) {
 		EditorNode::get_singleton()->show_warning(TTR("Error creating path for extracting templates:") + "\n" + template_path);
@@ -537,7 +537,7 @@ void ExportTemplateManager::_uninstall_template(const String &p_version) {
 
 void ExportTemplateManager::_uninstall_template_confirmed() {
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	const String &templates_dir = EditorSettings::get_singleton()->get_export_templates_dir();
+	const String &templates_dir = EditorPaths::get_singleton()->get_export_templates_dir();
 
 	Error err = da->change_dir(templates_dir);
 	ERR_FAIL_COND_MSG(err != OK, "Could not access templates directory at '" + templates_dir + "'.");
@@ -615,7 +615,7 @@ void ExportTemplateManager::_installed_table_button_cbk(Object *p_item, int p_co
 }
 
 void ExportTemplateManager::_open_template_folder(const String &p_version) {
-	const String &templates_dir = EditorSettings::get_singleton()->get_export_templates_dir();
+	const String &templates_dir = EditorPaths::get_singleton()->get_export_templates_dir();
 	OS::get_singleton()->shell_open("file://" + templates_dir.plus_file(p_version));
 }
 
@@ -639,12 +639,12 @@ void ExportTemplateManager::_hide_dialog() {
 }
 
 bool ExportTemplateManager::can_install_android_template() {
-	const String templates_dir = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
+	const String templates_dir = EditorPaths::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
 	return FileAccess::exists(templates_dir.plus_file("android_source.zip"));
 }
 
 Error ExportTemplateManager::install_android_template() {
-	const String &templates_path = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
+	const String &templates_path = EditorPaths::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
 	const String &source_zip = templates_path.plus_file("android_source.zip");
 	ERR_FAIL_COND_V(!FileAccess::exists(source_zip), ERR_CANT_OPEN);
 	return install_android_template_from_file(source_zip);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -41,6 +41,7 @@
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
 #include "editor/editor_run_script.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
@@ -1542,7 +1543,7 @@ void ScriptEditor::_show_save_theme_as_dialog() {
 	file_dialog_option = THEME_SAVE_AS;
 	file_dialog->clear_filters();
 	file_dialog->add_filter("*.tet");
-	file_dialog->set_current_path(EditorSettings::get_singleton()->get_text_editor_themes_dir().plus_file(EditorSettings::get_singleton()->get("text_editor/theme/color_theme")));
+	file_dialog->set_current_path(EditorPaths::get_singleton()->get_text_editor_themes_dir().plus_file(EditorSettings::get_singleton()->get("text_editor/theme/color_theme")));
 	file_dialog->popup_file_dialog();
 	file_dialog->set_title(TTR("Save Theme As..."));
 }
@@ -3264,7 +3265,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 	p_layout->set_value("ScriptEditor", "list_split_offset", list_split->get_split_offset());
 
 	// Save the cache.
-	script_editor_cache->save(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("script_editor_cache.cfg"));
+	script_editor_cache->save(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("script_editor_cache.cfg"));
 }
 
 void ScriptEditor::_help_class_open(const String &p_class) {
@@ -3645,7 +3646,7 @@ ScriptEditor::ScriptEditor() {
 	current_theme = "";
 
 	script_editor_cache.instantiate();
-	script_editor_cache->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("script_editor_cache.cfg"));
+	script_editor_cache->load(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("script_editor_cache.cfg"));
 
 	completion_cache = memnew(EditorScriptCodeCompletionCache);
 	restoring_layout = false;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/multi_node_edit.h"
@@ -3177,7 +3178,7 @@ void SceneTreeDock::_update_create_root_dialog() {
 			favorite_nodes->get_child(i)->queue_delete();
 		}
 
-		Ref<FileAccess> f = FileAccess::open(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("favorites.Node"), FileAccess::READ);
+		Ref<FileAccess> f = FileAccess::open(EditorPaths::get_singleton()->get_project_settings_dir().plus_file("favorites.Node"), FileAccess::READ);
 		if (f.is_valid()) {
 			while (!f->eof_reached()) {
 				String l = f->get_line().strip_edges();

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 
@@ -620,9 +621,9 @@ void ScriptCreateDialog::_update_template_menu() {
 				} else {
 					String template_directory;
 					if (template_location == ScriptLanguage::TEMPLATE_PROJECT) {
-						template_directory = EditorSettings::get_singleton()->get_project_script_templates_dir();
+						template_directory = EditorPaths::get_singleton()->get_project_script_templates_dir();
 					} else {
-						template_directory = EditorSettings::get_singleton()->get_script_templates_dir();
+						template_directory = EditorPaths::get_singleton()->get_script_templates_dir();
 					}
 					templates_found = _get_user_templates(language, current_node, template_directory, template_location);
 				}

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -51,7 +51,7 @@
 #endif
 
 #ifdef TOOLS_ENABLED
-#include "editor/editor_settings.h"
+#include "editor/editor_paths.h"
 #endif
 
 ///////////////////////////
@@ -848,7 +848,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 // Loading a template, don't parse.
 #ifdef TOOLS_ENABLED
-	if (EditorSettings::get_singleton() && basedir.begins_with(EditorSettings::get_singleton()->get_project_script_templates_dir())) {
+	if (EditorPaths::get_singleton() && basedir.begins_with(EditorPaths::get_singleton()->get_project_script_templates_dir())) {
 		return OK;
 	}
 #endif

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -189,7 +189,7 @@ MonoString *godot_icall_Internal_UpdateApiAssembliesFromPrebuilt(MonoString *p_c
 }
 
 MonoString *godot_icall_Internal_FullExportTemplatesDir() {
-	String full_templates_dir = EditorSettings::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
+	String full_templates_dir = EditorPaths::get_singleton()->get_export_templates_dir().plus_file(VERSION_FULL_CONFIG);
 	return GDMonoMarshal::mono_string_from_godot(full_templates_dir);
 }
 


### PR DESCRIPTION
If we have a class called `EditorPaths`, it should handle editor paths. It just makes sense.