### PR TITLE
RPC improvements to the conversion tool

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2045,6 +2045,8 @@ bool ProjectConverter3To4::test_conversion(const RegExContainer &reg_container) 
 	valid = valid & test_conversion_single_additional("\n\ntool", "\n\n@tool", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword");
 	valid = valid & test_conversion_single_additional("\n\nremote func", "\n\n@rpc(any_peer) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword");
 	valid = valid & test_conversion_single_additional("\n\nremotesync func", "\n\n@rpc(any_peer, call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword");
+	valid = valid & test_conversion_single_additional("\n\nsync func", "\n\n@rpc(any_peer, call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword");
+	valid = valid & test_conversion_single_additional("\n\nslave func", "\n\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword");
 	valid = valid & test_conversion_single_additional("\n\npuppet func", "\n\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword");
 	valid = valid & test_conversion_single_additional("\n\npuppetsync func", "\n\n@rpc(call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword");
 	valid = valid & test_conversion_single_additional("\n\nmaster func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword");
@@ -3237,6 +3239,22 @@ void ProjectConverter3To4::rename_gdscript_keywords(String &file_content) {
 		file_content = reg_second.sub(file_content, "@rpc(any_peer, call_local) func", true);
 	}
 	{
+		RegEx reg_first = RegEx("([\n]+)sync func");
+		CRASH_COND(!reg_first.is_valid());
+		file_content = reg_first.sub(file_content, "$1@rpc(any_peer, call_local) func", true);
+		RegEx reg_second = RegEx("^sync func");
+		CRASH_COND(!reg_second.is_valid());
+		file_content = reg_second.sub(file_content, "@rpc(any_peer, call_local) func", true);
+	}
+	{
+		RegEx reg_first = RegEx("([\n]+)slave func");
+		CRASH_COND(!reg_first.is_valid());
+		file_content = reg_first.sub(file_content, "$1@rpc func", true);
+		RegEx reg_second = RegEx("^slave func");
+		CRASH_COND(!reg_second.is_valid());
+		file_content = reg_second.sub(file_content, "@rpc func", true);
+	}
+	{
 		RegEx reg_first = RegEx("([\n]+)puppet func");
 		CRASH_COND(!reg_first.is_valid());
 		file_content = reg_first.sub(file_content, "$1@rpc func", true);
@@ -3325,6 +3343,24 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_keywords(Vector<S
 		}
 		if (old != line) {
 			found_things.append(line_formatter(current_line, "remotesync func", "@rpc(any_peer, call_local)) func", line));
+		}
+		old = line;
+		{
+			RegEx regex = RegEx("^sync func");
+			CRASH_COND(!regex.is_valid());
+			line = regex.sub(line, "@rpc(any_peer, call_local)) func", true);
+		}
+		if (old != line) {
+			found_things.append(line_formatter(current_line, "sync func", "@rpc(any_peer, call_local)) func", line));
+		}
+		old = line;
+		{
+			RegEx regex = RegEx("^slave func");
+			CRASH_COND(!regex.is_valid());
+			line = regex.sub(line, "@rpc func", true);
+		}
+		if (old != line) {
+			found_things.append(line_formatter(current_line, "slave func", "@rpc func", line));
 		}
 		old = line;
 		{

--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -55,6 +55,9 @@ private:
 	Vector<String> check_for_rename_csharp_functions(Vector<String> &file_content);
 	void process_csharp_line(String &line);
 
+	void rename_csharp_attributes(String &file_content);
+	Vector<String> check_for_rename_csharp_attributes(Vector<String> &file_content);
+
 	void rename_gdscript_keywords(String &file_content);
 	Vector<String> check_for_rename_gdscript_keywords(Vector<String> &file_content);
 


### PR DESCRIPTION
- Adds conversion for the `sync` and `slave` GDScript keywords. Deprecated in #22087 but they still exist in 3.x for compatibility.
- Adds conversion for the RPC attributes in C#. Converts all existing RPC attributes from 3.x to the new single RPC attribute in 4.0 (added in #62805) but only single attribute syntax (e.g.: `[Remote]`, `[Remote()]`, `[RemoteAttribute]` or `[RemoteAttribute()]`) and not multiple attribute syntax (e.g.: `[A, Remote, B]`) because I don't think it may be common enough and I don't want to over-complicate the regex.