### PR TITLE
Allow the inspector to reflect addition, removal and renaming of an instance uniform

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -109,12 +109,14 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 
 	if (mesh.is_valid()) {
 		mesh->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance3D::_mesh_changed));
+		mesh->disconnect(CoreStringNames::get_singleton()->property_list_changed, callable_mp(this, &MeshInstance3D::_mesh_property_list_changed));
 	}
 
 	mesh = p_mesh;
 
 	if (mesh.is_valid()) {
 		mesh->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance3D::_mesh_changed));
+		mesh->connect(CoreStringNames::get_singleton()->property_list_changed, callable_mp(this, &MeshInstance3D::_mesh_property_list_changed));
 		_mesh_changed();
 		set_base(mesh->get_rid());
 	} else {
@@ -381,6 +383,10 @@ void MeshInstance3D::_mesh_changed() {
 	}
 
 	update_gizmos();
+}
+
+void MeshInstance3D::_mesh_property_list_changed() {
+	notify_property_list_changed();
 }
 
 void MeshInstance3D::create_debug_tangents() {

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -51,6 +51,7 @@ protected:
 	Vector<Ref<Material>> surface_override_materials;
 
 	void _mesh_changed();
+	void _mesh_property_list_changed();
 	void _resolve_skeleton_path();
 
 protected:

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -107,6 +107,10 @@ void PrimitiveMesh::_update() const {
 	const_cast<PrimitiveMesh *>(this)->emit_changed();
 }
 
+void PrimitiveMesh::_material_property_list_changed() {
+	notify_property_list_changed();
+}
+
 void PrimitiveMesh::_request_update() {
 	if (pending_request) {
 		return;
@@ -226,7 +230,12 @@ void PrimitiveMesh::_bind_methods() {
 }
 
 void PrimitiveMesh::set_material(const Ref<Material> &p_material) {
+	if (material.is_valid()) {
+		material->disconnect(CoreStringNames::get_singleton()->property_list_changed, callable_mp(this, &PrimitiveMesh::_material_property_list_changed));
+	}
 	material = p_material;
+	material->connect(CoreStringNames::get_singleton()->property_list_changed, callable_mp(this, &PrimitiveMesh::_material_property_list_changed));
+
 	if (!pending_request) {
 		// just apply it, else it'll happen when _update is called.
 		RenderingServer::get_singleton()->mesh_surface_set_material(mesh, 0, material.is_null() ? RID() : material->get_rid());

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -60,6 +60,8 @@ private:
 	mutable bool pending_request = true;
 	void _update() const;
 
+	void _material_property_list_changed();
+
 protected:
 	// assume primitive triangles as the type, correct for all but one and it will change this :)
 	Mesh::PrimitiveType primitive_type = Mesh::PRIMITIVE_TRIANGLES;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #64060 