### PR TITLE
Make `current_dir` and `current_path` in `FileDialog` useable.

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -695,7 +695,7 @@ Vector<String> FileDialog::get_filters() const {
 }
 
 String FileDialog::get_current_dir() const {
-	return dir->get_text();
+	return dir_access->get_current_dir();
 }
 
 String FileDialog::get_current_file() const {
@@ -703,7 +703,8 @@ String FileDialog::get_current_file() const {
 }
 
 String FileDialog::get_current_path() const {
-	return dir->get_text().plus_file(file->get_text());
+	String file_text = file->get_text();
+	return file_text.is_absolute_path() ? file_text : dir_access->get_current_dir().plus_file(file_text);
 }
 
 void FileDialog::set_current_dir(const String &p_dir) {


### PR DESCRIPTION
Fixes #45822

Replace `dir->get_text()` with `dir_access->get_current_dir()` in `FileDialog::get_current_path` and `FileDialog::get_current_dir`.

The current implementation just returns the raw text value in the directory LineEdit, which ignores the driver so the path is not usable, especially considering that the driver itself is not exposed.

![screenshot](https://user-images.githubusercontent.com/12798270/183673629-9a9f1f0e-01a4-4ed5-ba2e-27fd129b5731.png)

Instead, this PR returns the value `dir_access->get_current_dir()` mentioned in the workaround in #45822 which is also used in many places in the source.

Example:

[FileDialogDebug.zip](https://github.com/godotengine/godot/files/9291611/FileDialogDebug.zip)

Select any file to get the output :

Before:

```
path: D:/gd_ws/GodotAreaMovementMono/icon.png.import current_dir: /gd_ws/GodotAreaMovementMono current_file: icon.png.import current_path: /gd_ws/GodotAreaMovementMono/icon.png.import
```

After:

```
path: D:/gd_ws/GodotAreaMovementMono/icon.png.import current_dir: D:/gd_ws/GodotAreaMovementMono current_file: icon.png.import current_path: D:/gd_ws/GodotAreaMovementMono/icon.png.import
```

