### PR TITLE
adds null case to weakref docs

### DIFF
--- a/doc/classes/WeakRef.xml
+++ b/doc/classes/WeakRef.xml
@@ -12,7 +12,7 @@
 		<method name="get_ref" qualifiers="const">
 			<return type="Variant" />
 			<description>
-				Returns the [Object] this weakref is referring to.
+				Returns the [Object] this weakref is referring to. Returns [code]null[/code] if that object no longer exists.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
I noticed the class reference for `weakref` doesn't mention `get_ref()` returns null if the object no longer exists. This is my first open source PR so let me know if this is right. Thank you.