### PR TITLE
Variant large bucket memory pool - for Projection

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -142,14 +142,20 @@ private:
 			Transform2D _transform2d;
 			::AABB _aabb;
 		};
-		union BucketLarge {
-			BucketLarge() {}
-			~BucketLarge() {}
+		union BucketMedium {
+			BucketMedium() {}
+			~BucketMedium() {}
 			Basis _basis;
 			Transform3D _transform3d;
 		};
+		union BucketLarge {
+			BucketLarge() {}
+			~BucketLarge() {}
+			Projection _projection;
+		};
 
 		static PagedAllocator<BucketSmall, true> _bucket_small;
+		static PagedAllocator<BucketMedium, true> _bucket_medium;
 		static PagedAllocator<BucketLarge, true> _bucket_large;
 	};
 

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -227,17 +227,18 @@ public:
 		v->type = Variant::AABB;
 	}
 	_FORCE_INLINE_ static void init_basis(Variant *v) {
-		v->_data._basis = (Basis *)Variant::Pools::_bucket_large.alloc();
+		v->_data._basis = (Basis *)Variant::Pools::_bucket_medium.alloc();
 		memnew_placement(v->_data._basis, Basis);
 		v->type = Variant::BASIS;
 	}
 	_FORCE_INLINE_ static void init_transform(Variant *v) {
-		v->_data._transform3d = (Transform3D *)Variant::Pools::_bucket_large.alloc();
+		v->_data._transform3d = (Transform3D *)Variant::Pools::_bucket_medium.alloc();
 		memnew_placement(v->_data._transform3d, Transform3D);
 		v->type = Variant::TRANSFORM3D;
 	}
 	_FORCE_INLINE_ static void init_projection(Variant *v) {
-		v->_data._projection = memnew(Projection);
+		v->_data._projection = (Projection *)Variant::Pools::_bucket_large.alloc();
+		memnew_placement(v->_data._projection, Projection);
 		v->type = Variant::PROJECTION;
 	}
 	_FORCE_INLINE_ static void init_string_name(Variant *v) {


### PR DESCRIPTION
Add a larger bucket size pool for the new Projection Matrix.

## Notes
* As discussed in the PR meeting today, adds an extra bucket for the new `Projection` type.
* Renamed the previous bucket to `medium` just to make the bucket names sensible.
* Logic etc is identical to the previous types.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
