### PR TITLE
Fix Editor Navigation debug edge connection visuals

### DIFF
--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -123,6 +123,12 @@ NavigationServer3D::NavigationServer3D() {
 	debug_navigation_enable_edge_lines = GLOBAL_DEF("debug/shapes/navigation/enable_edge_lines", true);
 	debug_navigation_enable_edge_lines_xray = GLOBAL_DEF("debug/shapes/navigation/enable_edge_lines_xray", true);
 	debug_navigation_enable_geometry_face_random_color = GLOBAL_DEF("debug/shapes/navigation/enable_geometry_face_random_color", true);
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		// enable NavigationServer3D when in Editor or else navmesh edge connections are invisible
+		// on runtime tests SceneTree has "Visible Navigation" set and main iteration takes care of this
+		set_debug_enabled(true);
+	}
 #endif // DEBUG_ENABLED
 }
 


### PR DESCRIPTION
Fixes missing Navigation debug edge connection visuals in Editor due to disabled NavigationServer.

This wasn't a problem before cause the debug was enabled by default but https://github.com/godotengine/godot/pull/63708 changed that and if a test scene is run with visible navigation debug the server gets enabled so it happened only on a fresh Editor start but was still annoying.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
