### PR TITLE
[doc] Use "param" instead of "code" to refer to parameters #3

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -22,8 +22,8 @@
 			<param index="0" name="subresources" type="bool" default="false" />
 			<description>
 				Duplicates the resource, returning a new resource with the exported members copied. [b]Note:[/b] To duplicate the resource the constructor is called without arguments. This method will error when the constructor doesn't have default values.
-				By default, sub-resources are shared between resource copies for efficiency. This can be changed by passing [code]true[/code] to the [code]subresources[/code] argument which will copy the subresources.
-				[b]Note:[/b] If [code]subresources[/code] is [code]true[/code], this method will only perform a shallow copy. Nested resources within subresources will not be duplicated and will still be shared.
+				By default, sub-resources are shared between resource copies for efficiency. This can be changed by passing [code]true[/code] to the [param subresources] argument which will copy the subresources.
+				[b]Note:[/b] If [param subresources] is [code]true[/code], this method will only perform a shallow copy. Nested resources within subresources will not be duplicated and will still be shared.
 				[b]Note:[/b] When duplicating a resource, only [code]export[/code]ed properties are copied. Other properties will be set to their default value in the new resource.
 			</description>
 		</method>

--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -28,7 +28,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="add_types" type="bool" />
 			<description>
-				If implemented, gets the dependencies of a given resource. If [code]add_types[/code] is [code]true[/code], paths should be appended [code]::TypeName[/code], where [code]TypeName[/code] is the class name of the dependency.
+				If implemented, gets the dependencies of a given resource. If [param add_types] is [code]true[/code], paths should be appended [code]::TypeName[/code], where [code]TypeName[/code] is the class name of the dependency.
 				[b]Note:[/b] Custom resource types defined by scripts aren't known by the [ClassDB], so you might just return [code]"Resource"[/code] for them.
 			</description>
 		</method>
@@ -67,8 +67,8 @@
 			<param index="2" name="use_sub_threads" type="bool" />
 			<param index="3" name="cache_mode" type="int" />
 			<description>
-				Loads a resource when the engine finds this loader to be compatible. If the loaded resource is the result of an import, [code]original_path[/code] will target the source file. Returns a [Resource] object on success, or an [enum Error] constant in case of failure.
-				The [code]cache_mode[/code] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
+				Loads a resource when the engine finds this loader to be compatible. If the loaded resource is the result of an import, [param original_path] will target the source file. Returns a [Resource] object on success, or an [enum Error] constant in case of failure.
+				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
 			</description>
 		</method>
 		<method name="_rename_dependencies" qualifiers="virtual const">
@@ -76,7 +76,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="renames" type="Dictionary" />
 			<description>
-				If implemented, renames dependencies within the given resource and saves it. [code]renames[/code] is a dictionary [code]{ String =&gt; String }[/code] mapping old dependency paths to new paths.
+				If implemented, renames dependencies within the given resource and saves it. [param renames] is a dictionary [code]{ String =&gt; String }[/code] mapping old dependency paths to new paths.
 				Returns [constant OK] on success, or an [enum Error] constant in case of failure.
 			</description>
 		</method>

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -30,7 +30,7 @@
 			<param index="1" name="resource" type="String" />
 			<param index="2" name="flags" type="int" />
 			<description>
-				Saves the given resource object to a file at the target [code]path[/code]. [code]flags[/code] is a bitmask composed with [enum ResourceSaver.SaverFlags] constants.
+				Saves the given resource object to a file at the target [param path]. [param flags] is a bitmask composed with [enum ResourceSaver.SaverFlags] constants.
 				Returns [constant OK] on success, or an [enum Error] constant in case of failure.
 			</description>
 		</method>

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -26,15 +26,15 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="type_hint" type="String" default="&quot;&quot;" />
 			<description>
-				Returns whether a recognized resource exists for the given [code]path[/code].
-				An optional [code]type_hint[/code] can be used to further specify the [Resource] type that should be handled by the [ResourceFormatLoader]. Anything that inherits from [Resource] can be used as a type hint, for example [Image].
+				Returns whether a recognized resource exists for the given [param path].
+				An optional [param type_hint] can be used to further specify the [Resource] type that should be handled by the [ResourceFormatLoader]. Anything that inherits from [Resource] can be used as a type hint, for example [Image].
 			</description>
 		</method>
 		<method name="get_dependencies">
 			<return type="PackedStringArray" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Returns the dependencies for the resource at the given [code]path[/code].
+				Returns the dependencies for the resource at the given [param path].
 			</description>
 		</method>
 		<method name="get_recognized_extensions_for_type">
@@ -55,7 +55,7 @@
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Returns whether a cached resource is available for the given [code]path[/code].
+				Returns whether a cached resource is available for the given [param path].
 				Once a resource has been loaded by the engine, it is cached in memory for faster access, and future calls to the [method load] method will use the cached version. The cached resource can be overridden by using [method Resource.take_over_path] on a new resource for that same path.
 			</description>
 		</method>
@@ -65,10 +65,10 @@
 			<param index="1" name="type_hint" type="String" default="&quot;&quot;" />
 			<param index="2" name="cache_mode" type="int" enum="ResourceLoader.CacheMode" default="1" />
 			<description>
-				Loads a resource at the given [code]path[/code], caching the result for further access.
+				Loads a resource at the given [param path], caching the result for further access.
 				The registered [ResourceFormatLoader]s are queried sequentially to find the first one which can handle the file's extension, and then attempt loading. If loading fails, the remaining ResourceFormatLoaders are also attempted.
-				An optional [code]type_hint[/code] can be used to further specify the [Resource] type that should be handled by the [ResourceFormatLoader]. Anything that inherits from [Resource] can be used as a type hint, for example [Image].
-				The [code]cache_mode[/code] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
+				An optional [param type_hint] can be used to further specify the [Resource] type that should be handled by the [ResourceFormatLoader]. Anything that inherits from [Resource] can be used as a type hint, for example [Image].
+				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
 				Returns an empty resource if no [ResourceFormatLoader] could handle the file.
 				GDScript has a simplified [method @GDScript.load] built-in method which can be used in most situations, leaving the use of [ResourceLoader] for more advanced scenarios.
 			</description>
@@ -86,8 +86,8 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="progress" type="Array" default="[]" />
 			<description>
-				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [code]path[/code]. See [enum ThreadLoadStatus] for possible return values.
-				An array variable can optionally be passed via [code]progress[/code], and will return a one-element array containing the percentage of completion of the threaded loading.
+				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
+				An array variable can optionally be passed via [param progress], and will return a one-element array containing the percentage of completion of the threaded loading.
 			</description>
 		</method>
 		<method name="load_threaded_request">
@@ -97,8 +97,8 @@
 			<param index="2" name="use_sub_threads" type="bool" default="false" />
 			<param index="3" name="cache_mode" type="int" enum="ResourceLoader.CacheMode" default="1" />
 			<description>
-				Loads the resource using threads. If [code]use_sub_threads[/code] is [code]true[/code], multiple threads will be used to load the resource, which makes loading faster, but may affect the main thread (and thus cause game slowdowns).
-				The [code]cache_mode[/code] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
+				Loads the resource using threads. If [param use_sub_threads] is [code]true[/code], multiple threads will be used to load the resource, which makes loading faster, but may affect the main thread (and thus cause game slowdowns).
+				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
 			</description>
 		</method>
 		<method name="remove_resource_format_loader">

--- a/doc/classes/ResourcePreloader.xml
+++ b/doc/classes/ResourcePreloader.xml
@@ -15,14 +15,14 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="resource" type="Resource" />
 			<description>
-				Adds a resource to the preloader with the given [code]name[/code]. If a resource with the given [code]name[/code] already exists, the new resource will be renamed to "[code]name[/code] N" where N is an incrementing number starting from 2.
+				Adds a resource to the preloader with the given [param name]. If a resource with the given [param name] already exists, the new resource will be renamed to "[param name] N" where N is an incrementing number starting from 2.
 			</description>
 		</method>
 		<method name="get_resource" qualifiers="const">
 			<return type="Resource" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the resource associated to [code]name[/code].
+				Returns the resource associated to [param name].
 			</description>
 		</method>
 		<method name="get_resource_list" qualifiers="const">
@@ -35,14 +35,14 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the preloader contains a resource associated to [code]name[/code].
+				Returns [code]true[/code] if the preloader contains a resource associated to [param name].
 			</description>
 		</method>
 		<method name="remove_resource">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes the resource associated to [code]name[/code] from the preloader.
+				Removes the resource associated to [param name] from the preloader.
 			</description>
 		</method>
 		<method name="rename_resource">
@@ -50,7 +50,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="newname" type="StringName" />
 			<description>
-				Renames a resource inside the preloader from [code]name[/code] to [code]newname[/code].
+				Renames a resource inside the preloader from [param name] to [param newname].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -39,8 +39,8 @@
 			<param index="1" name="path" type="String" default="&quot;&quot;" />
 			<param index="2" name="flags" type="int" enum="ResourceSaver.SaverFlags" default="0" />
 			<description>
-				Saves a resource to disk to the given path, using a [ResourceFormatSaver] that recognizes the resource object. If [code]path[/code] is empty, [ResourceSaver] will try to use [member Resource.resource_path].
-				The [code]flags[/code] bitmask can be specified to customize the save behavior using [enum SaverFlags] flags.
+				Saves a resource to disk to the given path, using a [ResourceFormatSaver] that recognizes the resource object. If [param path] is empty, [ResourceSaver] will try to use [member Resource.resource_path].
+				The [param flags] bitmask can be specified to customize the save behavior using [enum SaverFlags] flags.
 				Returns [constant OK] on success.
 			</description>
 		</method>

--- a/doc/classes/RichTextEffect.xml
+++ b/doc/classes/RichTextEffect.xml
@@ -27,7 +27,7 @@
 			<return type="bool" />
 			<param index="0" name="char_fx" type="CharFXTransform" />
 			<description>
-				Override this method to modify properties in [code]char_fx[/code]. The method must return [code]true[/code] if the character could be transformed successfully. If the method returns [code]false[/code], it will skip transformation to avoid displaying broken text.
+				Override this method to modify properties in [param char_fx]. The method must return [code]true[/code] if the character could be transformed successfully. If the method returns [code]false[/code], it will skip transformation to avoid displaying broken text.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -24,8 +24,8 @@
 			<param index="3" name="color" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="4" name="inline_align" type="int" enum="InlineAlignment" default="5" />
 			<description>
-				Adds an image's opening and closing tags to the tag stack, optionally providing a [code]width[/code] and [code]height[/code] to resize the image and a [code]color[/code] to tint the image.
-				If [code]width[/code] or [code]height[/code] is set to 0, the image size will be adjusted in order to keep the original aspect ratio.
+				Adds an image's opening and closing tags to the tag stack, optionally providing a [param width] and [param height] to resize the image and a [param color] to tint the image.
+				If [param width] or [param height] is set to 0, the image size will be adjusted in order to keep the original aspect ratio.
 			</description>
 		</method>
 		<method name="add_text">
@@ -39,7 +39,7 @@
 			<return type="void" />
 			<param index="0" name="bbcode" type="String" />
 			<description>
-				Parses [code]bbcode[/code] and adds tags to the tag stack as needed.
+				Parses [param bbcode] and adds tags to the tag stack as needed.
 				[b]Note:[/b] Using this method, you can't close a tag that was opened in a previous [method append_text] call. This is done to improve performance, especially when updating large RichTextLabels since rebuilding the whole BBCode every time would be slower. If you absolutely need to close a tag in a future method call, append the [member text] instead of using [method append_text].
 			</description>
 		</method>
@@ -176,7 +176,7 @@
 			<return type="void" />
 			<param index="0" name="effect" type="Variant" />
 			<description>
-				Installs a custom effect. [code]effect[/code] should be a valid [RichTextEffect].
+				Installs a custom effect. [param effect] should be a valid [RichTextEffect].
 			</description>
 		</method>
 		<method name="is_menu_visible" qualifiers="const">
@@ -208,7 +208,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="expressions" type="PackedStringArray" />
 			<description>
-				Parses BBCode parameter [code]expressions[/code] into a dictionary.
+				Parses BBCode parameter [param expressions] into a dictionary.
 			</description>
 		</method>
 		<method name="pop">
@@ -294,7 +294,7 @@
 			<return type="void" />
 			<param index="0" name="level" type="int" />
 			<description>
-				Adds an [code][indent][/code] tag to the tag stack. Multiplies [code]level[/code] by current [member tab_size] to determine new margin length.
+				Adds an [code][indent][/code] tag to the tag stack. Multiplies [param level] by current [member tab_size] to determine new margin length.
 			</description>
 		</method>
 		<method name="push_italics">
@@ -309,7 +309,7 @@
 			<param index="1" name="type" type="int" enum="RichTextLabel.ListType" />
 			<param index="2" name="capitalize" type="bool" />
 			<description>
-				Adds [code][ol][/code] or [code][ul][/code] tag to the tag stack. Multiplies [code]level[/code] by current [member tab_size] to determine new margin length.
+				Adds [code][ol][/code] or [code][ul][/code] tag to the tag stack. Multiplies [param level] by current [member tab_size] to determine new margin length.
 			</description>
 		</method>
 		<method name="push_meta">
@@ -380,21 +380,21 @@
 			<param index="0" name="line" type="int" />
 			<description>
 				Removes a line of content from the label. Returns [code]true[/code] if the line exists.
-				The [code]line[/code] argument is the index of the line to remove, it can take values in the interval [code][0, get_line_count() - 1][/code].
+				The [param line] argument is the index of the line to remove, it can take values in the interval [code][0, get_line_count() - 1][/code].
 			</description>
 		</method>
 		<method name="scroll_to_line">
 			<return type="void" />
 			<param index="0" name="line" type="int" />
 			<description>
-				Scrolls the window's top line to match [code]line[/code].
+				Scrolls the window's top line to match [param line].
 			</description>
 		</method>
 		<method name="scroll_to_paragraph">
 			<return type="void" />
 			<param index="0" name="paragraph" type="int" />
 			<description>
-				Scrolls the window's top line to match first line of the [code]paragraph[/code].
+				Scrolls the window's top line to match first line of the [param paragraph].
 			</description>
 		</method>
 		<method name="select_all">
@@ -440,9 +440,9 @@
 			<param index="1" name="expand" type="bool" />
 			<param index="2" name="ratio" type="int" />
 			<description>
-				Edits the selected column's expansion options. If [code]expand[/code] is [code]true[/code], the column expands in proportion to its expansion ratio versus the other columns' ratios.
+				Edits the selected column's expansion options. If [param expand] is [code]true[/code], the column expands in proportion to its expansion ratio versus the other columns' ratios.
 				For example, 2 columns with ratios 3 and 4 plus 70 pixels in available width would expand 30 and 40 pixels, respectively.
-				If [code]expand[/code] is [code]false[/code], the column will not contribute to the total ratio.
+				If [param expand] is [code]false[/code], the column will not contribute to the total ratio.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RigidDynamicBody2D.xml
+++ b/doc/classes/RigidDynamicBody2D.xml
@@ -36,7 +36,7 @@
 			<param index="1" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
 				Adds a constant positioned force to the body that keeps being applied over time until cleared with [code]constant_force = Vector2(0, 0)[/code].
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="add_constant_torque">
@@ -69,7 +69,7 @@
 			<param index="1" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
 				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="apply_impulse">
@@ -79,7 +79,7 @@
 			<description>
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="apply_torque">
@@ -200,14 +200,14 @@
 			<param index="0" name="body" type="Node" />
 			<description>
 				Emitted when a collision with another [PhysicsBody2D] or [TileMap] occurs. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
 			</description>
 		</signal>
 		<signal name="body_exited">
 			<param index="0" name="body" type="Node" />
 			<description>
 				Emitted when the collision with another [PhysicsBody2D] or [TileMap] ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
@@ -217,10 +217,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of this RigidDynamicBody2D's [Shape2D]s collides with another [PhysicsBody2D] or [TileMap]'s [Shape2D]s. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[code]body_rid[/code] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
-				[code]body_shape_index[/code] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this RigidDynamicBody2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param body_rid] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
+				[param body_shape_index] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape2D] of this RigidDynamicBody2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -230,10 +230,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when the collision between one of this RigidDynamicBody2D's [Shape2D]s and another [PhysicsBody2D] or [TileMap]'s [Shape2D]s ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[code]body_rid[/code] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
-				[code]body_shape_index[/code] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this RigidDynamicBody2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param body_rid] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
+				[param body_shape_index] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape2D] of this RigidDynamicBody2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="sleeping_state_changed">

