### PR TITLE
Fixed typo in project_converter_3_to_4.cpp

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1607,7 +1607,7 @@ int ProjectConverter3To4::convert() {
 	{
 		String conventer_text = "; Project was converted by built-in tool to Godot 4.0";
 
-		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), ERROR_CODE, "Current directory doesn't contains any Godot 3 project");
+		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), ERROR_CODE, "Current directory doesn't contain any Godot 3 projects");
 
 		Error err = OK;
 		String project_godot_content = FileAccess::get_file_as_string("project.godot", &err);

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1607,7 +1607,7 @@ int ProjectConverter3To4::convert() {
 	{
 		String conventer_text = "; Project was converted by built-in tool to Godot 4.0";
 
-		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), ERROR_CODE, "Current directory doesn't contains any Godot 3 project");
+		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), ERROR_CODE, "Current directory doesn't contain any Godot 3 project.");
 
 		Error err = OK;
 		String project_godot_content = FileAccess::get_file_as_string("project.godot", &err);


### PR DESCRIPTION
This commit fixes a typo found in project_converter_3_to_4.cpp

When trying to convert Godot 3 projects to Godot 4 using the --convert-3to4 flag when running Godot, if no Godot 3 projects are found, the command line prints: "Current directory doesn't contains any Godot 3 project"

This is changed to "Current directory doesn't contain any Godot 3 projects"