### PR TITLE
Add top-level @export to separate class_name.

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -189,10 +189,10 @@ void ScriptServer::init_languages() {
 
 			for (int i = 0; i < script_classes.size(); i++) {
 				Dictionary c = script_classes[i];
-				if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base")) {
+				if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("flags")) {
 					continue;
 				}
-				add_global_class(c["class"], c["base"], c["language"], c["path"]);
+				add_global_class(c["class"], c["base"], c["language"], c["path"], (GlobalScriptFlags)c["flags"].operator signed int());
 			}
 		}
 	}
@@ -236,12 +236,13 @@ void ScriptServer::global_classes_clear() {
 	global_classes.clear();
 }
 
-void ScriptServer::add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path) {
+void ScriptServer::add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, GlobalScriptFlags p_flags) {
 	ERR_FAIL_COND_MSG(p_class == p_base || (global_classes.has(p_base) && get_global_class_native_base(p_base) == p_class), "Cyclic inheritance in script class.");
 	GlobalScriptClass g;
 	g.language = p_language;
 	g.path = p_path;
 	g.base = p_base;
+	g.flags = p_flags;
 	global_classes[p_class] = g;
 }
 
@@ -277,6 +278,11 @@ StringName ScriptServer::get_global_class_native_base(const String &p_class) {
 	return base;
 }
 
+GlobalScriptFlags ScriptServer::get_global_class_flags(const StringName &p_class) {
+	ERR_FAIL_COND_V(!global_classes.has(p_class), GLOBAL_SCRIPT_NONE);
+	return global_classes[p_class].flags;
+}
+
 void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
 	List<StringName> classes;
 	for (const KeyValue<StringName, GlobalScriptClass> &E : global_classes) {
@@ -298,6 +304,7 @@ void ScriptServer::save_global_classes() {
 		d["language"] = global_classes[E].language;
 		d["path"] = global_classes[E].path;
 		d["base"] = global_classes[E].base;
+		d["flags"] = global_classes[E].flags;
 		gcarr.push_back(d);
 	}
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -40,6 +40,11 @@ class ScriptLanguage;
 
 typedef void (*ScriptEditRequestFunction)(const String &p_path);
 
+enum GlobalScriptFlags {
+	GLOBAL_SCRIPT_NONE = 0,
+	GLOBAL_SCRIPT_EXPORT = 1
+};
+
 class ScriptServer {
 	enum {
 		MAX_LANGUAGES = 16
@@ -55,6 +60,7 @@ class ScriptServer {
 		StringName language;
 		String path;
 		String base;
+		GlobalScriptFlags flags;
 	};
 
 	static HashMap<StringName, GlobalScriptClass> global_classes;
@@ -76,13 +82,14 @@ public:
 	static void thread_exit();
 
 	static void global_classes_clear();
-	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path);
+	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, GlobalScriptFlags p_flags);
 	static void remove_global_class(const StringName &p_class);
 	static bool is_global_class(const StringName &p_class);
 	static StringName get_global_class_language(const StringName &p_class);
 	static String get_global_class_path(const String &p_class);
 	static StringName get_global_class_base(const String &p_class);
 	static StringName get_global_class_native_base(const String &p_class);
+	static GlobalScriptFlags get_global_class_flags(const StringName &p_class);
 	static void get_global_class_list(List<StringName> *r_global_classes);
 	static void save_global_classes();
 
@@ -426,7 +433,7 @@ public:
 	virtual void frame();
 
 	virtual bool handles_global_class_type(const String &p_type) const { return false; }
-	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const { return String(); }
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr, GlobalScriptFlags *r_flags = nullptr) const { return String(); }
 
 	virtual ~ScriptLanguage() {}
 };

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -616,7 +616,7 @@ public:
 
 	GDVIRTUAL1RC(Dictionary, _get_global_class_name, const String &)
 
