### PR TITLE
Add `shuffle_array()` method to RandomNumberGenerator

### DIFF
--- a/core/math/random_number_generator.cpp
+++ b/core/math/random_number_generator.cpp
@@ -30,6 +30,10 @@
 
 #include "random_number_generator.h"
 
+void RandomNumberGenerator::shuffle_array(Array p_array) {
+	p_array.rng_shuffle(this);
+}
+
 void RandomNumberGenerator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_seed", "seed"), &RandomNumberGenerator::set_seed);
 	ClassDB::bind_method(D_METHOD("get_seed"), &RandomNumberGenerator::get_seed);
@@ -43,6 +47,8 @@ void RandomNumberGenerator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("randf_range", "from", "to"), &RandomNumberGenerator::randf_range);
 	ClassDB::bind_method(D_METHOD("randi_range", "from", "to"), &RandomNumberGenerator::randi_range);
 	ClassDB::bind_method(D_METHOD("rand_weighted", "weights"), &RandomNumberGenerator::rand_weighted);
+	ClassDB::bind_method(D_METHOD("shuffle_array", "array"), &RandomNumberGenerator::shuffle_array);
+
 	ClassDB::bind_method(D_METHOD("randomize"), &RandomNumberGenerator::randomize);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "seed"), "set_seed", "get_seed");

--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -58,5 +58,7 @@ public:
 
 	_FORCE_INLINE_ int64_t rand_weighted(const Vector<float> &p_weights) { return randbase.rand_weighted(p_weights); }
 
+	void shuffle_array(Array p_array);
+
 	RandomNumberGenerator() { randbase.randomize(); }
 };

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -32,6 +32,7 @@
 
 #include "container_type_validate.h"
 #include "core/math/math_funcs.h"
+#include "core/math/random_number_generator.h"
 #include "core/object/script_language.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/vector.h"
@@ -740,6 +741,21 @@ void Array::shuffle() {
 	for (int i = n - 1; i >= 1; i--) {
 		const int j = Math::rand() % (i + 1);
 		SWAP(data[i], data[j]);
+	}
+}
+
+void Array::rng_shuffle(RandomNumberGenerator *p_rng) {
+	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	const int n = _p->array.size();
+	if (n < 2) {
+		return;
+	}
+	Variant *data = _p->array.ptrw();
+	for (int i = n - 1; i >= 1; i--) {
+		const int j = p_rng->randi() % (i + 1);
+		const Variant tmp = data[j];
+		data[j] = data[i];
+		data[i] = tmp;
 	}
 }
 

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -38,7 +38,11 @@
 
 class Callable;
 class StringName;
+class RandomNumberGenerator;
 class Variant;
+
+template <typename T>
+class Ref;
 
 struct ArrayPrivate;
 struct ContainerType;
@@ -146,6 +150,7 @@ public:
 	void sort();
 	void sort_custom(const Callable &p_callable);
 	void shuffle();
+	void rng_shuffle(RandomNumberGenerator *p_rng);
 	int bsearch(const Variant &p_value, bool p_before = true) const;
 	int bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before = true) const;
 	void reverse();

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -722,7 +722,7 @@
 			<return type="void" />
 			<description>
 				Shuffles all elements of the array in a random order.
-				[b]Note:[/b] Like many similar functions in the engine (such as [method @GlobalScope.randi] or [method pick_random]), this method uses a common, global random seed. To get a predictable outcome from this method, see [method @GlobalScope.seed].
+				[b]Note:[/b] Like many similar functions in the engine (such as [method @GlobalScope.randi] or [method pick_random]), this method uses a common, global random seed. If you want to shuffle using a non-global random number generator, use [method RandomNumberGenerator.shuffle_array].
 			</description>
 		</method>
 		<method name="size" qualifiers="const">

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -79,6 +79,13 @@
 				Sets up a time-based seed for this [RandomNumberGenerator] instance. Unlike the [@GlobalScope] random number generation functions, different [RandomNumberGenerator] instances can use different seeds.
 			</description>
 		</method>
+		<method name="shuffle_array">
+			<return type="void" />
+			<param index="0" name="array" type="Array" />
+			<description>
+				Shuffles the given [param array] using this [RandomNumberGenerator] for randomization instead of the global one (unlike [method Array.shuffle]).
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="seed" type="int" setter="set_seed" getter="get_seed" default="0">


### PR DESCRIPTION
I noticed that the `shuffle()` method in Array can use only global RNG, which makes it difficult to get predictable results using RandomNumberGenerator object (e.g. for level generation etc.).

At first I tried to add optional RandomNumberGenerator to Array's `shuffle()`, but Variant binder doesn't seem to support Object binds.

Closes https://github.com/godotengine/godot-proposals/issues/11853