### PR TITLE
Add a method to print the stack trace

### DIFF
--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -254,3 +254,8 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 	}
 #endif
 }
+
+void print_stack_trace(int p_skip_called, int p_skip_callers) {
+	// Platform-specific implementations are done in OS, this error function is just a convenience wrapper.
+	OS::get_singleton()->print_stack_trace(p_skip_called + 1, p_skip_callers);
+}

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -70,6 +70,8 @@ struct ErrorHandlerList {
 void add_error_handler(ErrorHandlerList *p_handler);
 void remove_error_handler(const ErrorHandlerList *p_handler);
 
+void print_stack_trace(int p_skip_called = 0, int p_skip_callers = 0);
+
 // Functions used by the error macros.
 _NO_INLINE_ void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 _NO_INLINE_ void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, bool p_editor_notify = false, ErrorHandlerType p_type = ERR_HANDLER_ERROR);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -150,6 +150,10 @@ void OS::printerr(const char *p_format, ...) {
 	va_end(argp);
 }
 
+void OS::print_stack_trace(int p_skip_called, int p_skip_callers) {
+	printerr("Stack trace printing is not supported on this platform.\n");
+}
+
 void OS::alert(const String &p_alert, const String &p_title) {
 	fprintf(stderr, "%s: %s\n", p_title.utf8().get_data(), p_alert.utf8().get_data());
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -170,6 +170,7 @@ public:
 	void print(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
 	void print_rich(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
 	void printerr(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
+	virtual void print_stack_trace(int p_skip_called = 0, int p_skip_callers = 0);
 
 	virtual String get_stdin_string(int64_t p_buffer_size = 1024) = 0;
 	virtual PackedByteArray get_stdin_buffer(int64_t p_buffer_size = 1024) = 0;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -37,6 +37,7 @@
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "drivers/unix/file_access_unix_pipe.h"
+#include "drivers/unix/stack_trace_unix.h"
 #include "drivers/unix/thread_posix.h"
 
 #ifndef UNIX_SOCKET_UNAVAILABLE
@@ -195,6 +196,29 @@ void OS_Unix::finalize_core() {
 Vector<String> OS_Unix::get_video_adapter_driver_info() const {
 	return Vector<String>();
 }
+
+#if defined(__APPLE__) || defined(LINUXBSD_ENABLED)
+// Unix-style stack trace printing works on macOS, iOS, Linux, and BSDs, but does NOT work on Android or Web.
+void OS_Unix::print_stack_trace(int p_skip_called, int p_skip_callers) {
+#ifndef DEV_ENABLED
+	printerr("Warning: Godot is not compiled in DEV mode, so stack trace printing may be unreliable. Compile Godot with `dev_build=yes` for more complete stack traces.\n");
+#endif // DEV_ENABLED
+	p_skip_called += 1; // Skip the first one on the stack trace (this method, print_stack_trace)
+	p_skip_callers += 2; // Skip the final 2 callers (main method / program entry point).
+	void *callstack[StackTraceUnix::MAX_FRAMES];
+	const int frames = backtrace(callstack, StackTraceUnix::MAX_FRAMES);
+	if (frames <= 0) {
+		return;
+	}
+	const Vector<String> symbols = StackTraceUnix::collect_symbol_strings(callstack, frames);
+	// Print out the desired stack trace frames.
+	for (int i = p_skip_called; i < frames - p_skip_callers; i++) {
+		if (i < symbols.size()) {
+			print("%s\n", symbols[i].utf8().get_data());
+		}
+	}
+}
+#endif // defined(__APPLE__) || defined(LINUXBSD_ENABLED)
 
 String OS_Unix::get_stdin_string(int64_t p_buffer_size) {
 	Vector<uint8_t> data;

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -87,6 +87,11 @@ public:
 
 	virtual Vector<String> get_video_adapter_driver_info() const override;
 
+#if defined(__APPLE__) || defined(LINUXBSD_ENABLED)
+	// Unix-style stack trace printing works on macOS, iOS, Linux, and BSDs, but does NOT work on Android or Web.
+	virtual void print_stack_trace(int p_skip_called = 0, int p_skip_callers = 0) override;
+#endif
+
 	virtual String get_stdin_string(int64_t p_buffer_size = 1024) override;
 	virtual PackedByteArray get_stdin_buffer(int64_t p_buffer_size = 1024) override;
 	virtual StdHandleType get_stdin_type() const override;

--- a/drivers/unix/stack_trace_unix.h
+++ b/drivers/unix/stack_trace_unix.h
@@ -1,0 +1,113 @@
+/**************************************************************************/
+/*  stack_trace_unix.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#if defined(__cplusplus)
+
+// Unix-style stack trace printing works on macOS, iOS, Linux, and BSDs, but does NOT work on Android or Web.
+#if defined(__APPLE__) || defined(LINUXBSD_ENABLED)
+
+#include "core/os/os.h" // IWYU pragma: keep.
+
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+
+#include <cstdlib>
+
+namespace StackTraceUnix {
+
+constexpr int MAX_FRAMES = 256;
+
+inline Vector<uint64_t> collect_addresses(void *const *p_callstack, int p_frames) {
+	Vector<uint64_t> addresses;
+	for (int i = 0; i < p_frames; i++) {
+		addresses.push_back((uint64_t)p_callstack[i]);
+	}
+	return addresses;
+}
+
+inline Vector<String> collect_symbol_strings(void *const *p_callstack, int p_frames) {
+	Vector<String> symbols;
+	if (p_frames <= 0) {
+		return symbols;
+	}
+	char **const raw_symbols = backtrace_symbols(const_cast<void **>(p_callstack), p_frames);
+	if (raw_symbols == nullptr) {
+		return symbols;
+	}
+	symbols.resize(p_frames);
+	for (int i = 0; i < p_frames; i++) {
+		symbols.write[i] = raw_symbols[i];
+	}
+	free(raw_symbols);
+	return symbols;
+}
+
+inline String demangle_symbol_name(const char *p_symbol) {
+	if (p_symbol == nullptr) {
+		return String();
+	}
+	int status = 0;
+	char *demangled = abi::__cxa_demangle(p_symbol, nullptr, nullptr, &status);
+	if (status == 0 && demangled != nullptr) {
+		const String result = demangled;
+		free(demangled);
+		return result;
+	}
+	if (demangled != nullptr) {
+		free(demangled);
+	}
+	return p_symbol;
+}
+
+inline uint64_t find_executable_load_address(const String &p_exec_path) {
+	void *const handle = dlopen(p_exec_path.utf8().get_data(), RTLD_LAZY | RTLD_NOLOAD);
+	if (handle == nullptr) {
+		return 0;
+	}
+	void *const addr = dlsym(handle, "main");
+	uint64_t load_addr = 0;
+	if (addr != nullptr) {
+		Dl_info info = {};
+		if (dladdr(addr, &info) != 0) {
+			load_addr = (uint64_t)info.dli_fbase;
+		}
+	}
+	dlclose(handle);
+	return load_addr;
+}
+
+} // namespace StackTraceUnix
+
+#endif // defined(__APPLE__) || defined(LINUXBSD_ENABLED)
+
+#endif // defined(__cplusplus)

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -30,6 +30,8 @@
 
 #include "crash_handler_linuxbsd.h"
 
+#include "stack_trace_linuxbsd.h"
+
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/object/script_language.h"
@@ -37,6 +39,7 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"
+#include "drivers/unix/stack_trace_unix.h"
 #include "main/main.h"
 
 #ifndef DEBUG_ENABLED
@@ -44,39 +47,10 @@
 #endif
 
 #ifdef CRASH_HANDLER_ENABLED
-#include <cxxabi.h>
 #include <dlfcn.h>
-#include <execinfo.h>
-#include <link.h>
 
 #include <csignal>
-#include <cstdio>
 #include <cstdlib>
-
-inline String find_addr2line_executable() {
-	List<String> args;
-	args.push_back("--version");
-	String output;
-	OS *os = OS::get_singleton();
-	int ret = 0;
-	Error err = OK;
-	// First, check for addr2line in the home directory's cargo bin.
-	if (os->has_environment("HOME")) {
-		// Faster implementation from gimli-rs/addr2line.
-		const String cargo_addr2line = os->get_environment("HOME").path_join(String("/.cargo/bin/addr2line"));
-		err = os->execute(cargo_addr2line, args, &output, &ret);
-		if (err == OK && ret == 0) {
-			return cargo_addr2line;
-		}
-	}
-	// Otherwise, check for llvm-addr2line.
-	err = os->execute(String("llvm-addr2line"), args, &output, &ret);
-	if (err == OK && ret == 0) {
-		return String("llvm-addr2line");
-	}
-	// Fallback guess if none of the above returned a definitive result.
-	return String("addr2line");
-}
 
 static void handle_crash(int sig) {
 	signal(SIGSEGV, SIG_DFL);
@@ -91,8 +65,11 @@ static void handle_crash(int sig) {
 		std::_Exit(0);
 	}
 
-	void *bt_buffer[256];
-	size_t size = backtrace(bt_buffer, 256);
+	void *bt_buffer[StackTraceUnix::MAX_FRAMES];
+	int size = backtrace(bt_buffer, StackTraceUnix::MAX_FRAMES);
+	if (size <= 0) {
+		abort();
+	}
 	String _execpath = OS::get_singleton()->get_executable_path();
 
 	if (FileAccess::exists(_execpath + ".debugsymbols")) {
@@ -120,73 +97,34 @@ static void handle_crash(int sig) {
 		print_error(vformat("Engine version: %s (%s)", GODOT_VERSION_FULL_NAME, GODOT_VERSION_HASH));
 	}
 	print_error(vformat("Dumping the backtrace. %s", msg));
-	char **strings = backtrace_symbols(bt_buffer, size);
-	// PIE executable relocation, zero for non-PIE executables
-#ifdef __GLIBC__
-	// This is a glibc only thing apparently.
-	uintptr_t relocation = _r_debug.r_map->l_addr;
-#else
-	// Non glibc systems apparently don't give PIE relocation info.
-	uintptr_t relocation = 0;
-#endif //__GLIBC__
+	const Vector<String> symbols = StackTraceUnix::collect_symbol_strings(bt_buffer, size);
+	const uintptr_t relocation = StackTraceLinuxBSD::get_relocation_offset();
 
 	print_error(vformat("Load address: %x\n", (uint64_t)relocation));
 
-	if (strings) {
-		int ret;
-		const String exe_name = find_addr2line_executable();
+	const String addr2line_exe = StackTraceLinuxBSD::find_addr2line_executable();
+	const Vector<uint64_t> addresses = StackTraceUnix::collect_addresses(bt_buffer, size);
+	const Vector<String> addr2line_results = StackTraceLinuxBSD::symbolize_with_addr2line(OS::get_singleton(), addr2line_exe, addresses, relocation, _execpath);
 
-		List<String> args;
-		for (size_t i = 0; i < size; i++) {
-			char str[1024];
-			snprintf(str, 1024, "%p", (void *)((uintptr_t)bt_buffer[i] - relocation));
-			args.push_back(str);
+	if (!addr2line_results.is_empty()) {
+		// addr2line with -f -p -C gives "function at file:line" per frame, use it directly.
+		for (int i = 1; i < size; i++) {
+			const String a2l = i < addr2line_results.size() ? addr2line_results[i].replace("/./", "/") : String("??");
+			print_error(vformat("[%s] %x - %s", String::num_int64(i).lpad(2), (uint64_t)bt_buffer[i], a2l));
 		}
-		args.push_back("-e");
-		args.push_back(_execpath);
-		args.push_back("-f");
-		args.push_back("-p");
-		args.push_back("-C");
-
-		// Try to get the file/line number using addr2line
-		String output;
-		Error err = OS::get_singleton()->execute(exe_name, args, &output, &ret);
-		if (err == OK) {
-			Vector<String> addr2line_results = output.substr(0, output.length() - 1).split("\n", false);
-
-			for (size_t i = 1; i < size; i++) {
-				// Simplify printed file paths to remove redundant `/./` sections (e.g. `/opt/godot/./core` -> `/opt/godot/core`).
-				print_error(vformat("[%d] %x - %s", (int64_t)i, (uint64_t)bt_buffer[i], addr2line_results[i].replace("/./", "/")));
-			}
-		} else {
-			// Otherwise fall back to trace symbols.
-			for (size_t i = 1; i < size; i++) {
-				char fname[1024];
-				Dl_info info;
-
-				snprintf(fname, 1024, "%s", strings[i]);
-
-				// Try to demangle the function name to provide a more readable one.
-				if (dladdr(bt_buffer[i], &info) && info.dli_sname) {
-					if (info.dli_sname[0] == '_') {
-						int status = 0;
-						char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
-
-						if (status == 0 && demangled) {
-							snprintf(fname, 1024, "%s", demangled);
-						}
-
-						if (demangled) {
-							free(demangled);
-						}
-					}
+	} else {
+		// Fall back to dladdr/cxxabi demangling when addr2line is unavailable.
+		for (int i = 1; i < size; i++) {
+			String symbol_name = i < symbols.size() ? symbols[i] : String("<unknown symbol>");
+			Dl_info info = {};
+			if (dladdr(bt_buffer[i], &info) != 0 && info.dli_sname != nullptr) {
+				const String demangled_name = StackTraceUnix::demangle_symbol_name(info.dli_sname);
+				if (!demangled_name.is_empty()) {
+					symbol_name = demangled_name;
 				}
-
-				print_error(vformat("[%d] %x - %s", (int64_t)i, (uint64_t)bt_buffer[i], fname));
 			}
+			print_error(vformat("[%s] %x - %s", String::num_int64(i).lpad(2), (uint64_t)bt_buffer[i], symbol_name));
 		}
-
-		free(strings);
 	}
 	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -53,6 +53,31 @@
 #include <cstdio>
 #include <cstdlib>
 
+inline String find_addr2line_executable() {
+	List<String> args;
+	args.push_back("--version");
+	String output;
+	OS *os = OS::get_singleton();
+	int ret = 0;
+	Error err = OK;
+	// First, check for addr2line in the home directory's cargo bin.
+	if (os->has_environment("HOME")) {
+		// Faster implementation from gimli-rs/addr2line.
+		const String cargo_addr2line = os->get_environment("HOME").path_join(String("/.cargo/bin/addr2line"));
+		err = os->execute(cargo_addr2line, args, &output, &ret);
+		if (err == OK && ret == 0) {
+			return cargo_addr2line;
+		}
+	}
+	// Otherwise, check for llvm-addr2line.
+	err = os->execute(String("llvm-addr2line"), args, &output, &ret);
+	if (err == OK && ret == 0) {
+		return String("llvm-addr2line");
+	}
+	// Fallback guess if none of the above returned a definitive result.
+	return String("addr2line");
+}
+
 static void handle_crash(int sig) {
 	signal(SIGSEGV, SIG_DFL);
 	signal(SIGFPE, SIG_DFL);
@@ -109,31 +134,9 @@ static void handle_crash(int sig) {
 
 	if (strings) {
 		int ret;
+		const String exe_name = find_addr2line_executable();
 
 		List<String> args;
-		args.push_back("--version");
-		String exe_name;
-
-		if (exe_name.is_empty()) {
-			String output;
-			// Faster implementation from gimli-rs/addr2line.
-			Error err = OS::get_singleton()->execute(OS::get_singleton()->get_environment("HOME").path_join(String("/.cargo/bin/addr2line")), args, &output, &ret);
-			if (err == OK && ret == 0) {
-				exe_name = OS::get_singleton()->get_environment("HOME").path_join(String("/.cargo/bin/addr2line"));
-			}
-		}
-		if (exe_name.is_empty()) {
-			String output;
-			Error err = OS::get_singleton()->execute(String("llvm-addr2line"), args, &output, &ret);
-			if (err == OK && ret == 0) {
-				exe_name = String("llvm-addr2line");
-			}
-		}
-		if (exe_name.is_empty()) {
-			exe_name = String("addr2line");
-		}
-
-		args.clear();
 		for (size_t i = 0; i < size; i++) {
 			char str[1024];
 			snprintf(str, 1024, "%p", (void *)((uintptr_t)bt_buffer[i] - relocation));

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -36,6 +36,7 @@
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"
+#include "drivers/unix/stack_trace_unix.h"
 #include "main/main.h"
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
@@ -53,6 +54,8 @@
 #include "wayland/detect_prime_egl.h"
 #include "wayland/display_server_wayland.h"
 #endif
+
+#include "stack_trace_linuxbsd.h"
 
 #include "modules/modules_enabled.gen.h" // For regex.
 #ifdef MODULE_REGEX_ENABLED
@@ -540,6 +543,66 @@ Vector<String> OS_LinuxBSD::lspci_get_device_value(Vector<String> vendor_device_
 		}
 	}
 	return values;
+}
+
+void OS_LinuxBSD::print_stack_trace(int p_skip_called, int p_skip_callers) {
+#ifndef DEV_ENABLED
+	printerr("Warning: Godot is not compiled in DEV mode, so stack trace printing may be unreliable. Compile Godot with `dev_build=yes` for more complete stack traces.\n");
+#endif // DEV_ENABLED
+	p_skip_called += 1; // Skip the first one on the stack trace (this method, print_stack_trace).
+	p_skip_callers += 3; // Skip the final 3 callers (main method / program entry point).
+	void *callstack[StackTraceUnix::MAX_FRAMES];
+	const int frames = backtrace(callstack, StackTraceUnix::MAX_FRAMES);
+	if (frames <= 0) {
+		return;
+	}
+	const Vector<String> symbols = StackTraceUnix::collect_symbol_strings(callstack, frames);
+	const String exec_path = get_executable_path();
+	const String debug_exec_path = FileAccess::exists(exec_path + ".debugsymbols") ? exec_path + ".debugsymbols" : exec_path;
+	const uintptr_t relocation = StackTraceLinuxBSD::get_relocation_offset();
+	const Vector<uint64_t> addresses = StackTraceUnix::collect_addresses(callstack, frames);
+	const String addr2line_exe = StackTraceLinuxBSD::find_addr2line_executable();
+	const Vector<String> addr2line_results = StackTraceLinuxBSD::symbolize_with_addr2line(const_cast<OS_LinuxBSD *>(this), addr2line_exe, addresses, relocation, debug_exec_path);
+	const int from = MIN(p_skip_called, frames);
+	const int to = MAX(from, frames - p_skip_callers);
+	for (int i = from; i < to; i++) {
+		const uint64_t address = (uint64_t)callstack[i];
+		String module_name = "main";
+		uint64_t base_address = relocation;
+		Dl_info info = {};
+		if (dladdr(callstack[i], &info) != 0) {
+			base_address = (uint64_t)info.dli_fbase;
+			if (info.dli_fname != nullptr && info.dli_fname[0] != '\0') {
+				const String module_path = String(info.dli_fname).replace("/./", "/");
+				if (module_path != exec_path) {
+					module_name = module_path.to_lower().get_file();
+				}
+			}
+		}
+		const String frame_index_padded = String::num_int64(i - (from - 1)).lpad(2);
+		String line;
+		if (!addr2line_results.is_empty() && i < addr2line_results.size()) {
+			// addr2line with -f -p -C gives "function at file:line" per frame, use it directly.
+			const String a2l = addr2line_results[i].replace("/./", "/");
+			if (is_print_verbose_enabled()) {
+				line = vformat("[%s] %x (%s+%x)\t- %s\n", frame_index_padded, address, module_name, address - base_address, a2l);
+			} else {
+				line = vformat("[%s] %s\t- %s\n", frame_index_padded, module_name, a2l);
+			}
+		} else {
+			// Fall back to dladdr/cxxabi demangling when addr2line is unavailable.
+			String symbol_name = i < symbols.size() ? symbols[i] : String("<unknown symbol>");
+			if (info.dli_sname != nullptr) {
+				symbol_name = StackTraceUnix::demangle_symbol_name(info.dli_sname);
+			}
+			if (is_print_verbose_enabled()) {
+				line = vformat("[%s] %x (%s+%x)\t- %s (unknown file)\n", frame_index_padded, address, module_name, address - base_address, symbol_name);
+			} else {
+				line = vformat("[%s] %s\t- %s (unknown file)\n", frame_index_padded, module_name, symbol_name);
+			}
+		}
+		print("%s", line.utf8().get_data());
+	}
 }
 
 Error OS_LinuxBSD::shell_open(const String &p_uri) {

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -100,6 +100,8 @@ public:
 
 	virtual Vector<String> get_video_adapter_driver_info() const override;
 
+	virtual void print_stack_trace(int p_skip_called = 0, int p_skip_callers = 0) override;
+
 	virtual MainLoop *get_main_loop() const override;
 
 	virtual uint64_t get_embedded_pck_offset() const override;

--- a/platform/linuxbsd/stack_trace_linuxbsd.h
+++ b/platform/linuxbsd/stack_trace_linuxbsd.h
@@ -1,0 +1,102 @@
+/**************************************************************************/
+/*  stack_trace_linuxbsd.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include "core/os/os.h" // IWYU pragma: keep.
+
+#include <cstdio>
+
+#ifdef __GLIBC__
+#include <link.h>
+#endif
+
+namespace StackTraceLinuxBSD {
+
+inline String find_addr2line_executable() {
+	List<String> args;
+	args.push_back("--version");
+	String output;
+	OS *os = OS::get_singleton();
+	int ret = 0;
+	Error err = OK;
+	// First, check for addr2line in the home directory's cargo bin.
+	if (os->has_environment("HOME")) {
+		// Faster implementation from gimli-rs/addr2line.
+		const String cargo_addr2line = os->get_environment("HOME").path_join(String("/.cargo/bin/addr2line"));
+		err = os->execute(cargo_addr2line, args, &output, &ret);
+		if (err == OK && ret == 0) {
+			return cargo_addr2line;
+		}
+	}
+	// Otherwise, check for llvm-addr2line.
+	err = os->execute(String("llvm-addr2line"), args, &output, &ret);
+	if (err == OK && ret == 0) {
+		return String("llvm-addr2line");
+	}
+	// Fallback guess if none of the above returned a definitive result.
+	return String("addr2line");
+}
+
+inline Vector<String> symbolize_with_addr2line(OS *p_os, const String &p_addr2line_exe, const Vector<uint64_t> &p_addresses, uintptr_t p_relocation, const String &p_exec_path) {
+	List<String> args;
+	for (const uint64_t address_u64 : p_addresses) {
+		char address[32];
+		snprintf(address, sizeof(address), "%p", (void *)((uintptr_t)address_u64 - p_relocation));
+		args.push_back(address);
+	}
+	args.push_back("-e");
+	args.push_back(p_exec_path);
+	args.push_back("-f");
+	args.push_back("-p");
+	args.push_back("-C");
+	String output;
+	int ret = 0;
+	const Error err = p_os->execute(p_addr2line_exe, args, &output, &ret);
+	if (err == OK && ret == 0 && !output.is_empty()) {
+		return output.split("\n", false);
+	}
+	return Vector<String>();
+}
+
+inline uintptr_t get_relocation_offset() {
+#ifdef __GLIBC__
+	if (_r_debug.r_map != nullptr) {
+		return _r_debug.r_map->l_addr;
+	}
+#endif
+	return 0;
+}
+
+} // namespace StackTraceLinuxBSD
+
+#endif // __cplusplus

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -30,12 +30,15 @@
 
 #import "crash_handler_macos.h"
 
+#include "stack_trace_macos.h"
+
 #include "core/config/project_settings.h"
 #include "core/object/script_language.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"
+#include "drivers/unix/stack_trace_unix.h"
 #include "main/main.h"
 
 #include <unistd.h>
@@ -47,30 +50,8 @@
 #endif
 
 #ifdef CRASH_HANDLER_ENABLED
-#include <cxxabi.h>
-#include <dlfcn.h>
-#include <execinfo.h>
-#import <mach-o/dyld.h>
-#import <mach-o/getsect.h>
-
 #include <csignal>
 #include <cstdlib>
-
-static uint64_t load_address() {
-	char full_path[1024];
-	uint32_t size = sizeof(full_path);
-
-	if (!_NSGetExecutablePath(full_path, &size)) {
-		void *handle = dlopen(full_path, RTLD_LAZY | RTLD_NOLOAD);
-		void *addr = dlsym(handle, "main");
-		Dl_info info;
-		if (dladdr(addr, &info)) {
-			return (uint64_t)info.dli_fbase;
-		}
-	}
-
-	return 0;
-}
 
 static void handle_crash(int sig) {
 	signal(SIGSEGV, SIG_DFL);
@@ -86,8 +67,11 @@ static void handle_crash(int sig) {
 		std::_Exit(0);
 	}
 
-	void *bt_buffer[256];
-	size_t size = backtrace(bt_buffer, 256);
+	void *bt_buffer[StackTraceUnix::MAX_FRAMES];
+	int size = backtrace(bt_buffer, StackTraceUnix::MAX_FRAMES);
+	if (size <= 0) {
+		abort();
+	}
 	String _execpath = OS::get_singleton()->get_executable_path();
 
 	String msg;
@@ -112,87 +96,34 @@ static void handle_crash(int sig) {
 	}
 	print_error(vformat("Dumping the backtrace. %s", msg));
 
-	List<String> args;
-	args.push_back("-o");
-	args.push_back(_execpath);
+	const uint64_t load_addr = StackTraceUnix::find_executable_load_address(_execpath);
+	print_error(vformat("Load address: %x\n", load_addr));
 
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
-	args.push_back("-arch");
-	args.push_back("x86_64");
-#elif defined(__aarch64__)
-	args.push_back("-arch");
-	args.push_back("arm64");
-#endif
+	const Vector<uint64_t> addresses = StackTraceUnix::collect_addresses(bt_buffer, size);
+	const Vector<String> lines = StackTraceMacOS::symbolize_with_atos(OS::get_singleton(), _execpath, load_addr, addresses);
+	const Vector<String> symbols = StackTraceUnix::collect_symbol_strings(bt_buffer, size);
 
-	args.push_back("--fullPath");
-	args.push_back("-l");
-
-	char str[1024];
-	void *load_addr = (void *)load_address();
-	snprintf(str, 1024, "%p", load_addr);
-	args.push_back(str);
-
-	for (size_t i = 0; i < size; i++) {
-		snprintf(str, 1024, "%p", bt_buffer[i]);
-		args.push_back(str);
-	}
-
-	print_error(vformat("Load address: %x\n", (uint64_t)load_addr));
-
-	// Single execution of atos with all addresses.
-	String out;
-	int ret;
-	Error err = OS::get_singleton()->execute(String("atos"), args, &out, &ret);
-
-	if (err == OK) {
-		// Parse the multi-line output
-		Vector<String> lines = out.split("\n");
-
-		// Get demangled names from dladdr for fallback.
-		char **strings = backtrace_symbols(bt_buffer, size);
-
-		for (int i = 1; i < lines.size() && i < (int)size; i++) {
-			String output = lines[i];
-
-			// If atos failed for this address, fall back to dladdr.
-			if (output.substr(0, 2) == "0x" && strings) {
-				char fname[1024];
-				Dl_info info;
-
-				snprintf(fname, 1024, "%s", strings[i]);
-
-				if (dladdr(bt_buffer[i], &info) && info.dli_sname) {
-					if (info.dli_sname[0] == '_') {
-						int status;
-						char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, 0, &status);
-
-						if (status == 0 && demangled) {
-							snprintf(fname, 1024, "%s", demangled);
-						}
-
-						if (demangled) {
-							free(demangled);
-						}
+	for (int i = 1; i < size; i++) {
+		String output = i < lines.size() ? lines[i] : String();
+		if (output.is_empty() || StackTraceMacOS::is_unresolved_atos_line(output)) {
+			output = i < symbols.size() ? symbols[i] : String("<unknown symbol>");
+			Dl_info info = {};
+			if (dladdr(bt_buffer[i], &info) != 0 && info.dli_sname != nullptr) {
+				const String demangled_name = StackTraceUnix::demangle_symbol_name(info.dli_sname);
+				if (!demangled_name.is_empty()) {
+					// If demangling changed the name, it was a mangled C++ symbol: replace the raw text.
+					// If unchanged (C-style name), preserve the raw text unless it's unhelpful, to keep library context.
+					const bool was_mangled = demangled_name != String(info.dli_sname);
+					if (output.is_empty() || output.contains("??") || was_mangled) {
+						output = demangled_name;
+					} else if (!output.contains(demangled_name)) {
+						output = vformat("%s [%s]", output, demangled_name);
 					}
 				}
-				output = fname;
 			}
-
-			print_error(vformat("[%d] %x - %s", (int64_t)i, (uint64_t)bt_buffer[i], output));
 		}
 
-		if (strings) {
-			free(strings);
-		}
-	} else {
-		// Fallback if atos fails entirely
-		char **strings = backtrace_symbols(bt_buffer, size);
-		if (strings) {
-			for (size_t i = 0; i < size; i++) {
-				print_error(vformat("[%d] %x - %s", (int64_t)i, (uint64_t)bt_buffer[i], strings[i]));
-			}
-			free(strings);
-		}
+		print_error(vformat("[%s] %x - %s", String::num_int64(i).lpad(2), (uint64_t)bt_buffer[i], output));
 	}
 
 	print_error("-- END OF C++ BACKTRACE --");

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -113,6 +113,8 @@ public:
 
 	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, GDExtensionData *p_data = nullptr) override;
 
+	virtual void print_stack_trace(int p_skip_called = 0, int p_skip_callers = 0) override;
+
 	virtual MainLoop *get_main_loop() const override;
 
 	virtual String get_config_path() const override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -39,6 +39,8 @@
 #import "display_server_macos_embedded.h"
 #endif
 
+#include "stack_trace_macos.h"
+
 #include "core/config/engine.h"
 #include "core/crypto/crypto_core.h"
 #include "core/input/input.h"
@@ -48,6 +50,7 @@
 #include "core/profiling/profiling.h"
 #include "core/version_generated.gen.h"
 #include "drivers/apple/os_log_logger.h"
+#include "drivers/unix/stack_trace_unix.h"
 #include "main/main.h"
 
 #ifdef SDL_ENABLED
@@ -424,6 +427,93 @@ Error OS_MacOS::open_dynamic_library(const String &p_path, void *&p_library_hand
 	}
 
 	return OK;
+}
+
+void OS_MacOS::print_stack_trace(int p_skip_called, int p_skip_callers) {
+#ifndef DEV_ENABLED
+	printerr("Warning: Godot is not compiled in DEV mode, so stack trace printing may be unreliable. Compile Godot with `dev_build=yes` for more complete stack traces.\n");
+#endif // DEV_ENABLED
+	p_skip_called += 1; // Skip the first one on the stack trace (this method, print_stack_trace).
+	p_skip_callers += 23; // Skip the final 23 callers (main method / program entry point and lots of NSApplication stuff).
+	void *callstack[StackTraceUnix::MAX_FRAMES];
+	const int frames = backtrace(callstack, StackTraceUnix::MAX_FRAMES);
+	if (frames <= 0) {
+		return;
+	}
+	const Vector<String> symbols = StackTraceUnix::collect_symbol_strings(callstack, frames);
+	const String exec_path = get_executable_path();
+	const uint64_t load_addr = StackTraceUnix::find_executable_load_address(exec_path);
+	const Vector<uint64_t> addresses = StackTraceUnix::collect_addresses(callstack, frames);
+	const Vector<String> atos_results = StackTraceMacOS::symbolize_with_atos(const_cast<OS_MacOS *>(this), exec_path, load_addr, addresses);
+	const int from = MIN(p_skip_called, frames);
+	const int to = MAX(from, frames - p_skip_callers);
+	for (int i = from; i < to; i++) {
+		Dl_info info = {};
+		const bool has_dl_info = dladdr(callstack[i], &info) != 0;
+		String symbol_name = i < symbols.size() ? symbols[i] : String("<unknown symbol>");
+		// Try to use atos result if available.
+		if (i < atos_results.size()) {
+			const String atos_line = atos_results[i];
+			// Check if atos returned a valid result (not just hex address).
+			if (!StackTraceMacOS::is_unresolved_atos_line(atos_line)) {
+				symbol_name = atos_line;
+			} else if (has_dl_info && info.dli_sname != nullptr) {
+				// Fall back to dladdr demangling, but keep raw backtrace context when useful.
+				const String demangled_name = StackTraceUnix::demangle_symbol_name(info.dli_sname);
+				if (!demangled_name.is_empty()) {
+					if (symbol_name.is_empty() || symbol_name.contains("??")) {
+						symbol_name = demangled_name;
+					} else if (!symbol_name.contains(demangled_name)) {
+						symbol_name = vformat("%s [%s]", symbol_name, demangled_name);
+					}
+				}
+			}
+		} else if (has_dl_info && info.dli_sname != nullptr) {
+			// Fallback if atos didn't provide results, while preserving raw symbol detail.
+			const String demangled_name = StackTraceUnix::demangle_symbol_name(info.dli_sname);
+			if (!demangled_name.is_empty()) {
+				if (symbol_name.is_empty() || symbol_name.contains("??")) {
+					symbol_name = demangled_name;
+				} else if (!symbol_name.contains(demangled_name)) {
+					symbol_name = vformat("%s [%s]", symbol_name, demangled_name);
+				}
+			}
+		}
+		const uint64_t address = (uint64_t)callstack[i];
+		String module_name = "main";
+		uint64_t base_address = load_addr;
+		if (has_dl_info) {
+			base_address = (uint64_t)info.dli_fbase;
+			if (info.dli_fname != nullptr && info.dli_fname[0] != '\0') {
+				const String module_path = String(info.dli_fname).replace("/./", "/");
+				if (module_path != exec_path) {
+					module_name = module_path.to_lower().get_file();
+				}
+			}
+		}
+		const String frame_index_padded = String::num_int64(i - (from - 1)).lpad(2);
+		// Format the output similar to Linux/BSD version.
+		String line;
+		if (is_print_verbose_enabled()) {
+			line = vformat("[%s] %x (%s+%x)\t- %s", frame_index_padded, address, module_name, address - base_address, symbol_name);
+		} else {
+			line = vformat("[%s] %s\t- %s", frame_index_padded, module_name, symbol_name);
+		}
+		// Attempt to extract file location from atos output if available.
+		// atos typically outputs: "symbol_name (at file:line)" format.
+		String location;
+		if (i < atos_results.size()) {
+			location = StackTraceMacOS::extract_atos_location(atos_results[i]);
+		}
+		if (location.is_empty()) {
+			line += " (unknown file)\n";
+		} else if (is_print_verbose_enabled()) {
+			line += vformat(" (%s)\n", location);
+		} else {
+			line += vformat(" (%s)\n", location.get_file());
+		}
+		print("%s", line.utf8().get_data());
+	}
 }
 
 MainLoop *OS_MacOS::get_main_loop() const {

--- a/platform/macos/stack_trace_macos.h
+++ b/platform/macos/stack_trace_macos.h
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  stack_trace_macos.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/os/os.h" // IWYU pragma: keep.
+
+#include <cstdio>
+
+namespace StackTraceMacOS {
+
+inline Vector<String> symbolize_with_atos(OS *p_os, const String &p_exec_path, uint64_t p_load_addr, const Vector<uint64_t> &p_addresses) {
+	List<String> args;
+	args.push_back("-o");
+	args.push_back(p_exec_path);
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
+	args.push_back("-arch");
+	args.push_back("x86_64");
+#elif defined(__aarch64__) || defined(__arm64__)
+	args.push_back("-arch");
+	args.push_back("arm64");
+#endif
+	args.push_back("--fullPath");
+	args.push_back("-l");
+	{
+		char str[32];
+		snprintf(str, sizeof(str), "%p", (void *)p_load_addr);
+		args.push_back(str);
+	}
+	for (uint64_t address_u64 : p_addresses) {
+		char str[32];
+		snprintf(str, sizeof(str), "%p", (void *)address_u64);
+		args.push_back(str);
+	}
+	String atos_output;
+	int ret = 0;
+	const Error err = p_os->execute("atos", args, &atos_output, &ret);
+	if (err == OK && ret == 0 && !atos_output.is_empty()) {
+		return atos_output.split("\n", false);
+	}
+	return Vector<String>();
+}
+
+inline String extract_atos_location(const String &p_atos_line) {
+	int at_pos = p_atos_line.rfind(" (at ");
+	if (at_pos == -1) {
+		return String();
+	}
+	int end_pos = p_atos_line.rfind(")");
+	if (end_pos <= at_pos) {
+		return String();
+	}
+	return p_atos_line.substr(at_pos + 5, end_pos - at_pos - 5);
+}
+
+inline bool is_unresolved_atos_line(const String &p_line) {
+	return p_line.begins_with("0x");
+}
+
+} // namespace StackTraceMacOS

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -164,9 +164,9 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	module_handles.resize(cbNeeded / sizeof(HMODULE));
 	EnumProcessModules(process, &module_handles[0], module_handles.size() * sizeof(HMODULE), &cbNeeded);
 	std::transform(module_handles.begin(), module_handles.end(), std::back_inserter(modules), get_mod_info(process));
-	void *base = modules[0].base_address;
+	void *base_address = modules[0].base_address;
 
-	print_error(vformat("Load address: %x\n", (uint64_t)base));
+	print_error(vformat("Load address: %x\n", (uint64_t)base_address));
 
 	// Setup stuff:
 	CONTEXT *context = ep->ContextRecord;
@@ -199,25 +199,30 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 #endif
 
 	line.SizeOfStruct = sizeof(line);
-	IMAGE_NT_HEADERS *h = ImageNtHeader(base);
-	DWORD image_type = h->FileHeader.Machine;
+	IMAGE_NT_HEADERS *image_nt_headers = ImageNtHeader(base_address);
+	if (image_nt_headers == nullptr) {
+		SymCleanup(process);
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+	const DWORD image_type = image_nt_headers->FileHeader.Machine;
+	constexpr int MAX_FRAMES = 256;
 
-	int n = 0;
+	int frame_count = 0;
 	do {
 		if (skip_first) {
 			skip_first = false;
 		} else {
 			if (frame.AddrPC.Offset != 0) {
-				std::string fnName = symbol(process, frame.AddrPC.Offset).undecorated_name();
+				std::string symbol_name = symbol(process, frame.AddrPC.Offset).undecorated_name();
 
 				IMAGEHLP_MODULE64 mod_info;
 				memset(&mod_info, 0, sizeof(IMAGEHLP_MODULE64));
 				mod_info.SizeOfStruct = sizeof(IMAGEHLP_MODULE64);
-				uint64_t offset = (uint64_t)base;
+				uint64_t frame_base_address = (uint64_t)base_address;
 				String mod_name = "main";
 				if (SymGetModuleInfo64(process, frame.AddrPC.Offset, &mod_info)) {
-					offset = mod_info.BaseOfImage;
-					if (offset != (uint64_t)base) {
+					frame_base_address = mod_info.BaseOfImage;
+					if (frame_base_address != (uint64_t)base_address) {
 						if (mod_info.ImageName[0] != 0) {
 							mod_name = String((const char *)mod_info.ImageName).to_lower().get_file();
 						} else if (mod_info.ModuleName[0] != 0) {
@@ -228,21 +233,21 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 					}
 				}
 				if (SymGetLineFromAddr64(process, frame.AddrPC.Offset, &offset_from_symbol, &line)) {
-					print_error(vformat("[%d] %x (%s+%x) - %s (%s:%d)", n, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - offset, fnName.c_str(), (char *)line.FileName, (int)line.LineNumber));
+					print_error(vformat("[%d] %x (%s+%x) - %s (%s:%d)", frame_count, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - frame_base_address, symbol_name.c_str(), (char *)line.FileName, (int)line.LineNumber));
 				} else {
-					print_error(vformat("[%d] %x (%s+%x) - %s", n, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - offset, fnName.c_str()));
+					print_error(vformat("[%d] %x (%s+%x) - %s", frame_count, (uint64_t)frame.AddrPC.Offset, mod_name, (uint64_t)frame.AddrPC.Offset - frame_base_address, symbol_name.c_str()));
 				}
 			} else {
-				print_error(vformat("[%d] ???", n));
+				print_error(vformat("[%d] ???", frame_count));
 			}
 
-			n++;
+			frame_count++;
 		}
 
 		if (!StackWalk64(image_type, process, hThread, &frame, context, nullptr, SymFunctionTableAccess64, SymGetModuleBase64, nullptr)) {
 			break;
 		}
-	} while (frame.AddrReturn.Offset != 0 && n < 256);
+	} while (frame.AddrReturn.Offset != 0 && frame_count < MAX_FRAMES);
 
 	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2092,6 +2092,149 @@ void OS_Windows::unset_environment(const String &p_var) const {
 	SetEnvironmentVariableW((LPCWSTR)(p_var.utf16().get_data()), nullptr); // Null to delete.
 }
 
+void OS_Windows::print_stack_trace(int p_skip_called, int p_skip_callers) {
+#ifdef DEBUG_ENABLED
+#ifndef DEV_ENABLED
+	printerr("Warning: Godot is not compiled in DEV mode, so stack trace printing may be unreliable. Compile Godot with `dev_build=yes` for more complete stack traces.\n");
+#endif // DEV_ENABLED
+	p_skip_called += 1; // Skip the first one on the stack trace (this method, print_stack_trace)
+	p_skip_callers += 4; // Skip the final 4 callers (main method / program entry point).
+#if defined(_M_X64) || defined(_M_IX86) || defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM)
+	constexpr int MAX_FRAMES = 256;
+	constexpr size_t MAX_SYMBOL_NAME_LEN = 1024;
+	// The StackWalk method in Windows supports x86 and Arm architectures (technically, Itanium too).
+#if defined(_M_X64)
+	constexpr DWORD image_type = IMAGE_FILE_MACHINE_AMD64; // x86_64
+#elif defined(_M_IX86)
+	constexpr DWORD image_type = IMAGE_FILE_MACHINE_I386; // x86_32
+#elif defined(_M_ARM64) || defined(_M_ARM64EC) // arm64
+	constexpr DWORD image_type = IMAGE_FILE_MACHINE_ARM64;
+#elif defined(_M_ARM) // arm32
+	constexpr DWORD image_type = IMAGE_FILE_MACHINE_ARMNT;
+#endif
+	HANDLE process = GetCurrentProcess();
+	HANDLE thread = GetCurrentThread();
+	if (SymInitialize(process, NULL, TRUE) == FALSE) {
+		return;
+	}
+	SymSetOptions(SymGetOptions() | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_EXACT_SYMBOLS);
+
+	CONTEXT context = {};
+	context.ContextFlags = CONTEXT_FULL;
+	RtlCaptureContext(&context);
+
+	STACKFRAME64 frame = {};
+	frame.AddrPC.Mode = AddrModeFlat;
+	frame.AddrStack.Mode = AddrModeFlat;
+	frame.AddrFrame.Mode = AddrModeFlat;
+#if defined(_M_X64) // x86_64
+	frame.AddrPC.Offset = context.Rip;
+	frame.AddrStack.Offset = context.Rsp;
+	frame.AddrFrame.Offset = context.Rbp;
+#elif defined(_M_IX86) // x86_32
+	frame.AddrPC.Offset = context.Eip;
+	frame.AddrStack.Offset = context.Esp;
+	frame.AddrFrame.Offset = context.Ebp;
+#elif defined(_M_ARM64) || defined(_M_ARM64EC) // arm64
+	frame.AddrPC.Offset = context.Pc;
+	frame.AddrStack.Offset = context.Sp;
+	frame.AddrFrame.Offset = context.Fp;
+#elif defined(_M_ARM) // arm32
+	frame.AddrPC.Offset = context.Pc;
+	frame.AddrStack.Offset = context.Sp;
+	frame.AddrFrame.Offset = context.R11;
+#endif
+	void *base_address = GetModuleHandle(NULL);
+	// Helper struct, only needed in this method.
+	struct StackFrame {
+		uint64_t program_counter = 0;
+		uint64_t base_address = 0;
+		String symbol_name;
+		String module_name;
+		String file_name;
+		unsigned int line = 0;
+	};
+	Vector<StackFrame> frames;
+	while (frames.size() < MAX_FRAMES && StackWalk64(image_type, process, thread, &frame, &context, NULL, SymFunctionTableAccess64, SymGetModuleBase64, NULL)) {
+		StackFrame stack_frame = {};
+		stack_frame.program_counter = frame.AddrPC.Offset;
+		if (stack_frame.program_counter == 0) {
+			continue;
+		}
+
+		char symbol_buffer[sizeof(IMAGEHLP_SYMBOL64) + MAX_SYMBOL_NAME_LEN] = {};
+		PIMAGEHLP_SYMBOL64 symbol_info = reinterpret_cast<PIMAGEHLP_SYMBOL64>(symbol_buffer);
+		symbol_info->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+		symbol_info->MaxNameLength = MAX_SYMBOL_NAME_LEN - 1;
+		DWORD64 offset_from_symbol = 0;
+		if (SymGetSymFromAddr64(process, stack_frame.program_counter, &offset_from_symbol, symbol_info)) {
+			char undecorated_name[MAX_SYMBOL_NAME_LEN] = {};
+			if (UnDecorateSymbolName(symbol_info->Name, undecorated_name, MAX_SYMBOL_NAME_LEN, UNDNAME_COMPLETE) != 0) {
+				stack_frame.symbol_name = undecorated_name;
+			} else {
+				stack_frame.symbol_name = symbol_info->Name;
+			}
+		} else {
+			stack_frame.symbol_name = "<couldn't map PC to fn name>";
+		}
+
+		IMAGEHLP_MODULE64 module_info = {};
+		module_info.SizeOfStruct = sizeof(IMAGEHLP_MODULE64);
+		stack_frame.base_address = reinterpret_cast<uint64_t>(base_address);
+		stack_frame.module_name = "main";
+		if (SymGetModuleInfo64(process, stack_frame.program_counter, &module_info)) {
+			stack_frame.base_address = module_info.BaseOfImage;
+			if (stack_frame.base_address != reinterpret_cast<uint64_t>(base_address)) {
+				if (module_info.ImageName[0] != 0) {
+					stack_frame.module_name = String(module_info.ImageName).to_lower().get_file();
+				} else if (module_info.ModuleName[0] != 0) {
+					stack_frame.module_name = String(module_info.ModuleName).to_lower();
+				} else {
+					stack_frame.module_name = "<unknown module>";
+				}
+			}
+		}
+
+		IMAGEHLP_LINE64 line = {};
+		line.SizeOfStruct = sizeof(line);
+		DWORD line_offset_from_symbol = 0;
+		if (SymGetLineFromAddr64(process, stack_frame.program_counter, &line_offset_from_symbol, &line)) {
+			stack_frame.file_name = line.FileName;
+			stack_frame.line = line.LineNumber;
+		}
+
+		frames.push_back(stack_frame);
+	}
+	SymCleanup(process);
+	// Format and print out the desired stack trace frames.
+	for (int i = p_skip_called; i < frames.size() - p_skip_callers; i++) {
+		const StackFrame &stack_frame = frames[i];
+		const String frame_index_padded = String::num_int64(i - (p_skip_called - 1)).lpad(2);
+		String line;
+		// Start with the basic information, depending on the level of verbosity.
+		if (is_print_verbose_enabled()) {
+			line = vformat("[%s] %x (%s+%x)\t%s", frame_index_padded, stack_frame.program_counter, stack_frame.module_name, stack_frame.program_counter - stack_frame.base_address, stack_frame.symbol_name);
+		} else {
+			line = vformat("[%s] %s\t%s", frame_index_padded, stack_frame.module_name, stack_frame.symbol_name);
+		}
+		// Add on the file information if available.
+		if (stack_frame.file_name.is_empty()) {
+			line += " (unknown file)\n";
+		} else if (is_print_verbose_enabled()) {
+			line += vformat(" (%s:%d)\n", stack_frame.file_name, stack_frame.line);
+		} else {
+			line += vformat(" (%s:%d)\n", stack_frame.file_name.get_file(), stack_frame.line);
+		}
+		print(line.utf8().get_data());
+	}
+#else
+	printerr("Stack trace printing is not supported on this architecture on Windows.\n");
+#endif // Architecture checks.
+#else
+	printerr("Stack trace printing is not supported in release builds on Windows.\n");
+#endif // DEBUG_ENABLED
+}
+
 String OS_Windows::get_stdin_string(int64_t p_buffer_size) {
 	if (get_stdin_type() == STD_HANDLE_INVALID) {
 		return String();

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -149,6 +149,8 @@ protected:
 	virtual void finalize() override;
 	virtual void finalize_core() override;
 
+	virtual void print_stack_trace(int p_skip_called = 0, int p_skip_callers = 0) override;
+
 	virtual String get_stdin_string(int64_t p_buffer_size = 1024) override;
 	virtual PackedByteArray get_stdin_buffer(int64_t p_buffer_size = 1024) override;
 	virtual StdHandleType get_stdin_type() const override;


### PR DESCRIPTION
This adds a new method to the error macros that allows printing the stack trace. Add `print_stack_trace();` to any method to print the stack trace at that point. You can also specify if you want to skip a part of the stack trace at the beginning or end, to avoid any noisy lines you don't care about. It's only available in debug builds.

There is no way to print the stack trace in a cross-platform way, so we need platform-specific code. On Mac and Linux, the code to print the stack trace is simple, since there is a handy library that does all the work for us, but we don't have fine control over the output. On Windows, it's more complicated, the code was designed based on [this SO post](https://stackoverflow.com/questions/6205981/windows-c-stack-trace-from-a-running-app) and [this article](https://www.rioki.org/2017/01/09/windows_stacktrace.html). I made the Windows code's output somewhat mimic the Mac/Linux code for consistency between platforms. Also, Windows stack trace printing only works on x86_32 and x86_64 (and technically Itanium, but Godot doesn't run on that).

This work was sponsored by The Mirror, we plan to use this by adding `print_stack_trace(2);` to the `void _err_print_error` method so that we will get stack traces for every error (and the `2` skips the calls to `_err_print_error` itself). This is not included in this PR since it would be spammy, but it's one line away for anyone who wants it.