### PR TITLE
Add `editor_paths.h` include missing in mono module

### DIFF
--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -39,6 +39,7 @@
 #include "core/version.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_node.h"
+#include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "main/main.h"


### PR DESCRIPTION
Follow-up to #63603
