### PR TITLE
Fix regression where external resources did not have their paths set

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -151,7 +151,7 @@ Error ResourceInteractiveLoaderText::_parse_ext_resource(VariantParser::Stream *
 			path = ProjectSettings::get_singleton()->localize_path(res_path.get_base_dir().plus_file(path));
 		}
 
-		r_res = ResourceLoader::load(path, type, no_subresource_cache);
+		r_res = ResourceLoader::load(path, type, false);
 
 		if (r_res.is_null()) {
 			WARN_PRINT(String("Couldn't load external resource: " + path).utf8().get_data());


### PR DESCRIPTION
Fixes #64158, a regression caused by #62408, by forcing external resources to be cached.

Also made sure that both #59686 and #59752 still behave like after #62408.