### PR TITLE
Add Text Server related options to the build profiles editor.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -337,21 +337,27 @@ for path in module_search_paths:
 
 # Add module options.
 for name, path in modules_detected.items():
+    sys.path.insert(0, path)
+    import config
+
     if env_base["modules_enabled_by_default"]:
         enabled = True
-
-        sys.path.insert(0, path)
-        import config
-
         try:
             enabled = config.is_enabled()
         except AttributeError:
             pass
-        sys.path.remove(path)
-        sys.modules.pop("config")
     else:
         enabled = False
 
+    # Add module-specific options.
+    try:
+        for opt in config.get_opts(selected_platform):
+            opts.Add(opt)
+    except AttributeError:
+        pass
+
+    sys.path.remove(path)
+    sys.modules.pop("config")
     opts.Add(BoolVariable("module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled))
 
 methods.write_modules(modules_detected)

--- a/editor/editor_build_profile.h
+++ b/editor/editor_build_profile.h
@@ -53,7 +53,19 @@ public:
 		BUILD_OPTION_RENDERING_DEVICE,
 		BUILD_OPTION_OPENGL,
 		BUILD_OPTION_VULKAN,
-		BUILD_OPTION_MAX
+		BUILD_OPTION_TEXT_SERVER_FALLBACK,
+		BUILD_OPTION_TEXT_SERVER_ADVANCED,
+		BUILD_OPTION_DYNAMIC_FONTS,
+		BUILD_OPTION_WOFF2_FONTS,
+		BUILD_OPTION_GRPAHITE_FONTS,
+		BUILD_OPTION_MSDFGEN,
+		BUILD_OPTION_MAX,
+	};
+
+	enum BuildOptionCategory {
+		BUILD_OPTION_CATEGORY_GENERAL,
+		BUILD_OPTION_CATEGORY_TEXT_SERVER,
+		BUILD_OPTION_CATEGORY_MAX,
 	};
 
 private:
@@ -65,7 +77,9 @@ private:
 
 	bool build_options_disabled[BUILD_OPTION_MAX] = {};
 	static const char *build_option_identifiers[BUILD_OPTION_MAX];
+	static const bool build_option_disabled_by_default[BUILD_OPTION_MAX];
 	static const bool build_option_disable_values[BUILD_OPTION_MAX];
+	static const BuildOptionCategory build_option_category[BUILD_OPTION_MAX];
 
 	String _get_build_option_name(BuildOption p_build_option) { return get_build_option_name(p_build_option); }
 
@@ -93,11 +107,15 @@ public:
 	static String get_build_option_name(BuildOption p_build_option);
 	static String get_build_option_description(BuildOption p_build_option);
 	static bool get_build_option_disable_value(BuildOption p_build_option);
+	static BuildOptionCategory get_build_option_category(BuildOption p_build_option);
+
+	static String get_build_option_category_name(BuildOptionCategory p_build_option_category);
 
 	EditorBuildProfile();
 };
 
 VARIANT_ENUM_CAST(EditorBuildProfile::BuildOption)
+VARIANT_ENUM_CAST(EditorBuildProfile::BuildOptionCategory)
 
 class EditorFileSystemDirectory;
 

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -58,22 +58,23 @@ if env["builtin_freetype"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    thirdparty_brotli_dir = "#thirdparty/brotli/"
-    thirdparty_brotli_sources = [
-        "common/constants.c",
-        "common/context.c",
-        "common/dictionary.c",
-        "common/platform.c",
-        "common/shared_dictionary.c",
-        "common/transform.c",
-        "dec/bit_reader.c",
-        "dec/decode.c",
-        "dec/huffman.c",
-        "dec/state.c",
-    ]
-    thirdparty_sources += [thirdparty_brotli_dir + file for file in thirdparty_brotli_sources]
-    env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-    env_freetype.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
+    if env["brotli"]:
+        thirdparty_brotli_dir = "#thirdparty/brotli/"
+        thirdparty_brotli_sources = [
+            "common/constants.c",
+            "common/context.c",
+            "common/dictionary.c",
+            "common/platform.c",
+            "common/shared_dictionary.c",
+            "common/transform.c",
+            "dec/bit_reader.c",
+            "dec/decode.c",
+            "dec/huffman.c",
+            "dec/state.c",
+        ]
+        thirdparty_sources += [thirdparty_brotli_dir + file for file in thirdparty_brotli_sources]
+        env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
+        env_freetype.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
 
     if env.get("use_ubsan") or env.get("use_asan") or env.get("use_tsan") or env.get("use_lsan") or env.get("use_msan"):
         env_freetype.Append(CPPDEFINES=["BROTLI_BUILD_PORTABLE"])

--- a/modules/freetype/config.py
+++ b/modules/freetype/config.py
@@ -2,5 +2,13 @@ def can_build(env, platform):
     return True
 
 
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable("brotli", "Enable Brotli decompressor for WOFF2 fonts support", True),
+    ]
+
+
 def configure(env):
     pass

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -5,6 +5,37 @@ def can_build(env, platform):
     return not env["arch"].startswith("rv")
 
 
