### PR TITLE
Add operator `*` to `Plane`

### DIFF
--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -341,6 +341,8 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorXFormInv<Vector3, Vector3, Transform3D>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::TRANSFORM3D);
 	register_op<OperatorEvaluatorXForm<::AABB, Transform3D, ::AABB>>(Variant::OP_MULTIPLY, Variant::TRANSFORM3D, Variant::AABB);
 	register_op<OperatorEvaluatorXFormInv<::AABB, ::AABB, Transform3D>>(Variant::OP_MULTIPLY, Variant::AABB, Variant::TRANSFORM3D);
+	register_op<OperatorEvaluatorXForm<Plane, Transform3D, Plane>>(Variant::OP_MULTIPLY, Variant::TRANSFORM3D, Variant::PLANE);
+	register_op<OperatorEvaluatorXFormInv<Plane, Plane, Transform3D>>(Variant::OP_MULTIPLY, Variant::PLANE, Variant::TRANSFORM3D);
 	register_op<OperatorEvaluatorXForm<Vector<Vector3>, Transform3D, Vector<Vector3>>>(Variant::OP_MULTIPLY, Variant::TRANSFORM3D, Variant::PACKED_VECTOR3_ARRAY);
 	register_op<OperatorEvaluatorXFormInv<Vector<Vector3>, Vector<Vector3>, Transform3D>>(Variant::OP_MULTIPLY, Variant::PACKED_VECTOR3_ARRAY, Variant::TRANSFORM3D);
 

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -179,6 +179,13 @@
 				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
 			</description>
 		</operator>
+		<operator name="operator *">
+			<return type="Plane" />
+			<argument index="0" name="right" type="Transform3D" />
+			<description>
+				Inversely transforms (multiplies) the [Plane] by the given [Transform3D] transformation matrix.
+			</description>
+		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<argument index="0" name="right" type="Plane" />

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -175,6 +175,13 @@
 			</description>
 		</operator>
 		<operator name="operator *">
+			<return type="Plane" />
+			<argument index="0" name="right" type="Plane" />
+			<description>
+				Transforms (multiplies) the [Plane] by the given [Transform3D] transformation matrix.
+			</description>
+		</operator>
+		<operator name="operator *">
 			<return type="Transform3D" />
 			<argument index="0" name="right" type="Transform3D" />
 			<description>


### PR DESCRIPTION
Adds the asterisk (`*`) operator to the Plane class. It does the same thing that `Transform.xform(plane)` does in `3.x`. 

Fixes https://github.com/godotengine/godot/issues/63489.
