### PR TITLE
Remove AnimatedSprite3D.`is_playing()` for redundancy

### DIFF
--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -10,12 +10,6 @@
 		<link title="2D Sprite animation (also applies to 3D)">$DOCS_URL/tutorials/2d/2d_sprite_animation.html</link>
 	</tutorials>
 	<methods>
-		<method name="is_playing" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if an animation is currently being played.
-			</description>
-		</method>
 		<method name="play">
 			<return type="void" />
 			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
@@ -40,7 +34,7 @@
 		<member name="frames" type="SpriteFrames" setter="set_sprite_frames" getter="get_sprite_frames">
 			The [SpriteFrames] resource containing the animation(s).
 		</member>
-		<member name="playing" type="bool" setter="_set_playing" getter="_is_playing" default="false">
+		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
 			If [code]true[/code], the [member animation] is currently playing.
 		</member>
 	</members>

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1180,7 +1180,7 @@ void AnimatedSprite3D::_res_changed() {
 	_queue_update();
 }
 
-void AnimatedSprite3D::_set_playing(bool p_playing) {
+void AnimatedSprite3D::set_playing(bool p_playing) {
 	if (playing == p_playing) {
 		return;
 	}
@@ -1189,7 +1189,7 @@ void AnimatedSprite3D::_set_playing(bool p_playing) {
 	set_process_internal(playing);
 }
 
-bool AnimatedSprite3D::_is_playing() const {
+bool AnimatedSprite3D::is_playing() const {
 	return playing;
 }
 
@@ -1197,15 +1197,11 @@ void AnimatedSprite3D::play(const StringName &p_animation) {
 	if (p_animation) {
 		set_animation(p_animation);
 	}
-	_set_playing(true);
+	set_playing(true);
 }
 
 void AnimatedSprite3D::stop() {
-	_set_playing(false);
-}
-
-bool AnimatedSprite3D::is_playing() const {
-	return playing;
+	set_playing(false);
 }
 
 void AnimatedSprite3D::_reset_timeout() {
@@ -1268,12 +1264,11 @@ void AnimatedSprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_animation", "animation"), &AnimatedSprite3D::set_animation);
 	ClassDB::bind_method(D_METHOD("get_animation"), &AnimatedSprite3D::get_animation);
 
-	ClassDB::bind_method(D_METHOD("_set_playing", "playing"), &AnimatedSprite3D::_set_playing);
-	ClassDB::bind_method(D_METHOD("_is_playing"), &AnimatedSprite3D::_is_playing);
+	ClassDB::bind_method(D_METHOD("set_playing", "playing"), &AnimatedSprite3D::set_playing);
+	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite3D::is_playing);
 
 	ClassDB::bind_method(D_METHOD("play", "anim"), &AnimatedSprite3D::play, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite3D::stop);
-	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite3D::is_playing);
 
 	ClassDB::bind_method(D_METHOD("set_frame", "frame"), &AnimatedSprite3D::set_frame);
 	ClassDB::bind_method(D_METHOD("get_frame"), &AnimatedSprite3D::get_frame);
@@ -1286,7 +1281,7 @@ void AnimatedSprite3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "animation"), "set_animation", "get_animation");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frame"), "set_frame", "get_frame");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing"), "_set_playing", "_is_playing");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playing"), "set_playing", "is_playing");
 }
 
 AnimatedSprite3D::AnimatedSprite3D() {

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -219,8 +219,6 @@ class AnimatedSprite3D : public SpriteBase3D {
 	void _res_changed();
 
 	void _reset_timeout();
-	void _set_playing(bool p_playing);
-	bool _is_playing() const;
 
 	RID last_shader;
 	RID last_texture;
@@ -237,6 +235,8 @@ public:
 
 	void play(const StringName &p_animation = StringName());
 	void stop();
+
+	void set_playing(bool p_playing);
 	bool is_playing() const;
 
 	void set_animation(const StringName &p_animation);


### PR DESCRIPTION
This mysterious method has been in the **AnimatedSprite3D** documentation for quite a long time. As a standalone method It literally servers **no** purpose, as the setter and getters of `playing` already exist, and `is_playing()` is *literally* a carbon copy of `_is_playing()`, in the code.

Speaking of which, this PR also removes the underscore prefix from `_set_playing()` and `_is_playing()`. Because of this renaming, this is all technically compatibility-breaking, but I mean, who would actually use `set_playing()`, anyhow?