### PR TITLE
Port fixes from NavigationAgent nodes to NavigationObstacle nodes

### DIFF
--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -499,6 +499,7 @@ public:
 	inline T operator[](int p_index) const;
 
 	Error resize(int p_size);
+	Error clear() { return resize(0); }
 
 	void invert();
 	void sort();

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -696,6 +696,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolByteArray, push_back);
 	VCALL_LOCALMEM1(PoolByteArray, fill);
 	VCALL_LOCALMEM1(PoolByteArray, resize);
+	VCALL_LOCALMEM0(PoolByteArray, clear);
 	VCALL_LOCALMEM2R(PoolByteArray, insert);
 	VCALL_LOCALMEM1(PoolByteArray, remove);
 	VCALL_LOCALMEM1(PoolByteArray, append);
@@ -715,6 +716,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolIntArray, push_back);
 	VCALL_LOCALMEM1(PoolIntArray, fill);
 	VCALL_LOCALMEM1(PoolIntArray, resize);
+	VCALL_LOCALMEM0(PoolIntArray, clear);
 	VCALL_LOCALMEM2R(PoolIntArray, insert);
 	VCALL_LOCALMEM1(PoolIntArray, remove);
 	VCALL_LOCALMEM1(PoolIntArray, append);
@@ -733,6 +735,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolRealArray, push_back);
 	VCALL_LOCALMEM1(PoolRealArray, fill);
 	VCALL_LOCALMEM1(PoolRealArray, resize);
+	VCALL_LOCALMEM0(PoolRealArray, clear);
 	VCALL_LOCALMEM2R(PoolRealArray, insert);
 	VCALL_LOCALMEM1(PoolRealArray, remove);
 	VCALL_LOCALMEM1(PoolRealArray, append);
@@ -751,6 +754,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolStringArray, push_back);
 	VCALL_LOCALMEM1(PoolStringArray, fill);
 	VCALL_LOCALMEM1(PoolStringArray, resize);
+	VCALL_LOCALMEM0(PoolStringArray, clear);
 	VCALL_LOCALMEM2R(PoolStringArray, insert);
 	VCALL_LOCALMEM1(PoolStringArray, remove);
 	VCALL_LOCALMEM1(PoolStringArray, append);
@@ -770,6 +774,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolVector2Array, push_back);
 	VCALL_LOCALMEM1(PoolVector2Array, fill);
 	VCALL_LOCALMEM1(PoolVector2Array, resize);
+	VCALL_LOCALMEM0(PoolVector2Array, clear);
 	VCALL_LOCALMEM2R(PoolVector2Array, insert);
 	VCALL_LOCALMEM1(PoolVector2Array, remove);
 	VCALL_LOCALMEM1(PoolVector2Array, append);
@@ -788,6 +793,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolVector3Array, push_back);
 	VCALL_LOCALMEM1(PoolVector3Array, fill);
 	VCALL_LOCALMEM1(PoolVector3Array, resize);
+	VCALL_LOCALMEM0(PoolVector3Array, clear);
 	VCALL_LOCALMEM2R(PoolVector3Array, insert);
 	VCALL_LOCALMEM1(PoolVector3Array, remove);
 	VCALL_LOCALMEM1(PoolVector3Array, append);
@@ -806,6 +812,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolColorArray, push_back);
 	VCALL_LOCALMEM1(PoolColorArray, fill);
 	VCALL_LOCALMEM1(PoolColorArray, resize);
+	VCALL_LOCALMEM0(PoolColorArray, clear);
 	VCALL_LOCALMEM2R(PoolColorArray, insert);
 	VCALL_LOCALMEM1(PoolColorArray, remove);
 	VCALL_LOCALMEM1(PoolColorArray, append);
@@ -1981,6 +1988,7 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_BYTE_ARRAY, NIL, PoolByteArray, remove, INT, "idx", varray());
 	ADDFUNC2R(POOL_BYTE_ARRAY, INT, PoolByteArray, insert, INT, "idx", INT, "byte", varray());
 	ADDFUNC1(POOL_BYTE_ARRAY, NIL, PoolByteArray, resize, INT, "idx", varray());
