### PR TITLE
[3.x] Fix TileMap error msg when Navigation2D node is not set

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -157,7 +157,11 @@ void TileMap::_update_quadrant_transform() {
 
 	Transform2D nav_rel;
 	if (bake_navigation) {
-		nav_rel = get_relative_transform_to_parent(navigation);
+		if (navigation) {
+			nav_rel = get_relative_transform_to_parent(navigation);
+		} else {
+			nav_rel = get_transform();
+		}
 	}
 
 	for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
@@ -339,7 +343,11 @@ void TileMap::update_dirty_quadrants() {
 	Vector2 tofs = get_cell_draw_offset();
 	Transform2D nav_rel;
 	if (bake_navigation) {
-		nav_rel = get_relative_transform_to_parent(navigation);
+		if (navigation) {
+			nav_rel = get_relative_transform_to_parent(navigation);
+		} else {
+			nav_rel = get_transform();
+		}
 	}
 
 	Vector2 qofs;


### PR DESCRIPTION
Fixes TileMap error msg spam when `bake_navigation=true` but the optional and depr `Navigation2D` node is not set.

Fixes #64011

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
