### PR TITLE
Test also GLES3 in CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -170,10 +170,16 @@ jobs:
           mv "regression-test-project-4.0" "test_project"
 
       # Editor is quite complicated piece of software, so it is easy to introduce bug here
-      - name: Open and close editor
+      - name: Open and close editor (Vulkan)
         if: ${{ matrix.proj-test }}
         run: |
           VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --audio-driver Dummy --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
+          misc/scripts/check_ci_log.py sanitizers_log.txt
+
+      - name: Open and close editor (GLES3)
+        if: ${{ matrix.proj-test }}
+        run: |
+          DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --audio-driver Dummy --rendering-driver opengl3 --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
 
       # Run test project

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1608,6 +1608,8 @@ void fragment() {
 RasterizerCanvasGLES3::~RasterizerCanvasGLES3() {
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 
+	memdelete_arr(state.instance_data_array);
+
 	GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_free(state.canvas_shader_default_version);
 	material_storage->material_free(default_canvas_group_material);
 	material_storage->shader_free(default_canvas_group_shader);


### PR DESCRIPTION
This PR adds step with opening editor in Ci with GLES 3, to check if there are crashes or memory leaks

Also fixes memory leak:
```
 Direct leak of 65552 byte(s) in 1 object(s) allocated from:
    #0 0x7fdd1f60c808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x55eb79cdb505 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:75
    #2 0x55eb6ac313ce in RasterizerCanvasGLES3::InstanceData* memnew_arr_template<RasterizerCanvasGLES3::InstanceData>(unsigned long) core/os/memory.h:145
    #3 0x55eb6ac24cf9 in RasterizerCanvasGLES3::RasterizerCanvasGLES3() drivers/gles3/rasterizer_canvas_gles3.cpp:1563
    #4 0x55eb6a625ab6 in RasterizerGLES3::RasterizerGLES3() drivers/gles3/rasterizer_gles3.cpp:280
    #5 0x55eb616893c1 in RasterizerGLES3::_create_current() drivers/gles3/rasterizer_gles3.h:98
    #6 0x55eb76e7c684 in RendererCompositor::create() servers/rendering/renderer_compositor.cpp:42
    #7 0x55eb77019356 in RenderingServerDefault::RenderingServerDefault(bool) servers/rendering/rendering_server_default.cpp:401
    #8 0x55eb617342f7 in Main::setup2(unsigned long) main/main.cpp:1806
    #9 0x55eb6172c491 in Main::setup(char const*, int, char**, bool) main/main.cpp:1629
    #10 0x55eb6156ba40 in main platform/linuxbsd/godot_linuxbsd.cpp:61
    #11 0x7fdd1e433082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
```