### PR TITLE
Fix jumbled error output when using Windows spawn fix

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -420,6 +420,7 @@ def use_windows_spawn_fix(self, platform=None):
             startupinfo=startupinfo,
             shell=False,
             env=env,
+            text=True,
         )
         _, err = proc.communicate()
         rv = proc.wait()


### PR DESCRIPTION
In situations where the spawn fix is needed, compiler errors are reported like this because of `Popen` using stream mode by default:
```
=====
b"modules\\gltf\\structures\\gltf_skeleton.cpp:36:1: error: unknown type name 'intt'; did you mean 'int'?\r\nintt a;\r\n^~~~\r\nint\r\n1 error generated.\r\n"
=====
```

In contrast, with this PR, they look like this:
```
=====
modules\gltf\structures\gltf_skeleton.cpp:36:1: error: unknown type name 'intt'; did you mean 'int'?
intt a;
^~~~
int
1 error generated.

=====
```