### PR TITLE
Fix typo when setting NavigationRegion travel_cost

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -422,7 +422,7 @@ real_t NavigationRegion2D::get_enter_cost() const {
 void NavigationRegion2D::set_travel_cost(real_t p_travel_cost) {
 	ERR_FAIL_COND_MSG(p_travel_cost < 0.0, "The travel_cost must be positive.");
 	travel_cost = MAX(p_travel_cost, 0.0);
-	NavigationServer2D::get_singleton()->region_set_enter_cost(region, travel_cost);
+	NavigationServer2D::get_singleton()->region_set_travel_cost(region, travel_cost);
 }
 
 real_t NavigationRegion2D::get_travel_cost() const {

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -119,7 +119,7 @@ real_t NavigationRegion3D::get_enter_cost() const {
 void NavigationRegion3D::set_travel_cost(real_t p_travel_cost) {
 	ERR_FAIL_COND_MSG(p_travel_cost < 0.0, "The travel_cost must be positive.");
 	travel_cost = MAX(p_travel_cost, 0.0);
-	NavigationServer3D::get_singleton()->region_set_enter_cost(region, travel_cost);
+	NavigationServer3D::get_singleton()->region_set_travel_cost(region, travel_cost);
 }
 
 real_t NavigationRegion3D::get_travel_cost() const {


### PR DESCRIPTION
`set_travel_cost` on `NavigationRegion2D` and `NavigationRegion3D` was accidentally calling `region_set_enter_cost` on the underlying server.

I also checked all other usages of both `travel_cost` and `enter_cost` for any other typos.