### PR TITLE
[doc] Use "param" instead of "code" to refer to parameters #2

### DIFF
--- a/doc/classes/TCPServer.xml
+++ b/doc/classes/TCPServer.xml
@@ -33,10 +33,10 @@
 			<param index="0" name="port" type="int" />
 			<param index="1" name="bind_address" type="String" default="&quot;*&quot;" />
 			<description>
-				Listen on the [code]port[/code] binding to [code]bind_address[/code].
-				If [code]bind_address[/code] is set as [code]"*"[/code] (default), the server will listen on all available addresses (both IPv4 and IPv6).
-				If [code]bind_address[/code] is set as [code]"0.0.0.0"[/code] (for IPv4) or [code]"::"[/code] (for IPv6), the server will listen on all available addresses matching that IP type.
-				If [code]bind_address[/code] is set to any valid address (e.g. [code]"192.168.1.101"[/code], [code]"::1"[/code], etc), the server will only listen on the interface with that addresses (or fail if no interface with the given address exists).
+				Listen on the [param port] binding to [param bind_address].
+				If [param bind_address] is set as [code]"*"[/code] (default), the server will listen on all available addresses (both IPv4 and IPv6).
+				If [param bind_address] is set as [code]"0.0.0.0"[/code] (for IPv4) or [code]"::"[/code] (for IPv6), the server will listen on all available addresses matching that IP type.
+				If [param bind_address] is set to any valid address (e.g. [code]"192.168.1.101"[/code], [code]"::1"[/code], etc), the server will only listen on the interface with that addresses (or fail if no interface with the given address exists).
 			</description>
 		</method>
 		<method name="stop">

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -40,21 +40,21 @@
 			<return type="Texture2D" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns the [Texture2D] for the right button of the tab at index [code]tab_idx[/code] or [code]null[/code] if the button has no [Texture2D].
+				Returns the [Texture2D] for the right button of the tab at index [param tab_idx] or [code]null[/code] if the button has no [Texture2D].
 			</description>
 		</method>
 		<method name="get_tab_icon" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns the [Texture2D] for the tab at index [code]tab_idx[/code] or [code]null[/code] if the tab has no [Texture2D].
+				Returns the [Texture2D] for the tab at index [param tab_idx] or [code]null[/code] if the tab has no [Texture2D].
 			</description>
 		</method>
 		<method name="get_tab_idx_at_point" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="point" type="Vector2" />
 			<description>
-				Returns the index of the tab at local coordinates [code]point[/code]. Returns [code]-1[/code] if the point is outside the control boundaries or if there's no tab at the queried position.
+				Returns the index of the tab at local coordinates [param point]. Returns [code]-1[/code] if the point is outside the control boundaries or if there's no tab at the queried position.
 			</description>
 		</method>
 		<method name="get_tab_language" qualifiers="const">
@@ -88,21 +88,21 @@
 			<return type="String" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns the title of the tab at index [code]tab_idx[/code].
+				Returns the title of the tab at index [param tab_idx].
 			</description>
 		</method>
 		<method name="is_tab_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the tab at index [code]tab_idx[/code] is disabled.
+				Returns [code]true[/code] if the tab at index [param tab_idx] is disabled.
 			</description>
 		</method>
 		<method name="is_tab_hidden" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the tab at index [code]tab_idx[/code] is hidden.
+				Returns [code]true[/code] if the tab at index [param tab_idx] is hidden.
 			</description>
 		</method>
 		<method name="move_tab">
@@ -110,14 +110,14 @@
 			<param index="0" name="from" type="int" />
 			<param index="1" name="to" type="int" />
 			<description>
-				Moves a tab from [code]from[/code] to [code]to[/code].
+				Moves a tab from [param from] to [param to].
 			</description>
 		</method>
 		<method name="remove_tab">
 			<return type="void" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Removes the tab at index [code]tab_idx[/code].
+				Removes the tab at index [param tab_idx].
 			</description>
 		</method>
 		<method name="set_tab_button_icon">
@@ -125,7 +125,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="icon" type="Texture2D" />
 			<description>
-				Sets an [code]icon[/code] for the button of the tab at index [code]tab_idx[/code] (located to the right, before the close button), making it visible and clickable (See [signal tab_button_pressed]). Giving it a [code]null[/code] value will hide the button.
+				Sets an [param icon] for the button of the tab at index [param tab_idx] (located to the right, before the close button), making it visible and clickable (See [signal tab_button_pressed]). Giving it a [code]null[/code] value will hide the button.
 			</description>
 		</method>
 		<method name="set_tab_disabled">
@@ -133,7 +133,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="disabled" type="bool" />
 			<description>
-				If [code]disabled[/code] is [code]true[/code], disables the tab at index [code]tab_idx[/code], making it non-interactable.
+				If [param disabled] is [code]true[/code], disables the tab at index [param tab_idx], making it non-interactable.
 			</description>
 		</method>
 		<method name="set_tab_hidden">
@@ -141,7 +141,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="hidden" type="bool" />
 			<description>
-				If [code]hidden[/code] is [code]true[/code], hides the tab at index [code]tab_idx[/code], making it disappear from the tab area.
+				If [param hidden] is [code]true[/code], hides the tab at index [param tab_idx], making it disappear from the tab area.
 			</description>
 		</method>
 		<method name="set_tab_icon">
@@ -149,7 +149,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="icon" type="Texture2D" />
 			<description>
-				Sets an [code]icon[/code] for the tab at index [code]tab_idx[/code].
+				Sets an [param icon] for the tab at index [param tab_idx].
 			</description>
 		</method>
 		<method name="set_tab_language">
@@ -173,7 +173,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="title" type="String" />
 			<description>
-				Sets a [code]title[/code] for the tab at index [code]tab_idx[/code].
+				Sets a [param title] for the tab at index [param tab_idx].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -35,14 +35,14 @@
 			<return type="Texture2D" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns the button icon from the tab at index [code]tab_idx[/code].
+				Returns the button icon from the tab at index [param tab_idx].
 			</description>
 		</method>
 		<method name="get_tab_control" qualifiers="const">
 			<return type="Control" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns the [Control] node from the tab at index [code]tab_idx[/code].
+				Returns the [Control] node from the tab at index [param tab_idx].
 			</description>
 		</method>
 		<method name="get_tab_count" qualifiers="const">
@@ -55,42 +55,42 @@
 			<return type="Texture2D" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns the [Texture2D] for the tab at index [code]tab_idx[/code] or [code]null[/code] if the tab has no [Texture2D].
+				Returns the [Texture2D] for the tab at index [param tab_idx] or [code]null[/code] if the tab has no [Texture2D].
 			</description>
 		</method>
 		<method name="get_tab_idx_at_point" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="point" type="Vector2" />
 			<description>
-				Returns the index of the tab at local coordinates [code]point[/code]. Returns [code]-1[/code] if the point is outside the control boundaries or if there's no tab at the queried position.
+				Returns the index of the tab at local coordinates [param point]. Returns [code]-1[/code] if the point is outside the control boundaries or if there's no tab at the queried position.
 			</description>
 		</method>
 		<method name="get_tab_idx_from_control" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="control" type="Control" />
 			<description>
-				Returns the index of the tab tied to the given [code]control[/code]. The control must be a child of the [TabContainer].
+				Returns the index of the tab tied to the given [param control]. The control must be a child of the [TabContainer].
 			</description>
 		</method>
 		<method name="get_tab_title" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns the title of the tab at index [code]tab_idx[/code]. Tab titles default to the name of the indexed child node, but this can be overridden with [method set_tab_title].
+				Returns the title of the tab at index [param tab_idx]. Tab titles default to the name of the indexed child node, but this can be overridden with [method set_tab_title].
 			</description>
 		</method>
 		<method name="is_tab_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the tab at index [code]tab_idx[/code] is disabled.
+				Returns [code]true[/code] if the tab at index [param tab_idx] is disabled.
 			</description>
 		</method>
 		<method name="is_tab_hidden" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="tab_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the tab at index [code]tab_idx[/code] is hidden.
+				Returns [code]true[/code] if the tab at index [param tab_idx] is hidden.
 			</description>
 		</method>
 		<method name="set_popup">
@@ -105,7 +105,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="icon" type="Texture2D" />
 			<description>
-				Sets the button icon from the tab at index [code]tab_idx[/code].
+				Sets the button icon from the tab at index [param tab_idx].
 			</description>
 		</method>
 		<method name="set_tab_disabled">
@@ -113,7 +113,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="disabled" type="bool" />
 			<description>
-				If [code]disabled[/code] is [code]true[/code], disables the tab at index [code]tab_idx[/code], making it non-interactable.
+				If [param disabled] is [code]true[/code], disables the tab at index [param tab_idx], making it non-interactable.
 			</description>
 		</method>
 		<method name="set_tab_hidden">
@@ -121,7 +121,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="hidden" type="bool" />
 			<description>
-				If [code]hidden[/code] is [code]true[/code], hides the tab at index [code]tab_idx[/code], making it disappear from the tab area.
+				If [param hidden] is [code]true[/code], hides the tab at index [param tab_idx], making it disappear from the tab area.
 			</description>
 		</method>
 		<method name="set_tab_icon">
@@ -129,7 +129,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="icon" type="Texture2D" />
 			<description>
-				Sets an icon for the tab at index [code]tab_idx[/code].
+				Sets an icon for the tab at index [param tab_idx].
 			</description>
 		</method>
 		<method name="set_tab_title">
@@ -137,7 +137,7 @@
 			<param index="0" name="tab_idx" type="int" />
 			<param index="1" name="title" type="String" />
 			<description>
-				Sets a custom title for the tab at index [code]tab_idx[/code] (tab titles default to the name of the indexed child node). Set it back to the child's name to make the tab default to it again.
+				Sets a custom title for the tab at index [param tab_idx] (tab titles default to the name of the indexed child node). Set it back to the child's name to make the tab default to it again.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -32,7 +32,7 @@
 			<return type="void" />
 			<param index="0" name="unicode_char" type="int" />
 			<description>
-				Override this method to define what happens when the types in the provided key [code]unicode[/code].
+				Override this method to define what happens when the user types in the provided key [param unicode_char].
 			</description>
 		</method>
 		<method name="_paste" qualifiers="virtual">
@@ -52,7 +52,7 @@
 			<return type="void" />
 			<param index="0" name="at" type="int" default="-1" />
 			<description>
-				Register a new gutter to this [TextEdit]. Use [code]at[/code] to have a specific gutter order. A value of [code]-1[/code] appends the gutter to the right.
+				Register a new gutter to this [TextEdit]. Use [param at] to have a specific gutter order. A value of [code]-1[/code] appends the gutter to the right.
 			</description>
 		</method>
 		<method name="adjust_viewport_to_caret">
@@ -229,7 +229,7 @@
 			<param index="0" name="position" type="Vector2i" />
 			<param index="1" name="allow_out_of_bounds" type="bool" default="true" />
 			<description>
-				Returns the line and column at the given position. In the returned vector, [code]x[/code] is the column, [code]y[/code] is the line. If [code]allow_out_of_bounds[/code] is [code]false[/code] and the position is not over the text, both vector values will be set to [code]-1[/code].
+				Returns the line and column at the given position. In the returned vector, [code]x[/code] is the column, [code]y[/code] is the line. If [param allow_out_of_bounds] is [code]false[/code] and the position is not over the text, both vector values will be set to [code]-1[/code].
 			</description>
 		</method>
 		<method name="get_line_count" qualifiers="const">
@@ -243,7 +243,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="gutter" type="int" />
 			<description>
-				Returns the icon currently in [code]gutter[/code] at [code]line[/code].
+				Returns the icon currently in [param gutter] at [param line].
 			</description>
 		</method>
 		<method name="get_line_gutter_item_color" qualifiers="const">
@@ -251,7 +251,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="gutter" type="int" />
 			<description>
-				Returns the color currently in [code]gutter[/code] at [code]line[/code].
+				Returns the color currently in [param gutter] at [param line].
 			</description>
 		</method>
 		<method name="get_line_gutter_metadata" qualifiers="const">
@@ -259,7 +259,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="gutter" type="int" />
 			<description>
-				Returns the metadata currently in [code]gutter[/code] at [code]line[/code].
+				Returns the metadata currently in [param gutter] at [param line].
 			</description>
 		</method>
 		<method name="get_line_gutter_text" qualifiers="const">
@@ -267,7 +267,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="gutter" type="int" />
 			<description>
-				Returns the text currently in [code]gutter[/code] at [code]line[/code].
+				Returns the text currently in [param gutter] at [param line].
 			</description>
 		</method>
 		<method name="get_line_height" qualifiers="const">
@@ -281,7 +281,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="wrap_index" type="int" default="-1" />
 			<description>
-				Returns the width in pixels of the [code]wrap_index[/code] on [code]line[/code].
+				Returns the width in pixels of the [param wrap_index] on [param line].
 			</description>
 		</method>
 		<method name="get_line_wrap_count" qualifiers="const">
@@ -323,7 +323,7 @@
 			<return type="int" />
 			<param index="0" name="position" type="Vector2i" />
 			<description>
-				Returns the equivalent minimap line at [code]position[/code]
+				Returns the equivalent minimap line at [param position]
 			</description>
 		</method>
 		<method name="get_minimap_visible_lines" qualifiers="const">
@@ -346,7 +346,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="visible_amount" type="int" />
 			<description>
-				Returns the count to the next visible line from [code]line[/code] to [code]line + visible_amount[/code]. Can also count backwards. For example if a [TextEdit] has 5 lines with lines 2 and 3 hidden, calling this with [code]line = 1, visible_amount = 1[/code] would return 3.
+				Returns the count to the next visible line from [param line] to [code]line + visible_amount[/code]. Can also count backwards. For example if a [TextEdit] has 5 lines with lines 2 and 3 hidden, calling this with [code]line = 1, visible_amount = 1[/code] would return 3.
 			</description>
 		</method>
 		<method name="get_pos_at_line_column" qualifiers="const">
@@ -354,7 +354,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<description>
-				Returns the local position for the given [code]line[/code] and [code]column[/code]. If [code]x[/code] or [code]y[/code] of the returned vector equal [code]-1[/code], the position is outside of the viewable area of the control.
+				Returns the local position for the given [param line] and [param column]. If [code]x[/code] or [code]y[/code] of the returned vector equal [code]-1[/code], the position is outside of the viewable area of the control.
 				[b]Note:[/b] The Y position corresponds to the bottom side of the line. Use [method get_rect_at_line_column] to get the top side position.
 			</description>
 		</method>
@@ -363,7 +363,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<description>
-				Returns the local position and size for the grapheme at the given [code]line[/code] and [code]column[/code]. If [code]x[/code] or [code]y[/code] position of the returned rect equal [code]-1[/code], the position is outside of the viewable area of the control.
+				Returns the local position and size for the grapheme at the given [param line] and [param column]. If [code]x[/code] or [code]y[/code] position of the returned rect equal [code]-1[/code], the position is outside of the viewable area of the control.
 				[b]Note:[/b] The Y position of the returned rect corresponds to the top side of the line, unlike [method get_pos_at_line_column] which returns the bottom side.
 			</description>
 		</method>
@@ -378,7 +378,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="wrap_index" type="int" default="0" />
 			<description>
-				Returns the scroll position for [code]wrap_index[/code] of [code]line[/code].
+				Returns the scroll position for [param wrap_index] of [param line].
 			</description>
 		</method>
 		<method name="get_selected_text" qualifiers="const">
@@ -471,7 +471,7 @@
 			<return type="String" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Returns the word at [code]position[/code].
+				Returns the word at [param position].
 			</description>
 		</method>
 		<method name="get_word_under_caret" qualifiers="const">
@@ -509,7 +509,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="text" type="String" />
 			<description>
-				Inserts a new line with [code]text[/code] at [code]line[/code].
+				Inserts a new line with [param text] at [param line].
 			</description>
 		</method>
 		<method name="insert_text_at_caret">
@@ -577,7 +577,7 @@
 			<return type="bool" />
 			<param index="0" name="edges" type="bool" />
 			<description>
-				Returns whether the mouse is over selection. If [code]edges[/code] is [code]true[/code], the edges are considered part of the selection.
+				Returns whether the mouse is over selection. If [param edges] is [code]true[/code], the edges are considered part of the selection.
 			</description>
 		</method>
 		<method name="is_overtype_mode_enabled" qualifiers="const">
@@ -598,7 +598,7 @@
 			<param index="0" name="from_line" type="int" />
 			<param index="1" name="to_line" type="int" />
 			<description>
-				Merge the gutters from [code]from_line[/code] into [code]to_line[/code]. Only overwritable gutters will be copied.
+				Merge the gutters from [param from_line] into [param to_line]. Only overwritable gutters will be copied.
 			</description>
 		</method>
 		<method name="paste">
@@ -689,8 +689,8 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="adjust_viewport" type="bool" default="true" />
 			<description>
