### PR TITLE
[Linux] Disable speech-dispatcher, pulseaudio and udev wrapper builds, when library is not found.

### DIFF
--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -369,6 +369,7 @@ def configure(env):
             env.Append(CPPDEFINES=["PULSEAUDIO_ENABLED"])
             env.ParseConfig("pkg-config libpulse --cflags")  # Only cflags, we dlopen the library.
         else:
+            env["pulseaudio"] = False
             print("Warning: PulseAudio development libraries not found. Disabling the PulseAudio audio driver.")
 
     if env["speechd"]:
@@ -376,6 +377,7 @@ def configure(env):
             env.Append(CPPDEFINES=["SPEECHD_ENABLED"])
             env.ParseConfig("pkg-config speech-dispatcher --cflags")  # Only cflags, we dlopen the library.
         else:
+            env["speechd"] = False
             print("Warning: Speech Dispatcher development libraries not found. Disabling Text-to-Speech support.")
 
     if platform.system() == "Linux":
@@ -385,6 +387,7 @@ def configure(env):
                 env.Append(CPPDEFINES=["UDEV_ENABLED"])
                 env.ParseConfig("pkg-config libudev --cflags")  # Only cflags, we dlopen the library.
             else:
+                env["udev"] = False
                 print("Warning: libudev development libraries not found. Disabling controller hotplugging support.")
     else:
         env["udev"] = False  # Linux specific


### PR DESCRIPTION
Version of #60587 for 3.x

Fixes #63990
