### PR TITLE
Implement script editor hover hint with description

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -374,6 +374,31 @@ public:
 		LOOKUP_RESULT_MAX
 	};
 
+	struct SymbolHint {
+		enum Type {
+			SYMBOL_UNKNOWN,
+			SYMBOL_CLASS,
+			SYMBOL_METHOD,
+			SYMBOL_SIGNAL,
+			SYMBOL_PROPERTY,
+			SYMBOL_CONSTANT,
+			SYMBOL_LOCAL_VAR,
+			SYMBOL_ENUM,
+		};
+		struct Parameter {
+			String name;
+			String datatype;
+			Variant default_value;
+		};
+		Type type = SYMBOL_UNKNOWN;
+		String _namespace;
+		String datatype;
+		String symbol;
+		Variant value;
+		Vector<Parameter> parameters;
+		String description;
+	};
+
 	struct LookupResult {
 		LookupResultType type;
 		Ref<Script> script;
@@ -381,6 +406,7 @@ public:
 		String class_member;
 		String class_path;
 		int location;
+		SymbolHint hint;
 	};
 
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -384,6 +384,7 @@ public:
 			SYMBOL_CONSTANT,
 			SYMBOL_LOCAL_VAR,
 			SYMBOL_ENUM,
+			SYMBOL_ANNOTATION,
 		};
 		struct Parameter {
 			String name;

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -516,6 +516,12 @@
 				Emitted when the user requests code completion.
 			</description>
 		</signal>
+		<signal name="symbol_hovered">
+			<param index="0" name="symbol" type="String" />
+			<param index="1" name="symbol_column_line" type="Vector2i" />
+			<description>
+			</description>
+		</signal>
 		<signal name="symbol_lookup">
 			<param index="0" name="symbol" type="String" />
 			<param index="1" name="line" type="int" />

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -870,6 +870,20 @@
 		<member name="text_editor/help/show_help_index" type="bool" setter="" getter="">
 			If [code]true[/code], displays a table of contents at the left of the editor help (at the location where the members overview would appear when editing a script).
 		</member>
+		<member name="text_editor/hints/hover/description_default_color" type="Color" setter="" getter="">
+		</member>
+		<member name="text_editor/hints/hover/enabled" type="bool" setter="" getter="">
+		</member>
+		<member name="text_editor/hints/hover/hover_delay" type="float" setter="" getter="">
+		</member>
+		<member name="text_editor/hints/hover/max_size" type="Vector2i" setter="" getter="">
+		</member>
+		<member name="text_editor/hints/hover/symbol_color" type="Color" setter="" getter="">
+		</member>
+		<member name="text_editor/hints/hover/symbol_type_color" type="Color" setter="" getter="">
+		</member>
+		<member name="text_editor/hints/hover/value_color" type="Color" setter="" getter="">
+		</member>
 		<member name="text_editor/script_list/show_members_overview" type="bool" setter="" getter="">
 			If [code]true[/code], displays an overview of the current script's member variables and functions at the left of the script editor. See also [member text_editor/script_list/sort_members_outline_alphabetically].
 		</member>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -601,6 +601,12 @@
 				Returns the word at [param position].
 			</description>
 		</method>
+		<method name="get_word_line_column_at_pos" qualifiers="const">
+			<return type="Vector2i" />
+			<param index="0" name="position" type="Vector2" />
+			<description>
+			</description>
+		</method>
 		<method name="get_word_under_caret" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="caret_index" type="int" default="-1" />

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -604,6 +604,15 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/completion/add_type_hints", false);
 	_initial_set("text_editor/completion/use_single_quotes", false);
 
+	// Hints
+	_initial_set("text_editor/hints/hover/enabled", true);
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/hints/hover/hover_delay", 0.1, "0,5,0.01");
+	_initial_set("text_editor/hints/hover/max_size", Size2i(350, 145));
+	_initial_set("text_editor/hints/hover/symbol_type_color", Color(0, 1, 1));
+	_initial_set("text_editor/hints/hover/symbol_color", Color(.4, .6, 0));
+	_initial_set("text_editor/hints/hover/value_color", Color(0.9, 0.74, 0.34));
+	_initial_set("text_editor/hints/hover/description_default_color", Color(1, 1, 1));
+
 	// Help
 	_initial_set("text_editor/help/show_help_index", true);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_font_size", 16, "8,48,1")

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -54,12 +54,45 @@ public:
 	ConnectionInfoDialog();
 };
 
+class SymbolHintHelpBit : public MarginContainer {
+	GDCLASS(SymbolHintHelpBit, MarginContainer);
+
+	RichTextLabel *rich_text = nullptr;
+	void _go_to_help(String p_what);
+	void _meta_clicked(String p_select);
+
+	void _push_text(const String &p_text, bool p_pop = true);
+
+	ScriptLanguage::SymbolHint symbol_hint;
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	RichTextLabel *get_rich_text() const { return rich_text; }
+
+	void set_symbol_hint(const ScriptLanguage::SymbolHint &p_symbol_hint);
+	ScriptLanguage::SymbolHint get_symbol_hint() const { return symbol_hint; }
+
+	virtual Size2 get_minimum_size() const override;
+
+	SymbolHintHelpBit();
+};
+
 class ScriptTextEditor : public ScriptEditorBase {
 	GDCLASS(ScriptTextEditor, ScriptEditorBase);
 
 	CodeTextEditor *code_editor = nullptr;
 	RichTextLabel *warnings_panel = nullptr;
 	RichTextLabel *errors_panel = nullptr;
+
+	Vector2i symbol_hint_mouse_position;
+	Vector2i symbol_hint_column_line;
+	ScriptLanguage::SymbolHint symbol_hint;
+	PopupPanel *symbol_hint_popup = nullptr;
+	SymbolHintHelpBit *symbol_hint_help_bit = nullptr;
+	Ref<SceneTreeTimer> symbol_hint_timer;
 
 	Ref<Script> script;
 	bool script_is_valid = false;
@@ -190,7 +223,11 @@ protected:
 
 	void _goto_line(int p_line) { goto_line(p_line); }
 	void _lookup_symbol(const String &p_symbol, int p_row, int p_column);
-	void _validate_symbol(const String &p_symbol, bool p_lookup = true);
+	void _validate_symbol(const String &p_symbol);
+	void _hovered_symbol(const String &p_symbol, Point2i p_column_line);
+
+	void _show_symbol_hint();
+	void _hide_symbol_hint();
 
 	void _convert_case(CodeTextEditor::CaseStyle p_case);
 

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -190,7 +190,7 @@ protected:
 
 	void _goto_line(int p_line) { goto_line(p_line); }
 	void _lookup_symbol(const String &p_symbol, int p_row, int p_column);
-	void _validate_symbol(const String &p_symbol);
+	void _validate_symbol(const String &p_symbol, bool p_lookup = true);
 
 	void _convert_case(CodeTextEditor::CaseStyle p_case);
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -47,6 +47,7 @@
 #ifdef TOOLS_ENABLED
 #include "core/config/project_settings.h"
 #include "editor/editor_file_system.h"
+#include "editor/editor_help.h"
 #include "editor/editor_settings.h"
 #endif
 
@@ -3182,6 +3183,104 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						r_result.class_path = base_type.script_path;
 						Error err = OK;
 						r_result.script = GDScriptCache::get_shallow_script(r_result.class_path, err);
+						// TODO(require core): Description.
+						GDScriptParser::ClassNode *outer = base_type.class_type;
+						String _namespace;
+						while (outer && outer->identifier) {
+							if (!_namespace.is_empty()) {
+								_namespace = outer->identifier->name.operator String() + "." + _namespace;
+							} else {
+								_namespace = outer->identifier->name;
+							}
+							outer = outer->outer;
+						}
+						r_result.hint._namespace = _namespace;
+						GDScriptParser::ClassNode::Member member = base_type.class_type->get_member(p_symbol);
+						switch (member.type) {
+							case GDScriptParser::ClassNode::Member::CLASS:
+								r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CLASS;
+								break;
+							case GDScriptParser::ClassNode::Member::CONSTANT:
+								r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CONSTANT;
+								r_result.hint.value = member.constant->initializer->reduced_value;
+								break;
+							case GDScriptParser::ClassNode::Member::FUNCTION:
+								r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_METHOD;
+								if (member.function->return_type) {
+									for (int i = 0; i < member.function->return_type->type_chain.size(); i++) {
+										if (i == 0) {
+											r_result.hint.datatype = member.function->return_type->type_chain[0]->name;
+										} else {
+											r_result.hint.datatype += "." + member.function->return_type->type_chain[i]->name;
+										}
+									}
+								}
+								for (int i = 0; i < member.function->parameters.size(); i++) {
+									ScriptLanguage::SymbolHint::Parameter parameter;
+									parameter.name = member.function->parameters[i]->identifier->name;
+									if (member.function->parameters[i]->datatype_specifier) {
+										for (int j = 0; j < member.function->parameters[i]->datatype_specifier->type_chain.size(); j++) {
+											if (j == 0) {
+												parameter.datatype = member.function->parameters[i]->datatype_specifier->type_chain[0]->name;
+											} else {
+												parameter.datatype = member.function->parameters[i]->datatype_specifier->type_chain[j]->name.operator String() + "." + parameter.datatype;
+											}
+										}
+									}
+									if (member.function->parameters[i]->initializer && member.function->parameters[i]->initializer->is_constant && member.function->parameters[i]->initializer->reduced) {
+										parameter.default_value = member.function->parameters[i]->initializer->reduced_value;
+									}
+									r_result.hint.parameters.push_back(parameter);
+								}
+								break;
+							case GDScriptParser::ClassNode::Member::SIGNAL:
+								r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_SIGNAL;
+								for (int i = 0; i < member.signal->parameters.size(); i++) {
+									ScriptLanguage::SymbolHint::Parameter parameter;
+									parameter.name = member.signal->parameters[i]->identifier->name;
+									if (member.signal->parameters[i]->datatype_specifier) {
+										for (int j = 0; j < member.signal->parameters[i]->datatype_specifier->type_chain.size(); j++) {
+											if (j == 0) {
+												parameter.datatype = member.signal->parameters[i]->datatype_specifier->type_chain[0]->name;
+											} else {
+												parameter.datatype = member.signal->parameters[i]->datatype_specifier->type_chain[j]->name.operator String() + "." + parameter.datatype;
+											}
+										}
+									}
+									if (member.signal->parameters[i]->initializer && member.signal->parameters[i]->initializer->is_constant && member.function->parameters[i]->initializer->reduced) {
+										parameter.default_value = member.signal->parameters[i]->initializer->reduced_value;
+									}
+									r_result.hint.parameters.push_back(parameter);
+								}
+								break;
+							case GDScriptParser::ClassNode::Member::VARIABLE:
+								r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_PROPERTY;
+								if (member.variable->datatype_specifier) {
+									for (int i = 0; i < member.variable->datatype_specifier->type_chain.size(); i++) {
+										if (i == 0) {
+											r_result.hint.datatype = member.variable->datatype_specifier->type_chain[0]->name;
+										} else {
+											r_result.hint.datatype += "." + member.variable->datatype_specifier->type_chain[i]->name;
+										}
+									}
+								}
+								if (member.variable->initializer && member.variable->initializer->is_constant && member.variable->initializer->reduced) {
+									r_result.hint.value = member.variable->initializer->reduced_value;
+								}
+								break;
+							case GDScriptParser::ClassNode::Member::ENUM:
+								r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_ENUM;
+								break;
+							case GDScriptParser::ClassNode::Member::ENUM_VALUE:
+								r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_ENUM;
+								if (member.enum_value.custom_value && member.enum_value.custom_value->is_constant && member.enum_value.custom_value->reduced) {
+									r_result.hint.value = member.enum_value.custom_value->reduced_value;
+								}
+								break;
+							default:
+								break;
+						}
+
 						return err;
 					}
 					base_type = base_type.class_type->base_type;
