### PR TITLE
[4.x] Fix locale resource remapping with binary conversion on export

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -794,6 +794,8 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 		// To find the path of the remapped resource, we extract the locale name after
 		// the last ':' to match the project locale.
 
+		// An extra remap may still be necessary afterwards due to the text -> binary converter on export.
+
 		String locale = TranslationServer::get_singleton()->get_locale();
 		ERR_FAIL_COND_V_MSG(locale.length() < 2, p_path, "Could not remap path '" + p_path + "' for translation as configured locale '" + locale + "' is invalid.");
 
@@ -823,12 +825,10 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 
 	if (path_remaps.has(new_path)) {
 		new_path = path_remaps[new_path];
-	}
-
-	if (new_path == p_path) { // Did not remap.
+	} else {
 		// Try file remap.
 		Error err;
-		Ref<FileAccess> f = FileAccess::open(p_path + ".remap", FileAccess::READ, &err);
+		Ref<FileAccess> f = FileAccess::open(new_path + ".remap", FileAccess::READ, &err);
 		if (f.is_valid()) {
 			VariantParser::StreamFile stream;
 			stream.f = f;


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/63606 for Godot 4.x

I made the Godot 3.x version first, which is PR https://github.com/godotengine/godot/pull/63629

This is essentially the same fix as the Godot 3.x one, just cherry-picked and with the conflicts resolved.

As I noted there:

> I have no idea if this is the right fix, but it works and seems to make sense. The previous `if (new_path == p_path) {` seems to be checking if the `path_remap` had anything, so replacing that with an `else` allows the .remap files to get used even when there was a locale remap.