### PR TITLE
Allow `ScrollBar` to watch `ScrollContainer` in tree

### DIFF
--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -8,9 +8,22 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="is_watching" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the target [ScrollContainer] is sharing its corresponding internal [ScrollBar] with this [ScrollBar] according to the orientation of this [ScrollBar].
+				[b]Note:[/b] Share will only be attempted if both nodes are valid and in the tree.
+				See [method Range.share].
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="custom_step" type="float" setter="set_custom_step" getter="get_custom_step" default="-1.0">
 			Overrides the step used when clicking increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
+		</member>
+		<member name="watch_target_path" type="NodePath" setter="set_watch_target_path" getter="get_watch_target_path" default="NodePath(&quot;&quot;)">
+			The [NodePath] of the target [ScrollContainer] that the [ScrollBar] tries to watch. See [method is_watching].
 		</member>
 	</members>
 	<signals>

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -33,6 +33,7 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
+#include "scene/gui/scroll_container.h"
 #include "scene/main/window.h"
 
 bool ScrollBar::focus_by_default = false;
@@ -305,6 +306,8 @@ void ScrollBar::_notification(int p_what) {
 				drag_node->connect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
 				drag_node->connect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit), varray(), CONNECT_ONESHOT);
 			}
+
+			_try_watch();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -314,6 +317,8 @@ void ScrollBar::_notification(int p_what) {
 			}
 
 			drag_node = nullptr;
+
+			watching = false;
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
@@ -500,6 +505,41 @@ Size2 ScrollBar::get_minimum_size() const {
 	return minsize;
 }
 
+void ScrollBar::_try_watch() {
+	if (watch_target_path.is_empty()) {
+		return;
+	}
+
+	ScrollContainer *watch_target = Object::cast_to<ScrollContainer>(get_node(watch_target_path));
+	if (watch_target) {
+		ScrollBar *watch_target_bar = orientation == HORIZONTAL ? Object::cast_to<ScrollBar>(watch_target->get_h_scroll_bar()) : Object::cast_to<ScrollBar>(watch_target->get_v_scroll_bar());
+		if (watch_target_bar && watch_target_bar != this) {
+			watch_target_bar->share(this);
+			watching = true;
+		}
+	}
+}
+
+void ScrollBar::set_watch_target_path(const NodePath p_path) {
+	if (watch_target_path == p_path) {
+		return;
+	}
+	watch_target_path = p_path;
+	watching = false;
+
+	if (is_inside_tree()) {
+		_try_watch();
+	}
+}
+
+NodePath ScrollBar::get_watch_target_path() const {
+	return watch_target_path;
+}
+
+bool ScrollBar::is_watching() const {
+	return watching && has_node(watch_target_path);
+}
+
 void ScrollBar::set_custom_step(float p_custom_step) {
 	custom_step = p_custom_step;
 }
@@ -617,12 +657,17 @@ bool ScrollBar::is_smooth_scroll_enabled() const {
 }
 
 void ScrollBar::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_watch_target_path", "path"), &ScrollBar::set_watch_target_path);
+	ClassDB::bind_method(D_METHOD("get_watch_target_path"), &ScrollBar::get_watch_target_path);
+	ClassDB::bind_method(D_METHOD("is_watching"), &ScrollBar::is_watching);
+
 	ClassDB::bind_method(D_METHOD("set_custom_step", "step"), &ScrollBar::set_custom_step);
 	ClassDB::bind_method(D_METHOD("get_custom_step"), &ScrollBar::get_custom_step);
 
 	ADD_SIGNAL(MethodInfo("scrolling"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_step", PROPERTY_HINT_RANGE, "-1,4096,suffix:px"), "set_custom_step", "get_custom_step");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "watch_target_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "ScrollContainer"), "set_watch_target_path", "get_watch_target_path");
 }
 
 ScrollBar::ScrollBar(Orientation p_orientation) {

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -45,6 +45,9 @@ class ScrollBar : public Range {
 
 	static bool focus_by_default;
 
+	NodePath watch_target_path;
+	bool watching = false;
+
 	Orientation orientation;
 	Size2 size;
 	float custom_step = -1.0;
@@ -89,6 +92,8 @@ class ScrollBar : public Range {
 	void _drag_node_exit();
 	void _drag_node_input(const Ref<InputEvent> &p_input);
 
+	void _try_watch();
+
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 protected:
@@ -97,6 +102,10 @@ protected:
 	static void _bind_methods();
 
 public:
+	void set_watch_target_path(const NodePath p_path);
+	NodePath get_watch_target_path() const;
+	bool is_watching() const;
+
 	void set_custom_step(float p_custom_step);
 	float get_custom_step() const;
 


### PR DESCRIPTION
The `ScrollBar` is allowed to watch the `ScrollContainer` if both are in the tree.
That is, according to the `orientation` of this `ScrollBar`, the corresponding `ScrollBar` in the `ScrollContainer` is shared with this `ScrollBar`.

This patch will make it easy to replace the internal `ScrollBar` of the target `ScrollContainer` in the editor:
1. Set the corresponding `*_scroll_mode` in `ScrollContainer` to `SCROLL_MODE_SHOW_NEVER`; (Scrolling is not available and will be fixed by #63562.)
2. Add an extra `ScrollBar` and set its `watch_target_path` to the path of the target `ScrollContainer`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

https://user-images.githubusercontent.com/30386067/181773134-cd8b1a6a-e48b-4d4b-8431-f54b992f24cb.mp4

Close godotengine/godot-proposals#5012