@@ -3195,6 +3294,8 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						r_result.type = ScriptLanguage::LOOKUP_RESULT_SCRIPT_LOCATION;
 						r_result.location = line;
 						r_result.script = scr;
+						r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CLASS;
+						// TODO(require core): Description.
 						return OK;
 					}
 					Ref<Script> base_script = scr->get_base_script();
@@ -3219,6 +3320,43 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
 					r_result.class_name = base_type.native_type;
 					r_result.class_member = p_symbol;
+					r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_METHOD;
+					r_result.hint._namespace = class_name;
+					MethodInfo method_info;
+					ClassDB::get_method_info(class_name, p_symbol, &method_info, true);
+					if (method_info.return_val.type != Variant::NIL) {
+						if (method_info.return_val.type == Variant::OBJECT) {
+							r_result.hint.datatype = method_info.return_val.class_name;
+						} else {
+							r_result.hint.datatype = Variant::get_type_name(method_info.return_val.type);
+						}
+					}
+					for (int i = 0; i < method_info.arguments.size(); i++) {
+						ScriptLanguage::SymbolHint::Parameter parameter;
+						parameter.name = method_info.arguments[i].name;
+						if (method_info.arguments[i].type != Variant::NIL) {
+							if (method_info.arguments[i].type == Variant::OBJECT) {
+								parameter.datatype = method_info.arguments[i].class_name;
+							} else {
+								parameter.datatype = Variant::get_type_name(method_info.arguments[i].type);
+							}
+						} else {
+							parameter.datatype = "Variant";
+						}
+						if (i - (method_info.arguments.size() - method_info.default_arguments.size()) >= 0) {
+							parameter.default_value = method_info.default_arguments[i - (method_info.arguments.size() - method_info.default_arguments.size())];
+						}
+						r_result.hint.parameters.append(parameter);
+					}
+					if (EditorHelp::get_doc_data()->class_list.has(class_name)) {
+						const DocData::ClassDoc &class_doc = EditorHelp::get_doc_data()->class_list[class_name];
+						for (int i = 0; i < class_doc.methods.size(); i++) {
+							if (class_doc.methods[i].name == p_symbol) {
+								r_result.hint.description = class_doc.methods[i].description;
+								break;
+							}
+						}
+					}
 					return OK;
 				}
 
@@ -3229,6 +3367,36 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
 						r_result.class_name = base_type.native_type;
 						r_result.class_member = p_symbol;
+						r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_METHOD;
+						r_result.hint._namespace = class_name;
+						MethodInfo method_info;
+						ClassDB::get_method_info(class_name, p_symbol, &method_info, true);
+						if (method_info.return_val.type != Variant::NIL) {
+							if (method_info.return_val.type == Variant::OBJECT) {
+								r_result.hint.datatype = method_info.return_val.class_name;
+							} else {
+								r_result.hint.datatype = Variant::get_type_name(method_info.return_val.type);
+							}
+						}
+						for (int j = 0; j < method_info.arguments.size(); j++) {
+							ScriptLanguage::SymbolHint::Parameter parameter;
+							parameter.name = method_info.arguments[j].name;
+							parameter.datatype = method_info.arguments[j].class_name;
+							if (j - (method_info.arguments.size() - method_info.default_arguments.size()) >= 0) {
+								parameter.default_value = method_info.default_arguments[j - (method_info.arguments.size() - method_info.default_arguments.size())];
+							}
+						}
+						StringName parent_class = class_name;
+						while (EditorHelp::get_doc_data()->class_list.has(parent_class)) {
+							const DocData::ClassDoc &class_doc = EditorHelp::get_doc_data()->class_list[parent_class];
+							for (int i = 0; i < class_doc.methods.size(); i++) {
+								if (class_doc.methods[i].name == p_symbol) {
+									r_result.hint.description = class_doc.methods[i].description;
+									break;
+								}
+							}
+							parent_class = ClassDB::get_parent_class(parent_class);
+						}
 						return OK;
 					}
 				}
@@ -3245,6 +3413,18 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_ENUM;
 					r_result.class_name = base_type.native_type;
 					r_result.class_member = enum_name;
+					r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_ENUM;
+					r_result.hint._namespace = class_name;
+					r_result.hint.value = ClassDB::get_integer_constant(class_name, p_symbol);
+					if (EditorHelp::get_doc_data()->class_list.has(class_name)) {
+						DocData::ClassDoc &class_doc = EditorHelp::get_doc_data()->class_list[class_name];
+						for (int i = 0; i < class_doc.constants.size(); i++) {
+							if (class_doc.constants[i].name == p_symbol) {
+								r_result.hint.description = class_doc.constants[i].description;
+								break;
+							}
+						}
+					}
 					return OK;
 				}
 
@@ -3255,6 +3435,18 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
 						r_result.class_name = base_type.native_type;
 						r_result.class_member = p_symbol;
+						r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CONSTANT;
+						r_result.hint._namespace = class_name;
+						r_result.hint.value = ClassDB::get_integer_constant(class_name, p_symbol);
+						if (EditorHelp::get_doc_data()->class_list.has(class_name)) {
+							DocData::ClassDoc &class_doc = EditorHelp::get_doc_data()->class_list[class_name];
+							for (int i = 0; i < class_doc.constants.size(); i++) {
+								if (class_doc.constants[i].name == p_symbol) {
+									r_result.hint.description = class_doc.constants[i].description;
+									break;
+								}
+							}
+						}
 						return OK;
 					}
 				}
@@ -3263,6 +3455,26 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY;
 					r_result.class_name = base_type.native_type;
 					r_result.class_member = p_symbol;
