### PR TITLE
Add conversion for instance(), set_shader_param() and node path literals

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -516,7 +516,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "set_region_filter_clip", "set_region_filter_clip_enabled" }, // Sprite2D
 	{ "set_rotate", "set_rotates" }, // PathFollow2D
 	{ "set_scancode", "set_keycode" }, // InputEventKey
-	{ "set_shader_param", "set_shader_uniform" }, // InputEventWithModifiers
+	{ "set_shader_param", "set_shader_uniform" }, // ShaderMaterial
 	{ "set_shift", "set_shift_pressed" }, // InputEventWithModifiers
 	{ "set_size_override", "set_size_2d_override" }, // SubViewport broke ImageTexture
 	{ "set_size_override_stretch", "set_size_2d_override_stretch" }, // SubViewport


### PR DESCRIPTION
This addresses some items from #64003:

- `.instance(.*)` -> `.instantiate($1)` (guarded against messing up the .tscn metadata)
- Improved `get_object_of_execution` to handle node path literals:
    ```gd
    # 3.x code:
    var velocity = $viewport_container/viewport/ball.move_and_slide(velocity, Vector3.UP)
    # 4.x before:
    ball.set_motion_velocity(velocity)
    ball.set_up_direction(Vector3.UP)
    ball.move_and_slide()
    velocity = $viewport_container/viewport/ball.velocity  # <- this line is correct
    # 4.x with this PR:
    $viewport_container/viewport/ball.set_velocity(velocity)
    $viewport_container/viewport/ball.set_up_direction(Vector3.UP)
    $viewport_container/viewport/ball.move_and_slide()
    velocity = $viewport_container/viewport/ball.velocity
    ```
- `set_shader_param` -> `set_shader_uniform`
