### PR TITLE
Add a Framebuffer cache

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -79,7 +79,7 @@ class RID_Alloc : public RID_AllocBase {
 
 	const char *description = nullptr;
 
-	SpinLock spin_lock;
+	mutable SpinLock spin_lock;
 
 	_FORCE_INLINE_ RID _allocate_rid() {
 		if (THREAD_SAFE) {
@@ -220,7 +220,7 @@ public:
 		memnew_placement(mem, T(p_value));
 	}
 
-	_FORCE_INLINE_ bool owns(const RID &p_rid) {
+	_FORCE_INLINE_ bool owns(const RID &p_rid) const {
 		if (THREAD_SAFE) {
 			spin_lock.lock();
 		}
@@ -292,7 +292,7 @@ public:
 	_FORCE_INLINE_ uint32_t get_rid_count() const {
 		return alloc_count;
 	}
-	void get_owned_list(List<RID> *p_owned) {
+	void get_owned_list(List<RID> *p_owned) const {
 		if (THREAD_SAFE) {
 			spin_lock.lock();
 		}
@@ -308,7 +308,7 @@ public:
 	}
 
 	//used for fast iteration in the elements or RIDs
-	void fill_owned_buffer(RID *p_rid_buffer) {
+	void fill_owned_buffer(RID *p_rid_buffer) const {
 		if (THREAD_SAFE) {
 			spin_lock.lock();
 		}
@@ -402,7 +402,7 @@ public:
 		*ptr = p_new_ptr;
 	}
 
-	_FORCE_INLINE_ bool owns(const RID &p_rid) {
+	_FORCE_INLINE_ bool owns(const RID &p_rid) const {
 		return alloc.owns(p_rid);
 	}
 
@@ -414,11 +414,11 @@ public:
 		return alloc.get_rid_count();
 	}
 
-	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) {
+	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) const {
 		return alloc.get_owned_list(p_owned);
 	}
 
-	void fill_owned_buffer(RID *p_rid_buffer) {
+	void fill_owned_buffer(RID *p_rid_buffer) const {
 		alloc.fill_owned_buffer(p_rid_buffer);
 	}
 
@@ -458,7 +458,7 @@ public:
 		return alloc.get_or_null(p_rid);
 	}
 
-	_FORCE_INLINE_ bool owns(const RID &p_rid) {
+	_FORCE_INLINE_ bool owns(const RID &p_rid) const {
 		return alloc.owns(p_rid);
 	}
 
@@ -470,10 +470,10 @@ public:
 		return alloc.get_rid_count();
 	}
 
-	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) {
+	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) const {
 		return alloc.get_owned_list(p_owned);
 	}
-	void fill_owned_buffer(RID *p_rid_buffer) {
+	void fill_owned_buffer(RID *p_rid_buffer) const {
 		alloc.fill_owned_buffer(p_rid_buffer);
 	}
 

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -305,6 +305,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="framebuffer_is_valid" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="framebuffer" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="free_rid">
 			<return type="void" />
 			<argument index="0" name="rid" type="RID" />

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -392,6 +392,8 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 		uint32_t storage_mask = 0;
 		Vector<RID> texture_ids;
+		InvalidationCallback invalidated_callback = nullptr;
+		void *invalidated_callback_userdata = nullptr;
 
 		struct Version {
 			VkFramebuffer framebuffer = VK_NULL_HANDLE;
@@ -747,7 +749,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 		LocalVector<AttachableTexture> attachable_textures; //used for validation
 		Vector<Texture *> mutable_sampled_textures; //used for layout change
 		Vector<Texture *> mutable_storage_textures; //used for layout change
-		UniformSetInvalidatedCallback invalidated_callback = nullptr;
+		InvalidationCallback invalidated_callback = nullptr;
 		void *invalidated_callback_userdata = nullptr;
 	};
 
@@ -1059,13 +1061,15 @@ public:
 	/*********************/
 
 	virtual FramebufferFormatID framebuffer_format_create(const Vector<AttachmentFormat> &p_format, uint32_t p_view_count = 1);
-	virtual FramebufferFormatID framebuffer_format_create_multipass(const Vector<AttachmentFormat> &p_attachments, Vector<FramebufferPass> &p_passes, uint32_t p_view_count = 1);
+	virtual FramebufferFormatID framebuffer_format_create_multipass(const Vector<AttachmentFormat> &p_attachments, const Vector<FramebufferPass> &p_passes, uint32_t p_view_count = 1);
 	virtual FramebufferFormatID framebuffer_format_create_empty(TextureSamples p_samples = TEXTURE_SAMPLES_1);
 	virtual TextureSamples framebuffer_format_get_texture_samples(FramebufferFormatID p_format, uint32_t p_pass = 0);
 
 	virtual RID framebuffer_create(const Vector<RID> &p_texture_attachments, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1);
-	virtual RID framebuffer_create_multipass(const Vector<RID> &p_texture_attachments, Vector<FramebufferPass> &p_passes, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1);
+	virtual RID framebuffer_create_multipass(const Vector<RID> &p_texture_attachments, const Vector<FramebufferPass> &p_passes, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1);
 	virtual RID framebuffer_create_empty(const Size2i &p_size, TextureSamples p_samples = TEXTURE_SAMPLES_1, FramebufferFormatID p_format_check = INVALID_ID);
+	virtual bool framebuffer_is_valid(RID p_framebuffer) const;
+	virtual void framebuffer_set_invalidation_callback(RID p_framebuffer, InvalidationCallback p_callback, void *p_userdata);
 
 	virtual FramebufferFormatID framebuffer_get_format(RID p_framebuffer);
 
@@ -1110,7 +1114,7 @@ public:
 
 	virtual RID uniform_set_create(const Vector<Uniform> &p_uniforms, RID p_shader, uint32_t p_shader_set);
 	virtual bool uniform_set_is_valid(RID p_uniform_set);
-	virtual void uniform_set_set_invalidation_callback(RID p_uniform_set, UniformSetInvalidatedCallback p_callback, void *p_userdata);
+	virtual void uniform_set_set_invalidation_callback(RID p_uniform_set, InvalidationCallback p_callback, void *p_userdata);
 
 	virtual Error buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data, uint32_t p_post_barrier = BARRIER_MASK_ALL); //works for any buffer
 	virtual Error buffer_clear(RID p_buffer, uint32_t p_offset, uint32_t p_size, uint32_t p_post_barrier = BARRIER_MASK_ALL);

--- a/servers/rendering/renderer_rd/framebuffer_cache_rd.cpp
+++ b/servers/rendering/renderer_rd/framebuffer_cache_rd.cpp
@@ -1,0 +1,64 @@
+/*************************************************************************/
+/*  framebuffer_cache_rd.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "framebuffer_cache_rd.h"
+
+FramebufferCacheRD *FramebufferCacheRD::singleton = nullptr;
+
+void FramebufferCacheRD::_invalidate(Cache *p_cache) {
+	if (p_cache->prev) {
+		p_cache->prev->next = p_cache->next;
+	} else {
+		// At beginning of table
+		uint32_t table_idx = p_cache->hash % HASH_TABLE_SIZE;
+		hash_table[table_idx] = p_cache->next;
+	}
+
+	if (p_cache->next) {
+		p_cache->next->prev = p_cache->prev;
+	}
+
+	cache_allocator.free(p_cache);
+	cache_instances_used--;
+}
+void FramebufferCacheRD::_framebuffer_invalidation_callback(void *p_userdata) {
+	singleton->_invalidate(reinterpret_cast<Cache *>(p_userdata));
+}
+
+FramebufferCacheRD::FramebufferCacheRD() {
+	ERR_FAIL_COND(singleton != nullptr);
+	singleton = this;
+}
+
+FramebufferCacheRD::~FramebufferCacheRD() {
+	if (cache_instances_used > 0) {
+		ERR_PRINT("At exit: " + itos(cache_instances_used) + " framebuffer cache instance(s) still in use.");
+	}
+}

--- a/servers/rendering/renderer_rd/framebuffer_cache_rd.h
+++ b/servers/rendering/renderer_rd/framebuffer_cache_rd.h
@@ -1,0 +1,310 @@
+/*************************************************************************/
+/*  framebuffer_cache_rd.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef FRAMEBUFFER_CACHE_RD_H
+#define FRAMEBUFFER_CACHE_RD_H
+
+#include "core/templates/local_vector.h"
+#include "core/templates/paged_allocator.h"
+#include "servers/rendering/rendering_device.h"
+
+class FramebufferCacheRD : public Object {
+	GDCLASS(FramebufferCacheRD, Object)
+
+	struct Cache {
+		Cache *prev = nullptr;
+		Cache *next = nullptr;
+		uint32_t hash = 0;
+		RID cache;
+		LocalVector<RID> textures;
+		LocalVector<RD::FramebufferPass> passes;
+		uint32_t views = 0;
+	};
+
+	PagedAllocator<Cache> cache_allocator;
+
+	enum {
+		HASH_TABLE_SIZE = 16381 // Prime
+	};
+
+	Cache *hash_table[HASH_TABLE_SIZE] = {};
+
+	static _FORCE_INLINE_ uint32_t _hash_pass(const RD::FramebufferPass &p, uint32_t h) {
+		h = hash_murmur3_one_32(p.depth_attachment, h);
+		h = hash_murmur3_one_32(p.vrs_attachment, h);
+
+		h = hash_murmur3_one_32(p.color_attachments.size(), h);
+		for (int i = 0; i < p.color_attachments.size(); i++) {
+			h = hash_murmur3_one_32(p.color_attachments[i], h);
+		}
+
+		h = hash_murmur3_one_32(p.resolve_attachments.size(), h);
+		for (int i = 0; i < p.resolve_attachments.size(); i++) {
+			h = hash_murmur3_one_32(p.resolve_attachments[i], h);
+		}
+
+		h = hash_murmur3_one_32(p.preserve_attachments.size(), h);
+		for (int i = 0; i < p.preserve_attachments.size(); i++) {
+			h = hash_murmur3_one_32(p.preserve_attachments[i], h);
+		}
+
+		return h;
+	}
+
+	static _FORCE_INLINE_ bool _compare_pass(const RD::FramebufferPass &a, const RD::FramebufferPass &b) {
+		if (a.depth_attachment != b.depth_attachment) {
+			return false;
+		}
+
+		if (a.vrs_attachment != b.vrs_attachment) {
+			return false;
+		}
+
+		if (a.color_attachments.size() != b.color_attachments.size()) {
+			return false;
+		}
+
+		for (int i = 0; i < a.color_attachments.size(); i++) {
+			if (a.color_attachments[i] != b.color_attachments[i]) {
+				return false;
+			}
+		}
+
+		if (a.resolve_attachments.size() != b.resolve_attachments.size()) {
+			return false;
+		}
+
+		for (int i = 0; i < a.resolve_attachments.size(); i++) {
+			if (a.resolve_attachments[i] != b.resolve_attachments[i]) {
+				return false;
+			}
+		}
+
+		if (a.preserve_attachments.size() != b.preserve_attachments.size()) {
+			return false;
+		}
+
+		for (int i = 0; i < a.preserve_attachments.size(); i++) {
+			if (a.preserve_attachments[i] != b.preserve_attachments[i]) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	_FORCE_INLINE_ uint32_t _hash_rids(uint32_t h, const RID &arg) {
+		return hash_murmur3_one_64(arg.get_id(), h);
+	}
+
+	template <typename... Args>
+	uint32_t _hash_rids(uint32_t h, const RID &arg, Args... args) {
+		h = hash_murmur3_one_64(arg.get_id(), h);
+		return _hash_rids(h, args...);
+	}
+
+	_FORCE_INLINE_ bool _compare_args(uint32_t idx, const LocalVector<RID> &textures, const RID &arg) {
+		return textures[idx] == arg;
+	}
+
+	template <typename... Args>
+	_FORCE_INLINE_ bool _compare_args(uint32_t idx, const LocalVector<RID> &textures, const RID &arg, Args... args) {
+		if (textures[idx] != arg) {
+			return false;
+		}
+		return _compare_args(idx + 1, textures, args...);
+	}
+
+	_FORCE_INLINE_ void _create_args(Vector<RID> &textures, const RID &arg) {
+		textures.push_back(arg);
+	}
+
+	template <typename... Args>
+	_FORCE_INLINE_ void _create_args(Vector<RID> &textures, const RID &arg, Args... args) {
+		textures.push_back(arg);
+		_create_args(textures, args...);
+	}
+
+	static FramebufferCacheRD *singleton;
+
+	uint32_t cache_instances_used = 0;
+
+	void _invalidate(Cache *p_cache);
+	static void _framebuffer_invalidation_callback(void *p_userdata);
+
+	RID _allocate_from_data(uint32_t p_views, uint32_t p_hash, uint32_t p_table_idx, const Vector<RID> &p_textures, const Vector<RD::FramebufferPass> &p_passes) {
+		RID rid;
+		if (p_passes.size()) {
+			rid = RD::get_singleton()->framebuffer_create_multipass(p_textures, p_passes, RD::INVALID_ID, p_views);
+		} else {
+			rid = RD::get_singleton()->framebuffer_create(p_textures, RD::INVALID_ID, p_views);
+		}
+
+		ERR_FAIL_COND_V(rid.is_null(), rid);
+
+		Cache *c = cache_allocator.alloc();
+		c->views = p_views;
+		c->cache = rid;
+		c->hash = p_hash;
+		c->textures.resize(p_textures.size());
+		for (uint32_t i = 0; i < c->textures.size(); i++) {
+			c->textures[i] = p_textures[i];
+		}
+		c->passes.resize(p_passes.size());
+		for (uint32_t i = 0; i < c->passes.size(); i++) {
+			c->passes[i] = p_passes[i];
+		}
+		c->prev = nullptr;
+		c->next = hash_table[p_table_idx];
+		if (hash_table[p_table_idx]) {
+			hash_table[p_table_idx]->prev = c;
+		}
+		hash_table[p_table_idx] = c;
+
+		RD::get_singleton()->framebuffer_set_invalidation_callback(rid, _framebuffer_invalidation_callback, c);
+
+		cache_instances_used++;
+
+		return rid;
+	}
+
+public:
+	template <typename... Args>
+	RID get_cache(Args... args) {
+		uint32_t h = hash_murmur3_one_32(1); //1 view
+		h = hash_murmur3_one_32(sizeof...(Args), h);
+		h = _hash_args(h, args...);
+		h = hash_murmur3_one_32(0, h); // 0 passes
+		h = hash_fmix32(h);
+
+		uint32_t table_idx = h % HASH_TABLE_SIZE;
+		{
+			const Cache *c = hash_table[table_idx];
+
+			while (c) {
+				if (c->hash == h && c->passes.size() == 0 && c->textures.size() == sizeof...(Args) && c->views == 1 && _compare_args(0, c->textures, args...)) {
+					return c->cache;
+				}
+				c = c->next;
+			}
+		}
+
+		// Not in cache, create:
+
+		Vector<RID> textures;
+		_create_args(textures, args...);
+
+		return _allocate_from_data(1, h, table_idx, textures, Vector<RD::FramebufferPass>());
+	}
+
+	template <typename... Args>
+	RID get_cache_multiview(uint32_t p_views, Args... args) {
+		uint32_t h = hash_murmur3_one_32(p_views);
+		h = hash_murmur3_one_32(sizeof...(Args), h);
+		h = _hash_args(h, args...);
+		h = hash_murmur3_one_32(0, h); // 0 passes
+		h = hash_fmix32(h);
+
+		uint32_t table_idx = h % HASH_TABLE_SIZE;
+		{
+			const Cache *c = hash_table[table_idx];
+
+			while (c) {
+				if (c->hash == h && c->passes.size() == 0 && c->textures.size() == sizeof...(Args) && c->views == p_views && _compare_args(0, c->textures, args...)) {
+					return c->cache;
+				}
+				c = c->next;
+			}
+		}
+
+		// Not in cache, create:
+
+		Vector<RID> textures;
+		_create_args(textures, args...);
+
+		return _allocate_from_data(p_views, h, table_idx, textures, Vector<RD::FramebufferPass>());
+	}
+
+	RID get_cache_multipass(const Vector<RID> &p_textures, const Vector<RD::FramebufferPass> &p_passes, uint32_t p_views = 1) {
+		uint32_t h = hash_murmur3_one_32(p_views);
+		h = hash_murmur3_one_32(p_textures.size());
+		for (int i = 0; i < p_textures.size(); i++) {
+			h = hash_murmur3_one_64(p_textures[i].get_id(), h);
+		}
+		h = hash_murmur3_one_32(p_passes.size());
+		for (int i = 0; i < p_passes.size(); i++) {
+			h = _hash_pass(p_passes[i], h);
+		}
+
+		h = hash_fmix32(h);
+
+		uint32_t table_idx = h % HASH_TABLE_SIZE;
+		{
+			const Cache *c = hash_table[table_idx];
+
+			while (c) {
+				if (c->hash == h && c->views == p_views && c->textures.size() == (uint32_t)p_textures.size() && c->passes.size() == (uint32_t)p_passes.size()) {
+					bool all_ok = true;
+
+					for (int i = 0; i < p_textures.size(); i++) {
+						if (p_textures[i] != c->textures[i]) {
+							all_ok = false;
+							break;
+						}
+					}
+
+					if (all_ok) {
+						for (int i = 0; i < p_passes.size(); i++) {
+							if (!_compare_pass(p_passes[i], c->passes[i])) {
+								all_ok = false;
+								break;
+							}
+						}
+					}
+
+					if (all_ok) {
+						return c->cache;
+					}
+				}
+				c = c->next;
+			}
+		}
+
+		// Not in cache, create:
+		return _allocate_from_data(p_views, h, table_idx, p_textures, p_passes);
+	}
+
+	static FramebufferCacheRD *get_singleton() { return singleton; }
+
+	FramebufferCacheRD();
+	~FramebufferCacheRD();
+};
+
+#endif // FRAMEBUFFER_CACHE_RD_H

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -249,6 +249,7 @@ RendererCompositorRD *RendererCompositorRD::singleton = nullptr;
 
 RendererCompositorRD::RendererCompositorRD() {
 	uniform_set_cache = memnew(UniformSetCacheRD);
+	framebuffer_cache = memnew(FramebufferCacheRD);
 
 	{
 		String shader_cache_dir = Engine::get_singleton()->get_shader_cache_path();
@@ -316,5 +317,6 @@ RendererCompositorRD::RendererCompositorRD() {
 
 RendererCompositorRD::~RendererCompositorRD() {
 	memdelete(uniform_set_cache);
+	memdelete(framebuffer_cache);
 	ShaderRD::set_shader_cache_dir(String());
 }

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -37,6 +37,7 @@
 #include "servers/rendering/renderer_rd/environment/fog.h"
 #include "servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h"
 #include "servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h"
+#include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
 #include "servers/rendering/renderer_rd/renderer_canvas_render_rd.h"
 #include "servers/rendering/renderer_rd/shaders/blit.glsl.gen.h"
 #include "servers/rendering/renderer_rd/storage_rd/light_storage.h"
@@ -50,6 +51,7 @@
 class RendererCompositorRD : public RendererCompositor {
 protected:
 	UniformSetCacheRD *uniform_set_cache = nullptr;
+	FramebufferCacheRD *framebuffer_cache = nullptr;
 	RendererCanvasRenderRD *canvas = nullptr;
 	RendererRD::Utilities *utilities = nullptr;
 	RendererRD::LightStorage *light_storage = nullptr;

--- a/servers/rendering/renderer_rd/uniform_set_cache_rd.h
+++ b/servers/rendering/renderer_rd/uniform_set_cache_rd.h
@@ -163,7 +163,7 @@ public:
 			const Cache *c = hash_table[table_idx];
 
 			while (c) {
-				if (c->hash == h && c->set == p_set && c->shader == p_shader && _compare_args(0, c->uniforms, args...)) {
+				if (c->hash == h && c->set == p_set && c->shader == p_shader && sizeof...(Args) == c->uniforms.size() && _compare_args(0, c->uniforms, args...)) {
 					return c->cache;
 				}
 				c = c->next;
@@ -193,7 +193,7 @@ public:
 			const Cache *c = hash_table[table_idx];
 
 			while (c) {
-				if (c->hash == h && c->set == p_set && c->shader == p_shader) {
+				if (c->hash == h && c->set == p_set && c->shader == p_shader && (uint32_t)p_uniforms.size() == c->uniforms.size()) {
 					bool all_ok = true;
 					for (int i = 0; i < p_uniforms.size(); i++) {
 						if (!_compare_uniform(p_uniforms[i], c->uniforms[i])) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -387,6 +387,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("framebuffer_create_multipass", "textures", "passes", "validate_with_format", "view_count"), &RenderingDevice::_framebuffer_create_multipass, DEFVAL(INVALID_FORMAT_ID), DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("framebuffer_create_empty", "size", "samples", "validate_with_format"), &RenderingDevice::framebuffer_create_empty, DEFVAL(TEXTURE_SAMPLES_1), DEFVAL(INVALID_FORMAT_ID));
 	ClassDB::bind_method(D_METHOD("framebuffer_get_format", "framebuffer"), &RenderingDevice::framebuffer_get_format);
+	ClassDB::bind_method(D_METHOD("framebuffer_is_valid", "framebuffer"), &RenderingDevice::framebuffer_is_valid);
 
 	ClassDB::bind_method(D_METHOD("sampler_create", "state"), &RenderingDevice::_sampler_create);
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -129,6 +129,8 @@ public:
 	typedef Vector<uint8_t> (*ShaderCompileToSPIRVFunction)(ShaderStage p_stage, const String &p_source_code, ShaderLanguage p_language, String *r_error, const RenderingDevice *p_render_device);
 	typedef Vector<uint8_t> (*ShaderCacheFunction)(ShaderStage p_stage, const String &p_source_code, ShaderLanguage p_language);
 
+	typedef void (*InvalidationCallback)(void *);
+
 private:
 	static ShaderCompileToSPIRVFunction compile_to_spirv_function;
 	static ShaderCacheFunction cache_function;
@@ -547,13 +549,15 @@ public:
 		int32_t vrs_attachment = ATTACHMENT_UNUSED; // density map for VRS, only used if supported
 	};
 
-	virtual FramebufferFormatID framebuffer_format_create_multipass(const Vector<AttachmentFormat> &p_attachments, Vector<FramebufferPass> &p_passes, uint32_t p_view_count = 1) = 0;
+	virtual FramebufferFormatID framebuffer_format_create_multipass(const Vector<AttachmentFormat> &p_attachments, const Vector<FramebufferPass> &p_passes, uint32_t p_view_count = 1) = 0;
 	virtual FramebufferFormatID framebuffer_format_create_empty(TextureSamples p_samples = TEXTURE_SAMPLES_1) = 0;
 	virtual TextureSamples framebuffer_format_get_texture_samples(FramebufferFormatID p_format, uint32_t p_pass = 0) = 0;
 
 	virtual RID framebuffer_create(const Vector<RID> &p_texture_attachments, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1) = 0;
-	virtual RID framebuffer_create_multipass(const Vector<RID> &p_texture_attachments, Vector<FramebufferPass> &p_passes, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1) = 0;
+	virtual RID framebuffer_create_multipass(const Vector<RID> &p_texture_attachments, const Vector<FramebufferPass> &p_passes, FramebufferFormatID p_format_check = INVALID_ID, uint32_t p_view_count = 1) = 0;
 	virtual RID framebuffer_create_empty(const Size2i &p_size, TextureSamples p_samples = TEXTURE_SAMPLES_1, FramebufferFormatID p_format_check = INVALID_ID) = 0;
+	virtual bool framebuffer_is_valid(RID p_framebuffer) const = 0;
+	virtual void framebuffer_set_invalidation_callback(RID p_framebuffer, InvalidationCallback p_callback, void *p_userdata) = 0;
 
 	virtual FramebufferFormatID framebuffer_get_format(RID p_framebuffer) = 0;
 
@@ -793,8 +797,7 @@ public:
 
 	virtual RID uniform_set_create(const Vector<Uniform> &p_uniforms, RID p_shader, uint32_t p_shader_set) = 0;
 	virtual bool uniform_set_is_valid(RID p_uniform_set) = 0;
-	typedef void (*UniformSetInvalidatedCallback)(void *);
-	virtual void uniform_set_set_invalidation_callback(RID p_uniform_set, UniformSetInvalidatedCallback p_callback, void *p_userdata) = 0;
+	virtual void uniform_set_set_invalidation_callback(RID p_uniform_set, InvalidationCallback p_callback, void *p_userdata) = 0;
 
 	virtual Error buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const void *p_data, uint32_t p_post_barrier = BARRIER_MASK_ALL) = 0;
 	virtual Error buffer_clear(RID p_buffer, uint32_t p_offset, uint32_t p_size, uint32_t p_post_barrier = BARRIER_MASK_ALL) = 0;


### PR DESCRIPTION
Adds a FramebufferCache singleton that operates the same way as UniformSetCache. This is required for the rendering reorganization work.

Allows creating framebuffers on the fly (and keep them cached if re-requested) such as:

```C++
RID fb = FramebufferCache::get_singleton()->get_cache(texture1,texture2);
```

As plus, fixed a potential crash bug in UniformSetCache and cost corrected RID_Owner.
