### PR TITLE
Add checks and tests for empty/unnamed arguments

### DIFF
--- a/core/io/packed_data_container.cpp
+++ b/core/io/packed_data_container.cpp
@@ -353,7 +353,7 @@ Variant PackedDataContainer::_iter_get(const Variant &p_iter) {
 }
 
 void PackedDataContainer::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_set_data"), &PackedDataContainer::_set_data);
+	ClassDB::bind_method(D_METHOD("_set_data", "data"), &PackedDataContainer::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &PackedDataContainer::_get_data);
 	ClassDB::bind_method(D_METHOD("_iter_init"), &PackedDataContainer::_iter_init);
 	ClassDB::bind_method(D_METHOD("_iter_get"), &PackedDataContainer::_iter_get);

--- a/core/object/method_bind.cpp
+++ b/core/object/method_bind.cpp
@@ -63,7 +63,7 @@ PropertyInfo MethodBind::get_argument_info(int p_argument) const {
 
 	PropertyInfo info = _gen_argument_type_info(p_argument);
 #ifdef DEBUG_METHODS_ENABLED
-	info.name = p_argument < arg_names.size() ? String(arg_names[p_argument]) : String("arg" + itos(p_argument));
+	info.name = p_argument < arg_names.size() ? String(arg_names[p_argument]) : String("_unnamed_arg" + itos(p_argument));
 #endif
 	return info;
 }

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -141,7 +141,7 @@ void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("erase_message", "src_message", "context"), &Translation::erase_message, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_message_list"), &Translation::_get_message_list);
 	ClassDB::bind_method(D_METHOD("get_message_count"), &Translation::get_message_count);
-	ClassDB::bind_method(D_METHOD("_set_messages"), &Translation::_set_messages);
+	ClassDB::bind_method(D_METHOD("_set_messages", "messages"), &Translation::_set_messages);
 	ClassDB::bind_method(D_METHOD("_get_messages"), &Translation::_get_messages);
 
 	GDVIRTUAL_BIND(_get_plural_message, "src_message", "src_plural_message", "n", "context");

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -69,6 +69,40 @@ func _init():
 	CHECK_MESSAGE(int(ref_counted->get_meta("result")) == 42, "The script should assign object metadata successfully.");
 }
 
+TEST_CASE("[Modules][GDScript] Validate built-in API") {
+	GDScriptLanguage *lang = GDScriptLanguage::get_singleton();
+
+	// Validate methods.
+	List<MethodInfo> builtin_methods;
+	lang->get_public_functions(&builtin_methods);
+
+	SUBCASE("[Modules][GDScript] Validate built-in methods") {
+		for (const MethodInfo &mi : builtin_methods) {
+			for (int j = 0; j < mi.arguments.size(); j++) {
+				PropertyInfo arg = mi.arguments[j];
+
+				TEST_COND((arg.name.is_empty() || arg.name.begins_with("_unnamed_arg")),
+						vformat("Unnamed argument in position %d of built-in method '%s'.", j, mi.name));
+			}
+		}
+	}
+
+	// Validate annotations.
+	List<MethodInfo> builtin_annotations;
+	lang->get_public_annotations(&builtin_annotations);
+
+	SUBCASE("[Modules][GDScript] Validate built-in annotations") {
+		for (const MethodInfo &ai : builtin_annotations) {
+			for (int j = 0; j < ai.arguments.size(); j++) {
+				PropertyInfo arg = ai.arguments[j];
+
+				TEST_COND((arg.name.is_empty() || arg.name.begins_with("_unnamed_arg")),
+						vformat("Unnamed argument in position %d of built-in annotation '%s'.", j, ai.name));
+			}
+		}
+	}
+}
+
 } // namespace GDScriptTests
 
 #endif // GDSCRIPT_TEST_RUNNER_SUITE_H

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -2124,7 +2124,7 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_method_call_mode", "mode"), &AnimationPlayer::set_method_call_mode);
 	ClassDB::bind_method(D_METHOD("get_method_call_mode"), &AnimationPlayer::get_method_call_mode);
 
