### PR TITLE
`HTTPRequest`: Expose and add methods to make working with headers easier

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -116,7 +116,7 @@ Dictionary HTTPClient::_get_response_headers_as_dictionary() {
 		if (sp == -1) {
 			continue;
 		}
-		String key = s.substr(0, sp).strip_edges();
+		String key = s.substr(0, sp).strip_edges().to_lower();
 		String value = s.substr(sp + 1, s.length()).strip_edges();
 		ret[key] = value;
 	}

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -60,12 +60,12 @@
 		<method name="get_response_headers_as_dictionary">
 			<return type="Dictionary" />
 			<description>
-				Returns all response headers as a Dictionary of structure [code]{ "key": "value1; value2" }[/code] where the case-sensitivity of the keys and values is kept like the server delivers it. A value is a simple String, this string can have more than one value where "; " is used as separator.
+				Returns all response headers as a [Dictionary] of structure [code]{ "key": "value1; value2" }[/code] where the case-sensitivity is ignored and converted to lower-case keys. A value is a simple [String], this string can have more than one value where "; " is used as separator.
 				[b]Example:[/b]
 				[codeblock]
 				{
 				    "content-length": 12,
-				    "Content-Type": "application/json; charset=UTF-8",
+				    "content-type": "application/json; charset=UTF-8",
 				}
 				[/codeblock]
 			</description>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -173,16 +173,51 @@
 				[b]Note:[/b] Some Web servers may not send a body length. In this case, the value returned will be [code]-1[/code]. If using chunked transfer encoding, the body length will also be [code]-1[/code].
 			</description>
 		</method>
+		<method name="get_dictionary_from_headers" qualifiers="const">
+			<return type="Dictionary" />
+			<argument index="0" name="headers" type="PackedStringArray" />
+			<description>
+				Returns all response headers as a [Dictionary] of structure [code]{ "key": "value1; value2" }[/code] where the case-sensitivity is ignored and converted to lower-case keys. A value is a simple [String], this string can have more than one value where "; " is used as separator.
+				[b]Example:[/b]
+				[codeblock]
+				{
+				    "content-length": 12,
+				    "content-type": "application/json; charset=UTF-8",
+				}
+				[/codeblock]
+				[b]Note:[/b] [code]headers[/code] are meant to be supplied with [code]headers[/code] returned via [code]request_completed[/code].
+			</description>
+		</method>
 		<method name="get_downloaded_bytes" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the amount of bytes this HTTPRequest downloaded.
 			</description>
 		</method>
+		<method name="get_header_value" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="headers" type="PackedStringArray" />
+			<argument index="1" name="header_name" type="String" />
+			<description>
+				Returns a value of the header with the [code]header_name[/code] as String if found in [code]headers[/code]. Otherwise returns an empty String.
+				[b]Note:[/b] [code]headers[/code] are meant to be supplied with [code]headers[/code] returned via [code]request_completed[/code].
+				[b]Note:[/b] Header names are case-insensitive.
+			</description>
+		</method>
 		<method name="get_http_client_status" qualifiers="const">
 			<return type="int" enum="HTTPClient.Status" />
 			<description>
 				Returns the current status of the underlying [HTTPClient]. See [enum HTTPClient.Status].
+			</description>
+		</method>
+		<method name="has_header" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="headers" type="PackedStringArray" />
+			<argument index="1" name="header_name" type="String" />
+			<description>
+				Returns [code]true[/code] if given [code]header_name[/code] is found in [code]headers[/code]. Otherwise returns [code]false[/code].
+				[b]Note:[/b] [code]headers[/code] are meant to be supplied with [code]headers[/code] returned via [code]request_completed[/code].
+				[b]Note:[/b] Header names are case-insensitive.
 			</description>
 		</method>
 		<method name="request">

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -84,11 +84,11 @@ bool HTTPRequest::has_header(const PackedStringArray &p_headers, const String &p
 String HTTPRequest::get_header_value(const PackedStringArray &p_headers, const String &p_header_name) {
 	String value = "";
 
-	String lowwer_case_header_name = p_header_name.to_lower();
+	String lower_case_header_name = p_header_name.to_lower();
 	for (int i = 0; i < p_headers.size(); i++) {
 		if (p_headers[i].find(":") > 0) {
 			Vector<String> parts = p_headers[i].split(":", false, 1);
-			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lowwer_case_header_name) {
+			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lower_case_header_name) {
 				value = parts[1].strip_edges();
 				break;
 			}
@@ -555,6 +555,21 @@ void HTTPRequest::set_https_proxy(const String &p_host, int p_port) {
 	client->set_https_proxy(p_host, p_port);
 }
 
+Dictionary HTTPRequest::get_dictionary_from_headers(const PackedStringArray &p_headers) {
+	Dictionary ret;
+	for (const String &s : p_headers) {
+		int sp = s.find(":");
+		if (sp == -1) {
+			continue;
+		}
+		String key = s.substr(0, sp).strip_edges().to_lower();
+		String value = s.substr(sp + 1, s.length()).strip_edges();
+		ret[key] = value;
+	}
+
+	return ret;
+}
+
 void HTTPRequest::set_timeout(double p_timeout) {
 	ERR_FAIL_COND(p_timeout < 0);
 	timeout = p_timeout;
@@ -605,6 +620,11 @@ void HTTPRequest::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPRequest::set_http_proxy);
 	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPRequest::set_https_proxy);
+
+	ClassDB::bind_method(D_METHOD("has_header", "headers", "header_name"), &HTTPRequest::has_header);
+	ClassDB::bind_method(D_METHOD("get_header_value", "headers", "header_name"), &HTTPRequest::get_header_value);
+
+	ClassDB::bind_method(D_METHOD("get_dictionary_from_headers", "headers"), &HTTPRequest::get_dictionary_from_headers);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "download_file", PROPERTY_HINT_FILE), "set_download_file", "get_download_file");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "download_chunk_size", PROPERTY_HINT_RANGE, "256,16777216,suffix:B"), "set_download_chunk_size", "get_download_chunk_size");

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -105,9 +105,6 @@ private:
 	Error _parse_url(const String &p_url);
 	Error _request();
 
-	bool has_header(const PackedStringArray &p_headers, const String &p_header_name);
-	String get_header_value(const PackedStringArray &p_headers, const String &header_name);
-
 	SafeFlag thread_done;
 	SafeFlag thread_request_quit;
 
@@ -156,6 +153,11 @@ public:
 
 	void set_http_proxy(const String &p_host, int p_port);
 	void set_https_proxy(const String &p_host, int p_port);
+
+	bool has_header(const PackedStringArray &p_headers, const String &p_header_name);
+	String get_header_value(const PackedStringArray &p_headers, const String &header_name);
+
+	Dictionary get_dictionary_from_headers(const PackedStringArray &p_headers);
 
 	HTTPRequest();
 };


### PR DESCRIPTION
Closes [4734](https://github.com/godotengine/godot-proposals/issues/4734)

Exposes `has_header()` and `get_header_value()` methods and adds `get_dictionary_from_headers` method.

Also converts headers to lower-case in `HTTPClient::_get_response_headers_as_dictionary()` as well as in `HTTPRequest::get_dictionary_from_headers()` to keep consistensy.

This should be a done right version of [62962](https://github.com/godotengine/godot/pull/62962)