-				Moves the caret to the specified [code]column[/code] index.
-				If [code]adjust_viewport[/code] is [code]true[/code], the viewport will center at the caret position after the move occurs.
+				Moves the caret to the specified [param column] index.
+				If [param adjust_viewport] is [code]true[/code], the viewport will center at the caret position after the move occurs.
 			</description>
 		</method>
 		<method name="set_caret_line">
@@ -700,9 +700,9 @@
 			<param index="2" name="can_be_hidden" type="bool" default="true" />
 			<param index="3" name="wrap_index" type="int" default="0" />
 			<description>
-				Moves the caret to the specified [code]line[/code] index.
-				If [code]adjust_viewport[/code] is [code]true[/code], the viewport will center at the caret position after the move occurs.
-				If [code]can_be_hidden[/code] is [code]true[/code], the specified [code]line[/code] can be hidden.
+				Moves the caret to the specified [param line] index.
+				If [param adjust_viewport] is [code]true[/code], the viewport will center at the caret position after the move occurs.
+				If [param can_be_hidden] is [code]true[/code], the specified [code]line[/code] can be hidden.
 			</description>
 		</method>
 		<method name="set_gutter_clickable">
@@ -774,7 +774,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="wrap_index" type="int" default="0" />
 			<description>
-				Positions the [code]wrap_index[/code] of [code]line[/code] at the center of the viewport.
+				Positions the [param wrap_index] of [param line] at the center of the viewport.
 			</description>
 		</method>
 		<method name="set_line_as_first_visible">
@@ -782,7 +782,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="wrap_index" type="int" default="0" />
 			<description>
-				Positions the [code]wrap_index[/code] of [code]line[/code] at the top of the viewport.
+				Positions the [param wrap_index] of [param line] at the top of the viewport.
 			</description>
 		</method>
 		<method name="set_line_as_last_visible">
@@ -790,7 +790,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="wrap_index" type="int" default="0" />
 			<description>
-				Positions the [code]wrap_index[/code] of [code]line[/code] at the bottom of the viewport.
+				Positions the [param wrap_index] of [param line] at the bottom of the viewport.
 			</description>
 		</method>
 		<method name="set_line_background_color">
@@ -807,7 +807,7 @@
 			<param index="1" name="gutter" type="int" />
 			<param index="2" name="clickable" type="bool" />
 			<description>
-				Sets the [code]gutter[/code] on [code]line[/code] as clickable.
+				If [param clickable] is [code]true[/code], makes the [param gutter] on [param line] clickable. See [signal gutter_clicked].
 			</description>
 		</method>
 		<method name="set_line_gutter_icon">
@@ -816,7 +816,7 @@
 			<param index="1" name="gutter" type="int" />
 			<param index="2" name="icon" type="Texture2D" />
 			<description>
-				Sets the icon for [code]gutter[/code] on [code]line[/code].
+				Sets the icon for [param gutter] on [param line] to [param icon].
 			</description>
 		</method>
 		<method name="set_line_gutter_item_color">
@@ -825,7 +825,7 @@
 			<param index="1" name="gutter" type="int" />
 			<param index="2" name="color" type="Color" />
 			<description>
-				Sets the color for [code]gutter[/code] on [code]line[/code].
+				Sets the color for [param gutter] on [param line] to [param color].
 			</description>
 		</method>
 		<method name="set_line_gutter_metadata">
@@ -834,7 +834,7 @@
 			<param index="1" name="gutter" type="int" />
 			<param index="2" name="metadata" type="Variant" />
 			<description>
-				Sets the metadata for [code]gutter[/code] on [code]line[/code].
+				Sets the metadata for [param gutter] on [param line] to [param metadata].
 			</description>
 		</method>
 		<method name="set_line_gutter_text">
@@ -843,7 +843,7 @@
 			<param index="1" name="gutter" type="int" />
 			<param index="2" name="text" type="String" />
 			<description>
-				Sets the text for [code]gutter[/code] on [code]line[/code].
+				Sets the text for [param gutter] on [param line] to [param text].
 			</description>
 		</method>
 		<method name="set_overtype_mode_enabled">
@@ -857,7 +857,7 @@
 			<return type="void" />
 			<param index="0" name="flags" type="int" />
 			<description>
-				Sets the search flags. This is used with [method set_search_text] to highlight occurrences of the searched text. Search flags can be specified from the [enum SearchFlags] enum.
+				Sets the search [param flags]. This is used with [method set_search_text] to highlight occurrences of the searched text. Search flags can be specified from the [enum SearchFlags] enum.
 			</description>
 		</method>
 		<method name="set_search_text">
@@ -1052,7 +1052,7 @@
 			<param index="1" name="to_line" type="int" />
 			<description>
 				Emitted immediately when the text changes.
-				When text is added [code]from_line[/code] will be less then [code]to_line[/code]. On a remove [code]to_line[/code] will be less then [code]from_line[/code].
+				When text is added [param from_line] will be less then [param to_line]. On a remove [param to_line] will be less then [param from_line].
 			</description>
 		</signal>
 		<signal name="text_changed">

--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -16,7 +16,7 @@
 			<param index="2" name="inline_align" type="int" enum="InlineAlignment" default="5" />
 			<param index="3" name="length" type="int" default="1" />
 			<description>
-				Adds inline object to the text buffer, [code]key[/code] must be unique. In the text, object is represented as [code]length[/code] object replacement characters.
+				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
 		<method name="add_string">
@@ -42,7 +42,7 @@
 			<param index="1" name="pos" type="Vector2" />
 			<param index="2" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw text into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="draw_outline" qualifiers="const">
@@ -52,7 +52,7 @@
 			<param index="2" name="outline_size" type="int" default="1" />
 			<param index="3" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw text into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="get_line_ascent" qualifiers="const">

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -16,7 +16,7 @@
 			<param index="2" name="inline_align" type="int" enum="InlineAlignment" default="5" />
 			<param index="3" name="length" type="int" default="1" />
 			<description>
-				Adds inline object to the text buffer, [code]key[/code] must be unique. In the text, object is represented as [code]length[/code] object replacement characters.
+				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
 		<method name="add_string">
@@ -49,7 +49,7 @@
 			<param index="2" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="3" name="dc_color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw all lines of the text and drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw all lines of the text and drop cap into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="draw_dropcap" qualifiers="const">
@@ -58,7 +58,7 @@
 			<param index="1" name="pos" type="Vector2" />
 			<param index="2" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw drop cap into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="draw_dropcap_outline" qualifiers="const">
@@ -68,7 +68,7 @@
 			<param index="2" name="outline_size" type="int" default="1" />
 			<param index="3" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw drop cap outline into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw drop cap outline into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="draw_line" qualifiers="const">
@@ -78,7 +78,7 @@
 			<param index="2" name="line" type="int" />
 			<param index="3" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw single line of text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw single line of text into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="draw_line_outline" qualifiers="const">
@@ -89,7 +89,7 @@
 			<param index="3" name="outline_size" type="int" default="1" />
 			<param index="4" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw outline of the single line of text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw outline of the single line of text into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="draw_outline" qualifiers="const">
@@ -100,7 +100,7 @@
 			<param index="3" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="4" name="dc_color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw outlines of all lines of the text and drop cap into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the top left corner of the bounding box.
+				Draw outlines of all lines of the text and drop cap into a canvas item at a given position, with [param color]. [param pos] specifies the top left corner of the bounding box.
 			</description>
 		</method>
 		<method name="get_dropcap_lines" qualifiers="const">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -20,7 +20,7 @@
 			<param index="0" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Creates new buffer for complex text layout, with the given [code]direction[/code] and [code]orientation[/code]. To free the resulting buffer, use [method free_rid] method.
+				Creates new buffer for complex text layout, with the given [param direction] and [param orientation]. To free the resulting buffer, use [method free_rid] method.
 				[b]Note:[/b] Direction is ignored if server does not support [constant FEATURE_BIDI_LAYOUT] feature (supported by [TextServerAdvanced]).
 				[b]Note:[/b] Orientation is ignored if server does not support [constant FEATURE_VERTICAL_LAYOUT] feature (supported by [TextServerAdvanced]).
 			</description>
@@ -78,7 +78,7 @@
 			<param index="4" name="index" type="int" />
 			<param index="5" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draws single glyph into a canvas item at the position, using [code]font_rid[/code] at the size [code]size[/code].
+				Draws single glyph into a canvas item at the position, using [param font_rid] at the size [param size].
 				[b]Note:[/b] Glyph index is specific to the font, use glyphs indices returned by [method shaped_text_get_glyphs] or [method font_get_glyph_index].
 				[b]Note:[/b] If there are pending glyphs to render, calling this function might trigger the texture cache update.
 			</description>
@@ -93,7 +93,7 @@
 			<param index="5" name="index" type="int" />
 			<param index="6" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draws single glyph outline of size [code]outline_size[/code] into a canvas item at the position, using [code]font_rid[/code] at the size [code]size[/code].
+				Draws single glyph outline of size [param outline_size] into a canvas item at the position, using [param font_rid] at the size [param size].
 				[b]Note:[/b] Glyph index is specific to the font, use glyphs indices returned by [method shaped_text_get_glyphs] or [method font_get_glyph_index].
 				[b]Note:[/b] If there are pending glyphs to render, calling this function might trigger the texture cache update.
 			</description>
@@ -184,7 +184,7 @@
 			<param index="2" name="char" type="int" />
 			<param index="3" name="variation_selector" type="int" />
 			<description>
-				Returns the glyph index of a [code]char[/code], optionally modified by the [code]variation_selector[/code].
+				Returns the glyph index of a [param char], optionally modified by the [param variation_selector].
 			</description>
 		</method>
 		<method name="font_get_glyph_list" qualifiers="const">
@@ -280,7 +280,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
-				Returns [code]true[/code] if support override is enabled for the [code]language[/code].
+				Returns [code]true[/code] if support override is enabled for the [param language].
 			</description>
 		</method>
 		<method name="font_get_language_support_overrides">
@@ -338,7 +338,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
-				Returns [code]true[/code] if support override is enabled for the [code]script[/code].
+				Returns [code]true[/code] if support override is enabled for the [param script].
 			</description>
 		</method>
 		<method name="font_get_script_support_overrides">
@@ -444,7 +444,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="char" type="int" />
 			<description>
-				Returns [code]true[/code] if a Unicode [code]char[/code] is available in the font.
+				Returns [code]true[/code] if a Unicode [param char] is available in the font.
 			</description>
 		</method>
 		<method name="font_is_antialiased" qualifiers="const">
@@ -595,7 +595,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="strength" type="float" />
 			<description>
-				Sets font embolden strength. If [code]strength[/code] is not equal to zero, emboldens the font outlines. Negative values reduce the outline thickness.
+				Sets font embolden strength. If [param strength] is not equal to zero, emboldens the font outlines. Negative values reduce the outline thickness.
 			</description>
 		</method>
 		<method name="font_set_face_index">
@@ -881,7 +881,7 @@
 			<param index="0" name="number" type="String" />
 			<param index="1" name="language" type="String" default="&quot;&quot;" />
 			<description>
-				Converts a number from the Western Arabic (0..9) to the numeral systems used in [code]language[/code].
+				Converts a number from the Western Arabic (0..9) to the numeral systems used in [param language].
 			</description>
 		</method>
 		<method name="free_rid">
@@ -927,7 +927,7 @@
 			<return type="bool" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Returns [code]true[/code] if [code]rid[/code] is valid resource owned by this text server.
+				Returns [code]true[/code] if [param rid] is valid resource owned by this text server.
 			</description>
 		</method>
 		<method name="has_feature" qualifiers="const">
@@ -958,7 +958,7 @@
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Returns [code]true[/code] is [code]string[/code] is a valid identifier.
+				Returns [code]true[/code] is [param string] is a valid identifier.
 				If the text server supports the [constant FEATURE_UNICODE_IDENTIFIERS] feature, a valid identifier must:
 				- Conform to normalization form C.
 				- Begin with a Unicode character of class XID_Start or [code]"_"[/code].
@@ -989,7 +989,7 @@
 			<param index="0" name="number" type="String" />
 			<param index="1" name="language" type="String" default="&quot;&quot;" />
 			<description>
-				Converts a number from the numeral systems used in [code]language[/code] to Western Arabic (0..9).
+				Converts [param number] from the numeral systems used in [param language] to Western Arabic (0..9).
 			</description>
 		</method>
 		<method name="parse_structured_text" qualifiers="const">
@@ -1005,7 +1005,7 @@
 			<return type="String" />
 			<param index="0" name="language" type="String" default="&quot;&quot;" />
 			<description>
-				Returns percent sign used in the [code]language[/code].
+				Returns percent sign used in the [param language].
 			</description>
 		</method>
 		<method name="save_support_data" qualifiers="const">
@@ -1050,7 +1050,7 @@
 			<param index="3" name="inline_align" type="int" enum="InlineAlignment" default="5" />
 			<param index="4" name="length" type="int" default="1" />
 			<description>
-				Adds inline object to the text buffer, [code]key[/code] must be unique. In the text, object is represented as [code]length[/code] object replacement characters.
+				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
 		<method name="shaped_text_add_string">
@@ -1082,7 +1082,7 @@
 			<param index="4" name="clip_r" type="float" default="-1" />
 			<param index="5" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw shaped text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
+				Draw shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
 			</description>
 		</method>
 		<method name="shaped_text_draw_outline" qualifiers="const">
@@ -1095,7 +1095,7 @@
 			<param index="5" name="outline_size" type="int" default="1" />
 			<param index="6" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw the outline of the shaped text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
+				Draw the outline of the shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
 			</description>
 		</method>
 		<method name="shaped_text_fit_to_width">
@@ -1120,7 +1120,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="position" type="int" />
 			<description>
-				Returns shapes of the carets corresponding to the character offset [code]position[/code] in the text. Returned caret shape is 1 pixel wide rectangle.
+				Returns shapes of the carets corresponding to the character offset [param position] in the text. Returned caret shape is 1 pixel wide rectangle.
 			</description>
 		</method>
 		<method name="shaped_text_get_custom_punctuation" qualifiers="const">
@@ -1333,7 +1333,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="grapheme_flags" type="int" enum="TextServer.GraphemeFlag" default="264" />
 			<description>
-				Breaks text into words and returns array of character ranges. Use [code]grapheme_flags[/code] to set what characters are used for breaking (see [enum GraphemeFlag]).
+				Breaks text into words and returns array of character ranges. Use [param grapheme_flags] to set what characters are used for breaking (see [enum GraphemeFlag]).
 			</description>
 		</method>
 		<method name="shaped_text_hit_test_grapheme" qualifiers="const">
@@ -1364,7 +1364,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				Returns composite character end position closest to the [code]pos[/code].
+				Returns composite character end position closest to the [param pos].
 			</description>
 		</method>
 		<method name="shaped_text_overrun_trim_to_width">
@@ -1381,7 +1381,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				Returns composite character start position closest to the [code]pos[/code].
+				Returns composite character start position closest to the [param pos].
 			</description>
 		</method>
 		<method name="shaped_text_resize_object">
@@ -1475,7 +1475,7 @@
 			<param index="1" name="start" type="int" />
 			<param index="2" name="length" type="int" />
 			<description>
-				Returns text buffer for the substring of the text in the [code]shaped[/code] text buffer (including inline objects).
+				Returns text buffer for the substring of the text in the [param shaped] text buffer (including inline objects).
 			</description>
 		</method>
 		<method name="shaped_text_tab_align">
@@ -1490,7 +1490,7 @@
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Returns [code]true[/code] if [code]string[/code] is likely to be an attempt at confusing the reader.
+				Returns [code]true[/code] if [param string] is likely to be an attempt at confusing the reader.
 				[b]Note:[/b] Always returns [code]false[/code] if the server does not support the [constant FEATURE_UNICODE_SECURITY] feature.
 			</description>
 		</method>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -20,7 +20,7 @@
 			<param index="0" name="direction" type="int" enum="TextServer.Direction" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" />
 			<description>
-				Creates new buffer for complex text layout, with the given [code]direction[/code] and [code]orientation[/code]. To free the resulting buffer, use [method free_rid] method.
+				Creates new buffer for complex text layout, with the given [param direction] and [param orientation]. To free the resulting buffer, use [method free_rid] method.
 			</description>
 		</method>
 		<method name="draw_hex_code_box" qualifiers="virtual const">
@@ -75,7 +75,7 @@
 			<param index="4" name="index" type="int" />
 			<param index="5" name="color" type="Color" />
 			<description>
-				Draws single glyph into a canvas item at the position, using [code]font_rid[/code] at the size [code]size[/code].
+				Draws single glyph into a canvas item at the position, using [param font_rid] at the size [param size].
 			</description>
 		</method>
 		<method name="font_draw_glyph_outline" qualifiers="virtual const">
@@ -88,7 +88,7 @@
 			<param index="5" name="index" type="int" />
 			<param index="6" name="color" type="Color" />
 			<description>
-				Draws single glyph outline of size [code]outline_size[/code] into a canvas item at the position, using [code]font_rid[/code] at the size [code]size[/code].
+				Draws single glyph outline of size [param outline_size] into a canvas item at the position, using [param font_rid] at the size [param size].
 			</description>
 		</method>
 		<method name="font_get_ascent" qualifiers="virtual const">
