### PR TITLE
fix(gdscript): Infer type from preload const

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3238,12 +3238,12 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 			Variant value = p_subscript->base->reduced_value.get_named(p_subscript->attribute->name, valid);
 			if (!valid) {
 				push_error(vformat(R"(Cannot get member "%s" from "%s".)", p_subscript->attribute->name, p_subscript->base->reduced_value), p_subscript->index);
+				result_type.kind = GDScriptParser::DataType::VARIANT;
 			} else {
 				p_subscript->is_constant = true;
 				p_subscript->reduced_value = value;
 				result_type = type_from_variant(value, p_subscript);
 			}
-			result_type.kind = GDScriptParser::DataType::VARIANT;
 		} else {
 			GDScriptParser::DataType base_type = p_subscript->base->get_datatype();
 

--- a/modules/gdscript/tests/scripts/analyzer/features/gdscript_to_preload.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/gdscript_to_preload.gd
@@ -1,3 +1,5 @@
+const A := 42
+
 func test():
 	pass
 

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_constant_types_are_inferred.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_constant_types_are_inferred.gd
@@ -1,0 +1,6 @@
+const Constants = preload("gdscript_to_preload.gd")
+
+func test():
+	var a := Constants.A
+	print(a)
+

--- a/modules/gdscript/tests/scripts/analyzer/features/preload_constant_types_are_inferred.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/preload_constant_types_are_inferred.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+42


### PR DESCRIPTION
When resolving the type of the attribute from the variant, the result_type.kind was overwritten for no reason.
It is assumed that this only needs to be done, if the variant value is not valid to have any kind here.

Fixes #63715
