### PR TITLE
C#: Remove unused `Transform2D.ScaleBasis` method

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -320,14 +320,6 @@ namespace Godot
             return copy;
         }
 
-        private void ScaleBasis(Vector2 scale)
-        {
-            x.x *= scale.x;
-            x.y *= scale.y;
-            y.x *= scale.x;
-            y.y *= scale.y;
-        }
-
         private real_t Tdotx(Vector2 with)
         {
             return (this[0, 0] * with[0]) + (this[1, 0] * with[1]);


### PR DESCRIPTION
This method is not used anywhere and it's unexposed so user projects can't be using it either.

It used to be used to calculate the `Rotation` but that was simplified. C++ does implement a `Transform2D::scale_basis` and a `Transform2D::basis_scaled` methods but those aren't exposed to GDScript.