### PR TITLE
Add `Dictionary.find_key()`

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -195,6 +195,15 @@ bool Dictionary::has_all(const Array &p_keys) const {
 	return true;
 }
 
+Variant Dictionary::find_key(const Variant &p_value) const {
+	for (const KeyValue<Variant, Variant> &E : _p->variant_map) {
+		if (E.value == p_value) {
+			return E.key;
+		}
+	}
+	return Variant();
+}
+
 bool Dictionary::erase(const Variant &p_key) {
 	ERR_FAIL_COND_V_MSG(_p->read_only, false, "Dictionary is in read-only state.");
 	if (p_key.get_type() == Variant::STRING_NAME) {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -66,6 +66,7 @@ public:
 
 	bool has(const Variant &p_key) const;
 	bool has_all(const Array &p_keys) const;
+	Variant find_key(const Variant &p_value) const;
 
 	bool erase(const Variant &p_key);
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2009,6 +2009,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Dictionary, merge, sarray("dictionary", "overwrite"), varray(false));
 	bind_method(Dictionary, has, sarray("key"), varray());
 	bind_method(Dictionary, has_all, sarray("keys"), varray());
+	bind_method(Dictionary, find_key, sarray("value"), varray());
 	bind_method(Dictionary, erase, sarray("key"), varray());
 	bind_method(Dictionary, hash, sarray(), varray());
 	bind_method(Dictionary, keys, sarray(), varray());

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -4,7 +4,7 @@
 		Dictionary type.
 	</brief_description>
 	<description>
-		Dictionary type. Associative container which contains values referenced by unique keys. Dictionaries are composed of pairs of keys (which must be unique) and values. Dictionaries will preserve the insertion order when adding elements, even though this may not be reflected when printing the dictionary. In other programming languages, this data structure is sometimes referred to as a hash map or associative array.
+		Dictionary type. Associative container which contains values referenced by unique keys. Dictionaries are composed of pairs of keys (which must be unique) and values. Dictionaries will preserve the insertion order when adding elements. In other programming languages, this data structure is sometimes referred to as a hash map or associative array.
 		You can define a dictionary by placing a comma-separated list of [code]key: value[/code] pairs in curly braces [code]{}[/code].
 		Erasing elements while iterating over them [b]is not supported[/b] and will result in undefined behavior.
 		[b]Note:[/b] Dictionaries are always passed by reference. To get a copy of a dictionary which can be modified independently of the original dictionary, use [method duplicate].
@@ -216,6 +216,14 @@
 			<description>
 				Erase a dictionary key/value pair by key. Returns [code]true[/code] if the given key was present in the dictionary, [code]false[/code] otherwise.
 				[b]Note:[/b] Don't erase elements while iterating over the dictionary. You can iterate over the [method keys] array instead.
+			</description>
+		</method>
+		<method name="find_key" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="value" type="Variant" />
+			<description>
+				Returns the first key whose associated value is equal to [param value], or [code]null[/code] if no such value is found.
+				[b]Node:[/b] [code]null[/code] is also a valid key. I you have it in your [Dictionary], the [method find_key] method can give misleading results.
 			</description>
 		</method>
 		<method name="get" qualifiers="const">

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -500,6 +500,24 @@ TEST_CASE("[Dictionary] Recursive self comparison") {
 	d2.clear();
 }
 
+TEST_CASE("[Dictionary] Order and find") {
+	Dictionary d;
+	d[4] = "four";
+	d[8] = "eight";
+	d[12] = "twelve";
+	d["4"] = "four";
+
+	Array keys;
+	keys.append(4);
+	keys.append(8);
+	keys.append(12);
+	keys.append("4");
+
+	CHECK_EQ(d.keys(), keys);
+	CHECK_EQ(d.find_key("four"), Variant(4));
+	CHECK_EQ(d.find_key("does not exist"), Variant());
+}
+
 } // namespace TestDictionary
 
 #endif // TEST_DICTIONARY_H


### PR DESCRIPTION
I use `enum.keys().find(key)` to reverse-lookup an enum value saved as string. The problem is that `keys()` dumps all keys into an array, so `keys().find()` first extracts the array and then finds value in the array, which is just bad :/ The new method skips the extraction part and is ~10x faster.

I also added some unit tests.