### PR TITLE
Modified descriptions of 'command' and 'meta'

### DIFF
--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -14,13 +14,15 @@
 			State of the [kbd]Alt[/kbd] modifier.
 		</member>
 		<member name="command_pressed" type="bool" setter="set_command_pressed" getter="is_command_pressed" default="false">
-			State of the [kbd]Cmd[/kbd] modifier.
+			State of the [kbd]Cmd[/kbd] modifier. On macOS, this is equivalent to [member meta_pressed]. On other platforms, this is equivalent to [member ctrl_pressed].
+			This modifier should be preferred to [member ctrl_pressed] or [member meta_pressed] for system shortcuts, as it maintains better cross-platform compatibility.
 		</member>
 		<member name="ctrl_pressed" type="bool" setter="set_ctrl_pressed" getter="is_ctrl_pressed" default="false">
 			State of the [kbd]Ctrl[/kbd] modifier.
 		</member>
 		<member name="meta_pressed" type="bool" setter="set_meta_pressed" getter="is_meta_pressed" default="false">
-			State of the [kbd]Meta[/kbd] modifier.
+			State of the [kbd]Meta[/kbd] modifier. On Windows and Linux, this represents the Windows key (sometimes called "meta" or "super" on Linux). On macOS, this represents the Command key, and is equivalent to [member command_pressed].
+			For better cross-system compatibility, use [member command_pressed] instead.
 		</member>
 		<member name="shift_pressed" type="bool" setter="set_shift_pressed" getter="is_shift_pressed" default="false">
 			State of the [kbd]Shift[/kbd] modifier.


### PR DESCRIPTION
I originally proposed this in the 3.x branch (PR https://github.com/godotengine/godot/pull/63917), but it was suggested that it would also be useful here.

Basically, I noticed a lack of clarity on the descriptions of the `meta` and `command` modifiers within the `InputEventWithModifiers` class. This clarity is partially cleared up with the addition of the `store_command` variable, but I wanted to make it explicit.