### PR TITLE
Mend the non matching okhsl colors.

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -171,6 +171,9 @@ uniform float v = 1.0;
 void fragment() {
 	float x = UV.x - 0.5;
 	float y = UV.y - 0.5;
+	float h = atan(y, x) / (2.0 * M_PI);
+	float s = sqrt(x * x + y * y) * 2.0;
+	vec3 col = okhsl_to_srgb(vec3(h, s, v));
 	x += 0.001;
 	y += 0.001;
 	float b = float(sqrt(x * x + y * y) < 0.5);
@@ -180,9 +183,6 @@ void fragment() {
 	float b3 = float(sqrt(x * x + y * y) < 0.5);
 	x += 0.002;
 	float b4 = float(sqrt(x * x + y * y) < 0.5);
-	float s = sqrt(x * x + y * y);
-	float h = atan(y, x) / (2.0*M_PI);
-	vec3 col = okhsl_to_srgb(vec3(h, s, v));
 	COLOR = vec4(col, (b + b2 + b3 + b4) / 4.00);
 })");
 }


### PR DESCRIPTION
Closer match to c++.

Fixes: https://github.com/godotengine/godot/issues/63778

@JohanAR 

![Screenshot 2022-08-01 130349](https://user-images.githubusercontent.com/32321/182235290-1529c7f4-ecce-425a-9978-259c0c6a2ea7.png)

Edited:

I tested the other color picker types to rule out the canvas error. Then I tested Color(255,0,0).

Explaining the bug:

This color incorrectness bug was not a srgb conversion error.

We cut out a circle from a square, but geometrically we lost 1/2 of the 1/4 square.

The uvs are 0.5 on both axes so it's 1/4 the size. 

So multiply with a constant to fix it.
