### PR TITLE
Make VARIANT_META_TYPE_MASK exceed VARIANT_MAX

### DIFF
--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -62,7 +62,7 @@ Ref<MultiplayerAPI> MultiplayerAPI::create_default_interface() {
 // - The first LSB 5 bits are used for the variant type.
 // - The next two bits are used to store the encoding mode.
 // - The most significant is used to store the boolean value.
-#define VARIANT_META_TYPE_MASK 0x1F
+#define VARIANT_META_TYPE_MASK 0x3F
 #define VARIANT_META_EMODE_MASK 0x60
 #define VARIANT_META_BOOL_MASK 0x80
 #define ENCODE_8 0 << 5
@@ -70,7 +70,7 @@ Ref<MultiplayerAPI> MultiplayerAPI::create_default_interface() {
 #define ENCODE_32 2 << 5
 #define ENCODE_64 3 << 5
 Error MultiplayerAPI::encode_and_compress_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bool p_allow_object_decoding) {
-	// Unreachable because `VARIANT_MAX` == 27 and `ENCODE_VARIANT_MASK` == 31
+	// Unreachable because `VARIANT_MAX` == 38
 	CRASH_COND(p_variant.get_type() > VARIANT_META_TYPE_MASK);
 
 	uint8_t *buf = r_buffer;


### PR DESCRIPTION
This PR updates the outdated `VARIANT_META_TYPE_MASK` variable used in `MultiplayerAPI::encode_and_compress_variant`. Because the variable was set with the assumption of 27 Variants, the latest Vector4(i) and Projection variants caused PackedStringArray to exceed 31 and crash during scene replication via `MultiplayerSpawner` as reported in #64231.

I could not find any reference to `ENCODE_VARIANT_MASK` in the current codebase and removed the referencing comment. 

The last value assumed our Variants would stay under 32. This new value assumes they stay under 64. It could be this check is no longer needed, and would be happy to update the PR to reflect that. This at the very least removes the crash when using anything beyond `PACKED_INT64_ARRAY` as defined in `Variant.Type`. 