### PR TITLE
[doc] Use "param" instead of "code"  to refer to parameters

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -47,7 +47,7 @@
 			<return type="Tween" />
 			<param index="0" name="node" type="Node" />
 			<description>
-				Binds this [Tween] with the given [code]node[/code]. [Tween]s are processed directly by the [SceneTree], so they run independently of the animated nodes. When you bind a [Node] with the [Tween], the [Tween] will halt the animation when the object is not inside tree and the [Tween] will be automatically killed when the bound object is freed. Also [constant TWEEN_PAUSE_BOUND] will make the pausing behavior dependent on the bound node.
+				Binds this [Tween] with the given [param node]. [Tween]s are processed directly by the [SceneTree], so they run independently of the animated nodes. When you bind a [Node] with the [Tween], the [Tween] will halt the animation when the object is not inside tree and the [Tween] will be automatically killed when the bound object is freed. Also [constant TWEEN_PAUSE_BOUND] will make the pausing behavior dependent on the bound node.
 				For a shorter way to create and bind a [Tween], you can use [method Node.create_tween].
 			</description>
 		</method>
@@ -67,7 +67,7 @@
 			<return type="bool" />
 			<param index="0" name="delta" type="float" />
 			<description>
-				Processes the [Tween] by the given [code]delta[/code] value, in seconds. This is mostly useful for manual control when the [Tween] is paused. It can also be used to end the [Tween] animation immediately, by setting [code]delta[/code] longer than the whole duration of the [Tween] animation.
+				Processes the [Tween] by the given [param delta] value, in seconds. This is mostly useful for manual control when the [Tween] is paused. It can also be used to end the [Tween] animation immediately, by setting [param delta] longer than the whole duration of the [Tween] animation.
 				Returns [code]true[/code] if the [Tween] still has [Tweener]s that haven't finished.
 				[b]Note:[/b] The [Tween] will become invalid in the next processing frame after its animation finishes. Calling [method stop] after performing [method custom_step] instead keeps and resets the [Tween].
 			</description>
@@ -89,11 +89,11 @@
 			<param index="5" name="ease_type" type="int" enum="Tween.EaseType" />
 			<description>
 				This method can be used for manual interpolation of a value, when you don't want [Tween] to do animating for you. It's similar to [method @GlobalScope.lerp], but with support for custom transition and easing.
-				[code]initial_value[/code] is the starting value of the interpolation.
-				[code]delta_value[/code] is the change of the value in the interpolation, i.e. it's equal to [code]final_value - initial_value[/code].
-				[code]elapsed_time[/code] is the time in seconds that passed after the interpolation started and it's used to control the position of the interpolation. E.g. when it's equal to half of the [code]duration[/code], the interpolated value will be halfway between initial and final values. This value can also be greater than [code]duration[/code] or lower than 0, which will extrapolate the value.
-				[code]duration[/code] is the total time of the interpolation.
-				[b]Note:[/b] If [code]duration[/code] is equal to [code]0[/code], the method will always return the final value, regardless of [code]elapsed_time[/code] provided.
+				[param initial_value] is the starting value of the interpolation.
+				[param delta_value] is the change of the value in the interpolation, i.e. it's equal to [code]final_value - initial_value[/code].
+				[param elapsed_time] is the time in seconds that passed after the interpolation started and it's used to control the position of the interpolation. E.g. when it's equal to half of the [param duration], the interpolated value will be halfway between initial and final values. This value can also be greater than [param duration] or lower than 0, which will extrapolate the value.
+				[param duration] is the total time of the interpolation.
+				[b]Note:[/b] If [param duration] is equal to [code]0[/code], the method will always return the final value, regardless of [param elapsed_time] provided.
 			</description>
 		</method>
 		<method name="is_running">
@@ -160,7 +160,7 @@
 			<return type="Tween" />
 			<param index="0" name="parallel" type="bool" default="true" />
 			<description>
-				If [code]parallel[/code] is [code]true[/code], the [Tweener]s appended after this method will by default run simultaneously, as opposed to sequentially.
+				If [param parallel] is [code]true[/code], the [Tweener]s appended after this method will by default run simultaneously, as opposed to sequentially.
 			</description>
 		</method>
 		<method name="set_pause_mode">
@@ -221,7 +221,7 @@
 			<return type="IntervalTweener" />
 			<param index="0" name="time" type="float" />
 			<description>
-				Creates and appends an [IntervalTweener]. This method can be used to create delays in the tween animation, as an alternative to using the delay in other [Tweener]s, or when there's no animation (in which case the [Tween] acts as a timer). [code]time[/code] is the length of the interval, in seconds.
+				Creates and appends an [IntervalTweener]. This method can be used to create delays in the tween animation, as an alternative to using the delay in other [Tweener]s, or when there's no animation (in which case the [Tween] acts as a timer). [param time] is the length of the interval, in seconds.
 				Example: creating an interval in code execution.
 				[codeblock]
 				# ... some code
@@ -247,7 +247,7 @@
 			<param index="2" name="to" type="Variant" />
 			<param index="3" name="duration" type="float" />
 			<description>
-				Creates and appends a [MethodTweener]. This method is similar to a combination of [method tween_callback] and [method tween_property]. It calls a method over time with a tweened value provided as an argument. The value is tweened between [code]from[/code] and [code]to[/code] over the time specified by [code]duration[/code], in seconds. Use [method Callable.bind] to bind additional arguments for the call. You can use [method MethodTweener.set_ease] and [method MethodTweener.set_trans] to tweak the easing and transition of the value or [method MethodTweener.set_delay] to delay the tweening.
+				Creates and appends a [MethodTweener]. This method is similar to a combination of [method tween_callback] and [method tween_property]. It calls a method over time with a tweened value provided as an argument. The value is tweened between [param from] and [param to] over the time specified by [param duration], in seconds. Use [method Callable.bind] to bind additional arguments for the call. You can use [method MethodTweener.set_ease] and [method MethodTweener.set_trans] to tweak the easing and transition of the value or [method MethodTweener.set_delay] to delay the tweening.
 				Example: making a 3D object look from one point to another point.
 				[codeblock]
 				var tween = create_tween()
@@ -271,7 +271,7 @@
 			<param index="2" name="final_val" type="Variant" />
 			<param index="3" name="duration" type="float" />
 			<description>
