### PR TITLE
Add `Node.get_unique_node()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -272,7 +272,7 @@
 				Finds the first descendant of this node whose [member name] matches [param pattern], returning [code]null[/code] if no match is found. The matching is done against node names, [i]not[/i] their paths, through [method String.match]. As such, it is case-sensitive, [code]"*"[/code] matches zero or more characters, and [code]"?"[/code] matches any single character.
 				If [param recursive] is [code]false[/code], only this node's direct children are checked. Nodes are checked in tree order, so this node's first direct child is checked first, then its own direct children, etc., before moving to the second direct child, and so on. Internal children are also included in the search (see [code]internal[/code] parameter in [method add_child]).
 				If [param owned] is [code]true[/code], only descendants with a valid [member owner] node are checked.
-				[b]Note:[/b] This method can be very slow. Consider storing a reference to the found node in a variable. Alternatively, use [method get_node] with unique names (see [member unique_name_in_owner]).
+				[b]Note:[/b] This method can be very slow. Consider storing a reference to the found node in a variable. Alternatively, use [method get_unique_node] with unique names (see [member unique_name_in_owner]).
 				[b]Note:[/b] To find all descendant nodes matching a pattern or a class type, see [method find_children].
 			</description>
 		</method>
@@ -550,6 +550,32 @@
 				    ┖╴SplashScreen
 				       ┖╴Camera2D
 				[/codeblock]
+			</description>
+		</method>
+		<method name="get_unique_node" qualifiers="const">
+			<return type="Node" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns the unique node whose [member name] matches the specified [param name], within the current [member owner]. If the unique node does not exist, generates an error and [code]null[/code] is returned. Attempts to access methods on the return value will result in an [i]"Attempt to call &lt;method&gt; on a null instance."[/i] error.
+				This method is the equivalent of [method get_node], when using the unique name accessor [code]%[/code] to fetch a single node.
+				[b]Example:[/b] Assume Hero has been set with an unique name in the following scene:
+				[codeblock]
+				/Town
+				/Town/Tree
+				/Town/House
+				/Town/House/Hero
+				[/codeblock]
+				The following methods will safely return Hero, so long as its owner is the scene root:
+				[codeblocks]
+				[gdscript]
+				get_node("%Hero")
+				get_unique_node("Hero")
+				[/gdscript]
+				[csharp]
+				getNode("%Hero");
+				getUniqueNode("Hero");
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_viewport" qualifiers="const">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1881,6 +1881,34 @@ bool Node::has_node(const NodePath &p_path) const {
 	return get_node_or_null(p_path) != nullptr;
 }
 
+Node *Node::get_unique_node(const StringName &p_name) const {
+	if (!p_name) {
+		ERR_FAIL_V_MSG(nullptr, "'name' parameter cannot be empty");
+	}
+
+	const StringName key = StringName(UNIQUE_NODE_PREFIX + p_name);
+
+	if (data.owned_unique_nodes.size()) {
+		// Has unique nodes in ownership.
+		Node *const *unique = data.owned_unique_nodes.getptr(key);
+		if (!unique) {
+			// Could not find 'p_name' among the Unique Nodes this node owns.
+			return nullptr;
+		}
+		return *unique;
+	} else if (data.owner) {
+		Node **unique = data.owner->data.owned_unique_nodes.getptr(key);
+		if (!unique) {
+			// Could not find 'p_name' among the Unique Nodes this node's owner contains.
+			return nullptr;
+		}
+		return *unique;
+	} else {
+		// No Unique Nodes could be found across the owner.
+		return nullptr;
+	}
+}
+
 // Finds the first child node (in tree order) whose name matches the given pattern.
 // Can be recursive or not, and limited to owned nodes.
 Node *Node::find_child(const String &p_pattern, bool p_recursive, bool p_owned) const {
@@ -3395,6 +3423,22 @@ void Node::get_argument_options(const StringName &p_function, int p_idx, List<St
 			r_options->push_back(E.key.operator String().quote());
 		}
 	}
+	if ((pf == "get_unique_node") && p_idx == 0) {
+		HashMap<StringName, Node *>::ConstIterator elem = data.owned_unique_nodes.begin();
+		while (elem) {
+			String name = elem->value->data.name;
+			r_options->push_back(name.quote());
+			++elem;
+		}
+		if (data.owner) {
+			elem = data.owner->data.owned_unique_nodes.begin();
+			while (elem) {
+				String name = elem->value->data.name;
+				r_options->push_back(name.quote());
+				++elem;
+			}
+		}
+	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
 #endif
@@ -3612,6 +3656,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_node", "path"), &Node::has_node);
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);
 	ClassDB::bind_method(D_METHOD("get_node_or_null", "path"), &Node::get_node_or_null);
+	ClassDB::bind_method(D_METHOD("get_unique_node", "name"), &Node::get_unique_node);
 	ClassDB::bind_method(D_METHOD("get_parent"), &Node::get_parent);
 	ClassDB::bind_method(D_METHOD("find_child", "pattern", "recursive", "owned"), &Node::find_child, DEFVAL(true), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("find_children", "pattern", "type", "recursive", "owned"), &Node::find_children, DEFVAL(""), DEFVAL(true), DEFVAL(true));

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -466,6 +466,7 @@ public:
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;
+	Node *get_unique_node(const StringName &p_name) const;
 	Node *find_child(const String &p_pattern, bool p_recursive = true, bool p_owned = true) const;
 	TypedArray<Node> find_children(const String &p_pattern, const String &p_type = "", bool p_recursive = true, bool p_owned = true) const;
 	bool has_node_and_resource(const NodePath &p_path) const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5048

This PR adds a new method to **Node** called `get_unique_node()`. The code is almost copied and pasted from part of `get_node()`. However, unlike the latter that passes through a **NodePath**, this method requires a **StringName** `name` as argument, and accesses the `owned_unique_nodes` directly.

This method is complete with autocompletion:

![image](https://user-images.githubusercontent.com/66727710/183404522-91636e9a-d8d7-43de-b33c-ff90daea6479.png)


Also updates description of `find_child()` to mention `get_unique_node()`.

As a comparison, this method is *much* slower when the appropriate parameters are passed (NotePath VS. StringName), but it is faster when normal String parameters are passed to both, which is what most common users would write.

The reason for this massive discrepancy can be attributed to the computing time it takes to append "**%**":
```c++
const StringName key = StringName(UNIQUE_NODE_PREFIX + p_name);
```
This is a requirement because, **FOR SOME REASON**, the "**%**" is included in the key when the **Node** is set as an unique name. I find it very unnecessary, as there's no way anything *without* "**%**" can be inserted into the `owned_unique_nodes` **HashMap** anyhow, but okay. *I am emphasising this, because such a simple thing was the burden of me for 8+ hours*.

This can _probably_ be backported or cherrypicked to `3.x` with no issues. 