+	ADDFUNC0(POOL_BYTE_ARRAY, NIL, PoolByteArray, clear, varray());
 	ADDFUNC0(POOL_BYTE_ARRAY, NIL, PoolByteArray, invert, varray());
 	ADDFUNC2R(POOL_BYTE_ARRAY, POOL_BYTE_ARRAY, PoolByteArray, subarray, INT, "from", INT, "to", varray());
 	ADDFUNC2R(POOL_BYTE_ARRAY, INT, PoolByteArray, find, INT, "value", INT, "from", varray(0));
@@ -2006,6 +2014,7 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_INT_ARRAY, NIL, PoolIntArray, remove, INT, "idx", varray());
 	ADDFUNC2R(POOL_INT_ARRAY, INT, PoolIntArray, insert, INT, "idx", INT, "integer", varray());
 	ADDFUNC1(POOL_INT_ARRAY, NIL, PoolIntArray, resize, INT, "idx", varray());
+	ADDFUNC0(POOL_INT_ARRAY, NIL, PoolIntArray, clear, varray());
 	ADDFUNC0(POOL_INT_ARRAY, NIL, PoolIntArray, invert, varray());
 	ADDFUNC2R(POOL_INT_ARRAY, INT, PoolIntArray, find, INT, "value", INT, "from", varray(0));
 	ADDFUNC2R(POOL_INT_ARRAY, INT, PoolIntArray, rfind, INT, "value", INT, "from", varray(-1));
@@ -2023,6 +2032,7 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_REAL_ARRAY, NIL, PoolRealArray, remove, INT, "idx", varray());
 	ADDFUNC2R(POOL_REAL_ARRAY, INT, PoolRealArray, insert, INT, "idx", REAL, "value", varray());
 	ADDFUNC1(POOL_REAL_ARRAY, NIL, PoolRealArray, resize, INT, "idx", varray());
+	ADDFUNC0(POOL_REAL_ARRAY, NIL, PoolRealArray, clear, varray());
 	ADDFUNC0(POOL_REAL_ARRAY, NIL, PoolRealArray, invert, varray());
 	ADDFUNC2R(POOL_REAL_ARRAY, INT, PoolRealArray, find, REAL, "value", INT, "from", varray(0));
 	ADDFUNC2R(POOL_REAL_ARRAY, INT, PoolRealArray, rfind, REAL, "value", INT, "from", varray(-1));
@@ -2040,6 +2050,7 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_STRING_ARRAY, NIL, PoolStringArray, remove, INT, "idx", varray());
 	ADDFUNC2R(POOL_STRING_ARRAY, INT, PoolStringArray, insert, INT, "idx", STRING, "string", varray());
 	ADDFUNC1(POOL_STRING_ARRAY, NIL, PoolStringArray, resize, INT, "idx", varray());
+	ADDFUNC0(POOL_STRING_ARRAY, NIL, PoolStringArray, clear, varray());
 	ADDFUNC0(POOL_STRING_ARRAY, NIL, PoolStringArray, invert, varray());
 	ADDFUNC1(POOL_STRING_ARRAY, STRING, PoolStringArray, join, STRING, "delimiter", varray());
 	ADDFUNC2R(POOL_STRING_ARRAY, INT, PoolStringArray, find, STRING, "value", INT, "from", varray(0));
@@ -2058,6 +2069,7 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, remove, INT, "idx", varray());
 	ADDFUNC2R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, insert, INT, "idx", VECTOR2, "vector2", varray());
 	ADDFUNC1(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, resize, INT, "idx", varray());
+	ADDFUNC0(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, clear, varray());
 	ADDFUNC0(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, invert, varray());
 	ADDFUNC2R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, find, VECTOR2, "value", INT, "from", varray(0));
 	ADDFUNC2R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, rfind, VECTOR2, "value", INT, "from", varray(-1));
@@ -2075,6 +2087,7 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, remove, INT, "idx", varray());
 	ADDFUNC2R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, insert, INT, "idx", VECTOR3, "vector3", varray());
 	ADDFUNC1(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, resize, INT, "idx", varray());
+	ADDFUNC0(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, clear, varray());
 	ADDFUNC0(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, invert, varray());
 	ADDFUNC2R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, find, VECTOR3, "value", INT, "from", varray(0));
 	ADDFUNC2R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, rfind, VECTOR3, "value", INT, "from", varray(-1));
