### PR TITLE
Fix instance binding unreference callback regression

### DIFF
--- a/core/object/ref_counted.cpp
+++ b/core/object/ref_counted.cpp
@@ -85,7 +85,8 @@ bool RefCounted::unreference() {
 			_get_extension()->unreference(_get_extension_instance());
 		}
 
-		die = die && _instance_binding_reference(false);
+		bool binding_ret = _instance_binding_reference(false);
+		die = die && binding_ret;
 	}
 
 	return die;


### PR DESCRIPTION
This was a regression from 44691448911f1d29d4d79dbdd5553734761e57c4

The callback should be called, not only be called when the refcount reaches `0`. For example, the C# callback needs to know when the refcount reaches `1`, in order to swap to a weak GC handle.

Fixes #62224
