### PR TITLE
[3.x] Add Quaternion Based 6DOF Spring Joint Bullet Class

### DIFF
--- a/doc/classes/Generic6DOFJoint.xml
+++ b/doc/classes/Generic6DOFJoint.xml
@@ -4,7 +4,7 @@
 		The generic 6-degrees-of-freedom joint can implement a variety of joint types by locking certain axes' rotation or translation.
 	</brief_description>
 	<description>
-		The first 3 DOF axes are linear axes, which represent translation of Bodies, and the latter 3 DOF axes represent the angular motion. Each axis can be either locked, or limited.
+		The first 3 DOF axes are linear axes, which represent translation of Bodies, and the latter 3 DOF axes represent the angular motion. Each axis can be either locked, or limited. The joint may also take on spring and motor characteristics, influencing its linear and angular movement.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,36 +13,42 @@
 			<return type="bool" />
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag" />
 			<description>
+				Returns the current state of the joint flag, on the X axis, represented by the given [enum Flag].
 			</description>
 		</method>
 		<method name="get_flag_y" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag" />
 			<description>
+				Returns the current state of the joint flag, on the Y axis, represented by the given [enum Flag].
 			</description>
 		</method>
 		<method name="get_flag_z" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag" />
 			<description>
+				Returns the current state of the joint flag, on the Z axis, represented by the given [enum Flag].
 			</description>
 		</method>
 		<method name="get_param_x" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param" />
 			<description>
+				Returns the current state of the joint parameter, on the X axis, represented by the given [enum Param].
 			</description>
 		</method>
 		<method name="get_param_y" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param" />
 			<description>
+				Returns the current state of the joint parameter, on the Y axis, represented by the given [enum Param].
 			</description>
 		</method>
 		<method name="get_param_z" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param" />
 			<description>
+				Returns the current state of the joint parameter, on the Z axis, represented by the given [enum Param].
 			</description>
 		</method>
 		<method name="set_flag_x">
@@ -50,6 +56,7 @@
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag" />
 			<argument index="1" name="value" type="bool" />
 			<description>
+				Sets the joint flag, on the X axis, represented by the given [enum Flag] with the given [code]value[/code].
 			</description>
 		</method>
 		<method name="set_flag_y">
@@ -57,6 +64,7 @@
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag" />
 			<argument index="1" name="value" type="bool" />
 			<description>
+				Sets the joint flag, on the Y axis, represented by the given [enum Flag] with the given [code]value[/code].
 			</description>
 		</method>
 		<method name="set_flag_z">
@@ -64,6 +72,7 @@
 			<argument index="0" name="flag" type="int" enum="Generic6DOFJoint.Flag" />
 			<argument index="1" name="value" type="bool" />
 			<description>
+				Sets the joint flag, on the Z axis, represented by the given [enum Flag] with the given [code]value[/code].
 			</description>
 		</method>
 		<method name="set_param_x">
@@ -71,6 +80,7 @@
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param" />
 			<argument index="1" name="value" type="float" />
 			<description>
+				Sets the joint parameter, on the X axis, represented by the given [enum Param] with the given [code]value[/code].
 			</description>
 		</method>
 		<method name="set_param_y">
@@ -78,6 +88,7 @@
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param" />
 			<argument index="1" name="value" type="float" />
 			<description>
+				Sets the joint parameter, on the X axis, represented by the given [enum Param] with the given [code]value[/code].
 			</description>
 		</method>
 		<method name="set_param_z">
@@ -85,6 +96,7 @@
 			<argument index="0" name="param" type="int" enum="Generic6DOFJoint.Param" />
 			<argument index="1" name="value" type="float" />
 			<description>
+				Sets the joint parameter, on the X axis, represented by the given [enum Param] with the given [code]value[/code].
 			</description>
 		</method>
 	</methods>
@@ -189,29 +201,59 @@
 		<member name="angular_motor_z/target_velocity" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
 			Target speed for the motor at the Z axis.
 		</member>
+		<member name="angular_spring/quaternion_rotation_equilibrium" type="Quat" setter="set_quaternion_rotation_equilibrium" getter="get_quaternion_rotation_equilibrium">
+			Optionally, the joint's rotation equilibrium maybe driven by using a quaternion instead. This is way faster than using Euler angles to drive joint rotation.
+			Note that this property only works with [member ProjectSettings.physics/3d/physics_engine] set to [code]Bullet[/code].
+		</member>
+		<member name="angular_spring/use_global_rotation" type="bool" setter="set_use_global_rotation" getter="get_use_global_rotation" default="false">
+			If [code]true[/code], the set angular spring [code]equilibrium_point[/code] will be interpreted as [b]global[/b] rotation values. Otherwise, they will be interpreted as local rotation values. This is useful for copying global rotations.
+			[codeblock]
+			var target_global_angles = get_node(puppeteer_node).global_transform.basis.get_rotation_quat().get_euler()
+			self.set_param_x(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT,target_global_angles.x)
+			self.set_param_y(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT,target_global_angles.y)
+			self.set_param_z(PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT,target_global_angles.z)
+			[/codeblock]
+			Note that this property only works with [member ProjectSettings.physics/3d/physics_engine] set to [code]Bullet[/code].
+		</member>
+		<member name="angular_spring/use_quaternion_rotation_equilibrium" type="bool" setter="set_use_quaternion_rotation_equilibrium" getter="get_use_quaternion_rotation_equilibrium" default="false">
+			If [code]true[/code], the set [member angular_spring/quaternion_rotation_equilibrium] will be used instead of Euler angles set through angular spring [code]equilibrium_point[/code]s. It is highly recomended to use this in favour of Euler angles as it is faster.
+			Note that this property only works with [member ProjectSettings.physics/3d/physics_engine] set to [code]Bullet[/code].
+		</member>
 		<member name="angular_spring_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+			The dampening value for the angular spring characteristic around the X axis. This affects how much the angular spring joint oscillates before reaching its equilibrium angle. The higher the value the less oscillation. Please note that high damping values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="angular_spring_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
+			If [code]true[/code], the angular spring property around the X axis is enabled.
 		</member>
 		<member name="angular_spring_x/equilibrium_point" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+			The angle in radians the joint will try to maintain around the X axis relative to [member Joint.nodes/node_a].
 		</member>
 		<member name="angular_spring_x/stiffness" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+			The stiffness value for the angular spring characteristic around the X axis. This affects how fast the angular spring joint will rotate to reach its set equilibrium angle. The higher the value the more force is applied to maintain the set equilibrium angle. Please note that high stiffness values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="angular_spring_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+			The dampening value for the angular spring characteristic around the Y axis. This affects how much the angular spring joint oscillates before reaching its equilibrium angle. The higher the value the less oscillation. Please note that high damping values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="angular_spring_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
