### PR TITLE
Fix ColorPicker color and hsv sync issue

### DIFF
--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -156,6 +156,9 @@ private:
 	float v = 0.0;
 	Color last_color;
 
+	void _copy_color_to_hsv();
+	void _copy_hsv_to_color();
+
 	PickerShapeType _get_actual_shape() const;
 	void create_slider(GridContainer *gc, int idx);
 	void _reset_theme();


### PR DESCRIPTION
ColorPicker has both a Color and HSV values for the currently selected
color, fixed a few cases where those were not kept in sync.

Refactored a little regarding this, and removed a redundant update.

Fixes: #63777

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