-				Creates and appends a [PropertyTweener]. This method tweens a [code]property[/code] of an [code]object[/code] between an initial value and [code]final_val[/code] in a span of time equal to [code]duration[/code], in seconds. The initial value by default is the property's value at the time the tweening of the [PropertyTweener] starts. For example:
+				Creates and appends a [PropertyTweener]. This method tweens a [param property] of an [param object] between an initial value and [param final_val] in a span of time equal to [param duration], in seconds. The initial value by default is the property's value at the time the tweening of the [PropertyTweener] starts. For example:
 				[codeblock]
 				var tween = create_tween()
 				tween.tween_property($Sprite, "position", Vector2(100, 200), 1)

--- a/doc/classes/UDPServer.xml
+++ b/doc/classes/UDPServer.xml
@@ -146,7 +146,7 @@
 			<param index="0" name="port" type="int" />
 			<param index="1" name="bind_address" type="String" default="&quot;*&quot;" />
 			<description>
-				Starts the server by opening a UDP socket listening on the given port. You can optionally specify a [code]bind_address[/code] to only listen for packets sent to that address. See also [method PacketPeerUDP.bind].
+				Starts the server by opening a UDP socket listening on the given [param port]. You can optionally specify a [param bind_address] to only listen for packets sent to that address. See also [method PacketPeerUDP.bind].
 			</description>
 		</method>
 		<method name="poll">

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -67,7 +67,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="method" type="StringName" />
 			<description>
-				Register a method that will be called when the action is committed.
+				Register a [param method] that will be called when the action is committed.
 			</description>
 		</method>
 		<method name="add_do_property">
@@ -76,7 +76,7 @@
 			<param index="1" name="property" type="StringName" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Register a property value change for "do".
+				Register a [param property] that would change its value to [param value] when the action is committed.
 			</description>
 		</method>
 		<method name="add_do_reference">
@@ -91,7 +91,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="method" type="StringName" />
 			<description>
-				Register a method that will be called when the action is undone.
+				Register a [param method] that will be called when the action is undone.
 			</description>
 		</method>
 		<method name="add_undo_property">
@@ -100,7 +100,7 @@
 			<param index="1" name="property" type="StringName" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Register a property value change for "undo".
+				Register a [param property] that would change its value to [param value] when the action is undone.
 			</description>
 		</method>
 		<method name="add_undo_reference">
@@ -115,14 +115,14 @@
 			<param index="0" name="increase_version" type="bool" default="true" />
 			<description>
 				Clear the undo/redo history and associated references.
-				Passing [code]false[/code] to [code]increase_version[/code] will prevent the version number to be increased from this.
+				Passing [code]false[/code] to [param increase_version] will prevent the version number from increasing when the history is cleared.
 			</description>
 		</method>
 		<method name="commit_action">
 			<return type="void" />
 			<param index="0" name="execute" type="bool" default="true" />
 			<description>
-				Commit the action. If [code]execute[/code] is true (default), all "do" methods/properties are called/set when this function is called.
+				Commit the action. If [param execute] is [code]true[/code] (which it is by default), all "do" methods/properties are called/set when this function is called.
 			</description>
 		</method>
 		<method name="create_action">
@@ -131,7 +131,7 @@
 			<param index="1" name="merge_mode" type="int" enum="UndoRedo.MergeMode" default="0" />
 			<description>
 				Create a new action. After this is called, do all your calls to [method add_do_method], [method add_undo_method], [method add_do_property], and [method add_undo_property], then commit the action with [method commit_action].
-				The way actions are merged is dictated by the [code]merge_mode[/code] argument. See [enum MergeMode] for details.
+				The way actions are merged is dictated by [param merge_mode]. See [enum MergeMode] for details.
 			</description>
 		</method>
 		<method name="end_force_keep_in_merge_ends">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -42,7 +42,7 @@
 			<param index="0" name="x" type="float" />
 			<param index="1" name="y" type="float" />
 			<description>
-				Constructs a new [Vector2] from the given [code]x[/code] and [code]y[/code].
+				Constructs a new [Vector2] from the given [param x] and [param y].
 			</description>
 		</constructor>
 	</constructors>
@@ -92,7 +92,7 @@
 			<param index="2" name="end" type="Vector2" />
 			<param index="3" name="t" type="float" />
 			<description>
