### PR TITLE
Make initialization settings take effect in `SubViewport`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4148,6 +4148,10 @@ void SubViewport::_bind_methods() {
 	BIND_ENUM_CONSTANT(UPDATE_ALWAYS);
 }
 
-SubViewport::SubViewport() {}
+SubViewport::SubViewport() {
+	RS::get_singleton()->viewport_set_clear_mode(get_viewport_rid(), RS::ViewportClearMode(clear_mode));
+	RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::ViewportUpdateMode(update_mode));
+	set_size(_get_size());
+}
 
 SubViewport::~SubViewport() {}


### PR DESCRIPTION
`SubViewport` has some initialization settings of its own, but these settings are not synchronized to the `RenderingServer` when initialized, which causes some problems.

Split from #62854.

This is a prerequisite to resolve #55471, still need to modify `update_mode` manually, or add as a child to `SubViewportContainer` (`update_mode` is automatically set to `UPDATE_ALWAYS`).

Currently, `UPDATE_WHEN_VISIBLE` has no meaning for `SubViewport`. Presumably for **visible**, `RenderingServer` has different rules, viewport needs to have a visible **rect** to be considered **visible**, while `SubViewport` has only `size` and **no** `position`, so it is not considered **visible** even if it is set to be an active viewport (`RS::viewport_set_active`).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