+			If [code]true[/code], the angular spring property around the Y axis is enabled.
 		</member>
 		<member name="angular_spring_y/equilibrium_point" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+			The angle in radians the joint will try to maintain around the Y axis relative to [member Joint.nodes/node_a].
 		</member>
 		<member name="angular_spring_y/stiffness" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+			The stiffness value for the angular spring characteristic around the Y axis. This affects how fast the angular spring joint will rotate to reach its set equilibrium angle. The higher the value the more force is applied to maintain the set equilibrium angle. Please note that high stiffness values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="angular_spring_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+			The dampening value for the angular spring characteristic around the Z axis. This affects how much the angular spring joint oscillates before reaching its equilibrium angle. The higher the value the less oscillation. Please note that high damping values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="angular_spring_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
+			If [code]true[/code], the angular spring property around the Z axis is enabled.
 		</member>
 		<member name="angular_spring_z/equilibrium_point" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+			The angle in radians the joint will try to maintain around the Z axis relative to [member Joint.nodes/node_a].
 		</member>
 		<member name="angular_spring_z/stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+			The stiffness value for the angular spring characteristic around the Z axis. This affects how fast the angular spring joint will rotate to reach its set equilibrium angle. The higher the value the more force is applied to maintain the set equilibrium angle. Please note that high stiffness values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="linear_limit_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="1.0">
 			The amount of damping that happens at the X motion.
@@ -295,28 +337,40 @@
 			The speed that the linear motor will attempt to reach on the Z axis.
 		</member>
 		<member name="linear_spring_x/damping" type="float" setter="set_param_x" getter="get_param_x" default="0.01">
+			The dampening value for the linear spring characteristic at the X axis. This affects how much the linear spring joint oscillates before reaching its equilibrium point. The higher the value the less oscillation. Please note that high damping values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="linear_spring_x/enabled" type="bool" setter="set_flag_x" getter="get_flag_x" default="false">
+			If [code]true[/code], the linear spring property on the X axis is enabled.
 		</member>
 		<member name="linear_spring_x/equilibrium_point" type="float" setter="set_param_x" getter="get_param_x" default="0.0">
+			The position the joint will try to maintain on the X axis relative to [member Joint.nodes/node_a].
 		</member>
 		<member name="linear_spring_x/stiffness" type="float" setter="set_param_x" getter="get_param_x" default="0.01">
+			The stiffness value for the linear spring characteristic on the X axis. This affects how fast the linear spring joint will move to reach its set equilibrium point. The higher the value the more force is applied to maintain the set equilibrium point. Please note that high stiffness values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="linear_spring_y/damping" type="float" setter="set_param_y" getter="get_param_y" default="0.01">
+			The dampening value for the linear spring characteristic at the Y axis. This affects how much the linear spring joint oscillates before reaching its equilibrium point. The higher the value the less oscillation. Please note that high damping values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="linear_spring_y/enabled" type="bool" setter="set_flag_y" getter="get_flag_y" default="false">
+			If [code]true[/code], the linear spring property on the Y axis is enabled.
 		</member>
 		<member name="linear_spring_y/equilibrium_point" type="float" setter="set_param_y" getter="get_param_y" default="0.0">
+			The position the joint will try to maintain on the Y axis relative to [member Joint.nodes/node_a].
 		</member>
 		<member name="linear_spring_y/stiffness" type="float" setter="set_param_y" getter="get_param_y" default="0.01">
+			The stiffness value for the linear spring characteristic on the Y axis. This affects how fast the linear spring joint will move to reach its set equilibrium point. The higher the value the more force is applied to maintain the set equilibrium point. Please note that high stiffness values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="linear_spring_z/damping" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
+			The dampening value for the linear spring characteristic at the Z axis. This affects how much the linear spring joint oscillates before reaching its equilibrium point. The higher the value the less oscillation. Please note that high damping values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 		<member name="linear_spring_z/enabled" type="bool" setter="set_flag_z" getter="get_flag_z" default="false">
+			If [code]true[/code], the linear spring property on the Z axis is enabled.
 		</member>
 		<member name="linear_spring_z/equilibrium_point" type="float" setter="set_param_z" getter="get_param_z" default="0.0">
+			The position the joint will try to maintain on the Z axis relative to [member Joint.nodes/node_a].
 		</member>
 		<member name="linear_spring_z/stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
+			The stiffness value for the linear spring characteristic on the Z axis. This affects how fast the linear spring joint will move to reach its set equilibrium point. The higher the value the more force is applied to maintain the set equilibrium point. Please note that high stiffness values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</member>
 	</members>
 	<constants>
@@ -342,10 +396,13 @@
 			The maximum force the linear motor will apply while trying to reach the velocity target.
 		</constant>
 		<constant name="PARAM_LINEAR_SPRING_STIFFNESS" value="7" enum="Param">
+			The stiffness value for the linear spring characteristic on the axes. This affects how fast the linear spring joint will move to reach its set equilibrium point. The higher the value the more force is applied to maintain the set equilibrium point. Please note that high stiffness values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</constant>
 		<constant name="PARAM_LINEAR_SPRING_DAMPING" value="8" enum="Param">
+			The dampening value for the linear spring characteristic on the axes. This affects how much the linear spring joint oscillates before reaching its equilibrium point. The higher the value the less oscillation. Please note that high damping values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</constant>
 		<constant name="PARAM_LINEAR_SPRING_EQUILIBRIUM_POINT" value="9" enum="Param">
+			The position the joint will try to maintain on the axes relative to [member Joint.nodes/node_a].
 		</constant>
 		<constant name="PARAM_ANGULAR_LOWER_LIMIT" value="10" enum="Param">
 			The minimum rotation in negative direction to break loose and rotate around the axes.
@@ -375,10 +432,13 @@
 			Maximum acceleration for the motor at the axes.
 		</constant>
 		<constant name="PARAM_ANGULAR_SPRING_STIFFNESS" value="19" enum="Param">
+			The stiffness value for the angular spring characteristic around the axes. This affects how fast the angular spring joint will rotate to reach its set equilibrium angle. The higher the value the more force is applied to maintain the set equilibrium angle. Please note that high stiffness values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</constant>
 		<constant name="PARAM_ANGULAR_SPRING_DAMPING" value="20" enum="Param">
