### PR TITLE
Add capitalization for "BPM"

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -114,6 +114,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["bidi"] = "BiDi";
 	capitalize_string_remaps["bp"] = "BP";
 	capitalize_string_remaps["bpc"] = "BPC";
+	capitalize_string_remaps["bpm"] = "BPM";
 	capitalize_string_remaps["bptc"] = "BPTC";
 	capitalize_string_remaps["bvh"] = "BVH";
 	capitalize_string_remaps["ca"] = "CA";


### PR DESCRIPTION
For the AudioStreamMP3/AudioStreamOGGVorbis `bpm` property. 