### PR TITLE
Document Camera's frustum offset property requiring Frustum projection (3.x)

### DIFF
--- a/doc/classes/Camera.xml
+++ b/doc/classes/Camera.xml
@@ -100,7 +100,7 @@
 			<argument index="2" name="z_near" type="float" />
 			<argument index="3" name="z_far" type="float" />
 			<description>
-				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [code]size[/code], an [code]offset[/code], and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space units.
+				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [code]size[/code], an [code]offset[/code], and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space units. See also [member frustum_offset].
 			</description>
 		</method>
 		<method name="set_orthogonal">
@@ -164,6 +164,7 @@
 		</member>
 		<member name="frustum_offset" type="Vector2" setter="set_frustum_offset" getter="get_frustum_offset" default="Vector2( 0, 0 )">
 			The camera's frustum offset. This can be changed from the default to create "tilted frustum" effects such as [url=https://zdoom.org/wiki/Y-shearing]Y-shearing[/url].
+			[b]Note:[/b] Only effective if [member projection] is [constant PROJECTION_FRUSTUM].
 		</member>
 		<member name="h_offset" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">
 			The horizontal (X) offset of the camera viewport.


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/63857.

This closes https://github.com/godotengine/godot/issues/63849.