### PR TITLE
Quality of life visual shaders updates

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1698,13 +1698,13 @@ Error VisualShader::_write_node(Type type, StringBuilder *global_code, StringBui
 								inputs[i] = "(" + src_var + " ? 1.0 : 0.0)";
 							} break;
 							case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
-								inputs[i] = "dot(" + src_var + ", vec2(0.5, 0.5))";
+								inputs[i] = src_var + ".x";
 							} break;
 							case VisualShaderNode::PORT_TYPE_VECTOR_3D: {
-								inputs[i] = "dot(" + src_var + ", vec3(0.333333, 0.333333, 0.333333))";
+								inputs[i] = src_var + ".x";
 							} break;
 							case VisualShaderNode::PORT_TYPE_VECTOR_4D: {
-								inputs[i] = "dot(" + src_var + ", vec4(0.25, 0.25, 0.25, 0.25))";
+								inputs[i] = src_var + ".x";
 							} break;
 							default:
 								break;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -1015,7 +1015,7 @@ Vector<StringName> VisualShaderNodeCurveTexture::get_editable_properties() const
 }
 
 String VisualShaderNodeCurveTexture::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
-	return "uniform sampler2D " + make_unique_id(p_type, p_id, "curve") + ";\n";
+	return "uniform sampler2D " + make_unique_id(p_type, p_id, "curve") + " : repeat_disable;\n";
 }
 
 String VisualShaderNodeCurveTexture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
@@ -6823,23 +6823,23 @@ void VisualShaderNodeMultiplyAdd::set_op_type(OpType p_op_type) {
 	switch (p_op_type) {
 		case OP_TYPE_SCALAR: {
 			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
-			set_input_port_default_value(1, 0.0, get_input_port_default_value(1));
+			set_input_port_default_value(1, 1.0, get_input_port_default_value(1));
 			set_input_port_default_value(2, 0.0, get_input_port_default_value(2));
 		} break;
 		case OP_TYPE_VECTOR_2D: {
 			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
-			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+			set_input_port_default_value(1, Vector2(1.0, 1.0), get_input_port_default_value(1));
 			set_input_port_default_value(2, Vector2(), get_input_port_default_value(2));
 		} break;
 		case OP_TYPE_VECTOR_3D: {
 			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
-			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
+			set_input_port_default_value(1, Vector3(1.0, 1.0, 1.0), get_input_port_default_value(1));
 			set_input_port_default_value(2, Vector3(), get_input_port_default_value(2));
 		} break;
 		case OP_TYPE_VECTOR_4D: {
-			set_input_port_default_value(0, Quaternion(), get_input_port_default_value(0));
-			set_input_port_default_value(1, Quaternion(), get_input_port_default_value(1));
-			set_input_port_default_value(2, Quaternion(), get_input_port_default_value(2));
+			set_input_port_default_value(0, Vector4(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector4(1.0, 1.0, 1.0, 1.0), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector4(), get_input_port_default_value(2));
 		} break;
 		default:
 			break;
@@ -6873,7 +6873,7 @@ void VisualShaderNodeMultiplyAdd::_bind_methods() {
 
 VisualShaderNodeMultiplyAdd::VisualShaderNodeMultiplyAdd() {
 	set_input_port_default_value(0, 0.0);
-	set_input_port_default_value(1, 0.0);
+	set_input_port_default_value(1, 1.0);
 	set_input_port_default_value(2, 0.0);
 }
 


### PR DESCRIPTION
Closes #63993 
Addresses in part #63780 

- multiply part of addmultiply defaults to 1
- curvetexture's repeat is off
- vectors into float takes first component instead of average

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
