### PR TITLE
Fix NavigationRegion3D gizmo's odd visual behavior

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -494,7 +494,7 @@ void NavigationRegion2D::_notification(int p_what) {
 
 					// Generate the polygon color, slightly randomly modified from the settings one.
 					Color random_variation_color;
-					random_variation_color.set_hsv(color.get_h() + rand.random(-1.0, 1.0) * 0.05, color.get_s(), color.get_v() + rand.random(-1.0, 1.0) * 0.1);
+					random_variation_color.set_hsv(color.get_h() + rand.random(-1.0, 1.0) * 0.1, color.get_s(), color.get_v() + rand.random(-1.0, 1.0) * 0.2);
 					random_variation_color.a = color.a;
 					Vector<Color> colors;
 					colors.push_back(random_variation_color);

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -418,11 +418,14 @@ void NavigationRegion3D::_update_debug_mesh() {
 	Ref<StandardMaterial3D> face_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_face_material();
 	Ref<StandardMaterial3D> line_material = NavigationServer3D::get_singleton_mut()->get_debug_navigation_geometry_edge_material();
 
+	RandomPCG rand;
 	Color polygon_color = debug_navigation_geometry_face_color;
 
 	for (int i = 0; i < polygon_count; i++) {
 		if (enabled_geometry_face_random_color) {
-			polygon_color = debug_navigation_geometry_face_color * (Color(Math::randf(), Math::randf(), Math::randf()));
+			// Generate the polygon color, slightly randomly modified from the settings one.
+			polygon_color.set_hsv(debug_navigation_geometry_face_color.get_h() + rand.random(-1.0, 1.0) * 0.1, debug_navigation_geometry_face_color.get_s(), debug_navigation_geometry_face_color.get_v() + rand.random(-1.0, 1.0) * 0.2);
+			polygon_color.a = debug_navigation_geometry_face_color.a;
 		}
 
 		Vector<int> polygon = navmesh->get_polygon(i);


### PR DESCRIPTION
Does the following:
- Use gizmo managed materials so the gizmo's xray setting and selected status apply correctly to the visualization for the navigation mesh.
- Use the same technique for computing random face colors as NavigationRegion2D to avoid cases where a polygon appears to be missing due to it being mostly transparent.
- Slightly increase the variability of the face colors for both the 2D and 3D versions of NavigationRegion.

![image](https://user-images.githubusercontent.com/1929107/183279206-8dd3ffc2-30a0-4962-8419-babf412ee7a3.png)
