### PR TITLE
Use interleaved gradient noise for distance fade (3.x)

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -914,38 +914,21 @@ void SpatialMaterial::_update_shader() {
 		if ((distance_fade == DISTANCE_FADE_OBJECT_DITHER || distance_fade == DISTANCE_FADE_PIXEL_DITHER)) {
 			if (!VisualServer::get_singleton()->is_low_end()) {
 				code += "\t{\n";
+
 				if (distance_fade == DISTANCE_FADE_OBJECT_DITHER) {
 					code += "\t\tfloat fade_distance = abs((INV_CAMERA_MATRIX * WORLD_MATRIX[3]).z);\n";
 
 				} else {
-					code += "\t\tfloat fade_distance=-VERTEX.z;\n";
+					code += "\t\tfloat fade_distance = -VERTEX.z;\n";
 				}
+				// Use interleaved gradient noise, which is fast but still looks good.
+				code += "\t\tconst vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);";
+				code += "\t\tfloat fade = clamp(smoothstep(distance_fade_min, distance_fade_max, fade_distance), 0.0, 1.0);\n";
+				// Use a hard cap to prevent a few stray pixels from remaining when past the fade-out distance.
+				code += "\t\tif (fade < 0.001 || fade < fract(magic.z * fract(dot(FRAGCOORD.xy, magic.xy)))) {\n";
+				code += "\t\t\tdiscard;\n";
+				code += "\t\t}\n";
 
-				code += "\t\tfloat fade=clamp(smoothstep(distance_fade_min,distance_fade_max,fade_distance),0.0,1.0);\n";
-				code += "\t\tint x = int(FRAGCOORD.x) % 4;\n";
-				code += "\t\tint y = int(FRAGCOORD.y) % 4;\n";
-				code += "\t\tint index = x + y * 4;\n";
-				code += "\t\tfloat limit = 0.0;\n\n";
-				code += "\t\tif (x < 8) {\n";
-				code += "\t\t\tif (index == 0) limit = 0.0625;\n";
-				code += "\t\t\tif (index == 1) limit = 0.5625;\n";
-				code += "\t\t\tif (index == 2) limit = 0.1875;\n";
-				code += "\t\t\tif (index == 3) limit = 0.6875;\n";
-				code += "\t\t\tif (index == 4) limit = 0.8125;\n";
-				code += "\t\t\tif (index == 5) limit = 0.3125;\n";
-				code += "\t\t\tif (index == 6) limit = 0.9375;\n";
-				code += "\t\t\tif (index == 7) limit = 0.4375;\n";
-				code += "\t\t\tif (index == 8) limit = 0.25;\n";
-				code += "\t\t\tif (index == 9) limit = 0.75;\n";
-				code += "\t\t\tif (index == 10) limit = 0.125;\n";
-				code += "\t\t\tif (index == 11) limit = 0.625;\n";
-				code += "\t\t\tif (index == 12) limit = 1.0;\n";
-				code += "\t\t\tif (index == 13) limit = 0.5;\n";
-				code += "\t\t\tif (index == 14) limit = 0.875;\n";
-				code += "\t\t\tif (index == 15) limit = 0.375;\n";
-				code += "\t\t}\n\n";
-				code += "\tif (fade < limit)\n";
-				code += "\t\tdiscard;\n";
 				code += "\t}\n\n";
 			}
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/50297.

This provides better visuals and performance compared to the previous ordered dither.

**Testing project:** [test_distance_fade_3.x.zip](https://github.com/godotengine/godot/files/9276870/test_distance_fade_3.x.zip)

## Preview

*Click to view at full size (and click again to view at 1:1 scale, which is required to accurately preview the dithering pattern).*

![2022-08-07_15 27 27](https://user-images.githubusercontent.com/180032/183293097-c3ea3bb3-a240-454c-ae3e-4457c617f3b7.png)