### PR TITLE
Use negative mipmap LOD bias for sub-native bilinear 3D scale

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1974,7 +1974,7 @@
 		</member>
 		<member name="rendering/textures/default_filters/texture_mipmap_bias" type="float" setter="" getter="" default="0.0">
 			Affects the final texture sharpness by reading from a lower or higher mipmap (also called "texture LOD bias"). Negative values make mipmapped textures sharper but grainier when viewed at a distance, while positive values make mipmapped textures blurrier (even when up close). To get sharper textures at a distance without introducing too much graininess, set this between [code]-0.75[/code] and [code]0.0[/code]. Enabling temporal antialiasing ([member rendering/anti_aliasing/quality/use_taa]) can help reduce the graininess visible when using negative mipmap bias.
-			[b]Note:[/b] When the 3D scaling mode is set to FSR 1.0, this value is used to adjust the automatic mipmap bias which is calculated internally based on the scale factor. The formula for this is [code]-log2(1.0 / scale) + mipmap_bias[/code].
+			[b]Note:[/b] If [member rendering/scaling_3d/scale] is lower than [code]1.0[/code] (exclusive), [member rendering/textures/default_filters/texture_mipmap_bias] is used to adjust the automatic mipmap bias which is calculated internally based on the scale factor. The formula for this is [code]log2(scaling_3d_scale) + mipmap_bias[/code].
 			[b]Note:[/b] This property is only read when the project starts. To change the mipmap LOD bias at run-time, set [member Viewport.texture_mipmap_bias] instead.
 		</member>
 		<member name="rendering/textures/default_filters/use_nearest_mipmap_filter" type="bool" setter="" getter="" default="false">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -267,7 +267,7 @@
 		</member>
 		<member name="texture_mipmap_bias" type="float" setter="set_texture_mipmap_bias" getter="get_texture_mipmap_bias" default="0.0">
 			Affects the final texture sharpness by reading from a lower or higher mipmap (also called "texture LOD bias"). Negative values make mipmapped textures sharper but grainier when viewed at a distance, while positive values make mipmapped textures blurrier (even when up close). To get sharper textures at a distance without introducing too much graininess, set this between [code]-0.75[/code] and [code]0.0[/code]. Enabling temporal antialiasing ([member ProjectSettings.rendering/anti_aliasing/quality/use_taa]) can help reduce the graininess visible when using negative mipmap bias.
-			[b]Note:[/b] When the 3D scaling mode is set to FSR 1.0, this value is used to adjust the automatic mipmap bias which is calculated internally based on the scale factor. The formula for this is [code]-log2(1.0 / scale) + mipmap_bias[/code].
+			[b]Note:[/b] If [member scaling_3d_scale] is lower than [code]1.0[/code] (exclusive), [member texture_mipmap_bias] is used to adjust the automatic mipmap bias which is calculated internally based on the scale factor. The formula for this is [code]log2(scaling_3d_scale) + mipmap_bias[/code].
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/textures/default_filters/texture_mipmap_bias] project setting.
 		</member>
 		<member name="transparent_bg" type="bool" setter="set_transparent_background" getter="has_transparent_background" default="false">

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2459,8 +2459,7 @@ void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p
 		p_internal_width = p_width;
 	}
 
-	const float texture_mipmap_bias = -log2f(p_width / p_internal_width) + p_texture_mipmap_bias;
-	material_storage->sampler_rd_configure_custom(texture_mipmap_bias);
+	material_storage->sampler_rd_configure_custom(p_texture_mipmap_bias);
 	update_uniform_sets();
 
 	RenderBuffers *rb = render_buffers_owner.get_or_null(p_render_buffers);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -138,7 +138,11 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 
 			p_viewport->internal_size = Size2(render_width, render_height);
 
-			RSG::scene->render_buffers_configure(p_viewport->render_buffers, p_viewport->render_target, render_width, render_height, width, height, p_viewport->fsr_sharpness, p_viewport->texture_mipmap_bias, p_viewport->msaa, p_viewport->screen_space_aa, p_viewport->use_taa, p_viewport->use_debanding, p_viewport->get_view_count());
+			// At resolution scales lower than 1.0, use negative texture mipmap bias
+			// to compensate for the loss of sharpness.
+			const float texture_mipmap_bias = log2f(MIN(scaling_3d_scale, 1.0)) + p_viewport->texture_mipmap_bias;
+
+			RSG::scene->render_buffers_configure(p_viewport->render_buffers, p_viewport->render_target, render_width, render_height, width, height, p_viewport->fsr_sharpness, texture_mipmap_bias, p_viewport->msaa, p_viewport->screen_space_aa, p_viewport->use_taa, p_viewport->use_debanding, p_viewport->get_view_count());
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/64223 (can be merged independently, I'll rebase).

This automatic LOD bias is already used for FSR 1.0 (per AMD recommendations). Doing so with bilinear scaling as well provides a benefit similar to FSR 1.0 (greater texture sharpness at the cost of some graininess at sub-native resolution scales), but without the added performance cost of FSR 1.0.

**Testing project:** https://0x0.st/o2T8.zip <sub>(link expires in March 2023)</sub>
The project includes an animation so you can see how the filtering looks like in motion.

## Preview

*Click to view at full size.*

### 100% resolution scale

*For reference.*

![2022-08-10_17 17 44_scale_10](https://user-images.githubusercontent.com/180032/183943003-367ae446-a370-4ee6-8edf-608c38aa8c27.png)
### 80% resolution scale

Before | After
-|-
![2022-08-10_17 18 59_before_scale_08](https://user-images.githubusercontent.com/180032/183943028-df084450-7c11-448f-bc7a-fa8b0623eac6.png) | ![2022-08-10_17 17 59_after_scale_08](https://user-images.githubusercontent.com/180032/183943121-f3b4ff84-89b8-4799-9325-195ad473e96a.png)

### 70% resolution scale

Before | After
-|-
![2022-08-10_17 19 09_before_scale_07](https://user-images.githubusercontent.com/180032/183943029-7e916576-30bf-4041-ba51-0c34edcff79f.png) | ![2022-08-10_17 18 08_after_scale_07](https://user-images.githubusercontent.com/180032/183943021-63499504-3989-40b1-96d5-ddd4e5d3da22.png)

### 50% resolution scale

Before | After
-|-
![2022-08-10_17 19 18_before_scale_05](https://user-images.githubusercontent.com/180032/183943032-65a38393-a49a-4409-9c44-b6a2d80806b3.png) | ![2022-08-10_17 18 25_after_scale_05](https://user-images.githubusercontent.com/180032/183943024-b91e9c56-3ef1-48bb-9a08-c10a55765954.png)