-	ClassDB::bind_method(D_METHOD("set_movie_quit_on_finish_enabled"), &AnimationPlayer::set_movie_quit_on_finish_enabled);
+	ClassDB::bind_method(D_METHOD("set_movie_quit_on_finish_enabled", "enabled"), &AnimationPlayer::set_movie_quit_on_finish_enabled);
 	ClassDB::bind_method(D_METHOD("is_movie_quit_on_finish_enabled"), &AnimationPlayer::is_movie_quit_on_finish_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_current_animation_position"), &AnimationPlayer::get_current_animation_position);

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -387,7 +387,7 @@ String ConfirmationDialog::get_cancel_button_text() const {
 
 void ConfirmationDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cancel_button"), &ConfirmationDialog::get_cancel_button);
-	ClassDB::bind_method(D_METHOD("set_cancel_button_text"), &ConfirmationDialog::set_cancel_button_text);
+	ClassDB::bind_method(D_METHOD("set_cancel_button_text", "text"), &ConfirmationDialog::set_cancel_button_text);
 	ClassDB::bind_method(D_METHOD("get_cancel_button_text"), &ConfirmationDialog::get_cancel_button_text);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "cancel_button_text"), "set_cancel_button_text", "get_cancel_button_text");

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -498,7 +498,7 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_selected_id"), &OptionButton::get_selected_id);
 	ClassDB::bind_method(D_METHOD("get_selected_metadata"), &OptionButton::get_selected_metadata);
 	ClassDB::bind_method(D_METHOD("remove_item", "idx"), &OptionButton::remove_item);
-	ClassDB::bind_method(D_METHOD("_select_int"), &OptionButton::_select_int);
+	ClassDB::bind_method(D_METHOD("_select_int", "idx"), &OptionButton::_select_int);
 
 	ClassDB::bind_method(D_METHOD("get_popup"), &OptionButton::get_popup);
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5294,7 +5294,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_v_scroll_speed", "speed"), &TextEdit::set_v_scroll_speed);
 	ClassDB::bind_method(D_METHOD("get_v_scroll_speed"), &TextEdit::get_v_scroll_speed);
 
-	ClassDB::bind_method(D_METHOD("set_fit_content_height_enabled"), &TextEdit::set_fit_content_height_enabled);
+	ClassDB::bind_method(D_METHOD("set_fit_content_height_enabled", "enabled"), &TextEdit::set_fit_content_height_enabled);
 	ClassDB::bind_method(D_METHOD("is_fit_content_height_enabled"), &TextEdit::is_fit_content_height_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_scroll_pos_for_line", "line", "wrap_index"), &TextEdit::get_scroll_pos_for_line, DEFVAL(0));

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -138,7 +138,7 @@ void ResourcePreloader::get_resource_list(List<StringName> *p_list) {
 }
 
 void ResourcePreloader::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_set_resources"), &ResourcePreloader::_set_resources);
+	ClassDB::bind_method(D_METHOD("_set_resources", "resources"), &ResourcePreloader::_set_resources);
 	ClassDB::bind_method(D_METHOD("_get_resources"), &ResourcePreloader::_get_resources);
 
 	ClassDB::bind_method(D_METHOD("add_resource", "name", "resource"), &ResourcePreloader::add_resource);

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -669,7 +669,7 @@ void BitMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_size"), &BitMap::get_size);
 	ClassDB::bind_method(D_METHOD("resize", "new_size"), &BitMap::resize);
 
-	ClassDB::bind_method(D_METHOD("_set_data"), &BitMap::_set_data);
+	ClassDB::bind_method(D_METHOD("_set_data", "data"), &BitMap::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &BitMap::_get_data);
 
 	ClassDB::bind_method(D_METHOD("grow_mask", "pixels", "rect"), &BitMap::grow_mask);

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1190,7 +1190,7 @@ void Curve2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tessellate", "max_stages", "tolerance_degrees"), &Curve2D::tessellate, DEFVAL(5), DEFVAL(4));
 
 	ClassDB::bind_method(D_METHOD("_get_data"), &Curve2D::_get_data);
-	ClassDB::bind_method(D_METHOD("_set_data"), &Curve2D::_set_data);
+	ClassDB::bind_method(D_METHOD("_set_data", "data"), &Curve2D::_set_data);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bake_interval", PROPERTY_HINT_RANGE, "0.01,512,0.01"), "set_bake_interval", "get_bake_interval");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");
@@ -2002,7 +2002,7 @@ void Curve3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tessellate", "max_stages", "tolerance_degrees"), &Curve3D::tessellate, DEFVAL(5), DEFVAL(4));
 
 	ClassDB::bind_method(D_METHOD("_get_data"), &Curve3D::_get_data);
