### PR TITLE
Remove excessive `editor/property_editor.h` includes

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_scale.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
 #include "scene/animation/animation_player.h"
+#include "scene/gui/separator.h"
 #include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
 #include "scene/scene_string_names.h"

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -35,8 +35,12 @@
 #include "editor/editor_spin_slider.h"
 #include "editor/property_selector.h"
 
+#include "scene/3d/node_3d.h"
+#include "scene/gui/check_box.h"
 #include "scene/gui/control.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/scroll_bar.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_properties.h"
 #include "editor/editor_scale.h"
 #include "editor/export/editor_export.h"
+#include "scene/gui/check_button.h"
 #include "scene/gui/link_button.h"
 #include "scene/gui/tree.h"
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -53,6 +53,7 @@
 #include "scene/gui/flow_container.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/nine_patch_rect.h"
+#include "scene/gui/separator.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/gui/view_panner.h"
 #include "scene/main/canvas_layer.h"

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -32,8 +32,12 @@
 
 #include "core/os/keyboard.h"
 #include "editor/doc_tools.h"
+#include "editor/editor_help.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/rich_text_label.h"
+#include "scene/gui/tree.h"
 
 void PropertySelector::_text_changed(const String &p_newtext) {
 	_update_search();

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -31,9 +31,11 @@
 #ifndef PROPERTY_SELECTOR_H
 #define PROPERTY_SELECTOR_H
 
-#include "editor/editor_help.h"
-#include "editor/property_editor.h"
-#include "scene/gui/rich_text_label.h"
+#include "scene/gui/dialogs.h"
+
+class EditorHelpBit;
+class LineEdit;
+class Tree;
 
 class PropertySelector : public ConfirmationDialog {
 	GDCLASS(PropertySelector, ConfirmationDialog);

--- a/modules/multiplayer/editor/replication_editor_plugin.cpp
+++ b/modules/multiplayer/editor/replication_editor_plugin.cpp
@@ -32,9 +32,12 @@
 
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
 #include "editor/inspector_dock.h"
+#include "editor/scene_tree_editor.h"
 #include "modules/multiplayer/multiplayer_synchronizer.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
 
 void ReplicationEditor::_pick_node_filter_text_changed(const String &p_newtext) {

--- a/modules/multiplayer/editor/replication_editor_plugin.h
+++ b/modules/multiplayer/editor/replication_editor_plugin.h
@@ -40,7 +40,9 @@
 
 class ConfirmationDialog;
 class MultiplayerSynchronizer;
+class SceneTreeDialog;
 class Tree;
+class TreeItem;
 
 class ReplicationEditor : public VBoxContainer {
 	GDCLASS(ReplicationEditor, VBoxContainer);


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/63737. Apparently, `property_selector.h` did not need that include and I have no idea why I assumed it did.

So this cleans up a bit more in a similar manner.