+			The dampening value for the angular spring characteristic around the axes. This affects how much the angular spring joint oscillates before reaching its equilibrium angle. The higher the value the less oscillation. Please note that high damping values may adversely affect the joint arrangement when attached with "light" rigidbodies ([member RigidBody.mass] less than or equal to 1).
 		</constant>
 		<constant name="PARAM_ANGULAR_SPRING_EQUILIBRIUM_POINT" value="21" enum="Param">
+			The angle in radians the joint will try to maintain around the axes relative to [member Joint.nodes/node_a].
 		</constant>
 		<constant name="PARAM_MAX" value="22" enum="Param">
 			Represents the size of the [enum Param] enum.
@@ -390,8 +450,10 @@
 			If enabled, rotational motion is possible within the given limits.
 		</constant>
 		<constant name="FLAG_ENABLE_LINEAR_SPRING" value="3" enum="Flag">
+			If enabled, these axes will take on linear spring characterisitics.
 		</constant>
 		<constant name="FLAG_ENABLE_ANGULAR_SPRING" value="2" enum="Flag">
+			If enabled, these axes will take on angular spring characterisitics.
 		</constant>
 		<constant name="FLAG_ENABLE_MOTOR" value="4" enum="Flag">
 			If enabled, there is a rotational motor across these axes.

--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -122,6 +122,7 @@ if env["builtin_bullet"]:
         "BulletDynamics/ConstraintSolver/btGeneric6DofConstraint.cpp",
         "BulletDynamics/ConstraintSolver/btGeneric6DofSpringConstraint.cpp",
         "BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.cpp",
+        "BulletDynamics/ConstraintSolver/btGeneric6DofSpringConstraintQuaternion.cpp",
         "BulletDynamics/ConstraintSolver/btHinge2Constraint.cpp",
         "BulletDynamics/ConstraintSolver/btHingeConstraint.cpp",
         "BulletDynamics/ConstraintSolver/btPoint2PointConstraint.cpp",

--- a/modules/bullet/bullet_physics_server.cpp
+++ b/modules/bullet/bullet_physics_server.cpp
@@ -1479,6 +1479,51 @@ bool BulletPhysicsServer::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis
 	return generic_6dof_joint->get_flag(p_axis, p_flag);
 }
 
+void BulletPhysicsServer::generic_6dof_joint_set_use_global_rotation(RID p_joint, bool p_enable) {
+	JointBullet *joint = joint_owner.get(p_joint);
+	ERR_FAIL_COND(!joint);
+	ERR_FAIL_COND(joint->get_type() != JOINT_6DOF);
+	Generic6DOFJointBullet *generic_6dof_joint = static_cast<Generic6DOFJointBullet *>(joint);
+	generic_6dof_joint->set_use_global_rotation(p_enable);
+}
+
+bool BulletPhysicsServer::generic_6dof_joint_get_use_global_rotation(RID p_joint) {
+	JointBullet *joint = joint_owner.get(p_joint);
+	ERR_FAIL_COND_V(!joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_6DOF, false);
+	Generic6DOFJointBullet *generic_6dof_joint = static_cast<Generic6DOFJointBullet *>(joint);
+	return generic_6dof_joint->get_use_global_rotation();
+}
+
+void BulletPhysicsServer::generic_6dof_joint_set_use_quaternion_rotation_equilibrium(RID p_joint, bool p_enable) {
+	JointBullet *joint = joint_owner.get(p_joint);
+	ERR_FAIL_COND(!joint);
+	ERR_FAIL_COND(joint->get_type() != JOINT_6DOF);
+	Generic6DOFJointBullet *generic_6dof_joint = static_cast<Generic6DOFJointBullet *>(joint);
+	generic_6dof_joint->set_use_quaternion_rotation_equilibrium(p_enable);
+}
+bool BulletPhysicsServer::generic_6dof_joint_get_use_quaternion_rotation_equilibrium(RID p_joint) {
+	JointBullet *joint = joint_owner.get(p_joint);
+	ERR_FAIL_COND_V(!joint, false);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_6DOF, false);
+	Generic6DOFJointBullet *generic_6dof_joint = static_cast<Generic6DOFJointBullet *>(joint);
+	return generic_6dof_joint->get_use_quaternion_rotation_equilibrium();
+}
+void BulletPhysicsServer::generic_6dof_joint_set_quaternion_rotation_equilibrium(RID p_joint, Quat p_value) {
+	JointBullet *joint = joint_owner.get(p_joint);
+	ERR_FAIL_COND(!joint);
+	ERR_FAIL_COND(joint->get_type() != JOINT_6DOF);
+	Generic6DOFJointBullet *generic_6dof_joint = static_cast<Generic6DOFJointBullet *>(joint);
+	generic_6dof_joint->set_quaternion_rotation_equilibrium(p_value);
+}
+Quat BulletPhysicsServer::generic_6dof_joint_get_quaternion_rotation_equilibrium(RID p_joint) {
+	JointBullet *joint = joint_owner.get(p_joint);
+	ERR_FAIL_COND_V(!joint, Quat());
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_6DOF, Quat());
+	Generic6DOFJointBullet *generic_6dof_joint = static_cast<Generic6DOFJointBullet *>(joint);
+	return generic_6dof_joint->get_quaternion_rotation_equilibrium();
+}
+
 void BulletPhysicsServer::free(RID p_rid) {
 	if (!p_rid.is_valid()) {
 		ERR_FAIL_MSG("PhysicsServer attempted to free a NULL RID.");

--- a/modules/bullet/bullet_physics_server.h
+++ b/modules/bullet/bullet_physics_server.h
@@ -375,6 +375,14 @@ public:
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag, bool p_enable);
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag);
 
+	virtual void generic_6dof_joint_set_use_global_rotation(RID p_joint, bool p_enable);
+	virtual bool generic_6dof_joint_get_use_global_rotation(RID p_joint);
+
+	virtual void generic_6dof_joint_set_use_quaternion_rotation_equilibrium(RID p_joint, bool p_enabled);
+	virtual bool generic_6dof_joint_get_use_quaternion_rotation_equilibrium(RID p_joint);
+	virtual void generic_6dof_joint_set_quaternion_rotation_equilibrium(RID p_joint, Quat p_value);
+	virtual Quat generic_6dof_joint_get_quaternion_rotation_equilibrium(RID p_joint);
+
 	/* MISC */
 
 	virtual void free(RID p_rid);

--- a/modules/bullet/generic_6dof_joint_bullet.cpp
+++ b/modules/bullet/generic_6dof_joint_bullet.cpp
@@ -35,6 +35,9 @@
 #include "rigid_body_bullet.h"
 
 #include <BulletDynamics/ConstraintSolver/btGeneric6DofSpring2Constraint.h>
