### PR TITLE
Fix case where `h_separation` might not work in `Button`

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -114,7 +114,7 @@
 			Icon modulate [Color] used when the [Button] is being pressed.
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="2">
-			The horizontal space between [Button]'s icon and text.
+			The horizontal space between [Button]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -39,7 +39,7 @@
 			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">
-			The separation between the check icon and the text (in pixels).
+			The separation between the check icon and the text (in pixels). Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -39,7 +39,7 @@
 			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">
-			The separation between the toggle icon and the text (in pixels).
+			The separation between the toggle icon and the text (in pixels). Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -65,7 +65,7 @@
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="3">
-			The horizontal space between [MenuButton]'s icon and text.
+			The horizontal space between [MenuButton]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -246,7 +246,7 @@
 			The horizontal space between the arrow icon and the right edge of the button.
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="2">
-			The horizontal space between [OptionButton]'s icon and text.
+			The horizontal space between [OptionButton]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="modulate_arrow" data_type="constant" type="int" default="0">
 			If different than [code]0[/code], the arrow icon will be modulated to the font color.

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -34,11 +34,9 @@
 #include "servers/rendering_server.h"
 
 Size2 Button::get_minimum_size() const {
-	Ref<Texture2D> _icon;
-	if (icon.is_null() && has_theme_icon(SNAME("icon"))) {
+	Ref<Texture2D> _icon = icon;
+	if (_icon.is_null() && has_theme_icon(SNAME("icon"))) {
 		_icon = Control::get_theme_icon(SNAME("icon"));
-	} else {
-		_icon = icon;
 	}
 
 	return get_minimum_size_for_text_and_icon("", _icon);
@@ -342,13 +340,13 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		minsize.width = 0;
 	}
 
-	if (!expand_icon && !p_icon.is_null()) {
+	if (!expand_icon && p_icon.is_valid()) {
 		minsize.height = MAX(minsize.height, p_icon->get_height());
 
 		if (icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
 			minsize.width += p_icon->get_width();
 			if (!xl_text.is_empty() || !p_text.is_empty()) {
-				minsize.width += get_theme_constant(SNAME("hseparation"));
+				minsize.width += MAX(0, get_theme_constant(SNAME("h_separation")));
 			}
 		} else {
 			minsize.width = MAX(minsize.width, p_icon->get_width());

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -75,7 +75,7 @@ Size2 CheckBox::get_minimum_size() const {
 	Size2 tex_size = get_icon_size();
 	minsize.width += tex_size.width;
 	if (get_text().length() > 0) {
-		minsize.width += get_theme_constant(SNAME("h_separation"));
+		minsize.width += MAX(0, get_theme_constant(SNAME("h_separation")));
 	}
 	Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(SIDE_TOP) + sb->get_margin(SIDE_BOTTOM));

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -52,7 +52,7 @@ Size2 CheckButton::get_minimum_size() const {
 	Size2 tex_size = get_icon_size();
 	minsize.width += tex_size.width;
 	if (get_text().length() > 0) {
-		minsize.width += get_theme_constant(SNAME("h_separation"));
+		minsize.width += MAX(0, get_theme_constant(SNAME("h_separation")));
 	}
 	Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(SIDE_TOP) + sb->get_margin(SIDE_BOTTOM));

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -47,7 +47,7 @@ Size2 OptionButton::get_minimum_size() const {
 		const Size2 arrow_size = Control::get_theme_icon(SNAME("arrow"))->get_size();
 
 		Size2 content_size = minsize - padding;
-		content_size.width += arrow_size.width + get_theme_constant(SNAME("h_separation"));
+		content_size.width += arrow_size.width + MAX(0, get_theme_constant(SNAME("h_separation")));
 		content_size.height = MAX(content_size.height, arrow_size.height);
 
 		minsize = content_size + padding;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fix #64140.
*Bugsquad edit:* Fixes #64371

| Before | After |
| :-------: | :-----: |
|![1](https://user-images.githubusercontent.com/30386067/183910901-a320985d-b077-40c0-8b06-0bd1b96100fd.gif)|![2](https://user-images.githubusercontent.com/30386067/183910941-8aa1eb48-bec8-4ef4-b34e-ae67183f6fe1.gif) |

~~Split from #59340.~~

There are still issues with the drawing and will be fixed in another PR.

Edit:
This patch mainly solves two things:
1. The typo of `h_separation`;
2. Negative values of `h_separation` will be treated as `0` when used, to prevent the button's minimum `width` from being reduced by `h_separation`.

