### PR TITLE
Refactor Camera2D to separate property and display updates

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -18,34 +18,28 @@
 		<method name="align">
 			<return type="void" />
 			<description>
-				Aligns the camera to the tracked node.
-			</description>
-		</method>
-		<method name="force_update_scroll">
-			<return type="void" />
-			<description>
-				Forces the camera to update scroll immediately.
+				Resets the screen position to the camera position offset by [member drag_horizontal_offset] and [member drag_vertical_offset]. See also [method reset_smoothing].
 			</description>
 		</method>
 		<method name="get_drag_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="margin" type="int" enum="Side" />
 			<description>
-				Returns the specified [enum Side]'s margin. See also [member drag_bottom_margin], [member drag_top_margin], [member drag_left_margin], and [member drag_right_margin].
+				Returns the specified [enum Side]'s drag margin. See also [member drag_bottom_margin], [member drag_top_margin], [member drag_left_margin], and [member drag_right_margin].
 			</description>
 		</method>
 		<method name="get_limit" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="margin" type="int" enum="Side" />
 			<description>
-				Returns the camera limit for the specified [enum Side]. See also [member limit_bottom], [member limit_top], [member limit_left], and [member limit_right].
+				Returns the specified [enum Side]'s camera limit. See also [member limit_bottom], [member limit_top], [member limit_left], and [member limit_right].
 			</description>
 		</method>
 		<method name="get_screen_center_position" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the center of the screen from this camera's point of view, in global coordinates.
-				[b]Note:[/b] The exact targeted position of the camera may be different. See [method get_target_position].
+				Returns the current location of the camera's screen-center, in global coordinates.
+				[b]Note:[/b] If [member smoothing_enabled] the current location of the camera may be different from the [method get_target_position].
 			</description>
 		</method>
 		<method name="get_target_position" qualifiers="const">
@@ -58,7 +52,7 @@
 		<method name="reset_smoothing">
 			<return type="void" />
 			<description>
-				Sets the camera's position immediately to its current smoothing destination.
+				Sets the camera's current position immediately to its target postion (see [method get_target_position]).
 				This method has no effect if [member smoothing_enabled] is [code]false[/code].
 			</description>
 		</method>
@@ -67,7 +61,7 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="drag_margin" type="float" />
 			<description>
-				Sets the specified [enum Side]'s margin. See also [member drag_bottom_margin], [member drag_top_margin], [member drag_left_margin], and [member drag_right_margin].
+				Sets the specified [enum Side]'s drag margin. See also [member drag_bottom_margin], [member drag_top_margin], [member drag_left_margin], and [member drag_right_margin].
 			</description>
 		</method>
 		<method name="set_limit">
@@ -75,7 +69,7 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="limit" type="int" />
 			<description>
-				Sets the camera limit for the specified [enum Side]. See also [member limit_bottom], [member limit_top], [member limit_left], and [member limit_right].
+				Sets the specified [enum Side]'s camera limit. See also [member limit_bottom], [member limit_top], [member limit_left], and [member limit_right].
 			</description>
 		</method>
 	</methods>
@@ -84,7 +78,7 @@
 			The Camera2D's anchor point. See [enum AnchorMode] constants.
 		</member>
 		<member name="current" type="bool" setter="set_current" getter="is_current" default="false">
-			If [code]true[/code], the camera acts as the active camera for its [Viewport] ancestor. Only one camera can be current in a given viewport, so setting a different camera in the same viewport [code]current[/code] will disable whatever camera was already active in that viewport.
+			If [code]true[/code], the camera becomes the active camera for the [Viewport]. Only one camera can be active in a given viewport, so making a camera in the [Viewport] current, will set all other cameras in the [Viewport]'s [member current] property to [code]false[/code].
 		</member>
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">
 			The custom [Viewport] node attached to the [Camera2D]. If [code]null[/code] or not a [Viewport], uses the default viewport instead.
@@ -125,36 +119,40 @@
 			If [code]true[/code], draws the camera's screen rectangle in the editor.
 		</member>
 		<member name="limit_bottom" type="int" setter="set_limit" getter="get_limit" default="10000000">
