### PR TITLE
Improve usage of StringNames in GraphEdit

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -291,7 +291,7 @@
 			</description>
 		</signal>
 		<signal name="connection_drag_started">
-			<param index="0" name="from_node" type="String" />
+			<param index="0" name="from_node" type="StringName" />
 			<param index="1" name="from_port" type="int" />
 			<param index="2" name="is_output" type="bool" />
 			<description>

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -136,14 +136,14 @@ private:
 	bool arrange_nodes_button_hidden = false;
 
 	bool connecting = false;
-	String connecting_from;
+	StringName connecting_from;
 	bool connecting_out = false;
 	int connecting_index = 0;
 	int connecting_type = 0;
 	Color connecting_color;
 	bool connecting_target = false;
 	Vector2 connecting_to;
-	String connecting_target_to;
+	StringName connecting_target_to;
 	int connecting_target_index = 0;
 	bool just_disconnected = false;
 	bool connecting_valid = false;


### PR DESCRIPTION
I noticed that GraphEdit emits signals with StringName argument, using a variable of String type. What's more, StringNames are being assigned to that variable, resulting in String <-> StringName conversions all over the place.

I changed `connecting_from` and `connecting_target_to` to StringName and fixed their usage to avoid String conversions. I also improved and simplified some code (loops etc.).