### PR TITLE
[doc] Use "param" instead of "code" to refer to parameters (4)

### DIFF
--- a/doc/classes/PCKPacker.xml
+++ b/doc/classes/PCKPacker.xml
@@ -30,14 +30,14 @@
 			<param index="1" name="source_path" type="String" />
 			<param index="2" name="encrypt" type="bool" default="false" />
 			<description>
-				Adds the [code]source_path[/code] file to the current PCK package at the [code]pck_path[/code] internal path (should start with [code]res://[/code]).
+				Adds the [param source_path] file to the current PCK package at the [param pck_path] internal path (should start with [code]res://[/code]).
 			</description>
 		</method>
 		<method name="flush">
 			<return type="int" enum="Error" />
 			<param index="0" name="verbose" type="bool" default="false" />
 			<description>
-				Writes the files specified using all [method add_file] calls since the last flush. If [code]verbose[/code] is [code]true[/code], a list of files added will be printed to the console for easier debugging.
+				Writes the files specified using all [method add_file] calls since the last flush. If [param verbose] is [code]true[/code], a list of files added will be printed to the console for easier debugging.
 			</description>
 		</method>
 		<method name="pck_start">
@@ -47,7 +47,7 @@
 			<param index="2" name="key" type="String" default="&quot;0000000000000000000000000000000000000000000000000000000000000000&quot;" />
 			<param index="3" name="encrypt_directory" type="bool" default="false" />
 			<description>
-				Creates a new PCK file with the name [code]pck_name[/code]. The [code].pck[/code] file extension isn't added automatically, so it should be part of [code]pck_name[/code] (even though it's not required).
+				Creates a new PCK file with the name [param pck_name]. The [code].pck[/code] file extension isn't added automatically, so it should be part of [param pck_name] (even though it's not required).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -50,7 +50,7 @@
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -159,7 +159,7 @@
 			<param index="0" name="buffer_size" type="int" />
 			<param index="1" name="compression_mode" type="int" default="0" />
 			<description>
-				Returns a new [PackedByteArray] with the data decompressed. Set [code]buffer_size[/code] to the size of the uncompressed data. Set the compression mode using one of [enum File.CompressionMode]'s constants.
+				Returns a new [PackedByteArray] with the data decompressed. Set [param buffer_size] to the size of the uncompressed data. Set the compression mode using one of [enum File.CompressionMode]'s constants.
 			</description>
 		</method>
 		<method name="decompress_dynamic" qualifiers="const">
@@ -169,7 +169,7 @@
 			<description>
 				Returns a new [PackedByteArray] with the data decompressed. Set the compression mode using one of [enum File.CompressionMode]'s constants. [b]This method only accepts gzip and deflate compression modes.[/b]
 				This method is potentially slower than [code]decompress[/code], as it may have to re-allocate its output buffer multiple times while decompressing, whereas [code]decompress[/code] knows it's output buffer size from the beginning.
-				GZIP has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via [code]max_output_size[/code]. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.
+				GZIP has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via [param max_output_size]. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.
 			</description>
 		</method>
 		<method name="duplicate">
@@ -306,7 +306,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="int" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="has_encoded_var" qualifiers="const">
@@ -400,9 +400,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedByteArray], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedByteArray].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedByteArray], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedByteArray].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -50,7 +50,7 @@
 			<param index="0" name="value" type="Color" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -92,7 +92,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="Color" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="insert">
@@ -163,9 +163,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedColorArray], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedColorArray].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedColorArray], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedColorArray].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -51,7 +51,7 @@
 			<param index="0" name="value" type="float" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -93,7 +93,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="float" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="insert">
@@ -164,9 +164,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedFloat32Array], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedFloat32Array].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedFloat32Array], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedFloat32Array].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -51,7 +51,7 @@
 			<param index="0" name="value" type="float" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -93,7 +93,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="float" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="insert">
@@ -164,9 +164,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedFloat64Array], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedFloat64Array].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedFloat64Array], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedFloat64Array].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -51,7 +51,7 @@
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -93,7 +93,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="int" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="insert">
@@ -164,9 +164,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedInt32Array], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedInt32Array].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedInt32Array], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedInt32Array].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -51,7 +51,7 @@
 			<param index="0" name="value" type="int" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -93,7 +93,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="int" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="insert">
@@ -164,9 +164,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedInt64Array], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedInt64Array].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedInt64Array], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedInt64Array].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -57,7 +57,7 @@
 			<param index="0" name="value" type="String" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -99,7 +99,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="String" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="insert">
@@ -170,9 +170,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedStringArray], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedStringArray].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedStringArray], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedStringArray].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -51,7 +51,7 @@
 			<param index="0" name="value" type="Vector2" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -93,7 +93,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="Vector2" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="insert">
@@ -164,9 +164,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedVector2Array], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedVector2Array].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedVector2Array], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedVector2Array].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -50,7 +50,7 @@
 			<param index="0" name="value" type="Vector3" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -92,7 +92,7 @@
 			<return type="bool" />
 			<param index="0" name="value" type="Vector3" />
 			<description>
-				Returns [code]true[/code] if the array contains [code]value[/code].
+				Returns [code]true[/code] if the array contains [param value].
 			</description>
 		</method>
 		<method name="insert">
@@ -163,9 +163,9 @@
 			<param index="0" name="begin" type="int" />
 			<param index="1" name="end" type="int" default="2147483647" />
 			<description>
-				Returns the slice of the [PackedVector3Array], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [PackedVector3Array].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				Returns the slice of the [PackedVector3Array], from [param begin] (inclusive) to [param end] (exclusive), as a new [PackedVector3Array].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
 			</description>
 		</method>
 		<method name="sort">

--- a/doc/classes/PacketPeer.xml
+++ b/doc/classes/PacketPeer.xml
@@ -32,7 +32,7 @@
 			<return type="Variant" />
 			<param index="0" name="allow_objects" type="bool" default="false" />
 			<description>
-				Gets a Variant. If [code]allow_objects[/code] is [code]true[/code], decoding objects is allowed.
+				Gets a Variant. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
@@ -48,7 +48,7 @@
 			<param index="0" name="var" type="Variant" />
 			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
-				Sends a [Variant] as a packet. If [code]full_objects[/code] is [code]true[/code], encoding objects is allowed (and can potentially include code).
+				Sends a [Variant] as a packet. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PacketPeerDTLS.xml
+++ b/doc/classes/PacketPeerDTLS.xml
@@ -18,7 +18,7 @@
 			<param index="2" name="for_hostname" type="String" default="&quot;&quot;" />
 			<param index="3" name="valid_certificate" type="X509Certificate" default="null" />
 			<description>
-				Connects a [code]peer[/code] beginning the DTLS handshake using the underlying [PacketPeerUDP] which must be connected (see [method PacketPeerUDP.connect_to_host]). If [code]validate_certs[/code] is [code]true[/code], [PacketPeerDTLS] will validate that the certificate presented by the remote peer and match it with the [code]for_hostname[/code] argument. You can specify a custom [X509Certificate] to use for validation via the [code]valid_certificate[/code] argument.
+				Connects a [param packet_peer] beginning the DTLS handshake using the underlying [PacketPeerUDP] which must be connected (see [method PacketPeerUDP.connect_to_host]). If [param validate_certs] is [code]true[/code], [PacketPeerDTLS] will validate that the certificate presented by the remote peer and match it with the [param for_hostname] argument. You can specify a custom [X509Certificate] to use for validation via the [param valid_certificate] argument.
 			</description>
 		</method>
 		<method name="disconnect_from_peer">

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -16,10 +16,10 @@
 			<param index="1" name="bind_address" type="String" default="&quot;*&quot;" />
 			<param index="2" name="recv_buf_size" type="int" default="65536" />
 			<description>