-			Bottom scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
+			Bottom scroll limit in pixels. The camera stops moving when the bottom side of the camera reaches this value.
+			[b]Note[/b]: [member offset] Can push the view past the limit.
 		</member>
 		<member name="limit_left" type="int" setter="set_limit" getter="get_limit" default="-10000000">
-			Left scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
+			Left scroll limit in pixels. The camera stops moving when the left side of the camera reaches this value.
+			[b]Note[/b]: [member offset] Can push the view past the limit.
 		</member>
 		<member name="limit_right" type="int" setter="set_limit" getter="get_limit" default="10000000">
-			Right scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
+			Right scroll limit in pixels. The camera stops moving when the right side of the camera reaches this value.
+			[b]Note[/b]: [member offset] Can push the view past the limit.
 		</member>
 		<member name="limit_smoothed" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
-			If [code]true[/code], the camera smoothly stops when reaches its limits.
-			This property has no effect if [member smoothing_enabled] is [code]false[/code].
-			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_smoothing].
+			If [code]true[/code], when camera limits are changed, the camera smoothly scrolls to be within the new limits. Requires [member smoothing_enabled] to be [code]true[/code] too.
+			[b]Note:[/b] To immediately update the camera's position to be within new limits call [method reset_smoothing].
 		</member>
 		<member name="limit_top" type="int" setter="set_limit" getter="get_limit" default="-10000000">
-			Top scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
+			Top scroll limit in pixels. The camera stops moving when the top side of the camera reaches this value.
+			[b]Note[/b]: [member offset] Can push the view past the limit.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
-			The camera's relative offset. Useful for looking around or camera shake animations. The offsetted camera can go past the limits defined in [member limit_top], [member limit_bottom], [member limit_left] and [member limit_right].
+			The offset from the camera's current position. Useful for camera shake animations.
+			[b]Note[/b]: The offsetted camera can go past the limits defined in [member limit_top], [member limit_bottom], [member limit_left] and [member limit_right].
 		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="Camera2D.Camera2DProcessCallback" default="1">
-			The camera's process callback. See [enum Camera2DProcessCallback].
+			The process step during which the camera's position is updated. See [enum Camera2DProcessCallback].
 		</member>
 		<member name="rotating" type="bool" setter="set_rotating" getter="is_rotating" default="false">
 			If [code]true[/code], the camera view rotates with the target.
 		</member>
 		<member name="smoothing_enabled" type="bool" setter="set_enable_follow_smoothing" getter="is_follow_smoothing_enabled" default="false">
-			If [code]true[/code], the camera smoothly moves towards the target at [member smoothing_speed].
+			If [code]true[/code], the camera smoothly moves towards the target position at [member smoothing_speed].
 		</member>
-		<member name="smoothing_speed" type="float" setter="set_follow_smoothing" getter="get_follow_smoothing" default="5.0">
-			Speed in pixels per second of the camera's smoothing effect when [member smoothing_enabled] is [code]true[/code].
+		<member name="smoothing_speed" type="float" setter="set_smoothing_speed" getter="get_smoothing_speed" default="5.0">
+			When [member smoothing_enabled] is [code]true[/code], the asymptotic speed at which the camera closes the gap between the current position and the target position.
 		</member>
 		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom" default="Vector2(1, 1)">
 			The camera's zoom. A zoom of [code]Vector(2, 2)[/code] doubles the size seen in the viewport. A zoom of [code]Vector(0.5, 0.5)[/code] halves the size seen in the viewport.
@@ -162,16 +160,16 @@
 	</members>
 	<constants>
 		<constant name="ANCHOR_MODE_FIXED_TOP_LEFT" value="0" enum="AnchorMode">
-			The camera's position is fixed so that the top-left corner is always at the origin.
+			The top-left corner of the camera is used as the camera's target position.
 		</constant>
 		<constant name="ANCHOR_MODE_DRAG_CENTER" value="1" enum="AnchorMode">
