### PR TITLE
Fix backwards input in skeleton modification stack

### DIFF
--- a/scene/resources/skeleton_modification_3d_lookat.cpp
+++ b/scene/resources/skeleton_modification_3d_lookat.cpp
@@ -149,7 +149,6 @@ void SkeletonModification3DLookAt::set_bone_name(String p_name) {
 		}
 	}
 	execution_error_found = false;
-	notify_property_list_changed();
 }
 
 String SkeletonModification3DLookAt::get_bone_name() const {

--- a/scene/resources/skeleton_modification_3d_twoboneik.cpp
+++ b/scene/resources/skeleton_modification_3d_twoboneik.cpp
@@ -490,7 +490,6 @@ void SkeletonModification3DTwoBoneIK::set_joint_one_bone_name(String p_bone_name
 		joint_one_bone_idx = stack->skeleton->find_bone(p_bone_name);
 	}
 	execution_error_found = false;
-	notify_property_list_changed();
 }
 
 String SkeletonModification3DTwoBoneIK::get_joint_one_bone_name() const {
@@ -524,7 +523,6 @@ void SkeletonModification3DTwoBoneIK::set_joint_two_bone_name(String p_bone_name
 		joint_two_bone_idx = stack->skeleton->find_bone(p_bone_name);
 	}
 	execution_error_found = false;
-	notify_property_list_changed();
 }
 
 String SkeletonModification3DTwoBoneIK::get_joint_two_bone_name() const {


### PR DESCRIPTION
Fixes #62876

Problem was also in SkeletonModification3DTwoBoneIK since bone_name setters work the same there. With these editor updates removed input works normal and still updates the editor values.

Related PR: #63667 (same problem)