### PR TITLE
Capitalize shader uniform groups

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -233,7 +233,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 					if (!groups.has(last_group)) {
 						PropertyInfo info;
 						info.usage = PROPERTY_USAGE_GROUP;
-						info.name = last_group;
+						info.name = last_group.capitalize();
 
 						List<PropertyInfo> none_subgroup;
 						none_subgroup.push_back(info);
@@ -247,7 +247,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 					if (!groups[last_group].has(last_subgroup)) {
 						PropertyInfo info;
 						info.usage = PROPERTY_USAGE_SUBGROUP;
-						info.name = last_subgroup;
+						info.name = last_subgroup.capitalize();
 
 						List<PropertyInfo> subgroup;
 						subgroup.push_back(info);


### PR DESCRIPTION
Implements suggestion https://github.com/godotengine/godot/pull/62972#issuecomment-1184949516

```glsl
shader_type spatial;

uniform float test1;

group_uniforms hello;
uniform float test2;

group_uniforms hello.hello_subgroup;
uniform float test3;

```

![image](https://user-images.githubusercontent.com/14253836/183363160-7f467044-edc5-47b5-bc38-4b3f8b6bab58.png)
