### PR TITLE
For dev builds, keep track of resource names in the Vulkan driver

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1038,6 +1038,10 @@ class RenderingDeviceVulkan : public RenderingDevice {
 	void _finalize_command_bufers();
 	void _begin_frame();
 
+#ifdef DEV_ENABLED
+	HashMap<RID, String> resource_names;
+#endif
+
 public:
 	virtual RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t>> &p_data = Vector<Vector<uint8_t>>());
 	virtual RID texture_create_shared(const TextureView &p_view, RID p_with_texture);


### PR DESCRIPTION
I was diagnosing some memory leaks, if we forget to free resources we get a non-descript `WARNING: 5 RIDs of type "Texture" were leaked.` which result in searching for needle in a very large haystack.

We often record resource names in the Vulkan system by calling `set_resource_names` but these names are only recorded in the Vulkan driver, Godot forgets them. This PR simply keeps a HashMap of IDs and records the strings if `DEV_ENABLED` is set.

When resources are leaked we now dump the resource names. 
![image](https://user-images.githubusercontent.com/1945449/183567009-b44bc9a4-d14e-439a-a78f-5346c20d865d.png)
 
Not sure if we want to keep this or maybe want something nicer, but figured I would raise a PR in case we want further discussion.