### PR TITLE
Replace Array return types with TypedArray (part 1)

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -36,6 +36,7 @@
 #include "core/io/json.h"
 #include "core/license.gen.h"
 #include "core/os/os.h"
+#include "core/variant/typed_array.h"
 #include "core/version.h"
 
 void Engine::set_physics_ticks_per_second(int p_ips) {
@@ -136,8 +137,8 @@ Dictionary Engine::get_author_info() const {
 	return dict;
 }
 
-Array Engine::get_copyright_info() const {
-	Array components;
+TypedArray<Dictionary> Engine::get_copyright_info() const {
+	TypedArray<Dictionary> components;
 	for (int component_index = 0; component_index < COPYRIGHT_INFO_COUNT; component_index++) {
 		const ComponentCopyright &cp_info = COPYRIGHT_INFO[component_index];
 		Dictionary component_dict;

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -36,6 +36,9 @@
 #include "core/templates/list.h"
 #include "core/templates/vector.h"
 
+template <typename T>
+class TypedArray;
+
 class Engine {
 public:
 	struct Singleton {
@@ -139,7 +142,7 @@ public:
 
 	Dictionary get_version_info() const;
 	Dictionary get_author_info() const;
-	Array get_copyright_info() const;
+	TypedArray<Dictionary> get_copyright_info() const;
 	Dictionary get_donor_info() const;
 	Dictionary get_license_info() const;
 	String get_license_text() const;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -39,6 +39,7 @@
 #include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"
 #include "core/os/keyboard.h"
+#include "core/variant/typed_array.h"
 
 namespace core_bind {
 
@@ -2022,10 +2023,10 @@ Dictionary ClassDB::get_signal(StringName p_class, StringName p_signal) const {
 	}
 }
 
-Array ClassDB::get_signal_list(StringName p_class, bool p_no_inheritance) const {
+TypedArray<Dictionary> ClassDB::get_signal_list(StringName p_class, bool p_no_inheritance) const {
 	List<MethodInfo> signals;
 	::ClassDB::get_signal_list(p_class, &signals, p_no_inheritance);
-	Array ret;
+	TypedArray<Dictionary> ret;
 
 	for (const MethodInfo &E : signals) {
 		ret.push_back(E.operator Dictionary());
@@ -2034,10 +2035,10 @@ Array ClassDB::get_signal_list(StringName p_class, bool p_no_inheritance) const 
 	return ret;
 }
 
-Array ClassDB::get_property_list(StringName p_class, bool p_no_inheritance) const {
+TypedArray<Dictionary> ClassDB::get_property_list(StringName p_class, bool p_no_inheritance) const {
 	List<PropertyInfo> plist;
 	::ClassDB::get_property_list(p_class, &plist, p_no_inheritance);
-	Array ret;
+	TypedArray<Dictionary> ret;
 	for (const PropertyInfo &E : plist) {
 		ret.push_back(E.operator Dictionary());
 	}
@@ -2066,10 +2067,10 @@ bool ClassDB::has_method(StringName p_class, StringName p_method, bool p_no_inhe
 	return ::ClassDB::has_method(p_class, p_method, p_no_inheritance);
 }
 
-Array ClassDB::get_method_list(StringName p_class, bool p_no_inheritance) const {
+TypedArray<Dictionary> ClassDB::get_method_list(StringName p_class, bool p_no_inheritance) const {
 	List<MethodInfo> methods;
 	::ClassDB::get_method_list(p_class, &methods, p_no_inheritance);
-	Array ret;
+	TypedArray<Dictionary> ret;
 
 	for (const MethodInfo &E : methods) {
 #ifdef DEBUG_METHODS_ENABLED
@@ -2254,7 +2255,7 @@ Dictionary Engine::get_author_info() const {
 	return ::Engine::get_singleton()->get_author_info();
 }
 
-Array Engine::get_copyright_info() const {
+TypedArray<Dictionary> Engine::get_copyright_info() const {
 	return ::Engine::get_singleton()->get_copyright_info();
 }
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -45,6 +45,8 @@
 #include "core/templates/safe_refcount.h"
 
 class MainLoop;
+template <typename T>
+class TypedArray;
 
 namespace core_bind {
 
@@ -602,15 +604,15 @@ public:
 
 	bool has_signal(StringName p_class, StringName p_signal) const;
 	Dictionary get_signal(StringName p_class, StringName p_signal) const;
-	Array get_signal_list(StringName p_class, bool p_no_inheritance = false) const;
+	TypedArray<Dictionary> get_signal_list(StringName p_class, bool p_no_inheritance = false) const;
 
-	Array get_property_list(StringName p_class, bool p_no_inheritance = false) const;
+	TypedArray<Dictionary> get_property_list(StringName p_class, bool p_no_inheritance = false) const;
 	Variant get_property(Object *p_object, const StringName &p_property) const;
 	Error set_property(Object *p_object, const StringName &p_property, const Variant &p_value) const;
 
 	bool has_method(StringName p_class, StringName p_method, bool p_no_inheritance = false) const;
 
-	Array get_method_list(StringName p_class, bool p_no_inheritance = false) const;
+	TypedArray<Dictionary> get_method_list(StringName p_class, bool p_no_inheritance = false) const;
 
 	PackedStringArray get_integer_constant_list(const StringName &p_class, bool p_no_inheritance = false) const;
 	bool has_integer_constant(const StringName &p_class, const StringName &p_name) const;
@@ -661,7 +663,7 @@ public:
 
 	Dictionary get_version_info() const;
 	Dictionary get_author_info() const;
-	Array get_copyright_info() const;
+	TypedArray<Dictionary> get_copyright_info() const;
 	Dictionary get_donor_info() const;
 	Dictionary get_license_info() const;
 	String get_license_text() const;

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -209,8 +209,8 @@ bool AStar3D::has_point(int64_t p_id) const {
 	return points.has(p_id);
 }
 
-Array AStar3D::get_point_ids() {
-	Array point_list;
+PackedInt64Array AStar3D::get_point_ids() {
+	PackedInt64Array point_list;
 
 	for (OAHashMap<int64_t, Point *>::Iterator it = points.iter(); it.valid; it = points.next_iter(it)) {
 		point_list.push_back(*(it.key));
@@ -605,7 +605,7 @@ Vector<int64_t> AStar2D::get_point_connections(int64_t p_id) {
 	return astar.get_point_connections(p_id);
 }
 
-Array AStar2D::get_point_ids() {
+PackedInt64Array AStar2D::get_point_ids() {
 	return astar.get_point_ids();
 }
 

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -133,7 +133,7 @@ public:
 	void remove_point(int64_t p_id);
 	bool has_point(int64_t p_id) const;
 	Vector<int64_t> get_point_connections(int64_t p_id);
-	Array get_point_ids();
+	PackedInt64Array get_point_ids();
 
 	void set_point_disabled(int64_t p_id, bool p_disabled = true);
 	bool is_point_disabled(int64_t p_id) const;
@@ -183,7 +183,7 @@ public:
 	void remove_point(int64_t p_id);
 	bool has_point(int64_t p_id) const;
 	Vector<int64_t> get_point_connections(int64_t p_id);
-	Array get_point_ids();
+	PackedInt64Array get_point_ids();
 
 	void set_point_disabled(int64_t p_id, bool p_disabled = true);
 	bool is_point_disabled(int64_t p_id) const;

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -218,7 +218,7 @@
 			</description>
 		</method>
 		<method name="get_point_ids">
-			<return type="Array" />
+			<return type="PackedInt64Array" />
 			<description>
 				Returns an array of all point IDs.
 			</description>

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -245,7 +245,7 @@
 			</description>
 		</method>
 		<method name="get_point_ids">
-			<return type="Array" />
+			<return type="PackedInt64Array" />
 			<description>
 				Returns an array of all point IDs.
 			</description>

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -30,7 +30,7 @@
 			</description>
 		</method>
 		<method name="capture_get_device_list">
-			<return type="Array" />
+			<return type="PackedStringArray" />
 			<description>
 				Returns the names of all audio input devices detected on the system.
 			</description>
@@ -117,7 +117,7 @@
 			</description>
 		</method>
 		<method name="get_device_list">
-			<return type="Array" />
+			<return type="PackedStringArray" />
 			<description>
 				Returns the names of all audio devices detected on the system.
 			</description>

--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -58,7 +58,7 @@
 			</description>
 		</method>
 		<method name="opaque_to_polygons" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedVector2Array[]" />
 			<param index="0" name="rect" type="Rect2" />
 			<param index="1" name="epsilon" type="float" default="2.0" />
 			<description>

--- a/doc/classes/ButtonGroup.xml
+++ b/doc/classes/ButtonGroup.xml
@@ -11,7 +11,7 @@
 	</tutorials>
 	<methods>
 		<method name="get_buttons">
-			<return type="Array" />
+			<return type="BaseButton[]" />
 			<description>
 				Returns an [Array] of [Button]s who have this as their [ButtonGroup] (see [member BaseButton.button_group]).
 			</description>

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -37,7 +37,7 @@
 			</description>
 		</method>
 		<method name="get_frustum" qualifiers="const">
-			<return type="Array" />
+			<return type="Plane[]" />
 			<description>
 				Returns the camera's frustum planes in world space units as an array of [Plane]s in the following order: near, far, left, top, right, bottom. Not to be confused with [member frustum_offset].
 			</description>

--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -19,7 +19,7 @@
 			</description>
 		</method>
 		<method name="feeds">
-			<return type="Array" />
+			<return type="CameraFeed[]" />
 			<description>
 				Returns an array of [CameraFeed]s.
 			</description>

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -66,7 +66,7 @@
 			</description>
 		</method>
 		<method name="class_get_method_list" qualifiers="const">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
@@ -83,7 +83,7 @@
 			</description>
 		</method>
 		<method name="class_get_property_list" qualifiers="const">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
@@ -99,7 +99,7 @@
 			</description>
 		</method>
 		<method name="class_get_signal_list" qualifiers="const">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -18,7 +18,7 @@
 			</description>
 		</method>
 		<method name="_filter_code_completion_candidates" qualifiers="virtual const">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<param index="0" name="candidates" type="Dictionary[]" />
 			<description>
 				Override this method to define what items in [param candidates] should be displayed.
@@ -159,13 +159,13 @@
 			</description>
 		</method>
 		<method name="get_bookmarked_lines" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedInt32Array" />
 			<description>
 				Gets all bookmarked lines.
 			</description>
 		</method>
 		<method name="get_breakpointed_lines" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedInt32Array" />
 			<description>
 				Gets all breakpointed lines.
 			</description>
@@ -226,7 +226,7 @@
 			</description>
 		</method>
 		<method name="get_executing_lines" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedInt32Array" />
 			<description>
 				Gets all executing lines.
 			</description>

--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -55,7 +55,7 @@
 			</description>
 		</method>
 		<method name="get_shape_owners">
-			<return type="Array" />
+			<return type="PackedInt32Array" />
 			<description>
 				Returns an [Array] of [code]owner_id[/code] identifiers. You can use these ids in other methods that take [code]owner_id[/code] as an argument.
 			</description>

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -49,7 +49,7 @@
 			</description>
 		</method>
 		<method name="get_shape_owners">
-			<return type="Array" />
+			<return type="PackedInt32Array" />
 			<description>
 				Returns an [Array] of [code]owner_id[/code] identifiers. You can use these ids in other methods that take [code]owner_id[/code] as an argument.
 			</description>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -196,7 +196,7 @@
 			</description>
 		</method>
 		<method name="_structured_text_parser" qualifiers="virtual const">
-			<return type="Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="args" type="Array" />
 			<param index="1" name="text" type="String" />
 			<description>

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -105,7 +105,7 @@
 			</description>
 		</method>
 		<method name="get_display_cutouts" qualifiers="const">
-			<return type="Array" />
+			<return type="Rect2[]" />
 			<description>
 				Returns an [Array] of [Rect2], each of which is the bounding rectangle for a display cutout or notch. These are non-functional areas on edge-to-edge screens used by cameras and sensors. Returns an empty array if the device does not have cutouts. See also [method get_display_safe_area].
 				[b]Note:[/b] Currently only implemented on Android. Other platforms will return an empty array even if they do have display cutouts or notches.
@@ -857,7 +857,7 @@
 			</description>
 		</method>
 		<method name="tts_get_voices" qualifiers="const">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<description>
 				Returns an [Array] of voice information dictionaries.
 				Each [Dictionary] contains two [String] entries:

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -115,7 +115,7 @@
 	</tutorials>
 	<methods>
 		<method name="_get_import_options" qualifiers="virtual const">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="preset_index" type="int" />
 			<description>

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -101,7 +101,7 @@
 			</description>
 		</method>
 		<method name="get_open_scenes" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedStringArray" />
 			<description>
 				Returns an [Array] with the file paths of the currently opened scenes.
 			</description>
@@ -166,7 +166,7 @@
 			</description>
 		</method>
 		<method name="make_mesh_previews">
-			<return type="Array" />
+			<return type="Texture2D[]" />
 			<param index="0" name="meshes" type="Array" />
 			<param index="1" name="preview_size" type="int" />
 			<description>

--- a/doc/classes/EditorSelection.xml
+++ b/doc/classes/EditorSelection.xml
@@ -31,7 +31,7 @@
 			</description>
 		</method>
 		<method name="get_transformable_selected_nodes">
-			<return type="Array" />
+			<return type="Node[]" />
 			<description>
 				Gets the list of selected nodes, optimized for transform operations (i.e. moving them, rotating, etc). This list avoids situations where a node is selected and also child/grandchild.
 			</description>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -85,7 +85,7 @@
 			</description>
 		</method>
 		<method name="get_changed_settings" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedStringArray" />
 			<description>
 				Gets an array of the settings which have been changed since the last save. Note that internally [code]changed_settings[/code] is cleared after a successful save, so generally the most appropriate place to use this method is when processing [constant NOTIFICATION_EDITOR_SETTINGS_CHANGED]
 			</description>

--- a/doc/classes/EditorSyntaxHighlighter.xml
+++ b/doc/classes/EditorSyntaxHighlighter.xml
@@ -17,7 +17,7 @@
 			</description>
 		</method>
 		<method name="_get_supported_languages" qualifiers="virtual const">
-			<return type="Array" />
+			<return type="PackedStringArray" />
 			<description>
 				Virtual method which can be overridden to return the supported language names.
 			</description>

--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -17,7 +17,7 @@
 			</description>
 		</method>
 		<method name="get_file_diff">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<param index="0" name="file_path" type="String" />
 			<description>
 				Returns an [Array] of [Dictionary] objects containing the diff output from the VCS in use, if a VCS addon is initialized, else returns an empty [Array] object. The diff contents also consist of some contextual lines which provide context to the observed line change in the file.

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -34,7 +34,7 @@
 			</description>
 		</method>
 		<method name="get_copyright_info" qualifiers="const">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<description>
 				Returns an Array of copyright information Dictionaries.
 				[code]name[/code]    - String, component name

--- a/doc/classes/FontFile.xml
+++ b/doc/classes/FontFile.xml
@@ -146,7 +146,7 @@
 			</description>
 		</method>
 		<method name="get_glyph_list" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedInt32Array" />
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
@@ -199,7 +199,7 @@
 			</description>
 		</method>
 		<method name="get_kerning_list" qualifiers="const">
-			<return type="Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="cache_index" type="int" />
 			<param index="1" name="size" type="int" />
 			<description>
@@ -233,7 +233,7 @@
 			</description>
 		</method>
 		<method name="get_size_cache_list" qualifiers="const">
-			<return type="Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="cache_index" type="int" />
 			<description>
 				Returns list of the font sizes in the cache. Each size is [code]Vector2i[/code] with font size and outline size.

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -188,7 +188,7 @@
 			</description>
 		</method>
 		<method name="font_get_glyph_list" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedInt32Array" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
@@ -268,7 +268,7 @@
 			</description>
 		</method>
 		<method name="font_get_kerning_list" qualifiers="const">
-			<return type="Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
@@ -349,7 +349,7 @@
 			</description>
 		</method>
 		<method name="font_get_size_cache_list" qualifiers="const">
-			<return type="Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
 				Returns list of the font sizes in the cache. Each size is [code]Vector2i[/code] with font size and outline size.
@@ -993,7 +993,7 @@
 			</description>
 		</method>
 		<method name="parse_structured_text" qualifiers="const">
-			<return type="Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="parser_type" type="int" enum="TextServer.StructuredTextParser" />
 			<param index="1" name="args" type="Array" />
 			<param index="2" name="text" type="String" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -180,7 +180,7 @@
 			</description>
 		</method>
 		<method name="font_get_glyph_list" qualifiers="virtual const">
-			<return type="Array" />
+			<return type="PackedInt32Array" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
@@ -258,7 +258,7 @@
 			</description>
 		</method>
 		<method name="font_get_kerning_list" qualifiers="virtual const">
-			<return type="Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
@@ -339,7 +339,7 @@
 			</description>
 		</method>
 		<method name="font_get_size_cache_list" qualifiers="virtual const">
-			<return type="Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
 				Returns list of the font sizes in the cache. Each size is [code]Vector2i[/code] with font size and outline size.

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -50,7 +50,7 @@ Error AudioDriverALSA::init_device() {
 
 	// If there is a specified device check that it is really present
 	if (device_name != "Default") {
-		Array list = get_device_list();
+		PackedStringArray list = get_device_list();
 		if (list.find(device_name) == -1) {
 			device_name = "Default";
 			new_device = "Default";
@@ -266,8 +266,8 @@ AudioDriver::SpeakerMode AudioDriverALSA::get_speaker_mode() const {
 	return speaker_mode;
 }
 
-Array AudioDriverALSA::get_device_list() {
-	Array list;
+PackedStringArray AudioDriverALSA::get_device_list() {
+	PackedStringArray list;
 
 	list.push_back("Default");
 

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -77,7 +77,7 @@ public:
 	virtual void start();
 	virtual int get_mix_rate() const;
 	virtual SpeakerMode get_speaker_mode() const;
-	virtual Array get_device_list();
+	virtual PackedStringArray get_device_list();
 	virtual String get_device();
 	virtual void set_device(String device);
 	virtual void lock();

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -493,8 +493,8 @@ Error AudioDriverCoreAudio::capture_stop() {
 
 #ifdef MACOS_ENABLED
 
-Array AudioDriverCoreAudio::_get_device_list(bool capture) {
-	Array list;
+PackedStringArray AudioDriverCoreAudio::_get_device_list(bool capture) {
+	PackedStringArray list;
 
 	list.push_back("Default");
 
@@ -637,7 +637,7 @@ void AudioDriverCoreAudio::_set_device(const String &device, bool capture) {
 	}
 }
 
-Array AudioDriverCoreAudio::get_device_list() {
+PackedStringArray AudioDriverCoreAudio::get_device_list() {
 	return _get_device_list();
 }
 
@@ -659,7 +659,7 @@ void AudioDriverCoreAudio::capture_set_device(const String &p_name) {
 	}
 }
 
-Array AudioDriverCoreAudio::capture_get_device_list() {
+PackedStringArray AudioDriverCoreAudio::capture_get_device_list() {
 	return _get_device_list(true);
 }
 

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -59,7 +59,7 @@ class AudioDriverCoreAudio : public AudioDriver {
 	Vector<int16_t> input_buf;
 
 #ifdef MACOS_ENABLED
-	Array _get_device_list(bool capture = false);
+	PackedStringArray _get_device_list(bool capture = false);
 	void _set_device(const String &device, bool capture = false);
 
 	static OSStatus input_device_address_cb(AudioObjectID inObjectID,
@@ -107,11 +107,11 @@ public:
 	void stop();
 
 #ifdef MACOS_ENABLED
-	virtual Array get_device_list();
+	virtual PackedStringArray get_device_list();
 	virtual String get_device();
 	virtual void set_device(String device);
 
-	virtual Array capture_get_device_list();
+	virtual PackedStringArray capture_get_device_list();
 	virtual void capture_set_device(const String &p_name);
 	virtual String capture_get_device();
 #endif

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -178,7 +178,7 @@ Error AudioDriverPulseAudio::detect_channels(bool capture) {
 Error AudioDriverPulseAudio::init_device() {
 	// If there is a specified device check that it is really present
 	if (device_name != "Default") {
-		Array list = get_device_list();
+		PackedStringArray list = get_device_list();
 		if (list.find(device_name) == -1) {
 			device_name = "Default";
 			new_device = "Default";
@@ -599,7 +599,7 @@ void AudioDriverPulseAudio::pa_sinklist_cb(pa_context *c, const pa_sink_info *l,
 	ad->pa_status++;
 }
 
-Array AudioDriverPulseAudio::get_device_list() {
+PackedStringArray AudioDriverPulseAudio::get_device_list() {
 	pa_devices.clear();
 	pa_devices.push_back("Default");
 
@@ -681,7 +681,7 @@ void AudioDriverPulseAudio::finish() {
 Error AudioDriverPulseAudio::capture_init_device() {
 	// If there is a specified device check that it is really present
 	if (capture_device_name != "Default") {
-		Array list = capture_get_device_list();
+		PackedStringArray list = capture_get_device_list();
 		if (list.find(capture_device_name) == -1) {
 			capture_device_name = "Default";
 			capture_new_device = "Default";
@@ -785,7 +785,7 @@ void AudioDriverPulseAudio::pa_sourcelist_cb(pa_context *c, const pa_source_info
 	ad->pa_status++;
 }
 
-Array AudioDriverPulseAudio::capture_get_device_list() {
+PackedStringArray AudioDriverPulseAudio::capture_get_device_list() {
 	pa_rec_devices.clear();
 	pa_rec_devices.push_back("Default");
 

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -67,8 +67,8 @@ class AudioDriverPulseAudio : public AudioDriver {
 	int channels = 0;
 	int pa_ready = 0;
 	int pa_status = 0;
-	Array pa_devices;
-	Array pa_rec_devices;
+	PackedStringArray pa_devices;
+	PackedStringArray pa_rec_devices;
 
 	bool active = false;
 	bool thread_exited = false;
@@ -103,11 +103,11 @@ public:
 	virtual int get_mix_rate() const;
 	virtual SpeakerMode get_speaker_mode() const;
 
-	virtual Array get_device_list();
+	virtual PackedStringArray get_device_list();
 	virtual String get_device();
 	virtual void set_device(String device);
 
-	virtual Array capture_get_device_list();
+	virtual PackedStringArray capture_get_device_list();
 	virtual void capture_set_device(const String &p_name);
 	virtual String capture_get_device();
 

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -553,8 +553,8 @@ AudioDriver::SpeakerMode AudioDriverWASAPI::get_speaker_mode() const {
 	return get_speaker_mode_by_total_channels(channels);
 }
 
-Array AudioDriverWASAPI::audio_device_get_list(bool p_capture) {
-	Array list;
+PackedStringArray AudioDriverWASAPI::audio_device_get_list(bool p_capture) {
+	PackedStringArray list;
 	IMMDeviceCollection *devices = nullptr;
 	IMMDeviceEnumerator *enumerator = nullptr;
 
@@ -563,14 +563,14 @@ Array AudioDriverWASAPI::audio_device_get_list(bool p_capture) {
 	CoInitialize(nullptr);
 
 	HRESULT hr = CoCreateInstance(CLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL, IID_IMMDeviceEnumerator, (void **)&enumerator);
-	ERR_FAIL_COND_V(hr != S_OK, Array());
+	ERR_FAIL_COND_V(hr != S_OK, PackedStringArray());
 
 	hr = enumerator->EnumAudioEndpoints(p_capture ? eCapture : eRender, DEVICE_STATE_ACTIVE, &devices);
-	ERR_FAIL_COND_V(hr != S_OK, Array());
+	ERR_FAIL_COND_V(hr != S_OK, PackedStringArray());
 
 	UINT count = 0;
 	hr = devices->GetCount(&count);
-	ERR_FAIL_COND_V(hr != S_OK, Array());
+	ERR_FAIL_COND_V(hr != S_OK, PackedStringArray());
 
 	for (ULONG i = 0; i < count; i++) {
 		IMMDevice *device = nullptr;
@@ -600,7 +600,7 @@ Array AudioDriverWASAPI::audio_device_get_list(bool p_capture) {
 	return list;
 }
 
-Array AudioDriverWASAPI::get_device_list() {
+PackedStringArray AudioDriverWASAPI::get_device_list() {
 	return audio_device_get_list(false);
 }
 
@@ -950,7 +950,7 @@ void AudioDriverWASAPI::capture_set_device(const String &p_name) {
 	unlock();
 }
 
-Array AudioDriverWASAPI::capture_get_device_list() {
+PackedStringArray AudioDriverWASAPI::capture_get_device_list() {
 	return audio_device_get_list(true);
 }
 

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -91,7 +91,7 @@ class AudioDriverWASAPI : public AudioDriver {
 
 	Error audio_device_init(AudioDeviceWASAPI *p_device, bool p_capture, bool reinit);
 	Error audio_device_finish(AudioDeviceWASAPI *p_device);
-	Array audio_device_get_list(bool p_capture);
+	PackedStringArray audio_device_get_list(bool p_capture);
 
 public:
 	virtual const char *get_name() const {
@@ -103,7 +103,7 @@ public:
 	virtual int get_mix_rate() const;
 	virtual float get_latency();
 	virtual SpeakerMode get_speaker_mode() const;
-	virtual Array get_device_list();
+	virtual PackedStringArray get_device_list();
 	virtual String get_device();
 	virtual void set_device(String device);
 	virtual void lock();
@@ -112,7 +112,7 @@ public:
 
 	virtual Error capture_start();
 	virtual Error capture_stop();
-	virtual Array capture_get_device_list();
+	virtual PackedStringArray capture_get_device_list();
 	virtual void capture_set_device(const String &p_name);
 	virtual String capture_get_device();
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1789,7 +1789,7 @@ void CodeTextEditor::toggle_bookmark() {
 }
 
 void CodeTextEditor::goto_next_bookmark() {
-	Array bmarks = text_editor->get_bookmarked_lines();
+	PackedInt32Array bmarks = text_editor->get_bookmarked_lines();
 	if (bmarks.size() <= 0) {
 		return;
 	}
@@ -1813,7 +1813,7 @@ void CodeTextEditor::goto_next_bookmark() {
 }
 
 void CodeTextEditor::goto_prev_bookmark() {
-	Array bmarks = text_editor->get_bookmarked_lines();
+	PackedInt32Array bmarks = text_editor->get_bookmarked_lines();
 	if (bmarks.size() <= 0) {
 		return;
 	}

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1143,8 +1143,8 @@ void EditorSelection::_emit_change() {
 	emitted = false;
 }
 
-Array EditorSelection::_get_transformable_selected_nodes() {
-	Array ret;
+TypedArray<Node> EditorSelection::_get_transformable_selected_nodes() {
+	TypedArray<Node> ret;
 
 	for (const Node *E : selected_node_list) {
 		ret.push_back(E);

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -271,7 +271,7 @@ class EditorSelection : public Object {
 	List<Node *> selected_node_list;
 
 	void _update_node_list();
-	Array _get_transformable_selected_nodes();
+	TypedArray<Node> _get_transformable_selected_nodes();
 	void _emit_change();
 
 protected:

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -48,7 +48,7 @@
 #include "scene/gui/popup_menu.h"
 #include "servers/rendering_server.h"
 
-Array EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_size) {
+TypedArray<Texture2D> EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_size) {
 	Vector<Ref<Mesh>> meshes;
 
 	for (int i = 0; i < p_meshes.size(); i++) {
@@ -56,7 +56,7 @@ Array EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_
 	}
 
 	Vector<Ref<Texture2D>> textures = make_mesh_previews(meshes, nullptr, p_preview_size);
-	Array ret;
+	TypedArray<Texture2D> ret;
 	for (int i = 0; i < textures.size(); i++) {
 		ret.push_back(textures[i]);
 	}
@@ -216,8 +216,8 @@ Node *EditorInterface::get_edited_scene_root() {
 	return EditorNode::get_singleton()->get_edited_scene();
 }
 
-Array EditorInterface::get_open_scenes() const {
-	Array ret;
+PackedStringArray EditorInterface::get_open_scenes() const {
+	PackedStringArray ret;
 	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
 
 	int scns_amount = scenes.size();

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -67,7 +67,7 @@ protected:
 	static void _bind_methods();
 	static EditorInterface *singleton;
 
-	Array _make_mesh_previews(const Array &p_meshes, int p_preview_size);
+	TypedArray<Texture2D> _make_mesh_previews(const Array &p_meshes, int p_preview_size);
 
 public:
 	static EditorInterface *get_singleton() { return singleton; }
@@ -87,7 +87,7 @@ public:
 	String get_playing_scene() const;
 
 	Node *get_edited_scene_root();
-	Array get_open_scenes() const;
+	PackedStringArray get_open_scenes() const;
 	ScriptEditor *get_script_editor();
 
 	EditorCommandPalette *get_command_palette() const;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -963,8 +963,8 @@ void EditorSettings::save() {
 	}
 }
 
-Array EditorSettings::get_changed_settings() const {
-	Array arr;
+PackedStringArray EditorSettings::get_changed_settings() const {
+	PackedStringArray arr;
 	for (const String &setting : changed_settings) {
 		arr.push_back(setting);
 	}

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -141,7 +141,7 @@ public:
 		}
 	}
 	void add_property_hint(const PropertyInfo &p_hint);
-	Array get_changed_settings() const;
+	PackedStringArray get_changed_settings() const;
 	bool check_changed_settings_in_group(const String &p_setting_prefix) const;
 	void mark_setting_changed(const String &p_setting);
 

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -82,8 +82,8 @@ void EditorVCSInterface::_unstage_file(String p_file_path) {
 void EditorVCSInterface::_commit(String p_msg) {
 }
 
-Array EditorVCSInterface::_get_file_diff(String p_file_path) {
-	return Array();
+TypedArray<Dictionary> EditorVCSInterface::_get_file_diff(String p_file_path) {
+	return TypedArray<Dictionary>();
 }
 
 bool EditorVCSInterface::_shut_down() {
@@ -133,11 +133,11 @@ void EditorVCSInterface::commit(String p_msg) {
 	}
 }
 
-Array EditorVCSInterface::get_file_diff(String p_file_path) {
+TypedArray<Dictionary> EditorVCSInterface::get_file_diff(String p_file_path) {
 	if (is_addon_ready()) {
 		return call("_get_file_diff", p_file_path);
 	}
-	return Array();
+	return TypedArray<Dictionary>();
 }
 
 bool EditorVCSInterface::shut_down() {

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -52,7 +52,7 @@ protected:
 	virtual void _stage_file(String p_file_path);
 	virtual void _unstage_file(String p_file_path);
 	virtual void _commit(String p_msg);
-	virtual Array _get_file_diff(String p_file_path);
+	virtual TypedArray<Dictionary> _get_file_diff(String p_file_path);
 	virtual bool _shut_down();
 	virtual String _get_project_name();
 	virtual String _get_vcs_name();
@@ -76,7 +76,7 @@ public:
 	void stage_file(String p_file_path);
 	void unstage_file(String p_file_path);
 	void commit(String p_msg);
-	Array get_file_diff(String p_file_path);
+	TypedArray<Dictionary> get_file_diff(String p_file_path);
 	bool shut_down();
 	String get_project_name();
 	String get_vcs_name();

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -115,7 +115,7 @@ void EditorImportPlugin::get_import_options(const String &p_path, List<ResourceI
 	Array needed;
 	needed.push_back("name");
 	needed.push_back("default_value");
-	Array options;
+	TypedArray<Dictionary> options;
 	if (GDVIRTUAL_CALL(_get_import_options, p_path, p_preset, options)) {
 		for (int i = 0; i < options.size(); i++) {
 			Dictionary d = options[i];

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -32,6 +32,7 @@
 #define EDITOR_IMPORT_PLUGIN_H
 
 #include "core/io/resource_importer.h"
+#include "core/variant/typed_array.h"
 
 class EditorImportPlugin : public ResourceImporter {
 	GDCLASS(EditorImportPlugin, ResourceImporter);
@@ -44,7 +45,7 @@ protected:
 	GDVIRTUAL0RC(int, _get_preset_count)
 	GDVIRTUAL1RC(String, _get_preset_name, int)
 	GDVIRTUAL0RC(Vector<String>, _get_recognized_extensions)
-	GDVIRTUAL2RC(Array, _get_import_options, String, int)
+	GDVIRTUAL2RC(TypedArray<Dictionary>, _get_import_options, String, int)
 	GDVIRTUAL0RC(String, _get_save_extension)
 	GDVIRTUAL0RC(String, _get_resource_type)
 	GDVIRTUAL0RC(float, _get_priority)

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -66,12 +66,12 @@ String EditorSyntaxHighlighter::_get_name() const {
 	return "Unnamed";
 }
 
-Array EditorSyntaxHighlighter::_get_supported_languages() const {
-	Array ret;
+PackedStringArray EditorSyntaxHighlighter::_get_supported_languages() const {
+	PackedStringArray ret;
 	if (GDVIRTUAL_CALL(_get_supported_languages, ret)) {
 		return ret;
 	}
-	return Array();
+	return PackedStringArray();
 }
 
 Ref<EditorSyntaxHighlighter> EditorSyntaxHighlighter::_create() const {
@@ -1732,7 +1732,7 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 			continue;
 		}
 
-		Array bpoints = se->get_breakpoints();
+		PackedInt32Array bpoints = se->get_breakpoints();
 		for (int j = 0; j < bpoints.size(); j++) {
 			p_breakpoints->push_back(base + ":" + itos((int)bpoints[j] + 1));
 		}
@@ -2380,8 +2380,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 			se->add_syntax_highlighter(highlighter);
 
 			if (script != nullptr && !highlighter_set) {
-				Array languages = highlighter->_get_supported_languages();
-				if (languages.find(script->get_language()->get_name()) > -1) {
+				PackedStringArray languages = highlighter->_get_supported_languages();
+				if (languages.has(script->get_language()->get_name())) {
 					se->set_syntax_highlighter(highlighter);
 					highlighter_set = true;
 				}

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -59,11 +59,11 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL0RC(String, _get_name)
-	GDVIRTUAL0RC(Array, _get_supported_languages)
+	GDVIRTUAL0RC(PackedStringArray, _get_supported_languages)
 
 public:
 	virtual String _get_name() const;
-	virtual Array _get_supported_languages() const;
+	virtual PackedStringArray _get_supported_languages() const;
 
 	void _set_edited_resource(const Ref<Resource> &p_res) { edited_resourse = p_res; }
 	Ref<RefCounted> _get_edited_resource() { return edited_resourse; }
@@ -156,7 +156,7 @@ public:
 	virtual void ensure_focus() = 0;
 	virtual void tag_saved_version() = 0;
 	virtual void reload(bool p_soft) {}
-	virtual Array get_breakpoints() = 0;
+	virtual PackedInt32Array get_breakpoints() = 0;
 	virtual void set_breakpoint(int p_line, bool p_enabled) = 0;
 	virtual void clear_breakpoints() = 0;
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) = 0;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -596,7 +596,7 @@ void ScriptTextEditor::_update_bookmark_list() {
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
 
-	Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
+	PackedInt32Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
 	if (bookmark_list.size() == 0) {
 		return;
 	}
@@ -751,7 +751,7 @@ void ScriptTextEditor::_update_breakpoint_list() {
 	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_breakpoint"), DEBUG_GOTO_NEXT_BREAKPOINT);
 	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_breakpoint"), DEBUG_GOTO_PREV_BREAKPOINT);
 
-	Array breakpoint_list = code_editor->get_text_editor()->get_breakpointed_lines();
+	PackedInt32Array breakpoint_list = code_editor->get_text_editor()->get_breakpointed_lines();
 	if (breakpoint_list.size() == 0) {
 		return;
 	}
@@ -1264,7 +1264,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			EditorDebuggerNode::get_singleton()->set_breakpoint(script->get_path(), line + 1, dobreak);
 		} break;
 		case DEBUG_REMOVE_ALL_BREAKPOINTS: {
-			Array bpoints = tx->get_breakpointed_lines();
+			PackedInt32Array bpoints = tx->get_breakpointed_lines();
 
 			for (int i = 0; i < bpoints.size(); i++) {
 				int line = bpoints[i];
@@ -1274,7 +1274,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			}
 		} break;
 		case DEBUG_GOTO_NEXT_BREAKPOINT: {
-			Array bpoints = tx->get_breakpointed_lines();
+			PackedInt32Array bpoints = tx->get_breakpointed_lines();
 			if (bpoints.size() <= 0) {
 				return;
 			}
@@ -1300,7 +1300,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 		} break;
 		case DEBUG_GOTO_PREV_BREAKPOINT: {
-			Array bpoints = tx->get_breakpointed_lines();
+			PackedInt32Array bpoints = tx->get_breakpointed_lines();
 			if (bpoints.size() <= 0) {
 				return;
 			}
@@ -1441,7 +1441,7 @@ void ScriptTextEditor::reload(bool p_soft) {
 	scr->get_language()->reload_tool_script(scr, soft);
 }
 
-Array ScriptTextEditor::get_breakpoints() {
+PackedInt32Array ScriptTextEditor::get_breakpoints() {
 	return code_editor->get_text_editor()->get_breakpointed_lines();
 }
 

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -229,7 +229,7 @@ public:
 	virtual void clear_executing_line() override;
 
 	virtual void reload(bool p_soft) override;
-	virtual Array get_breakpoints() override;
+	virtual PackedInt32Array get_breakpoints() override;
 	virtual void set_breakpoint(int p_line, bool p_enabled) override;
 	virtual void clear_breakpoints() override;
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -994,7 +994,7 @@ void ShaderEditor::_update_bookmark_list() {
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
 
-	Array bookmark_list = shader_editor->get_text_editor()->get_bookmarked_lines();
+	PackedInt32Array bookmark_list = shader_editor->get_text_editor()->get_bookmarked_lines();
 	if (bookmark_list.size() == 0) {
 		return;
 	}

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -128,8 +128,8 @@ Control *TextEditor::get_base_editor() const {
 	return code_editor->get_text_editor();
 }
 
-Array TextEditor::get_breakpoints() {
-	return Array();
+PackedInt32Array TextEditor::get_breakpoints() {
+	return PackedInt32Array();
 }
 
 void TextEditor::reload_text() {
@@ -165,7 +165,7 @@ void TextEditor::_update_bookmark_list() {
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_next_bookmark"), BOOKMARK_GOTO_NEXT);
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/goto_previous_bookmark"), BOOKMARK_GOTO_PREV);
 
-	Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
+	PackedInt32Array bookmark_list = code_editor->get_text_editor()->get_bookmarked_lines();
 	if (bookmark_list.size() == 0) {
 		return;
 	}

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -118,7 +118,7 @@ public:
 	virtual Variant get_edit_state() override;
 	virtual void set_edit_state(const Variant &p_state) override;
 	virtual Vector<String> get_functions() override;
-	virtual Array get_breakpoints() override;
+	virtual PackedInt32Array get_breakpoints() override;
 	virtual void set_breakpoint(int p_line, bool p_enabled) override{};
 	virtual void clear_breakpoints() override{};
 	virtual void goto_line(int p_line, bool p_with_error = false) override;

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -242,7 +242,7 @@ void VersionControlEditorPlugin::_view_file_diff() {
 }
 
 void VersionControlEditorPlugin::_display_file_diff(String p_file_path) {
-	Array diff_content = EditorVCSInterface::get_singleton()->get_file_diff(p_file_path);
+	TypedArray<Dictionary> diff_content = EditorVCSInterface::get_singleton()->get_file_diff(p_file_path);
 
 	diff_file_name->set_text(p_file_path);
 

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -526,8 +526,8 @@ String GDScriptSyntaxHighlighter::_get_name() const {
 	return "GDScript";
 }
 
-Array GDScriptSyntaxHighlighter::_get_supported_languages() const {
-	Array languages;
+PackedStringArray GDScriptSyntaxHighlighter::_get_supported_languages() const {
+	PackedStringArray languages;
 	languages.push_back("GDScript");
 	return languages;
 }

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -88,7 +88,7 @@ public:
 	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) override;
 
 	virtual String _get_name() const override;
-	virtual Array _get_supported_languages() const override;
+	virtual PackedStringArray _get_supported_languages() const override;
 
 	virtual Ref<EditorSyntaxHighlighter> _create() const override;
 };

--- a/modules/regex/doc_classes/RegEx.xml
+++ b/modules/regex/doc_classes/RegEx.xml
@@ -76,7 +76,7 @@
 			</description>
 		</method>
 		<method name="get_names" qualifiers="const">
-			<return type="Array" />
+			<return type="PackedStringArray" />
 			<description>
 				Returns an array of names of named capturing groups in the compiled pattern. They are ordered by appearance.
 			</description>

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -351,8 +351,8 @@ int RegEx::get_group_count() const {
 	return count;
 }
 
-Array RegEx::get_names() const {
-	Array result;
+PackedStringArray RegEx::get_names() const {
+	PackedStringArray result;
 
 	ERR_FAIL_COND_V(!is_valid(), result);
 

--- a/modules/regex/regex.h
+++ b/modules/regex/regex.h
@@ -94,7 +94,7 @@ public:
 	bool is_valid() const;
 	String get_pattern() const;
 	int get_group_count() const;
-	Array get_names() const;
+	PackedStringArray get_names() const;
 
 	RegEx();
 	RegEx(const String &p_pattern);

--- a/modules/regex/tests/test_regex.h
+++ b/modules/regex/tests/test_regex.h
@@ -46,7 +46,7 @@ TEST_CASE("[RegEx] Initialization") {
 	CHECK(re1.get_pattern() == pattern);
 	CHECK(re1.get_group_count() == 1);
 
-	Array names = re1.get_names();
+	PackedStringArray names = re1.get_names();
 	CHECK(names.size() == 1);
 	CHECK(names[0] == "vowel");
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2170,12 +2170,12 @@ double TextServerAdvanced::font_get_oversampling(const RID &p_font_rid) const {
 	return fd->oversampling;
 }
 
-Array TextServerAdvanced::font_get_size_cache_list(const RID &p_font_rid) const {
+TypedArray<Vector2i> TextServerAdvanced::font_get_size_cache_list(const RID &p_font_rid) const {
 	FontAdvanced *fd = font_owner.get_or_null(p_font_rid);
-	ERR_FAIL_COND_V(!fd, Array());
+	ERR_FAIL_COND_V(!fd, TypedArray<Vector2i>());
 
 	MutexLock lock(fd->mutex);
-	Array ret;
+	TypedArray<Vector2i> ret;
 	for (const KeyValue<Vector2i, FontForSizeAdvanced *> &E : fd->cache) {
 		ret.push_back(E.key);
 	}
@@ -2454,15 +2454,15 @@ PackedInt32Array TextServerAdvanced::font_get_texture_offsets(const RID &p_font_
 	return tex.offsets;
 }
 
-Array TextServerAdvanced::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
+PackedInt32Array TextServerAdvanced::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
 	FontAdvanced *fd = font_owner.get_or_null(p_font_rid);
-	ERR_FAIL_COND_V(!fd, Array());
+	ERR_FAIL_COND_V(!fd, PackedInt32Array());
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Array());
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), PackedInt32Array());
 
-	Array ret;
+	PackedInt32Array ret;
 	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
 	for (const KeyValue<int32_t, FontGlyph> &E : gl) {
 		ret.push_back(E.key);
@@ -2811,16 +2811,16 @@ Dictionary TextServerAdvanced::font_get_glyph_contours(const RID &p_font_rid, in
 #endif
 }
 
-Array TextServerAdvanced::font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
+TypedArray<Vector2i> TextServerAdvanced::font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
 	FontAdvanced *fd = font_owner.get_or_null(p_font_rid);
-	ERR_FAIL_COND_V(!fd, Array());
+	ERR_FAIL_COND_V(!fd, TypedArray<Vector2i>());
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Array());
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), TypedArray<Vector2i>());
 
-	Array ret;
+	TypedArray<Vector2i> ret;
 	for (const KeyValue<Vector2i, FontForSizeAdvanced *> &E : fd->cache) {
 		ret.push_back(E.key);
 	}

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -537,7 +537,7 @@ public:
 	virtual void font_set_oversampling(const RID &p_font_rid, double p_oversampling) override;
 	virtual double font_get_oversampling(const RID &p_font_rid) const override;
 
-	virtual Array font_get_size_cache_list(const RID &p_font_rid) const override;
+	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const override;
 	virtual void font_clear_size_cache(const RID &p_font_rid) override;
 	virtual void font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) override;
 
@@ -566,7 +566,7 @@ public:
 	virtual void font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offset) override;
 	virtual PackedInt32Array font_get_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const override;
 
-	virtual Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override;
+	virtual PackedInt32Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override;
 	virtual void font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) override;
 	virtual void font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) override;
 
@@ -590,7 +590,7 @@ public:
 
 	virtual Dictionary font_get_glyph_contours(const RID &p_font, int64_t p_size, int64_t p_index) const override;
 
-	virtual Array font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const override;
+	virtual TypedArray<Vector2i> font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const override;
 	virtual void font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) override;
 	virtual void font_remove_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) override;
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1259,12 +1259,12 @@ double TextServerFallback::font_get_oversampling(const RID &p_font_rid) const {
 	return fd->oversampling;
 }
 
-Array TextServerFallback::font_get_size_cache_list(const RID &p_font_rid) const {
+TypedArray<Vector2i> TextServerFallback::font_get_size_cache_list(const RID &p_font_rid) const {
 	FontFallback *fd = font_owner.get_or_null(p_font_rid);
-	ERR_FAIL_COND_V(!fd, Array());
+	ERR_FAIL_COND_V(!fd, TypedArray<Vector2i>());
 
 	MutexLock lock(fd->mutex);
-	Array ret;
+	TypedArray<Vector2i> ret;
 	for (const KeyValue<Vector2i, FontForSizeFallback *> &E : fd->cache) {
 		ret.push_back(E.key);
 	}
@@ -1543,15 +1543,15 @@ PackedInt32Array TextServerFallback::font_get_texture_offsets(const RID &p_font_
 	return tex.offsets;
 }
 
-Array TextServerFallback::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
+PackedInt32Array TextServerFallback::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
 	FontFallback *fd = font_owner.get_or_null(p_font_rid);
-	ERR_FAIL_COND_V(!fd, Array());
+	ERR_FAIL_COND_V(!fd, PackedInt32Array());
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Array());
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), PackedInt32Array());
 
-	Array ret;
+	PackedInt32Array ret;
 	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
 	for (const KeyValue<int32_t, FontGlyph> &E : gl) {
 		ret.push_back(E.key);
@@ -1886,16 +1886,16 @@ Dictionary TextServerFallback::font_get_glyph_contours(const RID &p_font_rid, in
 #endif
 }
 
-Array TextServerFallback::font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
+TypedArray<Vector2i> TextServerFallback::font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
 	FontFallback *fd = font_owner.get_or_null(p_font_rid);
-	ERR_FAIL_COND_V(!fd, Array());
+	ERR_FAIL_COND_V(!fd, TypedArray<Vector2i>());
 
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size(fd, p_size);
 
-	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), Array());
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size), TypedArray<Vector2i>());
 
-	Array ret;
+	TypedArray<Vector2i> ret;
 	for (const KeyValue<Vector2i, Vector2> &E : fd->cache[size]->kerning_map) {
 		ret.push_back(E.key);
 	}

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -417,7 +417,7 @@ public:
 	virtual void font_set_oversampling(const RID &p_font_rid, double p_oversampling) override;
 	virtual double font_get_oversampling(const RID &p_font_rid) const override;
 
-	virtual Array font_get_size_cache_list(const RID &p_font_rid) const override;
+	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const override;
 	virtual void font_clear_size_cache(const RID &p_font_rid) override;
 	virtual void font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) override;
 
@@ -446,7 +446,7 @@ public:
 	virtual void font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offset) override;
 	virtual PackedInt32Array font_get_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const override;
 
-	virtual Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override;
+	virtual PackedInt32Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override;
 	virtual void font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) override;
 	virtual void font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) override;
 
@@ -469,7 +469,7 @@ public:
 
 	virtual Dictionary font_get_glyph_contours(const RID &p_font, int64_t p_size, int64_t p_index) const override;
 
-	virtual Array font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const override;
+	virtual TypedArray<Vector2i> font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const override;
 	virtual void font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) override;
 	virtual void font_remove_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) override;
 

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -2850,8 +2850,8 @@ void VisualScriptEditor::reload(bool p_soft) {
 	_update_graph();
 }
 
-Array VisualScriptEditor::get_breakpoints() {
-	Array breakpoints;
+PackedInt32Array VisualScriptEditor::get_breakpoints() {
+	PackedInt32Array breakpoints;
 	List<StringName> functions;
 	script->get_function_list(&functions);
 	for (int i = 0; i < functions.size(); i++) {

--- a/modules/visual_script/editor/visual_script_editor.h
+++ b/modules/visual_script/editor/visual_script_editor.h
@@ -341,7 +341,7 @@ public:
 	virtual void ensure_focus() override;
 	virtual void tag_saved_version() override;
 	virtual void reload(bool p_soft) override;
-	virtual Array get_breakpoints() override;
+	virtual PackedInt32Array get_breakpoints() override;
 	virtual void set_breakpoint(int p_line, bool p_enable) override{};
 	virtual void clear_breakpoints() override{};
 	virtual void add_callback(const String &p_function, PackedStringArray p_args) override;

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -83,7 +83,7 @@ bool DisplayServerAndroid::tts_is_paused() const {
 	return TTS_Android::is_paused();
 }
 
-Array DisplayServerAndroid::tts_get_voices() const {
+TypedArray<Dictionary> DisplayServerAndroid::tts_get_voices() const {
 	return TTS_Android::get_voices();
 }
 
@@ -136,7 +136,7 @@ bool DisplayServerAndroid::clipboard_has() const {
 	}
 }
 
-Array DisplayServerAndroid::get_display_cutouts() const {
+TypedArray<Rect2> DisplayServerAndroid::get_display_cutouts() const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_NULL_V(godot_io_java, Array());
 	return godot_io_java->get_display_cutouts();

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -93,7 +93,7 @@ public:
 
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
-	virtual Array tts_get_voices() const override;
+	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
 	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;
@@ -104,7 +104,7 @@ public:
 	virtual String clipboard_get() const override;
 	virtual bool clipboard_has() const override;
 
-	virtual Array get_display_cutouts() const override;
+	virtual TypedArray<Rect2> get_display_cutouts() const override;
 	virtual Rect2i get_display_safe_area() const override;
 
 	virtual void screen_set_keep_on(bool p_enable) override;

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -165,8 +165,8 @@ float GodotIOJavaWrapper::get_screen_refresh_rate(float fallback) {
 	return fallback;
 }
 
-Array GodotIOJavaWrapper::get_display_cutouts() {
-	Array result;
+TypedArray<Rect2> GodotIOJavaWrapper::get_display_cutouts() {
+	TypedArray<Rect2> result;
 	ERR_FAIL_NULL_V(_get_display_cutouts, result);
 	JNIEnv *env = get_jni_env();
 	ERR_FAIL_NULL_V(env, result);

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -38,7 +38,7 @@
 #include <jni.h>
 
 #include "core/math/rect2i.h"
-#include "core/variant/array.h"
+#include "core/variant/typed_array.h"
 #include "string_android.h"
 
 // Class that makes functions in java/src/org/godotengine/godot/GodotIO.java callable from C++
@@ -78,7 +78,7 @@ public:
 	int get_screen_dpi();
 	float get_scaled_density();
 	float get_screen_refresh_rate(float fallback);
-	Array get_display_cutouts();
+	TypedArray<Rect2> get_display_cutouts();
 	Rect2i get_display_safe_area();
 	String get_unique_id();
 	bool has_vk();

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -127,7 +127,7 @@ public:
 
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
-	virtual Array tts_get_voices() const override;
+	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
 	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -336,8 +336,8 @@ bool DisplayServerIOS::tts_is_paused() const {
 	return [tts isPaused];
 }
 
-Array DisplayServerIOS::tts_get_voices() const {
-	ERR_FAIL_COND_V(!tts, Array());
+TypedArray<Dictionary> DisplayServerIOS::tts_get_voices() const {
+	ERR_FAIL_COND_V(!tts, TypedArray<Dictionary>());
 	return [tts getVoices];
 }
 

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -296,7 +296,7 @@ void DisplayServerJavaScript::update_voices_callback(int p_size, const char **p_
 	}
 }
 
-Array DisplayServerJavaScript::tts_get_voices() const {
+TypedArray<Dictionary> DisplayServerJavaScript::tts_get_voices() const {
 	godot_js_tts_get_voices(update_voices_callback);
 	return voices;
 }

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -124,7 +124,7 @@ public:
 	// tts
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
-	virtual Array tts_get_voices() const override;
+	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
 	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -322,8 +322,8 @@ bool DisplayServerX11::tts_is_paused() const {
 	return tts->is_paused();
 }
 
-Array DisplayServerX11::tts_get_voices() const {
-	ERR_FAIL_COND_V(!tts, Array());
+TypedArray<Dictionary> DisplayServerX11::tts_get_voices() const {
+	ERR_FAIL_COND_V(!tts, TypedArray<Dictionary>());
 	return tts->get_voices();
 }
 

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -308,7 +308,7 @@ public:
 #ifdef SPEECHD_ENABLED
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
-	virtual Array tts_get_voices() const override;
+	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
 	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -277,7 +277,7 @@ public:
 
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
-	virtual Array tts_get_voices() const override;
+	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
 	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1656,7 +1656,7 @@ bool DisplayServerMacOS::tts_is_paused() const {
 	return [tts isPaused];
 }
 
-Array DisplayServerMacOS::tts_get_voices() const {
+TypedArray<Dictionary> DisplayServerMacOS::tts_get_voices() const {
 	ERR_FAIL_COND_V(!tts, Array());
 	return [tts getVoices];
 }

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -144,8 +144,8 @@ bool DisplayServerWindows::tts_is_paused() const {
 	return tts->is_paused();
 }
 
-Array DisplayServerWindows::tts_get_voices() const {
-	ERR_FAIL_COND_V(!tts, Array());
+TypedArray<Dictionary> DisplayServerWindows::tts_get_voices() const {
+	ERR_FAIL_COND_V(!tts, TypedArray<Dictionary>());
 	return tts->get_voices();
 }
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -478,7 +478,7 @@ public:
 
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
-	virtual Array tts_get_voices() const override;
+	virtual TypedArray<Dictionary> tts_get_voices() const override;
 
 	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false) override;
 	virtual void tts_pause() override;

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -361,8 +361,8 @@ void CollisionObject2D::get_shape_owners(List<uint32_t> *r_owners) {
 	}
 }
 
-Array CollisionObject2D::_get_shape_owners() {
-	Array ret;
+PackedInt32Array CollisionObject2D::_get_shape_owners() {
+	PackedInt32Array ret;
 	for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
 		ret.push_back(E.key);
 	}

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -125,7 +125,7 @@ public:
 	uint32_t create_shape_owner(Object *p_owner);
 	void remove_shape_owner(uint32_t owner);
 	void get_shape_owners(List<uint32_t> *r_owners);
-	Array _get_shape_owners();
+	PackedInt32Array _get_shape_owners();
 
 	void shape_owner_set_transform(uint32_t p_owner, const Transform2D &p_transform);
 	Transform2D shape_owner_get_transform(uint32_t p_owner) const;

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -485,7 +485,7 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_keep_aspect_mode"), &Camera3D::get_keep_aspect_mode);
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &Camera3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &Camera3D::get_doppler_tracking);
-	ClassDB::bind_method(D_METHOD("get_frustum"), &Camera3D::get_frustum);
+	ClassDB::bind_method(D_METHOD("get_frustum"), &Camera3D::_get_frustum);
 	ClassDB::bind_method(D_METHOD("is_position_in_frustum", "world_point"), &Camera3D::is_position_in_frustum);
 	ClassDB::bind_method(D_METHOD("get_camera_rid"), &Camera3D::get_camera);
 	ClassDB::bind_method(D_METHOD("get_pyramid_shape_rid"), &Camera3D::get_pyramid_shape_rid);
@@ -613,6 +613,11 @@ Vector<Plane> Camera3D::get_frustum() const {
 	}
 
 	return cm.get_projection_planes(get_camera_transform());
+}
+
+TypedArray<Plane> Camera3D::_get_frustum() const {
+	Variant ret = get_frustum();
+	return ret;
 }
 
 bool Camera3D::is_position_in_frustum(const Vector3 &p_position) const {

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -86,6 +86,7 @@ private:
 	// void _camera_make_current(Node *p_camera);
 	friend class Viewport;
 	void _update_audio_listener_state();
+	TypedArray<Plane> _get_frustum() const;
 
 	DopplerTracking doppler_tracking = DOPPLER_TRACKING_DISABLED;
 	Ref<VelocityTracker3D> velocity_tracker;

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -546,8 +546,8 @@ void CollisionObject3D::get_shape_owners(List<uint32_t> *r_owners) {
 	}
 }
 
-Array CollisionObject3D::_get_shape_owners() {
-	Array ret;
+PackedInt32Array CollisionObject3D::_get_shape_owners() {
+	PackedInt32Array ret;
 	for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
 		ret.push_back(E.key);
 	}

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -135,7 +135,7 @@ public:
 	uint32_t create_shape_owner(Object *p_owner);
 	void remove_shape_owner(uint32_t owner);
 	void get_shape_owners(List<uint32_t> *r_owners);
-	Array _get_shape_owners();
+	PackedInt32Array _get_shape_owners();
 
 	void shape_owner_set_transform(uint32_t p_owner, const Transform3D &p_transform);
 	Transform3D shape_owner_get_transform(uint32_t p_owner) const;

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -432,7 +432,7 @@ void Label3D::_shape() {
 			TS->shaped_text_set_spacing(text_rid, TextServer::SpacingType(i), font->get_spacing(TextServer::SpacingType(i)));
 		}
 
-		Array stt;
+		TypedArray<Vector2i> stt;
 		if (st_parser == TextServer::STRUCTURED_TEXT_CUSTOM) {
 			GDVIRTUAL_CALL(_structured_text_parser, st_args, text, stt);
 		} else {

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -490,8 +490,8 @@ void ButtonGroup::get_buttons(List<BaseButton *> *r_buttons) {
 	}
 }
 
-Array ButtonGroup::_get_buttons() {
-	Array btns;
+TypedArray<BaseButton> ButtonGroup::_get_buttons() {
+	TypedArray<BaseButton> btns;
 	for (const BaseButton *E : buttons) {
 		btns.push_back(E);
 	}

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -151,7 +151,7 @@ protected:
 public:
 	BaseButton *get_pressed_button();
 	void get_buttons(List<BaseButton *> *r_buttons);
-	Array _get_buttons();
+	TypedArray<BaseButton> _get_buttons();
 	ButtonGroup();
 };
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1280,8 +1280,8 @@ void CodeEdit::clear_breakpointed_lines() {
 	}
 }
 
-Array CodeEdit::get_breakpointed_lines() const {
-	Array ret;
+PackedInt32Array CodeEdit::get_breakpointed_lines() const {
+	PackedInt32Array ret;
 	for (int i = 0; i < get_line_count(); i++) {
 		if (is_line_breakpointed(i)) {
 			ret.append(i);
@@ -1309,8 +1309,8 @@ void CodeEdit::clear_bookmarked_lines() {
 	}
 }
 
-Array CodeEdit::get_bookmarked_lines() const {
-	Array ret;
+PackedInt32Array CodeEdit::get_bookmarked_lines() const {
+	PackedInt32Array ret;
 	for (int i = 0; i < get_line_count(); i++) {
 		if (is_line_bookmarked(i)) {
 			ret.append(i);
@@ -1338,8 +1338,8 @@ void CodeEdit::clear_executing_lines() {
 	}
 }
 
-Array CodeEdit::get_executing_lines() const {
-	Array ret;
+PackedInt32Array CodeEdit::get_executing_lines() const {
+	PackedInt32Array ret;
 	for (int i = 0; i < get_line_count(); i++) {
 		if (is_line_executing(i)) {
 			ret.append(i);
@@ -2769,7 +2769,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 			i++;
 		}
 
-		Array completion_options;
+		TypedArray<Dictionary> completion_options;
 
 		GDVIRTUAL_CALL(_filter_code_completion_candidates, completion_options_sources, completion_options);
 

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -266,7 +266,7 @@ protected:
 
 	GDVIRTUAL1(_confirm_code_completion, bool)
 	GDVIRTUAL1(_request_code_completion, bool)
-	GDVIRTUAL1RC(Array, _filter_code_completion_candidates, TypedArray<Dictionary>)
+	GDVIRTUAL1RC(TypedArray<Dictionary>, _filter_code_completion_candidates, TypedArray<Dictionary>)
 
 public:
 	/* General overrides */
@@ -322,19 +322,19 @@ public:
 	void set_line_as_breakpoint(int p_line, bool p_breakpointed);
 	bool is_line_breakpointed(int p_line) const;
 	void clear_breakpointed_lines();
-	Array get_breakpointed_lines() const;
+	PackedInt32Array get_breakpointed_lines() const;
 
 	// bookmarks
 	void set_line_as_bookmarked(int p_line, bool p_bookmarked);
 	bool is_line_bookmarked(int p_line) const;
 	void clear_bookmarked_lines();
-	Array get_bookmarked_lines() const;
+	PackedInt32Array get_bookmarked_lines() const;
 
 	// executing lines
 	void set_line_as_executing(int p_line, bool p_executing);
 	bool is_line_executing(int p_line) const;
 	void clear_executing_lines();
-	Array get_executing_lines() const;
+	PackedInt32Array get_executing_lines() const;
 
 	/* Line numbers */
 	void set_draw_line_numbers(bool p_draw);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2946,13 +2946,13 @@ void Control::end_bulk_theme_override() {
 
 // Internationalization.
 
-Array Control::structured_text_parser(TextServer::StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const {
+TypedArray<Vector2i> Control::structured_text_parser(TextServer::StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const {
 	if (p_parser_type == TextServer::STRUCTURED_TEXT_CUSTOM) {
-		Array ret;
+		TypedArray<Vector2i> ret;
 		if (GDVIRTUAL_CALL(_structured_text_parser, p_args, p_text, ret)) {
 			return ret;
 		} else {
-			return Array();
+			return TypedArray<Vector2i>();
 		}
 	} else {
 		return TS->parse_structured_text(p_parser_type, p_args, p_text);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -328,7 +328,7 @@ protected:
 
 	// Internationalization.
 
-	virtual Array structured_text_parser(TextServer::StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
+	virtual TypedArray<Vector2i> structured_text_parser(TextServer::StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
 
 	// Base object overrides.
 
@@ -341,7 +341,7 @@ protected:
 	// Exposed virtual methods.
 
 	GDVIRTUAL1RC(bool, _has_point, Vector2)
-	GDVIRTUAL2RC(Array, _structured_text_parser, Array, String)
+	GDVIRTUAL2RC(TypedArray<Vector2i>, _structured_text_parser, Array, String)
 	GDVIRTUAL0RC(Vector2, _get_minimum_size)
 
 	GDVIRTUAL1RC(Variant, _get_drag_data, Vector2)

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -31,6 +31,7 @@
 #include "bit_map.h"
 
 #include "core/io/image_loader.h"
+#include "core/variant/typed_array.h"
 
 void BitMap::create(const Size2 &p_size) {
 	ERR_FAIL_COND(p_size.width < 1);
@@ -576,12 +577,12 @@ void BitMap::shrink_mask(int p_pixels, const Rect2 &p_rect) {
 	grow_mask(-p_pixels, p_rect);
 }
 
-Array BitMap::_opaque_to_polygons_bind(const Rect2 &p_rect, float p_epsilon) const {
+TypedArray<PackedVector2Array> BitMap::_opaque_to_polygons_bind(const Rect2 &p_rect, float p_epsilon) const {
 	Vector<Vector<Vector2>> result = clip_opaque_to_polygons(p_rect, p_epsilon);
 
 	// Convert result to bindable types
 
-	Array result_array;
+	TypedArray<PackedVector2Array> result_array;
 	result_array.resize(result.size());
 	for (int i = 0; i < result.size(); i++) {
 		const Vector<Vector2> &polygon = result[i];

--- a/scene/resources/bit_map.h
+++ b/scene/resources/bit_map.h
@@ -35,6 +35,9 @@
 #include "core/io/resource.h"
 #include "core/io/resource_loader.h"
 
+template <typename T>
+class TypedArray;
+
 class BitMap : public Resource {
 	GDCLASS(BitMap, Resource);
 	OBJ_SAVE_TYPE(BitMap);
@@ -45,7 +48,7 @@ class BitMap : public Resource {
 
 	Vector<Vector2> _march_square(const Rect2i &rect, const Point2i &start) const;
 
-	Array _opaque_to_polygons_bind(const Rect2 &p_rect, float p_epsilon) const;
+	TypedArray<PackedVector2Array> _opaque_to_polygons_bind(const Rect2 &p_rect, float p_epsilon) const;
 
 protected:
 	void _set_data(const Dictionary &p_d);

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1267,7 +1267,7 @@ void FontFile::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 	for (int i = 0; i < cache.size(); i++) {
 		String prefix = "cache/" + itos(i) + "/";
-		Array sizes = get_size_cache_list(i);
+		TypedArray<Vector2i> sizes = get_size_cache_list(i);
 		p_list->push_back(PropertyInfo(Variant::DICTIONARY, prefix + "variation_coordinates", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 		p_list->push_back(PropertyInfo(Variant::INT, "face_index", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 		p_list->push_back(PropertyInfo(Variant::FLOAT, "embolden", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
@@ -1289,7 +1289,7 @@ void FontFile::_get_property_list(List<PropertyInfo> *p_list) const {
 				p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, prefix_sz + "textures/" + itos(k) + "/offsets", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 				p_list->push_back(PropertyInfo(Variant::OBJECT, prefix_sz + "textures/" + itos(k) + "/image", PROPERTY_HINT_RESOURCE_TYPE, "Image", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT));
 			}
-			Array glyphs = get_glyph_list(i, sz);
+			PackedInt32Array glyphs = get_glyph_list(i, sz);
 			for (int k = 0; k < glyphs.size(); k++) {
 				const int32_t &gl = glyphs[k];
 				if (sz.y == 0) {
@@ -1301,7 +1301,7 @@ void FontFile::_get_property_list(List<PropertyInfo> *p_list) const {
 				p_list->push_back(PropertyInfo(Variant::INT, prefix_sz + "glyphs/" + itos(gl) + "/texture_idx", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 			}
 			if (sz.y == 0) {
-				Array kerning_map = get_kerning_list(i, sz.x);
+				TypedArray<Vector2i> kerning_map = get_kerning_list(i, sz.x);
 				for (int k = 0; k < kerning_map.size(); k++) {
 					const Vector2i &gl_pair = kerning_map[k];
 					p_list->push_back(PropertyInfo(Variant::VECTOR2, prefix_sz + "kerning_overrides/" + itos(gl_pair.x) + "/" + itos(gl_pair.y), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
@@ -2089,7 +2089,7 @@ void FontFile::remove_cache(int p_cache_index) {
 	emit_changed();
 }
 
-Array FontFile::get_size_cache_list(int p_cache_index) const {
+TypedArray<Vector2i> FontFile::get_size_cache_list(int p_cache_index) const {
 	ERR_FAIL_COND_V(p_cache_index < 0, Array());
 	_ensure_rid(p_cache_index);
 	return TS->font_get_size_cache_list(cache[p_cache_index]);
@@ -2260,8 +2260,8 @@ PackedInt32Array FontFile::get_texture_offsets(int p_cache_index, const Vector2i
 	return TS->font_get_texture_offsets(cache[p_cache_index], p_size, p_texture_index);
 }
 
-Array FontFile::get_glyph_list(int p_cache_index, const Vector2i &p_size) const {
-	ERR_FAIL_COND_V(p_cache_index < 0, Array());
+PackedInt32Array FontFile::get_glyph_list(int p_cache_index, const Vector2i &p_size) const {
+	ERR_FAIL_COND_V(p_cache_index < 0, PackedInt32Array());
 	_ensure_rid(p_cache_index);
 	return TS->font_get_glyph_list(cache[p_cache_index], p_size);
 }
@@ -2338,7 +2338,7 @@ int FontFile::get_glyph_texture_idx(int p_cache_index, const Vector2i &p_size, i
 	return TS->font_get_glyph_texture_idx(cache[p_cache_index], p_size, p_glyph);
 }
 
-Array FontFile::get_kerning_list(int p_cache_index, int p_size) const {
+TypedArray<Vector2i> FontFile::get_kerning_list(int p_cache_index, int p_size) const {
 	ERR_FAIL_COND_V(p_cache_index < 0, Array());
 	_ensure_rid(p_cache_index);
 	return TS->font_get_kerning_list(cache[p_cache_index], p_size);

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -230,7 +230,7 @@ public:
 	virtual void clear_cache();
 	virtual void remove_cache(int p_cache_index);
 
-	virtual Array get_size_cache_list(int p_cache_index) const;
+	virtual TypedArray<Vector2i> get_size_cache_list(int p_cache_index) const;
 	virtual void clear_size_cache(int p_cache_index);
 	virtual void remove_size_cache(int p_cache_index, const Vector2i &p_size);
 
@@ -271,7 +271,7 @@ public:
 	virtual void set_texture_offsets(int p_cache_index, const Vector2i &p_size, int p_texture_index, const PackedInt32Array &p_offset);
 	virtual PackedInt32Array get_texture_offsets(int p_cache_index, const Vector2i &p_size, int p_texture_index) const;
 
-	virtual Array get_glyph_list(int p_cache_index, const Vector2i &p_size) const;
+	virtual PackedInt32Array get_glyph_list(int p_cache_index, const Vector2i &p_size) const;
 	virtual void clear_glyphs(int p_cache_index, const Vector2i &p_size);
 	virtual void remove_glyph(int p_cache_index, const Vector2i &p_size, int32_t p_glyph);
 
@@ -290,7 +290,7 @@ public:
 	virtual void set_glyph_texture_idx(int p_cache_index, const Vector2i &p_size, int32_t p_glyph, int p_texture_idx);
 	virtual int get_glyph_texture_idx(int p_cache_index, const Vector2i &p_size, int32_t p_glyph) const;
 
-	virtual Array get_kerning_list(int p_cache_index, int p_size) const;
+	virtual TypedArray<Vector2i> get_kerning_list(int p_cache_index, int p_size) const;
 	virtual void clear_kerning_map(int p_cache_index, int p_size);
 	virtual void remove_kerning(int p_cache_index, int p_size, const Vector2i &p_glyph_pair);
 

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -144,8 +144,8 @@ int AudioDriver::get_total_channels_by_speaker_mode(AudioDriver::SpeakerMode p_m
 	ERR_FAIL_V(2);
 }
 
-Array AudioDriver::get_device_list() {
-	Array list;
+PackedStringArray AudioDriver::get_device_list() {
+	PackedStringArray list;
 
 	list.push_back("Default");
 
@@ -156,8 +156,8 @@ String AudioDriver::get_device() {
 	return "Default";
 }
 
-Array AudioDriver::capture_get_device_list() {
-	Array list;
+PackedStringArray AudioDriver::capture_get_device_list() {
+	PackedStringArray list;
 
 	list.push_back("Default");
 
@@ -1637,7 +1637,7 @@ Ref<AudioBusLayout> AudioServer::generate_bus_layout() const {
 	return state;
 }
 
-Array AudioServer::get_device_list() {
+PackedStringArray AudioServer::get_device_list() {
 	return AudioDriver::get_singleton()->get_device_list();
 }
 
@@ -1649,7 +1649,7 @@ void AudioServer::set_device(String device) {
 	AudioDriver::get_singleton()->set_device(device);
 }
 
-Array AudioServer::capture_get_device_list() {
+PackedStringArray AudioServer::capture_get_device_list() {
 	return AudioDriver::get_singleton()->capture_get_device_list();
 }
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -94,7 +94,7 @@ public:
 	virtual void start() = 0;
 	virtual int get_mix_rate() const = 0;
 	virtual SpeakerMode get_speaker_mode() const = 0;
-	virtual Array get_device_list();
+	virtual PackedStringArray get_device_list();
 	virtual String get_device();
 	virtual void set_device(String device) {}
 	virtual void lock() = 0;
@@ -105,7 +105,7 @@ public:
 	virtual Error capture_stop() { return FAILED; }
 	virtual void capture_set_device(const String &p_name) {}
 	virtual String capture_get_device() { return "Default"; }
-	virtual Array capture_get_device_list(); // TODO: convert this and get_device_list to PackedStringArray
+	virtual PackedStringArray capture_get_device_list();
 
 	virtual float get_latency() { return 0; }
 
@@ -419,11 +419,11 @@ public:
 	void set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout);
 	Ref<AudioBusLayout> generate_bus_layout() const;
 
-	Array get_device_list();
+	PackedStringArray get_device_list();
 	String get_device();
 	void set_device(String device);
 
-	Array capture_get_device_list();
+	PackedStringArray capture_get_device_list();
 	String capture_get_device();
 	void capture_set_device(const String &p_name);
 

--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "camera_server.h"
+#include "core/variant/typed_array.h"
 #include "rendering_server.h"
 #include "servers/camera/camera_feed.h"
 
@@ -143,8 +144,8 @@ int CameraServer::get_feed_count() {
 	return feeds.size();
 };
 
-Array CameraServer::get_feeds() {
-	Array return_feeds;
+TypedArray<CameraFeed> CameraServer::get_feeds() {
+	TypedArray<CameraFeed> return_feeds;
 	int cc = get_feed_count();
 	return_feeds.resize(cc);
 

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -43,6 +43,8 @@
 **/
 
 class CameraFeed;
+template <typename T>
+class TypedArray;
 
 class CameraServer : public Object {
 	GDCLASS(CameraServer, Object);
@@ -100,7 +102,7 @@ public:
 	// Get our feeds.
 	Ref<CameraFeed> get_feed(int p_index);
 	int get_feed_count();
-	Array get_feeds();
+	TypedArray<CameraFeed> get_feeds();
 
 	// Intended for use with custom CameraServer implementation.
 	RID feed_texture(int p_id, FeedImage p_texture);

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -256,14 +256,14 @@ void DisplayServer::tts_resume() {
 	WARN_PRINT("TTS is not supported by this display server.");
 }
 
-Array DisplayServer::tts_get_voices() const {
+TypedArray<Dictionary> DisplayServer::tts_get_voices() const {
 	WARN_PRINT("TTS is not supported by this display server.");
-	return Array();
+	return TypedArray<Dictionary>();
 }
 
 PackedStringArray DisplayServer::tts_get_voices_for_language(const String &p_language) const {
 	PackedStringArray ret;
-	Array voices = tts_get_voices();
+	TypedArray<Dictionary> voices = tts_get_voices();
 	for (int i = 0; i < voices.size(); i++) {
 		const Dictionary &voice = voices[i];
 		if (voice.has("id") && voice.has("language") && voice["language"].operator String().begins_with(p_language)) {

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -198,7 +198,7 @@ private:
 public:
 	virtual bool tts_is_speaking() const;
 	virtual bool tts_is_paused() const;
-	virtual Array tts_get_voices() const;
+	virtual TypedArray<Dictionary> tts_get_voices() const;
 	virtual PackedStringArray tts_get_voices_for_language(const String &p_language) const;
 
 	virtual void tts_speak(const String &p_text, const String &p_voice, int p_volume = 50, float p_pitch = 1.f, float p_rate = 1.f, int p_utterance_id = 0, bool p_interrupt = false);
@@ -230,7 +230,7 @@ public:
 	virtual void clipboard_set_primary(const String &p_text);
 	virtual String clipboard_get_primary() const;
 
-	virtual Array get_display_cutouts() const { return Array(); }
+	virtual TypedArray<Rect2> get_display_cutouts() const { return TypedArray<Rect2>(); }
 	virtual Rect2i get_display_safe_area() const { return screen_get_usable_rect(); }
 
 	enum {

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -634,12 +634,12 @@ double TextServerExtension::font_get_oversampling(const RID &p_font_rid) const {
 	return 0.0;
 }
 
-Array TextServerExtension::font_get_size_cache_list(const RID &p_font_rid) const {
-	Array ret;
+TypedArray<Vector2i> TextServerExtension::font_get_size_cache_list(const RID &p_font_rid) const {
+	TypedArray<Vector2i> ret;
 	if (GDVIRTUAL_CALL(font_get_size_cache_list, p_font_rid, ret)) {
 		return ret;
 	}
-	return Array();
+	return TypedArray<Vector2i>();
 }
 
 void TextServerExtension::font_clear_size_cache(const RID &p_font_rid) {
@@ -750,12 +750,12 @@ PackedInt32Array TextServerExtension::font_get_texture_offsets(const RID &p_font
 	return PackedInt32Array();
 }
 
-Array TextServerExtension::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
-	Array ret;
+PackedInt32Array TextServerExtension::font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
+	PackedInt32Array ret;
 	if (GDVIRTUAL_CALL(font_get_glyph_list, p_font_rid, p_size, ret)) {
 		return ret;
 	}
-	return Array();
+	return PackedInt32Array();
 }
 
 void TextServerExtension::font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) {
@@ -850,12 +850,12 @@ Dictionary TextServerExtension::font_get_glyph_contours(const RID &p_font_rid, i
 	return Dictionary();
 }
 
-Array TextServerExtension::font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
-	Array ret;
+TypedArray<Vector2i> TextServerExtension::font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
+	TypedArray<Vector2i> ret;
 	if (GDVIRTUAL_CALL(font_get_kerning_list, p_font_rid, p_size, ret)) {
 		return ret;
 	}
-	return Array();
+	return TypedArray<Vector2i>();
 }
 
 void TextServerExtension::font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) {

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -35,6 +35,7 @@
 #include "core/object/script_language.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/native_ptr.h"
+#include "core/variant/typed_array.h"
 #include "servers/text_server.h"
 
 class TextServerExtension : public TextServer {
@@ -172,10 +173,10 @@ public:
 	GDVIRTUAL2(font_set_oversampling, RID, double);
 	GDVIRTUAL1RC(double, font_get_oversampling, RID);
 
-	virtual Array font_get_size_cache_list(const RID &p_font_rid) const override;
+	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const override;
 	virtual void font_clear_size_cache(const RID &p_font_rid) override;
 	virtual void font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) override;
-	GDVIRTUAL1RC(Array, font_get_size_cache_list, RID);
+	GDVIRTUAL1RC(TypedArray<Vector2i>, font_get_size_cache_list, RID);
 	GDVIRTUAL1(font_clear_size_cache, RID);
 	GDVIRTUAL2(font_remove_size_cache, RID, const Vector2i &);
 
@@ -221,10 +222,10 @@ public:
 	GDVIRTUAL4(font_set_texture_offsets, RID, const Vector2i &, int64_t, const PackedInt32Array &);
 	GDVIRTUAL3RC(PackedInt32Array, font_get_texture_offsets, RID, const Vector2i &, int64_t);
 
-	virtual Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override;
+	virtual PackedInt32Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override;
 	virtual void font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) override;
 	virtual void font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) override;
-	GDVIRTUAL2RC(Array, font_get_glyph_list, RID, const Vector2i &);
+	GDVIRTUAL2RC(PackedInt32Array, font_get_glyph_list, RID, const Vector2i &);
 	GDVIRTUAL2(font_clear_glyphs, RID, const Vector2i &);
 	GDVIRTUAL3(font_remove_glyph, RID, const Vector2i &, int64_t);
 
@@ -262,10 +263,10 @@ public:
 	virtual Dictionary font_get_glyph_contours(const RID &p_font, int64_t p_size, int64_t p_index) const override;
 	GDVIRTUAL3RC(Dictionary, font_get_glyph_contours, RID, int64_t, int64_t);
 
-	virtual Array font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const override;
+	virtual TypedArray<Vector2i> font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const override;
 	virtual void font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) override;
 	virtual void font_remove_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) override;
-	GDVIRTUAL2RC(Array, font_get_kerning_list, RID, int64_t);
+	GDVIRTUAL2RC(TypedArray<Vector2i>, font_get_kerning_list, RID, int64_t);
 	GDVIRTUAL2(font_clear_kerning_map, RID, int64_t);
 	GDVIRTUAL3(font_remove_kerning, RID, int64_t, const Vector2i &);
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "servers/text_server.h"
+#include "core/variant/typed_array.h"
 #include "servers/rendering_server.h"
 
 TextServerManager *TextServerManager::singleton = nullptr;
@@ -1585,8 +1586,8 @@ String TextServer::strip_diacritics(const String &p_string) const {
 	return result;
 }
 
-Array TextServer::parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const {
-	Array ret;
+TypedArray<Vector2i> TextServer::parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const {
+	TypedArray<Vector2i> ret;
 	switch (p_parser_type) {
 		case STRUCTURED_TEXT_URI: {
 			int prev = 0;

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -37,6 +37,9 @@
 #include "core/variant/native_ptr.h"
 #include "core/variant/variant.h"
 
+template <typename T>
+class TypedArray;
+
 struct Glyph;
 struct CaretInfo;
 
@@ -269,7 +272,7 @@ public:
 	virtual void font_set_oversampling(const RID &p_font_rid, double p_oversampling) = 0;
 	virtual double font_get_oversampling(const RID &p_font_rid) const = 0;
 
-	virtual Array font_get_size_cache_list(const RID &p_font_rid) const = 0;
+	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const = 0;
 	virtual void font_clear_size_cache(const RID &p_font_rid) = 0;
 	virtual void font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) = 0;
 
@@ -298,7 +301,7 @@ public:
 	virtual void font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offset) = 0;
 	virtual PackedInt32Array font_get_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const = 0;
 
-	virtual Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const = 0;
+	virtual PackedInt32Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const = 0;
 	virtual void font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) = 0;
 	virtual void font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) = 0;
 
@@ -321,7 +324,7 @@ public:
 
 	virtual Dictionary font_get_glyph_contours(const RID &p_font, int64_t p_size, int64_t p_index) const = 0;
 
-	virtual Array font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const = 0;
+	virtual TypedArray<Vector2i> font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const = 0;
 	virtual void font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) = 0;
 	virtual void font_remove_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) = 0;
 
@@ -476,7 +479,7 @@ public:
 	virtual String string_to_upper(const String &p_string, const String &p_language = "") const = 0;
 	virtual String string_to_lower(const String &p_string, const String &p_language = "") const = 0;
 
-	Array parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
+	TypedArray<Vector2i> parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
 
 	TextServer();
 	~TextServer();

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -74,7 +74,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 
 			code_edit->set_line_as_breakpoint(0, true);
 			CHECK(code_edit->is_line_breakpointed(0));
-			CHECK(code_edit->get_breakpointed_lines()[0] == Variant(0));
+			CHECK(code_edit->get_breakpointed_lines()[0] == 0);
 			SIGNAL_CHECK("breakpoint_toggled", args);
 
 			code_edit->set_line_as_breakpoint(0, false);
@@ -451,7 +451,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			ERR_PRINT_ON;
 
 			code_edit->set_line_as_bookmarked(0, true);
-			CHECK(code_edit->get_bookmarked_lines()[0] == Variant(0));
+			CHECK(code_edit->get_bookmarked_lines()[0] == 0);
 			CHECK(code_edit->is_line_bookmarked(0));
 
 			code_edit->set_line_as_bookmarked(0, false);
@@ -657,7 +657,7 @@ TEST_CASE("[SceneTree][CodeEdit] line gutters") {
 			ERR_PRINT_ON;
 
 			code_edit->set_line_as_executing(0, true);
-			CHECK(code_edit->get_executing_lines()[0] == Variant(0));
+			CHECK(code_edit->get_executing_lines()[0] == 0);
 			CHECK(code_edit->is_line_executing(0));
 
 			code_edit->set_line_as_executing(0, false);


### PR DESCRIPTION
This PR replaces return types of methods from Array to TypedArray or PackedArray where possible. I only changed methods exposed to scripting that have return type "Array" and methods called by these methods.

Obviously the changes turned out to be enormous, so I'm splitting it into multiple PRs (there will be 2 or 3 more).