### PR TITLE
[TextServer] Ensure that built-in library headers are always included before system header, add HarfBuzz version checks for optional features.

### DIFF
--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -36,7 +36,7 @@ if env["builtin_msdfgen"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_msdfgen.Append(CPPPATH=["#thirdparty/freetype/include", "#thirdparty/msdfgen", "#thirdparty/nanosvg"])
+    env_msdfgen.Prepend(CPPPATH=["#thirdparty/freetype/include", "#thirdparty/msdfgen", "#thirdparty/nanosvg"])
 
     lib = env_msdfgen.add_library("msdfgen_builtin", thirdparty_sources)
     thirdparty_obj += lib

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -117,11 +117,11 @@ if env["builtin_harfbuzz"]:
         ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_harfbuzz.Append(CPPPATH=["#thirdparty/harfbuzz/src"])
+    env_harfbuzz.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
 
     env_harfbuzz.Append(CCFLAGS=["-DHAVE_ICU"])
     if env["builtin_icu"]:
-        env_harfbuzz.Append(CPPPATH=["#thirdparty/icu4c/common/"])
+        env_harfbuzz.Prepend(CPPPATH=["#thirdparty/icu4c/common/"])
         env_harfbuzz.Append(CCFLAGS=["-DU_HAVE_LIB_SUFFIX=1", "-DU_LIB_SUFFIX_C_NAME=_godot", "-DHAVE_ICU_BUILTIN"])
 
     if freetype_enabled:
@@ -132,9 +132,9 @@ if env["builtin_harfbuzz"]:
             ]
         )
         if env["builtin_freetype"]:
-            env_harfbuzz.Append(CPPPATH=["#thirdparty/freetype/include"])
+            env_harfbuzz.Prepend(CPPPATH=["#thirdparty/freetype/include"])
         if env["builtin_graphite"]:
-            env_harfbuzz.Append(CPPPATH=["#thirdparty/graphite/include"])
+            env_harfbuzz.Prepend(CPPPATH=["#thirdparty/graphite/include"])
             env_harfbuzz.Append(CCFLAGS=["-DGRAPHITE2_STATIC"])
 
     if env["platform"] == "android" or env["platform"] == "linuxbsd":
@@ -146,7 +146,7 @@ if env["builtin_harfbuzz"]:
         else:
             env_harfbuzz.Append(CCFLAGS=["-DHB_NO_MT"])
 
-    env_text_server_adv.Append(CPPPATH=["#thirdparty/harfbuzz/src"])
+    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
 
     lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_sources)
     thirdparty_obj += lib
