### PR TITLE
Implement `screen_is_kept_on` for macOS.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -303,6 +303,7 @@ public:
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual void screen_set_keep_on(bool p_enable) override;
+	virtual bool screen_is_kept_on() const override;
 
 	virtual Vector<int> get_window_list() const override;
 

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1892,6 +1892,10 @@ float DisplayServerMacOS::screen_get_refresh_rate(int p_screen) const {
 	return SCREEN_REFRESH_RATE_FALLBACK;
 }
 
+bool DisplayServerMacOS::screen_is_kept_on() const {
+	return (screen_keep_on_assertion);
+}
+
 void DisplayServerMacOS::screen_set_keep_on(bool p_enable) {
 	if (screen_keep_on_assertion) {
 		IOPMAssertionRelease(screen_keep_on_assertion);


### PR DESCRIPTION
Adds `keep_screen_on` getter to the macOS display server (I have missed it in #63900).