### PR TITLE
Fix axis snapping of CollisionPolygon2D's newly created vertex

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -294,9 +294,9 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 							_commit_action();
 							return true;
 						} else {
-							pre_move_edit = vertices;
 							edited_point = PosVertex(insert.polygon, insert.vertex + 1, xform.affine_inverse().xform(insert.pos));
 							vertices.insert(edited_point.vertex, edited_point.pos);
+							pre_move_edit = vertices;
 							selected_point = Vertex(edited_point.polygon, edited_point.vertex);
 							edge_point = PosVertex();
 


### PR DESCRIPTION
Closes #64012 

In CollisionPolygon2D when you add a new vertex via clicking on an existing edge, that vertex can immediately be moved without releasing the left mouse button.
A copy collection of polygon vertexes that is used to determine their positions prior to being moved was populated before the new vertex was added which caused a critical error when later trying to reference that vertex when moving. This reference access only occured when snapping to axis via holding Shift key.
This fixes this behaviour by populating the collection after adding the new vertex.