### PR TITLE
Add missing import for mono build

### DIFF
--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -41,6 +41,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "main/main.h"
 


### PR DESCRIPTION
Just a missing import for editor_settings.h, probably after a refactoring.