+#include <BulletDynamics/ConstraintSolver/btGeneric6DofSpringConstraintQuaternion.h>
+
+#include <LinearMath/btQuaternion.h>
 
 /**
 	@author AndreaCatania
@@ -57,9 +60,9 @@ Generic6DOFJointBullet::Generic6DOFJointBullet(RigidBodyBullet *rbA, RigidBodyBu
 		btTransform btFrameB;
 		G_TO_B(scaled_BFrame, btFrameB);
 
-		sixDOFConstraint = bulletnew(btGeneric6DofSpring2Constraint(*rbA->get_bt_rigid_body(), *rbB->get_bt_rigid_body(), btFrameA, btFrameB));
+		sixDOFConstraint = bulletnew(btGeneric6DofSpringConstraintQuaternion(*rbA->get_bt_rigid_body(), *rbB->get_bt_rigid_body(), btFrameA, btFrameB));
 	} else {
-		sixDOFConstraint = bulletnew(btGeneric6DofSpring2Constraint(*rbA->get_bt_rigid_body(), btFrameA));
+		sixDOFConstraint = bulletnew(btGeneric6DofSpringConstraintQuaternion(*rbA->get_bt_rigid_body(), btFrameA));
 	}
 
 	setup(sixDOFConstraint);
@@ -260,4 +263,30 @@ void Generic6DOFJointBullet::set_flag(Vector3::Axis p_axis, PhysicsServer::G6DOF
 bool Generic6DOFJointBullet::get_flag(Vector3::Axis p_axis, PhysicsServer::G6DOFJointAxisFlag p_flag) const {
 	ERR_FAIL_INDEX_V(p_axis, 3, false);
 	return flags[p_axis][p_flag];
+}
+
+void Generic6DOFJointBullet::set_use_global_rotation(bool p_value) {
+	sixDOFConstraint->set_use_global_rotation(p_value);
+}
+
+bool Generic6DOFJointBullet::get_use_global_rotation() {
+	return sixDOFConstraint->get_use_global_rotation();
+}
+
+void Generic6DOFJointBullet::set_use_quaternion_rotation_equilibrium(bool p_enable) {
+	sixDOFConstraint->set_use_quaternion_rotation_equilibrium(p_enable);
+}
+
+bool Generic6DOFJointBullet::get_use_quaternion_rotation_equilibrium() {
+	return sixDOFConstraint->get_use_quaternion_rotation_equilibrium();
+}
+
+void Generic6DOFJointBullet::set_quaternion_rotation_equilibrium(Quat p_value) {
+	btQuaternion q_value = btQuaternion(p_value.x, p_value.y, p_value.z, p_value.w);
+	sixDOFConstraint->set_quaternion_rotation_equilibrium(q_value);
+}
+
+Quat Generic6DOFJointBullet::get_quaternion_rotation_equilibrium() {
+	btQuaternion q_value = sixDOFConstraint->get_quaternion_rotation_equilibrium();
+	return Quat(q_value.x(), q_value.y(), q_value.z(), q_value.w());
 }

--- a/modules/bullet/generic_6dof_joint_bullet.h
+++ b/modules/bullet/generic_6dof_joint_bullet.h
@@ -40,7 +40,7 @@
 class RigidBodyBullet;
 
 class Generic6DOFJointBullet : public JointBullet {
-	class btGeneric6DofSpring2Constraint *sixDOFConstraint;
+	class btGeneric6DofSpringConstraintQuaternion *sixDOFConstraint;
 
 	// First is linear second is angular
 	Vector3 limits_lower[2];
@@ -68,6 +68,14 @@ public:
 
 	void set_flag(Vector3::Axis p_axis, PhysicsServer::G6DOFJointAxisFlag p_flag, bool p_value);
 	bool get_flag(Vector3::Axis p_axis, PhysicsServer::G6DOFJointAxisFlag p_flag) const;
+
+	void set_use_global_rotation(bool p_value);
+	bool get_use_global_rotation();
+
+	void set_use_quaternion_rotation_equilibrium(bool p_enabled);
+	bool get_use_quaternion_rotation_equilibrium();
+	void set_quaternion_rotation_equilibrium(Quat p_value);
+	Quat get_quaternion_rotation_equilibrium();
 };
 
 #endif // GENERIC_6DOF_JOINT_BULLET_H

--- a/scene/3d/physics_joint.h
+++ b/scene/3d/physics_joint.h
@@ -34,6 +34,8 @@
 #include "scene/3d/physics_body.h"
 #include "scene/3d/spatial.h"
 
+#include "core/math/quat.h"
+
 class Joint : public Spatial {
 	GDCLASS(Joint, Spatial);
 
@@ -307,6 +309,13 @@ protected:
 	virtual RID _configure_joint(PhysicsBody *body_a, PhysicsBody *body_b);
 	static void _bind_methods();
 
+	virtual void _validate_property(PropertyInfo &p_property) const;
+
+private:
+	bool using_global_rotation;
+	bool using_quaternion_rotation_equilibrium;
+	Quat quaternion_rotation_equilibrium;
+
 public:
 	void set_param_x(Param p_param, float p_value);
 	float get_param_x(Param p_param) const;
@@ -325,6 +334,15 @@ public:
 
 	void set_flag_z(Flag p_flag, bool p_enabled);
 	bool get_flag_z(Flag p_flag) const;
+
+	void set_use_global_rotation(bool p_enabled);
+	bool get_use_global_rotation() const;
+
+	void set_use_quaternion_rotation_equilibrium(bool p_enabled);
+	bool get_use_quaternion_rotation_equilibrium() const;
+
+	void set_quaternion_rotation_equilibrium(Quat p_value);
+	Quat get_quaternion_rotation_equilibrium() const;
 
 	Generic6DOFJoint();
 };

--- a/servers/physics_server.h
+++ b/servers/physics_server.h
@@ -34,6 +34,8 @@
 #include "core/object.h"
 #include "core/resource.h"
 
+#include "core/math/quat.h"
+
 class PhysicsDirectSpaceState;
 
 class PhysicsDirectBodyState : public Object {
@@ -711,6 +713,14 @@ public:
 
 	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
 	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) = 0;
+
+	////PHOBOSS:////should not be pure virtual functions, so that other physics servers dont need to implement these
+	virtual void generic_6dof_joint_set_use_global_rotation(RID p_joint, bool p_enable) {}
+	virtual bool generic_6dof_joint_get_use_global_rotation(RID p_joint) { return false; }
+	virtual void generic_6dof_joint_set_use_quaternion_rotation_equilibrium(RID p_joint, bool p_enable) {}
+	virtual bool generic_6dof_joint_get_use_quaternion_rotation_equilibrium(RID p_joint) { return false; }
+	virtual void generic_6dof_joint_set_quaternion_rotation_equilibrium(RID p_joint, Quat p_value) {}
+	virtual Quat generic_6dof_joint_get_quaternion_rotation_equilibrium(RID p_joint) { return Quat(0.0, 0.0, 0.0, 1.0); }
 
 	/* QUERY API */
 

