### PR TITLE
Add spacing above the "Add Metadata" button

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3097,6 +3097,11 @@ void EditorInspector::update_tree() {
 	}
 
 	if (!hide_metadata) {
+		// Add 4px of spacing between the "Add Metadata" button and the content above it.
+		Control *spacer = memnew(Control);
+		spacer->set_custom_minimum_size(Size2(0, 4) * EDSCALE);
+		main_vbox->add_child(spacer);
+
 		Button *add_md = EditorInspector::create_inspector_action_button(TTR("Add Metadata"));
 		add_md->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		add_md->connect(SNAME("pressed"), callable_mp(this, &EditorInspector::_show_add_meta_dialog));


### PR DESCRIPTION
Adds 4px of spacing above the "Add Metadata" button in the inspector.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/182739343-58560d76-acd8-4755-92ba-d6afe1d8cb21.png) | ![image](https://user-images.githubusercontent.com/67974470/182739125-bcf6a5d5-ce8f-474c-beec-befa27086d0f.png) |