### PR TITLE
Fix `ShapeCast3D` creating runtime shape in editor

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -2569,8 +2569,11 @@ void ShapeCast3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	const Ref<StandardMaterial3D> material = shapecast->is_enabled() ? shapecast->get_debug_material() : get_material("shape_material_disabled");
 
-	p_gizmo->add_lines(shapecast->get_debug_shape_vertices(), material);
 	p_gizmo->add_lines(shapecast->get_debug_line_vertices(), material);
+
+	if (shapecast->get_shape().is_valid()) {
+		p_gizmo->add_lines(shapecast->get_debug_shape_vertices(), material);
+	}
 
 	p_gizmo->add_collision_segments(shapecast->get_debug_line_vertices());
 }

--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -577,13 +577,17 @@ void ShapeCast3D::_update_debug_shape() {
 		_create_debug_shape();
 	}
 
+	_update_debug_shape_vertices();
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
 	MeshInstance3D *mi = static_cast<MeshInstance3D *>(debug_shape);
 	Ref<ArrayMesh> mesh = mi->get_mesh();
 	if (!mesh.is_valid()) {
 		return;
 	}
-
-	_update_debug_shape_vertices();
 
 	mesh->clear_surfaces();
 


### PR DESCRIPTION
Fixes `ShapeCast3D` creating its runtime debug mesh in the editor, resulting in 2 debug shapes overlapping.
