### PR TITLE
Fix uniform set creation error due to null RID

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2662,7 +2662,11 @@ RID RenderForwardClustered::_setup_sdfgi_render_pass_uniform_set(RID p_albedo_te
 		RD::Uniform u;
 		u.binding = 1;
 		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
-		u.append_id(scene_state.instance_buffer[RENDER_LIST_SECONDARY]);
+		RID instance_buffer = scene_state.instance_buffer[RENDER_LIST_SECONDARY];
+		if (instance_buffer == RID()) {
+			instance_buffer = scene_shader.default_vec4_xform_buffer; // any buffer will do since its not used
+		}
+		u.append_id(instance_buffer);
 		uniforms.push_back(u);
 	}
 	{


### PR DESCRIPTION
I'm just replicating what is done in the quoted code to avoid the error. I'm not very sure if this is correct.
https://github.com/godotengine/godot/blob/c596369d7ac9bf77c60817524880860c9fac2ccf/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp#L2420-L2430