### PR TITLE
LocalVector - Add exact resizing and shrink_to_fit

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -323,7 +323,7 @@ WorkerThreadPool::GroupID WorkerThreadPool::_add_group_task(const Callable &p_ca
 	task_mutex.unlock();
 
 	if (!p_high_priority && use_native_low_priority_threads) {
-		group->low_priority_native_tasks.resize(p_tasks);
+		group->low_priority_native_tasks.resize(p_tasks, LocalVectorT::ALLOC_EXACT);
 	}
 
 	for (int i = 0; i < p_tasks; i++) {
@@ -419,7 +419,7 @@ void WorkerThreadPool::init(int p_thread_count, bool p_use_native_threads_low_pr
 
 	use_native_low_priority_threads = p_use_native_threads_low_priority;
 
-	threads.resize(p_thread_count);
+	threads.resize(p_thread_count, LocalVectorT::ALLOC_EXACT);
 
 	for (uint32_t i = 0; i < threads.size(); i++) {
 		threads[i].index = i;

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -68,7 +68,7 @@ private:
 		SafeFlag completed;
 		SafeNumeric<uint32_t> finished;
 		uint32_t tasks_used = 0;
-		TightLocalVector<Task *> low_priority_native_tasks;
+		LocalVector<Task *> low_priority_native_tasks;
 	};
 
 	struct Task {
@@ -106,7 +106,7 @@ private:
 		Thread thread;
 	};
 
-	TightLocalVector<ThreadData> threads;
+	LocalVector<ThreadData> threads;
 	SafeFlag exit_threads;
 
 	HashMap<Thread::ID, int> thread_ids;

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -9258,7 +9258,7 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 		vmaCreateAllocator(&allocatorInfo, &allocator);
 	}
 
-	frames.resize(frame_count);
+	frames.resize(frame_count, LocalVectorT::ALLOC_EXACT);
 	frame = 0;
 	// Create setup and frame buffers.
 	for (int i = 0; i < frame_count; i++) {
@@ -9304,12 +9304,12 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 
 			vkCreateQueryPool(device, &query_pool_create_info, nullptr, &frames[i].timestamp_pool);
 
-			frames[i].timestamp_names.resize(max_timestamp_query_elements);
-			frames[i].timestamp_cpu_values.resize(max_timestamp_query_elements);
+			frames[i].timestamp_names.resize(max_timestamp_query_elements, LocalVectorT::ALLOC_EXACT);
+			frames[i].timestamp_cpu_values.resize(max_timestamp_query_elements, LocalVectorT::ALLOC_EXACT);
 			frames[i].timestamp_count = 0;
-			frames[i].timestamp_result_names.resize(max_timestamp_query_elements);
-			frames[i].timestamp_cpu_result_values.resize(max_timestamp_query_elements);
-			frames[i].timestamp_result_values.resize(max_timestamp_query_elements);
+			frames[i].timestamp_result_names.resize(max_timestamp_query_elements, LocalVectorT::ALLOC_EXACT);
+			frames[i].timestamp_cpu_result_values.resize(max_timestamp_query_elements, LocalVectorT::ALLOC_EXACT);
+			frames[i].timestamp_result_values.resize(max_timestamp_query_elements, LocalVectorT::ALLOC_EXACT);
 			frames[i].timestamp_result_count = 0;
 		}
 	}

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -997,19 +997,19 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 		VkQueryPool timestamp_pool;
 
-		TightLocalVector<String> timestamp_names;
-		TightLocalVector<uint64_t> timestamp_cpu_values;
+		LocalVector<String> timestamp_names;
+		LocalVector<uint64_t> timestamp_cpu_values;
 		uint32_t timestamp_count = 0;
-		TightLocalVector<String> timestamp_result_names;
-		TightLocalVector<uint64_t> timestamp_cpu_result_values;
-		TightLocalVector<uint64_t> timestamp_result_values;
+		LocalVector<String> timestamp_result_names;
+		LocalVector<uint64_t> timestamp_cpu_result_values;
+		LocalVector<uint64_t> timestamp_result_values;
 		uint32_t timestamp_result_count = 0;
 		uint64_t index = 0;
 	};
 
 	uint32_t max_timestamp_query_elements = 0;
 
-	TightLocalVector<Frame> frames; // Frames available, for main device they are cycled (usually 3), for local devices only 1.
+	LocalVector<Frame> frames; // Frames available, for main device they are cycled (usually 3), for local devices only 1.
 	int frame = 0; // Current frame.
 	int frame_count = 0; // Total amount of frames.
 	uint64_t frames_drawn = 0;


### PR DESCRIPTION
Add the ability to resize and reserve to exact capacities, rather than power of two. Also adds a "shrink_to_fit" function to compact the vector.

* Alternative to #64120
* Replaces "tight" template argument from #55954
* Changes the small amount of code already using `TightLocalVector` to use the new functionality.

## Notes
The addition of the "tight" argument to `LocalVector` is problematic, in the sense that the logical conclusion of this approach is to add reallocation on each `push_back` and `insert`, as exemplified in #64120 . This makes such a `TightLocalVector` incredibly easy to misuse, because reallocation on each `push_back` could be prohibitively expensive.

Instead of having a specialization of `LocalVector`, an alternative approach is to simply integrate the ability for exact sizing into the regular `LocalVector`. This has several advantages:

* Regular `LocalVector`s can benefit from exact sizing, for instance for compaction after unloading a game level, or after an unknown number of `push_back`s.
* Exact sized `LocalVector`s are protected from the misuse that would occur by calling `push_back` etc.
* As these are regular `LocalVector`s, exact sized vectors can be passed to external functions that take a `LocalVector` as argument.

`shrink_to_fit` is named after the similar function in `std::vector`, with the small addition that this one can optionally shrink to power of two boundaries.

N.B. Marked milestone as 4.0 because as a core data structure further work and PRs will depend on this - already code is being written using `TightLocalVector` so it makes sense to make decision on this area sooner rather than later.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
