### PR TITLE
Implement `keep_screen_on` for Windows

### DIFF
--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -331,6 +331,8 @@ class DisplayServerWindows : public DisplayServer {
 	HINSTANCE hInstance; // Holds The Instance Of The Application
 	String rendering_driver;
 	bool app_focused = false;
+	bool keep_screen_on = false;
+	HANDLE power_request;
 
 	TTS_Windows *tts = nullptr;
 


### PR DESCRIPTION
Fixes #63881

Includes a nice reason string when viewing power information (e.g. via command line):
```
> powercfg /requests
DISPLAY:
[PROCESS] \Device\HarddiskVolume7\Sources\godot\bin\godot.windows.tools.64.exe
Godot Engine running with display/window/energy_saving/keep_screen_on = true
```