### PR TITLE
Don't rearrange self connections in GraphEdit

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2138,7 +2138,7 @@ void GraphEdit::arrange_nodes() {
 			HashSet<StringName> s;
 			for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
 				GraphNode *p_from = Object::cast_to<GraphNode>(node_names[E->get().from]);
-				if (E->get().to == gn->get_name() && p_from->is_selected()) {
+				if (E->get().to == gn->get_name() && p_from->is_selected() && E->get().to != E->get().from) {
 					if (!s.has(p_from->get_name())) {
 						s.insert(p_from->get_name());
 					}


### PR DESCRIPTION
Fixes #63501

While iterating through all nodes to get the to rearrange nodes before actually rearranging, ignore the connections where the to and from StringNames are the same (=self connections). Other rearranging still works the same after.