### PR TITLE
Expose `add_color_region` from GDScript Highlighter

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -81,9 +81,8 @@ private:
 	Color string_name_color;
 	Color type_color;
 
-	void add_color_region(const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only = false);
-
 public:
+	void add_color_region(const String &p_start_key, const String &p_end_key, const Color &p_color, bool p_line_only = false);
 	virtual void _update_cache() override;
 	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) override;
 


### PR DESCRIPTION
I'm creating an addon for 4.x, where it add macros, and having the ability to make custom color keywords for them would be nice!

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