-				Returns the point at the given [code]t[/code] on the [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by this vector and the given [code]control_1[/code], [code]control_2[/code], and [code]end[/code] points.
+				Returns the point at the given [param t] on the [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by this vector and the given [param control_1], [param control_2], and [param end] points.
 			</description>
 		</method>
 		<method name="bounce" qualifiers="const">
@@ -113,14 +113,14 @@
 			<param index="0" name="min" type="Vector2" />
 			<param index="1" name="max" type="Vector2" />
 			<description>
-				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+				Returns a new vector with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
 		<method name="cross" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="with" type="Vector2" />
 			<description>
-				Returns the 2D analog of the cross product for this vector and [code]with[/code].
+				Returns the 2D analog of the cross product for this vector and [param with].
 				This is the signed area of the parallelogram formed by the two vectors. If the second vector is clockwise from the first vector, then the cross product is the positive area. If counter-clockwise, the cross product is the negative area.
 				[b]Note:[/b] Cross product is not defined in 2D mathematically. This method embeds the 2D vectors in the XY plane of 3D space and uses their cross product's Z component as the analog.
 			</description>
@@ -132,21 +132,21 @@
 			<param index="2" name="post_b" type="Vector2" />
 			<param index="3" name="weight" type="float" />
 			<description>
-				Cubically interpolates between this vector and [code]b[/code] using [code]pre_a[/code] and [code]post_b[/code] as handles, and returns the result at position [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Cubically interpolates between this vector and [param b] using [param pre_a] and [param post_b] as handles, and returns the result at position [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="direction_to" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="to" type="Vector2" />
 			<description>
-				Returns the normalized vector pointing from this vector to [code]to[/code]. This is equivalent to using [code](b - a).normalized()[/code].
+				Returns the normalized vector pointing from this vector to [param to]. This is equivalent to using [code](b - a).normalized()[/code].
 			</description>
 		</method>
 		<method name="distance_squared_to" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="to" type="Vector2" />
 			<description>
-				Returns the squared distance between this vector and [code]to[/code].
+				Returns the squared distance between this vector and [param to].
 				This method runs faster than [method distance_to], so prefer it if you need to compare vectors or need the squared distance for some formula.
 			</description>
 		</method>
@@ -154,14 +154,14 @@
 			<return type="float" />
 			<param index="0" name="to" type="Vector2" />
 			<description>
-				Returns the distance between this vector and [code]to[/code].
+				Returns the distance between this vector and [param to].
 			</description>
 		</method>
 		<method name="dot" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="with" type="Vector2" />
 			<description>
-				Returns the dot product of this vector and [code]with[/code]. This can be used to compare the angle between two vectors. For example, this can be used to determine whether an enemy is facing the player.
+				Returns the dot product of this vector and [param with]. This can be used to compare the angle between two vectors. For example, this can be used to determine whether an enemy is facing the player.
 				The dot product will be [code]0[/code] for a straight angle (90 degrees), greater than 0 for angles narrower than 90 degrees and lower than 0 for angles wider than 90 degrees.
 				When using unit (normalized) vectors, the result will always be between [code]-1.0[/code] (180 degree angle) when the vectors are facing opposite directions, and [code]1.0[/code] (0 degree angle) when the vectors are aligned.
 				[b]Note:[/b] [code]a.dot(b)[/code] is equivalent to [code]b.dot(a)[/code].
@@ -177,7 +177,7 @@
 			<return type="Vector2" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Creates a unit [Vector2] rotated to the given [code]angle[/code] in radians. This is equivalent to doing [code]Vector2(cos(angle), sin(angle))[/code] or [code]Vector2.RIGHT.rotated(angle)[/code].
+				Creates a unit [Vector2] rotated to the given [param angle] in radians. This is equivalent to doing [code]Vector2(cos(angle), sin(angle))[/code] or [code]Vector2.RIGHT.rotated(angle)[/code].
 				[codeblock]
 				print(Vector2.from_angle(0)) # Prints (1, 0).
 				print(Vector2(1, 0).angle()) # Prints 0, which is the angle used above.
@@ -216,14 +216,14 @@
 			<param index="0" name="to" type="Vector2" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the linear interpolation between this vector and [code]to[/code] by amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="limit_length" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="length" type="float" default="1.0" />
 			<description>
-				Returns the vector with a maximum length by limiting its length to [code]length[/code].
+				Returns the vector with a maximum length by limiting its length to [param length].
 			</description>
 		</method>
 		<method name="max_axis_index" qualifiers="const">
@@ -243,7 +243,7 @@
 			<param index="0" name="to" type="Vector2" />
 			<param index="1" name="delta" type="float" />
 			<description>
-				Returns a new vector moved toward [code]to[/code] by the fixed [code]delta[/code] amount. Will not go past the final value.
+				Returns a new vector moved toward [param to] by the fixed [param delta] amount. Will not go past the final value.
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">
@@ -262,14 +262,14 @@
 			<return type="Vector2" />
 			<param index="0" name="mod" type="float" />
 			<description>
-				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [code]mod[/code].
+				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param mod].
 			</description>
 		</method>
 		<method name="posmodv" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="modv" type="Vector2" />
 			<description>
-				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [code]modv[/code]'s components.
+				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param modv]'s components.
 			</description>
 		</method>
 		<method name="project" qualifiers="const">
@@ -283,14 +283,14 @@
 			<return type="Vector2" />
 			<param index="0" name="n" type="Vector2" />
 			<description>
-				Returns the vector reflected (i.e. mirrored, or symmetric) over a line defined by the given direction vector [code]n[/code].
+				Returns the vector reflected (i.e. mirrored, or symmetric) over a line defined by the given direction vector [param n].
 			</description>
 		</method>
 		<method name="rotated" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Returns the vector rotated by [code]angle[/code] (in radians). See also [method @GlobalScope.deg2rad].
+				Returns the vector rotated by [param angle] (in radians). See also [method @GlobalScope.deg2rad].
 			</description>
 		</method>
 		<method name="round" qualifiers="const">
@@ -310,7 +310,7 @@
 			<param index="0" name="to" type="Vector2" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of spherical linear interpolation between this vector and [code]to[/code], by amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Returns the result of spherical linear interpolation between this vector and [param to], by amount [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 				This method also handles interpolating the lengths if the input vectors have different lengths. For the special case of one or both input vectors having zero length, this method behaves like [method lerp].
 			</description>
 		</method>
@@ -325,7 +325,7 @@
 			<return type="Vector2" />
 			<param index="0" name="step" type="Vector2" />
 			<description>
-				Returns this vector with each component snapped to the nearest multiple of [code]step[/code]. This can also be used to round to an arbitrary number of decimals.
+				Returns this vector with each component snapped to the nearest multiple of [param step]. This can also be used to round to an arbitrary number of decimals.
 			</description>
 		</method>
 	</methods>
@@ -454,14 +454,14 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2" />
 			<description>
-				Compares two [Vector2] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
+				Compares two [Vector2] vectors by first checking if the X value of the left vector is less than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2" />
 			<description>
-				Compares two [Vector2] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
+				Compares two [Vector2] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -476,21 +476,21 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2" />
 			<description>
-				Compares two [Vector2] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
+				Compares two [Vector2] vectors by first checking if the X value of the left vector is greater than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2" />
 			<description>
-				Compares two [Vector2] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
+				Compares two [Vector2] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="float" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], and [code]v[1][/code] is equivalent to [code]v.y[/code].
+				Access vector components using their [param index]. [code]v[0][/code] is equivalent to [code]v.x[/code], and [code]v[1][/code] is equivalent to [code]v.y[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -39,7 +39,7 @@
 			<param index="0" name="x" type="int" />
 			<param index="1" name="y" type="int" />
 			<description>
-				Constructs a new [Vector2i] from the given [code]x[/code] and [code]y[/code].
+				Constructs a new [Vector2i] from the given [param x] and [param y].
 			</description>
 		</constructor>
 	</constructors>
@@ -61,7 +61,7 @@
 			<param index="0" name="min" type="Vector2i" />
 			<param index="1" name="max" type="Vector2i" />
 			<description>
-				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+				Returns a new vector with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
 		<method name="length" qualifiers="const">
@@ -236,14 +236,14 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2i" />
 			<description>
-				Compares two [Vector2i] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
+				Compares two [Vector2i] vectors by first checking if the X value of the left vector is less than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2i" />
 			<description>
-				Compares two [Vector2i] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
+				Compares two [Vector2i] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -257,21 +257,21 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2i" />
 			<description>
-				Compares two [Vector2i] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
+				Compares two [Vector2i] vectors by first checking if the X value of the left vector is greater than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector2i" />
 			<description>
-				Compares two [Vector2i] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
+				Compares two [Vector2i] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], and [code]v[1][/code] is equivalent to [code]v.y[/code].
+				Access vector components using their [param index]. [code]v[0][/code] is equivalent to [code]v.x[/code], and [code]v[1][/code] is equivalent to [code]v.y[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -68,7 +68,7 @@
 			<param index="2" name="end" type="Vector3" />
 			<param index="3" name="t" type="float" />
 			<description>
-				Returns the point at the given [code]t[/code] on the [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by this vector and the given [code]control_1[/code], [code]control_2[/code], and [code]end[/code] points.
+				Returns the point at the given [param t] on the [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by this vector and the given [param control_1], [param control_2], and [param end] points.
 			</description>
 		</method>
 		<method name="bounce" qualifiers="const">
@@ -89,14 +89,14 @@
 			<param index="0" name="min" type="Vector3" />
 			<param index="1" name="max" type="Vector3" />
 			<description>
-				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+				Returns a new vector with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
 		<method name="cross" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="with" type="Vector3" />
 			<description>
-				Returns the cross product of this vector and [code]with[/code].
+				Returns the cross product of this vector and [param with].
 			</description>
 		</method>
 		<method name="cubic_interpolate" qualifiers="const">
@@ -106,21 +106,21 @@
 			<param index="2" name="post_b" type="Vector3" />
 			<param index="3" name="weight" type="float" />
 			<description>
-				Performs a cubic interpolation between this vector and [code]b[/code] using [code]pre_a[/code] and [code]post_b[/code] as handles, and returns the result at position [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Performs a cubic interpolation between this vector and [param b] using [param pre_a] and [param post_b] as handles, and returns the result at position [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="direction_to" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="to" type="Vector3" />
 			<description>
-				Returns the normalized vector pointing from this vector to [code]to[/code]. This is equivalent to using [code](b - a).normalized()[/code].
+				Returns the normalized vector pointing from this vector to [param to]. This is equivalent to using [code](b - a).normalized()[/code].
 			</description>
 		</method>
 		<method name="distance_squared_to" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="to" type="Vector3" />
 			<description>
-				Returns the squared distance between this vector and [code]to[/code].
+				Returns the squared distance between this vector and [param to].
 				This method runs faster than [method distance_to], so prefer it if you need to compare vectors or need the squared distance for some formula.
 			</description>
 		</method>
@@ -128,14 +128,14 @@
 			<return type="float" />
 			<param index="0" name="to" type="Vector3" />
 			<description>
-				Returns the distance between this vector and [code]to[/code].
+				Returns the distance between this vector and [param to].
 			</description>
 		</method>
 		<method name="dot" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="with" type="Vector3" />
 			<description>
-				Returns the dot product of this vector and [code]with[/code]. This can be used to compare the angle between two vectors. For example, this can be used to determine whether an enemy is facing the player.
+				Returns the dot product of this vector and [param with]. This can be used to compare the angle between two vectors. For example, this can be used to determine whether an enemy is facing the player.
 				The dot product will be [code]0[/code] for a straight angle (90 degrees), greater than 0 for angles narrower than 90 degrees and lower than 0 for angles wider than 90 degrees.
 				When using unit (normalized) vectors, the result will always be between [code]-1.0[/code] (180 degree angle) when the vectors are facing opposite directions, and [code]1.0[/code] (0 degree angle) when the vectors are aligned.
 				[b]Note:[/b] [code]a.dot(b)[/code] is equivalent to [code]b.dot(a)[/code].
@@ -157,7 +157,7 @@
 			<return type="bool" />
 			<param index="0" name="to" type="Vector3" />
 			<description>
-				Returns [code]true[/code] if this vector and [code]v[/code] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
+				Returns [code]true[/code] if this vector and [param to] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
 			</description>
 		</method>
 		<method name="is_normalized" qualifiers="const">
@@ -184,14 +184,14 @@
 			<param index="0" name="to" type="Vector3" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the linear interpolation between this vector and [code]to[/code] by amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="limit_length" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="length" type="float" default="1.0" />
 			<description>
-				Returns the vector with a maximum length by limiting its length to [code]length[/code].
+				Returns the vector with a maximum length by limiting its length to [param length].
 			</description>
 		</method>
 		<method name="max_axis_index" qualifiers="const">
@@ -211,7 +211,7 @@
 			<param index="0" name="to" type="Vector3" />
 			<param index="1" name="delta" type="float" />
 			<description>
-				Returns a new vector moved toward [code]to[/code] by the fixed [code]delta[/code] amount. Will not go past the final value.
+				Returns a new vector moved toward [param to] by the fixed [param delta] amount. Will not go past the final value.
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">
@@ -235,28 +235,28 @@
 			<return type="Basis" />
 			<param index="0" name="with" type="Vector3" />
 			<description>
-				Returns the outer product with [code]with[/code].
+				Returns the outer product with [param with].
 			</description>
 		</method>
 		<method name="posmod" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="mod" type="float" />
 			<description>
-				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [code]mod[/code].
+				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param mod].
 			</description>
 		</method>
 		<method name="posmodv" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="modv" type="Vector3" />
 			<description>
-				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [code]modv[/code]'s components.
+				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param modv]'s components.
 			</description>
 		</method>
 		<method name="project" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="b" type="Vector3" />
 			<description>
-				Returns this vector projected onto the vector [code]b[/code].
+				Returns this vector projected onto the vector [param b].
 			</description>
 		</method>
 		<method name="reflect" qualifiers="const">
@@ -271,7 +271,7 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Rotates this vector around a given axis by [code]angle[/code] (in radians). The axis must be a normalized vector.
+				Rotates this vector around a given axis by [param angle] (in radians). The axis must be a normalized vector.
 			</description>
 		</method>
 		<method name="round" qualifiers="const">
@@ -291,7 +291,7 @@
 			<param index="0" name="to" type="Vector3" />
 			<param index="1" name="axis" type="Vector3" />
 			<description>
-				Returns the signed angle to the given vector, in radians. The sign of the angle is positive in a counter-clockwise direction and negative in a clockwise direction when viewed from the side specified by the [code]axis[/code].
+				Returns the signed angle to the given vector, in radians. The sign of the angle is positive in a counter-clockwise direction and negative in a clockwise direction when viewed from the side specified by the [param axis].
 			</description>
 		</method>
 		<method name="slerp" qualifiers="const">
@@ -299,7 +299,7 @@
 			<param index="0" name="to" type="Vector3" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of spherical linear interpolation between this vector and [code]to[/code], by amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Returns the result of spherical linear interpolation between this vector and [param to], by amount [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 				This method also handles interpolating the lengths if the input vectors have different lengths. For the special case of one or both input vectors having zero length, this method behaves like [method lerp].
 			</description>
 		</method>
@@ -314,7 +314,7 @@
 			<return type="Vector3" />
 			<param index="0" name="step" type="Vector3" />
 			<description>
-				Returns this vector with each component snapped to the nearest multiple of [code]step[/code]. This can also be used to round to an arbitrary number of decimals.
+				Returns this vector with each component snapped to the nearest multiple of [param step]. This can also be used to round to an arbitrary number of decimals.
 			</description>
 		</method>
 	</methods>
@@ -469,14 +469,14 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3" />
 			<description>
-				Compares two [Vector3] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
+				Compares two [Vector3] vectors by first checking if the X value of the left vector is less than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3" />
 			<description>
-				Compares two [Vector3] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
+				Compares two [Vector3] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -491,21 +491,21 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3" />
 			<description>
-				Compares two [Vector3] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
+				Compares two [Vector3] vectors by first checking if the X value of the left vector is greater than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3" />
 			<description>
-				Compares two [Vector3] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
+				Compares two [Vector3] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="float" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], and [code]v[2][/code] is equivalent to [code]v.z[/code].
+				Access vector components using their [param index]. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], and [code]v[2][/code] is equivalent to [code]v.z[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -56,7 +56,7 @@
 			<param index="0" name="min" type="Vector3i" />
 			<param index="1" name="max" type="Vector3i" />
 			<description>
-				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+				Returns a new vector with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
 		<method name="length" qualifiers="const">
@@ -243,14 +243,14 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3i" />
 			<description>
-				Compares two [Vector3i] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
+				Compares two [Vector3i] vectors by first checking if the X value of the left vector is less than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3i" />
 			<description>
-				Compares two [Vector3i] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
+				Compares two [Vector3i] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -264,21 +264,21 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3i" />
 			<description>
-				Compares two [Vector3i] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
+				Compares two [Vector3i] vectors by first checking if the X value of the left vector is greater than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector3i" />
 			<description>
-				Compares two [Vector3i] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
+				Compares two [Vector3i] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], and [code]v[2][/code] is equivalent to [code]v.z[/code].
+				Access vector components using their [param index]. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], and [code]v[2][/code] is equivalent to [code]v.z[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -60,7 +60,7 @@
 			<param index="0" name="min" type="Vector4" />
 			<param index="1" name="max" type="Vector4" />
 			<description>
-				Returns a new vector with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+				Returns a new vector with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
 		<method name="cubic_interpolate" qualifiers="const">
@@ -70,28 +70,28 @@
 			<param index="2" name="post_b" type="Vector4" />
 			<param index="3" name="weight" type="float" />
 			<description>
-				Performs a cubic interpolation between this vector and [code]b[/code] using [code]pre_a[/code] and [code]post_b[/code] as handles, and returns the result at position [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Performs a cubic interpolation between this vector and [param b] using [param pre_a] and [param post_b] as handles, and returns the result at position [param weight]. [param weight] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="direction_to" qualifiers="const">
 			<return type="Vector4" />
 			<param index="0" name="to" type="Vector4" />
 			<description>
-				Returns the normalized vector pointing from this vector to [code]to[/code]. This is equivalent to using [code](b - a).normalized()[/code].
+				Returns the normalized vector pointing from this vector to [param to]. This is equivalent to using [code](b - a).normalized()[/code].
 			</description>
 		</method>
 		<method name="distance_to" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="to" type="Vector4" />
 			<description>
-				Returns the distance between this vector and [code]to[/code].
+				Returns the distance between this vector and [param to].
 			</description>
 		</method>
 		<method name="dot" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="with" type="Vector4" />
 			<description>
-				Returns the dot product of this vector and [code]with[/code].
+				Returns the dot product of this vector and [param with].
 			</description>
 		</method>
 		<method name="floor" qualifiers="const">
@@ -110,7 +110,7 @@
 			<return type="bool" />
 			<param index="0" name="with" type="Vector4" />
 			<description>
-				Returns [code]true[/code] if this vector and [code]v[/code] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
+				Returns [code]true[/code] if this vector and [param with] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
 			</description>
 		</method>
 		<method name="is_normalized" qualifiers="const">
@@ -136,7 +136,7 @@
 			<param index="0" name="to" type="Vector4" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the linear interpolation between this vector and [code]to[/code] by amount [code]weight[/code]. [code]weight[/code] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="max_axis_index" qualifiers="const">
@@ -161,14 +161,14 @@
 			<return type="Vector4" />
 			<param index="0" name="mod" type="float" />
 			<description>
-				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [code]mod[/code].
+				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param mod].
 			</description>
 		</method>
 		<method name="posmodv" qualifiers="const">
 			<return type="Vector4" />
 			<param index="0" name="modv" type="Vector4" />
 			<description>
-				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [code]modv[/code]'s components.
+				Returns a vector composed of the [method @GlobalScope.fposmod] of this vector's components and [param modv]'s components.
 			</description>
 		</method>
 		<method name="round" qualifiers="const">
@@ -187,7 +187,7 @@
 			<return type="Vector4" />
 			<param index="0" name="step" type="Vector4" />
 			<description>
-				Returns this vector with each component snapped to the nearest multiple of [code]step[/code]. This can also be used to round to an arbitrary number of decimals.
+				Returns this vector with each component snapped to the nearest multiple of [param step]. This can also be used to round to an arbitrary number of decimals.
 			</description>
 		</method>
 	</methods>
@@ -322,14 +322,14 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector4" />
 			<description>
-				Compares two [Vector4] vectors by first checking if the X value of the left vector is less than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, Z values of the two vectors, and then with the W values. This operator is useful for sorting vectors.
+				Compares two [Vector4] vectors by first checking if the X value of the left vector is less than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, Z values of the two vectors, and then with the W values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector4" />
 			<description>
-				Compares two [Vector4] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, Z values of the two vectors, and then with the W values. This operator is useful for sorting vectors.
+				Compares two [Vector4] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, Z values of the two vectors, and then with the W values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -344,21 +344,21 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Vector4" />
 			<description>
-				Compares two [Vector4] vectors by first checking if the X value of the left vector is greater than the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, Z values of the two vectors, and then with the W values. This operator is useful for sorting vectors.
+				Compares two [Vector4] vectors by first checking if the X value of the left vector is greater than the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, Z values of the two vectors, and then with the W values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Vector4" />
 			<description>
-				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], and [code]v[2][/code] is equivalent to [code]v.z[/code].
+				Compares two [Vector4] vectors by first checking if the X value of the left vector is greater than or equal to the X value of the [param right] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, Z values of the two vectors, and then with the W values. This operator is useful for sorting vectors.
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="float" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Access vector components using their index. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], [code]v[2][/code] is equivalent to [code]v.z[/code], and [code]v[3][/code] is equivalent to [code]v.w[/code].
+				Access vector components using their [param index]. [code]v[0][/code] is equivalent to [code]v.x[/code], [code]v[1][/code] is equivalent to [code]v.y[/code], [code]v[2][/code] is equivalent to [code]v.z[/code], and [code]v[3][/code] is equivalent to [code]v.w[/code].
 			</description>
 		</operator>
 		<operator name="operator unary+">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -142,7 +142,6 @@
 			<return type="void" />
 			<param index="0" name="text" type="String" />
 			<description>
-				Returns [code]true[/code] if the viewport is currently embedding windows.
 			</description>
 		</method>
 		<method name="push_unhandled_input">

--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -58,7 +58,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member layers], given a [code]layer_number[/code] between 1 and 20.
+				Based on [param value], enables or disables the specified layer in the [member layers], given a [param layer_number] between 1 and 20.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -17,7 +17,7 @@
 			<param index="2" name="position" type="Vector2" />
 			<param index="3" name="id" type="int" />
 			<description>
-				Adds the specified node to the shader.
+				Adds the specified [param node] to the shader.
 			</description>
 		</method>
 		<method name="add_varying">
@@ -77,7 +77,7 @@
 			<param index="0" name="type" type="int" enum="VisualShader.Type" />
 			<param index="1" name="id" type="int" />
 			<description>
-				Returns the shader node instance with specified [code]type[/code] and [code]id[/code].
+				Returns the shader node instance with specified [param type] and [param id].
 			</description>
 		</method>
 		<method name="get_node_connections" qualifiers="const">

--- a/doc/classes/VisualShaderNode.xml
+++ b/doc/classes/VisualShaderNode.xml
@@ -26,14 +26,14 @@
 			<return type="Variant" />
 			<param index="0" name="port" type="int" />
 			<description>
-				Returns the default value of the input [code]port[/code].
+				Returns the default value of the input [param port].
 			</description>
 		</method>
 		<method name="remove_input_port_default_value">
 			<return type="void" />
 			<param index="0" name="port" type="int" />
 			<description>
-				Removes the default value of the input [code]port[/code].
+				Removes the default value of the input [param port].
 			</description>
 		</method>
 		<method name="set_default_input_values">
@@ -49,7 +49,7 @@
 			<param index="1" name="value" type="Variant" />
 			<param index="2" name="prev_value" type="Variant" default="null" />
 			<description>
-				Sets the default value for the selected input [code]port[/code].
+				Sets the default [param value] for the selected input [param port].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -31,9 +31,9 @@
 			<param index="3" name="type" type="int" enum="VisualShader.Type" />
 			<description>
 				Override this method to define the actual shader code of the associated custom node. The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
-				The [code]input_vars[/code] and [code]output_vars[/code] arrays contain the string names of the various input and output variables, as defined by [code]_get_input_*[/code] and [code]_get_output_*[/code] virtual methods in this class.
+				The [param input_vars] and [param output_vars] arrays contain the string names of the various input and output variables, as defined by [code]_get_input_*[/code] and [code]_get_output_*[/code] virtual methods in this class.
 				The output ports can be assigned values in the shader code. For example, [code]return output_vars[0] + " = " + input_vars[0] + ";"[/code].
-				You can customize the generated code based on the shader [code]mode[/code] (see [enum Shader.Mode]) and/or [code]type[/code] (see [enum VisualShader.Type]).
+				You can customize the generated code based on the shader [param mode] (see [enum Shader.Mode]) and/or [param type] (see [enum VisualShader.Type]).
 				Defining this method is [b]required[/b].
 			</description>
 		</method>
@@ -51,7 +51,7 @@
 			<description>
 				Override this method to add a shader code to the beginning of each shader function (once). The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
 				If there are multiple custom nodes of different types which use this feature the order of each insertion is undefined.
-				You can customize the generated code based on the shader [code]mode[/code] (see [enum Shader.Mode]) and/or [code]type[/code] (see [enum VisualShader.Type]).
+				You can customize the generated code based on the shader [param mode] (see [enum Shader.Mode]) and/or [param type] (see [enum VisualShader.Type]).
 				Defining this method is [b]optional[/b].
 			</description>
 		</method>
@@ -61,7 +61,7 @@
 			<description>
 				Override this method to add shader code on top of the global shader, to define your own standard library of reusable methods, varyings, constants, uniforms, etc. The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
 				Be careful with this functionality as it can cause name conflicts with other custom nodes, so be sure to give the defined entities unique names.
-				You can customize the generated code based on the shader [code]mode[/code] (see [enum Shader.Mode]).
+				You can customize the generated code based on the shader [param mode] (see [enum Shader.Mode]).
 				Defining this method is [b]optional[/b].
 			</description>
 		</method>
@@ -130,7 +130,7 @@
 			<param index="0" name="mode" type="int" enum="Shader.Mode" />
 			<param index="1" name="type" type="int" enum="VisualShader.Type" />
 			<description>
-				Override this method to prevent the node to be visible in the member dialog for the certain [code]mode[/code] (see [enum Shader.Mode]) and/or [code]type[/code] (see [enum VisualShader.Type]).
+				Override this method to prevent the node to be visible in the member dialog for the certain [param mode] (see [enum Shader.Mode]) and/or [param type] (see [enum VisualShader.Type]).
 				Defining this method is [b]optional[/b]. If not overridden, it's [code]true[/code].
 			</description>
 		</method>

--- a/doc/classes/VisualShaderNodeGroupBase.xml
+++ b/doc/classes/VisualShaderNodeGroupBase.xml
@@ -15,7 +15,7 @@
 			<param index="1" name="type" type="int" />
 			<param index="2" name="name" type="String" />
 			<description>
-				Adds an input port with the specified [code]type[/code] (see [enum VisualShaderNode.PortType]) and [code]name[/code].
+				Adds an input port with the specified [param type] (see [enum VisualShaderNode.PortType]) and [param name].
 			</description>
 		</method>
 		<method name="add_output_port">
@@ -24,7 +24,7 @@
 			<param index="1" name="type" type="int" />
 			<param index="2" name="name" type="String" />
 			<description>
-				Adds an output port with the specified [code]type[/code] (see [enum VisualShaderNode.PortType]) and [code]name[/code].
+				Adds an output port with the specified [param type] (see [enum VisualShaderNode.PortType]) and [param name].
 			</description>
 		</method>
 		<method name="clear_input_ports">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -32,7 +32,7 @@
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="Window.Flags" />
 			<description>
-				Returns [code]true[/code] if the flag is set.
+				Returns [code]true[/code] if the [param flag] is set.
 			</description>
 		</method>
 		<method name="get_layout_direction" qualifiers="const">
@@ -52,7 +52,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns the [Color] at [code]name[/code] if the theme has [code]theme_type[/code].
+				Returns the [Color] at [param name] if the theme has [param theme_type].
 				See [method Control.get_theme_color] for more details.
 			</description>
 		</method>
@@ -61,7 +61,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns the constant at [code]name[/code] if the theme has [code]theme_type[/code].
+				Returns the constant at [param name] if the theme has [param theme_type].
 				See [method Control.get_theme_color] for more details.
 			</description>
 		</method>
@@ -91,7 +91,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns the [Font] at [code]name[/code] if the theme has [code]theme_type[/code].
+				Returns the [Font] at [param name] if the theme has [param theme_type].
 				See [method Control.get_theme_color] for more details.
 			</description>
 		</method>
@@ -100,7 +100,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns the font size at [code]name[/code] if the theme has [code]theme_type[/code].
+				Returns the font size at [param name] if the theme has [param theme_type].
 				See [method Control.get_theme_color] for more details.
 			</description>
 		</method>
@@ -109,7 +109,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns the icon at [code]name[/code] if the theme has [code]theme_type[/code].
+				Returns the icon at [param name] if the theme has [param theme_type].
 				See [method Control.get_theme_color] for more details.
 			</description>
 		</method>
@@ -118,7 +118,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns the [StyleBox] at [code]name[/code] if the theme has [code]theme_type[/code].
+				Returns the [StyleBox] at [param name] if the theme has [param theme_type].
 				See [method Control.get_theme_color] for more details.
 			</description>
 		</method>
@@ -139,7 +139,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if [Color] with [code]name[/code] is in [code]theme_type[/code].
+				Returns [code]true[/code] if [Color] with [param name] is in [param theme_type].
 			</description>
 		</method>
 		<method name="has_theme_constant" qualifiers="const">
@@ -147,7 +147,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if constant with [code]name[/code] is in [code]theme_type[/code].
+				Returns [code]true[/code] if constant with [param name] is in [param theme_type].
 			</description>
 		</method>
 		<method name="has_theme_font" qualifiers="const">
@@ -155,7 +155,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if [Font] with [code]name[/code] is in [code]theme_type[/code].
+				Returns [code]true[/code] if [Font] with [param name] is in [param theme_type].
 			</description>
 		</method>
 		<method name="has_theme_font_size" qualifiers="const">
@@ -163,7 +163,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if font size with [code]name[/code] is in [code]theme_type[/code].
+				Returns [code]true[/code] if font size with [param name] is in [param theme_type].
 			</description>
 		</method>
 		<method name="has_theme_icon" qualifiers="const">
@@ -171,7 +171,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if icon with [code]name[/code] is in [code]theme_type[/code].
+				Returns [code]true[/code] if icon with [param name] is in [param theme_type].
 			</description>
 		</method>
 		<method name="has_theme_stylebox" qualifiers="const">
@@ -179,7 +179,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if [StyleBox] with [code]name[/code] is in [code]theme_type[/code].
+				Returns [code]true[/code] if [StyleBox] with [param name] is in [param theme_type].
 			</description>
 		</method>
 		<method name="hide">
@@ -222,7 +222,7 @@
 			<return type="void" />
 			<param index="0" name="rect" type="Rect2i" default="Rect2i(0, 0, 0, 0)" />
 			<description>
-				Shows the [Window] and makes it transient (see [member transient]). If [code]rect[/code] is provided, it will be set as the [Window]'s size.
+				Shows the [Window] and makes it transient (see [member transient]). If [param rect] is provided, it will be set as the [Window]'s size.
 				Fails if called on the main window.
 			</description>
 		</method>
@@ -247,7 +247,7 @@
 			<return type="void" />
 			<param index="0" name="ratio" type="float" default="0.8" />
 			<description>
-				Popups the [Window] centered inside its parent [Window] and sets its size as a [code]ratio[/code] of parent's size.
+				Popups the [Window] centered inside its parent [Window] and sets its size as a [param ratio] of parent's size.
 			</description>
 		</method>
 		<method name="popup_on_parent">
@@ -282,7 +282,7 @@
 			<return type="void" />
 			<param index="0" name="active" type="bool" />
 			<description>
-				If [code]active[/code] is [code]true[/code], enables system's native IME (Input Method Editor).
+				If [param active] is [code]true[/code], enables system's native IME (Input Method Editor).
 			</description>
 		</method>
 		<method name="set_ime_position">

--- a/doc/classes/X509Certificate.xml
+++ b/doc/classes/X509Certificate.xml
@@ -14,14 +14,14 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Loads a certificate from [code]path[/code] ("*.crt" file).
+				Loads a certificate from [param path] ("*.crt" file).
 			</description>
 		</method>
 		<method name="save">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Saves a certificate to the given [code]path[/code] (should be a "*.crt" file).
+				Saves a certificate to the given [param path] (should be a "*.crt" file).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/XMLParser.xml
+++ b/doc/classes/XMLParser.xml
@@ -19,14 +19,14 @@
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Gets the name of the attribute specified by the index in [code]idx[/code] argument.
+				Gets the name of the attribute specified by the [param idx] index.
 			</description>
 		</method>
 		<method name="get_attribute_value" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Gets the value of the attribute specified by the index in [code]idx[/code] argument.
+				Gets the value of the attribute specified by the [param idx] index.
 			</description>
 		</method>
 		<method name="get_current_line" qualifiers="const">
@@ -39,14 +39,14 @@
 			<return type="String" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Gets the value of a certain attribute of the current element by name. This will raise an error if the element has no such attribute.
+				Gets the value of a certain attribute of the current element by [param name]. This will raise an error if the element has no such attribute.
 			</description>
 		</method>
 		<method name="get_named_attribute_value_safe" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Gets the value of a certain attribute of the current element by name. This will return an empty [String] if the attribute is not found.
+				Gets the value of a certain attribute of the current element by [param name]. This will return an empty [String] if the attribute is not found.
 			</description>
 		</method>
 		<method name="get_node_data" qualifiers="const">
@@ -90,14 +90,14 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="file" type="String" />
 			<description>
-				Opens an XML file for parsing. This returns an error code.
+				Opens an XML [param file] for parsing. This returns an error code.
 			</description>
 		</method>
 		<method name="open_buffer">
 			<return type="int" enum="Error" />
 			<param index="0" name="buffer" type="PackedByteArray" />
 			<description>
-				Opens an XML raw buffer for parsing. This returns an error code.
+				Opens an XML raw [param buffer] for parsing. This returns an error code.
 			</description>
 		</method>
 		<method name="read">

--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -17,7 +17,7 @@
 			<return type="Vector2" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns a [Vector2] for the input with the given [code]name[/code]. This is used for thumbsticks and thumbpads found on many controllers.
+				Returns a [Vector2] for the input with the given [param name]. This is used for thumbsticks and thumbpads found on many controllers.
 			</description>
 		</method>
 		<method name="get_tracker_hand" qualifiers="const">
@@ -30,14 +30,14 @@
 			<return type="float" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns a numeric value for the input with the given [code]name[/code]. This is used for triggers and grip sensors.
+				Returns a numeric value for the input with the given [param name]. This is used for triggers and grip sensors.
 			</description>
 		</method>
 		<method name="is_button_pressed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the button with the given [code]name[/code] is pressed.
+				Returns [code]true[/code] if the button with the given [param name] is pressed.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -93,8 +93,8 @@
 			<param index="5" name="delay_sec" type="float" />
 			<description>
 				Triggers a haptic pulse on a device associated with this interface.
-				[code]action_name[/code] is the name of the action for this pulse.
-				[code]tracker_name[/code] is optional and can be used to direct the pulse to a specific device provided that device is bound to this haptic.
+				[param action_name] is the name of the action for this pulse.
+				[param tracker_name] is optional and can be used to direct the pulse to a specific device provided that device is bound to this haptic.
 			</description>
 		</method>
 		<method name="uninitialize">

--- a/doc/classes/XRNode3D.xml
+++ b/doc/classes/XRNode3D.xml
@@ -36,7 +36,7 @@
 			<param index="4" name="delay_sec" type="float" />
 			<description>
 				Triggers a haptic pulse on a device associated with this interface.
-				[code]action_name[/code] is the name of the action for this pulse.
+				[param action_name] is the name of the action for this pulse.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -23,14 +23,14 @@
 			<return type="XRPose" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the current [XRPose] state object for the bound [code]pose[/code].
+				Returns the current [XRPose] state object for the bound [param name] pose.
 			</description>
 		</method>
 		<method name="has_pose" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the bound [code]tracker[/code] is available and is currently tracking the bound [code]pose[/code].
+				Returns [code]true[/code] if the tracker is available and is currently tracking the bound [param name] pose.
 			</description>
 		</method>
 		<method name="invalidate_pose">

--- a/doc/classes/XRServer.xml
+++ b/doc/classes/XRServer.xml
@@ -41,7 +41,7 @@
 			<return type="XRInterface" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Finds an interface by its name. For instance, if your project uses capabilities of an AR/VR platform, you can find the interface for that platform by name and initialize it.
+				Finds an interface by its [param name]. For instance, if your project uses capabilities of an AR/VR platform, you can find the interface for that platform by name and initialize it.
 			</description>
 		</method>
 		<method name="get_hmd_transform">
@@ -54,7 +54,7 @@
 			<return type="XRInterface" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the interface registered at a given index in our list of interfaces.
+				Returns the interface registered at the given [param idx] index in the list of interfaces.
 			</description>
 		</method>
 		<method name="get_interface_count" qualifiers="const">
@@ -79,28 +79,28 @@
 			<return type="XRPositionalTracker" />
 			<param index="0" name="tracker_name" type="StringName" />
 			<description>
-				Returns the positional tracker with this name.
+				Returns the positional tracker with the given [param tracker_name].
 			</description>
 		</method>
 		<method name="get_trackers">
 			<return type="Dictionary" />
 			<param index="0" name="tracker_types" type="int" />
 			<description>
-				Returns a dictionary of trackers for this type.
+				Returns a dictionary of trackers for [param tracker_types].
 			</description>
 		</method>
 		<method name="remove_interface">
 			<return type="void" />
 			<param index="0" name="interface" type="XRInterface" />
 			<description>
-				Removes this interface.
+				Removes this [param interface].
 			</description>
 		</method>
 		<method name="remove_tracker">
 			<return type="void" />
 			<param index="0" name="tracker" type="XRPositionalTracker" />
 			<description>
-				Removes this positional tracker.
+				Removes this positional [param tracker].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Also fixes a couple of descriptions in Vector4.xml and Viewport.xml.

This is the first of several commits to fix all of the class XML docs.

(Work based on discussion with @YuriSizov.)