### PR TITLE
removes unclear shadowing error

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3957,7 +3957,9 @@ bool GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_local, con
 
 	StringName base_native = base.native_type;
 
-	ERR_FAIL_COND_V_MSG(!class_exists(base_native), false, "Non-existent native base class.");
+	if (!class_exists(base_native)) {
+		return false;
+	}
 
 	StringName parent = base_native;
 	while (parent != StringName()) {


### PR DESCRIPTION
This error message is quite unclear and doesn't seem to really affect anything.

When making a new gdscript class that doesn't inherit from a base class this error ends up firing in the debug console, creating noise.

If there is a reason for it that I missed please let me know :)

*Bugsquad edit: See https://github.com/godotengine/godot/issues/61899#issuecomment-1211021261.*