### PR TITLE
Added `allow_echo` parameter to accept echo events for popup menu item shortcut

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -96,6 +96,7 @@
 			<param index="1" name="shortcut" type="Shortcut" />
 			<param index="2" name="id" type="int" default="-1" />
 			<param index="3" name="global" type="bool" default="false" />
+			<param index="4" name="p_allow_echo" type="bool" default="false" />
 			<description>
 				Adds a new item and assigns the specified [Shortcut] and icon [code]texture[/code] to it. Sets the label of the checkbox to the [Shortcut]'s name.
 				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
@@ -161,6 +162,7 @@
 			<param index="0" name="shortcut" type="Shortcut" />
 			<param index="1" name="id" type="int" default="-1" />
 			<param index="2" name="global" type="bool" default="false" />
+			<param index="3" name="p_allow_echo" type="bool" default="false" />
 			<description>
 				Adds a [Shortcut].
 				An [code]id[/code] can optionally be provided. If no [code]id[/code] is provided, one will be created from the index.
@@ -442,6 +444,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="shortcut" type="Shortcut" />
 			<param index="2" name="global" type="bool" default="false" />
+			<param index="3" name="allow_echo" type="bool" default="false" />
 			<description>
 				Sets a [Shortcut] for the item at the given [code]index[/code].
 			</description>

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -44,12 +44,12 @@ void MenuButton::shortcut_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	if (p_event->is_pressed() && !p_event->is_echo() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event) || Object::cast_to<InputEventShortcut>(*p_event))) {
+	if (p_event->is_pressed() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event) || Object::cast_to<InputEventShortcut>(*p_event))) {
 		if (!get_parent() || !is_visible_in_tree() || is_disabled()) {
 			return;
 		}
 
-		if (popup->activate_item_by_event(p_event, false)) {
+		if (popup->activate_item_by_event(p_event, false, p_event->is_echo())) {
 			accept_event();
 		}
 	}

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -72,6 +72,7 @@ class PopupMenu : public Popup {
 		Ref<Shortcut> shortcut;
 		bool shortcut_is_global = false;
 		bool shortcut_is_disabled = false;
+		bool shortcut_allow_echo = false;
 
 		// Returns (0,0) if icon is null.
 		Size2 get_icon_size() const {
@@ -158,8 +159,8 @@ public:
 
 	void add_multistate_item(const String &p_label, int p_max_states, int p_default_state = 0, int p_id = -1, Key p_accel = Key::NONE);
 
-	void add_shortcut(const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false);
-	void add_icon_shortcut(const Ref<Texture2D> &p_icon, const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false);
+	void add_shortcut(const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false, bool p_allow_echo = false);
+	void add_icon_shortcut(const Ref<Texture2D> &p_icon, const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false, bool p_allow_echo = false);
 	void add_check_shortcut(const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false);
 	void add_icon_check_shortcut(const Ref<Texture2D> &p_icon, const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false);
 	void add_radio_check_shortcut(const Ref<Shortcut> &p_shortcut, int p_id = -1, bool p_global = false);
@@ -182,7 +183,7 @@ public:
 	void set_item_as_checkable(int p_idx, bool p_checkable);
 	void set_item_as_radio_checkable(int p_idx, bool p_radio_checkable);
 	void set_item_tooltip(int p_idx, const String &p_tooltip);
-	void set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bool p_global = false);
+	void set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bool p_global = false, bool p_allow_echo = false);
 	void set_item_horizontal_offset(int p_idx, int p_offset);
 	void set_item_multistate(int p_idx, int p_state);
 	void toggle_item_multistate(int p_idx);
@@ -219,7 +220,7 @@ public:
 
 	void scroll_to_item(int p_item);
 
-	bool activate_item_by_event(const Ref<InputEvent> &p_event, bool p_for_global_only = false);
+	bool activate_item_by_event(const Ref<InputEvent> &p_event, bool p_for_global_only = false, bool p_is_echo = false);
 	void activate_item(int p_item);
 
 	void remove_item(int p_idx);


### PR DESCRIPTION
In popup menu, item shortcut currently only accepts first pressed event which is ok for most of the cases but accepting echo events can be useful for undo/redo items for example :
![pr_shortcut_echo](https://user-images.githubusercontent.com/40196601/184344702-22ea8574-8382-4e49-a2c3-e10632e312a4.gif)

So added optional parameter `allow_echo` on functions which add a shortcut to items.

Here a code to reproduce the behavior (you just need to add a MenuButton to your scene):
```gdscript
func _ready():
	var popup:PopupMenu = $MenuButton.get_popup()
	popup.add_item("Undo",0)
	var shortcut:Shortcut = Shortcut.new()
	var event:InputEventKey = InputEventKey.new()
	event.ctrl_pressed = true
	event.keycode = KEY_Z
	shortcut.events.push_back(event)
	popup.set_item_shortcut(0,shortcut,true,true) #here last parameter is allow_echo
	popup.id_pressed.connect(test_print)

func test_print(_id):
	print("undo")
```