@@ -2092,6 +2105,7 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_COLOR_ARRAY, NIL, PoolColorArray, remove, INT, "idx", varray());
 	ADDFUNC2R(POOL_COLOR_ARRAY, INT, PoolColorArray, insert, INT, "idx", COLOR, "color", varray());
 	ADDFUNC1(POOL_COLOR_ARRAY, NIL, PoolColorArray, resize, INT, "idx", varray());
+	ADDFUNC0(POOL_COLOR_ARRAY, NIL, PoolColorArray, clear, varray());
 	ADDFUNC0(POOL_COLOR_ARRAY, NIL, PoolColorArray, invert, varray());
 	ADDFUNC2R(POOL_COLOR_ARRAY, INT, PoolColorArray, find, COLOR, "value", INT, "from", varray(0));
 	ADDFUNC2R(POOL_COLOR_ARRAY, INT, PoolColorArray, rfind, COLOR, "value", INT, "from", varray(-1));

--- a/doc/classes/NavigationObstacle.xml
+++ b/doc/classes/NavigationObstacle.xml
@@ -16,6 +16,12 @@
 				Returns the [Navigation] node that the obstacle is using for its navigation system.
 			</description>
 		</method>
+		<method name="get_navigation_map" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node and not the map of the abstract agent on the NavigationServer. If the agent map is changed directly with the NavigationServer API the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the agent on the NavigationServer.
+			</description>
+		</method>
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
@@ -27,6 +33,13 @@
 			<argument index="0" name="navigation" type="Node" />
 			<description>
 				Sets the [Navigation] node used by the obstacle. Useful when you don't want to make the obstacle a child of a [Navigation] node.
+			</description>
+		</method>
+		<method name="set_navigation_map">
+			<return type="void" />
+			<argument index="0" name="navigation_map" type="RID" />
+			<description>
+				Sets the [RID] of the navigation map this NavigationObstacle node should use and also updates the [code]agent[/code] on the NavigationServer.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationObstacle2D.xml
+++ b/doc/classes/NavigationObstacle2D.xml
@@ -16,6 +16,12 @@
 				Returns the [Navigation2D] node that the obstacle is using for its navigation system.
 			</description>
 		</method>
+		<method name="get_navigation_map" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node and not the map of the abstract agent on the NavigationServer. If the agent map is changed directly with the NavigationServer API the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the agent on the NavigationServer.
+			</description>
+		</method>
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
@@ -27,6 +33,13 @@
 			<argument index="0" name="navigation" type="Node" />
 			<description>
 				Sets the [Navigation2D] node used by the obstacle. Useful when you don't want to make the obstacle a child of a [Navigation2D] node.
+			</description>
+		</method>
+		<method name="set_navigation_map">
+			<return type="void" />
+			<argument index="0" name="navigation_map" type="RID" />
+			<description>
+				Sets the [RID] of the navigation map this NavigationObstacle node should use and also updates the [code]agent[/code] on the NavigationServer.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -42,6 +42,11 @@
 				Appends a [PoolByteArray] at the end of this array.
 			</description>
 		</method>
+		<method name="clear">
+			<description>
+				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
+			</description>
+		</method>
 		<method name="compress">
 			<return type="PoolByteArray" />
 			<argument index="0" name="compression_mode" type="int" default="0" />

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -42,6 +42,11 @@
 				Appends a [PoolColorArray] at the end of this array.
 			</description>
 		</method>
+		<method name="clear">
+			<description>
+				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
+			</description>
+		</method>
 		<method name="count">
 			<return type="int" />
 			<argument index="0" name="value" type="Color" />

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -43,6 +43,11 @@
 				Appends a [PoolIntArray] at the end of this array.
 			</description>
 		</method>
+		<method name="clear">
+			<description>
+				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
+			</description>
+		</method>
 		<method name="count">
 			<return type="int" />
 			<argument index="0" name="value" type="int" />

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -43,6 +43,11 @@
 				Appends a [PoolRealArray] at the end of this array.
 			</description>
 		</method>
+		<method name="clear">
+			<description>
+				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
+			</description>
+		</method>
 		<method name="count">
 			<return type="int" />
 			<argument index="0" name="value" type="float" />

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -43,6 +43,11 @@
 				Appends a [PoolStringArray] at the end of this array.
 			</description>
 		</method>
