### PR TITLE
Improve the `make_rst.py` parser for BBCode tags

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -692,7 +692,7 @@
 			<return type="int" />
 			<param index="0" name="screen" type="int" default="-1" />
 			<description>
-				Returns the dots per inch density of the specified screen. If [param screen] is [/code]SCREEN_OF_MAIN_WINDOW[/code] (the default value), a screen with the main window will be used.
+				Returns the dots per inch density of the specified screen. If [param screen] is [constant SCREEN_OF_MAIN_WINDOW] (the default value), a screen with the main window will be used.
 				[b]Note:[/b] On macOS, returned value is inaccurate if fractional display scaling mode is used.
 				[b]Note:[/b] On Android devices, the actual screen densities are grouped into six generalized densities:
 				[codeblock]

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -942,7 +942,7 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="dict" type="PackedStringArray" />
 			<description>
-				Returns index of the first string in [code]dict[/dict] which is visually confusable with the [code]string[/string], or [code]-1[/code] if none is found.
+				Returns index of the first string in [param dict] which is visually confusable with the [param string], or [code]-1[/code] if none is found.
 				[b]Note:[/b] This method doesn't detect invisible characters, for spoof detection use it in combination with [method spoof_check].
 				[b]Note:[/b] Always returns [code]-1[/code] if the server does not support the [constant FEATURE_UNICODE_SECURITY] feature.
 			</description>
@@ -1707,10 +1707,10 @@
 			Glyph horizontal position is rounded to one quarter of the pixel size, each glyph is rasterized up to four times.
 		</constant>
 		<constant name="SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE" value="20" enum="SubpixelPositioning">
-			Maximum font size which will use one half of the pixel subpixel positioning in [constants SUBPIXEL_POSITIONING_AUTO] mode.
+			Maximum font size which will use one half of the pixel subpixel positioning in [constant SUBPIXEL_POSITIONING_AUTO] mode.
 		</constant>
 		<constant name="SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE" value="16" enum="SubpixelPositioning">
-			Maximum font size which will use one quarter of the pixel subpixel positioning in [constants SUBPIXEL_POSITIONING_AUTO] mode.
+			Maximum font size which will use one quarter of the pixel subpixel positioning in [constant SUBPIXEL_POSITIONING_AUTO] mode.
 		</constant>
 		<constant name="FEATURE_SIMPLE_LAYOUT" value="1" enum="Feature">
 			TextServer supports simple text layouts.

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -939,7 +939,7 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="dict" type="PackedStringArray" />
 			<description>
-				Returns index of the first string in [code]dict[/dict] which is visually confusable with the [code]string[/string], or [code]-1[/code] if none is found.
+				Returns index of the first string in [param dict] which is visually confusable with the [param string], or [code]-1[/code] if none is found.
 			</description>
 		</method>
 		<method name="is_locale_right_to_left" qualifiers="virtual const">

--- a/doc/classes/VisualShaderNodeUVFunc.xml
+++ b/doc/classes/VisualShaderNodeUVFunc.xml
@@ -17,7 +17,7 @@
 			Translates [code]uv[/code] by using [code]scale[/code] and [code]offset[/code] values using the following formula: [code]uv = uv + offset * scale[/code]. [code]uv[/code] port is connected to [code]UV[/code] built-in by default.
 		</constant>
 		<constant name="FUNC_SCALING" value="1" enum="Function">
-			Scales [code]uv[/uv] by using [code]scale[/code] and [code]pivot[/code] values using the following formula: [code]uv = (uv - pivot) * scale + pivot[/code]. [code]uv[/code] port is connected to [code]UV[/code] built-in by default.
+			Scales [code]uv[/code] by using [code]scale[/code] and [code]pivot[/code] values using the following formula: [code]uv = (uv - pivot) * scale + pivot[/code]. [code]uv[/code] port is connected to [code]UV[/code] built-in by default.
 		</constant>
 		<constant name="FUNC_MAX" value="2" enum="Function">
 			Represents the size of the [enum Function] enum.

--- a/modules/openxr/doc_classes/OpenXRAction.xml
+++ b/modules/openxr/doc_classes/OpenXRAction.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		This resource defines an OpenXR action. Actions can be used both for inputs (buttons/joystick/trigger/etc) and outputs (haptics).
-		OpenXR performs automatic conversion between action type and input type whenever possible. An analogue trigger bound to a boolean action will thus return [code]false[/core] if the trigger is depressed and [code]true[/code] if pressed fully.
+		OpenXR performs automatic conversion between action type and input type whenever possible. An analogue trigger bound to a boolean action will thus return [code]false[/code] if the trigger is depressed and [code]true[/code] if pressed fully.
 		Actions are not directly bound to specific devices, instead OpenXR recognises a limited number of top level paths that identify devices by usage. We can restrict which devices an action can be bound to by these top level paths. For instance an action that should only be used for hand held controllers can have the top level paths "/user/hand/left" and "/user/hand/right" associated with them. See the [url=https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#semantic-path-reserved]reserved path section in the OpenXR specification[/url] for more info on the top level paths.
 		Note that the name of the resource is used to register the action with.
 	</description>


### PR DESCRIPTION
This PR reorganizes `make_rst.py`, adds some comments, and tries to make the parser logic clearer overall. It also introduces additional checks, that help catch some issues with documentation formatting.

While working on https://github.com/godotengine/godot/pull/64164 we've discovered an annoying formatting issue that is hard to detect with our current BBCode parser in `make_rst.py`. Documentation contributors sometimes improperly close `[code]foo[/code]` tags and instead of the closing tag write the name of the property, e.g. `[code]foo[/foo]`. This goes under the radar, because this bit is often followed by another `[code]foo[/code]` sequence, and together they form one valid code block. At least that's what our formatter thinks.

And it looks like this in the end: `[code]foo[/foo] some text in between [code]foo[/code]`, which results in this:

![chrome_2022-08-10_19-45-05](https://user-images.githubusercontent.com/11782833/183974077-2e3bad74-bf74-44fd-b5ae-e9823b4d6bd1.png)

Now, we actually need to support writing tag-like sequences inside of the code block and inline code strings. We use this to document RichTextLabel, among other related things. So we can't explicitly forbid this kind of sequence inside code blocks. The introduction of `[param foo]` should make it less likely for these mistakes to happen, but I've decided to try and improve the logic of the parser anyway, and add new warnings that identify if a bit inside of a code tag looks like a closing tag.

It has [16 false positives](https://user-images.githubusercontent.com/11782833/183974409-c241d37c-2a1c-467e-b79d-433e51bacc35.png) in the current code base, but at least it's some form of reporting to work from. If needed, we could add some kind of extra argument, e.g. `[code unsafe]` that would remove warnings from these places and require the writer to pay attention to formatting and disabling the check.

I've also removed some unused code that has been introduced back in 2016 in the initial implementation https://github.com/godotengine/godot/commit/3ee4f4f19a3e3a63450f0b3bc612c01f44edba19. I checked, and the removed bits never get hits in the current state of the documentation. The refactoring also helped me to fix another formatting issue that wouldn't be detectable without a rework:

![chrome_2022-08-10_19-43-07](https://user-images.githubusercontent.com/11782833/183974568-992079a2-8e72-421e-8b46-4f73d89e842f.png)

Besides that and the fixes from the XMLs, the resulting RSTs are identical to the existing ones. So I count it as no regressions.