@@ -176,7 +176,7 @@
 			<param index="2" name="char" type="int" />
 			<param index="3" name="variation_selector" type="int" />
 			<description>
-				Returns the glyph index of a [code]char[/code], optionally modified by the [code]variation_selector[/code].
+				Returns the glyph index of a [param char], optionally modified by the [param variation_selector].
 			</description>
 		</method>
 		<method name="font_get_glyph_list" qualifiers="virtual const">
@@ -270,7 +270,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
-				Returns [code]true[/code] if support override is enabled for the [code]language[/code].
+				Returns [code]true[/code] if support override is enabled for the [param language].
 			</description>
 		</method>
 		<method name="font_get_language_support_overrides" qualifiers="virtual">
@@ -328,7 +328,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
-				Returns [code]true[/code] if support override is enabled for the [code]script[/code].
+				Returns [code]true[/code] if support override is enabled for the [param script].
 			</description>
 		</method>
 		<method name="font_get_script_support_overrides" qualifiers="virtual">
@@ -434,7 +434,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="char" type="int" />
 			<description>
-				Returns [code]true[/code] if a Unicode [code]char[/code] is available in the font.
+				Returns [code]true[/code] if a Unicode [param char] is available in the font.
 			</description>
 		</method>
 		<method name="font_is_antialiased" qualifiers="virtual const">
@@ -575,7 +575,7 @@
 			<param index="1" name="data_ptr" type="const uint8_t*" />
 			<param index="2" name="data_size" type="int" />
 			<description>
-				Sets font source data, e.g contents of the dynamic font source file. [code]data_ptr[/code] memory buffer must remain accessible during font lifetime.
+				Sets font source data, e.g contents of the dynamic font source file. [param data_ptr] memory buffer must remain accessible during font lifetime.
 			</description>
 		</method>
 		<method name="font_set_descent" qualifiers="virtual">
@@ -592,7 +592,7 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="strength" type="float" />
 			<description>
-				Sets font embolden strength. If [code]strength[/code] is not equal to zero, emboldens the font outlines. Negative values reduce the outline thickness.
+				Sets font embolden strength. If [param strength] is not equal to zero, emboldens the font outlines. Negative values reduce the outline thickness.
 			</description>
 		</method>
 		<method name="font_set_face_index" qualifiers="virtual">
@@ -877,7 +877,7 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
-				Converts a number from the Western Arabic (0..9) to the numeral systems used in [code]language[/code].
+				Converts a number from the Western Arabic (0..9) to the numeral systems used in [param language].
 			</description>
 		</method>
 		<method name="free_rid" qualifiers="virtual">
@@ -924,7 +924,7 @@
 			<return type="bool" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Returns [code]true[/code] if [code]rid[/code] is valid resource owned by this text server.
+				Returns [code]true[/code] if [param rid] is valid resource owned by this text server.
 			</description>
 		</method>
 		<method name="has_feature" qualifiers="virtual const">
@@ -953,7 +953,7 @@
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Returns [code]true[/code] is [code]string[/code] is a valid identifier.
+				Returns [code]true[/code] is [param string] is a valid identifier.
 			</description>
 		</method>
 		<method name="load_support_data" qualifiers="virtual">
@@ -975,7 +975,7 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
-				Converts a number from the numeral systems used in [code]language[/code] to Western Arabic (0..9).
+				Converts a number from the numeral systems used in [param language] to Western Arabic (0..9).
 			</description>
 		</method>
 		<method name="parse_structured_text" qualifiers="virtual const">
@@ -990,7 +990,7 @@
 			<return type="String" />
 			<param index="0" name="language" type="String" />
 			<description>
-				Returns percent sign used in the [code]language[/code].
+				Returns percent sign used in the [param language].
 			</description>
 		</method>
 		<method name="save_support_data" qualifiers="virtual const">
@@ -1035,7 +1035,7 @@
 			<param index="3" name="inline_align" type="int" enum="InlineAlignment" />
 			<param index="4" name="length" type="int" />
 			<description>
-				Adds inline object to the text buffer, [code]key[/code] must be unique. In the text, object is represented as [code]length[/code] object replacement characters.
+				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
 		<method name="shaped_text_add_string" qualifiers="virtual">
@@ -1067,7 +1067,7 @@
 			<param index="4" name="clip_r" type="float" />
 			<param index="5" name="color" type="Color" />
 			<description>
-				Draw shaped text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
+				Draw shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
 				[b]Note:[/b] If this method is not implemented in the plugin, the default implementation will be used.
 			</description>
 		</method>
@@ -1081,7 +1081,7 @@
 			<param index="5" name="outline_size" type="int" />
 			<param index="6" name="color" type="Color" />
 			<description>
-				Draw the outline of the shaped text into a canvas item at a given position, with [code]color[/code]. [code]pos[/code] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
+				Draw the outline of the shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout).
 				[b]Note:[/b] If this method is not implemented in the plugin, the default implementation will be used.
 			</description>
 		</method>
@@ -1107,7 +1107,7 @@
 			<param index="1" name="position" type="int" />
 			<param index="2" name="caret" type="CaretInfo*" />
 			<description>
-				Returns shapes of the carets corresponding to the character offset [code]position[/code] in the text. Returned caret shape is 1 pixel wide rectangle.
+				Returns shapes of the carets corresponding to the character offset [param position] in the text. Returned caret shape is 1 pixel wide rectangle.
 				[b]Note:[/b] If this method is not implemented in the plugin, the default implementation will be used.
 			</description>
 		</method>
@@ -1359,7 +1359,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				Returns composite character end position closest to the [code]pos[/code].
+				Returns composite character end position closest to the [param pos].
 				[b]Note:[/b] If this method is not implemented in the plugin, the default implementation will be used.
 			</description>
 		</method>
@@ -1377,7 +1377,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				Returns composite character start position closest to the [code]pos[/code].
+				Returns composite character start position closest to the [param pos].
 				[b]Note:[/b] If this method is not implemented in the plugin, the default implementation will be used.
 			</description>
 		</method>
@@ -1413,7 +1413,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="direction" type="int" enum="TextServer.Direction" />
 			<description>
-				Sets desired text direction. If set to [code]TEXT_DIRECTION_AUTO[/code], direction will be detected based on the buffer contents and current locale.
+				Sets desired text [param direction]. If set to [code]TEXT_DIRECTION_AUTO[/code], direction will be detected based on the buffer contents and current locale.
 			</description>
 		</method>
 		<method name="shaped_text_set_orientation" qualifiers="virtual">
@@ -1469,7 +1469,7 @@
 			<param index="1" name="start" type="int" />
 			<param index="2" name="length" type="int" />
 			<description>
-				Returns text buffer for the substring of the text in the [code]shaped[/code] text buffer (including inline objects).
+				Returns text buffer for the substring of the text in the [param shaped] text buffer (including inline objects).
 			</description>
 		</method>
 		<method name="shaped_text_tab_align" qualifiers="virtual">
@@ -1500,7 +1500,7 @@
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Returns [code]true[/code] if [code]string[/code] is likely to be an attempt at confusing the reader.
+				Returns [code]true[/code] if [param string] is likely to be an attempt at confusing the reader.
 			</description>
 		</method>
 		<method name="string_get_word_breaks" qualifiers="virtual const">

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -71,7 +71,7 @@
 			<param index="2" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="3" name="transpose" type="bool" default="false" />
 			<description>
-				Draws the texture using a [CanvasItem] with the [RenderingServer] API at the specified [code]position[/code].
+				Draws the texture using a [CanvasItem] with the [RenderingServer] API at the specified [param position].
 			</description>
 		</method>
 		<method name="draw_rect" qualifiers="const">

--- a/doc/classes/TextureLayered.xml
+++ b/doc/classes/TextureLayered.xml
@@ -61,7 +61,7 @@
 			<return type="Image" />
 			<param index="0" name="layer" type="int" />
 			<description>
-				Returns an [Image] resource with the data from specified [code]layer[/code].
+				Returns an [Image] resource with the data from specified [param layer].
 			</description>
 		</method>
 		<method name="get_layered_type" qualifiers="const">

--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -32,7 +32,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Removes the [Color] property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Removes the [Color] property defined by [param name] and [param theme_type], if it exists.
 				Fails if it doesn't exist. Use [method has_color] to check for existence.
 			</description>
 		</method>
@@ -41,7 +41,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Removes the constant property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Removes the constant property defined by [param name] and [param theme_type], if it exists.
 				Fails if it doesn't exist. Use [method has_constant] to check for existence.
 			</description>
 		</method>
@@ -50,7 +50,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Removes the [Font] property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Removes the [Font] property defined by [param name] and [param theme_type], if it exists.
 				Fails if it doesn't exist. Use [method has_font] to check for existence.
 			</description>
 		</method>
@@ -59,7 +59,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Removes the font size property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Removes the font size property defined by [param name] and [param theme_type], if it exists.
 				Fails if it doesn't exist. Use [method has_font_size] to check for existence.
 			</description>
 		</method>
@@ -68,7 +68,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Removes the icon property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Removes the icon property defined by [param name] and [param theme_type], if it exists.
 				Fails if it doesn't exist. Use [method has_icon] to check for existence.
 			</description>
 		</method>
@@ -77,7 +77,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Removes the [StyleBox] property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Removes the [StyleBox] property defined by [param name] and [param theme_type], if it exists.
 				Fails if it doesn't exist. Use [method has_stylebox] to check for existence.
 			</description>
 		</method>
@@ -87,7 +87,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Removes the theme property of [code]data_type[/code] defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Removes the theme property of [param data_type] defined by [param name] and [param theme_type], if it exists.
 				Fails if it doesn't exist. Use [method has_theme_item] to check for existence.
 				[b]Note:[/b] This method is analogous to calling the corresponding data type specific method, but can be used for more generalized logic.
 			</description>
@@ -96,7 +96,7 @@
 			<return type="void" />
 			<param index="0" name="theme_type" type="StringName" />
 			<description>
-				Unmarks [code]theme_type[/code] as being a variation of another theme type. See [method set_type_variation].
+				Unmarks [param theme_type] as being a variation of another theme type. See [method set_type_variation].
 			</description>
 		</method>
 		<method name="get_color" qualifiers="const">
@@ -104,7 +104,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns the [Color] property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Returns the [Color] property defined by [param name] and [param theme_type], if it exists.
 				Returns the default color value if the property doesn't exist. Use [method has_color] to check for existence.
 			</description>
 		</method>
@@ -112,7 +112,7 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="theme_type" type="String" />
 			<description>
-				Returns a list of names for [Color] properties defined with [code]theme_type[/code]. Use [method get_color_type_list] to get a list of possible theme type names.
+				Returns a list of names for [Color] properties defined with [param theme_type]. Use [method get_color_type_list] to get a list of possible theme type names.
 			</description>
 		</method>
 		<method name="get_color_type_list" qualifiers="const">
@@ -126,7 +126,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns the constant property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Returns the constant property defined by [param name] and [param theme_type], if it exists.
 				Returns [code]0[/code] if the property doesn't exist. Use [method has_constant] to check for existence.
 			</description>
 		</method>
@@ -134,7 +134,7 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="theme_type" type="String" />
 			<description>
-				Returns a list of names for constant properties defined with [code]theme_type[/code]. Use [method get_constant_type_list] to get a list of possible theme type names.
+				Returns a list of names for constant properties defined with [param theme_type]. Use [method get_constant_type_list] to get a list of possible theme type names.
 			</description>
 		</method>
 		<method name="get_constant_type_list" qualifiers="const">
@@ -148,7 +148,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns the [Font] property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Returns the [Font] property defined by [param name] and [param theme_type], if it exists.
 				Returns the default theme font if the property doesn't exist and the default theme font is set up (see [member default_font]). Use [method has_font] to check for existence of the property and [method has_default_font] to check for existence of the default theme font.
 				Returns the engine fallback font value, if neither exist.
 			</description>
@@ -157,7 +157,7 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="theme_type" type="String" />
 			<description>
-				Returns a list of names for [Font] properties defined with [code]theme_type[/code]. Use [method get_font_type_list] to get a list of possible theme type names.
+				Returns a list of names for [Font] properties defined with [param theme_type]. Use [method get_font_type_list] to get a list of possible theme type names.
 			</description>
 		</method>
 		<method name="get_font_size" qualifiers="const">
@@ -165,7 +165,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns the font size property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Returns the font size property defined by [param name] and [param theme_type], if it exists.
 				Returns the default theme font size if the property doesn't exist and the default theme font size is set up (see [member default_font_size]). Use [method has_font_size] to check for existence of the property and [method has_default_font_size] to check for existence of the default theme font.
 				Returns the engine fallback font size value, if neither exist.
 			</description>
@@ -174,7 +174,7 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="theme_type" type="String" />
 			<description>
-				Returns a list of names for font size properties defined with [code]theme_type[/code]. Use [method get_font_size_type_list] to get a list of possible theme type names.
+				Returns a list of names for font size properties defined with [param theme_type]. Use [method get_font_size_type_list] to get a list of possible theme type names.
 			</description>
 		</method>
 		<method name="get_font_size_type_list" qualifiers="const">
@@ -194,7 +194,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns the icon property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Returns the icon property defined by [param name] and [param theme_type], if it exists.
 				Returns the engine fallback icon value if the property doesn't exist. Use [method has_icon] to check for existence.
 			</description>
 		</method>
@@ -202,7 +202,7 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="theme_type" type="String" />
 			<description>
-				Returns a list of names for icon properties defined with [code]theme_type[/code]. Use [method get_icon_type_list] to get a list of possible theme type names.
+				Returns a list of names for icon properties defined with [param theme_type]. Use [method get_icon_type_list] to get a list of possible theme type names.
 			</description>
 		</method>
 		<method name="get_icon_type_list" qualifiers="const">
@@ -216,7 +216,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns the [StyleBox] property defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Returns the [StyleBox] property defined by [param name] and [param theme_type], if it exists.
 				Returns the engine fallback stylebox value if the property doesn't exist. Use [method has_stylebox] to check for existence.
 			</description>
 		</method>
@@ -224,7 +224,7 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="theme_type" type="String" />
 			<description>
-				Returns a list of names for [StyleBox] properties defined with [code]theme_type[/code]. Use [method get_stylebox_type_list] to get a list of possible theme type names.
+				Returns a list of names for [StyleBox] properties defined with [param theme_type]. Use [method get_stylebox_type_list] to get a list of possible theme type names.
 			</description>
 		</method>
 		<method name="get_stylebox_type_list" qualifiers="const">
@@ -239,7 +239,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Returns the theme property of [code]data_type[/code] defined by [code]name[/code] and [code]theme_type[/code], if it exists.
+				Returns the theme property of [param data_type] defined by [param name] and [param theme_type], if it exists.
 				Returns the engine fallback icon value if the property doesn't exist. Use [method has_theme_item] to check for existence.
 				[b]Note:[/b] This method is analogous to calling the corresponding data type specific method, but can be used for more generalized logic.
 			</description>
@@ -249,7 +249,7 @@
 			<param index="0" name="data_type" type="int" enum="Theme.DataType" />
 			<param index="1" name="theme_type" type="String" />
 			<description>
-				Returns a list of names for properties of [code]data_type[/code] defined with [code]theme_type[/code]. Use [method get_theme_item_type_list] to get a list of possible theme type names.
+				Returns a list of names for properties of [param data_type] defined with [param theme_type]. Use [method get_theme_item_type_list] to get a list of possible theme type names.
 				[b]Note:[/b] This method is analogous to calling the corresponding data type specific method, but can be used for more generalized logic.
 			</description>
 		</method>
@@ -257,7 +257,7 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="data_type" type="int" enum="Theme.DataType" />
 			<description>
-				Returns a list of all unique theme type names for [code]data_type[/code] properties. Use [method get_type_list] to get a list of all unique theme types.
+				Returns a list of all unique theme type names for [param data_type] properties. Use [method get_type_list] to get a list of all unique theme types.
 				[b]Note:[/b] This method is analogous to calling the corresponding data type specific method, but can be used for more generalized logic.
 			</description>
 		</method>
@@ -271,14 +271,14 @@
 			<return type="StringName" />
 			<param index="0" name="theme_type" type="StringName" />
 			<description>
-				Returns the name of the base theme type if [code]theme_type[/code] is a valid variation type. Returns an empty string otherwise.
+				Returns the name of the base theme type if [param theme_type] is a valid variation type. Returns an empty string otherwise.
 			</description>
 		</method>
 		<method name="get_type_variation_list" qualifiers="const">
 			<return type="PackedStringArray" />
 			<param index="0" name="base_type" type="StringName" />
 			<description>
-				Returns a list of all type variations for the given [code]base_type[/code].
+				Returns a list of all type variations for the given [param base_type].
 			</description>
 		</method>
 		<method name="has_color" qualifiers="const">
