### PR TITLE
Change `LineEdit` default secret character from "*" to "•".

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -221,8 +221,8 @@
 		<member name="secret" type="bool" setter="set_secret" getter="is_secret" default="false">
 			If [code]true[/code], every character is replaced with the secret character (see [member secret_character]).
 		</member>
-		<member name="secret_character" type="String" setter="set_secret_character" getter="get_secret_character" default="&quot;*&quot;">
-			The character to use to mask secret input (defaults to "*"). Only a single character can be used as the secret character.
+		<member name="secret_character" type="String" setter="set_secret_character" getter="get_secret_character" default="&quot;•&quot;">
+			The character to use to mask secret input (defaults to "•"). Only a single character can be used as the secret character.
 		</member>
 		<member name="selecting_enabled" type="bool" setter="set_selecting_enabled" getter="is_selecting_enabled" default="true">
 			If [code]false[/code], it's impossible to select the text using mouse nor keyboard.

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -95,7 +95,7 @@ private:
 	String text;
 	String placeholder;
 	String placeholder_translated;
-	String secret_character = "*";
+	String secret_character = U"•";
 	String ime_text;
 	Point2 ime_selection;
 


### PR DESCRIPTION
A more compact and modern looking display for the passwords.

<img width="281" alt="Screenshot 2022-08-11 at 11 50 37" src="https://user-images.githubusercontent.com/7645683/184097671-57a954fd-0fe3-4255-96b9-9acc4546bbf3.png">

As suggested in https://github.com/godotengine/godot/pull/64207#issuecomment-1210467426