### PR TITLE
fix for headless collision shape generation

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -37,17 +37,44 @@
 namespace RendererDummy {
 
 class MeshStorage : public RendererMeshStorage {
+private:
+	struct DummyMesh : public RID {
+		Vector<RS::SurfaceData> surfaces;
+		int blend_shape_count;
+		RS::BlendShapeMode blend_shape_mode;
+		PackedFloat32Array blend_shape_values;
+	};
+
+	mutable RID_Owner<DummyMesh> mesh_owner;
+
 public:
 	/* MESH API */
 
-	virtual RID mesh_allocate() override { return RID(); }
-	virtual void mesh_initialize(RID p_rid) override {}
+	virtual RID mesh_allocate() override {
+		return mesh_owner.allocate_rid();
+	}
+
+	virtual void mesh_initialize(RID p_rid) override {
+		mesh_owner.initialize_rid(p_rid, DummyMesh());
+	}
 	virtual void mesh_free(RID p_rid) override {}
 
 	virtual void mesh_set_blend_shape_count(RID p_mesh, int p_blend_shape_count) override {}
 	virtual bool mesh_needs_instance(RID p_mesh, bool p_has_skeleton) override { return false; }
 
-	virtual void mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface) override {}
+	virtual void mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface) override {
+		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_COND(!m);
+		m->surfaces.push_back(RS::SurfaceData());
+		RS::SurfaceData *s = &m->surfaces.write[m->surfaces.size() - 1];
+		s->format = p_surface.format;
+		s->primitive = p_surface.primitive;
+		s->vertex_data = p_surface.vertex_data;
+		s->attribute_data = p_surface.attribute_data;
+		s->vertex_count = p_surface.vertex_count;
+		s->index_data = p_surface.index_data;
+		s->index_count = p_surface.index_count;
+	}
 
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const override { return 0; }
 
@@ -61,8 +88,19 @@ public:
 	virtual void mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) override {}
 	virtual RID mesh_surface_get_material(RID p_mesh, int p_surface) const override { return RID(); }
 
-	virtual RS::SurfaceData mesh_get_surface(RID p_mesh, int p_surface) const override { return RS::SurfaceData(); }
-	virtual int mesh_get_surface_count(RID p_mesh) const override { return 0; }
+	virtual RS::SurfaceData mesh_get_surface(RID p_mesh, int p_surface) const override {
+		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_COND_V(!m, RS::SurfaceData());
+		RS::SurfaceData s = m->surfaces[p_surface];
+		return s;
+	}
+
+	virtual int mesh_get_surface_count(RID p_mesh) const override {
+		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_COND_V(!m, 0);
+		print_line(m->surfaces.size());
+		return m->surfaces.size();
+	}
 
 	virtual void mesh_set_custom_aabb(RID p_mesh, const AABB &p_aabb) override {}
 	virtual AABB mesh_get_custom_aabb(RID p_mesh) const override { return AABB(); }


### PR DESCRIPTION
this commit implements just enough of dummy mesh_storage so collision shapes are still generated in the headless mode
implementation was inspired by rasterizer_dummy.h from Godot3 (https://github.com/godotengine/godot/blob/3.x/drivers/dummy/rasterizer_dummy.h)

fixes https://github.com/godotengine/godot/issues/63623

This work was sponsored by The Mirror