### PR TITLE
Fix OmniLight/SpotLight shadow opacity calculation

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2869,7 +2869,9 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 					WARN_PRINT_ONCE("The DirectionalLight3D PSSM splits debug draw mode is not reimplemented yet.");
 				}
 
-				light_data.shadow_opacity = p_using_shadows && light_storage->light_has_shadow(base) ? light_storage->light_get_param(base, RS::LIGHT_PARAM_SHADOW_OPACITY) : 0.0;
+				light_data.shadow_opacity = (p_using_shadows && light_storage->light_has_shadow(base))
+						? light_storage->light_get_param(base, RS::LIGHT_PARAM_SHADOW_OPACITY)
+						: 0.0;
 
 				float angular_diameter = light_storage->light_get_param(base, RS::LIGHT_PARAM_SIZE);
 				if (angular_diameter > 0.0) {
@@ -3123,7 +3125,11 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 			light_data.projector_rect[3] = 0;
 		}
 
-		const bool needs_shadow = shadow_atlas && shadow_atlas->shadow_owners.has(li->self);
+		const bool needs_shadow =
+				shadow_atlas &&
+				shadow_atlas->shadow_owners.has(li->self) &&
+				p_using_shadows &&
+				light_storage->light_has_shadow(base);
 
 		bool in_shadow_range = true;
 		if (needs_shadow && light_storage->light_is_distance_fade_enabled(li->light)) {


### PR DESCRIPTION
When turning off the `shadow` property of `OmniLight`/`SpotLight`, the shadow was still rendered while the shadow atlas was no longer updated. This PR fixes the shadow opacity calculation so that it behaves the same as for directional lights. There is still some room for improvement, e.g. clear/free the shadow buffer(if possible) but that would require a significantly more complex approach.
![Peek 2022-08-08 18-33](https://user-images.githubusercontent.com/50084500/183468009-04ed2892-b91e-4068-a1db-6a1eef465cc0.gif)

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/50343.*