### PR TITLE
Expose parameters for open_scene_from_path method in EditorInterface

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -188,6 +188,11 @@
 		<method name="open_scene_from_path">
 			<return type="void" />
 			<param index="0" name="scene_filepath" type="String" />
+			<param index="1" name="ignore_broken_deps" type="bool" default="false" />
+			<param index="2" name="set_inherited" type="bool" default="false" />
+			<param index="3" name="clear_errors" type="bool" default="true" />
+			<param index="4" name="force_open_imported" type="bool" default="false" />
+			<param index="5" name="silent_change_tab" type="bool" default="false" />
 			<description>
 				Opens the scene at the given path.
 			</description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3886,7 +3886,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	return OK;
 }
 
-void EditorNode::open_request(const String &p_path) {
+void EditorNode::open_request(const String &p_path, bool p_ignore_broken_deps, bool p_set_inherited, bool p_clear_errors, bool p_force_open_imported, bool p_silent_change_tab) {
 	if (!opening_prev) {
 		List<String>::Element *prev_scene_item = previous_scenes.find(p_path);
 		if (prev_scene_item != nullptr) {
@@ -3894,7 +3894,7 @@ void EditorNode::open_request(const String &p_path) {
 		}
 	}
 
-	load_scene(p_path); // As it will be opened in separate tab.
+	load_scene(p_path, p_ignore_broken_deps, p_set_inherited, p_clear_errors, p_force_open_imported, p_silent_change_tab); // As it will be opened in separate tab.
 }
 
 void EditorNode::edit_foreign_resource(Ref<Resource> p_resource) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -801,7 +801,7 @@ public:
 
 	void select_editor_by_name(const String &p_name);
 
-	void open_request(const String &p_path);
+	void open_request(const String &p_path, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_clear_errors = true, bool p_force_open_imported = false, bool p_silent_change_tab = false);
 	void edit_foreign_resource(Ref<Resource> p_resource);
 
 	bool is_resource_read_only(Ref<Resource> p_resource, bool p_foreign_resources_are_writable = false);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -178,12 +178,12 @@ void EditorInterface::edit_script(const Ref<Script> &p_script, int p_line, int p
 	ScriptEditor::get_singleton()->edit(p_script, p_line, p_col, p_grab_focus);
 }
 
-void EditorInterface::open_scene_from_path(const String &scene_path) {
+void EditorInterface::open_scene_from_path(const String &scene_path, bool p_ignore_broken_deps, bool p_set_inherited, bool p_clear_errors, bool p_force_open_imported, bool p_silent_change_tab) {
 	if (EditorNode::get_singleton()->is_changing_scene()) {
 		return;
 	}
 
-	EditorNode::get_singleton()->open_request(scene_path);
+	EditorNode::get_singleton()->open_request(scene_path, p_ignore_broken_deps, p_set_inherited, p_clear_errors, p_force_open_imported, p_silent_change_tab);
 }
 
 void EditorInterface::reload_scene_from_path(const String &scene_path) {
@@ -358,7 +358,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
 	ClassDB::bind_method(D_METHOD("edit_node", "node"), &EditorInterface::edit_node);
 	ClassDB::bind_method(D_METHOD("edit_script", "script", "line", "column", "grab_focus"), &EditorInterface::edit_script, DEFVAL(-1), DEFVAL(0), DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath"), &EditorInterface::open_scene_from_path);
+	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath", "ignore_broken_deps", "set_inherited", "clear_errors", "force_open_imported", "silent_change_tab"), &EditorInterface::open_scene_from_path, DEFVAL(false), DEFVAL(false), DEFVAL(true), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
 	ClassDB::bind_method(D_METHOD("play_main_scene"), &EditorInterface::play_main_scene);
 	ClassDB::bind_method(D_METHOD("play_current_scene"), &EditorInterface::play_current_scene);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -77,7 +77,7 @@ public:
 	void edit_resource(const Ref<Resource> &p_resource);
 	void edit_node(Node *p_node);
 	void edit_script(const Ref<Script> &p_script, int p_line = -1, int p_col = 0, bool p_grab_focus = true);
-	void open_scene_from_path(const String &scene_path);
+	void open_scene_from_path(const String &scene_path, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_clear_errors = true, bool p_force_open_imported = false, bool p_silent_change_tab = false);
 	void reload_scene_from_path(const String &scene_path);
 
 	void play_main_scene();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Close https://github.com/godotengine/godot-proposals/issues/3907