### PR TITLE
Bring back Geometry2D.segment_intersects_circle

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -933,6 +933,7 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 
 void Geometry2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_point_in_circle", "point", "circle_position", "circle_radius"), &Geometry2D::is_point_in_circle);
+	ClassDB::bind_method(D_METHOD("segment_intersects_circle", "segment_from", "segment_to", "circle_position", "circle_radius"), &Geometry2D::segment_intersects_circle);
 	ClassDB::bind_method(D_METHOD("segment_intersects_segment", "from_a", "to_a", "from_b", "to_b"), &Geometry2D::segment_intersects_segment);
 	ClassDB::bind_method(D_METHOD("line_intersects_line", "from_a", "dir_a", "from_b", "dir_b"), &Geometry2D::line_intersects_line);
 

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -188,6 +188,16 @@
 				Returns if [code]point[/code] is inside the triangle specified by [code]a[/code], [code]b[/code] and [code]c[/code].
 			</description>
 		</method>
+		<method name="segment_intersects_circle">
+			<return type="float" />
+			<argument index="0" name="segment_from" type="Vector2" />
+			<argument index="1" name="segment_to" type="Vector2" />
+			<argument index="2" name="circle_position" type="Vector2" />
+			<argument index="3" name="circle_radius" type="float" />
+			<description>
+				Given the 2D segment ([code]segment_from[/code], [code]segment_to[/code]), returns the position on the segment (as a number between 0 and 1) at which the segment hits the circle that is located at position [code]circle_position[/code] and has radius [code]circle_radius[/code]. If the segment does not intersect the circle, -1 is returned (this is also the case if the line extending the segment would intersect the circle, but the segment does not).
+			</description>
+		</method>
 		<method name="segment_intersects_segment">
 			<return type="Variant" />
 			<argument index="0" name="from_a" type="Vector2" />


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Bring back Geometry2D.segment_intersects_circle, which seems to have disappeared while splitting Geometry 2D and 3D
Fixes [#63845](https://github.com/godotengine/godot/issues/63845)