### PR TITLE
Allow to apply the angular velocity of a moving platform

### DIFF
--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -41,10 +41,16 @@
 				Returns a [KinematicCollision3D], which contains information about the latest collision that occurred during the last call to [method move_and_slide].
 			</description>
 		</method>
+		<method name="get_platform_angular_velocity" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the angular velocity of the platform at the last collision point. Only valid after calling [method move_and_slide].
+			</description>
+		</method>
 		<method name="get_platform_velocity" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns the linear velocity of the floor at the last collision point. Only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+				Returns the linear velocity of the platform at the last collision point. Only valid after calling [method move_and_slide].
 			</description>
 		</method>
 		<method name="get_position_delta" qualifiers="const">

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1251,6 +1251,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 	platform_rid = RID();
 	platform_object_id = ObjectID();
 	platform_velocity = Vector3();
+	platform_angular_velocity = Vector3();
 	platform_ceiling_velocity = Vector3();
 	floor_normal = Vector3();
 	wall_normal = Vector3();
@@ -1511,6 +1512,7 @@ void CharacterBody3D::_move_and_slide_floating(double p_delta) {
 	platform_object_id = ObjectID();
 	floor_normal = Vector3();
 	platform_velocity = Vector3();
+	platform_angular_velocity = Vector3();
 
 	bool first_slide = true;
 	for (int iteration = 0; iteration < max_slides; ++iteration) {
@@ -1713,6 +1715,7 @@ void CharacterBody3D::_set_platform_data(const PhysicsServer3D::MotionCollision 
 	platform_rid = p_collision.collider;
 	platform_object_id = p_collision.collider_id;
 	platform_velocity = p_collision.collider_velocity;
+	platform_angular_velocity = p_collision.collider_angular_velocity;
 	platform_layer = PhysicsServer3D::get_singleton()->body_get_collision_layer(platform_rid);
 }
 
@@ -1783,6 +1786,10 @@ real_t CharacterBody3D::get_floor_angle(const Vector3 &p_up_direction) const {
 
 const Vector3 &CharacterBody3D::get_platform_velocity() const {
 	return platform_velocity;
+}
+
+const Vector3 &CharacterBody3D::get_platform_angular_velocity() const {
+	return platform_angular_velocity;
 }
 
 Vector3 CharacterBody3D::get_linear_velocity() const {
@@ -1937,6 +1944,7 @@ void CharacterBody3D::_notification(int p_what) {
 			platform_object_id = ObjectID();
 			motion_results.clear();
 			platform_velocity = Vector3();
+			platform_angular_velocity = Vector3();
 		} break;
 	}
 }
@@ -1991,6 +1999,7 @@ void CharacterBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_real_velocity"), &CharacterBody3D::get_real_velocity);
 	ClassDB::bind_method(D_METHOD("get_floor_angle", "up_direction"), &CharacterBody3D::get_floor_angle, DEFVAL(Vector3(0.0, 1.0, 0.0)));
 	ClassDB::bind_method(D_METHOD("get_platform_velocity"), &CharacterBody3D::get_platform_velocity);
+	ClassDB::bind_method(D_METHOD("get_platform_angular_velocity"), &CharacterBody3D::get_platform_angular_velocity);
 	ClassDB::bind_method(D_METHOD("get_slide_collision_count"), &CharacterBody3D::get_slide_collision_count);
 	ClassDB::bind_method(D_METHOD("get_slide_collision", "slide_idx"), &CharacterBody3D::_get_slide_collision);
 	ClassDB::bind_method(D_METHOD("get_last_slide_collision"), &CharacterBody3D::_get_last_slide_collision);

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -370,6 +370,7 @@ public:
 	const Vector3 &get_real_velocity() const;
 	real_t get_floor_angle(const Vector3 &p_up_direction = Vector3(0.0, 1.0, 0.0)) const;
 	const Vector3 &get_platform_velocity() const;
+	const Vector3 &get_platform_angular_velocity() const;
 
 	virtual Vector3 get_linear_velocity() const override;
 
@@ -422,6 +423,7 @@ private:
 	Vector3 ceiling_normal;
 	Vector3 last_motion;
 	Vector3 platform_velocity;
+	Vector3 platform_angular_velocity;
 	Vector3 platform_ceiling_velocity;
 	Vector3 previous_position;
 	Vector3 real_velocity;

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -991,6 +991,7 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 
 					Vector3 rel_vec = result.contact - (body->get_transform().origin + body->get_center_of_mass());
 					collision.collider_velocity = body->get_linear_velocity() + (body->get_angular_velocity()).cross(rel_vec);
+					collision.collider_angular_velocity = body->get_angular_velocity();
 				}
 
 				r_result->travel = safe * p_parameters.motion;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -541,6 +541,7 @@ public:
 		Vector3 position;
 		Vector3 normal;
 		Vector3 collider_velocity;
+		Vector3 collider_angular_velocity;
 		real_t depth = 0.0;
 		int local_shape = 0;
 		ObjectID collider_id;


### PR DESCRIPTION
I thought it was a bug but it was just more a limitation because it's not always wanted. This option adds a layer that allows to indicate if we have to apply or not the angular speed of a platform to the CharacterBody (as for the others)

EDIT: I added as reduz suggested a method to retrieve the angular velocity of the platform.

https://user-images.githubusercontent.com/6397893/181835398-7f4fa284-b5b6-4823-ad06-0490f6b7724c.mp4


