### PR TITLE
[3.x] Add explicit URL property in LinkButton node

### DIFF
--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -15,7 +15,10 @@
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="0" />
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" overrides="Control" enum="Control.CursorShape" default="2" />
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
-			The button's text that will be displayed inside the button's area.
+			The button's text that will be actually displayed inside the button's area.
+		</member>
+		<member name="url" type="String" setter="set_url" getter="get_url" default="&quot;&quot;">
+			The url to be opened when clicking the button. Will be used as displayed text if no value for the [text] property is provided
 		</member>
 		<member name="underline" type="int" setter="set_underline_mode" getter="get_underline_mode" enum="LinkButton.UnderlineMode" default="0">
 			Determines when to show the underline. See [enum UnderlineMode] for options.

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -36,18 +36,26 @@ void LinkButton::set_text(const String &p_text) {
 	if (text == p_text) {
 		return;
 	}
+
 	text = p_text;
-	xl_text = tr(p_text);
-	update();
 	_change_notify("text");
-	minimum_size_changed();
+	update_text();
 }
 
 void LinkButton::set_url(const String &p_url) {
 	if (url == p_url) {
 		return;
 	}
+
 	url = p_url;
+	_change_notify("url");
+	update_text();
+}
+
+void LinkButton::update_text() {
+	xl_text = tr((text.is_empty()) ? url : text);
+	update();
+	minimum_size_changed();
 }
 
 String LinkButton::get_text() const {
@@ -59,7 +67,7 @@ String LinkButton::get_url() const {
 }
 
 void LinkButton::pressed() {
-	if (url != "") {
+	if (!url.is_empty()) {
 		OS::get_singleton()->shell_open(url);
 	}
 }

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -53,7 +53,13 @@ void LinkButton::set_url(const String &p_url) {
 }
 
 void LinkButton::update_text() {
-	xl_text = tr((text.is_empty()) ? url : text);
+	if (text.empty()) {
+		xl_text = url;
+	}
+	else {
+		xl_text = tr(text);
+	}
+
 	update();
 	minimum_size_changed();
 }
@@ -67,7 +73,7 @@ String LinkButton::get_url() const {
 }
 
 void LinkButton::pressed() {
-	if (!url.is_empty()) {
+	if (!url.empty()) {
 		OS::get_singleton()->shell_open(url);
 	}
 }

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -29,7 +29,7 @@
 /*************************************************************************/
 
 #include "link_button.h"
-
+#include "core/os/os.h"
 #include "core/translation.h"
 
 void LinkButton::set_text(const String &p_text) {
@@ -43,8 +43,25 @@ void LinkButton::set_text(const String &p_text) {
 	minimum_size_changed();
 }
 
+void LinkButton::set_url(const String &p_url) {
+	if (url == p_url) {
+		return;
+	}
+	url = p_url;
+}
+
 String LinkButton::get_text() const {
 	return text;
+}
+
+String LinkButton::get_url() const {
+	return url;
+}
+
+void LinkButton::pressed() {
+	if (url != "") {
+		OS::get_singleton()->shell_open(url);
+	}
 }
 
 void LinkButton::set_underline_mode(UnderlineMode p_underline_mode) {
@@ -129,15 +146,19 @@ void LinkButton::_notification(int p_what) {
 void LinkButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &LinkButton::set_text);
 	ClassDB::bind_method(D_METHOD("get_text"), &LinkButton::get_text);
+	
+	ClassDB::bind_method(D_METHOD("set_url", "url"), &LinkButton::set_url);
+	ClassDB::bind_method(D_METHOD("get_url"), &LinkButton::get_url);
 
 	ClassDB::bind_method(D_METHOD("set_underline_mode", "underline_mode"), &LinkButton::set_underline_mode);
 	ClassDB::bind_method(D_METHOD("get_underline_mode"), &LinkButton::get_underline_mode);
-
+	
 	BIND_ENUM_CONSTANT(UNDERLINE_MODE_ALWAYS);
 	BIND_ENUM_CONSTANT(UNDERLINE_MODE_ON_HOVER);
 	BIND_ENUM_CONSTANT(UNDERLINE_MODE_NEVER);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text"), "set_text", "get_text");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "url"), "set_url", "get_url");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "underline", PROPERTY_HINT_ENUM, "Always,On Hover,Never"), "set_underline_mode", "get_underline_mode");
 }
 

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -46,6 +46,7 @@ public:
 
 private:
 	String text;
+	String url;
 	String xl_text;
 	UnderlineMode underline_mode;
 
@@ -53,10 +54,14 @@ protected:
 	virtual Size2 get_minimum_size() const;
 	void _notification(int p_what);
 	static void _bind_methods();
+	void pressed();
 
 public:
 	void set_text(const String &p_text);
 	String get_text() const;
+
+	void set_url(const String &p_url);
+	String get_url() const;
 
 	void set_underline_mode(UnderlineMode p_underline_mode);
 	UnderlineMode get_underline_mode() const;

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -56,6 +56,8 @@ protected:
 	static void _bind_methods();
 	void pressed();
 
+	void update_text();
+
 public:
 	void set_text(const String &p_text);
 	String get_text() const;


### PR DESCRIPTION
This PR adds a `url` property to `LinkButton` that points to a resource (most likely a webpage) to be opened when the button is clicked. Such value will be used as the visible text of the button when the `text` property isn't set.

The idea is to have something simpler than a RichTextLabel, which requires figuring out the BBCode syntax for a link and manually writing a script to actually open the URL when clicking. At the same time, LinkButtons right now (in Godot 3.x at least) are simply flat buttons with some underlined text which isn't actually treated as a link to anything (the dev is supposed to again manually write a script that opens the url when the button is pressed).

This PR aims at clarifying this system, where RichTextLabels may be used for complex text with multiple links (which could need to be treated separately in code) and where LinkButtons are a simple and quick way of displaying a single URL to (e.g.) one's GitHub profile.