### PR TITLE
Performance fixes for StringName stack objects and some theme regress…

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2805,7 +2805,7 @@ void _Thread::_start_func(void *ud) {
 Error _Thread::start(Object *p_instance, const StringName &p_method, const Variant &p_userdata, Priority p_priority) {
 	ERR_FAIL_COND_V_MSG(is_active(), ERR_ALREADY_IN_USE, "Thread already started.");
 	ERR_FAIL_COND_V(!p_instance, ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V(p_method == StringName() || !p_instance->has_method(p_method), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_method.is_empty() || !p_instance->has_method(p_method), ERR_INVALID_PARAMETER);
 	ERR_FAIL_INDEX_V(p_priority, PRIORITY_MAX, ERR_INVALID_PARAMETER);
 
 	ret = Variant();

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -692,7 +692,7 @@ Error ResourceInteractiveLoaderBinary::poll() {
 	for (int i = 0; i < pc; i++) {
 		StringName name = _get_string();
 
-		if (name == StringName()) {
+		if (name.is_empty()) {
 			error = ERR_FILE_CORRUPT;
 			ERR_FAIL_V(ERR_FILE_CORRUPT);
 		}

--- a/core/string_name.h
+++ b/core/string_name.h
@@ -120,6 +120,9 @@ public:
 			return 0;
 		}
 	}
+	_FORCE_INLINE_ bool is_empty() const {
+		return !(*this);
+	}
 	_FORCE_INLINE_ const void *data_unique_pointer() const {
 		return (void *)_data;
 	}

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -80,14 +80,14 @@ void Translation::set_locale(const String &p_locale) {
 }
 
 void Translation::add_context_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context) {
-	if (p_context != StringName()) {
+	if (p_context) {
 		WARN_PRINT("Translation class doesn't handle context.");
 	}
 	add_message(p_src_text, p_xlated_text);
 }
 
 StringName Translation::get_context_message(const StringName &p_src_text, const StringName &p_context) const {
-	if (p_context != StringName()) {
+	if (p_context) {
 		WARN_PRINT("Translation class doesn't handle context.");
 	}
 	return get_message(p_src_text);
@@ -148,7 +148,7 @@ Translation::Translation() :
 ///////////////////////////////////////////////
 
 void ContextTranslation::add_context_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context) {
-	if (p_context == StringName()) {
+	if (p_context.is_empty()) {
 		add_message(p_src_text, p_xlated_text);
 	} else {
 		context_translation_map[p_context][p_src_text] = p_xlated_text;
@@ -156,7 +156,7 @@ void ContextTranslation::add_context_message(const StringName &p_src_text, const
 }
 
 StringName ContextTranslation::get_context_message(const StringName &p_src_text, const StringName &p_context) const {
-	if (p_context == StringName()) {
+	if (p_context.is_empty()) {
 		return get_message(p_src_text);
 	}
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -961,7 +961,7 @@ void ConnectionsDock::update_tree() {
 						signaldesc += ", ";
 					}
 					String tname = "var";
-					if (pi.type == Variant::OBJECT && pi.class_name != StringName()) {
+					if (pi.type == Variant::OBJECT && pi.class_name) {
 						tname = pi.class_name.operator String();
 					} else if (pi.type != Variant::NIL) {
 						tname = Variant::get_type_name(pi.type);

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -202,7 +202,7 @@ static void return_doc_from_retinfo(DocData::MethodDoc &p_method, const Property
 			p_method.return_enum = p_method.return_enum.substr(1, p_method.return_enum.length());
 		}
 		p_method.return_type = "int";
-	} else if (p_retinfo.class_name != StringName()) {
+	} else if (p_retinfo.class_name) {
 		p_method.return_type = p_retinfo.class_name;
 	} else if (p_retinfo.hint == PROPERTY_HINT_RESOURCE_TYPE) {
 		p_method.return_type = p_retinfo.hint_string;
@@ -224,7 +224,7 @@ static void argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const Pr
 			p_argument.enumeration = p_argument.enumeration.substr(1, p_argument.enumeration.length());
 		}
 		p_argument.type = "int";
-	} else if (p_arginfo.class_name != StringName()) {
+	} else if (p_arginfo.class_name) {
 		p_argument.type = p_arginfo.class_name;
 	} else if (p_arginfo.hint == PROPERTY_HINT_RESOURCE_TYPE) {
 		p_argument.type = p_arginfo.hint_string;
@@ -361,7 +361,7 @@ void DocData::generate(bool p_basic_types) {
 			prop.getter = getter;
 
 			bool found_type = false;
-			if (getter != StringName()) {
+			if (getter) {
 				MethodBind *mb = ClassDB::get_method(name, getter);
 				if (mb) {
 					PropertyInfo retinfo = mb->get_return_info();
@@ -370,7 +370,7 @@ void DocData::generate(bool p_basic_types) {
 					if (retinfo.type == Variant::INT && retinfo.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
 						prop.enumeration = retinfo.class_name;
 						prop.type = "int";
-					} else if (retinfo.class_name != StringName()) {
+					} else if (retinfo.class_name) {
 						prop.type = retinfo.class_name;
 					} else if (retinfo.hint == PROPERTY_HINT_RESOURCE_TYPE) {
 						prop.type = retinfo.hint_string;
@@ -386,7 +386,7 @@ void DocData::generate(bool p_basic_types) {
 				setters_getters.insert(getter);
 			}
 
-			if (setter != StringName()) {
+			if (setter) {
 				setters_getters.insert(setter);
 			}
 

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -75,7 +75,7 @@ void EditorFeatureProfile::set_disable_class(const StringName &p_class, bool p_d
 }
 
 bool EditorFeatureProfile::is_class_disabled(const StringName &p_class) const {
-	if (p_class == StringName()) {
+	if (p_class.is_empty()) {
 		return false;
 	}
 	return disabled_classes.has(p_class) || is_class_disabled(ClassDB::get_parent_class_nocheck(p_class));
@@ -90,7 +90,7 @@ void EditorFeatureProfile::set_disable_class_editor(const StringName &p_class, b
 }
 
 bool EditorFeatureProfile::is_class_editor_disabled(const StringName &p_class) const {
-	if (p_class == StringName()) {
+	if (p_class.is_empty()) {
 		return false;
 	}
 	return disabled_editors.has(p_class) || is_class_editor_disabled(ClassDB::get_parent_class_nocheck(p_class));

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -255,7 +255,7 @@ bool EditorHelpSearch::Runner::_is_class_disabled_by_feature_profile(const Strin
 	}
 
 	StringName class_name = p_class;
-	while (class_name != StringName()) {
+	while (class_name) {
 		if (!ClassDB::class_exists(class_name)) {
 			return false;
 		}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -370,7 +370,7 @@ bool EditorPropertyRevert::can_property_revert(Object *p_object, const StringNam
 }
 
 void EditorProperty::update_revert_and_pin_status() {
-	if (property == StringName()) {
+	if (property.is_empty()) {
 		return; //no property, so nothing to do
 	}
 
@@ -486,7 +486,7 @@ bool EditorProperty::is_selected() const {
 }
 
 void EditorProperty::_gui_input(const Ref<InputEvent> &p_event) {
-	if (property == StringName()) {
+	if (property.is_empty()) {
 		return;
 	}
 
@@ -596,7 +596,7 @@ void EditorProperty::set_bottom_editor(Control *p_control) {
 	bottom_editor = p_control;
 }
 Variant EditorProperty::get_drag_data(const Point2 &p_point) {
-	if (property == StringName()) {
+	if (property.is_empty()) {
 		return Variant();
 	}
 
@@ -1376,7 +1376,7 @@ bool EditorInspector::_is_property_disabled_by_feature_profile(const StringName 
 
 	StringName class_name = object->get_class();
 
-	while (class_name != StringName()) {
+	while (class_name) {
 		if (profile->is_class_property_disabled(class_name, p_property)) {
 			return true;
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1899,7 +1899,7 @@ bool EditorNode::_is_class_editor_disabled_by_feature_profile(const StringName &
 
 	StringName class_name = p_class;
 
-	while (class_name != StringName()) {
+	while (class_name) {
 		if (profile->is_class_disabled(class_name)) {
 			return true;
 		}
@@ -3947,12 +3947,12 @@ Ref<Script> EditorNode::get_object_custom_type_base(const Object *p_object) cons
 	if (script.is_valid()) {
 		// Uncommenting would break things! Consider adding a parameter if you need it.
 		// StringName name = EditorNode::get_editor_data().script_class_get_name(base_script->get_path());
-		// if (name != StringName())
+		// if (name)
 		// 	return name;
 
 		// should probably be deprecated in 4.x
 		StringName base = script->get_instance_base_type();
-		if (base != StringName() && EditorNode::get_editor_data().get_custom_types().has(base)) {
+		if (base && EditorNode::get_editor_data().get_custom_types().has(base)) {
 			const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
 
 			Ref<Script> base_script = script;
@@ -3982,13 +3982,13 @@ StringName EditorNode::get_object_custom_type_name(const Object *p_object) const
 		Ref<Script> base_script = script;
 		while (base_script.is_valid()) {
 			StringName name = EditorNode::get_editor_data().script_class_get_name(base_script->get_path());
-			if (name != StringName()) {
+			if (name) {
 				return name;
 			}
 
 			// should probably be deprecated in 4.x
 			StringName base = base_script->get_instance_base_type();
-			if (base != StringName() && EditorNode::get_editor_data().get_custom_types().has(base)) {
+			if (base && EditorNode::get_editor_data().get_custom_types().has(base)) {
 				const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
 				for (int i = 0; i < types.size(); ++i) {
 					if (types[i].script == base_script) {
@@ -4057,7 +4057,7 @@ Ref<Texture> EditorNode::get_object_icon(const Object *p_object, const String &p
 
 			// should probably be deprecated in 4.x
 			StringName base = base_script->get_instance_base_type();
-			if (base != StringName() && EditorNode::get_editor_data().get_custom_types().has(base)) {
+			if (base && EditorNode::get_editor_data().get_custom_types().has(base)) {
 				const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
 				for (int i = 0; i < types.size(); ++i) {
 					if (types[i].script == base_script && types[i].icon.is_valid()) {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -746,7 +746,7 @@ void EditorResourcePicker::set_base_type(const String &p_base_type) {
 		}
 
 		if (!is_custom && !_is_type_valid(edited_resource->get_class(), allowed_types)) {
-			String class_str = (custom_class == StringName() ? edited_resource->get_class() : vformat("%s (%s)", custom_class, edited_resource->get_class()));
+			String class_str = (custom_class.is_empty() ? edited_resource->get_class() : vformat("%s (%s)", custom_class, edited_resource->get_class()));
 			WARN_PRINT(vformat("Value mismatch between the new base type of this EditorResourcePicker, '%s', and the type of the value it already has, '%s'.", base_type, class_str));
 		}
 	} else {
@@ -796,7 +796,7 @@ void EditorResourcePicker::set_edited_resource(RES p_resource) {
 		}
 
 		if (!is_custom && !_is_type_valid(p_resource->get_class(), allowed_types)) {
-			String class_str = (custom_class == StringName() ? p_resource->get_class() : vformat("%s (%s)", custom_class, p_resource->get_class()));
+			String class_str = (custom_class.is_empty() ? p_resource->get_class() : vformat("%s (%s)", custom_class, p_resource->get_class()));
 			ERR_FAIL_MSG(vformat("Failed to set a resource of the type '%s' because this EditorResourcePicker only accepts '%s' and its derivatives.", class_str, base_type));
 		}
 	}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -600,7 +600,7 @@ bool FileSystemDock::_is_file_type_disabled_by_feature_profile(const StringName 
 
 	StringName class_name = p_class;
 
-	while (class_name != StringName()) {
+	while (class_name) {
 		if (profile->is_class_disabled(class_name)) {
 			return true;
 		}

--- a/editor/plugins/animation_tree_player_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_player_editor_plugin.cpp
@@ -1068,7 +1068,7 @@ void AnimationTreePlayerEditor::_find_paths_for_filter(const StringName &p_node,
 
 	for (int i = 0; i < anim_tree->node_get_input_count(p_node); i++) {
 		StringName port = anim_tree->node_get_input_source(p_node, i);
-		if (port == StringName()) {
+		if (port.is_empty()) {
 			continue;
 		}
 		_find_paths_for_filter(port, paths);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -173,7 +173,7 @@ void ScriptTextEditor::_update_member_keywords() {
 
 	StringName instance_base = script->get_instance_base_type();
 
-	if (instance_base == StringName()) {
+	if (instance_base.is_empty()) {
 		return;
 	}
 	List<PropertyInfo> plist;
@@ -941,7 +941,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 				StringName success;
 				while (true) {
 					success = ClassDB::get_integer_constant_enum(cname, result.class_member, true);
-					if (success != StringName()) {
+					if (success) {
 						result.class_name = cname;
 						cname = ClassDB::get_parent_class(cname);
 					} else {

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2202,7 +2202,7 @@ OrderedHashMap<StringName, bool> ThemeTypeEditor::_get_type_items(String p_type_
 	if (include_default) {
 		names.clear();
 		String default_type = p_type_name;
-		if (edited_theme->get_type_variation_base(p_type_name) != StringName()) {
+		if (edited_theme->get_type_variation_base(p_type_name)) {
 			default_type = edited_theme->get_type_variation_base(p_type_name);
 		}
 
@@ -2563,7 +2563,7 @@ void ThemeTypeEditor::_add_type_button_cbk() {
 void ThemeTypeEditor::_add_default_type_items() {
 	List<StringName> names;
 	String default_type = edited_type;
-	if (edited_theme->get_type_variation_base(edited_type) != StringName()) {
+	if (edited_theme->get_type_variation_base(edited_type)) {
 		default_type = edited_theme->get_type_variation_base(edited_type);
 	}
 

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -116,8 +116,8 @@ void ThemeEditorPreview::_draw_picker_overlay() {
 		highlight_rect.position = picker_overlay->get_global_transform().affine_inverse().xform(highlight_rect.position);
 		picker_overlay->draw_style_box(theme_cache.preview_picker_overlay, highlight_rect);
 
-		String highlight_name = hovered_control->get_theme_type_variation();
-		if (highlight_name == StringName()) {
+		StringName highlight_name = hovered_control->get_theme_type_variation();
+		if (highlight_name.is_empty()) {
 			highlight_name = hovered_control->get_class_name();
 		}
 
@@ -152,7 +152,7 @@ void ThemeEditorPreview::_gui_input_picker_overlay(const Ref<InputEvent> &p_even
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
 		if (hovered_control) {
 			StringName theme_type = hovered_control->get_theme_type_variation();
-			if (theme_type == StringName()) {
+			if (theme_type.is_empty()) {
 				theme_type = hovered_control->get_class_name();
 			}
 

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -323,7 +323,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		item->set_tooltip(0, tooltip);
 	} else {
 		StringName type = EditorNode::get_singleton()->get_object_custom_type_name(p_node);
-		if (type == StringName()) {
+		if (type.is_empty()) {
 			type = p_node->get_class();
 		}
 

--- a/main/tests/test_main.cpp
+++ b/main/tests/test_main.cpp
@@ -47,6 +47,7 @@
 #include "test_render.h"
 #include "test_shader_lang.h"
 #include "test_string.h"
+#include "test_string_name.h"
 #include "test_theme.h"
 #include "test_transform.h"
 #include "test_xml_parser.h"
@@ -54,6 +55,7 @@
 const char **tests_get_names() {
 	static const char *test_names[] = {
 		"string",
+		"string_name",
 		"math",
 		"basis",
 		"transform",
@@ -80,6 +82,10 @@ const char **tests_get_names() {
 MainLoop *test_main(String p_test, const List<String> &p_args) {
 	if (p_test == "string") {
 		return TestString::test();
+	}
+
+	if (p_test == "string_name") {
+		return TestStringName::test();
 	}
 
 	if (p_test == "math") {

--- a/main/tests/test_string_name.cpp
+++ b/main/tests/test_string_name.cpp
@@ -1,0 +1,131 @@
+/*************************************************************************/
+/*  test_string_name.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "test_string_name.h"
+#include "core/os/os.h"
+#include "core/string_name.h"
+#include <stdio.h>
+#include <wchar.h>
+
+namespace TestStringName {
+#define CHECK(X)                                          \
+	if (!(X)) {                                           \
+		OS::get_singleton()->print("\tFAIL at %s\n", #X); \
+		return false;                                     \
+	} else {                                              \
+		OS::get_singleton()->print("\tPASS\n");           \
+	}
+
+bool test_empty_string_names() {
+	OS::get_singleton()->print("\n\ntest_empty_string_names\n");
+
+	CHECK(StringName("") == StringName());
+	CHECK(!StringName(""))
+	CHECK(!StringName())
+	CHECK(StringName().is_empty())
+	CHECK(StringName("").is_empty())
+	CHECK(!StringName("hi there").is_empty())
+
+	return true;
+}
+
+bool test_string_name_assignments() {
+	OS::get_singleton()->print("\n\ntest_string_name_assignments\n");
+
+	CHECK(StringName("asdf") == "asdf")
+	CHECK(StringName("") != StringName("asdf"))
+
+	StringName a;
+	CHECK(!a);
+
+	StringName b;
+	b = "";
+	CHECK(!b);
+	b = "asdf";
+	CHECK(b);
+
+	return true;
+}
+
+bool test_string_comparators_and_search() {
+	OS::get_singleton()->print("\n\ntest_string_name_comparators\n");
+
+	CHECK(StringName("asdf") > StringName())
+
+	StringName test_search("test string search");
+	CHECK(StringName::search("test string search"))
+
+	CHECK(!StringName::search("test_string_comparators_and_search definitely should be no stringname this unique"))
+
+	return true;
+}
+
+typedef bool (*TestFunc)();
+
+TestFunc test_funcs[] = {
+
+	test_empty_string_names,
+	test_string_name_assignments,
+	test_string_comparators_and_search,
+	nullptr
+
+};
+
+MainLoop *test() {
+	/** A character length != wchar_t may be forced, so the tests won't work */
+
+	ERR_FAIL_COND_V(sizeof(CharType) != sizeof(wchar_t), nullptr);
+
+	int count = 0;
+	int passed = 0;
+
+	while (true) {
+		if (!test_funcs[count]) {
+			break;
+		}
+		bool pass = test_funcs[count]();
+		if (pass) {
+			passed++;
+		}
+		OS::get_singleton()->print("\t%s\n", pass ? "PASS" : "FAILED");
+
+		count++;
+	}
+
+	OS::get_singleton()->print("\n\n\n");
+	OS::get_singleton()->print("*************\n");
+	OS::get_singleton()->print("***TOTALS!***\n");
+	OS::get_singleton()->print("*************\n");
+
+	OS::get_singleton()->print("Passed %i of %i tests\n", passed, count);
+
+	return nullptr;
+}
+} // namespace TestStringName

--- a/main/tests/test_string_name.h
+++ b/main/tests/test_string_name.h
@@ -1,0 +1,43 @@
+/*************************************************************************/
+/*  test_string_name.h                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TEST_STRING_NAME_H
+#define TEST_STRING_NAME_H
+
+#include "core/os/main_loop.h"
+#include "core/string_name.h"
+#include "core/ustring.h"
+
+namespace TestStringName {
+
+MainLoop *test();
+}
+
+#endif // TEST_STRING_NAME_H

--- a/main/tests/test_theme.cpp
+++ b/main/tests/test_theme.cpp
@@ -116,14 +116,14 @@ bool test_good_theme_type_names() {
 
 		ErrorDetector ed;
 		theme->set_type_variation(fixture.valid_type_name, name);
-		CHECK(ed.has_error == (name == StringName()));
+		CHECK(ed.has_error == (name.is_empty()));
 	}
 	for (const StringName &name : names) {
 		Ref<Theme> theme = memnew(Theme);
 
 		ErrorDetector ed;
 		theme->set_type_variation(name, fixture.valid_type_name);
-		CHECK(ed.has_error == (name == StringName()));
+		CHECK(ed.has_error == (name.is_empty()));
 	}
 
 	return true;

--- a/modules/gdnative/nativescript/api_generator.cpp
+++ b/modules/gdnative/nativescript/api_generator.cpp
@@ -123,7 +123,7 @@ static String get_type_name(const PropertyInfo &info) {
 	if (info.type == Variant::INT && (info.usage & PROPERTY_USAGE_CLASS_IS_ENUM)) {
 		return String("enum.") + String(info.class_name).replace(".", "::");
 	}
-	if (info.class_name != StringName()) {
+	if (info.class_name) {
 		return info.class_name;
 	}
 	if (info.hint == PROPERTY_HINT_RESOURCE_TYPE) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1065,7 +1065,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 
 						Vector<int> setchain;
 
-						if (assign_property != StringName()) {
+						if (assign_property) {
 							// recover and assign at the end, this allows stuff like
 							// position.x+=2.0
 							// in Node2D

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -599,7 +599,7 @@ static GDScriptCompletionIdentifier _type_from_property(const PropertyInfo &p_pr
 	ci.type.builtin_type = p_property.type;
 	if (p_property.type == Variant::OBJECT) {
 		ci.type.kind = GDScriptParser::DataType::NATIVE;
-		ci.type.native_type = p_property.class_name == StringName() ? "Object" : p_property.class_name;
+		ci.type.native_type = p_property.class_name.is_empty() ? "Object" : p_property.class_name;
 	} else {
 		ci.type.kind = GDScriptParser::DataType::BUILTIN;
 	}
@@ -1519,7 +1519,7 @@ static bool _guess_identifier_type_from_base(GDScriptCompletionContext &p_contex
 
 					if (prop.name == p_identifier) {
 						StringName getter = ClassDB::get_property_getter(class_name, p_identifier);
-						if (getter != StringName()) {
+						if (getter) {
 							MethodBind *g = ClassDB::get_method(class_name, getter);
 							if (g) {
 								r_type = _type_from_property(g->get_return_info());
@@ -1991,7 +1991,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionContext &p_context
 						base_type.kind = GDScriptParser::DataType::GDSCRIPT;
 						base_type.script_type = script->get_base();
 					} else {
-						base_type.has_type = script->get_instance_base_type() != StringName();
+						base_type.has_type = script->get_instance_base_type();
 						base_type.kind = GDScriptParser::DataType::NATIVE;
 						base_type.native_type = script->get_instance_base_type();
 					}
@@ -2748,7 +2748,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 						method_hint += arg;
 						if (use_type_hint && mi.arguments[i].type != Variant::NIL) {
 							method_hint += ": ";
-							if (mi.arguments[i].type == Variant::OBJECT && mi.arguments[i].class_name != StringName()) {
+							if (mi.arguments[i].type == Variant::OBJECT && mi.arguments[i].class_name) {
 								method_hint += mi.arguments[i].class_name.operator String();
 							} else {
 								method_hint += Variant::get_type_name(mi.arguments[i].type);
@@ -2761,7 +2761,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 					method_hint += " -> ";
 					if (mi.return_val.type == Variant::NIL) {
 						method_hint += "void";
-					} else if (mi.return_val.type == Variant::OBJECT && mi.return_val.class_name != StringName()) {
+					} else if (mi.return_val.type == Variant::OBJECT && mi.return_val.class_name) {
 						method_hint += mi.return_val.class_name.operator String();
 					} else {
 						method_hint += Variant::get_type_name(mi.return_val.type);
@@ -2873,7 +2873,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 					}
 				}
 				for (int i = 0; i < clss->subclasses.size(); i++) {
-					if (clss->subclasses[i]->name != StringName()) {
+					if (clss->subclasses[i]->name) {
 						ScriptCodeCompletionOption option(clss->subclasses[i]->name.operator String(), ScriptCodeCompletionOption::KIND_CLASS);
 						options.insert(option.display, option);
 					}
@@ -2972,7 +2972,7 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 								}
 							}
 							for (int i = 0; i < base_type.class_type->subclasses.size(); i++) {
-								if (base_type.class_type->subclasses[i]->name != StringName()) {
+								if (base_type.class_type->subclasses[i]->name) {
 									ScriptCodeCompletionOption option(base_type.class_type->subclasses[i]->name.operator String(), ScriptCodeCompletionOption::KIND_CLASS);
 									options.insert(option.display, option);
 								}
@@ -3214,7 +3214,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				StringName enum_name = ClassDB::get_integer_constant_enum(class_name, p_symbol, true);
-				if (enum_name != StringName()) {
+				if (enum_name) {
 					r_result.type = ScriptLanguage::LookupResult::RESULT_CLASS_ENUM;
 					r_result.class_name = base_type.native_type;
 					r_result.class_member = enum_name;
@@ -3244,7 +3244,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				StringName parent = ClassDB::get_parent_class(class_name);
-				if (parent != StringName()) {
+				if (parent) {
 					if (String(parent).begins_with("_")) {
 						base_type.native_type = String(parent).right(1);
 					} else {
@@ -3404,7 +3404,7 @@ Error GDScriptLanguage::lookup_code(const String &p_code, const String &p_symbol
 				}
 			}
 
-			if (context.function && context.function->name != StringName()) {
+			if (context.function && context.function->name) {
 				// Lookup function arguments
 				for (int i = 0; i < context.function->arguments.size(); i++) {
 					if (context.function->arguments[i] == p_symbol) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -645,7 +645,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 				completion_built_in_constant = bi_type;
 			}
 
-			if (identifier == StringName()) {
+			if (identifier.is_empty()) {
 				_set_error("Built-in type constant or static function expected after \".\".");
 				return nullptr;
 			}
@@ -1234,7 +1234,7 @@ GDScriptParser::Node *GDScriptParser::_parse_expression(Node *p_parent, bool p_s
 
 					StringName identifier;
 					if (_get_completable_identifier(COMPLETION_INDEX, identifier)) {
-						if (identifier == StringName()) {
+						if (identifier.is_empty()) {
 							identifier = "@temp"; //so it parses alright
 						}
 						completion_node = op;
@@ -3918,7 +3918,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				if (_get_completable_identifier(COMPLETION_VIRTUAL_FUNC, name)) {
 				}
 
-				if (name == StringName()) {
+				if (name.is_empty()) {
 					_set_error("Expected an identifier after \"func\" (syntax: \"func <identifier>([arguments]):\").");
 					return;
 				}
@@ -5626,7 +5626,7 @@ void GDScriptParser::_determine_inheritance(ClassNode *p_class, bool p_recursive
 			p_class->base_type.kind = DataType::GDSCRIPT;
 			p_class->base_type.script_type = script;
 			p_class->base_type.native_type = script->get_instance_base_type();
-		} else if (native != StringName()) {
+		} else if (native) {
 			p_class->base_type.has_type = true;
 			p_class->base_type.kind = DataType::NATIVE;
 			p_class->base_type.native_type = native;
@@ -5695,7 +5695,7 @@ String GDScriptParser::DataType::to_string() const {
 			if (is_meta_type) {
 				return "GDScript";
 			}
-			if (class_type->name == StringName()) {
+			if (class_type->name.is_empty()) {
 				return "self";
 			}
 			return class_type->name.operator String();
@@ -5794,7 +5794,7 @@ bool GDScriptParser::_parse_type(DataType &r_type, bool p_can_be_void) {
 
 					StringName id;
 					bool has_completion = _get_completable_identifier(COMPLETION_TYPE_HINT_INDEX, id);
-					if (id == StringName()) {
+					if (id.is_empty()) {
 						id = "@temp";
 					}
 
@@ -6068,7 +6068,7 @@ GDScriptParser::DataType GDScriptParser::_type_from_property(const PropertyInfo 
 	ret.builtin_type = p_property.type;
 	if (p_property.type == Variant::OBJECT) {
 		ret.kind = DataType::NATIVE;
-		ret.native_type = p_property.class_name == StringName() ? "Object" : p_property.class_name;
+		ret.native_type = p_property.class_name.is_empty() ? "Object" : p_property.class_name;
 	} else {
 		ret.kind = DataType::BUILTIN;
 	}
@@ -7038,7 +7038,7 @@ bool GDScriptParser::_get_function_signature(DataType &p_base_type, const String
 		base_script = base_script->get_base_script();
 	}
 
-	if (native == StringName()) {
+	if (native.is_empty()) {
 		// Empty native class, might happen in some Script implementations
 		// Just ignore it
 		return false;
@@ -7579,7 +7579,7 @@ bool GDScriptParser::_get_member_type(const DataType &p_base_type, const StringN
 		scr = scr->get_base_script();
 	}
 
-	if (native == StringName()) {
+	if (native.is_empty()) {
 		// Empty native class, might happen in some Script implementations
 		// Just ignore it
 		return false;
@@ -7615,7 +7615,7 @@ bool GDScriptParser::_get_member_type(const DataType &p_base_type, const StringN
 			if (E->get().name == p_member && IS_USAGE_MEMBER(E->get().usage)) {
 				// Check if a getter exists
 				StringName getter_name = ClassDB::get_property_getter(native, p_member);
-				if (getter_name != StringName()) {
+				if (getter_name) {
 					// Use the getter return type
 					MethodBind *getter_method = ClassDB::get_method(native, getter_name);
 					if (getter_method) {
@@ -7651,7 +7651,7 @@ bool GDScriptParser::_get_member_type(const DataType &p_base_type, const StringN
 			if (E->get().name == p_member && IS_USAGE_MEMBER(E->get().usage)) {
 				// Check if a getter exists
 				StringName getter_name = ClassDB::get_property_getter(native, p_member);
-				if (getter_name != StringName()) {
+				if (getter_name) {
 					// Use the getter return type
 					MethodBind *getter_method = ClassDB::get_method(native, getter_name);
 					if (getter_method) {
@@ -7969,7 +7969,7 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 		}
 
 		// Setter and getter
-		if (v.setter == StringName() && v.getter == StringName()) {
+		if (v.setter.is_empty() && v.getter.is_empty()) {
 			continue;
 		}
 
@@ -8019,7 +8019,7 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 			}
 		}
 
-		if ((found_getter || v.getter == StringName()) && (found_setter || v.setter == StringName())) {
+		if ((found_getter || v.getter.is_empty()) && (found_setter || v.setter.is_empty())) {
 			continue;
 		}
 
@@ -8037,12 +8037,12 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 			}
 		}
 
-		if (!found_setter && v.setter != StringName()) {
+		if (!found_setter && v.setter) {
 			_set_error("The setter function isn't defined.", v.line);
 			return;
 		}
 
-		if (!found_getter && v.getter != StringName()) {
+		if (!found_getter && v.getter) {
 			_set_error("The getter function isn't defined.", v.line);
 			return;
 		}
@@ -8080,7 +8080,7 @@ void GDScriptParser::_check_class_level_types(ClassNode *p_class) {
 		native = base.native_type;
 	}
 
-	if (native != StringName()) {
+	if (native) {
 		for (int i = 0; i < p_class->_signals.size(); i++) {
 			if (ClassDB::has_signal(native, p_class->_signals[i].name)) {
 				_set_error("The signal \"" + p_class->_signals[i].name + "\" already exists in a parent class.", p_class->_signals[i].line);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6109,11 +6109,11 @@ void GLTFDocument::_convert_mesh_instances(Ref<GLTFState> state) {
 					int bone_i = skin->get_bind_bone(bind_i);
 					Transform bind_pose = skin->get_bind_pose(bind_i);
 					StringName bind_name = skin->get_bind_name(bind_i);
-					if (bind_name != StringName()) {
+					if (bind_name) {
 						bone_i = bone_name_to_idx[bind_name];
 					}
 					ERR_CONTINUE(bone_i < 0 || bone_i >= bone_cnt);
-					if (bind_name == StringName()) {
+					if (bind_name.is_empty()) {
 						bind_name = skeleton->get_bone_name(bone_i);
 					}
 					GLTFNodeIndex skeleton_bone_i = gltf_skeleton->joints[bone_i];

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1184,7 +1184,7 @@ Error BindingsGenerator::generate_cs_api(const String &p_output_dir) {
 Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const String &p_output_file) {
 	CRASH_COND(!itype.is_object_type);
 
-	bool is_derived_type = itype.base_name != StringName();
+	bool is_derived_type = itype.base_name;
 
 	if (!is_derived_type) {
 		// Some Godot.Object assertions
@@ -1433,7 +1433,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 
 	// Search it in base types too
 	const TypeInterface *current_type = &p_itype;
-	while (!setter && current_type->base_name != StringName()) {
+	while (!setter && current_type->base_name) {
 		OrderedHashMap<StringName, TypeInterface>::Element base_match = obj_types.find(current_type->base_name);
 		ERR_FAIL_COND_V(!base_match, ERR_BUG);
 		current_type = &base_match.get();
@@ -1444,7 +1444,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 
 	// Search it in base types too
 	current_type = &p_itype;
-	while (!getter && current_type->base_name != StringName()) {
+	while (!getter && current_type->base_name) {
 		OrderedHashMap<StringName, TypeInterface>::Element base_match = obj_types.find(current_type->base_name);
 		ERR_FAIL_COND_V(!base_match, ERR_BUG);
 		current_type = &base_match.get();
@@ -1789,7 +1789,7 @@ Error BindingsGenerator::generate_glue(const String &p_output_dir) {
 	for (OrderedHashMap<StringName, TypeInterface>::Element type_elem = obj_types.front(); type_elem; type_elem = type_elem.next()) {
 		const TypeInterface &itype = type_elem.get();
 
-		bool is_derived_type = itype.base_name != StringName();
+		bool is_derived_type = itype.base_name;
 
 		if (!is_derived_type) {
 			// Some Object assertions
@@ -2307,9 +2307,9 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			iprop.setter = ClassDB::get_property_setter(type_cname, iprop.cname);
 			iprop.getter = ClassDB::get_property_getter(type_cname, iprop.cname);
 
-			if (iprop.setter != StringName())
+			if (iprop.setter)
 				accessor_methods[iprop.setter] = iprop.cname;
-			if (iprop.getter != StringName())
+			if (iprop.getter)
 				accessor_methods[iprop.getter] = iprop.cname;
 
 			bool valid = false;
@@ -2402,7 +2402,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			} else if (return_info.type == Variant::INT && return_info.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
 				imethod.return_type.cname = return_info.class_name;
 				imethod.return_type.is_enum = true;
-			} else if (return_info.class_name != StringName()) {
+			} else if (return_info.class_name) {
 				imethod.return_type.cname = return_info.class_name;
 				if (!imethod.is_virtual && ClassDB::is_parent_class(return_info.class_name, name_cache.type_Reference) && return_info.hint != PROPERTY_HINT_RESOURCE_TYPE) {
 					/* clang-format off */
@@ -2438,7 +2438,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				if (arginfo.type == Variant::INT && arginfo.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
 					iarg.type.cname = arginfo.class_name;
 					iarg.type.is_enum = true;
-				} else if (arginfo.class_name != StringName()) {
+				} else if (arginfo.class_name) {
 					iarg.type.cname = arginfo.class_name;
 				} else if (arginfo.hint == PROPERTY_HINT_RESOURCE_TYPE) {
 					iarg.type.cname = arginfo.hint_string;
@@ -3048,7 +3048,7 @@ void BindingsGenerator::_populate_global_constants() {
 			ConstantInterface iconstant(constant_name, snake_to_pascal_case(constant_name, true), constant_value);
 			iconstant.const_doc = const_doc;
 
-			if (enum_name != StringName()) {
+			if (enum_name) {
 				EnumInterface ienum(enum_name);
 				List<EnumInterface>::Element *enum_match = global_enums.find(ienum);
 				if (enum_match) {

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -182,7 +182,7 @@ PoolStringArray get_code_completion(CompletionKind p_kind, const String &p_scrip
 			script->get_script_signal_list(&signals);
 
 			StringName native = script->get_instance_base_type();
-			if (native != StringName()) {
+			if (native) {
 				ClassDB::get_signal_list(native, &signals, /* p_no_inheritance: */ false);
 			}
 

--- a/modules/mono/mono_gd/gd_mono_class.cpp
+++ b/modules/mono/mono_gd/gd_mono_class.cpp
@@ -231,7 +231,7 @@ void GDMonoClass::fetch_methods_with_godot_api_checks(GDMonoClass *p_native_base
 
 				StringName godot_method_name = CACHED_FIELD(GodotMethodAttribute, methodName)->get_string_value(attr);
 #ifdef DEBUG_ENABLED
-				CRASH_COND(godot_method_name == StringName());
+				CRASH_COND(godot_method_name.is_empty());
 #endif
 				MethodKey key = MethodKey(godot_method_name, method->get_parameters_count());
 				GDMonoMethod **existing_method = methods.getptr(key);

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -96,7 +96,7 @@ MonoObject *unmanaged_get_managed(Object *unmanaged) {
 	// Create a new one
 
 #ifdef DEBUG_ENABLED
-	CRASH_COND(script_binding.type_name == StringName());
+	CRASH_COND(script_binding.type_name.is_empty());
 	CRASH_COND(script_binding.wrapper_class == NULL);
 #endif
 

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -241,7 +241,7 @@ void VisualScript::_node_ports_changed(int p_id) {
 		}
 	}
 
-	ERR_FAIL_COND(function == StringName());
+	ERR_FAIL_COND(function.is_empty());
 
 	Function &func = functions[function];
 	Ref<VisualScriptNode> vsn = func.nodes[p_id].node;
@@ -2236,7 +2236,7 @@ VisualScriptInstance::~VisualScriptInstance() {
 /////////////////////
 
 Variant VisualScriptFunctionState::_signal_callback(const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
-	ERR_FAIL_COND_V(function == StringName(), Variant());
+	ERR_FAIL_COND_V(function.is_empty(), Variant());
 
 #ifdef DEBUG_ENABLED
 
@@ -2292,11 +2292,11 @@ void VisualScriptFunctionState::connect_to_signal(Object *p_obj, const String &p
 }
 
 bool VisualScriptFunctionState::is_valid() const {
-	return function != StringName();
+	return function;
 }
 
 Variant VisualScriptFunctionState::resume(Array p_args) {
-	ERR_FAIL_COND_V(function == StringName(), Variant());
+	ERR_FAIL_COND_V(function.is_empty(), Variant());
 #ifdef DEBUG_ENABLED
 
 	ERR_FAIL_COND_V_MSG(instance_id && !ObjectDB::get_instance(instance_id), Variant(), "Resumed after yield, but class instance is gone.");
@@ -2327,7 +2327,7 @@ VisualScriptFunctionState::VisualScriptFunctionState() {
 }
 
 VisualScriptFunctionState::~VisualScriptFunctionState() {
-	if (function != StringName()) {
+	if (function) {
 		Variant *s = ((Variant *)stack.ptr());
 		for (int i = 0; i < variant_stack_size; i++) {
 			s[i].~Variant();

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -66,7 +66,7 @@ protected:
 	}
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
-		if (sig == StringName()) {
+		if (sig.is_empty()) {
 			return false;
 		}
 
@@ -128,7 +128,7 @@ protected:
 	}
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
-		if (sig == StringName()) {
+		if (sig.is_empty()) {
 			return false;
 		}
 
@@ -153,7 +153,7 @@ protected:
 		return false;
 	}
 	void _get_property_list(List<PropertyInfo> *p_list) const {
-		if (sig == StringName()) {
+		if (sig.is_empty()) {
 			return;
 		}
 
@@ -204,7 +204,7 @@ protected:
 	}
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
-		if (var == StringName()) {
+		if (var.is_empty()) {
 			return false;
 		}
 
@@ -280,7 +280,7 @@ protected:
 	}
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
-		if (var == StringName()) {
+		if (var.is_empty()) {
 			return false;
 		}
 
@@ -312,7 +312,7 @@ protected:
 		return false;
 	}
 	void _get_property_list(List<PropertyInfo> *p_list) const {
-		if (var == StringName()) {
+		if (var.is_empty()) {
 			return;
 		}
 
@@ -3626,7 +3626,7 @@ void VisualScriptEditor::_port_action_menu(int p_option, const StringName &func)
 
 			VisualScriptNode::TypeGuess tg = _guess_output_type(port_action_node, port_action_output, vn);
 
-			if (tg.gdclass != StringName()) {
+			if (tg.gdclass) {
 				n->set_base_type(tg.gdclass);
 			} else {
 				n->set_base_type("Object");
@@ -3720,7 +3720,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 	bool port_node_exists = true;
 
 	StringName func = _get_function_of_node(port_action_node);
-	if (func == StringName()) {
+	if (func.is_empty()) {
 		func = default_func;
 		port_node_exists = false;
 	}
@@ -3884,7 +3884,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 			if (tg.type == Variant::OBJECT) {
 				vsfc->set_call_mode(VisualScriptFunctionCall::CALL_MODE_INSTANCE);
 				vsfc->set_base_type(String(""));
-				if (tg.gdclass != StringName()) {
+				if (tg.gdclass) {
 					vsfc->set_base_type(tg.gdclass);
 
 				} else if (script->get_node(func, port_action_node).is_valid()) {
@@ -3919,7 +3919,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 			if (tg.type == Variant::OBJECT) {
 				vsp->set_call_mode(VisualScriptPropertySet::CALL_MODE_INSTANCE);
 				vsp->set_base_type(String(""));
-				if (tg.gdclass != StringName()) {
+				if (tg.gdclass) {
 					vsp->set_base_type(tg.gdclass);
 
 				} else if (script->get_node(func, port_action_node).is_valid()) {
@@ -3949,7 +3949,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 			if (tg.type == Variant::OBJECT) {
 				vsp->set_call_mode(VisualScriptPropertyGet::CALL_MODE_INSTANCE);
 				vsp->set_base_type(String(""));
-				if (tg.gdclass != StringName()) {
+				if (tg.gdclass) {
 					vsp->set_base_type(tg.gdclass);
 
 				} else if (script->get_node(func, port_action_node).is_valid()) {
@@ -4095,7 +4095,7 @@ void VisualScriptEditor::_cancel_connect_node() {
 
 int VisualScriptEditor::_create_new_node_from_name(const String &p_text, const Vector2 &p_point, const StringName &p_func) {
 	StringName func = default_func;
-	if (p_func != StringName()) {
+	if (p_func) {
 		func = p_func;
 	}
 

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -979,7 +979,7 @@ String VisualScriptPropertySet::get_output_sequence_port_text(int p_port) const 
 }
 
 void VisualScriptPropertySet::_adjust_input_index(PropertyInfo &pinfo) const {
-	if (index != StringName()) {
+	if (index) {
 		Variant v;
 		Variant::CallError ce;
 		v = Variant::construct(pinfo.type, nullptr, 0, ce);
@@ -1004,7 +1004,7 @@ PropertyInfo VisualScriptPropertySet::get_input_value_port_info(int p_idx) const
 	for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 		if (E->get().name == property) {
 			String detail_prop_name = property;
-			if (index != StringName()) {
+			if (index) {
 				detail_prop_name += "." + String(index);
 			}
 			PropertyInfo pinfo = PropertyInfo(E->get().type, detail_prop_name, E->get().hint, E->get().hint_string);
@@ -1045,7 +1045,7 @@ String VisualScriptPropertySet::get_caption() const {
 	}
 
 	String prop = property;
-	if (index != StringName()) {
+	if (index) {
 		prop += "." + String(index);
 	}
 
@@ -1467,11 +1467,11 @@ public:
 	//virtual bool get_output_port_unsequenced(int p_idx,Variant* r_value,Variant* p_working_mem,String &r_error) const { return true; }
 
 	_FORCE_INLINE_ void _process_get(Variant &source, const Variant &p_argument, bool &valid) {
-		if (index != StringName() && assign_op == VisualScriptPropertySet::ASSIGN_OP_NONE) {
+		if (index && assign_op == VisualScriptPropertySet::ASSIGN_OP_NONE) {
 			source.set_named(index, p_argument, &valid);
 		} else {
 			Variant value;
-			if (index != StringName()) {
+			if (index) {
 				value = source.get_named(index, &valid);
 			} else {
 				value = source;
@@ -1515,7 +1515,7 @@ public:
 				}
 			}
 
-			if (index != StringName()) {
+			if (index) {
 				source.set_named(index, value, &valid);
 			} else {
 				source = value;
@@ -1611,7 +1611,7 @@ VisualScriptNodeInstance *VisualScriptPropertySet::instance(VisualScriptInstance
 	instance->node_path = base_path;
 	instance->assign_op = assign_op;
 	instance->index = index;
-	instance->needs_get = index != StringName() || assign_op != ASSIGN_OP_NONE;
+	instance->needs_get = index || assign_op != ASSIGN_OP_NONE;
 	return instance;
 }
 
@@ -1757,7 +1757,7 @@ PropertyInfo VisualScriptPropertyGet::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptPropertyGet::get_caption() const {
 	String prop = property;
-	if (index != StringName()) {
+	if (index) {
 		prop += "." + String(index);
 	}
 
@@ -1953,7 +1953,7 @@ Variant::Type VisualScriptPropertyGet::_get_type_cache() const {
 }
 
 void VisualScriptPropertyGet::_adjust_input_index(PropertyInfo &pinfo) const {
-	if (index != StringName()) {
+	if (index) {
 		Variant v;
 		Variant::CallError ce;
 		v = Variant::construct(pinfo.type, nullptr, 0, ce);
@@ -2145,7 +2145,7 @@ public:
 
 				*p_outputs[0] = object->get(property, &valid);
 
-				if (index != StringName()) {
+				if (index) {
 					*p_outputs[0] = p_outputs[0]->get_named(index);
 				}
 
@@ -2174,7 +2174,7 @@ public:
 
 				*p_outputs[0] = another->get(property, &valid);
 
-				if (index != StringName()) {
+				if (index) {
 					*p_outputs[0] = p_outputs[0]->get_named(index);
 				}
 
@@ -2191,7 +2191,7 @@ public:
 
 				// port 'pass' not backported to 3.x to keep script backwards compatibility
 				*p_outputs[0] = v.get(property, &valid);
-				if (index != StringName()) {
+				if (index) {
 					*p_outputs[0] = p_outputs[0]->get_named(index);
 				}
 

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -276,7 +276,7 @@ bool TouchScreenButton::_is_point_inside(const Point2 &p_point) {
 void TouchScreenButton::_press(int p_finger_pressed) {
 	finger_pressed = p_finger_pressed;
 
-	if (action != StringName()) {
+	if (action) {
 		Input::get_singleton()->action_press(action);
 		Ref<InputEventAction> iea;
 		iea.instance();
@@ -292,7 +292,7 @@ void TouchScreenButton::_press(int p_finger_pressed) {
 void TouchScreenButton::_release(bool p_exiting_tree) {
 	finger_pressed = -1;
 
-	if (action != StringName()) {
+	if (action) {
 		Input::get_singleton()->action_release(action);
 		if (!p_exiting_tree) {
 			Ref<InputEventAction> iea;

--- a/scene/3d/skeleton.cpp
+++ b/scene/3d/skeleton.cpp
@@ -316,7 +316,7 @@ void Skeleton::_notification(int p_what) {
 					for (uint32_t i = 0; i < bind_count; i++) {
 						StringName bind_name = skin->get_bind_name(i);
 
-						if (bind_name != StringName()) {
+						if (bind_name) {
 							//bind name used, use this
 							bool found = false;
 							for (int j = 0; j < len; j++) {

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -990,7 +990,7 @@ AnimationNodeBlendTree::ConnectionError AnimationNodeBlendTree::can_connect_node
 		return CONNECTION_ERROR_NO_INPUT_INDEX;
 	}
 
-	if (nodes[p_input_node].connections[p_input_index] != StringName()) {
+	if (nodes[p_input_node].connections[p_input_index]) {
 		return CONNECTION_ERROR_CONNECTION_EXISTS;
 	}
 
@@ -1009,7 +1009,7 @@ void AnimationNodeBlendTree::get_node_connections(List<NodeConnection> *r_connec
 	for (Map<StringName, Node>::Element *E = nodes.front(); E; E = E->next()) {
 		for (int i = 0; i < E->get().connections.size(); i++) {
 			StringName output = E->get().connections[i];
-			if (output != StringName()) {
+			if (output) {
 				NodeConnection nc;
 				nc.input_node = E->key();
 				nc.input_index = i;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -284,7 +284,7 @@ bool AnimationNodeStateMachinePlayback::_travel(AnimationNodeStateMachine *p_sta
 
 float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_state_machine, float p_time, bool p_seek) {
 	//if not playing and it can restart, then restart
-	if (!playing && start_request == StringName()) {
+	if (!playing && start_request.is_empty()) {
 		if (!stop_request && p_state_machine->start_node) {
 			start(p_state_machine->start_node);
 		} else {
@@ -300,7 +300,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 
 	bool play_start = false;
 
-	if (start_request != StringName()) {
+	if (start_request) {
 		if (start_request_travel) {
 			if (!playing) {
 				if (!stop_request && p_state_machine->start_node) {
@@ -339,10 +339,10 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 		}
 	}
 
-	bool do_start = (p_seek && p_time == 0) || play_start || current == StringName();
+	bool do_start = (p_seek && p_time == 0) || play_start || current.is_empty();
 
 	if (do_start) {
-		if (p_state_machine->start_node != StringName() && p_seek && p_time == 0) {
+		if (p_state_machine->start_node && p_seek && p_time == 0) {
 			current = p_state_machine->start_node;
 		}
 
@@ -357,7 +357,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 	}
 	float fade_blend = 1.0;
 
-	if (fading_from != StringName()) {
+	if (fading_from) {
 		if (!p_state_machine->states.has(fading_from)) {
 			fading_from = StringName();
 		} else {
@@ -373,7 +373,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 
 	float rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, fade_blend, AnimationNode::FILTER_IGNORE, false);
 
-	if (fading_from != StringName()) {
+	if (fading_from) {
 		p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, 1.0 - fade_blend, AnimationNode::FILTER_IGNORE, false);
 	}
 
@@ -410,7 +410,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 				auto_advance = true;
 			}
 			StringName advance_condition_name = p_state_machine->transitions[i].transition->get_advance_condition_name();
-			if (advance_condition_name != StringName() && bool(p_state_machine->get_parameter(advance_condition_name))) {
+			if (advance_condition_name && bool(p_state_machine->get_parameter(advance_condition_name))) {
 				auto_advance = true;
 			}
 
@@ -430,7 +430,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 	}
 
 	//if next, see when to transition
-	if (next != StringName()) {
+	if (next) {
 		bool goto_next = false;
 
 		if (switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
@@ -439,7 +439,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 				next_xfade = 0;
 			}
 		} else {
-			goto_next = fading_from == StringName();
+			goto_next = fading_from.is_empty();
 		}
 
 		if (goto_next) { //end_loop should be used because fade time may be too small or zero and animation may have looped
@@ -473,7 +473,7 @@ float AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_st
 	}
 
 	//compute time left for transitions by using the end node
-	if (p_state_machine->end_node != StringName() && p_state_machine->end_node != current) {
+	if (p_state_machine->end_node && p_state_machine->end_node != current) {
 		rem = p_state_machine->blend_node(p_state_machine->end_node, p_state_machine->states[p_state_machine->end_node].node, 0, true, 0, AnimationNode::FILTER_IGNORE, false);
 	}
 
@@ -507,7 +507,7 @@ void AnimationNodeStateMachine::get_parameter_list(List<PropertyInfo> *r_list) c
 	List<StringName> advance_conditions;
 	for (int i = 0; i < transitions.size(); i++) {
 		StringName ac = transitions[i].transition->get_advance_condition_name();
-		if (ac != StringName() && advance_conditions.find(ac) == nullptr) {
+		if (ac && advance_conditions.find(ac) == nullptr) {
 			advance_conditions.push_back(ac);
 		}
 	}
@@ -762,7 +762,7 @@ void AnimationNodeStateMachine::remove_transition_by_index(int p_transition) {
 }
 
 void AnimationNodeStateMachine::set_start_node(const StringName &p_node) {
-	ERR_FAIL_COND(p_node != StringName() && !states.has(p_node));
+	ERR_FAIL_COND(p_node && !states.has(p_node));
 	start_node = p_node;
 }
 
@@ -771,7 +771,7 @@ String AnimationNodeStateMachine::get_start_node() const {
 }
 
 void AnimationNodeStateMachine::set_end_node(const StringName &p_node) {
-	ERR_FAIL_COND(p_node != StringName() && !states.has(p_node));
+	ERR_FAIL_COND(p_node && !states.has(p_node));
 	end_node = p_node;
 }
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -169,7 +169,7 @@ void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	for (Map<StringName, AnimationData>::Element *E = animation_set.front(); E; E = E->next()) {
 		anim_names.push_back(PropertyInfo(Variant::OBJECT, "anims/" + String(E->key()), PROPERTY_HINT_RESOURCE_TYPE, "Animation", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE));
-		if (E->get().next != StringName()) {
+		if (E->get().next) {
 			anim_names.push_back(PropertyInfo(Variant::STRING, "next/" + String(E->key()), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NOEDITOR | PROPERTY_USAGE_INTERNAL));
 		}
 	}
@@ -1208,7 +1208,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 	}
 
 	StringName next = animation_get_next(p_name);
-	if (next != StringName() && animation_set.has(next)) {
+	if (next && animation_set.has(next)) {
 		queue(next);
 	}
 }

--- a/scene/animation/animation_tree_player.cpp
+++ b/scene/animation/animation_tree_player.cpp
@@ -1336,7 +1336,7 @@ AnimationTreePlayer::ConnectError AnimationTreePlayer::_cycle_test(const StringN
 	nb->cycletest = true;
 
 	for (int i = 0; i < nb->inputs.size(); i++) {
-		if (nb->inputs[i].node == StringName()) {
+		if (nb->inputs[i].node.is_empty()) {
 			return CONNECT_INCOMPLETE;
 		}
 
@@ -1418,7 +1418,7 @@ void AnimationTreePlayer::get_connection_list(List<Connection> *p_connections) c
 	for (Map<StringName, NodeBase *>::Element *E = node_map.front(); E; E = E->next()) {
 		NodeBase *nb = E->get();
 		for (int i = 0; i < nb->inputs.size(); i++) {
-			if (nb->inputs[i].node != StringName()) {
+			if (nb->inputs[i].node) {
 				Connection c;
 				c.src_node = nb->inputs[i].node;
 				c.dst_node = E->key();
@@ -1619,7 +1619,7 @@ Error AnimationTreePlayer::node_rename(const StringName &p_node, const StringNam
 	}
 	ERR_FAIL_COND_V(!node_map.has(p_node), ERR_ALREADY_EXISTS);
 	ERR_FAIL_COND_V(node_map.has(p_new_name), ERR_ALREADY_EXISTS);
-	ERR_FAIL_COND_V(p_new_name == StringName(), ERR_INVALID_DATA);
+	ERR_FAIL_COND_V(p_new_name.is_empty(), ERR_INVALID_DATA);
 	ERR_FAIL_COND_V(p_node == out_name, ERR_INVALID_DATA);
 	ERR_FAIL_COND_V(p_new_name == out_name, ERR_INVALID_DATA);
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -875,8 +875,8 @@ bool Control::has_theme_item_in_types(Control *p_theme_owner, Theme::DataType p_
 }
 
 void Control::_get_theme_type_dependencies(const StringName &p_theme_type, List<StringName> *p_list) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
-		if (Theme::get_project_default().is_valid() && Theme::get_project_default()->get_type_variation_base(data.theme_type_variation) != StringName()) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+		if (Theme::get_project_default().is_valid() && Theme::get_project_default()->get_type_variation_base(data.theme_type_variation)) {
 			Theme::get_project_default()->get_type_dependencies(get_class_name(), data.theme_type_variation, p_list);
 		} else {
 			Theme::get_default()->get_type_dependencies(get_class_name(), data.theme_type_variation, p_list);
@@ -887,7 +887,7 @@ void Control::_get_theme_type_dependencies(const StringName &p_theme_type, List<
 }
 
 Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		const Ref<Texture> *tex = data.icon_override.getptr(p_name);
 		if (tex) {
 			return *tex;
@@ -900,7 +900,7 @@ Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_the
 }
 
 Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name()) {
 		const Ref<Shader> *sdr = data.shader_override.getptr(p_name);
 		if (sdr) {
 			return *sdr;
@@ -915,7 +915,7 @@ Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_th
 	while (theme_owner) {
 		StringName class_name = type;
 
-		while (class_name != StringName()) {
+		while (class_name) {
 			if (theme_owner->data.theme->has_shader(p_name, class_name)) {
 				return theme_owner->data.theme->get_shader(p_name, class_name);
 			}
@@ -942,7 +942,7 @@ Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_th
 }
 
 Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		const Ref<StyleBox> *style = data.style_override.getptr(p_name);
 		if (style) {
 			return *style;
@@ -955,7 +955,7 @@ Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &
 }
 
 Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		const Ref<Font> *font = data.font_override.getptr(p_name);
 		if (font) {
 			return *font;
@@ -968,7 +968,7 @@ Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_theme_
 }
 
 Color Control::get_color(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		const Color *color = data.color_override.getptr(p_name);
 		if (color) {
 			return *color;
@@ -981,7 +981,7 @@ Color Control::get_color(const StringName &p_name, const StringName &p_theme_typ
 }
 
 int Control::get_constant(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		const int *constant = data.constant_override.getptr(p_name);
 		if (constant) {
 			return *constant;
@@ -1024,7 +1024,7 @@ bool Control::has_constant_override(const StringName &p_name) const {
 }
 
 bool Control::has_icon(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		if (has_icon_override(p_name)) {
 			return true;
 		}
@@ -1036,7 +1036,7 @@ bool Control::has_icon(const StringName &p_name, const StringName &p_theme_type)
 }
 
 bool Control::has_shader(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name()) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name()) {
 		if (has_shader_override(p_name)) {
 			return true;
 		}
@@ -1050,7 +1050,7 @@ bool Control::has_shader(const StringName &p_name, const StringName &p_theme_typ
 	while (theme_owner) {
 		StringName class_name = type;
 
-		while (class_name != StringName()) {
+		while (class_name) {
 			if (theme_owner->data.theme->has_shader(p_name, class_name)) {
 				return true;
 			}
@@ -1075,7 +1075,7 @@ bool Control::has_shader(const StringName &p_name, const StringName &p_theme_typ
 }
 
 bool Control::has_stylebox(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		if (has_stylebox_override(p_name)) {
 			return true;
 		}
@@ -1087,7 +1087,7 @@ bool Control::has_stylebox(const StringName &p_name, const StringName &p_theme_t
 }
 
 bool Control::has_font(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		if (has_font_override(p_name)) {
 			return true;
 		}
@@ -1099,7 +1099,7 @@ bool Control::has_font(const StringName &p_name, const StringName &p_theme_type)
 }
 
 bool Control::has_color(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		if (has_color_override(p_name)) {
 			return true;
 		}
@@ -1111,7 +1111,7 @@ bool Control::has_color(const StringName &p_name, const StringName &p_theme_type
 }
 
 bool Control::has_constant(const StringName &p_name, const StringName &p_theme_type) const {
-	if (p_theme_type == StringName() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
+	if (p_theme_type.is_empty() || p_theme_type == get_class_name() || p_theme_type == data.theme_type_variation) {
 		if (has_constant_override(p_name)) {
 			return true;
 		}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1116,7 +1116,7 @@ void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 
 		bool unique = true;
 
-		if (p_child->data.name == StringName()) {
+		if (p_child->data.name.is_empty()) {
 			//new unique name must be assigned
 			unique = false;
 		} else {
@@ -1169,7 +1169,7 @@ String increase_numeric_string(const String &s) {
 }
 
 void Node::_generate_serial_child_name(const Node *p_child, StringName &name) const {
-	if (name == StringName()) {
+	if (name.is_empty()) {
 		//no name and a new nade is needed, create one.
 
 		name = p_child->get_class();

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1625,7 +1625,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 
 			String header = "[node";
 			header += " name=\"" + String(name).c_escape() + "\"";
-			if (type != StringName()) {
+			if (type) {
 				header += " type=\"" + String(type) + "\"";
 			}
 			if (path != NodePath()) {

--- a/scene/resources/skin.cpp
+++ b/scene/resources/skin.cpp
@@ -54,7 +54,7 @@ void Skin::add_named_bind(const String &p_name, const Transform &p_pose) {
 
 void Skin::set_bind_name(int p_index, const StringName &p_name) {
 	ERR_FAIL_INDEX(p_index, bind_count);
-	bool notify_change = (binds_ptr[p_index].name != StringName()) != (p_name != StringName());
+	bool notify_change = (binds_ptr[p_index].name) != (p_name);
 	binds_ptr[p_index].name = p_name;
 	emit_changed();
 	if (notify_change) {
@@ -129,7 +129,7 @@ void Skin::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (int i = 0; i < get_bind_count(); i++) {
 		const String prefix = vformat("%s/%d/", PNAME("bind"), i);
 		p_list->push_back(PropertyInfo(Variant::STRING, prefix + PNAME("name")));
-		p_list->push_back(PropertyInfo(Variant::INT, prefix + PNAME("bone"), PROPERTY_HINT_RANGE, "0,16384,1,or_greater", get_bind_name(i) != StringName() ? PROPERTY_USAGE_NOEDITOR : PROPERTY_USAGE_DEFAULT));
+		p_list->push_back(PropertyInfo(Variant::INT, prefix + PNAME("bone"), PROPERTY_HINT_RANGE, "0,16384,1,or_greater", get_bind_name(i) ? PROPERTY_USAGE_NOEDITOR : PROPERTY_USAGE_DEFAULT));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM, prefix + PNAME("pose")));
 	}
 }

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1066,9 +1066,9 @@ void Theme::get_theme_item_types(DataType p_data_type, List<StringName> *p_list)
 void Theme::set_type_variation(const StringName &p_theme_type, const StringName &p_base_type) {
 	ERR_FAIL_COND_MSG(!is_valid_type_name(p_theme_type), vformat("Invalid type name: '%s'", p_theme_type));
 	ERR_FAIL_COND_MSG(!is_valid_type_name(p_base_type), vformat("Invalid type name: '%s'", p_base_type));
-	ERR_FAIL_COND_MSG(p_theme_type == StringName(), "An empty theme type cannot be marked as a variation of another type.");
+	ERR_FAIL_COND_MSG(p_theme_type.is_empty(), "An empty theme type cannot be marked as a variation of another type.");
 	ERR_FAIL_COND_MSG(ClassDB::class_exists(p_theme_type), "A type associated with a built-in class cannot be marked as a variation of another type.");
-	ERR_FAIL_COND_MSG(p_base_type == StringName(), "An empty theme type cannot be the base type of a variation. Use clear_type_variation() instead if you want to unmark '" + String(p_theme_type) + "' as a variation.");
+	ERR_FAIL_COND_MSG(p_base_type.is_empty(), "An empty theme type cannot be the base type of a variation. Use clear_type_variation() instead if you want to unmark '" + String(p_theme_type) + "' as a variation.");
 
 	if (variation_map.has(p_theme_type)) {
 		StringName old_base = variation_map[p_theme_type];
@@ -1141,7 +1141,7 @@ void Theme::remove_type(const StringName &p_theme_type) {
 	}
 
 	// If type is a variation, remove that connection.
-	if (get_type_variation_base(p_theme_type) != StringName()) {
+	if (get_type_variation_base(p_theme_type)) {
 		clear_type_variation(p_theme_type);
 	}
 
@@ -1198,9 +1198,9 @@ void Theme::get_type_dependencies(const StringName &p_base_type, const StringNam
 	ERR_FAIL_NULL(p_list);
 
 	// Build the dependency chain for type variations.
-	if (p_type_variation != StringName()) {
+	if (p_type_variation) {
 		StringName variation_name = p_type_variation;
-		while (variation_name != StringName()) {
+		while (variation_name) {
 			p_list->push_back(variation_name);
 			variation_name = get_type_variation_base(variation_name);
 
@@ -1213,7 +1213,7 @@ void Theme::get_type_dependencies(const StringName &p_base_type, const StringNam
 
 	// Continue building the chain using native class hierarchy.
 	StringName class_name = p_base_type;
-	while (class_name != StringName()) {
+	while (class_name) {
 		p_list->push_back(class_name);
 		class_name = ClassDB::get_parent_class_nocheck(class_name);
 	}

--- a/servers/audio/effects/audio_effect_compressor.cpp
+++ b/servers/audio/effects/audio_effect_compressor.cpp
@@ -49,7 +49,7 @@ void AudioEffectCompressorInstance::process(const AudioFrame *p_src_frames, Audi
 
 	const AudioFrame *src = p_src_frames;
 
-	if (base->sidechain != StringName() && current_channel != -1) {
+	if (base->sidechain && current_channel != -1) {
 		int bus = AudioServer::get_singleton()->thread_find_bus_index(base->sidechain);
 		if (bus >= 0) {
 			src = AudioServer::get_singleton()->thread_get_channel_mix_buffer(bus, current_channel);

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -2851,7 +2851,7 @@ bool ShaderLanguage::_get_completable_identifier(BlockNode *p_block, CompletionT
 			_set_tkpos(pos);
 		}
 		return true;
-	} else if (identifier != StringName()) {
+	} else if (identifier) {
 		_set_tkpos(pos);
 	}
 
@@ -3494,7 +3494,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 											}
 										}
 
-										if (!error && varname != StringName()) {
+										if (!error && varname) {
 											if (shader->constants.has(varname)) {
 												error = true;
 											} else if (shader->uniforms.has(varname)) {
@@ -3750,7 +3750,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 					}
 				}
 
-				if (identifier == StringName()) {
+				if (identifier.is_empty()) {
 					_set_error("Expected identifier as member");
 					return nullptr;
 				}
@@ -5656,7 +5656,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 	StringName shader_type_identifier;
 	_get_completable_identifier(nullptr, COMPLETION_SHADER_TYPE, shader_type_identifier);
 
-	if (shader_type_identifier == StringName()) {
+	if (shader_type_identifier.is_empty()) {
 		_set_error("Expected identifier after 'shader_type', indicating type of shader. Valid types are: " + _get_shader_type_list(p_shader_types));
 		return ERR_PARSE_ERROR;
 	}
@@ -5683,7 +5683,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 					StringName mode;
 					_get_completable_identifier(nullptr, COMPLETION_RENDER_MODE, mode);
 
-					if (mode == StringName()) {
+					if (mode.is_empty()) {
 						_set_error("Expected identifier for render mode");
 						return ERR_PARSE_ERROR;
 					}
@@ -6214,7 +6214,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 
 				_get_completable_identifier(nullptr, COMPLETION_MAIN_FUNCTION, name);
 
-				if (name == StringName()) {
+				if (name.is_empty()) {
 					_set_error("Expected function name after datatype");
 					return ERR_PARSE_ERROR;
 				}
@@ -7001,7 +7001,7 @@ Error ShaderLanguage::complete(const String &p_code, const Map<StringName, Funct
 						}
 					}
 
-					if (skip_function != StringName() && p_functions.has(skip_function)) {
+					if (skip_function && p_functions.has(skip_function)) {
 						for (Map<StringName, BuiltInInfo>::Element *E = p_functions[skip_function].built_ins.front(); E; E = E->next()) {
 							ScriptCodeCompletionOption::Kind kind = ScriptCodeCompletionOption::KIND_MEMBER;
 							if (E->get().constant) {


### PR DESCRIPTION
This is first of a potential series of fixes which address the performance regression that was introduced in this issue:  https://github.com/godotengine/godot/issues/64241

PR includes performance enhancements for string_name, as well as unit test for the newly added functionality & existing class.

Motive for this initial first part fix, is a lot of places in engine code this is happening:

```c++
if (someStringName == StringName()) {
    //Do something
} 
```

But what I'm seeing from profiling hot spots in the latest engine 3.5 code, is a decent amount of time spent here:

![image](https://user-images.githubusercontent.com/323868/184029919-be48e8d1-0ff8-4540-9c02-a44398b4a3d1.png)

What the above profiling snapshot tells me is that a significant amount of time spent in the StringName destructor is spent locking and unlocking a mutex.  And indeed that's the case, even for an empty `StringName()`, the destructor will `unref()` and that will require a lock & unlock of a global static mutex `lock` is static ):

![image](https://user-images.githubusercontent.com/323868/184030192-30a28691-fb77-4aaa-bea5-450cfae38b9a.png)

These stack objects of an empty `StringName` which are basically only used for comparison reasons are superfluous and detrimental to performance.

This commit removes all instances of `if (someStringName == StringName())` and replaces it with a `.is_empty()` inlined function which eliminates the need to construct a temporary stack `StringName` object. This avoids the overhead of an lock/unlock cycle on the global StringName mutex here:  

![image](https://user-images.githubusercontent.com/323868/184030898-884c96f1-1be3-443b-b2ca-36f89e2cfc9a.png)

Can probably be forward ported to master.  And future instances of this pattern: `if (someStringName == StringName())` should probably not be accepted.
