### PR TITLE
Fix iOS export bug after renaming "iphone" to "ios"

### DIFF
--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1528,8 +1528,6 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 
 		//write
 
-		file = file.replace_first("ios/", "");
-
 		if (files_to_parse.has(file)) {
 			_fix_config_file(p_preset, data, config_data, p_debug);
 		} else if (file.begins_with("libgodot.ios")) {


### PR DESCRIPTION
This PR fixes #63841 for iOS export. 

When renaming [`iphone` to `ios`](https://github.com/godotengine/godot/commit/8823eae328547991def3b13ee2919291d29a278b#diff-8e7537a6612e8df87678884017b270b87b2b54328f3cf4e39de3c050e7ab6908L1529-L1531) throughout the engine, this line should have been removed as it causes problems with file pathing. 

In the Godot iOS export template there is a directory named `godot_ios`. While exporting, the [following code](https://github.com/godotengine/godot/blob/master/platform/ios/export/export_plugin.cpp#L1554) looks for this path and replaces it with the binary name.
```
file = file.replace("godot_ios", binary_name);
print_line("ADDING: " + file + " size: " + itos(data.size()));
```

The line `file = file.replace_first("ios/", "");` causes this path the path to change to `godot_`, resulting in a failed export.

**Current Export Log**
```
READ: godot_ios/Images.xcassets/LaunchImage.launchimage/Contents.json
ADDING: godot_Images.xcassets/LaunchImage.launchimage/Contents.json size: 2567
```
**Expected Export Log**
```
READ: godot_ios/Images.xcassets/LaunchImage.launchimage/Contents.json
ADDING: <binary_name>/Images.xcassets/LaunchImage.launchimage/Contents.json size: 2567
```


