### PR TITLE
[Net] IP uses print_verbose when getaddrinfo fails.

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -95,12 +95,12 @@ void IPUnix::_resolve_hostname(List<IPAddress> &r_addresses, const String &p_hos
 
 	int s = getaddrinfo(p_hostname.utf8().get_data(), nullptr, &hints, &result);
 	if (s != 0) {
-		ERR_PRINT("getaddrinfo failed! Cannot resolve hostname.");
+		print_verbose("getaddrinfo failed! Cannot resolve hostname.");
 		return;
 	}
 
 	if (result == nullptr || result->ai_addr == nullptr) {
-		ERR_PRINT("Invalid response from getaddrinfo");
+		print_verbose("Invalid response from getaddrinfo");
 		if (result) {
 			freeaddrinfo(result);
 		}


### PR DESCRIPTION
Avoid spamming errors when network is disconnected.
Returned address will be invalid, so it can be checked by the user via `ret.is_valid_ip_address`.

Fixes #61605