### PR TITLE
Fix default values for rotation snapping in canvas_item_editor_plugin.cpp

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -214,8 +214,8 @@ private:
 	int primary_grid_steps = 8;
 	int grid_step_multiplier = 0;
 
-	real_t snap_rotation_step = 0.0;
-	real_t snap_rotation_offset = Math::deg2rad(15.0);
+	real_t snap_rotation_step = Math::deg2rad(15.0);
+	real_t snap_rotation_offset = 0.0;
 	real_t snap_scale_step = 0.1f;
 	bool smart_snap_active = false;
 	bool grid_snap_active = false;


### PR DESCRIPTION
Default values for snap_rotation_step and snap_rotation_offset were transposed. Swap them back.

Fixes #63674.