### PR TITLE
added `unload_current_scene` to SceneTree and removed ability for `change_scene_to` to continue when provided `null`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -204,6 +204,14 @@
 				Sets a custom [MultiplayerAPI] with the given [code]root_path[/code] (controlling also the relative subpaths), or override the default one if [code]root_path[/code] is empty.
 			</description>
 		</method>
+		<method name="unload_current_scene">
+			<return type="int" enum="Error" />
+			<description>
+				Unloads the currently active scene.
+				Returns [constant OK] on success, or [constant ERR_UNCONFIGURED] if no [member current_scene] has been defined yet.
+				[b]Note:[/b] This method cannot be used if the active scene and all its children are not yet ready.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="auto_accept_quit" type="bool" setter="set_auto_accept_quit" getter="is_auto_accept_quit" default="true">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1135,11 +1135,10 @@ Error SceneTree::change_scene(const String &p_path) {
 }
 
 Error SceneTree::change_scene_to(const Ref<PackedScene> &p_scene) {
-	Node *new_scene = nullptr;
-	if (p_scene.is_valid()) {
-		new_scene = p_scene->instantiate();
-		ERR_FAIL_COND_V(!new_scene, ERR_CANT_CREATE);
-	}
+	ERR_FAIL_NULL_V(p_scene, ERR_CANT_CREATE);
+
+	Node *new_scene = p_scene->instantiate();
+	ERR_FAIL_COND_V(!new_scene, ERR_CANT_CREATE);
 
 	call_deferred(SNAME("_change_scene"), new_scene);
 	return OK;
@@ -1149,6 +1148,15 @@ Error SceneTree::reload_current_scene() {
 	ERR_FAIL_COND_V(!current_scene, ERR_UNCONFIGURED);
 	String fname = current_scene->get_scene_file_path();
 	return change_scene(fname);
+}
+
+Error SceneTree::unload_current_scene() {
+	ERR_FAIL_COND_V(!current_scene, ERR_UNCONFIGURED);
+
+	memdelete(current_scene);
+	current_scene = nullptr;
+
+	return OK;
 }
 
 void SceneTree::add_current_scene(Node *p_current) {
@@ -1299,6 +1307,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("change_scene_to", "packed_scene"), &SceneTree::change_scene_to);
 
 	ClassDB::bind_method(D_METHOD("reload_current_scene"), &SceneTree::reload_current_scene);
+	ClassDB::bind_method(D_METHOD("unload_current_scene"), &SceneTree::unload_current_scene);
 
 	ClassDB::bind_method(D_METHOD("_change_scene"), &SceneTree::_change_scene);
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -236,7 +236,9 @@ public:
 		GROUP_CALL_UNIQUE = 4,
 	};
 
-	_FORCE_INLINE_ Window *get_root() const { return root; }
+	_FORCE_INLINE_ Window *get_root() const {
+		return root;
+	}
 
 	void call_group_flagsp(uint32_t p_call_flags, const StringName &p_group, const StringName &p_function, const Variant **p_args, int p_argcount);
 	void notify_group_flags(uint32_t p_call_flags, const StringName &p_group, int p_notification);
@@ -285,13 +287,19 @@ public:
 
 	void quit(int p_exit_code = EXIT_SUCCESS);
 
-	_FORCE_INLINE_ double get_physics_process_time() const { return physics_process_time; }
-	_FORCE_INLINE_ double get_process_time() const { return process_time; }
+	_FORCE_INLINE_ double get_physics_process_time() const {
+		return physics_process_time;
+	}
+	_FORCE_INLINE_ double get_process_time() const {
+		return process_time;
+	}
 
 #ifdef TOOLS_ENABLED
 	bool is_node_being_edited(const Node *p_node) const;
 #else
-	bool is_node_being_edited(const Node *p_node) const { return false; }
+	bool is_node_being_edited(const Node *p_node) const {
+		return false;
+	}
 #endif
 
 	void set_pause(bool p_enabled);
@@ -308,13 +316,19 @@ public:
 	bool is_debugging_navigation_hint() const;
 #else
 	void set_debug_collisions_hint(bool p_enabled) {}
-	bool is_debugging_collisions_hint() const { return false; }
+	bool is_debugging_collisions_hint() const {
+		return false;
+	}
 
 	void set_debug_paths_hint(bool p_enabled) {}
-	bool is_debugging_paths_hint() const { return false; }
+	bool is_debugging_paths_hint() const {
+		return false;
+	}
 
 	void set_debug_navigation_hint(bool p_enabled) {}
-	bool is_debugging_navigation_hint() const { return false; }
+	bool is_debugging_navigation_hint() const {
+		return false;
+	}
 #endif
 
 	void set_debug_collisions_color(const Color &p_color);
@@ -341,7 +355,9 @@ public:
 	Ref<Material> get_debug_collision_material();
 	Ref<ArrayMesh> get_debug_contact_mesh();
 
-	int get_collision_debug_contact_count() { return collision_debug_contacts; }
+	int get_collision_debug_contact_count() {
+		return collision_debug_contacts;
+	}
 
 	int64_t get_frame() const;
 
@@ -364,6 +380,7 @@ public:
 	Error change_scene(const String &p_path);
 	Error change_scene_to(const Ref<PackedScene> &p_scene);
 	Error reload_current_scene();
+	Error unload_current_scene();
 
 	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true);
 	Ref<Tween> create_tween();
@@ -372,7 +389,9 @@ public:
 	//used by Main::start, don't use otherwise
 	void add_current_scene(Node *p_current);
 
-	static SceneTree *get_singleton() { return singleton; }
+	static SceneTree *get_singleton() {
+		return singleton;
+	}
 
 	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 


### PR DESCRIPTION
This is the bigger half of the change mentioned in #63565 - this introduces a check for `null` on `change_scene_to` (it provides the same error of `ERR_CANT_CREATE` as if it were unable to instantiate the PackedScene). 

In order to provide the same functionality as that code, `unload_current_scene` was added which just nukes `current_scene`. Based on my working through the code, it seems like that was originally the path if `change_scene_to` was given a null value.

This is my first time interacting with the source code in anything more than a minor capacity, so comments and suggestions are absolutely welcome and encouraged, of course. I wouldn't be surprised if it could use some work to be in line with spec.

Thanks!
