### PR TITLE
fix(gdscript): Fix infinite loop crash on type inference from super() calls

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1473,11 +1473,16 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 					if (callee_type == GDScriptParser::Node::IDENTIFIER || call->is_super) {
 						// Simple call, so base is 'self'.
 						if (p_context.current_class) {
-							base.type.kind = GDScriptParser::DataType::CLASS;
-							base.type.type_source = GDScriptParser::DataType::INFERRED;
-							base.type.is_constant = true;
-							base.type.class_type = p_context.current_class;
-							base.value = p_context.base;
+							if (call->is_super) {
+								base.type = p_context.current_class->base_type;
+								base.value = p_context.base;
+							} else {
+								base.type.kind = GDScriptParser::DataType::CLASS;
+								base.type.type_source = GDScriptParser::DataType::INFERRED;
+								base.type.is_constant = true;
+								base.type.class_type = p_context.current_class;
+								base.value = p_context.base;
+							}
 						} else {
 							break;
 						}


### PR DESCRIPTION
When infering the type from a `super()` call, the gdscript_editor didn't use the base class to search for the original implementation of the method, but instead searched in the extending class.
This caused the same function to be analyzed for type inference which created the infinite loop.

Solves #63592