### PR TITLE
[3.x] Add area monitor callback error checking

### DIFF
--- a/modules/bullet/area_bullet.cpp
+++ b/modules/bullet/area_bullet.cpp
@@ -132,6 +132,10 @@ void AreaBullet::call_event(const OverlappingShapeData &p_overlapping_shape, Phy
 
 	Variant::CallError outResp;
 	areaGodoObject->call(event.event_callback_method, (const Variant **)call_event_res_ptr, 5, outResp);
+
+	if (outResp.error != Variant::CallError::CALL_OK) {
+		ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_call_error_text(areaGodoObject, event.event_callback_method, (const Variant **)call_event_res_ptr, 5, outResp));
+	}
 }
 
 int AreaBullet::_overlapping_shape_count(CollisionObjectBullet *p_other_object) {

--- a/servers/physics/area_sw.cpp
+++ b/servers/physics/area_sw.cpp
@@ -228,6 +228,10 @@ void AreaSW::call_queries() {
 
 				Variant::CallError ce;
 				obj->call(monitor_callback_method, (const Variant **)resptr, 5, ce);
+
+				if (ce.error != Variant::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling monitor callback method " + Variant::get_call_error_text(obj, monitor_callback_method, (const Variant **)resptr, 5, ce));
+				}
 			}
 		} else {
 			monitored_bodies.clear();
@@ -264,6 +268,10 @@ void AreaSW::call_queries() {
 
 				Variant::CallError ce;
 				obj->call(area_monitor_callback_method, (const Variant **)resptr, 5, ce);
+
+				if (ce.error != Variant::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling area monitor callback method " + Variant::get_call_error_text(obj, area_monitor_callback_method, (const Variant **)resptr, 5, ce));
+				}
 			}
 		} else {
 			monitored_areas.clear();

--- a/servers/physics_2d/area_2d_sw.cpp
+++ b/servers/physics_2d/area_2d_sw.cpp
@@ -228,6 +228,10 @@ void Area2DSW::call_queries() {
 
 				Variant::CallError ce;
 				obj->call(monitor_callback_method, (const Variant **)resptr, 5, ce);
+
+				if (ce.error != Variant::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling monitor callback method " + Variant::get_call_error_text(obj, monitor_callback_method, (const Variant **)resptr, 5, ce));
+				}
 			}
 		} else {
 			monitored_bodies.clear();
@@ -264,6 +268,10 @@ void Area2DSW::call_queries() {
 
 				Variant::CallError ce;
 				obj->call(area_monitor_callback_method, (const Variant **)resptr, 5, ce);
+
+				if (ce.error != Variant::CallError::CALL_OK) {
+					ERR_PRINT_ONCE("Error calling area monitor callback method " + Variant::get_call_error_text(obj, area_monitor_callback_method, (const Variant **)resptr, 5, ce));
+				}
 			}
 		} else {
 			monitored_areas.clear();


### PR DESCRIPTION
3.x version of #64078, fixes #59628.

If we want the errors to print more than once that's good with me too.