-				Binds this [PacketPeerUDP] to the specified [code]port[/code] and [code]address[/code] with a buffer size [code]recv_buf_size[/code], allowing it to receive incoming packets.
-				If [code]address[/code] is set to [code]"*"[/code] (default), the peer will be bound on all available addresses (both IPv4 and IPv6).
-				If [code]address[/code] is set to [code]"0.0.0.0"[/code] (for IPv4) or [code]"::"[/code] (for IPv6), the peer will be bound to all available addresses matching that IP type.
-				If [code]address[/code] is set to any valid address (e.g. [code]"192.168.1.101"[/code], [code]"::1"[/code], etc), the peer will only be bound to the interface with that addresses (or fail if no interface with the given address exists).
+				Binds this [PacketPeerUDP] to the specified [param port] and [param bind_address] with a buffer size [param recv_buf_size], allowing it to receive incoming packets.
+				If [param bind_address] is set to [code]"*"[/code] (default), the peer will be bound on all available addresses (both IPv4 and IPv6).
+				If [param bind_address] is set to [code]"0.0.0.0"[/code] (for IPv4) or [code]"::"[/code] (for IPv6), the peer will be bound to all available addresses matching that IP type.
+				If [param bind_address] is set to any valid address (e.g. [code]"192.168.1.101"[/code], [code]"::1"[/code], etc), the peer will only be bound to the interface with that addresses (or fail if no interface with the given address exists).
 			</description>
 		</method>
 		<method name="close">
@@ -33,7 +33,7 @@
 			<param index="0" name="host" type="String" />
 			<param index="1" name="port" type="int" />
 			<description>
-				Calling this method connects this UDP peer to the given [code]host[/code]/[code]port[/code] pair. UDP is in reality connectionless, so this option only means that incoming packets from different addresses are automatically discarded, and that outgoing packets are always sent to the connected address (future calls to [method set_dest_address] are not allowed). This method does not send any data to the remote peer, to do that, use [method PacketPeer.put_var] or [method PacketPeer.put_packet] as usual. See also [UDPServer].
+				Calling this method connects this UDP peer to the given [param host]/[param port] pair. UDP is in reality connectionless, so this option only means that incoming packets from different addresses are automatically discarded, and that outgoing packets are always sent to the connected address (future calls to [method set_dest_address] are not allowed). This method does not send any data to the remote peer, to do that, use [method PacketPeer.put_var] or [method PacketPeer.put_packet] as usual. See also [UDPServer].
 				[b]Note:[/b] Connecting to the remote peer does not help to protect from malicious attacks like IP spoofing, etc. Think about using an encryption technique like SSL or DTLS if you feel like your application is transferring sensitive information.
 			</description>
 		</method>
@@ -72,7 +72,7 @@
 			<param index="0" name="multicast_address" type="String" />
 			<param index="1" name="interface_name" type="String" />
 			<description>
-				Joins the multicast group specified by [code]multicast_address[/code] using the interface identified by [code]interface_name[/code].
+				Joins the multicast group specified by [param multicast_address] using the interface identified by [param interface_name].
 				You can join the same multicast group with multiple interfaces. Use [method IP.get_local_interfaces] to know which are available.
 				[b]Note:[/b] Some Android devices might require the [code]CHANGE_WIFI_MULTICAST_STATE[/code] permission for multicast to work.
 			</description>
@@ -82,7 +82,7 @@
 			<param index="0" name="multicast_address" type="String" />
 			<param index="1" name="interface_name" type="String" />
 			<description>
-				Removes the interface identified by [code]interface_name[/code] from the multicast group specified by [code]multicast_address[/code].
+				Removes the interface identified by [param interface_name] from the multicast group specified by [param multicast_address].
 			</description>
 		</method>
 		<method name="set_broadcast_enabled">

--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -19,7 +19,7 @@
 			<param index="1" name="callable" type="Callable" />
 			<param index="2" name="arguments" type="Array" default="[]" />
 			<description>
-				Adds a custom monitor with the name [code]id[/code]. You can specify the category of the monitor using slash delimiters in [code]id[/code] (for example: [code]"Game/NumberOfNPCs"[/code]). If there is more than one slash delimiter, then the default category is used. The default category is [code]"Custom"[/code]. Prints an error if given [code]id[/code] is already present.
+				Adds a custom monitor with the name [param id]. You can specify the category of the monitor using slash delimiters in [param id] (for example: [code]"Game/NumberOfNPCs"[/code]). If there is more than one slash delimiter, then the default category is used. The default category is [code]"Custom"[/code]. Prints an error if given [param id] is already present.
 				[codeblocks]
 				[gdscript]
 				func _ready():
@@ -75,7 +75,7 @@
 			<return type="Variant" />
 			<param index="0" name="id" type="StringName" />
 			<description>
-				Returns the value of custom monitor with given [code]id[/code]. The callable is called to get the value of custom monitor. See also [method has_custom_monitor]. Prints an error if the given [code]id[/code] is absent.
+				Returns the value of custom monitor with given [param id]. The callable is called to get the value of custom monitor. See also [method has_custom_monitor]. Prints an error if the given [param id] is absent.
 			</description>
 		</method>
 		<method name="get_custom_monitor_names">
@@ -110,14 +110,14 @@
 			<return type="bool" />
 			<param index="0" name="id" type="StringName" />
 			<description>
-				Returns [code]true[/code] if custom monitor with the given [code]id[/code] is present, [code]false[/code] otherwise.
+				Returns [code]true[/code] if custom monitor with the given [param id] is present, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="remove_custom_monitor">
 			<return type="void" />
 			<param index="0" name="id" type="StringName" />
 			<description>
-				Removes the custom monitor with given [code]id[/code]. Prints an error if the given [code]id[/code] is already absent.
+				Removes the custom monitor with given [param id]. Prints an error if the given [param id] is already absent.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsBody2D.xml
+++ b/doc/classes/PhysicsBody2D.xml
@@ -29,10 +29,10 @@
 			<param index="1" name="test_only" type="bool" default="false" />
 			<param index="2" name="safe_margin" type="float" default="0.08" />
 			<description>
-				Moves the body along the vector [code]distance[/code]. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [code]distance[/code] should be computed using [code]delta[/code].
+				Moves the body along the vector [param distance]. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [param distance] should be computed using [code]delta[/code].
 				Returns a [KinematicCollision2D], which contains information about the collision when stopped, or when touching another body along the motion.
-				If [code]test_only[/code] is [code]true[/code], the body does not move but the would-be collision information is given.
-				[code]safe_margin[/code] is the extra margin used for collision recovery (see [member CharacterBody2D.collision/safe_margin] for more details).
+				If [param test_only] is [code]true[/code], the body does not move but the would-be collision information is given.
+				[param safe_margin] is the extra margin used for collision recovery (see [member CharacterBody2D.collision/safe_margin] for more details).
 			</description>
 		</method>
 		<method name="remove_collision_exception_with">
@@ -49,10 +49,10 @@
 			<param index="2" name="collision" type="KinematicCollision2D" default="null" />
 			<param index="3" name="safe_margin" type="float" default="0.08" />
 			<description>
-				Checks for collisions without moving the body. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [code]distance[/code] should be computed using [code]delta[/code].
-				Virtually sets the node's position, scale and rotation to that of the given [Transform2D], then tries to move the body along the vector [code]distance[/code]. Returns [code]true[/code] if a collision would stop the body from moving along the whole path.
-				[code]collision[/code] is an optional object of type [KinematicCollision2D], which contains additional information about the collision when stopped, or when touching another body along the motion.
-				[code]safe_margin[/code] is the extra margin used for collision recovery (see [member CharacterBody2D.collision/safe_margin] for more details).
+				Checks for collisions without moving the body. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [param distance] should be computed using [code]delta[/code].
+				Virtually sets the node's position, scale and rotation to that of the given [Transform2D], then tries to move the body along the vector [param distance]. Returns [code]true[/code] if a collision would stop the body from moving along the whole path.
+				[param collision] is an optional object of type [KinematicCollision2D], which contains additional information about the collision when stopped, or when touching another body along the motion.
+				[param safe_margin] is the extra margin used for collision recovery (see [member CharacterBody2D.collision/safe_margin] for more details).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsBody3D.xml
+++ b/doc/classes/PhysicsBody3D.xml
@@ -21,7 +21,7 @@
 			<return type="bool" />
 			<param index="0" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
 			<description>
