### PR TITLE
Protocol registration module

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1194,6 +1194,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="AppProtocol" type="AppProtocol" setter="" getter="">
+			The [AppProtocol] singleton.
+		</member>
 		<member name="AudioServer" type="AudioServer" setter="" getter="">
 			The [AudioServer] singleton.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -193,6 +193,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="app_protocol/enable_app_protocol" type="bool" setter="" getter="" default="false">
+			Is this system enabled at all
+		</member>
+		<member name="app_protocol/protocol_name" type="String" setter="" getter="" default="&quot;godotapp&quot;">
+			The protocol name for example yourappname would resolve to yourappname:// but not YourAppName:// in all cases
+		</member>
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color(0.14, 0.14, 0.14, 1)">
 			Background color for the boot splash.
 		</member>

--- a/misc/dist/macos_template.app/Contents/Info.plist
+++ b/misc/dist/macos_template.app/Contents/Info.plist
@@ -22,6 +22,7 @@
 	<string>$short_version</string>
 	<key>CFBundleSignature</key>
 	<string>$signature</string>
+$registered_protocols
 	<key>CFBundleVersion</key>
 	<string>$version</string>
 $usage_descriptions

--- a/modules/app_protocol/SCsub
+++ b/modules/app_protocol/SCsub
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+Import("env")
+Import("env_modules")
+
+app_protocol = env_modules.Clone()
+
+# Godot's own source files
+app_protocol.add_source_files(env.modules_sources, "*.cpp")
+app_protocol.add_source_files(env.modules_sources, "#thirdparty/ipc/ipc.cpp")
+app_protocol.add_source_files(env.modules_sources, "#thirdparty/ipc/socket_posix.cpp")
+app_protocol.add_source_files(env.modules_sources, "#thirdparty/ipc/socket_windows.cpp")

