### PR TITLE
 Rename math 'phi' arguments to 'angle' in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -531,9 +531,9 @@ namespace Godot
         /// <param name="axis">The axis to rotate around. Must be normalized.</param>
         /// <param name="angle">The angle to rotate, in radians.</param>
         /// <returns>The rotated basis matrix.</returns>
-        public Basis Rotated(Vector3 axis, real_t phi)
+        public Basis Rotated(Vector3 axis, real_t angle)
         {
-            return new Basis(axis, phi) * this;
+            return new Basis(axis, angle) * this;
         }
 
         /// <summary>
@@ -774,15 +774,15 @@ namespace Godot
         /// </summary>
         /// <param name="axis">The axis to rotate around. Must be normalized.</param>
         /// <param name="angle">The angle to rotate, in radians.</param>
-        public Basis(Vector3 axis, real_t phi)
+        public Basis(Vector3 axis, real_t angle)
         {
             Vector3 axisSq = new Vector3(axis.x * axis.x, axis.y * axis.y, axis.z * axis.z);
-            real_t cosine = Mathf.Cos(phi);
+            real_t cosine = Mathf.Cos(angle);
             Row0.x = axisSq.x + cosine * (1.0f - axisSq.x);
             Row1.y = axisSq.y + cosine * (1.0f - axisSq.y);
             Row2.z = axisSq.z + cosine * (1.0f - axisSq.z);
 
-            real_t sine = Mathf.Sin(phi);
+            real_t sine = Mathf.Sin(angle);
             real_t t = 1.0f - cosine;
 
             real_t xyzt = axis.x * axis.y * t;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -301,9 +301,9 @@ namespace Godot
         /// </summary>
         /// <param name="angle">The angle to rotate, in radians.</param>
         /// <returns>The rotated transformation matrix.</returns>
-        public Transform2D Rotated(real_t phi)
+        public Transform2D Rotated(real_t angle)
         {
-            return this * new Transform2D(phi, new Vector2());
+            return this * new Transform2D(angle, new Vector2());
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -192,9 +192,9 @@ namespace Godot
         /// <param name="axis">The axis to rotate around. Must be normalized.</param>
         /// <param name="angle">The angle to rotate, in radians.</param>
         /// <returns>The rotated transformation matrix.</returns>
-        public Transform3D Rotated(Vector3 axis, real_t phi)
+        public Transform3D Rotated(Vector3 axis, real_t angle)
         {
-            return new Transform3D(new Basis(axis, phi), new Vector3()) * this;
+            return new Transform3D(new Basis(axis, angle), new Vector3()) * this;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -495,10 +495,10 @@ namespace Godot
         /// </summary>
         /// <param name="angle">The angle to rotate by, in radians.</param>
         /// <returns>The rotated vector.</returns>
-        public Vector2 Rotated(real_t phi)
+        public Vector2 Rotated(real_t angle)
         {
-            real_t sine = Mathf.Sin(phi);
-            real_t cosi = Mathf.Cos(phi);
+            real_t sine = Mathf.Sin(angle);
+            real_t cosi = Mathf.Cos(angle);
             return new Vector2(
                 x * cosi - y * sine,
                 x * sine + y * cosi);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -515,7 +515,7 @@ namespace Godot
         /// <param name="axis">The vector to rotate around. Must be normalized.</param>
         /// <param name="angle">The angle to rotate by, in radians.</param>
         /// <returns>The rotated vector.</returns>
-        public Vector3 Rotated(Vector3 axis, real_t phi)
+        public Vector3 Rotated(Vector3 axis, real_t angle)
         {
 #if DEBUG
             if (!axis.IsNormalized())
@@ -523,7 +523,7 @@ namespace Godot
                 throw new ArgumentException("Argument is not normalized", nameof(axis));
             }
 #endif
-            return new Basis(axis, phi).Xform(this);
+            return new Basis(axis, angle).Xform(this);
         }
 
         /// <summary>


### PR DESCRIPTION
- Follow-up to #60784