@@ -209,7 +209,7 @@ if env["builtin_graphite"] and freetype_enabled:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_graphite.Append(CPPPATH=["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
+    env_graphite.Prepend(CPPPATH=["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
     env_graphite.Append(
         CCFLAGS=[
             "-DGRAPHITE2_STATIC",
@@ -447,11 +447,11 @@ if env["builtin_icu"]:
     if env_icu["tools"]:
         env_icu.Depends("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name)
         env_icu.Command("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name, make_icu_data)
-        env_text_server_adv.Append(CPPPATH=["#thirdparty/icu4c/"])
+        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/"])
     else:
         thirdparty_sources += ["icu_data/icudata_stub.cpp"]
 
-    env_icu.Append(CPPPATH=["#thirdparty/icu4c/common/"])
+    env_icu.Prepend(CPPPATH=["#thirdparty/icu4c/common/"])
     env_icu.Append(
         CXXFLAGS=[
             "-DU_STATIC_IMPLEMENTATION",
@@ -480,7 +480,7 @@ if env["builtin_icu"]:
     if env_text_server_adv["tools"]:
         env_text_server_adv.Append(CXXFLAGS=["-DICU_STATIC_DATA"])
 
-    env_text_server_adv.Append(CPPPATH=["#thirdparty/icu4c/common/"])
+    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/common/"])
 
     lib = env_icu.add_library("icu_builtin", thirdparty_sources)
     thirdparty_obj += lib
@@ -504,13 +504,13 @@ if env["builtin_icu"]:
 module_obj = []
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    env_text_server_adv.Append(CPPPATH=["#thirdparty/msdfgen"])
+    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
-    env_text_server_adv.Append(CPPPATH=["#thirdparty/freetype/include"])
+    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/freetype/include"])
 
 if env["builtin_graphite"] and freetype_enabled:
-    env_text_server_adv.Append(CPPPATH=["#thirdparty/graphite/include"])
+    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/graphite/include"])
 
 env_text_server_adv.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1359,7 +1359,13 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 		fd->underline_position = (-FT_MulFix(fd->face->underline_position, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
 		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
 
+#if HB_VERSION_ATLEAST(3, 3, 0)
 		hb_font_set_synthetic_slant(fd->hb_handle, p_font_data->transform[0][1]);
+#else
+#ifndef _MSC_VER
+#warning Building with HarfBuzz < 3.3.0, synthetic slant offset correction disabled.
+#endif
+#endif
 
 		if (!p_font_data->face_init) {
 			// Get style flags and name.
@@ -1626,6 +1632,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 				for (unsigned int i = 0; i < count; i++) {
 					Dictionary ftr;
 
+#if HB_VERSION_ATLEAST(2, 1, 0)
 					hb_ot_name_id_t lbl_id;
 					if (hb_ot_layout_feature_get_name_ids(hb_face, HB_OT_TAG_GSUB, i, &lbl_id, nullptr, nullptr, nullptr, nullptr)) {
 						PackedInt32Array lbl;
@@ -1635,6 +1642,11 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 						hb_ot_name_get_utf32(hb_face, lbl_id, hb_language_from_string(TranslationServer::get_singleton()->get_tool_locale().ascii().get_data(), -1), &text_size, (uint32_t *)lbl.ptrw());
 						ftr["label"] = String((const char32_t *)lbl.ptr());
 					}
+#else
+#ifndef _MSC_VER
+#warning Building with HarfBuzz < 2.1.0, readable OpenType feature names disabled.
+#endif
+#endif
 					ftr["type"] = _get_tag_type(feature_tags[i]);
 					ftr["hidden"] = _get_tag_hidden(feature_tags[i]);
 
@@ -1649,6 +1661,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 				for (unsigned int i = 0; i < count; i++) {
 					Dictionary ftr;
 
+#if HB_VERSION_ATLEAST(2, 1, 0)
 					hb_ot_name_id_t lbl_id;
 					if (hb_ot_layout_feature_get_name_ids(hb_face, HB_OT_TAG_GPOS, i, &lbl_id, nullptr, nullptr, nullptr, nullptr)) {
 						PackedInt32Array lbl;
@@ -1658,6 +1671,11 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_f
 						hb_ot_name_get_utf32(hb_face, lbl_id, hb_language_from_string(TranslationServer::get_singleton()->get_tool_locale().ascii().get_data(), -1), &text_size, (uint32_t *)lbl.ptrw());
 						ftr["label"] = String((const char32_t *)lbl.ptr());
 					}
+#else
+#ifndef _MSC_VER
+#warning Building with HarfBuzz < 2.1.0, readable OpenType feature names disabled.
+#endif
+#endif
 					ftr["type"] = _get_tag_type(feature_tags[i]);
 					ftr["hidden"] = _get_tag_hidden(feature_tags[i]);
 

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -9,9 +9,9 @@ msdfgen_enabled = env.module_check_dependencies("text_server_fb", ["msdfgen"], T
 env_text_server_fb = env_modules.Clone()
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    env_text_server_fb.Append(CPPPATH=["#thirdparty/msdfgen"])
+    env_text_server_fb.Prepend(CPPPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
-    env_text_server_fb.Append(CPPPATH=["#thirdparty/freetype/include"])
+    env_text_server_fb.Prepend(CPPPATH=["#thirdparty/freetype/include"])
 
 env_text_server_fb.add_source_files(env.modules_sources, "*.cpp")


### PR DESCRIPTION
- Changes `Append` to `Prepend`, to ensure built-in headers are always included first.
- Adds compile time checks for non-important HarfBuzz features to allow building with older version of system HarfBuzz , should work with version 1.7.2+ (Ubuntu 18.04 LTS).

Fixes #63658