### PR TITLE
Document `outline` parameter of `Font.draw_char()`

### DIFF
--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -35,6 +35,7 @@
 			<argument index="5" name="outline" type="bool" default="false" />
 			<description>
 				Draw character [code]char[/code] into a canvas item using the font at a given position, with [code]modulate[/code] color, and optionally kerning if [code]next[/code] is passed. clipping the width. [code]position[/code] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis. The width used by the character is returned, making this function useful for drawing strings character by character.
+				If [code]outline[/code] is [code]true[/code], the outline of the character is drawn instead of the character itself.
 			</description>
 		</method>
 		<method name="get_ascent" qualifiers="const">


### PR DESCRIPTION
Resolves #64256

See https://github.com/godotengine/godot/issues/64256#issuecomment-1212661513 for description.