-			The camera's position takes into account vertical/horizontal offsets and the screen size.
+			The camera's center is used as the camera's target position. If drag margins are enabled, the target position will only be adjusted when the [Node2D] position reaches the drag margins.
 		</constant>
 		<constant name="CAMERA2D_PROCESS_PHYSICS" value="0" enum="Camera2DProcessCallback">
-			The camera updates with the [code]_physics_process[/code] callback.
+			The camera smoothing position updates during the [code]_physics_process[/code] step.
 		</constant>
 		<constant name="CAMERA2D_PROCESS_IDLE" value="1" enum="Camera2DProcessCallback">
-			The camera updates with the [code]_process[/code] callback.
+			The camera smoothing position updates during the [code]_process[/code] step.
 		</constant>
 	</constants>
 </class>

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -47,10 +47,11 @@ public:
 		CAMERA2D_PROCESS_IDLE
 	};
 
-protected:
-	Point2 camera_pos;
-	Point2 smoothed_camera_pos;
-	bool first = true;
+private:
+	bool initialized = false;
+	Point2 current_position;
+	Point2 target_position;
+	Vector2 screen_size;
 
 	ObjectID custom_viewport_id; // to check validity
 	Viewport *custom_viewport = nullptr;
@@ -65,11 +66,12 @@ protected:
 	AnchorMode anchor_mode = ANCHOR_MODE_DRAG_CENTER;
 	bool rotating = false;
 	bool current = false;
-	real_t smoothing = 5.0;
+	real_t smoothing_speed = 5.0;
 	bool smoothing_enabled = false;
+	// Smoothing can be enabled but not active in the editor.
+	bool smoothing_active = false;
 	int limit[4];
 	bool limit_smoothing_enabled = false;
-
 	real_t drag_margin[4];
 	bool drag_horizontal_enabled = false;
 	bool drag_vertical_enabled = false;
@@ -77,27 +79,22 @@ protected:
 	real_t drag_vertical_offset = 0.0;
 	bool drag_horizontal_offset_changed = false;
 	bool drag_vertical_offset_changed = false;
-
-	Point2 camera_screen_center;
-	void _update_process_callback();
-	void _update_scroll();
-
-	void _make_current(Object *p_which);
-	void set_current(bool p_current);
-
-	void _set_old_smoothing(real_t p_enable);
-
 	bool screen_drawing_enabled = true;
 	bool limit_drawing_enabled = false;
 	bool margin_drawing_enabled = false;
 
 	Camera2DProcessCallback process_callback = CAMERA2D_PROCESS_IDLE;
 
-	Size2 _get_camera_screen_size() const;
+	void _update_process_callback();
+	void _setup_viewport();
+	Transform2D _get_camera_transform();
+	void _update_viewport();
+	void _update_size();
+	void _update_position();
+	void _update_scroll();
+	void _clear_current();
 
 protected:
-	virtual Transform2D get_camera_transform();
-
 	void _notification(int p_what);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
@@ -136,26 +133,23 @@ public:
 	void set_enable_follow_smoothing(bool p_enabled);
 	bool is_follow_smoothing_enabled() const;
 
-	void set_follow_smoothing(real_t p_speed);
-	real_t get_follow_smoothing() const;
+	void set_smoothing_speed(real_t p_smoothing_speed);
+	real_t get_smoothing_speed() const;
 
 	void set_process_callback(Camera2DProcessCallback p_mode);
 	Camera2DProcessCallback get_process_callback() const;
 
-	void make_current();
-	void clear_current();
+	void set_current(bool p_current);
 	bool is_current() const;
 
 	void set_zoom(const Vector2 &p_zoom);
 	Vector2 get_zoom() const;
 
-	Point2 get_camera_screen_center() const;
-
 	void set_custom_viewport(Node *p_viewport);
 	Node *get_custom_viewport() const;
 
-	Vector2 get_camera_position() const;
-	void force_update_scroll();
+	Point2 get_camera_screen_center() const;
+	Point2 get_camera_position() const;
 	void reset_smoothing();
 	void align();
 


