### PR TITLE
`Vector4`/`Vector4i`: Add missing methods and tests

### DIFF
--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -33,6 +33,40 @@
 #include "core/math/basis.h"
 #include "core/string/print_string.h"
 
+void Vector4::set_axis(const int p_axis, const real_t p_value) {
+	ERR_FAIL_INDEX(p_axis, 4);
+	components[p_axis] = p_value;
+}
+
+real_t Vector4::get_axis(const int p_axis) const {
+	ERR_FAIL_INDEX_V(p_axis, 4, 0);
+	return operator[](p_axis);
+}
+
+Vector4::Axis Vector4::min_axis_index() const {
+	uint32_t min_index = 0;
+	real_t min_value = x;
+	for (uint32_t i = 1; i < 4; i++) {
+		if (operator[](i) <= min_value) {
+			min_index = i;
+			min_value = operator[](i);
+		}
+	}
+	return Vector4::Axis(min_index);
+}
+
+Vector4::Axis Vector4::max_axis_index() const {
+	uint32_t max_index = 0;
+	real_t max_value = x;
+	for (uint32_t i = 1; i < 4; i++) {
+		if (operator[](i) > max_value) {
+			max_index = i;
+			max_value = operator[](i);
+		}
+	}
+	return Vector4::Axis(max_index);
+}
+
 bool Vector4::is_equal_approx(const Vector4 &p_vec4) const {
 	return Math::is_equal_approx(x, p_vec4.x) && Math::is_equal_approx(y, p_vec4.y) && Math::is_equal_approx(z, p_vec4.z) && Math::is_equal_approx(w, p_vec4.w);
 }
@@ -51,6 +85,16 @@ Vector4 Vector4::normalized() const {
 
 bool Vector4::is_normalized() const {
 	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON); // Use less epsilon.
+}
+
+real_t Vector4::distance_to(const Vector4 &p_to) const {
+	return (p_to - *this).length();
+}
+
+Vector4 Vector4::direction_to(const Vector4 &p_to) const {
+	Vector4 ret(p_to.x - x, p_to.y - y, p_to.z - z, p_to.w - w);
+	ret.normalize();
+	return ret;
 }
 
 Vector4 Vector4::abs() const {
@@ -81,32 +125,38 @@ Vector4 Vector4::lerp(const Vector4 &p_to, const real_t p_weight) const {
 			w + (p_weight * (p_to.w - w)));
 }
 
