### PR TITLE
Store assigned groups in InstancePlaceholder

### DIFF
--- a/doc/classes/InstancePlaceholder.xml
+++ b/doc/classes/InstancePlaceholder.xml
@@ -25,6 +25,12 @@
 				Gets the path to the [PackedScene] resource file that is loaded by default when calling [method create_instance]. Not thread-safe. Use [method Object.call_deferred] if calling from a thread.
 			</description>
 		</method>
+		<method name="get_stored_groups">
+			<return type="Array" />
+			<description>
+				Returns the list of groups that will be applied to the node when [method create_instance] is called.
+			</description>
+		</method>
 		<method name="get_stored_values">
 			<return type="Dictionary" />
 			<param index="0" name="with_order" type="bool" default="false" />

--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -99,6 +99,10 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 		scene->set(E.name, E.value);
 	}
 
+	for (const StringName &E : stored_groups) {
+		scene->add_to_group(E, true);
+	}
+
 	if (p_replace) {
 		queue_delete();
 		base->remove_child(this);
@@ -128,8 +132,23 @@ Dictionary InstancePlaceholder::get_stored_values(bool p_with_order) {
 	return ret;
 };
 
+void InstancePlaceholder::store_group(const StringName &p_identifier) {
+	stored_groups.push_back(p_identifier);
+}
+
+Array InstancePlaceholder::get_stored_groups() {
+	Array ret;
+
+	for (const StringName &E : stored_groups) {
+		ret.push_back(E);
+	}
+
+	return ret;
+}
+
 void InstancePlaceholder::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_stored_values", "with_order"), &InstancePlaceholder::get_stored_values, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_stored_groups"), &InstancePlaceholder::get_stored_groups);
 	ClassDB::bind_method(D_METHOD("create_instance", "replace", "custom_scene"), &InstancePlaceholder::create_instance, DEFVAL(false), DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("get_instance_path"), &InstancePlaceholder::get_instance_path);
 }

--- a/scene/main/instance_placeholder.h
+++ b/scene/main/instance_placeholder.h
@@ -46,6 +46,8 @@ class InstancePlaceholder : public Node {
 
 	List<PropSet> stored_values;
 
+	List<StringName> stored_groups;
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -58,6 +60,9 @@ public:
 	String get_instance_path() const;
 
 	Dictionary get_stored_values(bool p_with_order = false);
+
+	void store_group(const StringName &p_identifier);
+	Array get_stored_groups();
 
 	Node *create_instance(bool p_replace = false, const Ref<PackedScene> &p_custom_scene = Ref<PackedScene>());
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -156,12 +156,12 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 					ERR_FAIL_COND_V(!sdata.is_valid(), nullptr);
 					node = sdata->instantiate(p_edit_state == GEN_EDIT_STATE_DISABLED ? PackedScene::GEN_EDIT_STATE_DISABLED : PackedScene::GEN_EDIT_STATE_INSTANCE);
 					ERR_FAIL_COND_V(!node, nullptr);
+					node->set_scene_instance_load_placeholder(true);
 				} else {
 					InstancePlaceholder *ip = memnew(InstancePlaceholder);
 					ip->set_instance_path(path);
 					node = ip;
 				}
-				node->set_scene_instance_load_placeholder(true);
 			} else {
 				Ref<PackedScene> sdata = props[n.instance & FLAG_MASK];
 				ERR_FAIL_COND_V(!sdata.is_valid(), nullptr);
@@ -329,9 +329,18 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			//name
 
 			//groups
-			for (int j = 0; j < n.groups.size(); j++) {
-				ERR_FAIL_INDEX_V(n.groups[j], sname_count, nullptr);
-				node->add_to_group(snames[n.groups[j]], true);
+			if (Object::cast_to<InstancePlaceholder>(node)) {
+				InstancePlaceholder *ip = Object::cast_to<InstancePlaceholder>(node);
+				for (int j = 0; j < n.groups.size(); j++) {
+					ERR_FAIL_INDEX_V(n.groups[j], sname_count, nullptr);
+					ip->store_group(snames[n.groups[j]]);
+				}
+				node = ip;
+			} else {
+				for (int j = 0; j < n.groups.size(); j++) {
+					ERR_FAIL_INDEX_V(n.groups[j], sname_count, nullptr);
+					node->add_to_group(snames[n.groups[j]], true);
+				}
 			}
 
 			if (n.instance >= 0 || n.type != TYPE_INSTANCED || i == 0) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
The first time, do **not** be gentle, I'm a masochist.

Partially solves #18697. Part of other InstancePlaceholder upgrades/bug fixes etc. More at: https://github.com/godotengine/godot-proposals/discussions/5128

Adds two new functions to InstancePlaceholders: `store_group()` and `get_stored_groups()` (this one exposed to gdscript).
Also alters SceneState::instantiate() to instead store the groups (using store_group) if the node is InstancePlaceholder. Alternatively to the casting check, we could store a boolean or even add the groups when the InstancePlaceholder was created.

Also InstancePlaceholders no longer return true when `Node.get_scene_instance_load_placeholder( )` is called. (Previous behaviour was incorrect, I can open a separate issue if we want to fight over the semantics).

To test the changes (Open Demo.tscn):
[InstancePlaceholder.zip](https://github.com/godotengine/godot/files/9303241/InstancePlaceholder.zip)

Breaks compatibility, if you previously relied on the buggy behaviour.

~~Also `get_stored_groups()` probably needs a short documentation. Now'll just need to figure out how to do it...~~
