### PR TITLE
Document editor settings in the class reference

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -151,6 +151,7 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="actions_list" type="Array" />
 			<description>
+				Overrides the built-in editor action [code]name[/code] with the input actions defined in [code]actions_list[/code].
 			</description>
 		</method>
 		<method name="set_favorites">
@@ -196,450 +197,726 @@
 	</methods>
 	<members>
 		<member name="debugger/profiler_frame_history_size" type="int" setter="" getter="">
+			The size of the profiler's frame history. The default value (3600) allows seeing up to 60 seconds of profiling if the project renders at a constant 60 FPS. Higher values allow viewing longer periods of profiling in the graphs, especially when the project is running at high framerates.
 		</member>
 		<member name="docks/filesystem/always_show_folders" type="bool" setter="" getter="">
+			If [code]true[/code], displays folders in the FileSystem dock's bottom pane when split mode is enabled. If [code]false[/code], only files will be displayed in the bottom pane. Split mode can be toggled by pressing the icon next to the [code]res://[/code] folder path.
+			[b]Note:[/b] This setting has no effect when split mode is disabled (which is the default).
 		</member>
 		<member name="docks/filesystem/textfile_extensions" type="String" setter="" getter="">
+			List of file extensions to consider as editable text files in the FileSystem dock (by double-clicking on the files).
 		</member>
 		<member name="docks/filesystem/thumbnail_size" type="int" setter="" getter="">
+			The thumbnail size to use in the FileSystem dock (in pixels). See also [member filesystem/file_dialog/thumbnail_size].
 		</member>
 		<member name="docks/property_editor/auto_refresh_interval" type="float" setter="" getter="">
+			The refresh interval to use for the inspector dock's properties. The effect of this setting is mainly noticeable when adjusting gizmos in the 2D/3D editor and looking at the inspector at the same time. Lower values make the inspector more often, but take up more CPU time.
 		</member>
 		<member name="docks/property_editor/subresource_hue_tint" type="float" setter="" getter="">
+			The tint intensity to use for the subresources background in the inspector dock. The tint is used to distinguish between different subresources in the inspector. Higher values result in a more noticeable background color difference.
 		</member>
 		<member name="docks/scene_tree/auto_expand_to_selected" type="bool" setter="" getter="">
+			If [code]true[/code], the scene tree dock will automatically unfold nodes when a node that has folded parents is selected.
 		</member>
 		<member name="docks/scene_tree/start_create_dialog_fully_expanded" type="bool" setter="" getter="">
+			If [code]true[/code], the Create dialog (Create New Node/Create New Resource) will start with all its sections expanded. Otherwise, sections will be collapsed until the user starts searching (which will automatically expand sections as needed).
 		</member>
 		<member name="editors/2d/bone_color1" type="Color" setter="" getter="">
+			The "start" stop of the color gradient to use for bones in the 2D skeleton editor.
 		</member>
 		<member name="editors/2d/bone_color2" type="Color" setter="" getter="">
+			The "end" stop of the color gradient to use for bones in the 2D skeleton editor.
 		</member>
 		<member name="editors/2d/bone_ik_color" type="Color" setter="" getter="">
+			The color to use for inverse kinematics-enabled bones in the 2D skeleton editor.
 		</member>
 		<member name="editors/2d/bone_outline_color" type="Color" setter="" getter="">
+			The outline color to use for non-selected bones in the 2D skeleton editor. See also [member editors/2d/bone_selected_color].
 		</member>
 		<member name="editors/2d/bone_outline_size" type="int" setter="" getter="">
+			The outline size in the 2D skeleton editor (in pixels). See also [member editors/2d/bone_width].
 		</member>
 		<member name="editors/2d/bone_selected_color" type="Color" setter="" getter="">
+			The color to use for selected bones in the 2D skeleton editor. See also [member editors/2d/bone_outline_color].
 		</member>
 		<member name="editors/2d/bone_width" type="int" setter="" getter="">
+			The bone width in the 2D skeleton editor (in pixels). See also [member editors/2d/bone_outline_size].
 		</member>
 		<member name="editors/2d/constrain_editor_view" type="bool" setter="" getter="">
+			If [code]true[/code], prevents the 2D editor viewport from leaving the scene. Limits are calculated dynamically based on nodes present in the current scene. If [code]false[/code], the 2D editor viewport will be able to move freely, but you risk getting lost when zooming out too far. You can refocus on the scene by selecting a node then pressing [kbd]F[/kbd].
 		</member>
 		<member name="editors/2d/grid_color" type="Color" setter="" getter="">
+			The grid color to use in the 2D editor.
 		</member>
 		<member name="editors/2d/guides_color" type="Color" setter="" getter="">
+			The guides color to use in the 2D editor. Guides can be created by dragging the mouse cursor from the rulers.
 		</member>
 		<member name="editors/2d/smart_snapping_line_color" type="Color" setter="" getter="">
+			The color to use when drawing smart snapping lines in the 2D editor. The smart snapping lines will automatically display when moving 2D nodes if smart snapping is enabled in the Snapping Options menu at the top of the 2D editor viewport.
 		</member>
 		<member name="editors/2d/viewport_border_color" type="Color" setter="" getter="">
+			The color of the viewport border in the 2D editor. This border represents the viewport's size at the base resolution defined in the Project Settings. Objects placed outside this border will not be visible unless a [Camera2D] node is used, or unless the window is resized and the stretch mode is set to [code]disabled[/code].
 		</member>
 		<member name="editors/3d/default_fov" type="float" setter="" getter="">
+			The default camera field of view to use in the 3D editor (in degrees). The camera field of view can be adjusted on a per-scene basis using the [b]View[/b] menu at the top of the 3D editor. If a scene had its camera field of view adjusted using the [b]View[/b] menu, this setting is ignored in the scene in question. This setting is also ignored while a Camera3D node is being previewed in the editor.
 		</member>
 		<member name="editors/3d/default_z_far" type="float" setter="" getter="">
+			The default camera far clip distance to use in the 3D editor (in degrees). Higher values make it possible to view objects placed further away from the camera, at the cost of lower precision in the depth buffer (which can result in visible Z-fighting in the distance). The camera far clip distance can be adjusted on a per-scene basis using the [b]View[/b] menu at the top of the 3D editor. If a scene had its camera far clip distance adjusted using the [b]View[/b] menu, this setting is ignored in the scene in question. This setting is also ignored while a Camera3D node is being previewed in the editor.
 		</member>
 		<member name="editors/3d/default_z_near" type="float" setter="" getter="">
+			The default camera near clip distance to use in the 3D editor (in degrees). Lower values make it possible to view objects placed closer to the camera, at the cost of lower precision in the depth buffer (which can result in visible Z-fighting in the distance). The camera near clip distance can be adjusted on a per-scene basis using the [b]View[/b] menu at the top of the 3D editor. If a scene had its camera near clip distance adjusted using the [b]View[/b] menu, this setting is ignored in the scene in question. This setting is also ignored while a Camera3D node is being previewed in the editor.
 		</member>
 		<member name="editors/3d/freelook/freelook_activation_modifier" type="int" setter="" getter="">
+			The modifier key to use to enable freelook in the 3D editor (on top of pressing the right mouse button).
+			[b]Note:[/b] Regardless of this setting, the freelook toggle keyboard shortcut ([kbd]Shift + F[/kbd] by default) is always available.
+			[b]Note:[/b] On certain window managers on Linux, the [kbd]Alt[/kbd] key will be intercepted by the window manager when clicking a mouse button at the same time. This means Godot will not see the modifier key as being pressed.
 		</member>
 		<member name="editors/3d/freelook/freelook_base_speed" type="float" setter="" getter="">