+def get_opts(platform):
+    from SCons.Variables import BoolVariable, PathVariable
+
+    default_mono_static = platform in ["ios", "javascript"]
+    default_mono_bundles_zlib = platform in ["javascript"]
+
+    return [
+        PathVariable(
+            "mono_prefix",
+            "Path to the Mono installation directory for the target platform and architecture",
+            "",
+            PathVariable.PathAccept,
+        ),
+        PathVariable(
+            "mono_bcl",
+            "Path to a custom Mono BCL (Base Class Library) directory for the target platform",
+            "",
+            PathVariable.PathAccept,
+        ),
+        BoolVariable("mono_static", "Statically link Mono", default_mono_static),
+        BoolVariable("mono_glue", "Build with the Mono glue sources", True),
+        BoolVariable("build_cil", "Build C# solutions", True),
+        BoolVariable(
+            "copy_mono_root", "Make a copy of the Mono installation directory to bundle with the editor", True
+        ),
+        BoolVariable(
+            "mono_bundles_zlib", "Specify if the Mono runtime was built with bundled zlib", default_mono_bundles_zlib
+        ),
+    ]
+
+
 def configure(env):
     platform = env["platform"]
 
@@ -12,45 +43,6 @@ def configure(env):
         raise RuntimeError("This module does not currently support building for this platform")
 
     env.add_module_version_string("mono")
-
-    from SCons.Script import BoolVariable, PathVariable, Variables, Help
-
-    default_mono_static = platform in ["ios", "javascript"]
-    default_mono_bundles_zlib = platform in ["javascript"]
-
-    envvars = Variables()
-    envvars.Add(
-        PathVariable(
-            "mono_prefix",
-            "Path to the Mono installation directory for the target platform and architecture",
-            "",
-            PathVariable.PathAccept,
-        )
-    )
-    envvars.Add(
-        PathVariable(
-            "mono_bcl",
-            "Path to a custom Mono BCL (Base Class Library) directory for the target platform",
-            "",
-            PathVariable.PathAccept,
-        )
-    )
-    envvars.Add(BoolVariable("mono_static", "Statically link Mono", default_mono_static))
-    envvars.Add(BoolVariable("mono_glue", "Build with the Mono glue sources", True))
-    envvars.Add(BoolVariable("build_cil", "Build C# solutions", True))
-    envvars.Add(
-        BoolVariable("copy_mono_root", "Make a copy of the Mono installation directory to bundle with the editor", True)
-    )
-
-    # TODO: It would be great if this could be detected automatically instead
-    envvars.Add(
-        BoolVariable(
-            "mono_bundles_zlib", "Specify if the Mono runtime was built with bundled zlib", default_mono_bundles_zlib
-        )
-    )
-
-    envvars.Update(env)
-    Help(envvars.GenerateHelpText(env))
 
     if env["mono_bundles_zlib"]:
         # Mono may come with zlib bundled for WASM or on newer version when built with MinGW.

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -113,8 +113,11 @@ if env["builtin_harfbuzz"]:
     if freetype_enabled:
         thirdparty_sources += [
             "src/hb-ft.cc",
-            "src/hb-graphite2.cc",
         ]
+        if env["graphite"]:
+            thirdparty_sources += [
+                "src/hb-graphite2.cc",
+            ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_harfbuzz.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
@@ -133,7 +136,7 @@ if env["builtin_harfbuzz"]:
         )
         if env["builtin_freetype"]:
             env_harfbuzz.Prepend(CPPPATH=["#thirdparty/freetype/include"])
-        if env["builtin_graphite"]:
+        if env["builtin_graphite"] and env["graphite"]:
             env_harfbuzz.Prepend(CPPPATH=["#thirdparty/graphite/include"])
             env_harfbuzz.Append(CCFLAGS=["-DGRAPHITE2_STATIC"])
 
@@ -165,7 +168,7 @@ if env["builtin_harfbuzz"]:
         env.Append(LIBS=[lib])
 
 
-if env["builtin_graphite"] and freetype_enabled:
+if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
     env_graphite = env_modules.Clone()
     env_graphite.disable_warnings()
 
@@ -514,7 +517,7 @@ if env["builtin_msdfgen"] and msdfgen_enabled:
 if env["builtin_freetype"] and freetype_enabled:
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/freetype/include"])
 
-if env["builtin_graphite"] and freetype_enabled:
+if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/graphite/include"])
 
 env_text_server_adv.add_source_files(module_obj, "*.cpp")

--- a/modules/text_server_adv/config.py
+++ b/modules/text_server_adv/config.py
@@ -2,6 +2,14 @@ def can_build(env, platform):
     return True
 
 
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable("graphite", "Enable SIL Graphite smart fonts support", True),
+    ]
+
+
 def configure(env):
     pass
 


### PR DESCRIPTION
- Adds SCons options to disable Brotli and Graphite.
- Adds option categories to the build profiles editor.
- Adds options default state to the build profiles editor.
- Adds Text Server related options to the build profiles editor.
- Fix misplaced OpenGL/Vulkan SCons options (were shifted due to missing "rendering device" option).

<img width="851" alt="Screenshot 2022-08-03 at 13 40 01" src="https://user-images.githubusercontent.com/7645683/182589280-c6daf3ea-2a72-4949-9523-dce6bcfa2724.png">

