### PR TITLE
Add `_can_add_to_scene()` virtual method

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -22,6 +22,22 @@
 		<link title="All Demos">https://github.com/godotengine/godot-demo-projects/</link>
 	</tutorials>
 	<methods>
+		<method name="_can_add_to_scene" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="to_parent" type="Node" />
+			<description>
+				Called right before the node is going to be added to a scene, passing its would-be parent as an argument. If the method returns [code]false[/code], the node will not be added to the parent and become an orphan node. This is useful for preventing initialization logic until a specific moment.
+				[b]Important:[/b] Make sure to store the node reference, otherwise the node will leak. The [code]to_parent[/code] argument can be used for that.
+				[codeblock]
+				func _can_add_to_scene(to_parent):
+				    if to_parent is Chest:
+				        to_parent.items.append(self)
+				        return false
+
+				    return true
+				[/codeblock]
+			</description>
+		</method>
 		<method name="_enter_tree" qualifiers="virtual">
 			<return type="void" />
 			<description>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2013,6 +2013,12 @@ Node *Node::get_deepest_editable_node(Node *p_start_node) const {
 	return node;
 }
 
+bool Node::can_add_to_scene(Node *p_to_parent) const {
+	bool can_add = true;
+	GDVIRTUAL_CALL(_can_add_to_scene, p_to_parent, can_add);
+	return can_add;
+}
+
 #ifdef TOOLS_ENABLED
 void Node::set_property_pinned(const String &p_property, bool p_pinned) {
 	bool current_pinned = false;
@@ -3002,6 +3008,7 @@ void Node::_bind_methods() {
 	GDVIRTUAL_BIND(_shortcut_input, "event");
 	GDVIRTUAL_BIND(_unhandled_input, "event");
 	GDVIRTUAL_BIND(_unhandled_key_input, "event");
+	GDVIRTUAL_BIND(_can_add_to_scene, "to_parent");
 }
 
 String Node::_get_name_num_separator() {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -246,6 +246,8 @@ protected:
 	GDVIRTUAL1(_unhandled_input, Ref<InputEvent>)
 	GDVIRTUAL1(_unhandled_key_input, Ref<InputEvent>)
 
+	GDVIRTUAL1RC(bool, _can_add_to_scene, Node *)
+
 public:
 	enum {
 		// you can make your own, but don't use the same numbers as other notifications in other nodes
@@ -374,6 +376,8 @@ public:
 	void set_editable_instance(Node *p_node, bool p_editable);
 	bool is_editable_instance(const Node *p_node) const;
 	Node *get_deepest_editable_node(Node *p_start_node) const;
+
+	bool can_add_to_scene(Node *p_to_parent) const;
 
 #ifdef TOOLS_ENABLED
 	void set_property_pinned(const String &p_property, bool p_pinned);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -338,9 +338,11 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				//if node was not part of instance, must set its name, parenthood and ownership
 				if (i > 0) {
 					if (parent) {
-						parent->_add_child_nocheck(node, snames[n.name]);
-						if (n.index >= 0 && n.index < parent->get_child_count() - 1) {
-							parent->move_child(node, n.index);
+						if (node->can_add_to_scene(parent)) {
+							parent->_add_child_nocheck(node, snames[n.name]);
+							if (n.index >= 0 && n.index < parent->get_child_count() - 1) {
+								parent->move_child(node, n.index);
+							}
 						}
 					} else {
 						//it may be possible that an instantiated scene has changed


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5102

Some simple test scene:
[CanAddTest.zip](https://github.com/godotengine/godot/files/9282885/CanAddTest.zip)

I opened this for an implementation reference, keep the discussion in the proposal until it's accepted or something.
