### PR TITLE
Print warning when running 32-bit Godot binary on 64-bit Windows

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1973,6 +1973,11 @@ void ProjectManager::_notification(int p_what) {
 			if (open_templates && open_templates->is_visible()) {
 				open_templates->popup_centered();
 			}
+
+			if (bit_warning && bit_warning->is_visible()) {
+				bit_warning->popup_centered();
+			}
+
 			if (asset_library) {
 				real_t size = get_size().x / EDSCALE;
 				// Adjust names of tabs to fit the new size.
@@ -1999,9 +2004,13 @@ void ProjectManager::_notification(int p_what) {
 			}
 #endif
 
-			// Suggest browsing asset library to get templates/demos.
-			if (asset_library && open_templates && _project_list->get_project_count() == 0) {
-				open_templates->popup_centered();
+			if (bit_warning) {
+				// Asset library suggestion dialog will be shown if relevant when the dialog is acknowledged
+				// (prevent multiple exclusive dialogs at once).
+				bit_warning->popup_centered();
+			} else {
+				// Suggest browsing asset library to get templates/demos.
+				_check_show_asset_library_dialog();
 			}
 		} break;
 
@@ -2721,6 +2730,12 @@ void ProjectManager::_bind_methods() {
 	ClassDB::bind_method("_version_button_pressed", &ProjectManager::_version_button_pressed);
 }
 
+void ProjectManager::_check_show_asset_library_dialog() {
+	if (asset_library && open_templates && _project_list->get_project_count() == 0) {
+		open_templates->popup_centered();
+	}
+}
+
 void ProjectManager::_open_asset_library() {
 	asset_library->disable_community_support();
 	tabs->set_current_tab(1);
@@ -3137,6 +3152,15 @@ ProjectManager::ProjectManager() {
 			open_templates->connect("confirmed", callable_mp(this, &ProjectManager::_open_asset_library));
 			add_child(open_templates);
 		}
+
+#ifdef WINDOWS_ENABLED
+		if (OS::get_singleton()->get_environment("PROCESSOR_ARCHITEW6432") == "AMD64" && !OS::get_singleton()->has_environment("GODOT_SILENCE_32BIT_WARNING")) {
+			bit_warning = memnew(AcceptDialog);
+			bit_warning->set_text(TTR("Running a 32-bit engine binary on a 64-bit operating system.\nThis is slower than running a 64-bit engine binary on a 64-bit operating system.\nSet the environment variable `GODOT_SILENCE_32BIT_WARNING` to 1 to silence this warning."));
+			bit_warning->connect("confirmed", callable_mp(this, &ProjectManager::_check_show_asset_library_dialog));
+			add_child(bit_warning);
+		}
+#endif
 
 		about = memnew(EditorAbout);
 		add_child(about);

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -370,6 +370,7 @@ class ProjectManager : public Control {
 	ConfirmationDialog *ask_full_convert_dialog = nullptr;
 	ConfirmationDialog *ask_update_settings = nullptr;
 	ConfirmationDialog *open_templates = nullptr;
+	AcceptDialog *bit_warning = nullptr;
 	EditorAbout *about = nullptr;
 
 	HBoxContainer *settings_hb = nullptr;
@@ -394,6 +395,7 @@ class ProjectManager : public Control {
 	LineEdit *new_tag_name = nullptr;
 	Label *tag_error = nullptr;
 
+	void _check_show_asset_library_dialog();
 	void _open_asset_library();
 	void _scan_projects();
 	void _run_project();


### PR DESCRIPTION
Running a 32-bit binary on a 64-bit OS is slower compared to running a 64-bit binary on a 64-bit OS.

This change only affects the project manager. The dialog can be disabled by setting the `GODOT_SILENCE_32BIT_WARNING` environment variable to 1.

Recent usage surveys in open source software have shown that people still occasionally run 32-bit software on a 64-bit OS (often by accident), which leaves some performance on the table.

Quoting from the [GZDoom 2021 usage survey](https://forum.zdoom.org/viewtopic.php?t=73425) (emphasis mine):[^1]

[^1]: To clarify, Godot 4.0 won't drop 32-bit support, and official 32-bit Windows binaries will continue to be distributed.

> One thing's certain, though. 4.7.1 will be the last build supporting 32 bit. **1% [of real 32-bit systems]** is nowhere near close enough to warrant this added work. Strangely enough, there's also **2.5% of users running the 32 bit on a 64 bit system**. Makes me wonder what they expect from that...

The warning is only implemented on Windows, but macOS doesn't have 32-bit support anymore, WebAssembly is 32 bit-only (for now), Android/iOS don't have a way to see console output for regular users and Linux makes it hard to run 32-bit apps on a 64-bit distribution unless you go out of your way. Therefore, I believe implementing this only for Windows is sufficient (but we could also implement it for Linux if there's a strong need).