### PR TITLE
Make "Godot source files" comment consistent in modules

### DIFF
--- a/modules/bmp/SCsub
+++ b/modules/bmp/SCsub
@@ -5,5 +5,5 @@ Import("env_modules")
 
 env_bmp = env_modules.Clone()
 
-# Godot's own source files
+# Godot source files
 env_bmp.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -3,10 +3,9 @@
 Import("env")
 Import("env_modules")
 
-# Godot's own source files
 env_csg = env_modules.Clone()
 
-# Godot's own source files
+# Godot source files
 env_csg.add_source_files(env.modules_sources, "*.cpp")
 if env["tools"]:
     env_csg.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -5,7 +5,7 @@ Import("env_modules")
 
 env_gltf = env_modules.Clone()
 
-# Godot's own source files
+# Godot source files
 env_gltf.add_source_files(env.modules_sources, "*.cpp")
 env_gltf.add_source_files(env.modules_sources, "extensions/*.cpp")
 env_gltf.add_source_files(env.modules_sources, "structures/*.cpp")

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -5,7 +5,7 @@ Import("env_modules")
 
 env_gridmap = env_modules.Clone()
 
-# Godot's own source files
+# Godot source files
 env_gridmap.add_source_files(env.modules_sources, "*.cpp")
 if env["tools"]:
     env_gridmap.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/hdr/SCsub
+++ b/modules/hdr/SCsub
@@ -5,5 +5,5 @@ Import("env_modules")
 
 env_hdr = env_modules.Clone()
 
-# Godot's own source files
+# Godot source files
 env_hdr.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/minimp3/SCsub
+++ b/modules/minimp3/SCsub
@@ -13,5 +13,5 @@ if not env.msvc:
 else:
     env_minimp3.Prepend(CPPPATH=[thirdparty_dir])
 
-# Godot's own source files
+# Godot source files
 env_minimp3.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/tga/SCsub
+++ b/modules/tga/SCsub
@@ -5,5 +5,5 @@ Import("env_modules")
 
 env_tga = env_modules.Clone()
 
-# Godot's own source files
+# Godot source files
 env_tga.add_source_files(env.modules_sources, "*.cpp")


### PR DESCRIPTION
These comments don't add anything of value, we assume that `*.cpp` is Godot's own source files. In one case this comment was placed on `env_csg = env_modules.Clone()` which is even more unhelpful.