--- a/doc/classes/RigidDynamicBody3D.xml
+++ b/doc/classes/RigidDynamicBody3D.xml
@@ -36,7 +36,7 @@
 			<param index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)" />
 			<description>
 				Adds a constant positioned force to the body that keeps being applied over time until cleared with [code]constant_force = Vector3(0, 0, 0)[/code].
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="add_constant_torque">
@@ -69,7 +69,7 @@
 			<param index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)" />
 			<description>
 				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="apply_impulse">
@@ -79,7 +79,7 @@
 			<description>
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="apply_torque">
@@ -206,14 +206,14 @@
 			<param index="0" name="body" type="Node" />
 			<description>
 				Emitted when a collision with another [PhysicsBody3D] or [GridMap] occurs. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
 			</description>
 		</signal>
 		<signal name="body_exited">
 			<param index="0" name="body" type="Node" />
 			<description>
 				Emitted when the collision with another [PhysicsBody3D] or [GridMap] ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
@@ -223,10 +223,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of this RigidDynamicBody3D's [Shape3D]s collides with another [PhysicsBody3D] or [GridMap]'s [Shape3D]s. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[code]body_rid[/code] the [RID] of the other [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D].
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
-				[code]body_shape_index[/code] the index of the [Shape3D] of the other [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape3D] of this RigidDynamicBody3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param body_rid] the [RID] of the other [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
+				[param body_shape_index] the index of the [Shape3D] of the other [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape3D] of this RigidDynamicBody3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -236,10 +236,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when the collision between one of this RigidDynamicBody3D's [Shape3D]s and another [PhysicsBody3D] or [GridMap]'s [Shape3D]s ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member contacts_reported] to be set high enough to detect all the collisions. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[code]body_rid[/code] the [RID] of the other [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D]. [GridMap]s are detected if the Meshes have [Shape3D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
-				[code]body_shape_index[/code] the index of the [Shape3D] of the other [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape3D] of this RigidDynamicBody3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param body_rid] the [RID] of the other [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D]. [GridMap]s are detected if the Meshes have [Shape3D]s.
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
+				[param body_shape_index] the index of the [Shape3D] of the other [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape3D] of this RigidDynamicBody3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="sleeping_state_changed">

--- a/doc/classes/SceneState.xml
+++ b/doc/classes/SceneState.xml
@@ -14,7 +14,7 @@
 			<return type="Array" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the list of bound parameters for the signal at [code]idx[/code].
+				Returns the list of bound parameters for the signal at [param idx].
 			</description>
 		</method>
 		<method name="get_connection_count" qualifiers="const">
@@ -28,42 +28,42 @@
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the connection flags for the signal at [code]idx[/code]. See [enum Object.ConnectFlags] constants.
+				Returns the connection flags for the signal at [param idx]. See [enum Object.ConnectFlags] constants.
 			</description>
 		</method>
 		<method name="get_connection_method" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the method connected to the signal at [code]idx[/code].
+				Returns the method connected to the signal at [param idx].
 			</description>
 		</method>
 		<method name="get_connection_signal" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the name of the signal at [code]idx[/code].
+				Returns the name of the signal at [param idx].
 			</description>
 		</method>
 		<method name="get_connection_source" qualifiers="const">
 			<return type="NodePath" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the path to the node that owns the signal at [code]idx[/code], relative to the root node.
+				Returns the path to the node that owns the signal at [param idx], relative to the root node.
 			</description>
 		</method>
 		<method name="get_connection_target" qualifiers="const">
 			<return type="NodePath" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the path to the node that owns the method connected to the signal at [code]idx[/code], relative to the root node.
+				Returns the path to the node that owns the method connected to the signal at [param idx], relative to the root node.
 			</description>
 		</method>
 		<method name="get_connection_unbinds" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the number of unbound parameters for the signal at [code]idx[/code].
+				Returns the number of unbound parameters for the signal at [param idx].
 			</description>
 		</method>
 		<method name="get_node_count" qualifiers="const">
@@ -77,42 +77,42 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the list of group names associated with the node at [code]idx[/code].
+				Returns the list of group names associated with the node at [param idx].
 			</description>
 		</method>
 		<method name="get_node_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the node's index, which is its position relative to its siblings. This is only relevant and saved in scenes for cases where new nodes are added to an instantiated or inherited scene among siblings from the base scene. Despite the name, this index is not related to the [code]idx[/code] argument used here and in other methods.
+				Returns the node's index, which is its position relative to its siblings. This is only relevant and saved in scenes for cases where new nodes are added to an instantiated or inherited scene among siblings from the base scene. Despite the name, this index is not related to the [param idx] argument used here and in other methods.
 			</description>
 		</method>
 		<method name="get_node_instance" qualifiers="const">
 			<return type="PackedScene" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns a [PackedScene] for the node at [code]idx[/code] (i.e. the whole branch starting at this node, with its child nodes and resources), or [code]null[/code] if the node is not an instance.
+				Returns a [PackedScene] for the node at [param idx] (i.e. the whole branch starting at this node, with its child nodes and resources), or [code]null[/code] if the node is not an instance.
 			</description>
 		</method>
 		<method name="get_node_instance_placeholder" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the path to the represented scene file if the node at [code]idx[/code] is an [InstancePlaceholder].
+				Returns the path to the represented scene file if the node at [param idx] is an [InstancePlaceholder].
 			</description>
 		</method>
 		<method name="get_node_name" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the name of the node at [code]idx[/code].
+				Returns the name of the node at [param idx].
 			</description>
 		</method>
 		<method name="get_node_owner_path" qualifiers="const">
 			<return type="NodePath" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the path to the owner of the node at [code]idx[/code], relative to the root node.
+				Returns the path to the owner of the node at [param idx], relative to the root node.
 			</description>
 		</method>
 		<method name="get_node_path" qualifiers="const">
@@ -120,15 +120,15 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="for_parent" type="bool" default="false" />
 			<description>
-				Returns the path to the node at [code]idx[/code].
-				If [code]for_parent[/code] is [code]true[/code], returns the path of the [code]idx[/code] node's parent instead.
+				Returns the path to the node at [param idx].
+				If [param for_parent] is [code]true[/code], returns the path of the [param idx] node's parent instead.
 			</description>
 		</method>
 		<method name="get_node_property_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the number of exported or overridden properties for the node at [code]idx[/code].
+				Returns the number of exported or overridden properties for the node at [param idx].
 				The [code]prop_idx[/code] argument used to query node property data in other [code]get_node_property_*[/code] methods in the interval [code][0, get_node_property_count() - 1][/code].
 			</description>
 		</method>
@@ -137,7 +137,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="prop_idx" type="int" />
 			<description>
-				Returns the name of the property at [code]prop_idx[/code] for the node at [code]idx[/code].
+				Returns the name of the property at [param prop_idx] for the node at [param idx].
 			</description>
 		</method>
 		<method name="get_node_property_value" qualifiers="const">
@@ -145,21 +145,21 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="prop_idx" type="int" />
 			<description>
-				Returns the value of the property at [code]prop_idx[/code] for the node at [code]idx[/code].
+				Returns the value of the property at [param prop_idx] for the node at [param idx].
 			</description>
 		</method>
 		<method name="get_node_type" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the type of the node at [code]idx[/code].
+				Returns the type of the node at [param idx].
 			</description>
 		</method>
 		<method name="is_node_instance_placeholder" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the node at [code]idx[/code] is an [InstancePlaceholder].
+				Returns [code]true[/code] if the node at [param idx] is an [InstancePlaceholder].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -18,7 +18,7 @@
 			<param index="0" name="group" type="StringName" />
 			<param index="1" name="method" type="StringName" />
 			<description>
-				Calls [code]method[/code] on each member of the given group. You can pass arguments to [code]method[/code] by specifying them at the end of the method call. If a node doesn't have the given method or the argument list does not match (either in count or in types), it will be skipped.
+				Calls [param method] on each member of the given group. You can pass arguments to [param method] by specifying them at the end of the method call. If a node doesn't have the given method or the argument list does not match (either in count or in types), it will be skipped.
 				[b]Note:[/b] [method call_group] will call methods immediately on all members at once, which can cause stuttering if an expensive method is called on lots of members. To wait for one frame after [method call_group] was called, use [method call_group_flags] with the [constant GROUP_CALL_DEFERRED] flag.
 			</description>
 		</method>
@@ -28,20 +28,20 @@
 			<param index="1" name="group" type="StringName" />
 			<param index="2" name="method" type="StringName" />
 			<description>
-				Calls [code]method[/code] on each member of the given group, respecting the given [enum GroupCallFlags]. You can pass arguments to [code]method[/code] by specifying them at the end of the method call. If a node doesn't have the given method or the argument list does not match (either in count or in types), it will be skipped.
+				Calls [param method] on each member of the given group, respecting the given [enum GroupCallFlags]. You can pass arguments to [param method] by specifying them at the end of the method call. If a node doesn't have the given method or the argument list does not match (either in count or in types), it will be skipped.
 				[codeblock]
 				# Call the method in a deferred manner and in reverse order.
 				get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFERRED | SceneTree.GROUP_CALL_REVERSE)
 				[/codeblock]
