### PR TITLE
Fix `Vector4::min_axis_index` for equal components

### DIFF
--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -89,7 +89,7 @@ Vector4::Axis Vector4::min_axis_index() const {
 	uint32_t min_index = 0;
 	real_t min_value = x;
 	for (uint32_t i = 1; i < 4; i++) {
-		if (operator[](i) < min_value) {
+		if (operator[](i) <= min_value) {
 			min_index = i;
 			min_value = operator[](i);
 		}

--- a/core/math/vector4i.cpp
+++ b/core/math/vector4i.cpp
@@ -47,7 +47,7 @@ Vector4i::Axis Vector4i::min_axis_index() const {
 	uint32_t min_index = 0;
 	int32_t min_value = x;
 	for (uint32_t i = 1; i < 4; i++) {
-		if (operator[](i) < min_value) {
+		if (operator[](i) <= min_value) {
 			min_index = i;
 			min_value = operator[](i);
 		}


### PR DESCRIPTION
The documentation says if all components are equal it must return `AXIS_W` but it was returning `AXIS_X`.

Thanks to @antonWetzel for discovering the bug!