+Vector4 Vector4::cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight) const {
+	Vector4 res = *this;
+	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
+	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
+	res.z = Math::cubic_interpolate(res.z, p_b.z, p_pre_a.z, p_post_b.z, p_weight);
+	res.w = Math::cubic_interpolate(res.w, p_b.w, p_pre_a.w, p_post_b.w, p_weight);
+	return res;
+}
+
+Vector4 Vector4::posmod(const real_t p_mod) const {
+	return Vector4(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod), Math::fposmod(w, p_mod));
+}
+
+Vector4 Vector4::posmodv(const Vector4 &p_modv) const {
+	return Vector4(Math::fposmod(x, p_modv.x), Math::fposmod(y, p_modv.y), Math::fposmod(z, p_modv.z), Math::fposmod(w, p_modv.w));
+}
+
+void Vector4::snap(const Vector4 &p_step) {
+	x = Math::snapped(x, p_step.x);
+	y = Math::snapped(y, p_step.y);
+	z = Math::snapped(z, p_step.z);
+	w = Math::snapped(w, p_step.w);
+}
+
+Vector4 Vector4::snapped(const Vector4 &p_step) const {
+	Vector4 v = *this;
+	v.snap(p_step);
+	return v;
+}
+
 Vector4 Vector4::inverse() const {
 	return Vector4(1.0f / x, 1.0f / y, 1.0f / z, 1.0f / w);
-}
-
-Vector4::Axis Vector4::min_axis_index() const {
-	uint32_t min_index = 0;
-	real_t min_value = x;
-	for (uint32_t i = 1; i < 4; i++) {
-		if (operator[](i) <= min_value) {
-			min_index = i;
-			min_value = operator[](i);
-		}
-	}
-	return Vector4::Axis(min_index);
-}
-
-Vector4::Axis Vector4::max_axis_index() const {
-	uint32_t max_index = 0;
-	real_t max_value = x;
-	for (uint32_t i = 1; i < 4; i++) {
-		if (operator[](i) > max_value) {
-			max_index = i;
-			max_value = operator[](i);
-		}
-	}
-	return Vector4::Axis(max_index);
 }
 
 Vector4 Vector4::clamp(const Vector4 &p_min, const Vector4 &p_max) const {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -62,6 +62,15 @@ struct _NO_DISCARD_ Vector4 {
 		DEV_ASSERT((unsigned int)p_axis < 4);
 		return components[p_axis];
 	}
+
+	_FORCE_INLINE_ void set_all(const real_t p_value);
+
+	void set_axis(const int p_axis, const real_t p_value);
+	real_t get_axis(const int p_axis) const;
+
+	Vector4::Axis min_axis_index() const;
+	Vector4::Axis max_axis_index() const;
+
 	_FORCE_INLINE_ real_t length_squared() const;
 	bool is_equal_approx(const Vector4 &p_vec4) const;
 	real_t length() const;
@@ -69,15 +78,21 @@ struct _NO_DISCARD_ Vector4 {
 	Vector4 normalized() const;
 	bool is_normalized() const;
 
+	real_t distance_to(const Vector4 &p_to) const;
+	Vector4 direction_to(const Vector4 &p_to) const;
+
 	Vector4 abs() const;
 	Vector4 sign() const;
 	Vector4 floor() const;
 	Vector4 ceil() const;
 	Vector4 round() const;
 	Vector4 lerp(const Vector4 &p_to, const real_t p_weight) const;
+	Vector4 cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight) const;
 
-	Vector4::Axis min_axis_index() const;
-	Vector4::Axis max_axis_index() const;
+	Vector4 posmod(const real_t p_mod) const;
+	Vector4 posmodv(const Vector4 &p_modv) const;
+	void snap(const Vector4 &p_step);
+	Vector4 snapped(const Vector4 &p_step) const;
 	Vector4 clamp(const Vector4 &p_min, const Vector4 &p_max) const;
 
 	Vector4 inverse() const;
@@ -129,6 +144,10 @@ struct _NO_DISCARD_ Vector4 {
 		w = p_vec4.w;
 	}
 };
+
+void Vector4::set_all(const real_t p_value) {
+	x = y = z = p_value;
+}
 
 real_t Vector4::dot(const Vector4 &p_vec4) const {
 	return x * p_vec4.x + y * p_vec4.y + z * p_vec4.z + w * p_vec4.w;
@@ -193,7 +212,7 @@ Vector4 Vector4::operator/(const Vector4 &p_vec4) const {
 }
 
 Vector4 Vector4::operator-() const {
-	return Vector4(x, y, z, w);
+	return Vector4(-x, -y, -z, -w);
 }
 
 Vector4 Vector4::operator*(const real_t &s) const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1737,9 +1737,15 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector4, ceil, sarray(), varray());
 	bind_method(Vector4, round, sarray(), varray());
 	bind_method(Vector4, lerp, sarray("to", "weight"), varray());
+	bind_method(Vector4, cubic_interpolate, sarray("b", "pre_a", "post_b", "weight"), varray());
+	bind_method(Vector4, posmod, sarray("mod"), varray());
+	bind_method(Vector4, posmodv, sarray("modv"), varray());
+	bind_method(Vector4, snapped, sarray("step"), varray());
 	bind_method(Vector4, clamp, sarray("min", "max"), varray());
 	bind_method(Vector4, normalized, sarray(), varray());
 	bind_method(Vector4, is_normalized, sarray(), varray());
+	bind_method(Vector4, direction_to, sarray("to"), varray());
+	bind_method(Vector4, distance_to, sarray("to"), varray());
 	bind_method(Vector4, dot, sarray("with"), varray());
 	bind_method(Vector4, inverse, sarray(), varray());
 	bind_method(Vector4, is_equal_approx, sarray("with"), varray());

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -63,6 +63,30 @@
 				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
