### PR TITLE
Add ShapeCast2D editor handle and improve debug drawing

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -140,6 +140,7 @@
 #include "editor/plugins/bone_map_editor_plugin.h"
 #include "editor/plugins/camera_3d_editor_plugin.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
+#include "editor/plugins/cast_2d_editor_plugin.h"
 #include "editor/plugins/collision_polygon_2d_editor_plugin.h"
 #include "editor/plugins/collision_shape_2d_editor_plugin.h"
 #include "editor/plugins/control_editor_plugin.h"
@@ -174,7 +175,6 @@
 #include "editor/plugins/physical_bone_3d_editor_plugin.h"
 #include "editor/plugins/polygon_2d_editor_plugin.h"
 #include "editor/plugins/polygon_3d_editor_plugin.h"
-#include "editor/plugins/ray_cast_2d_editor_plugin.h"
 #include "editor/plugins/resource_preloader_editor_plugin.h"
 #include "editor/plugins/root_motion_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
@@ -7190,7 +7190,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(NavigationPolygonEditorPlugin));
 	add_editor_plugin(memnew(Path2DEditorPlugin));
 	add_editor_plugin(memnew(Polygon2DEditorPlugin));
-	add_editor_plugin(memnew(RayCast2DEditorPlugin));
+	add_editor_plugin(memnew(Cast2DEditorPlugin));
 	add_editor_plugin(memnew(Skeleton2DEditorPlugin));
 	add_editor_plugin(memnew(Sprite2DEditorPlugin));
 	add_editor_plugin(memnew(TilesEditorPlugin));

--- a/editor/plugins/cast_2d_editor_plugin.h
+++ b/editor/plugins/cast_2d_editor_plugin.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  ray_cast_2d_editor_plugin.h                                          */
+/*  cast_2d_editor_plugin.h                                              */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,20 +28,20 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RAY_CAST_2D_EDITOR_PLUGIN_H
-#define RAY_CAST_2D_EDITOR_PLUGIN_H
+#ifndef CAST_2D_EDITOR_PLUGIN_H
+#define CAST_2D_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
-#include "scene/2d/ray_cast_2d.h"
+#include "scene/2d/node_2d.h"
 
 class CanvasItemEditor;
 
-class RayCast2DEditor : public Control {
-	GDCLASS(RayCast2DEditor, Control);
+class Cast2DEditor : public Control {
+	GDCLASS(Cast2DEditor, Control);
 
 	UndoRedo *undo_redo = nullptr;
 	CanvasItemEditor *canvas_item_editor = nullptr;
-	RayCast2D *node;
+	Node2D *node;
 
 	bool pressed = false;
 	Point2 original_target_position;
@@ -53,27 +53,27 @@ protected:
 public:
 	bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
-	void edit(Node *p_node);
+	void edit(Node2D *p_node);
 
-	RayCast2DEditor();
+	Cast2DEditor();
 };
 
-class RayCast2DEditorPlugin : public EditorPlugin {
-	GDCLASS(RayCast2DEditorPlugin, EditorPlugin);
+class Cast2DEditorPlugin : public EditorPlugin {
+	GDCLASS(Cast2DEditorPlugin, EditorPlugin);
 
-	RayCast2DEditor *ray_cast_2d_editor = nullptr;
+	Cast2DEditor *cast_2d_editor = nullptr;
 
 public:
-	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return ray_cast_2d_editor->forward_canvas_gui_input(p_event); }
-	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { ray_cast_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
+	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return cast_2d_editor->forward_canvas_gui_input(p_event); }
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { cast_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
-	virtual String get_name() const override { return "RayCast2D"; }
+	virtual String get_name() const override { return "Cast2D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool visible) override;
 
-	RayCast2DEditorPlugin();
+	Cast2DEditorPlugin();
 };
 
-#endif // RAY_CAST_2D_EDITOR_PLUGIN_H
+#endif // CAST_2D_EDITOR_PLUGIN_H

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -217,7 +217,7 @@ void ShapeCast2D::_notification(int p_what) {
 			if (shape.is_null()) {
 				break;
 			}
-			Color draw_col = get_tree()->get_debug_collisions_color();
+			Color draw_col = collided ? Color(1.0, 0.01, 0) : get_tree()->get_debug_collisions_color();
 			if (!enabled) {
 				float g = draw_col.get_v();
 				draw_col.r = g;
@@ -235,18 +235,25 @@ void ShapeCast2D::_notification(int p_what) {
 
 			// Draw an arrow indicating where the ShapeCast is pointing to.
 			if (target_position != Vector2()) {
+				const real_t max_arrow_size = 6;
+				const real_t line_width = 1.4;
+				bool no_line = target_position.length() < line_width;
+				real_t arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
+
+				if (no_line) {
+					arrow_size = target_position.length();
+				} else {
+					draw_line(Vector2(), target_position - target_position.normalized() * arrow_size, draw_col, line_width);
+				}
+
 				Transform2D xf;
 				xf.rotate(target_position.angle());
-				xf.translate_local(Vector2(target_position.length(), 0));
-
-				draw_line(Vector2(), target_position, draw_col, 2);
-
-				float tsize = 8;
+				xf.translate_local(Vector2(no_line ? 0 : target_position.length() - arrow_size, 0));
 
 				Vector<Vector2> pts = {
-					xf.xform(Vector2(tsize, 0)),
-					xf.xform(Vector2(0, Math_SQRT12 * tsize)),
-					xf.xform(Vector2(0, -Math_SQRT12 * tsize))
+					xf.xform(Vector2(arrow_size, 0)),
+					xf.xform(Vector2(0, 0.5 * arrow_size)),
+					xf.xform(Vector2(0, -0.5 * arrow_size))
 				};
 
 				Vector<Color> cols = { draw_col, draw_col, draw_col };
@@ -291,6 +298,8 @@ void ShapeCast2D::_update_shapecast_state() {
 	collision_safe_fraction = 0.0;
 	collision_unsafe_fraction = 0.0;
 
+	bool prev_collision_state = collided;
+
 	if (target_position != Vector2()) {
 		dss->cast_motion(params, collision_safe_fraction, collision_unsafe_fraction);
 		if (collision_unsafe_fraction < 1.0) {
@@ -314,6 +323,10 @@ void ShapeCast2D::_update_shapecast_state() {
 		}
 	}
 	collided = !result.is_empty();
+
+	if (prev_collision_state != collided) {
+		update();
+	}
 }
 
 void ShapeCast2D::force_shapecast_update() {


### PR DESCRIPTION
Applies the changes from https://github.com/godotengine/godot/pull/59337 and #46675 to ShapeCast2D

- Add support for editing `ShapeCast2D.target_position` in the viewport.
- Rename RayCast2DEditorPlugin to Cast2DEditorPlugin and use it for both RayCast2D and ShapeCast2D.
- Apply RayCast2D debug drawing improvements to ShapeCast2D.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/182153179-11af55dd-d8f8-4028-bcb4-40424c70e22c.png) | ![image](https://user-images.githubusercontent.com/67974470/182153087-4fb4cc8f-69a3-4bca-9f2d-cec6a9d0e965.png) |
