### PR TITLE
Make `LocalVector` respect its `tight` template parameter

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -59,11 +59,7 @@ public:
 
 	_FORCE_INLINE_ void push_back(T p_elem) {
 		if (unlikely(count == capacity)) {
-			if (capacity == 0) {
-				capacity = 1;
-			} else {
-				capacity <<= 1;
-			}
+			capacity = tight ? (capacity + 1) : MAX((U)1, capacity << 1);
 			data = (T *)memrealloc(data, capacity * sizeof(T));
 			CRASH_COND_MSG(!data, "Out of memory");
 		}
@@ -87,7 +83,7 @@ public:
 	}
 
 	/// Removes the item copying the last value into the position of the one to
-	/// remove. It's generally faster than `remove`.
+	/// remove. It's generally faster than `remove_at`.
 	void remove_at_unordered(U p_index) {
 		ERR_FAIL_INDEX(p_index, count);
 		count--;
@@ -143,12 +139,7 @@ public:
 			count = p_size;
 		} else if (p_size > count) {
 			if (unlikely(p_size > capacity)) {
-				if (capacity == 0) {
-					capacity = 1;
-				}
-				while (capacity < p_size) {
-					capacity <<= 1;
-				}
+				capacity = tight ? p_size : nearest_power_of_2_templated(p_size);
 				data = (T *)memrealloc(data, capacity * sizeof(T));
 				CRASH_COND_MSG(!data, "Out of memory");
 			}


### PR DESCRIPTION
`tight` template parameter was taken into account only in `reserve` but not it `push_back`/`insert`. Now the new `capacity` is calculated the same way as in `reserve`. Copy-paste instead of calling `reserve` because here conditions are `unlikely`.