### PR TITLE
Changed storage structs to private

### DIFF
--- a/servers/rendering/renderer_rd/effects/vrs.cpp
+++ b/servers/rendering/renderer_rd/effects/vrs.cpp
@@ -146,10 +146,11 @@ void VRS::update_vrs_texture(RID p_vrs_fb, RID p_render_target) {
 		if (vrs_mode == RS::VIEWPORT_VRS_TEXTURE) {
 			RID vrs_texture = texture_storage->render_target_get_vrs_texture(p_render_target);
 			if (vrs_texture.is_valid()) {
-				Texture *texture = texture_storage->get_texture(vrs_texture);
-				if (texture) {
+				RID rd_texture = texture_storage->texture_get_rd_texture(vrs_texture);
+				int layers = texture_storage->texture_get_layers(vrs_texture);
+				if (rd_texture.is_valid()) {
 					// Copy into our density buffer
-					copy_vrs(texture->rd_texture, p_vrs_fb, texture->layers > 1);
+					copy_vrs(rd_texture, p_vrs_fb, layers > 1);
 				}
 			}
 		} else if (vrs_mode == RS::VIEWPORT_VRS_XR) {
@@ -157,10 +158,12 @@ void VRS::update_vrs_texture(RID p_vrs_fb, RID p_render_target) {
 			if (interface.is_valid()) {
 				RID vrs_texture = interface->get_vrs_texture();
 				if (vrs_texture.is_valid()) {
-					Texture *texture = texture_storage->get_texture(vrs_texture);
-					if (texture) {
+					RID rd_texture = texture_storage->texture_get_rd_texture(vrs_texture);
+					int layers = texture_storage->texture_get_layers(vrs_texture);
+
+					if (rd_texture.is_valid()) {
 						// Copy into our density buffer
-						copy_vrs(texture->rd_texture, p_vrs_fb, texture->layers > 1);
+						copy_vrs(rd_texture, p_vrs_fb, layers > 1);
 					}
 				}
 			}

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -180,7 +180,7 @@ private:
 
 	Vector3i _point_get_position_in_froxel_volume(const Vector3 &p_point, float fog_end, const Vector2 &fog_near_size, const Vector2 &fog_far_size, float volumetric_fog_detail_spread, const Vector3 &fog_size, const Transform3D &p_cam_transform);
 
-	struct FogShaderData : public RendererRD::ShaderData {
+	struct FogShaderData : public RendererRD::MaterialStorage::ShaderData {
 		bool valid = false;
 		RID version;
 
@@ -212,7 +212,7 @@ private:
 		virtual ~FogShaderData();
 	};
 
-	struct FogMaterialData : public RendererRD::MaterialData {
+	struct FogMaterialData : public RendererRD::MaterialStorage::MaterialData {
 		FogShaderData *shader_data = nullptr;
 		RID uniform_set;
 		bool uniform_set_updated;
@@ -223,11 +223,11 @@ private:
 		virtual ~FogMaterialData();
 	};
 
-	RendererRD::ShaderData *_create_fog_shader_func();
-	static RendererRD::ShaderData *_create_fog_shader_funcs();
+	RendererRD::MaterialStorage::ShaderData *_create_fog_shader_func();
+	static RendererRD::MaterialStorage::ShaderData *_create_fog_shader_funcs();
 
-	RendererRD::MaterialData *_create_fog_material_func(FogShaderData *p_shader);
-	static RendererRD::MaterialData *_create_fog_material_funcs(RendererRD::ShaderData *p_shader);
+	RendererRD::MaterialStorage::MaterialData *_create_fog_material_func(FogShaderData *p_shader);
+	static RendererRD::MaterialStorage::MaterialData *_create_fog_material_funcs(RendererRD::MaterialStorage::ShaderData *p_shader);
 
 public:
 	static Fog *get_singleton() { return singleton; }

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -734,7 +734,7 @@ void GI::SDFGI::create(RID p_env, const Vector3 &p_world_position, uint32_t p_re
 				if (j < cascades.size()) {
 					u.append_id(cascades[j].sdf_tex);
 				} else {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 				}
 			}
 			uniforms.push_back(u);
@@ -978,7 +978,7 @@ void GI::SDFGI::create(RID p_env, const Vector3 &p_world_position, uint32_t p_re
 				if (j < cascades.size()) {
 					u.append_id(cascades[j].sdf_tex);
 				} else {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 				}
 			}
 			uniforms.push_back(u);
@@ -991,7 +991,7 @@ void GI::SDFGI::create(RID p_env, const Vector3 &p_world_position, uint32_t p_re
 				if (j < cascades.size()) {
 					u.append_id(cascades[j].light_tex);
 				} else {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 				}
 			}
 			uniforms.push_back(u);
@@ -1004,7 +1004,7 @@ void GI::SDFGI::create(RID p_env, const Vector3 &p_world_position, uint32_t p_re
 				if (j < cascades.size()) {
 					u.append_id(cascades[j].light_aniso_0_tex);
 				} else {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 				}
 			}
 			uniforms.push_back(u);
@@ -1017,7 +1017,7 @@ void GI::SDFGI::create(RID p_env, const Vector3 &p_world_position, uint32_t p_re
 				if (j < cascades.size()) {
 					u.append_id(cascades[j].light_aniso_1_tex);
 				} else {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 				}
 			}
 			uniforms.push_back(u);
@@ -1498,7 +1498,7 @@ void GI::SDFGI::debug_draw(uint32_t p_view_count, const Projection *p_projection
 					if (i < cascades.size()) {
 						u.append_id(cascades[i].sdf_tex);
 					} else {
-						u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+						u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 					}
 				}
 				uniforms.push_back(u);
@@ -1511,7 +1511,7 @@ void GI::SDFGI::debug_draw(uint32_t p_view_count, const Projection *p_projection
 					if (i < cascades.size()) {
 						u.append_id(cascades[i].light_tex);
 					} else {
-						u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+						u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 					}
 				}
 				uniforms.push_back(u);
@@ -1524,7 +1524,7 @@ void GI::SDFGI::debug_draw(uint32_t p_view_count, const Projection *p_projection
 					if (i < cascades.size()) {
 						u.append_id(cascades[i].light_aniso_0_tex);
 					} else {
-						u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+						u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 					}
 				}
 				uniforms.push_back(u);
@@ -1537,7 +1537,7 @@ void GI::SDFGI::debug_draw(uint32_t p_view_count, const Projection *p_projection
 					if (i < cascades.size()) {
 						u.append_id(cascades[i].light_aniso_1_tex);
 					} else {
-						u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+						u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 					}
 				}
 				uniforms.push_back(u);
@@ -3353,9 +3353,9 @@ void GI::init(SkyRD *p_sky) {
 				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 0;
 				if (p_sky->sky_use_cubemap_array) {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_WHITE));
 				} else {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_WHITE));
 				}
 				uniforms.push_back(u);
 			}
@@ -3550,7 +3550,7 @@ void GI::setup_voxel_gi_instances(RID p_render_buffers, const Transform3D &p_tra
 		}
 
 		if (texture == RID()) {
-			texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+			texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 		}
 
 		if (texture != rb->rbgi.voxel_gi_textures[i]) {
@@ -3761,7 +3761,7 @@ void GI::process_gi(RID p_render_buffers, const RID *p_normal_roughness_slices, 
 					if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
 						u.append_id(rb->sdfgi->cascades[j].sdf_tex);
 					} else {
-						u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+						u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 					}
 				}
 				uniforms.push_back(u);
@@ -3774,7 +3774,7 @@ void GI::process_gi(RID p_render_buffers, const RID *p_normal_roughness_slices, 
 					if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
 						u.append_id(rb->sdfgi->cascades[j].light_tex);
 					} else {
-						u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+						u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 					}
 				}
 				uniforms.push_back(u);
@@ -3787,7 +3787,7 @@ void GI::process_gi(RID p_render_buffers, const RID *p_normal_roughness_slices, 
 					if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
 						u.append_id(rb->sdfgi->cascades[j].light_aniso_0_tex);
 					} else {
-						u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+						u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 					}
 				}
 				uniforms.push_back(u);
@@ -3800,7 +3800,7 @@ void GI::process_gi(RID p_render_buffers, const RID *p_normal_roughness_slices, 
 					if (rb->sdfgi && j < rb->sdfgi->cascades.size()) {
 						u.append_id(rb->sdfgi->cascades[j].light_aniso_1_tex);
 					} else {
-						u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+						u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 					}
 				}
 				uniforms.push_back(u);
@@ -3812,7 +3812,7 @@ void GI::process_gi(RID p_render_buffers, const RID *p_normal_roughness_slices, 
 				if (rb->sdfgi) {
 					u.append_id(rb->sdfgi->occlusion_texture);
 				} else {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 				}
 				uniforms.push_back(u);
 			}
@@ -3854,7 +3854,7 @@ void GI::process_gi(RID p_render_buffers, const RID *p_normal_roughness_slices, 
 				if (rb->sdfgi) {
 					u.append_id(rb->sdfgi->lightprobe_texture);
 				} else {
-					u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE));
+					u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE));
 				}
 				uniforms.push_back(u);
 			}
@@ -3876,7 +3876,7 @@ void GI::process_gi(RID p_render_buffers, const RID *p_normal_roughness_slices, 
 				RD::Uniform u;
 				u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 				u.binding = 14;
-				RID buffer = p_voxel_gi_buffer.is_valid() ? p_voxel_gi_buffer : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
+				RID buffer = p_voxel_gi_buffer.is_valid() ? p_voxel_gi_buffer : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 				u.append_id(buffer);
 				uniforms.push_back(u);
 			}
@@ -3914,7 +3914,7 @@ void GI::process_gi(RID p_render_buffers, const RID *p_normal_roughness_slices, 
 				RD::Uniform u;
 				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;
 				u.binding = 19;
-				RID buffer = p_vrs_slices[v].is_valid() ? p_vrs_slices[v] : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_VRS);
+				RID buffer = p_vrs_slices[v].is_valid() ? p_vrs_slices[v] : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_VRS);
 				u.append_id(buffer);
 				uniforms.push_back(u);
 			}

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -655,7 +655,7 @@ RID SkyRD::Sky::get_textures(SkyTextureSetVersion p_version, RID p_default_shade
 		if (radiance.is_valid() && p_version <= SKY_TEXTURE_SET_QUARTER_RES) {
 			u.append_id(radiance);
 		} else {
-			u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
+			u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
 		}
 		uniforms.push_back(u);
 	}
@@ -671,9 +671,9 @@ RID SkyRD::Sky::get_textures(SkyTextureSetVersion p_version, RID p_default_shade
 			}
 		} else {
 			if (p_version < SKY_TEXTURE_SET_CUBEMAP) {
-				u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE));
+				u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE));
 			} else {
-				u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
+				u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
 			}
 		}
 		uniforms.push_back(u);
@@ -690,9 +690,9 @@ RID SkyRD::Sky::get_textures(SkyTextureSetVersion p_version, RID p_default_shade
 			}
 		} else {
 			if (p_version < SKY_TEXTURE_SET_CUBEMAP) {
-				u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE));
+				u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE));
 			} else {
-				u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
+				u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
 			}
 		}
 		uniforms.push_back(u);
@@ -789,24 +789,24 @@ Ref<Image> SkyRD::Sky::bake_panorama(float p_energy, int p_roughness_layers, con
 ////////////////////////////////////////////////////////////////////////////////
 // SkyRD
 
-RendererRD::ShaderData *SkyRD::_create_sky_shader_func() {
+RendererRD::MaterialStorage::ShaderData *SkyRD::_create_sky_shader_func() {
 	SkyShaderData *shader_data = memnew(SkyShaderData);
 	return shader_data;
 }
 
-RendererRD::ShaderData *SkyRD::_create_sky_shader_funcs() {
+RendererRD::MaterialStorage::ShaderData *SkyRD::_create_sky_shader_funcs() {
 	// !BAS! Why isn't _create_sky_shader_func not just static too?
 	return static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton)->sky._create_sky_shader_func();
 };
 
-RendererRD::MaterialData *SkyRD::_create_sky_material_func(SkyShaderData *p_shader) {
+RendererRD::MaterialStorage::MaterialData *SkyRD::_create_sky_material_func(SkyShaderData *p_shader) {
 	SkyMaterialData *material_data = memnew(SkyMaterialData);
 	material_data->shader_data = p_shader;
 	//update will happen later anyway so do nothing.
 	return material_data;
 }
 
-RendererRD::MaterialData *SkyRD::_create_sky_material_funcs(RendererRD::ShaderData *p_shader) {
+RendererRD::MaterialStorage::MaterialData *SkyRD::_create_sky_material_funcs(RendererRD::MaterialStorage::ShaderData *p_shader) {
 	// !BAS! same here, we could just make _create_sky_material_func static?
 	return static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton)->sky._create_sky_material_func(static_cast<SkyShaderData *>(p_shader));
 };
@@ -855,8 +855,8 @@ void SkyRD::init() {
 	}
 
 	// register our shader funds
-	material_storage->shader_set_data_request_function(RendererRD::SHADER_TYPE_SKY, _create_sky_shader_funcs);
-	material_storage->material_set_data_request_function(RendererRD::SHADER_TYPE_SKY, _create_sky_material_funcs);
+	material_storage->shader_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_SKY, _create_sky_shader_funcs);
+	material_storage->material_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_SKY, _create_sky_material_funcs);
 
 	{
 		ShaderCompiler::DefaultIdentifierActions actions;
@@ -937,7 +937,7 @@ void sky() {
 
 		material_storage->material_set_shader(sky_shader.default_material, sky_shader.default_shader);
 
-		SkyMaterialData *md = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_shader.default_material, RendererRD::SHADER_TYPE_SKY));
+		SkyMaterialData *md = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 		sky_shader.default_shader_rd = sky_shader.shader.version_get_shader(md->shader_data->version, SKY_VERSION_BACKGROUND);
 
 		sky_scene_state.uniform_buffer = RD::get_singleton()->uniform_buffer_create(sizeof(SkySceneState::UBO));
@@ -999,7 +999,7 @@ void sky() {
 			RD::Uniform u;
 			u.binding = 0;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
-			RID vfog = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+			RID vfog = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 			u.append_id(vfog);
 			uniforms.push_back(u);
 		}
@@ -1033,21 +1033,21 @@ void sky() {
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 0;
-			u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
+			u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 1;
-			u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE));
+			u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE));
 			uniforms.push_back(u);
 		}
 		{
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			u.binding = 2;
-			u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE));
+			u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE));
 			uniforms.push_back(u);
 		}
 
@@ -1080,7 +1080,7 @@ SkyRD::~SkyRD() {
 	// cleanup anything created in init...
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
-	SkyMaterialData *md = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_shader.default_material, RendererRD::SHADER_TYPE_SKY));
+	SkyMaterialData *md = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 	sky_shader.shader.version_free(md->shader_data->version);
 	RD::get_singleton()->free(sky_scene_state.directional_light_buffer);
 	RD::get_singleton()->free(sky_scene_state.uniform_buffer);
