### PR TITLE
[3.x] Fix locale resource remapping with binary conversion on export

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -724,6 +724,8 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 		// We also fall back in case of regional locales as done in TranslationServer::translate
 		// (e.g. 'ru_RU' -> 'ru' if the former has no specific mapping).
 
+		// An extra remap may still be necessary afterwards due to the text -> binary converter on export.
+
 		String locale = TranslationServer::get_singleton()->get_locale();
 		ERR_FAIL_COND_V_MSG(locale.length() < 2, p_path, "Could not remap path '" + p_path + "' for translation as configured locale '" + locale + "' is invalid.");
 		String lang = TranslationServer::get_language_code(locale);
@@ -763,12 +765,10 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 
 	if (path_remaps.has(new_path)) {
 		new_path = path_remaps[new_path];
-	}
-
-	if (new_path == p_path) { // Did not remap.
+	} else {
 		// Try file remap.
 		Error err;
-		FileAccess *f = FileAccess::open(p_path + ".remap", FileAccess::READ, &err);
+		FileAccess *f = FileAccess::open(new_path + ".remap", FileAccess::READ, &err);
 
 		if (f) {
 			VariantParser::StreamFile stream;


### PR DESCRIPTION
Fixes #63606

I have no idea if this is the right fix, but it works and seems to make sense. The previous `if (new_path == p_path) {` seems to be checking if the `path_remap` had anything, so replacing that with an `else` allows the .remap files to get used even when there was a locale remap.