--- a/modules/app_protocol/app_protocol.cpp
+++ b/modules/app_protocol/app_protocol.cpp
@@ -1,0 +1,151 @@
+/*************************************************************************/
+/*  app_protocol.cpp                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "app_protocol.h"
+#include "core/object/object.h"
+#include "thirdparty/ipc/ipc.h"
+
+#include "core/config/project_settings.h"
+#include "core/os/memory.h"
+
+AppProtocol *AppProtocol::singleton = nullptr;
+
+AppProtocol::AppProtocol() {
+	singleton = this;
+}
+
+AppProtocol::~AppProtocol() {
+	singleton = nullptr; // we only ever have one
+}
+
+void AppProtocol::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("on_url_received", PropertyInfo(Variant::STRING, "url")));
+	ClassDB::bind_method(D_METHOD("poll_server"), &AppProtocol::poll_server);
+	// TODO: add signal registration for incoming messages.
+}
+
+void AppProtocol::initialize() {
+	if (singleton == nullptr) {
+		new AppProtocol();
+	}
+}
+void AppProtocol::finalize() {
+	if (singleton != nullptr) {
+		delete singleton;
+	}
+}
+
+AppProtocol *AppProtocol::get_singleton() {
+	return singleton;
+}
+
+void AppProtocol::register_project_settings() {
+	GLOBAL_DEF("app_protocol/enable_app_protocol", false);
+	GLOBAL_DEF("app_protocol/protocol_name", "godotapp");
+
+	ProjectSettings *projectSettings = ProjectSettings::get_singleton();
+	if (!(bool)projectSettings->get("app_protocol/enable_app_protocol")) {
+		return;
+	}
+
+	const String protocol_name = projectSettings->get("app_protocol/protocol_name");
+
+	// editor is not the server
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
+	// If a server is already registered there is no way to register another protocol until it closes.
+	if (!protocol_name.is_empty() && this->Server == nullptr && !is_server_already_running()) {
+		print_verbose("Starting IPC server");
+		this->Server = memnew(IPCServer);
+		this->Server->setup();
+		this->Server->add_receive_callback(&AppProtocol::on_server_get_message);
+		CompiledPlatform.register_protocol_handler(protocol_name);
+	}
+}
+
+bool AppProtocol::is_server_already_running() {
+	// connection will be refused if it is - connection will be closed instantly.
+	IPCClient client;
+	return client.setup();
+}
+
+void AppProtocol::poll_server() {
+	if (get_singleton()->Server) {
+		get_singleton()->Server->poll_update();
+	}
+}
+
+bool AppProtocol::is_server_running_locally() {
+	return get_singleton() && get_singleton()->Server;
+}
+
+void AppProtocol::on_server_get_message(const char *p_str, int strlen) {
+	const String str = p_str;
+	if (str.contains("client_init"))
+		return;
+	get_singleton()->emit_signal(SNAME("on_url_received"), str);
+	print_error("Got message from client: " + String(p_str));
+}
+
+void AppProtocol::on_os_get_arguments(const List<String> &args) {
+	String str;
+	for (const String &s : args) {
+		str += s;
+	}
+	get_singleton()->emit_signal(SNAME("on_url_received"), str);
+}
+
+bool ProtocolPlatformImplementation::validate_protocol(const String &p_protocol) {
+#ifdef TOOLS_ENABLED
+	// This warning should be shared between platforms, so putting it here.
+	// However, it's not technically related to validation.
+	WARN_PRINT("Registering protocols in the editor likely won't work as expected, since it will point to the editor binary. Consider only doing this in exported projects.");
+#endif
+	// https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1
+	// Protocols can't be empty, must be lowercase, must start with a letter,
+	// can only contain letters, numbers, '+', '-', and '.' characters.
+	if (p_protocol.is_empty()) {
+		return false;
+	}
+	if (p_protocol[0] > 'z' || p_protocol[0] < 'a') {
+		ERR_PRINT("Invalid protocol character: " + String::chr(p_protocol[0]) + ". Protocols must start with a lowercase letter.");
+		return false;
+	}
+	for (int i = 1; i < p_protocol.length(); i++) {
+		char32_t c = p_protocol[i];
+		if (c != '+' && c != '-' && c != '.' && !(c >= 'a' && c <= 'z') && !(c >= '0' && c <= '9')) {
+			ERR_PRINT("Invalid protocol character: " + String::chr(c) + ". Protocols must be lowercase, must start with a letter, can only contain letters, numbers, '+', '-', and '.' characters.");
+			return false;
+		}
+	}
+	return true;
+}

--- a/modules/app_protocol/app_protocol.h
+++ b/modules/app_protocol/app_protocol.h
@@ -1,0 +1,196 @@
+/*************************************************************************/
+/*  app_protocol.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef APP_PROTOCOL_H
+#define APP_PROTOCOL_H
+
+#include "core/config/project_settings.h"
+#include "core/os/os.h"
+#include "core/string/ustring.h"
+#include "thirdparty/ipc/ipc.h"
+
+class ProtocolPlatformImplementation {
+public:
+	ProtocolPlatformImplementation(){};
+	virtual ~ProtocolPlatformImplementation(){};
+	virtual bool validate_protocol(const String &p_protocol);
+	virtual Error register_protocol_handler(const String &p_protocol) = 0;
+};
+
+#if !defined(WINDOWS_ENABLED) && !defined(OSX_ENABLED)
+class LinuxDesktopProtocol : public ProtocolPlatformImplementation {
+public:
+	virtual Error register_protocol_handler(const String &p_protocol) {
+		ERR_FAIL_COND_V(!validate_protocol(p_protocol), ERR_INVALID_PARAMETER);
+		OS *os = OS::get_singleton();
+
+		// Generate the desktop entry.
+		const String scheme_handler = "x-scheme-handler/" + p_protocol;
+		const String name = "\nName=" + p_protocol.to_upper() + " Protocol Handler";
+#ifdef TOOLS_ENABLED
+		// tools enabled / source folders must call explicit path to application
+		const String exec = "\nExec=" + os->get_executable_path() + " --path \"" + ProjectSettings::get_singleton()->get_resource_path() + "\" --uri \"%u\"";
+#else
+		// non tools we assume its an exported game and runs from the current folder - we should test this assumption
+		const String exec = "\nExec=" + os->get_executable_path() + " --uri \"%u\"";
+#endif
+		const String mime = "\nMimeType=" + scheme_handler + ";\n";
+		// Example file:
+		// [Desktop Entry]
+		// Type=Application
+		// Name=MYPROTOCOL Protocol Handler
+		// Exec=/path/to/godot --uri="%u"
+		// MimeType=x-scheme-handler/myprotocol;
+		const String desktop_entry = "[Desktop Entry]\nType=Application" + name + exec + mime;
+		// Write the desktop entry to a file.
+		const String file_name = p_protocol + "-protocol-handler.desktop";
+		{
+			const String path = os->get_environment("HOME") + "/.local/share/applications/" + file_name;
+			Error err;
+			Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err);
+			if (err) {
+				return err;
+			}
+			file->store_string(desktop_entry);
+		}
+		// Register this new file with xdg-mime.
+		List<String> args;
+		args.push_back("default");
+		args.push_back(file_name);
+		args.push_back(scheme_handler);
+		return os->execute("xdg-mime", args);
+	}
+};
+#endif
+
+#ifdef WINDOWS_ENABLED
+class WindowsDesktopProtocol : public ProtocolPlatformImplementation {
+public:
+	virtual Error register_protocol_handler(const String &p_protocol) {
+		ERR_FAIL_COND_V(!validate_protocol(p_protocol), ERR_INVALID_PARAMETER);
+
+		const String ExecPath = OS::get_singleton()->get_executable_path().replace("/", "\\");
+#ifdef TOOLS_ENABLED
+		const String open_command = ExecPath + " --path \"" + ProjectSettings::get_singleton()->get_resource_path() + "\" --uri \"%1\"";
+#else
+		const String open_command = ExecPath + " --uri \"%1\"";
+#endif
+
+		// Create the subkey of HKEY_CLASSES_ROOT if it does not exist.
+		HKEY hkey;
+		String key_path = "SOFTWARE\\Classes\\" + p_protocol;
+		LONG open_res = RegCreateKeyEx(HKEY_CURRENT_USER, key_path.utf8().get_data(), 0, nullptr, 0, KEY_SET_VALUE, nullptr, &hkey, nullptr);
+		if (open_res != ERROR_SUCCESS) {
+			return FAILED;
+		}
+
+		// Set empty protocol header (Windows 11 defaults to using the root name of this node)
+		LONG set_res2 = RegSetValueEx(hkey, "URL Protocol", 0, REG_SZ, (BYTE *)"", 0);
+		// Close the key.
+		LONG close_res = RegCloseKey(hkey);
+
+		// Check if all operations were successful.
+		if (set_res2 != ERROR_SUCCESS || close_res != ERROR_SUCCESS) {
+			return FAILED;
+		}
+
+		// Set the shell/open/command subkey.
+		String shell_path = "SOFTWARE\\Classes\\" + p_protocol + "\\shell\\open\\command";
+		open_res = RegCreateKeyEx(HKEY_CURRENT_USER, shell_path.utf8().get_data(), 0, nullptr, 0, KEY_SET_VALUE, nullptr, &hkey, nullptr);
+		if (open_res != ERROR_SUCCESS) {
+			return FAILED;
+		}
+		LONG set_res3 = RegSetValueEx(hkey, nullptr, 0, REG_SZ, (BYTE *)open_command.utf8().get_data(), open_command.utf8().length() + 1);
+		// Close the key.
+		LONG close_res2 = RegCloseKey(hkey);
+
+		// Check if all operations were successful.
+		if (set_res3 != ERROR_SUCCESS || close_res2 != ERROR_SUCCESS) {
+			return FAILED;
+		}
+
+		return OK;
+	}
+};
+#endif
+
+#ifdef OSX_ENABLED
+class ApplePlatform : public ProtocolPlatformImplementation {
+public:
+	virtual Error register_protocol_handler(const String &p_protocol) {
+		return OK;
+	}
+};
+#endif // OSX only.
+
+// TODO: make this swap depending on the compiled platform.
+// Here I made the assumption that the compiled platform is what uses this
+// In the case you run the editor its the CurrentPlatformDefiniton
+// In the case you are using an export template it can also be the CurrentPlatformDefiniton since
+// The events are happening at export time, and baked into the application
+// If this assumption needs to change, totally open to this.
+
+#if defined(WINDOWS_ENABLED) && defined(OSX_ENABLED)
+#error "sanity check failed"
+#endif
+
+#if defined(WINDOWS_ENABLED)
+using CurrentPlatformDefiniton = WindowsDesktopProtocol;
+#elif defined(OSX_ENABLED)
+using CurrentPlatformDefiniton = ApplePlatform;
+#else
+using CurrentPlatformDefiniton = LinuxDesktopProtocol; /* Apple is the same across all devices, so specified as 'apple' generically here, nice job apple :) */
+#endif
+
+class AppProtocol : public Object {
+	GDCLASS(AppProtocol, Object);
+
+protected:
+	static AppProtocol *singleton;
+	IPCServer *Server = nullptr; // only active when this is enabled, and will be authoritive over this socket until its shutdown.
+	static void _bind_methods();
+
+public:
+	AppProtocol();
+	~AppProtocol();
+	static void initialize();
+	static void finalize();
+	static AppProtocol *get_singleton();
+	static bool is_server_running_locally();
+	// this object is compile time, so we always keep the same class.
+	CurrentPlatformDefiniton CompiledPlatform;
+	void register_project_settings();
+	static bool is_server_already_running();
+	void poll_server();
+	static void on_server_get_message(const char *p_str, int strlen);
+	static void on_os_get_arguments(const List<String> &args);
+};
+
+#endif // APP_PROTOCOL_H

