### PR TITLE
Improve `ShapeCast2D` and `ShapeCast3D` docs

### DIFF
--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -6,7 +6,7 @@
 	<description>
 		Shape casting allows to detect collision objects by sweeping the [member shape] along the cast direction determined by [member target_position] (useful for things like beam weapons).
 		Immediate collision overlaps can be done with the [member target_position] set to [code]Vector2(0, 0)[/code] and by calling [method force_shapecast_update] within the same [b]physics_frame[/b]. This also helps to overcome some limitations of [Area2D] when used as a continuous detection area, often requiring waiting a couple of frames before collision information is available to [Area2D] nodes, and when using the signals creates unnecessary complexity.
-		The node can detect multiple collision objects, but usually the first detected collision
+		The node can detect multiple collision objects, but it's usually used to detect the first collision.
 		[b]Note:[/b] shape casting is more computationally expensive compared to ray casting.
 	</description>
 	<tutorials>
@@ -42,27 +42,27 @@
 		<method name="get_closest_collision_safe_fraction" qualifiers="const">
 			<return type="float" />
 			<description>
-				The fraction of the motion (between 0 and 1) of how far the shape can move without triggering a collision. The motion is determined by [member target_position].
+				The fraction from the [ShapeCast2D]'s origin to its [member target_position] (between 0 and 1) of how far the shape can move without triggering a collision.
 			</description>
 		</method>
 		<method name="get_closest_collision_unsafe_fraction" qualifiers="const">
 			<return type="float" />
 			<description>
