### PR TITLE
Remove some MeshLibrary editor updates

### DIFF
--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -122,7 +122,6 @@ void MeshLibrary::set_item_name(int p_item, const String &p_name) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].name = p_name;
 	emit_changed();
-	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
@@ -138,7 +137,6 @@ void MeshLibrary::set_item_mesh_transform(int p_item, const Transform3D &p_trans
 	item_map[p_item].mesh_transform = p_transform;
 	notify_change_to_owners();
 	emit_changed();
-	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes) {
@@ -164,7 +162,6 @@ void MeshLibrary::set_item_navmesh_transform(int p_item, const Transform3D &p_tr
 	item_map[p_item].navmesh_transform = p_transform;
 	notify_change_to_owners();
 	emit_changed();
-	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {


### PR DESCRIPTION
The properties for which the `notify_property_list_changed()` call were removed, had issues with caret placing and tab navigation.
Since other node editors do not call this notify on all setters, it is assumed that removing them on certain fields should not impair any functionality.
See f.e. navigation_mesh.cpp `set_source_group_name` vs `set_source_geometry_mode`.

Fixes #63549 