### PR TITLE
Added Godot.Transform Helper Properties

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -21,6 +21,85 @@ namespace Godot
     [StructLayout(LayoutKind.Sequential)]
     public struct Transform3D : IEquatable<Transform3D>
     {
+
+        /// <summary>
+        /// Returns the locally translated forward vector.
+        /// which is equivalent to calling "-basis.z"
+        /// Refer to <see cref="Basis"/> for more information. 
+        /// </summary>
+        public Vector3 Forward 
+        {
+            get 
+            {
+                return -basis.z;
+            }
+        }
+
+        /// <summary>
+        /// Returns the locally translated backwards vector.
+        /// which is equivalent to calling "basis.z"
+        /// Refer to <see cref="Basis"/> for more information. 
+        /// </summary>
+        public Vector3 Backwards 
+        {
+            get 
+            {
+                return basis.z;
+            }
+        }
+
+        /// <summary>
+        /// Returns the locally translated right vector.
+        /// which is equivalent to calling "basis.x"
+        /// Refer to <see cref="Basis"/> for more information. 
+        /// </summary>
+        public Vector3 Right 
+        {
+            get 
+            {
+                return basis.x;
+            }
+        }
+
+        /// <summary>
+        /// Returns the locally translated left vector.
+        /// which is equivalent to calling "-basis.x"
+        /// Refer to <see cref="Basis"/> for more information. 
+        /// </summary>
+        public Vector3 Left 
+        {
+            get 
+            {
+                return -basis.x;
+            }
+        }
+
+        /// <summary>
+        /// Returns the locally translated up vector.
+        /// which is equivalent to calling "basis.y"
+        /// Refer to <see cref="Basis"/> for more information. 
+        /// </summary>
+        public Vector3 Up 
+        {
+            get 
+            {
+                return basis.y;
+            }
+        }
+
+        /// <summary>
+        /// Returns the locally translated down vector.
+        /// which is equivalent to calling "-basis.y"
+        /// Refer to <see cref="Basis"/> for more information. 
+        /// </summary>
+        public Vector3 Down 
+        {
+            get 
+            {
+                return -basis.y;
+            }
+        }
+
         /// <summary>
         /// The <see cref="Basis"/> of this transform. Contains the X, Y, and Z basis
         /// vectors (columns 0 to 2) and is responsible for rotation and scale.


### PR DESCRIPTION
I've been working on a tutorial series for new game developers to use Godot Mono (C#) with lots of similarities drawn to Unity because of my experience with Unity. I personally prefer Godot's structure and approach in every possible way compared to Unity, but the one sticking point is that I miss calling Transform.Forward to get a translated Vector. 

This feature is both for ease of use as well as ease of onboarding. Intended to be optional for developers, but would generally create more readable code overall especially when using the basis vectors to create more complex functionality.

This is my first time contributing code so I'm hoping I'm doing this right!

Added some helper properties: "Forwards", "Backwards", "Left", "Right", "Up", "Down" which all return their equivalent basis property. Intended to be similar to Unity's helper properties to ease working with Transforms

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
