### PR TITLE
Tweak Label3D defaults for better readability

### DIFF
--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -53,7 +53,7 @@
 		<member name="font" type="Font" setter="set_font" getter="get_font">
 			Font configuration used to display text.
 		</member>
-		<member name="font_size" type="int" setter="set_font_size" getter="get_font_size" default="16">
+		<member name="font_size" type="int" setter="set_font_size" getter="get_font_size" default="32">
 			Font size of the [Label3D]'s text.
 		</member>
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="1">
@@ -82,10 +82,10 @@
 			[b]Note:[/b] This only applies if [member alpha_cut] is set to [constant ALPHA_CUT_DISABLED] (default value).
 			[b]Note:[/b] This only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
 		</member>
-		<member name="outline_size" type="int" setter="set_outline_size" getter="get_outline_size" default="0">
+		<member name="outline_size" type="int" setter="set_outline_size" getter="get_outline_size" default="12">
 			Text outline size.
 		</member>
-		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.01">
+		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.005">
 			The size of one pixel's width on the label to scale it in 3D.
 		</member>
 		<member name="render_priority" type="int" setter="set_render_priority" getter="get_render_priority" default="0">

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -55,7 +55,7 @@ public:
 	};
 
 private:
-	real_t pixel_size = 0.01;
+	real_t pixel_size = 0.005;
 	bool flags[FLAG_MAX] = {};
 	AlphaCutMode alpha_cut = ALPHA_CUT_DISABLED;
 	float alpha_scissor_threshold = 0.5;
@@ -109,7 +109,7 @@ private:
 	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
 	float width = 500.0;
 
-	int font_size = 16;
+	int font_size = 32;
 	Ref<Font> font_override;
 	mutable Ref<Font> theme_font;
 	Color modulate = Color(1, 1, 1, 1);
@@ -117,7 +117,7 @@ private:
 	int outline_render_priority = -1;
 	int render_priority = 0;
 
-	int outline_size = 0;
+	int outline_size = 12;
 	Color outline_modulate = Color(0, 0, 0, 1);
 
 	float line_spacing = 0.f;


### PR DESCRIPTION
This speeds up prototyping when you need to add Label3Ds for debugging purposes.

- Increase font size and decrease pixel size.
  - The font is rendered at the same physical size, but is more detailed, which is visible when the camera is up close.
- Add an outline to improve readability on mixed-color backgrounds.
  - The outline is fairly thick to ensure it doesn't get too grainy at a distance (without requiring MSDF or mipmaps on the default project font).

**Testing project:** [test_label_3d_defaults.zip](https://github.com/godotengine/godot/files/9291604/test_label_3d_defaults.zip)

## Preview

*Click to view at full size.*

### 1024×600

Before | After
-|-
![2022-08-09_15 37 31](https://user-images.githubusercontent.com/180032/183675322-a1161008-8152-4df6-b49c-1e503d548bfd.png) | ![2022-08-09_15 37 52](https://user-images.githubusercontent.com/180032/183675328-4d4e288d-4af8-4792-b785-568a80604717.png)

### 2560×1440

Before | After
-|-
![2022-08-09_15 37 35](https://user-images.githubusercontent.com/180032/183675324-6d6bd227-2dff-4be5-8125-aa055ff70177.png) | ![2022-08-09_15 37 55](https://user-images.githubusercontent.com/180032/183675332-b368a410-2cb9-4500-b1ac-676239625243.png)