-	ClassDB::bind_method(D_METHOD("_set_data"), &Curve3D::_set_data);
+	ClassDB::bind_method(D_METHOD("_set_data", "data"), &Curve3D::_set_data);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bake_interval", PROPERTY_HINT_RANGE, "0.01,512,0.01"), "set_bake_interval", "get_bake_interval");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -340,13 +340,13 @@ void MultiMesh::_bind_methods() {
 
 #ifndef DISABLE_DEPRECATED
 	// Kept for compatibility from 3.x to 4.0.
-	ClassDB::bind_method(D_METHOD("_set_transform_array"), &MultiMesh::_set_transform_array);
+	ClassDB::bind_method(D_METHOD("_set_transform_array", "array"), &MultiMesh::_set_transform_array);
 	ClassDB::bind_method(D_METHOD("_get_transform_array"), &MultiMesh::_get_transform_array);
-	ClassDB::bind_method(D_METHOD("_set_transform_2d_array"), &MultiMesh::_set_transform_2d_array);
+	ClassDB::bind_method(D_METHOD("_set_transform_2d_array", "array"), &MultiMesh::_set_transform_2d_array);
 	ClassDB::bind_method(D_METHOD("_get_transform_2d_array"), &MultiMesh::_get_transform_2d_array);
-	ClassDB::bind_method(D_METHOD("_set_color_array"), &MultiMesh::_set_color_array);
+	ClassDB::bind_method(D_METHOD("_set_color_array", "array"), &MultiMesh::_set_color_array);
 	ClassDB::bind_method(D_METHOD("_get_color_array"), &MultiMesh::_get_color_array);
-	ClassDB::bind_method(D_METHOD("_set_custom_data_array"), &MultiMesh::_set_custom_data_array);
+	ClassDB::bind_method(D_METHOD("_set_custom_data_array", "array"), &MultiMesh::_set_custom_data_array);
 	ClassDB::bind_method(D_METHOD("_get_custom_data_array"), &MultiMesh::_get_custom_data_array);
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "transform_array", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "_set_transform_array", "_get_transform_array");

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1779,7 +1779,7 @@ void PackedScene::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("pack", "path"), &PackedScene::pack);
 	ClassDB::bind_method(D_METHOD("instantiate", "edit_state"), &PackedScene::instantiate, DEFVAL(GEN_EDIT_STATE_DISABLED));
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &PackedScene::can_instantiate);
-	ClassDB::bind_method(D_METHOD("_set_bundled_scene"), &PackedScene::_set_bundled_scene);
+	ClassDB::bind_method(D_METHOD("_set_bundled_scene", "scene"), &PackedScene::_set_bundled_scene);
 	ClassDB::bind_method(D_METHOD("_get_bundled_scene"), &PackedScene::_get_bundled_scene);
 	ClassDB::bind_method(D_METHOD("get_state"), &PackedScene::get_state);
 

--- a/scene/resources/polygon_path_finder.cpp
+++ b/scene/resources/polygon_path_finder.cpp
@@ -553,7 +553,7 @@ void PolygonPathFinder::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_penalty", "idx"), &PolygonPathFinder::get_point_penalty);
 
 	ClassDB::bind_method(D_METHOD("get_bounds"), &PolygonPathFinder::get_bounds);