+		<method name="cubic_interpolate" qualifiers="const">
+			<return type="Vector4" />
+			<argument index="0" name="b" type="Vector4" />
+			<argument index="1" name="pre_a" type="Vector4" />
+			<argument index="2" name="post_b" type="Vector4" />
+			<argument index="3" name="weight" type="float" />
+			<description>
+				Performs a cubic interpolation between this vector and [code]b[/code] using [code]pre_a[/code] and [code]post_b[/code] as handles, and returns the result at position [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+			</description>
+		</method>
+		<method name="direction_to" qualifiers="const">
+			<return type="Vector4" />
+			<argument index="0" name="to" type="Vector4" />
+			<description>
+				Returns the normalized vector pointing from this vector to [code]to[/code]. This is equivalent to using [code](b - a).normalized()[/code].
+			</description>
+		</method>
+		<method name="distance_to" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="to" type="Vector4" />
+			<description>
+				Returns the distance between this vector and [code]to[/code].
+			</description>
+		</method>
 		<method name="dot" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="with" type="Vector4" />
@@ -133,6 +157,20 @@
 				Returns the vector scaled to unit length. Equivalent to [code]v / v.length()[/code].
 			</description>
 		</method>
+		<method name="posmod" qualifiers="const">
+			<return type="Vector4" />
+			<argument index="0" name="mod" type="float" />
+			<description>
+				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [code]mod[/code].
+			</description>
+		</method>
+		<method name="posmodv" qualifiers="const">
+			<return type="Vector4" />
+			<argument index="0" name="modv" type="Vector4" />
+			<description>
+				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [code]modv[/code]'s components.
+			</description>
+		</method>
 		<method name="round" qualifiers="const">
 			<return type="Vector4" />
 			<description>
@@ -143,6 +181,13 @@
 			<return type="Vector4" />
 			<description>
 				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
+			</description>
+		</method>
+		<method name="snapped" qualifiers="const">
+			<return type="Vector4" />
+			<argument index="0" name="step" type="Vector4" />
+			<description>
+				Returns this vector with each component snapped to the nearest multiple of [code]step[/code]. This can also be used to round to an arbitrary number of decimals.
 			</description>
 		</method>
 	</methods>

--- a/tests/core/math/test_vector4.h
+++ b/tests/core/math/test_vector4.h
@@ -1,0 +1,312 @@
+/*************************************************************************/
+/*  test_vector4.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_VECTOR4_H
+#define TEST_VECTOR4_H
+
+#include "core/math/vector4.h"
+#include "tests/test_macros.h"
+
+#define Math_SQRT3 1.7320508075688772935274463415059
+
+namespace TestVector4 {
+
+TEST_CASE("[Vector4] Axis methods") {
+	Vector4 vector = Vector4(1.2, 3.4, 5.6, -0.9);
+	CHECK_MESSAGE(
+			vector.max_axis_index() == Vector4::Axis::AXIS_Z,
+			"Vector4 max_axis_index should work as expected.");
+	CHECK_MESSAGE(
+			vector.min_axis_index() == Vector4::Axis::AXIS_W,
+			"Vector4 min_axis_index should work as expected.");
+	CHECK_MESSAGE(
+			vector.get_axis(vector.max_axis_index()) == (real_t)5.6,
+			"Vector4 get_axis should work as expected.");
+	CHECK_MESSAGE(
+			vector[vector.min_axis_index()] == (real_t)-0.9,
+			"Vector4 array operator should work as expected.");
+
+	vector.set_axis(Vector4::Axis::AXIS_Y, 4.7);
+	CHECK_MESSAGE(
+			vector.get_axis(Vector4::Axis::AXIS_Y) == (real_t)4.7,
+			"Vector4 set_axis should work as expected.");
+	vector[Vector4::Axis::AXIS_Y] = 3.7;
+	CHECK_MESSAGE(
+			vector[Vector4::Axis::AXIS_Y] == (real_t)3.7,
+			"Vector4 array operator setter should work as expected.");
+}
+
+TEST_CASE("[Vector4] Interpolation methods") {
+	const Vector4 vector1 = Vector4(1, 2, 3, 4);
+	const Vector4 vector2 = Vector4(4, 5, 6, 7);
+	CHECK_MESSAGE(
+			vector1.lerp(vector2, 0.5) == Vector4(2.5, 3.5, 4.5, 5.5),
+			"Vector4 lerp should work as expected.");
+	CHECK_MESSAGE(
+			vector1.lerp(vector2, 1.0 / 3.0).is_equal_approx(Vector4(2, 3, 4, 5)),
+			"Vector4 lerp should work as expected.");
+	CHECK_MESSAGE(
+			vector1.cubic_interpolate(vector2, Vector4(), Vector4(7, 7, 7, 7), 0.5) == Vector4(2.375, 3.5, 4.625, 5.75),
+			"Vector4 cubic_interpolate should work as expected.");
+	CHECK_MESSAGE(
+			vector1.cubic_interpolate(vector2, Vector4(), Vector4(7, 7, 7, 7), 1.0 / 3.0).is_equal_approx(Vector4(1.851851940155029297, 2.962963104248046875, 4.074074268341064453, 5.185185185185)),
+			"Vector4 cubic_interpolate should work as expected.");
+}
+
+TEST_CASE("[Vector4] Length methods") {
+	const Vector4 vector1 = Vector4(10, 10, 10, 10);
+	const Vector4 vector2 = Vector4(20, 30, 40, 50);
+	CHECK_MESSAGE(
+			vector1.length_squared() == 400,
+			"Vector4 length_squared should work as expected and return exact result.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(vector1.length(), 20),
+			"Vector4 length should work as expected.");
+	CHECK_MESSAGE(
+			vector2.length_squared() == 5400,
+			"Vector4 length_squared should work as expected and return exact result.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(vector2.length(), (real_t)73.484692283495),
+			"Vector4 length should work as expected.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(vector1.distance_to(vector2), (real_t)54.772255750517),
+			"Vector4 distance_to should work as expected.");
+}
+
+TEST_CASE("[Vector4] Limiting methods") {
+	const Vector4 vector = Vector4(10, 10, 10, 10);
+	CHECK_MESSAGE(
+			Vector4(-5, 5, 15, -15).clamp(Vector4(), vector) == Vector4(0, 5, 10, 0),
+			"Vector4 clamp should work as expected.");
+	CHECK_MESSAGE(
+			vector.clamp(Vector4(0, 10, 15, 18), Vector4(5, 10, 20, 25)) == Vector4(5, 10, 15, 18),
+			"Vector4 clamp should work as expected.");
+}
+
+TEST_CASE("[Vector4] Normalization methods") {
+	CHECK_MESSAGE(
+			Vector4(1, 0, 0, 0).is_normalized() == true,
+			"Vector4 is_normalized should return true for a normalized vector.");
+	CHECK_MESSAGE(
+			Vector4(1, 1, 1, 1).is_normalized() == false,
+			"Vector4 is_normalized should return false for a non-normalized vector.");
+	CHECK_MESSAGE(
+			Vector4(1, 0, 0, 0).normalized() == Vector4(1, 0, 0, 0),
+			"Vector4 normalized should return the same vector for a normalized vector.");
+	CHECK_MESSAGE(
+			Vector4(1, 1, 0, 0).normalized().is_equal_approx(Vector4(Math_SQRT12, Math_SQRT12, 0, 0)),
+			"Vector4 normalized should work as expected.");
+	CHECK_MESSAGE(
+			Vector4(1, 1, 1, 1).normalized().is_equal_approx(Vector4(0.5, 0.5, 0.5, 0.5)),
+			"Vector4 normalized should work as expected.");
+}
+
+TEST_CASE("[Vector4] Operators") {
+	const Vector4 decimal1 = Vector4(2.3, 4.9, 7.8, 3.2);
+	const Vector4 decimal2 = Vector4(1.2, 3.4, 5.6, 1.7);
+	const Vector4 power1 = Vector4(0.75, 1.5, 0.625, 0.125);
+	const Vector4 power2 = Vector4(0.5, 0.125, 0.25, 0.75);
+	const Vector4 int1 = Vector4(4, 5, 9, 2);
+	const Vector4 int2 = Vector4(1, 2, 3, 1);
+
+	CHECK_MESSAGE(
+			-decimal1 == Vector4(-2.3, -4.9, -7.8, -3.2),
+			"Vector4 change of sign should work as expected.");
+	CHECK_MESSAGE(
+			(decimal1 + decimal2).is_equal_approx(Vector4(3.5, 8.3, 13.4, 4.9)),
+			"Vector4 addition should behave as expected.");
+	CHECK_MESSAGE(
+			(power1 + power2) == Vector4(1.25, 1.625, 0.875, 0.875),
+			"Vector4 addition with powers of two should give exact results.");
+	CHECK_MESSAGE(
+			(int1 + int2) == Vector4(5, 7, 12, 3),
+			"Vector4 addition with integers should give exact results.");
+
+	CHECK_MESSAGE(
+			(decimal1 - decimal2).is_equal_approx(Vector4(1.1, 1.5, 2.2, 1.5)),
+			"Vector4 subtraction should behave as expected.");
+	CHECK_MESSAGE(
+			(power1 - power2) == Vector4(0.25, 1.375, 0.375, -0.625),
+			"Vector4 subtraction with powers of two should give exact results.");
+	CHECK_MESSAGE(
+			(int1 - int2) == Vector4(3, 3, 6, 1),
+			"Vector4 subtraction with integers should give exact results.");
+
+	CHECK_MESSAGE(
+			(decimal1 * decimal2).is_equal_approx(Vector4(2.76, 16.66, 43.68, 5.44)),
+			"Vector4 multiplication should behave as expected.");
+	CHECK_MESSAGE(
+			(power1 * power2) == Vector4(0.375, 0.1875, 0.15625, 0.09375),
+			"Vector4 multiplication with powers of two should give exact results.");
+	CHECK_MESSAGE(
+			(int1 * int2) == Vector4(4, 10, 27, 2),
+			"Vector4 multiplication with integers should give exact results.");
+
+	CHECK_MESSAGE(
+			(decimal1 / decimal2).is_equal_approx(Vector4(1.91666666666666666, 1.44117647058823529, 1.39285714285714286, 1.88235294118)),
+			"Vector4 division should behave as expected.");
+	CHECK_MESSAGE(
+			(power1 / power2) == Vector4(1.5, 12.0, 2.5, 1.0 / 6.0),
+			"Vector4 division with powers of two should give exact results.");
+	CHECK_MESSAGE(
+			(int1 / int2) == Vector4(4, 2.5, 3, 2),
+			"Vector4 division with integers should give exact results.");
+
+	CHECK_MESSAGE(
+			(decimal1 * 2).is_equal_approx(Vector4(4.6, 9.8, 15.6, 6.4)),
+			"Vector4 multiplication should behave as expected.");
+	CHECK_MESSAGE(
+			(power1 * 2) == Vector4(1.5, 3, 1.25, 0.25),
+			"Vector4 multiplication with powers of two should give exact results.");
+	CHECK_MESSAGE(
+			(int1 * 2) == Vector4(8, 10, 18, 4),
+			"Vector4 multiplication with integers should give exact results.");
+
+	CHECK_MESSAGE(
+			(decimal1 / 2).is_equal_approx(Vector4(1.15, 2.45, 3.9, 1.6)),
+			"Vector4 division should behave as expected.");
+	CHECK_MESSAGE(
+			(power1 / 2) == Vector4(0.375, 0.75, 0.3125, 0.0625),
+			"Vector4 division with powers of two should give exact results.");
+	CHECK_MESSAGE(
+			(int1 / 2) == Vector4(2, 2.5, 4.5, 1),
+			"Vector4 division with integers should give exact results.");
+
+	CHECK_MESSAGE(
+			((String)decimal1) == "(2.3, 4.9, 7.8, 3.2)",
+			"Vector4 cast to String should work as expected.");
+	CHECK_MESSAGE(
+			((String)decimal2) == "(1.2, 3.4, 5.6, 1.7)",
+			"Vector4 cast to String should work as expected.");
+	CHECK_MESSAGE(
+			((String)Vector4(9.7, 9.8, 9.9, -1.8)) == "(9.7, 9.8, 9.9, -1.8)",
+			"Vector4 cast to String should work as expected.");
+#ifdef REAL_T_IS_DOUBLE
+	CHECK_MESSAGE(
+			((String)Vector4(Math_E, Math_SQRT2, Math_SQRT3, Math_SQRT3)) == "(2.71828182845905, 1.4142135623731, 1.73205080756888, 1.73205080756888)",
+			"Vector4 cast to String should print the correct amount of digits for real_t = double.");
+#else
+	CHECK_MESSAGE(
+			((String)Vector4(Math_E, Math_SQRT2, Math_SQRT3, Math_SQRT3)) == "(2.718282, 1.414214, 1.732051, 1.732051)",
+			"Vector4 cast to String should print the correct amount of digits for real_t = float.");
+#endif // REAL_T_IS_DOUBLE
+}
+
+TEST_CASE("[Vector4] Other methods") {
+	const Vector4 vector = Vector4(1.2, 3.4, 5.6, 1.6);
+	CHECK_MESSAGE(
+			vector.direction_to(Vector4()).is_equal_approx(-vector.normalized()),
+			"Vector4 direction_to should work as expected.");
+	CHECK_MESSAGE(
+			Vector4(1, 1, 1, 1).direction_to(Vector4(2, 2, 2, 2)).is_equal_approx(Vector4(0.5, 0.5, 0.5, 0.5)),
+			"Vector4 direction_to should work as expected.");
+	CHECK_MESSAGE(
+			vector.inverse().is_equal_approx(Vector4(1 / 1.2, 1 / 3.4, 1 / 5.6, 1 / 1.6)),
+			"Vector4 inverse should work as expected.");
+	CHECK_MESSAGE(
+			vector.posmod(2).is_equal_approx(Vector4(1.2, 1.4, 1.6, 1.6)),
+			"Vector4 posmod should work as expected.");
+	CHECK_MESSAGE(
+			(-vector).posmod(2).is_equal_approx(Vector4(0.8, 0.6, 0.4, 0.4)),
+			"Vector4 posmod should work as expected.");
+	CHECK_MESSAGE(
+			vector.posmodv(Vector4(1, 2, 3, 4)).is_equal_approx(Vector4(0.2, 1.4, 2.6, 1.6)),
+			"Vector4 posmodv should work as expected.");
+	CHECK_MESSAGE(
+			(-vector).posmodv(Vector4(2, 3, 4, 5)).is_equal_approx(Vector4(0.8, 2.6, 2.4, 3.4)),
+			"Vector4 posmodv should work as expected.");
+	CHECK_MESSAGE(
+			vector.snapped(Vector4(1, 1, 1, 1)) == Vector4(1, 3, 6, 2),
+			"Vector4 snapped to integers should be the same as rounding.");
+	CHECK_MESSAGE(
+			vector.snapped(Vector4(0.25, 0.25, 0.25, 0.25)) == Vector4(1.25, 3.5, 5.5, 1.5),
+			"Vector4 snapped to 0.25 should give exact results.");
+}
+
+TEST_CASE("[Vector4] Rounding methods") {
+	const Vector4 vector1 = Vector4(1.2, 3.4, 5.6, 1.6);
+	const Vector4 vector2 = Vector4(1.2, -3.4, -5.6, -1.6);
+	CHECK_MESSAGE(
+			vector1.abs() == vector1,
+			"Vector4 abs should work as expected.");
+	CHECK_MESSAGE(
+			vector2.abs() == vector1,
+			"Vector4 abs should work as expected.");
+	CHECK_MESSAGE(
+			vector1.ceil() == Vector4(2, 4, 6, 2),
+			"Vector4 ceil should work as expected.");
+	CHECK_MESSAGE(
+			vector2.ceil() == Vector4(2, -3, -5, -1),
+			"Vector4 ceil should work as expected.");
+
+	CHECK_MESSAGE(
+			vector1.floor() == Vector4(1, 3, 5, 1),
+			"Vector4 floor should work as expected.");
+	CHECK_MESSAGE(
+			vector2.floor() == Vector4(1, -4, -6, -2),
+			"Vector4 floor should work as expected.");
+
+	CHECK_MESSAGE(
+			vector1.round() == Vector4(1, 3, 6, 2),
+			"Vector4 round should work as expected.");
+	CHECK_MESSAGE(
+			vector2.round() == Vector4(1, -3, -6, -2),
+			"Vector4 round should work as expected.");
+
+	CHECK_MESSAGE(
+			vector1.sign() == Vector4(1, 1, 1, 1),
+			"Vector4 sign should work as expected.");
+	CHECK_MESSAGE(
+			vector2.sign() == Vector4(1, -1, -1, -1),
+			"Vector4 sign should work as expected.");
+}
+
+TEST_CASE("[Vector4] Linear algebra methods") {
+	const Vector4 vector_x = Vector4(1, 0, 0, 0);
+	const Vector4 vector_y = Vector4(0, 1, 0, 0);
+	const Vector4 vector1 = Vector4(1.7, 2.3, 1, 9.1);
+	const Vector4 vector2 = Vector4(-8.2, -16, 3, 2.4);
+
+	CHECK_MESSAGE(
+			vector_x.dot(vector_y) == 0.0,
+			"Vector4 dot product of perpendicular vectors should be zero.");
+	CHECK_MESSAGE(
+			vector_x.dot(vector_x) == 1.0,
+			"Vector4 dot product of identical unit vectors should be one.");
+	CHECK_MESSAGE(
+			(vector_x * 10).dot(vector_x * 10) == 100.0,
+			"Vector4 dot product of same direction vectors should behave as expected.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx((vector1 * 2).dot(vector2 * 4), (real_t)-25.9 * 8),
+			"Vector4 dot product should work as expected.");
+}
+} // namespace TestVector4
+
+#endif // TEST_VECTOR4_H

--- a/tests/core/math/test_vector4i.h
+++ b/tests/core/math/test_vector4i.h
@@ -1,0 +1,148 @@
+/*************************************************************************/
+/*  test_vector4i.h                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_VECTOR4I_H
+#define TEST_VECTOR4I_H
+
+#include "core/math/vector4i.h"
+#include "tests/test_macros.h"
+
+namespace TestVector4i {
+
+TEST_CASE("[Vector4i] Axis methods") {
+	Vector4i vector = Vector4i(1, 2, 3, 4);
+	CHECK_MESSAGE(
+			vector.max_axis_index() == Vector4i::Axis::AXIS_W,
+			"Vector4i max_axis_index should work as expected.");
+	CHECK_MESSAGE(
+			vector.min_axis_index() == Vector4i::Axis::AXIS_X,
+			"Vector4i min_axis_index should work as expected.");
+	CHECK_MESSAGE(
+			vector.get_axis(vector.max_axis_index()) == 4,
+			"Vector4i get_axis should work as expected.");
+	CHECK_MESSAGE(
+			vector[vector.min_axis_index()] == 1,
+			"Vector4i array operator should work as expected.");
+
+	vector.set_axis(Vector4i::Axis::AXIS_Y, 5);
+	CHECK_MESSAGE(
+			vector.get_axis(Vector4i::Axis::AXIS_Y) == 5,
+			"Vector4i set_axis should work as expected.");
+	vector[Vector4i::Axis::AXIS_Y] = 5;
+	CHECK_MESSAGE(
+			vector[Vector4i::Axis::AXIS_Y] == 5,
+			"Vector4i array operator setter should work as expected.");
+}
+
+TEST_CASE("[Vector4i] Clamp method") {
+	const Vector4i vector = Vector4i(10, 10, 10, 10);
+	CHECK_MESSAGE(
+			Vector4i(-5, 5, 15, INT_MAX).clamp(Vector4i(), vector) == Vector4i(0, 5, 10, 10),
+			"Vector4i clamp should work as expected.");
+	CHECK_MESSAGE(
+			vector.clamp(Vector4i(0, 10, 15, -10), Vector4i(5, 10, 20, -5)) == Vector4i(5, 10, 15, -5),
+			"Vector4i clamp should work as expected.");
+}
+
+TEST_CASE("[Vector4i] Length methods") {
+	const Vector4i vector1 = Vector4i(10, 10, 10, 10);
+	const Vector4i vector2 = Vector4i(20, 30, 40, 50);
+	CHECK_MESSAGE(
+			vector1.length_squared() == 400,
+			"Vector4i length_squared should work as expected and return exact result.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(vector1.length(), 20),
+			"Vector4i length should work as expected.");
+	CHECK_MESSAGE(
+			vector2.length_squared() == 5400,
+			"Vector4i length_squared should work as expected and return exact result.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(vector2.length(), 73.4846922835),
+			"Vector4i length should work as expected.");
+}
+
+TEST_CASE("[Vector4i] Operators") {
+	const Vector4i vector1 = Vector4i(4, 5, 9, 2);
+	const Vector4i vector2 = Vector4i(1, 2, 3, 4);
+
+	CHECK_MESSAGE(
+			-vector1 == Vector4i(-4, -5, -9, -2),
+			"Vector4i change of sign should work as expected.");
+	CHECK_MESSAGE(
+			(vector1 + vector2) == Vector4i(5, 7, 12, 6),
+			"Vector4i addition with integers should give exact results.");
+	CHECK_MESSAGE(
+			(vector1 - vector2) == Vector4i(3, 3, 6, -2),
+			"Vector4i subtraction with integers should give exact results.");
+	CHECK_MESSAGE(
+			(vector1 * vector2) == Vector4i(4, 10, 27, 8),
+			"Vector4i multiplication with integers should give exact results.");
+	CHECK_MESSAGE(
+			(vector1 / vector2) == Vector4i(4, 2, 3, 0),
+			"Vector4i division with integers should give exact results.");
+
+	CHECK_MESSAGE(
+			(vector1 * 2) == Vector4i(8, 10, 18, 4),
+			"Vector4i multiplication with integers should give exact results.");
+	CHECK_MESSAGE(
+			(vector1 / 2) == Vector4i(2, 2, 4, 1),
+			"Vector4i division with integers should give exact results.");
+
+	CHECK_MESSAGE(
+			((Vector4)vector1) == Vector4(4, 5, 9, 2),
+			"Vector4i cast to Vector4 should work as expected.");
+	CHECK_MESSAGE(
+			((Vector4)vector2) == Vector4(1, 2, 3, 4),
+			"Vector4i cast to Vector4 should work as expected.");
+	CHECK_MESSAGE(
+			Vector4i(Vector4(1.1, 2.9, 3.9, 100.5)) == Vector4i(1, 2, 3, 100),
+			"Vector4i constructed from Vector4 should work as expected.");
+}
+
+TEST_CASE("[Vector4i] Abs and sign methods") {
+	const Vector4i vector1 = Vector4i(1, 3, 5, 7);
+	const Vector4i vector2 = Vector4i(1, -3, -5, 7);
+	CHECK_MESSAGE(
+			vector1.abs() == vector1,
+			"Vector4i abs should work as expected.");
+	CHECK_MESSAGE(
+			vector2.abs() == vector1,
+			"Vector4i abs should work as expected.");
+
+	CHECK_MESSAGE(
+			vector1.sign() == Vector4i(1, 1, 1, 1),
+			"Vector4i sign should work as expected.");
+	CHECK_MESSAGE(
+			vector2.sign() == Vector4i(1, -1, -1, 1),
+			"Vector4i sign should work as expected.");
+}
+} // namespace TestVector4i
+
+#endif // TEST_VECTOR4I_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -58,6 +58,8 @@
 #include "tests/core/math/test_vector2i.h"
 #include "tests/core/math/test_vector3.h"
 #include "tests/core/math/test_vector3i.h"
+#include "tests/core/math/test_vector4.h"
+#include "tests/core/math/test_vector4i.h"
 #include "tests/core/object/test_class_db.h"
 #include "tests/core/object/test_method_bind.h"
 #include "tests/core/object/test_object.h"


### PR DESCRIPTION
- Implement the following methods for Vektor4:
	 `get_axis, set_axis, set_all, cubic_interpolate, posmod, posmodv, snap, snapped, distance_to, direction_to`
- Add basic tests for Vektor4 and Vektor4i
	- Vektor4: Fix operator-()