### PR TITLE
Add text overrun behavior for the theme type selector

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3381,6 +3381,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 
 	theme_type_list = memnew(OptionButton);
 	theme_type_list->set_h_size_flags(SIZE_EXPAND_FILL);
+	theme_type_list->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 	type_list_hb->add_child(theme_type_list);
 	theme_type_list->connect("item_selected", callable_mp(this, &ThemeTypeEditor::_list_type_selected));
 


### PR DESCRIPTION
This PR makes sure that even if a theme type has an unreasonably long name, it will no longer break the editor UI.

![godot windows tools 64_2022-08-04_19-02-29](https://user-images.githubusercontent.com/11782833/182895273-9d5d111a-c770-426b-8052-b572c9180e74.png)

This uses the new text overrun behavior for buttons (https://github.com/godotengine/godot/pull/61819) similar to https://github.com/godotengine/godot/pull/61702. Unfortunately, it doesn't look as nice as it should, because there seems to be a regression in this feature (https://github.com/godotengine/godot/issues/63914).