### PR TITLE
Modified descriptions of 'command' and 'meta'

### DIFF
--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -16,13 +16,15 @@
 			State of the [code]Alt[/code] modifier.
 		</member>
 		<member name="command" type="bool" setter="set_command" getter="get_command" default="false">
-			State of the [code]Command[/code] modifier.
+			State of the [code]Command[/code] modifier. On macOS, this is equivelent to [member meta]. On other platforms, this is equivelent to [member control].
+			This modifier should be preferred to [member control] or [member meta] for system shortcuts, as it maintains better cross-platform comatibility.
 		</member>
 		<member name="control" type="bool" setter="set_control" getter="get_control" default="false">
 			State of the [code]Ctrl[/code] modifier.
 		</member>
 		<member name="meta" type="bool" setter="set_metakey" getter="get_metakey" default="false">
-			State of the [code]Meta[/code] modifier.
+			State of the [code]Meta[/code] modifier. On Windows, this represents the Windows key. On macOS, this represents the command key, and is equivelent to [member command]. 
+			For better cross-system compatibility, use [member command] instead.
 		</member>
 		<member name="shift" type="bool" setter="set_shift" getter="get_shift" default="false">
 			State of the [code]Shift[/code] modifier.

--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -23,7 +23,7 @@
 			State of the [code]Ctrl[/code] modifier.
 		</member>
 		<member name="meta" type="bool" setter="set_metakey" getter="get_metakey" default="false">
-			State of the [code]Meta[/code] modifier. On Windows, this represents the Windows key. On macOS, this represents the command key, and is equivelent to [member command]. 
+			State of the [code]Meta[/code] modifier. On Windows, this represents the Windows key. On macOS, this represents the command key, and is equivelent to [member command].
 			For better cross-system compatibility, use [member command] instead.
 		</member>
 		<member name="shift" type="bool" setter="set_shift" getter="get_shift" default="false">


### PR DESCRIPTION
This has been clarified slightly in the 4.0 documentation, but I thought it would be nice to have it here as well.

When setting up keyboard shortcuts for a recent application, I found this page to be confusing. The description for `meta `was simply 'state of the `meta` modifier,' and this gave me no information as to what the `meta` modifier actually was. In addition, I would have liked to know ahead of time that the `command` modifier took care of many cross platform problems for me, as it would have saved a lot of headache and prolonged if statements.

I do not know what the `meta` modifier does on Linux platforms, so if anyone else can clarify, I would appreciate it.

First time contributing to the documentation, so if I did anything wrong, let me know.
