### PR TITLE
Add area monitor callback error checking

### DIFF
--- a/servers/physics_2d/godot_area_2d.cpp
+++ b/servers/physics_2d/godot_area_2d.cpp
@@ -248,6 +248,10 @@ void GodotArea2D::call_queries() {
 				Callable::CallError ce;
 				Variant ret;
 				monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
+
+				if (ce.error != Callable::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(monitor_callback, (const Variant **)resptr, 5, ce));
+				}
 			}
 		} else {
 			monitored_bodies.clear();
@@ -286,6 +290,10 @@ void GodotArea2D::call_queries() {
 				Callable::CallError ce;
 				Variant ret;
 				area_monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
+
+				if (ce.error != Callable::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(area_monitor_callback, (const Variant **)resptr, 5, ce));
+				}
 			}
 		} else {
 			monitored_areas.clear();

--- a/servers/physics_3d/godot_area_3d.cpp
+++ b/servers/physics_3d/godot_area_3d.cpp
@@ -277,6 +277,10 @@ void GodotArea3D::call_queries() {
 				Callable::CallError ce;
 				Variant ret;
 				monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
+
+				if (ce.error != Callable::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling monitor callback method " + Variant::get_callable_error_text(monitor_callback, (const Variant **)resptr, 5, ce));
+				}
 			}
 		} else {
 			monitored_bodies.clear();
@@ -315,6 +319,10 @@ void GodotArea3D::call_queries() {
 				Callable::CallError ce;
 				Variant ret;
 				area_monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
+
+				if (ce.error != Callable::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling area monitor callback method " + Variant::get_callable_error_text(area_monitor_callback, (const Variant **)resptr, 5, ce));
+				}
 			}
 		} else {
 			monitored_areas.clear();


### PR DESCRIPTION
Fixes #59628

I have the error only print once because with the referenced issue it felt like a good idea to only print the error once. If we want the error to print every time then that's good with me too.