--- a/modules/app_protocol/config.py
+++ b/modules/app_protocol/config.py
@@ -1,0 +1,14 @@
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return ["AppProtocol"]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/app_protocol/doc_classes/AppProtocol.xml
+++ b/modules/app_protocol/doc_classes/AppProtocol.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AppProtocol" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		App protocols let you register urls for your application to browsers and desktop applications.
+	</brief_description>
+	<description>
+		When you declare a protocol it lets you launch via web links in browser (with permission)
+		You can implement protocols for windows,mac and linux and have a uniform API for this.
+		On Mac you must register the binary at export time, so we enable this primarily after you execute and run your game.
+		The idea is you go to a website and click a link and your game opens, but additionally will pass data
+		from your browser to an already running game via an IPC library
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="poll_server">
+			<return type="void" />
+			<description>
+				Call this every frame in your GDScript.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="on_url_received">
+			<argument index="0" name="url" type="String" />
+			<description>
+				the url format will return the exact link clicked
+				for example yourappname://your_event_here could be put on a web browser page
+				this would directly be called in this signal
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/modules/app_protocol/doc_classes/AppProtocol.xml
+++ b/modules/app_protocol/doc_classes/AppProtocol.xml
@@ -22,7 +22,7 @@
 	</methods>
 	<signals>
 		<signal name="on_url_received">
-			<argument index="0" name="url" type="String" />
+			<param index="0" name="url" type="String" />
 			<description>
 				the url format will return the exact link clicked
 				for example yourappname://your_event_here could be put on a web browser page

--- a/modules/app_protocol/register_types.cpp
+++ b/modules/app_protocol/register_types.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  godot_application_delegate.h                                         */
+/*  register_types.cpp                                                   */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,20 +28,23 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_APPLICATION_DELEGATE_H
-#define GODOT_APPLICATION_DELEGATE_H
+#include "register_types.h"
+#include "app_protocol.h"
 
-#include "core/os/os.h"
+void initialize_app_protocol_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		AppProtocol::initialize();
+		AppProtocol::get_singleton()->register_project_settings();
+		if (!Engine::get_singleton()->has_singleton("AppProtocol")) {
+			Engine::get_singleton()->add_singleton(
+					Engine::Singleton("AppProtocol", AppProtocol::get_singleton()));
+		}
+		GDREGISTER_CLASS(AppProtocol);
+	}
+}
 
