### PR TITLE
UPNP: Don't delete previous mappings when adding new port mappings

### DIFF
--- a/modules/upnp/upnp.cpp
+++ b/modules/upnp/upnp.cpp
@@ -319,8 +319,6 @@ int UPNP::add_port_mapping(int port, int port_internal, String desc, String prot
 		return UPNP_RESULT_NO_GATEWAY;
 	}
 
-	dev->delete_port_mapping(port, proto);
-
 	return dev->add_port_mapping(port, port_internal, desc, proto, duration);
 }
 


### PR DESCRIPTION
![onlyadd](https://user-images.githubusercontent.com/1654763/182314683-0d110cac-5cfb-4010-a5ba-3cbb2c364d40.PNG)

Currently when adding UPNP port mappings, the code tries to delete previously existing mappings first.

As discussed on Rocketchat, this was leftover code from a previous workaround for a specific router, its better to remove this.
It also results in misleading error messages if no previous mapping exists, misleading users (see issue below).

If its still needed in specific cases, it can be done in user code.
Fixes https://github.com/godotengine/godot/issues/38149.