### PR TITLE
[3.x] Add `TorusMesh`

### DIFF
--- a/doc/classes/TorusMesh.xml
+++ b/doc/classes/TorusMesh.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TorusMesh" inherits="PrimitiveMesh" version="3.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Class representing a torus [PrimitiveMesh].
+	</brief_description>
+	<description>
+		Class representing a torus [PrimitiveMesh].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+	</methods>
+	<members>
+		<member name="inner_radius" type="float" setter="set_inner_radius" getter="get_inner_radius" default="0.5">
+			The inner radius of the torus.
+		</member>
+		<member name="outer_radius" type="float" setter="set_outer_radius" getter="get_outer_radius" default="1.0">
+			The outer radius of the torus.
+		</member>
+		<member name="ring_segments" type="int" setter="set_ring_segments" getter="get_ring_segments" default="32">
+			The number of edges each ring of the torus is constructed of.
+		</member>
+		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="64">
+			The number of slices the torus is constructed of.
+		</member>
+	</members>
+	<constants>
+	</constants>
+</class>

--- a/editor/icons/icon_torus_mesh.svg
+++ b/editor/icons/icon_torus_mesh.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><ellipse cx="8" cy="7.5" fill="none" rx="6" ry="3.5" stroke="#ffd684" stroke-linecap="square" stroke-linejoin="round" stroke-width="2"/></svg>

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -665,6 +665,7 @@ void register_scene_types() {
 	ClassDB::register_class<QuadMesh>();
 	ClassDB::register_class<SphereMesh>();
 	ClassDB::register_class<TextMesh>();
+	ClassDB::register_class<TorusMesh>();
 	ClassDB::register_class<PointMesh>();
 	ClassDB::register_virtual_class<Material>();
 	ClassDB::register_class<SpatialMaterial>();

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -352,6 +352,38 @@ public:
 };
 
 /**
+	Big donut
+*/
+class TorusMesh : public PrimitiveMesh {
+	GDCLASS(TorusMesh, PrimitiveMesh);
+
+private:
+	float inner_radius = 0.5;
+	float outer_radius = 1.0;
+	int rings = 64;
+	int ring_segments = 32;
+
+protected:
+	static void _bind_methods();
+	virtual void _create_mesh_array(Array &p_arr) const;
+
+public:
+	void set_inner_radius(const float p_inner_radius);
+	float get_inner_radius() const;
+
+	void set_outer_radius(const float p_outer_radius);
+	float get_outer_radius() const;
+
+	void set_rings(const int p_rings);
+	int get_rings() const;
+
+	void set_ring_segments(const int p_ring_segments);
+	int get_ring_segments() const;
+
+	TorusMesh();
+};
+
+/**
 	A single point for use in particle systems
 */
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/60843.

I kept the default size consistent with 4.0, as the CSG and primitive meshes' default sizes are already inconsistent in 3.x anyway.

**Testing project:** [test_torusmesh_3.x.zip](https://github.com/godotengine/godot/files/9276626/test_torusmesh_3.x.zip)

## Preview

CSG meshes on the front, primitive meshes on the back:

![2022-08-07_12 40 23](https://user-images.githubusercontent.com/180032/183287029-ad951a24-df26-4709-b540-051d981503c1.png)