### PR TITLE
Remove / Replace old Navigation Debug Visualization

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -477,9 +477,6 @@
 		<member name="debug/shapes/collision/shape_color" type="Color" setter="" getter="" default="Color(0, 0.6, 0.7, 0.42)">
 			Color of the collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
-		<member name="debug/shapes/navigation/disabled_geometry_color" type="Color" setter="" getter="" default="Color(1, 0.7, 0.1, 0.4)">
-			Color of the disabled navigation geometry, visible when "Visible Navigation" is enabled in the Debug menu.
-		</member>
 		<member name="debug/shapes/navigation/edge_connection_color" type="Color" setter="" getter="" default="Color(1, 0, 1, 1)">
 			Color to display edge connections between navigation regions, visible when "Visible Navigation" is enabled in the Debug menu.
 		</member>
@@ -503,9 +500,6 @@
 		</member>
 		<member name="debug/shapes/navigation/enable_link_connections_xray" type="bool" setter="" getter="" default="true">
 			If enabled, displays navigation link connections through geometry when "Visible Navigation" is enabled in the Debug menu.
-		</member>
-		<member name="debug/shapes/navigation/geometry_color" type="Color" setter="" getter="" default="Color(0.1, 1, 0.7, 0.4)">
-			Color of the navigation geometry, visible when "Visible Navigation" is enabled in the Debug menu.
 		</member>
 		<member name="debug/shapes/navigation/geometry_edge_color" type="Color" setter="" getter="" default="Color(0.5, 1, 1, 1)">
 			Color to display enabled navigation mesh polygon edges, visible when "Visible Navigation" is enabled in the Debug menu.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -566,8 +566,6 @@ void EditorNode::_update_from_settings() {
 	SceneTree *tree = get_tree();
 	tree->set_debug_collisions_color(GLOBAL_GET("debug/shapes/collision/shape_color"));
 	tree->set_debug_collision_contact_color(GLOBAL_GET("debug/shapes/collision/contact_color"));
-	tree->set_debug_navigation_color(GLOBAL_GET("debug/shapes/navigation/geometry_color"));
-	tree->set_debug_navigation_disabled_color(GLOBAL_GET("debug/shapes/navigation/disabled_geometry_color"));
 
 #ifdef DEBUG_ENABLED
 	NavigationServer3D::get_singleton_mut()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/edge_connection_color"));

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -40,6 +40,10 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_undo_redo_manager.h"
 
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_server_3d.h"
+#endif // DEBUG_ENABLED
+
 void TileDataEditor::_tile_set_changed_plan_update() {
 	_tile_set_changed_update_needed = true;
 	call_deferred(SNAME("_tile_set_changed_deferred_update"));
@@ -2674,7 +2678,9 @@ void TileDataNavigationEditor::_tile_set_changed() {
 void TileDataNavigationEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			polygon_editor->set_polygons_color(get_tree()->get_debug_navigation_color());
+#ifdef DEBUG_ENABLED
+			polygon_editor->set_polygons_color(NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color());
+#endif // DEBUG_ENABLED
 		} break;
 	}
 }
@@ -2701,7 +2707,10 @@ void TileDataNavigationEditor::draw_over_tile(CanvasItem *p_canvas_item, Transfo
 			return;
 		}
 
-		Color color = p_canvas_item->get_tree()->get_debug_navigation_color();
+		Color color = Color(0.5, 1.0, 1.0, 1.0);
+#ifdef DEBUG_ENABLED
+		color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
+#endif // DEBUG_ENABLED
 		if (p_selected) {
 			Color grid_color = EditorSettings::get_singleton()->get("editors/tiles_editor/grid_color");
 			Color selection_color = Color().from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -643,6 +643,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 				}
 				nm.region = region;
 