@@ -286,7 +286,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the [Color] property defined by [code]name[/code] and [code]theme_type[/code] exists.
+				Returns [code]true[/code] if the [Color] property defined by [param name] and [param theme_type] exists.
 				Returns [code]false[/code] if it doesn't exist. Use [method set_color] to define it.
 			</description>
 		</method>
@@ -295,7 +295,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the constant property defined by [code]name[/code] and [code]theme_type[/code] exists.
+				Returns [code]true[/code] if the constant property defined by [param name] and [param theme_type] exists.
 				Returns [code]false[/code] if it doesn't exist. Use [method set_constant] to define it.
 			</description>
 		</method>
@@ -325,7 +325,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the [Font] property defined by [code]name[/code] and [code]theme_type[/code] exists, or if the default theme font is set up (see [method has_default_font]).
+				Returns [code]true[/code] if the [Font] property defined by [param name] and [param theme_type] exists, or if the default theme font is set up (see [method has_default_font]).
 				Returns [code]false[/code] if neither exist. Use [method set_font] to define the property.
 			</description>
 		</method>
@@ -334,8 +334,8 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if [member default_font_size] has a valid value.
-				Returns [code]false[/code] if it doesn't. The value must be greater than [code]0[/code] to be considered valid.
+				Returns [code]true[/code] if the font size property defined by [param name] and [param theme_type] exists, or if the default theme font size is set up (see [method has_default_font_size]).
+				Returns [code]false[/code] if neither exist. Use [method set_font_size] to define the property.
 			</description>
 		</method>
 		<method name="has_icon" qualifiers="const">
@@ -343,7 +343,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the icon property defined by [code]name[/code] and [code]theme_type[/code] exists.
+				Returns [code]true[/code] if the icon property defined by [param name] and [param theme_type] exists.
 				Returns [code]false[/code] if it doesn't exist. Use [method set_icon] to define it.
 			</description>
 		</method>
@@ -352,7 +352,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the [StyleBox] property defined by [code]name[/code] and [code]theme_type[/code] exists.
+				Returns [code]true[/code] if the [StyleBox] property defined by [param name] and [param theme_type] exists.
 				Returns [code]false[/code] if it doesn't exist. Use [method set_stylebox] to define it.
 			</description>
 		</method>
@@ -362,7 +362,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the theme property of [code]data_type[/code] defined by [code]name[/code] and [code]theme_type[/code] exists.
+				Returns [code]true[/code] if the theme property of [param data_type] defined by [param name] and [param theme_type] exists.
 				Returns [code]false[/code] if it doesn't exist. Use [method set_theme_item] to define it.
 				[b]Note:[/b] This method is analogous to calling the corresponding data type specific method, but can be used for more generalized logic.
 			</description>
@@ -372,14 +372,14 @@
 			<param index="0" name="theme_type" type="StringName" />
 			<param index="1" name="base_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if [code]theme_type[/code] is marked as a variation of [code]base_type[/code].
+				Returns [code]true[/code] if [param theme_type] is marked as a variation of [param base_type].
 			</description>
 		</method>
 		<method name="merge_with">
 			<return type="void" />
 			<param index="0" name="other" type="Theme" />
 			<description>
-				Adds missing and overrides existing definitions with values from the [code]other[/code] theme resource.
+				Adds missing and overrides existing definitions with values from the [param other] theme resource.
 				[b]Note:[/b] This modifies the current theme. If you want to merge two themes together without modifying either one, create a new empty theme and merge the other two into it one after another.
 			</description>
 		</method>
@@ -396,7 +396,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Renames the [Color] property defined by [code]old_name[/code] and [code]theme_type[/code] to [code]name[/code], if it exists.
+				Renames the [Color] property defined by [param old_name] and [param theme_type] to [param name], if it exists.
 				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_color] to check for existence, and [method clear_color] to remove the existing property.
 			</description>
 		</method>
@@ -406,7 +406,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Renames the constant property defined by [code]old_name[/code] and [code]theme_type[/code] to [code]name[/code], if it exists.
+				Renames the constant property defined by [param old_name] and [param theme_type] to [param name], if it exists.
 				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_constant] to check for existence, and [method clear_constant] to remove the existing property.
 			</description>
 		</method>
@@ -416,7 +416,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Renames the [Font] property defined by [code]old_name[/code] and [code]theme_type[/code] to [code]name[/code], if it exists.
+				Renames the [Font] property defined by [param old_name] and [param theme_type] to [param name], if it exists.
 				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_font] to check for existence, and [method clear_font] to remove the existing property.
 			</description>
 		</method>
@@ -426,8 +426,8 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the font size property defined by [code]name[/code] and [code]theme_type[/code] exists, or if the default theme font size is set up (see [method has_default_font_size]).
-				Returns [code]false[/code] if neither exist. Use [method set_font_size] to define the property.
+				Renames the font size property defined by [param old_name] and [param theme_type] to [param name], if it exists.
+				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_font_size] to check for existence, and [method clear_font_size] to remove the existing property.
 			</description>
 		</method>
 		<method name="rename_icon">
@@ -436,7 +436,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Renames the icon property defined by [code]old_name[/code] and [code]theme_type[/code] to [code]name[/code], if it exists.
+				Renames the icon property defined by [param old_name] and [param theme_type] to [param name], if it exists.
 				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_icon] to check for existence, and [method clear_icon] to remove the existing property.
 			</description>
 		</method>
@@ -446,7 +446,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="theme_type" type="StringName" />
 			<description>
-				Renames the [StyleBox] property defined by [code]old_name[/code] and [code]theme_type[/code] to [code]name[/code], if it exists.
+				Renames the [StyleBox] property defined by [param old_name] and [param theme_type] to [param name], if it exists.
 				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_stylebox] to check for existence, and [method clear_stylebox] to remove the existing property.
 			</description>
 		</method>
@@ -457,7 +457,7 @@
 			<param index="2" name="name" type="StringName" />
 			<param index="3" name="theme_type" type="StringName" />
 			<description>
-				Renames the theme property of [code]data_type[/code] defined by [code]old_name[/code] and [code]theme_type[/code] to [code]name[/code], if it exists.
+				Renames the theme property of [param data_type] defined by [param old_name] and [param theme_type] to [param name], if it exists.
 				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_theme_item] to check for existence, and [method clear_theme_item] to remove the existing property.
 				[b]Note:[/b] This method is analogous to calling the corresponding data type specific method, but can be used for more generalized logic.
 			</description>
@@ -468,7 +468,7 @@
 			<param index="1" name="theme_type" type="StringName" />
 			<param index="2" name="color" type="Color" />
 			<description>
-				Creates or changes the value of the [Color] property defined by [code]name[/code] and [code]theme_type[/code]. Use [method clear_color] to remove the property.
+				Creates or changes the value of the [Color] property defined by [param name] and [param theme_type]. Use [method clear_color] to remove the property.
 			</description>
 		</method>
 		<method name="set_constant">
@@ -477,7 +477,7 @@
 			<param index="1" name="theme_type" type="StringName" />
 			<param index="2" name="constant" type="int" />
 			<description>
-				Creates or changes the value of the constant property defined by [code]name[/code] and [code]theme_type[/code]. Use [method clear_constant] to remove the property.
+				Creates or changes the value of the constant property defined by [param name] and [param theme_type]. Use [method clear_constant] to remove the property.
 			</description>
 		</method>
 		<method name="set_font">
@@ -486,7 +486,7 @@
 			<param index="1" name="theme_type" type="StringName" />
 			<param index="2" name="font" type="Font" />
 			<description>
-				Creates or changes the value of the [Font] property defined by [code]name[/code] and [code]theme_type[/code]. Use [method clear_font] to remove the property.
+				Creates or changes the value of the [Font] property defined by [param name] and [param theme_type]. Use [method clear_font] to remove the property.
 			</description>
 		</method>
 		<method name="set_font_size">
@@ -495,8 +495,7 @@
 			<param index="1" name="theme_type" type="StringName" />
 			<param index="2" name="font_size" type="int" />
 			<description>
-				Renames the font size property defined by [code]old_name[/code] and [code]theme_type[/code] to [code]name[/code], if it exists.
-				Fails if it doesn't exist, or if a similar property with the new name already exists. Use [method has_font_size] to check for existence, and [method clear_font_size] to remove the existing property.
+				Creates or changes the value of the font size property defined by [param name] and [param theme_type]. Use [method clear_font_size] to remove the property.
 			</description>
 		</method>
 		<method name="set_icon">
@@ -505,7 +504,7 @@
 			<param index="1" name="theme_type" type="StringName" />
 			<param index="2" name="texture" type="Texture2D" />
 			<description>
-				Creates or changes the value of the icon property defined by [code]name[/code] and [code]theme_type[/code]. Use [method clear_icon] to remove the property.
+				Creates or changes the value of the icon property defined by [param name] and [param theme_type]. Use [method clear_icon] to remove the property.
 			</description>
 		</method>
 		<method name="set_stylebox">
@@ -514,7 +513,7 @@
 			<param index="1" name="theme_type" type="StringName" />
 			<param index="2" name="texture" type="StyleBox" />
 			<description>
-				Creates or changes the value of the [StyleBox] property defined by [code]name[/code] and [code]theme_type[/code]. Use [method clear_stylebox] to remove the property.
+				Creates or changes the value of the [StyleBox] property defined by [param name] and [param theme_type]. Use [method clear_stylebox] to remove the property.
 			</description>
 		</method>
 		<method name="set_theme_item">
@@ -524,8 +523,8 @@
 			<param index="2" name="theme_type" type="StringName" />
 			<param index="3" name="value" type="Variant" />
 			<description>
-				Creates or changes the value of the theme property of [code]data_type[/code] defined by [code]name[/code] and [code]theme_type[/code]. Use [method clear_theme_item] to remove the property.
-				Fails if the [code]value[/code] type is not accepted by [code]data_type[/code].
+				Creates or changes the value of the theme property of [param data_type] defined by [param name] and [param theme_type]. Use [method clear_theme_item] to remove the property.
+				Fails if the [param value] type is not accepted by [param data_type].
 				[b]Note:[/b] This method is analogous to calling the corresponding data type specific method, but can be used for more generalized logic.
 			</description>
 		</method>
@@ -534,9 +533,9 @@
 			<param index="0" name="theme_type" type="StringName" />
 			<param index="1" name="base_type" type="StringName" />
 			<description>
-				Marks [code]theme_type[/code] as a variation of [code]base_type[/code].
-				This adds [code]theme_type[/code] as a suggested option for [member Control.theme_type_variation] on a [Control] that is of the [code]base_type[/code] class.
-				Variations can also be nested, i.e. [code]base_type[/code] can be another variation. If a chain of variations ends with a [code]base_type[/code] matching the class of the [Control], the whole chain is going to be suggested as options.
+				Marks [param theme_type] as a variation of [param base_type].
+				This adds [param theme_type] as a suggested option for [member Control.theme_type_variation] on a [Control] that is of the [param base_type] class.
+				Variations can also be nested, i.e. [param base_type] can be another variation. If a chain of variations ends with a [param base_type] matching the class of the [Control], the whole chain is going to be suggested as options.
 				[b]Note:[/b] Suggestions only show up if this theme resource is set as the project default theme. See [member ProjectSettings.gui/theme/custom].
 			</description>
 		</method>

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -37,9 +37,9 @@
 			<param index="0" name="callable" type="Callable" />
 			<param index="1" name="priority" type="int" enum="Thread.Priority" default="1" />
 			<description>
-				Starts a new [Thread] that calls [code]callable[/code].
+				Starts a new [Thread] that calls [param callable].
 				If the method takes some arguments, you can pass them using [method Callable.bind].
-				The [code]priority[/code] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
+				The [param priority] of the [Thread] can be changed by passing a value from the [enum Priority] enum.
 				Returns [constant OK] on success, or [constant ERR_CANT_CREATE] on failure.
 			</description>
 		</method>

--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -19,7 +19,7 @@
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="polygon_index" type="int" />
 			<description>
-				Returns the one-way margin (for one-way platforms) of the polygon at index [code]polygon_index[/code] for TileSet physics layer with index [code]layer_id[/code].
+				Returns the one-way margin (for one-way platforms) of the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="get_collision_polygon_points" qualifiers="const">
@@ -27,14 +27,14 @@
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="polygon_index" type="int" />
 			<description>
-				Returns the points of the polygon at index [code]polygon_index[/code] for TileSet physics layer with index [code]layer_id[/code].
+				Returns the points of the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="get_collision_polygons_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="layer_id" type="int" />
 			<description>
-				Returns how many polygons the tile has for TileSet physics layer with index [code]layer_id[/code].
+				Returns how many polygons the tile has for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="get_constant_angular_velocity" qualifiers="const">
@@ -55,35 +55,35 @@
 			<return type="Variant" />
 			<param index="0" name="layer_name" type="String" />
 			<description>
-				Returns the custom data value for custom data layer named [code]layer_name[/code].
+				Returns the custom data value for custom data layer named [param layer_name].
 			</description>
 		</method>
 		<method name="get_custom_data_by_layer_id" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="layer_id" type="int" />
 			<description>
-				Returns the custom data value for custom data layer with index [code]layer_id[/code].
+				Returns the custom data value for custom data layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="get_navigation_polygon" qualifiers="const">
 			<return type="NavigationPolygon" />
 			<param index="0" name="layer_id" type="int" />
 			<description>
-				Returns the navigation polygon of the tile for the TileSet navigation layer with index [code]layer_id[/code].
+				Returns the navigation polygon of the tile for the TileSet navigation layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="get_occluder" qualifiers="const">
 			<return type="OccluderPolygon2D" />
 			<param index="0" name="layer_id" type="int" />
 			<description>
-				Returns the occluder polygon of the tile for the TileSet occlusion layer with index [code]layer_id[/code].
+				Returns the occluder polygon of the tile for the TileSet occlusion layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="get_terrain_peering_bit" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="peering_bit" type="int" enum="TileSet.CellNeighbor" />
 			<description>
-				Returns the tile's terrain bit for the given [code]peering_bit[/code] direction.
+				Returns the tile's terrain bit for the given [param peering_bit] direction.
 			</description>
 		</method>
 		<method name="is_collision_polygon_one_way" qualifiers="const">
@@ -91,7 +91,7 @@
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="polygon_index" type="int" />
 			<description>
-				Returns whether one-way collisions are enabled for the polygon at index [code]polygon_index[/code] for TileSet physics layer with index [code]layer_id[/code].
+				Returns whether one-way collisions are enabled for the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="remove_collision_polygon">
@@ -99,7 +99,7 @@
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="polygon_index" type="int" />
 			<description>
-				Removes the polygon at index [code]polygon_index[/code] for TileSet physics layer with index [code]layer_id[/code].
+				Removes the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_collision_polygon_one_way">
@@ -108,7 +108,7 @@
 			<param index="1" name="polygon_index" type="int" />
 			<param index="2" name="one_way" type="bool" />
 			<description>
-				Enables/disables one-way collisions on the polygon at index [code]polygon_index[/code] for TileSet physics layer with index [code]layer_id[/code].
+				Enables/disables one-way collisions on the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_collision_polygon_one_way_margin">
@@ -117,7 +117,7 @@
 			<param index="1" name="polygon_index" type="int" />
 			<param index="2" name="one_way_margin" type="float" />
 			<description>
-				Enables/disables one-way collisions on the polygon at index [code]polygon_index[/code] for TileSet physics layer with index [code]layer_id[/code].
+				Enables/disables one-way collisions on the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_collision_polygon_points">
@@ -126,7 +126,7 @@
 			<param index="1" name="polygon_index" type="int" />
 			<param index="2" name="polygon" type="PackedVector2Array" />
 			<description>
-				Sets the points of the polygon at index [code]polygon_index[/code] for TileSet physics layer with index [code]layer_id[/code].
+				Sets the points of the polygon at index [param polygon_index] for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_collision_polygons_count">
@@ -134,7 +134,7 @@
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="polygons_count" type="int" />
 			<description>
-				Sets the polygons count for TileSet physics layer with index [code]layer_id[/code].
+				Sets the polygons count for TileSet physics layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_constant_angular_velocity">
@@ -158,7 +158,7 @@
 			<param index="0" name="layer_name" type="String" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Sets the tile's custom data value for the TileSet custom data layer with name [code]layer_name[/code].
+				Sets the tile's custom data value for the TileSet custom data layer with name [param layer_name].
 			</description>
 		</method>
 		<method name="set_custom_data_by_layer_id">
@@ -166,7 +166,7 @@
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Sets the tile's custom data value for the TileSet custom data layer with index [code]layer_id[/code].
+				Sets the tile's custom data value for the TileSet custom data layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_navigation_polygon">
@@ -174,7 +174,7 @@
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="navigation_polygon" type="NavigationPolygon" />
 			<description>
-				Sets the navigation polygon for the TileSet navigation layer with index [code]layer_id[/code].
+				Sets the navigation polygon for the TileSet navigation layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_occluder">
@@ -182,7 +182,7 @@
 			<param index="0" name="layer_id" type="int" />
 			<param index="1" name="occluder_polygon" type="OccluderPolygon2D" />
 			<description>
