### PR TITLE
Force disable S3TC support on Android/iOS since we don't handle it

### DIFF
--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -64,7 +64,14 @@ Config::Config() {
 #else
 	float_texture_supported = extensions.has("GL_ARB_texture_float") || extensions.has("GL_OES_texture_float");
 	etc2_supported = true;
+#if defined(ANDROID_ENABLED) || defined(IPHONE_ENABLED)
+	// Some Android devices report support for S3TC but we don't expect that and don't export the textures.
+	// This could be fixed but so few devices support it that it doesn't seem useful (and makes bigger APKs).
+	// For good measure we do the same hack for iOS, just in case.
+	s3tc_supported = false;
+#else
 	s3tc_supported = extensions.has("GL_EXT_texture_compression_dxt1") || extensions.has("GL_EXT_texture_compression_s3tc") || extensions.has("WEBGL_compressed_texture_s3tc");
+#endif
 	rgtc_supported = extensions.has("GL_EXT_texture_compression_rgtc") || extensions.has("GL_ARB_texture_compression_rgtc") || extensions.has("EXT_texture_compression_rgtc");
 #endif
 

--- a/servers/rendering/renderer_rd/storage_rd/utilities.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.cpp
@@ -290,9 +290,14 @@ bool Utilities::has_os_feature(const String &p_feature) const {
 		return true;
 	}
 
+#if !defined(ANDROID_ENABLED) && !defined(IPHONE_ENABLED)
+	// Some Android devices report support for S3TC but we don't expect that and don't export the textures.
+	// This could be fixed but so few devices support it that it doesn't seem useful (and makes bigger APKs).
+	// For good measure we do the same hack for iOS, just in case.
 	if (p_feature == "s3tc" && RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_BC1_RGB_UNORM_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT)) {
 		return true;
 	}
+#endif
 
 	if (p_feature == "bptc" && RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_BC7_UNORM_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT)) {
 		return true;


### PR DESCRIPTION
Fixes #63909 for now.
This could be improved in the future if we want to properly support S3TC on mobile.

Redo of #32255 and #62909 for `master` to "fix" exports to Quest 2.