-				Returns [code]true[/code] if the specified linear or rotational [code]axis[/code] is locked.
+				Returns [code]true[/code] if the specified linear or rotational [param axis] is locked.
 			</description>
 		</method>
 		<method name="get_collision_exceptions">
@@ -37,11 +37,11 @@
 			<param index="2" name="safe_margin" type="float" default="0.001" />
 			<param index="3" name="max_collisions" type="int" default="1" />
 			<description>
-				Moves the body along the vector [code]distance[/code]. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [code]distance[/code] should be computed using [code]delta[/code].
+				Moves the body along the vector [param distance]. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [param distance] should be computed using [code]delta[/code].
 				The body will stop if it collides. Returns a [KinematicCollision3D], which contains information about the collision when stopped, or when touching another body along the motion.
-				If [code]test_only[/code] is [code]true[/code], the body does not move but the would-be collision information is given.
-				[code]safe_margin[/code] is the extra margin used for collision recovery (see [member CharacterBody3D.collision/safe_margin] for more details).
-				[code]max_collisions[/code] allows to retrieve more than one collision result.
+				If [param test_only] is [code]true[/code], the body does not move but the would-be collision information is given.
+				[param safe_margin] is the extra margin used for collision recovery (see [member CharacterBody3D.collision/safe_margin] for more details).
+				[param max_collisions] allows to retrieve more than one collision result.
 			</description>
 		</method>
 		<method name="remove_collision_exception_with">
@@ -56,7 +56,7 @@
 			<param index="0" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
 			<param index="1" name="lock" type="bool" />
 			<description>
-				Locks or unlocks the specified linear or rotational [code]axis[/code] depending on the value of [code]lock[/code].
+				Locks or unlocks the specified linear or rotational [param axis] depending on the value of [param lock].
 			</description>
 		</method>
 		<method name="test_move">
@@ -67,11 +67,11 @@
 			<param index="3" name="safe_margin" type="float" default="0.001" />
 			<param index="4" name="max_collisions" type="int" default="1" />
 			<description>
-				Checks for collisions without moving the body. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [code]distance[/code] should be computed using [code]delta[/code].
-				Virtually sets the node's position, scale and rotation to that of the given [Transform3D], then tries to move the body along the vector [code]distance[/code]. Returns [code]true[/code] if a collision would stop the body from moving along the whole path.
-				[code]collision[/code] is an optional object of type [KinematicCollision3D], which contains additional information about the collision when stopped, or when touching another body along the motion.
-				[code]safe_margin[/code] is the extra margin used for collision recovery (see [member CharacterBody3D.collision/safe_margin] for more details).
-				[code]max_collisions[/code] allows to retrieve more than one collision result.
+				Checks for collisions without moving the body. In order to be frame rate independent in [method Node._physics_process] or [method Node._process], [param distance] should be computed using [code]delta[/code].
+				Virtually sets the node's position, scale and rotation to that of the given [Transform3D], then tries to move the body along the vector [param distance]. Returns [code]true[/code] if a collision would stop the body from moving along the whole path.
+				[param collision] is an optional object of type [KinematicCollision3D], which contains additional information about the collision when stopped, or when touching another body along the motion.
+				[param safe_margin] is the extra margin used for collision recovery (see [member CharacterBody3D.collision/safe_margin] for more details).
+				[param max_collisions] allows to retrieve more than one collision result.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -25,7 +25,7 @@
 			<param index="1" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
 				Adds a constant positioned force to the body that keeps being applied over time until cleared with [code]constant_force = Vector2(0, 0)[/code].
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="add_constant_torque">
@@ -58,7 +58,7 @@
 			<param index="1" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
 				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="apply_impulse">
@@ -68,7 +68,7 @@
 			<description>
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="apply_torque">

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -25,7 +25,7 @@
 			<param index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)" />
 			<description>
 				Adds a constant positioned force to the body that keeps being applied over time until cleared with [code]constant_force = Vector3(0, 0, 0)[/code].
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="add_constant_torque">
@@ -58,7 +58,7 @@
 			<param index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)" />
 			<description>
 				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="apply_impulse">
@@ -68,7 +68,7 @@
 			<description>
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="apply_torque">

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -53,7 +53,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				The number of intersections can be limited with the [code]max_results[/code] parameter, to reduce the processing time.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 				[b]Note:[/b] [ConcavePolygonShape2D]s and [CollisionPolygon2D]s in [code]Segments[/code] build mode are not solid shapes. Therefore, they will not be detected.
 			</description>
 		</method>
@@ -81,7 +81,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				The number of intersections can be limited with the [code]max_results[/code] parameter, to reduce the processing time.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -55,7 +55,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				The number of intersections can be limited with the [code]max_results[/code] parameter, to reduce the processing time.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 			</description>
 		</method>
 		<method name="intersect_ray">
@@ -82,7 +82,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				The number of intersections can be limited with the [code]max_results[/code] parameter, to reduce the processing time.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object.
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -232,7 +232,7 @@
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
 				Adds a constant positioned force to the body that keeps being applied over time until cleared with [code]body_set_constant_force(body, Vector2(0, 0))[/code].
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="body_add_constant_torque">
@@ -279,7 +279,7 @@
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
 				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="body_apply_impulse">
@@ -290,7 +290,7 @@
 			<description>
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="body_apply_torque">
@@ -597,7 +597,7 @@
 			<param index="2" name="enable" type="bool" />
 			<param index="3" name="margin" type="float" />
 			<description>
-				Enables one way collision on body if [code]enable[/code] is [code]true[/code].
+				Enables one way collision on body if [param enable] is [code]true[/code].
 			</description>
 		</method>
 		<method name="body_set_shape_disabled">
@@ -606,7 +606,7 @@
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
-				Disables shape in body if [code]disable[/code] is [code]true[/code].
+				Disables shape in body if [param disabled] is [code]true[/code].
 			</description>
 		</method>
 		<method name="body_set_shape_transform">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -226,7 +226,7 @@
 			<param index="2" name="position" type="Vector3" default="Vector3(0, 0, 0)" />
 			<description>
 				Adds a constant positioned force to the body that keeps being applied over time until cleared with [code]body_set_constant_force(body, Vector3(0, 0, 0))[/code].
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="body_add_constant_torque">
@@ -273,7 +273,7 @@
 			<param index="2" name="position" type="Vector3" default="Vector3(0, 0, 0)" />
 			<description>
 				Applies a positioned force to the body. A force is time dependent and meant to be applied every physics update.
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="body_apply_impulse">
@@ -284,7 +284,7 @@
 			<description>
 				Applies a positioned impulse to the body.
 				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
-				[code]position[/code] is the offset from the body origin in global coordinates.
+				[param position] is the offset from the body origin in global coordinates.
 			</description>
 		</method>
 		<method name="body_apply_torque">
@@ -582,7 +582,7 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Sets the body pickable with rays if [code]enabled[/code] is set.
+				Sets the body pickable with rays if [param enable] is set.
 			</description>
 		</method>
 		<method name="body_set_shape">

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -30,7 +30,7 @@
 			<param index="2" name="c" type="float" />
 			<param index="3" name="d" type="float" />
 			<description>
