### PR TITLE
[3.x] Don't ignore axis values of 0 when mapping axis events

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -998,7 +998,7 @@ InputDefault::JoyEvent InputDefault::_get_mapped_axis_event(const JoyDeviceMappi
 				value = -value;
 			}
 			if (binding.input.axis.range == FULL_AXIS ||
-					(binding.input.axis.range == POSITIVE_HALF_AXIS && value > 0) ||
+					(binding.input.axis.range == POSITIVE_HALF_AXIS && value >= 0) ||
 					(binding.input.axis.range == NEGATIVE_HALF_AXIS && value < 0)) {
 				event.type = binding.outputType;
 				float shifted_positive_value = 0;


### PR DESCRIPTION
3.x version of #64210.