-				[b]Note:[/b] Group call flags are used to control the method calling behavior. By default, methods will be called immediately in a way similar to [method call_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [code]flags[/code] argument, methods will be called with a one-frame delay in a way similar to [method Object.set_deferred].
+				[b]Note:[/b] Group call flags are used to control the method calling behavior. By default, methods will be called immediately in a way similar to [method call_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param flags] argument, methods will be called with a one-frame delay in a way similar to [method Object.set_deferred].
 			</description>
 		</method>
 		<method name="change_scene">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Changes the running scene to the one at the given [code]path[/code], after loading it into a [PackedScene] and creating a new instance.
-				Returns [constant OK] on success, [constant ERR_CANT_OPEN] if the [code]path[/code] cannot be loaded into a [PackedScene], or [constant ERR_CANT_CREATE] if that scene cannot be instantiated.
+				Changes the running scene to the one at the given [param path], after loading it into a [PackedScene] and creating a new instance.
+				Returns [constant OK] on success, [constant ERR_CANT_OPEN] if the [param path] cannot be loaded into a [PackedScene], or [constant ERR_CANT_CREATE] if that scene cannot be instantiated.
 				[b]Note:[/b] The scene change is deferred, which means that the new scene node is added on the next idle frame. You won't be able to access it immediately after the [method change_scene] call.
 			</description>
 		</method>
@@ -59,7 +59,7 @@
 			<param index="0" name="time_sec" type="float" />
 			<param index="1" name="process_always" type="bool" default="true" />
 			<description>
-				Returns a [SceneTreeTimer] which will [signal SceneTreeTimer.timeout] after the given time in seconds elapsed in this [SceneTree]. If [code]process_always[/code] is set to [code]false[/code], pausing the [SceneTree] will also pause the timer.
+				Returns a [SceneTreeTimer] which will [signal SceneTreeTimer.timeout] after the given time in seconds elapsed in this [SceneTree]. If [param process_always] is set to [code]false[/code], pausing the [SceneTree] will also pause the timer.
 				Commonly used to create a one-shot delay timer as in the following example:
 				[codeblocks]
 				[gdscript]
@@ -103,7 +103,7 @@
 			<return type="MultiplayerAPI" />
 			<param index="0" name="for_path" type="NodePath" default="NodePath(&quot;&quot;)" />
 			<description>
-				Return the [MultiplayerAPI] configured for the given path, or the default one if [code]for_path[/code] is empty.
+				Return the [MultiplayerAPI] configured for the given path, or the default one if [param for_path] is empty.
 			</description>
 		</method>
 		<method name="get_node_count" qualifiers="const">
@@ -137,7 +137,7 @@
 			<param index="0" name="group" type="StringName" />
 			<param index="1" name="notification" type="int" />
 			<description>
-				Sends the given notification to all members of the [code]group[/code].
+				Sends the given notification to all members of the [param group].
 				[b]Note:[/b] [method notify_group] will immediately notify all members at once, which can cause stuttering if an expensive method is called as a result of sending the notification lots of members. To wait for one frame, use [method notify_group_flags] with the [constant GROUP_CALL_DEFERRED] flag.
 			</description>
 		</method>
@@ -147,8 +147,8 @@
 			<param index="1" name="group" type="StringName" />
 			<param index="2" name="notification" type="int" />
 			<description>
-				Sends the given notification to all members of the [code]group[/code], respecting the given [enum GroupCallFlags].
-				[b]Note:[/b] Group call flags are used to control the notification sending behavior. By default, notifications will be sent immediately in a way similar to [method notify_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [code]flags[/code] argument, notifications will be sent with a one-frame delay in a way similar to using [code]Object.call_deferred("notification", ...)[/code].
+				Sends the given notification to all members of the [param group], respecting the given [enum GroupCallFlags].
+				[b]Note:[/b] Group call flags are used to control the notification sending behavior. By default, notifications will be sent immediately in a way similar to [method notify_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param call_flags] argument, notifications will be sent with a one-frame delay in a way similar to using [code]Object.call_deferred("notification", ...)[/code].
 			</description>
 		</method>
 		<method name="queue_delete">
@@ -162,7 +162,7 @@
 			<return type="void" />
 			<param index="0" name="exit_code" type="int" default="0" />
 			<description>
-				Quits the application at the end of the current iteration. Argument [code]exit_code[/code] can optionally be given (defaulting to 0) to customize the exit status code.
+				Quits the application at the end of the current iteration. Argument [param exit_code] can optionally be given (defaulting to 0) to customize the exit status code.
 				By convention, an exit code of [code]0[/code] indicates success whereas a non-zero exit code indicates an error.
 				For portability reasons, the exit code should be set between 0 and 125 (inclusive).
 				[b]Note:[/b] On iOS this method doesn't work. Instead, as recommended by the iOS Human Interface Guidelines, the user is expected to close apps via the Home button.
@@ -181,7 +181,7 @@
 			<param index="1" name="property" type="String" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets the given [code]property[/code] to [code]value[/code] on all members of the given group.
+				Sets the given [param property] to [param value] on all members of the given group.
 				[b]Note:[/b] [method set_group] will set the property immediately on all members at once, which can cause stuttering if a property with an expensive setter is set on lots of members. To wait for one frame, use [method set_group_flags] with the [constant GROUP_CALL_DEFERRED] flag.
 			</description>
 		</method>
@@ -192,8 +192,8 @@
 			<param index="2" name="property" type="String" />
 			<param index="3" name="value" type="Variant" />
 			<description>
-				Sets the given [code]property[/code] to [code]value[/code] on all members of the given group, respecting the given [enum GroupCallFlags].
-				[b]Note:[/b] Group call flags are used to control the property setting behavior. By default, properties will be set immediately in a way similar to [method set_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [code]flags[/code] argument, properties will be set with a one-frame delay in a way similar to [method Object.call_deferred].
+				Sets the given [param property] to [param value] on all members of the given group, respecting the given [enum GroupCallFlags].
+				[b]Note:[/b] Group call flags are used to control the property setting behavior. By default, properties will be set immediately in a way similar to [method set_group]. However, if the [constant GROUP_CALL_DEFERRED] flag is present in the [param call_flags] argument, properties will be set with a one-frame delay in a way similar to [method Object.call_deferred].
 			</description>
 		</method>
 		<method name="set_multiplayer">
@@ -201,7 +201,7 @@
 			<param index="0" name="multiplayer" type="MultiplayerAPI" />
 			<param index="1" name="root_path" type="NodePath" default="NodePath(&quot;&quot;)" />
 			<description>
-				Sets a custom [MultiplayerAPI] with the given [code]root_path[/code] (controlling also the relative subpaths), or override the default one if [code]root_path[/code] is empty.
+				Sets a custom [MultiplayerAPI] with the given [param root_path] (controlling also the relative subpaths), or override the default one if [param root_path] is empty.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -78,7 +78,7 @@
 			<return type="bool" />
 			<param index="0" name="base_object" type="Object" />
 			<description>
-				Returns [code]true[/code] if [code]base_object[/code] is an instance of this script.
+				Returns [code]true[/code] if [param base_object] is an instance of this script.
 			</description>
 		</method>
 		<method name="is_tool" qualifiers="const">

--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -45,7 +45,7 @@
 			<param index="0" name="base_name" type="String" />
 			<param index="1" name="base_path" type="String" />
 			<description>
-				Opens the script create dialog. The script will extend [code]base_name[/code]. The file extension can be omitted from [code]base_path[/code]. It will be added based on the selected scripting language.
+				Opens the script create dialog. The script will extend [param base_name]. The file extension can be omitted from [param base_path]. It will be added based on the selected scripting language.
 			</description>
 		</method>
 		<method name="register_syntax_highlighter">

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -16,7 +16,7 @@
 			<return type="void" />
 			<param index="0" name="control" type="Control" />
 			<description>
-				Ensures the given [code]control[/code] is visible (must be a direct or indirect child of the ScrollContainer). Used by [member follow_focus].
+				Ensures the given [param control] is visible (must be a direct or indirect child of the ScrollContainer). Used by [member follow_focus].
 				[b]Note:[/b] This will not work on a node that was just added during the same frame. If you want to scroll to a newly added child, you must wait until the next frame using [signal SceneTree.process_frame]:
 				[codeblock]
 				add_child(child_node)

--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -16,8 +16,8 @@
 			<param index="1" name="index" type="int" default="0" />
 			<description>
 				Returns the texture that is set as default for the specified parameter.
-				[b]Note:[/b] [code]param[/code] must match the name of the uniform in the code exactly.
-				[b]Note:[/b] If the sampler array is used use [code]index[/code] to access the specified texture.
+				[b]Note:[/b] [param param] must match the name of the uniform in the code exactly.
+				[b]Note:[/b] If the sampler array is used use [param index] to access the specified texture.
 			</description>
 		</method>
 		<method name="get_mode" qualifiers="const">
@@ -31,7 +31,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Returns [code]true[/code] if the shader has this param defined as a uniform in its code.
-				[b]Note:[/b] [code]param[/code] must match the name of the uniform in the code exactly.
+				[b]Note:[/b] [param name] must match the name of the uniform in the code exactly.
 			</description>
 		</method>
 		<method name="set_default_texture_param">
@@ -41,8 +41,8 @@
 			<param index="2" name="index" type="int" default="0" />
 			<description>
 				Sets the default texture to be used with a texture uniform. The default is used if a texture is not set in the [ShaderMaterial].
-				[b]Note:[/b] [code]param[/code] must match the name of the uniform in the code exactly.
-				[b]Note:[/b] If the sampler array is used use [code]index[/code] to access the specified texture.
+				[b]Note:[/b] [param param] must match the name of the uniform in the code exactly.
+				[b]Note:[/b] If the sampler array is used use [param index] to access the specified texture.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -21,14 +21,14 @@
 			<return type="bool" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if the property identified by [code]name[/code] can be reverted to a default value.
+				Returns [code]true[/code] if the property identified by [param name] can be reverted to a default value.
 			</description>
 		</method>
 		<method name="property_get_revert">
 			<return type="Variant" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the default value of the material property with given [code]name[/code].
+				Returns the default value of the material property with given [param name].
 			</description>
 		</method>
 		<method name="set_shader_uniform">
@@ -37,7 +37,7 @@
 			<param index="1" name="value" type="Variant" />
 			<description>
 				Changes the value set for this material of a uniform in the shader.
-				[b]Note:[/b] [code]param[/code] must match the name of the uniform in the code exactly.
+				[b]Note:[/b] [param param] must match the name of the uniform in the code exactly.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -17,7 +17,7 @@
 			<param index="2" name="shape_xform" type="Transform2D" />
 			<description>
 				Returns [code]true[/code] if this shape is colliding with another.
-				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the shape to check collisions with ([code]with_shape[/code]), and the transformation matrix of that shape ([code]shape_xform[/code]).
+				This method needs the transformation matrix for this shape ([param local_xform]), the shape to check collisions with ([param with_shape]), and the transformation matrix of that shape ([param shape_xform]).
 			</description>
 		</method>
 		<method name="collide_and_get_contacts">
@@ -27,9 +27,9 @@
 			<param index="2" name="shape_xform" type="Transform2D" />
 			<description>
 				Returns a list of contact point pairs where this shape touches another.
-				If there are no collisions, the returned list is empty. Otherwise, the returned list contains contact points arranged in pairs, with entries alternating between points on the boundary of this shape and points on the boundary of [code]with_shape[/code].
+				If there are no collisions, the returned list is empty. Otherwise, the returned list contains contact points arranged in pairs, with entries alternating between points on the boundary of this shape and points on the boundary of [param with_shape].
 				A collision pair A, B can be used to calculate the collision normal with [code](B - A).normalized()[/code], and the collision depth with [code](B - A).length()[/code]. This information is typically used to separate shapes, particularly in collision solvers.
-				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the shape to check collisions with ([code]with_shape[/code]), and the transformation matrix of that shape ([code]shape_xform[/code]).
+				This method needs the transformation matrix for this shape ([param local_xform]), the shape to check collisions with ([param with_shape]), and the transformation matrix of that shape ([param shape_xform]).
 			</description>
 		</method>
 		<method name="collide_with_motion">
@@ -41,7 +41,7 @@
 			<param index="4" name="shape_motion" type="Vector2" />
 			<description>
 				Returns whether this shape would collide with another, if a given movement was applied.
-				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the movement to test on this shape ([code]local_motion[/code]), the shape to check collisions with ([code]with_shape[/code]), the transformation matrix of that shape ([code]shape_xform[/code]), and the movement to test onto the other object ([code]shape_motion[/code]).
+				This method needs the transformation matrix for this shape ([param local_xform]), the movement to test on this shape ([param local_motion]), the shape to check collisions with ([param with_shape]), the transformation matrix of that shape ([param shape_xform]), and the movement to test onto the other object ([param shape_motion]).
 			</description>
 		</method>
 		<method name="collide_with_motion_and_get_contacts">
@@ -53,9 +53,9 @@
 			<param index="4" name="shape_motion" type="Vector2" />
 			<description>
 				Returns a list of contact point pairs where this shape would touch another, if a given movement was applied.
-				If there would be no collisions, the returned list is empty. Otherwise, the returned list contains contact points arranged in pairs, with entries alternating between points on the boundary of this shape and points on the boundary of [code]with_shape[/code].
+				If there would be no collisions, the returned list is empty. Otherwise, the returned list contains contact points arranged in pairs, with entries alternating between points on the boundary of this shape and points on the boundary of [param with_shape].
 				A collision pair A, B can be used to calculate the collision normal with [code](B - A).normalized()[/code], and the collision depth with [code](B - A).length()[/code]. This information is typically used to separate shapes, particularly in collision solvers.
-				This method needs the transformation matrix for this shape ([code]local_xform[/code]), the movement to test on this shape ([code]local_motion[/code]), the shape to check collisions with ([code]with_shape[/code]), the transformation matrix of that shape ([code]shape_xform[/code]), and the movement to test onto the other object ([code]shape_motion[/code]).
+				This method needs the transformation matrix for this shape ([param local_xform]), the movement to test on this shape ([param local_motion]), the shape to check collisions with ([param with_shape]), the transformation matrix of that shape ([param shape_xform]), and the movement to test onto the other object ([param shape_motion]).
 			</description>
 		</method>
 		<method name="draw">
@@ -63,7 +63,7 @@
 			<param index="0" name="canvas_item" type="RID" />
 			<param index="1" name="color" type="Color" />
 			<description>
-				Draws a solid shape onto a [CanvasItem] with the [RenderingServer] API filled with the specified [code]color[/code]. The exact drawing method is specific for each shape and cannot be configured.
+				Draws a solid shape onto a [CanvasItem] with the [RenderingServer] API filled with the specified [param color]. The exact drawing method is specific for each shape and cannot be configured.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -55,14 +55,14 @@
 			<return type="Object" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the collided [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the collided [Object] of one of the multiple collisions at [param index], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the shape ID of the colliding shape of one of the multiple collisions at [code]index[/code], or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the shape ID of the colliding shape of one of the multiple collisions at [param index], or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collision_count" qualifiers="const">
@@ -75,21 +75,21 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_collision_normal" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the normal of one of the multiple collisions at [code]index[/code] of the intersecting object.
+				Returns the normal of one of the multiple collisions at [param index] of the intersecting object.
 			</description>
 		</method>
 		<method name="get_collision_point" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the collision point of one of the multiple collisions at [code]index[/code] where the shape intersects the colliding object.
+				Returns the collision point of one of the multiple collisions at [param index] where the shape intersects the colliding object.
 				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>
@@ -118,7 +118,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -55,14 +55,14 @@
 			<return type="Object" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the collided [Object] of one of the multiple collisions at [code]index[/code], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the collided [Object] of one of the multiple collisions at [param index], or [code]null[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the shape ID of the colliding shape of one of the multiple collisions at [code]index[/code], or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
+				Returns the shape ID of the colliding shape of one of the multiple collisions at [param index], or [code]0[/code] if no object is intersecting the shape (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
 		<method name="get_collision_count" qualifiers="const">
@@ -75,21 +75,21 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_collision_normal" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the normal of one of the multiple collisions at [code]index[/code] of the intersecting object.
+				Returns the normal of one of the multiple collisions at [param index] of the intersecting object.
 			</description>
 		</method>
 		<method name="get_collision_point" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the collision point of one of the multiple collisions at [code]index[/code] where the shape intersects the colliding object.
+				Returns the collision point of one of the multiple collisions at [param index] where the shape intersects the colliding object.
 				[b]Note:[/b] this point is in the [b]global[/b] coordinate system.
 			</description>
 		</method>
@@ -125,7 +125,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Shortcut.xml
+++ b/doc/classes/Shortcut.xml
@@ -26,7 +26,7 @@
 			<return type="bool" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Returns whether any [InputEvent] in [member events] equals [code]event[/code].
+				Returns whether any [InputEvent] in [member events] equals [param event].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -28,7 +28,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="signal" type="StringName" />
 			<description>
-				Creates a new [Signal] with the name [code]signal[/code] in the specified [code]object[/code].
+				Creates a new [Signal] with the name [param signal] in the specified [param object].
 			</description>
 		</constructor>
 	</constructors>

--- a/doc/classes/Skeleton2D.xml
+++ b/doc/classes/Skeleton2D.xml
@@ -23,7 +23,7 @@
 			<return type="Bone2D" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns a [Bone2D] from the node hierarchy parented by Skeleton2D. The object to return is identified by the parameter [code]idx[/code]. Bones are indexed by descending the node hierarchy from top to bottom, adding the children of each branch before moving to the next sibling.
+				Returns a [Bone2D] from the node hierarchy parented by Skeleton2D. The object to return is identified by the parameter [param idx]. Bones are indexed by descending the node hierarchy from top to bottom, adding the children of each branch before moving to the next sibling.
 			</description>
 		</method>
 		<method name="get_bone_count" qualifiers="const">
@@ -36,7 +36,7 @@
 			<return type="Transform2D" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the local pose override transform for [code]bone_idx[/code].
+				Returns the local pose override transform for [param bone_idx].
 			</description>
 		</method>
 		<method name="get_modification_stack" qualifiers="const">
@@ -58,9 +58,9 @@
 			<param index="2" name="strength" type="float" />
 			<param index="3" name="persistent" type="bool" />
 			<description>
-				Sets the local pose transform, [code]pose[/code], for the bone at [code]bone_idx[/code].
-				[code]amount[/code] is the interpolation strength that will be used when applying the pose, and [code]persistent[/code] determines if the applied pose will remain.
-				[b]Note:[/b] The pose transform needs to be a local transform relative to the [Bone2D] node at [code]bone_idx[/code]!
+				Sets the local pose transform, [param override_pose], for the bone at [param bone_idx].
+				[param strength] is the interpolation strength that will be used when applying the pose, and [param persistent] determines if the applied pose will remain.
+				[b]Note:[/b] The pose transform needs to be a local transform relative to the [Bone2D] node at [param bone_idx]!
 			</description>
 		</method>
 		<method name="set_modification_stack">

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -17,7 +17,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Adds a bone, with name [code]name[/code]. [method get_bone_count] will become the bone index.
+				Adds a bone, with name [param name]. [method get_bone_count] will become the bone index.
 			</description>
 		</method>
 		<method name="add_bone_child">
@@ -64,7 +64,7 @@
 			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the bone index that matches [code]name[/code] as its name.
+				Returns the bone index that matches [param name] as its name.
 			</description>
 		</method>
 		<method name="force_update_all_bone_transforms">
@@ -77,14 +77,14 @@
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Force updates the bone transform for the bone at [code]bone_idx[/code] and all of its children.
+				Force updates the bone transform for the bone at [param bone_idx] and all of its children.
 			</description>
 		</method>
 		<method name="get_bone_children">
 			<return type="PackedInt32Array" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns an array containing the bone indexes of all the children node of the passed in bone, [code]bone_idx[/code].
+				Returns an array containing the bone indexes of all the children node of the passed in bone, [param bone_idx].
 			</description>
 		</method>
 		<method name="get_bone_count" qualifiers="const">
@@ -111,36 +111,36 @@
 			<return type="Transform3D" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the global pose override transform for [code]bone_idx[/code].
+				Returns the global pose override transform for [param bone_idx].
 			</description>
 		</method>
 		<method name="get_bone_global_rest" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the global rest transform for [code]bone_idx[/code].
+				Returns the global rest transform for [param bone_idx].
 			</description>
 		</method>
 		<method name="get_bone_local_pose_override" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the local pose override transform for [code]bone_idx[/code].
+				Returns the local pose override transform for [param bone_idx].
 			</description>
 		</method>
 		<method name="get_bone_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the name of the bone at index [code]index[/code].
+				Returns the name of the bone at index [param bone_idx].
 			</description>
 		</method>
 		<method name="get_bone_parent" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the bone index which is the parent of the bone at [code]bone_idx[/code]. If -1, then bone has no parent.
-				[b]Note:[/b] The parent bone returned will always be less than [code]bone_idx[/code].
+				Returns the bone index which is the parent of the bone at [param bone_idx]. If -1, then bone has no parent.
+				[b]Note:[/b] The parent bone returned will always be less than [param bone_idx].
 			</description>
 		</method>
 		<method name="get_bone_pose" qualifiers="const">
@@ -172,7 +172,7 @@
 			<return type="Transform3D" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the rest transform for a bone [code]bone_idx[/code].
+				Returns the rest transform for a bone [param bone_idx].
 			</description>
 		</method>
 		<method name="get_modification_stack">
@@ -209,7 +209,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="basis" type="Basis" />
 			<description>
-				Rotates the given [Basis] so that the forward axis of the Basis is facing in the forward direction of the bone at [code]bone_idx[/code].
+				Rotates the given [Basis] so that the forward axis of the Basis is facing in the forward direction of the bone at [param bone_idx].
 				This is helper function to make using [method Transform3D.looking_at] easier with bone poses.
 			</description>
 		</method>
@@ -217,7 +217,7 @@
 			<return type="bool" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns whether the bone pose for the bone at [code]bone_idx[/code] is enabled.
+				Returns whether the bone pose for the bone at [param bone_idx] is enabled.
 			</description>
 		</method>
 		<method name="local_pose_to_global_pose">
@@ -225,7 +225,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="local_pose" type="Transform3D" />
 			<description>
-				Converts the passed-in local pose to a global pose relative to the inputted bone, [code]bone_idx[/code].
+				Converts the passed-in local pose to a global pose relative to the inputted bone, [param bone_idx].
 				This could be used to convert [method get_bone_pose] for use with the [method set_bone_global_pose_override] function.
 			</description>
 		</method>
@@ -277,7 +277,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="child_bone_idx" type="int" />
 			<description>
-				Removes the passed in child bone index, [code]child_bone_idx[/code], from the passed-in bone, [code]bone_idx[/code], if it exists.
+				Removes the passed in child bone index, [param child_bone_idx], from the passed-in bone, [param bone_idx], if it exists.
 				[b]Note:[/b] This does not remove the child bone, but instead it removes the connection it has to the parent bone.
 			</description>
 		</method>
@@ -286,7 +286,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="bone_children" type="PackedInt32Array" />
 			<description>
-				Sets the children for the passed in bone, [code]bone_idx[/code], to the passed-in array of bone indexes, [code]bone_children[/code].
+				Sets the children for the passed in bone, [param bone_idx], to the passed-in array of bone indexes, [param bone_children].
 			</description>
 		</method>
 		<method name="set_bone_enabled">
@@ -294,7 +294,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="enabled" type="bool" default="true" />
 			<description>
-				Disables the pose for the bone at [code]bone_idx[/code] if [code]false[/code], enables the bone pose if [code]true[/code].
+				Disables the pose for the bone at [param bone_idx] if [code]false[/code], enables the bone pose if [code]true[/code].
 			</description>
 		</method>
 		<method name="set_bone_global_pose_override">
@@ -304,8 +304,8 @@
 			<param index="2" name="amount" type="float" />
 			<param index="3" name="persistent" type="bool" default="false" />
 			<description>
-				Sets the global pose transform, [code]pose[/code], for the bone at [code]bone_idx[/code].
-				[code]amount[/code] is the interpolation strength that will be used when applying the pose, and [code]persistent[/code] determines if the applied pose will remain.
+				Sets the global pose transform, [param pose], for the bone at [param bone_idx].
+				[param amount] is the interpolation strength that will be used when applying the pose, and [param persistent] determines if the applied pose will remain.
 				[b]Note:[/b] The pose transform needs to be a global pose! Use [method world_transform_to_global_pose] to convert a world transform, like one you can get from a [Node3D], to a global pose.
 			</description>
 		</method>
@@ -316,8 +316,8 @@
 			<param index="2" name="amount" type="float" />
 			<param index="3" name="persistent" type="bool" default="false" />
 			<description>
-				Sets the local pose transform, [code]pose[/code], for the bone at [code]bone_idx[/code].
-				[code]amount[/code] is the interpolation strength that will be used when applying the pose, and [code]persistent[/code] determines if the applied pose will remain.
+				Sets the local pose transform, [param pose], for the bone at [param bone_idx].
+				[param amount] is the interpolation strength that will be used when applying the pose, and [param persistent] determines if the applied pose will remain.
 				[b]Note:[/b] The pose transform needs to be a local pose! Use [method global_pose_to_local_pose] to convert a global pose to a local pose.
 			</description>
 		</method>
@@ -333,8 +333,8 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="parent_idx" type="int" />
 			<description>
-				Sets the bone index [code]parent_idx[/code] as the parent of the bone at [code]bone_idx[/code]. If -1, then bone has no parent.
-				[b]Note:[/b] [code]parent_idx[/code] must be less than [code]bone_idx[/code].
+				Sets the bone index [param parent_idx] as the parent of the bone at [param bone_idx]. If -1, then bone has no parent.
+				[b]Note:[/b] [param parent_idx] must be less than [param bone_idx].
 			</description>
 		</method>
 		<method name="set_bone_pose_position">
@@ -363,21 +363,21 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="rest" type="Transform3D" />
 			<description>
-				Sets the rest transform for bone [code]bone_idx[/code].
+				Sets the rest transform for bone [param bone_idx].
 			</description>
 		</method>
 		<method name="set_modification_stack">
 			<return type="void" />
 			<param index="0" name="modification_stack" type="SkeletonModificationStack3D" />
 			<description>
-				Sets the modification stack for this skeleton to the passed-in modification stack, [code]modification_stack[/code].
+				Sets the modification stack for this skeleton to the passed-in modification stack, [param modification_stack].
 			</description>
 		</method>
 		<method name="unparent_bone_and_rest">
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Unparents the bone at [code]bone_idx[/code] and sets its rest position to that of its parent prior to being reset.
+				Unparents the bone at [param bone_idx] and sets its rest position to that of its parent prior to being reset.
 			</description>
 		</method>
 		<method name="world_transform_to_global_pose">

--- a/doc/classes/SkeletonModification2D.xml
+++ b/doc/classes/SkeletonModification2D.xml
@@ -38,7 +38,7 @@
 			<param index="2" name="max" type="float" />
 			<param index="3" name="invert" type="bool" />
 			<description>
-				Takes a angle and clamps it so it is within the passed-in [code]min[/code] and [code]max[/code] range. [code]invert[/code] will inversely clamp the angle, clamping it to the range outside of the given bounds.
+				Takes a angle and clamps it so it is within the passed-in [param min] and [param max] range. [param invert] will inversely clamp the angle, clamping it to the range outside of the given bounds.
 			</description>
 		</method>
 		<method name="get_editor_draw_gizmo" qualifiers="const">

--- a/doc/classes/SkeletonModification2DCCDIK.xml
+++ b/doc/classes/SkeletonModification2DCCDIK.xml
@@ -16,49 +16,49 @@
 			<return type="NodePath" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the [Bone2D] node assigned to the CCDIK joint at [code]joint_idx[/code].
+				Returns the [Bone2D] node assigned to the CCDIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_ccdik_joint_bone_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the index of the [Bone2D] node assigned to the CCDIK joint at [code]joint_idx[/code].
+				Returns the index of the [Bone2D] node assigned to the CCDIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_ccdik_joint_constraint_angle_invert" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns whether the CCDIK joint at [code]joint_idx[/code] uses an inverted joint constraint. See [method set_ccdik_joint_constraint_angle_invert] for details.
+				Returns whether the CCDIK joint at [param joint_idx] uses an inverted joint constraint. See [method set_ccdik_joint_constraint_angle_invert] for details.
 			</description>
 		</method>
 		<method name="get_ccdik_joint_constraint_angle_max" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the maximum angle constraint for the joint at [code]joint_idx[/code].
+				Returns the maximum angle constraint for the joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_ccdik_joint_constraint_angle_min" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the minimum angle constraint for the joint at [code]joint_idx[/code].
+				Returns the minimum angle constraint for the joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_ccdik_joint_enable_constraint" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns whether angle constraints on the CCDIK joint at [code]joint_idx[/code] are enabled.
+				Returns whether angle constraints on the CCDIK joint at [param joint_idx] are enabled.
 			</description>
 		</method>
 		<method name="get_ccdik_joint_rotate_from_joint" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns whether the joint at [code]joint_idx[/code] is set to rotate from the joint, [code]true[/code], or to rotate from the tip, [code]false[/code]. The default is to rotate from the tip.
+				Returns whether the joint at [param joint_idx] is set to rotate from the joint, [code]true[/code], or to rotate from the tip, [code]false[/code]. The default is to rotate from the tip.
 			</description>
 		</method>
 		<method name="set_ccdik_joint_bone2d_node">
@@ -66,7 +66,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone2d_nodepath" type="NodePath" />
 			<description>
-				Sets the [Bone2D] node assigned to the CCDIK joint at [code]joint_idx[/code].
+				Sets the [Bone2D] node assigned to the CCDIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_ccdik_joint_bone_index">
@@ -74,7 +74,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone_idx" type="int" />
 			<description>
-				Sets the bone index, [code]bone_index[/code], of the CCDIK joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone2d_node[/code] of the CCDIK joint based on data provided by the linked skeleton.
+				Sets the bone index, [param bone_idx], of the CCDIK joint at [param joint_idx]. When possible, this will also update the [code]bone2d_node[/code] of the CCDIK joint based on data provided by the linked skeleton.
 			</description>
 		</method>
 		<method name="set_ccdik_joint_constraint_angle_invert">
@@ -82,7 +82,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="invert" type="bool" />
 			<description>
-				Sets whether the CCDIK joint at [code]joint_idx[/code] uses an inverted joint constraint.
+				Sets whether the CCDIK joint at [param joint_idx] uses an inverted joint constraint.
 				An inverted joint constraint only constraints the CCDIK joint to the angles [i]outside of[/i] the inputted minimum and maximum angles. For this reason, it is referred to as an inverted joint constraint, as it constraints the joint to the outside of the inputted values.
 			</description>
 		</method>
@@ -91,7 +91,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="angle_max" type="float" />
 			<description>
-				Sets the maximum angle constraint for the joint at [code]joint_idx[/code].
+				Sets the maximum angle constraint for the joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_ccdik_joint_constraint_angle_min">
@@ -99,7 +99,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="angle_min" type="float" />
 			<description>
-				Sets the minimum angle constraint for the joint at [code]joint_idx[/code].
+				Sets the minimum angle constraint for the joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_ccdik_joint_enable_constraint">
@@ -107,7 +107,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="enable_constraint" type="bool" />
 			<description>
-				Determines whether angle constraints on the CCDIK joint at [code]joint_idx[/code] are enabled. When [code]true[/code], constraints will be enabled and taken into account when solving.
+				Determines whether angle constraints on the CCDIK joint at [param joint_idx] are enabled. When [code]true[/code], constraints will be enabled and taken into account when solving.
 			</description>
 		</method>
 		<method name="set_ccdik_joint_rotate_from_joint">
@@ -115,7 +115,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="rotate_from_joint" type="bool" />
 			<description>
-				Sets whether the joint at [code]joint_idx[/code] is set to rotate from the joint, [code]true[/code], or to rotate from the tip, [code]false[/code].
+				Sets whether the joint at [param joint_idx] is set to rotate from the joint, [code]true[/code], or to rotate from the tip, [code]false[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SkeletonModification2DFABRIK.xml
+++ b/doc/classes/SkeletonModification2DFABRIK.xml
@@ -17,21 +17,21 @@
 			<return type="NodePath" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the [Bone2D] node assigned to the FABRIK joint at [code]joint_idx[/code].
+				Returns the [Bone2D] node assigned to the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_bone_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the index of the [Bone2D] node assigned to the FABRIK joint at [code]joint_idx[/code].
+				Returns the index of the [Bone2D] node assigned to the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_magnet_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the magnet position vector for the joint at [code]joint_idx[/code].
+				Returns the magnet position vector for the joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_use_target_rotation" qualifiers="const">
@@ -46,7 +46,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone2d_nodepath" type="NodePath" />
 			<description>
-				Sets the [Bone2D] node assigned to the FABRIK joint at [code]joint_idx[/code].
+				Sets the [Bone2D] node assigned to the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_fabrik_joint_bone_index">
@@ -54,7 +54,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone_idx" type="int" />
 			<description>
-				Sets the bone index, [code]bone_index[/code], of the FABRIK joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone2d_node[/code] of the FABRIK joint based on data provided by the linked skeleton.
+				Sets the bone index, [param bone_idx], of the FABRIK joint at [param joint_idx]. When possible, this will also update the [code]bone2d_node[/code] of the FABRIK joint based on data provided by the linked skeleton.
 			</description>
 		</method>
 		<method name="set_fabrik_joint_magnet_position">
@@ -62,7 +62,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="magnet_position" type="Vector2" />
 			<description>
-				Sets the magnet position vector for the joint at [code]joint_idx[/code].
+				Sets the magnet position vector for the joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_fabrik_joint_use_target_rotation">
@@ -70,7 +70,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="use_target_rotation" type="bool" />
 			<description>
-				Sets whether the joint at [code]joint_idx[/code] will use the target node's rotation rather than letting FABRIK rotate the node.
+				Sets whether the joint at [param joint_idx] will use the target node's rotation rather than letting FABRIK rotate the node.
 				[b]Note:[/b] This option only works for the tip/final joint in the chain. For all other nodes, this option will be ignored.
 			</description>
 		</method>

--- a/doc/classes/SkeletonModification2DJiggle.xml
+++ b/doc/classes/SkeletonModification2DJiggle.xml
@@ -21,56 +21,56 @@
 			<return type="NodePath" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the [Bone2D] node assigned to the Jiggle joint at [code]joint_idx[/code].
+				Returns the [Bone2D] node assigned to the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_bone_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the index of the [Bone2D] node assigned to the Jiggle joint at [code]joint_idx[/code].
+				Returns the index of the [Bone2D] node assigned to the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_damping" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the amount of damping of the Jiggle joint at [code]joint_idx[/code].
+				Returns the amount of damping of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_gravity" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns a [Vector2] representing the amount of gravity the Jiggle joint at [code]joint_idx[/code] is influenced by.
+				Returns a [Vector2] representing the amount of gravity the Jiggle joint at [param joint_idx] is influenced by.
 			</description>
 		</method>
 		<method name="get_jiggle_joint_mass" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the amount of mass of the jiggle joint at [code]joint_idx[/code].
+				Returns the amount of mass of the jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_override" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns a boolean that indicates whether the joint at [code]joint_idx[/code] is overriding the default Jiggle joint data defined in the modification.
+				Returns a boolean that indicates whether the joint at [param joint_idx] is overriding the default Jiggle joint data defined in the modification.
 			</description>
 		</method>
 		<method name="get_jiggle_joint_stiffness" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the stiffness of the Jiggle joint at [code]joint_idx[/code].
+				Returns the stiffness of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_use_gravity" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns a boolean that indicates whether the joint at [code]joint_idx[/code] is using gravity or not.
+				Returns a boolean that indicates whether the joint at [param joint_idx] is using gravity or not.
 			</description>
 		</method>
 		<method name="get_use_colliders" qualifiers="const">
@@ -91,7 +91,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone2d_node" type="NodePath" />
 			<description>
-				Sets the [Bone2D] node assigned to the Jiggle joint at [code]joint_idx[/code].
+				Sets the [Bone2D] node assigned to the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_bone_index">
@@ -99,7 +99,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone_idx" type="int" />
 			<description>
-				Sets the bone index, [code]bone_index[/code], of the Jiggle joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone2d_node[/code] of the Jiggle joint based on data provided by the linked skeleton.
+				Sets the bone index, [param bone_idx], of the Jiggle joint at [param joint_idx]. When possible, this will also update the [code]bone2d_node[/code] of the Jiggle joint based on data provided by the linked skeleton.
 			</description>
 		</method>
 		<method name="set_jiggle_joint_damping">
@@ -107,7 +107,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="damping" type="float" />
 			<description>
-				Sets the amount of dampening of the Jiggle joint at [code]joint_idx[/code].
+				Sets the amount of dampening of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_gravity">
@@ -115,7 +115,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="gravity" type="Vector2" />
 			<description>
-				Sets the gravity vector of the Jiggle joint at [code]joint_idx[/code].
+				Sets the gravity vector of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_mass">
@@ -123,7 +123,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="mass" type="float" />
 			<description>
-				Sets the of mass of the Jiggle joint at [code]joint_idx[/code].
+				Sets the of mass of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_override">
@@ -131,7 +131,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="override" type="bool" />
 			<description>
-				Sets whether the Jiggle joint at [code]joint_idx[/code] should override the default Jiggle joint settings. Setting this to [code]true[/code] will make the joint use its own settings rather than the default ones attached to the modification.
+				Sets whether the Jiggle joint at [param joint_idx] should override the default Jiggle joint settings. Setting this to [code]true[/code] will make the joint use its own settings rather than the default ones attached to the modification.
 			</description>
 		</method>
 		<method name="set_jiggle_joint_stiffness">
@@ -139,7 +139,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="stiffness" type="float" />
 			<description>
-				Sets the of stiffness of the Jiggle joint at [code]joint_idx[/code].
+				Sets the of stiffness of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_use_gravity">
@@ -147,7 +147,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="use_gravity" type="bool" />
 			<description>
-				Sets whether the Jiggle joint at [code]joint_idx[/code] should use gravity.
+				Sets whether the Jiggle joint at [param joint_idx] should use gravity.
 			</description>
 		</method>
 		<method name="set_use_colliders">

--- a/doc/classes/SkeletonModification2DPhysicalBones.xml
+++ b/doc/classes/SkeletonModification2DPhysicalBones.xml
@@ -19,7 +19,7 @@
 			<return type="NodePath" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the [PhysicalBone2D] node at [code]joint_idx[/code].
+				Returns the [PhysicalBone2D] node at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_physical_bone_node">
@@ -27,7 +27,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="physicalbone2d_node" type="NodePath" />
 			<description>
-				Sets the [PhysicalBone2D] node at [code]joint_idx[/code].
+				Sets the [PhysicalBone2D] node at [param joint_idx].
 				[b]Note:[/b] This is just the index used for this modification, not the bone index used in the [Skeleton2D].
 			</description>
 		</method>

--- a/doc/classes/SkeletonModification3D.xml
+++ b/doc/classes/SkeletonModification3D.xml
@@ -32,7 +32,7 @@
 			<param index="2" name="max" type="float" />
 			<param index="3" name="invert" type="bool" />
 			<description>
-				Takes a angle and clamps it so it is within the passed-in [code]min[/code] and [code]max[/code] range. [code]invert[/code] will inversely clamp the angle, clamping it to the range outside of the given bounds.
+				Takes a angle and clamps it so it is within the passed-in [param min] and [param max] range. [param invert] will inversely clamp the angle, clamping it to the range outside of the given bounds.
 			</description>
 		</method>
 		<method name="get_is_setup" qualifiers="const">

--- a/doc/classes/SkeletonModification3DCCDIK.xml
+++ b/doc/classes/SkeletonModification3DCCDIK.xml
@@ -16,49 +16,49 @@
 			<return type="int" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the bone index of the bone assigned to the CCDIK joint at [code]joint_idx[/code].
+				Returns the bone index of the bone assigned to the CCDIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_ccdik_joint_bone_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the name of the bone that is assigned to the CCDIK joint at [code]joint_idx[/code].
+				Returns the name of the bone that is assigned to the CCDIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_ccdik_joint_ccdik_axis" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the integer representing the joint axis of the CCDIK joint at [code]joint_idx[/code].
+				Returns the integer representing the joint axis of the CCDIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_ccdik_joint_constraint_angle_max" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the maximum angle constraint for the joint at [code]joint_idx[/code]. [b]Note:[/b] This angle is in degrees!
+				Returns the maximum angle constraint for the joint at [param joint_idx]. [b]Note:[/b] This angle is in degrees!
 			</description>
 		</method>
 		<method name="get_ccdik_joint_constraint_angle_min" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the minimum angle constraint for the joint at [code]joint_idx[/code]. [b]Note:[/b] This angle is in degrees!
+				Returns the minimum angle constraint for the joint at [param joint_idx]. [b]Note:[/b] This angle is in degrees!
 			</description>
 		</method>
 		<method name="get_ccdik_joint_constraint_invert" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns whether the CCDIK joint at [code]joint_idx[/code] uses an inverted joint constraint. See [method set_ccdik_joint_constraint_invert] for details.
+				Returns whether the CCDIK joint at [param joint_idx] uses an inverted joint constraint. See [method set_ccdik_joint_constraint_invert] for details.
 			</description>
 		</method>
 		<method name="get_ccdik_joint_enable_joint_constraint" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Enables angle constraints to the CCDIK joint at [code]joint_idx[/code].
+				Enables angle constraints to the CCDIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_ccdik_joint_bone_index">
@@ -66,7 +66,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone_index" type="int" />
 			<description>
-				Sets the bone index, [code]bone_index[/code], of the CCDIK joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone_name[/code] of the CCDIK joint based on data provided by the linked skeleton.
+				Sets the bone index, [param bone_index], of the CCDIK joint at [param joint_idx]. When possible, this will also update the [code]bone_name[/code] of the CCDIK joint based on data provided by the linked skeleton.
 			</description>
 		</method>
 		<method name="set_ccdik_joint_bone_name">
@@ -74,7 +74,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone_name" type="String" />
 			<description>
-				Sets the bone name, [code]bone_name[/code], of the CCDIK joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone_index[/code] of the CCDIK joint based on data provided by the linked skeleton.
+				Sets the bone name, [param bone_name], of the CCDIK joint at [param joint_idx]. When possible, this will also update the [code]bone_index[/code] of the CCDIK joint based on data provided by the linked skeleton.
 			</description>
 		</method>
 		<method name="set_ccdik_joint_ccdik_axis">
@@ -82,7 +82,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="axis" type="int" />
 			<description>
-				Sets the joint axis of the CCDIK joint at [code]joint_idx[/code] to the passed-in joint axis, [code]axis[/code].
+				Sets the joint axis of the CCDIK joint at [param joint_idx] to the passed-in joint axis, [param axis].
 			</description>
 		</method>
 		<method name="set_ccdik_joint_constraint_angle_max">
@@ -90,7 +90,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="max_angle" type="float" />
 			<description>
-				Sets the maximum angle constraint for the joint at [code]joint_idx[/code]. [b]Note:[/b] This angle must be in radians!
+				Sets the maximum angle constraint for the joint at [param joint_idx]. [b]Note:[/b] This angle must be in radians!
 			</description>
 		</method>
 		<method name="set_ccdik_joint_constraint_angle_min">
@@ -98,7 +98,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="min_angle" type="float" />
 			<description>
-				Sets the minimum angle constraint for the joint at [code]joint_idx[/code]. [b]Note:[/b] This angle must be in radians!
+				Sets the minimum angle constraint for the joint at [param joint_idx]. [b]Note:[/b] This angle must be in radians!
 			</description>
 		</method>
 		<method name="set_ccdik_joint_constraint_invert">
@@ -106,7 +106,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="invert" type="bool" />
 			<description>
-				Sets whether the CCDIK joint at [code]joint_idx[/code] uses an inverted joint constraint.
+				Sets whether the CCDIK joint at [param joint_idx] uses an inverted joint constraint.
 				An inverted joint constraint only constraints the CCDIK joint to the angles [i]outside of[/i] the inputted minimum and maximum angles. For this reason, it is referred to as an inverted joint constraint, as it constraints the joint to the outside of the inputted values.
 			</description>
 		</method>
@@ -115,7 +115,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Sets whether joint constraints are enabled for the CCDIK joint at [code]joint_idx[/code].
+				Sets whether joint constraints are enabled for the CCDIK joint at [param joint_idx].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SkeletonModification3DFABRIK.xml
+++ b/doc/classes/SkeletonModification3DFABRIK.xml
@@ -17,49 +17,49 @@
 			<return type="void" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Will attempt to automatically calculate the length of the bone assigned to the FABRIK joint at [code]joint_idx[/code].
+				Will attempt to automatically calculate the length of the bone assigned to the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_auto_calculate_length" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns a boolean that indicates whether this modification will attempt to autocalculate the length of the bone assigned to the FABRIK joint at [code]joint_idx[/code].
+				Returns a boolean that indicates whether this modification will attempt to autocalculate the length of the bone assigned to the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_bone_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the bone index of the bone assigned to the FABRIK joint at [code]joint_idx[/code].
+				Returns the bone index of the bone assigned to the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_bone_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the name of the bone that is assigned to the FABRIK joint at [code]joint_idx[/code].
+				Returns the name of the bone that is assigned to the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_length" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the length of the FABRIK joint at [code]joint_idx[/code].
+				Returns the length of the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_magnet" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the magnet vector of the FABRIK joint at [code]joint_idx[/code].
+				Returns the magnet vector of the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_fabrik_joint_tip_node" qualifiers="const">
 			<return type="NodePath" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the [Node3D]-based node placed at the tip of the FABRIK joint at [code]joint_idx[/code], if one has been set.
+				Returns the [Node3D]-based node placed at the tip of the FABRIK joint at [param joint_idx], if one has been set.
 			</description>
 		</method>
 		<method name="get_fabrik_joint_use_target_basis" qualifiers="const">
@@ -74,7 +74,7 @@
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Sets the [Node3D]-based node that will be used as the tip of the FABRIK joint at [code]joint_idx[/code].
+				Sets the [Node3D]-based node that will be used as the tip of the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_fabrik_joint_auto_calculate_length">
@@ -82,7 +82,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="auto_calculate_length" type="bool" />
 			<description>
-				When [code]true[/code], this modification will attempt to automatically calculate the length of the bone for the FABRIK joint at [code]joint_idx[/code]. It does this by either using the tip node assigned, if there is one assigned, or the distance the of the bone's children, if the bone has any. If the bone has no children and no tip node is assigned, then the modification [b]cannot[/b] autocalculate the joint's length. In this case, the joint length should be entered manually or a tip node assigned.
+				When [code]true[/code], this modification will attempt to automatically calculate the length of the bone for the FABRIK joint at [param joint_idx]. It does this by either using the tip node assigned, if there is one assigned, or the distance the of the bone's children, if the bone has any. If the bone has no children and no tip node is assigned, then the modification [b]cannot[/b] autocalculate the joint's length. In this case, the joint length should be entered manually or a tip node assigned.
 			</description>
 		</method>
 		<method name="set_fabrik_joint_bone_index">
@@ -90,7 +90,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone_index" type="int" />
 			<description>
-				Sets the bone index, [code]bone_index[/code], of the FABRIK joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone_name[/code] of the FABRIK joint based on data provided by the [Skeleton3D].
+				Sets the bone index, [param bone_index], of the FABRIK joint at [param joint_idx]. When possible, this will also update the [code]bone_name[/code] of the FABRIK joint based on data provided by the [Skeleton3D].
 			</description>
 		</method>
 		<method name="set_fabrik_joint_bone_name">
@@ -98,7 +98,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone_name" type="String" />
 			<description>
-				Sets the bone name, [code]bone_name[/code], of the FABRIK joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone_index[/code] of the FABRIK joint based on data provided by the [Skeleton3D].
+				Sets the bone name, [param bone_name], of the FABRIK joint at [param joint_idx]. When possible, this will also update the [code]bone_index[/code] of the FABRIK joint based on data provided by the [Skeleton3D].
 			</description>
 		</method>
 		<method name="set_fabrik_joint_length">
@@ -106,7 +106,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="length" type="float" />
 			<description>
-				Sets the joint length, [code]length[/code], of the FABRIK joint at [code]joint_idx[/code].
+				Sets the joint length, [param length], of the FABRIK joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_fabrik_joint_magnet">
@@ -114,7 +114,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="magnet_position" type="Vector3" />
 			<description>
-				Sets the magenet position to [code]magnet_position[/code] for the joint at [code]joint_idx[/code]. The magnet position is used to nudge the joint in that direction when solving, which gives some control over how that joint will bend when being solved.
+				Sets the magenet position to [param magnet_position] for the joint at [param joint_idx]. The magnet position is used to nudge the joint in that direction when solving, which gives some control over how that joint will bend when being solved.
 			</description>
 		</method>
 		<method name="set_fabrik_joint_tip_node">
@@ -122,7 +122,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="tip_node" type="NodePath" />
 			<description>
-				Sets the nodepath of the FARIK joint at [code]joint_idx[/code] to [code]tip_node[/code]. The tip node is used to calculate the length of the FABRIK joint when set to automatically calculate joint length.
+				Sets the nodepath of the FARIK joint at [param joint_idx] to [param tip_node]. The tip node is used to calculate the length of the FABRIK joint when set to automatically calculate joint length.
 				[b]Note:[/b] The tip node should generally be a child node of a [BoneAttachment3D] node attached to the bone that this FABRIK joint operates on, with the child node being offset so it is at the end of the bone.
 			</description>
 		</method>
@@ -131,7 +131,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="use_target_basis" type="bool" />
 			<description>
-				Sets whether the FABRIK joint at [code]joint_idx[/code] uses the target's [Basis] for its rotation.
+				Sets whether the FABRIK joint at [param joint_idx] uses the target's [Basis] for its rotation.
 				[b]Note:[/b] This option is only available for the final bone in the FABRIK chain, with this setting being ignored for all other bones.
 			</description>
 		</method>
@@ -140,7 +140,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="use_tip_node" type="bool" />
 			<description>
-				Sets whether the tip node should be used when autocalculating the joint length for the FABRIK joint at [code]joint_idx[/code]. This will only work if there is a node assigned to the tip nodepath for this joint.
+				Sets whether the tip node should be used when autocalculating the joint length for the FABRIK joint at [param joint_idx]. This will only work if there is a node assigned to the tip nodepath for this joint.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SkeletonModification3DJiggle.xml
+++ b/doc/classes/SkeletonModification3DJiggle.xml
@@ -21,42 +21,42 @@
 			<return type="int" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the bone index of the bone assigned to the Jiggle joint at [code]joint_idx[/code].
+				Returns the bone index of the bone assigned to the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_bone_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the name of the bone that is assigned to the Jiggle joint at [code]joint_idx[/code].
+				Returns the name of the bone that is assigned to the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_damping" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the amount of dampening of the Jiggle joint at [code]joint_idx[/code].
+				Returns the amount of dampening of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_gravity" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns a [Vector3] representign the amount of gravity the Jiggle joint at [code]joint_idx[/code] is influenced by.
+				Returns a [Vector3] representign the amount of gravity the Jiggle joint at [param joint_idx] is influenced by.
 			</description>
 		</method>
 		<method name="get_jiggle_joint_mass" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the amount of mass of the Jiggle joint at [code]joint_idx[/code].
+				Returns the amount of mass of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_override" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns a boolean that indicates whether the joint at [code]joint_idx[/code] is overriding the default jiggle joint data defined in the modification.
+				Returns a boolean that indicates whether the joint at [param joint_idx] is overriding the default jiggle joint data defined in the modification.
 			</description>
 		</method>
 		<method name="get_jiggle_joint_roll" qualifiers="const">
@@ -70,14 +70,14 @@
 			<return type="float" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns the stiffness of the Jiggle joint at [code]joint_idx[/code].
+				Returns the stiffness of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="get_jiggle_joint_use_gravity" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint_idx" type="int" />
 			<description>
-				Returns a boolean that indicates whether the joint at [code]joint_idx[/code] is using gravity or not.
+				Returns a boolean that indicates whether the joint at [param joint_idx] is using gravity or not.
 			</description>
 		</method>
 		<method name="get_use_colliders" qualifiers="const">
@@ -98,7 +98,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="bone_idx" type="int" />
 			<description>
-				Sets the bone index, [code]bone_index[/code], of the Jiggle joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone_name[/code] of the Jiggle joint based on data provided by the [Skeleton3D].
+				Sets the bone index, [param bone_idx], of the Jiggle joint at [param joint_idx]. When possible, this will also update the [code]bone_name[/code] of the Jiggle joint based on data provided by the [Skeleton3D].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_bone_name">
@@ -106,7 +106,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="name" type="String" />
 			<description>
-				Sets the bone name, [code]bone_name[/code], of the Jiggle joint at [code]joint_idx[/code]. When possible, this will also update the [code]bone_index[/code] of the Jiggle joint based on data provided by the [Skeleton3D].
+				Sets the bone name, [param name], of the Jiggle joint at [param joint_idx]. When possible, this will also update the [code]bone_index[/code] of the Jiggle joint based on data provided by the [Skeleton3D].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_damping">
@@ -114,7 +114,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="damping" type="float" />
 			<description>
-				Sets the amount of dampening of the Jiggle joint at [code]joint_idx[/code].
+				Sets the amount of dampening of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_gravity">
@@ -122,7 +122,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="gravity" type="Vector3" />
 			<description>
-				Sets the gravity vector of the Jiggle joint at [code]joint_idx[/code].
+				Sets the gravity vector of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_mass">
@@ -130,7 +130,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="mass" type="float" />
 			<description>
-				Sets the of mass of the Jiggle joint at [code]joint_idx[/code].
+				Sets the of mass of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_override">
@@ -138,7 +138,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="override" type="bool" />
 			<description>
-				Sets whether the Jiggle joint at [code]joint_idx[/code] should override the default Jiggle joint settings. Setting this to true will make the joint use its own settings rather than the default ones attached to the modification.
+				Sets whether the Jiggle joint at [param joint_idx] should override the default Jiggle joint settings. Setting this to true will make the joint use its own settings rather than the default ones attached to the modification.
 			</description>
 		</method>
 		<method name="set_jiggle_joint_roll">
@@ -154,7 +154,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="stiffness" type="float" />
 			<description>
-				Sets the of stiffness of the Jiggle joint at [code]joint_idx[/code].
+				Sets the of stiffness of the Jiggle joint at [param joint_idx].
 			</description>
 		</method>
 		<method name="set_jiggle_joint_use_gravity">
@@ -162,7 +162,7 @@
 			<param index="0" name="joint_idx" type="int" />
 			<param index="1" name="use_gravity" type="bool" />
 			<description>
-				Sets whether the Jiggle joint at [code]joint_idx[/code] should use gravity.
+				Sets whether the Jiggle joint at [param joint_idx] should use gravity.
 			</description>
 		</method>
 		<method name="set_use_colliders">

--- a/doc/classes/SkeletonModification3DTwoBoneIK.xml
+++ b/doc/classes/SkeletonModification3DTwoBoneIK.xml
@@ -101,14 +101,14 @@
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Sets the bone index, [code]bone_index[/code], of the first bone. When possible, this will also update the [code]bone_name[/code] of the first bone based on data provided by the [Skeleton3D].
+				Sets the bone index, [param bone_idx], of the first bone. When possible, this will also update the [code]bone_name[/code] of the first bone based on data provided by the [Skeleton3D].
 			</description>
 		</method>
 		<method name="set_joint_one_bone_name">
 			<return type="void" />
 			<param index="0" name="bone_name" type="String" />
 			<description>
-				Sets the bone name, [code]bone_name[/code], of the first bone. When possible, this will also update the [code]bone_index[/code] of the first bone based on data provided by the [Skeleton3D].
+				Sets the bone name, [param bone_name], of the first bone. When possible, this will also update the [code]bone_index[/code] of the first bone based on data provided by the [Skeleton3D].
 			</description>
 		</method>
 		<method name="set_joint_one_length">
@@ -129,14 +129,14 @@
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Sets the bone index, [code]bone_index[/code], of the second bone. When possible, this will also update the [code]bone_name[/code] of the second bone based on data provided by the [Skeleton3D].
+				Sets the bone index, [param bone_idx], of the second bone. When possible, this will also update the [code]bone_name[/code] of the second bone based on data provided by the [Skeleton3D].
 			</description>
 		</method>
 		<method name="set_joint_two_bone_name">
 			<return type="void" />
 			<param index="0" name="bone_name" type="String" />
 			<description>
-				Sets the bone name, [code]bone_name[/code], of the second bone. When possible, this will also update the [code]bone_index[/code] of the second bone based on data provided by the [Skeleton3D].
+				Sets the bone name, [param bone_name], of the second bone. When possible, this will also update the [code]bone_index[/code] of the second bone based on data provided by the [Skeleton3D].
 			</description>
 		</method>
 		<method name="set_joint_two_length">

--- a/doc/classes/SkeletonModificationStack2D.xml
+++ b/doc/classes/SkeletonModificationStack2D.xml
@@ -22,7 +22,7 @@
 			<return type="void" />
 			<param index="0" name="mod_idx" type="int" />
 			<description>
-				Deletes the [SkeletonModification2D] at the index position [code]mod_idx[/code], if it exists.
+				Deletes the [SkeletonModification2D] at the index position [param mod_idx], if it exists.
 			</description>
 		</method>
 		<method name="enable_all_modifications">
@@ -37,7 +37,7 @@
 			<param index="0" name="delta" type="float" />
 			<param index="1" name="execution_mode" type="int" />
 			<description>
-				Executes all of the [SkeletonModification2D]s in the stack that use the same execution mode as the passed-in [code]execution_mode[/code], starting from index [code]0[/code] to [member modification_count].
+				Executes all of the [SkeletonModification2D]s in the stack that use the same execution mode as the passed-in [param execution_mode], starting from index [code]0[/code] to [member modification_count].
 				[b]Note:[/b] The order of the modifications can matter depending on the modifications. For example, modifications on a spine should operate before modifications on the arms in order to get proper results.
 			</description>
 		</method>
@@ -51,7 +51,7 @@
 			<return type="SkeletonModification2D" />
 			<param index="0" name="mod_idx" type="int" />
 			<description>
-				Returns the [SkeletonModification2D] at the passed-in index, [code]mod_idx[/code].
+				Returns the [SkeletonModification2D] at the passed-in index, [param mod_idx].
 			</description>
 		</method>
 		<method name="get_skeleton" qualifiers="const">
@@ -65,7 +65,7 @@
 			<param index="0" name="mod_idx" type="int" />
 			<param index="1" name="modification" type="SkeletonModification2D" />
 			<description>
-				Sets the modification at [code]mod_idx[/code] to the passed-in modification, [code]modification[/code].
+				Sets the modification at [param mod_idx] to the passed-in modification, [param modification].
 			</description>
 		</method>
 		<method name="setup">

--- a/doc/classes/SkeletonModificationStack3D.xml
+++ b/doc/classes/SkeletonModificationStack3D.xml
@@ -21,7 +21,7 @@
 			<return type="void" />
 			<param index="0" name="mod_idx" type="int" />
 			<description>
-				Deletes the [SkeletonModification3D] at the index position [code]mod_idx[/code], if it exists.
+				Deletes the [SkeletonModification3D] at the index position [param mod_idx], if it exists.
 			</description>
 		</method>
 		<method name="enable_all_modifications">
@@ -36,7 +36,7 @@
 			<param index="0" name="delta" type="float" />
 			<param index="1" name="execution_mode" type="int" />
 			<description>
-				Executes all of the [SkeletonModification3D]s in the stack that use the same execution mode as the passed-in [code]execution_mode[/code], starting from index [code]0[/code] to [member modification_count].
+				Executes all of the [SkeletonModification3D]s in the stack that use the same execution mode as the passed-in [param execution_mode], starting from index [code]0[/code] to [member modification_count].
 				[b]Note:[/b] The order of the modifications can matter depending on the modifications. For example, modifications on a spine should operate before modifications on the arms in order to get proper results.
 			</description>
 		</method>
@@ -50,7 +50,7 @@
 			<return type="SkeletonModification3D" />
 			<param index="0" name="mod_idx" type="int" />
 			<description>
-				Returns the [SkeletonModification3D] at the passed-in index, [code]mod_idx[/code].
+				Returns the [SkeletonModification3D] at the passed-in index, [param mod_idx].
 			</description>
 		</method>
 		<method name="get_skeleton" qualifiers="const">
@@ -64,7 +64,7 @@
 			<param index="0" name="mod_idx" type="int" />
 			<param index="1" name="modification" type="SkeletonModification3D" />
 			<description>
-				Sets the modification at [code]mod_idx[/code] to the passed-in modification, [code]modification[/code].
+				Sets the modification at [param mod_idx] to the passed-in modification, [param modification].
 			</description>
 		</method>
 		<method name="setup">

--- a/doc/classes/SkeletonProfile.xml
+++ b/doc/classes/SkeletonProfile.xml
@@ -13,14 +13,14 @@
 			<return type="int" />
 			<param index="0" name="bone_name" type="StringName" />
 			<description>
-				Returns the bone index that matches [code]bone_name[/code] as its name.
+				Returns the bone index that matches [param bone_name] as its name.
 			</description>
 		</method>
 		<method name="get_bone_name" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the name of the bone at [code]bone_idx[/code] that will be the key name in the [BoneMap].
+				Returns the name of the bone at [param bone_idx] that will be the key name in the [BoneMap].
 				In the retargeting process, the returned bone name is the bone name of the target skeleton.
 			</description>
 		</method>
@@ -28,35 +28,35 @@
 			<return type="StringName" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the name of the bone which is the parent to the bone at [code]bone_idx[/code]. The result is empty if the bone has no parent.
+				Returns the name of the bone which is the parent to the bone at [param bone_idx]. The result is empty if the bone has no parent.
 			</description>
 		</method>
 		<method name="get_bone_tail" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the name of the bone which is the tail of the bone at [code]bone_idx[/code].
+				Returns the name of the bone which is the tail of the bone at [param bone_idx].
 			</description>
 		</method>
 		<method name="get_group" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the group of the bone at [code]bone_idx[/code].
+				Returns the group of the bone at [param bone_idx].
 			</description>
 		</method>
 		<method name="get_group_name" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="group_idx" type="int" />
 			<description>
-				Returns the name of the group at [code]group_idx[/code] that will be the drawing group in the [BoneMap] editor.
+				Returns the name of the group at [param group_idx] that will be the drawing group in the [BoneMap] editor.
 			</description>
 		</method>
 		<method name="get_handle_offset" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the offset of the bone at [code]bone_idx[/code] that will be the button position in the [BoneMap] editor.
+				Returns the offset of the bone at [param bone_idx] that will be the button position in the [BoneMap] editor.
 				This is the offset with origin at the top left corner of the square.
 			</description>
 		</method>
@@ -64,21 +64,21 @@
 			<return type="Transform3D" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the reference pose transform for bone [code]bone_idx[/code].
+				Returns the reference pose transform for bone [param bone_idx].
 			</description>
 		</method>
 		<method name="get_tail_direction" qualifiers="const">
 			<return type="int" enum="SkeletonProfile.TailDirection" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
-				Returns the tail direction of the bone at [code]bone_idx[/code].
+				Returns the tail direction of the bone at [param bone_idx].
 			</description>
 		</method>
 		<method name="get_texture" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="group_idx" type="int" />
 			<description>
-				Returns the texture of the group at [code]group_idx[/code] that will be the drawing group background image in the [BoneMap] editor.
+				Returns the texture of the group at [param group_idx] that will be the drawing group background image in the [BoneMap] editor.
 			</description>
 		</method>
 		<method name="set_bone_name">
@@ -86,7 +86,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="bone_name" type="StringName" />
 			<description>
-				Sets the name of the bone at [code]bone_idx[/code] that will be the key name in the [BoneMap].
+				Sets the name of the bone at [param bone_idx] that will be the key name in the [BoneMap].
 				In the retargeting process, the setting bone name is the bone name of the target skeleton.
 			</description>
 		</method>
@@ -95,7 +95,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="bone_parent" type="StringName" />
 			<description>
-				Sets the bone with name [code]bone_parent[/code] as the parent of the bone at [code]bone_idx[/code]. If an empty string is passed, then the bone has no parent.
+				Sets the bone with name [param bone_parent] as the parent of the bone at [param bone_idx]. If an empty string is passed, then the bone has no parent.
 			</description>
 		</method>
 		<method name="set_bone_tail">
@@ -103,7 +103,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="bone_tail" type="StringName" />
 			<description>
-				Sets the bone with name [code]bone_tail[/code] as the tail of the bone at [code]bone_idx[/code].
+				Sets the bone with name [param bone_tail] as the tail of the bone at [param bone_idx].
 			</description>
 		</method>
 		<method name="set_group">
@@ -111,7 +111,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="group" type="StringName" />
 			<description>
-				Sets the group of the bone at [code]bone_idx[/code].
+				Sets the group of the bone at [param bone_idx].
 			</description>
 		</method>
 		<method name="set_group_name">
@@ -119,7 +119,7 @@
 			<param index="0" name="group_idx" type="int" />
 			<param index="1" name="group_name" type="StringName" />
 			<description>
-				Sets the name of the group at [code]group_idx[/code] that will be the drawing group in the [BoneMap] editor.
+				Sets the name of the group at [param group_idx] that will be the drawing group in the [BoneMap] editor.
 			</description>
 		</method>
 		<method name="set_handle_offset">
@@ -127,7 +127,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="handle_offset" type="Vector2" />
 			<description>
-				Sets the offset of the bone at [code]bone_idx[/code] that will be the button position in the [BoneMap] editor.
+				Sets the offset of the bone at [param bone_idx] that will be the button position in the [BoneMap] editor.
 				This is the offset with origin at the top left corner of the square.
 			</description>
 		</method>
@@ -136,7 +136,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="bone_name" type="Transform3D" />
 			<description>
-				Sets the reference pose transform for bone [code]bone_idx[/code].
+				Sets the reference pose transform for bone [param bone_idx].
 			</description>
 		</method>
 		<method name="set_tail_direction">
@@ -144,7 +144,7 @@
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="tail_direction" type="int" enum="SkeletonProfile.TailDirection" />
 			<description>
-				Sets the tail direction of the bone at [code]bone_idx[/code].
+				Sets the tail direction of the bone at [param bone_idx].
 				[b]Note:[/b] This only specifies the method of calculation. The actual coordinates required should be stored in an external skeleton, so the calculation itself needs to be done externally.
 			</description>
 		</method>
@@ -153,7 +153,7 @@
 			<param index="0" name="group_idx" type="int" />
 			<param index="1" name="texture" type="Texture2D" />
 			<description>
-				Sets the texture of the group at [code]group_idx[/code] that will be the drawing group background image in the [BoneMap] editor.
+				Sets the texture of the group at [param group_idx] that will be the drawing group background image in the [BoneMap] editor.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -27,7 +27,7 @@
 		<signal name="drag_ended">
 			<param index="0" name="value_changed" type="bool" />
 			<description>
-				Emitted when dragging stops. If [code]value_changed[/code] is true, [member Range.value] is different from the value when you started the dragging.
+				Emitted when dragging stops. If [param value_changed] is true, [member Range.value] is different from the value when you started the dragging.
 			</description>
 		</signal>
 		<signal name="drag_started">

--- a/doc/classes/SoftDynamicBody3D.xml
+++ b/doc/classes/SoftDynamicBody3D.xml
@@ -28,14 +28,14 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_layer] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_layer] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_collision_mask_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_physics_rid" qualifiers="const">
@@ -69,7 +69,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_layer], given a [code]layer_number[/code] between 1 and 32.
+				Based on [code]value[/code], enables or disables the specified layer in the [member collision_layer], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_collision_mask_value">
@@ -77,7 +77,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_point_pinned">
@@ -86,7 +86,7 @@
 			<param index="1" name="pinned" type="bool" />
 			<param index="2" name="attachment_path" type="NodePath" default="NodePath(&quot;&quot;)" />
 			<description>
-				Sets the pinned state of a surface vertex. When set to [code]true[/code], the optional [code]attachment_path[/code] can define a [Node3D] the pinned vertex will be attached to.
+				Sets the pinned state of a surface vertex. When set to [code]true[/code], the optional [param attachment_path] can define a [Node3D] the pinned vertex will be attached to.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -101,7 +101,7 @@
 			<param index="0" name="anim" type="StringName" />
 			<param index="1" name="newname" type="StringName" />
 			<description>
-				Changes the animation's name to [code]newname[/code].
+				Changes the animation's name to [param newname].
 			</description>
 		</method>
 		<method name="set_animation_loop">

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -44,7 +44,7 @@
 			<return type="Array" />
 			<param index="0" name="bytes" type="int" />
 			<description>
-				Returns a chunk data with the received bytes. The amount of bytes to be received can be requested in the [code]bytes[/code] argument. If not enough bytes are available, the function will block until the desired amount is received. This function returns two values, an [enum @GlobalScope.Error] code and a data array.
+				Returns a chunk data with the received bytes. The amount of bytes to be received can be requested in the [param bytes] argument. If not enough bytes are available, the function will block until the desired amount is received. This function returns two values, an [enum @GlobalScope.Error] code and a data array.
 			</description>
 		</method>
 		<method name="get_double">
@@ -70,7 +70,7 @@
 			<return type="String" />
 			<param index="0" name="bytes" type="int" default="-1" />
 			<description>
-				Gets an ASCII string with byte-length [code]bytes[/code] from the stream. If [code]bytes[/code] is negative (default) the length will be read from the stream using the reverse process of [method put_string].
+				Gets an ASCII string with byte-length [param bytes] from the stream. If [param bytes] is negative (default) the length will be read from the stream using the reverse process of [method put_string].
 			</description>
 		</method>
 		<method name="get_u16">
@@ -101,14 +101,14 @@
 			<return type="String" />
 			<param index="0" name="bytes" type="int" default="-1" />
 			<description>
-				Gets an UTF-8 string with byte-length [code]bytes[/code] from the stream (this decodes the string sent as UTF-8). If [code]bytes[/code] is negative (default) the length will be read from the stream using the reverse process of [method put_utf8_string].
+				Gets an UTF-8 string with byte-length [param bytes] from the stream (this decodes the string sent as UTF-8). If [param bytes] is negative (default) the length will be read from the stream using the reverse process of [method put_utf8_string].
 			</description>
 		</method>
 		<method name="get_var">
 			<return type="Variant" />
 			<param index="0" name="allow_objects" type="bool" default="false" />
 			<description>
-				Gets a Variant from the stream. If [code]allow_objects[/code] is [code]true[/code], decoding objects is allowed.
+				Gets a Variant from the stream. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
@@ -233,7 +233,7 @@
 			<param index="0" name="value" type="Variant" />
 			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
-				Puts a Variant into the stream. If [code]full_objects[/code] is [code]true[/code] encoding objects is allowed (and can potentially include code).
+				Puts a Variant into the stream. If [param full_objects] is [code]true[/code] encoding objects is allowed (and can potentially include code).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/StreamPeerBuffer.xml
+++ b/doc/classes/StreamPeerBuffer.xml
@@ -45,7 +45,7 @@
 			<return type="void" />
 			<param index="0" name="position" type="int" />
 			<description>
-				Moves the cursor to the specified position. [code]position[/code] must be a valid index of [member data_array].
+				Moves the cursor to the specified position. [param position] must be a valid index of [member data_array].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/StreamPeerSSL.xml
+++ b/doc/classes/StreamPeerSSL.xml
@@ -18,7 +18,7 @@
 			<param index="2" name="certificate" type="X509Certificate" />
 			<param index="3" name="chain" type="X509Certificate" default="null" />
 			<description>
-				Accepts a peer connection as a server using the given [code]private_key[/code] and providing the given [code]certificate[/code] to the client. You can pass the optional [code]chain[/code] parameter to provide additional CA chain information along with the certificate.
+				Accepts a peer connection as a server using the given [param private_key] and providing the given [param certificate] to the client. You can pass the optional [param chain] parameter to provide additional CA chain information along with the certificate.
 			</description>
 		</method>
 		<method name="connect_to_stream">
@@ -28,8 +28,8 @@
 			<param index="2" name="for_hostname" type="String" default="&quot;&quot;" />
 			<param index="3" name="valid_certificate" type="X509Certificate" default="null" />
 			<description>
-				Connects to a peer using an underlying [StreamPeer] [code]stream[/code]. If [code]validate_certs[/code] is [code]true[/code], [StreamPeerSSL] will validate that the certificate presented by the peer matches the [code]for_hostname[/code].
-				[b]Note:[/b] Specifying a custom [code]valid_certificate[/code] is not supported in HTML5 exports due to browsers restrictions.
+				Connects to a peer using an underlying [StreamPeer] [param stream]. If [param validate_certs] is [code]true[/code], [StreamPeerSSL] will validate that the certificate presented by the peer matches the [param for_hostname].
+				[b]Note:[/b] Specifying a custom [param valid_certificate] is not supported in HTML5 exports due to browsers restrictions.
 			</description>
 		</method>
 		<method name="disconnect_from_stream">

--- a/doc/classes/StreamPeerTCP.xml
+++ b/doc/classes/StreamPeerTCP.xml
@@ -16,7 +16,7 @@
 			<param index="1" name="host" type="String" default="&quot;*&quot;" />
 			<description>
 				Opens the TCP socket, and binds it to the specified local address.
-				This method is generally not needed, and only used to force the subsequent call to [method connect_to_host] to use the specified [code]host[/code] and [code]port[/code] as source address. This can be desired in some NAT punchthrough techniques, or when forcing the source network interface.
+				This method is generally not needed, and only used to force the subsequent call to [method connect_to_host] to use the specified [param host] and [param port] as source address. This can be desired in some NAT punchthrough techniques, or when forcing the source network interface.
 			</description>
 		</method>
 		<method name="connect_to_host">
@@ -67,7 +67,7 @@
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>
-				If [code]enabled[/code] is [code]true[/code], packets will be sent immediately. If [code]enabled[/code] is [code]false[/code] (the default), packet transfers will be delayed and combined using [url=https://en.wikipedia.org/wiki/Nagle%27s_algorithm]Nagle's algorithm[/url].
+				If [param enabled] is [code]true[/code], packets will be sent immediately. If [param enabled] is [code]false[/code] (the default), packet transfers will be delayed and combined using [url=https://en.wikipedia.org/wiki/Nagle%27s_algorithm]Nagle's algorithm[/url].
 				[b]Note:[/b] It's recommended to leave this disabled for applications that send large packets or need to transfer a lot of data, as enabling this can decrease the total available bandwidth.
 			</description>
 		</method>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -95,8 +95,8 @@
 			<param index="0" name="to" type="String" />
 			<description>
 				Performs a case-sensitive comparison to another string. Returns [code]-1[/code] if less than, [code]1[/code] if greater than, or [code]0[/code] if equal. "less than" or "greater than" are determined by the [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode code points[/url] of each string, which roughly matches the alphabetical order.
-				[b]Behavior with different string lengths:[/b] Returns [code]1[/code] if the "base" string is longer than the [code]to[/code] string or [code]-1[/code] if the "base" string is shorter than the [code]to[/code] string. Keep in mind this length is determined by the number of Unicode codepoints, [i]not[/i] the actual visible characters.
-				[b]Behavior with empty strings:[/b] Returns [code]-1[/code] if the "base" string is empty, [code]1[/code] if the [code]to[/code] string is empty or [code]0[/code] if both strings are empty.
+				[b]Behavior with different string lengths:[/b] Returns [code]1[/code] if the "base" string is longer than the [param to] string or [code]-1[/code] if the "base" string is shorter than the [param to] string. Keep in mind this length is determined by the number of Unicode codepoints, [i]not[/i] the actual visible characters.
+				[b]Behavior with empty strings:[/b] Returns [code]-1[/code] if the "base" string is empty, [code]1[/code] if the [param to] string is empty or [code]0[/code] if both strings are empty.
 				To get a boolean result from a string comparison, use the [code]==[/code] operator instead. See also [method nocasecmp_to] and [method naturalnocasecmp_to].
 			</description>
 		</method>
@@ -124,7 +124,7 @@
 			<param index="1" name="from" type="int" default="0" />
 			<param index="2" name="to" type="int" default="0" />
 			<description>
-				Returns the number of occurrences of substring [code]what[/code] between [code]from[/code] and [code]to[/code] positions. If [code]from[/code] and [code]to[/code] equals 0 the whole string will be used. If only [code]to[/code] equals 0 the remained substring will be used.
+				Returns the number of occurrences of substring [param what] between [param from] and [param to] positions. If [param from] and [param to] equals 0 the whole string will be used. If only [param to] equals 0 the remained substring will be used.
 			</description>
 		</method>
 		<method name="countn" qualifiers="const">
@@ -133,7 +133,7 @@
 			<param index="1" name="from" type="int" default="0" />
 			<param index="2" name="to" type="int" default="0" />
 			<description>
-				Returns the number of occurrences of substring [code]what[/code] (ignoring case) between [code]from[/code] and [code]to[/code] positions. If [code]from[/code] and [code]to[/code] equals 0 the whole string will be used. If only [code]to[/code] equals 0 the remained substring will be used.
+				Returns the number of occurrences of substring [param what] (ignoring case) between [param from] and [param to] positions. If [param from] and [param to] equals 0 the whole string will be used. If only [param to] equals 0 the remained substring will be used.
 			</description>
 		</method>
 		<method name="dedent" qualifiers="const">
@@ -180,8 +180,8 @@
 			<param index="0" name="values" type="Variant" />
 			<param index="1" name="placeholder" type="String" default="&quot;{_}&quot;" />
 			<description>
-				Formats the string by replacing all occurrences of [code]placeholder[/code] with the elements of [code]values[/code].
-				[code]values[/code] can be a [Dictionary] or an [Array]. Any underscores in [code]placeholder[/code] will be replaced with the corresponding keys in advance. Array elements use their index as keys.
+				Formats the string by replacing all occurrences of [param placeholder] with the elements of [param values].
+				[param values] can be a [Dictionary] or an [Array]. Any underscores in [param placeholder] will be replaced with the corresponding keys in advance. Array elements use their index as keys.
 				[codeblock]
 				# Prints: Waiting for Godot is a play by Samuel Beckett, and Godot Engine is named after it.
 				var use_array_values = "Waiting for {0} is a play by {1}, and {0} Engine is named after it."
@@ -190,7 +190,7 @@
 				# Prints: User 42 is Godot.
 				print("User {id} is {name}.".format({"id": 42, "name": "Godot"}))
 				[/codeblock]
-				Some additional handling is performed when [code]values[/code] is an array. If [code]placeholder[/code] does not contain an underscore, the elements of the array will be used to replace one occurrence of the placeholder in turn; If an array element is another 2-element array, it'll be interpreted as a key-value pair.
+				Some additional handling is performed when [param values] is an array. If [param placeholder] does not contain an underscore, the elements of the array will be used to replace one occurrence of the placeholder in turn; If an array element is another 2-element array, it'll be interpreted as a key-value pair.
 				[codeblock]
 				# Prints: User 42 is Godot.
 				print("User {} is {}.".format([42, "Godot"], "{}"))
@@ -237,7 +237,7 @@
 			<param index="0" name="delimiter" type="String" />
 			<param index="1" name="slice" type="int" />
 			<description>
-				Splits a string using a [code]delimiter[/code] and returns a substring at index [code]slice[/code]. Returns an empty string if the index doesn't exist.
+				Splits a string using a [param delimiter] and returns a substring at index [param slice]. Returns an empty string if the index doesn't exist.
 				This is a more performant alternative to [method split] for cases when you need only one element from the array at a fixed index.
 				Example:
 				[codeblock]
@@ -249,7 +249,7 @@
 			<return type="int" />
 			<param index="0" name="delimiter" type="String" />
 			<description>
-				Splits a string using a [code]delimiter[/code] and returns a number of slices.
+				Splits a string using a [param delimiter] and returns a number of slices.
 			</description>
 		</method>
 		<method name="get_slicec" qualifiers="const">
@@ -257,7 +257,7 @@
 			<param index="0" name="delimiter" type="int" />
 			<param index="1" name="slice" type="int" />
 			<description>
-				Splits a string using a Unicode character with code [code]delimiter[/code] and returns a substring at index [code]slice[/code]. Returns an empty string if the index doesn't exist.
+				Splits a string using a Unicode character with code [param delimiter] and returns a substring at index [param slice]. Returns an empty string if the index doesn't exist.
 				This is a more performant alternative to [method split] for cases when you need only one element from the array at a fixed index.
 			</description>
 		</method>
@@ -296,7 +296,7 @@
 			<return type="String" />
 			<param index="0" name="prefix" type="String" />
 			<description>
-				Returns a copy of the string with lines indented with [code]prefix[/code].
+				Returns a copy of the string with lines indented with [param prefix].
 				For example, the string can be indented with two tabs using [code]"\t\t"[/code], or four spaces using [code]"    "[/code]. The prefix can be any string so it can also be used to comment out strings with e.g. [code]"# "[/code]. See also [method dedent] to remove indentation.
 				[b]Note:[/b] Empty lines are kept empty.
 			</description>
@@ -306,7 +306,7 @@
 			<param index="0" name="position" type="int" />
 			<param index="1" name="what" type="String" />
 			<description>
-				Returns a copy of the string with the substring [code]what[/code] inserted at the given position.
+				Returns a copy of the string with the substring [param what] inserted at the given [param position].
 			</description>
 		</method>
 		<method name="is_absolute_path" qualifiers="const">
@@ -364,7 +364,7 @@
 			<return type="bool" />
 			<param index="0" name="with_prefix" type="bool" default="false" />
 			<description>
-				Returns [code]true[/code] if this string contains a valid hexadecimal number. If [code]with_prefix[/code] is [code]true[/code], then a validity of the hexadecimal number is determined by [code]0x[/code] prefix, for instance: [code]0xDEADC0DE[/code].
+				Returns [code]true[/code] if this string contains a valid hexadecimal number. If [param with_prefix] is [code]true[/code], then a validity of the hexadecimal number is determined by [code]0x[/code] prefix, for instance: [code]0xDEADC0DE[/code].
 			</description>
 		</method>
 		<method name="is_valid_html_color" qualifiers="const">
@@ -407,7 +407,7 @@
 			<return type="String" />
 			<param index="0" name="parts" type="PackedStringArray" />
 			<description>
-				Returns a [String] which is the concatenation of the [code]parts[/code]. The separator between elements is the string providing this method.
+				Returns a [String] which is the concatenation of the [param parts]. The separator between elements is the string providing this method.
 				Example:
 				[codeblocks]
 				[gdscript]
@@ -429,7 +429,7 @@
 			<return type="String" />
 			<param index="0" name="length" type="int" />
 			<description>
-				Returns a number of characters from the left of the string. If negative [code]length[/code] is used, the characters are counted downwards from [String]'s length.
+				Returns a number of characters from the left of the string. If negative [param length] is used, the characters are counted downwards from [String]'s length.
 				Examples:
 				[codeblock]
 				print("sample text".left(3)) #prints "sam"
@@ -448,15 +448,15 @@
 			<param index="0" name="min_length" type="int" />
 			<param index="1" name="character" type="String" default="&quot; &quot;" />
 			<description>
-				Formats a string to be at least [code]min_length[/code] long by adding [code]character[/code]s to the left of the string.
+				Formats a string to be at least [param min_length] long by adding [param character]s to the left of the string.
 			</description>
 		</method>
 		<method name="lstrip" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="chars" type="String" />
 			<description>
-				Returns a copy of the string with characters removed from the left. The [code]chars[/code] argument is a string specifying the set of characters to be removed.
-				[b]Note:[/b] The [code]chars[/code] is not a prefix. See [method trim_prefix] method that will remove a single prefix string rather than a set of characters.
+				Returns a copy of the string with characters removed from the left. The [param chars] argument is a string specifying the set of characters to be removed.
+				[b]Note:[/b] The [param chars] is not a prefix. See [method trim_prefix] method that will remove a single prefix string rather than a set of characters.
 			</description>
 		</method>
 		<method name="match" qualifiers="const">
@@ -491,8 +491,8 @@
 			<description>
 				Performs a case-insensitive [i]natural order[/i] comparison to another string. Returns [code]-1[/code] if less than, [code]1[/code] if greater than, or [code]0[/code] if equal. "less than" or "greater than" are determined by the [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode code points[/url] of each string, which roughly matches the alphabetical order. Internally, lowercase characters will be converted to uppercase during the comparison.
 				When used for sorting, natural order comparison will order suites of numbers as expected by most people. If you sort the numbers from 1 to 10 using natural order, you will get [code][1, 2, 3, ...][/code] instead of [code][1, 10, 2, 3, ...][/code].
-				[b]Behavior with different string lengths:[/b] Returns [code]1[/code] if the "base" string is longer than the [code]to[/code] string or [code]-1[/code] if the "base" string is shorter than the [code]to[/code] string. Keep in mind this length is determined by the number of Unicode codepoints, [i]not[/i] the actual visible characters.
-				[b]Behavior with empty strings:[/b] Returns [code]-1[/code] if the "base" string is empty, [code]1[/code] if the [code]to[/code] string is empty or [code]0[/code] if both strings are empty.
+				[b]Behavior with different string lengths:[/b] Returns [code]1[/code] if the "base" string is longer than the [param to] string or [code]-1[/code] if the "base" string is shorter than the [param to] string. Keep in mind this length is determined by the number of Unicode codepoints, [i]not[/i] the actual visible characters.
+				[b]Behavior with empty strings:[/b] Returns [code]-1[/code] if the "base" string is empty, [code]1[/code] if the [param to] string is empty or [code]0[/code] if both strings are empty.
 				To get a boolean result from a string comparison, use the [code]==[/code] operator instead. See also [method nocasecmp_to] and [method casecmp_to].
 			</description>
 		</method>
@@ -501,8 +501,8 @@
 			<param index="0" name="to" type="String" />
 			<description>
 				Performs a case-insensitive comparison to another string. Returns [code]-1[/code] if less than, [code]1[/code] if greater than, or [code]0[/code] if equal. "less than" or "greater than" are determined by the [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode code points[/url] of each string, which roughly matches the alphabetical order. Internally, lowercase characters will be converted to uppercase during the comparison.
-				[b]Behavior with different string lengths:[/b] Returns [code]1[/code] if the "base" string is longer than the [code]to[/code] string or [code]-1[/code] if the "base" string is shorter than the [code]to[/code] string. Keep in mind this length is determined by the number of Unicode codepoints, [i]not[/i] the actual visible characters.
-				[b]Behavior with empty strings:[/b] Returns [code]-1[/code] if the "base" string is empty, [code]1[/code] if the [code]to[/code] string is empty or [code]0[/code] if both strings are empty.
+				[b]Behavior with different string lengths:[/b] Returns [code]1[/code] if the "base" string is longer than the [param to] string or [code]-1[/code] if the "base" string is shorter than the [param to] string. Keep in mind this length is determined by the number of Unicode codepoints, [i]not[/i] the actual visible characters.
+				[b]Behavior with empty strings:[/b] Returns [code]-1[/code] if the "base" string is empty, [code]1[/code] if the [param to] string is empty or [code]0[/code] if both strings are empty.
 				To get a boolean result from a string comparison, use the [code]==[/code] operator instead. See also [method casecmp_to] and [method naturalnocasecmp_to].
 			</description>
 		</method>
@@ -512,7 +512,7 @@
 			<param index="1" name="decimals" type="int" default="-1" />
 			<description>
 				Converts a [float] to a string representation of a decimal number.
-				The number of decimal places can be specified with [code]decimals[/code]. If [code]decimals[/code] is [code]-1[/code] (default), decimal places will be automatically adjusted so that the string representation has 14 significant digits (counting both digits to the left and the right of the decimal point).
+				The number of decimal places can be specified with [param decimals]. If [param decimals] is [code]-1[/code] (default), decimal places will be automatically adjusted so that the string representation has 14 significant digits (counting both digits to the left and the right of the decimal point).
 				Trailing zeros are not included in the string. The last digit will be rounded and not truncated.
 				Some examples:
 				[codeblock]
@@ -556,21 +556,21 @@
 			<return type="String" />
 			<param index="0" name="digits" type="int" />
 			<description>
-				Formats a number to have an exact number of [code]digits[/code] after the decimal point.
+				Formats a number to have an exact number of [param digits] after the decimal point.
 			</description>
 		</method>
 		<method name="pad_zeros" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="digits" type="int" />
 			<description>
-				Formats a number to have an exact number of [code]digits[/code] before the decimal point.
+				Formats a number to have an exact number of [param digits] before the decimal point.
 			</description>
 		</method>
 		<method name="plus_file" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="file" type="String" />
 			<description>
-				If the string is a path, this concatenates [code]file[/code] at the end of the string as a subpath. E.g. [code]"this/is".plus_file("path") == "this/is/path"[/code].
+				If the string is a path, this concatenates [param file] at the end of the string as a subpath. E.g. [code]"this/is".plus_file("path") == "this/is/path"[/code].
 			</description>
 		</method>
 		<method name="repeat" qualifiers="const">
@@ -616,7 +616,7 @@
 			<return type="String" />
 			<param index="0" name="length" type="int" />
 			<description>
-				Returns a number of characters from the right of the string. If negative [code]length[/code] is used, the characters are counted downwards from [String]'s length.
+				Returns a number of characters from the right of the string. If negative [param length] is used, the characters are counted downwards from [String]'s length.
 				Examples:
 				[codeblock]
 				print("sample text".right(3)) #prints "ext"
@@ -629,7 +629,7 @@
 			<param index="0" name="min_length" type="int" />
 			<param index="1" name="character" type="String" default="&quot; &quot;" />
 			<description>
-				Formats a string to be at least [code]min_length[/code] long by adding [code]character[/code]s to the right of the string.
+				Formats a string to be at least [param min_length] long by adding [param character]s to the right of the string.
 			</description>
 		</method>
 		<method name="rsplit" qualifiers="const">
@@ -638,10 +638,10 @@
 			<param index="1" name="allow_empty" type="bool" default="true" />
 			<param index="2" name="maxsplit" type="int" default="0" />
 			<description>
-				Splits the string by a [code]delimiter[/code] string and returns an array of the substrings, starting from right.
+				Splits the string by a [param delimiter] string and returns an array of the substrings, starting from right.
 				The splits in the returned array are sorted in the same order as the original string, from left to right.
-				If [code]allow_empty[/code] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
-				If [code]maxsplit[/code] is specified, it defines the number of splits to do from the right up to [code]maxsplit[/code]. The default value of 0 means that all items are split, thus giving the same result as [method split].
+				If [param allow_empty] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
+				If [param maxsplit] is specified, it defines the number of splits to do from the right up to [param maxsplit]. The default value of 0 means that all items are split, thus giving the same result as [method split].
 				Example:
 				[codeblocks]
 				[gdscript]
@@ -661,8 +661,8 @@
 			<return type="String" />
 			<param index="0" name="chars" type="String" />
 			<description>
-				Returns a copy of the string with characters removed from the right. The [code]chars[/code] argument is a string specifying the set of characters to be removed.
-				[b]Note:[/b] The [code]chars[/code] is not a suffix. See [method trim_suffix] method that will remove a single suffix string rather than a set of characters.
+				Returns a copy of the string with characters removed from the right. The [param chars] argument is a string specifying the set of characters to be removed.
+				[b]Note:[/b] The [param chars] is not a suffix. See [method trim_suffix] method that will remove a single suffix string rather than a set of characters.
 			</description>
 		</method>
 		<method name="sha1_buffer" qualifiers="const">
@@ -714,9 +714,9 @@
 			<param index="1" name="allow_empty" type="bool" default="true" />
 			<param index="2" name="maxsplit" type="int" default="0" />
 			<description>
-				Splits the string by a [code]delimiter[/code] string and returns an array of the substrings. The [code]delimiter[/code] can be of any length.
-				If [code]allow_empty[/code] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
-				If [code]maxsplit[/code] is specified, it defines the number of splits to do from the left up to [code]maxsplit[/code]. The default value of [code]0[/code] means that all items are split.
+				Splits the string by a [param delimiter] string and returns an array of the substrings. The [param delimiter] can be of any length.
+				If [param allow_empty] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
+				If [param maxsplit] is specified, it defines the number of splits to do from the left up to [param maxsplit]. The default value of [code]0[/code] means that all items are split.
 				If you need only one element from the array at a specific index, [method get_slice] is a more performant option.
 				Example:
 				[codeblocks]
@@ -744,7 +744,7 @@
 			<description>
 				Splits the string in floats by using a delimiter string and returns an array of the substrings.
 				For example, [code]"1,2.5,3"[/code] will return [code][1,2.5,3][/code] if split by [code]","[/code].
-				If [code]allow_empty[/code] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
+				If [param allow_empty] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
 			</description>
 		</method>
 		<method name="strip_edges" qualifiers="const">
@@ -766,7 +766,7 @@
 			<param index="0" name="from" type="int" />
 			<param index="1" name="len" type="int" default="-1" />
 			<description>
-				Returns part of the string from the position [code]from[/code] with length [code]len[/code]. Argument [code]len[/code] is optional and using [code]-1[/code] will return remaining characters from given position.
+				Returns part of the string from the position [param from] with length [param len]. Argument [param len] is optional and using [code]-1[/code] will return remaining characters from given position.
 			</description>
 		</method>
 		<method name="to_ascii_buffer" qualifiers="const">
@@ -846,7 +846,7 @@
 			<return type="int" />
 			<param index="0" name="at" type="int" />
 			<description>
-				Returns the character code at position [code]at[/code].
+				Returns the character code at position [param at].
 			</description>
 		</method>
 		<method name="uri_decode" qualifiers="const">
@@ -887,7 +887,7 @@
 			<return type="String" />
 			<param index="0" name="escape_quotes" type="bool" default="false" />
 			<description>
-				Returns a copy of the string with special characters escaped using the XML standard. If [code]escape_quotes[/code] is [code]true[/code], the single quote ([code]'[/code]) and double quote ([code]"[/code]) characters are also escaped.
+				Returns a copy of the string with special characters escaped using the XML standard. If [param escape_quotes] is [code]true[/code], the single quote ([code]'[/code]) and double quote ([code]"[/code]) characters are also escaped.
 			</description>
 		</method>
 		<method name="xml_unescape" qualifiers="const">

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -94,7 +94,7 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="offset" type="float" />
 			<description>
-				Sets the default value of the specified [enum Side] to [code]offset[/code] pixels.
+				Sets the default value of the specified [enum Side] to [param offset] pixels.
 			</description>
 		</method>
 		<method name="test_mask" qualifiers="const">

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -41,7 +41,7 @@
 			<return type="int" />
 			<param index="0" name="corner" type="int" enum="Corner" />
 			<description>
-				Returns the given [code]corner[/code]'s radius. See [enum Corner] for possible values.
+				Returns the given [param corner]'s radius. See [enum Corner] for possible values.
 			</description>
 		</method>
 		<method name="get_expand_margin" qualifiers="const">
@@ -56,14 +56,14 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="width" type="int" />
 			<description>
-				Sets the specified [enum Side]'s border width to [code]width[/code] pixels.
+				Sets the specified [enum Side]'s border width to [param width] pixels.
 			</description>
 		</method>
 		<method name="set_border_width_all">
 			<return type="void" />
 			<param index="0" name="width" type="int" />
 			<description>
-				Sets the border width to [code]width[/code] pixels for all sides.
+				Sets the border width to [param width] pixels for all sides.
 			</description>
 		</method>
 		<method name="set_corner_radius">
@@ -71,14 +71,14 @@
 			<param index="0" name="corner" type="int" enum="Corner" />
 			<param index="1" name="radius" type="int" />
 			<description>
-				Sets the corner radius to [code]radius[/code] pixels for the given [code]corner[/code]. See [enum Corner] for possible values.
+				Sets the corner radius to [param radius] pixels for the given [param corner]. See [enum Corner] for possible values.
 			</description>
 		</method>
 		<method name="set_corner_radius_all">
 			<return type="void" />
 			<param index="0" name="radius" type="int" />
 			<description>
-				Sets the corner radius to [code]radius[/code] pixels for all corners.
+				Sets the corner radius to [param radius] pixels for all corners.
 			</description>
 		</method>
 		<method name="set_corner_radius_individual">
@@ -88,7 +88,7 @@
 			<param index="2" name="radius_bottom_right" type="int" />
 			<param index="3" name="radius_bottom_left" type="int" />
 			<description>
-				Sets the corner radius for each corner to [code]radius_top_left[/code], [code]radius_top_right[/code], [code]radius_bottom_right[/code], and [code]radius_bottom_left[/code] pixels.
+				Sets the corner radius for each corner to [param radius_top_left], [param radius_top_right], [param radius_bottom_right], and [param radius_bottom_left] pixels.
 			</description>
 		</method>
 		<method name="set_expand_margin">
@@ -96,14 +96,14 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="size" type="float" />
 			<description>
-				Sets the expand margin to [code]size[/code] pixels for the specified [enum Side].
+				Sets the expand margin to [param size] pixels for the specified [enum Side].
 			</description>
 		</method>
 		<method name="set_expand_margin_all">
 			<return type="void" />
 			<param index="0" name="size" type="float" />
 			<description>
-				Sets the expand margin to [code]size[/code] pixels for all margins.
+				Sets the expand margin to [param size] pixels for all margins.
 			</description>
 		</method>
 		<method name="set_expand_margin_individual">
@@ -113,7 +113,7 @@
 			<param index="2" name="size_right" type="float" />
 			<param index="3" name="size_bottom" type="float" />
 			<description>
-				Sets the expand margin for each margin to [code]size_left[/code], [code]size_top[/code], [code]size_right[/code], and [code]size_bottom[/code] pixels.
+				Sets the expand margin for each margin to [param size_left], [param size_top], [param size_right], and [param size_bottom] pixels.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -27,7 +27,7 @@
 			<return type="void" />
 			<param index="0" name="size" type="float" />
 			<description>
-				Sets the expand margin to [code]size[/code] pixels for all margins.
+				Sets the expand margin to [param size] pixels for all margins.
 			</description>
 		</method>
 		<method name="set_expand_margin_individual">
@@ -37,7 +37,7 @@
 			<param index="2" name="size_right" type="float" />
 			<param index="3" name="size_bottom" type="float" />
 			<description>
-				Sets the expand margin for each margin to [code]size_left[/code], [code]size_top[/code], [code]size_right[/code], and [code]size_bottom[/code] pixels.
+				Sets the expand margin for each margin to [param size_left], [param size_top], [param size_right], and [param size_bottom] pixels.
 			</description>
 		</method>
 		<method name="set_expand_margin_size">
@@ -45,7 +45,7 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="size" type="float" />
 			<description>
-				Sets the expand margin to [code]size[/code] pixels for the specified [enum Side].
+				Sets the expand margin to [param size] pixels for the specified [enum Side].
 			</description>
 		</method>
 		<method name="set_margin_size">
@@ -53,7 +53,7 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="size" type="float" />
 			<description>
-				Sets the margin to [code]size[/code] pixels for the specified [enum Side].
+				Sets the margin to [param size] pixels for the specified [enum Side].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -86,7 +86,7 @@
 			<param index="1" name="flags" type="int" default="0" />
 			<description>
 				Returns a constructed [ArrayMesh] from current information passed in. If an existing [ArrayMesh] is passed in as an argument, will add an extra surface to the existing [ArrayMesh].
-				[b]FIXME:[/b] Document possible values for [code]flags[/code], it changed in 4.0. Likely some combinations of [enum Mesh.ArrayFormat].
+				[b]FIXME:[/b] Document possible values for [param flags], it changed in 4.0. Likely some combinations of [enum Mesh.ArrayFormat].
 			</description>
 		</method>
 		<method name="commit_to_arrays">
@@ -123,7 +123,7 @@
 			<param index="0" name="nd_threshold" type="float" />
 			<param index="1" name="target_index_count" type="int" default="3" />
 			<description>
-				Generates a LOD for a given [code]nd_threshold[/code] in linear units (square root of quadric error metric), using at most [code]target_index_count[/code] indices.
+				Generates a LOD for a given [param nd_threshold] in linear units (square root of quadric error metric), using at most [param target_index_count] indices.
 				Deprecated. Unused internally and neglects to preserve normals or UVs. Consider using [method ImporterMesh.generate_lods] instead.
 			</description>
 		</method>
@@ -131,7 +131,7 @@
 			<return type="void" />
 			<param index="0" name="flip" type="bool" default="false" />
 			<description>
-				Generates normals from vertices so you do not have to do it manually. If [code]flip[/code] is [code]true[/code], the resulting normals will be inverted. [method generate_normals] should be called [i]after[/i] generating geometry and [i]before[/i] committing the mesh using [method commit] or [method commit_to_arrays]. For correct display of normal-mapped surfaces, you will also have to generate tangents using [method generate_tangents].
+				Generates normals from vertices so you do not have to do it manually. If [param flip] is [code]true[/code], the resulting normals will be inverted. [method generate_normals] should be called [i]after[/i] generating geometry and [i]before[/i] committing the mesh using [method commit] or [method commit_to_arrays]. For correct display of normal-mapped surfaces, you will also have to generate tangents using [method generate_tangents].
 				[b]Note:[/b] [method generate_normals] only works if the primitive type to be set to [constant Mesh.PRIMITIVE_TRIANGLES].
 			</description>
 		</method>
@@ -151,7 +151,7 @@
 			<return type="int" enum="SurfaceTool.CustomFormat" />
 			<param index="0" name="channel_index" type="int" />
 			<description>
-				Returns the format for custom [code]channel_index[/code] (currently up to 4). Returns [constant CUSTOM_MAX] if this custom channel is unused.
+				Returns the format for custom [param channel_index] (currently up to 4). Returns [constant CUSTOM_MAX] if this custom channel is unused.
 			</description>
 		</method>
 		<method name="get_primitive_type" qualifiers="const">
@@ -184,7 +184,7 @@
 			<return type="void" />
 			<param index="0" name="bones" type="PackedInt32Array" />
 			<description>
-				Specifies an array of bones to use for the [i]next[/i] vertex. [code]bones[/code] must contain 4 integers.
+				Specifies an array of bones to use for the [i]next[/i] vertex. [param bones] must contain 4 integers.
 			</description>
 		</method>
 		<method name="set_color">
@@ -200,8 +200,8 @@
 			<param index="0" name="channel_index" type="int" />
 			<param index="1" name="custom_color" type="Color" />
 			<description>
-				Sets the custom value on this vertex for [code]channel_index[/code].
-				[method set_custom_format] must be called first for this [code]channel_index[/code]. Formats which are not RGBA will ignore other color channels.
+				Sets the custom value on this vertex for [param channel_index].
+				[method set_custom_format] must be called first for this [param channel_index]. Formats which are not RGBA will ignore other color channels.
 			</description>
 		</method>
 		<method name="set_custom_format">
@@ -209,7 +209,7 @@
 			<param index="0" name="channel_index" type="int" />
 			<param index="1" name="format" type="int" enum="SurfaceTool.CustomFormat" />
 			<description>
-				Sets the color format for this custom [code]channel_index[/code]. Use [constant CUSTOM_MAX] to disable.
+				Sets the color format for this custom [param channel_index]. Use [constant CUSTOM_MAX] to disable.
 				Must be invoked after [method begin] and should be set before [method commit] or [method commit_to_arrays].
 			</description>
 		</method>
@@ -268,7 +268,7 @@
 			<return type="void" />
 			<param index="0" name="weights" type="PackedFloat32Array" />
 			<description>
-				Specifies weight values to use for the [i]next[/i] vertex. [code]weights[/code] must contain 4 values. If every vertex needs to have this information set and you fail to submit it for the first vertex, this information may not be used at all.
+				Specifies weight values to use for the [i]next[/i] vertex. [param weights] must contain 4 values. If every vertex needs to have this information set and you fail to submit it for the first vertex, this information may not be used at all.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -84,7 +84,7 @@
 			<return type="float" />
 			<param index="0" name="to" type="Vector4" />
 			<description>
-				Returns the squared distance between this vector and [code]to[/code].
+				Returns the squared distance between this vector and [param to].
 				This method runs faster than [method distance_to], so prefer it if you need to compare vectors or need the squared distance for some formula.
 			</description>
 		</method>


### PR DESCRIPTION
One of several commits to fix all of the class XML docs (see #64134, #64164).