### PR TITLE
[ci] Allow skipping builds with [skip build]

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -15,6 +15,7 @@ jobs:
   android-template:
     runs-on: "ubuntu-20.04"
     name: Template (target=release, tools=no)
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -15,6 +15,7 @@ jobs:
   ios-template:
     runs-on: "macos-latest"
     name: Template (target=release, tools=no)
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -17,6 +17,7 @@ jobs:
   javascript-template:
     runs-on: "ubuntu-20.04"
     name: Template (target=release, tools=no)
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -15,6 +15,7 @@ jobs:
   build-linux:
     runs-on: "ubuntu-20.04"
     name: ${{ matrix.name }}
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
     strategy:
       fail-fast: false
       matrix:
@@ -195,8 +196,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot-cpp
-          submodules: 'recursive'
-          path: 'godot-cpp'
+          submodules: "recursive"
+          path: "godot-cpp"
 
       # Check extension API
       - name: Check for extension api updates

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -15,6 +15,7 @@ jobs:
   build-macos:
     runs-on: "macos-latest"
     name: ${{ matrix.name }}
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -18,6 +18,7 @@ jobs:
     # Windows 10 with latest image
     runs-on: "windows-latest"
     name: ${{ matrix.name }}
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +47,6 @@ jobs:
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
-
 
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps


### PR DESCRIPTION
When working with the XML doc files, we don't need to build everything with every PR (as discussed with @YuriSizov in #64164).

With this change, adding the text `[skip build]` to a commit message will skip the builds and just run the static checks. (You should see the results with the GitHub actions on this PR -- hmmm I know there are issues trying to change CI Actions with PRs - here's [my actions on this commit](https://github.com/asmaloney/godot/actions?query=branch%3Aci-skip-build++)).

This will save a lot of time working on the docs and also stop a lot of extra builds. No more waiting for a macOS instance to become available!