### PR TITLE
[3.x] Fix Translated method in C# affecting the original transform

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform.cs
@@ -241,9 +241,9 @@ namespace Godot
         {
             return new Transform(basis, new Vector3
             (
-                origin[0] += basis.Row0.Dot(offset),
-                origin[1] += basis.Row1.Dot(offset),
-                origin[2] += basis.Row2.Dot(offset)
+                origin[0] + basis.Row0.Dot(offset),
+                origin[1] + basis.Row1.Dot(offset),
+                origin[2] + basis.Row2.Dot(offset)
             ));
         }
 


### PR DESCRIPTION
This bug was discovered by @bluenote10, thanks! https://github.com/godotengine/godot/pull/55923#discussion_r933804096