+					r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_PROPERTY;
+					r_result.hint._namespace = class_name;
+					PropertyInfo propinfo;
+					ClassDB::get_property_info(class_name, p_symbol, &propinfo, true);
+					if (propinfo.type != Variant::NIL) {
+						if (propinfo.type == Variant::OBJECT) {
+							r_result.hint.datatype = propinfo.class_name;
+						} else {
+							r_result.hint.datatype = Variant::get_type_name(propinfo.type);
+						}
+					}
+					if (EditorHelp::get_doc_data()->class_list.has(class_name)) {
+						DocData::ClassDoc &class_doc = EditorHelp::get_doc_data()->class_list[class_name];
+						for (int i = 0; i < class_doc.properties.size(); i++) {
+							if (class_doc.properties[i].name == p_symbol) {
+								r_result.hint.description = class_doc.properties[i].description;
+								break;
+							}
+						}
+					}
 					return OK;
 				}
 
@@ -3280,6 +3492,18 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
 					r_result.class_name = Variant::get_type_name(base_type.builtin_type);
 					r_result.class_member = p_symbol;
+					r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CONSTANT;
+					r_result.hint._namespace = r_result.class_name;
+					r_result.hint.value = Variant::get_constant_value(base_type.builtin_type, p_symbol);
+					if (EditorHelp::get_doc_data()->class_list.has(r_result.class_name)) {
+						DocData::ClassDoc &class_doc = EditorHelp::get_doc_data()->class_list[r_result.class_name];
+						for (int i = 0; i < class_doc.constants.size(); i++) {
+							if (class_doc.constants[i].name == p_symbol) {
+								r_result.hint.description = class_doc.constants[i].description;
+								break;
+							}
+						}
+					}
 					return OK;
 				}
 
@@ -3300,6 +3524,30 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
 					r_result.class_name = Variant::get_type_name(base_type.builtin_type);
 					r_result.class_member = p_symbol;
+					r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_METHOD;
+					r_result.hint._namespace = r_result.class_name;
+					int argc = Variant::get_builtin_method_argument_count(base_type.builtin_type, p_symbol);
+					Vector<Variant> default_args = Variant::get_builtin_method_default_arguments(base_type.builtin_type, p_symbol);
+					for (int i = 0; i < argc; i++) {
+						ScriptLanguage::SymbolHint::Parameter parameter;
+						parameter.name = Variant::get_builtin_method_argument_name(base_type.builtin_type, p_symbol, i);
+						Variant::Type arg_type = Variant::get_builtin_method_argument_type(base_type.builtin_type, p_symbol, i);
+						parameter.datatype = Variant::get_type_name(arg_type);
+						if (i - (argc - default_args.size()) >= 0) {
+							parameter.default_value = default_args[i - (argc - default_args.size())];
+						}
+						r_result.hint.parameters.append(parameter);
+					}
+					if (EditorHelp::get_doc_data()->class_list.has(r_result.class_name)) {
+						DocData::ClassDoc &class_doc = EditorHelp::get_doc_data()->class_list[r_result.class_name];
+						for (int i = 0; i < class_doc.methods.size(); i++) {
+							if (class_doc.methods[i].name == p_symbol) {
+								r_result.hint.description = class_doc.methods[i].description;
+								r_result.hint.datatype = class_doc.methods[i].return_type;
+								break;
+							}
+						}
+					}
 					return OK;
 				}
 
@@ -3309,6 +3557,18 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_PROPERTY;
 					r_result.class_name = Variant::get_type_name(base_type.builtin_type);
 					r_result.class_member = p_symbol;
+					r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_PROPERTY;
+					r_result.hint._namespace = r_result.class_name;
+					if (EditorHelp::get_doc_data()->class_list.has(r_result.class_name)) {
+						DocData::ClassDoc &class_doc = EditorHelp::get_doc_data()->class_list[r_result.class_name];
+						for (int i = 0; i < class_doc.properties.size(); i++) {
+							if (class_doc.properties[i].name == p_symbol) {
+								r_result.hint.description = class_doc.properties[i].description;
+								r_result.hint.datatype = class_doc.properties[i].type;
+								break;
+							}
+						}
+					}
 					return OK;
 				}
 			} break;
@@ -3334,6 +3594,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 		if (Variant::get_type_name(t) == p_symbol) {
 			r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
 			r_result.class_name = Variant::get_type_name(t);
+			r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CLASS;
+			if (EditorHelp::get_doc_data()->class_list.has(p_symbol)) {
+				r_result.hint.description = EditorHelp::get_doc_data()->class_list[p_symbol].brief_description;
+			}
 			return OK;
 		}
 	}
@@ -3342,6 +3606,24 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
 		r_result.class_name = "@GDScript";
 		r_result.class_member = p_symbol;
+		r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_METHOD;
+		MethodInfo func_info = GDScriptUtilityFunctions::get_function_info(p_symbol);
+		r_result.hint.datatype = func_info.return_val.class_name;
+		for (int j = 0; j < func_info.arguments.size(); j++) {
+			ScriptLanguage::SymbolHint::Parameter parameter;
+			parameter.name = func_info.arguments[j].name;
+			parameter.datatype = func_info.arguments[j].class_name;
+			if (j - (func_info.arguments.size() - func_info.default_arguments.size()) >= 0) {
+				parameter.default_value = func_info.default_arguments[j - (func_info.arguments.size() - func_info.default_arguments.size())];
+			}
+		}
+		DocData::ClassDoc gdscript = EditorHelp::get_doc_data()->class_list["@GDScript"];
+		for (int j = 0; j < gdscript.methods.size(); j++) {
+			if (gdscript.methods[j].name == p_symbol) {
+				r_result.hint.description = gdscript.methods[j].description;
+				break;
+			}
+		}
 		return OK;
 	}
 
@@ -3359,7 +3641,20 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 			r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_METHOD;
 			r_result.class_name = "@GDScript";
 			r_result.class_member = p_symbol;
-			return OK;
+			r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CONSTANT;
+		DocData::ClassDoc gdscript = EditorHelp::get_doc_data()->class_list["@GDScript"];
+		for (int i = 0; i < gdscript.constants.size(); i++) {
+			if (gdscript.constants[i].name == p_symbol) {
+				if ("PI" == p_symbol || "TAU" == p_symbol) {
+					r_result.hint.value = gdscript.constants[i].value.to_float();
+				} else {
+					r_result.hint.value = gdscript.constants[i].value;
+				}
+				r_result.hint.description = gdscript.constants[i].description;
+				break;
+			}
+		}
+		return OK;
 		}
 	}
 
@@ -3368,11 +3663,30 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 
 	if (context.current_class && context.current_class->extends.size() > 0) {
 		bool success = false;
-		ClassDB::get_integer_constant(context.current_class->extends[0]->name, p_symbol, &success);
+		int const_value = ClassDB::get_integer_constant(context.current_class->extends[0]->name, p_symbol, &success);
 		if (success) {
 			r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
 			r_result.class_name = context.current_class->extends[0]->name;
 			r_result.class_member = p_symbol;
+			r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CONSTANT;
+			r_result.hint._namespace = r_result.class_name;
+			r_result.hint.value = const_value;
+			StringName parent_class = r_result.class_name;
+			while (EditorHelp::get_doc_data()->class_list.has(parent_class)) {
+				DocData::ClassDoc class_doc = EditorHelp::get_doc_data()->class_list[parent_class];
+				bool found = false;
+				for (int i = 0; i < class_doc.constants.size(); i++) {
+					if (class_doc.constants[i].name == p_symbol) {
+						r_result.hint.description = class_doc.constants[i].description;
+						found = true;
+						break;
+					}
+				}
+				if (found) {
+					break;
+				}
+				parent_class = ClassDB::get_parent_class(parent_class);
+			}
 			return OK;
 		}
 	}
@@ -3386,6 +3700,18 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
 				r_result.class_name = Variant::get_type_name(context.builtin_type);
 				r_result.class_member = p_symbol;
+				r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CONSTANT;
+				r_result.hint._namespace = r_result.class_name;
+				if (EditorHelp::get_doc_data()->class_list.has(r_result.class_name)) {
+					DocData::ClassDoc class_doc = EditorHelp::get_doc_data()->class_list[r_result.class_name];
+					for (int i = 0; i < class_doc.constants.size(); i++) {
+						if (class_doc.constants[i].name == p_symbol) {
+							r_result.hint.value = class_doc.constants[i].value;
+							r_result.hint.description = class_doc.constants[i].description;
+							break;
+						}
+					}
+				}
 				return OK;
 			}
 			// A method.
@@ -3423,6 +3749,12 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					if (suite->has_local(p_symbol)) {
 						r_result.type = ScriptLanguage::LOOKUP_RESULT_SCRIPT_LOCATION;
 						r_result.location = suite->get_local(p_symbol).start_line;
+						r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_LOCAL_VAR;
+						if (context.current_class->identifier) {
+							r_result.hint._namespace = context.current_class->identifier->name;
+						}
+						// TODO: Datatype suite->get_local(p_symbol).
+						// TODO(require core): Implement local variable description.
 						return OK;
 					}
 					suite = suite->parent_block;
