### PR TITLE
Add GridMap function to change navigation map for baked navigation regions

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -94,6 +94,13 @@
 				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [code]layer_number[/code] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_navigation_map" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the navigation map this GridMap node uses for its cell baked navigation meshes.
+				This function returns always the map set on the GridMap node and not the map on the NavigationServer. If the map is changed directly with the NavigationServer API the GridMap node will not be aware of the map change.
+			</description>
+		</method>
 		<method name="get_orthogonal_index_from_basis" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="basis" type="Basis" />
@@ -174,6 +181,13 @@
 			<param index="1" name="value" type="bool" />
 			<description>
 				Based on [code]value[/code], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [code]layer_number[/code] between 1 and 32.
+			</description>
+		</method>
+		<method name="set_navigation_map">
+			<return type="void" />
+			<param index="0" name="navigation_map" type="RID" />
+			<description>
+				Sets the [RID] of the navigation map this GridMap node should use for its cell baked navigation meshes.
 			</description>
 		</method>
 	</methods>

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -226,6 +226,27 @@ bool GridMap::is_baking_navigation() {
 	return bake_navigation;
 }
 
+void GridMap::set_navigation_map(RID p_navigation_map) {
+	map_override = p_navigation_map;
+	for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
+		Octant &g = *octant_map[E.key];
+		for (KeyValue<IndexKey, Octant::NavMesh> &F : g.navmesh_ids) {
+			if (F.value.region.is_valid()) {
+				NavigationServer3D::get_singleton()->region_set_map(F.value.region, map_override);
+			}
+		}
+	}
+}
+
+RID GridMap::get_navigation_map() const {
+	if (map_override.is_valid()) {
+		return map_override;
+	} else if (is_inside_tree()) {
+		return get_world_3d()->get_navigation_map();
+	}
+	return RID();
+}
+
 void GridMap::set_navigation_layers(uint32_t p_navigation_layers) {
 	navigation_layers = p_navigation_layers;
 	_recreate_octant_data();
@@ -639,7 +660,11 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 				NavigationServer3D::get_singleton()->region_set_navmesh(region, navmesh);
 				NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * nm.xform);
 				if (is_inside_tree()) {
-					NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
+					if (map_override.is_valid()) {
+						NavigationServer3D::get_singleton()->region_set_map(region, map_override);
+					} else {
+						NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
+					}
 				}
 				nm.region = region;
 
@@ -757,7 +782,11 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 					NavigationServer3D::get_singleton()->region_set_navigation_layers(region, navigation_layers);
 					NavigationServer3D::get_singleton()->region_set_navmesh(region, nm);
 					NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * F.value.xform);
-					NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
+					if (map_override.is_valid()) {
+						NavigationServer3D::get_singleton()->region_set_map(region, map_override);
+					} else {
+						NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
+					}
 
 					F.value.region = region;
 				}
@@ -1021,6 +1050,9 @@ void GridMap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bake_navigation", "bake_navigation"), &GridMap::set_bake_navigation);
 	ClassDB::bind_method(D_METHOD("is_baking_navigation"), &GridMap::is_baking_navigation);
+
+	ClassDB::bind_method(D_METHOD("set_navigation_map", "navigation_map"), &GridMap::set_navigation_map);
+	ClassDB::bind_method(D_METHOD("get_navigation_map"), &GridMap::get_navigation_map);
 
 	ClassDB::bind_method(D_METHOD("set_navigation_layers", "layers"), &GridMap::set_navigation_layers);
 	ClassDB::bind_method(D_METHOD("get_navigation_layers"), &GridMap::get_navigation_layers);

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -152,6 +152,7 @@ class GridMap : public Node3D {
 	uint32_t collision_mask = 1;
 	Ref<PhysicsMaterial> physics_material;
 	bool bake_navigation = false;
+	RID map_override;
 	uint32_t navigation_layers = 1;
 
 	Transform3D last_transform;
@@ -246,6 +247,9 @@ public:
 
 	void set_bake_navigation(bool p_bake_navigation);
 	bool is_baking_navigation();
+
+	void set_navigation_map(RID p_navigation_map);
+	RID get_navigation_map() const;
 
 	void set_navigation_layers(uint32_t p_navigation_layers);
 	uint32_t get_navigation_layers() const;


### PR DESCRIPTION
Adds function to change the navigation map for baked navigation regions.
Before all cells with a baked navigation mesh were locked to the default navigation map of the world resource.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
