### PR TITLE
enable default value for typed arrays by assigning untyped arrays

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1717,6 +1717,10 @@ void GDScriptAnalyzer::resolve_parameter(GDScriptParser::ParameterNode *p_parame
 		result.is_meta_type = false;
 
 		if (p_parameter->default_value != nullptr) {
+			// Check if default value is an array literal, so we can make it a typed array too if appropriate.
+			if (result.has_container_element_type() && p_parameter->default_value->type == GDScriptParser::Node::ARRAY) {
+				update_array_literal_element_type(result, static_cast<GDScriptParser::ArrayNode *>(p_parameter->default_value));
+			}
 			if (!is_type_compatible(result, p_parameter->default_value->get_datatype())) {
 				push_error(vformat(R"(Type of default value for parameter "%s" (%s) is not compatible with parameter type (%s).)", p_parameter->identifier->name, p_parameter->default_value->get_datatype().to_string(), p_parameter->datatype_specifier->get_datatype().to_string()), p_parameter->default_value);
 			} else if (p_parameter->default_value->get_datatype().is_variant()) {


### PR DESCRIPTION
Fixes #63502 

Reused what was done for assigning an initial value to a typed array variable