### PR TITLE
Reduce code duplication for how struct types are decoded

### DIFF
--- a/core/io/marshalls.h
+++ b/core/io/marshalls.h
@@ -172,6 +172,10 @@ static inline uint32_t decode_uint32(const uint8_t *p_arr) {
 	return u;
 }
 
+static inline int32_t decode_int32_t(const uint8_t *p_arr) {
+	return decode_uint32(p_arr);
+}
+
 static inline float decode_float(const uint8_t *p_arr) {
 	MarshallFloat mf;
 	mf.i = decode_uint32(p_arr);


### PR DESCRIPTION
This PR implements https://github.com/godotengine/godot-proposals/issues/4408, at least for the part about decoding structs. 

This approach uses a lot less code, 88% fewer lines, although I had to add a method for decoding `int32_t` (the old code was just using the uint32 method). It also fixes a bug in Projection decoding (see if you can find the bug in the old code), although I am not assigning the bug label because I wasn't actually able to get it to fail in practice.

For more information, take a look at the proposal, and the comment I posted on it recently.