### PR TITLE
Avoid paths with invalid characters in `IsRider`

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathManager.cs
@@ -66,6 +66,9 @@ namespace GodotTools.Ides.Rider
             if (string.IsNullOrEmpty(path))
                 return false;
 
+            if (path.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+                return false;
+
             var fileInfo = new FileInfo(path);
             string filename = fileInfo.Name.ToLowerInvariant();
             return filename.StartsWith("rider", StringComparison.Ordinal);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/39432#issuecomment-1185300927

I haven't really tested this as I don't use Rider but this looks like it should fix it from the reported stack trace. Also, I'm not sure if we should print an error to the console instead of silently ignore paths with invalid characters.