### PR TITLE
Tests: Silence some intentional errors

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -431,6 +431,7 @@ Error Main::test_setup() {
 
 	/** INITIALIZE SERVERS **/
 	register_server_types();
+	XRServer::set_xr_mode(XRServer::XRMODE_OFF); // Skip in tests.
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
 

--- a/tests/core/io/test_marshalls.h
+++ b/tests/core/io/test_marshalls.h
@@ -254,11 +254,13 @@ TEST_CASE("[Marshalls] Invalid data Variant decoding") {
 	uint8_t some_buffer[1] = { 0x00 };
 	uint8_t out_of_range_type_buffer[4] = { 0xff }; // Greater than Variant::VARIANT_MAX
 
+	ERR_PRINT_OFF;
 	CHECK(decode_variant(variant, some_buffer, /* less than 4 */ 1, &r_len) == ERR_INVALID_DATA);
 	CHECK(r_len == 0);
 
 	CHECK(decode_variant(variant, out_of_range_type_buffer, 4, &r_len) == ERR_INVALID_DATA);
 	CHECK(r_len == 0);
+	ERR_PRINT_ON;
 }
 
 TEST_CASE("[Marshalls] NIL Variant decoding") {

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -299,34 +299,28 @@ TEST_CASE("[AABB] Get longest/shortest axis") {
 			"get_shortest_axis_size() should return the expected value.");
 }
 
-#ifndef _MSC_VER
-#warning Support tests need to be re-done
-#endif
-
-/* Support function was actually broken. As it was fixed, the tests now fail. Tests need to be re-done.
-
 TEST_CASE("[AABB] Get support") {
 	const AABB aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6));
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(1, 0, 0)).is_equal_approx(Vector3(-1.5, 7, 3.5)),
+			aabb.get_support(Vector3(1, 0, 0)).is_equal_approx(Vector3(2.5, 2, -2.5)),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(0.5, 1, 0)).is_equal_approx(Vector3(-1.5, 2, 3.5)),
+			aabb.get_support(Vector3(0.5, 1, 0)).is_equal_approx(Vector3(2.5, 7, -2.5)),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(0.5, 1, -400)).is_equal_approx(Vector3(-1.5, 2, 3.5)),
+			aabb.get_support(Vector3(0.5, 1, -400)).is_equal_approx(Vector3(2.5, 7, -2.5)),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(0, -1, 0)).is_equal_approx(Vector3(2.5, 7, 3.5)),
+			aabb.get_support(Vector3(0, -1, 0)).is_equal_approx(Vector3(-1.5, 2, -2.5)),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3(0, -0.1, 0)).is_equal_approx(Vector3(2.5, 7, 3.5)),
+			aabb.get_support(Vector3(0, -0.1, 0)).is_equal_approx(Vector3(-1.5, 2, -2.5)),
 			"get_support() should return the expected value.");
 	CHECK_MESSAGE(
-			aabb.get_support(Vector3()).is_equal_approx(Vector3(2.5, 7, 3.5)),
+			aabb.get_support(Vector3()).is_equal_approx(Vector3(-1.5, 2, -2.5)),
 			"get_support() should return the expected value with a null vector.");
 }
-*/
+
 TEST_CASE("[AABB] Grow") {
 	const AABB aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6));
 	CHECK_MESSAGE(

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -493,13 +493,13 @@ void add_exposed_classes(Context &r_context) {
 		}
 
 		if (!ClassDB::is_class_exposed(class_name)) {
-			MESSAGE(vformat("Ignoring class '%s' because it's not exposed.", class_name).utf8().get_data());
+			MESSAGE(vformat("Ignoring class '%s' because it's not exposed.", class_name));
 			class_list.pop_front();
 			continue;
 		}
 
 		if (!ClassDB::is_class_enabled(class_name)) {
-			MESSAGE(vformat("Ignoring class '%s' because it's not enabled.", class_name).utf8().get_data());
+			MESSAGE(vformat("Ignoring class '%s' because it's not enabled.", class_name));
 			class_list.pop_front();
 			continue;
 		}

--- a/tests/core/object/test_method_bind.h
+++ b/tests/core/object/test_method_bind.h
@@ -155,7 +155,6 @@ public:
 TEST_CASE("[MethodBind] check all method binds") {
 	MethodBindTester *mbt = memnew(MethodBindTester);
 
-	print_line("testing method bind");
 	mbt->run_tests();
 
 	CHECK(mbt->test_valid[MethodBindTester::TEST_METHOD]);

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -697,7 +697,9 @@ TEST_CASE("[String] sprintf") {
 	format = "fish %-05d frog";
 	args.clear();
 	args.push_back(-5);
+	ERR_PRINT_OFF; // Silence warning about 0 ignored.
 	output = format.sprintf(args, &error);
+	ERR_PRINT_ON;
 	REQUIRE(error == false);
 	CHECK(output == String("fish -5    frog"));
 
@@ -795,7 +797,9 @@ TEST_CASE("[String] sprintf") {
 	format = "fish %-011f frog";
 	args.clear();
 	args.push_back(-99.99);
+	ERR_PRINT_OFF; // Silence warning about 0 ignored.
 	output = format.sprintf(args, &error);
+	ERR_PRINT_ON;
 	REQUIRE(error == false);
 	CHECK(output == String("fish -99.990000  frog"));
 

--- a/tests/core/templates/test_hash_set.h
+++ b/tests/core/templates/test_hash_set.h
@@ -38,7 +38,6 @@
 namespace TestHashSet {
 
 TEST_CASE("[HashSet] Insert element") {
-	print_line("SMALL BEGIN MEM: ", Memory::get_mem_usage());
 	HashSet<int> set;
 	HashSet<int>::Iterator e = set.insert(42);
 
@@ -47,7 +46,6 @@ TEST_CASE("[HashSet] Insert element") {
 	CHECK(set.has(42));
 	CHECK(set.find(42));
 	set.reset();
-	print_line("SMALL END MEM: ", Memory::get_mem_usage());
 }
 
 TEST_CASE("[HashSet] Insert existing element") {

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -291,8 +291,10 @@ TEST_CASE("[Vector] Slice") {
 	CHECK(slice6[1] == 3);
 	CHECK(slice6[2] == 4);
 
+	ERR_PRINT_OFF;
 	Vector<int> slice7 = vector.slice(5, 1);
-	CHECK(slice7.size() == 0);
+	CHECK(slice7.size() == 0); // Expected to fail.
+	ERR_PRINT_ON;
 }
 
 TEST_CASE("[Vector] Find, has") {

--- a/tests/scene/test_sprite_frames.h
+++ b/tests/scene/test_sprite_frames.h
@@ -144,7 +144,7 @@ TEST_CASE("[SpriteFrames] Animation Speed getter and setter") {
 			frames.get_animation_speed(test_animation_name) == 5.0,
 			"Sets new animation to default speed");
 
-	frames.set_animation_speed("GodotTest", 123.0004);
+	frames.set_animation_speed(test_animation_name, 123.0004);
 
 	CHECK_MESSAGE(
 			frames.get_animation_speed(test_animation_name) == 123.0004,
@@ -197,7 +197,7 @@ TEST_CASE("[SpriteFrames] Animation Loop getter and setter") {
 }
 
 // TODO
-TEST_CASE("[SpriteFrames] Frame addition, removal, and retrival") {
+TEST_CASE("[SpriteFrames] Frame addition, removal, and retrieval") {
 	Ref<Texture2D> dummy_frame1;
 	dummy_frame1.instantiate();
 
@@ -212,13 +212,14 @@ TEST_CASE("[SpriteFrames] Frame addition, removal, and retrival") {
 
 	frames.add_frame(test_animation_name, dummy_frame1, 0);
 	frames.add_frame(test_animation_name, dummy_frame1, 1);
+	frames.add_frame(test_animation_name, dummy_frame1, 2);
 
 	CHECK_MESSAGE(
-			frames.get_frame_count(test_animation_name) == 2,
+			frames.get_frame_count(test_animation_name) == 3,
 			"Adds multiple frames");
 
-	frames.remove_frame(test_animation_name, 0);
 	frames.remove_frame(test_animation_name, 1);
+	frames.remove_frame(test_animation_name, 0);
 
 	CHECK_MESSAGE(
 			frames.get_frame_count(test_animation_name) == 1,

--- a/tests/scene/test_theme.h
+++ b/tests/scene/test_theme.h
@@ -101,18 +101,24 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Good theme type names") {
 
 	SUBCASE("set_type_variation") {
 		for (const StringName &name : names) {
+			if (name == StringName()) { // Skip empty here, not allowed.
+				continue;
+			}
 			Ref<Theme> theme = memnew(Theme);
 
 			ErrorDetector ed;
 			theme->set_type_variation(valid_type_name, name);
-			CHECK(ed.has_error == (name == StringName()));
+			CHECK_FALSE(ed.has_error);
 		}
 		for (const StringName &name : names) {
+			if (name == StringName()) { // Skip empty here, not allowed.
+				continue;
+			}
 			Ref<Theme> theme = memnew(Theme);
 
 			ErrorDetector ed;
 			theme->set_type_variation(name, valid_type_name);
-			CHECK(ed.has_error == (name == StringName()));
+			CHECK_FALSE(ed.has_error);
 		}
 	}
 }
@@ -124,6 +130,8 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Bad theme type names") {
 		"With@various$symbols!",
 		String::utf8("contains_汉字"),
 	};
+
+	ERR_PRINT_OFF; // All these rightfully print errors.
 
 	SUBCASE("add_type") {
 		for (const StringName &name : names) {
@@ -175,6 +183,8 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Bad theme type names") {
 			CHECK(ed.has_error);
 		}
 	}
+
+	ERR_PRINT_ON;
 }
 
 TEST_CASE_FIXTURE(Fixture, "[Theme] Good theme item names") {
@@ -223,6 +233,8 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Bad theme item names") {
 		String::utf8("contains_汉字"),
 	};
 
+	ERR_PRINT_OFF; // All these rightfully print errors.
+
 	SUBCASE("set_theme_item") {
 		for (const StringName &name : names) {
 			for (const DataEntry &entry : valid_data) {
@@ -250,6 +262,8 @@ TEST_CASE_FIXTURE(Fixture, "[Theme] Bad theme item names") {
 			}
 		}
 	}
+
+	ERR_PRINT_ON;
 }
 
 } // namespace TestTheme


### PR DESCRIPTION
Also fix printing messages in ClassDB test.

This fixes most of the spam output we used to have when running `--test`.

What remains as of this PR:
```
$ godot-git --test
[doctest] doctest version is "2.4.9"
[doctest] run with "--help" for options
ERROR: The axis Vector3 must be normalized.
   at: set_axis_angle (core/math/basis.cpp:905)
===============================================================================
./tests/core/object/test_class_db.h:837:
TEST SUITE: [ClassDB]
TEST CASE:  [ClassDB] Add exposed classes, builtin types, and global enums

./tests/core/object/test_class_db.h:496: MESSAGE: Ignoring class 'GDScriptEditorTranslationParserPlugin' because it's not exposed.

./tests/core/object/test_class_db.h:496: MESSAGE: Ignoring class 'IPUnix' because it's not exposed.

./tests/core/object/test_class_db.h:496: MESSAGE: Ignoring class 'MovieWriterMJPEG' because it's not exposed.

./tests/core/object/test_class_db.h:496: MESSAGE: Ignoring class 'MovieWriterPNGWAV' because it's not exposed.

===============================================================================
[doctest] test cases:     582 |     582 passed | 0 failed | 1 skipped
[doctest] assertions: 2286494 | 2286494 passed | 0 failed |
[doctest] Status: SUCCESS!
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (core/object/object.cpp:1896)
```

- The `Vector3` error will be fixed by #63912.
- The ClassDB messages should be reviewed - do we want to expose these classes, if not why are they in ClassDB?
- There's 1 skipped test, didn't check which one yet. Would be good to fix and enable again?
- There are leaks on exit. Passing `--verbose` doesn't seem to actually work to get more info.