### PR TITLE
Refactor toggling script list

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1548,7 +1548,8 @@ void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 }
 
 void CodeTextEditor::_toggle_scripts_pressed() {
-	ScriptEditor::get_singleton()->toggle_scripts_panel();
+	ERR_FAIL_NULL(toggle_scripts_list);
+	toggle_scripts_list->set_visible(!toggle_scripts_list->is_visible());
 	update_toggle_scripts_button();
 }
 
@@ -1723,16 +1724,18 @@ void CodeTextEditor::set_code_complete_func(CodeTextEditorCodeCompleteFunc p_cod
 	code_complete_ud = p_ud;
 }
 
+void CodeTextEditor::set_toggle_list_control(Control *p_control) {
+	toggle_scripts_list = p_control;
+}
+
 void CodeTextEditor::show_toggle_scripts_button() {
 	toggle_scripts_button->show();
 }
 
 void CodeTextEditor::update_toggle_scripts_button() {
-	if (is_layout_rtl()) {
-		toggle_scripts_button->set_icon(get_editor_theme_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? SNAME("Forward") : SNAME("Back")));
-	} else {
-		toggle_scripts_button->set_icon(get_editor_theme_icon(ScriptEditor::get_singleton()->is_scripts_panel_toggled() ? SNAME("Back") : SNAME("Forward")));
-	}
+	ERR_FAIL_NULL(toggle_scripts_list);
+	bool forward = toggle_scripts_list->is_visible() == is_layout_rtl();
+	toggle_scripts_button->set_icon(get_editor_theme_icon(forward ? SNAME("Forward") : SNAME("Back")));
 	toggle_scripts_button->set_tooltip_text(vformat("%s (%s)", TTR("Toggle Scripts Panel"), ED_GET_SHORTCUT("script_editor/toggle_scripts_panel")->get_as_text()));
 }
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -161,6 +161,7 @@ class CodeTextEditor : public VBoxContainer {
 	HBoxContainer *status_bar = nullptr;
 
 	Button *toggle_scripts_button = nullptr;
+	Control *toggle_scripts_list = nullptr;
 	Button *error_button = nullptr;
 	Button *warning_button = nullptr;
 
@@ -285,6 +286,7 @@ public:
 
 	void validate_script();
 
+	void set_toggle_list_control(Control *p_control);
 	void show_toggle_scripts_button();
 	void update_toggle_scripts_button();
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2373,6 +2373,7 @@ void ScriptTextEditor::_enable_code_editor() {
 
 ScriptTextEditor::ScriptTextEditor() {
 	code_editor = memnew(CodeTextEditor);
+	code_editor->set_toggle_list_control(ScriptEditor::get_singleton()->get_left_list_split());
 	code_editor->add_theme_constant_override("separation", 2);
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	code_editor->set_code_complete_func(_code_complete_scripts, this);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -149,7 +149,9 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 			}
 		}
 		es.shader_inc = Ref<ShaderInclude>(si);
-		es.shader_editor = memnew(TextShaderEditor);
+		TextShaderEditor *text_shader = memnew(TextShaderEditor);
+		text_shader->get_code_editor()->set_toggle_list_control(left_panel);
+		es.shader_editor = text_shader;
 		es.shader_editor->edit_shader_include(si);
 		shader_tabs->add_child(es.shader_editor);
 	} else {
@@ -166,7 +168,9 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 		if (vs.is_valid()) {
 			es.shader_editor = memnew(VisualShaderEditor);
 		} else {
-			es.shader_editor = memnew(TextShaderEditor);
+			TextShaderEditor *text_shader = memnew(TextShaderEditor);
+			text_shader->get_code_editor()->set_toggle_list_control(left_panel);
+			es.shader_editor = text_shader;
 		}
 		shader_tabs->add_child(es.shader_editor);
 		es.shader_editor->edit_shader(es.shader);
@@ -434,6 +438,10 @@ void ShaderEditorPlugin::_close_shader(int p_index) {
 	edited_shaders.remove_at(p_index);
 	_update_shader_list();
 	EditorUndoRedoManager::get_singleton()->clear_history(); // To prevent undo on deleted graphs.
+
+	if (shader_tabs->get_tab_count() == 0) {
+		left_panel->show(); // Make sure the panel is visible, because it can't be toggled without open shaders.
+	}
 }
 
 void ShaderEditorPlugin::_close_builtin_shaders_from_scene(const String &p_scene) {
@@ -768,10 +776,10 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	Ref<Shortcut> make_floating_shortcut = ED_SHORTCUT_AND_COMMAND("shader_editor/make_floating", TTR("Make Floating"));
 	window_wrapper->set_wrapped_control(main_split, make_floating_shortcut);
 
-	VBoxContainer *vb = memnew(VBoxContainer);
+	left_panel = memnew(VBoxContainer);
 
 	HBoxContainer *menu_hb = memnew(HBoxContainer);
-	vb->add_child(menu_hb);
+	left_panel->add_child(menu_hb);
 	file_menu = memnew(MenuButton);
 	file_menu->set_text(TTR("File"));
 	file_menu->set_shortcut_context(main_split);
@@ -803,14 +811,14 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	shader_list = memnew(ItemList);
 	shader_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	shader_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	vb->add_child(shader_list);
+	left_panel->add_child(shader_list);
 	shader_list->connect(SceneStringName(item_selected), callable_mp(this, &ShaderEditorPlugin::_shader_selected));
 	shader_list->connect("item_clicked", callable_mp(this, &ShaderEditorPlugin::_shader_list_clicked));
 	shader_list->set_allow_rmb_select(true);
 	SET_DRAG_FORWARDING_GCD(shader_list, ShaderEditorPlugin);
 
-	main_split->add_child(vb);
-	vb->set_custom_minimum_size(Size2(200, 300) * EDSCALE);
+	main_split->add_child(left_panel);
+	left_panel->set_custom_minimum_size(Size2(200, 300) * EDSCALE);
 
 	shader_tabs = memnew(TabContainer);
 	shader_tabs->set_tabs_visible(false);
@@ -823,7 +831,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	button = EditorNode::get_bottom_panel()->add_item(TTR("Shader Editor"), window_wrapper, ED_SHORTCUT_AND_COMMAND("bottom_panels/toggle_shader_editor_bottom_panel", TTR("Toggle Shader Editor Bottom Panel"), KeyModifierMask::ALT | Key::S));
 
 	shader_create_dialog = memnew(ShaderCreateDialog);
-	vb->add_child(shader_create_dialog);
+	main_split->add_child(shader_create_dialog);
 	shader_create_dialog->connect("shader_created", callable_mp(this, &ShaderEditorPlugin::_shader_created));
 	shader_create_dialog->connect("shader_include_created", callable_mp(this, &ShaderEditorPlugin::_shader_include_created));
 }

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -40,6 +40,7 @@ class ShaderCreateDialog;
 class ShaderEditor;
 class TabContainer;
 class TextShaderEditor;
+class VBoxContainer;
 class VisualShaderEditor;
 class WindowWrapper;
 
@@ -82,6 +83,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 	};
 
 	HSplitContainer *main_split = nullptr;
