### PR TITLE
[3.x] Add error messages and docs to explain restrictions when calling NetworkedMultiplayerCustom.initialize()

### DIFF
--- a/core/io/networked_multiplayer_custom.cpp
+++ b/core/io/networked_multiplayer_custom.cpp
@@ -139,9 +139,10 @@ NetworkedMultiplayerPeer::ConnectionStatus NetworkedMultiplayerCustom::get_conne
 //
 
 void NetworkedMultiplayerCustom::initialize(int p_self_id) {
-	if (connection_status != ConnectionStatus::CONNECTION_CONNECTING) {
-		return;
-	}
+	ERR_FAIL_COND_MSG(connection_status != ConnectionStatus::CONNECTION_CONNECTING,
+			"Can only initialize if connection status is CONNECTION_CONNECTING.");
+	ERR_FAIL_COND_MSG(p_self_id < 0 || p_self_id > ~(1 << 31),
+			"Cannot initialize with invalid unique network id.");
 
 	self_id = p_self_id;
 	if (self_id == 1) {
@@ -159,9 +160,9 @@ void NetworkedMultiplayerCustom::set_connection_status(NetworkedMultiplayerPeer:
 	}
 
 	ERR_FAIL_COND_MSG(p_connection_status == ConnectionStatus::CONNECTION_CONNECTING && connection_status != ConnectionStatus::CONNECTION_DISCONNECTED,
-			"Can only change connection status to CONNECTION_CONNECTING from CONNECTION_DISCONNECTED");
+			"Can only change connection status to CONNECTION_CONNECTING from CONNECTION_DISCONNECTED.");
 	ERR_FAIL_COND_MSG(p_connection_status == ConnectionStatus::CONNECTION_CONNECTED && connection_status != ConnectionStatus::CONNECTION_CONNECTING,
-			"Can only change connection status to CONNECTION_CONNECTED from CONNECTION_CONNECTING");
+			"Can only change connection status to CONNECTION_CONNECTED from CONNECTION_CONNECTING.");
 
 	if (p_connection_status == ConnectionStatus::CONNECTION_CONNECTED) {
 		connection_status = p_connection_status;

--- a/doc/classes/NetworkedMultiplayerCustom.xml
+++ b/doc/classes/NetworkedMultiplayerCustom.xml
@@ -24,6 +24,7 @@
 			<argument index="0" name="self_peer_id" type="int" />
 			<description>
 				Initialize the peer with the given [code]peer_id[/code] (must be between 1 and 2147483647).
+				Can only be called if the connection status is [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTING]. See [method set_connection_status].
 			</description>
 		</method>
 		<method name="set_connection_status">
@@ -32,7 +33,7 @@
 			<description>
 				Set the state of the connection. See [enum NetworkedMultiplayerPeer.ConnectionStatus].
 				This will emit the [signal NetworkedMultiplayerPeer.connection_succeeded], [signal NetworkedMultiplayerPeer.connection_failed] or [signal NetworkedMultiplayerPeer.server_disconnected] signals depending on the status and if the peer has the unique network id of [code]1[/code].
-				You can only change to [code]CONNECTION_CONNECTING[/code] from [code]CONNECTION_DISCONNECTED[/code] and to [code]CONNECTION_CONNECTED[/code] from [code]CONNECTION_CONNECTING[/code].
+				You can only change to [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTING] from [constant NetworkedMultiplayerPeer.CONNECTION_DISCONNECTED] and to [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTED] from [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTING].
 			</description>
 		</method>
 		<method name="set_max_packet_size">


### PR DESCRIPTION
This is _another_ follow-up to https://github.com/godotengine/godot/pull/63163 (which is similar to PR https://github.com/godotengine/godot/pull/63628)

The same user who was testing the feature there, made another suggestion for where error messages and documentation would have been helpful in understanding the restrictions when calling `NetworkedMultipalyerCustom.initialize()`

This PR adds that too!