-	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const override {
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr, GlobalScriptFlags *r_flags = nullptr) const override {
 		Dictionary ret;
 		GDVIRTUAL_REQUIRED_CALL(_get_global_class_name, p_path, ret);
 		if (!ret.has("name")) {
@@ -627,6 +627,9 @@ public:
 		}
 		if (r_icon_path != nullptr && ret.has("icon_path")) {
 			*r_icon_path = ret["icon_path"];
+		}
+		if (r_flags != nullptr && ret.has("flags")) {
+			*r_flags = (GlobalScriptFlags)ret["flags"].operator signed int();
 		}
 		return ret["name"];
 	}

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -152,6 +152,11 @@ bool CreateDialog::_should_hide_type(const String &p_type) const {
 			return true;
 		}
 
+		GlobalScriptFlags flags = ScriptServer::get_global_class_flags(p_type);
+		if (!(flags & GLOBAL_SCRIPT_EXPORT)) {
+			return true; // Global class is not exported to editor
+		}
+
 		String script_path = ScriptServer::get_global_class_path(p_type);
 		if (script_path.begins_with("res://addons/")) {
 			if (!EditorNode::get_singleton()->is_addon_plugin_enabled(script_path.get_slicec('/', 3))) {

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -64,6 +64,7 @@ class EditorFileSystemDirectory : public Object {
 		String script_class_name;
 		String script_class_extends;
 		String script_class_icon_path;
+		GlobalScriptFlags script_class_flags = GLOBAL_SCRIPT_NONE;
 	};
 
 	struct FileInfoSort {
@@ -199,6 +200,7 @@ class EditorFileSystem : public Node {
 		String script_class_name;
 		String script_class_extends;
 		String script_class_icon_path;
+		GlobalScriptFlags script_class_flags = GLOBAL_SCRIPT_NONE;
 	};
 
 	HashMap<String, FileCache> file_cache;
@@ -262,7 +264,7 @@ class EditorFileSystem : public Node {
 	SafeFlag update_script_classes_queued;
 	void _queue_update_script_classes();
 
-	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path) const;
+	String _get_global_script_class(const String &p_type, const String &p_path, String *r_extends, String *r_icon_path, GlobalScriptFlags *r_flags) const;
 
 	static Error _resource_import(const String &p_path);
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -509,7 +509,7 @@ void EditorResourcePicker::_button_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<String> *p_vector) const {
+void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<String> *r_typeset) const {
 	Vector<String> allowed_types = base_type.split(",");
 	int size = allowed_types.size();
 
@@ -518,13 +518,19 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<Strin
 
 	for (int i = 0; i < size; i++) {
 		String base = allowed_types[i].strip_edges();
-		p_vector->insert(base);
+		if (ScriptServer::is_global_class(base)) {
+			GlobalScriptFlags flags = ScriptServer::get_global_class_flags(base);
+			if (!(flags & GLOBAL_SCRIPT_EXPORT)) {
+				continue;
+			}
+		}
+		r_typeset->insert(base);
 
 		// If we hit a familiar base type, take all the data from cache.
 		if (allowed_types_cache.has(base)) {
 			List<StringName> allowed_subtypes = allowed_types_cache[base];
 			for (const StringName &subtype_name : allowed_subtypes) {
-				p_vector->insert(subtype_name);
+				r_typeset->insert(subtype_name);
 			}
 		} else {
 			List<StringName> allowed_subtypes;
@@ -532,13 +538,18 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<Strin
 			List<StringName> inheriters;
 			ClassDB::get_inheriters_from_class(base, &inheriters);
 			for (const StringName &subtype_name : inheriters) {
-				p_vector->insert(subtype_name);
+				r_typeset->insert(subtype_name);
 				allowed_subtypes.push_back(subtype_name);
 			}
 
 			for (const StringName &subtype_name : global_classes) {
+				GlobalScriptFlags flags = ScriptServer::get_global_class_flags(subtype_name);
+				if ((flags & GLOBAL_SCRIPT_EXPORT) == 0) {
+					continue;
+				}
+
 				if (EditorNode::get_editor_data().script_class_is_parent(subtype_name, base)) {
-					p_vector->insert(subtype_name);
+					r_typeset->insert(subtype_name);
 					allowed_subtypes.push_back(subtype_name);
 				}
 			}
@@ -549,11 +560,11 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<Strin
 
 		if (p_with_convert) {
 			if (base == "BaseMaterial3D") {
-				p_vector->insert("Texture2D");
+				r_typeset->insert("Texture2D");
 			} else if (base == "ShaderMaterial") {
-				p_vector->insert("Shader");
+				r_typeset->insert("Shader");
 			} else if (base == "Texture2D") {
-				p_vector->insert("Image");
+				r_typeset->insert("Image");
 			}
 		}
 	}
@@ -562,7 +573,7 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, HashSet<Strin
 		Vector<EditorData::CustomType> custom_resources = EditorNode::get_editor_data().get_custom_types()["Resource"];
 
 		for (int i = 0; i < custom_resources.size(); i++) {
-			p_vector->insert(custom_resources[i].name);
+			r_typeset->insert(custom_resources[i].name);
 		}
 	}
 }
@@ -769,6 +780,12 @@ void EditorResourcePicker::_notification(int p_what) {
 }
 
 void EditorResourcePicker::set_base_type(const String &p_base_type) {
+	GlobalScriptFlags flags = GLOBAL_SCRIPT_NONE;
+	if (ScriptServer::is_global_class(base_type)) {
+		flags = ScriptServer::get_global_class_flags(base_type);
+		ERR_FAIL_COND_MSG(!(flags & GLOBAL_SCRIPT_EXPORT), vformat("Cannot set EditorResourcePicker base class to '%s' as it is a non-exported global script class.", base_type));
+	}
+
 	base_type = p_base_type;
 
 	// There is a possibility that the new base type is conflicting with the existing value.
@@ -824,6 +841,14 @@ void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
 	}
 
 	if (!base_type.is_empty()) {
+		if (ScriptServer::is_global_class(base_type)) {
+			GlobalScriptFlags flags = ScriptServer::get_global_class_flags(base_type);
+			if (!(flags & GLOBAL_SCRIPT_EXPORT)) {
+				// TODO: Possibly update inspector tree after re-assigning base class to global class native base type?
+				ERR_FAIL_MSG(vformat("Failed to set the resource because this EditorResourcePicker's required base class '%s' is a non-exported global script class.", base_type));
+			}
+		}
+
 		HashSet<String> allowed_types;
 		_get_allowed_types(true, &allowed_types);
 

--- a/modules/gdscript/editor/script_templates/VisualShaderNodeCustom/basic.gd
+++ b/modules/gdscript/editor/script_templates/VisualShaderNodeCustom/basic.gd
@@ -1,6 +1,7 @@
 # meta-description: Visual shader's node plugin template
 
 @tool
+@export
 class_name VisualShaderNode_CLASS_
 extends _BASE_
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2143,7 +2143,7 @@ bool GDScriptLanguage::handles_global_class_type(const String &p_type) const {
 	return p_type == "GDScript";
 }
 
-String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
+String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path, GlobalScriptFlags *r_flags) const {
 	Vector<uint8_t> sourcef;
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
@@ -2165,6 +2165,9 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 			} else if (c->icon_path.is_relative_path()) {
 				*r_icon_path = p_path.get_base_dir().plus_file(c->icon_path).simplify_path();
 			}
+		}
+		if (r_flags) {
+			*r_flags = c->global_script_flags;
 		}
 		if (r_base_type) {
 			const GDScriptParser::ClassNode *subclass = c;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -504,7 +504,7 @@ public:
 	/* GLOBAL CLASSES */
 
 	virtual bool handles_global_class_type(const String &p_type) const override;
-	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr) const override;
+	virtual String get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr, GlobalScriptFlags *r_flags = nullptr) const override;
 
 	void add_orphan_subclass(const String &p_qualified_name, const ObjectID &p_subclass);
 	Ref<GDScript> get_orphan_subclass(const String &p_qualified_name);

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -484,12 +484,23 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 		if (parser->script_path == ScriptServer::get_global_class_path(first)) {
 			result = parser->head->get_datatype();
 		} else {
-			Ref<GDScriptParserRef> ref = get_parser_for(ScriptServer::get_global_class_path(first));
-			if (!ref.is_valid() || ref->raise_status(GDScriptParserRef::INTERFACE_SOLVED) != OK) {
-				push_error(vformat(R"(Could not parse global class "%s" from "%s".)", first, ScriptServer::get_global_class_path(first)), p_type);
-				return GDScriptParser::DataType();
+			String path = ScriptServer::get_global_class_path(first);
+			String ext = path.get_extension();
+			if (ext == GDScriptLanguage::get_singleton()->get_extension()) {
+				Ref<GDScriptParserRef> ref = get_parser_for(path);
+				if (!ref.is_valid() || ref->raise_status(GDScriptParserRef::INTERFACE_SOLVED) != OK) {
+					push_error(vformat(R"(Could not parse global class "%s" from "%s".)", first, ScriptServer::get_global_class_path(first)), p_type);
+					return GDScriptParser::DataType();
+				}
+				result = ref->get_parser()->head->get_datatype();
+			} else {
+				result.kind = GDScriptParser::DataType::SCRIPT;
+				result.native_type = ScriptServer::get_global_class_native_base(first);
+				result.script_type = ResourceLoader::load(path, "Script");
+				result.script_path = path;
+				result.is_constant = true;
+				result.is_meta_type = false;
 			}
-			result = ref->get_parser()->head->get_datatype();
 		}
 	} else if (ProjectSettings::get_singleton()->has_autoload(first) && ProjectSettings::get_singleton()->get_autoload(first).is_singleton) {
 		const ProjectSettings::AutoloadInfo &autoload = ProjectSettings::get_singleton()->get_autoload(first);
@@ -540,12 +551,13 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 								result = ref->get_parser()->head->get_datatype();
 								result.is_meta_type = false;
 							} else {
-								Ref<GDScript> script = member.constant->initializer->reduced_value;
+								Ref<Script> script = member.constant->initializer->reduced_value;
 								result.kind = GDScriptParser::DataType::SCRIPT;
 								result.builtin_type = Variant::OBJECT;
 								result.script_type = script;
 								result.script_path = script->get_path();
 								result.native_type = script->get_instance_base_type();
+								result.is_meta_type = false;
 							}
 							break;
 						}