### PR DESCRIPTION
Currently, almost any property change to `Camera2D` and almost all internal notifications call `_update_scroll()` which updates the `Viewport` transform by calling `_get_camera_transform()`. However, `_get_camera_transform()` is responsible for:

1. Updating the camera's target position (adjusted for drag margins and limits)
2. Updating the camera's current screen position (adjusted for smooth scrolling and limits).
3. Creating the `Viewport`'s new `Transform2D`

This causes updates and recalculations to occur not only unnecessarily, but also undesirably. For example, changes to `Camera2D`'s properties shouldn't cause updates to the current screen position. Therefore, currently, every time a property is updated, the changes to the current screen position need to be undone (see #2764, #39567, #63580 required to fix #2074, #16323 and #63083 respectively). Furthermore, making `_get_camera_transform()` responsible for everything results in various difficult to troubleshoot bugs (see #44358, #56336, #63330, #63572, #63738, etc.). To make matters worse, users call [`force_update_scroll()`](https://docs.godotengine.org/en/stable/classes/class_camera2d.html#class-camera2d-method-force-update-scroll) or even the hidden, but bound, method `_update_scroll()` to try workaround bugs.

This PR refactors the `private` methods `_update_scroll()` and `_get_camera_transform()` and adds:
- `void _update_viewport()`
- `void _update_size()`
- `void _update_position()`

`_update_position()` is used to update the camera's target position based on the `Node2D` position and adjusted for drag margins and limits. It is called every time the position is updated or any of the properties (drag margins and limits) that affect the target position are changed.

`_update_scroll()` is now only called by the internal process notifications and only does anything when [`smoothing_enabled`](https://docs.godotengine.org/en/stable/classes/class_camera2d.html#class-camera2d-property-smoothing-enabled) is `true`. It is used to close the gap between the current camera position and the target position in a consistent manner.

`_get_camera_transform()` now only calculates the `Viewport` transform based on the current camera position, zoom and, if [`rotating`](https://docs.godotengine.org/en/stable/classes/class_camera2d.html#class-camera2d-property-rotating) is `true`, rotation.

`_update_viewport()` is used instead of `_update_scroll()` to update the `Viewport` or the editor.

`_update_size()` is used to update the new `screen_size` variable when the screen size or zoom changes; instead of recalculating it every time it is needed.

This PR also includes forward ports of:
- #46717
- #46829
- #53459

In addition, some internal variables have been renamed to make them easier to understand:
- `camera_pos` -> `target_position`
- `smoothed_camera_pos` -> `current_position`
- `smoothing` -> `smoothing_speed` (along with its getter and setter)
- `first` -> `initialised` (and reversed the logic)

And unneeded methods have been removed or unbound:
- `_get_camera_screen_size()`: removed
- `force_update_scroll()`: removed
- `_update_scroll()`: unbound

Fixes #44358
Fixes #49747
Fixes #63572
Fixes #63738 
Closes #56336

This PR also includes some additional enhancements:
1. When the `Viewport` size is larger than the camera limits, which can happen when zooming out, it interpolates the camera position between the limits; instead of the current arbitrary behaviour (https://github.com/godotengine/godot/issues/62441#issuecomment-1186246018) of locking it to the top-right corner due to the internal order of calculation.
2. As identified [here](https://github.com/godotengine/godot/issues/49747#issuecomment-864523313) and [here](https://github.com/godotengine/godot/issues/56336#issuecomment-1195045495), it ensures that scroll updates do not overshoot.
3. It updates the editor to only allow sensible values for `smoothing_speed` between 0 and 60 and drops the incorrect `px/s` suffix.
4. Finally, in addition to fixing #49747 i.e. reverts the change made by 1063ddfeb52c796a3207a62142cc3b7ae3fbccb7 to `smoothing_speed` to describe it as the speed is in pixels per second when it isn't, it also makes some minor documentation updates to hopefully make other methods and properties clearer.
