### PR TITLE
Move rotation interpolation to Curve3d and refactor baking

### DIFF
--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -132,6 +132,15 @@
 				If the curve has no up vectors, the function sends an error to the console, and returns [code](0, 1, 0)[/code].
 			</description>
 		</method>
+		<method name="sample_baked_with_rotation" qualifiers="const">
+			<return type="Transform3D" />
+			<param index="0" name="offset" type="float" />
+			<param index="1" name="cubic" type="bool" default="false" />
+			<param index="2" name="apply_tilt" type="bool" default="false" />
+			<description>
+				Similar with [code]interpolate_baked()[/code]. The the return value is [code]Transform3D[/code], with [code]origin[/code] as point position, [code]basis.x[/code] as sideway vector, [code]basis.y[/code] as up vector, [code]basis.z[/code] as forward vector. When the curve length is 0, there is no reasonable way to caculate the rotation, all vectors aligned with global space axes.
+			</description>
+		</method>
 		<method name="samplef" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="fofs" type="float" />

--- a/doc/classes/PathFollow3D.xml
+++ b/doc/classes/PathFollow3D.xml
@@ -9,6 +9,16 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="correct_posture" qualifiers="static">
+			<return type="Transform3D" />
+			<param index="0" name="transform" type="Transform3D" />
+			<param index="1" name="rotation_mode" type="int" enum="PathFollow3D.RotationMode" />
+			<description>
+				Correct the [code]transform[/code]. [code]rotation_mode[/code] implicitly specifies how posture (forward, up and sideway direction) is caculated.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="cubic_interp" type="bool" setter="set_cubic_interpolation" getter="get_cubic_interpolation" default="true">
 			If [code]true[/code], the position between two cached points is interpolated cubically, and linearly otherwise.
@@ -29,6 +39,9 @@
 		</member>
 		<member name="rotation_mode" type="int" setter="set_rotation_mode" getter="get_rotation_mode" enum="PathFollow3D.RotationMode" default="3">
 			Allows or forbids rotation on one or more axes, depending on the [enum RotationMode] constants being used.
+		</member>
+		<member name="tilt_enabled" type="bool" setter="set_tilt_enabled" getter="is_tilt_enabled" default="true">
+			If [code]true[/code], the tilt property of [Curve3D] takes effect.
 		</member>
 		<member name="v_offset" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
 			The node's offset perpendicular to the curve.

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -72,14 +72,16 @@ public:
 		ROTATION_ORIENTED
 	};
 
+	static Transform3D correct_posture(Transform3D p_transform, PathFollow3D::RotationMode p_rotation_mode);
+
 private:
 	Path3D *path = nullptr;
-	real_t prev_offset = 0.0; // Offset during the last _update_transform.
 	real_t progress = 0.0;
 	real_t h_offset = 0.0;
 	real_t v_offset = 0.0;
 	bool cubic = true;
 	bool loop = true;
+	bool tilt_enabled = true;
 	RotationMode rotation_mode = ROTATION_XYZ;
 
 	void _update_transform(bool p_update_xyz_rot = true);
@@ -105,6 +107,9 @@ public:
 
 	void set_loop(bool p_loop);
 	bool has_loop() const;
+
+	void set_tilt_enabled(bool p_enable);
+	bool is_tilt_enabled() const;
 
 	void set_rotation_mode(RotationMode p_rotation_mode);
 	RotationMode get_rotation_mode() const;

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -238,11 +238,6 @@ class Curve3D : public Resource {
 
 	Vector<Point> points;
 
-	struct BakedPoint {
-		real_t ofs = 0.0;
-		Vector3 point;
-	};
-
 	mutable bool baked_cache_dirty = false;
 	mutable PackedVector3Array baked_point_cache;
 	mutable Vector<real_t> baked_tilt_cache;
@@ -253,6 +248,15 @@ class Curve3D : public Resource {
 	void mark_dirty();
 
 	void _bake() const;
+
+	struct Interval {
+		int idx;
+		real_t frac;
+	};
+	Interval _find_interval(real_t p_offset) const;
+	Vector3 _sample_baked(Interval p_interval, bool p_cubic) const;
+	real_t _sample_baked_tilt(Interval p_interval) const;
+	Basis _sample_posture(Interval p_interval, bool p_apply_tilt = false) const;
 
 	real_t bake_interval = 0.2;
 	bool up_vector_enabled = true;
@@ -296,9 +300,10 @@ public:
 
 	real_t get_baked_length() const;
 	Vector3 sample_baked(real_t p_offset, bool p_cubic = false) const;
+	Transform3D sample_baked_with_rotation(real_t p_offset, bool p_cubic = false, bool p_apply_tilt = false) const;
 	real_t sample_baked_tilt(real_t p_offset) const;
 	Vector3 sample_baked_up_vector(real_t p_offset, bool p_apply_tilt = false) const;
-	PackedVector3Array get_baked_points() const; //useful for going through
+	PackedVector3Array get_baked_points() const; // Useful for going through.
 	Vector<real_t> get_baked_tilts() const; //useful for going through
 	PackedVector3Array get_baked_up_vectors() const;
 	Vector3 get_closest_point(const Vector3 &p_to_point) const;


### PR DESCRIPTION
Related with PR #64043, PR #63956 there are two purpose of this PR:
1. Continuing #64043 's effort, move all remaining rotation interpolation modes from PathFollower3D to Curve3D
2. Reimplement baking for Curve3D with geometry methods of Basis class

The new implementation should be more stable. Although I test it for some cases, further testers are needed, as I mainly use Curve2D for current project. 


https://user-images.githubusercontent.com/6020486/184269597-c10be248-62af-4a0b-a251-ea096f943cac.mov

Tested against examples in the following tickets:
[48864](https://github.com/godotengine/godot/issues/48864)
[27137](https://github.com/godotengine/godot/issues/27137)
[60151](https://github.com/godotengine/godot/pull/60151)