@@ -2676,31 +2688,45 @@ void GDScriptAnalyzer::reduce_get_node(GDScriptParser::GetNodeNode *p_get_node) 
 GDScriptParser::DataType GDScriptAnalyzer::make_global_class_meta_type(const StringName &p_class_name, const GDScriptParser::Node *p_source) {
 	GDScriptParser::DataType type;
 
-	Ref<GDScriptParserRef> ref = get_parser_for(ScriptServer::get_global_class_path(p_class_name));
-	if (ref.is_null()) {
-		push_error(vformat(R"(Could not find script for class "%s".)", p_class_name), p_source);
-		type.type_source = GDScriptParser::DataType::UNDETECTED;
-		type.kind = GDScriptParser::DataType::VARIANT;
+	String path = ScriptServer::get_global_class_path(p_class_name);
+	String ext = path.get_extension();
+	if (ext == GDScriptLanguage::get_singleton()->get_extension()) {
+		Ref<GDScriptParserRef> ref = get_parser_for(path);
+		if (ref.is_null()) {
+			push_error(vformat(R"(Could not find script for class "%s".)", p_class_name), p_source);
+			type.type_source = GDScriptParser::DataType::UNDETECTED;
+			type.kind = GDScriptParser::DataType::VARIANT;
+			return type;
+		}
+
+		Error err = ref->raise_status(GDScriptParserRef::INTERFACE_SOLVED);
+		if (err) {
+			push_error(vformat(R"(Could not resolve class "%s", because of a parser error.)", p_class_name), p_source);
+			type.type_source = GDScriptParser::DataType::UNDETECTED;
+			type.kind = GDScriptParser::DataType::VARIANT;
+			return type;
+		}
+
+		type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
+		type.kind = GDScriptParser::DataType::CLASS;
+		type.builtin_type = Variant::OBJECT;
+		type.native_type = ScriptServer::get_global_class_native_base(p_class_name);
+		type.class_type = ref->get_parser()->head;
+		type.script_path = ref->get_parser()->script_path;
+		type.is_constant = true;
+		type.is_meta_type = true;
+		return type;
+	} else {
+		type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
+		type.kind = GDScriptParser::DataType::SCRIPT;
+		type.builtin_type = Variant::OBJECT;
+		type.native_type = ScriptServer::get_global_class_native_base(p_class_name);
+		type.script_type = ResourceLoader::load(path, "Script");
+		type.script_path = path;
+		type.is_constant = true;
+		type.is_meta_type = true;
 		return type;
 	}
-
-	Error err = ref->raise_status(GDScriptParserRef::INTERFACE_SOLVED);
-	if (err) {
-		push_error(vformat(R"(Could not resolve class "%s", because of a parser error.)", p_class_name), p_source);
-		type.type_source = GDScriptParser::DataType::UNDETECTED;
-		type.kind = GDScriptParser::DataType::VARIANT;
-		return type;
-	}
-
-	type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
-	type.kind = GDScriptParser::DataType::CLASS;
-	type.builtin_type = Variant::OBJECT;
-	type.native_type = ScriptServer::get_global_class_native_base(p_class_name);
-	type.class_type = ref->get_parser()->head;
-	type.script_path = ref->get_parser()->script_path;
-	type.is_constant = true;
-	type.is_meta_type = true;
-	return type;
 }
 
 void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType *p_base) {
@@ -3807,7 +3833,7 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 
 	Ref<Script> base_script = p_base_type.script_type;
 
-	while (base_script.is_valid() && base_script->is_valid()) {
+	while (base_script.is_valid() && base_script->has_method(function_name)) {
 		MethodInfo info = base_script->get_method_info(function_name);
 
 		if (!(info == MethodInfo())) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3769,6 +3769,33 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 					return false;
 				}
 				break;
+			case GDScriptParser::DataType::CLASS:
+				// can assume type is a global GDScript class.
+				if (!ClassDB::is_parent_class(export_type.native_type, Resource::get_class_static())) {
+					push_error(R"(Exported script type must extend Resource.)");
+					return false;
+				}
+				variable->export_info.type = Variant::OBJECT;
+				variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
+				variable->export_info.hint_string = export_type.class_type->identifier->name;
+				break;
+			case GDScriptParser::DataType::SCRIPT: {
+				StringName class_name;
+				if (export_type.script_type != nullptr && export_type.script_type.is_valid()) {
+					class_name = export_type.script_type->get_language()->get_global_class_name(export_type.script_type->get_path());
+				}
+				if (class_name == StringName()) {
+					Ref<Script> script = ResourceLoader::load(export_type.script_path, Script::get_class_static());
+					if (script.is_valid()) {
+						class_name = script->get_language()->get_global_class_name(export_type.script_path);
+					}
+				}
+				if (class_name != StringName() && ClassDB::is_parent_class(ScriptServer::get_global_class_native_base(class_name), Resource::get_class_static())) {
+					variable->export_info.type = Variant::OBJECT;
+					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
+					variable->export_info.hint_string = class_name;
+				}
+			} break;
 			case GDScriptParser::DataType::ENUM: {
 				variable->export_info.type = Variant::INT;
 				variable->export_info.hint = PROPERTY_HINT_ENUM;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -120,7 +120,7 @@ GDScriptParser::GDScriptParser() {
 	register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 	register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 	// Export annotations.
-	register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
+	register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE | AnnotationInfo::SCRIPT, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
 	register_annotation(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::INT>, varray(), true);
 	register_annotation(MethodInfo("@export_file", PropertyInfo(Variant::STRING, "filter")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_FILE, Variant::STRING>, varray(""), true);
 	register_annotation(MethodInfo("@export_dir"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_DIR, Variant::STRING>);
@@ -553,10 +553,10 @@ void GDScriptParser::parse_program() {
 				// @tool annotation has no specific target.
 				annotation->apply(this, nullptr);
 			} else if (annotation->applies_to(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE)) {
-				premature_annotation = annotation;
 				if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
-					push_error(R"(Expected newline after a standalone annotation.)");
+					push_error(vformat(R"(Expected newline after a standalone "%s" annotation.)", annotation->name));
 				}
+				premature_annotation = annotation;
 				annotation->apply(this, head);
 			} else {
 				premature_annotation = annotation;
@@ -601,19 +601,8 @@ void GDScriptParser::parse_program() {
 		}
 	}
 
-	if (match(GDScriptTokenizer::Token::ANNOTATION)) {
-		// Check for a script-level, or standalone annotation.
-		AnnotationNode *annotation = parse_annotation(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE | AnnotationInfo::CLASS_LEVEL);
-		if (annotation != nullptr) {
-			if (annotation->applies_to(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE)) {
-				if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
-					push_error(R"(Expected newline after a standalone annotation.)");
-				}
-				annotation->apply(this, head);
-			} else {
-				annotation_stack.push_back(annotation);
-			}
-		}
+	if (head->identifier == nullptr && head->global_script_flags & GLOBAL_SCRIPT_EXPORT && !check(GDScriptTokenizer::Token::VAR)) {
+		push_error(R"("@export" can only apply to script-level classes that use "class_name".)");
 	}
 
 	parse_class_body(true);
@@ -840,9 +829,23 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 				advance();
 
 				// Check for class-level annotations.
-				AnnotationNode *annotation = parse_annotation(AnnotationInfo::STANDALONE | AnnotationInfo::CLASS_LEVEL);
+				AnnotationNode *annotation = parse_annotation(AnnotationInfo::SCRIPT | AnnotationInfo::STANDALONE | AnnotationInfo::CLASS_LEVEL);
 				if (annotation != nullptr) {
-					if (annotation->applies_to(AnnotationInfo::STANDALONE)) {
+					// Need to check NEWLINE too b/c the @export annotation can apply to both scripts (action: apply) and things within a script (action: add to stack).
+					// TODO: Devise a means of concretely knowing the intended target of a given annotation without resorting to this terrible hack.
+					if (annotation->applies_to(AnnotationInfo::SCRIPT) && previous.type == GDScriptTokenizer::Token::NEWLINE) {
+						if (current_class != head) {
+							push_error(vformat(R"("%s" script annotation can only be used for the top-level class.)"));
+						}
+						if (annotation->name == SNAME("@tool")) {
+							if (_is_tool) {
+								push_error(R"("@tool" script annotation cannot be declared multiple times.)");
+							} else {
+								push_error(R"("@tool" script annotation must be declared before all others.)");
+							}
+						}
+						annotation->apply(this, head);
+					} else if (annotation->applies_to(AnnotationInfo::STANDALONE)) {
 						if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
 							push_error(R"(Expected newline after a standalone annotation.)");
 						}
@@ -3696,7 +3699,17 @@ bool GDScriptParser::onready_annotation(const AnnotationNode *p_annotation, Node
 
 template <PropertyHint t_hint, Variant::Type t_type>
 bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node *p_node) {
-	ERR_FAIL_COND_V_MSG(p_node->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
+	ERR_FAIL_COND_V_MSG(p_node->type != Node::VARIABLE && p_node->type != Node::CLASS, false, vformat(R"("%s" annotation can only be applied to variables or the script-level class.)", p_annotation->name));
+
+	if (p_node->type == Node::CLASS && !check(GDScriptTokenizer::Token::VAR)) {
+		ClassNode *class_node = static_cast<ClassNode *>(p_node);
+
+		ERR_FAIL_COND_V_MSG(class_node != head, false, vformat(R"("%s" annotation applied to a class can only be applied to the script-level class.)", p_annotation->name));
+
+		class_node->global_script_flags = GLOBAL_SCRIPT_EXPORT;
+
+		return true;
+	}
 
 	{
 		const int max_flags = 32;
@@ -3769,16 +3782,22 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 					return false;
 				}
 				break;
-			case GDScriptParser::DataType::CLASS:
+			case GDScriptParser::DataType::CLASS: {
 				// can assume type is a global GDScript class.
 				if (!ClassDB::is_parent_class(export_type.native_type, Resource::get_class_static())) {
 					push_error(R"(Exported script type must extend Resource.)");
 					return false;
 				}
+				String class_name = export_type.class_type->identifier->name;
+				GlobalScriptFlags flags = ScriptServer::get_global_class_flags(class_name);
+				if ((flags & GLOBAL_SCRIPT_EXPORT) == 0) {
+					push_error(R"(Exported resource script property must use a globally exported script type with "@export" above "class_name".)", variable);
+					return false;
+				}
 				variable->export_info.type = Variant::OBJECT;
 				variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
-				variable->export_info.hint_string = export_type.class_type->identifier->name;
-				break;
+				variable->export_info.hint_string = class_name;
+			} break;
 			case GDScriptParser::DataType::SCRIPT: {
 				StringName class_name;
 				if (export_type.script_type != nullptr && export_type.script_type.is_valid()) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -639,6 +639,7 @@ public:
 
 		IdentifierNode *identifier = nullptr;
 		String icon_path;
+		GlobalScriptFlags global_script_flags = GLOBAL_SCRIPT_NONE;
 		Vector<Member> members;
 		HashMap<StringName, int> members_indices;
 		ClassNode *outer = nullptr;
@@ -1210,6 +1211,7 @@ private:
 	friend class GDScriptAnalyzer;
 
 	bool _is_tool = false;
+	bool _is_exported = false;
 	String script_path;
 	bool for_completion = false;
 	bool panic_mode = false;

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -300,15 +300,16 @@ bool GDScriptTestRunner::generate_class_index() {
 	for (int i = 0; i < tests.size(); i++) {
 		GDScriptTest test = tests[i];
 		String base_type;
+		GlobalScriptFlags flags;
 
-		String class_name = GDScriptLanguage::get_singleton()->get_global_class_name(test.get_source_file(), &base_type);
+		String class_name = GDScriptLanguage::get_singleton()->get_global_class_name(test.get_source_file(), &base_type, nullptr, &flags);
 		if (class_name.is_empty()) {
 			continue;
 		}
 		ERR_FAIL_COND_V_MSG(ScriptServer::is_global_class(class_name), false,
 				"Class name '" + class_name + "' from " + test.get_source_file() + " is already used in " + ScriptServer::get_global_class_path(class_name));
 
-		ScriptServer::add_global_class(class_name, base_type, gdscript_name, test.get_source_file());
+		ScriptServer::add_global_class(class_name, base_type, gdscript_name, test.get_source_file(), flags);
 	}
 	return true;
 }

--- a/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.gd
@@ -1,6 +1,6 @@
 # Error here. `class_name` should be used *before* annotations, not after (except @tool).
 @icon("res://path/to/optional/icon.svg")
-class_name HelloWorld
+class_name HelloWorldIconBefore
 
 func test():
     pass


### PR DESCRIPTION
Closes godotengine/godot-proposals#4493.

Depends on #62411. Can be rebased after it is merged.

It *also* involves a change to the filesystem cache just like #60606.

Modifies `@export` annotation in GDScript so that it can be used similarly to `@tool`, but for the purpose of exposing a given class to the editor. Without it, the class will not be visible in the `CreateDialog` or `EditorResourcePicker`. This would be a compatibility-breaking change needed for 4.0 *IF* we do indeed want the default behavior of `class_name` to not include editor exposure.

Under the hood, I've added a `GlobalScriptFlags` enum to global script class information stored by the `ScriptServer` and `EditorFileSystem` cache. It can have - for now - either `GLOBAL_SCRIPT_NONE` or `GLOBAL_SCRIPT_EXPORT`, with the potential for additional flags to be added over time (perhaps `GLOBAL_SCRIPT_ABSTRACT` or `GLOBAL_SCRIPT_STATIC`, etc.). Adding the `@export` class annotation merely changes what value is exposed for the `flags` value passed to `ScriptServer::get_global_class_name(...)`.

Edit: I noticed that there was a template for creating VisualScriptNodes using GDScript that relies on `class_name` definitions. Should that functionality also be dependent on the given `GDScript` having the `@export` class annotation?