### PR TITLE
Don't ignore axis values of 0 when mapping axis events

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1129,7 +1129,7 @@ Input::JoyEvent Input::_get_mapped_axis_event(const JoyDeviceMapping &mapping, J
 				value = -value;
 			}
 			if (binding.input.axis.range == FULL_AXIS ||
-					(binding.input.axis.range == POSITIVE_HALF_AXIS && value > 0) ||
+					(binding.input.axis.range == POSITIVE_HALF_AXIS && value >= 0) ||
 					(binding.input.axis.range == NEGATIVE_HALF_AXIS && value < 0)) {
 				event.type = binding.outputType;
 				float shifted_positive_value = 0;


### PR DESCRIPTION
Hopefully fixes #63972, but since I can't reproduce the issue, I cannot confirm that it does.
