### PR TITLE
Round icon position and size in buttons to make them look sharper

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -258,7 +258,8 @@ void Button::_notification(int p_what) {
 				}
 
 				if (icon_region.size.width > 0) {
-					draw_texture_rect_region(_icon, icon_region, Rect2(Point2(), _icon->get_size()), color_icon);
+					Rect2 icon_region_rounded = Rect2(icon_region.position.round(), icon_region.size.round());
+					draw_texture_rect(_icon, icon_region_rounded, false, color_icon);
 				}
 			}
 


### PR DESCRIPTION
I'm not sure if this is a good fix, but it's a naïve one that seems to work for now. For the longest time in 4.0 I've noticed that at an editor scale >100% buttons have blurry icons. It affected all the buttons, but it didn't affect the same icons used in `TextureRect`s, for example. Even though both would render the button at the same size.

I'd tried to spot if there is any difference between the approach to submitting a texture to render in `Button` and in `TextureRect`, but I could find nothing. I'd checked, and the blurred texture was still the same size as it was supposed to be, just a bit offset. So I assumed that it may be something related to floating point imprecision. I don't see any code that rounds position and scale in `TextureRect`, but maybe it just happens by accident because the source values it uses for positioining are already rounded. Not sure.

However, when I'd tried to round position and size of icons in buttons, it did help. It can create an uneven offset, because we're dealing with small pixel sizes at this point, but it works as a naïve approach, as I've already mentioned. Maybe there is a way to force pixel snapping for icons in GUI that would work better? I guess this issue would return if your UI element is anchored to some non-integer position, so this is definitely not a cure. But it makes the editor look way better.

So up to reviewers to decide, I guess!

Comparison screenshots (_the extra pair of icons on the toolbar are for testing/demo, not a part of the actual UI nor of this PR; but notice how one is blurry and another is sharp in the "before" — the sharp one is TextureRect_).

![all-before](https://user-images.githubusercontent.com/11782833/183081742-57bd2f43-5a94-4f62-9b3f-bac35af56bdd.png)
![all-later](https://user-images.githubusercontent.com/11782833/183081751-09af2566-a006-4ab7-a302-59c25a71098d.png)

-----
Not sure why button used the `*_region` method there, since it copied the entire size of the original texture anyway. I can revert that part if there is a reason for that.