-	ClassDB::bind_method(D_METHOD("_set_data"), &PolygonPathFinder::_set_data);
+	ClassDB::bind_method(D_METHOD("_set_data", "data"), &PolygonPathFinder::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &PolygonPathFinder::_get_data);
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -207,7 +207,7 @@ void SpriteFrames::_bind_methods() {
 
 	// `animations` property is for serialization.
 
-	ClassDB::bind_method(D_METHOD("_set_animations"), &SpriteFrames::_set_animations);
+	ClassDB::bind_method(D_METHOD("_set_animations", "animations"), &SpriteFrames::_set_animations);
 	ClassDB::bind_method(D_METHOD("_get_animations"), &SpriteFrames::_get_animations);
 
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "animations", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_animations", "_get_animations");

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -71,6 +71,7 @@ struct ArgumentData {
 	String name;
 	bool has_defval = false;
 	Variant defval;
+	int position;
 };
 
 struct MethodData {
@@ -371,6 +372,39 @@ void validate_property(const Context &p_context, const ExposedClass &p_class, co
 	}
 }
 
+void validate_argument(const Context &p_context, const ExposedClass &p_class, const String &p_owner_name, const String &p_owner_type, const ArgumentData &p_arg) {
+	TEST_COND((p_arg.name.is_empty() || p_arg.name.begins_with("_unnamed_arg")),
+			vformat("Unnamed argument in position %d of %s '%s.%s'.", p_arg.position, p_owner_type, p_class.name, p_owner_name));
+
+	const ExposedClass *arg_class = p_context.find_exposed_class(p_arg.type);
+	if (arg_class) {
+		TEST_COND(arg_class->is_singleton,
+				vformat("Argument type is a singleton: '%s' of %s '%s.%s'.", p_arg.name, p_owner_type, p_class.name, p_owner_name));
+
+		if (p_class.api_type == ClassDB::API_CORE) {
+			TEST_COND(arg_class->api_type == ClassDB::API_EDITOR,
+					vformat("Argument '%s' of %s '%s.%s' has type '%s' from the editor API. Core API cannot have dependencies on the editor API.",
+							p_arg.name, p_owner_type, p_class.name, p_owner_name, arg_class->name));
+		}
+	} else {
+		// Look for types that don't inherit Object.
+		TEST_FAIL_COND(!p_context.has_type(p_arg.type),
+				vformat("Argument type '%s' not found: '%s' of %s '%s.%s'.", p_arg.type.name, p_arg.name, p_owner_type, p_class.name, p_owner_name));
+	}
+
+	if (p_arg.has_defval) {
+		String type_error_msg;
+		bool arg_defval_assignable_to_type = arg_default_value_is_assignable_to_type(p_context, p_arg.defval, p_arg.type, &type_error_msg);
+
+		String err_msg = vformat("Invalid default value for parameter '%s' of %s '%s.%s'.", p_arg.name, p_owner_type, p_class.name, p_owner_name);
+		if (!type_error_msg.is_empty()) {
+			err_msg += " " + type_error_msg;
+		}
+
+		TEST_COND(!arg_defval_assignable_to_type, err_msg.utf8().get_data());
+	}
+}
+
 void validate_method(const Context &p_context, const ExposedClass &p_class, const MethodData &p_method) {
 	if (p_method.return_type.name != StringName()) {
 		const ExposedClass *return_class = p_context.find_exposed_class(p_method.return_type);
@@ -392,54 +426,14 @@ void validate_method(const Context &p_context, const ExposedClass &p_class, cons
 
 	for (const ArgumentData &F : p_method.arguments) {
 		const ArgumentData &arg = F;
-
-		const ExposedClass *arg_class = p_context.find_exposed_class(arg.type);
-		if (arg_class) {
-			TEST_COND(arg_class->is_singleton,
-					"Argument type is a singleton: '", arg.name, "' of method '", p_class.name, ".", p_method.name, "'.");
-
-			if (p_class.api_type == ClassDB::API_CORE) {
-				TEST_COND(arg_class->api_type == ClassDB::API_EDITOR,
-						"Argument '", arg.name, "' of method '", p_class.name, ".", p_method.name, "' has type '",
-						arg_class->name, "' from the editor API. Core API cannot have dependencies on the editor API.");
-			}
-		} else {
-			// Look for types that don't inherit Object
-			TEST_FAIL_COND(!p_context.has_type(arg.type),
-					"Argument type '", arg.type.name, "' not found: '", arg.name, "' of method", p_class.name, ".", p_method.name, "'.");
-		}
-
-		if (arg.has_defval) {
-			String type_error_msg;
-			bool arg_defval_assignable_to_type = arg_default_value_is_assignable_to_type(p_context, arg.defval, arg.type, &type_error_msg);
-			String err_msg = vformat("Invalid default value for parameter '%s' of method '%s.%s'.", arg.name, p_class.name, p_method.name);
-			if (!type_error_msg.is_empty()) {
-				err_msg += " " + type_error_msg;
-			}
-			TEST_COND(!arg_defval_assignable_to_type, err_msg.utf8().get_data());
-		}
+		validate_argument(p_context, p_class, p_method.name, "method", arg);
 	}
 }
 
 void validate_signal(const Context &p_context, const ExposedClass &p_class, const SignalData &p_signal) {
 	for (const ArgumentData &F : p_signal.arguments) {
 		const ArgumentData &arg = F;
-
-		const ExposedClass *arg_class = p_context.find_exposed_class(arg.type);
-		if (arg_class) {
-			TEST_COND(arg_class->is_singleton,
-					"Argument class is a singleton: '", arg.name, "' of signal '", p_class.name, ".", p_signal.name, "'.");
-
-			if (p_class.api_type == ClassDB::API_CORE) {
-				TEST_COND(arg_class->api_type == ClassDB::API_EDITOR,
-						"Argument '", arg.name, "' of signal '", p_class.name, ".", p_signal.name, "' has type '",
-						arg_class->name, "' from the editor API. Core API cannot have dependencies on the editor API.");
-			}
-		} else {
-			// Look for types that don't inherit Object
-			TEST_FAIL_COND(!p_context.has_type(arg.type),
-					"Argument type '", arg.type.name, "' not found: '", arg.name, "' of signal", p_class.name, ".", p_signal.name, "'.");
-		}
+		validate_argument(p_context, p_class, p_signal.name, "signal", arg);
 	}
 }
 
@@ -625,6 +619,7 @@ void add_exposed_classes(Context &r_context) {
 
 				ArgumentData arg;
 				arg.name = orig_arg_name;
+				arg.position = i;
 
 				if (arg_info.type == Variant::INT && arg_info.usage & (PROPERTY_USAGE_CLASS_IS_ENUM | PROPERTY_USAGE_CLASS_IS_BITFIELD)) {
 					arg.type.name = arg_info.class_name;
@@ -693,6 +688,7 @@ void add_exposed_classes(Context &r_context) {
 
 				ArgumentData arg;
 				arg.name = orig_arg_name;
+				arg.position = i;
 
 				if (arg_info.type == Variant::INT && arg_info.usage & (PROPERTY_USAGE_CLASS_IS_ENUM | PROPERTY_USAGE_CLASS_IS_BITFIELD)) {
 					arg.type.name = arg_info.class_name;
@@ -841,7 +837,7 @@ TEST_SUITE("[ClassDB]") {
 		add_builtin_types(context);
 		add_global_enums(context);
 
-		SUBCASE("[ClassDB] Find exposed class") {
+		SUBCASE("[ClassDB] Validate exposed classes") {
 			const ExposedClass *object_class = context.find_exposed_class(context.names_cache.object_class);
 			TEST_FAIL_COND(!object_class, "Object class not found.");
 			TEST_FAIL_COND(object_class->base != StringName(),


### PR DESCRIPTION
Sometimes developers forget to change the argument information in method bindings when changing the method itself. This results in unnamed arguments in the documentation, which doesn't make good docs. We sometimes fix it by hand, but with this change we should start catching the issue on CI for every PR.

It would look something like this and the Static Checks task would fail.:
https://github.com/YuriSizov/godot/runs/7706112708?check_suite_focus=true

![Code_2022-08-06_19-16-18](https://user-images.githubusercontent.com/11782833/183258288-b473f8f2-3470-4641-babd-b0897874cb87.png)

I've decided to change the default name of the unnamed argument/parameter for better grepping. I don't think it would break anything, and if it does then **name your parameters** 😈

-----
I briefly played with an option to fail in the doctool itself, so developers can test it locally while running it to sync up the docs, but we don't have a way to fail CI from the doctool at the moment (even if you return a non-zero exit code). It is still possible to add checks to the doctool without making it fail, something like this (if we still want to report an exit code; otherwise swap for the `ERR_CONTINUE_MSG` macro):

```cpp
// Log as error, but don't fail.
if (arginfo.name.is_empty() || arginfo.name.begins_with("_unnamed_arg")) {
	exit_code = EXIT_FAILURE;
	ERR_PRINT(vformat("In '%s' the '%s' method has unnamed argument in position %d; check '%s::_bind_methods'.", lang->get_name(), md.name, j, lang->get_name()));
}
```

We also don't typically check anything about classes in doctools, it just creates XML and `make_rst.py` does the checking on CI. So this would be an extra option, on top of this PR, if we want that.

For the reference, `make_rst.py` can be run locally with `--dry-run` to not produce any files and only check for errors. Can probably include in pre-commit hooks as a simpler solution?