-				Creates a plane from the four parameters. The three components of the resulting plane's [member normal] are [code]a[/code], [code]b[/code] and [code]c[/code], and the plane has a distance of [code]d[/code] from the origin.
+				Creates a plane from the four parameters. The three components of the resulting plane's [member normal] are [param a], [param b] and [param c], and the plane has a distance of [param d] from the origin.
 			</description>
 		</constructor>
 		<constructor name="Plane">
@@ -77,7 +77,7 @@
 			<return type="float" />
 			<param index="0" name="point" type="Vector3" />
 			<description>
-				Returns the shortest distance from the plane to the position [code]point[/code]. If the point is above the plane, the distance will be positive. If below, the distance will be negative.
+				Returns the shortest distance from the plane to the position [param point]. If the point is above the plane, the distance will be positive. If below, the distance will be negative.
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">
@@ -85,7 +85,7 @@
 			<param index="0" name="point" type="Vector3" />
 			<param index="1" name="tolerance" type="float" default="1e-05" />
 			<description>
-				Returns [code]true[/code] if [code]point[/code] is inside the plane. Comparison uses a custom minimum [code]tolerance[/code] threshold.
+				Returns [code]true[/code] if [param point] is inside the plane. Comparison uses a custom minimum [param tolerance] threshold.
 			</description>
 		</method>
 		<method name="intersect_3" qualifiers="const">
@@ -93,7 +93,7 @@
 			<param index="0" name="b" type="Plane" />
 			<param index="1" name="c" type="Plane" />
 			<description>
-				Returns the intersection point of the three planes [code]b[/code], [code]c[/code] and this plane. If no intersection is found, [code]null[/code] is returned.
+				Returns the intersection point of the three planes [param b], [param c] and this plane. If no intersection is found, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="intersects_ray" qualifiers="const">
@@ -101,7 +101,7 @@
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="dir" type="Vector3" />
 			<description>
-				Returns the intersection point of a ray consisting of the position [code]from[/code] and the direction normal [code]dir[/code] with this plane. If no intersection is found, [code]null[/code] is returned.
+				Returns the intersection point of a ray consisting of the position [param from] and the direction normal [param dir] with this plane. If no intersection is found, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="intersects_segment" qualifiers="const">
@@ -109,21 +109,21 @@
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="to" type="Vector3" />
 			<description>
-				Returns the intersection point of a segment from position [code]from[/code] to position [code]to[/code] with this plane. If no intersection is found, [code]null[/code] is returned.
+				Returns the intersection point of a segment from position [param from] to position [param to] with this plane. If no intersection is found, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="is_equal_approx" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="to_plane" type="Plane" />
 			<description>
-				Returns [code]true[/code] if this plane and [code]plane[/code] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
+				Returns [code]true[/code] if this plane and [param to_plane] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
 			</description>
 		</method>
 		<method name="is_point_over" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector3" />
 			<description>
-				Returns [code]true[/code] if [code]point[/code] is located above the plane.
+				Returns [code]true[/code] if [param point] is located above the plane.
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">
@@ -136,7 +136,7 @@
 			<return type="Vector3" />
 			<param index="0" name="point" type="Vector3" />
 			<description>
-				Returns the orthogonal projection of [code]point[/code] into a point in the plane.
+				Returns the orthogonal projection of [param point] into a point in the plane.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -14,7 +14,7 @@
 			<param index="0" name="path" type="NodePath" />
 			<param index="1" name="weights" type="PackedFloat32Array" />
 			<description>
-				Adds a bone with the specified [code]path[/code] and [code]weights[/code].
+				Adds a bone with the specified [param path] and [param weights].
 			</description>
 		</method>
 		<method name="clear_bones">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -19,8 +19,8 @@
 			<param index="1" name="id" type="int" default="-1" />
 			<param index="2" name="accel" type="int" enum="Key" default="0" />
 			<description>
-				Adds a new checkable item with text [code]label[/code].
-				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
+				Adds a new checkable item with text [param label].
+				An [param id] can optionally be provided, as well as an accelerator ([param accel]). If no [param id] is provided, one will be created from the index. If no [param accel] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
 				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method set_item_checked] for more info on how to control it.
 			</description>
 		</method>
@@ -31,7 +31,7 @@
 			<param index="2" name="global" type="bool" default="false" />
 			<description>
 				Adds a new checkable item and assigns the specified [Shortcut] to it. Sets the label of the checkbox to the [Shortcut]'s name.
-				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
+				An [param id] can optionally be provided. If no [param id] is provided, one will be created from the index.
 				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method set_item_checked] for more info on how to control it.
 			</description>
 		</method>
@@ -42,8 +42,8 @@
 			<param index="2" name="id" type="int" default="-1" />
 			<param index="3" name="accel" type="int" enum="Key" default="0" />
 			<description>
-				Adds a new checkable item with text [code]label[/code] and icon [code]texture[/code].
-				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
+				Adds a new checkable item with text [param label] and icon [param texture].
+				An [param id] can optionally be provided, as well as an accelerator ([param accel]). If no [param id] is provided, one will be created from the index. If no [param accel] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
 				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method set_item_checked] for more info on how to control it.
 			</description>
 		</method>
@@ -54,8 +54,8 @@
 			<param index="2" name="id" type="int" default="-1" />
 			<param index="3" name="global" type="bool" default="false" />
 			<description>
-				Adds a new checkable item and assigns the specified [Shortcut] and icon [code]texture[/code] to it. Sets the label of the checkbox to the [Shortcut]'s name.
-				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
+				Adds a new checkable item and assigns the specified [Shortcut] and icon [param texture] to it. Sets the label of the checkbox to the [Shortcut]'s name.
+				An [param id] can optionally be provided. If no [param id] is provided, one will be created from the index.
 				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method set_item_checked] for more info on how to control it.
 			</description>
 		</method>
@@ -66,8 +66,8 @@
 			<param index="2" name="id" type="int" default="-1" />
 			<param index="3" name="accel" type="int" enum="Key" default="0" />
 			<description>
-				Adds a new item with text [code]label[/code] and icon [code]texture[/code].
-				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
+				Adds a new item with text [param label] and icon [param texture].
+				An [param id] can optionally be provided, as well as an accelerator ([param accel]). If no [param id] is provided, one will be created from the index. If no [param accel] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
 			</description>
 		</method>
 		<method name="add_icon_radio_check_item">
@@ -97,8 +97,8 @@
 			<param index="2" name="id" type="int" default="-1" />
 			<param index="3" name="global" type="bool" default="false" />
 			<description>
-				Adds a new item and assigns the specified [Shortcut] and icon [code]texture[/code] to it. Sets the label of the checkbox to the [Shortcut]'s name.
-				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
+				Adds a new item and assigns the specified [Shortcut] and icon [param texture] to it. Sets the label of the checkbox to the [Shortcut]'s name.
+				An [param id] can optionally be provided. If no [param id] is provided, one will be created from the index.
 			</description>
 		</method>
 		<method name="add_item">
@@ -107,9 +107,9 @@
 			<param index="1" name="id" type="int" default="-1" />
 			<param index="2" name="accel" type="int" enum="Key" default="0" />
 			<description>
-				Adds a new item with text [code]label[/code].
-				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
-				[b]Note:[/b] The provided [code]id[/code] is used only in [signal id_pressed] and [signal id_focused] signals. It's not related to the [code]index[/code] arguments in e.g. [method set_item_checked].
+				Adds a new item with text [param label].
+				An [param id] can optionally be provided, as well as an accelerator ([param accel]). If no [param id] is provided, one will be created from the index. If no [param accel] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
+				[b]Note:[/b] The provided [param id] is used only in [signal id_pressed] and [signal id_focused] signals. It's not related to the [code]index[/code] arguments in e.g. [method set_item_checked].
 			</description>
 		</method>
 		<method name="add_multistate_item">
@@ -120,9 +120,9 @@
 			<param index="3" name="id" type="int" default="-1" />
 			<param index="4" name="accel" type="int" enum="Key" default="0" />
 			<description>