@@ -1122,7 +1122,7 @@ void SkyRD::setup(RID p_env, RID p_render_buffers, const PagedArray<RID> &p_ligh
 		sky_material = sky_get_material(RendererSceneRenderRD::get_singleton()->environment_get_sky(p_env));
 
 		if (sky_material.is_valid()) {
-			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 			if (!material || !material->shader_data->valid) {
 				material = nullptr;
 			}
@@ -1130,7 +1130,7 @@ void SkyRD::setup(RID p_env, RID p_render_buffers, const PagedArray<RID> &p_ligh
 
 		if (!material) {
 			sky_material = sky_shader.default_material;
-			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 		}
 
 		ERR_FAIL_COND(!material);
@@ -1330,7 +1330,7 @@ void SkyRD::update(RID p_env, const Projection &p_projection, const Transform3D 
 	SkyMaterialData *material = nullptr;
 
 	if (sky_material.is_valid()) {
-		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 		if (!material || !material->shader_data->valid) {
 			material = nullptr;
 		}
@@ -1338,7 +1338,7 @@ void SkyRD::update(RID p_env, const Projection &p_projection, const Transform3D 
 
 	if (!material) {
 		sky_material = sky_shader.default_material;
-		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 	}
 
 	ERR_FAIL_COND(!material);
@@ -1506,7 +1506,7 @@ void SkyRD::draw(RID p_env, bool p_can_continue_color, bool p_can_continue_depth
 		sky_material = sky_get_material(RendererSceneRenderRD::get_singleton()->environment_get_sky(p_env));
 
 		if (sky_material.is_valid()) {
-			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 			if (!material || !material->shader_data->valid) {
 				material = nullptr;
 			}
@@ -1514,13 +1514,13 @@ void SkyRD::draw(RID p_env, bool p_can_continue_color, bool p_can_continue_depth
 
 		if (!material) {
 			sky_material = sky_shader.default_material;
-			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 		}
 	}
 
 	if (background == RS::ENV_BG_CLEAR_COLOR || background == RS::ENV_BG_COLOR) {
 		sky_material = sky_scene_state.fog_material;
-		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 	}
 
 	ERR_FAIL_COND(!material);
@@ -1610,7 +1610,7 @@ void SkyRD::update_res_buffers(RID p_env, uint32_t p_view_count, const Projectio
 	sky_material = sky_get_material(RendererSceneRenderRD::get_singleton()->environment_get_sky(p_env));
 
 	if (sky_material.is_valid()) {
-		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 		if (!material || !material->shader_data->valid) {
 			material = nullptr;
 		}
@@ -1618,7 +1618,7 @@ void SkyRD::update_res_buffers(RID p_env, uint32_t p_view_count, const Projectio
 
 	if (!material) {
 		sky_material = sky_shader.default_material;
-		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 	}
 
 	ERR_FAIL_COND(!material);
@@ -1698,7 +1698,7 @@ void SkyRD::draw(RD::DrawListID p_draw_list, RID p_env, RID p_fb, uint32_t p_vie
 		sky_material = sky_get_material(RendererSceneRenderRD::get_singleton()->environment_get_sky(p_env));
 
 		if (sky_material.is_valid()) {
-			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 			if (!material || !material->shader_data->valid) {
 				material = nullptr;
 			}
@@ -1706,13 +1706,13 @@ void SkyRD::draw(RD::DrawListID p_draw_list, RID p_env, RID p_fb, uint32_t p_vie
 
 		if (!material) {
 			sky_material = sky_shader.default_material;
-			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+			material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 		}
 	}
 
 	if (background == RS::ENV_BG_CLEAR_COLOR || background == RS::ENV_BG_COLOR) {
 		sky_material = sky_scene_state.fog_material;
-		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::SHADER_TYPE_SKY));
+		material = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 	}
 
 	ERR_FAIL_COND(!material);

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -107,7 +107,7 @@ private:
 		// 128 is the max size of a push constant. We can replace "pad" but we can't add any more.
 	};
 
-	struct SkyShaderData : public RendererRD::ShaderData {
+	struct SkyShaderData : public RendererRD::MaterialStorage::ShaderData {
 		bool valid = false;
 		RID version;
 
@@ -231,7 +231,7 @@ public:
 		RID default_shader_rd;
 	} sky_shader;
 
-	struct SkyMaterialData : public RendererRD::MaterialData {
+	struct SkyMaterialData : public RendererRD::MaterialStorage::MaterialData {
 		SkyShaderData *shader_data = nullptr;
 		RID uniform_set;
 		bool uniform_set_updated;
@@ -285,11 +285,11 @@ public:
 	mutable RID_Owner<Sky, true> sky_owner;
 	int roughness_layers;
 
-	RendererRD::ShaderData *_create_sky_shader_func();
-	static RendererRD::ShaderData *_create_sky_shader_funcs();
+	RendererRD::MaterialStorage::ShaderData *_create_sky_shader_func();
+	static RendererRD::MaterialStorage::ShaderData *_create_sky_shader_funcs();
 
-	RendererRD::MaterialData *_create_sky_material_func(SkyShaderData *p_shader);
-	static RendererRD::MaterialData *_create_sky_material_funcs(RendererRD::ShaderData *p_shader);
+	RendererRD::MaterialStorage::MaterialData *_create_sky_material_func(SkyShaderData *p_shader);
+	static RendererRD::MaterialStorage::MaterialData *_create_sky_material_funcs(RendererRD::MaterialStorage::ShaderData *p_shader);
 
 	SkyRD();
 	void init();

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2433,7 +2433,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 		if (p_radiance_texture.is_valid()) {
 			radiance_texture = p_radiance_texture;
 		} else {
-			radiance_texture = texture_storage->texture_rd_get_default(is_using_radiance_cubemap_array() ? RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK : RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
+			radiance_texture = texture_storage->texture_rd_get_default(is_using_radiance_cubemap_array() ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
 		}
 		RD::Uniform u;
 		u.binding = 2;
@@ -2450,7 +2450,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 		if (ref_texture.is_valid()) {
 			u.append_id(ref_texture);
 		} else {
-			u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK));
+			u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK));
 		}
 		uniforms.push_back(u);
 	}
@@ -2464,7 +2464,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			texture = shadow_atlas_get_texture(p_render_data->shadow_atlas);
 		}
 		if (!texture.is_valid()) {
-			texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_DEPTH);
+			texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_DEPTH);
 		}
 		u.append_id(texture);
 		uniforms.push_back(u);
@@ -2476,7 +2476,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 		if (p_use_directional_shadow_atlas && directional_shadow_get_texture().is_valid()) {
 			u.append_id(directional_shadow_get_texture());
 		} else {
-			u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_DEPTH));
+			u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_DEPTH));
 		}
 		uniforms.push_back(u);
 	}
@@ -2485,7 +2485,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 		u.binding = 6;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 
-		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
+		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 		for (uint32_t i = 0; i < scene_state.max_lightmaps; i++) {
 			if (p_render_data && i < p_render_data->lightmaps->size()) {
 				RID base = lightmap_instance_get_lightmap((*p_render_data->lightmaps)[i]);
@@ -2503,7 +2503,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 		RD::Uniform u;
 		u.binding = 7;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
-		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 		for (int i = 0; i < MAX_VOXEL_GI_INSTANCESS; i++) {
 			if (p_render_data && i < (int)p_render_data->voxel_gi_instances->size()) {
 				RID tex = gi.voxel_gi_instance_get_texture((*p_render_data->voxel_gi_instances)[i]);
@@ -2533,7 +2533,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 		u.binding = 9;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID dbt = rb ? render_buffers_get_back_depth_texture(p_render_data->render_buffers) : RID();
-		RID texture = (dbt.is_valid()) ? dbt : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_DEPTH);
+		RID texture = (dbt.is_valid()) ? dbt : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_DEPTH);
 		u.append_id(texture);
 		uniforms.push_back(u);
 	}
@@ -2542,7 +2542,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 		u.binding = 10;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID bbt = rb ? render_buffers_get_back_buffer_texture(p_render_data->render_buffers) : RID();
-		RID texture = bbt.is_valid() ? bbt : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
+		RID texture = bbt.is_valid() ? bbt : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 		u.append_id(texture);
 		uniforms.push_back(u);
 	}
@@ -2552,7 +2552,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			RD::Uniform u;
 			u.binding = 11;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
-			RID texture = rb && rb->normal_roughness_buffer.is_valid() ? rb->normal_roughness_buffer : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_NORMAL);
+			RID texture = rb && rb->normal_roughness_buffer.is_valid() ? rb->normal_roughness_buffer : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_NORMAL);
 			u.append_id(texture);
 			uniforms.push_back(u);
 		}
@@ -2562,7 +2562,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			u.binding = 12;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID aot = rb ? render_buffers_get_ao_texture(p_render_data->render_buffers) : RID();
-			RID texture = aot.is_valid() ? aot : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
+			RID texture = aot.is_valid() ? aot : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 			u.append_id(texture);
 			uniforms.push_back(u);
 		}
@@ -2572,7 +2572,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			u.binding = 13;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID ambient_buffer = rb ? render_buffers_get_gi_ambient_texture(p_render_data->render_buffers) : RID();
-			RID texture = ambient_buffer.is_valid() ? ambient_buffer : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
+			RID texture = ambient_buffer.is_valid() ? ambient_buffer : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 			u.append_id(texture);
 			uniforms.push_back(u);
 		}
@@ -2582,7 +2582,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			u.binding = 14;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID reflection_buffer = rb ? render_buffers_get_gi_reflection_texture(p_render_data->render_buffers) : RID();
-			RID texture = reflection_buffer.is_valid() ? reflection_buffer : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
+			RID texture = reflection_buffer.is_valid() ? reflection_buffer : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 			u.append_id(texture);
 			uniforms.push_back(u);
 		}
@@ -2594,7 +2594,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			if (rb && render_buffers_is_sdfgi_enabled(p_render_data->render_buffers)) {
 				t = render_buffers_get_sdfgi_irradiance_probes(p_render_data->render_buffers);
 			} else {
-				t = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
+				t = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 			}
 			u.append_id(t);
 			uniforms.push_back(u);
@@ -2606,7 +2606,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			if (rb && render_buffers_is_sdfgi_enabled(p_render_data->render_buffers)) {
 				u.append_id(render_buffers_get_sdfgi_occlusion_texture(p_render_data->render_buffers));
 			} else {
-				u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE));
+				u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE));
 			}
 			uniforms.push_back(u);
 		}
@@ -2625,10 +2625,10 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			if (rb && render_buffers_has_volumetric_fog(p_render_data->render_buffers)) {
 				vfog = render_buffers_get_volumetric_fog_texture(p_render_data->render_buffers);
 				if (vfog.is_null()) {
-					vfog = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+					vfog = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 				}
 			} else {
-				vfog = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+				vfog = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 			}
 			u.append_id(vfog);
 			uniforms.push_back(u);
@@ -2638,7 +2638,7 @@ RID RenderForwardClustered::_setup_render_pass_uniform_set(RenderListType p_rend
 			u.binding = 19;
 			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 			RID ssil = rb ? render_buffers_get_ssil_texture(p_render_data->render_buffers) : RID();
-			RID texture = ssil.is_valid() ? ssil : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
+			RID texture = ssil.is_valid() ? ssil : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 			u.append_id(texture);
 			uniforms.push_back(u);
 		}
@@ -2667,7 +2667,7 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 	}
 	{
 		// No radiance texture.
-		RID radiance_texture = texture_storage->texture_rd_get_default(is_using_radiance_cubemap_array() ? RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK : RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
+		RID radiance_texture = texture_storage->texture_rd_get_default(is_using_radiance_cubemap_array() ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
 		RD::Uniform u;
 		u.binding = 2;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
@@ -2677,7 +2677,7 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 
 	{
 		// No reflection atlas.
-		RID ref_texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK);
+		RID ref_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK);
 		RD::Uniform u;
 		u.binding = 3;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
@@ -2690,7 +2690,7 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 		RD::Uniform u;
 		u.binding = 4;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
-		RID texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_DEPTH);
+		RID texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_DEPTH);
 		u.append_id(texture);
 		uniforms.push_back(u);
 	}
@@ -2700,7 +2700,7 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 		RD::Uniform u;
 		u.binding = 5;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
-		RID texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_DEPTH);
+		RID texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_DEPTH);
 		u.append_id(texture);
 		uniforms.push_back(u);
 	}
@@ -2711,7 +2711,7 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 		u.binding = 6;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 
-		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
+		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 		for (uint32_t i = 0; i < scene_state.max_lightmaps; i++) {
 			u.append_id(default_tex);
 		}
@@ -2725,7 +2725,7 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 		u.binding = 7;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 
-		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 		for (int i = 0; i < MAX_VOXEL_GI_INSTANCESS; i++) {
 			u.append_id(default_tex);
 		}
