### PR TITLE
[3.x] Add `ShapeCast` and `ShapeCast2D` nodes

### DIFF
--- a/doc/classes/ShapeCast.xml
+++ b/doc/classes/ShapeCast.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ShapeCast" inherits="Spatial" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Node for physics collision sweep and immediate overlap queries. Similar to the [RayCast] node.
+	</brief_description>
+	<description>
+		Shape casting allows to detect collision objects by sweeping the [member shape] along the cast direction determined by [member target_position] (useful for things like beam weapons).
+		Immediate collision overlaps can be done with the [member target_position] set to [code]Vector3(0, 0, 0)[/code] and by calling [method force_shapecast_update] within the same [b]physics_frame[/b]. This also helps to overcome some limitations of [Area] when used as a continuous detection area, often requiring waiting a couple of frames before collision information is available to [Area] nodes, and when using the signals creates unnecessary complexity.
+		The node can detect multiple collision objects, but it's usually used to detect the first collision.
+		[b]Note:[/b] Shape casting is more computationally expensive compared to ray casting.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_exception">
+			<return type="void" />
+			<argument index="0" name="node" type="Object" />
+			<description>
+				Adds a collision exception so the shape does not report collisions with the specified [CollisionObject] node.
+			</description>
+		</method>
+		<method name="add_exception_rid">
+			<return type="void" />
+			<argument index="0" name="rid" type="RID" />
+			<description>
+				Adds a collision exception so the shape does not report collisions with the specified [RID].
+			</description>
+		</method>
+		<method name="clear_exceptions">
+			<return type="void" />
+			<description>
+				Removes all collision exceptions for this [ShapeCast].
+			</description>
+		</method>
+		<method name="force_shapecast_update">
+			<return type="void" />
+			<description>
+				Updates the collision information for the shape. Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the shape or its parent has changed state.
+				[b]Note:[/b] [code]enabled[/code] is not required for this to work.
+			</description>
+		</method>
+		<method name="get_closest_collision_safe_fraction" qualifiers="const">
+			<return type="float" />
+			<description>
+				The fraction from the [ShapeCast]'s origin to its [member target_position] (between 0 and 1) of how far the shape can move without triggering a collision.
+			</description>
+		</method>
+		<method name="get_closest_collision_unsafe_fraction" qualifiers="const">
+			<return type="float" />
+			<description>
+				The fraction from the [ShapeCast]'s origin to its [member target_position] (between 0 and 1) of how far the shape must move to trigger a collision.
+			</description>
+		</method>
+		<method name="get_collider" qualifiers="const">
+			<return type="Object" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the collided [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+			</description>
+		</method>
+		<method name="get_collider_shape" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the shape ID of the colliding shape of one of the multiple collisions at [code]index[/code], or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+			</description>
+		</method>
+		<method name="get_collision_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				The number of collisions detected at the point of impact. Use this to iterate over multiple collisions as provided by [method get_collider], [method get_collider_shape], [method get_collision_point], and [method get_collision_normal] methods.
+			</description>
+		</method>
+		<method name="get_collision_mask_value" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
+		<method name="get_collision_normal" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the normal of one of the multiple collisions at [code]index[/code] of the intersecting object.
+			</description>
+		</method>
+		<method name="get_collision_point" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the collision point of one of the multiple collisions at [code]index[/code] where the shape intersects the colliding object.
+				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
+			</description>
+		</method>
+		<method name="is_colliding" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether any object is intersecting with the shape's vector (considering the vector length).
+			</description>
+		</method>
+		<method name="remove_exception">
+			<return type="void" />
+			<argument index="0" name="node" type="Object" />
+			<description>
+				Removes a collision exception so the shape does report collisions with the specified [CollisionObject] node.
+			</description>
+		</method>
+		<method name="remove_exception_rid">
+			<return type="void" />
+			<argument index="0" name="rid" type="RID" />
+			<description>
+				Removes a collision exception so the shape does report collisions with the specified [RID].
+			</description>
+		</method>
+		<method name="resource_changed">
+			<return type="void" />
+			<argument index="0" name="resource" type="Resource" />
+			<description>
+				This method is used internally to update the debug gizmo in the editor. Any code placed in this function will be called whenever the [member shape] resource is modified.
+			</description>
+		</method>
+		<method name="set_collision_mask_value">
+			<return type="void" />
+			<argument index="0" name="layer_number" type="int" />
+			<argument index="1" name="value" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
+			If [code]true[/code], collision with [Area]s will be reported.
+		</member>
+		<member name="collide_with_bodies" type="bool" setter="set_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
+			If [code]true[/code], collision with [PhysicsBody]s will be reported.
+		</member>
+		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
+			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+		</member>
+		<member name="collision_result" type="Array" setter="" getter="_get_collision_result">
+			Returns the complete collision information from the collision sweep. The data returned is the same as in the [method PhysicsDirectSpaceState.get_rest_info] method.
+		</member>
+		<member name="debug_shape_custom_color" type="Color" setter="set_debug_shape_custom_color" getter="get_debug_shape_custom_color" default="Color( 0, 0, 0, 1 )">
+			The custom color to use to draw the shape in the editor and at run-time if [b]Visible Collision Shapes[/b] is enabled in the [b]Debug[/b] menu. This color will be highlighted at run-time if the [ShapeCast] is colliding with something.
+			If set to [code]Color(0.0, 0.0, 0.0)[/code] (by default), the color set in [member ProjectSettings.debug/shapes/collision/shape_color] is used.
+		</member>
+		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
+			If [code]true[/code], collisions will be reported.
+		</member>
+		<member name="exclude_parent" type="bool" setter="set_exclude_parent_body" getter="get_exclude_parent_body" default="true">
+			If [code]true[/code], the parent node will be excluded from collision detection.
+		</member>
+		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
+			The collision margin for the shape. A larger margin helps detecting collisions more consistently, at the cost of precision.
+		</member>
+		<member name="max_results" type="int" setter="set_max_results" getter="get_max_results" default="32">
+			The number of intersections can be limited with this parameter, to reduce the processing time.
+		</member>
+		<member name="shape" type="Shape" setter="set_shape" getter="get_shape">
+			The [Shape] to be used for collision queries.
+		</member>
+		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3( 0, -1, 0 )">
+			The shape's destination point, relative to this node's [code]position[/code].
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ShapeCast2D" inherits="Node2D" version="3.5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Node for physics collision sweep and immediate overlap queries. Similar to the [RayCast2D] node.
+	</brief_description>
+	<description>
+		Shape casting allows to detect collision objects by sweeping the [member shape] along the cast direction determined by [member target_position] (useful for things like beam weapons).
+		Immediate collision overlaps can be done with the [member target_position] set to [code]Vector2(0, 0)[/code] and by calling [method force_shapecast_update] within the same [b]physics_frame[/b]. This also helps to overcome some limitations of [Area2D] when used as a continuous detection area, often requiring waiting a couple of frames before collision information is available to [Area2D] nodes, and when using the signals creates unnecessary complexity.
+		The node can detect multiple collision objects, but it's usually used to detect the first collision.
+		[b]Note:[/b] Shape casting is more computationally expensive compared to ray casting.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_exception">
+			<return type="void" />
+			<argument index="0" name="node" type="Object" />
+			<description>
+				Adds a collision exception so the shape does not report collisions with the specified [CollisionObject2D] node.
+			</description>
+		</method>
+		<method name="add_exception_rid">
+			<return type="void" />
+			<argument index="0" name="rid" type="RID" />
+			<description>
+				Adds a collision exception so the shape does not report collisions with the specified [RID].
+			</description>
+		</method>
+		<method name="clear_exceptions">
+			<return type="void" />
+			<description>
+				Removes all collision exceptions for this shape.
+			</description>
+		</method>
+		<method name="force_shapecast_update">
+			<return type="void" />
+			<description>
+				Updates the collision information for the shape. Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the shape or its parent has changed state.
+				[b]Note:[/b] [code]enabled[/code] is not required for this to work.
+			</description>
+		</method>
+		<method name="get_closest_collision_safe_fraction" qualifiers="const">
+			<return type="float" />
+			<description>
+				The fraction from the [ShapeCast2D]'s origin to its [member target_position] (between 0 and 1) of how far the shape can move without triggering a collision.
+			</description>
+		</method>
+		<method name="get_closest_collision_unsafe_fraction" qualifiers="const">
+			<return type="float" />
+			<description>
+				The fraction from the [ShapeCast2D]'s origin to its [member target_position] (between 0 and 1) of how far the shape must move to trigger a collision.
+			</description>
+		</method>
+		<method name="get_collider" qualifiers="const">
+			<return type="Object" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the collided [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+			</description>
+		</method>
+		<method name="get_collider_shape" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the shape ID of the colliding shape of one of the multiple collisions at [code]index[/code], or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+			</description>
+		</method>
+		<method name="get_collision_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				The number of collisions detected at the point of impact. Use this to iterate over multiple collisions as provided by [method get_collider], [method get_collider_shape], [method get_collision_point], and [method get_collision_normal] methods.
+			</description>
+		</method>
+		<method name="get_collision_mask_value" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
+		<method name="get_collision_normal" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the normal of one of the multiple collisions at [code]index[/code] of the intersecting object.
+			</description>
+		</method>
+		<method name="get_collision_point" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the collision point of one of the multiple collisions at [code]index[/code] where the shape intersects the colliding object.
+				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
+			</description>
+		</method>
+		<method name="is_colliding" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether any object is intersecting with the shape's vector (considering the vector length).
+			</description>
+		</method>
+		<method name="remove_exception">
+			<return type="void" />
+			<argument index="0" name="node" type="Object" />
+			<description>
+				Removes a collision exception so the shape does report collisions with the specified [CollisionObject2D] node.
+			</description>
+		</method>
+		<method name="remove_exception_rid">
+			<return type="void" />
+			<argument index="0" name="rid" type="RID" />
+			<description>
+				Removes a collision exception so the shape does report collisions with the specified [RID].
+			</description>
+		</method>
+		<method name="set_collision_mask_value">
+			<return type="void" />
+			<argument index="0" name="layer_number" type="int" />
+			<argument index="1" name="value" type="bool" />
+			<description>
+				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
+			If [code]true[/code], collision with [Area2D]s will be reported.
+		</member>
+		<member name="collide_with_bodies" type="bool" setter="set_collide_with_bodies" getter="is_collide_with_bodies_enabled" default="true">
+			If [code]true[/code], collision with [PhysicsBody2D]s will be reported.
+		</member>
+		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
+			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected.
+		</member>
+		<member name="collision_result" type="Array" setter="" getter="_get_collision_result">
+			Returns the complete collision information from the collision sweep. The data returned is the same as in the [method Physics2DDirectSpaceState.get_rest_info] method.
+		</member>
+		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
+			If [code]true[/code], collisions will be reported.
+		</member>
+		<member name="exclude_parent" type="bool" setter="set_exclude_parent_body" getter="get_exclude_parent_body" default="true">
+			If [code]true[/code], the parent node will be excluded from collision detection.
+		</member>
+		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">
+			The collision margin for the shape. A larger margin helps detecting collisions more consistently, at the cost of precision.
+		</member>
+		<member name="max_results" type="int" setter="set_max_results" getter="get_max_results" default="32">
+			The number of intersections can be limited with this parameter, to reduce the processing time.
+		</member>
+		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
+			The [Shape2D]-derived shape to be used for collision queries.
+		</member>
+		<member name="target_position" type="Vector2" setter="set_target_position" getter="get_target_position" default="Vector2( 0, 50 )">
+			The shape's destination point, relative to this node's [code]position[/code].
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/editor/icons/icon_shape_cast.svg
+++ b/editor/icons/icon_shape_cast.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><g fill="#fc7f7f"><path d="m7 1v9h-3l4 5 4-5h-3v-9z"/><circle cx="7.990566" cy="4.8202" r="4.009434"/></g></svg>

--- a/editor/icons/icon_shape_cast_2d.svg
+++ b/editor/icons/icon_shape_cast_2d.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><g fill="#8da5f3"><path d="m7 1v9h-3l4 5 4-5h-3v-9z"/><circle cx="7.990566" cy="4.8202" r="4.009434"/></g></svg>

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -6494,6 +6494,7 @@ void SpatialEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<SkeletonSpatialGizmoPlugin>(memnew(SkeletonSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<Position3DSpatialGizmoPlugin>(memnew(Position3DSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<RayCastSpatialGizmoPlugin>(memnew(RayCastSpatialGizmoPlugin)));
+	add_gizmo_plugin(Ref<ShapeCastGizmoPlugin>(memnew(ShapeCastGizmoPlugin)));
 	add_gizmo_plugin(Ref<SpringArmSpatialGizmoPlugin>(memnew(SpringArmSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<VehicleWheelSpatialGizmoPlugin>(memnew(VehicleWheelSpatialGizmoPlugin)));
 	add_gizmo_plugin(Ref<VisibilityNotifierGizmoPlugin>(memnew(VisibilityNotifierGizmoPlugin)));

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -51,6 +51,7 @@
 #include "scene/3d/ray_cast.h"
 #include "scene/3d/reflection_probe.h"
 #include "scene/3d/room.h"
+#include "scene/3d/shape_cast.h"
 #include "scene/3d/soft_body.h"
 #include "scene/3d/spring_arm.h"
 #include "scene/3d/sprite_3d.h"
@@ -1997,6 +1998,44 @@ void RayCastSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 	}
 
 	p_gizmo->add_collision_segments(raycast->get_debug_line_vertices());
+}
+
+/////
+
+ShapeCastGizmoPlugin::ShapeCastGizmoPlugin() {
+	const Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/shape");
+	create_material("shape_material", gizmo_color);
+	const float gizmo_value = gizmo_color.get_v();
+	const Color gizmo_color_disabled = Color(gizmo_value, gizmo_value, gizmo_value, 0.65);
+	create_material("shape_material_disabled", gizmo_color_disabled);
+}
+
+bool ShapeCastGizmoPlugin::has_gizmo(Spatial *p_spatial) {
+	return Object::cast_to<ShapeCast>(p_spatial) != nullptr;
+}
+
+String ShapeCastGizmoPlugin::get_name() const {
+	return "ShapeCast";
+}
+
+int ShapeCastGizmoPlugin::get_priority() const {
+	return -1;
+}
+
+void ShapeCastGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
+	ShapeCast *shapecast = Object::cast_to<ShapeCast>(p_gizmo->get_spatial_node());
+
+	p_gizmo->clear();
+
+	const Ref<SpatialMaterial> material = shapecast->is_enabled() ? shapecast->get_debug_material() : get_material("shape_material_disabled");
+
+	p_gizmo->add_lines(shapecast->get_debug_line_vertices(), material);
+
+	if (shapecast->get_shape().is_valid()) {
+		p_gizmo->add_lines(shapecast->get_debug_shape_vertices(), material);
+	}
+
+	p_gizmo->add_collision_segments(shapecast->get_debug_line_vertices());
 }
 
 /////

--- a/editor/spatial_editor_gizmos.h
+++ b/editor/spatial_editor_gizmos.h
@@ -190,6 +190,18 @@ public:
 	RayCastSpatialGizmoPlugin();
 };
 
+class ShapeCastGizmoPlugin : public EditorSpatialGizmoPlugin {
+	GDCLASS(ShapeCastGizmoPlugin, EditorSpatialGizmoPlugin);
+
+public:
+	bool has_gizmo(Spatial *p_spatial);
+	String get_name() const;
+	int get_priority() const;
+	void redraw(EditorSpatialGizmo *p_gizmo);
+
+	ShapeCastGizmoPlugin();
+};
+
 class SpringArmSpatialGizmoPlugin : public EditorSpatialGizmoPlugin {
 	GDCLASS(SpringArmSpatialGizmoPlugin, EditorSpatialGizmoPlugin);
 

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -1,0 +1,460 @@
+/*************************************************************************/
+/*  shape_cast_2d.cpp                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "shape_cast_2d.h"
+
+#include "core/core_string_names.h"
+#include "core/engine.h"
+#include "scene/2d/collision_object_2d.h"
+#include "scene/2d/physics_body_2d.h"
+#include "scene/resources/circle_shape_2d.h"
+#include "servers/physics_2d_server.h"
+
+void ShapeCast2D::set_target_position(const Vector2 &p_point) {
+	target_position = p_point;
+	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint())) {
+		update();
+	}
+}
+
+Vector2 ShapeCast2D::get_target_position() const {
+	return target_position;
+}
+
+void ShapeCast2D::set_margin(real_t p_margin) {
+	margin = p_margin;
+}
+
+real_t ShapeCast2D::get_margin() const {
+	return margin;
+}
+
+void ShapeCast2D::set_max_results(int p_max_results) {
+	max_results = p_max_results;
+}
+
+int ShapeCast2D::get_max_results() const {
+	return max_results;
+}
+
+void ShapeCast2D::set_collision_mask(uint32_t p_mask) {
+	collision_mask = p_mask;
+}
+
+uint32_t ShapeCast2D::get_collision_mask() const {
+	return collision_mask;
+}
+
+void ShapeCast2D::set_collision_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
+	uint32_t mask = get_collision_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_collision_mask(mask);
+}
+
+bool ShapeCast2D::get_collision_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
+	return get_collision_mask() & (1 << (p_layer_number - 1));
+}
+
+int ShapeCast2D::get_collision_count() const {
+	return result.size();
+}
+
+bool ShapeCast2D::is_colliding() const {
+	return collided;
+}
+
+Object *ShapeCast2D::get_collider(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), nullptr, "No collider found.");
+
+	if (result[p_idx].collider_id == 0) {
+		return nullptr;
+	}
+	return ObjectDB::get_instance(result[p_idx].collider_id);
+}
+
+int ShapeCast2D::get_collider_shape(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), -1, "No collider shape found.");
+	return result[p_idx].shape;
+}
+
+Vector2 ShapeCast2D::get_collision_point(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), Vector2(), "No collision point found.");
+	return result[p_idx].point;
+}
+
+Vector2 ShapeCast2D::get_collision_normal(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), Vector2(), "No collision normal found.");
+	return result[p_idx].normal;
+}
+
+real_t ShapeCast2D::get_closest_collision_safe_fraction() const {
+	return collision_safe_fraction;
+}
+
+real_t ShapeCast2D::get_closest_collision_unsafe_fraction() const {
+	return collision_unsafe_fraction;
+}
+
+void ShapeCast2D::set_enabled(bool p_enabled) {
+	enabled = p_enabled;
+	update();
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
+		set_physics_process_internal(p_enabled);
+	}
+	if (!p_enabled) {
+		collided = false;
+	}
+}
+
+bool ShapeCast2D::is_enabled() const {
+	return enabled;
+}
+
+void ShapeCast2D::set_shape(const Ref<Shape2D> &p_shape) {
+	shape = p_shape;
+	if (p_shape.is_valid()) {
+		shape->connect(CoreStringNames::get_singleton()->changed, this, "_redraw_shape");
+		shape_rid = shape->get_rid();
+	}
+	update_configuration_warning();
+	update();
+}
+
+Ref<Shape2D> ShapeCast2D::get_shape() const {
+	return shape;
+}
+
+void ShapeCast2D::set_exclude_parent_body(bool p_exclude_parent_body) {
+	if (exclude_parent_body == p_exclude_parent_body) {
+		return;
+	}
+	exclude_parent_body = p_exclude_parent_body;
+
+	if (!is_inside_tree()) {
+		return;
+	}
+	if (Object::cast_to<CollisionObject2D>(get_parent())) {
+		if (exclude_parent_body) {
+			exclude.insert(Object::cast_to<CollisionObject2D>(get_parent())->get_rid());
+		} else {
+			exclude.erase(Object::cast_to<CollisionObject2D>(get_parent())->get_rid());
+		}
+	}
+}
+
+bool ShapeCast2D::get_exclude_parent_body() const {
+	return exclude_parent_body;
+}
+
+void ShapeCast2D::_redraw_shape() {
+	update();
+}
+
+void ShapeCast2D::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (enabled && !Engine::get_singleton()->is_editor_hint()) {
+				set_physics_process_internal(true);
+			} else {
+				set_physics_process_internal(false);
+			}
+			if (Object::cast_to<CollisionObject2D>(get_parent())) {
+				if (exclude_parent_body) {
+					exclude.insert(Object::cast_to<CollisionObject2D>(get_parent())->get_rid());
+				} else {
+					exclude.erase(Object::cast_to<CollisionObject2D>(get_parent())->get_rid());
+				}
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (enabled) {
+				set_physics_process_internal(false);
+			}
+		} break;
+
+		case NOTIFICATION_DRAW: {
+#ifdef TOOLS_ENABLED
+			ERR_FAIL_COND(!is_inside_tree());
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+				break;
+			}
+			if (shape.is_null()) {
+				break;
+			}
+			Color draw_col = get_tree()->get_debug_collisions_color();
+			if (!enabled) {
+				float g = draw_col.get_v();
+				draw_col.r = g;
+				draw_col.g = g;
+				draw_col.b = g;
+			}
+			// Draw continuous chain of shapes along the cast.
+			const int steps = MAX(2, target_position.length() / shape->get_rect().get_size().length() * 4);
+			for (int i = 0; i <= steps; ++i) {
+				Vector2 t = (real_t(i) / steps) * target_position;
+				draw_set_transform(t, 0.0, Size2(1, 1));
+				shape->draw(get_canvas_item(), draw_col);
+			}
+			draw_set_transform(Vector2(), 0.0, Size2(1, 1));
+
+			// Draw an arrow indicating where the ShapeCast is pointing to.
+			if (target_position != Vector2()) {
+				Transform2D xf;
+				xf.rotate(target_position.angle());
+				xf.translate(Vector2(target_position.length(), 0));
+
+				draw_line(Vector2(), target_position, draw_col, 2);
+
+				float tsize = 8;
+
+				Vector<Vector2> pts;
+				pts.push_back(xf.xform(Vector2(tsize, 0)));
+				pts.push_back(xf.xform(Vector2(0, Math_SQRT12 * tsize)));
+				pts.push_back(xf.xform(Vector2(0, -Math_SQRT12 * tsize)));
+
+				Vector<Color> cols;
+				cols.push_back(draw_col);
+				cols.push_back(draw_col);
+				cols.push_back(draw_col);
+
+				draw_primitive(pts, cols, Vector<Vector2>());
+			}
+#endif
+		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (!enabled) {
+				break;
+			}
+			_update_shapecast_state();
+		} break;
+	}
+}
+
+void ShapeCast2D::_update_shapecast_state() {
+	result.clear();
+
+	ERR_FAIL_COND_MSG(shape.is_null(), "Invalid shape.");
+
+	Ref<World2D> w2d = get_world_2d();
+	ERR_FAIL_COND(w2d.is_null());
+
+	Physics2DDirectSpaceState *dss = Physics2DServer::get_singleton()->space_get_direct_state(w2d->get_space());
+	ERR_FAIL_COND(!dss);
+
+	Transform2D gt = get_global_transform();
+
+	collision_safe_fraction = 0.0;
+	collision_unsafe_fraction = 0.0;
+
+	if (target_position != Vector2()) {
+		dss->cast_motion(shape_rid, gt, target_position, margin, collision_safe_fraction, collision_unsafe_fraction, exclude, collision_mask, collide_with_bodies, collide_with_areas);
+		if (collision_unsafe_fraction < 1.0) {
+			// Move shape transform to the point of impact,
+			// so we can collect contact info at that point.
+			gt.set_origin(gt.get_origin() + target_position * (collision_unsafe_fraction + CMP_EPSILON));
+		}
+	}
+
+	// Regardless of whether the shape is stuck or it's moved along
+	// the motion vector, we'll only consider static collisions from now on.
+	Set<RID> intersected_objects = exclude;
+	bool intersected = true;
+	while (intersected && result.size() < max_results) {
+		Physics2DDirectSpaceState::ShapeRestInfo info;
+		intersected = dss->rest_info(shape_rid, gt, target_position, margin, &info, exclude, collision_mask, collide_with_bodies, collide_with_areas);
+		if (intersected) {
+			result.push_back(info);
+			intersected_objects.insert(info.rid);
+		}
+	}
+	collided = !result.empty();
+}
+
+void ShapeCast2D::force_shapecast_update() {
+	_update_shapecast_state();
+}
+
+void ShapeCast2D::add_exception_rid(const RID &p_rid) {
+	exclude.insert(p_rid);
+}
+
+void ShapeCast2D::add_exception(const Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
+	if (!co) {
+		return;
+	}
+	add_exception_rid(co->get_rid());
+}
+
+void ShapeCast2D::remove_exception_rid(const RID &p_rid) {
+	exclude.erase(p_rid);
+}
+
+void ShapeCast2D::remove_exception(const Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
+	if (!co) {
+		return;
+	}
+	remove_exception_rid(co->get_rid());
+}
+
+void ShapeCast2D::clear_exceptions() {
+	exclude.clear();
+}
+
+void ShapeCast2D::set_collide_with_areas(bool p_clip) {
+	collide_with_areas = p_clip;
+}
+
+bool ShapeCast2D::is_collide_with_areas_enabled() const {
+	return collide_with_areas;
+}
+
+void ShapeCast2D::set_collide_with_bodies(bool p_clip) {
+	collide_with_bodies = p_clip;
+}
+
+bool ShapeCast2D::is_collide_with_bodies_enabled() const {
+	return collide_with_bodies;
+}
+
+Array ShapeCast2D::_get_collision_result() const {
+	Array ret;
+
+	for (int i = 0; i < result.size(); ++i) {
+		const Physics2DDirectSpaceState::ShapeRestInfo &sri = result[i];
+
+		Dictionary col;
+		col["point"] = sri.point;
+		col["normal"] = sri.normal;
+		col["rid"] = sri.rid;
+		col["collider"] = ObjectDB::get_instance(sri.collider_id);
+		col["collider_id"] = sri.collider_id;
+		col["shape"] = sri.shape;
+		col["linear_velocity"] = sri.linear_velocity;
+
+		ret.push_back(col);
+	}
+	return ret;
+}
+
+String ShapeCast2D::get_configuration_warning() const {
+	String warning = Node2D::get_configuration_warning();
+
+	if (shape.is_null()) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("This node cannot interact with other objects unless a Shape2D is assigned.");
+	}
+
+	return warning;
+}
+
+void ShapeCast2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &ShapeCast2D::set_enabled);
+	ClassDB::bind_method(D_METHOD("is_enabled"), &ShapeCast2D::is_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &ShapeCast2D::set_shape);
+	ClassDB::bind_method(D_METHOD("get_shape"), &ShapeCast2D::get_shape);
+
+	ClassDB::bind_method(D_METHOD("set_target_position", "local_point"), &ShapeCast2D::set_target_position);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &ShapeCast2D::get_target_position);
+
+	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &ShapeCast2D::set_margin);
+	ClassDB::bind_method(D_METHOD("get_margin"), &ShapeCast2D::get_margin);
+
+	ClassDB::bind_method(D_METHOD("set_max_results", "max_results"), &ShapeCast2D::set_max_results);
+	ClassDB::bind_method(D_METHOD("get_max_results"), &ShapeCast2D::get_max_results);
+
+	ClassDB::bind_method(D_METHOD("is_colliding"), &ShapeCast2D::is_colliding);
+	ClassDB::bind_method(D_METHOD("get_collision_count"), &ShapeCast2D::get_collision_count);
+
+	ClassDB::bind_method(D_METHOD("force_shapecast_update"), &ShapeCast2D::force_shapecast_update);
+
+	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast2D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider_shape", "index"), &ShapeCast2D::get_collider_shape);
+	ClassDB::bind_method(D_METHOD("get_collision_point", "index"), &ShapeCast2D::get_collision_point);
+	ClassDB::bind_method(D_METHOD("get_collision_normal", "index"), &ShapeCast2D::get_collision_normal);
+
+	ClassDB::bind_method(D_METHOD("get_closest_collision_safe_fraction"), &ShapeCast2D::get_closest_collision_safe_fraction);
+	ClassDB::bind_method(D_METHOD("get_closest_collision_unsafe_fraction"), &ShapeCast2D::get_closest_collision_unsafe_fraction);
+
+	ClassDB::bind_method(D_METHOD("add_exception_rid", "rid"), &ShapeCast2D::add_exception_rid);
+	ClassDB::bind_method(D_METHOD("add_exception", "node"), &ShapeCast2D::add_exception);
+
+	ClassDB::bind_method(D_METHOD("remove_exception_rid", "rid"), &ShapeCast2D::remove_exception_rid);
+	ClassDB::bind_method(D_METHOD("remove_exception", "node"), &ShapeCast2D::remove_exception);
+
+	ClassDB::bind_method(D_METHOD("clear_exceptions"), &ShapeCast2D::clear_exceptions);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &ShapeCast2D::set_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &ShapeCast2D::get_collision_mask);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask_value", "layer_number", "value"), &ShapeCast2D::set_collision_mask_value);
+	ClassDB::bind_method(D_METHOD("get_collision_mask_value", "layer_number"), &ShapeCast2D::get_collision_mask_value);
+
+	ClassDB::bind_method(D_METHOD("set_exclude_parent_body", "mask"), &ShapeCast2D::set_exclude_parent_body);
+	ClassDB::bind_method(D_METHOD("get_exclude_parent_body"), &ShapeCast2D::get_exclude_parent_body);
+
+	ClassDB::bind_method(D_METHOD("set_collide_with_areas", "enable"), &ShapeCast2D::set_collide_with_areas);
+	ClassDB::bind_method(D_METHOD("is_collide_with_areas_enabled"), &ShapeCast2D::is_collide_with_areas_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &ShapeCast2D::set_collide_with_bodies);
+	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &ShapeCast2D::is_collide_with_bodies_enabled);
+
+	ClassDB::bind_method(D_METHOD("_get_collision_result"), &ShapeCast2D::_get_collision_result);
+
+	ClassDB::bind_method(D_METHOD("_redraw_shape"), &ShapeCast2D::_redraw_shape);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_parent"), "set_exclude_parent_body", "get_exclude_parent_body");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "target_position", PROPERTY_HINT_NONE), "set_target_position", "get_target_position");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_results"), "set_max_results", "get_max_results");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_mask", "get_collision_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "collision_result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE), "", "_get_collision_result");
+	ADD_GROUP("Collide With", "collide_with");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collide_with_areas", "is_collide_with_areas_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
+}

--- a/scene/2d/shape_cast_2d.h
+++ b/scene/2d/shape_cast_2d.h
@@ -1,0 +1,123 @@
+/*************************************************************************/
+/*  shape_cast_2d.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SHAPE_CAST_2D_H
+#define SHAPE_CAST_2D_H
+
+#include "scene/2d/node_2d.h"
+#include "scene/resources/shape_2d.h"
+#include "scene/resources/world_2d.h"
+
+class CollisionObject2D;
+
+class ShapeCast2D : public Node2D {
+	GDCLASS(ShapeCast2D, Node2D);
+
+	bool enabled = true;
+
+	Ref<Shape2D> shape;
+	RID shape_rid;
+	Vector2 target_position = Vector2(0, 50);
+
+	Set<RID> exclude;
+	real_t margin = 0.0;
+	uint32_t collision_mask = 1;
+	bool exclude_parent_body = true;
+	bool collide_with_areas = false;
+	bool collide_with_bodies = true;
+
+	// Result
+	int max_results = 32;
+	Vector<Physics2DDirectSpaceState::ShapeRestInfo> result;
+	bool collided = false;
+	real_t collision_safe_fraction = 1.0;
+	real_t collision_unsafe_fraction = 1.0;
+
+	Array _get_collision_result() const;
+	void _redraw_shape();
+
+protected:
+	void _notification(int p_what);
+	void _update_shapecast_state();
+	static void _bind_methods();
+
+public:
+	void set_collide_with_areas(bool p_clip);
+	bool is_collide_with_areas_enabled() const;
+
+	void set_collide_with_bodies(bool p_clip);
+	bool is_collide_with_bodies_enabled() const;
+
+	void set_enabled(bool p_enabled);
+	bool is_enabled() const;
+
+	void set_shape(const Ref<Shape2D> &p_shape);
+	Ref<Shape2D> get_shape() const;
+
+	void set_target_position(const Vector2 &p_point);
+	Vector2 get_target_position() const;
+
+	void set_margin(real_t p_margin);
+	real_t get_margin() const;
+
+	void set_max_results(int p_max_results);
+	int get_max_results() const;
+
+	void set_collision_mask(uint32_t p_mask);
+	uint32_t get_collision_mask() const;
+
+	void set_collision_mask_value(int p_layer_number, bool p_value);
+	bool get_collision_mask_value(int p_layer_number) const;
+
+	void set_exclude_parent_body(bool p_exclude_parent_body);
+	bool get_exclude_parent_body() const;
+
+	void force_shapecast_update();
+	bool is_colliding() const;
+
+	int get_collision_count() const;
+	Object *get_collider(int p_idx) const;
+	int get_collider_shape(int p_idx) const;
+	Vector2 get_collision_point(int p_idx) const;
+	Vector2 get_collision_normal(int p_idx) const;
+
+	real_t get_closest_collision_safe_fraction() const;
+	real_t get_closest_collision_unsafe_fraction() const;
+
+	void add_exception_rid(const RID &p_rid);
+	void add_exception(const Object *p_object);
+	void remove_exception_rid(const RID &p_rid);
+	void remove_exception(const Object *p_object);
+	void clear_exceptions();
+
+	virtual String get_configuration_warning() const;
+};
+
+#endif // SHAPE_CAST_2D_H

--- a/scene/3d/shape_cast.cpp
+++ b/scene/3d/shape_cast.cpp
@@ -1,0 +1,632 @@
+/*************************************************************************/
+/*  shape_cast.cpp                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "shape_cast.h"
+
+#include "collision_object.h"
+#include "core/engine.h"
+#include "mesh_instance.h"
+#include "scene/resources/concave_polygon_shape.h"
+
+void ShapeCast::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				_update_debug_shape_vertices();
+			}
+			if (enabled && !Engine::get_singleton()->is_editor_hint()) {
+				set_physics_process_internal(true);
+			} else {
+				set_physics_process_internal(false);
+			}
+
+			if (get_tree()->is_debugging_collisions_hint()) {
+				_update_debug_shape();
+			}
+
+			if (Object::cast_to<CollisionObject>(get_parent())) {
+				if (exclude_parent_body) {
+					exclude.insert(Object::cast_to<CollisionObject>(get_parent())->get_rid());
+				} else {
+					exclude.erase(Object::cast_to<CollisionObject>(get_parent())->get_rid());
+				}
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (enabled) {
+				set_physics_process_internal(false);
+			}
+
+			if (debug_shape) {
+				_clear_debug_shape();
+			}
+		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (!enabled) {
+				break;
+			}
+
+			bool prev_collision_state = collided;
+			_update_shapecast_state();
+			if (get_tree()->is_debugging_collisions_hint()) {
+				if (prev_collision_state != collided) {
+					_update_debug_shape_material(true);
+				}
+				if (collided) {
+					_update_debug_shape();
+				}
+				if (prev_collision_state == collided && !collided) {
+					_update_debug_shape();
+				}
+			}
+		} break;
+	}
+}
+
+void ShapeCast::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("resource_changed", "resource"), &ShapeCast::resource_changed);
+
+	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &ShapeCast::set_enabled);
+	ClassDB::bind_method(D_METHOD("is_enabled"), &ShapeCast::is_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &ShapeCast::set_shape);
+	ClassDB::bind_method(D_METHOD("get_shape"), &ShapeCast::get_shape);
+
+	ClassDB::bind_method(D_METHOD("set_target_position", "local_point"), &ShapeCast::set_target_position);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &ShapeCast::get_target_position);
+
+	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &ShapeCast::set_margin);
+	ClassDB::bind_method(D_METHOD("get_margin"), &ShapeCast::get_margin);
+
+	ClassDB::bind_method(D_METHOD("set_max_results", "max_results"), &ShapeCast::set_max_results);
+	ClassDB::bind_method(D_METHOD("get_max_results"), &ShapeCast::get_max_results);
+
+	ClassDB::bind_method(D_METHOD("is_colliding"), &ShapeCast::is_colliding);
+	ClassDB::bind_method(D_METHOD("get_collision_count"), &ShapeCast::get_collision_count);
+
+	ClassDB::bind_method(D_METHOD("force_shapecast_update"), &ShapeCast::force_shapecast_update);
+
+	ClassDB::bind_method(D_METHOD("get_collider", "index"), &ShapeCast::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider_shape", "index"), &ShapeCast::get_collider_shape);
+	ClassDB::bind_method(D_METHOD("get_collision_point", "index"), &ShapeCast::get_collision_point);
+	ClassDB::bind_method(D_METHOD("get_collision_normal", "index"), &ShapeCast::get_collision_normal);
+
+	ClassDB::bind_method(D_METHOD("get_closest_collision_safe_fraction"), &ShapeCast::get_closest_collision_safe_fraction);
+	ClassDB::bind_method(D_METHOD("get_closest_collision_unsafe_fraction"), &ShapeCast::get_closest_collision_unsafe_fraction);
+
+	ClassDB::bind_method(D_METHOD("add_exception_rid", "rid"), &ShapeCast::add_exception_rid);
+	ClassDB::bind_method(D_METHOD("add_exception", "node"), &ShapeCast::add_exception);
+
+	ClassDB::bind_method(D_METHOD("remove_exception_rid", "rid"), &ShapeCast::remove_exception_rid);
+	ClassDB::bind_method(D_METHOD("remove_exception", "node"), &ShapeCast::remove_exception);
+
+	ClassDB::bind_method(D_METHOD("clear_exceptions"), &ShapeCast::clear_exceptions);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &ShapeCast::set_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &ShapeCast::get_collision_mask);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask_value", "layer_number", "value"), &ShapeCast::set_collision_mask_value);
+	ClassDB::bind_method(D_METHOD("get_collision_mask_value", "layer_number"), &ShapeCast::get_collision_mask_value);
+
+	ClassDB::bind_method(D_METHOD("set_exclude_parent_body", "mask"), &ShapeCast::set_exclude_parent_body);
+	ClassDB::bind_method(D_METHOD("get_exclude_parent_body"), &ShapeCast::get_exclude_parent_body);
+
+	ClassDB::bind_method(D_METHOD("set_collide_with_areas", "enable"), &ShapeCast::set_collide_with_areas);
+	ClassDB::bind_method(D_METHOD("is_collide_with_areas_enabled"), &ShapeCast::is_collide_with_areas_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &ShapeCast::set_collide_with_bodies);
+	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &ShapeCast::is_collide_with_bodies_enabled);
+
+	ClassDB::bind_method(D_METHOD("_get_collision_result"), &ShapeCast::_get_collision_result);
+
+	ClassDB::bind_method(D_METHOD("set_debug_shape_custom_color", "debug_shape_custom_color"), &ShapeCast::set_debug_shape_custom_color);
+	ClassDB::bind_method(D_METHOD("get_debug_shape_custom_color"), &ShapeCast::get_debug_shape_custom_color);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape"), "set_shape", "get_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclude_parent"), "set_exclude_parent_body", "get_exclude_parent_body");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_position", PROPERTY_HINT_NONE), "set_target_position", "get_target_position");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "margin", PROPERTY_HINT_RANGE, "0,100,0.01"), "set_margin", "get_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_results"), "set_max_results", "get_max_results");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "collision_result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_SCRIPT_VARIABLE), "", "_get_collision_result");
+
+	ADD_GROUP("Collide With", "collide_with");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_areas", "is_collide_with_areas_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
+
+	ADD_GROUP("Debug Shape", "debug_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_shape_custom_color"), "set_debug_shape_custom_color", "get_debug_shape_custom_color");
+}
+
+String ShapeCast::get_configuration_warning() const {
+	String warning = Spatial::get_configuration_warning();
+
+	if (shape.is_null()) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("This node cannot interact with other objects unless a Shape is assigned.");
+	}
+
+	if (shape.is_valid() && Object::cast_to<ConcavePolygonShape>(*shape)) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("ShapeCast does not support ConcavePolygonShapes. Collisions will not be reported.");
+	}
+
+	return warning;
+}
+
+void ShapeCast::set_enabled(bool p_enabled) {
+	enabled = p_enabled;
+	update_gizmo();
+
+	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
+		set_physics_process_internal(p_enabled);
+	}
+	if (!p_enabled) {
+		collided = false;
+	}
+
+	if (is_inside_tree() && get_tree()->is_debugging_collisions_hint()) {
+		if (p_enabled) {
+			_update_debug_shape();
+		} else {
+			_clear_debug_shape();
+		}
+	}
+}
+
+bool ShapeCast::is_enabled() const {
+	return enabled;
+}
+
+void ShapeCast::set_target_position(const Vector3 &p_point) {
+	target_position = p_point;
+	if (is_inside_tree()) {
+		_update_debug_shape();
+	}
+	update_gizmo();
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		if (is_inside_tree()) {
+			_update_debug_shape_vertices();
+		}
+	} else if (debug_shape) {
+		_update_debug_shape();
+	}
+}
+
+Vector3 ShapeCast::get_target_position() const {
+	return target_position;
+}
+
+void ShapeCast::set_margin(real_t p_margin) {
+	margin = p_margin;
+}
+
+real_t ShapeCast::get_margin() const {
+	return margin;
+}
+
+void ShapeCast::set_max_results(int p_max_results) {
+	max_results = p_max_results;
+}
+
+int ShapeCast::get_max_results() const {
+	return max_results;
+}
+
+void ShapeCast::set_collision_mask(uint32_t p_mask) {
+	collision_mask = p_mask;
+}
+
+uint32_t ShapeCast::get_collision_mask() const {
+	return collision_mask;
+}
+
+void ShapeCast::set_collision_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
+	uint32_t mask = get_collision_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_collision_mask(mask);
+}
+
+bool ShapeCast::get_collision_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
+	return get_collision_mask() & (1 << (p_layer_number - 1));
+}
+
+int ShapeCast::get_collision_count() const {
+	return result.size();
+}
+
+bool ShapeCast::is_colliding() const {
+	return collided;
+}
+
+Object *ShapeCast::get_collider(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), nullptr, "No collider found.");
+
+	if (result[p_idx].collider_id == 0) {
+		return nullptr;
+	}
+	return ObjectDB::get_instance(result[p_idx].collider_id);
+}
+
+int ShapeCast::get_collider_shape(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), -1, "No collider shape found.");
+	return result[p_idx].shape;
+}
+
+Vector3 ShapeCast::get_collision_point(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), Vector3(), "No collision point found.");
+	return result[p_idx].point;
+}
+
+Vector3 ShapeCast::get_collision_normal(int p_idx) const {
+	ERR_FAIL_INDEX_V_MSG(p_idx, result.size(), Vector3(), "No collision normal found.");
+	return result[p_idx].normal;
+}
+
+real_t ShapeCast::get_closest_collision_safe_fraction() const {
+	return collision_safe_fraction;
+}
+
+real_t ShapeCast::get_closest_collision_unsafe_fraction() const {
+	return collision_unsafe_fraction;
+}
+
+void ShapeCast::resource_changed(Ref<Resource> p_res) {
+	if (is_inside_tree()) {
+		_update_debug_shape();
+	}
+	update_gizmo();
+}
+
+void ShapeCast::set_shape(const Ref<Shape> &p_shape) {
+	if (p_shape == shape) {
+		return;
+	}
+	if (!shape.is_null()) {
+		shape->unregister_owner(this);
+	}
+	shape = p_shape;
+	if (!shape.is_null()) {
+		shape->register_owner(this);
+	}
+	if (p_shape.is_valid()) {
+		shape_rid = shape->get_rid();
+	}
+
+	if (is_inside_tree()) {
+		_update_debug_shape();
+	}
+
+	update_gizmo();
+	update_configuration_warning();
+}
+
+Ref<Shape> ShapeCast::get_shape() const {
+	return shape;
+}
+
+void ShapeCast::set_exclude_parent_body(bool p_exclude_parent_body) {
+	if (exclude_parent_body == p_exclude_parent_body) {
+		return;
+	}
+	exclude_parent_body = p_exclude_parent_body;
+
+	if (!is_inside_tree()) {
+		return;
+	}
+	if (Object::cast_to<CollisionObject>(get_parent())) {
+		if (exclude_parent_body) {
+			exclude.insert(Object::cast_to<CollisionObject>(get_parent())->get_rid());
+		} else {
+			exclude.erase(Object::cast_to<CollisionObject>(get_parent())->get_rid());
+		}
+	}
+}
+
+bool ShapeCast::get_exclude_parent_body() const {
+	return exclude_parent_body;
+}
+
+void ShapeCast::_update_shapecast_state() {
+	result.clear();
+
+	ERR_FAIL_COND_MSG(shape.is_null(), "Null reference to shape. ShapeCast requires a Shape3D to sweep for collisions.");
+
+	Ref<World> w3d = get_world();
+	ERR_FAIL_COND(w3d.is_null());
+
+	PhysicsDirectSpaceState *dss = PhysicsServer::get_singleton()->space_get_direct_state(w3d->get_space());
+	ERR_FAIL_COND(!dss);
+
+	Transform gt = get_global_transform();
+
+	collision_safe_fraction = 0.0;
+	collision_unsafe_fraction = 0.0;
+
+	if (target_position != Vector3()) {
+		dss->cast_motion(shape_rid, gt, target_position, margin, collision_safe_fraction, collision_unsafe_fraction, exclude, collision_mask, collide_with_bodies, collide_with_areas);
+		if (collision_unsafe_fraction < 1.0) {
+			// Move shape transform to the point of impact,
+			// so we can collect contact info at that point.
+			gt.set_origin(gt.get_origin() + target_position * (collision_unsafe_fraction + CMP_EPSILON));
+		}
+	}
+
+	// Regardless of whether the shape is stuck or it's moved along
+	// the motion vector, we'll only consider static collisions from now on.
+	bool intersected = true;
+	Set<RID> intersected_objects = exclude;
+	while (intersected && result.size() < max_results) {
+		PhysicsDirectSpaceState::ShapeRestInfo info;
+		intersected = dss->rest_info(shape_rid, gt, margin, &info, intersected_objects, collision_mask, collide_with_bodies, collide_with_areas);
+		if (intersected) {
+			result.push_back(info);
+			intersected_objects.insert(info.rid);
+		}
+	}
+	collided = !result.empty();
+}
+
+void ShapeCast::force_shapecast_update() {
+	_update_shapecast_state();
+}
+
+void ShapeCast::add_exception_rid(const RID &p_rid) {
+	exclude.insert(p_rid);
+}
+
+void ShapeCast::add_exception(const Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
+	if (!co) {
+		return;
+	}
+	add_exception_rid(co->get_rid());
+}
+
+void ShapeCast::remove_exception_rid(const RID &p_rid) {
+	exclude.erase(p_rid);
+}
+
+void ShapeCast::remove_exception(const Object *p_object) {
+	ERR_FAIL_NULL(p_object);
+	const CollisionObject *co = Object::cast_to<CollisionObject>(p_object);
+	if (!co) {
+		return;
+	}
+	remove_exception_rid(co->get_rid());
+}
+
+void ShapeCast::clear_exceptions() {
+	exclude.clear();
+}
+
+void ShapeCast::set_collide_with_areas(bool p_clip) {
+	collide_with_areas = p_clip;
+}
+
+bool ShapeCast::is_collide_with_areas_enabled() const {
+	return collide_with_areas;
+}
+
+void ShapeCast::set_collide_with_bodies(bool p_clip) {
+	collide_with_bodies = p_clip;
+}
+
+bool ShapeCast::is_collide_with_bodies_enabled() const {
+	return collide_with_bodies;
+}
+
+Array ShapeCast::_get_collision_result() const {
+	Array ret;
+
+	for (int i = 0; i < result.size(); ++i) {
+		const PhysicsDirectSpaceState::ShapeRestInfo &sri = result[i];
+
+		Dictionary col;
+		col["point"] = sri.point;
+		col["normal"] = sri.normal;
+		col["rid"] = sri.rid;
+		col["collider"] = ObjectDB::get_instance(sri.collider_id);
+		col["collider_id"] = sri.collider_id;
+		col["shape"] = sri.shape;
+		col["linear_velocity"] = sri.linear_velocity;
+
+		ret.push_back(col);
+	}
+	return ret;
+}
+
+void ShapeCast::_update_debug_shape_vertices() {
+	debug_shape_vertices.clear();
+	debug_line_vertices.clear();
+
+	if (!shape.is_null()) {
+		debug_shape_vertices.append_array(shape->get_debug_mesh_lines());
+		for (int i = 0; i < debug_shape_vertices.size(); i++) {
+			debug_shape_vertices.set(i, debug_shape_vertices[i] + Vector3(target_position * get_closest_collision_safe_fraction()));
+		}
+	}
+
+	if (target_position == Vector3()) {
+		return;
+	}
+
+	debug_line_vertices.push_back(Vector3());
+	debug_line_vertices.push_back(target_position);
+}
+
+const Vector<Vector3> &ShapeCast::get_debug_shape_vertices() const {
+	return debug_shape_vertices;
+}
+
+const Vector<Vector3> &ShapeCast::get_debug_line_vertices() const {
+	return debug_line_vertices;
+}
+
+void ShapeCast::set_debug_shape_custom_color(const Color &p_color) {
+	debug_shape_custom_color = p_color;
+	if (debug_material.is_valid()) {
+		_update_debug_shape_material();
+	}
+}
+
+Ref<SpatialMaterial> ShapeCast::get_debug_material() {
+	_update_debug_shape_material();
+	return debug_material;
+}
+
+const Color &ShapeCast::get_debug_shape_custom_color() const {
+	return debug_shape_custom_color;
+}
+
+void ShapeCast::_create_debug_shape() {
+	_update_debug_shape_material();
+
+	Ref<ArrayMesh> mesh = memnew(ArrayMesh);
+
+	MeshInstance *mi = memnew(MeshInstance);
+	mi->set_mesh(mesh);
+
+	add_child(mi);
+	debug_shape = mi;
+}
+
+void ShapeCast::_update_debug_shape_material(bool p_check_collision) {
+	if (!debug_material.is_valid()) {
+		Ref<SpatialMaterial> material = memnew(SpatialMaterial);
+		debug_material = material;
+
+		material->set_flag(SpatialMaterial::FLAG_UNSHADED, true);
+		material->set_feature(SpatialMaterial::FEATURE_TRANSPARENT, true);
+		// Use double-sided rendering so that the RayCast can be seen if the camera is inside.
+		material->set_cull_mode(SpatialMaterial::CULL_DISABLED);
+	}
+
+	Color color = debug_shape_custom_color;
+	if (color == Color(0.0, 0.0, 0.0)) {
+		// Use the default debug shape color defined in the Project Settings.
+		color = get_tree()->get_debug_collisions_color();
+	}
+
+	if (p_check_collision && collided) {
+		if ((color.get_h() < 0.055 || color.get_h() > 0.945) && color.get_s() > 0.5 && color.get_v() > 0.5) {
+			// If base color is already quite reddish, highlight collision with green color
+			color = Color(0.0, 1.0, 0.0, color.a);
+		} else {
+			// Else, highlight collision with red color
+			color = Color(1.0, 0, 0, color.a);
+		}
+	}
+
+	Ref<SpatialMaterial> material = static_cast<Ref<SpatialMaterial>>(debug_material);
+	material->set_albedo(color);
+}
+
+void ShapeCast::_update_debug_shape() {
+	if (!enabled) {
+		return;
+	}
+
+	if (!debug_shape) {
+		_create_debug_shape();
+	}
+
+	_update_debug_shape_vertices();
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
+	MeshInstance *mi = static_cast<MeshInstance *>(debug_shape);
+	Ref<ArrayMesh> mesh = mi->get_mesh();
+	if (!mesh.is_valid()) {
+		return;
+	}
+
+	mesh->clear_surfaces();
+
+	Array a;
+	a.resize(Mesh::ARRAY_MAX);
+
+	uint32_t flags = 0;
+	int surface_count = 0;
+
+	if (!debug_shape_vertices.empty()) {
+		a[Mesh::ARRAY_VERTEX] = debug_shape_vertices;
+		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, a, Array(), flags);
+		mesh->surface_set_material(surface_count, debug_material);
+		++surface_count;
+	}
+
+	if (!debug_line_vertices.empty()) {
+		a[Mesh::ARRAY_VERTEX] = debug_line_vertices;
+		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, a, Array(), flags);
+		mesh->surface_set_material(surface_count, debug_material);
+		++surface_count;
+	}
+}
+
+void ShapeCast::_clear_debug_shape() {
+	if (!debug_shape) {
+		return;
+	}
+
+	MeshInstance *mi = static_cast<MeshInstance *>(debug_shape);
+	if (mi->is_inside_tree()) {
+		mi->queue_delete();
+	} else {
+		memdelete(mi);
+	}
+
+	debug_shape = nullptr;
+}
+
+ShapeCast::~ShapeCast() {
+	if (!shape.is_null()) {
+		shape->unregister_owner(this);
+	}
+}

--- a/scene/3d/shape_cast.h
+++ b/scene/3d/shape_cast.h
@@ -1,0 +1,142 @@
+/*************************************************************************/
+/*  shape_cast.h                                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SHAPE_CAST_H
+#define SHAPE_CAST_H
+
+#include "scene/3d/spatial.h"
+#include "scene/resources/shape.h"
+
+class ShapeCast : public Spatial {
+	GDCLASS(ShapeCast, Spatial);
+
+	bool enabled = true;
+	void resource_changed(Ref<Resource> p_res);
+
+	Ref<Shape> shape;
+	RID shape_rid;
+	Vector3 target_position = Vector3(0, -1, 0);
+
+	Set<RID> exclude;
+	real_t margin = 0.0;
+	uint32_t collision_mask = 1;
+	bool exclude_parent_body = true;
+	bool collide_with_areas = false;
+	bool collide_with_bodies = true;
+
+	Node *debug_shape = nullptr;
+	Ref<Material> debug_material;
+	Color debug_shape_custom_color = Color(0.0, 0.0, 0.0);
+	Vector<Vector3> debug_shape_vertices;
+	Vector<Vector3> debug_line_vertices;
+
+	void _create_debug_shape();
+	void _update_debug_shape();
+	void _update_debug_shape_material(bool p_check_collision = false);
+	void _update_debug_shape_vertices();
+	void _clear_debug_shape();
+
+	// Result
+	int max_results = 32;
+	Vector<PhysicsDirectSpaceState::ShapeRestInfo> result;
+	bool collided = false;
+	real_t collision_safe_fraction = 1.0;
+	real_t collision_unsafe_fraction = 1.0;
+
+	Array _get_collision_result() const;
+
+	~ShapeCast();
+
+protected:
+	void _notification(int p_what);
+	void _update_shapecast_state();
+	static void _bind_methods();
+
+public:
+	void set_collide_with_areas(bool p_clip);
+	bool is_collide_with_areas_enabled() const;
+
+	void set_collide_with_bodies(bool p_clip);
+	bool is_collide_with_bodies_enabled() const;
+
+	void set_enabled(bool p_enabled);
+	bool is_enabled() const;
+
+	void set_shape(const Ref<Shape> &p_shape);
+	Ref<Shape> get_shape() const;
+
+	void set_target_position(const Vector3 &p_point);
+	Vector3 get_target_position() const;
+
+	void set_margin(real_t p_margin);
+	real_t get_margin() const;
+
+	void set_max_results(int p_max_results);
+	int get_max_results() const;
+
+	void set_collision_mask(uint32_t p_mask);
+	uint32_t get_collision_mask() const;
+
+	void set_collision_mask_value(int p_layer_number, bool p_value);
+	bool get_collision_mask_value(int p_layer_number) const;
+
+	void set_exclude_parent_body(bool p_exclude_parent_body);
+	bool get_exclude_parent_body() const;
+
+	const Color &get_debug_shape_custom_color() const;
+	void set_debug_shape_custom_color(const Color &p_color);
+
+	const Vector<Vector3> &get_debug_shape_vertices() const;
+	const Vector<Vector3> &get_debug_line_vertices() const;
+
+	Ref<SpatialMaterial> get_debug_material();
+
+	int get_collision_count() const;
+	Object *get_collider(int p_idx) const;
+	int get_collider_shape(int p_idx) const;
+	Vector3 get_collision_point(int p_idx) const;
+	Vector3 get_collision_normal(int p_idx) const;
+
+	real_t get_closest_collision_safe_fraction() const;
+	real_t get_closest_collision_unsafe_fraction() const;
+
+	void force_shapecast_update();
+	bool is_colliding() const;
+
+	void add_exception_rid(const RID &p_rid);
+	void add_exception(const Object *p_object);
+	void remove_exception_rid(const RID &p_rid);
+	void remove_exception(const Object *p_object);
+	void clear_exceptions();
+
+	virtual String get_configuration_warning() const;
+};
+
+#endif // SHAPE_CAST_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -62,6 +62,7 @@
 #include "scene/2d/position_2d.h"
 #include "scene/2d/ray_cast_2d.h"
 #include "scene/2d/remote_transform_2d.h"
+#include "scene/2d/shape_cast_2d.h"
 #include "scene/2d/skeleton_2d.h"
 #include "scene/2d/sprite.h"
 #include "scene/2d/tile_map.h"
@@ -213,6 +214,7 @@
 #include "scene/3d/room.h"
 #include "scene/3d/room_group.h"
 #include "scene/3d/room_manager.h"
+#include "scene/3d/shape_cast.h"
 #include "scene/3d/skeleton.h"
 #include "scene/3d/soft_body.h"
 #include "scene/3d/spring_arm.h"
@@ -490,6 +492,7 @@ void register_scene_types() {
 	ClassDB::register_class<CollisionShape>();
 	ClassDB::register_class<CollisionPolygon>();
 	ClassDB::register_class<RayCast>();
+	ClassDB::register_class<ShapeCast>();
 	ClassDB::register_class<MultiMeshInstance>();
 
 	ClassDB::register_class<Curve3D>();
@@ -610,6 +613,7 @@ void register_scene_types() {
 	ClassDB::register_class<CollisionShape2D>();
 	ClassDB::register_class<CollisionPolygon2D>();
 	ClassDB::register_class<RayCast2D>();
+	ClassDB::register_class<ShapeCast2D>();
 	ClassDB::register_class<VisibilityNotifier2D>();
 	ClassDB::register_class<VisibilityEnabler2D>();
 	ClassDB::register_class<Polygon2D>();


### PR DESCRIPTION
Adds a high-level wrapper around direct space state shape cast calls.

Tested and works in both Bullet and GodotPhysics.

`3.x` backport of https://github.com/godotengine/godot/pull/63161 and https://github.com/godotengine/godot/pull/54803.