+			The base 3D freelook speed in units per second. This can be adjusted by using the mouse wheel while in freelook mode, or by holding down the "fast" or "slow" modifier keys ([kbd]Shift[/kbd] and [kbd]Alt[/kbd] by default, respectively).
 		</member>
 		<member name="editors/3d/freelook/freelook_inertia" type="float" setter="" getter="">
+			The inertia of the 3D freelook camera. Higher values make the camera start and stop slower, which looks smoother but adds latency.
 		</member>
 		<member name="editors/3d/freelook/freelook_navigation_scheme" type="int" setter="" getter="">
+			The navigation scheme to use when freelook is enabled in the 3D editor. Some of the navigation schemes below may be more convenient when designing specific levels in the 3D editor.
+			- [b]Default:[/b] The "Freelook Forward", "Freelook Backward", "Freelook Up" and "Freelook Down" keys will move relative to the camera, taking its pitch angle into account for the movement.
+			- [b]Partially Axis-Locked:[/b] The "Freelook Forward" and "Freelook Backward" keys will move relative to the camera, taking its pitch angle into account for the movement. The "Freelook Up" and "Freelook Down" keys will move in an "absolute" manner, [i]not[/i] taking the camera's pitch angle into account for the movement.
+			- [b]Fully Axis-Locked:[/b] The "Freelook Forward", "Freelook Backward", "Freelook Up" and "Freelook Down" keys will move in an "absolute" manner, [i]not[/i] taking the camera's pitch angle into account for the movement.
+			See also [member editors/3d/navigation/navigation_scheme].
 		</member>
 		<member name="editors/3d/freelook/freelook_sensitivity" type="float" setter="" getter="">
+			The mouse sensitivity to use while freelook mode is active in the 3D editor. See also [member editors/3d/navigation_feel/orbit_sensitivity].
 		</member>
 		<member name="editors/3d/freelook/freelook_speed_zoom_link" type="bool" setter="" getter="">
+			If [code]true[/code], freelook speed is linked to the zoom value used in the camera orbit mode in the 3D editor.
 		</member>
 		<member name="editors/3d/grid_division_level_bias" type="float" setter="" getter="">
+			The grid division bias to use in the 3D editor. Negative values will cause small grid divisions to appear earlier, whereas positive values will cause small grid divisions to appear later.
 		</member>
 		<member name="editors/3d/grid_division_level_max" type="int" setter="" getter="">
+			The smallest grid division to use in the 3D editor, specified as a power of 2. The grid will not be able to get larger than [code]1 ^ grid_division_level_max[/code] units. By default, this means grid divisions cannot get smaller than 100 units each, no matter how far away the camera is from the grid.
 		</member>
 		<member name="editors/3d/grid_division_level_min" type="int" setter="" getter="">
+			The smallest grid division to use in the 3D editor, specified as a power of 2. The grid will not be able to get smaller than [code]1 ^ grid_division_level_min[/code] units. By default, this means grid divisions cannot get smaller than 1 unit each, no matter how close the camera is from the grid.
 		</member>
 		<member name="editors/3d/grid_size" type="int" setter="" getter="">
+			The grid size in units. Higher values prevent the grid from appearing "cut off" at certain angles, but make the grid more demanding to render. Depending on the camera's position, the grid may not be fully visible since a shader is used to fade it progressively.
 		</member>
 		<member name="editors/3d/grid_xy_plane" type="bool" setter="" getter="">
+			If [code]true[/code], render the grid on an XY plane. This can be useful for 3D side-scrolling games.
 		</member>
 		<member name="editors/3d/grid_xz_plane" type="bool" setter="" getter="">
+			If [code]true[/code], render the grid on an XZ plane.
 		</member>
 		<member name="editors/3d/grid_yz_plane" type="bool" setter="" getter="">
+			If [code]true[/code], render the grid on an YZ plane. This can be useful for 3D side-scrolling games.
 		</member>
 		<member name="editors/3d/navigation/emulate_3_button_mouse" type="bool" setter="" getter="">
+			If [code]true[/code], enables 3-button mouse emulation mode. This is useful on laptops when using a trackpad.
+			When 3-button mouse emulation mode is enabled, the pan, zoom and orbit modifiers can always be used in the 3D editor viewport, even when not holding down any mouse button.
+			[b]Note:[/b] No matter the orbit modifier configured in [member editors/3d/navigation/orbit_modifier], [kbd]Alt[/kbd] will always remain usable for orbiting in this mode to improve usability with graphics tablets.
 		</member>
 		<member name="editors/3d/navigation/emulate_numpad" type="bool" setter="" getter="">
+			If [code]true[/code], allows using the top row [kbd]0[/kbd]-[kbd]9[/kbd] keys to function as their equivalent numpad keys for 3D editor navigation. This should be enabled on keyboards that have no numeric keypad available.
 		</member>
 		<member name="editors/3d/navigation/invert_x_axis" type="bool" setter="" getter="">
+			If [code]true[/code], invert the horizontal mouse axis when panning or orbiting in the 3D editor. This setting does [i]not[/i] apply to freelook mode.
 		</member>
 		<member name="editors/3d/navigation/invert_y_axis" type="bool" setter="" getter="">
+			If [code]true[/code], invert the vertical mouse axis when panning, orbiting, or using freelook mode in the 3D editor.
 		</member>
 		<member name="editors/3d/navigation/navigation_scheme" type="int" setter="" getter="">
+			The navigation scheme to use in the 3D editor. Changing this setting will affect the mouse buttons that must be held down to perform certain operations in the 3D editor viewport.
+			- [b]Godot[/b] Middle mouse button to orbit, [kbd]Shift + Middle mouse button[/kbd] to pan. [kbd]Mouse wheel[/kbd] to zoom.
+			- [b]Maya:[/b] [kbd]Alt + Left mouse buttton[/kbd] to orbit. [kbd]Middle mouse button[/kbd] to pan, [kbd]Shift + Middle mouse button[/kbd] to pan 10 times faster. [kbd]Mouse wheel[/kbd] to zoom.
+			- [b]Modo:[/b] [kbd]Alt + Left mouse buttton[/kbd] to orbit. [kbd]Alt + Shift + Left mouse button[/kbd] to pan. [kbd]Ctrl + Alt + Left mouse button[/kbd] to zoom.
+			See also [member editors/3d/freelook/freelook_navigation_scheme].
+			[b]Note:[/b] On certain window managers on Linux, the [kbd]Alt[/kbd] key will be intercepted by the window manager when clicking a mouse button at the same time. This means Godot will not see the modifier key as being pressed.
 		</member>
 		<member name="editors/3d/navigation/orbit_modifier" type="int" setter="" getter="">
+			The modifier key that must be held to orbit in the 3D editor.
+			[b]Note:[/b] If [member editors/3d/navigation/emulate_3_button_mouse] is [code]true[/code], [kbd]Alt[/kbd] will always remain usable for orbiting to improve usability with graphics tablets.
+			[b]Note:[/b] On certain window managers on Linux, the [kbd]Alt[/kbd] key will be intercepted by the window manager when clicking a mouse button at the same time. This means Godot will not see the modifier key as being pressed.
 		</member>
 		<member name="editors/3d/navigation/pan_modifier" type="int" setter="" getter="">
+			The modifier key that must be held to pan in the 3D editor.
+			[b]Note:[/b] On certain window managers on Linux, the [kbd]Alt[/kbd] key will be intercepted by the window manager when clicking a mouse button at the same time. This means Godot will not see the modifier key as being pressed.
 		</member>
 		<member name="editors/3d/navigation/warped_mouse_panning" type="bool" setter="" getter="">
+			If [code]true[/code], warps the mouse around the 3D viewport while panning in the 3D editor. This makes it possible to pan over a large area without having to exit panning then mouse the mouse back constantly.
 		</member>
 		<member name="editors/3d/navigation/zoom_modifier" type="int" setter="" getter="">
