### PR TITLE
Disable multiview shader versions when xr is disabled

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -345,6 +345,11 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 						}
 
 						int variant = shader_version + shader_flags;
+
+						if (!static_cast<SceneShaderForwardClustered *>(singleton)->shader.is_variant_enabled(variant)) {
+							continue;
+						}
+
 						RID shader_variant = shader_singleton->shader.version_get_shader(version, variant);
 						color_pipelines[i][j][l].setup(shader_variant, primitive_rd, raster_state, multisample_state, depth_stencil, blend_state, 0, singleton->default_specialization_constants);
 					}
@@ -577,7 +582,14 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 			shader.set_variant_enabled(SHADER_VERSION_DEPTH_PASS_MULTIVIEW, false);
 			shader.set_variant_enabled(SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_MULTIVIEW, false);
 			shader.set_variant_enabled(SHADER_VERSION_DEPTH_PASS_WITH_NORMAL_AND_ROUGHNESS_AND_VOXEL_GI_MULTIVIEW, false);
-			// TODO Add a way to enable/disable color pass flags
+
+			// Disable Color Passes
+			for (int i = 0; i < SHADER_COLOR_PASS_FLAG_COUNT; i++) {
+				// Selectively disable any shader pass that includes Multiview.
+				if ((i & SHADER_COLOR_PASS_FLAG_MULTIVIEW)) {
+					shader.set_variant_enabled(i + SHADER_VERSION_COLOR_PASS, false);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Partially addresses: https://github.com/godotengine/godot/issues/63217

This change disables colour passes that include Multiview when XR is disabled. This avoids compiling multiview variants of shaders when not using XR. Accordingly, non-XR users will not have shader compilation failures because their shader fails to compile for XR.

This PR does not fix- https://github.com/godotengine/godot/issues/63217 As the same problem will still arise for XR-users. When XR is enabled, the shader will still crash when using the ``NORMAL_ROUGHNESS_TEXTURE``