@@ -3449,6 +3781,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 							r_result.type = ScriptLanguage::LOOKUP_RESULT_SCRIPT_LOCATION;
 							r_result.location = 0;
 							r_result.script = ResourceLoader::load(scr_path);
+							r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_PROPERTY;
+							r_result.hint._namespace = "@autoload";
+							r_result.hint.datatype = "Script";
+							// TODO(require core): Script description.
 							return OK;
 						}
 					}
@@ -3461,11 +3797,12 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 					if (value.get_type() == Variant::OBJECT) {
 						Object *obj = value;
 						if (obj) {
+							r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+							r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CLASS;
+							// TODO: Description.
 							if (Object::cast_to<GDScriptNativeClass>(obj)) {
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
 								r_result.class_name = Object::cast_to<GDScriptNativeClass>(obj)->get_name();
 							} else {
-								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
 								r_result.class_name = obj->get_class();
 							}
 
@@ -3496,6 +3833,15 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_TBD_GLOBALSCOPE;
 						r_result.class_name = "@GlobalScope";
 						r_result.class_member = p_symbol;
+						r_result.hint.type = ScriptLanguage::SymbolHint::SYMBOL_CONSTANT;
+						DocData::ClassDoc global_scope = EditorHelp::get_doc_data()->class_list["@GlobalScope"];
+						for (int i = 0; i < global_scope.constants.size(); i++) {
+							if (global_scope.constants[i].name == p_symbol) {
+								r_result.hint.value = global_scope.constants[i].value;
+								r_result.hint.description = global_scope.constants[i].description;
+								break;
+							}
+						}
 						return OK;
 					}
 				} else {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -34,10 +34,6 @@
 #include "core/string/string_builder.h"
 #include "core/string/ustring.h"
 
-#ifdef TOOLS_ENABLED
-#include "scene/gui/rich_text_label.h"
-#endif
-
 void CodeEdit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
@@ -219,308 +215,6 @@ void CodeEdit::_notification(int p_what) {
 					yofs += theme_cache.line_spacing;
 				}
 			}