--- a/thirdparty/bullet/BulletDynamics/ConstraintSolver/btGeneric6DofSpringConstraintQuaternion.cpp
+++ b/thirdparty/bullet/BulletDynamics/ConstraintSolver/btGeneric6DofSpringConstraintQuaternion.cpp
@@ -1,0 +1,354 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  https://bulletphysics.org
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+///This file was created by PHOBOSS (Kim Obordo) on 2022 August
+///The btGeneric6DofSpringConstraintQuaternion class is based on btGeneric6DofSpring2Constraint.
+///This class was made to provide more control over spring joint "equilibrium" rotation using quaternions instead of Euler Axes.
+///This makes it useful for "puppeteering" joint controlled active ragdolls.
+
+///4 May: btGeneric6DofSpring2Constraint is created from the original (2.82.2712) btGeneric6DofConstraint by Gabor Puhr and Tamas UmenhofferPros:
+///- Much more accurate and stable in a lot of situation. (Especially when a sleeping chain of RBs connected with 6dof2 is pulled)
+///- Stable and accurate spring with minimal energy loss that works with all of the solvers. (latter is not true for the original 6dof spring)
+///- Servo motor functionality
+///- Much more accurate bouncing. 0 really means zero bouncing (not true for the original 6odf) and there is only a minimal energy loss when the value is 1 (because of the solvers' precision)
+///- Rotation order for the Euler system can be set. (One axis' freedom is still limited to pi/2)
+///
+///Cons:
+///- It is slower than the original 6dof. There is no exact ratio, but half speed is a good estimation.
+///- At bouncing the correct velocity is calculated, but not the correct position. (it is because of the solver can correct position or velocity, but not both.)
+
+/// 2009 March: btGeneric6DofConstraint refactored by Roman Ponomarev
+/// Added support for generic constraint solver through getInfo1Q/getInfo2 methods
+
+///2007-09-09
+///btGeneric6DofConstraint Refactored by Francisco Le?n
+///email: projectileman@yahoo.com
+///http://gimpact.sf.net
+
+#include "btGeneric6DofSpringConstraintQuaternion.h"
+#include "btGeneric6DofSpring2Constraint.h"
+#include "BulletDynamics/Dynamics/btRigidBody.h"
+#include "LinearMath/btTransformUtil.h"
+#include <cmath>
+#include <new>
+
+btGeneric6DofSpringConstraintQuaternion::btGeneric6DofSpringConstraintQuaternion(btRigidBody& rbA, btRigidBody& rbB, const btTransform& frameInA, const btTransform& frameInB, RotateOrder rotOrder)
+	: btGeneric6DofSpring2Constraint(rbA, rbB, frameInA, frameInB, rotOrder)
+{
+}
+
+
+btGeneric6DofSpringConstraintQuaternion::btGeneric6DofSpringConstraintQuaternion(btRigidBody & rbB, const btTransform& frameInB, RotateOrder rotOrder)
+	: btGeneric6DofSpring2Constraint(rbB, frameInB, rotOrder)
+{
+}
+
+
+void btGeneric6DofSpringConstraintQuaternion::set_use_global_rotation(bool p_value) {
+	using_global_rotation = p_value;
+}
+bool btGeneric6DofSpringConstraintQuaternion::get_use_global_rotation() {
+	return using_global_rotation;
+}
+
+void btGeneric6DofSpringConstraintQuaternion::set_use_quaternion_rotation_equilibrium(bool p_enable) {
+	using_quaternion_rotation_equilibrium = p_enable;
+}
+bool btGeneric6DofSpringConstraintQuaternion::get_use_quaternion_rotation_equilibrium() {
+	return using_quaternion_rotation_equilibrium;
+}
+void btGeneric6DofSpringConstraintQuaternion::set_quaternion_rotation_equilibrium(btQuaternion p_value) {
+	quaternion_rotation_equilibrium = p_value;
+}
+btQuaternion btGeneric6DofSpringConstraintQuaternion::get_quaternion_rotation_equilibrium() {
+	return quaternion_rotation_equilibrium;
+}
+
+void btGeneric6DofSpringConstraintQuaternion::getInfo2(btConstraintInfo2* info)
+{
+	const btTransform& transA = m_rbA.getCenterOfMassTransform();
+	const btTransform& transB = m_rbB.getCenterOfMassTransform();
+	const btVector3& linVelA = m_rbA.getLinearVelocity();
+	const btVector3& linVelB = m_rbB.getLinearVelocity();
+	const btVector3& angVelA = m_rbA.getAngularVelocity();
+	const btVector3& angVelB = m_rbB.getAngularVelocity();
+
+	int row = setAngularLimitsQuaternion(info, 0, transA, transB, linVelA, linVelB, angVelA, angVelB);
+	setLinearLimits(info, row, transA, transB, linVelA, linVelB, angVelA, angVelB);
+}
+
+///PHOBOSS: this function is based from btGeneric6DofSpring2Constraint's "setAngularLimits" function
+///Here, quaternions are used to compute for the rotation error used to compute for the constraints
+int btGeneric6DofSpringConstraintQuaternion::setAngularLimitsQuaternion(btConstraintInfo2 *info, int row_offset, const btTransform &transA, const btTransform &transB, const btVector3 &linVelA, const btVector3 &linVelB, const btVector3 &angVelA, const btVector3 &angVelB) {
+	int row = row_offset;
+
+	int cIdx[] = { 2, 0, 1 }; ///PHOBOSS: arbitrary, order doesn't actually matter here
+
+	///PHOBOSS: interpret equilibrium rotation as global rotation
+	btVector3 body_axis[] = { btVector3(1.0, 0.0, 0.0), btVector3(0.0, 1.0, 0.0), btVector3(0.0, 0.0, 1.0) };
+	btQuaternion current_rotation_quat = (transB).getRotation();
+	if (!using_global_rotation) {
+		////PHOBOSS: rotation axis should be body A's basis matrix
+		body_axis[0] = transA.getBasis().getColumn(0);
+		body_axis[1] = transA.getBasis().getColumn(1);
+		body_axis[2] = transA.getBasis().getColumn(2);
+		current_rotation_quat = (transA.inverse() * transB).getRotation(); ////PHOBOSS: body B's rotation relative to body A
+	}
+	btQuaternion equilibrium_rotation_quat = quaternion_rotation_equilibrium; ////PHOBOSS: faster
+	if (!using_quaternion_rotation_equilibrium) {
+		equilibrium_rotation_quat = btQuaternion(m_angularLimits[1].m_equilibriumPoint, m_angularLimits[0].m_equilibriumPoint, m_angularLimits[2].m_equilibriumPoint);
+	}
+	
+	btQuaternion rotation_change = equilibrium_rotation_quat * current_rotation_quat.inverse();
+
+	///btScalar angle = rotation_change.getAngleShortestPath();
+	btScalar angle = 0.0; ///PHOBOSS: this is more robust for some reason
+	if (abs(rotation_change[3]) <= 1.0) ///PHOBOSS: protection against NAN
+	{
+		angle = 2.0 * acos(rotation_change[3]);
+		if (angle > SIMD_PI)
+			angle -= 2.0 * SIMD_PI;
+	}
+	///PHOBOSS: I know, I should have passed the angle and calculated for the quaternion_axis (axis_q) separately inside "get_limit_motor_info_quaternion" but I think it wouldn't save much execution time anyways
+
+	btVector3 axis_q = rotation_change.getAxis();
+	btVector3 vec_angle_error = axis_q * angle;
+
+	///PHOBOSS: tried to implement my own impulse calculation using critical damping, it didn't work out for me... here's a reference:https://www.gamedev.net/tutorials/programming/math-and-physics/towards-a-simpler-stiffer-and-more-stable-spring-r3227/ //
+	///btMatrix3x3 reduced_moment_of_inertia = (m_rbA.getInvInertiaTensorWorld() + m_rbB.getInvInertiaTensorWorld()).inverse();
+	///btVector3 kd = btVector3(m_angularLimits[0].m_springDamping, m_angularLimits[1].m_springDamping, m_angularLimits[2].m_springDamping);// values should be [0-1]
+	///btVector3 ks = btVector3(m_angularLimits[0].m_springStiffness, m_angularLimits[1].m_springStiffness, m_angularLimits[2].m_springStiffness);// values should be [0-1]
+	///btVector3 P = quat_angle_error;
+	///btVector3 D = m_rbB.getAngularVelocity() - m_rbA.getAngularVelocity() * -1.0;
+	///btVector3 calculated_spring_velocity = P + D;
+	///btVector3 calculated_spring_impulse = reduced_moment_of_inertia * calculated_spring_velocity;
+
+	for (int ii = 0; ii < 3; ii++) {
+		int i = cIdx[ii];
+		if (m_angularLimits[i].m_currentLimit || m_angularLimits[i].m_enableMotor || m_angularLimits[i].m_enableSpring) {
+			btVector3 axis = body_axis[i];
+			int flags = m_flags >> ((i + 3) * BT_6DOF_FLAGS_AXIS_SHIFT2);
+			if (!(flags & BT_6DOF_FLAGS_CFM_STOP2)) {
+				m_angularLimits[i].m_stopCFM = info->cfm[0];
+			}
+			if (!(flags & BT_6DOF_FLAGS_ERP_STOP2)) {
+				m_angularLimits[i].m_stopERP = info->erp;
+			}
+			if (!(flags & BT_6DOF_FLAGS_CFM_MOTO2)) {
+				m_angularLimits[i].m_motorCFM = info->cfm[0];
+			}
+			if (!(flags & BT_6DOF_FLAGS_ERP_MOTO2)) {
+				m_angularLimits[i].m_motorERP = info->erp;
+			}
+
+			row += get_limit_motor_info_quaternion(&m_angularLimits[i], transA, transB, linVelA, linVelB, angVelA, angVelB, info, row, axis, vec_angle_error[i]);
+		}
+	}
+
+	return row;
+}
+
+///PHOBOSS: this function is based from btGeneric6DofSpring2Constraint's "get_limit_motor_info2" function modified for the sole purpose of finding angular constraints
+int btGeneric6DofSpringConstraintQuaternion::get_limit_motor_info_quaternion(
+	btRotationalLimitMotor2* limot,
+	const btTransform& transA, const btTransform& transB, const btVector3& linVelA, const btVector3& linVelB, const btVector3& angVelA, const btVector3& angVelB,
+	btConstraintInfo2* info, int row, btVector3& ax1, btScalar& vec_rotation_error_element, int rotAllowed)
+{
+	int count = 0;
+	int srow = row * info->rowskip;
+
+	if (limot->m_currentLimit == 4)
+	{
+		btScalar vel = angVelA.dot(ax1) - angVelB.dot(ax1);
+
+		calculateJacobi(limot, transA, transB, info, srow, ax1, 1, rotAllowed);
+
+		info->m_constraintError[srow] = info->fps * limot->m_stopERP * limot->m_currentLimitError * -1;
+
+		if (info->m_constraintError[srow] - vel * limot->m_stopERP > 0)
+		{
+			btScalar bounceerror = -limot->m_bounce * vel;
+			if (bounceerror > info->m_constraintError[srow]) info->m_constraintError[srow] = bounceerror;
+		}
+
+		info->m_lowerLimit[srow] = 0;
+		info->m_upperLimit[srow] = SIMD_INFINITY;
+		info->cfm[srow] = limot->m_stopCFM;
+		srow += info->rowskip;
+		++count;
+
+
+		calculateJacobi(limot, transA, transB, info, srow, ax1, 1, rotAllowed);
+	
+		info->m_constraintError[srow] = info->fps * limot->m_stopERP * limot->m_currentLimitErrorHi * -1;
+
+		if (info->m_constraintError[srow] - vel * limot->m_stopERP < 0)
+		{
+			btScalar bounceerror = -limot->m_bounce * vel;
+			if (bounceerror < info->m_constraintError[srow]) info->m_constraintError[srow] = bounceerror;
+		}
+
+
+		info->m_lowerLimit[srow] = -SIMD_INFINITY;
+		info->m_upperLimit[srow] = 0;
+		info->cfm[srow] = limot->m_stopCFM;
+		srow += info->rowskip;
+		++count;
+	}
+	else if (limot->m_currentLimit == 3)
+	{
+
+		calculateJacobi(limot, transA, transB, info, srow, ax1, 1, rotAllowed);
+		info->m_constraintError[srow] = info->fps * limot->m_stopERP * limot->m_currentLimitError * -1;
+		info->m_lowerLimit[srow] = -SIMD_INFINITY;
+		info->m_upperLimit[srow] = SIMD_INFINITY;
+		info->cfm[srow] = limot->m_stopCFM;
+		srow += info->rowskip;
+		++count;
+	}
+
+	if (limot->m_enableMotor && !limot->m_servoMotor)
+	{
+
+		calculateJacobi(limot, transA, transB, info, srow, ax1, 1, rotAllowed);
+		btScalar tag_vel = limot->m_targetVelocity;
+		btScalar mot_fact = getMotorFactor(limot->m_currentPosition,
+										   limot->m_loLimit,
+										   limot->m_hiLimit,
+										   tag_vel,
+										   info->fps * limot->m_motorERP);
+		info->m_constraintError[srow] = mot_fact * limot->m_targetVelocity;
+		info->m_lowerLimit[srow] = -limot->m_maxMotorForce / info->fps;
+		info->m_upperLimit[srow] = limot->m_maxMotorForce / info->fps;
+		info->cfm[srow] = limot->m_motorCFM;
+		srow += info->rowskip;
+		++count;
+	}
+
+	if (limot->m_enableMotor && limot->m_servoMotor)
+	{
+		btScalar error = limot->m_currentPosition - limot->m_servoTarget;
+		btScalar curServoTarget = limot->m_servoTarget;
+
+		if (error > SIMD_PI)
+		{
+			error -= SIMD_2_PI;
+			curServoTarget += SIMD_2_PI;
+		}
+		if (error < -SIMD_PI)
+		{
+			error += SIMD_2_PI;
+			curServoTarget -= SIMD_2_PI;
+		}
+
+		calculateJacobi(limot, transA, transB, info, srow, ax1, 1, rotAllowed);
+		btScalar targetvelocity = error < 0 ? -limot->m_targetVelocity : limot->m_targetVelocity;
+		btScalar tag_vel = -targetvelocity;
+		btScalar mot_fact;
+		if (error != 0)
+		{
+			btScalar lowLimit;
+			btScalar hiLimit;
+			if (limot->m_loLimit > limot->m_hiLimit)
+			{
+				lowLimit = error > 0 ? curServoTarget : -SIMD_INFINITY;
+				hiLimit = error < 0 ? curServoTarget : SIMD_INFINITY;
+			}
+			else
+			{
+				lowLimit = error > 0 && curServoTarget > limot->m_loLimit ? curServoTarget : limot->m_loLimit;
+				hiLimit = error < 0 && curServoTarget < limot->m_hiLimit ? curServoTarget : limot->m_hiLimit;
+			}
+			mot_fact = getMotorFactor(limot->m_currentPosition, lowLimit, hiLimit, tag_vel, info->fps * limot->m_motorERP);
+		}
+		else
+		{
+			mot_fact = 0;
+		}
+
+		info->m_constraintError[srow] = mot_fact * targetvelocity * -1;
+		info->m_lowerLimit[srow] = -limot->m_maxMotorForce / info->fps;
+		info->m_upperLimit[srow] = limot->m_maxMotorForce / info->fps;
+		info->cfm[srow] = limot->m_motorCFM;
+		srow += info->rowskip;
+		++count;
+	}
+
+	if (limot->m_enableSpring)
+	{
+
+		btScalar error = vec_rotation_error_element;
+
+		calculateJacobi(limot, transA, transB, info, srow, ax1, 1, rotAllowed);
+
+		btScalar dt = BT_ONE / info->fps;
+		btScalar kd = limot->m_springDamping;
+		btScalar ks = limot->m_springStiffness;
+		btScalar vel;
+
+		vel = angVelA.dot(ax1) - angVelB.dot(ax1);
+
+		btScalar cfm = BT_ZERO;
+		btScalar mA = BT_ONE / m_rbA.getInvMass();
+		btScalar mB = BT_ONE / m_rbB.getInvMass();
+
+		btScalar rrA = (m_calculatedTransformA.getOrigin() - transA.getOrigin()).length2();
+		btScalar rrB = (m_calculatedTransformB.getOrigin() - transB.getOrigin()).length2();
+		if (m_rbA.getInvMass()) mA = mA * rrA + 1 / (m_rbA.getInvInertiaTensorWorld() * ax1).length();
+		if (m_rbB.getInvMass()) mB = mB * rrB + 1 / (m_rbB.getInvInertiaTensorWorld() * ax1).length();
+
+		btScalar m;
+		if (m_rbA.getInvMass() == 0)
+			m = mB;
+		else if (m_rbB.getInvMass() == 0)
+			m = mA;
+		else
+			m = mA * mB / (mA + mB);
+		btScalar angularfreq = btSqrt(ks / m);
+
+		if (limot->m_springStiffnessLimited && 0.25 < angularfreq * dt)
+		{
+			ks = BT_ONE / dt / dt / btScalar(16.0) * m;
+		}
+
+		if (limot->m_springDampingLimited && kd * dt > m)
+		{
+			kd = m / dt;
+		}
+		btScalar fs = ks * error * dt;
+		btScalar fd = -kd * (vel) * -1* dt;
+		btScalar f = (fs + fd);
+
+		if (m_flags & BT_6DOF_FLAGS_USE_INFINITE_ERROR)
+			info->m_constraintError[srow] = -1 * (f < 0 ? -SIMD_INFINITY : SIMD_INFINITY);
+		else
+			info->m_constraintError[srow] = vel + f / m * -1;
+
+
+		btScalar minf = f < fd ? f : fd;
+		btScalar maxf = f < fd ? fd : f;
+
+		info->m_lowerLimit[srow] = -maxf > 0 ? 0 : -maxf;
+		info->m_upperLimit[srow] = -minf < 0 ? 0 : -minf;
+
+		info->cfm[srow] = cfm;
+		srow += info->rowskip;
+		++count;
+	}
+
+	return count;
+}
+
+

