### PR TITLE
Expose and rename ItemList's `_check_shape_changed` to `force_update_list_size`

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -57,6 +57,12 @@
 				Ensure current selection is visible, adjusting the scroll position as necessary.
 			</description>
 		</method>
+		<method name="force_update_list_size">
+			<return type="void" />
+			<description>
+				Forces an update to the list size based on its items. This happens automatically whenever size of the items, or other relevant settings like [member auto_height], change. The method can be used to trigger the update ahead of next drawing pass.
+			</description>
+		</method>
 		<method name="get_item_at_position" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1011,7 +1011,7 @@ void ItemList::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			_check_shape_changed();
+			force_update_list_size();
 
 			int scroll_bar_minwidth = scroll_bar->get_minimum_size().x;
 			scroll_bar->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -scroll_bar_minwidth);
@@ -1314,7 +1314,7 @@ void ItemList::_notification(int p_what) {
 	}
 }
 
-void ItemList::_check_shape_changed() {
+void ItemList::force_update_list_size() {
 	if (!shape_changed) {
 		return;
 	}
@@ -1854,6 +1854,8 @@ void ItemList::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_text_overrun_behavior", "overrun_behavior"), &ItemList::set_text_overrun_behavior);
 	ClassDB::bind_method(D_METHOD("get_text_overrun_behavior"), &ItemList::get_text_overrun_behavior);
+
+	ClassDB::bind_method(D_METHOD("force_update_list_size"), &ItemList::force_update_list_size);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "select_mode", PROPERTY_HINT_ENUM, "Single,Multi"), "set_select_mode", "get_select_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -148,7 +148,6 @@ private:
 	} theme_cache;
 
 	void _scroll_changed(double);
-	void _check_shape_changed();
 	void _shape_text(int p_idx);
 	void _mouse_exited();
 
@@ -280,6 +279,8 @@ public:
 	Size2 get_minimum_size() const override;
 
 	void set_autoscroll_to_bottom(const bool p_enable);
+
+	void force_update_list_size();
 
 	VScrollBar *get_v_scroll_bar() { return scroll_bar; }
 


### PR DESCRIPTION
Closes godotengine/godot-proposals#254

Exposes `force_update_list_size` to allow users to update auto_height_value early before draw if shape_changed is true, can be retrieved via `get_minimum_size()`. 

## Exposed Additions
ItemList:
```gdscript
func force_update_list_size()
```