-				Adds a new multistate item with text [code]label[/code].
-				Contrarily to normal binary items, multistate items can have more than two states, as defined by [code]max_states[/code]. Each press or activate of the item will increase the state by one. The default value is defined by [code]default_state[/code].
-				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
+				Adds a new multistate item with text [param label].
+				Contrarily to normal binary items, multistate items can have more than two states, as defined by [param max_states]. Each press or activate of the item will increase the state by one. The default value is defined by [param default_state].
+				An [param id] can optionally be provided, as well as an accelerator ([param accel]). If no [param id] is provided, one will be created from the index. If no [param accel] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
 			</description>
 		</method>
 		<method name="add_radio_check_item">
@@ -131,8 +131,8 @@
 			<param index="1" name="id" type="int" default="-1" />
 			<param index="2" name="accel" type="int" enum="Key" default="0" />
 			<description>
-				Adds a new radio check button with text [code]label[/code].
-				An [code]id[/code] can optionally be provided, as well as an accelerator ([code]accel[/code]). If no [code]id[/code] is provided, one will be created from the index. If no [code]accel[/code] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
+				Adds a new radio check button with text [param label].
+				An [param id] can optionally be provided, as well as an accelerator ([param accel]). If no [param id] is provided, one will be created from the index. If no [param accel] is provided then the default [code]0[/code] will be assigned to it. See [method get_item_accelerator] for more info on accelerators.
 				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method set_item_checked] for more info on how to control it.
 			</description>
 		</method>
@@ -143,7 +143,7 @@
 			<param index="2" name="global" type="bool" default="false" />
 			<description>
 				Adds a new radio check button and assigns a [Shortcut] to it. Sets the label of the checkbox to the [Shortcut]'s name.
-				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
+				An [param id] can optionally be provided. If no [param id] is provided, one will be created from the index.
 				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method set_item_checked] for more info on how to control it.
 			</description>
 		</method>
@@ -152,8 +152,8 @@
 			<param index="0" name="label" type="String" default="&quot;&quot;" />
 			<param index="1" name="id" type="int" default="-1" />
 			<description>
-				Adds a separator between items. Separators also occupy an index, which you can set by using the [code]id[/code] parameter.
-				A [code]label[/code] can optionally be provided, which will appear at the center of the separator.
+				Adds a separator between items. Separators also occupy an index, which you can set by using the [param id] parameter.
+				A [param label] can optionally be provided, which will appear at the center of the separator.
 			</description>
 		</method>
 		<method name="add_shortcut">
@@ -163,7 +163,7 @@
 			<param index="2" name="global" type="bool" default="false" />
 			<description>
 				Adds a [Shortcut].
-				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
+				An [param id] can optionally be provided. If no [param id] is provided, one will be created from the index.
 			</description>
 		</method>
 		<method name="add_submenu_item">
@@ -172,8 +172,8 @@
 			<param index="1" name="submenu" type="String" />
 			<param index="2" name="id" type="int" default="-1" />
 			<description>
-				Adds an item that will act as a submenu of the parent [PopupMenu] node when clicked. The [code]submenu[/code] argument is the name of the child [PopupMenu] node that will be shown when the item is clicked.
-				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
+				Adds an item that will act as a submenu of the parent [PopupMenu] node when clicked. The [param submenu] argument is the name of the child [PopupMenu] node that will be shown when the item is clicked.
+				An [param id] can optionally be provided. If no [param id] is provided, one will be created from the index.
 			</description>
 		</method>
 		<method name="clear">
@@ -192,35 +192,35 @@
 			<return type="int" enum="Key" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the accelerator of the item at the given [code]index[/code]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
+				Returns the accelerator of the item at the given [param index]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
 			</description>
 		</method>
 		<method name="get_item_horizontal_offset" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the horizontal offset of the item at the given [code]index[/code].
+				Returns the horizontal offset of the item at the given [param index].
 			</description>
 		</method>
 		<method name="get_item_icon" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the icon of the item at the given [code]index[/code].
+				Returns the icon of the item at the given [param index].
 			</description>
 		</method>
 		<method name="get_item_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the id of the item at the given [code]index[/code]. [code]id[/code] can be manually assigned, while index can not.
+				Returns the id of the item at the given [param index]. [code]id[/code] can be manually assigned, while index can not.
 			</description>
 		</method>
 		<method name="get_item_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns the index of the item containing the specified [code]id[/code]. Index is automatically assigned to each item by the engine and can not be set manually.
+				Returns the index of the item containing the specified [param id]. Index is automatically assigned to each item by the engine and can not be set manually.
 			</description>
 		</method>
 		<method name="get_item_language" qualifiers="const">
@@ -241,21 +241,21 @@
 			<return type="Shortcut" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the [Shortcut] associated with the item at the given [code]index[/code].
+				Returns the [Shortcut] associated with the item at the given [param index].
 			</description>
 		</method>
 		<method name="get_item_submenu" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the submenu name of the item at the given [code]index[/code]. See [method add_submenu_item] for more info on how to add a submenu.
+				Returns the submenu name of the item at the given [param index]. See [method add_submenu_item] for more info on how to add a submenu.
 			</description>
 		</method>
 		<method name="get_item_text" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the text of the item at the given [code]index[/code].
+				Returns the text of the item at the given [param index].
 			</description>
 		</method>
 		<method name="get_item_text_direction" qualifiers="const">
@@ -269,14 +269,14 @@
 			<return type="String" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the tooltip associated with the item at the given [code]index[/code].
+				Returns the tooltip associated with the item at the given [param index].
 			</description>
 		</method>
 		<method name="is_item_checkable" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at the given [code]index[/code] is checkable in some way, i.e. if it has a checkbox or radio button.
+				Returns [code]true[/code] if the item at the given [param index] is checkable in some way, i.e. if it has a checkbox or radio button.
 				[b]Note:[/b] Checkable items just display a checkmark or radio button, but don't have any built-in checking behavior and must be checked/unchecked manually.
 			</description>
 		</method>
@@ -284,14 +284,14 @@
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at the given [code]index[/code] is checked.
+				Returns [code]true[/code] if the item at the given [param index] is checked.
 			</description>
 		</method>
 		<method name="is_item_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at the given [code]index[/code] is disabled. When it is disabled it can't be selected, or its action invoked.
+				Returns [code]true[/code] if the item at the given [param index] is disabled. When it is disabled it can't be selected, or its action invoked.
 				See [method set_item_disabled] for more info on how to disable an item.
 			</description>
 		</method>
@@ -299,7 +299,7 @@
 			<return type="bool" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at the given [code]index[/code] has radio button-style checkability.
+				Returns [code]true[/code] if the item at the given [param index] has radio button-style checkability.
 				[b]Note:[/b] This is purely cosmetic; you must add the logic for checking/unchecking items in radio groups.
 			</description>
 		</method>
@@ -321,7 +321,7 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes the item at the given [code]index[/code] from the menu.
+				Removes the item at the given [param index] from the menu.
 				[b]Note:[/b] The indices of items after the removed item will be shifted by one.
 			</description>
 		</method>
@@ -329,14 +329,14 @@
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Moves the scroll view to make the item at the given [code]index[/code] visible.
+				Moves the scroll view to make the item at the given [param index] visible.
 			</description>
 		</method>
 		<method name="set_current_index">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Sets the currently focused item as the given [code]index[/code].
+				Sets the currently focused item as the given [param index].
 			</description>
 		</method>
 		<method name="set_item_accelerator">
@@ -344,7 +344,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="accel" type="int" enum="Key" />
 			<description>
-				Sets the accelerator of the item at the given [code]index[/code]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
+				Sets the accelerator of the item at the given [param index]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
 			</description>
 		</method>
 		<method name="set_item_as_checkable">
