### PR TITLE
Improve Shape2D's `custom_solver_bias` description

### DIFF
--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -69,7 +69,8 @@
 	</methods>
 	<members>
 		<member name="custom_solver_bias" type="float" setter="set_custom_solver_bias" getter="get_custom_solver_bias" default="0.0">
-			The shape's custom solver bias.
+			The shape's custom solver bias. Defines how much bodies react to enforce contact separation when this shape is involved.
+			When set to [code]0.0[/code], the default value of [code]0.3[/code] is used.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
This backports the description from `master`. See https://github.com/godotengine/godot/pull/51121#issuecomment-1118008465.