### PR TITLE
Fix elements not being shown on first selected script/doc

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2154,8 +2154,11 @@ void ScriptEditor::_update_script_names() {
 		}
 		if (tab_container->get_current_tab() == sedata_filtered[i].index) {
 			script_list->select(index);
+			_script_selected(index);
+
 			script_name_label->set_text(sedata_filtered[i].name);
 			script_icon->set_texture(sedata_filtered[i].icon);
+
 			ScriptEditorBase *se = _get_current_editor();
 			if (se) {
 				se->enable_editor();


### PR DESCRIPTION
Before, the first selected script/doc in the Sxript editor would not trigger the update of the property list, making it showing up completely empty.

Finishes fixing #47030.