### PR TITLE
[3.x] Tree: Don't draw selection background of individual cells in Row mode

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1177,7 +1177,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				}
 				p_item->set_meta("__focus_rect", Rect2(r.position, r.size));
 
-				if (p_item->cells[i].selected) {
+				if (select_mode != SELECT_ROW && p_item->cells[i].selected) {
 					if (has_focus()) {
 						cache.selected_focus->draw(ci, r);
 					} else {


### PR DESCRIPTION
3.x version of #63472.

Should be easily cherry-pickable to 3.5.