### PR TITLE
Automatically use execinfo for crash handler on *BSD and musl-based Linux

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -363,8 +363,10 @@ def configure(env: "Environment"):
     if platform.system() == "Linux":
         env.Append(LIBS=["dl"])
 
-    if platform.system().find("BSD") >= 0:
-        env["execinfo"] = True
+    if not env["execinfo"] and platform.libc_ver()[0] != "glibc":
+        # The default crash handler depends on glibc, so if the host uses
+        # a different libc (BSD libc, musl), fall back to libexecinfo.
+        print("Note: Using `execinfo=yes` for the crash handler as required on platforms where glibc is missing.")
 
     if env["execinfo"]:
         env.Append(LIBS=["execinfo"])


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/57193 and closes https://github.com/godotengine/godot-proposals/issues/2439.

Tested on an Alpine Linux container (`docker run -itv $PWD:/opt/godot alpine` in a Godot repository clone, then [install dependencies](https://docs.godotengine.org/en/latest/development/compiling/compiling_for_linuxbsd.html#distro-specific-one-liners)), it works as expected.

Unlike my glibc-based desktop, I get a crash on startup when running the project manager with `--headless`:

```
/opt/godot # bin/godot.linuxbsd.tools.64 --headless
Godot Engine v4.0.alpha.custom_build.e06a61b25 - https://godotengine.org

================================================================
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.0.alpha.custom_build (e06a61b25877003aa53d5617d48012b93adb5ebd) 

Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
-- END OF BACKTRACE --
================================================================
Aborted (core dumped)
```

`--version` works though:

```
/opt/godot # bin/godot.linuxbsd.tools.64 --version
4.0.alpha.custom_build.e06a61b25
```