### PR TITLE
[3.x] Add error messages and docs to explain allowed transitions in NetworkedMultiplayerCustom.set_connection_status()

### DIFF
--- a/core/io/networked_multiplayer_custom.cpp
+++ b/core/io/networked_multiplayer_custom.cpp
@@ -154,17 +154,19 @@ void NetworkedMultiplayerCustom::set_max_packet_size(int p_max_packet_size) {
 }
 
 void NetworkedMultiplayerCustom::set_connection_status(NetworkedMultiplayerPeer::ConnectionStatus p_connection_status) {
-	// Can only go to connecting, if we are disconnected.
-	if (p_connection_status == ConnectionStatus::CONNECTION_CONNECTING && connection_status == ConnectionStatus::CONNECTION_DISCONNECTED) {
-		connection_status = p_connection_status;
+	if (connection_status == p_connection_status) {
+		return;
 	}
-	// Can only go to connected, if we are connecting.
-	else if (p_connection_status == ConnectionStatus::CONNECTION_CONNECTED && connection_status == ConnectionStatus::CONNECTION_CONNECTING) {
+
+	ERR_FAIL_COND_MSG(p_connection_status == ConnectionStatus::CONNECTION_CONNECTING && connection_status != ConnectionStatus::CONNECTION_DISCONNECTED,
+			"Can only change connection status to CONNECTION_CONNECTING from CONNECTION_DISCONNECTED");
+	ERR_FAIL_COND_MSG(p_connection_status == ConnectionStatus::CONNECTION_CONNECTED && connection_status != ConnectionStatus::CONNECTION_CONNECTING,
+			"Can only change connection status to CONNECTION_CONNECTED from CONNECTION_CONNECTING");
+
+	if (p_connection_status == ConnectionStatus::CONNECTION_CONNECTED) {
 		connection_status = p_connection_status;
 		emit_signal("connection_succeeded");
-	}
-	// Can only go to disconnected, if we aren't already disconnected.
-	else if (p_connection_status == ConnectionStatus::CONNECTION_DISCONNECTED && connection_status != ConnectionStatus::CONNECTION_DISCONNECTED) {
+	} else if (p_connection_status == ConnectionStatus::CONNECTION_DISCONNECTED) {
 		ConnectionStatus old_connection_status = connection_status;
 		connection_status = p_connection_status;
 
@@ -175,6 +177,8 @@ void NetworkedMultiplayerCustom::set_connection_status(NetworkedMultiplayerPeer:
 				emit_signal("server_disconnected");
 			}
 		}
+	} else {
+		connection_status = p_connection_status;
 	}
 }
 

--- a/doc/classes/NetworkedMultiplayerCustom.xml
+++ b/doc/classes/NetworkedMultiplayerCustom.xml
@@ -31,6 +31,8 @@
 			<argument index="0" name="connection_status" type="int" enum="NetworkedMultiplayerPeer.ConnectionStatus" />
 			<description>
 				Set the state of the connection. See [enum NetworkedMultiplayerPeer.ConnectionStatus].
+				This will emit the [signal NetworkedMultiplayerPeer.connection_succeeded], [signal NetworkedMultiplayerPeer.connection_failed] or [signal NetworkedMultiplayerPeer.server_disconnected] signals depending on the status and if the peer has the unique network id of [code]1[/code].
+				You can only change to [code]CONNECTION_CONNECTING[/code] from [code]CONNECTION_DISCONNECTED[/code] and to [code]CONNECTION_CONNECTED[/code] from [code]CONNECTION_CONNECTING[/code].
 			</description>
 		</method>
 		<method name="set_max_packet_size">


### PR DESCRIPTION
This is a follow-up to #63163 

A user tried using the new class, and commented there that some error messages and documentation about which transitions are allowed in `NetworkedMultiplayerCustom.set_connection_status()` would have been helpful.

This PR adds those!