### PR TITLE
[3.x] Update NetworkedMultiplayerCustom.xml with more explicit documentation to guide usage

### DIFF
--- a/doc/classes/NetworkedMultiplayerCustom.xml
+++ b/doc/classes/NetworkedMultiplayerCustom.xml
@@ -31,9 +31,9 @@
 			<argument index="0" name="connection_status" type="int" enum="NetworkedMultiplayerPeer.ConnectionStatus" />
 			<description>
 				Set the state of the connection. See [enum NetworkedMultiplayerPeer.ConnectionStatus].
-				This will emit the [signal NetworkedMultiplayerPeer.connection_succeeded] signal when set to [code]CONNECTION_CONNECTED[/code].
-				You can only change to [code]CONNECTION_CONNECTING[/code] from [code]CONNECTION_DISCONNECTED[/code] and to [code]CONNECTION_CONNECTED[/code] from [code]CONNECTION_CONNECTING[/code].
-				Setting this to [code]CONNECTION_DISCONNECTED[/code] will emit the [signal NetworkedMultiplayerPeer.connection_failed] if it was previously set to [code]CONNECTION_CONNECTING[/code] or [signal NetworkedMultiplayerPeer.server_disconnected] if previously [code]CONNECTION_CONNECTED[/code]. Note that this is only true if the peer is not in server mode (has the unique network id of [code]1[/code]), otherwise the connection status will be set to [code]CONNECTION_DISCONNECTED[/code] without emitting any signals.
+				This will emit the [signal NetworkedMultiplayerPeer.connection_succeeded] signal when set to [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTED].
+				You can only change to [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTING] from [constant NetworkedMultiplayerPeer.CONNECTION_DISCONNECTED] and to [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTED] from [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTING].
+				Setting this to [constant NetworkedMultiplayerPeer.CONNECTION_DISCONNECTED] will emit the [signal NetworkedMultiplayerPeer.connection_failed] if it was previously set to [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTING] or [signal NetworkedMultiplayerPeer.server_disconnected] if previously [constant NetworkedMultiplayerPeer.CONNECTION_CONNECTED]. Note that this is only true if the peer is not in server mode (has the unique network id of [code]1[/code]), otherwise the connection status will be set to [constant NetworkedMultiplayerPeer.CONNECTION_DISCONNECTED] without emitting any signals.
 			</description>
 		</method>
 		<method name="set_max_packet_size">

--- a/doc/classes/NetworkedMultiplayerCustom.xml
+++ b/doc/classes/NetworkedMultiplayerCustom.xml
@@ -31,8 +31,9 @@
 			<argument index="0" name="connection_status" type="int" enum="NetworkedMultiplayerPeer.ConnectionStatus" />
 			<description>
 				Set the state of the connection. See [enum NetworkedMultiplayerPeer.ConnectionStatus].
-				This will emit the [signal NetworkedMultiplayerPeer.connection_succeeded], [signal NetworkedMultiplayerPeer.connection_failed] or [signal NetworkedMultiplayerPeer.server_disconnected] signals depending on the status and if the peer has the unique network id of [code]1[/code].
+				This will emit the [signal NetworkedMultiplayerPeer.connection_succeeded] signal when set to [code]CONNECTION_CONNECTED[/code].
 				You can only change to [code]CONNECTION_CONNECTING[/code] from [code]CONNECTION_DISCONNECTED[/code] and to [code]CONNECTION_CONNECTED[/code] from [code]CONNECTION_CONNECTING[/code].
+				Setting this to [code]CONNECTION_DISCONNECTED[/code] will emit the [signal NetworkedMultiplayerPeer.connection_failed] if it was previously set to [code]CONNECTION_CONNECTING[/code] or [signal NetworkedMultiplayerPeer.server_disconnected] if previously [code]CONNECTION_CONNECTED[/code]. Note that this is only true if the peer is not in server mode (has the unique network id of [code]1[/code]), otherwise the connection status will be set to [code]CONNECTION_DISCONNECTED[/code] without emitting any signals.
 			</description>
 		</method>
 		<method name="set_max_packet_size">
@@ -49,8 +50,9 @@
 			<argument index="1" name="buffer" type="PoolByteArray" />
 			<argument index="2" name="transfer_mode" type="int" />
 			<description>
-				Emitted when the local [MultiplayerAPI] generates a packet.
+				Emitted when the local [MultiplayerAPI] generates a packet (e.g. when calling [method Node.rpc]).
 				Your script should take this packet and send it to the requested peer over the network (which should call [method deliver_packet] with the data when it's received).
+				The [code]peer_id[/code] is the [code]target_peer[/code] set by [method NetworkedMultiplayerPeer.set_target_peer].
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
Some suggestions based on the new `NetworkedMultiplayerCustom` class introduced in #63163 to be used in 3.x.

@dsnopek I've made some suggestions to the docs based on what would have helped me through my first time. This in conjunction with #63628 and your new additions in #63637 should help new users understand what's going on without having to dig through the source code.

I'd also like some help improving the `deliver_packet` method docs since I haven't gotten around to really digging through how that gets propagated. I assume the `from_peer_id` is meant to be the unique network id the sender of that packet was initialized with? And am I correct in assuming the `target_id`/`target_peer` is what it uses to deliver it the right place locally? I think some further documentation here would be helpful to know how to use `set_target_peer` in conjunction with this.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
