### PR TITLE
Add `@GDScript.type_exists` documentation, Fix typo in weakref documentation

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1125,7 +1125,7 @@
 			<return type="Variant" />
 			<argument index="0" name="obj" type="Variant" />
 			<description>
-				Returns a weak reference to an object, or [code]null[/code] is the argument is invalid.
+				Returns a weak reference to an object, or [code]null[/code] if the argument is invalid.
 				A weak reference to an object is not enough to keep the object alive: when the only remaining references to a referent are weak references, garbage collection is free to destroy the referent and reuse its memory for something else. However, until the object is actually destroyed the weak reference may return the object even if there are no strong references to it.
 			</description>
 		</method>

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -239,6 +239,11 @@
 			<return type="bool" />
 			<argument index="0" name="type" type="StringName" />
 			<description>
+				Returns whether the given [Object]-derived class exists in [ClassDB]. Note that [Variant] data types are not registered in [ClassDB].
+				[codeblock]
+				type_exists("Sprite2D") # Returns true
+				type_exists("NonExistentClass") # Returns false
+				[/codeblock]
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
- Re-adds documentation for the `@GDScript.type_exists` method that was lost in #44911.
- Fixes a typo in `@GlobalScope.weakref` documentation.
