### PR TITLE
Add editor setting to make following links add to history in script editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -521,6 +521,9 @@
 		</member>
 		<member name="text_editor/behavior/files/trim_trailing_whitespace_on_save" type="bool" setter="" getter="">
 		</member>
+		<member name="text_editor/behavior/history/following_links_always_saves_to_history" type="bool" setter="" getter="">
+			If enabled, following a link in the text editor will always save to the editor history, even if the link doesn't lead to a new tab.
+		</member>
 		<member name="text_editor/behavior/indent/auto_indent" type="bool" setter="" getter="">
 		</member>
 		<member name="text_editor/behavior/indent/size" type="int" setter="" getter="">

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -139,7 +139,14 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		if (table->has(link)) {
 			// Found in the current page.
 			if (class_desc->is_ready()) {
+				bool save_history = EDITOR_GET("text_editor/behavior/history/following_links_always_saves_to_history");
+				if (save_history) {
+					emit_signal(SNAME("request_update_current_history_state"));
+				}
 				class_desc->scroll_to_paragraph((*table)[link]);
+				if (save_history) {
+					emit_signal(SNAME("request_save_new_history_state"));
+				}
 			} else {
 				scroll_to = (*table)[link];
 			}
@@ -2073,6 +2080,8 @@ void EditorHelp::_bind_methods() {
 	ClassDB::bind_method("_help_callback", &EditorHelp::_help_callback);
 
 	ADD_SIGNAL(MethodInfo("go_to_help"));
+	ADD_SIGNAL(MethodInfo("request_update_current_history_state"));
+	ADD_SIGNAL(MethodInfo("request_save_new_history_state"));
 }
 
 EditorHelp::EditorHelp() {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -558,6 +558,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/convert_indent_on_save", true);
 	_initial_set("text_editor/behavior/files/auto_reload_scripts_on_external_change", false);
 
+	// Behavior: History
+	_initial_set("text_editor/behavior/history/following_links_always_saves_to_history", false);
+
 	// Script list
 	_initial_set("text_editor/script_list/show_members_overview", true);
 	_initial_set("text_editor/script_list/sort_members_outline_alphabetically", false);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -307,6 +307,7 @@ class ScriptEditor : public PanelContainer {
 
 	Vector<ScriptHistory> history;
 	int history_pos;
+	int history_save_depth = 0;
 
 	List<String> previous_scripts;
 	List<int> script_close_queue;
@@ -441,7 +442,8 @@ class ScriptEditor : public PanelContainer {
 	void _help_class_goto(const String &p_desc);
 	bool _help_tab_goto(const String &p_name, const String &p_desc);
 	void _update_history_arrows();
-	void _save_history();
+	void _update_current_history_state();
+	void _save_new_history_state();
 	void _go_to_tab(int p_idx);
 	void _update_history_pos(int p_new_pos);
 	void _update_script_colors();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -810,11 +810,19 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 
 		switch (result.type) {
 			case ScriptLanguage::LOOKUP_RESULT_SCRIPT_LOCATION: {
+				bool save_history = EDITOR_GET("text_editor/behavior/history/following_links_always_saves_to_history");
+				if (save_history) {
+					emit_signal(SNAME("request_update_current_history_state"));
+				}
 				if (result.script.is_valid()) {
 					emit_signal(SNAME("request_open_script_at_line"), result.script, result.location - 1);
+
 				} else {
-					emit_signal(SNAME("request_save_history"));
+					// This used to always save history, I'm not sure why.
 					goto_line_centered(result.location - 1);
+				}
+				if (save_history) {
+					emit_signal(SNAME("request_save_new_history_state"));
 				}
 			} break;
 			case ScriptLanguage::LOOKUP_RESULT_CLASS: {


### PR DESCRIPTION
Implements (main proposal in) godotengine/godot-proposals#4462, and should be combinable with #63515 with not much effort.

Add editor setting to enable following links to add to history, even if the link lands on the same page. This effects both script editor and help tabs.

The addition of a "history save depth" should allow different saving behaviours to coexist, so more could be added as toggelable options. (History save depth also fixes #63681.)