+		<method name="clear">
+			<description>
+				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
+			</description>
+		</method>
 		<method name="count">
 			<return type="int" />
 			<argument index="0" name="value" type="String" />

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -43,6 +43,11 @@
 				Appends a [PoolVector2Array] at the end of this array.
 			</description>
 		</method>
+		<method name="clear">
+			<description>
+				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
+			</description>
+		</method>
 		<method name="count">
 			<return type="int" />
 			<argument index="0" name="value" type="Vector2" />

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -42,6 +42,11 @@
 				Appends a [PoolVector3Array] at the end of this array.
 			</description>
 		</method>
+		<method name="clear">
+			<description>
+				Clears the array. This is equivalent to using [method resize] with a size of [code]0[/code].
+			</description>
+		</method>
 		<method name="count">
 			<return type="int" />
 			<argument index="0" name="value" type="Vector3" />

--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1F1575721F582BE20003B888 /* dylibs in Resources */ = {isa = PBXBuildFile; fileRef = 1F1575711F582BE20003B888 /* dylibs */; };
 		DEADBEEF2F582BE20003B888 /* $binary.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEADBEEF1F582BE20003B888 /* $binary.xcframework */; };
 		$modules_buildfile
+		$swift_runtime_buildfile
 		1FF8DBB11FBA9DE1009DE660 /* dummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */; };
 		D07CD44E1C5D589C00B7FB28 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D07CD44D1C5D589C00B7FB28 /* Images.xcassets */; };
 		D0BCFE4618AEBDA2004A7AAE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D0BCFE4418AEBDA2004A7AAE /* InfoPlist.strings */; };
@@ -35,6 +36,7 @@
 		1F1575711F582BE20003B888 /* dylibs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = dylibs; path = "$binary/dylibs"; sourceTree = "<group>"; };
 		DEADBEEF1F582BE20003B888 /* $binary.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = godot; path = "$binary.xcframework"; sourceTree = "<group>"; };
 		$modules_fileref
+		$swift_runtime_fileref
 		1FF4C1881F584E6300A41E41 /* $binary.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "$binary.entitlements"; sourceTree = "<group>"; };
 		1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dummy.cpp; sourceTree = "<group>"; };
 		D07CD44D1C5D589C00B7FB28 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 				D07CD44D1C5D589C00B7FB28 /* Images.xcassets */,
 				D0BCFE4218AEBDA2004A7AAE /* Supporting Files */,
 				1FF8DBB01FBA9DE1009DE660 /* dummy.cpp */,
+				$swift_runtime_binary_files
 			);
 			path = "$binary";
 			sourceTree = "<group>";
@@ -145,6 +148,7 @@
 				TargetAttributes = {
 					D0BCFE3318AEBDA2004A7AAE = {
 						DevelopmentTeam = $team_id;
+						$swift_runtime_migration
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 						};
@@ -190,6 +194,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1FF8DBB11FBA9DE1009DE660 /* dummy.cpp in Sources */,
+				$swift_runtime_build_phase
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -321,6 +326,7 @@
 				TARGETED_DEVICE_FAMILY = "$targeted_device_family";
 				VALID_ARCHS = "armv7 armv7s arm64 i386 x86_64";
 				WRAPPER_EXTENSION = app;
+				$swift_runtime_build_settings
 			};
 			name = Debug;
 		};
@@ -352,6 +358,7 @@
 				TARGETED_DEVICE_FAMILY = "$targeted_device_family";
 				VALID_ARCHS = "armv7 armv7s arm64 i386 x86_64";
 				WRAPPER_EXTENSION = app;
+				$swift_runtime_build_settings
 			};
 			name = Release;
 		};

