### PR TITLE
SCons: Fix X11 `use_lld` fallback not being applied

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -151,7 +151,7 @@ def configure(env):
             print("Can't specify both `use_lld=yes` and a non-default `linker`. Remove `use_lld=yes`.")
             sys.exit(255)
         print("The `use_lld=yes` option is deprecated, use `linker=lld` instead.")
-        env["linker"] == "lld"
+        env["linker"] = "lld"
 
     if env["linker"] != "default":
         print("Using linker program: " + env["linker"])


### PR DESCRIPTION
Only relevant for `3.x`, didn't keep the fallback in `master`.