### PR TITLE
Fix GraphEdit::arrange_nodes causing a freeze when cycle in Graph

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1823,7 +1823,20 @@ HashMap<int, Vector<StringName>> GraphEdit::_layering(const HashSet<StringName> 
 		}
 		if (!selected) {
 			current_layer++;
+			uint32_t previous_size_z = z.size();
 			_set_operations(GraphEdit::UNION, z, u);
+			if (z.size() == previous_size_z) {
+				WARN_PRINT("Graph contains cycle(s). The cycle(s) will not be rearranged accurately.");
+				Vector<StringName> t;
+				if (l.has(0)) {
+					t.append_array(l[0]);
+				}
+				for (const StringName &E : p) {
+					t.push_back(E);
+				}
+				l.insert(0, t);
+				break;
+			}
 		}
 		selected = false;
 	}
@@ -2138,7 +2151,7 @@ void GraphEdit::arrange_nodes() {
 			HashSet<StringName> s;
 			for (List<Connection>::Element *E = connections.front(); E; E = E->next()) {
 				GraphNode *p_from = Object::cast_to<GraphNode>(node_names[E->get().from]);
-				if (E->get().to == gn->get_name() && p_from->is_selected()) {
+				if (E->get().to == gn->get_name() && p_from->is_selected() && E->get().to != E->get().from) {
 					if (!s.has(p_from->get_name())) {
 						s.insert(p_from->get_name());
 					}


### PR DESCRIPTION
When a Graph contains cycle(s), e.g. GraphNode->GraphNode _layering would end up in an infinite loop since IS_SUBSET would never be true. By keeping check of the size of z, which contains the already layered nodes, one can detect a freeze (since it should change after current_layer increases). If it doesn't "u" didn't change and q and u will  never be equal resulting  in a freeze/infinite while loop).
If a freeze happens warn the user and put all the nodes part of the cycle (leftover in p) to the  first layer which will then just list them top to bottom at the end.

This is the more complete version of #63765. While not optimal (see video, everything part of cycle just gets listed randomly) it still sorts the non cyclic graphs part of the selected nodes, breaks the freeze and doesn't really impact performance of the more common non cyclic graphs (ShaderEditor, etc.). 

https://user-images.githubusercontent.com/69000267/182458611-138a1197-993b-483b-80b4-b177c81a35fd.mp4


*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/63501
