### PR TITLE
Expand Invalid RID Error Messages

### DIFF
--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -1481,7 +1481,7 @@ bool BulletPhysicsServer::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis
 
 void BulletPhysicsServer::free(RID p_rid) {
 	if (!p_rid.is_valid()) {
-		ERR_FAIL_MSG("Invalid RID.");
+		ERR_FAIL_MSG("PhysicsServer attempted to free a NULL RID.");
 		return;
 	}
 
@@ -1540,7 +1540,7 @@ void BulletPhysicsServer::free(RID p_rid) {
 		bulletdelete(space);
 
 	} else {
-		ERR_FAIL_MSG("Invalid RID.");
+		ERR_FAIL_MSG("RID not found by PhysicsServer.");
 	}
 }
 

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -554,7 +554,7 @@ COMMAND_4(agent_set_callback, RID, p_agent, Object *, p_receiver, StringName, p_
 
 COMMAND_1(free, RID, p_object) {
 	if (!p_object.is_valid()) {
-		ERR_FAIL_MSG("Invalid RID.");
+		ERR_FAIL_MSG("NavigationServer attempted to free a NULL RID.");
 		return;
 	}
 	if (map_owner.owns(p_object)) {
@@ -605,7 +605,7 @@ COMMAND_1(free, RID, p_object) {
 		memdelete(agent);
 
 	} else {
-		ERR_FAIL_COND("Invalid RID.");
+		ERR_FAIL_COND("RID not found by NavigationServer.");
 	}
 }
 

--- a/servers/physics/physics_server_sw.cpp
+++ b/servers/physics/physics_server_sw.cpp
@@ -1200,7 +1200,7 @@ bool PhysicsServerSW::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis p_a
 
 void PhysicsServerSW::free(RID p_rid) {
 	if (!p_rid.is_valid()) {
-		ERR_FAIL_MSG("Invalid RID.");
+		ERR_FAIL_MSG("PhysicsServer attempted to free a NULL RID.");
 		return;
 	}
 
@@ -1279,7 +1279,7 @@ void PhysicsServerSW::free(RID p_rid) {
 		memdelete(joint);
 
 	} else {
-		ERR_FAIL_MSG("Invalid RID.");
+		ERR_FAIL_MSG("RID not found by PhysicsServer.");
 	}
 };
 

--- a/servers/physics_2d/physics_2d_server_sw.cpp
+++ b/servers/physics_2d/physics_2d_server_sw.cpp
@@ -1122,7 +1122,7 @@ Physics2DServer::JointType Physics2DServerSW::joint_get_type(RID p_joint) const 
 
 void Physics2DServerSW::free(RID p_rid) {
 	if (!p_rid.is_valid()) {
-		ERR_FAIL_MSG("Invalid RID.");
+		ERR_FAIL_MSG("PhysicsServer attempted to free a NULL RID.");
 		return;
 	}
 
@@ -1195,7 +1195,7 @@ void Physics2DServerSW::free(RID p_rid) {
 		memdelete(joint);
 
 	} else {
-		ERR_FAIL_MSG("Invalid RID.");
+		ERR_FAIL_MSG("RID not found by PhysicsServer.");
 	}
 };
 

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -66,7 +66,7 @@ void VisualServerRaster::_draw_margins() {
 
 void VisualServerRaster::free(RID p_rid) {
 	if (!p_rid.is_valid()) {
-		ERR_FAIL_MSG("Invalid RID.");
+		ERR_FAIL_MSG("VisualServer attempted to free a NULL RID.");
 		return;
 	}
 
@@ -86,7 +86,7 @@ void VisualServerRaster::free(RID p_rid) {
 		return;
 	}
 
-	ERR_FAIL_MSG("Invalid RID.");
+	ERR_FAIL_MSG("RID not found by VisualServer.");
 }
 
 /* EVENT QUEUING */


### PR DESCRIPTION
Differentiates error messages between null, invalid RIDs and those that are not found when calling the `free()` functions in Visual, Physics, and Navigation Servers.

Addresses @lawnjelly 's comments:
https://github.com/godotengine/godot/pull/55764#discussion_r866305892

>Perhaps if the message "Invalid RID" is now being used for a NULL RID with the first check, these messages at the end could be something like "RID not found."? 🤔

>That might be handy to differentiate the two cases (although I doubt this later case will happen often).

and
https://github.com/godotengine/godot/issues/64199#issuecomment-1210157376
> The other problem as I mentioned in the PR, is that this error message does not distinguish between a NULL RID and a RID not found.

@akien-mga 