-
-#ifdef TOOLS_ENABLED
-			if (hovered_hint.type != ScriptLanguage::SymbolHint::SYMBOL_UNKNOWN) {
-
-				/*
-				For the reviewer:
-					I don't think this is the proper way to draw the hint box and it's text. I call draw_string()
-					for each piece of string and call get_string_size() to get offset to draw the next string repeatedly.
-					Also this may be on it's own separate function instead of dumping everything here for maintainability.
-					But consider the below code as a working sample to implement it properly.
-				*/
-
-				/* FIXME: HARDCODED BEGIN */
-				int char_per_line = 80;
-				int max_hint_lines = 8;
-				Ref<Font> hint_font = font;
-				float hint_box_margin = 4;
-				Color hint_color_bg_rect = Color(.25, .25, .25);
-				Color hint_color_type = Color(0, 1, 1);
-				Color hint_color_class = Color(.4, .6, 0);
-				Color hint_color_symbol = Color(0.9, 0.74, 0.34);
-				/* HARDCODED END */
-
-				Point2 rect_draw_pos(hovered_word_position.x, (hovered_word_position.y + 1) * row_height);
-				Size2 hint_rect_size;
-				Vector<String> lines;
-				Point2 pos(rect_draw_pos);
-
-				if (!hovered_hint.description.is_empty()) {
-					Vector<String> words = hovered_hint.description.split(" ", false);
-					int word_count = 0;
-					String desc_line;
-					while (word_count < words.size()) {
-						if (lines.size() == max_hint_lines) {
-							lines.append("...");
-							desc_line = String();
-							break;
-						}
-						if ((!desc_line.is_empty() ? desc_line.size() + 1 : 0) + words[word_count].size() > char_per_line) {
-							if (!desc_line.is_empty()) {
-								hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(desc_line).width);
-								lines.append(desc_line);
-								desc_line = words[word_count];
-							} else {
-								hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(desc_line).width);
-								lines.append(words[word_count].substr(0, char_per_line));
-								desc_line = desc_line.substr(char_per_line);
-							}
-							word_count++;
-							continue;
-						}
-						if (desc_line.is_empty()) {
-							desc_line = words[word_count++];
-						} else {
-							desc_line = desc_line + " " + words[word_count++];
-						}
-					}
-					if (!desc_line.is_empty()) {
-						hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(desc_line).width);
-						lines.append(desc_line);
-					}
-					if (lines.size() > 0) {
-						hint_rect_size.height += (line_spacing + hint_font->get_height(font_size)) * lines.size();
-					}
-				}
-
-				switch (hovered_hint.type) {
-					case ScriptLanguage::SymbolHint::SYMBOL_CLASS: {
-						Size2 hint_line_size = hint_font->get_string_size("class " + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + "::" : "") + hovered_hint.symbol);
-						hint_rect_size.height += hint_line_size.height;
-						hint_rect_size.width = MAX(hint_rect_size.width, hint_line_size.width);
-
-						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
-						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
-						draw_string(hint_font, pos, "class ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
-						pos.width += hint_font->get_string_size("class ").width;
-						if (!hovered_hint._namespace.is_empty()) {
-							draw_string(hint_font, pos, hovered_hint._namespace, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-							pos.width += hint_font->get_string_size(hovered_hint._namespace).width;
-							draw_string(hint_font, pos, "::");
-							pos.width += hint_font->get_string_size("::").width;
-						}
-						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-					} break;
-					case ScriptLanguage::SymbolHint::SYMBOL_METHOD:
-					case ScriptLanguage::SymbolHint::SYMBOL_SIGNAL: {
-						bool is_method = hovered_hint.type == ScriptLanguage::SymbolHint::SYMBOL_METHOD;
-						Vector<String> hint_lines;
-						String hint_line = ((is_method) ? "method " : "signal ") + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + "::" : "");
-						if (hint_line.size() + hovered_hint.symbol.size() + 1 > char_per_line) {
-							hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
-							hint_lines.append(hint_line);
-							hint_line = hovered_hint.symbol + "(";
-						} else {
-							hint_line += hovered_hint.symbol + "(";
-						}
-						for (int i = 0; i < hovered_hint.parameters.size(); i++) {
-							if (i != 0) {
-								hint_line += ", ";
-							}
-							if (hint_line.size() + hovered_hint.parameters[i].name.size() > char_per_line) {
-								hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
-								hint_lines.append(hint_line);
-								hint_line = hovered_hint.parameters[i].name;
-							} else {
-								hint_line += hovered_hint.parameters[i].name;
-							}
-
-							if (!hovered_hint.parameters[i].datatype.is_empty()) {
-								if (hovered_hint.parameters[i].datatype == Variant::get_type_name(Variant::NIL)) {
-									hovered_hint.parameters.write[i].datatype = "Variant";
-								}
-								if (hint_line.size() + 1 + hovered_hint.parameters[i].datatype.size() > char_per_line) {
-									hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
-									hint_lines.append(hint_line);
-									hint_line = ":" + hovered_hint.parameters[i].datatype;
-								} else {
-									hint_line += ":" + hovered_hint.parameters[i].datatype;
-								}
-							}
-							if (hovered_hint.parameters[i].default_value.get_type() != Variant::NIL) {
-								if (hint_line.size() + 3 + hovered_hint.parameters[i].default_value.operator String().size() > char_per_line) {
-									hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
-									hint_lines.append(hint_line);
-									hint_line = " = " + hovered_hint.parameters[i].default_value.operator String();
-								} else {
-									hint_line += " = " + hovered_hint.parameters[i].default_value.operator String();
-								}
-							}
-						}
-						hint_line += ")";
-						if (is_method && !hovered_hint.datatype.is_empty()) {
-							if (hint_line.size() + 4 + hovered_hint.datatype.size() > char_per_line) {
-								hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
-								hint_lines.append(hint_line);
-								hint_line = " -> " + hovered_hint.datatype;
-							} else {
-								hint_line += " -> " + hovered_hint.datatype;
-							}
-						}
-						if (!hint_line.is_empty()) {
-							hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
-							hint_lines.append(hint_line);
-						}
-						hint_rect_size.height += hint_lines.size() * (hint_font->get_height(font_size) + line_spacing) - line_spacing;
-
-						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
-						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
-
-						// Draw text.
-						int line_char_size = 0;
-						draw_string(hint_font, pos, ((is_method) ? "method" : "signal"), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
-						pos.width += hint_font->get_string_size(((is_method) ? "method " : "signal ")).width;
-						line_char_size += 6; // Length of "method" / "signal".
-						if (!hovered_hint._namespace.is_empty()) {
-							draw_string(hint_font, pos, hovered_hint._namespace, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-							pos.width += hint_font->get_string_size(hovered_hint._namespace).width;
-							draw_string(hint_font, pos, "::");
-							pos.width += hint_font->get_string_size("::").width;
-							line_char_size += hovered_hint._namespace.size() + 2;
-						}
-						if (line_char_size + hovered_hint.symbol.size() + 1 > char_per_line) {
-							pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
-							line_char_size = 0;
-						}
-						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
-						pos.width += hint_font->get_string_size(hovered_hint.symbol).width;
-						draw_string(hint_font, pos, "(");
-						pos.width += hint_font->get_string_size("(").width;
-						line_char_size += hovered_hint.symbol.size();
-
-						for (int i = 0; i < hovered_hint.parameters.size(); i++) {
-							if (i != 0) {
-								draw_string(hint_font, pos, ", ");
-								pos.width += hint_font->get_string_size(", ").width;
-								line_char_size += 2;
-							}
-							if (line_char_size + hovered_hint.parameters[i].name.size() > char_per_line) {
-								pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
-								hint_line = hovered_hint.parameters[i].name;
-								line_char_size = 0;
-							}
-							draw_string(hint_font, pos, hovered_hint.parameters[i].name);
-							pos.width += hint_font->get_string_size(hovered_hint.parameters[i].name).width;
-							line_char_size += hovered_hint.parameters[i].name.size();
-
-							if (!hovered_hint.parameters[i].datatype.is_empty()) {
-								if (line_char_size + 1 + hovered_hint.parameters[i].datatype.size() > char_per_line) {
-									pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
-									line_char_size = 0;
-								}
-								draw_string(hint_font, pos, ":");
-								pos.width += hint_font->get_string_size(":").width;
-								draw_string(hint_font, pos, hovered_hint.parameters[i].datatype, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-								pos.width += hint_font->get_string_size(hovered_hint.parameters[i].datatype).width;
-								line_char_size += 1 + hovered_hint.parameters[i].datatype.size();
-							}
-							if (hovered_hint.parameters[i].default_value.get_type() != Variant::NIL) {
-								if (line_char_size + 3 + hovered_hint.parameters[i].default_value.operator String().size() > char_per_line) {
-									pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
-									line_char_size = 0;
-								}
-								draw_string(hint_font, pos, " = ");
-								pos.width += hint_font->get_string_size(" = ").width;
-								draw_string(hint_font, pos, hovered_hint.parameters[i].default_value.operator String(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
-								pos.width += hint_font->get_string_size(hovered_hint.parameters[i].default_value.operator String()).width;
-								line_char_size += 3 + hovered_hint.parameters[i].default_value.operator String().size();
-							}
-						}
-						draw_string(hint_font, pos, ")");
-						pos.width += hint_font->get_string_size(")").width;
-						line_char_size += 1;
-
-						if (is_method && !hovered_hint.datatype.is_empty()) {
-							if (line_char_size + 4 + hovered_hint.datatype.size() > char_per_line) {
-								pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
-								line_char_size = 0;
-							}
-							draw_string(hint_font, pos, " -> ");
-							pos.width += hint_font->get_string_size(" -> ").width;
-							draw_string(hint_font, pos, hovered_hint.datatype, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-							line_char_size += 4 + hovered_hint.datatype.size();
-						}
-					} break;
-					case ScriptLanguage::SymbolHint::SYMBOL_PROPERTY: {
-						Size2 hint_line_size = hint_font->get_string_size("property " + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + "::" : "") + hovered_hint.symbol + (!hovered_hint.datatype.is_empty() ? ":" + hovered_hint.datatype : ""));
-						hint_rect_size.height += hint_line_size.height;
-						hint_rect_size.width = MAX(hint_rect_size.width, hint_line_size.width);
-
-						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
-						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
-						draw_string(hint_font, pos, "property ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
-						pos.width += hint_font->get_string_size("property ").width;
-						if (!hovered_hint._namespace.is_empty()) {
-							draw_string(hint_font, pos, hovered_hint._namespace, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-							pos.width += hint_font->get_string_size(hovered_hint._namespace).width;
-							draw_string(hint_font, pos, "::");
-							pos.width += hint_font->get_string_size("::").width;
-						}
-						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
-						if (!hovered_hint.datatype.is_empty()) {
-							pos.width += hint_font->get_string_size(hovered_hint.symbol).width;
-							draw_string(hint_font, pos, ":");
-							pos.width += hint_font->get_string_size(":").width;
-							draw_string(hint_font, pos, hovered_hint.datatype, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-						}
-					} break;
-					case ScriptLanguage::SymbolHint::SYMBOL_CONSTANT: {
-						String value = hovered_hint.value.operator String();
-						Size2 hint_line_size = hint_font->get_string_size("constant " + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + "::" : "") + hovered_hint.symbol + " = " + value);
-						hint_rect_size.height += hint_line_size.height;
-						hint_rect_size.width = MAX(hint_rect_size.width, hint_line_size.width);
-
-						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
-						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
-						draw_string(hint_font, pos, "constant ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
-						pos.width += hint_font->get_string_size("constant ").width;
-						if (!hovered_hint._namespace.is_empty()) {
-							draw_string(hint_font, pos, hovered_hint._namespace, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-							pos.width += hint_font->get_string_size(hovered_hint._namespace).width;
-							draw_string(hint_font, pos, "::");
-							pos.width += hint_font->get_string_size("::").width;
-						}
-						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
-						pos.width += hint_font->get_string_size(hovered_hint.symbol + " ").width;
-						draw_string(hint_font, pos, "=");
-						pos.width += hint_font->get_string_size("= ").width;
-						draw_string(hint_font, pos, value, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
-					} break;
-					case ScriptLanguage::SymbolHint::SYMBOL_LOCAL_VAR: {
-						Size2 hint_line_size = hint_font->get_string_size("local_var " + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + " " : "") + hovered_hint.symbol + (!hovered_hint.datatype.is_empty() ? ":" + hovered_hint.datatype : ""));
-						hint_rect_size.height += hint_line_size.height;
-						hint_rect_size.width = MAX(hint_rect_size.width, hint_line_size.width);
-
-						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
-						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
-						draw_string(hint_font, pos, "local_var ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
-						pos.width += hint_font->get_string_size("local_var ").width;
-						if (!hovered_hint._namespace.is_empty()) {
-							draw_string(hint_font, pos, hovered_hint._namespace + " ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-							pos.width += hint_font->get_string_size(hovered_hint._namespace + " ").width;
-						}
-						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
-						if (!hovered_hint.datatype.is_empty()) {
-							pos.width += hint_font->get_string_size(hovered_hint.symbol).width;
-							draw_string(hint_font, pos, ":");
-							pos.width += hint_font->get_string_size(":").width;
-							draw_string(hint_font, pos, hovered_hint.datatype, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
-						}
-					} break;
-					case ScriptLanguage::SymbolHint::SYMBOL_ENUM: {
-					} break;
-					default: {
-					} break;
-				}
-
-				for (int i = 0; i < lines.size(); i++) {
-					pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
-					draw_string(hint_font, pos, lines[i]);
-				}
-			}
-#endif
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {
@@ -723,24 +417,10 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					emit_signal(SNAME("symbol_validate"), symbol_lookup_new_word);
 				}
 			} else {
-#ifdef TOOLS_ENABLED
-				if (!is_dragging_cursor() && symbol_lookup_new_word != hovered_hint.symbol) {
-					if (symbol_lookup_new_word.is_empty()) {
-						hovered_hint.symbol = String();
-						hovered_hint.type = ScriptLanguage::SymbolHint::SYMBOL_UNKNOWN;
-					} else {
-						Vector2 mouse_pos = mm->get_position();
-						// hovered_word_position.x is the x position of the hint rect but
-						// hovered_word_position.y is the line number of the rect and position will be
-						// calculated to align the rect with the next line.
-						hovered_word_position = get_line_column_at_pos(mouse_pos);
-						hovered_word_position.x = mouse_pos.x;
-						emit_signal("hovered_symbol_validate", symbol_lookup_new_word);
-					}
+				emit_signal("symbol_hovered", get_word_at_pos(mpos), get_word_line_column_at_pos(mpos));
+				if (!mm->is_command_or_control_pressed() || (!mm->get_button_mask().is_empty() && symbol_lookup_pos != get_line_column_at_pos(mpos))) {
+					set_symbol_lookup_word_as_valid(false);
 				}
-				else
-#endif // TOOLS_ENABLED
-				set_symbol_lookup_word_as_valid(false);
 			}
 		}
 
@@ -2621,16 +2301,6 @@ void CodeEdit::set_symbol_lookup_word_as_valid(bool p_valid) {
 	}
 }
 
-#ifdef TOOLS_ENABLED
-void CodeEdit::set_hovered_hint(const ScriptLanguage::SymbolHint &p_symbol_hint) {
-	static RichTextLabel bbcode_to_text;
-	bbcode_to_text.set_use_bbcode(true);
-	hovered_hint = p_symbol_hint;
-	bbcode_to_text.parse_bbcode(hovered_hint.description.replace("\t", "").replace("\n", " "));
-	hovered_hint.description = bbcode_to_text.get_text();
-}
-#endif // TOOLS_ENABLED
-
 void CodeEdit::_bind_methods() {
 	/* Indent management */
 	ClassDB::bind_method(D_METHOD("set_indent_size", "size"), &CodeEdit::set_indent_size);
@@ -2855,9 +2525,7 @@ void CodeEdit::_bind_methods() {
 	/* Symbol lookup */
 	ADD_SIGNAL(MethodInfo("symbol_lookup", PropertyInfo(Variant::STRING, "symbol"), PropertyInfo(Variant::INT, "line"), PropertyInfo(Variant::INT, "column")));
 	ADD_SIGNAL(MethodInfo("symbol_validate", PropertyInfo(Variant::STRING, "symbol")));
-#ifdef TOOLS_ENABLED
-	ADD_SIGNAL(MethodInfo("hovered_symbol_validate", PropertyInfo(Variant::STRING, "symbol")));
-#endif
+	ADD_SIGNAL(MethodInfo("symbol_hovered", PropertyInfo(Variant::STRING, "symbol"), PropertyInfo(Variant::VECTOR2I, "symbol_column_line")));
 }
 
 /* Auto brace completion */

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -34,6 +34,10 @@
 #include "core/string/string_builder.h"
 #include "core/string/ustring.h"
 
+#ifdef TOOLS_ENABLED
+#include "scene/gui/rich_text_label.h"
+#endif
+
 void CodeEdit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
@@ -215,6 +219,308 @@ void CodeEdit::_notification(int p_what) {
 					yofs += theme_cache.line_spacing;
 				}
 			}
+
+#ifdef TOOLS_ENABLED
+			if (hovered_hint.type != ScriptLanguage::SymbolHint::SYMBOL_UNKNOWN) {
+
+				/*
+				For the reviewer:
+					I don't think this is the proper way to draw the hint box and it's text. I call draw_string()
+					for each piece of string and call get_string_size() to get offset to draw the next string repeatedly.
+					Also this may be on it's own separate function instead of dumping everything here for maintainability.
+					But consider the below code as a working sample to implement it properly.
+				*/
+
+				/* FIXME: HARDCODED BEGIN */
+				int char_per_line = 80;
+				int max_hint_lines = 8;
+				Ref<Font> hint_font = font;
+				float hint_box_margin = 4;
+				Color hint_color_bg_rect = Color(.25, .25, .25);
+				Color hint_color_type = Color(0, 1, 1);
+				Color hint_color_class = Color(.4, .6, 0);
+				Color hint_color_symbol = Color(0.9, 0.74, 0.34);
+				/* HARDCODED END */
+
+				Point2 rect_draw_pos(hovered_word_position.x, (hovered_word_position.y + 1) * row_height);
+				Size2 hint_rect_size;
+				Vector<String> lines;
+				Point2 pos(rect_draw_pos);
+
+				if (!hovered_hint.description.is_empty()) {
+					Vector<String> words = hovered_hint.description.split(" ", false);
+					int word_count = 0;
+					String desc_line;
+					while (word_count < words.size()) {
+						if (lines.size() == max_hint_lines) {
+							lines.append("...");
+							desc_line = String();
+							break;
+						}
+						if ((!desc_line.is_empty() ? desc_line.size() + 1 : 0) + words[word_count].size() > char_per_line) {
+							if (!desc_line.is_empty()) {
+								hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(desc_line).width);
+								lines.append(desc_line);
+								desc_line = words[word_count];
+							} else {
+								hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(desc_line).width);
+								lines.append(words[word_count].substr(0, char_per_line));
+								desc_line = desc_line.substr(char_per_line);
+							}
+							word_count++;
+							continue;
+						}
+						if (desc_line.is_empty()) {
+							desc_line = words[word_count++];
+						} else {
+							desc_line = desc_line + " " + words[word_count++];
+						}
+					}
+					if (!desc_line.is_empty()) {
+						hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(desc_line).width);
+						lines.append(desc_line);
+					}
+					if (lines.size() > 0) {
+						hint_rect_size.height += (line_spacing + hint_font->get_height(font_size)) * lines.size();
+					}
+				}
+
+				switch (hovered_hint.type) {
+					case ScriptLanguage::SymbolHint::SYMBOL_CLASS: {
+						Size2 hint_line_size = hint_font->get_string_size("class " + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + "::" : "") + hovered_hint.symbol);
+						hint_rect_size.height += hint_line_size.height;
+						hint_rect_size.width = MAX(hint_rect_size.width, hint_line_size.width);
+
+						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
+						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
+						draw_string(hint_font, pos, "class ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
+						pos.width += hint_font->get_string_size("class ").width;
+						if (!hovered_hint._namespace.is_empty()) {
+							draw_string(hint_font, pos, hovered_hint._namespace, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+							pos.width += hint_font->get_string_size(hovered_hint._namespace).width;
+							draw_string(hint_font, pos, "::");
+							pos.width += hint_font->get_string_size("::").width;
+						}
+						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+					} break;
+					case ScriptLanguage::SymbolHint::SYMBOL_METHOD:
+					case ScriptLanguage::SymbolHint::SYMBOL_SIGNAL: {
+						bool is_method = hovered_hint.type == ScriptLanguage::SymbolHint::SYMBOL_METHOD;
+						Vector<String> hint_lines;
+						String hint_line = ((is_method) ? "method " : "signal ") + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + "::" : "");
+						if (hint_line.size() + hovered_hint.symbol.size() + 1 > char_per_line) {
+							hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
+							hint_lines.append(hint_line);
+							hint_line = hovered_hint.symbol + "(";
+						} else {
+							hint_line += hovered_hint.symbol + "(";
+						}
+						for (int i = 0; i < hovered_hint.parameters.size(); i++) {
+							if (i != 0) {
+								hint_line += ", ";
+							}
+							if (hint_line.size() + hovered_hint.parameters[i].name.size() > char_per_line) {
+								hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
+								hint_lines.append(hint_line);
+								hint_line = hovered_hint.parameters[i].name;
+							} else {
+								hint_line += hovered_hint.parameters[i].name;
+							}
+
+							if (!hovered_hint.parameters[i].datatype.is_empty()) {
+								if (hovered_hint.parameters[i].datatype == Variant::get_type_name(Variant::NIL)) {
+									hovered_hint.parameters.write[i].datatype = "Variant";
+								}
+								if (hint_line.size() + 1 + hovered_hint.parameters[i].datatype.size() > char_per_line) {
+									hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
+									hint_lines.append(hint_line);
+									hint_line = ":" + hovered_hint.parameters[i].datatype;
+								} else {
+									hint_line += ":" + hovered_hint.parameters[i].datatype;
+								}
+							}
+							if (hovered_hint.parameters[i].default_value.get_type() != Variant::NIL) {
+								if (hint_line.size() + 3 + hovered_hint.parameters[i].default_value.operator String().size() > char_per_line) {
+									hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
+									hint_lines.append(hint_line);
+									hint_line = " = " + hovered_hint.parameters[i].default_value.operator String();
+								} else {
+									hint_line += " = " + hovered_hint.parameters[i].default_value.operator String();
+								}
+							}
+						}
+						hint_line += ")";
+						if (is_method && !hovered_hint.datatype.is_empty()) {
+							if (hint_line.size() + 4 + hovered_hint.datatype.size() > char_per_line) {
+								hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
+								hint_lines.append(hint_line);
+								hint_line = " -> " + hovered_hint.datatype;
+							} else {
+								hint_line += " -> " + hovered_hint.datatype;
+							}
+						}
+						if (!hint_line.is_empty()) {
+							hint_rect_size.width = MAX(hint_rect_size.width, hint_font->get_string_size(hint_line).width);
+							hint_lines.append(hint_line);
+						}
+						hint_rect_size.height += hint_lines.size() * (hint_font->get_height(font_size) + line_spacing) - line_spacing;
+
+						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
+						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
+
+						// Draw text.
+						int line_char_size = 0;
+						draw_string(hint_font, pos, ((is_method) ? "method" : "signal"), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
+						pos.width += hint_font->get_string_size(((is_method) ? "method " : "signal ")).width;
+						line_char_size += 6; // Length of "method" / "signal".
+						if (!hovered_hint._namespace.is_empty()) {
+							draw_string(hint_font, pos, hovered_hint._namespace, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+							pos.width += hint_font->get_string_size(hovered_hint._namespace).width;
+							draw_string(hint_font, pos, "::");
+							pos.width += hint_font->get_string_size("::").width;
+							line_char_size += hovered_hint._namespace.size() + 2;
+						}
+						if (line_char_size + hovered_hint.symbol.size() + 1 > char_per_line) {
+							pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
+							line_char_size = 0;
+						}
+						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
+						pos.width += hint_font->get_string_size(hovered_hint.symbol).width;
+						draw_string(hint_font, pos, "(");
+						pos.width += hint_font->get_string_size("(").width;
+						line_char_size += hovered_hint.symbol.size();
+
+						for (int i = 0; i < hovered_hint.parameters.size(); i++) {
+							if (i != 0) {
+								draw_string(hint_font, pos, ", ");
+								pos.width += hint_font->get_string_size(", ").width;
+								line_char_size += 2;
+							}
+							if (line_char_size + hovered_hint.parameters[i].name.size() > char_per_line) {
+								pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
+								hint_line = hovered_hint.parameters[i].name;
+								line_char_size = 0;
+							}
+							draw_string(hint_font, pos, hovered_hint.parameters[i].name);
+							pos.width += hint_font->get_string_size(hovered_hint.parameters[i].name).width;
+							line_char_size += hovered_hint.parameters[i].name.size();
+
+							if (!hovered_hint.parameters[i].datatype.is_empty()) {
+								if (line_char_size + 1 + hovered_hint.parameters[i].datatype.size() > char_per_line) {
+									pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
+									line_char_size = 0;
+								}
+								draw_string(hint_font, pos, ":");
+								pos.width += hint_font->get_string_size(":").width;
+								draw_string(hint_font, pos, hovered_hint.parameters[i].datatype, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+								pos.width += hint_font->get_string_size(hovered_hint.parameters[i].datatype).width;
+								line_char_size += 1 + hovered_hint.parameters[i].datatype.size();
+							}
+							if (hovered_hint.parameters[i].default_value.get_type() != Variant::NIL) {
+								if (line_char_size + 3 + hovered_hint.parameters[i].default_value.operator String().size() > char_per_line) {
+									pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
+									line_char_size = 0;
+								}
+								draw_string(hint_font, pos, " = ");
+								pos.width += hint_font->get_string_size(" = ").width;
+								draw_string(hint_font, pos, hovered_hint.parameters[i].default_value.operator String(), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
+								pos.width += hint_font->get_string_size(hovered_hint.parameters[i].default_value.operator String()).width;
+								line_char_size += 3 + hovered_hint.parameters[i].default_value.operator String().size();
+							}
+						}
+						draw_string(hint_font, pos, ")");
+						pos.width += hint_font->get_string_size(")").width;
+						line_char_size += 1;
+
+						if (is_method && !hovered_hint.datatype.is_empty()) {
+							if (line_char_size + 4 + hovered_hint.datatype.size() > char_per_line) {
+								pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
+								line_char_size = 0;
+							}
+							draw_string(hint_font, pos, " -> ");
+							pos.width += hint_font->get_string_size(" -> ").width;
+							draw_string(hint_font, pos, hovered_hint.datatype, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+							line_char_size += 4 + hovered_hint.datatype.size();
+						}
+					} break;
+					case ScriptLanguage::SymbolHint::SYMBOL_PROPERTY: {
+						Size2 hint_line_size = hint_font->get_string_size("property " + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + "::" : "") + hovered_hint.symbol + (!hovered_hint.datatype.is_empty() ? ":" + hovered_hint.datatype : ""));
+						hint_rect_size.height += hint_line_size.height;
+						hint_rect_size.width = MAX(hint_rect_size.width, hint_line_size.width);
+
+						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
+						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
+						draw_string(hint_font, pos, "property ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
+						pos.width += hint_font->get_string_size("property ").width;
+						if (!hovered_hint._namespace.is_empty()) {
+							draw_string(hint_font, pos, hovered_hint._namespace, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+							pos.width += hint_font->get_string_size(hovered_hint._namespace).width;
+							draw_string(hint_font, pos, "::");
+							pos.width += hint_font->get_string_size("::").width;
+						}
+						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
+						if (!hovered_hint.datatype.is_empty()) {
+							pos.width += hint_font->get_string_size(hovered_hint.symbol).width;
+							draw_string(hint_font, pos, ":");
+							pos.width += hint_font->get_string_size(":").width;
+							draw_string(hint_font, pos, hovered_hint.datatype, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+						}
+					} break;
+					case ScriptLanguage::SymbolHint::SYMBOL_CONSTANT: {
+						String value = hovered_hint.value.operator String();
+						Size2 hint_line_size = hint_font->get_string_size("constant " + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + "::" : "") + hovered_hint.symbol + " = " + value);
+						hint_rect_size.height += hint_line_size.height;
+						hint_rect_size.width = MAX(hint_rect_size.width, hint_line_size.width);
+
+						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
+						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
+						draw_string(hint_font, pos, "constant ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
+						pos.width += hint_font->get_string_size("constant ").width;
+						if (!hovered_hint._namespace.is_empty()) {
+							draw_string(hint_font, pos, hovered_hint._namespace, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+							pos.width += hint_font->get_string_size(hovered_hint._namespace).width;
+							draw_string(hint_font, pos, "::");
+							pos.width += hint_font->get_string_size("::").width;
+						}
+						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
+						pos.width += hint_font->get_string_size(hovered_hint.symbol + " ").width;
+						draw_string(hint_font, pos, "=");
+						pos.width += hint_font->get_string_size("= ").width;
+						draw_string(hint_font, pos, value, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
+					} break;
+					case ScriptLanguage::SymbolHint::SYMBOL_LOCAL_VAR: {
+						Size2 hint_line_size = hint_font->get_string_size("local_var " + (!hovered_hint._namespace.is_empty() ? hovered_hint._namespace + " " : "") + hovered_hint.symbol + (!hovered_hint.datatype.is_empty() ? ":" + hovered_hint.datatype : ""));
+						hint_rect_size.height += hint_line_size.height;
+						hint_rect_size.width = MAX(hint_rect_size.width, hint_line_size.width);
+
+						draw_rect(Rect2(pos, hint_rect_size + 2 * Size2(hint_box_margin, hint_box_margin)), hint_color_bg_rect);
+						pos += Point2(hint_box_margin, hint_font->get_height(font_size));
+						draw_string(hint_font, pos, "local_var ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_type);
+						pos.width += hint_font->get_string_size("local_var ").width;
+						if (!hovered_hint._namespace.is_empty()) {
+							draw_string(hint_font, pos, hovered_hint._namespace + " ", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+							pos.width += hint_font->get_string_size(hovered_hint._namespace + " ").width;
+						}
+						draw_string(hint_font, pos, hovered_hint.symbol, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_symbol);
+						if (!hovered_hint.datatype.is_empty()) {
+							pos.width += hint_font->get_string_size(hovered_hint.symbol).width;
+							draw_string(hint_font, pos, ":");
+							pos.width += hint_font->get_string_size(":").width;
+							draw_string(hint_font, pos, hovered_hint.datatype, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, hint_color_class);
+						}
+					} break;
+					case ScriptLanguage::SymbolHint::SYMBOL_ENUM: {
+					} break;
+					default: {
+					} break;
+				}
+
+				for (int i = 0; i < lines.size(); i++) {
+					pos = Point2(rect_draw_pos.x + hint_box_margin, pos.height + hint_font->get_height(font_size) + line_spacing);
+					draw_string(hint_font, pos, lines[i]);
+				}
+			}
+#endif
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {
@@ -416,7 +722,24 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				if (symbol_lookup_new_word != symbol_lookup_word) {
 					emit_signal(SNAME("symbol_validate"), symbol_lookup_new_word);
 				}
-			} else if (!mm->is_command_or_control_pressed() || (!mm->get_button_mask().is_empty() && symbol_lookup_pos != get_line_column_at_pos(mpos))) {
+			} else {
+#ifdef TOOLS_ENABLED
+				if (!is_dragging_cursor() && symbol_lookup_new_word != hovered_hint.symbol) {
+					if (symbol_lookup_new_word.is_empty()) {
+						hovered_hint.symbol = String();
+						hovered_hint.type = ScriptLanguage::SymbolHint::SYMBOL_UNKNOWN;
+					} else {
+						Vector2 mouse_pos = mm->get_position();
+						// hovered_word_position.x is the x position of the hint rect but
+						// hovered_word_position.y is the line number of the rect and position will be
+						// calculated to align the rect with the next line.
+						hovered_word_position = get_line_column_at_pos(mouse_pos);
+						hovered_word_position.x = mouse_pos.x;
+						emit_signal("hovered_symbol_validate", symbol_lookup_new_word);
+					}
+				}
+				else
+#endif // TOOLS_ENABLED
 				set_symbol_lookup_word_as_valid(false);
 			}
 		}
@@ -2298,6 +2621,16 @@ void CodeEdit::set_symbol_lookup_word_as_valid(bool p_valid) {
 	}
 }
 
+#ifdef TOOLS_ENABLED
+void CodeEdit::set_hovered_hint(const ScriptLanguage::SymbolHint &p_symbol_hint) {
+	static RichTextLabel bbcode_to_text;
+	bbcode_to_text.set_use_bbcode(true);
+	hovered_hint = p_symbol_hint;
+	bbcode_to_text.parse_bbcode(hovered_hint.description.replace("\t", "").replace("\n", " "));
+	hovered_hint.description = bbcode_to_text.get_text();
+}
+#endif // TOOLS_ENABLED
+
 void CodeEdit::_bind_methods() {
 	/* Indent management */
 	ClassDB::bind_method(D_METHOD("set_indent_size", "size"), &CodeEdit::set_indent_size);
@@ -2522,6 +2855,9 @@ void CodeEdit::_bind_methods() {
 	/* Symbol lookup */
 	ADD_SIGNAL(MethodInfo("symbol_lookup", PropertyInfo(Variant::STRING, "symbol"), PropertyInfo(Variant::INT, "line"), PropertyInfo(Variant::INT, "column")));
 	ADD_SIGNAL(MethodInfo("symbol_validate", PropertyInfo(Variant::STRING, "symbol")));
+#ifdef TOOLS_ENABLED
+	ADD_SIGNAL(MethodInfo("hovered_symbol_validate", PropertyInfo(Variant::STRING, "symbol")));
+#endif
 }
 
 /* Auto brace completion */

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -33,12 +33,8 @@
 
 #include "scene/gui/text_edit.h"
 
-#ifdef TOOLS_ENABLED
-#include "core/object/script_language.h"
-#endif
-
 class CodeEdit : public TextEdit {
-	GDCLASS(CodeEdit, TextEdit)
+	GDCLASS(CodeEdit, TextEdit);
 
 public:
 	// Keep enums in sync with:
@@ -230,11 +226,6 @@ private:
 	String symbol_lookup_new_word = "";
 	String symbol_lookup_word = "";
 	Point2i symbol_lookup_pos;
-
-#ifdef TOOLS_ENABLED
-	ScriptLanguage::SymbolHint hovered_hint;
-	Vector2i hovered_word_position;
-#endif
 
 	/* Visual */
 	struct ThemeCache {
@@ -467,10 +458,6 @@ public:
 	String get_text_for_symbol_lookup();
 
 	void set_symbol_lookup_word_as_valid(bool p_valid);
-
-#ifdef TOOLS_ENABLED
-	void set_hovered_hint(const ScriptLanguage::SymbolHint &p_symbol_hint);
-#endif
 
 	CodeEdit();
 	~CodeEdit();

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -33,6 +33,10 @@
 
 #include "scene/gui/text_edit.h"
 
+#ifdef TOOLS_ENABLED
+#include "core/object/script_language.h"
+#endif
+
 class CodeEdit : public TextEdit {
 	GDCLASS(CodeEdit, TextEdit)
 
@@ -226,6 +230,11 @@ private:
 	String symbol_lookup_new_word = "";
 	String symbol_lookup_word = "";
 	Point2i symbol_lookup_pos;
+
+#ifdef TOOLS_ENABLED
+	ScriptLanguage::SymbolHint hovered_hint;
+	Vector2i hovered_word_position;
+#endif
 
 	/* Visual */
 	struct ThemeCache {
@@ -458,6 +467,10 @@ public:
 	String get_text_for_symbol_lookup();
 
 	void set_symbol_lookup_word_as_valid(bool p_valid);
+
+#ifdef TOOLS_ENABLED
+	void set_hovered_hint(const ScriptLanguage::SymbolHint &p_symbol_hint);
+#endif
 
 	CodeEdit();
 	~CodeEdit();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4274,6 +4274,50 @@ String TextEdit::get_word_at_pos(const Vector2 &p_pos) const {
 	return String();
 }
 
+Point2i TextEdit::get_word_line_column_at_pos(const Vector2 &p_pos) const {
+	Point2i pos = get_line_column_at_pos(p_pos, false);
+
+	if (pos.y == -1) {
+		return pos;
+	}
+
+	int row = pos.y;
+	int col = pos.x;
+
+	String s = text[row];
+	if (s.length() == 0 || col >= s.length()) {
+		return Point2i(-1, -1);
+	}
+	int beg, end;
+	if (select_word(s, col, beg, end)) {
+		bool inside_quotes = false;
+		char32_t selected_quote = '\0';
+		int qbegin = 0, qend = 0;
+		for (int i = 0; i < s.length(); i++) {
+			if (s[i] == '"' || s[i] == '\'') {
+				if (i == 0 || s[i - 1] != '\\') {
+					if (inside_quotes && selected_quote == s[i]) {
+						qend = i;
+						inside_quotes = false;
+						selected_quote = '\0';
+						if (col >= qbegin && col <= qend) {
+							return Point2i(qbegin + 1, row);
+						}
+					} else if (!inside_quotes) {
+						qbegin = i + 1;
+						inside_quotes = true;
+						selected_quote = s[i];
+					}
+				}
+			}
+		}
+
+		return Point2i(beg + 1, row);
+	}
+
+	return Point2i(-1, -1);
+}
+
 Point2i TextEdit::get_line_column_at_pos(const Point2i &p_pos, bool p_allow_out_of_bounds) const {
 	float rows = p_pos.y;
 	rows -= theme_cache.style_normal->get_margin(SIDE_TOP);
@@ -6190,6 +6234,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_local_mouse_pos"), &TextEdit::get_local_mouse_pos);
 
 	ClassDB::bind_method(D_METHOD("get_word_at_pos", "position"), &TextEdit::get_word_at_pos);
+
+	ClassDB::bind_method(D_METHOD("get_word_line_column_at_pos", "position"), &TextEdit::get_word_line_column_at_pos);
 
 	ClassDB::bind_method(D_METHOD("get_line_column_at_pos", "position", "allow_out_of_bounds"), &TextEdit::get_line_column_at_pos, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_pos_at_line_column", "line", "column"), &TextEdit::get_pos_at_line_column);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -806,6 +806,7 @@ public:
 	Point2 get_local_mouse_pos() const;
 
 	String get_word_at_pos(const Vector2 &p_pos) const;
+	Point2i get_word_line_column_at_pos(const Vector2 &p_pos) const;
 
 	Point2i get_line_column_at_pos(const Point2i &p_pos, bool p_allow_out_of_bounds = true) const;
 	Point2i get_pos_at_line_column(int p_line, int p_column) const;


### PR DESCRIPTION
Supersedes #41502
Closes  godotengine/godot-proposals#1393

~~Right now this is just a rebase and basic conversion of #41502 to master, (including CodeEdit changes) I tried to ensure it has a bare minimum functionality testing it, it does properly display the hints, but some things are as of now missed, and I seem to have not gotten documentation to work properly, it'll stay a draft until I can clean this up a bit.~~

This is no longer a direct conversion of #41502, there are things I missed in implementing this proposal in full, I'm not entirely confident this is even a totally correct implementation, hence why I left the initial convert commit (despite being somewhat bugged) unchanged for now and the big reason its still a draft, (the initial conversion was still fairly bugged too and sort of re-implemented rich text popup functionality in CodeEdit) however this does implement many more improvements, alongside some few bugs. I committed this to get eyes on it and to improve this beyond what I've been able to do from this point.

### Improvements
* Hover hints appear on the line below the first character of the hovered symbol 
* Supports hover hints for annotations
* Uses editor settings to enable and modify the hint display
* Relies upon RichTextLabel inside a PopupPanel to display hint text
    * The hint can't currently be focused but it does use a duplicate of the `_add_text_to_rt` function from [/editor/editor_help.cpp](https://github.com/godotengine/godot/blob/005a49704c39d5bbc95d6d15eaab85c4b0ad2a86/editor/editor_help.cpp#L1648).
* Local variables should be able to support descriptions
* All inbuilt classes can display hover hints with descriptions
* CodeEdit only has a new `symbol_hovered(symbol : String, symbol_column_line : Vector2)` signal that ScriptTextEditor relies on for hover hints
* Added `get_word_line_column_at_pos(mouse_pos : Vector2) -> Vector2i` to TextEdit
    * Duplicates `get_word_at_pos` but retrieves the line and column of the first character of the word, used by the `symbol_hovered` signal to abstract the need for retrieving the mouse position.

### Known Issues
* The RichTextLabel may overflow the popup in some cases
* Short symbols may erroneously be wrapped by the RichTextLabel inside the popup
* Hovered symbols may feel incorrect since they do not account for the last character, for single character identifiers this can result in a very deceptively tiny region to activate the hint. (this appears to be the fault of `get_word_at_pos`)
* Symbols inside a `$` may be treated as the type they are named after regardless of whether they're actually based on that type (for example if you named a `Popup` as PopupMenu, the symbol hint for `$PopupMenu` will display a hint for `PopupMenu`)