### PR TITLE
Removed faulty function update after get_property_list.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -472,7 +472,6 @@ Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) co
 
 void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) const {
 	if (script_instance && p_reversed) {
-		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
 		script_instance->get_property_list(p_list);
 	}
 
@@ -503,7 +502,6 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	}
 
 	if (script_instance && !p_reversed) {
-		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
 		script_instance->get_property_list(p_list);
 	}
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -101,6 +101,31 @@ Dictionary Script::_get_script_constant_map() {
 	return ret;
 }
 
+#ifdef TOOLS_ENABLED
+
+PropertyInfo Script::get_class_category() const {
+	String path = get_path();
+	String name;
+
+	if (is_built_in()) {
+		if (get_name().is_empty()) {
+			name = TTR("Built-in script");
+		} else {
+			name = vformat("%s (%s)", get_name(), TTR("Built-in"));
+		}
+	} else {
+		if (get_name().is_empty()) {
+			name = path.get_file();
+		} else {
+			name = get_name();
+		}
+	}
+
+	return PropertyInfo(Variant::NIL, name, PROPERTY_HINT_NONE, path, PROPERTY_USAGE_CATEGORY);
+}
+
+#endif // TOOLS_ENABLED
+
 void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &Script::can_instantiate);
 	//ClassDB::bind_method(D_METHOD("instance_create","base_object"),&Script::instance_create);

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -132,6 +132,7 @@ public:
 
 #ifdef TOOLS_ENABLED
 	virtual Vector<DocData::ClassDoc> get_documentation() const = 0;
