### PR TITLE
[3.x] Document C# RPC attributes

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs
@@ -2,27 +2,58 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// RPC calls to methods annotated with this attribute go via the network and execute remotely.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
     public class RemoteAttribute : Attribute { }
 
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    public class SyncAttribute : Attribute { }
-
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    public class MasterAttribute : Attribute { }
-
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    public class PuppetAttribute : Attribute { }
-
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    public class SlaveAttribute : Attribute { }
-
+    /// <summary>
+    /// RPC calls to methods annotated with this attribute go via the network and execute remotely,
+    /// but will also execute locally (do a normal method call).
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
     public class RemoteSyncAttribute : Attribute { }
 
+    /// <summary>
+    /// Same as <see cref="RemoteSyncAttribute"/>.
+    /// </summary>
+    [Obsolete("Use the RemoteSync attribute instead.")]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
-    public class MasterSyncAttribute : Attribute { }
+    public class SyncAttribute : Attribute { }
 
+    /// <summary>
+    /// Same as <see cref="PuppetAttribute"/>.
+    /// </summary>
+    [Obsolete("Use the Puppet attribute instead.")]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
+    public class SlaveAttribute : Attribute { }
+
+    /// <summary>
+    /// RPC calls to methods annotated with this attribute go via the network and execute only
+    /// on the peers that are not set as master of the node.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
+    public class PuppetAttribute : Attribute { }
+
+    /// <summary>
+    /// RPC calls to methods annotated with this attribute go via the network and execute only
+    /// on the peers that are not set as master of the node but will also execute locally (do a normal method call).
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
     public class PuppetSyncAttribute : Attribute { }
+
+    /// <summary>
+    /// RPC calls to methods annotated with this attribute go via the network and execute only
+    /// on the peer that is set as master of the node.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
+    public class MasterAttribute : Attribute { }
+
+    /// <summary>
+    /// RPC calls to methods annotated with this attribute go via the network and execute only
+    /// on the peer that is set as master of the node but will also execute locally (do a normal method call).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property)]
+    public class MasterSyncAttribute : Attribute { }
 }


### PR DESCRIPTION
_This only applies to 3.x, in 4.0 these attributes were replaced with a new RPC attribute in #62805_

Documents all the C# RPC attributes (I also moved them a bit to have the `*Sync` attributes follow their non-sync counterpart) and deprecates the `Slave` attribute (renamed to `Puppet` but kept for compatibility) and the `Sync` attribute (renamed to `RemoteSync` but kept for compatibility) that have been deprecated since 3.1 (see #22087).

I'd appreciate a review of the added documentation as I'm not very familiar with RPC and might have made a mistake.