### PR TITLE
Show main window using SW_SHOWNORMAL the first time, fixing maximizing problem

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3740,7 +3740,14 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		}
 	}
 
-	show_window(MAIN_WINDOW_ID);
+	WindowData &wd = windows[main_window];
+
+	// As specified in https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow,
+	// the ShowWindow's flag must be "SW_SHOWNORMAL" when displaying the window for the first time.
+	// Not doing this may cause some bugs, like preventing window from getting maximized after a MoveWindow.
+	ShowWindow(wd.hWnd, SW_SHOWNORMAL);
+	SetForegroundWindow(wd.hWnd); // Slightly higher priority.
+	SetFocus(wd.hWnd); // Set keyboard focus.
 
 #if defined(VULKAN_ENABLED)
 


### PR DESCRIPTION
Fixes #57662

As specified in the [ShowWindow docs](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow), the first time a window is shown, it should be using the `SW_SHOWNORMAL` flag.

Not using this flag causes some weird bugs, notably preventing the window from being maximized after a `MoveWindow` call, causing the issue linked above.