### PR TITLE
Add `get_depth()` to `KinematicCollision2D/3D`

### DIFF
--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -53,6 +53,12 @@
 				Returns the colliding body's velocity.
 			</description>
 		</method>
+		<method name="get_depth" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the colliding body's length of overlap along the collision normal.
+			</description>
+		</method>
 		<method name="get_local_shape" qualifiers="const">
 			<return type="Object" />
 			<description>

--- a/doc/classes/KinematicCollision3D.xml
+++ b/doc/classes/KinematicCollision3D.xml
@@ -66,6 +66,12 @@
 				Returns the number of detected collisions.
 			</description>
 		</method>
+		<method name="get_depth" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the colliding body's length of overlap along the collision normal.
+			</description>
+		</method>
 		<method name="get_local_shape" qualifiers="const">
 			<return type="Object" />
 			<param index="0" name="collision_index" type="int" default="0" />

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1823,6 +1823,10 @@ real_t KinematicCollision2D::get_angle(const Vector2 &p_up_direction) const {
 	return result.get_angle(p_up_direction);
 }
 
+real_t KinematicCollision2D::get_depth() const {
+	return result.collision_depth;
+}
+
 Object *KinematicCollision2D::get_local_shape() const {
 	if (!owner) {
 		return nullptr;
@@ -1874,6 +1878,7 @@ void KinematicCollision2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_travel"), &KinematicCollision2D::get_travel);
 	ClassDB::bind_method(D_METHOD("get_remainder"), &KinematicCollision2D::get_remainder);
 	ClassDB::bind_method(D_METHOD("get_angle", "up_direction"), &KinematicCollision2D::get_angle, DEFVAL(Vector2(0.0, -1.0)));
+	ClassDB::bind_method(D_METHOD("get_depth"), &KinematicCollision2D::get_depth);
 	ClassDB::bind_method(D_METHOD("get_local_shape"), &KinematicCollision2D::get_local_shape);
 	ClassDB::bind_method(D_METHOD("get_collider"), &KinematicCollision2D::get_collider);
 	ClassDB::bind_method(D_METHOD("get_collider_id"), &KinematicCollision2D::get_collider_id);

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -473,6 +473,7 @@ public:
 	Vector2 get_travel() const;
 	Vector2 get_remainder() const;
 	real_t get_angle(const Vector2 &p_up_direction = Vector2(0.0, -1.0)) const;
+	real_t get_depth() const;
 	Object *get_local_shape() const;
 	Object *get_collider() const;
 	ObjectID get_collider_id() const;

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -2057,6 +2057,10 @@ int KinematicCollision3D::get_collision_count() const {
 	return result.collision_count;
 }
 
+real_t KinematicCollision3D::get_depth() const {
+	return result.collision_depth;
+}
+
 Vector3 KinematicCollision3D::get_position(int p_collision_index) const {
 	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, Vector3());
 	return result.collisions[p_collision_index].position;
@@ -2127,6 +2131,7 @@ Vector3 KinematicCollision3D::get_collider_velocity(int p_collision_index) const
 void KinematicCollision3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_travel"), &KinematicCollision3D::get_travel);
 	ClassDB::bind_method(D_METHOD("get_remainder"), &KinematicCollision3D::get_remainder);
+	ClassDB::bind_method(D_METHOD("get_depth"), &KinematicCollision3D::get_depth);
 	ClassDB::bind_method(D_METHOD("get_collision_count"), &KinematicCollision3D::get_collision_count);
 	ClassDB::bind_method(D_METHOD("get_position", "collision_index"), &KinematicCollision3D::get_position, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_normal", "collision_index"), &KinematicCollision3D::get_normal, DEFVAL(0));

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -504,6 +504,7 @@ public:
 	Vector3 get_travel() const;
 	Vector3 get_remainder() const;
 	int get_collision_count() const;
+	real_t get_depth() const;
 	Vector3 get_position(int p_collision_index = 0) const;
 	Vector3 get_normal(int p_collision_index = 0) const;
 	real_t get_angle(int p_collision_index = 0, const Vector3 &p_up_direction = Vector3(0.0, 1.0, 0.0)) const;

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -989,6 +989,7 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 				r_result->collision_unsafe_fraction = unsafe;
 
 				r_result->collision_count = rcd.result_count;
+				r_result->collision_depth = rcd.best_result.len;
 			}
 
 			collided = true;
@@ -1002,6 +1003,7 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 
 		r_result->collision_safe_fraction = 1.0;
 		r_result->collision_unsafe_fraction = 1.0;
+		r_result->collision_depth = 0.0;
 	}
 
 	return collided;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -550,6 +550,7 @@ public:
 	struct MotionResult {
 		Vector3 travel;
 		Vector3 remainder;
+		real_t collision_depth = 0.0;
 		real_t collision_safe_fraction = 0.0;
 		real_t collision_unsafe_fraction = 0.0;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/3066

Add `get_depth()` to KinematicCollision3D and KinematicCollision2D.

https://user-images.githubusercontent.com/61938263/183789290-2ef5d0a7-cefd-4cff-92c4-0e50c66decba.mp4

[physics_test.zip](https://github.com/godotengine/godot/files/9295687/physics_test.zip)

With this feature, for example, when a player is caught and press between objects, we can calculate damage according to the depth value.

If the penetration is too large, the collision is completely filled and the normals are inverted, making the value of depth not desirable. I think another PR is needed in the future for solving that problem.
