### PR TITLE
Add alpha awareness to Multiply blend mode

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -223,7 +223,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 			blend_attachment.alpha_blend_op = RD::BLEND_OP_ADD;
 			blend_attachment.color_blend_op = RD::BLEND_OP_ADD;
 			blend_attachment.src_color_blend_factor = RD::BLEND_FACTOR_DST_COLOR;
-			blend_attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ZERO;
+			blend_attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 			blend_attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_DST_ALPHA;
 			blend_attachment.dst_alpha_blend_factor = RD::BLEND_FACTOR_ZERO;
 			uses_blend_alpha = true; //force alpha used because of blend

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -224,7 +224,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 			blend_attachment.alpha_blend_op = RD::BLEND_OP_ADD;
 			blend_attachment.color_blend_op = RD::BLEND_OP_ADD;
 			blend_attachment.src_color_blend_factor = RD::BLEND_FACTOR_DST_COLOR;
-			blend_attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ZERO;
+			blend_attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 			blend_attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_DST_ALPHA;
 			blend_attachment.dst_alpha_blend_factor = RD::BLEND_FACTOR_ZERO;
 			uses_blend_alpha = true; //force alpha used because of blend

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2084,7 +2084,7 @@ void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code) {
 			attachment.alpha_blend_op = RD::BLEND_OP_ADD;
 			attachment.color_blend_op = RD::BLEND_OP_ADD;
 			attachment.src_color_blend_factor = RD::BLEND_FACTOR_DST_COLOR;
-			attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ZERO;
+			attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 			attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_DST_ALPHA;
 			attachment.dst_alpha_blend_factor = RD::BLEND_FACTOR_ZERO;
 


### PR DESCRIPTION
Following up on my 3.6 PR (#63514) this 4.0 one changes the Multiply blend mode in all renderers (I'm aware of) to use alpha to dictate color blending, making the mode _much_ more useful.

![image](https://user-images.githubusercontent.com/33995085/181788494-b83c4fb2-f904-4c55-9c5e-3d5aab1971de.png)

Premultiplied alpha textures and/or modulate usage are still _required_ in order to avoid pseudo-additive blending. I am even less sure where modulate is handled in RenderingServer to possibly add auto alpha multiplying for Multiply/Premultiplied Alpha blend modes to prevent entirely the issue for modulate usage. 

To do this premultiplication yourself in a shader, start your fragment code by multiplying the modulate color by its alpha by doing `COLOR.rgb *= COLOR.a;`, then proceed to multiply it with your texture and any other desired things.

In spatial shaders, just remember to multiply your `ALBEDO` by the `ALPHA` you're passing.
