### PR TITLE
Add arrow navigation for the Create New Node window

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -291,12 +291,13 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 			p_type_category == TypeCategory::OTHER_TYPE;
 	bool is_virtual = ClassDB::class_exists(p_type) && ClassDB::is_virtual(p_type);
 
+	r_item->set_meta(SNAME("__instantiable"), can_instantiate && !is_virtual);
+
 	if (can_instantiate && !is_virtual) {
 		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, icon_fallback));
 	} else {
 		r_item->set_icon(0, EditorNode::get_singleton()->get_class_icon(p_type, "NodeDisabled"));
 		r_item->set_custom_color(0, search_options->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
-		r_item->set_selectable(0, false);
 	}
 
 	bool is_deprecated = EditorHelp::get_doc_data()->class_list[p_type].is_deprecated;
@@ -395,6 +396,11 @@ void CreateDialog::_confirmed() {
 		return;
 	}
 
+	TreeItem *selected = search_options->get_selected();
+	if (!selected->get_meta("__instantiable", true)) {
+		return;
+	}
+
 	{
 		Ref<FileAccess> f = FileAccess::open(EditorPaths::get_singleton()->get_project_settings_dir().path_join("create_recent." + base_type), FileAccess::WRITE);
 		if (f.is_valid()) {
@@ -421,13 +427,20 @@ void CreateDialog::_text_changed(const String &p_newtext) {
 
 void CreateDialog::_sbox_input(const Ref<InputEvent> &p_ie) {
 	Ref<InputEventKey> k = p_ie;
-	if (k.is_valid()) {
+	if (k.is_valid() && k->is_pressed()) {
 		switch (k->get_keycode()) {
 			case Key::UP:
 			case Key::DOWN:
 			case Key::PAGEUP:
 			case Key::PAGEDOWN: {
 				search_options->gui_input(k);
+				search_box->accept_event();
+			} break;
+			case Key::SPACE: {
+				TreeItem *ti = search_options->get_selected();
+				if (ti) {
+					ti->set_collapsed(!ti->is_collapsed());
+				}
 				search_box->accept_event();
 			} break;
 			default:


### PR DESCRIPTION
Added the ability to collapse/expand groups of nodes in the Create New Node window using keyboard arrows.

<details><summary>Before:</summary>

https://user-images.githubusercontent.com/1756388/182036368-8a0aee2e-c740-4a45-b6fb-6c6436282b55.mp4
</details>

<details><summary>After:</summary>

https://user-images.githubusercontent.com/1756388/182036375-e6489aca-3a9b-4f9d-92b1-44ef4915662f.mp4
</details>

P.S. You can't move caret inside Search Box using left and right arrow :'(