-#import <AppKit/AppKit.h>
-#import <Foundation/Foundation.h>
-
-@interface GodotApplicationDelegate : NSObject
-- (void)forceUnbundledWindowActivationHackStep1;
-- (void)forceUnbundledWindowActivationHackStep2;
-- (void)forceUnbundledWindowActivationHackStep3;
-- (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
-- (void)handleAppleEvent:(NSAppleEventDescriptor *)event onAppUrlEvent:(NSAppleEventDescriptor *)replyEvent;
-@end
-
-#endif // GODOT_APPLICATION_DELEGATE_H
+void uninitialize_app_protocol_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		AppProtocol::finalize();
+	}
+}

--- a/modules/app_protocol/register_types.h
+++ b/modules/app_protocol/register_types.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  godot_application_delegate.h                                         */
+/*  register_types.h                                                     */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,20 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_APPLICATION_DELEGATE_H
-#define GODOT_APPLICATION_DELEGATE_H
+#include "modules/register_module_types.h"
 
-#include "core/os/os.h"
-
-#import <AppKit/AppKit.h>
-#import <Foundation/Foundation.h>
-
-@interface GodotApplicationDelegate : NSObject
-- (void)forceUnbundledWindowActivationHackStep1;
-- (void)forceUnbundledWindowActivationHackStep2;
-- (void)forceUnbundledWindowActivationHackStep3;
-- (void)handleAppleEvent:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
-- (void)handleAppleEvent:(NSAppleEventDescriptor *)event onAppUrlEvent:(NSAppleEventDescriptor *)replyEvent;
-@end
-
-#endif // GODOT_APPLICATION_DELEGATE_H
+void initialize_app_protocol_module(ModuleInitializationLevel p_level);
+void uninitialize_app_protocol_module(ModuleInitializationLevel p_level);

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -346,6 +346,21 @@ void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_pres
 			strnew += lines[i].replace("$copyright", p_preset->get("application/copyright")) + "\n";
 		} else if (lines[i].find("$highres") != -1) {
 			strnew += lines[i].replace("$highres", p_preset->get("display/high_res") ? "\t<true/>" : "\t<false/>") + "\n";
+		} else if (lines[i].find("$registered_protocols") != -1) {
+			ProjectSettings *projectSettings = ProjectSettings::get_singleton();
+			const bool app_protocol_enabled = projectSettings->get("app_protocol/enable_app_protocol");
+			const String protocol = app_protocol_enabled ? projectSettings->get("app_protocol/protocol_name") : "";
+			/* App must have a valid bundle ID for this to work properly on MacOS */
+			String bundle_id = p_preset->get("application/bundle_identifier");
+			if (!protocol.is_empty()) {
+				String s = "\t<key>CFBundleURLTypes</key>\n\t";
+				s += "<array>\n\t\t<dict>\n\t\t\t<key>CFBundleURLName</key>\n";
+				s += "\t\t\t<string>" + bundle_id + "</string>\n";
+				s += "\t\t\t<key>CFBundleURLSchemes</key>\n\t\t\t<array>\n";
+				s += "\t\t\t\t<string>" + protocol + "</string>\n";
+				s += "\t\t\t</array>\n\t\t</dict>\n\t</array>\n";
+				strnew += lines[i].replace("$registered_protocols", s);
+			}
 		} else if (lines[i].find("$usage_descriptions") != -1) {
 			String descriptions;
 			if (!((String)p_preset->get("privacy/microphone_usage_description")).is_empty()) {

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -246,6 +246,18 @@ Files generated from upstream source:
 - Step 3: Delete `data/out` folder and rebuild data - `cd data && rm -rf ./out && make`.
 - Step 4: Copy `source/data/out/icudt71l.dat` to the `{GODOT_SOURCE}/thirdparty/icu4c/icudt71l.dat`.
 
+## ipc
+
+- Upstream: https://github.com/RevoluPowered/Generic-IPC-Handler
+- Version 3476b0b8ead4d3f6bc6f6fb8f6e0cca953d7ca28
+- License - MIT (for the files we use)
+
+Files extracted from upstream source:
+- `src/ipc.cpp`
+- `src/ipc.h`
+- `src/socket_implementation.h`
+- `src/socket_posix.cpp`
+- `src/socket_windows.cpp`
 
 ## jpeg-compressor
 

--- a/thirdparty/ipc/ipc.cpp
+++ b/thirdparty/ipc/ipc.cpp
@@ -1,0 +1,224 @@
+#include "ipc.h"
+
+#include "socket_implementation.h"
+
+IPCBase::IPCBase(){
+}
+IPCBase::~IPCBase(){
+
+}
+
+IPCClient::IPCClient(){}
+IPCClient::~IPCClient(){
+    SocketImplementation::close(data_socket);
+}
+
+IPCServer::IPCServer(){}
+IPCServer::~IPCServer(){
+    SocketImplementation::close(connection_socket);
+}
+
+// called to register the only callback for when data arrives
+void IPCBase::add_receive_callback( CallbackDefinition callback )
+{
+    // func pointer to func pointer.
+    activeCallback = callback;
+}
+
+bool IPCClient::setup()
+{
+    printf("Starting socket\n");
+
+    data_socket = SocketImplementation::create_af_unix_socket(name, SOCKET_NAME);
+    if(data_socket == -1)
+    {
+        SocketImplementation::perror("Socket creation failed");
+        return false;
+    }
+
+    if( SocketImplementation::set_non_blocking(data_socket) == -1)
+    {
+        SocketImplementation::perror("non blocking failure");
+        return false;
+    }
+
+    if(SocketImplementation::connect(data_socket, (const struct sockaddr*) &name, sizeof(name)) == -1)
+    {
+#ifdef _WIN32
+        if(WSAEWOULDBLOCK != WSAGetLastError())
+        {
+            SocketImplementation::perror("connect failure");
+            return false;
+        }
+#else
+        SocketImplementation::perror("connect failure");
+        return false;
+#endif
+    }
+
+    return true;
+}
+
+bool IPCClient::setup_one_shot( const char *str, int n )
+{
+	if( IPCClient::setup() )
+	{
+		// We must send the data to the client requested
+		int OK = SocketImplementation::send(data_socket, str, n);
+		if(OK == -1)
+		{
+			SocketImplementation::perror("cant send message");
+			SocketImplementation::close(data_socket);
+			return false;
+		}
+
+		printf("Waiting for read of client_init [%d] %s\n", __LINE__, __FILE__ );
+
+		/* Non blocking */
+		int len = SocketImplementation::recv(data_socket, buffer, BufferSize);
+		if(len == -1)
+		{
+			SocketImplementation::perror("read client socket");
+			SocketImplementation::close(data_socket);
+			return false;
+		}
+
+		buffer[BufferSize - 1] = 0;
+		if(strncmp(str, buffer, len) != 0)
+		{
+			SocketImplementation::perror("comparison buffer result wrong client");
+			SocketImplementation::close(data_socket);
+			return false;
+		}
+
+		SocketImplementation::close(data_socket);
+        return true;
+    }
+	return false;
+}
+
+void IPCClient::send_message( const char * str, int n )
+{
+	int OK = SocketImplementation::send(data_socket, str, n );
+	if(OK == -1)
+	{
+        SocketImplementation::perror("write");
+	}
+}
+
+bool IPCClient::poll_update() {
+    return true;
+}
+
+bool IPCServer::setup()
+{
+    SocketImplementation::unlink(SOCKET_NAME);
+
+    printf("Setting up server connection socket\n");
+    connection_socket = SocketImplementation::create_af_unix_socket(name, SOCKET_NAME);
+    if(connection_socket == -1)
+    {
+        SocketImplementation::perror("Socket creation failed");
+        return false;
+    }
+
+    if(SocketImplementation::set_non_blocking(connection_socket) == -1)
+    {
+        SocketImplementation::perror("non blocking failure");
+        return false;
+    }
+
+    printf("trying to bind connection\n");
+    int OK = SocketImplementation::bind(connection_socket, (const struct sockaddr *) &name, sizeof(name));
+    if (OK == -1) {
+        SocketImplementation::perror("bind");
+        return false;
+    }
+
+    printf("Starting listen logic\n");
+    OK = SocketImplementation::listen(connection_socket, 8); // assume spamming of new connections
+    if (OK == -1) {
+        SocketImplementation::perror("listen");
+        return false;
+    }
+    // TODO move to init code ?
+#if defined(SO_NOSIGPIPE)
+	// Disable SIGPIPE (should only be relevant to stream sockets, but seems to affect UDP too on iOS)
+	int par = 1;
+	if (setsockopt(connection_socket, SOL_SOCKET, SO_NOSIGPIPE, &par, sizeof(int)) != 0) {
+		printf("Unable to turn off SIGPIPE on socket");
+	}
+#endif
+
+    printf("started listening for new connections\n");
+    return true;
+}
+
+/* We process and read the buffer once per tick */
+bool IPCServer::poll_update()
+{
+	{
+        int ret = SocketImplementation::poll(connection_socket);
+		if(ret == -1) {
+			perror("poll error");
+			return false;
+		} else if( ret == EAGAIN || ret == 0) {
+            return true; // would block or no connections
+        }
+	}
+
+	struct sockaddr_storage their_addr;
+	socklen_t size = sizeof(their_addr);
+	data_socket = SocketImplementation::accept(connection_socket, (struct sockaddr *)&their_addr, &size);
+
+    // both are checked for portability to all OS's.
+
+    // EWOULDBLOCK & EAGAIN sometimes are the same
+	// this can produce a warning which is why I used two IF's for the same thing.
+	// example: error: logical 'or' of equal expressions [-Werror=logical-op]
+	if(IPC_AGAIN(data_socket)) {
+        return true; // not an error
+	} else if (data_socket == -1) {
+		SocketImplementation::perror("socket open failed");
+		return false;
+	} else {
+        printf("Server accepted connection\n");
+    }
+
+    if(SocketImplementation::set_non_blocking(data_socket) == -1)
+    {
+        return false;
+    }
+//
+    /* end server only. */
+    int len = SocketImplementation::recv(data_socket, buffer, BufferSize);
+    if (len == -1) {
+        SocketImplementation::perror("server read");
+        return false;
+    }
+    else
+    {
+        printf("socket read success\n");
+    }
+
+    /* Buffer must be null terminated */
+    buffer[BufferSize - 1] = 0;
+
+    int OK = SocketImplementation::send(data_socket, buffer, len);
+    if(OK == -1)
+    {
+        SocketImplementation::perror("cant send message");
+        SocketImplementation::close(data_socket);
+        return false;
+    }
+
+    /* Pass data to the application hooked in */
+    printf("Received message from client: %s\n", buffer);
+    if (activeCallback) {
+        activeCallback(buffer, strlen(buffer));
+    }
+
+    SocketImplementation::close(data_socket);
+
+    return true;
+}

--- a/thirdparty/ipc/ipc.h
+++ b/thirdparty/ipc/ipc.h
@@ -1,0 +1,75 @@
+#ifndef AF_UNIX_IPC_INCLUDE
+#define AF_UNIX_IPC_INCLUDE
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <mswsock.h>
+#include <afunix.h>
+#else
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif // _WIN32
+
+/* Inter process communication system 
+ * - Platform agnostic using AF_UNIX sockets
+ *   On Mac we must use DGRAM mode.
+ *   We'd like to make this connectionless would be easier code wise.
+ */
+
+using CallbackDefinition = void (*)(const char * /* string data received */, int /*strlen */);
+#define BufferSize 256
+
+// TODO: this should be dynamic
+// Must be an OS specific temp directory
+// UNDER 108 char limit across all operating systems.
+#ifdef _WIN32
+#define SOCKET_NAME "c:/temp/som74yhe.socket"
+#else
+#define SOCKET_NAME "/tmp/som74yhe.socket"
+#endif
+
+class IPCBase 
+{
+    protected:
+    CallbackDefinition activeCallback = nullptr;
+    struct sockaddr_un name;
+    // last char is always null, preventing reading more than buffer size.
+    char buffer[BufferSize] = {0};
+    int data_socket = -1;
+    public:
+    IPCBase();
+    virtual ~IPCBase();
+	virtual bool setup() = 0; // setup is always different
+    virtual bool poll_update() = 0;
+	virtual void add_receive_callback( CallbackDefinition callback );
+};
+
+class IPCClient : public IPCBase
+{
+	public:
+	IPCClient();
+	virtual ~IPCClient();
+    bool setup();
+	bool setup_one_shot( const char *str, int n );
+    bool poll_update();
+	void send_message( const char * str, int n /* length */);
+};
+
+class IPCServer : public IPCBase
+{
+    // server has more than one handle here
+    int connection_socket = -1;
+    public:
+    IPCServer();
+    virtual ~IPCServer();
+    bool setup();
+    bool poll_update();
+};
+
+#endif // AF_UNIX_IPC_INCLUDE

--- a/thirdparty/ipc/socket_implementation.h
+++ b/thirdparty/ipc/socket_implementation.h
@@ -1,0 +1,76 @@
+#ifndef GENERIC_IPC_HANDLER_SOCKET_IMPLEMENTATION_H
+#define GENERIC_IPC_HANDLER_SOCKET_IMPLEMENTATION_H
+
+#include <stddef.h>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <stdio.h>
+#else
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+
+/* This is because when WERROR and all errors are enabled you get the warning
+ * error: duplicated 'if' condition and is better than disabling the error */
+#if EAGAIN == EWOULDBLOCK
+#define IPC_AGAIN(x) \
+x == EAGAIN
+#else
+#define IPC_AGAIN(x) \
+x == EAGAIN || x == EWOULDBLOCK
+#endif
+
+
+struct SocketImplementation
+{
+    static void initialize();
+    static void finalize();
+
+    /* Limit to 108 chars */
+    static int create_af_unix_socket(
+            struct sockaddr_un& name,
+            const char * file_path );
+    /*
+     * Sets the socket into non-blocking mode for read/write operations
+     * listen() is non-blocking on Linux but not on Mac, on Mac you must poll() first.
+     * Windows has a different handler for setting the socket to non-blocking
+     * Unix, Linux and Mac uses fcntl.
+    */
+    static int set_non_blocking( int socket_handle );
+    static int connect( int socket_handle, const struct sockaddr *address, socklen_t address_len );
+    static int send( int socket_handle, const char * msg, size_t len);
+    static int recv( int socket_handle, char * buffer, size_t bufferSize );
+    static int poll( int socket_handle );
+    static int poll( struct pollfd * pfd, int timeout = 1, int n = 1 );
+    static int accept( int socket_handle, struct sockaddr *addr, socklen_t * addrlen);
+    static int bind( int socket_handle, const struct sockaddr *addr, size_t len);
+    static int listen( int socket_handle, int connection_pool_size);
+    static void close( int socket_handle );
+    static void unlink( const char * unlink_file );
+    static void perror( const char * msg );
+};
+
+/*
+ * Really because we shouldn't need to tell the OS to start and finalise but we do because Microsoft's
+ * API requires WSAStartup and Shutdown
+ */
+struct InitializerMagic
+{
+    InitializerMagic()
+    {
+        SocketImplementation::initialize();
+    }
+
+    ~InitializerMagic()
+    {
+        SocketImplementation::finalize();
+    }
+};
+
+#endif //GENERIC_IPC_HANDLER_SOCKET_IMPLEMENTATION_H

--- a/thirdparty/ipc/socket_posix.cpp
+++ b/thirdparty/ipc/socket_posix.cpp
@@ -1,0 +1,109 @@
+#include "socket_implementation.h"
+#ifndef _WIN32
+
+/* Creating AF Unix socket the entire point */
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int SocketImplementation::create_af_unix_socket(
+        struct sockaddr_un& name,
+        const char * file_path )
+{
+    const int socket_id = socket(AF_UNIX, SOCK_STREAM, 0);
+    if(socket_id == -1) {
+        perror("client socket");
+        return -1;
+    }
+    /* Ensure portable by resetting all to zero */
+    memset(&name, 0, sizeof(name));
+
+    /* AF_UNIX */
+    name.sun_family = AF_UNIX;
+    strncpy(name.sun_path, file_path, sizeof(name.sun_path) - 1);
+
+    return socket_id;
+}
+
+int SocketImplementation::set_non_blocking(int socket_handle) {
+    int flags = fcntl(socket_handle, F_GETFD );
+    return fcntl(socket_handle, F_SETFD, flags | O_NONBLOCK);
+}
+
+/* A poll method where you don't need the manual
+ * Since we are using this specific to AF_UNIX I kept this simple
+ */
+int SocketImplementation::poll( int socket_handle )
+{
+    struct pollfd pfd;
+    pfd.fd = socket_handle;
+    pfd.events = POLLIN | POLLOUT;
+    pfd.revents = 0;
+    return ::poll(&pfd, 1, 0);
+}
+
+int SocketImplementation::poll( struct pollfd * pfd, int timeout, int n )
+{
+	return ::poll(pfd, n, timeout);
+}
+
+/* Why so many proxy functions?
+ * Well cotton, the reason is WinSock API has a bunch of differences, so linux is basically just a passthrough of the
+ * unix functionality.
+ * If M$ used the Posix / IEEE socket implementation and used this API it would be much cleaner, but they don't.
+ * The other option is using a bunch of ifdefs inside logic which may need to change per OS
+ * In the future when another tech comes along you can use this API to swap in another implementation, so its not
+ * a total loss.
+ */
+
+int SocketImplementation::connect( int socket_handle, const struct sockaddr *address, socklen_t address_len )
+{
+    return ::connect(socket_handle, address, address_len);
+}
+
+int SocketImplementation::send( int socket_handle, const char * msg, size_t len )
+{
+    return ::send(socket_handle, msg, len, MSG_DONTWAIT);
+}
+
+int SocketImplementation::recv( int socket_handle, char * buffer, size_t bufferSize )
+{
+    return ::recv(socket_handle, buffer, bufferSize, 0);
+}
+
+int SocketImplementation::accept(
+        int socket_handle,
+        struct sockaddr *addr,
+        socklen_t * addrlen )
+{
+    return ::accept(socket_handle, addr, addrlen);
+}
+
+int SocketImplementation::bind( int socket_handle, const struct sockaddr *addr, size_t len)
+{
+    return ::bind(socket_handle, addr, len);
+}
+
+int SocketImplementation::listen( int socket_handle, int connection_pool_size )
+{
+    return ::listen(socket_handle, connection_pool_size);
+}
+
+void SocketImplementation::close(int socket_handle) {
+    ::close(socket_handle);
+}
+
+void SocketImplementation::unlink(const char *unlink_file) {
+    ::unlink(unlink_file);
+}
+
+void SocketImplementation::perror(const char *err) {
+	::perror(err);
+}
+
+#endif

--- a/thirdparty/ipc/socket_windows.cpp
+++ b/thirdparty/ipc/socket_windows.cpp
@@ -1,0 +1,186 @@
+// We need different code for Windows sockets compared to other platforms.
+#ifdef _WIN32
+#define _CRT_SECURE_NO_WARNINGS
+#include "socket_implementation.h"
+
+#include <afunix.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+// danger will robinson danger
+InitializerMagic magic;
+
+void SocketImplementation::initialize()
+{
+    // prevent printf failing this is windows
+    setvbuf (stdout, NULL, _IONBF, 0);
+
+    // Initialise winsock
+    WSADATA wsaData;
+    int err = WSAStartup(MAKEWORD(2,2), &wsaData);
+    if(err != 0)
+    {
+        printf("WSAStartup Failed: %d", err);
+    }
+
+}
+
+void SocketImplementation::finalize()
+{
+    WSACleanup();
+}
+
+/* Limit to 108 chars */
+int SocketImplementation::create_af_unix_socket(
+            struct sockaddr_un& name,
+            const char * file_path )
+{
+    const int socket_id = socket(AF_UNIX, SOCK_STREAM, 0);
+    if(socket_id == -1) {
+        perror("client socket");
+        return -1;
+    }
+    /* Ensure portable by resetting all to zero */
+    memset(&name, 0, sizeof(name));
+
+    /* AF_UNIX */
+    name.sun_family = AF_UNIX;
+    strncpy(name.sun_path, file_path, sizeof(name.sun_path) - 1);
+
+    return socket_id;
+}
+
+/*
+ * Sets the socket into non-blocking mode for read/write operations
+ * listen() is non-blocking on Linux but not on Mac, on Mac you must poll() first.
+ * Windows has a different handler for setting the socket to non-blocking
+ * Unix, Linux and Mac uses fcntl.
+*/
+int SocketImplementation::set_non_blocking( int socket_handle )
+{
+//    return 0;
+    unsigned long enable_non_blocking = 1;
+    return ioctlsocket(socket_handle, FIONBIO, &enable_non_blocking ) == 0;
+}
+int SocketImplementation::connect( int socket_handle, const struct sockaddr *address, socklen_t address_len )
+{
+    return ::connect(socket_handle, address, address_len);
+}
+int SocketImplementation::send( int socket_handle, const char * msg, size_t len)
+{
+    struct pollfd pfd;
+    pfd.fd = socket_handle;
+    pfd.events = POLLWRNORM;
+
+    if(SocketImplementation::poll(&pfd) == -1 )
+    {
+        SocketImplementation::perror("poll waiting error");
+        return -1;
+    }
+    else if( pfd.revents & POLLWRNORM )
+    {
+        printf("waiting for write [%d] %s \n", __LINE__, __FILE__);
+
+        int OK = ::send(socket_handle, msg, len, 0);
+        if(OK == -1)
+        {
+            SocketImplementation::perror("cant send message");
+            SocketImplementation::close(socket_handle);
+            return -1;
+        }
+        else
+        {
+            return 0;
+        }
+
+    }
+
+    return 0;
+}
+int SocketImplementation::recv( int socket_handle, char * buffer, size_t bufferSize )
+{
+    struct pollfd pfd;
+    pfd.fd = socket_handle;
+    pfd.events = POLLRDNORM;
+
+    if(SocketImplementation::poll(&pfd) == -1 )
+    {
+        SocketImplementation::perror("poll read error");
+        return -1;
+    }
+    else if( pfd.revents & POLLRDNORM )
+    {
+        printf("waiting for recv [%d] %s \n", __LINE__, __FILE__);
+
+        int OK = ::recv(socket_handle, buffer, bufferSize, 0);
+        if(OK == -1)
+        {
+            SocketImplementation::perror("cant read message");
+            SocketImplementation::close(socket_handle);
+            return -1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    return 0;
+}
+
+int SocketImplementation::poll( struct pollfd * pfd, int timeout, int n )
+{
+    return ::WSAPoll(pfd, n, timeout);
+}
+
+int SocketImplementation::poll( int socket_handle )
+{
+    struct pollfd pfd;
+    pfd.fd = socket_handle;
+    pfd.events = POLLIN | POLLOUT;
+    pfd.revents = 0;
+    return ::WSAPoll(&pfd, 1, 0);
+}
+int SocketImplementation::accept( int socket_handle, struct sockaddr *addr, socklen_t * addrlen)
+{
+    return ::accept(socket_handle, addr, addrlen);
+}
+int SocketImplementation::bind( int socket_handle, const struct sockaddr *addr, size_t len)
+{
+    return ::bind(socket_handle, addr, len);
+}
+int SocketImplementation::listen( int socket_handle, int connection_pool_size)
+{
+    return ::listen(socket_handle, connection_pool_size);
+}
+void SocketImplementation::close( int socket_handle )
+{
+    ::closesocket(socket_handle);
+}
+void SocketImplementation::unlink( const char * unlink_file )
+{
+    _unlink(unlink_file);
+}
+
+void SocketImplementation::perror( const char * msg)
+{
+    LPVOID lpMsgBuf;
+    int e;
+
+    lpMsgBuf = (LPVOID)"Unknown error";
+    e = WSAGetLastError();
+    if (FormatMessage(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER |
+            FORMAT_MESSAGE_FROM_SYSTEM |
+            FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, e,
+            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            // Default language
+            (LPTSTR)&lpMsgBuf, 0, NULL)) {
+        fprintf(stderr, "%s: Error %d: %s\n", msg, e, (char *)lpMsgBuf);
+        LocalFree(lpMsgBuf);
+    } else
+        fprintf(stderr, "%s: Error %d\n", msg, e);
+}
+
+#endif


### PR DESCRIPTION
https://github.com/RevoluPowered/Generic-IPC-Handler

Allows launching of yourappname:// from a modern web browser, but also passes data to running instances when already open.

### Features:
- Allows launching Godot games from web URL's (for example as a player you can click a web link and have your game register to accept those URLS)
- Adds a simple IPC library built for this using AF_UNIX (works on all platforms)
- When the app is already running it uses the IPC buffer to pass the data to the running app.
- On MacOS the event delegates pass the data via the same interface.

### How to use this:
In your scripts
```gdscript
func _on_url_received( url ):
    print("URL:", url)

func _ready():
    AppProtocol.connect("on_url_received", _on_url_received)

func _process(delta):
    AppProtocol.poll_server()
```

> On Linux and Windows, this will just work at runtime without exporting the game via export templates.
> You MUST export the app on MacOS to test if your app name works.

In the project settings you must enable this, and restart your editor **(again you must export the game to test on MacOS)**
<img width="954" alt="Screenshot 2022-07-29 at 16 33 08" src="https://user-images.githubusercontent.com/748770/181793885-1aa6a721-7ace-459c-8546-763c7c6768a4.png">


### DEMO
https://user-images.githubusercontent.com/748770/181796894-b57b2bab-212b-4fde-a390-62c54fa8d91c.mov

### Later
- Allows us to get IPC (non TCP) debugging if you want to re-use the library for it.
- Allows passing data from any app, with a browser link.
- IPC lib can be dropped into any project to send and recv data from any application. (potentially a use case here)

Kindly Sponsored by The Mirror