+#ifdef DEBUG_ENABLED
 				// add navigation debugmesh visual instances if debug is enabled
 				SceneTree *st = SceneTree::get_singleton();
 				if (st && st->is_debugging_navigation_hint()) {
@@ -650,15 +651,14 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 						RID navmesh_debug_rid = navmesh->get_debug_mesh()->get_rid();
 						nm.navmesh_debug_instance = RS::get_singleton()->instance_create();
 						RS::get_singleton()->instance_set_base(nm.navmesh_debug_instance, navmesh_debug_rid);
-						RS::get_singleton()->mesh_surface_set_material(navmesh_debug_rid, 0, st->get_debug_navigation_material()->get_rid());
 					}
 					if (is_inside_tree()) {
 						RS::get_singleton()->instance_set_scenario(nm.navmesh_debug_instance, get_world_3d()->get_scenario());
 						RS::get_singleton()->instance_set_transform(nm.navmesh_debug_instance, get_global_transform() * nm.xform);
 					}
 				}
+#endif // DEBUG_ENABLED
 			}
-
 			g.navmesh_ids[E] = nm;
 		}
 	}

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -34,6 +34,10 @@
 #include "scene/resources/world_2d.h"
 #include "servers/navigation_server_2d.h"
 
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_server_3d.h"
+#endif // DEBUG_ENABLED
+
 HashMap<Vector2i, TileSet::CellNeighbor> TileMap::TerrainConstraint::get_overlapping_coords_and_peering_bits() const {
 	HashMap<Vector2i, TileSet::CellNeighbor> output;
 
@@ -1656,14 +1660,6 @@ void TileMap::_navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND(!tile_set.is_valid());
 
-	// Get colors for debug.
-	SceneTree *st = SceneTree::get_singleton();
-	Color debug_navigation_color;
-	bool debug_navigation = st && st->is_debugging_navigation_hint();
-	if (debug_navigation) {
-		debug_navigation_color = st->get_debug_navigation_color();
-	}
-
 	Transform2D tilemap_xform = get_global_transform();
 	SelfList<TileMapQuadrant> *q_list_element = r_dirty_quadrant_list.first();
 	while (q_list_element) {
@@ -1766,7 +1762,10 @@ void TileMap::_navigation_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 
 	RenderingServer *rs = RenderingServer::get_singleton();
 
-	Color color = get_tree()->get_debug_navigation_color();
+	Color color = Color(0.5, 1.0, 1.0, 1.0);
+#ifdef DEBUG_ENABLED
+	color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
+#endif // DEBUG_ENABLED
 	RandomPCG rand;
 
 	Vector2 quadrant_pos = map_to_local(p_quadrant->coords * get_effective_quadrant_size(p_quadrant->layer));

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -539,6 +539,7 @@ void NavigationRegion3D::_update_debug_edge_connections_mesh() {
 	}
 
 	Vector<Vector3> vertex_array;
+	vertex_array.resize(connections_count * 6);
 
 	for (int i = 0; i < connections_count; i++) {
 		Vector3 connection_pathway_start = NavigationServer3D::get_singleton()->region_get_connection_pathway_start(region, i);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -722,22 +722,6 @@ float SceneTree::get_debug_paths_width() const {
 	return debug_paths_width;
 }
 
-void SceneTree::set_debug_navigation_color(const Color &p_color) {
-	debug_navigation_color = p_color;
-}
-
-Color SceneTree::get_debug_navigation_color() const {
-	return debug_navigation_color;
-}
-
-void SceneTree::set_debug_navigation_disabled_color(const Color &p_color) {
-	debug_navigation_disabled_color = p_color;
-}
-
-Color SceneTree::get_debug_navigation_disabled_color() const {
-	return debug_navigation_disabled_color;
-}
-
 Ref<Material> SceneTree::get_debug_paths_material() {
 	if (debug_paths_material.is_valid()) {
 		return debug_paths_material;
@@ -753,40 +737,6 @@ Ref<Material> SceneTree::get_debug_paths_material() {
 	debug_paths_material = _debug_material;
 
 	return debug_paths_material;
-}
-
-Ref<Material> SceneTree::get_debug_navigation_material() {
-	if (navigation_material.is_valid()) {
-		return navigation_material;
-	}
-
-	Ref<StandardMaterial3D> line_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	line_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	line_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
-	line_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
-	line_material->set_albedo(get_debug_navigation_color());
-
-	navigation_material = line_material;
-
-	return navigation_material;
-}
-
-Ref<Material> SceneTree::get_debug_navigation_disabled_material() {
-	if (navigation_disabled_material.is_valid()) {
-		return navigation_disabled_material;
-	}
-
-	Ref<StandardMaterial3D> line_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	line_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	line_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
-	line_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
-	line_material->set_albedo(get_debug_navigation_disabled_color());
-
-	navigation_disabled_material = line_material;
-
-	return navigation_disabled_material;
 }
 
 Ref<Material> SceneTree::get_debug_collision_material() {
@@ -1404,8 +1354,6 @@ SceneTree::SceneTree() {
 	debug_collision_contact_color = GLOBAL_DEF("debug/shapes/collision/contact_color", Color(1.0, 0.2, 0.1, 0.8));
 	debug_paths_color = GLOBAL_DEF("debug/shapes/paths/geometry_color", Color(0.1, 1.0, 0.7, 0.4));
 	debug_paths_width = GLOBAL_DEF("debug/shapes/paths/geometry_width", 2.0);
-	debug_navigation_color = GLOBAL_DEF("debug/shapes/navigation/geometry_color", Color(0.1, 1.0, 0.7, 0.4));
-	debug_navigation_disabled_color = GLOBAL_DEF("debug/shapes/navigation/disabled_geometry_color", Color(1.0, 0.7, 0.1, 0.4));
 	collision_debug_contacts = GLOBAL_DEF("debug/shapes/collision/max_contacts_displayed", 10000);
 	ProjectSettings::get_singleton()->set_custom_property_info("debug/shapes/collision/max_contacts_displayed", PropertyInfo(Variant::INT, "debug/shapes/collision/max_contacts_displayed", PROPERTY_HINT_RANGE, "0,20000,1")); // No negative
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -334,15 +334,7 @@ public:
 	void set_debug_paths_width(float p_width);
 	float get_debug_paths_width() const;
 
-	void set_debug_navigation_color(const Color &p_color);
-	Color get_debug_navigation_color() const;
-
-	void set_debug_navigation_disabled_color(const Color &p_color);
-	Color get_debug_navigation_disabled_color() const;
-
 	Ref<Material> get_debug_paths_material();
-	Ref<Material> get_debug_navigation_material();
-	Ref<Material> get_debug_navigation_disabled_material();
 	Ref<Material> get_debug_collision_material();
 	Ref<ArrayMesh> get_debug_contact_mesh();
 

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -32,7 +32,7 @@
 
 #ifdef DEBUG_ENABLED
 #include "servers/navigation_server_3d.h"
-#endif
+#endif // DEBUG_ENABLED
 
 void NavigationMesh::create_from_mesh(const Ref<Mesh> &p_mesh) {
 	ERR_FAIL_COND(p_mesh.is_null());
@@ -341,94 +341,8 @@ void NavigationMesh::clear_polygons() {
 	polygons.clear();
 }
 
-#ifndef DISABLE_DEPRECATED
-Ref<Mesh> NavigationMesh::get_debug_mesh() {
-	if (debug_mesh.is_valid()) {
-		return debug_mesh;
-	}
-
-	Vector<Vector3> vertices = get_vertices();
-	const Vector3 *vr = vertices.ptr();
-	List<Face3> faces;
-	for (int i = 0; i < get_polygon_count(); i++) {
-		Vector<int> p = get_polygon(i);
-
-		for (int j = 2; j < p.size(); j++) {
-			Face3 f;
-			f.vertex[0] = vr[p[0]];
-			f.vertex[1] = vr[p[j - 1]];
-			f.vertex[2] = vr[p[j]];
-
-			faces.push_back(f);
-		}
-	}
-
-	HashMap<_EdgeKey, bool, _EdgeKey> edge_map;
-	Vector<Vector3> tmeshfaces;
-	tmeshfaces.resize(faces.size() * 3);
-
-	{
-		Vector3 *tw = tmeshfaces.ptrw();
-		int tidx = 0;
-
-		for (const Face3 &f : faces) {
-			for (int j = 0; j < 3; j++) {
-				tw[tidx++] = f.vertex[j];
-				_EdgeKey ek;
-				ek.from = f.vertex[j].snapped(Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON));
-				ek.to = f.vertex[(j + 1) % 3].snapped(Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON));
-				if (ek.from < ek.to) {
-					SWAP(ek.from, ek.to);
-				}
-
-				HashMap<_EdgeKey, bool, _EdgeKey>::Iterator F = edge_map.find(ek);
-
-				if (F) {
-					F->value = false;
-
-				} else {
-					edge_map[ek] = true;
-				}
-			}
-		}
-	}
-	List<Vector3> lines;
-
-	for (const KeyValue<_EdgeKey, bool> &E : edge_map) {
-		if (E.value) {
-			lines.push_back(E.key.from);
-			lines.push_back(E.key.to);
-		}
-	}
-
-	Vector<Vector3> varr;
-	varr.resize(lines.size());
-	{
-		Vector3 *w = varr.ptrw();
-		int idx = 0;
-		for (const Vector3 &E : lines) {
-			w[idx++] = E;
-		}
-	}
-
-	debug_mesh = Ref<ArrayMesh>(memnew(ArrayMesh));
-
-	if (!lines.size()) {
-		return debug_mesh;
-	}
-
-	Array arr;
-	arr.resize(Mesh::ARRAY_MAX);
-	arr[Mesh::ARRAY_VERTEX] = varr;
-
-	debug_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, arr);
-
-	return debug_mesh;
-}
-#endif // DISABLE_DEPRECATED
-
 #ifdef DEBUG_ENABLED
-Ref<ArrayMesh> NavigationMesh::_get_debug_mesh() {
+Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 	if (debug_mesh.is_valid()) {
 		// Blocks further updates for now, code below is intended for dynamic updates e.g. when settings change.
 		return debug_mesh;
@@ -479,8 +393,6 @@ Ref<ArrayMesh> NavigationMesh::_get_debug_mesh() {
 		for (int i = 0; i < polygon_count; i++) {
 			polygon_color = debug_navigation_geometry_face_color * (Color(Math::randf(), Math::randf(), Math::randf()));
 
-			Vector<int> polygon = get_polygon(i);
-
 			face_color_array.push_back(polygon_color);
 			face_color_array.push_back(polygon_color);
 			face_color_array.push_back(polygon_color);
@@ -490,7 +402,7 @@ Ref<ArrayMesh> NavigationMesh::_get_debug_mesh() {
 
 	debug_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, face_mesh_array);
 	Ref<StandardMaterial3D> debug_geometry_face_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_material();
-	debug_mesh->surface_set_material(debug_mesh->get_surface_count(), debug_geometry_face_material);
+	debug_mesh->surface_set_material(0, debug_geometry_face_material);
 
 	// if enabled build geometry edge line surface
 	bool enabled_edge_lines = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
@@ -515,12 +427,12 @@ Ref<ArrayMesh> NavigationMesh::_get_debug_mesh() {
 		line_mesh_array[Mesh::ARRAY_VERTEX] = line_vertex_array;
 		debug_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, line_mesh_array);
 		Ref<StandardMaterial3D> debug_geometry_edge_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_material();
-		debug_mesh->surface_set_material(debug_mesh->get_surface_count(), debug_geometry_edge_material);
+		debug_mesh->surface_set_material(1, debug_geometry_edge_material);
 	}
 
 	return debug_mesh;
 }
-#endif
+#endif // DEBUG_ENABLED
 
 void NavigationMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sample_partition_type", "sample_partition_type"), &NavigationMesh::set_sample_partition_type);

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -202,11 +202,9 @@ public:
 	Vector<int> get_polygon(int p_idx);
 	void clear_polygons();
 
-#ifndef DISABLE_DEPRECATED
-	Ref<Mesh> get_debug_mesh();
-#endif // DISABLE_DEPRECATED
-
-	Ref<ArrayMesh> _get_debug_mesh();
+#ifdef DEBUG_ENABLED
+	Ref<ArrayMesh> get_debug_mesh();
+#endif // DEBUG_ENABLED
 
 	NavigationMesh();
 };


### PR DESCRIPTION
Followup for #62601

- removes / replaces old navigation debug code leftovers
- cleanes SceneTree and ProjectSettings from old navigation debug

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/65300

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
