### PR TITLE
Implement coloring for disabled branches in the shader editor

### DIFF
--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -48,6 +48,21 @@ class VisualShaderEditor;
 class HSplitContainer;
 class ShaderCreateDialog;
 
+class GDShaderSyntaxHighlighter : public CodeHighlighter {
+	GDCLASS(GDShaderSyntaxHighlighter, CodeHighlighter)
+
+private:
+	Vector<Point2i> disabled_branch_regions;
+	Color disabled_branch_color;
+
+public:
+	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) override;
+
+	void add_disabled_branch_region(const Point2i &p_region);
+	void clear_disabled_branch_regions();
+	void set_disabled_branch_color(const Color &p_color);
+};
+
 class ShaderTextEditor : public CodeTextEditor {
 	GDCLASS(ShaderTextEditor, CodeTextEditor);
 
@@ -57,7 +72,7 @@ class ShaderTextEditor : public CodeTextEditor {
 		_ALWAYS_INLINE_ bool operator()(const ShaderWarning &p_a, const ShaderWarning &p_b) const { return (p_a.get_line() < p_b.get_line()); }
 	};
 
-	Ref<CodeHighlighter> syntax_highlighter;
+	Ref<GDShaderSyntaxHighlighter> syntax_highlighter;
 	RichTextLabel *warnings_panel = nullptr;
 	Ref<Shader> shader;
 	Ref<ShaderInclude> shader_inc;

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -82,7 +82,7 @@ void Shader::set_code(const String &p_code) {
 		// 1) Need to keep track of include dependencies at resource level
 		// 2) Server does not do interaction with Resource filetypes, this is a scene level feature.
 		ShaderPreprocessor preprocessor;
-		preprocessor.preprocess(p_code, pp_code, nullptr, nullptr, &new_include_dependencies);
+		preprocessor.preprocess(p_code, "", pp_code, nullptr, nullptr, nullptr, &new_include_dependencies);
 	}
 
 	// This ensures previous include resources are not freed and then re-loaded during parse (which would make compiling slower)

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -47,7 +47,7 @@ void ShaderInclude::set_code(const String &p_code) {
 	{
 		String pp_code;
 		ShaderPreprocessor preprocessor;
-		preprocessor.preprocess(p_code, pp_code, nullptr, nullptr, &new_dependencies);
+		preprocessor.preprocess(p_code, "", pp_code, nullptr, nullptr, nullptr, &new_dependencies);
 	}
 
 	// This ensures previous include resources are not freed and then re-loaded during parse (which would make compiling slower)

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -58,6 +58,14 @@ public:
 		int line = 0;
 	};
 
+	struct Region {
+		String file;
+		int from_line = -1;
+		int to_line = -1;
+		bool enabled = false;
+		Region *parent = nullptr;
+	};
+
 private:
 	struct Token {
 		char32_t text;
@@ -134,10 +142,13 @@ private:
 		RBSet<String> includes;
 		List<uint64_t> cyclic_include_hashes; // Holds code hash of includes.
 		int include_depth = 0;
-		String current_include;
+		String current_filename;
 		String current_shader_type;
 		String error;
 		List<FilePosition> include_positions;
+		bool save_regions = false;
+		RBMap<String, List<Region>> regions;
+		Region *previous_region = nullptr;
 		RBMap<String, Vector<SkippedCondition *>> skipped_conditions;
 		bool disabled = false;
 		CompletionType completion_type = COMPLETION_TYPE_NONE;
@@ -167,6 +178,7 @@ private:
 	void process_pragma(Tokenizer *p_tokenizer);
 	void process_undef(Tokenizer *p_tokenizer);
 
+	void add_region(int p_line, bool p_enabled, Region *p_parent_region);
 	void start_branch_condition(Tokenizer *p_tokenizer, bool p_success);
 
 	void expand_output_macros(int p_start, int p_line);
@@ -188,7 +200,7 @@ private:
 public:
 	typedef void (*IncludeCompletionFunction)(List<ScriptLanguage::CodeCompletionOption> *);
 
-	Error preprocess(const String &p_code, String &r_result, String *r_error_text = nullptr, List<FilePosition> *r_error_position = nullptr, HashSet<Ref<ShaderInclude>> *r_includes = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_options = nullptr, IncludeCompletionFunction p_include_completion_func = nullptr);
+	Error preprocess(const String &p_code, const String &p_filename, String &r_result, String *r_error_text = nullptr, List<FilePosition> *r_error_position = nullptr, List<Region> *r_regions = nullptr, HashSet<Ref<ShaderInclude>> *r_includes = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_options = nullptr, IncludeCompletionFunction p_include_completion_func = nullptr);
 
 	static void get_keyword_list(List<String> *r_keywords, bool p_include_shader_keywords);
 	static void get_pragma_list(List<String> *r_pragmas);


### PR DESCRIPTION
This PR implement dimming of the disabled branches of the shader preprocessor. To do it, besides adding a handling of the branch to the shader preprocessor, I've implemented some new methods to the `CodeHighlighter`:

![image](https://user-images.githubusercontent.com/3036176/182606793-9be5aab1-30ba-489d-82e0-21fe3671cd07.png)

This is a part of https://github.com/godotengine/godot-proposals/issues/5062
