### PR TITLE
fixed Tree UI control to no longer corrupt child cache on item moving operations

### DIFF
--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -342,6 +342,13 @@ public:
 	Array get_children();
 	int get_index();
 
+#ifdef DEV_ENABLED
+	// This debugging code can be removed once the current refactoring of this class is complete.
+	void validate_cache() const;
+#else
+	void validate_cache() const {}
+#endif
+
 	void move_before(TreeItem *p_item);
 	void move_after(TreeItem *p_item);
 


### PR DESCRIPTION
Update code for `children_cache` was corrupting the cache when tree items are moved while the cache has not been built.  This would lead to an array index error on subsequent use of the cache (since it would only have one item in it.)

The DEV_ENABLED safety code was agreed with @KoBeWi to stay in the code until refactoring work in this area is completed.  It detects the bug fixed here and similar cache corruption.  There are no unit tests for this, so this safety code will be useful until the class is again stable.
