### PR TITLE
Expose ObjectID among the native structure in GDExtension

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -269,6 +269,7 @@ void register_core_types() {
 	_marshalls = memnew(core_bind::Marshalls);
 	_engine_debugger = memnew(core_bind::EngineDebugger);
 
+	GDREGISTER_NATIVE_STRUCT(ObjectID, "uint64_t id = 0");
 	GDREGISTER_NATIVE_STRUCT(AudioFrame, "float left;float right");
 	GDREGISTER_NATIVE_STRUCT(ScriptLanguageExtensionProfilingInfo, "StringName signature;uint64_t call_count;uint64_t total_time;uint64_t self_time");
 


### PR DESCRIPTION
`ObjectID` is referenced by `PhysicsServer3DExtension*Result`, hence it should be among the native structures:

https://github.com/godotengine/godot/blob/428aed8e877b0b9e2de6502a7cbeb496bfba159f/servers/register_server_types.cpp#L142-L144
