### PR TITLE
File: Remove `\r` in `get_as_text()` to keep standardized Unix format

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1237,7 +1237,7 @@ String File::get_as_text() const {
 
 	const_cast<FileAccess *>(*f)->seek(original_pos);
 
-	return text;
+	return text.replace("\r", "");
 }
 
 String File::get_md5(const String &p_path) const {


### PR DESCRIPTION
This fixes a compatibility breakage from #63481.
See discussion in #63434.