@@ -352,7 +352,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Sets whether the item at the given [code]index[/code] has a checkbox. If [code]false[/code], sets the type of the item to plain text.
+				Sets whether the item at the given [param index] has a checkbox. If [code]false[/code], sets the type of the item to plain text.
 				[b]Note:[/b] Checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually.
 			</description>
 		</method>
@@ -361,7 +361,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Sets the type of the item at the given [code]index[/code] to radio button. If [code]false[/code], sets the type of the item to plain text.
+				Sets the type of the item at the given [param index] to radio button. If [code]false[/code], sets the type of the item to plain text.
 			</description>
 		</method>
 		<method name="set_item_as_separator">
@@ -369,7 +369,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Mark the item at the given [code]index[/code] as a separator, which means that it would be displayed as a line. If [code]false[/code], sets the type of the item to plain text.
+				Mark the item at the given [param index] as a separator, which means that it would be displayed as a line. If [code]false[/code], sets the type of the item to plain text.
 			</description>
 		</method>
 		<method name="set_item_checked">
@@ -377,7 +377,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="checked" type="bool" />
 			<description>
-				Sets the checkstate status of the item at the given [code]index[/code].
+				Sets the checkstate status of the item at the given [param index].
 			</description>
 		</method>
 		<method name="set_item_disabled">
@@ -385,7 +385,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="disabled" type="bool" />
 			<description>
-				Enables/disables the item at the given [code]index[/code]. When it is disabled, it can't be selected and its action can't be invoked.
+				Enables/disables the item at the given [param index]. When it is disabled, it can't be selected and its action can't be invoked.
 			</description>
 		</method>
 		<method name="set_item_horizontal_offset">
@@ -393,7 +393,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="offset" type="int" />
 			<description>
-				Sets the horizontal offset of the item at the given [code]index[/code].
+				Sets the horizontal offset of the item at the given [param index].
 			</description>
 		</method>
 		<method name="set_item_icon">
@@ -401,7 +401,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="icon" type="Texture2D" />
 			<description>
-				Replaces the [Texture2D] icon of the item at the given [code]index[/code].
+				Replaces the [Texture2D] icon of the item at the given [param index].
 			</description>
 		</method>
 		<method name="set_item_id">
@@ -409,8 +409,8 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="id" type="int" />
 			<description>
-				Sets the [code]id[/code] of the item at the given [code]index[/code].
-				The [code]id[/code] is used in [signal id_pressed] and [signal id_focused] signals.
+				Sets the [param id] of the item at the given [param index].
+				The [param id] is used in [signal id_pressed] and [signal id_focused] signals.
 			</description>
 		</method>
 		<method name="set_item_language">
@@ -443,7 +443,7 @@
 			<param index="1" name="shortcut" type="Shortcut" />
 			<param index="2" name="global" type="bool" default="false" />
 			<description>
-				Sets a [Shortcut] for the item at the given [code]index[/code].
+				Sets a [Shortcut] for the item at the given [param index].
 			</description>
 		</method>
 		<method name="set_item_shortcut_disabled">
@@ -451,7 +451,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="disabled" type="bool" />
 			<description>
-				Disables the [Shortcut] of the item at the given [code]index[/code].
+				Disables the [Shortcut] of the item at the given [param index].
 			</description>
 		</method>
 		<method name="set_item_submenu">
@@ -459,7 +459,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="submenu" type="String" />
 			<description>
-				Sets the submenu of the item at the given [code]index[/code]. The submenu is the name of a child [PopupMenu] node that would be shown when the item is clicked.
+				Sets the submenu of the item at the given [param index]. The submenu is the name of a child [PopupMenu] node that would be shown when the item is clicked.
 			</description>
 		</method>
 		<method name="set_item_text">
@@ -467,7 +467,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="text" type="String" />
 			<description>
-				Sets the text of the item at the given [code]index[/code].
+				Sets the text of the item at the given [param index].
 			</description>
 		</method>
 		<method name="set_item_text_direction">
@@ -483,14 +483,14 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="tooltip" type="String" />
 			<description>
-				Sets the [String] tooltip of the item at the given [code]index[/code].
+				Sets the [String] tooltip of the item at the given [param index].
 			</description>
 		</method>
 		<method name="toggle_item_checked">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Toggles the check state of the item at the given [code]index[/code].
+				Toggles the check state of the item at the given [param index].
 			</description>
 		</method>
 		<method name="toggle_item_multistate">
@@ -525,19 +525,19 @@
 		<signal name="id_focused">
 			<param index="0" name="id" type="int" />
 			<description>
-				Emitted when user navigated to an item of some [code]id[/code] using [code]ui_up[/code] or [code]ui_down[/code] action.
+				Emitted when user navigated to an item of some [param id] using [code]ui_up[/code] or [code]ui_down[/code] action.
 			</description>
 		</signal>
 		<signal name="id_pressed">
 			<param index="0" name="id" type="int" />
 			<description>
-				Emitted when an item of some [code]id[/code] is pressed or its accelerator is activated.
+				Emitted when an item of some [param id] is pressed or its accelerator is activated.
 			</description>
 		</signal>
 		<signal name="index_pressed">
 			<param index="0" name="index" type="int" />
 			<description>
