### PR TITLE
Improve `_internal_margin` in `OptionButton`

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -104,12 +104,13 @@ void OptionButton::_notification(int p_what) {
 		}
 		case NOTIFICATION_THEME_CHANGED: {
 			if (has_theme_icon(SNAME("arrow"))) {
+				int arrow_margin = MAX(0, get_theme_constant(SNAME("arrow_margin")));
 				if (is_layout_rtl()) {
-					_set_internal_margin(SIDE_LEFT, Control::get_theme_icon(SNAME("arrow"))->get_width());
+					_set_internal_margin(SIDE_LEFT, Control::get_theme_icon(SNAME("arrow"))->get_width() + arrow_margin);
 					_set_internal_margin(SIDE_RIGHT, 0.f);
 				} else {
 					_set_internal_margin(SIDE_LEFT, 0.f);
-					_set_internal_margin(SIDE_RIGHT, Control::get_theme_icon(SNAME("arrow"))->get_width());
+					_set_internal_margin(SIDE_RIGHT, Control::get_theme_icon(SNAME("arrow"))->get_width() + arrow_margin);
 				}
 			}
 			_refresh_size_cache();
@@ -521,15 +522,16 @@ OptionButton::OptionButton(const String &p_text) :
 		Button(p_text) {
 	set_toggle_mode(true);
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
-	if (is_layout_rtl()) {
-		if (has_theme_icon(SNAME("arrow"))) {
-			_set_internal_margin(SIDE_LEFT, Control::get_theme_icon(SNAME("arrow"))->get_width());
-		}
-	} else {
-		if (has_theme_icon(SNAME("arrow"))) {
-			_set_internal_margin(SIDE_RIGHT, Control::get_theme_icon(SNAME("arrow"))->get_width());
+
+	if (has_theme_icon(SNAME("arrow"))) {
+		int arrow_margin = MAX(0, get_theme_constant(SNAME("arrow_margin")));
+		if (is_layout_rtl()) {
+			_set_internal_margin(SIDE_LEFT, Control::get_theme_icon(SNAME("arrow"))->get_width() + arrow_margin);
+		} else {
+			_set_internal_margin(SIDE_RIGHT, Control::get_theme_icon(SNAME("arrow"))->get_width() + arrow_margin);
 		}
 	}
+
 	set_action_mode(ACTION_MODE_BUTTON_PRESS);
 
 	popup = memnew(PopupMenu);


### PR DESCRIPTION
~~`_internal_margin` is now mainly used to reserve drawing rect for internal elements of `Button`-derived classes in `Button`.~~

~~Conventions are now used to indicate the position of internal elements (left or right):~~
~~1. For the horizontal axis, positive values mean counting from the left toward the center, and negative values mean counting from the right toward the center.~~
~~2. For the vertical axis, a positive value means counting from the center to the bottom, and a negative value means counting from the center to the top.~~
~~3. The length on one axis of `_internal_margin` is the length of the internal element on the corresponding axis.~~

I probably know how `_internal_margin` should be used.

The previous definition makes sense, drawing `Button`-derived objects in `Button` doesn't require much information, except the `arrow_margin` in `OptionButton`. 



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
