### PR TITLE
Style: Workaround clang-format 14 bug with `Inline` oneliner functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 # AllowShortEnumsOnASingleLine: true
 # AllowShortBlocksOnASingleLine: Never
 # AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
+# AllowShortFunctionsOnASingleLine: All
 # AllowShortLambdasOnASingleLine: All
 # AllowShortIfStatementsOnASingleLine: Never
 # AllowShortLoopsOnASingleLine: false


### PR DESCRIPTION
We use 'All' which is the default in the base LLVM style.

That's not the style we want but it works around the upstream
regression until clang-format 15.0 is released and widely used:
https://github.com/llvm/llvm-project/issues/54901

Now clang-format 14 should be usable without issue.