### PR TITLE
Increases the number of maximum detected collisions

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1273,7 +1273,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 	for (int iteration = 0; iteration < max_slides; ++iteration) {
 		PhysicsServer3D::MotionParameters parameters(get_global_transform(), motion, margin);
-		parameters.max_collisions = 4;
+		parameters.max_collisions = 6; // There can be 4 collisions between 2 walls + 2 more for the floor.
 
 		PhysicsServer3D::MotionResult result;
 		bool collided = move_and_collide(parameters, result, false, !sliding_enabled);


### PR DESCRIPTION
Help a bit with an issue of #57048.

A capsule that passes between two close walls has 4 collision points, 2 points (top and bottom) per wall.

With only 4 points, there are not enough points to have the ground, so it is no longer considered on the ground and falls permanently.
