### PR TITLE
Add a GDScript error checker class

### DIFF
--- a/doc/classes/GDScriptErrorChecker.xml
+++ b/doc/classes/GDScriptErrorChecker.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptErrorChecker" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Tool to check for errors on GDScript source code.
+	</brief_description>
+	<description>
+		[GDScriptErrorChecker] takes the source code of a GDScript file and runs it through the GDScript parser in order to expose any errors it finds.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_error" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="idx" type="int" />
+			<description>
+				Returns the message for an error at the given index.
+			</description>
+		</method>
+		<method name="get_error_column" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="idx" type="int" />
+			<description>
+				Returns the column on the line the error at the given index happened.
+			</description>
+		</method>
+		<method name="get_error_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of errors the parser found.
+			</description>
+		</method>
+		<method name="get_error_line" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="idx" type="int" />
+			<description>
+				Returns the line the error at the given index happened.
+			</description>
+		</method>
+		<method name="has_errors" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether or not the parser found any errors.
+			</description>
+		</method>
+		<method name="set_source">
+			<return type="int" enum="Error" />
+			<argument index="0" name="source_code" type="String" />
+			<description>
+				Sets the source code and runs it through the parser. This is necessary for the other functions to run.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gdscript/gdscript_error_checker.cpp
+++ b/modules/gdscript/gdscript_error_checker.cpp
@@ -1,0 +1,88 @@
+/*************************************************************************/
+/*  gdscript_error_checker.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_error_checker.h"
+
+#include "gdscript_parser.h"
+
+void GDScriptErrorChecker::_bind_methods() {
+	ClassDB::bind_method("has_errors", &GDScriptErrorChecker::has_errors);
+	ClassDB::bind_method("get_error_count", &GDScriptErrorChecker::get_error_count);
+	ClassDB::bind_method(D_METHOD("set_source", "source_code"), &GDScriptErrorChecker::set_source);
+	ClassDB::bind_method(D_METHOD("get_error", "idx"), &GDScriptErrorChecker::get_error);
+	ClassDB::bind_method(D_METHOD("get_error_line", "idx"), &GDScriptErrorChecker::get_error_line);
+	ClassDB::bind_method(D_METHOD("get_error_column", "idx"), &GDScriptErrorChecker::get_error_column);
+}
+
+bool GDScriptErrorChecker::has_errors() const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, false, "No source code provided.");
+	return !parser->get_errors().is_empty();
+}
+
+int GDScriptErrorChecker::get_error_count() const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, false, "No source code provided.");
+	return parser->get_errors().size();
+}
+
+String GDScriptErrorChecker::get_error(const int p_idx) const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, String(), "No source code provided.");
+	ERR_FAIL_INDEX_V(p_idx, parser->get_errors().size(), String());
+	return parser->get_errors()[p_idx].message;
+}
+
+int GDScriptErrorChecker::get_error_line(const int p_idx) const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, -1, "No source code provided.");
+	ERR_FAIL_INDEX_V(p_idx, parser->get_errors().size(), -1);
+	return parser->get_errors()[p_idx].line;
+}
+
+int GDScriptErrorChecker::get_error_column(const int p_idx) const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, -1, "No source code provided.");
+	ERR_FAIL_INDEX_V(p_idx, parser->get_errors().size(), -1);
+	return parser->get_errors()[p_idx].column;
+}
+
+Error GDScriptErrorChecker::set_source(const String &p_source) {
+	if (parser != nullptr) {
+		memdelete(parser);
+		parser = nullptr;
+	}
+	parser = memnew(GDScriptParser);
+	return parser->parse(p_source, "", false);
+}
+
+GDScriptErrorChecker::GDScriptErrorChecker() = default;
+
+GDScriptErrorChecker::~GDScriptErrorChecker() {
+	if (parser != nullptr) {
+		memdelete(parser);
+		parser = nullptr;
+	}
+}

--- a/modules/gdscript/gdscript_error_checker.h
+++ b/modules/gdscript/gdscript_error_checker.h
@@ -1,0 +1,59 @@
+/*************************************************************************/
+/*  gdscript_error_checker.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_ERROR_CHECKER_H
+#define GDSCRIPT_ERROR_CHECKER_H
+
+#include "core/object/ref_counted.h"
+
+class GDScriptParser;
+
+class GDScriptErrorChecker : public RefCounted {
+	GDCLASS(GDScriptErrorChecker, RefCounted);
+
+	GDScriptParser *parser = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	bool has_errors() const;
+	int get_error_count() const;
+	String get_error(int p_idx) const;
+	int get_error_line(int p_idx) const;
+	int get_error_column(int p_idx) const;
+
+	Error set_source(const String &p_source);
+
+	GDScriptErrorChecker();
+	~GDScriptErrorChecker();
+};
+
+#endif // GDSCRIPT_ERROR_CHECKER_H

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -37,6 +37,7 @@
 #include "gdscript.h"
 #include "gdscript_analyzer.h"
 #include "gdscript_cache.h"
+#include "gdscript_error_checker.h"
 #include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
 
@@ -127,6 +128,8 @@ void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 		gdscript_cache = memnew(GDScriptCache);
 
 		GDScriptUtilityFunctions::register_functions();
+
+		GDREGISTER_CLASS(GDScriptErrorChecker);
 	}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Adds the GDScriptErrorChecker RefCounted object to indirectly access the GDScriptParser's error checking routine.

For use by meta apps, like [GDQuest's Learn GDScript](https://github.com/GDQuest/learn-gdscript) and [Calinou's GDScript Online](https://github.com/gdscript-online/gdscript-online.github.io).

It cannot be cherry-picked for 3.x, since the 3.x parser only returns a single error, resulting in a different API. So a separate PR has been added (#64066).