+			The modifier key that must be held to zoom in the 3D editor.
+			[b]Note:[/b] On certain window managers on Linux, the [kbd]Alt[/kbd] key will be intercepted by the window manager when clicking a mouse button at the same time. This means Godot will not see the modifier key as being pressed.
 		</member>
 		<member name="editors/3d/navigation/zoom_style" type="int" setter="" getter="">
+			The mouse cursor movement direction to use when zooming by moving the mouse. This does not affect zooming with the mouse wheel.
 		</member>
 		<member name="editors/3d/navigation_feel/orbit_inertia" type="float" setter="" getter="">
+			The inertia to use when orbiting in the 3D editor. Higher values make the camera start and stop slower, which looks smoother but adds latency.
 		</member>
 		<member name="editors/3d/navigation_feel/orbit_sensitivity" type="float" setter="" getter="">
+			The mouse sensitivity to use when orbiting in the 3D editor. See also [member editors/3d/freelook/freelook_sensitivity].
 		</member>
 		<member name="editors/3d/navigation_feel/translation_inertia" type="float" setter="" getter="">
+			The inertia to use when panning in the 3D editor. Higher values make the camera start and stop slower, which looks smoother but adds latency.
 		</member>
 		<member name="editors/3d/navigation_feel/zoom_inertia" type="float" setter="" getter="">
+			The inertia to use when zooming in the 3D editor. Higher values make the camera start and stop slower, which looks smoother but adds latency.
 		</member>
 		<member name="editors/3d/primary_grid_color" type="Color" setter="" getter="">
+			The color to use for the primary 3D grid. The color's alpha channel affects the grid's opacity.
 		</member>
 		<member name="editors/3d/primary_grid_steps" type="int" setter="" getter="">
+			If set above 0, where a primary grid line should be drawn. By default, primary lines are configured to be more visible than secondary lines. This helps with measurements in the 3D editor. See also [member editors/3d/primary_grid_color] and [member editors/3d/secondary_grid_color].
 		</member>
 		<member name="editors/3d/secondary_grid_color" type="Color" setter="" getter="">
+			The color to use for the secondary 3D grid. This is generally a less visible color than [member editors/3d/primary_grid_color]. The color's alpha channel affects the grid's opacity.
 		</member>
 		<member name="editors/3d/selection_box_color" type="Color" setter="" getter="">
+			The color to use for the selection box that surrounds selected nodes in the 3D editor viewport. The color's alpha channel influences the selection box's opacity.
 		</member>
 		<member name="editors/3d_gizmos/gizmo_colors/instantiated" type="Color" setter="" getter="">
+			The color override to use for 3D editor gizmos if the [Node3D] in question is part of an instanced scene file (from the perspective of the current scene).
 		</member>
 		<member name="editors/3d_gizmos/gizmo_colors/joint" type="Color" setter="" getter="">
+			The 3D editor gizmo color for [Joint3D]s and [PhysicalBone3D]s.
 		</member>
 		<member name="editors/3d_gizmos/gizmo_colors/shape" type="Color" setter="" getter="">
+			The 3D editor gizmo color for [CollisionShape3D]s, [VehicleWheel3D]s, [RayCast3D]s and [SpringArm3D]s.
 		</member>
 		<member name="editors/animation/autorename_animation_tracks" type="bool" setter="" getter="">
+			If [code]true[/code], automatically updates animation tracks' target paths when renaming or reparenting nodes in the Scene tree dock.
 		</member>
 		<member name="editors/animation/confirm_insert_track" type="bool" setter="" getter="">
+			If [code]true[/code], display a confirmation dialog when adding a new track to an animation by pressing the "key" icon next to a property.
 		</member>
 		<member name="editors/animation/default_create_bezier_tracks" type="bool" setter="" getter="">
+			If [code]true[/code], create a Bezier track instead of a standard track when pressing the "key" icon next to a property. Bezier tracks provide more control over animation curves, but are more difficult to adjust quickly.
 		</member>
 		<member name="editors/animation/default_create_reset_tracks" type="bool" setter="" getter="">
+			If [code]true[/code], create a [code]RESET[/code] track when creating a new animation track. This track can be used to restore the animation to a "default" state.
 		</member>
 		<member name="editors/animation/onion_layers_future_color" type="Color" setter="" getter="">
+			The modulate color to use for "future" frames displayed in the animation editor's onion skinning feature.
 		</member>
 		<member name="editors/animation/onion_layers_past_color" type="Color" setter="" getter="">
+			The modulate color to use for "past" frames displayed in the animation editor's onion skinning feature.
 		</member>
 		<member name="editors/grid_map/pick_distance" type="float" setter="" getter="">
+			The maximum distance at which tiles can be placed on a GridMap, relative to the camera position (in 3D units).
 		</member>
 		<member name="editors/panning/2d_editor_pan_speed" type="int" setter="" getter="">
+			The panning speed when using the mouse wheel or touchscreen events in the 2D editor. This setting does not apply to panning by holding down the middle or right mouse buttons.
 		</member>
 		<member name="editors/panning/2d_editor_panning_scheme" type="int" setter="" getter="">
+			Controls whether the mouse wheel scroll zooms or pans in the 2D editor. See also [member editors/panning/sub_editors_panning_scheme] and [member editors/panning/animation_editors_panning_scheme].
 		</member>
 		<member name="editors/panning/animation_editors_panning_scheme" type="int" setter="" getter="">
