### PR TITLE
Move rotation interpolation logic from PathFollower2D to Curve2D

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -102,6 +102,22 @@
 				Cubic interpolation tends to follow the curves better, but linear is faster (and often, precise enough).
 			</description>
 		</method>
+		<method name="sample_baked_with_rotation" qualifiers="const">
+			<return type="Transform2D" />
+			<param index="0" name="offset" type="float" />
+			<param index="1" name="cubic" type="bool" default="false" />
+			<param index="2" name="loop" type="bool" default="true" />
+			<param index="3" name="lookahead" type="float" default="4.0" />
+			<description>
+				Similar to [method sample_baked], but returns [Transform2D] that includes a rotation along the curve. Returns empty transform if length of the curve is [code]0[/code].
+				Use [param loop] to smooth the tangent at the end of the curve. [param lookahead] defines the distance to a nearby point for calculating the tangent vector.
+				[codeblock]
+				var transform = curve.sample_baked_with_rotation(offset)
+				position = transform.get_origin()
+				rotation = transform.get_rotation()
+				[/codeblock]
+			</description>
+		</method>
 		<method name="samplef" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="fofs" type="float" />

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -216,6 +216,7 @@ public:
 
 	real_t get_baked_length() const;
 	Vector2 sample_baked(real_t p_offset, bool p_cubic = false) const;
+	Transform2D sample_baked_with_rotation(real_t p_offset, bool p_cubic = false, bool p_loop = true, real_t p_lookahead = 4.0) const;
 	PackedVector2Array get_baked_points() const; //useful for going through
 	Vector2 get_closest_point(const Vector2 &p_to_point) const;
 	real_t get_closest_offset(const Vector2 &p_to_point) const;


### PR DESCRIPTION
Move the rotation interpolation logic from PathFollower2D to Curve2D, for two reasons:
1. theoretically sampling is a natural operation on curve
2. practically sample curve without PathFollower2D is more efficient for projects that need to sample a lot of curves (For example, urban road network traffic simulation game)

There are two commits in this pull request. The first add an rotation sampling method on Curve2D, with code from PathFollower2D. The second reimplement the
`_update_transform` method on PathFollower2D with the new sampling method.
