### PR TITLE
Fix Navigation Debug always enabled

### DIFF
--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -209,7 +209,7 @@ public:
 	virtual ~NavigationServer3D();
 
 #ifdef DEBUG_ENABLED
-	bool debug_enabled = true;
+	bool debug_enabled = false;
 	bool debug_dirty = true;
 	void _emit_navigation_debug_changed_signal();
 


### PR DESCRIPTION
Fixes that the new Navigation Debug is always enabled in Godot debug builds.
Should only get enabled inside Editor or when "Visible Navigation" is turned on for test runs.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
