### PR TITLE
[3.x] Add a GDScript error checker class

### DIFF
--- a/doc/classes/GDScriptErrorChecker.xml
+++ b/doc/classes/GDScriptErrorChecker.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GDScriptErrorChecker" inherits="Reference" version="3.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Tool to check for errors on GDScript source code.
+	</brief_description>
+	<description>
+		[GDScriptErrorChecker] takes the source code of a GDScript file and runs it through the GDScript parser in order to expose any error it finds.
+
+		The parser only reports the first error it runs into.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_error" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the message for the current error.
+			</description>
+		</method>
+		<method name="get_error_column" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the column on the line the error happened.
+			</description>
+		</method>
+		<method name="get_error_line" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the line the error happened.
+			</description>
+		</method>
+		<method name="has_error" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether or not the parser found an error.
+			</description>
+		</method>
+		<method name="set_source">
+			<return type="int" enum="Error" />
+			<argument index="0" name="source_code" type="String" />
+			<description>
+				Sets the source code and runs it through the parser. This is necessary for the other functions to run.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/modules/gdscript/gdscript_error_checker.cpp
+++ b/modules/gdscript/gdscript_error_checker.cpp
@@ -1,0 +1,79 @@
+/*************************************************************************/
+/*  gdscript_error_checker.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "gdscript_error_checker.h"
+
+#include "gdscript_parser.h"
+
+void GDScriptErrorChecker::_bind_methods() {
+	ClassDB::bind_method("has_error", &GDScriptErrorChecker::has_error);
+	ClassDB::bind_method(D_METHOD("set_source", "source_code"), &GDScriptErrorChecker::set_source);
+	ClassDB::bind_method("get_error", &GDScriptErrorChecker::get_error);
+	ClassDB::bind_method("get_error_line", &GDScriptErrorChecker::get_error_line);
+	ClassDB::bind_method("get_error_column", &GDScriptErrorChecker::get_error_column);
+}
+
+bool GDScriptErrorChecker::has_error() const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, false, "No source code provided.");
+	return parser->has_error();
+}
+
+String GDScriptErrorChecker::get_error() const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, String(), "No source code provided.");
+	return parser->get_error();
+}
+
+int GDScriptErrorChecker::get_error_line() const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, -1, "No source code provided.");
+	return parser->get_error_line();
+}
+
+int GDScriptErrorChecker::get_error_column() const {
+	ERR_FAIL_COND_V_MSG(parser == nullptr, -1, "No source code provided.");
+	return parser->get_error_column();
+}
+
+Error GDScriptErrorChecker::set_source(const String &p_source) {
+	if (parser != nullptr) {
+		memdelete(parser);
+		parser = nullptr;
+	}
+	parser = memnew(GDScriptParser);
+	return parser->parse(p_source);
+}
+
+GDScriptErrorChecker::GDScriptErrorChecker() = default;
+
+GDScriptErrorChecker::~GDScriptErrorChecker() {
+	if (parser != nullptr) {
+		memdelete(parser);
+		parser = nullptr;
+	}
+}

--- a/modules/gdscript/gdscript_error_checker.h
+++ b/modules/gdscript/gdscript_error_checker.h
@@ -1,0 +1,58 @@
+/*************************************************************************/
+/*  gdscript_error_checker.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GDSCRIPT_ERROR_CHECKER_H
+#define GDSCRIPT_ERROR_CHECKER_H
+
+#include "core/reference.h"
+
+class GDScriptParser;
+
+class GDScriptErrorChecker : public Reference {
+	GDCLASS(GDScriptErrorChecker, Reference);
+
+	GDScriptParser *parser = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	bool has_error() const;
+	String get_error() const;
+	int get_error_line() const;
+	int get_error_column() const;
+
+	Error set_source(const String &p_source);
+
+	GDScriptErrorChecker();
+	~GDScriptErrorChecker();
+};
+
+#endif // GDSCRIPT_ERROR_CHECKER_H

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -35,6 +35,7 @@
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
 #include "gdscript.h"
+#include "gdscript_error_checker.h"
 #include "gdscript_tokenizer.h"
 
 GDScriptLanguage *script_language_gd = nullptr;
@@ -151,6 +152,7 @@ static void _editor_init() {
 void register_gdscript_types() {
 	ClassDB::register_class<GDScript>();
 	ClassDB::register_virtual_class<GDScriptFunctionState>();
+	ClassDB::register_class<GDScriptErrorChecker>();
 
 	script_language_gd = memnew(GDScriptLanguage);
 	ScriptServer::register_language(script_language_gd);


### PR DESCRIPTION
Adds the GDScriptErrorChecker Reference object to indirectly access the GDScriptParser's error checking routine.

For use by meta apps, like [GDQuest's Learn GDScript](https://github.com/GDQuest/learn-gdscript) and [Calinou's GDScript Online](https://github.com/gdscript-online/gdscript-online.github.io).

It's a separate PR from the 4.0 version (#64065) since the 3.x parser only returns a single error, resulting in a different API.