-				Emitted when an item of some [code]index[/code] is pressed or its accelerator is activated.
+				Emitted when an item of some [param index] is pressed or its accelerator is activated.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -87,7 +87,7 @@
 			<return type="String" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Returns the absolute, native OS path corresponding to the localized [code]path[/code] (starting with [code]res://[/code] or [code]user://[/code]). The returned path will vary depending on the operating system and user preferences. See [url=$DOCS_URL/tutorials/io/data_paths.html]File paths in Godot projects[/url] to see what those paths convert to. See also [method localize_path].
+				Returns the absolute, native OS path corresponding to the localized [param path] (starting with [code]res://[/code] or [code]user://[/code]). The returned path will vary depending on the operating system and user preferences. See [url=$DOCS_URL/tutorials/io/data_paths.html]File paths in Godot projects[/url] to see what those paths convert to. See also [method localize_path].
 				[b]Note:[/b] [method globalize_path] with [code]res://[/code] will not work in an exported project. Instead, prepend the executable's base directory to the path when running from an exported project:
 				[codeblock]
 				var path = ""
@@ -117,16 +117,16 @@
 			<param index="1" name="replace_files" type="bool" default="true" />
 			<param index="2" name="offset" type="int" default="0" />
 			<description>
-				Loads the contents of the .pck or .zip file specified by [code]pack[/code] into the resource filesystem ([code]res://[/code]). Returns [code]true[/code] on success.
-				[b]Note:[/b] If a file from [code]pack[/code] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [code]pack[/code] unless [code]replace_files[/code] is set to [code]false[/code].
-				[b]Note:[/b] The optional [code]offset[/code] parameter can be used to specify the offset in bytes to the start of the resource pack. This is only supported for .pck files.
+				Loads the contents of the .pck or .zip file specified by [param pack] into the resource filesystem ([code]res://[/code]). Returns [code]true[/code] on success.
+				[b]Note:[/b] If a file from [param pack] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [param pack] unless [param replace_files] is set to [code]false[/code].
+				[b]Note:[/b] The optional [param offset] parameter can be used to specify the offset in bytes to the start of the resource pack. This is only supported for .pck files.
 			</description>
 		</method>
 		<method name="localize_path" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Returns the localized path (starting with [code]res://[/code]) corresponding to the absolute, native OS [code]path[/code]. See also [method globalize_path].
+				Returns the localized path (starting with [code]res://[/code]) corresponding to the absolute, native OS [param path]. See also [method globalize_path].
 			</description>
 		</method>
 		<method name="property_can_revert">

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -70,7 +70,7 @@
 			<return type="float" />
 			<param index="0" name="to" type="Quaternion" />
 			<description>
-				Returns the angle between this quaternion and [code]to[/code]. This is the magnitude of the angle you would need to rotate by to get from one to the other.
+				Returns the angle between this quaternion and [param to]. This is the magnitude of the angle you would need to rotate by to get from one to the other.
 				[b]Note:[/b] This method has an abnormally high amount of floating-point error, so methods such as [code]is_zero_approx[/code] will not work reliably.
 			</description>
 		</method>
@@ -112,7 +112,7 @@
 			<return type="bool" />
 			<param index="0" name="to" type="Quaternion" />
 			<description>
-				Returns [code]true[/code] if this quaternion and [code]quat[/code] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
+				Returns [code]true[/code] if this quaternion and [param to] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
 			</description>
 		</method>
 		<method name="is_normalized" qualifiers="const">
@@ -149,7 +149,7 @@
 			<param index="0" name="to" type="Quaternion" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the spherical linear interpolation between this quaternion and [code]to[/code] by amount [code]weight[/code].
+				Returns the result of the spherical linear interpolation between this quaternion and [param to] by amount [param weight].
 				[b]Note:[/b] Both quaternions must be normalized.
 			</description>
 		</method>
@@ -158,7 +158,7 @@
 			<param index="0" name="to" type="Quaternion" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the spherical linear interpolation between this quaternion and [code]to[/code] by amount [code]weight[/code], but without checking if the rotation path is not bigger than 90 degrees.
+				Returns the result of the spherical linear interpolation between this quaternion and [param to] by amount [param weight], but without checking if the rotation path is not bigger than 90 degrees.
 			</description>
 		</method>
 		<method name="spherical_cubic_interpolate" qualifiers="const">
@@ -168,7 +168,7 @@
 			<param index="2" name="post_b" type="Quaternion" />
 			<param index="3" name="weight" type="float" />
 			<description>
-				Performs a spherical cubic interpolation between quaternions [code]pre_a[/code], this vector, [code]b[/code], and [code]post_b[/code], by the given amount [code]weight[/code].
+				Performs a spherical cubic interpolation between quaternions [param pre_a], this vector, [param b], and [param post_b], by the given amount [param weight].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -30,7 +30,7 @@
 			<param index="0" name="from" type="float" />
 			<param index="1" name="to" type="float" />
 			<description>
-				Returns a pseudo-random float between [code]from[/code] and [code]to[/code] (inclusive).
+				Returns a pseudo-random float between [param from] and [param to] (inclusive).
 			</description>
 		</method>
 		<method name="randfn">
@@ -38,7 +38,7 @@
 			<param index="0" name="mean" type="float" default="0.0" />
 			<param index="1" name="deviation" type="float" default="1.0" />
 			<description>
-				Returns a [url=https://en.wikipedia.org/wiki/Normal_distribution]normally-distributed[/url] pseudo-random number, using Box-Muller transform with the specified [code]mean[/code] and a standard [code]deviation[/code]. This is also called Gaussian distribution.
+				Returns a [url=https://en.wikipedia.org/wiki/Normal_distribution]normally-distributed[/url] pseudo-random number, using Box-Muller transform with the specified [param mean] and a standard [param deviation]. This is also called Gaussian distribution.
 			</description>
 		</method>
 		<method name="randi">
@@ -52,7 +52,7 @@
 			<param index="0" name="from" type="int" />
 			<param index="1" name="to" type="int" />
 			<description>
-				Returns a pseudo-random 32-bit signed integer between [code]from[/code] and [code]to[/code] (inclusive).
+				Returns a pseudo-random 32-bit signed integer between [param from] and [param to] (inclusive).
 			</description>
 		</method>
 		<method name="randomize">

--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -72,7 +72,7 @@
 			<param index="0" name="value" type="float" />
 			<description>
 				Emitted when [member value] changes. When used on a [Slider], this is called continuously while dragging (potentially every frame). If you are performing an expensive operation in a function connected to [signal value_changed], consider using a [i]debouncing[/i] [Timer] to call the function less often.
-				[b]Note:[/b] Unlike signals such as [signal LineEdit.text_changed], [signal value_changed] is also emitted when [code]value[/code] is set directly via code.
+				[b]Note:[/b] Unlike signals such as [signal LineEdit.text_changed], [signal value_changed] is also emitted when [param value] is set directly via code.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -57,7 +57,7 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_collision_normal" qualifiers="const">
@@ -98,7 +98,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -58,7 +58,7 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_collision_normal" qualifiers="const">
@@ -99,7 +99,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -106,7 +106,7 @@
 			<return type="Rect2" />
 			<param index="0" name="amount" type="float" />
 			<description>
-				Returns a copy of the [Rect2] grown by the specified [code]amount[/code] on all sides.
+				Returns a copy of the [Rect2] grown by the specified [param amount] on all sides.
 			</description>
 		</method>
 		<method name="grow_individual" qualifiers="const">
@@ -124,7 +124,7 @@
 			<param index="0" name="side" type="int" />
 			<param index="1" name="amount" type="float" />
 			<description>
-				Returns a copy of the [Rect2] grown by the specified [code]amount[/code] on the specified [enum Side].
+				Returns a copy of the [Rect2] grown by the specified [param amount] on the specified [enum Side].
 			</description>
 		</method>
 		<method name="has_no_area" qualifiers="const">
@@ -146,7 +146,7 @@
 			<return type="Rect2" />
 			<param index="0" name="b" type="Rect2" />
 			<description>
-				Returns the intersection of this [Rect2] and [code]b[/code].
+				Returns the intersection of this [Rect2] and [param b].
 				If the rectangles do not intersect, an empty [Rect2] is returned.
 			</description>
 		</method>
@@ -156,21 +156,21 @@
 			<param index="1" name="include_borders" type="bool" default="false" />
 			<description>
 				Returns [code]true[/code] if the [Rect2] overlaps with [code]b[/code] (i.e. they have at least one point in common).
-				If [code]include_borders[/code] is [code]true[/code], they will also be considered overlapping if their borders touch, even without intersection.
+				If [param include_borders] is [code]true[/code], they will also be considered overlapping if their borders touch, even without intersection.
 			</description>
 		</method>
 		<method name="is_equal_approx" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="rect" type="Rect2" />
 			<description>
-				Returns [code]true[/code] if this [Rect2] and [code]rect[/code] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
+				Returns [code]true[/code] if this [Rect2] and [param rect] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
 			</description>
 		</method>
 		<method name="merge" qualifiers="const">
 			<return type="Rect2" />
 			<param index="0" name="b" type="Rect2" />
 			<description>
-				Returns a larger [Rect2] that contains this [Rect2] and [code]b[/code].
+				Returns a larger [Rect2] that contains this [Rect2] and [param b].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -104,7 +104,7 @@
 			<return type="Rect2i" />
 			<param index="0" name="amount" type="int" />
 			<description>
-				Returns a copy of the [Rect2i] grown by the specified [code]amount[/code] on all sides.
+				Returns a copy of the [Rect2i] grown by the specified [param amount] on all sides.
 			</description>
 		</method>
 		<method name="grow_individual" qualifiers="const">
@@ -122,7 +122,7 @@
 			<param index="0" name="side" type="int" />
 			<param index="1" name="amount" type="int" />
 			<description>
-				Returns a copy of the [Rect2i] grown by the specified [code]amount[/code] on the specified [enum Side].
+				Returns a copy of the [Rect2i] grown by the specified [param amount] on the specified [enum Side].
 			</description>
 		</method>
 		<method name="has_no_area" qualifiers="const">
@@ -159,7 +159,7 @@
 			<return type="Rect2i" />
 			<param index="0" name="b" type="Rect2i" />
 			<description>
-				Returns a larger [Rect2i] that contains this [Rect2i] and [code]b[/code].
+				Returns a larger [Rect2i] that contains this [Rect2i] and [param b].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -103,7 +103,7 @@
 			<param index="3" name="z_near" type="float" />
 			<param index="4" name="z_far" type="float" />
 			<description>
-				Sets camera to use frustum projection. This mode allows adjusting the [code]offset[/code] argument to create "tilted frustum" effects.
+				Sets camera to use frustum projection. This mode allows adjusting the [param offset] argument to create "tilted frustum" effects.
 			</description>
 		</method>
 		<method name="camera_set_orthogonal">
@@ -1172,7 +1172,7 @@
 			<param index="0" name="size" type="int" />
 			<param index="1" name="depth" type="int" />
 			<description>
-				Sets the resolution of the volumetric fog's froxel buffer. [code]size[/code] is modified by the screen's aspect ratio and then used to set the width and height of the buffer. While [code]depth[/code] is directly used to set the depth of the buffer.
+				Sets the resolution of the volumetric fog's froxel buffer. [param size] is modified by the screen's aspect ratio and then used to set the width and height of the buffer. While [param depth] is directly used to set the depth of the buffer.
 			</description>
 		</method>
 		<method name="fog_volume_create">
@@ -1290,7 +1290,7 @@
 			<return type="void" />
 			<param index="0" name="half_resolution" type="bool" />
 			<description>
-				If [code]half_resolution[/code] is [code]true[/code], renders [VoxelGI] and SDFGI ([member Environment.sdfgi_enabled]) buffers at halved resolution (e.g. 960×540 when the viewport size is 1920×1080). This improves performance significantly when VoxelGI or SDFGI is enabled, at the cost of artifacts that may be visible on polygon edges. The loss in quality becomes less noticeable as the viewport resolution increases. [LightmapGI] rendering is not affected by this setting. See also [member ProjectSettings.rendering/global_illumination/gi/use_half_resolution].
+				If [param half_resolution] is [code]true[/code], renders [VoxelGI] and SDFGI ([member Environment.sdfgi_enabled]) buffers at halved resolution (e.g. 960×540 when the viewport size is 1920×1080). This improves performance significantly when VoxelGI or SDFGI is enabled, at the cost of artifacts that may be visible on polygon edges. The loss in quality becomes less noticeable as the viewport resolution increases. [LightmapGI] rendering is not affected by this setting. See also [member ProjectSettings.rendering/global_illumination/gi/use_half_resolution].
 			</description>
 		</method>
 		<method name="global_shader_uniform_add">
@@ -1355,7 +1355,7 @@
 			<return type="bool" />
 			<param index="0" name="feature" type="String" />
 			<description>
-				Returns [code]true[/code] if the OS supports a certain feature. Features might be [code]s3tc[/code], [code]etc[/code], and [code]etc2[/code].
+				Returns [code]true[/code] if the OS supports a certain [param feature]. Features might be [code]s3tc[/code], [code]etc[/code], and [code]etc2[/code].
 			</description>
 		</method>
 		<method name="instance_attach_object_instance_id">
@@ -1474,9 +1474,9 @@
 			<param index="1" name="transparency" type="float" />
 			<description>
 				Sets the transparency for the given geometry instance. Equivalent to [member GeometryInstance3D.transparency].
-				A transparency of [code]0.0[/code] is fully opaque, while [code]1.0[/code] is fully transparent. Values greater than [code]0.0[/code] (exclusive) will force the geometry's materials to go through the transparent pipeline, which is slower to render and can exhibit rendering issues due to incorrect transparency sorting. However, unlike using a transparent material, setting [code]transparency[/code] to a value greater than [code]0.0[/code] (exclusive) will [i]not[/i] disable shadow rendering.
+				A transparency of [code]0.0[/code] is fully opaque, while [code]1.0[/code] is fully transparent. Values greater than [code]0.0[/code] (exclusive) will force the geometry's materials to go through the transparent pipeline, which is slower to render and can exhibit rendering issues due to incorrect transparency sorting. However, unlike using a transparent material, setting [param transparency] to a value greater than [code]0.0[/code] (exclusive) will [i]not[/i] disable shadow rendering.
 				In spatial shaders, [code]1.0 - transparency[/code] is set as the default value of the [code]ALPHA[/code] built-in.
-				[b]Note:[/b] [code]transparency[/code] is clamped between [code]0.0[/code] and [code]1.0[/code], so this property cannot be used to make transparent materials more opaque than they originally are.
+				[b]Note:[/b] [param transparency] is clamped between [code]0.0[/code] and [code]1.0[/code], so this property cannot be used to make transparent materials more opaque than they originally are.
 			</description>
 		</method>
 		<method name="instance_geometry_set_visibility_range">
@@ -2693,7 +2693,7 @@
 			<param index="2" name="scale" type="bool" />
 			<param index="3" name="use_filter" type="bool" default="true" />
 			<description>
-				Sets a boot image. The color defines the background color. If [code]scale[/code] is [code]true[/code], the image will be scaled to fit the screen size. If [code]use_filter[/code] is [code]true[/code], the image will be scaled with linear interpolation. If [code]use_filter[/code] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
+				Sets a boot image. The color defines the background color. If [param scale] is [code]true[/code], the image will be scaled to fit the screen size. If [param use_filter] is [code]true[/code], the image will be scaled with linear interpolation. If [param use_filter] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
 			</description>
 		</method>
 		<method name="set_debug_generate_wireframes">
@@ -2731,7 +2731,7 @@
 			<param index="2" name="index" type="int" default="0" />
 			<description>
 				Returns a default texture from a shader searched by name.
-				[b]Note:[/b] If the sampler array is used use [code]index[/code] to access the specified texture.
+				[b]Note:[/b] If the sampler array is used use [param index] to access the specified texture.
 			</description>
 		</method>
 		<method name="shader_get_param_default" qualifiers="const">
@@ -2763,7 +2763,7 @@
 			<param index="3" name="index" type="int" default="0" />
 			<description>
 				Sets a shader's default texture. Overwrites the texture given by name.
-				[b]Note:[/b] If the sampler array is used use [code]index[/code] to access the specified texture.
+				[b]Note:[/b] If the sampler array is used use [param index] to access the specified texture.
 			</description>
 		</method>
 		<method name="shader_set_path_hint">
@@ -3039,7 +3039,7 @@
 			<param index="1" name="rect" type="Rect2" default="Rect2(0, 0, 0, 0)" />
 			<param index="2" name="screen" type="int" default="0" />
 			<description>
-				Copies the viewport to a region of the screen specified by [code]rect[/code]. If [method viewport_set_render_direct_to_screen] is [code]true[/code], then the viewport does not use a framebuffer and the contents of the viewport are rendered directly to screen. However, note that the root viewport is drawn last, therefore it will draw over the screen. Accordingly, you must set the root viewport to an area that does not cover the area that you have attached this viewport to.
+				Copies the viewport to a region of the screen specified by [param rect]. If [method viewport_set_render_direct_to_screen] is [code]true[/code], then the viewport does not use a framebuffer and the contents of the viewport are rendered directly to screen. However, note that the root viewport is drawn last, therefore it will draw over the screen. Accordingly, you must set the root viewport to an area that does not cover the area that you have attached this viewport to.
 				For example, you can set the root viewport to not render at all with the following code:
 				FIXME: The method seems to be non-existent.
 				[codeblocks]
@@ -3110,7 +3110,7 @@
 			<param index="3" name="sublayer" type="int" />
 			<description>
 				Sets the stacking order for a viewport's canvas.
-				[code]layer[/code] is the actual canvas layer, while [code]sublayer[/code] specifies the stacking order of the canvas among those in the same layer.
+				[param layer] is the actual canvas layer, while [param sublayer] specifies the stacking order of the canvas among those in the same layer.
 			</description>
 		</method>
 		<method name="viewport_set_canvas_transform">


### PR DESCRIPTION
One of several commits to fix all of the class XML docs (see #64134, #64164, #64196).