### PR TITLE
Fix editing of remote objects in the inspector

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -36,7 +36,7 @@
 #include "scene/debugger/scene_debugger.h"
 
 bool EditorDebuggerRemoteObject::_set(const StringName &p_name, const Variant &p_value) {
-	if (!editable || !prop_values.has(p_name) || String(p_name).begins_with("Constants/")) {
+	if (!prop_values.has(p_name) || String(p_name).begins_with("Constants/")) {
 		return false;
 	}
 
@@ -91,7 +91,6 @@ void EditorDebuggerRemoteObject::_bind_methods() {
 
 EditorDebuggerInspector::EditorDebuggerInspector() {
 	variables = memnew(EditorDebuggerRemoteObject);
-	variables->editable = false;
 }
 
 EditorDebuggerInspector::~EditorDebuggerInspector() {

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -43,7 +43,6 @@ protected:
 	static void _bind_methods();
 
 public:
-	bool editable = false;
 	ObjectID remote_object_id;
 	String type_name;
 	List<PropertyInfo> prop_list;


### PR DESCRIPTION
Fixes #54977

Removed field `editable` seems to be just some leftover from previous refactoring, it wasn't referenced or set anywhere else in the code.