-				Sets the occluder for the TileSet occlusion layer with index [code]layer_id[/code].
+				Sets the occluder for the TileSet occlusion layer with index [param layer_id].
 			</description>
 		</method>
 		<method name="set_terrain_peering_bit">
@@ -190,7 +190,7 @@
 			<param index="0" name="peering_bit" type="int" enum="TileSet.CellNeighbor" />
 			<param index="1" name="terrain" type="int" />
 			<description>
-				Sets the tile's terrain bit for the given [code]peering_bit[/code] direction.
+				Sets the tile's terrain bit for the given [param peering_bit] direction.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -23,9 +23,9 @@
 			<param index="2" name="tile_data" type="TileData" />
 			<description>
 				Called with a TileData object about to be used internally by the TileMap, allowing its modification at runtime.
-				This method is only called if [method _use_tile_data_runtime_update] is implemented and returns [code]true[/code] for the given tile [code]coords[/coords] and [code]layer[/code].
-				[b]Warning:[/b] The [code]tile_data[/code] object's sub-resources are the same as the one in the TileSet. Modifying them might impact the whole TileSet. Instead, make sure to duplicate those resources.
-				[b]Note:[/b] If the properties of [code]tile_data[/code] object should change over time, use [method force_update] to trigger a TileMap update.
+				This method is only called if [method _use_tile_data_runtime_update] is implemented and returns [code]true[/code] for the given tile [param coords] and [param layer].
+				[b]Warning:[/b] The [param tile_data] object's sub-resources are the same as the one in the TileSet. Modifying them might impact the whole TileSet. Instead, make sure to duplicate those resources.
+				[b]Note:[/b] If the properties of [param tile_data] object should change over time, use [method force_update] to trigger a TileMap update.
 			</description>
 		</method>
 		<method name="_use_tile_data_runtime_update" qualifiers="virtual">
@@ -33,7 +33,7 @@
 			<param index="0" name="layer" type="int" />
 			<param index="1" name="coords" type="Vector2i" />
 			<description>
-				Should return [code]true[/code] if the tile at coordinates [code]coords[/coords] on layer [code]layer[/code] requires a runtime update.
+				Should return [code]true[/code] if the tile at coordinates [param coords] on layer [param layer] requires a runtime update.
 				[b]Warning:[/b] Make sure this function only return [code]true[/code] when needed. Any tile processed at runtime without a need for it will imply a significant performance penalty.
 			</description>
 		</method>
@@ -41,7 +41,7 @@
 			<return type="void" />
 			<param index="0" name="to_position" type="int" />
 			<description>
-				Adds a layer at the given position [code]to_position[/code] in the array. If [code]to_position[/code] is -1, adds it at the end of the array.
+				Adds a layer at the given position [param to_position] in the array. If [param to_position] is -1, adds it at the end of the array.
 			</description>
 		</method>
 		<method name="clear">
@@ -62,7 +62,7 @@
 			<param index="0" name="layer" type="int" />
 			<param index="1" name="coords" type="Vector2i" />
 			<description>
-				Erases the cell on layer [code]layer[/code] at coordinates [code]coords[/code].
+				Erases the cell on layer [param layer] at coordinates [param coords].
 			</description>
 		</method>
 		<method name="fix_invalid_tiles">
@@ -75,7 +75,7 @@
 			<return type="void" />
 			<param index="0" name="layer" type="int" default="-1" />
 			<description>
-				Triggers an update of the TileMap. If [code]layer[/code] is provided, only updates the given layer.
+				Triggers an update of the TileMap. If [param layer] is provided, only updates the given layer.
 				[b]Note:[/b] The TileMap node updates automatically when one of its properties is modified. A manual update is only needed if runtime modifications (implemented in [method _tile_data_runtime_update]) need to be applied.
 				[b]Warning:[/b] Updating the TileMap is a performance demanding task. Limit occurrences of those updates to the minimum and limit the amount tiles they impact (by segregating tiles updated often to a dedicated layer for example).
 			</description>
@@ -86,7 +86,7 @@
 			<param index="1" name="coords" type="Vector2i" />
 			<param index="2" name="use_proxies" type="bool" />
 			<description>
-				Returns the tile alternative ID of the cell on layer [code]layer[/code] at [code]coords[/code]. If [code]use_proxies[/code] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
+				Returns the tile alternative ID of the cell on layer [param layer] at [param coords]. If [param use_proxies] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
 			</description>
 		</method>
 		<method name="get_cell_atlas_coords" qualifiers="const">
@@ -95,7 +95,7 @@
 			<param index="1" name="coords" type="Vector2i" />
 			<param index="2" name="use_proxies" type="bool" />
 			<description>
-				Returns the tile atlas coordinates ID of the cell on layer [code]layer[/code] at coordinates [code]coords[/code]. If [code]use_proxies[/code] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
+				Returns the tile atlas coordinates ID of the cell on layer [param layer] at coordinates [param coords]. If [param use_proxies] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
 			</description>
 		</method>
 		<method name="get_cell_source_id" qualifiers="const">
@@ -104,7 +104,7 @@
 			<param index="1" name="coords" type="Vector2i" />
 			<param index="2" name="use_proxies" type="bool" />
 			<description>
-				Returns the tile source ID of the cell on layer [code]layer[/code] at coordinates [code]coords[/code]. If [code]use_proxies[/code] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
+				Returns the tile source ID of the cell on layer [param layer] at coordinates [param coords]. If [param use_proxies] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
 			</description>
 		</method>
 		<method name="get_coords_for_body_rid">
@@ -152,7 +152,7 @@
 			<param index="0" name="coords" type="Vector2i" />
 			<param index="1" name="neighbor" type="int" enum="TileSet.CellNeighbor" />
 			<description>
-				Returns the neighboring cell to the one at coordinates [code]coords[/code], identified by the [code]neighbor[/code] direction. This method takes into account the different layouts a TileMap can take.
+				Returns the neighboring cell to the one at coordinates [param coords], identified by the [param neighbor] direction. This method takes into account the different layouts a TileMap can take.
 			</description>
 		</method>
 		<method name="get_pattern">
@@ -167,7 +167,7 @@
 			<return type="Vector2i[]" />
 			<param index="0" name="coords" type="Vector2i" />
 			<description>
-				Returns the list of all neighbourings cells to the one at [code]coords[/code]
+				Returns the list of all neighbourings cells to the one at [param coords]
 			</description>
 		</method>
 		<method name="get_used_cells" qualifiers="const">
@@ -203,7 +203,7 @@
 			<param index="1" name="coords_in_pattern" type="Vector2i" />
 			<param index="2" name="pattern" type="TileMapPattern" />
 			<description>
-				Returns for the given coordinate [code]coords_in_pattern[/code] in a [TileMapPattern] the corresponding cell coordinates if the pattern was pasted at the [code]position_in_tilemap[/code] coordinates (see [method set_pattern]). This mapping is required as in half-offset tile shapes, the mapping might not work by calculating [code]position_in_tile_map + coords_in_pattern[/code]
+				Returns for the given coordinate [param coords_in_pattern] in a [TileMapPattern] the corresponding cell coordinates if the pattern was pasted at the [param position_in_tilemap] coordinates (see [method set_pattern]). This mapping is required as in half-offset tile shapes, the mapping might not work by calculating [code]position_in_tile_map + coords_in_pattern[/code]
 			</description>
 		</method>
 		<method name="map_to_world" qualifiers="const">
@@ -219,14 +219,14 @@
 			<param index="0" name="layer" type="int" />
 			<param index="1" name="to_position" type="int" />
 			<description>
-				Moves the layer at index [code]layer_index[/code] to the given position [code]to_position[/code] in the array.
+				Moves the layer at index [param layer] to the given position [param to_position] in the array.
 			</description>
 		</method>
 		<method name="remove_layer">
 			<return type="void" />
 			<param index="0" name="layer" type="int" />
 			<description>
-				Removes the layer at index [code]layer[/code].
+				Removes the layer at index [param layer].
 			</description>
 		</method>
 		<method name="set_cell">
@@ -237,10 +237,10 @@
 			<param index="3" name="atlas_coords" type="Vector2i" default="Vector2i(-1, -1)" />
 			<param index="4" name="alternative_tile" type="int" default="0" />
 			<description>
-				Sets the tile indentifiers for the cell on layer [code]layer[/code] at coordinates [code]coords[/code]. Each tile of the [TileSet] is identified using three parts:
-				- The source identifier [code]source_id[/code] identifies a [TileSetSource] identifier. See [method TileSet.set_source_id],
-				- The atlas coordinates identifier [code]atlas_coords[/code] identifies a tile coordinates in the atlas (if the source is a [TileSetAtlasSource]. For [TileSetScenesCollectionSource] it should be 0),
-				- The alternative tile identifier [code]alternative_tile[/code] identifies a tile alternative the source is a [TileSetAtlasSource], and the scene for a [TileSetScenesCollectionSource].
+				Sets the tile indentifiers for the cell on layer [param layer] at coordinates [param coords]. Each tile of the [TileSet] is identified using three parts:
+				- The source identifier [param source_id] identifies a [TileSetSource] identifier. See [method TileSet.set_source_id],
+				- The atlas coordinates identifier [param atlas_coords] identifies a tile coordinates in the atlas (if the source is a [TileSetAtlasSource]. For [TileSetScenesCollectionSource] it should be 0),
+				- The alternative tile identifier [param alternative_tile] identifies a tile alternative the source is a [TileSetAtlasSource], and the scene for a [TileSetScenesCollectionSource].
 			</description>
 		</method>
 		<method name="set_cells_terrain_connect">
@@ -251,8 +251,9 @@
 			<param index="3" name="terrain" type="int" />
 			<param index="4" name="ignore_empty_terrains" type="bool" default="true" />
 			<description>
-				Update all the cells in the [code]cells[/code] coordinates array so that they use the given [code]terrain[/code] for the given [code]terrain_set[/code]. If an updated cell has the same terrain as one of its neighboring cells, this function tries to join the two. This function might update neighboring tiles if needed to create correct terrain transitions.				If [code]ignore_empty_terrains[/code] is true, empty terrains will be ignored when trying to find the best fitting tile for the given terrain constraints.
-				If [code]ignore_empty_terrains[/code] is true, empty terrains will be ignored when trying to find the best fitting tile for the given terrain constraints.
+				Update all the cells in the [param cells] coordinates array so that they use the given [param terrain] for the given [param terrain_set]. If an updated cell has the same terrain as one of its neighboring cells, this function tries to join the two. This function might update neighboring tiles if needed to create correct terrain transitions.
+				If [param ignore_empty_terrains] is true, empty terrains will be ignored when trying to find the best fitting tile for the given terrain constraints.
+				If [param ignore_empty_terrains] is true, empty terrains will be ignored when trying to find the best fitting tile for the given terrain constraints.
 				[b]Note:[/b] To work correctly, [code]set_cells_terrain_connect[/code] requires the TileMap's TileSet to have terrains set up with all required terrain combinations. Otherwise, it may produce unexpected results.
 			</description>
 		</method>
@@ -264,8 +265,8 @@
 			<param index="3" name="terrain" type="int" />
 			<param index="4" name="ignore_empty_terrains" type="bool" default="true" />
 			<description>
-				Update all the cells in the [code]cells[/code] coordinates array so that they use the given [code]terrain[/code] for the given [code]terrain_set[/code]. The function will also connect two successive cell in the path with the same terrain. This function might update neighboring tiles if needed to create correct terrain transitions.
-				If [code]ignore_empty_terrains[/code] is true, empty terrains will be ignored when trying to find the best fitting tile for the given terrain constraints.
+				Update all the cells in the [param path] coordinates array so that they use the given [param terrain] for the given [param terrain_set]. The function will also connect two successive cell in the path with the same terrain. This function might update neighboring tiles if needed to create correct terrain transitions.
+				If [param ignore_empty_terrains] is true, empty terrains will be ignored when trying to find the best fitting tile for the given terrain constraints.
 				[b]Note:[/b] To work correctly, [code]set_cells_terrain_path[/code] requires the TileMap's TileSet to have terrains set up with all required terrain combinations. Otherwise, it may produce unexpected results.
 			</description>
 		</method>
@@ -274,7 +275,7 @@
 			<param index="0" name="layer" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				Enables or disables the layer [code]layer[/code]. A disabled layer is not processed at all (no rendering, no physics, etc...).
+				Enables or disables the layer [param layer]. A disabled layer is not processed at all (no rendering, no physics, etc...).
 			</description>
 		</method>
 		<method name="set_layer_modulate">
@@ -325,7 +326,7 @@
 			<param index="1" name="position" type="Vector2i" />
 			<param index="2" name="pattern" type="TileMapPattern" />
 			<description>
-				Paste the given [TileMapPattern] at the given [code]position[/code] and [code]layer[/code] in the tile map.
+				Paste the given [TileMapPattern] at the given [param position] and [param layer] in the tile map.
 			</description>
 		</method>
 		<method name="world_to_map" qualifiers="const">

--- a/doc/classes/TileMapPattern.xml
+++ b/doc/classes/TileMapPattern.xml
@@ -14,21 +14,21 @@
 			<return type="int" />
 			<param index="0" name="coords" type="Vector2i" />
 			<description>
-				Returns the tile alternative ID of the cell at [code]coords[/code].
+				Returns the tile alternative ID of the cell at [param coords].
 			</description>
 		</method>
 		<method name="get_cell_atlas_coords" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="coords" type="Vector2i" />
 			<description>
-				Returns the tile atlas coordinates ID of the cell at [code]coords[/code].
+				Returns the tile atlas coordinates ID of the cell at [param coords].
 			</description>
 		</method>
 		<method name="get_cell_source_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="coords" type="Vector2i" />
 			<description>
-				Returns the tile source ID of the cell at [code]coords[/code].
+				Returns the tile source ID of the cell at [param coords].
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">
@@ -71,7 +71,7 @@
 			<param index="2" name="atlas_coords" type="Vector2i" default="Vector2i(-1, -1)" />
 			<param index="3" name="alternative_tile" type="int" default="-1" />
 			<description>
-				Sets the tile indentifiers for the cell at coordinates [code]coords[/code]. See [method TileMap.set_cell].
+				Sets the tile indentifiers for the cell at coordinates [param coords]. See [method TileMap.set_cell].
 			</description>
 		</method>
 		<method name="set_size">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -26,7 +26,7 @@
 			<return type="void" />
 			<param index="0" name="to_position" type="int" default="-1" />
 			<description>
-				Adds a custom data layer to the TileSet at the given position [code]to_position[/code] in the array. If [code]to_position[/code] is -1, adds it at the end of the array.
+				Adds a custom data layer to the TileSet at the given position [param to_position] in the array. If [param to_position] is -1, adds it at the end of the array.
 				Custom data layers allow assigning custom properties to atlas tiles.
 			</description>
 		</method>
@@ -34,7 +34,7 @@
 			<return type="void" />
 			<param index="0" name="to_position" type="int" default="-1" />
 			<description>
-				Adds a navigation layer to the TileSet at the given position [code]to_position[/code] in the array. If [code]to_position[/code] is -1, adds it at the end of the array.
+				Adds a navigation layer to the TileSet at the given position [param to_position] in the array. If [param to_position] is -1, adds it at the end of the array.
 				Navigation layers allow assigning a navigable area to atlas tiles.
 			</description>
 		</method>
@@ -42,7 +42,7 @@
 			<return type="void" />
 			<param index="0" name="to_position" type="int" default="-1" />
 			<description>
-				Adds an occlusion layer to the TileSet at the given position [code]to_position[/code] in the array. If [code]to_position[/code] is -1, adds it at the end of the array.
+				Adds an occlusion layer to the TileSet at the given position [param to_position] in the array. If [param to_position] is -1, adds it at the end of the array.
 				Occlusion layers allow assigning occlusion polygons to atlas tiles.
 			</description>
 		</method>
@@ -51,14 +51,14 @@
 			<param index="0" name="pattern" type="TileMapPattern" />
 			<param index="1" name="index" type="int" default="-1" />
 			<description>
-				Adds a [TileMapPattern] to be stored in the TileSet resource. If provided, insert it at the given [code]index[/code].
+				Adds a [TileMapPattern] to be stored in the TileSet resource. If provided, insert it at the given [param index].
 			</description>
 		</method>
 		<method name="add_physics_layer">
 			<return type="void" />
 			<param index="0" name="to_position" type="int" default="-1" />
 			<description>
-				Adds a physics layer to the TileSet at the given position [code]to_position[/code] in the array. If [code]to_position[/code] is -1, adds it at the end of the array.
+				Adds a physics layer to the TileSet at the given position [param to_position] in the array. If [param to_position] is -1, adds it at the end of the array.
 				Physics layers allow assigning collision polygons to atlas tiles.
 			</description>
 		</method>
@@ -67,7 +67,7 @@
 			<param index="0" name="source" type="TileSetSource" />
 			<param index="1" name="atlas_source_id_override" type="int" default="-1" />
 			<description>