+	virtual PropertyInfo get_class_category() const;
 #endif // TOOLS_ENABLED
 
 	virtual bool has_method(const StringName &p_method) const = 0;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -663,6 +663,14 @@ public:
 		if (native_info->get_property_list_func) {
 			uint32_t pcount;
 			const GDNativePropertyInfo *pinfo = native_info->get_property_list_func(instance, &pcount);
+
+#ifdef TOOLS_ENABLED
+			Ref<Script> script = get_script();
+			if (script->is_valid() && pcount > 0) {
+				p_list->push_back(script->get_class_category());
+			}
+#endif // TOOLS_ENABLED
+
 			for (uint32_t i = 0; i < pcount; i++) {
 				p_list->push_back(PropertyInfo(pinfo[i]));
 			}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2539,7 +2539,6 @@ void EditorInspector::update_tree() {
 
 	List<PropertyInfo> plist;
 	object->get_property_list(&plist, true);
-	_update_script_class_properties(*object, plist);
 
 	HashMap<VBoxContainer *, HashMap<String, VBoxContainer *>> vbox_per_path;
 	HashMap<String, EditorInspectorArray *> editor_inspector_array_per_prefix;
@@ -2624,6 +2623,7 @@ void EditorInspector::update_tree() {
 			category_vbox = nullptr; //reset
 
 			String type = p.name;
+			String label = p.name;
 			type_name = p.name;
 
 			// Set the category icon.
@@ -2631,11 +2631,16 @@ void EditorInspector::update_tree() {
 				// If we have a category inside a script, search for the first script with a valid icon.
 				Ref<Script> script = ResourceLoader::load(p.hint_string, "Script");
 				StringName base_type;
+				StringName name;
 				if (script.is_valid()) {
 					base_type = script->get_instance_base_type();
+					name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
+					if (name != StringName() && label != name) {
+						label = name;
+					}
 				}
 				while (script.is_valid()) {
-					StringName name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
+					name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
 					String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
 					if (name != StringName() && icon_path.length()) {
 						category->icon = ResourceLoader::load(icon_path, "Texture");
@@ -2654,7 +2659,7 @@ void EditorInspector::update_tree() {
 			}
 
 			// Set the category label.
-			category->label = type;
+			category->label = label;
 
 			if (use_doc_hints) {
 				// Sets the category tooltip to show documentation.
@@ -3757,93 +3762,6 @@ String EditorInspector::get_object_class() const {
 
 void EditorInspector::_feature_profile_changed() {
 	update_tree();
-}
-
-void EditorInspector::_update_script_class_properties(const Object &p_object, List<PropertyInfo> &r_list) const {
-	Ref<Script> script = p_object.get_script();
-	if (script.is_null()) {
-		return;
-	}
-
-	List<Ref<Script>> classes;
-
-	// NodeC -> NodeB -> NodeA
-	while (script.is_valid()) {
-		classes.push_front(script);
-		script = script->get_base_script();
-	}
-
-	if (classes.is_empty()) {
-		return;
-	}
-
-	// Script Variables -> to insert: NodeC..B..A -> bottom (insert_here)
-	List<PropertyInfo>::Element *script_variables = nullptr;
-	List<PropertyInfo>::Element *bottom = nullptr;
-	List<PropertyInfo>::Element *insert_here = nullptr;
-	for (List<PropertyInfo>::Element *E = r_list.front(); E; E = E->next()) {
-		PropertyInfo &pi = E->get();
-		if (pi.name != "Script Variables") {
-			continue;
-		}
-		script_variables = E;
-		bottom = r_list.insert_after(script_variables, PropertyInfo());
-		insert_here = bottom;
-		break;
-	}
-
-	HashSet<StringName> added;
-	for (const Ref<Script> &s : classes) {
-		String path = s->get_path();
-		String name = EditorNode::get_editor_data().script_class_get_name(path);
-		if (name.is_empty()) {
-			if (s->is_built_in()) {
-				if (s->get_name().is_empty()) {
-					name = TTR("Built-in script");
-				} else {
-					name = vformat("%s (%s)", s->get_name(), TTR("Built-in"));
-				}
-			} else {
-				name = path.get_file();
-			}
-		}
-
-		List<PropertyInfo> props;
-		s->get_script_property_list(&props);
-
-		// Script Variables -> NodeA -> bottom (insert_here)
-		List<PropertyInfo>::Element *category = r_list.insert_before(insert_here, PropertyInfo(Variant::NIL, name, PROPERTY_HINT_NONE, path, PROPERTY_USAGE_CATEGORY));
-
-		// Script Variables -> NodeA -> A props... -> bottom (insert_here)
-		for (List<PropertyInfo>::Element *P = props.front(); P; P = P->next()) {
-			PropertyInfo &pi = P->get();
-			if (added.has(pi.name)) {
-				continue;
-			}
-			added.insert(pi.name);
-
-			r_list.insert_before(insert_here, pi);
-
-			List<PropertyInfo>::Element *prop_below = bottom->next();
-			while (prop_below) {
-				if (prop_below->get() == pi) {
-					List<PropertyInfo>::Element *to_delete = prop_below;
-					prop_below = prop_below->next();
-					r_list.erase(to_delete);
-				} else {
-					prop_below = prop_below->next();
-				}
-			}
-		}
-
-		// Script Variables -> NodeA (insert_here) -> A props... -> bottom
-		insert_here = category;
-	}
-
-	if (script_variables) {
-		r_list.erase(script_variables);
-		r_list.erase(bottom);
-	}
 }
 
 void EditorInspector::set_restrict_to_basic_settings(bool p_restrict) {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -528,7 +528,6 @@ class EditorInspector : public ScrollContainer {
 	void _vscroll_changed(double);
 
 	void _feature_profile_changed();
-	void _update_script_class_properties(const Object &p_object, List<PropertyInfo> &r_list) const;
 
 	bool _is_property_disabled_by_feature_profile(const StringName &p_property);
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -325,15 +325,22 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 		for (int i = 0; i < msort.size(); i++) {
 			props.push_front(sptr->member_info[msort[i].name]);
 		}
+
+#ifdef TOOLS_ENABLED
+		r_list->push_back(sptr->get_class_category());
+#endif // TOOLS_ENABLED
+
+		for (const PropertyInfo &E : props) {
+			r_list->push_back(E);
+		}
+
+		props.clear();
+
 		if (!p_include_base) {
 			break;
 		}
 
 		sptr = sptr->_base;
-	}
-
-	for (const PropertyInfo &E : props) {
-		r_list->push_back(E);
 	}
 }
 
@@ -434,16 +441,16 @@ void GDScript::set_source_code(const String &p_code) {
 
 #ifdef TOOLS_ENABLED
 void GDScript::_update_exports_values(HashMap<StringName, Variant> &values, List<PropertyInfo> &propnames) {
-	if (base_cache.is_valid()) {
-		base_cache->_update_exports_values(values, propnames);
-	}
-
 	for (const KeyValue<StringName, Variant> &E : member_default_values_cache) {
 		values[E.key] = E.value;
 	}
 
 	for (const PropertyInfo &E : members_cache) {
 		propnames.push_back(E);
+	}
+
+	if (base_cache.is_valid()) {
+		base_cache->_update_exports_values(values, propnames);
 	}
 }
 
@@ -703,6 +710,8 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 			member_default_values_cache.clear();
 			_signals.clear();
 
+			members_cache.push_back(get_class_category());
+
 			for (int i = 0; i < c->members.size(); i++) {
 				const GDScriptParser::ClassNode::Member &member = c->members[i];
 
@@ -727,6 +736,9 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 							parameters_names.write[j] = member.signal->parameters[j]->identifier->name;
 						}
 						_signals[member.signal->identifier->name] = parameters_names;
+					} break;
+					case GDScriptParser::ClassNode::Member::GROUP: {
+						members_cache.push_back(member.annotation->export_info);
 					} break;
 					default:
 						break; // Nothing.
@@ -1510,11 +1522,17 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 			props.push_front(sptr->member_info[msort[i].name]);
 		}
 
-		sptr = sptr->_base;
-	}
+#ifdef TOOLS_ENABLED
+		p_properties->push_back(sptr->get_class_category());
+#endif // TOOLS_ENABLED
 
-	for (const PropertyInfo &E : props) {
-		p_properties->push_back(E);
+		for (const PropertyInfo &prop : props) {
+			p_properties->push_back(prop);
+		}
+
+		props.clear();
+
+		sptr = sptr->_base;
 	}
 }
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1206,6 +1206,10 @@ bool VisualScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void VisualScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
+#ifdef TOOLS_ENABLED
+	p_properties->push_back(script->get_class_category());
+#endif // TOOLS_ENABLED
+
 	for (const KeyValue<StringName, VisualScript::Variable> &E : script->variables) {
 		if (!E.value._export) {
 			continue;


### PR DESCRIPTION
The function tried to rearrange properties but that lead to problems with duplication or deleted properties. Implemented the logic that that function did inside the get_property_list both for tool scripts and non-tool scripts.

Fixes #63668

There shouldn't be an update function that rearranges properties in the first place. If there was a requirement for properties to be split into categories based on the class inheritance this should've initially been implemented into GDScript or GDScriptInstance function for getting properties.

NOT TESTED on GDExtension and C# scripts but it should work.
