### PR TITLE
Remove rect_ prefix from control properties when keyframing

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -144,7 +144,7 @@
 				# This code block is part of a script that inherits from Node3D.
 				# `control` is a reference to a node inheriting from Control.
 				control.visible = not get_viewport().get_camera_3d().is_position_behind(global_transform.origin)
-				control.rect_position = get_viewport().get_camera_3d().unproject_position(global_transform.origin)
+				control.position = get_viewport().get_camera_3d().unproject_position(global_transform.origin)
 				[/codeblock]
 			</description>
 		</method>

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4237,13 +4237,13 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 			Control *ctrl = Object::cast_to<Control>(canvas_item);
 
 			if (key_pos) {
-				te->insert_node_value_key(ctrl, "rect_position", ctrl->get_position(), p_on_existing);
+				te->insert_node_value_key(ctrl, "position", ctrl->get_position(), p_on_existing);
 			}
 			if (key_rot) {
-				te->insert_node_value_key(ctrl, "rect_rotation", ctrl->get_rotation(), p_on_existing);
+				te->insert_node_value_key(ctrl, "rotation", ctrl->get_rotation(), p_on_existing);
 			}
 			if (key_scale) {
-				te->insert_node_value_key(ctrl, "rect_size", ctrl->get_size(), p_on_existing);
+				te->insert_node_value_key(ctrl, "size", ctrl->get_size(), p_on_existing);
 			}
 		}
 	}

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -450,7 +450,7 @@ void GraphNode::_validate_property(PropertyInfo &property) const {
 	Control::_validate_property(property);
 	GraphEdit *graph = Object::cast_to<GraphEdit>(get_parent());
 	if (graph) {
-		if (property.name == "rect_position") {
+		if (property.name == "position") {
 			property.usage |= PROPERTY_USAGE_READ_ONLY;
 		}
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #63948 
Not sure about changing that also in scene/gui/graph_node.cpp

Noob question: there is a bunch of doc files mentioning the properties with the rect_ prefix as well, including in all language translations.
Should I update all those files as well ? or are they somehow generated ?