-				Adds a [TileSetSource] to the TileSet. If [code]atlas_source_id_override[/code] is not -1, also set its source ID. Otherwise, a unique identifier is automatically generated.
+				Adds a [TileSetSource] to the TileSet. If [param atlas_source_id_override] is not -1, also set its source ID. Otherwise, a unique identifier is automatically generated.
 				The function returns the added source source ID or -1 if the source could not be added.
 			</description>
 		</method>
@@ -76,14 +76,14 @@
 			<param index="0" name="terrain_set" type="int" />
 			<param index="1" name="to_position" type="int" default="-1" />
 			<description>
-				Adds a new terrain to the given terrain set [code]terrain_set[/code] at the given position [code]to_position[/code] in the array. If [code]to_position[/code] is -1, adds it at the end of the array.
+				Adds a new terrain to the given terrain set [param terrain_set] at the given position [param to_position] in the array. If [param to_position] is -1, adds it at the end of the array.
 			</description>
 		</method>
 		<method name="add_terrain_set">
 			<return type="void" />
 			<param index="0" name="to_position" type="int" default="-1" />
 			<description>
-				Adds a new terrain set at the given position [code]to_position[/code] in the array. If [code]to_position[/code] is -1, adds it at the end of the array.
+				Adds a new terrain set at the given position [param to_position] in the array. If [param to_position] is -1, adds it at the end of the array.
 			</description>
 		</method>
 		<method name="cleanup_invalid_tile_proxies">
@@ -187,7 +187,7 @@
 			<return type="TileMapPattern" />
 			<param index="0" name="index" type="int" default="-1" />
 			<description>
-				Returns the [TileMapPattern] at the given [code]index[/code].
+				Returns the [TileMapPattern] at the given [param index].
 			</description>
 		</method>
 		<method name="get_patterns_count">
@@ -227,7 +227,7 @@
 			<return type="TileSetSource" />
 			<param index="0" name="source_id" type="int" />
 			<description>
-				Returns the [TileSetSource] with ID [code]source_id[/code].
+				Returns the [TileSetSource] with ID [param source_id].
 			</description>
 		</method>
 		<method name="get_source_count" qualifiers="const">
@@ -240,7 +240,7 @@
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the source ID for source with index [code]index[/code].
+				Returns the source ID for source with index [param index].
 			</description>
 		</method>
 		<method name="get_source_level_tile_proxy">
@@ -334,7 +334,7 @@
 			<param index="0" name="layer_index" type="int" />
 			<param index="1" name="to_position" type="int" />
 			<description>
-				Moves the custom data layer at index [code]layer_index[/code] to the given position [code]to_position[/code] in the array. Also updates the atlas tiles accordingly.
+				Moves the custom data layer at index [param layer_index] to the given position [param to_position] in the array. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="move_navigation_layer">
@@ -342,7 +342,7 @@
 			<param index="0" name="layer_index" type="int" />
 			<param index="1" name="to_position" type="int" />
 			<description>
-				Moves the navigation layer at index [code]layer_index[/code] to the given position [code]to_position[/code] in the array. Also updates the atlas tiles accordingly.
+				Moves the navigation layer at index [param layer_index] to the given position [param to_position] in the array. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="move_occlusion_layer">
@@ -350,7 +350,7 @@
 			<param index="0" name="layer_index" type="int" />
 			<param index="1" name="to_position" type="int" />
 			<description>
-				Moves the occlusion layer at index [code]layer_index[/code] to the given position [code]to_position[/code] in the array. Also updates the atlas tiles accordingly.
+				Moves the occlusion layer at index [param layer_index] to the given position [param to_position] in the array. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="move_physics_layer">
@@ -358,7 +358,7 @@
 			<param index="0" name="layer_index" type="int" />
 			<param index="1" name="to_position" type="int" />
 			<description>
-				Moves the physics layer at index [code]layer_index[/code] to the given position [code]to_position[/code] in the array. Also updates the atlas tiles accordingly.
+				Moves the physics layer at index [param layer_index] to the given position [param to_position] in the array. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="move_terrain">
@@ -367,7 +367,7 @@
 			<param index="1" name="terrain_index" type="int" />
 			<param index="2" name="to_position" type="int" />
 			<description>
-				Moves the terrain at index [code]terrain_index[/code] for terrain set [code]terrain_set[/code] to the given position [code]to_position[/code] in the array. Also updates the atlas tiles accordingly.
+				Moves the terrain at index [param terrain_index] for terrain set [param terrain_set] to the given position [param to_position] in the array. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="move_terrain_set">
@@ -375,7 +375,7 @@
 			<param index="0" name="terrain_set" type="int" />
 			<param index="1" name="to_position" type="int" />
 			<description>
-				Moves the terrain set at index [code]terrain_set[/code] to the given position [code]to_position[/code] in the array. Also updates the atlas tiles accordingly.
+				Moves the terrain set at index [param terrain_set] to the given position [param to_position] in the array. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="remove_alternative_level_tile_proxy">
@@ -399,21 +399,21 @@
 			<return type="void" />
 			<param index="0" name="layer_index" type="int" />
 			<description>
-				Removes the custom data layer at index [code]layer_index[/code]. Also updates the atlas tiles accordingly.
+				Removes the custom data layer at index [param layer_index]. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="remove_navigation_layer">
 			<return type="void" />
 			<param index="0" name="layer_index" type="int" />
 			<description>
-				Removes the navigation layer at index [code]layer_index[/code]. Also updates the atlas tiles accordingly.
+				Removes the navigation layer at index [param layer_index]. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="remove_occlusion_layer">
 			<return type="void" />
 			<param index="0" name="layer_index" type="int" />
 			<description>
-				Removes the occlusion layer at index [code]layer_index[/code]. Also updates the atlas tiles accordingly.
+				Removes the occlusion layer at index [param layer_index]. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="remove_pattern">
@@ -427,7 +427,7 @@
 			<return type="void" />
 			<param index="0" name="layer_index" type="int" />
 			<description>
-				Removes the physics layer at index [code]layer_index[/code]. Also updates the atlas tiles accordingly.
+				Removes the physics layer at index [param layer_index]. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="remove_source">
@@ -449,14 +449,14 @@
 			<param index="0" name="terrain_set" type="int" />
 			<param index="1" name="terrain_index" type="int" />
 			<description>
-				Removes the terrain at index [code]terrain_index[/code] in the given terrain set [code]terrain_set[/code]. Also updates the atlas tiles accordingly.
+				Removes the terrain at index [param terrain_index] in the given terrain set [param terrain_set]. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="remove_terrain_set">
 			<return type="void" />
 			<param index="0" name="terrain_set" type="int" />
 			<description>
-				Removes the terrain set at index [code]terrain_set[/code]. Also updates the atlas tiles accordingly.
+				Removes the terrain set at index [param terrain_set]. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
 		<method name="set_alternative_level_tile_proxy">

--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -20,8 +20,8 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="alternative_id_override" type="int" default="-1" />
 			<description>
-				Creates an alternative tile for the tile at coords [code]atlas_coords[/code]. If [code]alternative_id_override[/code] is -1, give it an automatically generated unique ID, or assigns it the given ID otherwise.
-				Returns the new alternative identifier, or -1 if the alternative could not be created with a provided [code]alternative_id_override[/code].
+				Creates an alternative tile for the tile at coordinates [param atlas_coords]. If [param alternative_id_override] is -1, give it an automatically generated unique ID, or assigns it the given ID otherwise.
+				Returns the new alternative identifier, or -1 if the alternative could not be created with a provided [param alternative_id_override].
 			</description>
 		</method>
 		<method name="create_tile">
@@ -29,7 +29,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="size" type="Vector2i" default="Vector2i(1, 1)" />
 			<description>
-				Creates a new tile at coords [code]atlas_coords[/code] with size [code]size[/code].
+				Creates a new tile at coordinates [param atlas_coords] with the given [param size].
 			</description>
 		</method>
 		<method name="get_atlas_grid_size" qualifiers="const">
@@ -56,7 +56,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="frame" type="int" />
 			<description>
-				Returns the region of the tile at coordinates [code]atlas_coords[/code] for frame [code]frame[/code] inside the texture returned by [method get_runtime_texture].
+				Returns the region of the tile at coordinates [param atlas_coords] for the given [param frame] inside the texture returned by [method get_runtime_texture].
 				[b]Note:[/b] If [member use_texture_padding] is [code]false[/code], returns the same as [method get_tile_texture_region].
 			</description>
 		</method>
@@ -64,7 +64,7 @@
 			<return type="int" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns how many columns the tile at [code]atlas_coords[/code] has in its animation layout.
+				Returns how many columns the tile at [param atlas_coords] has in its animation layout.
 			</description>
 		</method>
 		<method name="get_tile_animation_frame_duration" qualifiers="const">
@@ -72,42 +72,42 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="frame_index" type="int" />
 			<description>
-				Returns the animation frame duration of frame [code]frame_index[/code] for the tile at coordinates [code]atlas_coords[/code].
+				Returns the animation frame duration of frame [param frame_index] for the tile at coordinates [param atlas_coords].
 			</description>
 		</method>
 		<method name="get_tile_animation_frames_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns how many animation frames has the tile at coordinates [code]atlas_coords[/code].
+				Returns how many animation frames has the tile at coordinates [param atlas_coords].
 			</description>
 		</method>
 		<method name="get_tile_animation_separation" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns the separation (as in the atlas grid) between each frame of an animated tile at coordinates [code]atlas_coords[/code].
+				Returns the separation (as in the atlas grid) between each frame of an animated tile at coordinates [param atlas_coords].
 			</description>
 		</method>
 		<method name="get_tile_animation_speed" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns the animation speed of the tile at coordinates [code]atlas_coords[/code].
+				Returns the animation speed of the tile at coordinates [param atlas_coords].
 			</description>
 		</method>
 		<method name="get_tile_animation_total_duration" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns the sum of the sum of the frame durations of the tile at coordinates [code]atlas_coords[/code]. This value needs to be divided by the animation speed to get the actual animation loop duration.
+				Returns the sum of the sum of the frame durations of the tile at coordinates [param atlas_coords]. This value needs to be divided by the animation speed to get the actual animation loop duration.
 			</description>
 		</method>
 		<method name="get_tile_at_coords" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				If there is a tile covering the [code]atlas_coords[/code] coordinates, returns the top-left coordinates of the tile (thus its coordinate ID). Returns [code]Vector2i(-1, -1)[/code] otherwise.
+				If there is a tile covering the [param atlas_coords] coordinates, returns the top-left coordinates of the tile (thus its coordinate ID). Returns [code]Vector2i(-1, -1)[/code] otherwise.
 			</description>
 		</method>
 		<method name="get_tile_data" qualifiers="const">
@@ -122,7 +122,7 @@
 			<return type="Vector2i" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns the size of the tile (in the grid coordinates system) at coordinates [code]atlas_coords[/code].
+				Returns the size of the tile (in the grid coordinates system) at coordinates [param atlas_coords].
 			</description>
 		</method>
 		<method name="get_tile_texture_region" qualifiers="const">
@@ -130,7 +130,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="frame" type="int" default="0" />
 			<description>
-				Returns a tile's texture region in the atlas texture. For animated tiles, a [code]frame[/code] argument might be provided for the different frames of the animation.
+				Returns a tile's texture region in the atlas texture. For animated tiles, a [param frame] argument might be provided for the different frames of the animation.
 			</description>
 		</method>
 		<method name="get_tiles_to_be_removed_on_change">
@@ -140,7 +140,7 @@
 			<param index="2" name="separation" type="Vector2i" />
 			<param index="3" name="texture_region_size" type="Vector2i" />
 			<description>
-				Returns an array of tiles coordinates ID that will be automatically removed when modifying one or several of those properties: [code]texture[/code], [code]margins[/code], [code]separation[/code] or [code]texture_region_size[/code]. This can be used to undo changes that would have caused tiles data loss.
+				Returns an array of tiles coordinates ID that will be automatically removed when modifying one or several of those properties: [param texture], [param margins], [param separation] or [param texture_region_size]. This can be used to undo changes that would have caused tiles data loss.
 			</description>
 		</method>
 		<method name="has_room_for_tile" qualifiers="const">
@@ -152,7 +152,7 @@
 			<param index="4" name="frames_count" type="int" />
 			<param index="5" name="ignored_tile" type="Vector2i" default="Vector2i(-1, -1)" />
 			<description>
-				Returns whether there is enough room in an atlas to create/modify a tile with the given properties. If [code]ignored_tile[/code] is provided, act as is the given tile was not present in the atlas. This may be used when you want to modify a tile's properties.
+				Returns whether there is enough room in an atlas to create/modify a tile with the given properties. If [param ignored_tile] is provided, act as is the given tile was not present in the atlas. This may be used when you want to modify a tile's properties.
 			</description>
 		</method>
 		<method name="move_tile_in_atlas">
@@ -161,8 +161,8 @@
 			<param index="1" name="new_atlas_coords" type="Vector2i" default="Vector2i(-1, -1)" />
 			<param index="2" name="new_size" type="Vector2i" default="Vector2i(-1, -1)" />
 			<description>
-				Move the tile and its alternatives at the [code]atlas_coords[/code] coordinates to the [code]new_atlas_coords[/code] coordinates with the [code]new_size[/code] size. This functions will fail if a tile is already present in the given area.
-				If [code]new_atlas_coords[/code] is [code]Vector2i(-1, -1)[/code], keeps the tile's coordinates. If [code]new_size[/code] is [code]Vector2i(-1, -1)[/code], keeps the tile's size.
+				Move the tile and its alternatives at the [param atlas_coords] coordinates to the [param new_atlas_coords] coordinates with the [param new_size] size. This functions will fail if a tile is already present in the given area.
+				If [param new_atlas_coords] is [code]Vector2i(-1, -1)[/code], keeps the tile's coordinates. If [param new_size] is [code]Vector2i(-1, -1)[/code], keeps the tile's size.
 				To avoid an error, first check if a move is possible using [method has_room_for_tile].
 			</description>
 		</method>
@@ -171,15 +171,15 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="alternative_tile" type="int" />
 			<description>
-				Remove a tile's alternative with alternative ID [code]alternative_tile[/code].
-				Calling this function with [code]alternative_tile[/code] equals to 0 will fail, as the base tile alternative cannot be removed.
+				Remove a tile's alternative with alternative ID [param alternative_tile].
+				Calling this function with [param alternative_tile] equals to 0 will fail, as the base tile alternative cannot be removed.
 			</description>
 		</method>
 		<method name="remove_tile">
 			<return type="void" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Remove a tile and its alternative at coordinates [code]atlas_coords[/code].
+				Remove a tile and its alternative at coordinates [param atlas_coords].
 			</description>
 		</method>
 		<method name="set_alternative_tile_id">
@@ -188,8 +188,8 @@
 			<param index="1" name="alternative_tile" type="int" />
 			<param index="2" name="new_id" type="int" />
 			<description>
-				Change a tile's alternative ID from [code]alternative_tile[/code] to [code]new_id[/code].
-				Calling this function with [code]alternative_id[/code] equals to 0 will fail, as the base tile alternative cannot be moved.
+				Change a tile's alternative ID from [param alternative_tile] to [param new_id].
+				Calling this function with [param new_id] of 0 will fail, as the base tile alternative cannot be moved.
 			</description>
 		</method>
 		<method name="set_tile_animation_columns">
@@ -197,7 +197,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="frame_columns" type="int" />
 			<description>
-				Sets the number of columns in the animation layout of the tile at coordinates [code]atlas_coords[/code]. If set to 0, then the different frames of the animation are laid out as a single horizontal line in the atlas.
+				Sets the number of columns in the animation layout of the tile at coordinates [param atlas_coords]. If set to 0, then the different frames of the animation are laid out as a single horizontal line in the atlas.
 			</description>
 		</method>
 		<method name="set_tile_animation_frame_duration">
@@ -206,7 +206,7 @@
 			<param index="1" name="frame_index" type="int" />
 			<param index="2" name="duration" type="float" />
 			<description>
-				Sets the animation frame duration of frame [code]frame_index[/code] for the tile at coordinates [code]atlas_coords[/code].
+				Sets the animation frame [param duration] of frame [param frame_index] for the tile at coordinates [param atlas_coords].
 			</description>
 		</method>
 		<method name="set_tile_animation_frames_count">
@@ -214,7 +214,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="frames_count" type="int" />
 			<description>
-				Sets how many animation frames the tile at coordinates [code]atlas_coords[/code] has.
+				Sets how many animation frames the tile at coordinates [param atlas_coords] has.
 			</description>
 		</method>
 		<method name="set_tile_animation_separation">
@@ -222,7 +222,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="separation" type="Vector2i" />
 			<description>
-				Sets the margin (in grid tiles) between each tile in the animation layout of the tile at coordinates [code]atlas_coords[/code] has.
+				Sets the margin (in grid tiles) between each tile in the animation layout of the tile at coordinates [param atlas_coords] has.
 			</description>
 		</method>
 		<method name="set_tile_animation_speed">
@@ -230,7 +230,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="speed" type="float" />
 			<description>