--- a/misc/dist/ios_xcode/godot_ios/dummy.h
+++ b/misc/dist/ios_xcode/godot_ios/dummy.h
@@ -1,0 +1,31 @@
+/*************************************************************************/
+/*  dummy.h                                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+// #import <Foundation/Foundation.h>

--- a/misc/dist/ios_xcode/godot_ios/dummy.swift
+++ b/misc/dist/ios_xcode/godot_ios/dummy.swift
@@ -1,0 +1,31 @@
+/*************************************************************************/
+/*  dummy.swift                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+import Foundation

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -79,6 +79,7 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 		String modules_buildphase;
 		String modules_buildgrp;
 		Vector<String> capabilities;
+		bool use_swift_runtime;
 	};
 	struct ExportArchitecture {
 		String name;
@@ -682,6 +683,35 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 				}
 			}
 			strnew += lines[i].replace("$pbx_locale_build_reference", locale_files);
+		} else if (lines[i].find("$swift_runtime_migration") != -1) {
+			String value = !p_config.use_swift_runtime ? "" : "LastSwiftMigration = 1250;";
+			strnew += lines[i].replace("$swift_runtime_migration", value) + "\n";
+		} else if (lines[i].find("$swift_runtime_build_settings") != -1) {
+			String value = !p_config.use_swift_runtime ? "" : R"(
+            CLANG_ENABLE_MODULES = YES;
+            SWIFT_OBJC_BRIDGING_HEADER = "$binary/dummy.h";
+            SWIFT_VERSION = 5.0;
+            )";
+			value = value.replace("$binary", p_config.binary_name);
+			strnew += lines[i].replace("$swift_runtime_build_settings", value) + "\n";
+		} else if (lines[i].find("$swift_runtime_fileref") != -1) {
+			String value = !p_config.use_swift_runtime ? "" : R"(
+            90B4C2AA2680BC560039117A /* dummy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "dummy.h"; sourceTree = "<group>"; };
+            90B4C2B52680C7E90039117A /* dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "dummy.swift"; sourceTree = "<group>"; };
+            )";
+			strnew += lines[i].replace("$swift_runtime_fileref", value) + "\n";
+		} else if (lines[i].find("$swift_runtime_binary_files") != -1) {
+			String value = !p_config.use_swift_runtime ? "" : R"(
+            90B4C2AA2680BC560039117A /* dummy.h */,
+            90B4C2B52680C7E90039117A /* dummy.swift */,
+            )";
+			strnew += lines[i].replace("$swift_runtime_binary_files", value) + "\n";
+		} else if (lines[i].find("$swift_runtime_buildfile") != -1) {
+			String value = !p_config.use_swift_runtime ? "" : "90B4C2B62680C7E90039117A /* dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B4C2B52680C7E90039117A /* dummy.swift */; };";
+			strnew += lines[i].replace("$swift_runtime_buildfile", value) + "\n";
+		} else if (lines[i].find("$swift_runtime_build_phase") != -1) {
+			String value = !p_config.use_swift_runtime ? "" : "90B4C2B62680C7E90039117A /* dummy.swift */,";
+			strnew += lines[i].replace("$swift_runtime_build_phase", value) + "\n";
 		} else {
 			strnew += lines[i] + "\n";
 		}
@@ -1591,6 +1621,10 @@ Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset>
 
 		plugin_initialization_cpp_code += "\t" + initialization_method;
 		plugin_deinitialization_cpp_code += "\t" + deinitialization_method;
+
+		if (plugin.use_swift_runtime) {
+			p_config_data.use_swift_runtime = true;
+		}
 	}
 
 	// Updating `Info.plist`
@@ -1775,7 +1809,8 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 		"",
 		"",
 		"",
-		Vector<String>()
+		Vector<String>(),
+		false
 	};
 
 	Vector<IOSExportAsset> assets;

--- a/platform/iphone/plugin/godot_plugin_config.h
+++ b/platform/iphone/plugin/godot_plugin_config.h
@@ -39,6 +39,7 @@
  The `config` section and fields are required and defined as follow:
 - **name**: name of the plugin
 - **binary**: path to static `.a` library
+- **use_swift_runtime**: optional boolean field used to determine if Swift runtime is used
 
 The `dependencies` and fields are optional.
 - **linked**: dependencies that should only be linked.
