### PR TITLE
Remove FOV adjustment with Alt + mouse wheel in the 3D editor (3.x)

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -1172,26 +1172,18 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		float zoom_factor = 1 + (ZOOM_FREELOOK_MULTIPLIER - 1) * b->get_factor();
 		switch (b->get_button_index()) {
 			case BUTTON_WHEEL_UP: {
-				if (b->get_alt()) {
-					scale_fov(-0.05);
+				if (is_freelook_active()) {
+					scale_freelook_speed(zoom_factor);
 				} else {
-					if (is_freelook_active()) {
-						scale_freelook_speed(zoom_factor);
-					} else {
-						scale_cursor_distance(1.0 / zoom_factor);
-					}
+					scale_cursor_distance(1.0 / zoom_factor);
 				}
 			} break;
 
 			case BUTTON_WHEEL_DOWN: {
-				if (b->get_alt()) {
-					scale_fov(0.05);
+				if (is_freelook_active()) {
+					scale_freelook_speed(1.0 / zoom_factor);
 				} else {
-					if (is_freelook_active()) {
-						scale_freelook_speed(1.0 / zoom_factor);
-					} else {
-						scale_cursor_distance(zoom_factor);
-					}
+					scale_cursor_distance(zoom_factor);
 				}
 			} break;
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/64070. Follow-up to https://github.com/godotengine/godot/pull/54207. This fixes a usability regression, so this should be cherry-picked for 3.5 too.

This shortcut got in the way when using the Maya navigation scheme, and also when using the slow freelook modifier (regardless of avigation scheme). See https://godotengine.org/qa/136662/how-do-i-get-rid-of-the-fov-scroll.