-				Sets the animation speed of the tile at coordinates [code]atlas_coords[/code] has.
+				Sets the animation speed of the tile at coordinates [param atlas_coords] has.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TileSetScenesCollectionSource.xml
+++ b/doc/classes/TileSetScenesCollectionSource.xml
@@ -29,21 +29,21 @@
 			<return type="bool" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns whether the scene tile with id [code]id[/code] displays a placeholder in the editor.
+				Returns whether the scene tile with [param id] displays a placeholder in the editor.
 			</description>
 		</method>
 		<method name="get_scene_tile_id">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the scene tile ID of the scene tile at index [code]index[/code].
+				Returns the scene tile ID of the scene tile at [param index].
 			</description>
 		</method>
 		<method name="get_scene_tile_scene" qualifiers="const">
 			<return type="PackedScene" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns the [PackedScene] resource of scene tile with id [code]id[/code].
+				Returns the [PackedScene] resource of scene tile with [param id].
 			</description>
 		</method>
 		<method name="get_scene_tiles_count">
@@ -56,14 +56,14 @@
 			<return type="bool" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns whether this TileSet source has a scene tile with id [code]id[/code].
+				Returns whether this TileSet source has a scene tile with [param id].
 			</description>
 		</method>
 		<method name="remove_scene_tile">
 			<return type="void" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Remove the scene tile with id [code]id[/code].
+				Remove the scene tile with [param id].
 			</description>
 		</method>
 		<method name="set_scene_tile_display_placeholder">
@@ -71,7 +71,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="display_placeholder" type="bool" />
 			<description>
-				Sets whether or not the scene tile with id [code]id[/code] should display a placeholder in the editor. This might be useful for scenes that are not visible.
+				Sets whether or not the scene tile with [param id] should display a placeholder in the editor. This might be useful for scenes that are not visible.
 			</description>
 		</method>
 		<method name="set_scene_tile_id">
@@ -79,7 +79,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="new_id" type="int" />
 			<description>
-				Changes a scene tile's ID from [code]id[/code] to [code]new_id[/code]. This will fail if there is already a tile with a ID equal to [code]new_id[/code].
+				Changes a scene tile's ID from [param id] to [param new_id]. This will fail if there is already a tile with a ID equal to [param new_id].
 			</description>
 		</method>
 		<method name="set_scene_tile_scene">
@@ -87,7 +87,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="packed_scene" type="PackedScene" />
 			<description>
-				Assigns a [PackedScene] resource to the scene tile with id [code]id[/code]. This will fail if the scene does not extend CanvasItem, as positioning properties are needed to place the scene on the TileMap.
+				Assigns a [PackedScene] resource to the scene tile with [param id]. This will fail if the scene does not extend CanvasItem, as positioning properties are needed to place the scene on the TileMap.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TileSetSource.xml
+++ b/doc/classes/TileSetSource.xml
@@ -18,14 +18,14 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="index" type="int" />
 			<description>
-				Returns the alternative ID for the tile with coordinates ID [code]atlas_coords[/code] at index [code]index[/code].
+				Returns the alternative ID for the tile with coordinates ID [param atlas_coords] at index [param index].
 			</description>
 		</method>
 		<method name="get_alternative_tiles_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns the number of alternatives tiles for the coordinates ID [code]atlas_coords[/code].
+				Returns the number of alternatives tiles for the coordinates ID [param atlas_coords].
 				For [TileSetAtlasSource], this always return at least 1, as the base tile with ID 0 is always part of the alternatives list.
 				Returns -1 if there is not tile at the given coords.
 			</description>
@@ -34,7 +34,7 @@
 			<return type="Vector2i" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the tile coordinates ID of the tile with index [code]index[/code].
+				Returns the tile coordinates ID of the tile with index [param index].
 			</description>
 		</method>
 		<method name="get_tiles_count" qualifiers="const">
@@ -48,14 +48,14 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="alternative_tile" type="int" />
 			<description>
-				Returns if the base tile at coordinates [code]atlas_coords[/code] has an alternative with ID [code]alternative_tile[/code].
+				Returns if the base tile at coordinates [param atlas_coords] has an alternative with ID [param alternative_tile].
 			</description>
 		</method>
 		<method name="has_tile" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns if this atlas has a tile with coordinates ID [code]atlas_coordinates[/code].
+				Returns if this atlas has a tile with coordinates ID [param atlas_coords].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Time.xml
+++ b/doc/classes/Time.xml
@@ -18,7 +18,7 @@
 			<param index="0" name="utc" type="bool" default="false" />
 			<description>
 				Returns the current date as a dictionary of keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]weekday[/code], and [code]dst[/code] (Daylight Savings Time).
-				The returned values are in the system's local time when [code]utc[/code] is false, otherwise they are in UTC.
+				The returned values are in the system's local time when [param utc] is [code]false[/code], otherwise they are in UTC.
 			</description>
 		</method>
 		<method name="get_date_dict_from_unix_time" qualifiers="const">
@@ -33,7 +33,7 @@
 			<param index="0" name="utc" type="bool" default="false" />
 			<description>
 				Returns the current date as an ISO 8601 date string (YYYY-MM-DD).
-				The returned values are in the system's local time when [code]utc[/code] is false, otherwise they are in UTC.
+				The returned values are in the system's local time when [param utc] is [code]false[/code], otherwise they are in UTC.
 			</description>
 		</method>
 		<method name="get_date_string_from_unix_time" qualifiers="const">
@@ -49,7 +49,7 @@
 			<param index="1" name="weekday" type="bool" />
 			<description>
 				Converts the given ISO 8601 date and time string (YYYY-MM-DDTHH:MM:SS) to a dictionary of keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]weekday[/code], [code]hour[/code], [code]minute[/code], and [code]second[/code].
-				If [code]weekday[/code] is false, then the [code]weekday[/code] entry is excluded (the calculation is relatively expensive).
+				If [param weekday] is [code]false[/code], then the [code]weekday[/code] entry is excluded (the calculation is relatively expensive).
 				[b]Note:[/b] Any decimal fraction in the time string will be ignored silently.
 			</description>
 		</method>
@@ -76,7 +76,7 @@
 				Converts the given dictionary of keys to an ISO 8601 date and time string (YYYY-MM-DDTHH:MM:SS).
 				The given dictionary can be populated with the following keys: [code]year[/code], [code]month[/code], [code]day[/code], [code]hour[/code], [code]minute[/code], and [code]second[/code]. Any other entries (including [code]dst[/code]) are ignored.
 				If the dictionary is empty, [code]0[/code] is returned. If some keys are omitted, they default to the equivalent values for the Unix epoch timestamp 0 (1970-01-01 at 00:00:00).
-				If [code]use_space[/code] is true, use a space instead of the letter T in the middle.
+				If [param use_space] is [code]true[/code], the date and time bits are separated by an empty space character instead of the letter T.
 			</description>
 		</method>
 		<method name="get_datetime_string_from_system" qualifiers="const">
@@ -85,8 +85,8 @@
 			<param index="1" name="use_space" type="bool" default="false" />
 			<description>
 				Returns the current date and time as an ISO 8601 date and time string (YYYY-MM-DDTHH:MM:SS).
-				The returned values are in the system's local time when [code]utc[/code] is false, otherwise they are in UTC.
-				If [code]use_space[/code] is true, use a space instead of the letter T in the middle.
+				The returned values are in the system's local time when [param utc] is [code]false[/code], otherwise they are in UTC.
+				If [param use_space] is [code]true[/code], the date and time bits are separated by an empty space character instead of the letter T.
 			</description>
 		</method>
 		<method name="get_datetime_string_from_unix_time" qualifiers="const">
@@ -95,7 +95,7 @@
 			<param index="1" name="use_space" type="bool" default="false" />
 			<description>
 				Converts the given Unix timestamp to an ISO 8601 date and time string (YYYY-MM-DDTHH:MM:SS).
-				If [code]use_space[/code] is true, use a space instead of the letter T in the middle.
+				If [param use_space] is [code]true[/code], the date and time bits are separated by an empty space character instead of the letter T.
 			</description>
 		</method>
 		<method name="get_offset_string_from_offset_minutes" qualifiers="const">
@@ -124,7 +124,7 @@
 			<param index="0" name="utc" type="bool" default="false" />
 			<description>
 				Returns the current time as a dictionary of keys: [code]hour[/code], [code]minute[/code], and [code]second[/code].
-				The returned values are in the system's local time when [code]utc[/code] is false, otherwise they are in UTC.
+				The returned values are in the system's local time when [param utc] is [code]false[/code], otherwise they are in UTC.
 			</description>
 		</method>
 		<method name="get_time_dict_from_unix_time" qualifiers="const">
@@ -139,7 +139,7 @@
 			<param index="0" name="utc" type="bool" default="false" />
 			<description>
 				Returns the current time as an ISO 8601 time string (HH:MM:SS).
-				The returned values are in the system's local time when [code]utc[/code] is false, otherwise they are in UTC.
+				The returned values are in the system's local time when [param utc] is [code]false[/code], otherwise they are in UTC.
 			</description>
 		</method>
 		<method name="get_time_string_from_unix_time" qualifiers="const">

--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -21,7 +21,7 @@
 			<return type="void" />
 			<param index="0" name="time_sec" type="float" default="-1" />
 			<description>
-				Starts the timer. Sets [member wait_time] to [code]time_sec[/code] if [code]time_sec &gt; 0[/code]. This also resets the remaining time to [member wait_time].
+				Starts the timer. Sets [member wait_time] to [param time_sec] if [code]time_sec &gt; 0[/code]. This also resets the remaining time to [member wait_time].
 				[b]Note:[/b] This method will not resume a paused timer. See [member paused].
 			</description>
 		</method>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -107,7 +107,7 @@
 			<param index="0" name="xform" type="Transform2D" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns a transform interpolated between this transform and another by a given [code]weight[/code] (on the range of 0.0 to 1.0).
+				Returns a transform interpolated between this transform and another by a given [param weight] (on the range of 0.0 to 1.0).
 			</description>
 		</method>
 		<method name="inverse" qualifiers="const">
@@ -127,7 +127,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="target" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Returns a copy of the transform rotated such that it's rotation on the X-axis points towards the [code]target[/code] position.
+				Returns a copy of the transform rotated such that it's rotation on the X-axis points towards the [param target] position.
 				Operations take place in global space.
 			</description>
 		</method>
@@ -141,7 +141,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Returns a copy of the transform rotated by the given [code]angle[/code] (in radians).
+				Returns a copy of the transform rotated by the given [param angle] (in radians).
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding rotation transform [code]R[/code] from the left, i.e., [code]R * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
@@ -151,7 +151,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Returns a copy of the transform rotated by the given [code]angle[/code] (in radians).
+				Returns a copy of the transform rotated by the given [param angle] (in radians).
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding rotation transform [code]R[/code] from the right, i.e., [code]X * R[/code].
 				This can be seen as transforming with respect to the local frame.
@@ -161,7 +161,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="scale" type="Vector2" />
 			<description>
-				Returns a copy of the transform scaled by the given [code]scale[/code] factor.
+				Returns a copy of the transform scaled by the given [param scale] factor.
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding scaling transform [code]S[/code] from the left, i.e., [code]S * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
@@ -171,7 +171,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="scale" type="Vector2" />
 			<description>
-				Returns a copy of the transform scaled by the given [code]scale[/code] factor.
+				Returns a copy of the transform scaled by the given [param scale] factor.
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding scaling transform [code]S[/code] from the right, i.e., [code]X * S[/code].
 				This can be seen as transforming with respect to the local frame.
@@ -203,7 +203,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="offset" type="Vector2" />
 			<description>
-				Returns a copy of the transform translated by the given [code]offset[/code].
+				Returns a copy of the transform translated by the given [param offset].
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding translation transform [code]T[/code] from the left, i.e., [code]T * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
@@ -213,7 +213,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="offset" type="Vector2" />
 			<description>
-				Returns a copy of the transform translated by the given [code]offset[/code].
+				Returns a copy of the transform translated by the given [param offset].
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding translation transform [code]T[/code] from the right, i.e., [code]X * T[/code].
 				This can be seen as transforming with respect to the local frame.

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -66,7 +66,7 @@
 			<param index="0" name="xform" type="Transform3D" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns a transform interpolated between this transform and another by a given [code]weight[/code] (on the range of 0.0 to 1.0).
+				Returns a transform interpolated between this transform and another by a given [param weight] (on the range of 0.0 to 1.0).
 			</description>
 		</method>
 		<method name="inverse" qualifiers="const">
@@ -87,8 +87,8 @@
 			<param index="0" name="target" type="Vector3" />
 			<param index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
 			<description>
-				Returns a copy of the transform rotated such that the forward axis (-Z) points towards the [code]target[/code] position.
-				The up axis (+Y) points as close to the [code]up[/code] vector as possible while staying perpendicular to the forward axis. The resulting transform is orthonormalized. The existing rotation, scale, and skew information from the original transform is discarded. The [code]target[/code] and [code]up[/code] vectors cannot be zero, cannot be parallel to each other, and are defined in global/parent space.
+				Returns a copy of the transform rotated such that the forward axis (-Z) points towards the [param target] position.
+				The up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the forward axis. The resulting transform is orthonormalized. The existing rotation, scale, and skew information from the original transform is discarded. The [param target] and [param up] vectors cannot be zero, cannot be parallel to each other, and are defined in global/parent space.
 			</description>
 		</method>
 		<method name="orthonormalized" qualifiers="const">
@@ -102,8 +102,8 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Returns a copy of the transform rotated around the given [code]axis[/code] by the given [code]angle[/code] (in radians).
-				The [code]axis[/code] must be a normalized vector.
+				Returns a copy of the transform rotated around the given [param axis] by the given [param angle] (in radians).
+				The [param axis] must be a normalized vector.
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding rotation transform [code]R[/code] from the left, i.e., [code]R * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
@@ -114,8 +114,8 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Returns a copy of the transform rotated around the given [code]axis[/code] by the given [code]angle[/code] (in radians).
-				The [code]axis[/code] must be a normalized vector.
+				Returns a copy of the transform rotated around the given [param axis] by the given [param angle] (in radians).
+				The [param axis] must be a normalized vector.
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding rotation transform [code]R[/code] from the right, i.e., [code]X * R[/code].
 				This can be seen as transforming with respect to the local frame.
@@ -125,7 +125,7 @@
 			<return type="Transform3D" />
 			<param index="0" name="scale" type="Vector3" />
 			<description>
-				Returns a copy of the transform scaled by the given [code]scale[/code] factor.
+				Returns a copy of the transform scaled by the given [param scale] factor.
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding scaling transform [code]S[/code] from the left, i.e., [code]S * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
@@ -135,7 +135,7 @@
 			<return type="Transform3D" />
 			<param index="0" name="scale" type="Vector3" />
 			<description>
-				Returns a copy of the transform scaled by the given [code]scale[/code] factor.
+				Returns a copy of the transform scaled by the given [param scale] factor.
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding scaling transform [code]S[/code] from the right, i.e., [code]X * S[/code].
 				This can be seen as transforming with respect to the local frame.
@@ -146,14 +146,14 @@
 			<param index="0" name="xform" type="Transform3D" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns a transform spherically interpolated between this transform and another by a given [code]weight[/code] (on the range of 0.0 to 1.0).
+				Returns a transform spherically interpolated between this transform and another by a given [param weight] (on the range of 0.0 to 1.0).
 			</description>
 		</method>
 		<method name="translated" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="offset" type="Vector3" />
 			<description>
-				Returns a copy of the transform translated by the given [code]offset[/code].
+				Returns a copy of the transform translated by the given [param offset].
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding translation transform [code]T[/code] from the left, i.e., [code]T * X[/code].
 				This can be seen as transforming with respect to the global/parent frame.
@@ -163,7 +163,7 @@
 			<return type="Transform3D" />
 			<param index="0" name="offset" type="Vector3" />
 			<description>
-				Returns a copy of the transform translated by the given [code]offset[/code].
+				Returns a copy of the transform translated by the given [param offset].
 				This method is an optimized version of multiplying the given transform [code]X[/code]
 				with a corresponding translation transform [code]T[/code] from the right, i.e., [code]X * T[/code].
 				This can be seen as transforming with respect to the local frame.

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -85,7 +85,7 @@
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Returns a message's translation involving plurals.
-				The number [code]n[/code] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
+				The number [param n] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -54,14 +54,14 @@
 			<return type="String" />
 			<param index="0" name="country" type="String" />
 			<description>
-				Returns readable country name for the [code]country[/code] code.
+				Returns readable country name for the [param country] code.
 			</description>
 		</method>
 		<method name="get_language_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="language" type="String" />
 			<description>
-				Returns readable language name for the [code]language[/code] code.
+				Returns readable language name for the [param language] code.
 			</description>
 		</method>
 		<method name="get_loaded_locales" qualifiers="const">
@@ -88,7 +88,7 @@
 			<return type="String" />
 			<param index="0" name="script" type="String" />
 			<description>