@@ -57,6 +58,7 @@ struct PluginConfigIOS {
 	static const char *CONFIG_SECTION;
 	static const char *CONFIG_NAME_KEY;
 	static const char *CONFIG_BINARY_KEY;
+	static const char *CONFIG_USE_SWIFT_KEY;
 	static const char *CONFIG_INITIALIZE_KEY;
 	static const char *CONFIG_DEINITIALIZE_KEY;
 
@@ -93,6 +95,7 @@ struct PluginConfigIOS {
 	// Required config section
 	String name;
 	String binary;
+	bool use_swift_runtime;
 	String initialization_method;
 	String deinitialization_method;
 
@@ -118,6 +121,7 @@ const char *PluginConfigIOS::PLUGIN_CONFIG_EXT = ".gdip";
 const char *PluginConfigIOS::CONFIG_SECTION = "config";
 const char *PluginConfigIOS::CONFIG_NAME_KEY = "name";
 const char *PluginConfigIOS::CONFIG_BINARY_KEY = "binary";
+const char *PluginConfigIOS::CONFIG_USE_SWIFT_KEY = "use_swift_runtime";
 const char *PluginConfigIOS::CONFIG_INITIALIZE_KEY = "initialization";
 const char *PluginConfigIOS::CONFIG_DEINITIALIZE_KEY = "deinitialization";
 
@@ -281,6 +285,7 @@ static inline PluginConfigIOS load_plugin_config(Ref<ConfigFile> config_file, co
 	String config_base_dir = path.get_base_dir();
 
 	plugin_config.name = config_file->get_value(PluginConfigIOS::CONFIG_SECTION, PluginConfigIOS::CONFIG_NAME_KEY, String());
+	plugin_config.use_swift_runtime = config_file->get_value(PluginConfigIOS::CONFIG_SECTION, PluginConfigIOS::CONFIG_USE_SWIFT_KEY, false);
 	plugin_config.initialization_method = config_file->get_value(PluginConfigIOS::CONFIG_SECTION, PluginConfigIOS::CONFIG_INITIALIZE_KEY, String());
 	plugin_config.deinitialization_method = config_file->get_value(PluginConfigIOS::CONFIG_SECTION, PluginConfigIOS::CONFIG_DEINITIALIZE_KEY, String());
 

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -40,9 +40,11 @@ class NavigationObstacle2D : public Node {
 	GDCLASS(NavigationObstacle2D, Node);
 
 	Navigation2D *navigation;
-	Node2D *parent_node2d = nullptr;
+	Node2D *agent_parent = nullptr;
+
 	RID agent;
 	RID map_before_pause;
+	RID map_override;
 
 	bool estimate_radius = true;
 	real_t radius = 1.0;
@@ -67,6 +69,11 @@ public:
 	RID get_rid() const {
 		return agent;
 	}
+
+	void set_agent_parent(Node *p_agent_parent);
+
+	void set_navigation_map(RID p_navigation_map);
+	RID get_navigation_map() const;
 
 	void set_estimate_radius(bool p_estimate_radius);
 	bool is_radius_estimated() const {

--- a/scene/3d/navigation_obstacle.h
+++ b/scene/3d/navigation_obstacle.h
@@ -39,11 +39,12 @@ class Navigation;
 class NavigationObstacle : public Node {
 	GDCLASS(NavigationObstacle, Node);
 
-	Spatial *parent_spatial = nullptr;
 	Navigation *navigation;
+	Spatial *agent_parent = nullptr;
 
 	RID agent;
 	RID map_before_pause;
+	RID map_override;
 
 	bool estimate_radius = true;
 	real_t radius = 1.0;
@@ -68,6 +69,11 @@ public:
 	RID get_rid() const {
 		return agent;
 	}
+
+	void set_agent_parent(Node *p_agent_parent);
+
+	void set_navigation_map(RID p_navigation_map);
+	RID get_navigation_map() const;
 
 	void set_estimate_radius(bool p_estimate_radius);
 	bool is_radius_estimated() const {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -151,7 +151,7 @@ Error ResourceInteractiveLoaderText::_parse_ext_resource(VariantParser::Stream *
 			path = ProjectSettings::get_singleton()->localize_path(res_path.get_base_dir().plus_file(path));
 		}
 
-		r_res = ResourceLoader::load(path, type, no_subresource_cache);
+		r_res = ResourceLoader::load(path, type, false);
 
 		if (r_res.is_null()) {
 			WARN_PRINT(String("Couldn't load external resource: " + path).utf8().get_data());


### PR DESCRIPTION
Ports all the missing (re)parent bugfixes and navigation map handling improvements from NavigationAgent nodes to the NavigationObstacle nodes.

Fixes Godot 3.5 specific issue that NavigationObstacles nodes do not registering on the default world navigation map when no deprecated  Navigation / Navigation2D node is found.

Fixes  #64185

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
