### PR TITLE
Rebuild the trees in the `EditorFeatureProfile` dialog when the editor theme changes

### DIFF
--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -324,6 +324,11 @@ void EditorFeatureProfileManager::_notification(int p_what) {
 			}
 			_update_profile_list(current_profile);
 		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			// Make sure that the icons are correctly adjusted if the theme's lightness was switched.
+			_update_selected_profile();
+		} break;
 	}
 }
 


### PR DESCRIPTION
Noticed this while testing PRs. This makes icons hard to appreciate, because they don't adjust to the theme properly. This change should be enough, and the main selection is preserved as well.
