### PR TITLE
Various fixes to C# documentation

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -916,7 +916,7 @@ namespace Godot
         /// <c>new Color(1 - c.r, 1 - c.g, 1 - c.b, 1 - c.a)</c>.
         /// </summary>
         /// <param name="color">The color to invert.</param>
-        /// <returns>The inverted color</returns>
+        /// <returns>The inverted color.</returns>
         public static Color operator -(Color color)
         {
             return Colors.White - color;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -239,11 +239,20 @@ namespace Godot
         }
 
         /// <summary>
-        /// Converts one or more arguments of any type to string in the best way possible and prints them to the console. The following BBCode tags are supported: b, i, u, s, indent, code, url, center, right, color, bgcolor, fgcolor. Color tags only support named colors such as [code]red[/code], [i]not[/i] hexadecimal color codes. Unsupported tags will be left as-is in standard output.
-        /// When printing to standard output, the supported subset of BBCode is converted to ANSI escape codes for the terminal emulator to display. Displaying ANSI escape codes is currently only supported on Linux and macOS. Support for ANSI escape codes may vary across terminal emulators, especially for italic and strikethrough.
+        /// Converts one or more arguments of any type to string in the best way possible
+        /// and prints them to the console.
+        /// The following BBCode tags are supported: b, i, u, s, indent, code, url, center,
+        /// right, color, bgcolor, fgcolor.
+        /// Color tags only support named colors such as <c>red</c>, not hexadecimal color codes.
+        /// Unsupported tags will be left as-is in standard output.
+        /// When printing to standard output, the supported subset of BBCode is converted to
+        /// ANSI escape codes for the terminal emulator to display. Displaying ANSI escape codes
+        /// is currently only supported on Linux and macOS. Support for ANSI escape codes may vary
+        /// across terminal emulators, especially for italic and strikethrough.
         ///
         /// Note: Consider using <see cref="PushError(string)"/> and <see cref="PushWarning(string)"/>
-        /// to print error and warning messages instead of <see cref="Print(object[])"/> or <see cref="PrintRich(object[])"/>.
+        /// to print error and warning messages instead of <see cref="Print(object[])"/> or
+        /// <see cref="PrintRich(object[])"/>.
         /// This distinguishes them from print messages used for debugging purposes,
         /// while also displaying a stack trace when an error or warning is printed.
         /// </summary>
@@ -253,7 +262,6 @@ namespace Godot
         /// </code>
         /// </example>
         /// <param name="what">Arguments that will be printed.</param>
-        /// </summary>
         public static void PrintRich(params object[] what)
         {
             godot_icall_GD_print_rich(GetPrintParams(what));

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalInfo.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalInfo.cs
@@ -18,7 +18,7 @@ namespace Godot
         public StringName Name => _signalName;
 
         /// <summary>
-        /// Creates a new <see cref="Signal"/> with the name <paramref name="name"/>
+        /// Creates a new <see cref="SignalInfo"/> with the name <paramref name="name"/>
         /// in the specified <paramref name="owner"/>.
         /// </summary>
         /// <param name="owner">Object that contains the signal.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -534,7 +534,7 @@ namespace Godot
         ///
         /// This method also handles interpolating the lengths if the input vectors
         /// have different lengths. For the special case of one or both input vectors
-        /// having zero length, this method behaves like <see cref="Lerp"/>.
+        /// having zero length, this method behaves like <see cref="Lerp(Vector2, real_t)"/>.
         /// </summary>
         /// <param name="to">The destination vector for interpolation.</param>
         /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -574,7 +574,7 @@ namespace Godot
         ///
         /// This method also handles interpolating the lengths if the input vectors
         /// have different lengths. For the special case of one or both input vectors
-        /// having zero length, this method behaves like <see cref="Lerp"/>.
+        /// having zero length, this method behaves like <see cref="Lerp(Vector3, real_t)"/>.
         /// </summary>
         /// <param name="to">The destination vector for interpolation.</param>
         /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>


### PR DESCRIPTION
Minor documentation fixes.

The only changes that would apply to 3.x if we wanted to cherry-pick this is the changes to `Color.cs`.