### PR TITLE
Add interpolation param to `Image::rotate_90` method

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -965,6 +965,7 @@ bool Image::is_size_po2() const {
 
 void Image::resize_to_po2(bool p_square, Interpolation p_interpolation) {
 	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot resize in compressed or custom image formats.");
+	ERR_FAIL_INDEX((int)p_interpolation, (int)INTERPOLATE_MAX);
 
 	int w = next_power_of_2(width);
 	int h = next_power_of_2(height);
@@ -992,6 +993,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH, "Image width cannot be greater than " + itos(MAX_WIDTH) + ".");
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT, "Image height cannot be greater than " + itos(MAX_HEIGHT) + ".");
 	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS, "Too many pixels for image, maximum is " + itos(MAX_PIXELS));
+	ERR_FAIL_INDEX((int)p_interpolation, (int)INTERPOLATE_MAX);
 
 	if (p_width == width && p_height == height) {
 		return;
@@ -1272,6 +1274,8 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 				}
 			}
 		} break;
+		default:
+			break;
 	}
 
 	if (interpolate_mipmaps) {
@@ -1339,17 +1343,18 @@ void Image::crop(int p_width, int p_height) {
 	crop_from_point(0, 0, p_width, p_height);
 }
 
-void Image::rotate_90(ClockDirection p_direction) {
+void Image::rotate_90(ClockDirection p_direction, Interpolation p_interpolation) {
 	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot rotate in compressed or custom image formats.");
 	ERR_FAIL_COND_MSG(width <= 1, "The Image width specified (" + itos(width) + " pixels) must be greater than 1 pixels.");
 	ERR_FAIL_COND_MSG(height <= 1, "The Image height specified (" + itos(height) + " pixels) must be greater than 1 pixels.");
+	ERR_FAIL_INDEX((int)p_interpolation, (int)INTERPOLATE_MAX);
 
 	int saved_width = height;
 	int saved_height = width;
 
 	if (width != height) {
 		int n = MAX(width, height);
-		resize(n, n, INTERPOLATE_NEAREST);
+		resize(n, n, p_interpolation);
 	}
 
 	bool used_mipmaps = has_mipmaps();
@@ -1403,7 +1408,7 @@ void Image::rotate_90(ClockDirection p_direction) {
 	}
 
 	if (saved_width != saved_height) {
-		resize(saved_width, saved_height, INTERPOLATE_NEAREST);
+		resize(saved_width, saved_height, p_interpolation);
 	} else if (used_mipmaps) {
 		generate_mipmaps();
 	}
@@ -3319,7 +3324,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("decompress"), &Image::decompress);
 	ClassDB::bind_method(D_METHOD("is_compressed"), &Image::is_compressed);
 
-	ClassDB::bind_method(D_METHOD("rotate_90", "direction"), &Image::rotate_90);
+	ClassDB::bind_method(D_METHOD("rotate_90", "direction", "interpolation"), &Image::rotate_90, DEFVAL(INTERPOLATE_BILINEAR));
 	ClassDB::bind_method(D_METHOD("rotate_180"), &Image::rotate_180);
 
 	ClassDB::bind_method(D_METHOD("fix_alpha_edges"), &Image::fix_alpha_edges);
@@ -3406,6 +3411,7 @@ void Image::_bind_methods() {
 	BIND_ENUM_CONSTANT(INTERPOLATE_CUBIC);
 	BIND_ENUM_CONSTANT(INTERPOLATE_TRILINEAR);
 	BIND_ENUM_CONSTANT(INTERPOLATE_LANCZOS);
+	BIND_ENUM_CONSTANT(INTERPOLATE_MAX);
 
 	BIND_ENUM_CONSTANT(ALPHA_NONE);
 	BIND_ENUM_CONSTANT(ALPHA_BIT);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -121,6 +121,7 @@ public:
 		INTERPOLATE_LANCZOS,
 		/* INTERPOLATE_TRICUBIC, */
 		/* INTERPOLATE GAUSS */
+		INTERPOLATE_MAX,
 	};
 
 	//this is used for compression
@@ -254,7 +255,7 @@ public:
 	void crop_from_point(int p_x, int p_y, int p_width, int p_height);
 	void crop(int p_width, int p_height);
 
-	void rotate_90(ClockDirection p_direction);
+	void rotate_90(ClockDirection p_direction, Interpolation p_interpolation = INTERPOLATE_BILINEAR);
 	void rotate_180();
 
 	void flip_x();

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -387,8 +387,9 @@
 		<method name="rotate_90">
 			<return type="void" />
 			<argument index="0" name="direction" type="int" enum="ClockDirection" />
+			<argument index="1" name="interpolation" type="int" enum="Image.Interpolation" default="1" />
 			<description>
-				Rotates the image in the specified [code]direction[/code] by [code]90[/code] degrees. The width and height of the image must be greater than [code]1[/code]. If the width and height are not equal, the image will be resized.
+				Rotates the image in the specified [code]direction[/code] by [code]90[/code] degrees. The width and height of the image must be greater than [code]1[/code]. If the width and height are not equal, the image will be resized using the specified [code]interpolation[/code].
 			</description>
 		</method>
 		<method name="save_exr" qualifiers="const">
@@ -667,6 +668,9 @@
 		</constant>
 		<constant name="INTERPOLATE_LANCZOS" value="4" enum="Interpolation">
 			Performs Lanczos interpolation. This is the slowest image resizing mode, but it typically gives the best results, especially when downscalng images.
+		</constant>
+		<constant name="INTERPOLATE_MAX" value="5" enum="Interpolation">
+			Represents the size of the [enum Interpolation] enum.
 		</constant>
 		<constant name="ALPHA_NONE" value="0" enum="AlphaMode">
 			Image does not have alpha.


### PR DESCRIPTION
It is assigned to bilinear by default, which will fix https://github.com/godotengine/godot/issues/64048. Also added checks for incorrect value of interpolation parameter in other functions (by adding `INTERPOLATE_MAX`). 

PS: Maybe `INTERPOLATE_` enum inner names should be renamed to `INTERPOLATION_` ?