-				The fraction of the motion (between 0 and 1) when the shape triggers a collision. The motion is determined by [member target_position].
+				The fraction from the [ShapeCast2D]'s origin to its [member target_position] (between 0 and 1) of how far the shape must move to trigger a collision.
 			</description>
 		</method>
 		<method name="get_collider" qualifiers="const">
 			<return type="Object" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Returns the [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the collided [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Returns the shape ID of one of the multiple collisions at [code]index[/code] that the shape intersects, or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the shape ID of the colliding shape of one of the multiple collisions at [code]index[/code], or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collision_count" qualifiers="const">
@@ -82,14 +82,14 @@
 			<return type="Vector2" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Returns the normal containing one of the multiple collisions at [code]index[/code] of the intersecting object.
+				Returns the normal of one of the multiple collisions at [code]index[/code] of the intersecting object.
 			</description>
 		</method>
 		<method name="get_collision_point" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Returns the collision point containing one of the multiple collisions at [code]index[/code] at which the shape intersects the object.
+				Returns the collision point of one of the multiple collisions at [code]index[/code] where the shape intersects the colliding object.
 				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>
@@ -133,7 +133,7 @@
 			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected.
 		</member>
 		<member name="collision_result" type="Array" setter="" getter="_get_collision_result" default="[]">
-			A complete collision information. The data returned is the same as in the [method PhysicsDirectSpaceState2D.get_rest_info] method.
+			Returns the complete collision information from the collision sweep. The data returned is the same as in the [method PhysicsDirectSpaceState2D.get_rest_info] method.
 		</member>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			If [code]true[/code], collisions will be reported.
@@ -148,7 +148,7 @@
 			The number of intersections can be limited with this parameter, to reduce the processing time.
 		</member>
 		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
-			Any [Shape2D] derived shape used for collision queries.
+			The [Shape2D]-derived shape to be used for collision queries.
 		</member>
 		<member name="target_position" type="Vector2" setter="set_target_position" getter="get_target_position" default="Vector2(0, 50)">
 			The shape's destination point, relative to this node's [code]position[/code].

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -6,7 +6,7 @@
 	<description>
 		Shape casting allows to detect collision objects by sweeping the [member shape] along the cast direction determined by [member target_position] (useful for things like beam weapons).
 		Immediate collision overlaps can be done with the [member target_position] set to [code]Vector3(0, 0, 0)[/code] and by calling [method force_shapecast_update] within the same [b]physics_frame[/b]. This also helps to overcome some limitations of [Area3D] when used as a continuous detection area, often requiring waiting a couple of frames before collision information is available to [Area3D] nodes, and when using the signals creates unnecessary complexity.
-		The node can detect multiple collision objects, but usually the first detected collision.
+		The node can detect multiple collision objects, but it's usually used to detect the first collision.
 		[b]Note:[/b] Shape casting is more computationally expensive compared to ray casting.
 	</description>
 	<tutorials>
@@ -29,7 +29,7 @@
 		<method name="clear_exceptions">
 			<return type="void" />
 			<description>
-				Removes all collision exceptions for this shape.
+				Removes all collision exceptions for this [ShapeCast3D].
 			</description>
 		</method>
 		<method name="force_shapecast_update">
@@ -42,27 +42,27 @@
 		<method name="get_closest_collision_safe_fraction" qualifiers="const">
 			<return type="float" />
 			<description>
-				The fraction of the motion (between 0 and 1) of how far the shape can move without triggering a collision. The motion is determined by [member target_position].
+				The fraction from the [ShapeCast3D]'s origin to its [member target_position] (between 0 and 1) of how far the shape can move without triggering a collision.
 			</description>
 		</method>
 		<method name="get_closest_collision_unsafe_fraction" qualifiers="const">
 			<return type="float" />
 			<description>
-				The fraction of the motion (between 0 and 1) when the shape triggers a collision. The motion is determined by [member target_position].
+				The fraction from the [ShapeCast3D]'s origin to its [member target_position] (between 0 and 1) of how far the shape must move to trigger a collision.
 			</description>
 		</method>
 		<method name="get_collider" qualifiers="const">
 			<return type="Object" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Returns the [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the collided [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Returns the shape ID of one of the multiple collisions at [code]index[/code] that the shape intersects, or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the shape ID of the colliding shape of one of the multiple collisions at [code]index[/code], or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collision_count" qualifiers="const">
@@ -82,14 +82,14 @@
 			<return type="Vector3" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Returns the normal containing one of the multiple collisions at [code]index[/code] of the intersecting object.
+				Returns the normal of one of the multiple collisions at [code]index[/code] of the intersecting object.
 			</description>
 		</method>
 		<method name="get_collision_point" qualifiers="const">
 			<return type="Vector3" />
 			<argument index="0" name="index" type="int" />
 			<description>
-				Returns the collision point containing one of the multiple collisions at [code]index[/code] at which the shape intersects the object.
+				Returns the collision point of one of the multiple collisions at [code]index[/code] where the shape intersects the colliding object.
 				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>
@@ -117,7 +117,7 @@
 			<return type="void" />
 			<argument index="0" name="resource" type="Resource" />
 			<description>
-				Used internally to update the debug gizmo in the editor. Any code placed in this function will be called whenever the [member shape] resource is modified.
+				This method is used internally to update the debug gizmo in the editor. Any code placed in this function will be called whenever the [member shape] resource is modified.
 			</description>
 		</method>
 		<method name="set_collision_mask_value">
@@ -137,10 +137,10 @@
 			If [code]true[/code], collision with [PhysicsBody3D]s will be reported.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
-			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected.
+			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="collision_result" type="Array" setter="" getter="_get_collision_result" default="[]">
-			A complete collision information. The data returned is the same as in the [method PhysicsDirectSpaceState3D.get_rest_info] method.
+			Returns the complete collision information from the collision sweep. The data returned is the same as in the [method PhysicsDirectSpaceState3D.get_rest_info] method.
 		</member>
 		<member name="debug_shape_custom_color" type="Color" setter="set_debug_shape_custom_color" getter="get_debug_shape_custom_color" default="Color(0, 0, 0, 1)">
 			The custom color to use to draw the shape in the editor and at run-time if [b]Visible Collision Shapes[/b] is enabled in the [b]Debug[/b] menu. This color will be highlighted at run-time if the [ShapeCast3D] is colliding with something.
@@ -159,7 +159,7 @@
 			The number of intersections can be limited with this parameter, to reduce the processing time.
 		</member>
 		<member name="shape" type="Shape3D" setter="set_shape" getter="get_shape">
-			Any [Shape3D] derived shape used for collision queries.
+			The [Shape3D]-derived shape to be used for collision queries.
 		</member>
 		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3(0, -1, 0)">
 			The shape's destination point, relative to this node's [code]position[/code].


### PR DESCRIPTION
Updates the API reference for `ShapeCast2D` and `ShapeCast3D` to be easier to understand and fixes some grammar issues.
