### PR TITLE
Ensure color picker eyedropper notifies button

### DIFF
--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -210,7 +210,9 @@ private:
 	void _screen_input(const Ref<InputEvent> &p_event);
 	void _text_changed(const String &p_new_text);
 	void _add_preset_pressed();
-	void _screen_pick_pressed();
+	void _screen_pick_toggled(bool p_button_pressed);
+	void _focus_enter();
+	void _focus_exit();
 	void _html_focus_exit();
 
 	inline int _get_preset_size();


### PR DESCRIPTION
color_changed is continuously emitted while moving the picker, unless
deferred mode is enabled.

Added a workaround so that color_changed is always emitted when the
eyedropper screen object is hidden, since it is not currently able to
receive any mouse button events itself.

Fixes #62858 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
