### PR TITLE
Allow shading language to use `switch` statement with uints

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -7153,9 +7153,12 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			if (!n) {
 				return ERR_PARSE_ERROR;
 			}
-			if (n->get_datatype() != TYPE_INT) {
-				_set_error(RTR("Expected an integer expression."));
-				return ERR_PARSE_ERROR;
+			{
+				const ShaderLanguage::DataType switch_type = n->get_datatype();
+				if (switch_type != TYPE_INT && switch_type != TYPE_UINT) {
+					_set_error(RTR("Expected an integer expression."));
+					return ERR_PARSE_ERROR;
+				}
 			}
 			tk = _get_token();
 			if (tk.type != TK_PARENTHESIS_CLOSE) {


### PR DESCRIPTION
Considering the following shader code:
```glsl
	uint x = 1u;
	switch(x) {
		case 1:
			ALBEDO = vec3(1.0, 0.0, 0.0);
			break;
		case 2:
			ALBEDO = vec3(0.0, 1.0, 0.0);
			break;
	}
```
Godot's shader parser fails at the `switch` saying `Expected an integer expression`. But this should be valid.