### PR TITLE
Add commit hash to the list of supported features for the project manager

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -97,6 +97,9 @@ const PackedStringArray ProjectSettings::_get_supported_features() {
 	features.append(VERSION_BRANCH "." _MKSTR(VERSION_PATCH));
 	features.append(VERSION_FULL_CONFIG);
 	features.append(VERSION_FULL_BUILD);
+	features.append(VERSION_BUILD);
+	features.append(VERSION_HASH);
+	features.append(String(VERSION_HASH).left(8));
 	// For now, assume Vulkan is always supported.
 	// This should be removed if it's possible to build the editor without Vulkan.
 	features.append("Vulkan Clustered");


### PR DESCRIPTION
This allows pinning a project to a specific commit hash of the editor. Either the full hash, or the first 8 chars, can be used. I ran into a situation where people were using slightly different versions of the editor which broke things, in which case this feature would be helpful. I also added the build name to the list of supported features.

This work was sponsored by The Mirror.