### PR TITLE
Adjust default ItemList `guide_color` and Tree `drop_position_color`

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -445,7 +445,7 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the item is selected.
 		</theme_item>
-		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0, 0, 0, 0.1)">
+		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0.7, 0.7, 0.7, 0.25)">
 			[Color] of the guideline. The guideline is a line drawn between each row of items.
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -461,7 +461,7 @@
 		<theme_item name="custom_button_font_highlight" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">
 			Text [Color] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
-		<theme_item name="drop_position_color" data_type="color" type="Color" default="Color(1, 0.3, 0.2, 1)">
+		<theme_item name="drop_position_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			[Color] used to draw possible drop locations. See [enum DropModeFlags] constants for further description of drop locations.
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.7, 0.7, 0.7, 1)">

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -741,7 +741,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_selected_color", "Tree", control_font_pressed_color);
 	theme->set_color("font_outline_color", "Tree", Color(1, 1, 1));
 	theme->set_color("guide_color", "Tree", Color(0.7, 0.7, 0.7, 0.25));
-	theme->set_color("drop_position_color", "Tree", Color(1, 0.3, 0.2));
+	theme->set_color("drop_position_color", "Tree", Color(1, 1, 1));
 	theme->set_color("relationship_line_color", "Tree", Color(0.27, 0.27, 0.27));
 	theme->set_color("parent_hl_line_color", "Tree", Color(0.27, 0.27, 0.27));
 	theme->set_color("children_hl_line_color", "Tree", Color(0.27, 0.27, 0.27));
@@ -776,7 +776,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color", "ItemList", control_font_lower_color);
 	theme->set_color("font_selected_color", "ItemList", control_font_pressed_color);
 	theme->set_color("font_outline_color", "ItemList", Color(1, 1, 1));
-	theme->set_color("guide_color", "ItemList", Color(0, 0, 0, 0.1));
+	theme->set_color("guide_color", "ItemList", Color(0.7, 0.7, 0.7, 0.25));
 	theme->set_stylebox("selected", "ItemList", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("selected_focus", "ItemList", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("cursor", "ItemList", focus);


### PR DESCRIPTION
- Change Tree's `drop_position_color` from orange to white to better fit in with the rest of the theme.
- Change ItemList's `guide_color` to the same color as Tree's, which fits in with a dark theme better.

| | Before | After |
---|---|---
| **Tree** | ![image](https://user-images.githubusercontent.com/67974470/182737499-140e1df7-2028-4a6a-bead-a7839b35b86c.png) | ![image](https://user-images.githubusercontent.com/67974470/182737316-f322720f-3364-4257-903d-1b83c5bfbf55.png) |
| **ItemList** | ![image](https://user-images.githubusercontent.com/67974470/182737437-4cbc9a76-647f-4971-a876-f897603e3a8d.png) | ![image](https://user-images.githubusercontent.com/67974470/182737380-e1ca1b43-46ea-4b5e-903b-923443f15640.png) |