### PR TITLE
[TextServer] Add a build warning when building with external FreeType without Brotli support.

### DIFF
--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -507,6 +507,7 @@ if env["builtin_msdfgen"] and msdfgen_enabled:
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
+    env_text_server_adv.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/freetype/include"])
 
 if env["builtin_graphite"] and freetype_enabled:

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -112,7 +112,10 @@ using namespace godot;
 #include FT_ADVANCES_H
 #include FT_MULTIPLE_MASTERS_H
 #include FT_BBOX_H
-
+#include FT_CONFIG_OPTIONS_H
+#if !defined(FT_CONFIG_OPTION_USE_BROTLI) && !defined(_MSC_VER)
+#warning FreeType is configured without Brotli support, built-in fonts will not be available.
+#endif
 #include <hb-ft.h>
 #include <hb-ot.h>
 #endif

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -12,6 +12,7 @@ if env["builtin_msdfgen"] and msdfgen_enabled:
     env_text_server_fb.Prepend(CPPPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
+    env_text_server_fb.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
     env_text_server_fb.Prepend(CPPPATH=["#thirdparty/freetype/include"])
 
 env_text_server_fb.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -98,6 +98,10 @@ using namespace godot;
 #include FT_ADVANCES_H
 #include FT_MULTIPLE_MASTERS_H
 #include FT_BBOX_H
+#include FT_CONFIG_OPTIONS_H
+#if !defined(FT_CONFIG_OPTION_USE_BROTLI) && !defined(_MSC_VER)
+#warning FreeType is configured without Brotli support, built-in fonts will not be available.
+#endif
 #endif
 
 /*************************************************************************/


### PR DESCRIPTION
See #62552