### PR TITLE
Re-add AnimationNodeStateMachine::end_node for root state machine

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -784,8 +784,7 @@ void AnimationNodeStateMachineEditor::_open_connect_menu(const Vector2 &p_positi
 	if (anodesm.is_valid()) {
 		_create_submenu(connect_menu, anodesm, connecting_to_node, connecting_to_node);
 	} else {
-		Ref<AnimationNodeStateMachine> prev = state_machine;
-		_create_submenu(connect_menu, prev, connecting_to_node, connecting_to_node, true);
+		_create_submenu(connect_menu, state_machine, connecting_to_node, connecting_to_node, true);
 	}
 
 	connect_menu->add_submenu_item(TTR("To") + " Animation", connecting_to_node);
@@ -817,6 +816,10 @@ bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<Ani
 	String prev_path;
 	Vector<Ref<AnimationNodeStateMachine>> parents = p_parents;
 
+	if (from_root && p_nodesm->get_prev_state_machine() == nullptr) {
+		return false;
+	}
+
 	if (from_root) {
 		AnimationNodeStateMachine *prev = p_nodesm->get_prev_state_machine();
 
@@ -826,6 +829,8 @@ bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<Ani
 			prev_path += "../";
 			prev = prev->get_prev_state_machine();
 		}
+		end_menu->add_item("Root", nodes_to_connect.size());
+		nodes_to_connect.push_back(prev_path + state_machine->end_node);
 		prev_path.remove_at(prev_path.size() - 1);
 	}
 
@@ -856,22 +861,22 @@ bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<Ani
 			}
 
 			if (ansm.is_valid()) {
-				bool found = false;
+				bool parent_found = false;
 
 				for (int i = 0; i < parents.size(); i++) {
 					if (parents[i] == ansm) {
 						path = path.replace_first("/../" + E, "");
-						found = true;
+						parent_found = true;
 						break;
 					}
 				}
 
-				if (!found) {
-					state_machine_menu->add_item(E, nodes_to_connect.size());
-					nodes_to_connect.push_back(path);
-				} else {
+				if (parent_found) {
 					end_menu->add_item(E, nodes_to_connect.size());
 					nodes_to_connect.push_back(path + "/" + state_machine->end_node);
+				} else {
+					state_machine_menu->add_item(E, nodes_to_connect.size());
+					nodes_to_connect.push_back(path);
 				}
 
 				if (_create_submenu(nodes_menu, ansm, E, path, false, parents)) {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -594,11 +594,13 @@ double AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_s
 	if (p_state_machine->end_node != current) {
 		rem = 1;
 	} else {
-		Ref<AnimationNodeStateMachinePlayback> prev_playback = p_state_machine->prev_state_machine->get_parameter("playback");
+		if (p_state_machine->prev_state_machine != nullptr) {
+			Ref<AnimationNodeStateMachinePlayback> prev_playback = p_state_machine->prev_state_machine->get_parameter(p_state_machine->playback);
 
-		if (prev_playback.is_valid()) {
-			prev_playback->current_transition = current_transition;
-			prev_playback->force_auto_advance = true;
+			if (prev_playback.is_valid()) {
+				prev_playback->current_transition = current_transition;
+				prev_playback->force_auto_advance = true;
+			}
 		}
 	}
 
@@ -883,10 +885,6 @@ void AnimationNodeStateMachine::_rename_transitions(const StringName &p_name, co
 void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
 	List<StringName> nodes;
 	for (const KeyValue<StringName, State> &E : states) {
-		if (E.key == end_node && prev_state_machine == nullptr) {
-			continue;
-		}
-
 		nodes.push_back(E.key);
 	}
 	nodes.sort_custom<StringName::AlphCompare>();


### PR DESCRIPTION
Fix #63660

`EndState` is required for `OneShot` as commented here https://github.com/godotengine/godot/issues/63660#issuecomment-1201475180

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
