### PR TITLE
[Font] Set TextServer font data pointer when it's null, to prevent TS from reading old, non-existing data.

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1817,11 +1817,9 @@ void FontFile::set_data_ptr(const uint8_t *p_data, size_t p_size) {
 	data_ptr = p_data;
 	data_size = p_size;
 
-	if (data_ptr != nullptr) {
-		for (int i = 0; i < cache.size(); i++) {
-			if (cache[i].is_valid()) {
-				TS->font_set_data_ptr(cache[i], data_ptr, data_size);
-			}
+	for (int i = 0; i < cache.size(); i++) {
+		if (cache[i].is_valid()) {
+			TS->font_set_data_ptr(cache[i], data_ptr, data_size);
 		}
 	}
 }
@@ -1831,11 +1829,9 @@ void FontFile::set_data(const PackedByteArray &p_data) {
 	data_ptr = data.ptr();
 	data_size = data.size();
 
-	if (data_ptr != nullptr) {
-		for (int i = 0; i < cache.size(); i++) {
-			if (cache[i].is_valid()) {
-				TS->font_set_data_ptr(cache[i], data_ptr, data_size);
-			}
+	for (int i = 0; i < cache.size(); i++) {
+		if (cache[i].is_valid()) {
+			TS->font_set_data_ptr(cache[i], data_ptr, data_size);
 		}
 	}
 }


### PR DESCRIPTION
This check is excessive (it's checked on the TextServer side when accessing data), and cause TextServer to preserve pointer to the old data, and accessing it after it's freed.

Fixes https://github.com/godotengine/godot/issues/60632
