### PR TITLE
Improve the interaction between `SubViewport` and `SubViewportContainer`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4195,10 +4195,6 @@ void SubViewport::_internal_set_size(const Size2i &p_size, bool p_force) {
 	}
 
 	_set_size(p_size, _get_size_2d_override(), true);
-
-	if (c) {
-		c->update_minimum_size();
-	}
 }
 
 Size2i SubViewport::get_size() const {


### PR DESCRIPTION
~~Follow-up to #64138, split from #62854.~~

~~`SubViewport` has some settings applied on initialization, and the side effects of these settings are delayed until it enters the tree.~~

**Edit:**

Handle the `size_changed` signal of `SubViewport` when `SubViewportContainer` adds/removes child nodes.

~~When the `SubViewport` re-enters the tree due to moving in the tree, `update_mode` is set according to the `is_visible_in_tree()` of the new parent `SubViewportContainer` node.~~

This patch makes `SubViewport` and `SubViewportContainer` work better out of the box.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