--- a/thirdparty/bullet/BulletDynamics/ConstraintSolver/btGeneric6DofSpringConstraintQuaternion.h
+++ b/thirdparty/bullet/BulletDynamics/ConstraintSolver/btGeneric6DofSpringConstraintQuaternion.h
@@ -1,0 +1,83 @@
+/*
+Bullet Continuous Collision Detection and Physics Library
+Copyright (c) 2003-2006 Erwin Coumans  https://bulletphysics.org
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+
+
+///This file was created by PHOBOSS (Kim Obordo) on 2022 August 
+///The btGeneric6DofSpringConstraintQuaternion class is based on btGeneric6DofSpring2Constraint.
+///This class was made to provide more control over spring joint "equilibrium" rotation using quaternions instead of Euler Axes.
+///This makes it useful for "puppeteering" joint controlled active ragdolls.
+
+
+///4 May: btGeneric6DofSpring2Constraint is created from the original (2.82.2712) btGeneric6DofConstraint by Gabor Puhr and Tamas UmenhofferPros:
+///- Much more accurate and stable in a lot of situation. (Especially when a sleeping chain of RBs connected with 6dof2 is pulled)
+///- Stable and accurate spring with minimal energy loss that works with all of the solvers. (latter is not true for the original 6dof spring)
+///- Servo motor functionality
+///- Much more accurate bouncing. 0 really means zero bouncing (not true for the original 6odf) and there is only a minimal energy loss when the value is 1 (because of the solvers' precision)
+///- Rotation order for the Euler system can be set. (One axis' freedom is still limited to pi/2)
+///
+///Cons:
+///- It is slower than the original 6dof. There is no exact ratio, but half speed is a good estimation.
+///- At bouncing the correct velocity is calculated, but not the correct position. (it is because of the solver can correct position or velocity, but not both.)
+
+
+/// 2009 March: btGeneric6DofConstraint refactored by Roman Ponomarev
+/// Added support for generic constraint solver through getInfo1Q/getInfo2 methods
+
+
+///2007-09-09
+///btGeneric6DofConstraint Refactored by Francisco Le?n
+///email: projectileman@yahoo.com
+///http://gimpact.sf.net
+
+
+#ifndef BT_GENERIC_6DOF_CONSTRAINT_QUAT_H
+#define BT_GENERIC_6DOF_CONSTRAINT_QUAT_H
+
+#include "btGeneric6DofSpring2Constraint.h"
+#include "LinearMath/btVector3.h"
+#include "btJacobianEntry.h"
+#include "btTypedConstraint.h"
+
+#include "LinearMath/btQuaternion.h"
+
+ATTRIBUTE_ALIGNED16(class)
+btGeneric6DofSpringConstraintQuaternion : public btGeneric6DofSpring2Constraint{
+	public:
+		BT_DECLARE_ALIGNED_ALLOCATOR()
+		btGeneric6DofSpringConstraintQuaternion(btRigidBody & rbA, btRigidBody & rbB, const btTransform& frameInA, const btTransform& frameInB, RotateOrder rotOrder = RO_XYZ);
+		btGeneric6DofSpringConstraintQuaternion(btRigidBody & rbB, const btTransform& frameInB, RotateOrder rotOrder = RO_XYZ);
+		void getInfo2(btConstraintInfo2 * info);
+
+		void set_use_global_rotation(bool p_value);
+		bool get_use_global_rotation();
+
+		void set_use_quaternion_rotation_equilibrium(bool p_enable);
+		bool get_use_quaternion_rotation_equilibrium();
+		void set_quaternion_rotation_equilibrium(btQuaternion p_value);
+		btQuaternion get_quaternion_rotation_equilibrium();
+
+	protected:
+		bool using_global_rotation;
+		bool using_quaternion_rotation_equilibrium;
+		btQuaternion quaternion_rotation_equilibrium;
+		
+		int setAngularLimitsQuaternion(btConstraintInfo2 * info, int row_offset, const btTransform& transA, const btTransform& transB, const btVector3& linVelA, const btVector3& linVelB, const btVector3& angVelA, const btVector3& angVelB);
+		int get_limit_motor_info_quaternion(
+			btRotationalLimitMotor2 * limot,
+			const btTransform& transA, const btTransform& transB, const btVector3& linVelA, const btVector3& linVelB, const btVector3& angVelA, const btVector3& angVelB,
+			btConstraintInfo2* info, int row, btVector3& ax1, btScalar& vec_rotation_error_element, int rotAllowed = false);
+};
+#endif


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
# btGeneric6DofSpringConstraintQuaternion

Based on btGeneric6DofSpring2Constraint.
This class was made to provide more control over spring joint "equilibrium" rotation using quaternions instead of Euler Axes. This makes it useful for "puppeteering" joint controlled active ragdolls.



![image](https://user-images.githubusercontent.com/37253663/184157387-41127b6f-2db7-42a2-937c-4530f9d28fd3.png)

This was made in response to this feature request:
https://github.com/godotengine/godot-proposals/issues/3891

The implementation involved modifying the "Generic6DOFJoint" node to use btGeneric6DofSpringConstraintQuaternion instead of btGeneric6DofSpring2Constraint meaning no new nodes were added minimizing changes on how users would interact with the node.

Angle parameters are passed in just as before thru the "angular_spring_[x,y,z]/equilibrium_point" parameters.

Here is an example of its use:
![image](https://user-images.githubusercontent.com/37253663/184170333-9da68225-23bf-47fe-a93f-10745d63b101.png)

In the image above, note that the targetPosition(Slab(green)) is attached to a mesh node (point(blue)) rotated to the following degrees relative to the first RigidBody node(Pillar). A 6DOFJoint(Generic6DOFJoint2) is positioned where the "point" node is, connecting the two RigidBodies.

![image](https://user-images.githubusercontent.com/37253663/184162060-7135a5a1-0669-4491-9540-4010bce67af5.png)

Passing the mentioned set angles as angular equilibrium parameters to Generic6DOFJoint2, the joint acts accordingly and rotates the rigid bodies in a stable manner (depending on the set stiffness and damping parameters) to the desired expected position:

![image](https://user-images.githubusercontent.com/37253663/184164606-50da96a0-2daf-449a-a8a1-f4d56ead48cd.png)

compared to using the Euler axis based joint as before:
![image](https://user-images.githubusercontent.com/37253663/184169312-a74e739d-10e6-4ec5-bc65-704116de2662.png)
(you don't see it in the picture, but the whole thing is wiggling in game)


Here are some videos of the earlier prototypes:
(GDScript)
![image](https://user-images.githubusercontent.com/37253663/184158083-4d9be35d-6def-4bed-b3b7-2d92af31ff1e.png)
https://youtu.be/htMDZ0fXJWo

![image](https://user-images.githubusercontent.com/37253663/184158759-5d5aeb98-9511-48e2-970c-59c21cca124b.png)
https://youtu.be/pFo2pOIqcXs

![image](https://user-images.githubusercontent.com/37253663/184158932-b2a9e6e6-a3cf-4731-bceb-8b8d23d58d89.png)
https://youtu.be/m_vrJUQA_s8

![image](https://user-images.githubusercontent.com/37253663/184159205-735b2aac-c400-46a2-b42d-a5bf55db8c4c.png)
https://youtu.be/g4WuGlEvRG8


(C++ in Bullet Physics)
![image](https://user-images.githubusercontent.com/37253663/184158476-c7872096-a5c4-40f2-9467-031fa3956813.png)
https://youtu.be/EoKXfdmpNz0
I also made a pull request on the Bullet Physics Repo(Review Pending). I didn't want to wait so here it is.