+	VBoxContainer *left_panel = nullptr;
 	ItemList *shader_list = nullptr;
 	TabContainer *shader_tabs = nullptr;
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/split_container.h"
 
 void TextEditor::add_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) {
 	ERR_FAIL_COND(p_highlighter.is_null());
@@ -606,6 +607,7 @@ TextEditor::TextEditor() {
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	code_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	code_editor->show_toggle_scripts_button();
+	code_editor->set_toggle_list_control(ScriptEditor::get_singleton()->get_left_list_split());
 
 	update_settings();
 

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1256,4 +1256,5 @@ TextShaderEditor::TextShaderEditor() {
 	add_child(disk_changed);
 
 	_editor_settings_changed();
+	code_editor->show_toggle_scripts_button(); // TODO: Disabled for now, because it doesn't work properly.
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5017

The button for toggling script list was hard-coded to use ScriptEditor singleton. I changed it and now the control it toggles has to be assigned first. This allows to implement it in shader editor (which also uses CodeTextEditor).

I actually added the necessary code to do it in shader editor, but it doesn't work with the current structure:
![](https://chat.godotengine.org/file-upload/xWYKjTy3AeNAjRNhG/godot.windows.tools.64_ukG2kaHeEk.gif)
It needs further work, so I commented-out the line that shows the toggle button.

Another thing required for https://github.com/godotengine/godot-proposals/issues/5017 is a status bar in VisualShader editor, similar to VisualScript:
![image](https://user-images.githubusercontent.com/2223172/182045493-63bf6377-09d2-41e1-9967-e4dfbac03726.png)
CC @Chaosus, I guess.