### PR TITLE
Fix binary resource internal cache not being filled at polling time

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -315,7 +315,7 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant &r_v) {
 						path = remaps[path];
 					}
 
-					RES res = ResourceLoader::load(path, exttype, no_subresource_cache);
+					RES res = ResourceLoader::load(path, exttype, false);
 
 					if (res.is_null()) {
 						WARN_PRINT(String("Couldn't load resource: " + path).utf8().get_data());
@@ -608,7 +608,7 @@ Error ResourceInteractiveLoaderBinary::poll() {
 		if (remaps.has(path)) {
 			path = remaps[path];
 		}
-		RES res = ResourceLoader::load(path, external_resources[s].type, no_subresource_cache);
+		RES res = ResourceLoader::load(path, external_resources[s].type, false);
 		if (res.is_null()) {
 			if (!ResourceLoader::get_abort_on_missing_resources()) {
 				ResourceLoader::notify_dependency_error(local_path, path, external_resources[s].type);
@@ -711,6 +711,7 @@ Error ResourceInteractiveLoaderBinary::poll() {
 #endif
 	stage++;
 
+	internal_resources_cache[subindex] = res;
 	resource_cache.push_back(res);
 
 	if (main) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -403,7 +403,7 @@ Error ResourceInteractiveLoaderText::poll() {
 			path = remaps[path];
 		}
 
-		RES res = ResourceLoader::load(path, type, no_subresource_cache);
+		RES res = ResourceLoader::load(path, type, false);
 
 		if (res.is_null()) {
 			if (ResourceLoader::get_abort_on_missing_resources()) {


### PR DESCRIPTION
Fixes #64280 by making sure resource format binary's poller put internal resources into its internal cache.

Also applies the fix that #64200 implements for text resources, except for binary ones, before someone stumbles upon it. (I confirmed that the same bug it fixed existed.)

Also fixes a regression that caused Zylann/godot_heightmap_plugin#338 and its commensurate version in the binary loader.

Made sure to test that both #59686 and #59752 were still fixed to avoid a regression in a regression fix.