-				Returns readable script name for the [code]script[/code] code.
+				Returns readable script name for the [param script] code.
 			</description>
 		</method>
 		<method name="get_tool_locale">
@@ -102,15 +102,15 @@
 			<return type="Translation" />
 			<param index="0" name="locale" type="String" />
 			<description>
-				Returns the [Translation] instance based on the [code]locale[/code] passed in.
-				It will return [code]null[/code] if there is no [Translation] instance that matches the [code]locale[/code].
+				Returns the [Translation] instance based on the [param locale] passed in.
+				It will return [code]null[/code] if there is no [Translation] instance that matches the [param locale].
 			</description>
 		</method>
 		<method name="pseudolocalize" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="message" type="StringName" />
 			<description>
-				Returns the pseudolocalized string based on the [code]p_message[/code] passed in.
+				Returns the pseudolocalized string based on the [param message] passed in.
 			</description>
 		</method>
 		<method name="reload_pseudolocalization">
@@ -130,7 +130,7 @@
 			<return type="void" />
 			<param index="0" name="locale" type="String" />
 			<description>
-				Sets the locale of the project. The [code]locale[/code] string will be standardized to match known locales (e.g. [code]en-US[/code] would be matched to [code]en_US[/code]).
+				Sets the locale of the project. The [param locale] string will be standardized to match known locales (e.g. [code]en-US[/code] would be matched to [code]en_US[/code]).
 				If translations have been loaded beforehand for the new locale, they will be applied.
 			</description>
 		</method>
@@ -138,7 +138,7 @@
 			<return type="String" />
 			<param index="0" name="locale" type="String" />
 			<description>
-				Returns [code]locale[/code] string standardized to match known locales (e.g. [code]en-US[/code] would be matched to [code]en_US[/code]).
+				Returns [param locale] string standardized to match known locales (e.g. [code]en-US[/code] would be matched to [code]en_US[/code]).
 			</description>
 		</method>
 		<method name="translate" qualifiers="const">
@@ -157,7 +157,7 @@
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Returns the current locale's translation for the given message (key), plural_message and context.
-				The number [code]n[/code] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
+				The number [param n] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -47,9 +47,9 @@
 			<param index="0" name="parent" type="TreeItem" default="null" />
 			<param index="1" name="idx" type="int" default="-1" />
 			<description>
-				Creates an item in the tree and adds it as a child of [code]parent[/code], which can be either a valid [TreeItem] or [code]null[/code].
-				If [code]parent[/code] is [code]null[/code], the root item will be the parent, or the new item will be the root itself if the tree is empty.
-				The new item will be the [code]idx[/code]th child of parent, or it will be the last child if there are not enough siblings.
+				Creates an item in the tree and adds it as a child of [param parent], which can be either a valid [TreeItem] or [code]null[/code].
+				If [param parent] is [code]null[/code], the root item will be the parent, or the new item will be the root itself if the tree is empty.
+				The new item will be the [param idx]th child of parent, or it will be the last child if there are not enough siblings.
 			</description>
 		</method>
 		<method name="edit_selected">
@@ -70,14 +70,14 @@
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Returns the button id at [code]position[/code], or -1 if no button is there.
+				Returns the button id at [param position], or -1 if no button is there.
 			</description>
 		</method>
 		<method name="get_column_at_position" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Returns the column index at [code]position[/code], or -1 if no item is there.
+				Returns the column index at [param position], or -1 if no item is there.
 			</description>
 		</method>
 		<method name="get_column_expand_ratio" qualifiers="const">
@@ -124,7 +124,7 @@
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Returns the drop section at [code]position[/code], or -100 if no item is there.
+				Returns the drop section at [param position], or -100 if no item is there.
 				Values -1, 0, or 1 will be returned for the "above item", "on item", and "below item" drop sections, respectively. See [enum DropModeFlags] for a description of each drop section.
 				To get the item which the returned drop section is relative to, use [method get_item_at_position].
 			</description>
@@ -167,7 +167,7 @@
 			<param index="1" name="column" type="int" default="-1" />
 			<param index="2" name="button_index" type="int" default="-1" />
 			<description>
-				Returns the rectangle area for the specified [TreeItem]. If [code]column[/code] is specified, only get the position and size of that column, otherwise get the rectangle containing all columns. If a button index is specified, the rectangle of that button will be returned.
+				Returns the rectangle area for the specified [TreeItem]. If [param column] is specified, only get the position and size of that column, otherwise get the rectangle containing all columns. If a button index is specified, the rectangle of that button will be returned.
 			</description>
 		</method>
 		<method name="get_item_at_position" qualifiers="const">
@@ -182,7 +182,7 @@
 			<param index="0" name="from" type="TreeItem" />
 			<description>
 				Returns the next selected [TreeItem] after the given one, or [code]null[/code] if the end is reached.
-				If [code]from[/code] is [code]null[/code], this returns the first selected item.
+				If [param from] is [code]null[/code], this returns the first selected item.
 			</description>
 		</method>
 		<method name="get_pressed_button" qualifiers="const">

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -18,14 +18,14 @@
 			<param index="3" name="disabled" type="bool" default="false" />
 			<param index="4" name="tooltip" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a button with [Texture2D] [code]button[/code] at column [code]column[/code]. The [code]id[/code] is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately before this method. Optionally, the button can be [code]disabled[/code] and have a [code]tooltip[/code].
+				Adds a button with [Texture2D] [param button] at column [param column]. The [param id] is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately before this method. Optionally, the button can be [param disabled] and have a [param tooltip].
 			</description>
 		</method>
 		<method name="call_recursive" qualifiers="vararg">
 			<return type="void" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Calls the [code]method[/code] on the actual TreeItem and its children recursively. Pass parameters as a comma separated list.
+				Calls the [param method] on the actual TreeItem and its children recursively. Pass parameters as a comma separated list.
 			</description>
 		</method>
 		<method name="clear_custom_bg_color">
@@ -47,7 +47,7 @@
 			<param index="0" name="idx" type="int" default="-1" />
 			<description>
 				Creates an item and adds it as a child.
-				The new item will be inserted as position [code]idx[/code] (the default value [code]-1[/code] means the last position), or it will be the last child if [code]idx[/code] is higher than the child count.
+				The new item will be inserted as position [param idx] (the default value [code]-1[/code] means the last position), or it will be the last child if [param idx] is higher than the child count.
 			</description>
 		</method>
 		<method name="deselect">
@@ -62,7 +62,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="button_idx" type="int" />
 			<description>
-				Removes the button at index [code]button_idx[/code] in column [code]column[/code].
+				Removes the button at index [param button_idx] in column [param column].
 			</description>
 		</method>
 		<method name="get_button" qualifiers="const">
@@ -70,7 +70,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="button_idx" type="int" />
 			<description>
-				Returns the [Texture2D] of the button at index [code]button_idx[/code] in column [code]column[/code].
+				Returns the [Texture2D] of the button at index [param button_idx] in column [param column].
 			</description>
 		</method>
 		<method name="get_button_by_id" qualifiers="const">
@@ -78,14 +78,14 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="id" type="int" />
 			<description>
-				Returns the button index if there is a button with id [code]id[/code] in column [code]column[/code], otherwise returns -1.
+				Returns the button index if there is a button with id [param id] in column [param column], otherwise returns -1.
 			</description>
 		</method>
 		<method name="get_button_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns the number of buttons in column [code]column[/code].
+				Returns the number of buttons in column [param column].
 			</description>
 		</method>
 		<method name="get_button_id" qualifiers="const">
@@ -93,7 +93,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="button_idx" type="int" />
 			<description>
-				Returns the id for the button at index [code]button_idx[/code] in column [code]column[/code].
+				Returns the id for the button at index [param button_idx] in column [param column].
 			</description>
 		</method>
 		<method name="get_button_tooltip" qualifiers="const">
@@ -101,7 +101,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="button_idx" type="int" />
 			<description>
-				Returns the tooltip string for the button at index [code]button_idx[/code] in column [code]column[/code].
+				Returns the tooltip string for the button at index [param button_idx] in column [param column].
 			</description>
 		</method>
 		<method name="get_cell_mode" qualifiers="const">
@@ -135,28 +135,28 @@
 			<return type="Color" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns the custom background color of column [code]column[/code].
+				Returns the custom background color of column [param column].
 			</description>
 		</method>
 		<method name="get_custom_color" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns the custom color of column [code]column[/code].
+				Returns the custom color of column [param column].
 			</description>
 		</method>
 		<method name="get_custom_font" qualifiers="const">
 			<return type="Font" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns custom font used to draw text in the column [code]column[/code].
+				Returns custom font used to draw text in the column [param column].
 			</description>
 		</method>
 		<method name="get_custom_font_size" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns custom font size used to draw text in the column [code]column[/code].
+				Returns custom font size used to draw text in the column [param column].
 			</description>
 		</method>
 		<method name="get_expand_right" qualifiers="const">
@@ -231,7 +231,7 @@
 			<param index="0" name="wrap" type="bool" default="false" />
 			<description>
 				Returns the next visible sibling TreeItem in the tree or a null object if there is none.
-				If [code]wrap[/code] is enabled, the method will wrap around to the first visible element in the tree when called on the last visible element, otherwise it returns [code]null[/code].
+				If [param wrap] is enabled, the method will wrap around to the first visible element in the tree when called on the last visible element, otherwise it returns [code]null[/code].
 			</description>
 		</method>
 		<method name="get_parent" qualifiers="const">
@@ -251,7 +251,7 @@
 			<param index="0" name="wrap" type="bool" default="false" />
 			<description>
 				Returns the previous visible sibling TreeItem in the tree or a null object if there is none.
-				If [code]wrap[/code] is enabled, the method will wrap around to the last visible element in the tree when called on the first visible element, otherwise it returns [code]null[/code].
+				If [param wrap] is enabled, the method will wrap around to the last visible element in the tree when called on the first visible element, otherwise it returns [code]null[/code].
 			</description>
 		</method>
 		<method name="get_range" qualifiers="const">
@@ -326,14 +326,14 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="button_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the button at index [code]button_idx[/code] for the given column is disabled.
+				Returns [code]true[/code] if the button at index [param button_idx] for the given [param column] is disabled.
 			</description>
 		</method>
 		<method name="is_checked" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns [code]true[/code] if the given column is checked.
+				Returns [code]true[/code] if the given [param column] is checked.
 			</description>
 		</method>
 		<method name="is_custom_set_as_button" qualifiers="const">
@@ -346,35 +346,35 @@
 			<return type="bool" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns [code]true[/code] if column [code]column[/code] is editable.
+				Returns [code]true[/code] if the given [param column] is editable.
 			</description>
 		</method>
 		<method name="is_indeterminate" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns [code]true[/code] if the given column is indeterminate.
+				Returns [code]true[/code] if the given [param column] is indeterminate.
 			</description>
 		</method>
 		<method name="is_selectable" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns [code]true[/code] if column [code]column[/code] is selectable.
+				Returns [code]true[/code] if the given [param column] is selectable.
 			</description>
 		</method>
 		<method name="is_selected">
 			<return type="bool" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns [code]true[/code] if column [code]column[/code] is selected.
+				Returns [code]true[/code] if the given [param column] is selected.
 			</description>
 		</method>
 		<method name="move_after">
 			<return type="void" />
 			<param index="0" name="item" type="TreeItem" />
 			<description>
-				Moves this TreeItem right after the given [code]item[/code].
+				Moves this TreeItem right after the given [param item].
 				[b]Note:[/b] You can't move to the root or move the root.
 			</description>
 		</method>
@@ -382,7 +382,7 @@
 			<return type="void" />
 			<param index="0" name="item" type="TreeItem" />
 			<description>
-				Moves this TreeItem right before the given [code]item[/code].
+				Moves this TreeItem right before the given [param item].
 				[b]Note:[/b] You can't move to the root or move the root.
 			</description>
 		</method>
@@ -391,7 +391,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="emit_signal" type="bool" default="true" />
 			<description>
-				Propagates this item's checked status to its children and parents for the given [code]column[/code]. It is possible to process the items affected by this method call by connecting to [signal Tree.check_propagated_to_item]. The order that the items affected will be processed is as follows: the item invoking this method, children of that item, and finally parents of that item. If [code]emit_signal[/code] is [code]false[/code], then [signal Tree.check_propagated_to_item] will not be emitted.
+				Propagates this item's checked status to its children and parents for the given [param column]. It is possible to process the items affected by this method call by connecting to [signal Tree.check_propagated_to_item]. The order that the items affected will be processed is as follows: the item invoking this method, children of that item, and finally parents of that item. If [param emit_signal] is [code]false[/code], then [signal Tree.check_propagated_to_item] will not be emitted.
 			</description>
 		</method>
 		<method name="remove_child">
@@ -405,7 +405,7 @@
 			<return type="void" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Selects the column [code]column[/code].
+				Selects the given [param column].
 			</description>
 		</method>
 		<method name="set_button">
@@ -414,7 +414,7 @@
 			<param index="1" name="button_idx" type="int" />
 			<param index="2" name="button" type="Texture2D" />
 			<description>
-				Sets the given column's button [Texture2D] at index [code]button_idx[/code] to [code]button[/code].
+				Sets the given column's button [Texture2D] at index [param button_idx] to [param button].
 			</description>
 		</method>
 		<method name="set_button_disabled">
@@ -423,7 +423,7 @@
 			<param index="1" name="button_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
-				If [code]true[/code], disables the button at index [code]button_idx[/code] in column [code]column[/code].
+				If [code]true[/code], disables the button at index [param button_idx] in the given [param column].
 			</description>
 		</method>
 		<method name="set_cell_mode">
@@ -431,7 +431,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="mode" type="int" enum="TreeItem.TreeCellMode" />
 			<description>
-				Sets the given column's cell mode to [code]mode[/code]. See [enum TreeCellMode] constants.
+				Sets the given column's cell mode to [param mode]. See [enum TreeCellMode] constants.
 			</description>
 		</method>
 		<method name="set_checked">
@@ -439,7 +439,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="checked" type="bool" />
 			<description>
-				If [code]true[/code], the column [code]column[/code] is checked. Clears column's indeterminate status.
+				If [code]true[/code], the given [param column] is checked. Clears column's indeterminate status.
 			</description>
 		</method>
 		<method name="set_custom_as_button">
@@ -472,8 +472,8 @@
 			<param index="1" name="object" type="Object" />
 			<param index="2" name="callback" type="StringName" />
 			<description>
-				Sets the given column's custom draw callback to [code]callback[/code] method on [code]object[/code].
-				The [code]callback[/code] should accept two arguments: the [TreeItem] that is drawn and its position and size as a [Rect2].
+				Sets the given column's custom draw callback to [param callback] method on [param object].
+				The [param callback] should accept two arguments: the [TreeItem] that is drawn and its position and size as a [Rect2].
 			</description>
 		</method>
 		<method name="set_custom_font">
@@ -481,7 +481,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="font" type="Font" />
 			<description>
-				Sets custom font used to draw text in the column [code]column[/code].
+				Sets custom font used to draw text in the given [param column].
 			</description>
 		</method>
 		<method name="set_custom_font_size">
@@ -489,7 +489,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="font_size" type="int" />
 			<description>
-				Sets custom font size used to draw text in the column [code]column[/code].
+				Sets custom font size used to draw text in the given [param column].
 			</description>
 		</method>
 		<method name="set_editable">
@@ -497,7 +497,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [code]true[/code], column [code]column[/code] is editable.
+				If [code]true[/code], the given [param column] is editable.
 			</description>
 		</method>
 		<method name="set_expand_right">
@@ -505,7 +505,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], column [code]column[/code] is expanded to the right.
+				If [code]true[/code], the given [param column] is expanded to the right.
 			</description>
 		</method>
 		<method name="set_icon">
@@ -529,7 +529,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="modulate" type="Color" />
 			<description>
-				Modulates the given column's icon with [code]modulate[/code].
+				Modulates the given column's icon with [param modulate].
 			</description>
 		</method>
 		<method name="set_icon_region">
@@ -545,7 +545,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="indeterminate" type="bool" />
 			<description>
-				If [code]true[/code], the column [code]column[/code] is marked indeterminate.
+				If [code]true[/code], the given [param column] is marked [param indeterminate].
 				[b]Note:[/b] If set [code]true[/code] from [code]false[/code], then column is cleared of checked status.
 			</description>
 		</method>
@@ -582,7 +582,7 @@
 			<param index="4" name="expr" type="bool" default="false" />
 			<description>
 				Sets the range of accepted values for a column. The column must be in the [constant CELL_MODE_RANGE] mode.
-				If [code]expr[/code] is [code]true[/code], the edit mode slider will use an exponential scale as with [member Range.exp_edit].
+				If [param expr] is [code]true[/code], the edit mode slider will use an exponential scale as with [member Range.exp_edit].
 			</description>
 		</method>
 		<method name="set_selectable">


### PR DESCRIPTION
Also fixes the `set_font_size` description in Theme.xml.

One of several commits to fix all of the class XML docs (see #64134).