@@ -2860,7 +2860,7 @@ void RenderForwardClustered::_geometry_instance_add_surface_with_material(Geomet
 	void *surface_shadow = nullptr;
 	if (!p_material->shader_data->uses_particle_trails && !p_material->shader_data->writes_modelview_or_projection && !p_material->shader_data->uses_vertex && !p_material->shader_data->uses_position && !p_material->shader_data->uses_discard && !p_material->shader_data->uses_depth_pre_pass && !p_material->shader_data->uses_alpha_clip && p_material->shader_data->cull_mode == SceneShaderForwardClustered::ShaderData::CULL_BACK) {
 		flags |= GeometryInstanceSurfaceDataCache::FLAG_USES_SHARED_SHADOW_MATERIAL;
-		material_shadow = static_cast<SceneShaderForwardClustered::MaterialData *>(RendererRD::MaterialStorage::get_singleton()->material_get_data(scene_shader.default_material, RendererRD::SHADER_TYPE_3D));
+		material_shadow = static_cast<SceneShaderForwardClustered::MaterialData *>(RendererRD::MaterialStorage::get_singleton()->material_get_data(scene_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 
 		RID shadow_mesh = mesh_storage->mesh_get_shadow_mesh(p_mesh);
 
@@ -2921,7 +2921,7 @@ void RenderForwardClustered::_geometry_instance_add_surface_with_material_chain(
 
 	while (material->next_pass.is_valid()) {
 		RID next_pass = material->next_pass;
-		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(next_pass, RendererRD::SHADER_TYPE_3D));
+		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(next_pass, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		if (!material || !material->shader_data->valid) {
 			break;
 		}
@@ -2941,7 +2941,7 @@ void RenderForwardClustered::_geometry_instance_add_surface(GeometryInstanceForw
 	SceneShaderForwardClustered::MaterialData *material = nullptr;
 
 	if (m_src.is_valid()) {
-		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(m_src, RendererRD::SHADER_TYPE_3D));
+		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(m_src, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		if (!material || !material->shader_data->valid) {
 			material = nullptr;
 		}
@@ -2952,7 +2952,7 @@ void RenderForwardClustered::_geometry_instance_add_surface(GeometryInstanceForw
 			material_storage->material_update_dependency(m_src, &ginstance->data->dependency_tracker);
 		}
 	} else {
-		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(scene_shader.default_material, RendererRD::SHADER_TYPE_3D));
+		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(scene_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		m_src = scene_shader.default_material;
 	}
 
@@ -2963,7 +2963,7 @@ void RenderForwardClustered::_geometry_instance_add_surface(GeometryInstanceForw
 	if (ginstance->data->material_overlay.is_valid()) {
 		m_src = ginstance->data->material_overlay;
 
-		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(m_src, RendererRD::SHADER_TYPE_3D));
+		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(m_src, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		if (material && material->shader_data->valid) {
 			if (ginstance->data->dirty_dependencies) {
 				material_storage->material_update_dependency(m_src, &ginstance->data->dependency_tracker);

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -488,7 +488,7 @@ SceneShaderForwardClustered::ShaderData::~ShaderData() {
 	}
 }
 
-RendererRD::ShaderData *SceneShaderForwardClustered::_create_shader_func() {
+RendererRD::MaterialStorage::ShaderData *SceneShaderForwardClustered::_create_shader_func() {
 	ShaderData *shader_data = memnew(ShaderData);
 	singleton->shader_list.add(&shader_data->shader_list_element);
 	return shader_data;
@@ -512,7 +512,7 @@ SceneShaderForwardClustered::MaterialData::~MaterialData() {
 	free_parameters_uniform_set(uniform_set);
 }
 
-RendererRD::MaterialData *SceneShaderForwardClustered::_create_material_func(ShaderData *p_shader) {
+RendererRD::MaterialStorage::MaterialData *SceneShaderForwardClustered::_create_material_func(ShaderData *p_shader) {
 	MaterialData *material_data = memnew(MaterialData);
 	material_data->shader_data = p_shader;
 	//update will happen later anyway so do nothing.
@@ -610,8 +610,8 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 
 	valid_color_pass_pipelines.insert(PIPELINE_COLOR_PASS_FLAG_MOTION_VECTORS);
 
-	material_storage->shader_set_data_request_function(RendererRD::SHADER_TYPE_3D, _create_shader_funcs);
-	material_storage->material_set_data_request_function(RendererRD::SHADER_TYPE_3D, _create_material_funcs);
+	material_storage->shader_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_3D, _create_shader_funcs);
+	material_storage->material_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_3D, _create_material_funcs);
 
 	{
 		//shader compiler
@@ -817,7 +817,7 @@ void fragment() {
 		material_storage->material_initialize(default_material);
 		material_storage->material_set_shader(default_material, default_shader);
 
-		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(default_material, RendererRD::SHADER_TYPE_3D));
+		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		default_shader_rd = shader.version_get_shader(md->shader_data->version, SHADER_VERSION_COLOR_PASS);
 		default_shader_sdfgi_rd = shader.version_get_shader(md->shader_data->version, SHADER_VERSION_DEPTH_PASS_WITH_SDF);
 
@@ -845,7 +845,7 @@ void fragment() {
 		material_storage->material_initialize(overdraw_material);
 		material_storage->material_set_shader(overdraw_material, overdraw_material_shader);
 
-		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(overdraw_material, RendererRD::SHADER_TYPE_3D));
+		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(overdraw_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		overdraw_material_shader_ptr = md->shader_data;
 		overdraw_material_uniform_set = md->uniform_set;
 	}

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -93,7 +93,7 @@ public:
 		SHADER_SPECIALIZATION_DIRECTIONAL_SOFT_SHADOWS = 1 << 3,
 	};
 
-	struct ShaderData : public RendererRD::ShaderData {
+	struct ShaderData : public RendererRD::MaterialStorage::ShaderData {
 		enum BlendMode { //used internally
 			BLEND_MODE_MIX,
 			BLEND_MODE_ADD,
@@ -198,12 +198,12 @@ public:
 
 	SelfList<ShaderData>::List shader_list;
 
-	RendererRD::ShaderData *_create_shader_func();
-	static RendererRD::ShaderData *_create_shader_funcs() {
+	RendererRD::MaterialStorage::ShaderData *_create_shader_func();
+	static RendererRD::MaterialStorage::ShaderData *_create_shader_funcs() {
 		return static_cast<SceneShaderForwardClustered *>(singleton)->_create_shader_func();
 	}
 
-	struct MaterialData : public RendererRD::MaterialData {
+	struct MaterialData : public RendererRD::MaterialStorage::MaterialData {
 		ShaderData *shader_data = nullptr;
 		RID uniform_set;
 		uint64_t last_pass = 0;
@@ -216,8 +216,8 @@ public:
 		virtual ~MaterialData();
 	};
 
-	RendererRD::MaterialData *_create_material_func(ShaderData *p_shader);
-	static RendererRD::MaterialData *_create_material_funcs(RendererRD::ShaderData *p_shader) {
+	RendererRD::MaterialStorage::MaterialData *_create_material_func(ShaderData *p_shader);
+	static RendererRD::MaterialStorage::MaterialData *_create_material_funcs(RendererRD::MaterialStorage::ShaderData *p_shader) {
 		return static_cast<SceneShaderForwardClustered *>(singleton)->_create_material_func(static_cast<ShaderData *>(p_shader));
 	}
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -337,7 +337,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 		if (p_radiance_texture.is_valid()) {
 			radiance_texture = p_radiance_texture;
 		} else {
-			radiance_texture = texture_storage->texture_rd_get_default(is_using_radiance_cubemap_array() ? RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK : RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
+			radiance_texture = texture_storage->texture_rd_get_default(is_using_radiance_cubemap_array() ? RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK : RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
 		}
 		RD::Uniform u;
 		u.binding = 2;
@@ -354,7 +354,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 		if (ref_texture.is_valid()) {
 			u.append_id(ref_texture);
 		} else {
-			u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK));
+			u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK));
 		}
 		uniforms.push_back(u);
 	}
@@ -368,7 +368,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 			texture = shadow_atlas_get_texture(p_render_data->shadow_atlas);
 		}
 		if (!texture.is_valid()) {
-			texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_DEPTH);
+			texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_DEPTH);
 		}
 		u.append_id(texture);
 		uniforms.push_back(u);
@@ -380,7 +380,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 		if (p_use_directional_shadow_atlas && directional_shadow_get_texture().is_valid()) {
 			u.append_id(directional_shadow_get_texture());
 		} else {
-			u.append_id(texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_DEPTH));
+			u.append_id(texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_DEPTH));
 		}
 		uniforms.push_back(u);
 	}
@@ -391,7 +391,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 		u.binding = 6;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 
-		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
+		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 		for (uint32_t i = 0; i < scene_state.max_lightmaps; i++) {
 			if (p_render_data && i < p_render_data->lightmaps->size()) {
 				RID base = lightmap_instance_get_lightmap((*p_render_data->lightmaps)[i]);
@@ -412,7 +412,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 		u.binding = 7;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		u.ids.resize(MAX_VOXEL_GI_INSTANCESS);
-		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+		RID default_tex = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 		for (int i = 0; i < MAX_VOXEL_GI_INSTANCESS; i++) {
 			if (i < (int)p_voxel_gi_instances.size()) {
 				RID tex = gi.voxel_gi_instance_get_texture(p_voxel_gi_instances[i]);
@@ -443,7 +443,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 		u.binding = 9;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID dbt = rb ? render_buffers_get_back_depth_texture(p_render_data->render_buffers) : RID();
-		RID texture = (dbt.is_valid()) ? dbt : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_DEPTH);
+		RID texture = (dbt.is_valid()) ? dbt : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_DEPTH);
 		u.append_id(texture);
 		uniforms.push_back(u);
 	}
@@ -452,7 +452,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 		u.binding = 10;
 		u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
 		RID bbt = rb ? render_buffers_get_back_buffer_texture(p_render_data->render_buffers) : RID();
-		RID texture = bbt.is_valid() ? bbt : texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
+		RID texture = bbt.is_valid() ? bbt : texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 		u.append_id(texture);
 		uniforms.push_back(u);
 	}
@@ -2227,7 +2227,7 @@ void RenderForwardMobile::_geometry_instance_add_surface_with_material(GeometryI
 	void *surface_shadow = nullptr;
 	if (!p_material->shader_data->uses_particle_trails && !p_material->shader_data->writes_modelview_or_projection && !p_material->shader_data->uses_vertex && !p_material->shader_data->uses_discard && !p_material->shader_data->uses_depth_pre_pass && !p_material->shader_data->uses_alpha_clip) {
 		flags |= GeometryInstanceSurfaceDataCache::FLAG_USES_SHARED_SHADOW_MATERIAL;
-		material_shadow = static_cast<SceneShaderForwardMobile::MaterialData *>(RendererRD::MaterialStorage::get_singleton()->material_get_data(scene_shader.default_material, RendererRD::SHADER_TYPE_3D));
+		material_shadow = static_cast<SceneShaderForwardMobile::MaterialData *>(RendererRD::MaterialStorage::get_singleton()->material_get_data(scene_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 
 		RID shadow_mesh = mesh_storage->mesh_get_shadow_mesh(p_mesh);
 
@@ -2286,7 +2286,7 @@ void RenderForwardMobile::_geometry_instance_add_surface_with_material_chain(Geo
 
 	while (material->next_pass.is_valid()) {
 		RID next_pass = material->next_pass;
-		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(next_pass, RendererRD::SHADER_TYPE_3D));
+		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(next_pass, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		if (!material || !material->shader_data->valid) {
 			break;
 		}
@@ -2306,7 +2306,7 @@ void RenderForwardMobile::_geometry_instance_add_surface(GeometryInstanceForward
 	SceneShaderForwardMobile::MaterialData *material = nullptr;
 
 	if (m_src.is_valid()) {
-		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(m_src, RendererRD::SHADER_TYPE_3D));
+		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(m_src, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		if (!material || !material->shader_data->valid) {
 			material = nullptr;
 		}
@@ -2317,7 +2317,7 @@ void RenderForwardMobile::_geometry_instance_add_surface(GeometryInstanceForward
 			material_storage->material_update_dependency(m_src, &ginstance->data->dependency_tracker);
 		}
 	} else {
-		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(scene_shader.default_material, RendererRD::SHADER_TYPE_3D));
+		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(scene_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		m_src = scene_shader.default_material;
 	}
 
@@ -2328,7 +2328,7 @@ void RenderForwardMobile::_geometry_instance_add_surface(GeometryInstanceForward
 	if (ginstance->data->material_overlay.is_valid()) {
 		m_src = ginstance->data->material_overlay;
 
-		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(m_src, RendererRD::SHADER_TYPE_3D));
+		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(m_src, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		if (material && material->shader_data->valid) {
 			if (ginstance->data->dirty_dependencies) {
 				material_storage->material_update_dependency(m_src, &ginstance->data->dependency_tracker);

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -445,7 +445,7 @@ SceneShaderForwardMobile::ShaderData::~ShaderData() {
 	}
 }
 
-RendererRD::ShaderData *SceneShaderForwardMobile::_create_shader_func() {
+RendererRD::MaterialStorage::ShaderData *SceneShaderForwardMobile::_create_shader_func() {
 	ShaderData *shader_data = memnew(ShaderData);
 	singleton->shader_list.add(&shader_data->shader_list_element);
 	return shader_data;
@@ -469,7 +469,7 @@ SceneShaderForwardMobile::MaterialData::~MaterialData() {
 	free_parameters_uniform_set(uniform_set);
 }
 
-RendererRD::MaterialData *SceneShaderForwardMobile::_create_material_func(ShaderData *p_shader) {
+RendererRD::MaterialStorage::MaterialData *SceneShaderForwardMobile::_create_material_func(ShaderData *p_shader) {
 	MaterialData *material_data = memnew(MaterialData);
 	material_data->shader_data = p_shader;
 	//update will happen later anyway so do nothing.
@@ -512,8 +512,8 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		}
 	}
 
-	material_storage->shader_set_data_request_function(RendererRD::SHADER_TYPE_3D, _create_shader_funcs);
-	material_storage->material_set_data_request_function(RendererRD::SHADER_TYPE_3D, _create_material_funcs);
+	material_storage->shader_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_3D, _create_shader_funcs);
+	material_storage->material_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_3D, _create_material_funcs);
 
 	{
 		//shader compiler
@@ -716,7 +716,7 @@ void fragment() {
 		material_storage->material_initialize(default_material);
 		material_storage->material_set_shader(default_material, default_shader);
 
-		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(default_material, RendererRD::SHADER_TYPE_3D));
+		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(default_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		default_shader_rd = shader.version_get_shader(md->shader_data->version, SHADER_VERSION_COLOR_PASS);
 
 		default_material_shader_ptr = md->shader_data;
@@ -743,7 +743,7 @@ void fragment() {
 		material_storage->material_initialize(overdraw_material);
 		material_storage->material_set_shader(overdraw_material, overdraw_material_shader);
 
-		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(overdraw_material, RendererRD::SHADER_TYPE_3D));
+		MaterialData *md = static_cast<MaterialData *>(material_storage->material_get_data(overdraw_material, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		overdraw_material_shader_ptr = md->shader_data;
 		overdraw_material_uniform_set = md->uniform_set;
 	}

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -55,7 +55,7 @@ public:
 		SHADER_VERSION_MAX
 	};
 
-	struct ShaderData : public RendererRD::ShaderData {
+	struct ShaderData : public RendererRD::MaterialStorage::ShaderData {
 		enum BlendMode { //used internally
 			BLEND_MODE_MIX,
 			BLEND_MODE_ADD,
@@ -157,12 +157,12 @@ public:
 		virtual ~ShaderData();
 	};
 
-	RendererRD::ShaderData *_create_shader_func();
-	static RendererRD::ShaderData *_create_shader_funcs() {
+	RendererRD::MaterialStorage::ShaderData *_create_shader_func();
+	static RendererRD::MaterialStorage::ShaderData *_create_shader_funcs() {
 		return static_cast<SceneShaderForwardMobile *>(singleton)->_create_shader_func();
 	}
 
-	struct MaterialData : public RendererRD::MaterialData {
+	struct MaterialData : public RendererRD::MaterialStorage::MaterialData {
 		ShaderData *shader_data = nullptr;
 		RID uniform_set;
 		uint64_t last_pass = 0;
@@ -177,8 +177,8 @@ public:
 
 	SelfList<ShaderData>::List shader_list;
 
-	RendererRD::MaterialData *_create_material_func(ShaderData *p_shader);
-	static RendererRD::MaterialData *_create_material_funcs(RendererRD::ShaderData *p_shader) {
+	RendererRD::MaterialStorage::MaterialData *_create_material_func(ShaderData *p_shader);
+	static RendererRD::MaterialStorage::MaterialData *_create_material_funcs(RendererRD::MaterialStorage::ShaderData *p_shader) {
 		return static_cast<SceneShaderForwardMobile *>(singleton)->_create_material_func(static_cast<ShaderData *>(p_shader));
 	}
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -192,7 +192,7 @@ RendererCanvasRender::PolygonID RendererCanvasRenderRD::request_polygon(const Ve
 			vd.stride = 0;
 
 			descriptions.write[1] = vd;
-			buffers.write[1] = mesh_storage->mesh_get_default_rd_buffer(RendererRD::DEFAULT_RD_BUFFER_COLOR);
+			buffers.write[1] = mesh_storage->mesh_get_default_rd_buffer(RendererRD::MeshStorage::DEFAULT_RD_BUFFER_COLOR);
 		}
 
 		//uvs
@@ -220,7 +220,7 @@ RendererCanvasRender::PolygonID RendererCanvasRenderRD::request_polygon(const Ve
 			vd.stride = 0;
 
 			descriptions.write[2] = vd;
-			buffers.write[2] = mesh_storage->mesh_get_default_rd_buffer(RendererRD::DEFAULT_RD_BUFFER_TEX_UV);
+			buffers.write[2] = mesh_storage->mesh_get_default_rd_buffer(RendererRD::MeshStorage::DEFAULT_RD_BUFFER_TEX_UV);
 		}
 
 		//bones
@@ -253,7 +253,7 @@ RendererCanvasRender::PolygonID RendererCanvasRenderRD::request_polygon(const Ve
 			vd.stride = 0;
 
 			descriptions.write[3] = vd;
-			buffers.write[3] = mesh_storage->mesh_get_default_rd_buffer(RendererRD::DEFAULT_RD_BUFFER_BONES);
+			buffers.write[3] = mesh_storage->mesh_get_default_rd_buffer(RendererRD::MeshStorage::DEFAULT_RD_BUFFER_BONES);
 		}
 
 		//weights
@@ -286,7 +286,7 @@ RendererCanvasRender::PolygonID RendererCanvasRenderRD::request_polygon(const Ve
 			vd.stride = 0;
 
 			descriptions.write[4] = vd;
-			buffers.write[4] = mesh_storage->mesh_get_default_rd_buffer(RendererRD::DEFAULT_RD_BUFFER_WEIGHTS);
+			buffers.write[4] = mesh_storage->mesh_get_default_rd_buffer(RendererRD::MeshStorage::DEFAULT_RD_BUFFER_WEIGHTS);
 		}
 
 		//check that everything is as it should be
@@ -988,7 +988,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 		} else {
 			screen = texture_storage->render_target_get_rd_backbuffer(p_to_render_target);
 			if (screen.is_null()) { //unallocated backbuffer
-				screen = RendererRD::TextureStorage::get_singleton()->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE);
+				screen = RendererRD::TextureStorage::get_singleton()->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
 			}
 		}
 		u.append_id(screen);
@@ -1115,7 +1115,7 @@ void RendererCanvasRenderRD::_render_items(RID p_to_render_target, int p_item_co
 		if (material != prev_material) {
 			CanvasMaterialData *material_data = nullptr;
 			if (material.is_valid()) {
-				material_data = static_cast<CanvasMaterialData *>(material_storage->material_get_data(material, RendererRD::SHADER_TYPE_2D));
+				material_data = static_cast<CanvasMaterialData *>(material_storage->material_get_data(material, RendererRD::MaterialStorage::SHADER_TYPE_2D));
 			}
 
 			if (material_data) {
@@ -1383,7 +1383,7 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 		RID material = ci->material_owner == nullptr ? ci->material : ci->material_owner->material;
 
 		if (material.is_valid()) {
-			CanvasMaterialData *md = static_cast<CanvasMaterialData *>(material_storage->material_get_data(material, RendererRD::SHADER_TYPE_2D));
+			CanvasMaterialData *md = static_cast<CanvasMaterialData *>(material_storage->material_get_data(material, RendererRD::MaterialStorage::SHADER_TYPE_2D));
 			if (md && md->shader_data->valid) {
 				if (md->shader_data->uses_screen_texture && canvas_group_owner == nullptr) {
 					if (!material_screen_texture_found) {
@@ -2261,7 +2261,7 @@ RendererCanvasRenderRD::CanvasShaderData::~CanvasShaderData() {
 	}
 }
 
-RendererRD::ShaderData *RendererCanvasRenderRD::_create_shader_func() {
+RendererRD::MaterialStorage::ShaderData *RendererCanvasRenderRD::_create_shader_func() {
 	CanvasShaderData *shader_data = memnew(CanvasShaderData);
 	return shader_data;
 }
@@ -2276,7 +2276,7 @@ RendererCanvasRenderRD::CanvasMaterialData::~CanvasMaterialData() {
 	free_parameters_uniform_set(uniform_set);
 }
 
-RendererRD::MaterialData *RendererCanvasRenderRD::_create_material_func(CanvasShaderData *p_shader) {
+RendererRD::MaterialStorage::MaterialData *RendererCanvasRenderRD::_create_material_func(CanvasShaderData *p_shader) {
 	CanvasMaterialData *material_data = memnew(CanvasMaterialData);
 	material_data->shader_data = p_shader;
 	//update will happen later anyway so do nothing.
@@ -2629,8 +2629,8 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 	state.shadow_texture_size = GLOBAL_GET("rendering/2d/shadow_atlas/size");
 
 	//create functions for shader and material
-	material_storage->shader_set_data_request_function(RendererRD::SHADER_TYPE_2D, _create_shader_funcs);
-	material_storage->material_set_data_request_function(RendererRD::SHADER_TYPE_2D, _create_material_funcs);
+	material_storage->shader_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_2D, _create_shader_funcs);
+	material_storage->material_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_2D, _create_material_funcs);
 
 	state.time = 0;
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -149,7 +149,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		ShaderCompiler compiler;
 	} shader;
 
-	struct CanvasShaderData : public RendererRD::ShaderData {
+	struct CanvasShaderData : public RendererRD::MaterialStorage::ShaderData {
 		enum BlendMode { //used internally
 			BLEND_MODE_MIX,
 			BLEND_MODE_ADD,
@@ -193,12 +193,12 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		virtual ~CanvasShaderData();
 	};
 
-	RendererRD::ShaderData *_create_shader_func();
-	static RendererRD::ShaderData *_create_shader_funcs() {
+	RendererRD::MaterialStorage::ShaderData *_create_shader_func();
+	static RendererRD::MaterialStorage::ShaderData *_create_shader_funcs() {
 		return static_cast<RendererCanvasRenderRD *>(singleton)->_create_shader_func();
 	}
 
-	struct CanvasMaterialData : public RendererRD::MaterialData {
+	struct CanvasMaterialData : public RendererRD::MaterialStorage::MaterialData {
 		CanvasShaderData *shader_data = nullptr;
 		RID uniform_set;
 
@@ -208,8 +208,8 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		virtual ~CanvasMaterialData();
 	};
 
-	RendererRD::MaterialData *_create_material_func(CanvasShaderData *p_shader);
-	static RendererRD::MaterialData *_create_material_funcs(RendererRD::ShaderData *p_shader) {
+	RendererRD::MaterialStorage::MaterialData *_create_material_func(CanvasShaderData *p_shader);
+	static RendererRD::MaterialStorage::MaterialData *_create_material_funcs(RendererRD::MaterialStorage::ShaderData *p_shader) {
 		return static_cast<RendererCanvasRenderRD *>(singleton)->_create_material_func(static_cast<CanvasShaderData *>(p_shader));
 	}
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2007,7 +2007,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			tonemap.exposure_texture = rb->luminance.current;
 			tonemap.auto_exposure_grey = environment_get_auto_exp_scale(p_render_data->environment);
 		} else {
-			tonemap.exposure_texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE);
+			tonemap.exposure_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
 		}
 
 		if (can_use_effects && p_render_data->environment.is_valid() && environment_get_glow_enabled(p_render_data->environment)) {
@@ -2026,12 +2026,12 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				tonemap.glow_map = texture_storage->texture_get_rd_texture(environment_get_glow_map(p_render_data->environment));
 			} else {
 				tonemap.glow_map_strength = 0.0f;
-				tonemap.glow_map = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE);
+				tonemap.glow_map = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
 			}
 
 		} else {
-			tonemap.glow_texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
-			tonemap.glow_map = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE);
+			tonemap.glow_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
+			tonemap.glow_map = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
 		}
 
 		if (rb->screen_space_aa == RS::VIEWPORT_SCREEN_SPACE_AA_FXAA) {
@@ -2053,7 +2053,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 		tonemap.use_color_correction = false;
 		tonemap.use_1d_color_correction = false;
-		tonemap.color_correction_texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+		tonemap.color_correction_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 
 		if (can_use_effects && p_render_data->environment.is_valid()) {
 			tonemap.use_bcs = environment_get_adjustments_enabled(p_render_data->environment);
@@ -2123,14 +2123,14 @@ void RendererSceneRenderRD::_post_process_subpass(RID p_source_texture, RID p_fr
 	}
 
 	tonemap.use_glow = false;
-	tonemap.glow_texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
-	tonemap.glow_map = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE);
+	tonemap.glow_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
+	tonemap.glow_map = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
 	tonemap.use_auto_exposure = false;
-	tonemap.exposure_texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_WHITE);
+	tonemap.exposure_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
 
 	tonemap.use_color_correction = false;
 	tonemap.use_1d_color_correction = false;
-	tonemap.color_correction_texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_3D_WHITE);
+	tonemap.color_correction_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 
 	if (can_use_effects && p_render_data->environment.is_valid()) {
 		tonemap.use_bcs = environment_get_adjustments_enabled(p_render_data->environment);
@@ -2174,7 +2174,7 @@ void RendererSceneRenderRD::_render_buffers_debug_draw(RID p_render_buffers, RID
 			RID shadow_atlas_texture = shadow_atlas_get_texture(p_shadow_atlas);
 
 			if (shadow_atlas_texture.is_null()) {
-				shadow_atlas_texture = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_BLACK);
+				shadow_atlas_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 			}
 
 			Size2 rtsize = texture_storage->render_target_get_size(rb->render_target);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -56,7 +56,7 @@ LightStorage::LightStorage() {
 		}
 
 		for (int i = 0; i < lightmap_textures.size(); i++) {
-			lightmap_textures.write[i] = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
+			lightmap_textures.write[i] = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 		}
 	}
 
@@ -366,6 +366,13 @@ AABB LightStorage::light_get_aabb(RID p_light) const {
 	ERR_FAIL_V(AABB());
 }
 
+Dependency *LightStorage::light_get_dependency(RID p_light) const {
+	Light *light = light_owner.get_or_null(p_light);
+	ERR_FAIL_NULL_V(light, nullptr);
+
+	return &light->dependency;
+}
+
 /* REFLECTION PROBE */
 
 RID LightStorage::reflection_probe_allocate() {
@@ -601,6 +608,13 @@ float LightStorage::reflection_probe_get_ambient_color_energy(RID p_probe) const
 	return reflection_probe->ambient_color_energy;
 }
 
+Dependency *LightStorage::reflection_probe_get_dependency(RID p_probe) const {
+	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);
+	ERR_FAIL_NULL_V(reflection_probe, nullptr);
+
+	return &reflection_probe->dependency;
+}
+
 /* LIGHTMAP API */
 
 RID LightStorage::lightmap_allocate() {
@@ -628,17 +642,17 @@ void LightStorage::lightmap_set_textures(RID p_lightmap, RID p_light, bool p_use
 
 	//erase lightmap users
 	if (lm->light_texture.is_valid()) {
-		RendererRD::Texture *t = RendererRD::TextureStorage::get_singleton()->get_texture(lm->light_texture);
+		RendererRD::TextureStorage::Texture *t = RendererRD::TextureStorage::get_singleton()->get_texture(lm->light_texture);
 		if (t) {
 			t->lightmap_users.erase(p_lightmap);
 		}
 	}
 
-	RendererRD::Texture *t = RendererRD::TextureStorage::get_singleton()->get_texture(p_light);
+	RendererRD::TextureStorage::Texture *t = RendererRD::TextureStorage::get_singleton()->get_texture(p_light);
 	lm->light_texture = p_light;
 	lm->uses_spherical_harmonics = p_uses_spherical_haromics;
 
-	RID default_2d_array = texture_storage->texture_rd_get_default(RendererRD::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
+	RID default_2d_array = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 	if (!t) {
 		if (using_lightmap_array) {
 			if (lm->array_index >= 0) {
@@ -723,6 +737,13 @@ PackedInt32Array LightStorage::lightmap_get_probe_capture_bsp_tree(RID p_lightma
 
 void LightStorage::lightmap_set_probe_capture_update_speed(float p_speed) {
 	lightmap_probe_capture_update_speed = p_speed;
+}
+
+Dependency *LightStorage::lightmap_get_dependency(RID p_lightmap) const {
+	Lightmap *lm = lightmap_owner.get_or_null(p_lightmap);
+	ERR_FAIL_NULL_V(lm, nullptr);
+
+	return &lm->dependency;
 }
 
 void LightStorage::lightmap_tap_sh_light(RID p_lightmap, const Vector3 &p_point, Color *r_sh) {

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -39,86 +39,80 @@
 
 namespace RendererRD {
 
-/* LIGHT */
-
-struct Light {
-	RS::LightType type;
-	float param[RS::LIGHT_PARAM_MAX];
-	Color color = Color(1, 1, 1, 1);
-	RID projector;
-	bool shadow = false;
-	bool negative = false;
-	bool reverse_cull = false;
-	RS::LightBakeMode bake_mode = RS::LIGHT_BAKE_DYNAMIC;
-	uint32_t max_sdfgi_cascade = 2;
-	uint32_t cull_mask = 0xFFFFFFFF;
-	bool distance_fade = false;
-	real_t distance_fade_begin = 40.0;
-	real_t distance_fade_shadow = 50.0;
-	real_t distance_fade_length = 10.0;
-	RS::LightOmniShadowMode omni_shadow_mode = RS::LIGHT_OMNI_SHADOW_DUAL_PARABOLOID;
-	RS::LightDirectionalShadowMode directional_shadow_mode = RS::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL;
-	bool directional_blend_splits = false;
-	RS::LightDirectionalSkyMode directional_sky_mode = RS::LIGHT_DIRECTIONAL_SKY_MODE_LIGHT_AND_SKY;
-	uint64_t version = 0;
-
-	Dependency dependency;
-};
-
-/* REFLECTION PROBE */
-
-struct ReflectionProbe {
-	RS::ReflectionProbeUpdateMode update_mode = RS::REFLECTION_PROBE_UPDATE_ONCE;
-	int resolution = 256;
-	float intensity = 1.0;
-	RS::ReflectionProbeAmbientMode ambient_mode = RS::REFLECTION_PROBE_AMBIENT_ENVIRONMENT;
-	Color ambient_color;
-	float ambient_color_energy = 1.0;
-	float max_distance = 0;
-	Vector3 extents = Vector3(1, 1, 1);
-	Vector3 origin_offset;
-	bool interior = false;
-	bool box_projection = false;
-	bool enable_shadows = false;
-	uint32_t cull_mask = (1 << 20) - 1;
-	float mesh_lod_threshold = 0.01;
-
-	Dependency dependency;
-};
-
-/* LIGHTMAP */
-
-struct Lightmap {
-	RID light_texture;
-	bool uses_spherical_harmonics = false;
-	bool interior = false;
-	AABB bounds = AABB(Vector3(), Vector3(1, 1, 1));
-	int32_t array_index = -1; //unassigned
-	PackedVector3Array points;
-	PackedColorArray point_sh;
-	PackedInt32Array tetrahedra;
-	PackedInt32Array bsp_tree;
-
-	struct BSP {
-		static const int32_t EMPTY_LEAF = INT32_MIN;
-		float plane[4];
-		int32_t over = EMPTY_LEAF, under = EMPTY_LEAF;
-	};
-
-	Dependency dependency;
-};
-
 class LightStorage : public RendererLightStorage {
 private:
 	static LightStorage *singleton;
 
 	/* LIGHT */
+	struct Light {
+		RS::LightType type;
+		float param[RS::LIGHT_PARAM_MAX];
+		Color color = Color(1, 1, 1, 1);
+		RID projector;
+		bool shadow = false;
+		bool negative = false;
+		bool reverse_cull = false;
+		RS::LightBakeMode bake_mode = RS::LIGHT_BAKE_DYNAMIC;
+		uint32_t max_sdfgi_cascade = 2;
+		uint32_t cull_mask = 0xFFFFFFFF;
+		bool distance_fade = false;
+		real_t distance_fade_begin = 40.0;
+		real_t distance_fade_shadow = 50.0;
+		real_t distance_fade_length = 10.0;
+		RS::LightOmniShadowMode omni_shadow_mode = RS::LIGHT_OMNI_SHADOW_DUAL_PARABOLOID;
+		RS::LightDirectionalShadowMode directional_shadow_mode = RS::LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL;
+		bool directional_blend_splits = false;
+		RS::LightDirectionalSkyMode directional_sky_mode = RS::LIGHT_DIRECTIONAL_SKY_MODE_LIGHT_AND_SKY;
+		uint64_t version = 0;
+
+		Dependency dependency;
+	};
+
 	mutable RID_Owner<Light, true> light_owner;
 
 	/* REFLECTION PROBE */
+
+	struct ReflectionProbe {
+		RS::ReflectionProbeUpdateMode update_mode = RS::REFLECTION_PROBE_UPDATE_ONCE;
+		int resolution = 256;
+		float intensity = 1.0;
+		RS::ReflectionProbeAmbientMode ambient_mode = RS::REFLECTION_PROBE_AMBIENT_ENVIRONMENT;
+		Color ambient_color;
+		float ambient_color_energy = 1.0;
+		float max_distance = 0;
+		Vector3 extents = Vector3(1, 1, 1);
+		Vector3 origin_offset;
+		bool interior = false;
+		bool box_projection = false;
+		bool enable_shadows = false;
+		uint32_t cull_mask = (1 << 20) - 1;
+		float mesh_lod_threshold = 0.01;
+
+		Dependency dependency;
+	};
 	mutable RID_Owner<ReflectionProbe, true> reflection_probe_owner;
 
 	/* LIGHTMAP */
+
+	struct Lightmap {
+		RID light_texture;
+		bool uses_spherical_harmonics = false;
+		bool interior = false;
+		AABB bounds = AABB(Vector3(), Vector3(1, 1, 1));
+		int32_t array_index = -1; //unassigned
+		PackedVector3Array points;
+		PackedColorArray point_sh;
+		PackedInt32Array tetrahedra;
+		PackedInt32Array bsp_tree;
+
+		struct BSP {
+			static const int32_t EMPTY_LEAF = INT32_MIN;
+			float plane[4];
+			int32_t over = EMPTY_LEAF, under = EMPTY_LEAF;
+		};
+
+		Dependency dependency;
+	};
 
 	bool using_lightmap_array;
 	Vector<RID> lightmap_textures;
@@ -135,7 +129,6 @@ public:
 
 	/* LIGHT */
 
-	Light *get_light(RID p_rid) { return light_owner.get_or_null(p_rid); };
 	bool owns_light(RID p_rid) { return light_owner.owns(p_rid); };
 
 	void _light_initialize(RID p_rid, RS::LightType p_type);
@@ -268,9 +261,10 @@ public:
 	virtual uint32_t light_get_max_sdfgi_cascade(RID p_light) override;
 	virtual uint64_t light_get_version(RID p_light) const override;
 
+	Dependency *light_get_dependency(RID p_light) const;
+
 	/* REFLECTION PROBE */
 
-	ReflectionProbe *get_reflection_probe(RID p_rid) { return reflection_probe_owner.get_or_null(p_rid); };
 	bool owns_reflection_probe(RID p_rid) { return reflection_probe_owner.owns(p_rid); };
 
 	virtual RID reflection_probe_allocate() override;
@@ -310,9 +304,10 @@ public:
 	Color reflection_probe_get_ambient_color(RID p_probe) const;
 	float reflection_probe_get_ambient_color_energy(RID p_probe) const;
 
+	Dependency *reflection_probe_get_dependency(RID p_probe) const;
+
 	/* LIGHTMAP */
 
-	Lightmap *get_lightmap(RID p_rid) { return lightmap_owner.get_or_null(p_rid); };
 	bool owns_lightmap(RID p_rid) { return lightmap_owner.owns(p_rid); };
 
 	virtual RID lightmap_allocate() override;
@@ -331,6 +326,8 @@ public:
 	virtual bool lightmap_is_interior(RID p_lightmap) const override;
 	virtual void lightmap_tap_sh_light(RID p_lightmap, const Vector3 &p_point, Color *r_sh) override;
 	virtual void lightmap_set_probe_capture_update_speed(float p_speed) override;
+
+	Dependency *lightmap_get_dependency(RID p_lightmap) const;
 
 	virtual float lightmap_get_probe_capture_update_speed() const override {
 		return lightmap_probe_capture_update_speed;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -926,9 +926,9 @@ _FORCE_INLINE_ static void _fill_std140_ubo_empty(ShaderLanguage::DataType type,
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// MaterialData
+// MaterialStorage::MaterialData
 
-void MaterialData::update_uniform_buffer(const HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const HashMap<StringName, Variant> &p_parameters, uint8_t *p_buffer, uint32_t p_buffer_size, bool p_use_linear_color) {
+void MaterialStorage::MaterialData::update_uniform_buffer(const HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const HashMap<StringName, Variant> &p_parameters, uint8_t *p_buffer, uint32_t p_buffer_size, bool p_use_linear_color) {
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 	bool uses_global_buffer = false;
 
@@ -1007,7 +1007,7 @@ void MaterialData::update_uniform_buffer(const HashMap<StringName, ShaderLanguag
 	}
 }
 
-MaterialData::~MaterialData() {
+MaterialStorage::MaterialData::~MaterialData() {
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 
 	if (global_buffer_E) {
@@ -1033,14 +1033,14 @@ MaterialData::~MaterialData() {
 	}
 }
 
-void MaterialData::update_textures(const HashMap<StringName, Variant> &p_parameters, const HashMap<StringName, HashMap<int, RID>> &p_default_textures, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, RID *p_textures, bool p_use_linear_color) {
+void MaterialStorage::MaterialData::update_textures(const HashMap<StringName, Variant> &p_parameters, const HashMap<StringName, HashMap<int, RID>> &p_default_textures, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, RID *p_textures, bool p_use_linear_color) {
 	TextureStorage *texture_storage = TextureStorage::get_singleton();
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 
 #ifdef TOOLS_ENABLED
-	Texture *roughness_detect_texture = nullptr;
+	TextureStorage::Texture *roughness_detect_texture = nullptr;
 	RS::TextureDetectRoughnessChannel roughness_channel = RS::TEXTURE_DETECT_ROUGHNESS_R;
-	Texture *normal_detect_texture = nullptr;
+	TextureStorage::Texture *normal_detect_texture = nullptr;
 #endif
 
 	bool uses_global_textures = false;
@@ -1123,19 +1123,19 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 				case ShaderLanguage::TYPE_SAMPLER2D: {
 					switch (p_texture_uniforms[i].hint) {
 						case ShaderLanguage::ShaderNode::Uniform::HINT_DEFAULT_BLACK: {
-							rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_BLACK);
+							rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 						} break;
 						case ShaderLanguage::ShaderNode::Uniform::HINT_ANISOTROPY: {
-							rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_ANISO);
+							rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_ANISO);
 						} break;
 						case ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL: {
-							rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_NORMAL);
+							rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_NORMAL);
 						} break;
 						case ShaderLanguage::ShaderNode::Uniform::HINT_ROUGHNESS_NORMAL: {
-							rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_NORMAL);
+							rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_NORMAL);
 						} break;
 						default: {
-							rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_WHITE);
+							rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
 						} break;
 					}
 				} break;
@@ -1143,27 +1143,27 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 				case ShaderLanguage::TYPE_SAMPLERCUBE: {
 					switch (p_texture_uniforms[i].hint) {
 						case ShaderLanguage::ShaderNode::Uniform::HINT_DEFAULT_BLACK: {
-							rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
+							rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_BLACK);
 						} break;
 						default: {
-							rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_CUBEMAP_WHITE);
+							rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_WHITE);
 						} break;
 					}
 				} break;
 				case ShaderLanguage::TYPE_SAMPLERCUBEARRAY: {
-					rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK);
+					rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK);
 				} break;
 
 				case ShaderLanguage::TYPE_ISAMPLER3D:
 				case ShaderLanguage::TYPE_USAMPLER3D:
 				case ShaderLanguage::TYPE_SAMPLER3D: {
-					rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_3D_WHITE);
+					rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_3D_WHITE);
 				} break;
 
 				case ShaderLanguage::TYPE_ISAMPLER2DARRAY:
 				case ShaderLanguage::TYPE_USAMPLER2DARRAY:
 				case ShaderLanguage::TYPE_SAMPLER2DARRAY: {
-					rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
+					rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 				} break;
 
 				default: {
@@ -1185,7 +1185,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 			bool srgb = p_use_linear_color && p_texture_uniforms[i].use_color;
 
 			for (int j = 0; j < textures.size(); j++) {
-				Texture *tex = TextureStorage::get_singleton()->get_texture(textures[j]);
+				TextureStorage::Texture *tex = TextureStorage::get_singleton()->get_texture(textures[j]);
 
 				if (tex) {
 					rd_texture = (srgb && tex->rd_texture_srgb.is_valid()) ? tex->rd_texture_srgb : tex->rd_texture;
@@ -1207,7 +1207,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 #endif
 				}
 				if (rd_texture.is_null()) {
-					rd_texture = texture_storage->texture_rd_get_default(DEFAULT_RD_TEXTURE_WHITE);
+					rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_WHITE);
 				}
 #ifdef TOOLS_ENABLED
 				if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
@@ -1248,14 +1248,14 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 	}
 }
 
-void MaterialData::free_parameters_uniform_set(RID p_uniform_set) {
+void MaterialStorage::MaterialData::free_parameters_uniform_set(RID p_uniform_set) {
 	if (p_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(p_uniform_set)) {
 		RD::get_singleton()->uniform_set_set_invalidation_callback(p_uniform_set, nullptr, nullptr);
 		RD::get_singleton()->free(p_uniform_set);
 	}
 }
 
-bool MaterialData::update_parameters_uniform_set(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty, const HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, const HashMap<StringName, HashMap<int, RID>> &p_default_texture_params, uint32_t p_ubo_size, RID &uniform_set, RID p_shader, uint32_t p_shader_uniform_set, uint32_t p_barrier) {
+bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty, const HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, const HashMap<StringName, HashMap<int, RID>> &p_default_texture_params, uint32_t p_ubo_size, RID &uniform_set, RID p_shader, uint32_t p_shader_uniform_set, uint32_t p_barrier) {
 	if ((uint32_t)ubo_data.size() != p_ubo_size) {
 		p_uniform_dirty = true;
 		if (uniform_buffer.is_valid()) {
@@ -2577,6 +2577,15 @@ void MaterialStorage::material_set_shader(RID p_material, RID p_shader) {
 	_material_queue_update(material, true, true);
 }
 
+MaterialStorage::ShaderData *MaterialStorage::material_get_shader_data(RID p_material) {
+	const MaterialStorage::Material *material = MaterialStorage::get_singleton()->get_material(p_material);
+	if (material && material->shader && material->shader->data) {
+		return material->shader->data;
+	}
+
+	return nullptr;
+}
+
 void MaterialStorage::material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) {
 	Material *material = material_owner.get_or_null(p_material);
 	ERR_FAIL_COND(!material);
@@ -2678,12 +2687,12 @@ void MaterialStorage::material_update_dependency(RID p_material, DependencyTrack
 	}
 }
 
-void MaterialStorage::material_set_data_request_function(ShaderType p_shader_type, MaterialDataRequestFunction p_function) {
+void MaterialStorage::material_set_data_request_function(ShaderType p_shader_type, MaterialStorage::MaterialDataRequestFunction p_function) {
 	ERR_FAIL_INDEX(p_shader_type, SHADER_TYPE_MAX);
 	material_data_request_func[p_shader_type] = p_function;
 }
 
-MaterialDataRequestFunction MaterialStorage::material_get_data_request_function(ShaderType p_shader_type) {
+MaterialStorage::MaterialDataRequestFunction MaterialStorage::material_get_data_request_function(ShaderType p_shader_type) {
 	ERR_FAIL_INDEX_V(p_shader_type, SHADER_TYPE_MAX, nullptr);
 	return material_data_request_func[p_shader_type];
 }

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -758,6 +758,13 @@ bool MeshStorage::mesh_needs_instance(RID p_mesh, bool p_has_skeleton) {
 	return mesh->blend_shape_count > 0 || (mesh->has_bone_weights && p_has_skeleton);
 }
 
+Dependency *MeshStorage::mesh_get_dependency(RID p_mesh) const {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND_V(!mesh, nullptr);
+
+	return &mesh->dependency;
+}
+
 /* MESH INSTANCE */
 
 RID MeshStorage::mesh_instance_create(RID p_base) {
@@ -1471,6 +1478,13 @@ RID MeshStorage::multimesh_get_mesh(RID p_multimesh) const {
 	ERR_FAIL_COND_V(!multimesh, RID());
 
 	return multimesh->mesh;
+}
+
+Dependency *MeshStorage::multimesh_get_dependency(RID p_multimesh) const {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, nullptr);
+
+	return &multimesh->dependency;
 }
 
 Transform3D MeshStorage::multimesh_instance_get_transform(RID p_multimesh, int p_index) const {

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -43,231 +43,203 @@
 
 namespace RendererRD {
 
-/* PARTICLES */
-
-struct ParticleData {
-	float xform[16];
-	float velocity[3];
-	uint32_t active;
-	float color[4];
-	float custom[3];
-	float lifetime;
-};
-
-struct ParticlesFrameParams {
-	enum {
-		MAX_ATTRACTORS = 32,
-		MAX_COLLIDERS = 32,
-		MAX_3D_TEXTURES = 7
-	};
-
-	enum AttractorType {
-		ATTRACTOR_TYPE_SPHERE,
-		ATTRACTOR_TYPE_BOX,
-		ATTRACTOR_TYPE_VECTOR_FIELD,
-	};
-
-	struct Attractor {
-		float transform[16];
-		float extents[3]; //exents or radius
-		uint32_t type;
-
-		uint32_t texture_index; //texture index for vector field
-		float strength;
-		float attenuation;
-		float directionality;
-	};
-
-	enum CollisionType {
-		COLLISION_TYPE_SPHERE,
-		COLLISION_TYPE_BOX,
-		COLLISION_TYPE_SDF,
-		COLLISION_TYPE_HEIGHT_FIELD,
-		COLLISION_TYPE_2D_SDF,
-
-	};
-
-	struct Collider {
-		float transform[16];
-		float extents[3]; //exents or radius
-		uint32_t type;
-
-		uint32_t texture_index; //texture index for vector field
-		real_t scale;
-		uint32_t pad[2];
-	};
-
-	uint32_t emitting;
-	float system_phase;
-	float prev_system_phase;
-	uint32_t cycle;
-
-	real_t explosiveness;
-	real_t randomness;
-	float time;
-	float delta;
-
-	uint32_t frame;
-	uint32_t pad0;
-	uint32_t pad1;
-	uint32_t pad2;
-
-	uint32_t random_seed;
-	uint32_t attractor_count;
-	uint32_t collider_count;
-	float particle_size;
-
-	float emission_transform[16];
-
-	Attractor attractors[MAX_ATTRACTORS];
-	Collider colliders[MAX_COLLIDERS];
-};
-
-struct ParticleEmissionBufferData {
-};
-
-struct ParticleEmissionBuffer {
-	struct Data {
-		float xform[16];
-		float velocity[3];
-		uint32_t flags;
-		float color[4];
-		float custom[4];
-	};
-
-	int32_t particle_count;
-	int32_t particle_max;
-	uint32_t pad1;
-	uint32_t pad2;
-	Data data[1]; //its 2020 and empty arrays are still non standard in C++
-};
-
-struct Particles {
-	RS::ParticlesMode mode = RS::PARTICLES_MODE_3D;
-	bool inactive = true;
-	double inactive_time = 0.0;
-	bool emitting = false;
-	bool one_shot = false;
-	int amount = 0;
-	double lifetime = 1.0;
-	double pre_process_time = 0.0;
-	real_t explosiveness = 0.0;
-	real_t randomness = 0.0;
-	bool restart_request = false;
-	AABB custom_aabb = AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8));
-	bool use_local_coords = true;
-	bool has_collision_cache = false;
-
-	bool has_sdf_collision = false;
-	Transform2D sdf_collision_transform;
-	Rect2 sdf_collision_to_screen;
-	RID sdf_collision_texture;
-
-	RID process_material;
-	uint32_t frame_counter = 0;
-	RS::ParticlesTransformAlign transform_align = RS::PARTICLES_TRANSFORM_ALIGN_DISABLED;
-
-	RS::ParticlesDrawOrder draw_order = RS::PARTICLES_DRAW_ORDER_INDEX;
-
-	Vector<RID> draw_passes;
-	Vector<Transform3D> trail_bind_poses;
-	bool trail_bind_poses_dirty = false;
-	RID trail_bind_pose_buffer;
-	RID trail_bind_pose_uniform_set;
-
-	RID particle_buffer;
-	RID particle_instance_buffer;
-	RID frame_params_buffer;
-
-	uint32_t userdata_count = 0;
-
-	RID particles_material_uniform_set;
-	RID particles_copy_uniform_set;
-	RID particles_transforms_buffer_uniform_set;
-	RID collision_textures_uniform_set;
-
-	RID collision_3d_textures[ParticlesFrameParams::MAX_3D_TEXTURES];
-	uint32_t collision_3d_textures_used = 0;
-	RID collision_heightmap_texture;
-
-	RID particles_sort_buffer;
-	RID particles_sort_uniform_set;
-
-	bool dirty = false;
-	Particles *update_list = nullptr;
-
-	RID sub_emitter;
-
-	double phase = 0.0;
-	double prev_phase = 0.0;
-	uint64_t prev_ticks = 0;
-	uint32_t random_seed = 0;
-
-	uint32_t cycle_number = 0;
-
-	double speed_scale = 1.0;
-
-	int fixed_fps = 30;
-	bool interpolate = true;
-	bool fractional_delta = false;
-	double frame_remainder = 0;
-	real_t collision_base_size = 0.01;
-
-	bool clear = true;
-
-	bool force_sub_emit = false;
-
-	Transform3D emission_transform;
-
-	Vector<uint8_t> emission_buffer_data;
-
-	ParticleEmissionBuffer *emission_buffer = nullptr;
-	RID emission_storage_buffer;
-
-	HashSet<RID> collisions;
-
-	Dependency dependency;
-
-	double trail_length = 1.0;
-	bool trails_enabled = false;
-	LocalVector<ParticlesFrameParams> frame_history;
-	LocalVector<ParticlesFrameParams> trail_params;
-
-	Particles() {
-	}
-};
-
-/* Particles Collision */
-
-struct ParticlesCollision {
-	RS::ParticlesCollisionType type = RS::PARTICLES_COLLISION_TYPE_SPHERE_ATTRACT;
-	uint32_t cull_mask = 0xFFFFFFFF;
-	float radius = 1.0;
-	Vector3 extents = Vector3(1, 1, 1);
-	float attractor_strength = 1.0;
-	float attractor_attenuation = 1.0;
-	float attractor_directionality = 0.0;
-	RID field_texture;
-	RID heightfield_texture;
-	RID heightfield_fb;
-	Size2i heightfield_fb_size;
-
-	RS::ParticlesCollisionHeightfieldResolution heightfield_resolution = RS::PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_1024;
-
-	Dependency dependency;
-};
-
-struct ParticlesCollisionInstance {
-	RID collision;
-	Transform3D transform;
-	bool active = false;
-};
-
 class ParticlesStorage : public RendererParticlesStorage {
 private:
 	static ParticlesStorage *singleton;
 
 	/* PARTICLES */
+
+	struct ParticleData {
+		float xform[16];
+		float velocity[3];
+		uint32_t active;
+		float color[4];
+		float custom[3];
+		float lifetime;
+	};
+
+	struct ParticlesFrameParams {
+		enum {
+			MAX_ATTRACTORS = 32,
+			MAX_COLLIDERS = 32,
+			MAX_3D_TEXTURES = 7
+		};
+
+		enum AttractorType {
+			ATTRACTOR_TYPE_SPHERE,
+			ATTRACTOR_TYPE_BOX,
+			ATTRACTOR_TYPE_VECTOR_FIELD,
+		};
+
+		struct Attractor {
+			float transform[16];
+			float extents[3]; //exents or radius
+			uint32_t type;
+
+			uint32_t texture_index; //texture index for vector field
+			float strength;
+			float attenuation;
+			float directionality;
+		};
+
+		enum CollisionType {
+			COLLISION_TYPE_SPHERE,
+			COLLISION_TYPE_BOX,
+			COLLISION_TYPE_SDF,
+			COLLISION_TYPE_HEIGHT_FIELD,
+			COLLISION_TYPE_2D_SDF,
+
+		};
+
+		struct Collider {
+			float transform[16];
+			float extents[3]; //exents or radius
+			uint32_t type;
+
+			uint32_t texture_index; //texture index for vector field
+			real_t scale;
+			uint32_t pad[2];
+		};
+
+		uint32_t emitting;
+		float system_phase;
+		float prev_system_phase;
+		uint32_t cycle;
+
+		real_t explosiveness;
+		real_t randomness;
+		float time;
+		float delta;
+
+		uint32_t frame;
+		uint32_t pad0;
+		uint32_t pad1;
+		uint32_t pad2;
+
+		uint32_t random_seed;
+		uint32_t attractor_count;
+		uint32_t collider_count;
+		float particle_size;
+
+		float emission_transform[16];
+
+		Attractor attractors[MAX_ATTRACTORS];
+		Collider colliders[MAX_COLLIDERS];
+	};
+
+	struct ParticleEmissionBufferData {
+	};
+
+	struct ParticleEmissionBuffer {
+		struct Data {
+			float xform[16];
+			float velocity[3];
+			uint32_t flags;
+			float color[4];
+			float custom[4];
+		};
+
+		int32_t particle_count;
+		int32_t particle_max;
+		uint32_t pad1;
+		uint32_t pad2;
+		Data data[1]; //its 2020 and empty arrays are still non standard in C++
+	};
+
+	struct Particles {
+		RS::ParticlesMode mode = RS::PARTICLES_MODE_3D;
+		bool inactive = true;
+		double inactive_time = 0.0;
+		bool emitting = false;
+		bool one_shot = false;
+		int amount = 0;
+		double lifetime = 1.0;
+		double pre_process_time = 0.0;
+		real_t explosiveness = 0.0;
+		real_t randomness = 0.0;
+		bool restart_request = false;
+		AABB custom_aabb = AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8));
+		bool use_local_coords = true;
+		bool has_collision_cache = false;
+
+		bool has_sdf_collision = false;
+		Transform2D sdf_collision_transform;
+		Rect2 sdf_collision_to_screen;
+		RID sdf_collision_texture;
+
+		RID process_material;
+		uint32_t frame_counter = 0;
+		RS::ParticlesTransformAlign transform_align = RS::PARTICLES_TRANSFORM_ALIGN_DISABLED;
+
+		RS::ParticlesDrawOrder draw_order = RS::PARTICLES_DRAW_ORDER_INDEX;
+
+		Vector<RID> draw_passes;
+		Vector<Transform3D> trail_bind_poses;
+		bool trail_bind_poses_dirty = false;
+		RID trail_bind_pose_buffer;
+		RID trail_bind_pose_uniform_set;
+
+		RID particle_buffer;
+		RID particle_instance_buffer;
+		RID frame_params_buffer;
+
+		uint32_t userdata_count = 0;
+
+		RID particles_material_uniform_set;
+		RID particles_copy_uniform_set;
+		RID particles_transforms_buffer_uniform_set;
+		RID collision_textures_uniform_set;
+
+		RID collision_3d_textures[ParticlesFrameParams::MAX_3D_TEXTURES];
+		uint32_t collision_3d_textures_used = 0;
+		RID collision_heightmap_texture;
+
+		RID particles_sort_buffer;
+		RID particles_sort_uniform_set;
+
+		bool dirty = false;
+		Particles *update_list = nullptr;
+
+		RID sub_emitter;
+
+		double phase = 0.0;
+		double prev_phase = 0.0;
+		uint64_t prev_ticks = 0;
+		uint32_t random_seed = 0;
+
+		uint32_t cycle_number = 0;
+
+		double speed_scale = 1.0;
+
+		int fixed_fps = 30;
+		bool interpolate = true;
+		bool fractional_delta = false;
+		double frame_remainder = 0;
+		real_t collision_base_size = 0.01;
+
+		bool clear = true;
+
+		bool force_sub_emit = false;
+
+		Transform3D emission_transform;
+
+		Vector<uint8_t> emission_buffer_data;
+
+		ParticleEmissionBuffer *emission_buffer = nullptr;
+		RID emission_storage_buffer;
+
+		HashSet<RID> collisions;
+
+		Dependency dependency;
+
+		double trail_length = 1.0;
+		bool trails_enabled = false;
+		LocalVector<ParticlesFrameParams> frame_history;
+		LocalVector<ParticlesFrameParams> trail_params;
+
+		Particles() {
+		}
+	};
 
 	void _particles_process(Particles *p_particles, double p_delta);
 	void _particles_allocate_emission_buffer(Particles *particles);
@@ -340,7 +312,7 @@ private:
 
 	/* Particle Shader */
 
-	struct ParticlesShaderData : public ShaderData {
+	struct ParticlesShaderData : public MaterialStorage::ShaderData {
 		bool valid = false;
 		RID version;
 		bool uses_collision = false;
@@ -377,12 +349,12 @@ private:
 		virtual ~ParticlesShaderData();
 	};
 
-	ShaderData *_create_particles_shader_func();
-	static ShaderData *_create_particles_shader_funcs() {
+	MaterialStorage::ShaderData *_create_particles_shader_func();
+	static MaterialStorage::ShaderData *_create_particles_shader_funcs() {
 		return ParticlesStorage::get_singleton()->_create_particles_shader_func();
 	}
 
-	struct ParticlesMaterialData : public MaterialData {
+	struct ParticlesMaterialData : public MaterialStorage::MaterialData {
 		ParticlesShaderData *shader_data = nullptr;
 		RID uniform_set;
 
@@ -392,12 +364,36 @@ private:
 		virtual ~ParticlesMaterialData();
 	};
 
-	MaterialData *_create_particles_material_func(ParticlesShaderData *p_shader);
-	static MaterialData *_create_particles_material_funcs(ShaderData *p_shader) {
+	MaterialStorage::MaterialData *_create_particles_material_func(ParticlesShaderData *p_shader);
+	static MaterialStorage::MaterialData *_create_particles_material_funcs(MaterialStorage::ShaderData *p_shader) {
 		return ParticlesStorage::get_singleton()->_create_particles_material_func(static_cast<ParticlesShaderData *>(p_shader));
 	}
 
 	/* Particles Collision */
+
+	struct ParticlesCollision {
+		RS::ParticlesCollisionType type = RS::PARTICLES_COLLISION_TYPE_SPHERE_ATTRACT;
+		uint32_t cull_mask = 0xFFFFFFFF;
+		float radius = 1.0;
+		Vector3 extents = Vector3(1, 1, 1);
+		float attractor_strength = 1.0;
+		float attractor_attenuation = 1.0;
+		float attractor_directionality = 0.0;
+		RID field_texture;
+		RID heightfield_texture;
+		RID heightfield_fb;
+		Size2i heightfield_fb_size;
+
+		RS::ParticlesCollisionHeightfieldResolution heightfield_resolution = RS::PARTICLES_COLLISION_HEIGHTFIELD_RESOLUTION_1024;
+
+		Dependency dependency;
+	};
+
+	struct ParticlesCollisionInstance {
+		RID collision;
+		Transform3D transform;
+		bool active = false;
+	};
 
 	mutable RID_Owner<ParticlesCollision, true> particles_collision_owner;
 
@@ -411,7 +407,6 @@ public:
 
 	/* PARTICLES */
 
-	Particles *get_particles(RID p_rid) { return particles_owner.get_or_null(p_rid); }
 	bool owns_particles(RID p_rid) { return particles_owner.owns(p_rid); }
 
 	virtual RID particles_allocate() override;
@@ -526,9 +521,10 @@ public:
 
 	virtual void update_particles() override;
 
+	Dependency *particles_get_dependency(RID p_particles) const;
+
 	/* Particles Collision */
 
-	ParticlesCollision *get_particles_collision(RID p_rid) { return particles_collision_owner.get_or_null(p_rid); }
 	bool owns_particles_collision(RID p_rid) { return particles_collision_owner.owns(p_rid); }
 
 	virtual RID particles_collision_allocate() override;
@@ -550,8 +546,9 @@ public:
 	virtual bool particles_collision_is_heightfield(RID p_particles_collision) const override;
 	virtual RID particles_collision_get_heightfield_framebuffer(RID p_particles_collision) const override;
 
+	Dependency *particles_collision_get_dependency(RID p_particles) const;
+
 	//used from 2D and 3D
-	ParticlesCollisionInstance *get_particles_collision_instance(RID p_rid) { return particles_collision_instance_owner.get_or_null(p_rid); }
 	bool owns_particles_collision_instance(RID p_rid) { return particles_collision_instance_owner.owns(p_rid); }
 
 	virtual RID particles_collision_instance_create(RID p_collision) override;

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -35,9 +35,9 @@
 using namespace RendererRD;
 
 ///////////////////////////////////////////////////////////////////////////
-// CanvasTexture
+// TextureStorage::CanvasTexture
 
-void CanvasTexture::clear_sets() {
+void TextureStorage::CanvasTexture::clear_sets() {
 	if (cleared_cache) {
 		return;
 	}
@@ -52,14 +52,14 @@ void CanvasTexture::clear_sets() {
 	cleared_cache = true;
 }
 
-CanvasTexture::~CanvasTexture() {
+TextureStorage::CanvasTexture::~CanvasTexture() {
 	clear_sets();
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// Texture
+// TextureStorage::Texture
 
-void Texture::cleanup() {
+void TextureStorage::Texture::cleanup() {
 	if (RD::get_singleton()->texture_is_valid(rd_texture_srgb)) {
 		//erase this first, as it's a dependency of the one below
 		RD::get_singleton()->free(rd_texture_srgb);
@@ -534,7 +534,7 @@ bool TextureStorage::canvas_texture_get_uniform_set(RID p_texture, RS::CanvasIte
 
 		ct = t->canvas_texture;
 	} else {
-		ct = get_canvas_texture(p_texture);
+		ct = canvas_texture_owner.get_or_null(p_texture);
 	}
 
 	if (!ct) {
@@ -657,7 +657,7 @@ void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_im
 
 	Texture texture;
 
-	texture.type = Texture::TYPE_2D;
+	texture.type = TextureStorage::TYPE_2D;
 
 	texture.width = p_image->get_width();
 	texture.height = p_image->get_height();
@@ -753,7 +753,7 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 
 	Texture texture;
 
-	texture.type = Texture::TYPE_LAYERED;
+	texture.type = TextureStorage::TYPE_LAYERED;
 	texture.layered_type = p_layered_type;
 
 	texture.width = p_layers[0]->get_width();
@@ -883,7 +883,7 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 
 	Texture texture;
 
-	texture.type = Texture::TYPE_3D;
+	texture.type = TextureStorage::TYPE_3D;
 	texture.width = p_width;
 	texture.height = p_height;
 	texture.depth = p_depth;
@@ -975,7 +975,7 @@ void TextureStorage::_texture_2d_update(RID p_texture, const Ref<Image> &p_image
 	ERR_FAIL_COND(p_image->get_width() != tex->width || p_image->get_height() != tex->height);
 	ERR_FAIL_COND(p_image->get_format() != tex->format);
 
-	if (tex->type == Texture::TYPE_LAYERED) {
+	if (tex->type == TextureStorage::TYPE_LAYERED) {
 		ERR_FAIL_INDEX(p_layer, tex->layers);
 	}
 
@@ -995,7 +995,7 @@ void TextureStorage::texture_2d_update(RID p_texture, const Ref<Image> &p_image,
 void TextureStorage::texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) {
 	Texture *tex = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_COND(!tex);
-	ERR_FAIL_COND(tex->type != Texture::TYPE_3D);
+	ERR_FAIL_COND(tex->type != TextureStorage::TYPE_3D);
 
 	Image::Image3DValidateError verr = Image::validate_3d_image(tex->format, tex->width, tex->height, tex->depth, tex->mipmaps > 1, p_data);
 	if (verr != Image::VALIDATE_3D_OK) {
@@ -1167,7 +1167,7 @@ Ref<Image> TextureStorage::texture_2d_layer_get(RID p_texture, int p_layer) cons
 Vector<Ref<Image>> TextureStorage::texture_3d_get(RID p_texture) const {
 	Texture *tex = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_COND_V(!tex, Vector<Ref<Image>>());
-	ERR_FAIL_COND_V(tex->type != Texture::TYPE_3D, Vector<Ref<Image>>());
+	ERR_FAIL_COND_V(tex->type != TextureStorage::TYPE_3D, Vector<Ref<Image>>());
 
 	Vector<uint8_t> all_data = RD::get_singleton()->texture_get_data(tex->rd_texture, 0);
 
@@ -1243,7 +1243,7 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 void TextureStorage::texture_set_size_override(RID p_texture, int p_width, int p_height) {
 	Texture *tex = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_COND(!tex);
-	ERR_FAIL_COND(tex->type != Texture::TYPE_2D);
+	ERR_FAIL_COND(tex->type != TextureStorage::TYPE_2D);
 
 	tex->width_2d = p_width;
 	tex->height_2d = p_height;
@@ -1853,6 +1853,13 @@ AABB TextureStorage::decal_get_aabb(RID p_decal) const {
 	ERR_FAIL_COND_V(!decal, AABB());
 
 	return AABB(-decal->extents, decal->extents * 2.0);
+}
+
+Dependency *TextureStorage::decal_get_dependency(RID p_decal) {
+	Decal *decal = decal_owner.get_or_null(p_decal);
+	ERR_FAIL_COND_V(!decal, nullptr);
+
+	return &decal->dependency;
 }
 
 void TextureStorage::update_decal_atlas() {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -38,248 +38,132 @@
 
 namespace RendererRD {
 
-enum DefaultRDTexture {
-	DEFAULT_RD_TEXTURE_WHITE,
-	DEFAULT_RD_TEXTURE_BLACK,
-	DEFAULT_RD_TEXTURE_NORMAL,
-	DEFAULT_RD_TEXTURE_ANISO,
-	DEFAULT_RD_TEXTURE_DEPTH,
-	DEFAULT_RD_TEXTURE_MULTIMESH_BUFFER,
-	DEFAULT_RD_TEXTURE_CUBEMAP_BLACK,
-	DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK,
-	DEFAULT_RD_TEXTURE_CUBEMAP_WHITE,
-	DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_WHITE,
-	DEFAULT_RD_TEXTURE_3D_WHITE,
-	DEFAULT_RD_TEXTURE_3D_BLACK,
-	DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE,
-	DEFAULT_RD_TEXTURE_2D_UINT,
-	DEFAULT_RD_TEXTURE_VRS,
-	DEFAULT_RD_TEXTURE_MAX
-};
+class LightStorage;
+class MaterialStorage;
 
-class CanvasTexture {
+class TextureStorage : public RendererTextureStorage {
 public:
-	RID diffuse;
-	RID normal_map;
-	RID specular;
-	Color specular_color = Color(1, 1, 1, 1);
-	float shininess = 1.0;
+	enum DefaultRDTexture {
+		DEFAULT_RD_TEXTURE_WHITE,
+		DEFAULT_RD_TEXTURE_BLACK,
+		DEFAULT_RD_TEXTURE_NORMAL,
+		DEFAULT_RD_TEXTURE_ANISO,
+		DEFAULT_RD_TEXTURE_DEPTH,
+		DEFAULT_RD_TEXTURE_MULTIMESH_BUFFER,
+		DEFAULT_RD_TEXTURE_CUBEMAP_BLACK,
+		DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK,
+		DEFAULT_RD_TEXTURE_CUBEMAP_WHITE,
+		DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_WHITE,
+		DEFAULT_RD_TEXTURE_3D_WHITE,
+		DEFAULT_RD_TEXTURE_3D_BLACK,
+		DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE,
+		DEFAULT_RD_TEXTURE_2D_UINT,
+		DEFAULT_RD_TEXTURE_VRS,
+		DEFAULT_RD_TEXTURE_MAX
+	};
 
-	RS::CanvasItemTextureFilter texture_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_DEFAULT;
-	RS::CanvasItemTextureRepeat texture_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_DEFAULT;
-	RID uniform_sets[RS::CANVAS_ITEM_TEXTURE_FILTER_MAX][RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX];
-
-	Size2i size_cache = Size2i(1, 1);
-	bool use_normal_cache = false;
-	bool use_specular_cache = false;
-	bool cleared_cache = true;
-
-	void clear_sets();
-	~CanvasTexture();
-};
-
-class Texture {
-public:
-	enum Type {
+	enum TextureType {
 		TYPE_2D,
 		TYPE_LAYERED,
 		TYPE_3D
 	};
 
-	Type type;
-	RS::TextureLayeredType layered_type = RS::TEXTURE_LAYERED_2D_ARRAY;
-
-	RenderingDevice::TextureType rd_type;
-	RID rd_texture;
-	RID rd_texture_srgb;
-	RenderingDevice::DataFormat rd_format;
-	RenderingDevice::DataFormat rd_format_srgb;
-
-	RD::TextureView rd_view;
-
-	Image::Format format;
-	Image::Format validated_format;
-
-	int width;
-	int height;
-	int depth;
-	int layers;
-	int mipmaps;
-
-	int height_2d;
-	int width_2d;
-
-	struct BufferSlice3D {
-		Size2i size;
-		uint32_t offset = 0;
-		uint32_t buffer_size = 0;
-	};
-	Vector<BufferSlice3D> buffer_slices_3d;
-	uint32_t buffer_size_3d = 0;
-
-	bool is_render_target;
-	bool is_proxy;
-
-	Ref<Image> image_cache_2d;
-	String path;
-
-	RID proxy_to;
-	Vector<RID> proxies;
-
-	HashSet<RID> lightmap_users;
-
-	RS::TextureDetectCallback detect_3d_callback = nullptr;
-	void *detect_3d_callback_ud = nullptr;
-
-	RS::TextureDetectCallback detect_normal_callback = nullptr;
-	void *detect_normal_callback_ud = nullptr;
-
-	RS::TextureDetectRoughnessCallback detect_roughness_callback = nullptr;
-	void *detect_roughness_callback_ud = nullptr;
-
-	CanvasTexture *canvas_texture = nullptr;
-
-	void cleanup();
-};
-
-struct DecalAtlas {
-	struct Texture {
-		int panorama_to_dp_users;
-		int users;
-		Rect2 uv_rect;
-	};
-
-	struct SortItem {
-		RID texture;
-		Size2i pixel_size;
-		Size2i size;
-		Point2i pos;
-
-		bool operator<(const SortItem &p_item) const {
-			//sort larger to smaller
-			if (size.height == p_item.size.height) {
-				return size.width > p_item.size.width;
-			} else {
-				return size.height > p_item.size.height;
-			}
-		}
-	};
-
-	HashMap<RID, Texture> textures;
-	bool dirty = true;
-	int mipmaps = 5;
-
-	RID texture;
-	RID texture_srgb;
-	struct MipMap {
-		RID fb;
-		RID texture;
-		Size2i size;
-	};
-	Vector<MipMap> texture_mipmaps;
-
-	Size2i size;
-};
-
-struct Decal {
-	Vector3 extents = Vector3(1, 1, 1);
-	RID textures[RS::DECAL_TEXTURE_MAX];
-	float emission_energy = 1.0;
-	float albedo_mix = 1.0;
-	Color modulate = Color(1, 1, 1, 1);
-	uint32_t cull_mask = (1 << 20) - 1;
-	float upper_fade = 0.3;
-	float lower_fade = 0.3;
-	bool distance_fade = false;
-	float distance_fade_begin = 40.0;
-	float distance_fade_length = 10.0;
-	float normal_fade = 0.0;
-
-	Dependency dependency;
-};
-
-struct RenderTarget {
-	Size2i size;
-	uint32_t view_count;
-	RID framebuffer;
-	RID color;
-
-	//used for retrieving from CPU
-	RD::DataFormat color_format = RD::DATA_FORMAT_R4G4_UNORM_PACK8;
-	RD::DataFormat color_format_srgb = RD::DATA_FORMAT_R4G4_UNORM_PACK8;
-	Image::Format image_format = Image::FORMAT_L8;
-
-	bool is_transparent = false;
-
-	bool sdf_enabled = false;
-
-	RID backbuffer; //used for effects
-	RID backbuffer_fb;
-	RID backbuffer_mipmap0;
-
-	Vector<RID> backbuffer_mipmaps;
-
-	RID framebuffer_uniform_set;
-	RID backbuffer_uniform_set;
-
-	RID sdf_buffer_write;
-	RID sdf_buffer_write_fb;
-	RID sdf_buffer_process[2];
-	RID sdf_buffer_read;
-	RID sdf_buffer_process_uniform_sets[2];
-	RS::ViewportSDFOversize sdf_oversize = RS::VIEWPORT_SDF_OVERSIZE_120_PERCENT;
-	RS::ViewportSDFScale sdf_scale = RS::VIEWPORT_SDF_SCALE_50_PERCENT;
-	Size2i process_size;
-
-	// VRS
-	RS::ViewportVRSMode vrs_mode = RS::VIEWPORT_VRS_DISABLED;
-	RID vrs_texture;
-
-	//texture generated for this owner (nor RD).
-	RID texture;
-	bool was_used;
-
-	//clear request
-	bool clear_requested;
-	Color clear_color;
-};
-
-struct RenderTargetSDF {
-	enum {
-		SHADER_LOAD,
-		SHADER_LOAD_SHRINK,
-		SHADER_PROCESS,
-		SHADER_PROCESS_OPTIMIZED,
-		SHADER_STORE,
-		SHADER_STORE_SHRINK,
-		SHADER_MAX
-	};
-
-	struct PushConstant {
-		int32_t size[2];
-		int32_t stride;
-		int32_t shift;
-		int32_t base_size[2];
-		int32_t pad[2];
-	};
-
-	CanvasSdfShaderRD shader;
-	RID shader_version;
-	RID pipelines[SHADER_MAX];
-};
-
-class TextureStorage : public RendererTextureStorage {
 private:
+	friend class LightStorage;
+	friend class MaterialStorage;
+
 	static TextureStorage *singleton;
+
+	RID default_rd_textures[DEFAULT_RD_TEXTURE_MAX];
 
 	/* Canvas Texture API */
 
-	RID_Owner<RendererRD::CanvasTexture, true> canvas_texture_owner;
+	class CanvasTexture {
+	public:
+		RID diffuse;
+		RID normal_map;
+		RID specular;
+		Color specular_color = Color(1, 1, 1, 1);
+		float shininess = 1.0;
+
+		RS::CanvasItemTextureFilter texture_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_DEFAULT;
+		RS::CanvasItemTextureRepeat texture_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_DEFAULT;
+		RID uniform_sets[RS::CANVAS_ITEM_TEXTURE_FILTER_MAX][RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX];
+
+		Size2i size_cache = Size2i(1, 1);
+		bool use_normal_cache = false;
+		bool use_specular_cache = false;
+		bool cleared_cache = true;
+
+		void clear_sets();
+		~CanvasTexture();
+	};
+
+	RID_Owner<CanvasTexture, true> canvas_texture_owner;
 
 	/* Texture API */
 
+	class Texture {
+	public:
+		TextureType type;
+		RS::TextureLayeredType layered_type = RS::TEXTURE_LAYERED_2D_ARRAY;
+
+		RenderingDevice::TextureType rd_type;
+		RID rd_texture;
+		RID rd_texture_srgb;
+		RenderingDevice::DataFormat rd_format;
+		RenderingDevice::DataFormat rd_format_srgb;
+
+		RD::TextureView rd_view;
+
+		Image::Format format;
+		Image::Format validated_format;
+
+		int width;
+		int height;
+		int depth;
+		int layers;
+		int mipmaps;
+
+		int height_2d;
+		int width_2d;
+
+		struct BufferSlice3D {
+			Size2i size;
+			uint32_t offset = 0;
+			uint32_t buffer_size = 0;
+		};
+		Vector<BufferSlice3D> buffer_slices_3d;
+		uint32_t buffer_size_3d = 0;
+
+		bool is_render_target;
+		bool is_proxy;
+
+		Ref<Image> image_cache_2d;
+		String path;
+
+		RID proxy_to;
+		Vector<RID> proxies;
+
+		HashSet<RID> lightmap_users;
+
+		RS::TextureDetectCallback detect_3d_callback = nullptr;
+		void *detect_3d_callback_ud = nullptr;
+
+		RS::TextureDetectCallback detect_normal_callback = nullptr;
+		void *detect_normal_callback_ud = nullptr;
+
+		RS::TextureDetectRoughnessCallback detect_roughness_callback = nullptr;
+		void *detect_roughness_callback_ud = nullptr;
+
+		CanvasTexture *canvas_texture = nullptr;
+
+		void cleanup();
+	};
+
 	//textures can be created from threads, so this RID_Owner is thread safe
 	mutable RID_Owner<Texture, true> texture_owner;
+	Texture *get_texture(RID p_rid) { return texture_owner.get_or_null(p_rid); };
 
 	struct TextureToRDFormat {
 		RD::DataFormat format;
@@ -303,13 +187,115 @@ private:
 
 	/* DECAL API */
 
-	DecalAtlas decal_atlas;
+	struct DecalAtlas {
+		struct Texture {
+			int panorama_to_dp_users;
+			int users;
+			Rect2 uv_rect;
+		};
+
+		struct SortItem {
+			RID texture;
+			Size2i pixel_size;
+			Size2i size;
+			Point2i pos;
+
+			bool operator<(const SortItem &p_item) const {
+				//sort larger to smaller
+				if (size.height == p_item.size.height) {
+					return size.width > p_item.size.width;
+				} else {
+					return size.height > p_item.size.height;
+				}
+			}
+		};
+
+		HashMap<RID, Texture> textures;
+		bool dirty = true;
+		int mipmaps = 5;
+
+		RID texture;
+		RID texture_srgb;
+		struct MipMap {
+			RID fb;
+			RID texture;
+			Size2i size;
+		};
+		Vector<MipMap> texture_mipmaps;
+
+		Size2i size;
+	} decal_atlas;
+
+	struct Decal {
+		Vector3 extents = Vector3(1, 1, 1);
+		RID textures[RS::DECAL_TEXTURE_MAX];
+		float emission_energy = 1.0;
+		float albedo_mix = 1.0;
+		Color modulate = Color(1, 1, 1, 1);
+		uint32_t cull_mask = (1 << 20) - 1;
+		float upper_fade = 0.3;
+		float lower_fade = 0.3;
+		bool distance_fade = false;
+		float distance_fade_begin = 40.0;
+		float distance_fade_length = 10.0;
+		float normal_fade = 0.0;
+
+		Dependency dependency;
+	};
 
 	mutable RID_Owner<Decal, true> decal_owner;
+	Decal *get_decal(RID p_rid) const { return decal_owner.get_or_null(p_rid); };
 
 	/* RENDER TARGET API */
 
+	struct RenderTarget {
+		Size2i size;
+		uint32_t view_count;
+		RID framebuffer;
+		RID color;
+
+		//used for retrieving from CPU
+		RD::DataFormat color_format = RD::DATA_FORMAT_R4G4_UNORM_PACK8;
+		RD::DataFormat color_format_srgb = RD::DATA_FORMAT_R4G4_UNORM_PACK8;
+		Image::Format image_format = Image::FORMAT_L8;
+
+		bool is_transparent = false;
+
+		bool sdf_enabled = false;
+
+		RID backbuffer; //used for effects
+		RID backbuffer_fb;
+		RID backbuffer_mipmap0;
+
+		Vector<RID> backbuffer_mipmaps;
+
+		RID framebuffer_uniform_set;
+		RID backbuffer_uniform_set;
+
+		RID sdf_buffer_write;
+		RID sdf_buffer_write_fb;
+		RID sdf_buffer_process[2];
+		RID sdf_buffer_read;
+		RID sdf_buffer_process_uniform_sets[2];
+		RS::ViewportSDFOversize sdf_oversize = RS::VIEWPORT_SDF_OVERSIZE_120_PERCENT;
+		RS::ViewportSDFScale sdf_scale = RS::VIEWPORT_SDF_SCALE_50_PERCENT;
+		Size2i process_size;
+
+		// VRS
+		RS::ViewportVRSMode vrs_mode = RS::VIEWPORT_VRS_DISABLED;
+		RID vrs_texture;
+
+		//texture generated for this owner (nor RD).
+		RID texture;
+		bool was_used;
+
+		//clear request
+		bool clear_requested;
+		Color clear_color;
+	};
+
 	mutable RID_Owner<RenderTarget> render_target_owner;
+	RenderTarget *get_render_target(RID p_rid) const { return render_target_owner.get_or_null(p_rid); };
 
 	void _clear_render_target(RenderTarget *rt);
 	void _update_render_target(RenderTarget *rt);
@@ -318,12 +304,32 @@ private:
 	void _render_target_clear_sdf(RenderTarget *rt);
 	Rect2i _render_target_get_sdf_rect(const RenderTarget *rt) const;
 
-	RenderTargetSDF rt_sdf;
+	struct RenderTargetSDF {
+		enum {
+			SHADER_LOAD,
+			SHADER_LOAD_SHRINK,
+			SHADER_PROCESS,
+			SHADER_PROCESS_OPTIMIZED,
+			SHADER_STORE,
+			SHADER_STORE_SHRINK,
+			SHADER_MAX
+		};
+
+		struct PushConstant {
+			int32_t size[2];
+			int32_t stride;
+			int32_t shift;
+			int32_t base_size[2];
+			int32_t pad[2];
+		};
+
+		CanvasSdfShaderRD shader;
+		RID shader_version;
+		RID pipelines[SHADER_MAX];
+	} rt_sdf;
 
 public:
 	static TextureStorage *get_singleton();
-
-	RID default_rd_textures[DEFAULT_RD_TEXTURE_MAX];
 
 	_FORCE_INLINE_ RID texture_rd_get_default(DefaultRDTexture p_texture) {
 		return default_rd_textures[p_texture];
@@ -334,7 +340,6 @@ public:
 
 	/* Canvas Texture API */
 
-	CanvasTexture *get_canvas_texture(RID p_rid) { return canvas_texture_owner.get_or_null(p_rid); };
 	bool owns_canvas_texture(RID p_rid) { return canvas_texture_owner.owns(p_rid); };
 
 	virtual RID canvas_texture_allocate() override;
@@ -351,8 +356,7 @@ public:
 
 	/* Texture API */
 
-	Texture *get_texture(RID p_rid) { return texture_owner.get_or_null(p_rid); };
-	bool owns_texture(RID p_rid) { return texture_owner.owns(p_rid); };
+	bool owns_texture(RID p_rid) const { return texture_owner.owns(p_rid); };
 
 	virtual bool can_create_resources_async() const override;
 
@@ -394,12 +398,29 @@ public:
 	virtual Size2 texture_size_with_proxy(RID p_proxy) override;
 
 	//internal usage
+	_FORCE_INLINE_ TextureType texture_get_type(RID p_texture) {
+		RendererRD::TextureStorage::Texture *tex = texture_owner.get_or_null(p_texture);
+		if (tex == nullptr) {
+			return TYPE_2D;
+		}
+
+		return tex->type;
+	}
+
+	_FORCE_INLINE_ int texture_get_layers(RID p_texture) {
+		RendererRD::TextureStorage::Texture *tex = texture_owner.get_or_null(p_texture);
+		if (tex == nullptr) {
+			return 1;
+		}
+
+		return tex->layers;
+	}
 
 	_FORCE_INLINE_ RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) {
 		if (p_texture.is_null()) {
 			return RID();
 		}
-		RendererRD::Texture *tex = texture_owner.get_or_null(p_texture);
+		RendererRD::TextureStorage::Texture *tex = texture_owner.get_or_null(p_texture);
 
 		if (!tex) {
 			return RID();
@@ -411,7 +432,7 @@ public:
 		if (p_texture.is_null()) {
 			return Size2i();
 		}
-		RendererRD::Texture *tex = texture_owner.get_or_null(p_texture);
+		RendererRD::TextureStorage::Texture *tex = texture_owner.get_or_null(p_texture);
 
 		if (!tex) {
 			return Size2i();
@@ -423,8 +444,7 @@ public:
 
 	void update_decal_atlas();
 
-	Decal *get_decal(RID p_rid) { return decal_owner.get_or_null(p_rid); };
-	bool owns_decal(RID p_rid) { return decal_owner.owns(p_rid); };
+	bool owns_decal(RID p_rid) const { return decal_owner.owns(p_rid); };
 
 	RID decal_atlas_get_texture() const;
 	RID decal_atlas_get_texture_srgb() const;
@@ -518,11 +538,11 @@ public:
 	}
 
 	virtual AABB decal_get_aabb(RID p_decal) const override;
+	Dependency *decal_get_dependency(RID p_decal);
 
 	/* RENDER TARGET API */
 
-	RenderTarget *get_render_target(RID p_rid) { return render_target_owner.get_or_null(p_rid); };
-	bool owns_render_target(RID p_rid) { return render_target_owner.owns(p_rid); };
+	bool owns_render_target(RID p_rid) const { return render_target_owner.owns(p_rid); };
 
 	virtual RID render_target_create() override;
 	virtual void render_target_free(RID p_rid) override;

--- a/servers/rendering/renderer_rd/storage_rd/utilities.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.cpp
@@ -138,35 +138,37 @@ bool Utilities::free(RID p_rid) {
 
 void Utilities::base_update_dependency(RID p_base, DependencyTracker *p_instance) {
 	if (MeshStorage::get_singleton()->owns_mesh(p_base)) {
-		Mesh *mesh = MeshStorage::get_singleton()->get_mesh(p_base);
-		p_instance->update_dependency(&mesh->dependency);
+		Dependency *dependency = MeshStorage::get_singleton()->mesh_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
 	} else if (MeshStorage::get_singleton()->owns_multimesh(p_base)) {
-		MultiMesh *multimesh = MeshStorage::get_singleton()->get_multimesh(p_base);
-		p_instance->update_dependency(&multimesh->dependency);
-		if (multimesh->mesh.is_valid()) {
-			base_update_dependency(multimesh->mesh, p_instance);
+		Dependency *dependency = MeshStorage::get_singleton()->multimesh_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
+
+		RID mesh = MeshStorage::get_singleton()->multimesh_get_mesh(p_base);
+		if (mesh.is_valid()) {
+			base_update_dependency(mesh, p_instance);
 		}
 	} else if (LightStorage::get_singleton()->owns_reflection_probe(p_base)) {
-		ReflectionProbe *rp = LightStorage::get_singleton()->get_reflection_probe(p_base);
-		p_instance->update_dependency(&rp->dependency);
+		Dependency *dependency = LightStorage::get_singleton()->reflection_probe_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
 	} else if (TextureStorage::get_singleton()->owns_decal(p_base)) {
-		Decal *decal = TextureStorage::get_singleton()->get_decal(p_base);
-		p_instance->update_dependency(&decal->dependency);
+		Dependency *dependency = TextureStorage::get_singleton()->decal_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
 	} else if (GI::get_singleton()->owns_voxel_gi(p_base)) {
 		GI::VoxelGI *gip = GI::get_singleton()->get_voxel_gi(p_base);
 		p_instance->update_dependency(&gip->dependency);
 	} else if (LightStorage::get_singleton()->owns_lightmap(p_base)) {
-		Lightmap *lm = LightStorage::get_singleton()->get_lightmap(p_base);
-		p_instance->update_dependency(&lm->dependency);
+		Dependency *dependency = LightStorage::get_singleton()->lightmap_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
 	} else if (LightStorage::get_singleton()->owns_light(p_base)) {
-		Light *l = LightStorage::get_singleton()->get_light(p_base);
-		p_instance->update_dependency(&l->dependency);
+		Dependency *dependency = LightStorage::get_singleton()->light_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
 	} else if (ParticlesStorage::get_singleton()->owns_particles(p_base)) {
-		Particles *p = ParticlesStorage::get_singleton()->get_particles(p_base);
-		p_instance->update_dependency(&p->dependency);
+		Dependency *dependency = ParticlesStorage::get_singleton()->particles_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
 	} else if (ParticlesStorage::get_singleton()->owns_particles_collision(p_base)) {
-		ParticlesCollision *pc = ParticlesStorage::get_singleton()->get_particles_collision(p_base);
-		p_instance->update_dependency(&pc->dependency);
+		Dependency *dependency = ParticlesStorage::get_singleton()->particles_collision_get_dependency(p_base);
+		p_instance->update_dependency(dependency);
 	} else if (Fog::get_singleton()->owns_fog_volume(p_base)) {
 		Fog::FogVolume *fv = Fog::get_singleton()->get_fog_volume(p_base);
 		p_instance->update_dependency(&fv->dependency);


### PR DESCRIPTION
Changed storage structs to private and encapsulated them into the storage classes. This to ensure we keep the ability to extend the rendering implementation externally.

Note that the current exceptions remain `MaterialStorage::ShaderData` and `MaterialStorage::MaterialData`, we need to find a way to expose these properly to external renderers or rewrite the shader logic that drives our scene shaders, sky shaders and particle shaders. 