### PR TITLE
Fix vector field particle attractor texture sampling

### DIFF
--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -458,11 +458,11 @@ void main() {
 
 				} break;
 				case ATTRACTOR_TYPE_VECTOR_FIELD: {
-					vec3 uvw_pos = (local_pos / FRAME.attractors[i].extents) * 2.0 - 1.0;
+					vec3 uvw_pos = (local_pos / FRAME.attractors[i].extents + 1.0) * 0.5;
 					if (any(lessThan(uvw_pos, vec3(0.0))) || any(greaterThan(uvw_pos, vec3(1.0)))) {
 						continue;
 					}
-					vec3 s = texture(sampler3D(sdf_vec_textures[FRAME.attractors[i].texture_index], material_samplers[SAMPLER_LINEAR_CLAMP]), uvw_pos).xyz;
+					vec3 s = texture(sampler3D(sdf_vec_textures[FRAME.attractors[i].texture_index], material_samplers[SAMPLER_LINEAR_CLAMP]), uvw_pos).xyz * 2.0 - 1.0;
 					dir = mat3(FRAME.attractors[i].transform) * safe_normalize(s); //revert direction
 					amount = length(s);
 


### PR DESCRIPTION
Fixes #63625 

The offending shader code is this part in `particles.glsl` (comments mine):

```glsl
case ATTRACTOR_TYPE_VECTOR_FIELD: {
	vec3 uvw_pos = (local_pos / FRAME.attractors[i].extents) * 2.0 - 1.0; // This part is wrong, the mapping should be the opposite
	if (any(lessThan(uvw_pos, vec3(0.0))) || any(greaterThan(uvw_pos, vec3(1.0)))) {
		continue;
	}
	vec3 s = texture(sampler3D(sdf_vec_textures[FRAME.attractors[i].texture_index], material_samplers[SAMPLER_LINEAR_CLAMP]), uvw_pos).xyz; // * 2.0 - 1.0 belongs in here instead
	dir = mat3(FRAME.attractors[i].transform) * safe_normalize(s);
	amount = length(s);

	} break;
```

The first line is supposed to map a location in 3D space to texture space, but it does the opposite. `x * 2 - 1` is used to map from the `[0 ... 1]` range to the `[-1 ... +1]` range, but what we want is to map in the other direction. This caused the shader code to always read the wrong coordinate from the vector field texture.

The line where the texture is sampled was missing the mapping back to 3D space. Without it, the vectors would always point in positive X, Y, and Z directions, which caused the relatively uniform diagonal movement that was described in the issue.