+			Controls whether the mouse wheel scroll zooms or pans in the animation track and Bezier editors. See also [member editors/panning/2d_editor_panning_scheme] and [member editors/panning/sub_editors_panning_scheme] (which controls the animation blend tree editor's pan behavior).
 		</member>
 		<member name="editors/panning/simple_panning" type="bool" setter="" getter="">
+			If [code]true[/code], allows panning by holding down [kbd]Space[/kbd] in the 2D editor viewport (in addition to panning with the middle or right mouse buttons). If [code]false[/code], the left mouse button must be held down while holding down [kbd]Space[/kbd] to pan in the 2D editor viewport.
 		</member>
 		<member name="editors/panning/sub_editors_panning_scheme" type="int" setter="" getter="">
+			Controls whether the mouse wheel scroll zooms or pans in subeditors. The list of affected subeditors is: animation blend tree editor, [Polygon2D] editor, tileset editor, texture region editor, visual shader editor and visual script editor. See also [member editors/panning/2d_editor_panning_scheme] and [member editors/panning/animation_editors_panning_scheme].
 		</member>
 		<member name="editors/panning/warped_mouse_panning" type="bool" setter="" getter="">
+			If [code]true[/code], warps the mouse around the 2D viewport while panning in the 2D editor. This makes it possible to pan over a large area without having to exit panning then mouse the mouse back constantly.
 		</member>
 		<member name="editors/polygon_editor/point_grab_radius" type="int" setter="" getter="">
+			The radius in which points can be selected in the [Polygon2D] and [CollisionPolygon2D] editors (in pixels). Higher values make it easier to select points quickly, but can make it more difficult to select the expected point when several points are located close to each other.
 		</member>
 		<member name="editors/polygon_editor/show_previous_outline" type="bool" setter="" getter="">
+			If [code]true[/code], displays the polygon's previous shape in the 2D polygon editors with an opaque gray outline. This outline is displayed while dragging a point until the left mouse button is released.
 		</member>
 		<member name="editors/tiles_editor/display_grid" type="bool" setter="" getter="">
+			If [code]true[/code], displays a grid while the TileMap editor is active. See also [member editors/tiles_editor/grid_color].
 		</member>
 		<member name="editors/tiles_editor/grid_color" type="Color" setter="" getter="">
+			The color to use for the TileMap editor's grid.
+			[b]Note:[/b] Only effective if [member editors/tiles_editor/display_grid] is [code]true[/code].
 		</member>
 		<member name="editors/visual_editors/lines_curvature" type="float" setter="" getter="">
+			The curvature to use for connection lines in the visual script and visual shader editors. Higher values will make connection lines appear more curved, with values above [code]0.5[/code] resulting in more "angular" turns in the middle of connection lines.
 		</member>
 		<member name="editors/visual_editors/minimap_opacity" type="float" setter="" getter="">
+			The opacity of the minimap displayed in the bottom-right corner of the visual script and visual shader editors.
 		</member>
 		<member name="editors/visual_editors/visual_shader/port_preview_size" type="int" setter="" getter="">
+			The size to use for port previews in the visual shader uniforms (toggled by clicking the "eye" icon next to an output). The value is defined in pixels at 100% zoom, and will scale with zoom automatically.
 		</member>
 		<member name="filesystem/directories/autoscan_project_path" type="String" setter="" getter="">
+			The folder where projects should be scanned for (recursively), in a way similar to the project manager's [b]Scan[/b]button. This can be set to the same value as [member filesystem/directories/default_project_path] for convenience.
+			[b]Note:[/b] Setting this path to a folder with very large amounts of files/folders can slow down the project manager startup significantly. To keep the project manager quick to start up, it is recommended to set this value to a folder as "specific" as possible.
 		</member>
 		<member name="filesystem/directories/default_project_path" type="String" setter="" getter="">
+			The folder where new projects should be created by default when clicking the project manager's [b]New Project[/b] button. This can be set to the same value as [member filesystem/directories/autoscan_project_path] for convenience.
 		</member>
 		<member name="filesystem/file_dialog/display_mode" type="int" setter="" getter="">
+			The display mode to use in the editor's file dialogs.
+			- [b]Thumbnails[/b] takes more space, but displays dynamic resource thumbnails, making resources easier to preview without having to open them.
+			- [b]List[/b] is more compact but doesn't display dynamic resource thumbnails. Instead, it displays static icons based on the file extension.
 		</member>
 		<member name="filesystem/file_dialog/show_hidden_files" type="bool" setter="" getter="">
+			If [code]true[/code], display hidden files in the editor's file dialogs. Files that have names starting with [code].[/code] are considered hidden (e.g. [code].hidden_file[/code]).
 		</member>
 		<member name="filesystem/file_dialog/thumbnail_size" type="int" setter="" getter="">
+			The thumbnail size to use in the editor's file dialogs (in pixels). See also [member docks/filesystem/thumbnail_size].
 		</member>
 		<member name="filesystem/on_save/compress_binary_resources" type="bool" setter="" getter="">
+			If [code]true[/code], uses lossless compression for binary resources.
 		</member>
 		<member name="filesystem/on_save/safe_save_on_backup_then_rename" type="bool" setter="" getter="">
+			If [code]true[/code], when saving a file, the editor will rename the old file to a different name, save a new file, then only remove the old file once the new file has been saved. This makes loss of data less likely to happen if the editor or operating system exits unexpectedly while saving (e.g. due to a crash or power outage).
+			[b]Note:[/b] On Windows, this feature can interact negatively with certain antivirus programs. In this case, you may have to set this to [code]false[/code] to prevent file locking issues.
 		</member>
 		<member name="interface/editor/automatically_open_screenshots" type="bool" setter="" getter="">
+			If [code]true[/code], automatically opens screenshots with the default program associated to [code].png[/code] files after a screenshot is taken using the [b]Editor &gt; Take Screenshot[/b] action.
 		</member>
 		<member name="interface/editor/code_font" type="String" setter="" getter="">
+			The font to use for the script editor. Must be a resource of a [Font] type such as a [code].ttf[/code] or [code].otf[/code] font file.
 		</member>
 		<member name="interface/editor/code_font_contextual_ligatures" type="int" setter="" getter="">
+			The font ligatures to enable for the currently configured code font. Not all fonts include support for ligatures.
+			[b]Note:[/b] The default editor code font (Hack) does not have contextual ligatures in its font file.
 		</member>
 		<member name="interface/editor/code_font_custom_opentype_features" type="String" setter="" getter="">
+			List of custom OpenType features to use, if supported by the currently configured code font. Not all fonts include support for custom OpenType features. The string should follow the OpenType specification.
+			[b]Note:[/b] The default editor code font (Hack) does not have custom OpenType features in its font file.
 		</member>
 		<member name="interface/editor/code_font_custom_variations" type="String" setter="" getter="">
+			List of alternative characters to use, if supported by the currently configured code font. Not all fonts include support for custom variations. The string should follow the OpenType specification.
+			[b]Note:[/b] The default editor code font (Hack) does not have alternate characters in its font file.
 		</member>
 		<member name="interface/editor/code_font_size" type="int" setter="" getter="">
+			The size of the font in the script editor. This setting does not impact the font size of the Output panel (see [member run/output/font_size]).
 		</member>
 		<member name="interface/editor/custom_display_scale" type="float" setter="" getter="">
+			The custom editor scale factor to use. This can be used for displays with very high DPI where a scale factor of 200% is not sufficient.
+			[b]Note:[/b] Only effective if [member interface/editor/display_scale] is set to [b]Custom[/b].
 		</member>
 		<member name="interface/editor/debug/enable_pseudolocalization" type="bool" setter="" getter="">
+			If [code]true[/code], lengthens the editor's localizable strings and replaces their characters with accented variants. This allows spotting non-localizable strings easily, while also ensuring the UI layout doesn't break when strings are made longer (as many languages require strings to be longer).
+			This is a debugging feature and should only be enabled when working on the editor itself.
 		</member>
 		<member name="interface/editor/display_scale" type="int" setter="" getter="">
+			The display scale factor to use for the editor interface. Higher values are more suited to hiDPI/Retina displays.
+			If set to [b]Auto[/b], the editor scale is automatically determined based on the screen resolution and reported display DPI. This heuristic is not always ideal, which means you can get better results by setting the editor scale manually.
+			If set to [b]Custom[/b], the scaling value in [member interface/editor/custom_display_scale] will be used.
 		</member>
 		<member name="interface/editor/editor_language" type="String" setter="" getter="">
+			The language to use for the editor interface.
+			Translations are provided by the community. If you spot a mistake, [url=https://docs.godotengine.org/en/latest/community/contributing/editor_and_docs_localization.html]contribute to editor translations on Weblate![/url]
 		</member>
 		<member name="interface/editor/font_antialiased" type="bool" setter="" getter="">
+			If [code]true[/code], enables FreeType's font antialiasing on the editor fonts. Most fonts are not designed to look good with antialiasing disabled, so it's recommended to leave this enabled unless you're using a pixel art font.
 		</member>
 		<member name="interface/editor/font_hinting" type="int" setter="" getter="">
+			The font hinting mode to use for the editor fonts. FreeType supports the following font hinting modes:
+			- [b]None:[/b] Don't use font hinting when rasterizing the font. This results in a smooth font, but it can look blurry.
+			- [b]Light:[/b] Use hinting on the X axis only. This is a compromise between font sharpness and smoothness.
+			- [b]Normal:[/b] Use hinting on both X and Y axes. This results in a sharp font, but it doesn't look very smooth.
+			If set to [b]Auto[/b], the font hinting mode will be set to match the current operating system in use. This means the [b]Light[/b] hinting mode will be used on Windows and Linux, and the [b]None[/b] hinting mode will be used on macOS.
 		</member>
 		<member name="interface/editor/font_subpixel_positioning" type="int" setter="" getter="">
+			The subpixel positioning mode to use when rendering editor font glyphs. This affects both the main and code fonts. [b]Disabled[/b] is the fastest to render and uses the least memory. [b]Auto[/b] only uses subpixel positioning for small font sizes (where the benefit is the most noticeable). [b]One half of a pixel[/b] and [b]One quarter of a pixel[/b] force the same subpixel positioning mode for all editor fonts, regardless of their size (with [b]One quarter of a pixel[/b] being the highest-quality option).
 		</member>
 		<member name="interface/editor/low_processor_mode_sleep_usec" type="float" setter="" getter="">
+			The amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU/GPU usage, which can improve battery life on laptops. However, higher values will result in a less responsive editor. The default value is set to allow for maximum smoothness on monitors up to 144 Hz. See also [member interface/editor/unfocused_low_processor_mode_sleep_usec].
 		</member>
 		<member name="interface/editor/main_font" type="String" setter="" getter="">
+			The font to use for the editor interface. Must be a resource of a [Font] type such as a [code].ttf[/code] or [code].otf[/code] font file.
 		</member>
 		<member name="interface/editor/main_font_bold" type="String" setter="" getter="">
+			The font to use for bold text in the editor interface. Must be a resource of a [Font] type such as a [code].ttf[/code] or [code].otf[/code] font file.
 		</member>
 		<member name="interface/editor/main_font_size" type="int" setter="" getter="">
+			The size of the font in the editor interface.
 		</member>
 		<member name="interface/editor/mouse_extra_buttons_navigate_history" type="bool" setter="" getter="">
+			If [code]true[/code], the mouse's additional side buttons will be usable to navigate in the script editor's file history. Set this to [code]false[/code] if you're using the side buttons for other purposes (such as a push-to-talk button in a VoIP program).
 		</member>
 		<member name="interface/editor/save_each_scene_on_quit" type="bool" setter="" getter="">
+			If [code]true[/code], the editor will save all scenes when confirming the [b]Save[/b] action when quitting the editor or quitting to the project list. If [code]false[/code], the editor will ask to save each scene individually.
 		</member>
 		<member name="interface/editor/separate_distraction_mode" type="bool" setter="" getter="">
+			If [code]true[/code], the editor's Script tab will have a separate distraction mode setting from the 2D/3D/AssetLib tabs. If [code]false[/code], the distraction-free mode toggle is shared between all tabs.
 		</member>
 		<member name="interface/editor/show_internal_errors_in_toast_notifications" type="int" setter="" getter="">
+			If enabled, displays internal engine errors in toast notifications (toggleable by clicking the "bell" icon at the bottom of the editor). No matter the value of this setting, non-internal engine errors will always be visible in toast notifications.
+			The default [b]Auto[/b] value will only enable this if the editor was compiled with the [code]dev=yes[/code] option (the default is [code]dev=no[/code]).
 		</member>
 		<member name="interface/editor/single_window_mode" type="bool" setter="" getter="">
+			If [code]true[/code], embed modal windows such as docks inside the main editor window. When single-window mode is enabled, tooltips will also be embedded inside the main editor window, which means they can't be displayed outside of the editor window.
 		</member>
 		<member name="interface/editor/unfocused_low_processor_mode_sleep_usec" type="float" setter="" getter="">
+			When the editor window is unfocused, the amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU/GPU usage, which can improve battery life on laptops (in addition to improving the running project's performance if the editor has to redraw continuously). However, higher values will result in a less responsive editor. The default value is set to limit the editor to 20 FPS when the editor window is unfocused. See also [member interface/editor/low_processor_mode_sleep_usec].
 		</member>
 		<member name="interface/inspector/max_array_dictionary_items_per_page" type="int" setter="" getter="">
+			The number of [Array] or [Dictionary] items to display on each "page" in the inspector. Higher values allow viewing more values per page, but take more time to load. This increased load time is noticeable when selecting nodes that have array or dictionary properties in the editor.
 		</member>
 		<member name="interface/inspector/show_low_level_opentype_features" type="bool" setter="" getter="">
+			If [code]true[/code], display OpenType features marked as [code]hidden[/code] by the font file in the [Font] editor.
 		</member>
 		<member name="interface/scene_tabs/display_close_button" type="int" setter="" getter="">
+			Controls when the Close (X) button is displayed on scene tabs at the top of the editor.
 		</member>
 		<member name="interface/scene_tabs/maximum_width" type="int" setter="" getter="">
+			The maximum width of each scene tab at the top editor (in pixels).
 		</member>
 		<member name="interface/scene_tabs/show_script_button" type="bool" setter="" getter="">
+			If [code]true[/code], show a button next to each scene tab that opens the scene's "dominant" script when clicked. The "dominant" script is the one that is at the highest level in the scene's hierarchy.
 		</member>
 		<member name="interface/scene_tabs/show_thumbnail_on_hover" type="bool" setter="" getter="">
+			If [code]true[/code], display an automatically-generated thumbnail when hovering scene tabs with the mouse. Scene thumbnails are generated when saving the scene.
 		</member>
 		<member name="interface/theme/accent_color" type="Color" setter="" getter="">
+			The color to use for "highlighted" user interface elements in the editor (pressed and hovered items).
 		</member>
 		<member name="interface/theme/additional_spacing" type="float" setter="" getter="">
+			The spacing to add for buttons and list items in the editor (in pixels). Increasing this value is useful to improve usability on touch screens, at the cost of reducing the amount of usable screen real estate.
 		</member>
 		<member name="interface/theme/base_color" type="Color" setter="" getter="">
+			The base color to use for user interface elements in the editor. Secondary colors (such as darker/lighter variants) are derived from this color.
 		</member>
 		<member name="interface/theme/border_size" type="int" setter="" getter="">
+			The border size to use for interface elements (in pixels).
 		</member>
 		<member name="interface/theme/contrast" type="float" setter="" getter="">
+			The contrast factor to use when deriving the editor theme's base color (see [member interface/theme/base_color]). When using a positive values, the derived colors will be [i]darker[/i] than the base color. This contrast factor can be set to a negative value, which will make the derived colors [i]brighter[/i] than the base color. Negative contrast rates often look better for light themes.
 		</member>
 		<member name="interface/theme/corner_radius" type="int" setter="" getter="">
+			The corner radius to use for interface elements (in pixels). [code]0[/code] is square.
 		</member>
 		<member name="interface/theme/custom_theme" type="String" setter="" getter="">
+			The custom theme resource to use for the editor. Must be a Godot theme resource in [code].tres[/code] or [code].res[/code] format.
 		</member>
 		<member name="interface/theme/icon_and_font_color" type="int" setter="" getter="">
+			The icon and font color scheme to use in the editor.
+			- [b]Auto[/b] determines the color scheme to use automatically based on [member interface/theme/base_color].
+			- [b]Dark[/b] makes fonts and icons light (suitable for dark themes).
+			- [b]Light[/b] makes fonts and icons dark (suitable for light themes). Icon colors are automatically converted by the editor following [url=https://github.com/godotengine/godot/blob/master/editor/editor_themes.cpp#L135]this set of rules[/url].
 		</member>
 		<member name="interface/theme/icon_saturation" type="float" setter="" getter="">
+			The saturation to use for editor icons. Higher values result in more vibrant colors.
+			[b]Note:[/b] The default editor icon saturation was increased by 30% in Godot 4.0 and later. To get Godot 3.x's icon saturation back, set [member interface/theme/icon_saturation] to [code]0.77[/code].
 		</member>
 		<member name="interface/theme/preset" type="String" setter="" getter="">
+			The editor theme preset to use.
 		</member>
 		<member name="interface/theme/relationship_line_opacity" type="float" setter="" getter="">
+			The opacity to use when drawing relationship lines in the editor's [Tree]-based GUIs (such as the Scene tree dock).
 		</member>
 		<member name="network/debug/remote_host" type="String" setter="" getter="">
+			The address to listen to when starting the remote debugger. This can be set to [code]0.0.0.0[/code] to allow external clients to connect to the remote debugger (instead of restricting the remote debugger to connections from [code]localhost[/code]).
 		</member>
 		<member name="network/debug/remote_port" type="int" setter="" getter="">
+			The port to listen to when starting the remote debugger. Godot will try to use port numbers above the configured number if the configured number is already taken by another application.
 		</member>
 		<member name="network/http_proxy/host" type="String" setter="" getter="">
+			The host to use to contact the HTTP and HTTPS proxy in the editor (for the asset library and export template downloads). See also [member network/http_proxy/port].
+			[b]Note:[/b] Godot currently doesn't automatically use system proxy settings, so you have to enter them manually here if needed.
 		</member>
 		<member name="network/http_proxy/port" type="int" setter="" getter="">
+			The port number to use to contact the HTTP and HTTPS proxy in the editor (for the asset library and export template downloads). See also [member network/http_proxy/host].
+			[b]Note:[/b] Godot currently doesn't automatically use system proxy settings, so you have to enter them manually here if needed.
 		</member>
 		<member name="network/ssl/editor_ssl_certificates" type="String" setter="" getter="">
+			The SSL certificate bundle to use for HTTP requests made within the editor (e.g. from the AssetLib tab). If left empty, the [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]included Mozilla certificate bundle[/url] will be used.
 		</member>
 		<member name="project_manager/sorting_order" type="int" setter="" getter="">
+			The sorting order to use in the project manager. When changing the sorting order in the project manager, this setting is set permanently in the editor settings.
 		</member>
 		<member name="run/auto_save/save_before_running" type="bool" setter="" getter="">
+			If [code]true[/code], saves all scenes and scripts automatically before running the project. Setting this to [code]false[/code] prevents the editor from saving if there are no changes which can speed up the project startup slightly, but it makes it possible to run a project that has unsaved changes. (Unsaved changes will not be visible in the running project.)
 		</member>
 		<member name="run/output/always_clear_output_on_play" type="bool" setter="" getter="">
+			If [code]true[/code], the editor will clear the Output panel when running the project.
 		</member>
 		<member name="run/output/always_close_output_on_stop" type="bool" setter="" getter="">
+			If [code]true[/code], the editor will collapse the Output panel when stopping the project.
 		</member>
 		<member name="run/output/always_open_output_on_play" type="bool" setter="" getter="">
+			If [code]true[/code], the editor will expand the Output panel when running the project.
 		</member>
 		<member name="run/output/font_size" type="int" setter="" getter="">
+			The size of the font in the [b]Output[/b] panel at the bottom of the editor. This setting does not impact the font size of the script editor (see [member interface/editor/code_font_size]).
 		</member>
 		<member name="run/window_placement/rect" type="int" setter="" getter="">
+			The window mode to use to display the project when starting the project from the editor.
 		</member>
 		<member name="run/window_placement/rect_custom_position" type="Vector2" setter="" getter="">
+			The custom position to use when starting the project from the editor (in pixels from the top-left corner). Only effective if [member run/window_placement/rect] is set to [b]Custom Position[/b].
 		</member>
 		<member name="run/window_placement/screen" type="int" setter="" getter="">
+			The monitor to display the project on when starting the project from the editor.
 		</member>
 		<member name="text_editor/appearance/caret/caret_blink" type="bool" setter="" getter="">
+			If [code]true[/code], makes the caret blink according to [member text_editor/appearance/caret/caret_blink_speed]. Disabling this setting can improve battery life on laptops if you spend long amounts of time in the script editor, since it will reduce the frequency at which the editor needs to be redrawn.
 		</member>
 		<member name="text_editor/appearance/caret/caret_blink_speed" type="float" setter="" getter="">
+			The interval at which to blink the caret (in seconds). See also [member text_editor/appearance/caret/caret_blink].
 		</member>
 		<member name="text_editor/appearance/caret/highlight_all_occurrences" type="bool" setter="" getter="">
+			If [code]true[/code], highlights all occurrences of the currently selected text in the script editor. See also [member text_editor/theme/highlighting/word_highlighted_color].
 		</member>
 		<member name="text_editor/appearance/caret/highlight_current_line" type="bool" setter="" getter="">
+			If [code]true[/code], colors the background of the line the caret is currently on with [member text_editor/theme/highlighting/current_line_color].
 		</member>
 		<member name="text_editor/appearance/caret/type" type="int" setter="" getter="">
+			The shape of the caret to use in the script editor. [b]Line[/b] displays a vertical line to the left of the current character, whereas [b]Block[/b] displays a outline over the current character.
 		</member>
 		<member name="text_editor/appearance/guidelines/line_length_guideline_hard_column" type="int" setter="" getter="">
+			The column at which to display a subtle line as a line length guideline for scripts. This should generally be greater than [member text_editor/appearance/guidelines/line_length_guideline_soft_column].
 		</member>
 		<member name="text_editor/appearance/guidelines/line_length_guideline_soft_column" type="int" setter="" getter="">
+			The column at which to display a [i]very[/i] subtle line as a line length guideline for scripts. This should generally be lower than [member text_editor/appearance/guidelines/line_length_guideline_hard_column].
 		</member>
 		<member name="text_editor/appearance/guidelines/show_line_length_guidelines" type="bool" setter="" getter="">
+			If [code]true[/code], displays line length guidelines to help you keep line lengths in check. See also [member text_editor/appearance/guidelines/line_length_guideline_soft_column] and [member text_editor/appearance/guidelines/line_length_guideline_hard_column].
 		</member>
 		<member name="text_editor/appearance/gutters/highlight_type_safe_lines" type="bool" setter="" getter="">
+			If [code]true[/code], highlights type-safe lines by displaying their line number color with [member text_editor/theme/highlighting/safe_line_number_color] instead of [member text_editor/theme/highlighting/line_number_color]. Type-safe lines are lines of code where the type of all variables is known at compile-time. These type-safe lines will run faster in Godot 4.0 and later thanks to typed instructions.
 		</member>
 		<member name="text_editor/appearance/gutters/line_numbers_zero_padded" type="bool" setter="" getter="">
+			If [code]true[/code], displays line numbers with zero padding (e.g. [code]007[/code] instead of [code]7[/code]).
 		</member>
 		<member name="text_editor/appearance/gutters/show_bookmark_gutter" type="bool" setter="" getter="">
+			If [code]true[/code], displays a gutter at the left containing icons for bookmarks.
 		</member>
 		<member name="text_editor/appearance/gutters/show_info_gutter" type="bool" setter="" getter="">
+			If [code]true[/code], displays a gutter at the left containing icons for methods with signal connections.
 		</member>
 		<member name="text_editor/appearance/gutters/show_line_numbers" type="bool" setter="" getter="">
+			If [code]true[/code], displays line numbers in the gutter at the left.
 		</member>
 		<member name="text_editor/appearance/lines/code_folding" type="bool" setter="" getter="">
+			If [code]true[/code], displays the folding arrows next to indented code sections and allows code folding. If [code]false[/code], hides the folding arrows next to indented code sections and disallows code folding.
 		</member>
 		<member name="text_editor/appearance/lines/word_wrap" type="int" setter="" getter="">
+			If [code]true[/code], wraps long lines over multiple lines to avoid horizontal scrolling. This is a display-only feature; it does not actually insert line breaks in your scripts.
 		</member>
 		<member name="text_editor/appearance/minimap/minimap_width" type="int" setter="" getter="">
+			The width of the minimap in the script editor (in pixels).
 		</member>
 		<member name="text_editor/appearance/minimap/show_minimap" type="bool" setter="" getter="">
+			If [code]true[/code], draws an overview of the script near the scroll bar. The minimap can be left-clicked to scroll directly to a location in an "absolute" manner.
 		</member>
 		<member name="text_editor/appearance/whitespace/draw_spaces" type="bool" setter="" getter="">
+			If [code]true[/code], draws space characters as centered points.
 		</member>
 		<member name="text_editor/appearance/whitespace/draw_tabs" type="bool" setter="" getter="">
+			If [code]true[/code], draws tab characters as chevrons.
 		</member>
 		<member name="text_editor/appearance/whitespace/line_spacing" type="int" setter="" getter="">
+			The space to add between lines (in pixels). Greater line spacing can help improve readability at the cost of displaying less lines on screen.
 		</member>
 		<member name="text_editor/behavior/files/auto_reload_scripts_on_external_change" type="bool" setter="" getter="">
+			If [code]true[/code], automatically reloads scripts in the editor when they have been modified and saved by external editors.
 		</member>
 		<member name="text_editor/behavior/files/autosave_interval_secs" type="int" setter="" getter="">
+			If set to a value greater than [code]0[/code], automatically saves the current script following the specified interval (in seconds). This can be used to prevent data loss if the editor crashes.
 		</member>
 		<member name="text_editor/behavior/files/convert_indent_on_save" type="bool" setter="" getter="">
+			If [code]true[/code], converts indentation to match the script editor's indentation settings when saving a script. See also [member text_editor/behavior/indent/type].
 		</member>
 		<member name="text_editor/behavior/files/restore_scripts_on_load" type="bool" setter="" getter="">
+			If [code]true[/code], reopens scripts that were opened in the last session when the editor is reopened on a given project.
 		</member>
 		<member name="text_editor/behavior/files/trim_trailing_whitespace_on_save" type="bool" setter="" getter="">
+			If [code]true[/code], trims trailing whitespace when saving a script. Trailing whitespace refers to tab and space characters placed at the end of lines. Since these serve no practical purpose, they can and should be removed to make version control diffs less noisy.
 		</member>
 		<member name="text_editor/behavior/indent/auto_indent" type="bool" setter="" getter="">
+			If [code]true[/code], automatically indents code when pressing the [kbd]Enter[/kbd] key based on blocks above the new line.
 		</member>
 		<member name="text_editor/behavior/indent/size" type="int" setter="" getter="">
+			When using tab indentation, determines the length of each tab. When using space indentation, determines how many spaces are inserted when pressing [kbd]Tab[/kbd] and when automatic indentation is performed.
 		</member>
 		<member name="text_editor/behavior/indent/type" type="int" setter="" getter="">
+			The indentation style to use (tabs or spaces).
+			[b]Note:[/b] The [url=https://docs.godotengine.org/en/latest/getting_started/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url] recommends using tabs for indentation. It is advised to change this setting only if you need to work on a project that currently uses spaces for indentation.
 		</member>
 		<member name="text_editor/behavior/navigation/drag_and_drop_selection" type="bool" setter="" getter="">
+			If [code]true[/code], allows drag-and-dropping text in the script editor to move text. Disable this if you find yourself accidentally drag-and-dropping text in the script editor.
 		</member>
 		<member name="text_editor/behavior/navigation/move_caret_on_right_click" type="bool" setter="" getter="">
+			If [code]true[/code], the caret will be moved when right-clicking somewhere in the script editor (like when left-clicking or middle-clicking). If [code]false[/code], the caret will only be moved when left-clicking or middle-clicking somewhere.
 		</member>
 		<member name="text_editor/behavior/navigation/scroll_past_end_of_file" type="bool" setter="" getter="">
+			If [code]true[/code], allows scrolling past the end of the file.
 		</member>
 		<member name="text_editor/behavior/navigation/smooth_scrolling" type="bool" setter="" getter="">
+			If [code]true[/code], allows scrolling in sub-line intervals and enables a smooth scrolling animation when using the mouse wheel to scroll.
+			[b]Note:[/b] [member text_editor/behavior/navigation/smooth_scrolling] currently behaves poorly in projects where [member ProjectSettings.physics/common/physics_ticks_per_second] has been increased significantly from its default value ([code]60[/code]). In this case, it is recommended to disable this setting.
 		</member>
 		<member name="text_editor/behavior/navigation/stay_in_script_editor_on_node_selected" type="bool" setter="" getter="">
+			If [code]true[/code], prevents automatically switching between the Script and 2D/3D screens when selecting a node in the Scene tree dock.
 		</member>
 		<member name="text_editor/behavior/navigation/v_scroll_speed" type="int" setter="" getter="">
+			The number of pixels to scroll with every mouse wheel increment. Higher values make the script scroll by faster when using the mouse wheel.
+			[b]Note:[/b] You can hold down [kbd]Alt[/kbd] while using the mouse wheel to temporarily scroll 5 times faster.
 		</member>
 		<member name="text_editor/completion/add_type_hints" type="bool" setter="" getter="">
+			If [code]true[/code], adds static typing hints such as [code]-&gt; void[/code] and [code]: int[/code] when performing method definition autocompletion.
 		</member>
 		<member name="text_editor/completion/auto_brace_complete" type="bool" setter="" getter="">
+			If [code]true[/code], automatically completes braces when making use of code completion.
 		</member>
 		<member name="text_editor/completion/code_complete_delay" type="float" setter="" getter="">
+			The delay in seconds after which autocompletion suggestions should be displayed when the user stops typing.
 		</member>
 		<member name="text_editor/completion/complete_file_paths" type="bool" setter="" getter="">
+			If [code]true[/code], provides autocompletion suggestions for file paths in methods such as [code]load()[/code] and [code]preload()[/code].
 		</member>
 		<member name="text_editor/completion/idle_parse_delay" type="float" setter="" getter="">
+			The delay in seconds after which the script editor should check for errors when the user stops typing.
 		</member>
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
+			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.
 		</member>
 		<member name="text_editor/completion/use_single_quotes" type="bool" setter="" getter="">
+			If [code]true[/code], performs string autocompletion with single quotes. If [code]false[/code], performs string autocompletion with double quotes (which matches the [url=https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]).
 		</member>
 		<member name="text_editor/help/class_reference_examples" type="int" setter="" getter="">
+			Controls which multi-line code blocks should be displayed in the editor help. This setting does not affect single-line code literals in the editor help.
 		</member>
 		<member name="text_editor/help/help_font_size" type="int" setter="" getter="">
+			The font size to use for the editor help (built-in class reference).
 		</member>
 		<member name="text_editor/help/help_source_font_size" type="int" setter="" getter="">
+			The font size to use for code samples in the editor help (built-in class reference).
 		</member>
 		<member name="text_editor/help/help_title_font_size" type="int" setter="" getter="">
+			The font size to use for headings in the editor help (built-in class reference).
 		</member>
 		<member name="text_editor/help/show_help_index" type="bool" setter="" getter="">
+			If [code]true[/code], displays a table of contents at the left of the editor help (at the location where the members overview would appear when editing a script).
 		</member>
 		<member name="text_editor/script_list/show_members_overview" type="bool" setter="" getter="">
+			If [code]true[/code], displays an overview of the current script's member variables and functions at the left of the script editor. See also [member text_editor/script_list/sort_members_outline_alphabetically].
 		</member>
 		<member name="text_editor/script_list/sort_members_outline_alphabetically" type="bool" setter="" getter="">
+			If [code]true[/code], sorts the members outline (located at the left of the script editor) using alphabetical order. If [code]false[/code], sorts the members outline depending on the order in which members are found in the script.
+			[b]Note:[/b] Only effective if [member text_editor/script_list/show_members_overview] is [code]true[/code].
 		</member>
 		<member name="text_editor/theme/color_theme" type="String" setter="" getter="">
+			The syntax theme to use in the script editor.
+			You can save your own syntax theme from your current settings by using [b]File &gt; Theme &gt; Save As...[/b] at the top of the script editor. The syntax theme will then be available locally in the list of color themes.
+			You can find additional syntax themes to install in the [url=https://github.com/godotengine/godot-syntax-themes]godot-syntax-themes[/url] repository.
 		</member>
 		<member name="text_editor/theme/highlighting/background_color" type="Color" setter="" getter="">
+			The script editor's background color. If set to a translucent color, the editor theme's base color will be visible behind.
 		</member>
 		<member name="text_editor/theme/highlighting/base_type_color" type="Color" setter="" getter="">
+			The script editor's base type color (used for types like [Vector2], [Vector3], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/bookmark_color" type="Color" setter="" getter="">
+			The script editor's bookmark icon color (displayed in the gutter).
 		</member>
 		<member name="text_editor/theme/highlighting/brace_mismatch_color" type="Color" setter="" getter="">
+			The script editor's brace mismatch color. Used when the caret is currently on a mismatched brace, parenthesis or bracket character.
 		</member>
 		<member name="text_editor/theme/highlighting/breakpoint_color" type="Color" setter="" getter="">
+			The script editor's breakpoint icon color (displayed in the gutter).
 		</member>
 		<member name="text_editor/theme/highlighting/caret_background_color" type="Color" setter="" getter="">
+			The script editor's caret background color.
+			[b]Note:[/b] This setting has no effect as it's currently unused.
 		</member>
 		<member name="text_editor/theme/highlighting/caret_color" type="Color" setter="" getter="">
+			The script editor's caret color.
 		</member>
 		<member name="text_editor/theme/highlighting/code_folding_color" type="Color" setter="" getter="">
+			The script editor's color for the code folding icon (displayed in the gutter).
 		</member>
 		<member name="text_editor/theme/highlighting/comment_color" type="Color" setter="" getter="">
+			The script editor's comment color.
+			[b]Note:[/b] In GDScript, unlike Python, multiline strings are not considered to be comments, and will use the string highlighting color instead.
 		</member>
 		<member name="text_editor/theme/highlighting/completion_background_color" type="Color" setter="" getter="">
+			The script editor's autocompletion box background color.
 		</member>
 		<member name="text_editor/theme/highlighting/completion_existing_color" type="Color" setter="" getter="">
+			The script editor's autocompletion box background color to highlight existing characters in the completion results. This should be a translucent color so that [member text_editor/theme/highlighting/completion_selected_color] can be seen behind.
 		</member>
 		<member name="text_editor/theme/highlighting/completion_font_color" type="Color" setter="" getter="">
+			The script editor's autocompletion box text color.
 		</member>
 		<member name="text_editor/theme/highlighting/completion_scroll_color" type="Color" setter="" getter="">
+			The script editor's autocompletion box scroll bar color.
 		</member>
 		<member name="text_editor/theme/highlighting/completion_scroll_hovered_color" type="Color" setter="" getter="">
+			The script editor's autocompletion box scroll bar color when hovered or pressed with the mouse.
 		</member>
 		<member name="text_editor/theme/highlighting/completion_selected_color" type="Color" setter="" getter="">
+			The script editor's autocompletion box background color for the currently selected line.
 		</member>
 		<member name="text_editor/theme/highlighting/control_flow_keyword_color" type="Color" setter="" getter="">
+			The script editor's control flow keyword color (used for keywords like [code]if[/code], [code]for[/code], [code]return[/code], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/current_line_color" type="Color" setter="" getter="">
+			The script editor's background color for the line the caret is currently on. This should be set to a translucent color so that it can display on top of other line color modifiers such as [member text_editor/theme/highlighting/mark_color].
 		</member>
 		<member name="text_editor/theme/highlighting/engine_type_color" type="Color" setter="" getter="">
+			The script editor's engine type color ([Vector2], [Vector3], [Color], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/executing_line_color" type="Color" setter="" getter="">
+			The script editor's color for the debugger's executing line icon (displayed in the gutter).
 		</member>
 		<member name="text_editor/theme/highlighting/function_color" type="Color" setter="" getter="">
+			The script editor's function call color.
+			[b]Note:[/b] When using the GDScript syntax highlighter, this is replaced by the function declaration color configured in the syntax theme for function declarations (e.g. [code]func _ready():[/code]).
 		</member>
 		<member name="text_editor/theme/highlighting/keyword_color" type="Color" setter="" getter="">
+			The script editor's non-control flow keyword color (used for keywords like [code]var[/code], [code]func[/code], some built-in methods, ...).
 		</member>
 		<member name="text_editor/theme/highlighting/line_length_guideline_color" type="Color" setter="" getter="">
+			The script editor's color for the line length guideline. The "hard" line length guideline will be drawn with this color, whereas the "soft" line length guideline will be drawn with an opacity twice as low.
 		</member>
 		<member name="text_editor/theme/highlighting/line_number_color" type="Color" setter="" getter="">
+			The script editor's color for line numbers. See also [member text_editor/theme/highlighting/safe_line_number_color].
 		</member>
 		<member name="text_editor/theme/highlighting/mark_color" type="Color" setter="" getter="">
+			The script editor's background color for lines with errors. This should be set to a translucent color so that it can display on top of other line color modifiers such as [member text_editor/theme/highlighting/current_line_color].
 		</member>
 		<member name="text_editor/theme/highlighting/member_variable_color" type="Color" setter="" getter="">
+			The script editor's color for member variables on objects (e.g. [code]self.some_property[/code]).
+			[b]Note:[/b] This color is not used for local variable declaration and access.
 		</member>
 		<member name="text_editor/theme/highlighting/number_color" type="Color" setter="" getter="">
+			The script editor's color for numbers (integer and floating-point).
 		</member>
 		<member name="text_editor/theme/highlighting/safe_line_number_color" type="Color" setter="" getter="">
+			The script editor's color for type-safe line numbers. See also [member text_editor/theme/highlighting/line_number_color].
+			[b]Note:[/b] Only displayed if [member text_editor/appearance/gutters/highlight_type_safe_lines] is [code]true[/code].
 		</member>
 		<member name="text_editor/theme/highlighting/search_result_border_color" type="Color" setter="" getter="">
+			The script editor's color for the border of search results. This border helps bring further attention to the search result. Set this color's opacity to 0 to disable the border.
 		</member>
 		<member name="text_editor/theme/highlighting/search_result_color" type="Color" setter="" getter="">
+			The script editor's background color for search results.
 		</member>
 		<member name="text_editor/theme/highlighting/selection_color" type="Color" setter="" getter="">
+			The script editor's background color for the currently selected text.
 		</member>
 		<member name="text_editor/theme/highlighting/string_color" type="Color" setter="" getter="">
+			The script editor's color for strings (single-line and multi-line).
 		</member>
 		<member name="text_editor/theme/highlighting/symbol_color" type="Color" setter="" getter="">
+			The script editor's color for operators ([code]( ) [ ] { } + - * /[/code], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/text_color" type="Color" setter="" getter="">
+			The script editor's color for text not highlighted by any syntax highlighting rule.
 		</member>
 		<member name="text_editor/theme/highlighting/text_selected_color" type="Color" setter="" getter="">
+			The script editor's background color for text. This should be set to a translucent color so that it can display on top of other line color modifiers such as [member text_editor/theme/highlighting/current_line_color].
 		</member>
 		<member name="text_editor/theme/highlighting/user_type_color" type="Color" setter="" getter="">
+			The script editor's color for user-defined types (using [code]@class_name[/code]).
 		</member>
 		<member name="text_editor/theme/highlighting/word_highlighted_color" type="Color" setter="" getter="">
+			The script editor's color for words highlighted by selecting them. Only visible if [member text_editor/appearance/caret/highlight_all_occurrences] is [code]true[/code].
 		</member>
 	</members>
 	<signals>


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/48548.

Note that despite fully filling in the XML, this doesn't actually document *all* editor settings due to some of them being registered too late (see https://github.com/godotengine/godot/pull/48548#discussion_r628672846). This will require a separate PR to move those settings' registration to happen early enough.