### PR TITLE
[doc] Use "param" instead of "code" to refer to parameters (5)

### DIFF
--- a/doc/classes/IP.xml
+++ b/doc/classes/IP.xml
@@ -13,14 +13,14 @@
 			<return type="void" />
 			<param index="0" name="hostname" type="String" default="&quot;&quot;" />
 			<description>
-				Removes all of a [code]hostname[/code]'s cached references. If no [code]hostname[/code] is given, all cached IP addresses are removed.
+				Removes all of a [param hostname]'s cached references. If no [param hostname] is given, all cached IP addresses are removed.
 			</description>
 		</method>
 		<method name="erase_resolve_item">
 			<return type="void" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Removes a given item [code]id[/code] from the queue. This should be used to free a queue after it has completed to enable more queries to happen.
+				Removes a given item [param id] from the queue. This should be used to free a queue after it has completed to enable more queries to happen.
 			</description>
 		</method>
 		<method name="get_local_addresses" qualifiers="const">
@@ -48,7 +48,7 @@
 			<return type="String" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns a queued hostname's IP address, given its queue [code]id[/code]. Returns an empty string on error or if resolution hasn't happened yet (see [method get_resolve_item_status]).
+				Returns a queued hostname's IP address, given its queue [param id]. Returns an empty string on error or if resolution hasn't happened yet (see [method get_resolve_item_status]).
 			</description>
 		</method>
 		<method name="get_resolve_item_addresses" qualifiers="const">
@@ -62,7 +62,7 @@
 			<return type="int" enum="IP.ResolverStatus" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns a queued hostname's status as a [enum ResolverStatus] constant, given its queue [code]id[/code].
+				Returns a queued hostname's status as a [enum ResolverStatus] constant, given its queue [param id].
 			</description>
 		</method>
 		<method name="resolve_hostname">
@@ -70,7 +70,7 @@
 			<param index="0" name="host" type="String" />
 			<param index="1" name="ip_type" type="int" enum="IP.Type" default="3" />
 			<description>
-				Returns a given hostname's IPv4 or IPv6 address when resolved (blocking-type method). The address type returned depends on the [enum Type] constant given as [code]ip_type[/code].
+				Returns a given hostname's IPv4 or IPv6 address when resolved (blocking-type method). The address type returned depends on the [enum Type] constant given as [param ip_type].
 			</description>
 		</method>
 		<method name="resolve_hostname_addresses">
@@ -78,7 +78,7 @@
 			<param index="0" name="host" type="String" />
 			<param index="1" name="ip_type" type="int" enum="IP.Type" default="3" />
 			<description>
-				Resolves a given hostname in a blocking way. Addresses are returned as an [Array] of IPv4 or IPv6 addresses depending on [code]ip_type[/code].
+				Resolves a given hostname in a blocking way. Addresses are returned as an [Array] of IPv4 or IPv6 addresses depending on [param ip_type].
 			</description>
 		</method>
 		<method name="resolve_hostname_queue_item">
@@ -86,7 +86,7 @@
 			<param index="0" name="host" type="String" />
 			<param index="1" name="ip_type" type="int" enum="IP.Type" default="3" />
 			<description>
-				Creates a queue item to resolve a hostname to an IPv4 or IPv6 address depending on the [enum Type] constant given as [code]ip_type[/code]. Returns the queue ID if successful, or [constant RESOLVER_INVALID_ID] on error.
+				Creates a queue item to resolve a hostname to an IPv4 or IPv6 address depending on the [enum Type] constant given as [param ip_type]. Returns the queue ID if successful, or [constant RESOLVER_INVALID_ID] on error.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -28,7 +28,7 @@
 			<param index="2" name="selectable" type="bool" default="true" />
 			<description>
 				Adds an item to the item list with specified text. Returns the index of an added item.
-				Specify an [code]icon[/code], or use [code]null[/code] as the [code]icon[/code] for a list item with no icon.
+				Specify an [param icon], or use [code]null[/code] as the [param icon] for a list item with no icon.
 				If selectable is [code]true[/code], the list item will be selectable.
 			</description>
 		</method>
@@ -62,22 +62,22 @@
 			<param index="0" name="position" type="Vector2" />
 			<param index="1" name="exact" type="bool" default="false" />
 			<description>
-				Returns the item index at the given [code]position[/code].
-				When there is no item at that point, -1 will be returned if [code]exact[/code] is [code]true[/code], and the closest item index will be returned otherwise.
+				Returns the item index at the given [param position].
+				When there is no item at that point, -1 will be returned if [param exact] is [code]true[/code], and the closest item index will be returned otherwise.
 			</description>
 		</method>
 		<method name="get_item_custom_bg_color" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the custom background color of the item specified by [code]idx[/code] index.
+				Returns the custom background color of the item specified by [param idx] index.
 			</description>
 		</method>
 		<method name="get_item_custom_fg_color" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the custom foreground color of the item specified by [code]idx[/code] index.
+				Returns the custom foreground color of the item specified by [param idx] index.
 			</description>
 		</method>
 		<method name="get_item_icon" qualifiers="const">
@@ -195,14 +195,14 @@
 			<param index="0" name="from_idx" type="int" />
 			<param index="1" name="to_idx" type="int" />
 			<description>
-				Moves item from index [code]from_idx[/code] to [code]to_idx[/code].
+				Moves item from index [param from_idx] to [param to_idx].
 			</description>
 		</method>
 		<method name="remove_item">
 			<return type="void" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Removes the item specified by [code]idx[/code] index from the list.
+				Removes the item specified by [param idx] index from the list.
 			</description>
 		</method>
 		<method name="select">
@@ -219,7 +219,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="custom_bg_color" type="Color" />
 			<description>
-				Sets the background color of the item specified by [code]idx[/code] index to the specified [Color].
+				Sets the background color of the item specified by [param idx] index to the specified [Color].
 			</description>
 		</method>
 		<method name="set_item_custom_fg_color">
@@ -227,7 +227,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="custom_fg_color" type="Color" />
 			<description>
-				Sets the foreground color of the item specified by [code]idx[/code] index to the specified [Color].
+				Sets the foreground color of the item specified by [param idx] index to the specified [Color].
 			</description>
 		</method>
 		<method name="set_item_disabled">

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -52,7 +52,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="json_string" type="String" />
 			<description>
-				Attempts to parse the [code]json_string[/code] provided.
+				Attempts to parse the [param json_string] provided.
 				Returns an [enum Error]. If the parse was successful, it returns [code]OK[/code] and the result can be retrieved using [method get_data]. If unsuccessful, use [method get_error_line] and [method get_error_message] for identifying the source of the failure.
 			</description>
 		</method>
@@ -65,8 +65,8 @@
 			<description>
 				Converts a [Variant] var to JSON text and returns the result. Useful for serializing data to store or send over the network.
 				[b]Note:[/b] The JSON specification does not define integer or float types, but only a [i]number[/i] type. Therefore, converting a Variant to JSON text will convert all numerical values to [float] types.
-				[b]Note:[/b] If [code]full_precision[/code] is true, when stringifying floats, the unreliable digits are stringified in addition to the reliable digits to guarantee exact decoding.
-				The [code]indent[/code] parameter controls if and how something is indented, the string used for this parameter will be used where there should be an indent in the output, even spaces like [code]"   "[/code] will work. [code]\t[/code] and [code]\n[/code] can also be used for a tab indent, or to make a newline for each indent respectively.
+				[b]Note:[/b] If [param full_precision] is [code]true[/code], when stringifying floats, the unreliable digits are stringified in addition to the reliable digits to guarantee exact decoding.
+				The [param indent] parameter controls if and how something is indented, the string used for this parameter will be used where there should be an indent in the output, even spaces like [code]"   "[/code] will work. [code]\t[/code] and [code]\n[/code] can also be used for a tab indent, or to make a newline for each indent respectively.
 				[b]Example output:[/b]
 				[codeblock]
 				## JSON.stringify(my_dictionary)

--- a/doc/classes/JSONRPC.xml
+++ b/doc/classes/JSONRPC.xml
@@ -15,8 +15,8 @@
 			<param index="1" name="params" type="Variant" />
 			<description>
 				Returns a dictionary in the form of a JSON-RPC notification. Notifications are one-shot messages which do not expect a response.
-				- [code]method[/code]: Name of the method being called.
-				- [code]params[/code]: An array or dictionary of parameters being passed to the method.
+				- [param method]: Name of the method being called.
+				- [param params]: An array or dictionary of parameters being passed to the method.
 			</description>
 		</method>
 		<method name="make_request">
@@ -26,9 +26,9 @@
 			<param index="2" name="id" type="Variant" />
 			<description>
 				Returns a dictionary in the form of a JSON-RPC request. Requests are sent to a server with the expectation of a response. The ID field is used for the server to specify which exact request it is responding to.
-				- [code]method[/code]: Name of the method being called.
-				- [code]params[/code]: An array or dictionary of parameters being passed to the method.
-				- [code]id[/code]: Uniquely identifies this request. The server is expected to send a response with the same ID.
+				- [param method]: Name of the method being called.
+				- [param params]: An array or dictionary of parameters being passed to the method.
+				- [param id]: Uniquely identifies this request. The server is expected to send a response with the same ID.
 			</description>
 		</method>
 		<method name="make_response">
@@ -37,8 +37,8 @@
 			<param index="1" name="id" type="Variant" />
 			<description>
 				When a server has received and processed a request, it is expected to send a response. If you did not want a response then you need to have sent a Notification instead.
-				- [code]result[/code]: The return value of the function which was called.
-				- [code]id[/code]: The ID of the request this response is targeted to.
+				- [param result]: The return value of the function which was called.
+				- [param id]: The ID of the request this response is targeted to.
 			</description>
 		</method>
 		<method name="make_response_error" qualifiers="const">
@@ -48,9 +48,9 @@
 			<param index="2" name="id" type="Variant" default="null" />
 			<description>
 				Creates a response which indicates a previous reply has failed in some way.
-				- [code]code[/code]: The error code corresponding to what kind of error this is. See the [enum ErrorCode] constants.
-				- [code]message[/code]: A custom message about this error.
-				- [code]id[/code]: The request this error is a response to.
+				- [param code]: The error code corresponding to what kind of error this is. See the [enum ErrorCode] constants.
+				- [param message]: A custom message about this error.
+				- [param id]: The request this error is a response to.
 			</description>
 		</method>
 		<method name="process_action">
@@ -60,7 +60,7 @@
 			<description>
 				Given a Dictionary which takes the form of a JSON-RPC request: unpack the request and run it. Methods are resolved by looking at the field called "method" and looking for an equivalently named function in the JSONRPC object. If one is found that method is called.
 				To add new supported methods extend the JSONRPC class and call [method process_action] on your subclass.
-				[code]action[/code]: The action to be run, as a Dictionary in the form of a JSON-RPC request or notification.
+				[param action]: The action to be run, as a Dictionary in the form of a JSON-RPC request or notification.
 			</description>
 		</method>
 		<method name="process_string">

--- a/doc/classes/JavaScript.xml
+++ b/doc/classes/JavaScript.xml
@@ -22,7 +22,7 @@
 			<return type="Variant" />
 			<param index="0" name="object" type="String" />
 			<description>
-				Creates a new JavaScript object using the [code]new[/code] constructor. The [code]object[/code] must a valid property of the JavaScript [code]window[/code]. See [JavaScriptObject] for usage.
+				Creates a new JavaScript object using the [code]new[/code] constructor. The [param object] must a valid property of the JavaScript [code]window[/code]. See [JavaScriptObject] for usage.
 			</description>
 		</method>
 		<method name="download_buffer">
@@ -31,8 +31,8 @@
 			<param index="1" name="name" type="String" />
 			<param index="2" name="mime" type="String" default="&quot;application/octet-stream&quot;" />
 			<description>
-				Prompts the user to download a file containing the specified [code]buffer[/code]. The file will have the given [code]name[/code] and [code]mime[/code] type.
-				[b]Note:[/b] The browser may override the [url=https://en.wikipedia.org/wiki/Media_type]MIME type[/url] provided based on the file [code]name[/code]'s extension.
+				Prompts the user to download a file containing the specified [param buffer]. The file will have the given [param name] and [param mime] type.
+				[b]Note:[/b] The browser may override the [url=https://en.wikipedia.org/wiki/Media_type]MIME type[/url] provided based on the file [param name]'s extension.
 				[b]Note:[/b] Browsers might block the download if [method download_buffer] is not being called from a user interaction (e.g. button click).
 				[b]Note:[/b] Browsers might ask the user for permission or block the download if multiple download requests are made in a quick succession.
 			</description>
@@ -42,15 +42,15 @@
 			<param index="0" name="code" type="String" />
 			<param index="1" name="use_global_execution_context" type="bool" default="false" />
 			<description>
-				Execute the string [code]code[/code] as JavaScript code within the browser window. This is a call to the actual global JavaScript function [code]eval()[/code].
-				If [code]use_global_execution_context[/code] is [code]true[/code], the code will be evaluated in the global execution context. Otherwise, it is evaluated in the execution context of a function within the engine's runtime environment.
+				Execute the string [param code] as JavaScript code within the browser window. This is a call to the actual global JavaScript function [code]eval()[/code].
+				If [param use_global_execution_context] is [code]true[/code], the code will be evaluated in the global execution context. Otherwise, it is evaluated in the execution context of a function within the engine's runtime environment.
 			</description>
 		</method>
 		<method name="get_interface">
 			<return type="JavaScriptObject" />
 			<param index="0" name="interface" type="String" />
 			<description>
-				Returns an interface to a JavaScript object that can be used by scripts. The [code]interface[/code] must be a valid property of the JavaScript [code]window[/code]. The callback must accept a single [Array] argument, which will contain the JavaScript [code]arguments[/code]. See [JavaScriptObject] for usage.
+				Returns an interface to a JavaScript object that can be used by scripts. The [param interface] must be a valid property of the JavaScript [code]window[/code]. The callback must accept a single [Array] argument, which will contain the JavaScript [code]arguments[/code]. See [JavaScriptObject] for usage.
 			</description>
 		</method>
 		<method name="pwa_needs_update" qualifiers="const">

--- a/doc/classes/KinematicCollision2D.xml
+++ b/doc/classes/KinematicCollision2D.xml
@@ -14,7 +14,7 @@
 			<return type="float" />
 			<param index="0" name="up_direction" type="Vector2" default="Vector2(0, -1)" />
 			<description>
-				Returns the collision angle according to [code]up_direction[/code], which is [code]Vector2.UP[/code] by default. This value is always positive.
+				Returns the collision angle according to [param up_direction], which is [constant Vector2.UP] by default. This value is always positive.
 			</description>
 		</method>
 		<method name="get_collider" qualifiers="const">

--- a/doc/classes/KinematicCollision3D.xml
+++ b/doc/classes/KinematicCollision3D.xml
@@ -15,7 +15,7 @@
 			<param index="0" name="collision_index" type="int" default="0" />
 			<param index="1" name="up_direction" type="Vector3" default="Vector3(0, 1, 0)" />
 			<description>
-				Returns the collision angle according to [code]up_direction[/code], which is [code]Vector3.UP[/code] by default. This value is always positive.
+				Returns the collision angle according to [param up_direction], which is [constant Vector3.UP] by default. This value is always positive.
 			</description>
 		</method>
 		<method name="get_collider" qualifiers="const">

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -21,9 +21,9 @@
 			<return type="int" />
 			<param index="0" name="line" type="int" default="-1" />
 			<description>
-				Returns the height of the line [code]line[/code].
-				If [code]line[/code] is set to [code]-1[/code], returns the biggest line height.
-				If there're no lines returns font size in pixels.
+				Returns the height of the line [param line].
+				If [param line] is set to [code]-1[/code], returns the biggest line height.
+				If there are no lines, returns font size in pixels.
 			</description>
 		</method>
 		<method name="get_total_character_count" qualifiers="const">

--- a/doc/classes/LightmapGIData.xml
+++ b/doc/classes/LightmapGIData.xml
@@ -35,7 +35,7 @@
 			<return type="NodePath" />
 			<param index="0" name="user_idx" type="int" />
 			<description>
-				Returns the [NodePath] of the baked object at index [code]user_idx[/code].
+				Returns the [NodePath] of the baked object at index [param user_idx].
 			</description>
 		</method>
 		<method name="is_using_spherical_harmonics" qualifiers="const">
@@ -48,7 +48,7 @@
 			<return type="void" />
 			<param index="0" name="uses_spherical_harmonics" type="bool" />
 			<description>
-				If [code]uses_spherical_harmonics[/code] is [code]true[/code], tells the engine to treat the lightmap data as if it was baked with directional information.
+				If [param uses_spherical_harmonics] is [code]true[/code], tells the engine to treat the lightmap data as if it was baked with directional information.
 				[b]Note:[/b] Changing this value on already baked lightmaps will not cause them to be baked again. This means the material appearance will look incorrect until lightmaps are baked again, in which case the value set here is discarded as the entire [LightmapGIData] resource is replaced by the lightmapper.
 			</description>
 		</method>

--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -16,8 +16,8 @@
 			<param index="0" name="position" type="Vector2" />
 			<param index="1" name="at_position" type="int" default="-1" />
 			<description>
-				Adds a point at the [code]position[/code]. Appends the point at the end of the line.
-				If [code]at_position[/code] is given, the point is inserted before the point number [code]at_position[/code], moving that point (and every point after) after the inserted point. If [code]at_position[/code] is not given, or is an illegal value ([code]at_position &lt; 0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
+				Adds a point at the [param position]. Appends the point at the end of the line.
+				If [param at_position] is given, the point is inserted before the point number [param at_position], moving that point (and every point after) after the inserted point. If [param at_position] is not given, or is an illegal value ([code]at_position &lt; 0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
 			</description>
 		</method>
 		<method name="clear_points">
@@ -36,14 +36,14 @@
 			<return type="Vector2" />
 			<param index="0" name="i" type="int" />
 			<description>
-				Returns point [code]i[/code]'s position.
+				Returns point [param i]'s position.
 			</description>
 		</method>
 		<method name="remove_point">
 			<return type="void" />
 			<param index="0" name="i" type="int" />
 			<description>
-				Removes the point at index [code]i[/code] from the line.
+				Removes the point at index [param i] from the line.
 			</description>
 		</method>
 		<method name="set_point_position">
@@ -51,7 +51,7 @@
 			<param index="0" name="i" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Overwrites the position in point [code]i[/code] with the supplied [code]position[/code].
+				Overwrites the position in point [param i] with the supplied [param position].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -48,7 +48,7 @@
 			<param index="0" name="from_column" type="int" />
 			<param index="1" name="to_column" type="int" />
 			<description>
-				Deletes a section of the [member text] going from position [code]from_column[/code] to [code]to_column[/code]. Both parameters should be within the text's length.
+				Deletes a section of the [member text] going from position [param from_column] to [param to_column]. Both parameters should be within the text's length.
 			</description>
 		</method>
 		<method name="deselect">
@@ -92,7 +92,7 @@
 			<return type="void" />
 			<param index="0" name="text" type="String" />
 			<description>
-				Inserts [code]text[/code] at the caret. If the resulting value is longer than [member max_length], nothing happens.
+				Inserts [param text] at the caret. If the resulting value is longer than [member max_length], nothing happens.
 			</description>
 		</method>
 		<method name="is_menu_visible" qualifiers="const">
@@ -113,7 +113,7 @@
 			<param index="0" name="from" type="int" default="0" />
 			<param index="1" name="to" type="int" default="-1" />
 			<description>
-				Selects characters inside [LineEdit] between [code]from[/code] and [code]to[/code]. By default, [code]from[/code] is at the beginning and [code]to[/code] at the end.
+				Selects characters inside [LineEdit] between [param from] and [param to]. By default, [param from] is at the beginning and [param to] at the end.
 				[codeblocks]
 				[gdscript]
 				text = "Welcome"

--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -76,7 +76,7 @@
 			<return type="bool" />
 			<param index="0" name="delta" type="float" />
 			<description>
-				Called each physics frame with the time since the last physics frame as argument ([code]delta[/code], in seconds). Equivalent to [method Node._physics_process].
+				Called each physics frame with the time since the last physics frame as argument ([param delta], in seconds). Equivalent to [method Node._physics_process].
 				If implemented, the method must return a boolean value. [code]true[/code] ends the main loop, while [code]false[/code] lets it proceed to the next frame.
 			</description>
 		</method>

--- a/doc/classes/Marshalls.xml
+++ b/doc/classes/Marshalls.xml
@@ -13,14 +13,14 @@
 			<return type="PackedByteArray" />
 			<param index="0" name="base64_str" type="String" />
 			<description>
-				Returns a decoded [PackedByteArray] corresponding to the Base64-encoded string [code]base64_str[/code].
+				Returns a decoded [PackedByteArray] corresponding to the Base64-encoded string [param base64_str].
 			</description>
 		</method>
 		<method name="base64_to_utf8">
 			<return type="String" />
 			<param index="0" name="base64_str" type="String" />
 			<description>
-				Returns a decoded string corresponding to the Base64-encoded string [code]base64_str[/code].
+				Returns a decoded string corresponding to the Base64-encoded string [param base64_str].
 			</description>
 		</method>
 		<method name="base64_to_variant">
@@ -28,7 +28,7 @@
 			<param index="0" name="base64_str" type="String" />
 			<param index="1" name="allow_objects" type="bool" default="false" />
 			<description>
-				Returns a decoded [Variant] corresponding to the Base64-encoded string [code]base64_str[/code]. If [code]allow_objects[/code] is [code]true[/code], decoding objects is allowed.
+				Returns a decoded [Variant] corresponding to the Base64-encoded string [param base64_str]. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
@@ -43,7 +43,7 @@
 			<return type="String" />
 			<param index="0" name="utf8_str" type="String" />
 			<description>
-				Returns a Base64-encoded string of the UTF-8 string [code]utf8_str[/code].
+				Returns a Base64-encoded string of the UTF-8 string [param utf8_str].
 			</description>
 		</method>
 		<method name="variant_to_base64">
@@ -51,7 +51,7 @@
 			<param index="0" name="variant" type="Variant" />
 			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
-				Returns a Base64-encoded string of the [Variant] [code]variant[/code]. If [code]full_objects[/code] is [code]true[/code], encoding objects is allowed (and can potentially include code).
+				Returns a Base64-encoded string of the [Variant] [param variant]. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -102,8 +102,8 @@
 			<param index="1" name="simplify" type="bool" default="false" />
 			<description>
 				Calculate a [ConvexPolygonShape3D] from the mesh.
-				If [code]clean[/code] is [code]true[/code] (default), duplicate and interior vertices are removed automatically. You can set it to [code]false[/code] to make the process faster if not needed.
-				If [code]simplify[/code] is [code]true[/code], the geometry can be further simplified to reduce the amount of vertices. Disabled by default.
+				If [param clean] is [code]true[/code] (default), duplicate and interior vertices are removed automatically. You can set it to [code]false[/code] to make the process faster if not needed.
+				If [param simplify] is [code]true[/code], the geometry can be further simplified to reduce the amount of vertices. Disabled by default.
 			</description>
 		</method>
 		<method name="create_outline" qualifiers="const">

--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -19,8 +19,8 @@
 			<param index="1" name="simplify" type="bool" default="false" />
 			<description>
 				This helper creates a [StaticBody3D] child node with a [ConvexPolygonShape3D] collision shape calculated from the mesh geometry. It's mainly used for testing.
-				If [code]clean[/code] is [code]true[/code] (default), duplicate and interior vertices are removed automatically. You can set it to [code]false[/code] to make the process faster if not needed.
-				If [code]simplify[/code] is [code]true[/code], the geometry can be further simplified to reduce the amount of vertices. Disabled by default.
+				If [param clean] is [code]true[/code] (default), duplicate and interior vertices are removed automatically. You can set it to [code]false[/code] to make the process faster if not needed.
+				If [param simplify] is [code]true[/code], the geometry can be further simplified to reduce the amount of vertices. Disabled by default.
 			</description>
 		</method>
 		<method name="create_debug_tangents">

--- a/doc/classes/MovieWriter.xml
+++ b/doc/classes/MovieWriter.xml
@@ -31,7 +31,7 @@
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Called when the engine determines whether this [MovieWriter] is able to handle the file at [code]path[/code]. Must return [code]true[/code] if this [MovieWriter] is able to handle the given file path, [code]false[/code] otherwise. Typically, [method _handles_file] is overridden as follows to allow the user to record a file at any path with a given file extension:
+				Called when the engine determines whether this [MovieWriter] is able to handle the file at [param path]. Must return [code]true[/code] if this [MovieWriter] is able to handle the given file path, [code]false[/code] otherwise. Typically, [method _handles_file] is overridden as follows to allow the user to record a file at any path with a given file extension:
 				[codeblock]
 				func _handles_file(path):
 				    # Allows specifying an output file with a `.mkv` file extension (case-insensitive),
@@ -46,7 +46,7 @@
 			<param index="1" name="fps" type="int" />
 			<param index="2" name="base_path" type="String" />
 			<description>
-				Called once before the engine starts writing video and audio data. [code]movie_size[/code] is the width and height of the video to save. [code]fps[/code] is the number of frames per second specified in the project settings or using the [code]--fixed-fps &lt;fps&gt;[/code] command line argument.
+				Called once before the engine starts writing video and audio data. [param movie_size] is the width and height of the video to save. [param fps] is the number of frames per second specified in the project settings or using the [code]--fixed-fps &lt;fps&gt;[/code] command line argument.
 			</description>
 		</method>
 		<method name="_write_end" qualifiers="virtual">
@@ -61,7 +61,7 @@
 			<param index="0" name="frame_image" type="Image" />
 			<param index="1" name="audio_frame_block" type="const void*" />
 			<description>
-				Called at the end of every rendered frame. The [code]frame_image[/code] and [code]audio_frame_block[/code] function arguments should be written to.
+				Called at the end of every rendered frame. The [param frame_image] and [param audio_frame_block] function arguments should be written to.
 			</description>
 		</method>
 		<method name="add_writer" qualifiers="static">

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -60,7 +60,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="configuration" type="Variant" />
 			<description>
-				Notifies the MultiplayerAPI of a new [code]configuration[/code] for the given [code]object[/code]. This method is used internally by [SceneTree] to configure the root path for this MultiplayerAPI (passing [code]null[/code] and a valid [NodePath] as [code]configuration[/code]). This method can be further used by MultiplayerAPI implementations to provide additional features, refer to specific implementation (e.g. [SceneMultiplayer]) for details on how they use it.
+				Notifies the MultiplayerAPI of a new [param configuration] for the given [param object]. This method is used internally by [SceneTree] to configure the root path for this MultiplayerAPI (passing [code]null[/code] and a valid [NodePath] as [param configuration]). This method can be further used by MultiplayerAPI implementations to provide additional features, refer to specific implementation (e.g. [SceneMultiplayer]) for details on how they use it.
 				[b]Note:[/b] This method is mostly relevant when extending or overriding the MultiplayerAPI behavior via [MultiplayerAPIExtension].
 			</description>
 		</method>
@@ -69,7 +69,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="configuration" type="Variant" />
 			<description>
-				Notifies the MultiplayerAPI to remove a [code]configuration[/code] for the given [code]object[/code]. This method is used internally by [SceneTree] to configure the root path for this MultiplayerAPI (passing [code]null[/code] and an empty [NodePath] as [code]configuration[/code]). This method can be further used by MultiplayerAPI implementations to provide additional features, refer to specific implementation (e.g. [SceneMultiplayer]) for details on how they use it.
+				Notifies the MultiplayerAPI to remove a [param configuration] for the given [param object]. This method is used internally by [SceneTree] to configure the root path for this MultiplayerAPI (passing [code]null[/code] and an empty [NodePath] as [param configuration]). This method can be further used by MultiplayerAPI implementations to provide additional features, refer to specific implementation (e.g. [SceneMultiplayer]) for details on how they use it.
 				[b]Note:[/b] This method is mostly relevant when extending or overriding the MultiplayerAPI behavior via [MultiplayerAPIExtension].
 			</description>
 		</method>
@@ -87,7 +87,7 @@
 			<param index="2" name="method" type="StringName" />
 			<param index="3" name="arguments" type="Array" default="[]" />
 			<description>
-				Sends an RPC to the target [code]peer[/code]. The given [code]method[/code] will be called on the remote [code]object[/code] with the provided [code]arguments[/code]. The RPC may also be called locally depending on the implementation and RPC configuration. See [method Node.rpc] and [method Node.rpc_config].
+				Sends an RPC to the target [param peer]. The given [param method] will be called on the remote [param object] with the provided [param arguments]. The RPC may also be called locally depending on the implementation and RPC configuration. See [method Node.rpc] and [method Node.rpc_config].
 				[b]Note:[/b] Prefer using [method Node.rpc], [method Node.rpc_id], or [code]my_method.rpc(peer, arg1, arg2, ...)[/code] (in GDScript), since they are faster. This method is mostly useful in conjunction with [MultiplayerAPIExtension] when augmenting or replacing the multiplayer capabilities.
 			</description>
 		</method>

--- a/doc/classes/MultiplayerPeer.xml
+++ b/doc/classes/MultiplayerPeer.xml
@@ -48,7 +48,7 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Sets the peer to which packets will be sent.
-				The [code]id[/code] can be one of: [constant TARGET_PEER_BROADCAST] to send to all connected peers, [constant TARGET_PEER_SERVER] to send to the peer acting as server, a valid peer ID to send to that specific peer, a negative peer ID to send to all peers except that one. By default, the target peer is [constant TARGET_PEER_BROADCAST].
+				The [param id] can be one of: [constant TARGET_PEER_BROADCAST] to send to all connected peers, [constant TARGET_PEER_SERVER] to send to the peer acting as server, a valid peer ID to send to that specific peer, a negative peer ID to send to all peers except that one. By default, the target peer is [constant TARGET_PEER_BROADCAST].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -32,7 +32,7 @@
 			<param index="0" name="r_buffer" type="const uint8_t **" />
 			<param index="1" name="r_buffer_size" type="int32_t*" />
 			<description>
-				Called when a packet needs to be received by the [MultiplayerAPI], with [code]p_buffer_size[/code] being the size of the binary [code]p_buffer[/code] in bytes.
+				Called when a packet needs to be received by the [MultiplayerAPI], with [param r_buffer_size] being the size of the binary [param r_buffer] in bytes.
 			</description>
 		</method>
 		<method name="_get_packet_peer" qualifiers="virtual const">
@@ -88,7 +88,7 @@
 			<param index="0" name="p_buffer" type="const uint8_t*" />
 			<param index="1" name="p_buffer_size" type="int" />
 			<description>
-				Called when a packet needs to be sent by the [MultiplayerAPI], with [code]p_buffer_size[/code] being the size of the binary [code]p_buffer[/code] in bytes.
+				Called when a packet needs to be sent by the [MultiplayerAPI], with [param p_buffer_size] being the size of the binary [param p_buffer] in bytes.
 			</description>
 		</method>
 		<method name="_put_packet_script" qualifiers="virtual">

--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -38,7 +38,7 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_navigation_map" qualifiers="const">
@@ -88,7 +88,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_navigation_map">

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -38,7 +38,7 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_navigation_map" qualifiers="const">
@@ -88,7 +88,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_navigation_map">

--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -28,14 +28,14 @@
 			<param index="0" name="mesh" type="Mesh" />
 			<description>
 				Initializes the navigation mesh by setting the vertices and indices according to a [Mesh].
-				[b]Note:[/b] The given [code]mesh[/code] must be of type [constant Mesh.PRIMITIVE_TRIANGLES] and have an index array.
+				[b]Note:[/b] The given [param mesh] must be of type [constant Mesh.PRIMITIVE_TRIANGLES] and have an index array.
 			</description>
 		</method>
 		<method name="get_collision_mask_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member geometry_collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member geometry_collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_polygon">
@@ -62,7 +62,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member geometry_collision_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member geometry_collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_vertices">

--- a/doc/classes/NavigationMeshGenerator.xml
+++ b/doc/classes/NavigationMeshGenerator.xml
@@ -18,14 +18,14 @@
 			<param index="0" name="nav_mesh" type="NavigationMesh" />
 			<param index="1" name="root_node" type="Node" />
 			<description>
-				Bakes navigation data to the provided [code]nav_mesh[/code] by parsing child nodes under the provided [code]root_node[/code] or a specific group of nodes for potential source geometry. The parse behavior can be controlled with the [member NavigationMesh.geometry_parsed_geometry_type] and [member NavigationMesh.geometry_source_geometry_mode] properties on the [NavigationMesh] resource.
+				Bakes navigation data to the provided [param nav_mesh] by parsing child nodes under the provided [param root_node] or a specific group of nodes for potential source geometry. The parse behavior can be controlled with the [member NavigationMesh.geometry_parsed_geometry_type] and [member NavigationMesh.geometry_source_geometry_mode] properties on the [NavigationMesh] resource.
 			</description>
 		</method>
 		<method name="clear">
 			<return type="void" />
 			<param index="0" name="nav_mesh" type="NavigationMesh" />
 			<description>
-				Removes all polygons and vertices from the provided [code]nav_mesh[/code] resource.
+				Removes all polygons and vertices from the provided [param nav_mesh] resource.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationRegion2D.xml
+++ b/doc/classes/NavigationRegion2D.xml
@@ -18,7 +18,7 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_region_rid" qualifiers="const">
@@ -32,7 +32,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationRegion3D.xml
+++ b/doc/classes/NavigationRegion3D.xml
@@ -18,14 +18,14 @@
 			<return type="void" />
 			<param index="0" name="on_thread" type="bool" default="true" />
 			<description>
-				Bakes the [NavigationMesh]. If [code]on_thread[/code] is set to [code]true[/code] (default), the baking is done on a separate thread. Baking on separate thread is useful because navigation baking is not a cheap operation. When it is completed, it automatically sets the new [NavigationMesh]. Please note that baking on separate thread may be very slow if geometry is parsed from meshes as async access to each mesh involves heavy synchronization. Also, please note that baking on a separate thread is automatically disabled on operating systems that cannot use threads (such as HTML5 with threads disabled).
+				Bakes the [NavigationMesh]. If [param on_thread] is set to [code]true[/code] (default), the baking is done on a separate thread. Baking on separate thread is useful because navigation baking is not a cheap operation. When it is completed, it automatically sets the new [NavigationMesh]. Please note that baking on separate thread may be very slow if geometry is parsed from meshes as async access to each mesh involves heavy synchronization. Also, please note that baking on a separate thread is automatically disabled on operating systems that cannot use threads (such as HTML5 with threads disabled).
 			</description>
 		</method>
 		<method name="get_navigation_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_region_rid" qualifiers="const">
@@ -39,7 +39,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -27,7 +27,7 @@
 			<return type="RID" />
 			<param index="0" name="agent" type="RID" />
 			<description>
-				Returns the navigation map [RID] the requested [code]agent[/code] is currently assigned to.
+				Returns the navigation map [RID] the requested [param agent] is currently assigned to.
 			</description>
 		</method>
 		<method name="agent_is_map_changed" qualifiers="const">
@@ -44,8 +44,8 @@
 			<param index="2" name="method" type="StringName" />
 			<param index="3" name="userdata" type="Variant" default="null" />
 			<description>
-				Callback called at the end of the RVO process. If a callback is created manually and the agent is placed on a navigation map it will calculate avoidance for the agent and dispatch the calculated [code]safe_velocity[/code] to the [code]receiver[/code] object with a signal to the chosen [code]method[/code] name.
-				[b]Note:[/b] Created callbacks are always processed independently of the SceneTree state as long as the agent is on a navigation map and not freed. To disable the dispatch of a callback from an agent use [method agent_set_callback] again with a [code]null[/code] object as the [code]receiver[/code].
+				Callback called at the end of the RVO process. If a callback is created manually and the agent is placed on a navigation map it will calculate avoidance for the agent and dispatch the calculated [code]safe_velocity[/code] to the [param receiver] object with a signal to the chosen [param method] name.
+				[b]Note:[/b] Created callbacks are always processed independently of the SceneTree state as long as the agent is on a navigation map and not freed. To disable the dispatch of a callback from an agent use [method agent_set_callback] again with a [code]null[/code] object as the [param receiver].
 			</description>
 		</method>
 		<method name="agent_set_map" qualifiers="const">
@@ -143,7 +143,7 @@
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<description>
-				This function immediately forces synchronization of the specified navigation [code]map[/code] [RID]. By default navigation maps are only synchronized at the end of each physics frame. This function can be used to immediately (re)calculate all the navigation meshes and region connections of the navigation map. This makes it possible to query a navigation path for a changed map immediately and in the same frame (multiple times if needed).
+				This function immediately forces synchronization of the specified navigation [param map] [RID]. By default navigation maps are only synchronized at the end of each physics frame. This function can be used to immediately (re)calculate all the navigation meshes and region connections of the navigation map. This makes it possible to query a navigation path for a changed map immediately and in the same frame (multiple times if needed).
 				Due to technical restrictions the current NavigationServer command queue will be flushed. This means all already queued update commands for this physics frame will be executed, even those intended for other maps, regions and agents not part of the specified map. The expensive computation of the navigation meshes and region connections of a map will only be done for the specified map. Other maps will receive the normal synchronization at the end of the physics frame. Should the specified map receive changes after the forced update it will update again as well when the other maps receive their update.
 				Avoidance processing and dispatch of the [code]safe_velocity[/code] signals is untouched by this function and continues to happen for all maps and agents at the end of the physics frame.
 				[b]Note:[/b] With great power comes great responsibility. This function should only be used by users that really know what they are doing and have a good reason for it. Forcing an immediate update of a navigation map requires locking the NavigationServer and flushing the entire NavigationServer command queue. Not only can this severely impact the performance of a game but it can also introduce bugs if used inappropriately without much foresight.
@@ -153,7 +153,7 @@
 			<return type="Array" />
 			<param index="0" name="map" type="RID" />
 			<description>
-				Returns all navigation agents [RID]s that are currently assigned to the requested navigation [code]map[/code].
+				Returns all navigation agents [RID]s that are currently assigned to the requested navigation [param map].
 			</description>
 		</method>
 		<method name="map_get_cell_size" qualifiers="const">
@@ -168,7 +168,7 @@
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="to_point" type="Vector2" />
 			<description>
-				Returns the point closest to the provided [code]to_point[/code] on the navigation mesh surface.
+				Returns the point closest to the provided [param to_point] on the navigation mesh surface.
 			</description>
 		</method>
 		<method name="map_get_closest_point_owner" qualifiers="const">
@@ -194,14 +194,14 @@
 			<param index="3" name="optimize" type="bool" />
 			<param index="4" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns the navigation path to reach the destination from the origin. [code]navigation_layers[/code] is a bitmask of all region navigation layers that are allowed to be in the path.
+				Returns the navigation path to reach the destination from the origin. [param navigation_layers] is a bitmask of all region navigation layers that are allowed to be in the path.
 			</description>
 		</method>
 		<method name="map_get_regions" qualifiers="const">
 			<return type="Array" />
 			<param index="0" name="map" type="RID" />
 			<description>
-				Returns all navigation regions [RID]s that are currently assigned to the requested navigation [code]map[/code].
+				Returns all navigation regions [RID]s that are currently assigned to the requested navigation [param map].
 			</description>
 		</method>
 		<method name="map_is_active" qualifiers="const">
@@ -246,7 +246,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="connection" type="int" />
 			<description>
-				Returns the ending point of a connection door. [code]connection[/code] is an index between 0 and the return value of [method region_get_connections_count].
+				Returns the ending point of a connection door. [param connection] is an index between 0 and the return value of [method region_get_connections_count].
 			</description>
 		</method>
 		<method name="region_get_connection_pathway_start" qualifiers="const">
@@ -254,28 +254,28 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="connection" type="int" />
 			<description>
-				Returns the starting point of a connection door. [code]connection[/code] is an index between 0 and the return value of [method region_get_connections_count].
+				Returns the starting point of a connection door. [param connection] is an index between 0 and the return value of [method region_get_connections_count].
 			</description>
 		</method>
 		<method name="region_get_connections_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns how many connections this [code]region[/code] has with other regions in the map.
+				Returns how many connections this [param region] has with other regions in the map.
 			</description>
 		</method>
 		<method name="region_get_enter_cost" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the [code]enter_cost[/code] of this [code]region[/code].
+				Returns the [code]enter_cost[/code] of this [param region].
 			</description>
 		</method>
 		<method name="region_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the navigation map [RID] the requested [code]region[/code] is currently assigned to.
+				Returns the navigation map [RID] the requested [param region] is currently assigned to.
 			</description>
 		</method>
 		<method name="region_get_navigation_layers" qualifiers="const">
@@ -289,7 +289,7 @@
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the [code]travel_cost[/code] of this [code]region[/code].
+				Returns the [code]travel_cost[/code] of this [param region].
 			</description>
 		</method>
 		<method name="region_owns_point" qualifiers="const">
@@ -297,7 +297,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="point" type="Vector2" />
 			<description>
-				Returns [code]true[/code] if the provided [code]point[/code] in world space is currently owned by the provided navigation [code]region[/code]. Owned in this context means that one of the region's navigation mesh polygon faces has a possible position at the closest distance to this point compared to all other navigation meshes from other navigation regions that are also registered on the navigation map of the provided region.
+				Returns [code]true[/code] if the provided [param point] in world space is currently owned by the provided navigation [param region]. Owned in this context means that one of the region's navigation mesh polygon faces has a possible position at the closest distance to this point compared to all other navigation meshes from other navigation regions that are also registered on the navigation map of the provided region.
 				If multiple navigation meshes have positions at equal distance the navigation region whose polygons are processed first wins the ownership. Polygons are processed in the same order that navigation regions were registered on the NavigationServer.
 				[b]Note:[/b] If navigation meshes from different navigation regions overlap (which should be avoided in general) the result might not be what is expected.
 			</description>
@@ -307,7 +307,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="enter_cost" type="float" />
 			<description>
-				Sets the [code]enter_cost[/code] for this [code]region[/code].
+				Sets the [param enter_cost] for this [param region].
 			</description>
 		</method>
 		<method name="region_set_map" qualifiers="const">
@@ -347,7 +347,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="travel_cost" type="float" />
 			<description>
-				Sets the [code]travel_cost[/code] for this [code]region[/code].
+				Sets the [param travel_cost] for this [param region].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -27,7 +27,7 @@
 			<return type="RID" />
 			<param index="0" name="agent" type="RID" />
 			<description>
-				Returns the navigation map [RID] the requested [code]agent[/code] is currently assigned to.
+				Returns the navigation map [RID] the requested [param agent] is currently assigned to.
 			</description>
 		</method>
 		<method name="agent_is_map_changed" qualifiers="const">
@@ -44,8 +44,8 @@
 			<param index="2" name="method" type="StringName" />
 			<param index="3" name="userdata" type="Variant" default="null" />
 			<description>
-				Callback called at the end of the RVO process. If a callback is created manually and the agent is placed on a navigation map it will calculate avoidance for the agent and dispatch the calculated [code]safe_velocity[/code] to the [code]receiver[/code] object with a signal to the chosen [code]method[/code] name.
-				[b]Note:[/b] Created callbacks are always processed independently of the SceneTree state as long as the agent is on a navigation map and not freed. To disable the dispatch of a callback from an agent use [method agent_set_callback] again with a [code]null[/code] object as the [code]receiver[/code].
+				Callback called at the end of the RVO process. If a callback is created manually and the agent is placed on a navigation map it will calculate avoidance for the agent and dispatch the calculated [code]safe_velocity[/code] to the [param receiver] object with a signal to the chosen [param method] name.
+				[b]Note:[/b] Created callbacks are always processed independently of the SceneTree state as long as the agent is on a navigation map and not freed. To disable the dispatch of a callback from an agent use [method agent_set_callback] again with a [code]null[/code] object as the [param receiver].
 			</description>
 		</method>
 		<method name="agent_set_map" qualifiers="const">
@@ -143,7 +143,7 @@
 			<return type="void" />
 			<param index="0" name="map" type="RID" />
 			<description>
-				This function immediately forces synchronization of the specified navigation [code]map[/code] [RID]. By default navigation maps are only synchronized at the end of each physics frame. This function can be used to immediately (re)calculate all the navigation meshes and region connections of the navigation map. This makes it possible to query a navigation path for a changed map immediately and in the same frame (multiple times if needed).
+				This function immediately forces synchronization of the specified navigation [param map] [RID]. By default navigation maps are only synchronized at the end of each physics frame. This function can be used to immediately (re)calculate all the navigation meshes and region connections of the navigation map. This makes it possible to query a navigation path for a changed map immediately and in the same frame (multiple times if needed).
 				Due to technical restrictions the current NavigationServer command queue will be flushed. This means all already queued update commands for this physics frame will be executed, even those intended for other maps, regions and agents not part of the specified map. The expensive computation of the navigation meshes and region connections of a map will only be done for the specified map. Other maps will receive the normal synchronization at the end of the physics frame. Should the specified map receive changes after the forced update it will update again as well when the other maps receive their update.
 				Avoidance processing and dispatch of the [code]safe_velocity[/code] signals is untouched by this function and continues to happen for all maps and agents at the end of the physics frame.
 				[b]Note:[/b] With great power comes great responsibility. This function should only be used by users that really know what they are doing and have a good reason for it. Forcing an immediate update of a navigation map requires locking the NavigationServer and flushing the entire NavigationServer command queue. Not only can this severely impact the performance of a game but it can also introduce bugs if used inappropriately without much foresight.
@@ -153,7 +153,7 @@
 			<return type="Array" />
 			<param index="0" name="map" type="RID" />
 			<description>
-				Returns all navigation agents [RID]s that are currently assigned to the requested navigation [code]map[/code].
+				Returns all navigation agents [RID]s that are currently assigned to the requested navigation [param map].
 			</description>
 		</method>
 		<method name="map_get_cell_size" qualifiers="const">
@@ -168,7 +168,7 @@
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="to_point" type="Vector3" />
 			<description>
-				Returns the point closest to the provided [code]point[/code] on the navigation mesh surface.
+				Returns the point closest to the provided [param to_point] on the navigation mesh surface.
 			</description>
 		</method>
 		<method name="map_get_closest_point_normal" qualifiers="const">
@@ -212,14 +212,14 @@
 			<param index="3" name="optimize" type="bool" />
 			<param index="4" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns the navigation path to reach the destination from the origin. [code]navigation_layers[/code] is a bitmask of all region navigation layers that are allowed to be in the path.
+				Returns the navigation path to reach the destination from the origin. [param navigation_layers] is a bitmask of all region navigation layers that are allowed to be in the path.
 			</description>
 		</method>
 		<method name="map_get_regions" qualifiers="const">
 			<return type="Array" />
 			<param index="0" name="map" type="RID" />
 			<description>
-				Returns all navigation regions [RID]s that are currently assigned to the requested navigation [code]map[/code].
+				Returns all navigation regions [RID]s that are currently assigned to the requested navigation [param map].
 			</description>
 		</method>
 		<method name="map_get_up" qualifiers="const">
@@ -296,7 +296,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="connection" type="int" />
 			<description>
-				Returns the ending point of a connection door. [code]connection[/code] is an index between 0 and the return value of [method region_get_connections_count].
+				Returns the ending point of a connection door. [param connection] is an index between 0 and the return value of [method region_get_connections_count].
 			</description>
 		</method>
 		<method name="region_get_connection_pathway_start" qualifiers="const">
@@ -304,28 +304,28 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="connection" type="int" />
 			<description>
-				Returns the starting point of a connection door. [code]connection[/code] is an index between 0 and the return value of [method region_get_connections_count].
+				Returns the starting point of a connection door. [param connection] is an index between 0 and the return value of [method region_get_connections_count].
 			</description>
 		</method>
 		<method name="region_get_connections_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns how many connections this [code]region[/code] has with other regions in the map.
+				Returns how many connections this [param region] has with other regions in the map.
 			</description>
 		</method>
 		<method name="region_get_enter_cost" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the [code]enter_cost[/code] of this [code]region[/code].
+				Returns the [code]enter_cost[/code] of this [param region].
 			</description>
 		</method>
 		<method name="region_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the navigation map [RID] the requested [code]region[/code] is currently assigned to.
+				Returns the navigation map [RID] the requested [param region] is currently assigned to.
 			</description>
 		</method>
 		<method name="region_get_navigation_layers" qualifiers="const">
@@ -339,7 +339,7 @@
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
 			<description>
-				Returns the [code]travel_cost[/code] of this [code]region[/code].
+				Returns the [code]travel_cost[/code] of this [param region].
 			</description>
 		</method>
 		<method name="region_owns_point" qualifiers="const">
@@ -347,7 +347,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="point" type="Vector3" />
 			<description>
-				Returns [code]true[/code] if the provided [code]point[/code] in world space is currently owned by the provided navigation [code]region[/code]. Owned in this context means that one of the region's navigation mesh polygon faces has a possible position at the closest distance to this point compared to all other navigation meshes from other navigation regions that are also registered on the navigation map of the provided region.
+				Returns [code]true[/code] if the provided [param point] in world space is currently owned by the provided navigation [param region]. Owned in this context means that one of the region's navigation mesh polygon faces has a possible position at the closest distance to this point compared to all other navigation meshes from other navigation regions that are also registered on the navigation map of the provided region.
 				If multiple navigation meshes have positions at equal distance the navigation region whose polygons are processed first wins the ownership. Polygons are processed in the same order that navigation regions were registered on the NavigationServer.
 				[b]Note:[/b] If navigation meshes from different navigation regions overlap (which should be avoided in general) the result might not be what is expected.
 			</description>
@@ -357,7 +357,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="enter_cost" type="float" />
 			<description>
-				Sets the [code]enter_cost[/code] for this [code]region[/code].
+				Sets the [param enter_cost] for this [param region].
 			</description>
 		</method>
 		<method name="region_set_map" qualifiers="const">
@@ -397,7 +397,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="travel_cost" type="float" />
 			<description>
-				Sets the [code]travel_cost[/code] for this [code]region[/code].
+				Sets the [param travel_cost] for this [param region].
 			</description>
 		</method>
 		<method name="set_active" qualifiers="const">

--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -21,7 +21,7 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<param index="1" name="value" type="int" />
 			<description>
-				Sets the size of the margin on the specified [enum Side] to [code]value[/code] pixels.
+				Sets the size of the margin on the specified [enum Side] to [param value] pixels.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -59,7 +59,7 @@
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
 			<description>
-				Called during the physics processing step of the main loop. Physics processing means that the frame rate is synced to the physics, i.e. the [code]delta[/code] variable should be constant. [code]delta[/code] is in seconds.
+				Called during the physics processing step of the main loop. Physics processing means that the frame rate is synced to the physics, i.e. the [param delta] variable should be constant. [param delta] is in seconds.
 				It is only called if physics processing is enabled, which is done automatically if this method is overridden, and can be toggled with [method set_physics_process].
 				Corresponds to the [constant NOTIFICATION_PHYSICS_PROCESS] notification in [method Object._notification].
 				[b]Note:[/b] This method is only called if the node is present in the scene tree (i.e. if it's not an orphan).
@@ -69,7 +69,7 @@
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
 			<description>
-				Called during the processing step of the main loop. Processing happens at every frame and as fast as possible, so the [code]delta[/code] time since the previous frame is not constant. [code]delta[/code] is in seconds.
+				Called during the processing step of the main loop. Processing happens at every frame and as fast as possible, so the [param delta] time since the previous frame is not constant. [param delta] is in seconds.
 				It is only called if processing is enabled, which is done automatically if this method is overridden, and can be toggled with [method set_process].
 				Corresponds to the [constant NOTIFICATION_PROCESS] notification in [method Object._notification].
 				[b]Note:[/b] This method is only called if the node is present in the scene tree (i.e. if it's not an orphan).
@@ -125,8 +125,8 @@
 			<param index="2" name="internal" type="int" enum="Node.InternalMode" default="0" />
 			<description>
 				Adds a child node. Nodes can have any number of children, but every child must have a unique name. Child nodes are automatically deleted when the parent node is deleted, so an entire scene can be removed by deleting its topmost node.
-				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have a human-readable name based on the name of the node being instantiated instead of its type.
-				If [code]internal[/code] is different than [constant INTERNAL_MODE_DISABLED], the child will be added as internal node. Such nodes are ignored by methods like [method get_children], unless their parameter [code]include_internal[/code] is [code]true[/code].The intended usage is to hide the internal nodes from the user, so the user won't accidentally delete or modify them. Used by some GUI nodes, e.g. [ColorPicker]. See [enum InternalMode] for available modes.
+				If [param legible_unique_name] is [code]true[/code], the child node will have a human-readable name based on the name of the node being instantiated instead of its type.
+				If [param internal] is different than [constant INTERNAL_MODE_DISABLED], the child will be added as internal node. Such nodes are ignored by methods like [method get_children], unless their parameter [code]include_internal[/code] is [code]true[/code].The intended usage is to hide the internal nodes from the user, so the user won't accidentally delete or modify them. Used by some GUI nodes, e.g. [ColorPicker]. See [enum InternalMode] for available modes.
 				[b]Note:[/b] If the child node already has a parent, the function will fail. Use [method remove_child] first to remove the node from its current parent. For example:
 				[codeblocks]
 				[gdscript]
@@ -153,8 +153,8 @@
 			<param index="0" name="sibling" type="Node" />
 			<param index="1" name="legible_unique_name" type="bool" default="false" />
 			<description>
-				Adds a [code]sibling[/code] node to current's node parent, at the same level as that node, right below it.
-				If [code]legible_unique_name[/code] is [code]true[/code], the child node will have a human-readable name based on the name of the node being instantiated instead of its type.
+				Adds a [param sibling] node to current's node parent, at the same level as that node, right below it.
+				If [param legible_unique_name] is [code]true[/code], the child node will have a human-readable name based on the name of the node being instantiated instead of its type.
 				Use [method add_child] instead of this method if you don't need the child node to be added below a specific node in the list of children.
 				[b]Note:[/b] If this node is internal, the new sibling will be internal too (see [code]internal[/code] parameter in [method add_child]).
 			</description>
@@ -165,7 +165,7 @@
 			<param index="1" name="persistent" type="bool" default="false" />
 			<description>
 				Adds the node to a group. Groups are helpers to name and organize a subset of nodes, for example "enemies" or "collectables". A node can be in any number of groups. Nodes can be assigned a group at any time, but will not be added until they are inside the scene tree (see [method is_inside_tree]). See notes in the description, and the group methods in [SceneTree].
-				The [code]persistent[/code] option is used when packing node to [PackedScene] and saving to file. Non-persistent groups aren't stored.
+				The [param persistent] option is used when packing node to [PackedScene] and saving to file. Non-persistent groups aren't stored.
 				[b]Note:[/b] For performance reasons, the order of node groups is [i]not[/i] guaranteed. The order of node groups should not be relied upon as it can vary across project runs.
 			</description>
 		</method>
@@ -189,7 +189,7 @@
 			<param index="0" name="flags" type="int" default="15" />
 			<description>
 				Duplicates the node, returning a new node.
-				You can fine-tune the behavior using the [code]flags[/code] (see [enum DuplicateFlags]).
+				You can fine-tune the behavior using the [param flags] (see [enum DuplicateFlags]).
 				[b]Note:[/b] It will not work properly if the node contains a script with constructor arguments (i.e. needs to supply arguments to [method Object._init] method). In that case, the node will be duplicated without a script.
 			</description>
 		</method>
@@ -199,10 +199,10 @@
 			<param index="1" name="recursive" type="bool" default="true" />
 			<param index="2" name="owned" type="bool" default="true" />
 			<description>
-				Finds the first descendant of this node whose name matches [code]pattern[/code] as in [method String.match].
-				[code]pattern[/code] does not match against the full path, just against individual node names. It is case-sensitive, with [code]"*"[/code] matching zero or more characters and [code]"?"[/code] matching any single character except [code]"."[/code]).
-				If [code]recursive[/code] is [code]true[/code], all child nodes are included, even if deeply nested. Nodes are checked in tree order, so this node's first direct child is checked first, then its own direct children, etc., before moving to the second direct child, and so on. If [code]recursive[/code] is [code]false[/code], only this node's direct children are matched.
-				If [code]owned[/code] is [code]true[/code], this method only finds nodes who have an assigned [member Node.owner]. This is especially important for scenes instantiated through a script, because those scenes don't have an owner.
+				Finds the first descendant of this node whose name matches [param pattern] as in [method String.match].
+				[param pattern] does not match against the full path, just against individual node names. It is case-sensitive, with [code]"*"[/code] matching zero or more characters and [code]"?"[/code] matching any single character except [code]"."[/code]).
+				If [param recursive] is [code]true[/code], all child nodes are included, even if deeply nested. Nodes are checked in tree order, so this node's first direct child is checked first, then its own direct children, etc., before moving to the second direct child, and so on. If [param recursive] is [code]false[/code], only this node's direct children are matched.
+				If [param owned] is [code]true[/code], this method only finds nodes who have an assigned [member Node.owner]. This is especially important for scenes instantiated through a script, because those scenes don't have an owner.
 				Returns [code]null[/code] if no matching [Node] is found.
 				[b]Note:[/b] As this method walks through all the descendants of the node, it is the slowest way to get a reference to another node. Whenever possible, consider using [method get_node] with unique names instead (see [member unique_name_in_owner]), or caching the node references into variable.
 				[b]Note:[/b] To find all descendant nodes matching a pattern or a class type, see [method find_children].
@@ -215,11 +215,11 @@
 			<param index="2" name="recursive" type="bool" default="true" />
 			<param index="3" name="owned" type="bool" default="true" />
 			<description>
-				Finds descendants of this node whose name matches [code]pattern[/code] as in [method String.match], and/or type matches [code]type[/code] as in [method Object.is_class].
-				[code]pattern[/code] does not match against the full path, just against individual node names. It is case-sensitive, with [code]"*"[/code] matching zero or more characters and [code]"?"[/code] matching any single character except [code]"."[/code]).
-				[code]type[/code] will check equality or inheritance, and is case-sensitive. [code]"Object"[/code] will match a node whose type is [code]"Node"[/code] but not the other way around.
-				If [code]recursive[/code] is [code]true[/code], all child nodes are included, even if deeply nested. Nodes are checked in tree order, so this node's first direct child is checked first, then its own direct children, etc., before moving to the second direct child, and so on. If [code]recursive[/code] is [code]false[/code], only this node's direct children are matched.
-				If [code]owned[/code] is [code]true[/code], this method only finds nodes who have an assigned [member Node.owner]. This is especially important for scenes instantiated through a script, because those scenes don't have an owner.
+				Finds descendants of this node whose name matches [param pattern] as in [method String.match], and/or type matches [param type] as in [method Object.is_class].
+				[param pattern] does not match against the full path, just against individual node names. It is case-sensitive, with [code]"*"[/code] matching zero or more characters and [code]"?"[/code] matching any single character except [code]"."[/code]).
+				[param type] will check equality or inheritance, and is case-sensitive. [code]"Object"[/code] will match a node whose type is [code]"Node"[/code] but not the other way around.
+				If [param recursive] is [code]true[/code], all child nodes are included, even if deeply nested. Nodes are checked in tree order, so this node's first direct child is checked first, then its own direct children, etc., before moving to the second direct child, and so on. If [param recursive] is [code]false[/code], only this node's direct children are matched.
+				If [param owned] is [code]true[/code], this method only finds nodes who have an assigned [member Node.owner]. This is especially important for scenes instantiated through a script, because those scenes don't have an owner.
 				Returns an empty array if no matching nodes are found.
 				[b]Note:[/b] As this method walks through all the descendants of the node, it is the slowest way to get references to other nodes. Whenever possible, consider caching the node references into variables.
 				[b]Note:[/b] If you only want to find the first descendant node that matches a pattern, see [method find_child].
@@ -229,8 +229,8 @@
 			<return type="Node" />
 			<param index="0" name="pattern" type="String" />
 			<description>
-				Finds the first parent of the current node whose name matches [code]pattern[/code] as in [method String.match].
-				[code]pattern[/code] does not match against the full path, just against individual node names. It is case-sensitive, with [code]"*"[/code] matching zero or more characters and [code]"?"[/code] matching any single character except [code]"."[/code]).
+				Finds the first parent of the current node whose name matches [param pattern] as in [method String.match].
+				[param pattern] does not match against the full path, just against individual node names. It is case-sensitive, with [code]"*"[/code] matching zero or more characters and [code]"?"[/code] matching any single character except [code]"."[/code]).
 				[b]Note:[/b] As this method walks upwards in the scene tree, it can be slow in large, deeply nested scene trees. Whenever possible, consider using [method get_node] with unique names instead (see [member unique_name_in_owner]), or caching the node references into variable.
 			</description>
 		</method>
@@ -241,7 +241,7 @@
 			<description>
 				Returns a child node by its index (see [method get_child_count]). This method is often used for iterating all children of a node.
 				Negative indices access the children from the last one.
-				If [code]include_internal[/code] is [code]true[/code], internal children are skipped (see [code]internal[/code] parameter in [method add_child]).
+				If [param include_internal] is [code]true[/code], internal children are skipped (see [code]internal[/code] parameter in [method add_child]).
 				To access a child node via its name, use [method get_node].
 			</description>
 		</method>
@@ -250,7 +250,7 @@
 			<param index="0" name="include_internal" type="bool" default="false" />
 			<description>
 				Returns the number of child nodes.
-				If [code]include_internal[/code] is [code]false[/code], internal children aren't counted (see [code]internal[/code] parameter in [method add_child]).
+				If [param include_internal] is [code]false[/code], internal children aren't counted (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
 		<method name="get_children" qualifiers="const">
@@ -258,7 +258,7 @@
 			<param index="0" name="include_internal" type="bool" default="false" />
 			<description>
 				Returns an array of references to node's children.
-				If [code]include_internal[/code] is [code]false[/code], the returned array won't include internal children (see [code]internal[/code] parameter in [method add_child]).
+				If [param include_internal] is [code]false[/code], the returned array won't include internal children (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
 		<method name="get_groups" qualifiers="const">
@@ -281,7 +281,7 @@
 			<param index="0" name="include_internal" type="bool" default="false" />
 			<description>
 				Returns the node's order in the scene tree branch. For example, if called on the first child node the position is [code]0[/code].
-				If [code]include_internal[/code] is [code]false[/code], the index won't take internal children into account, i.e. first non-internal child will have index of 0 (see [code]internal[/code] parameter in [method add_child]).
+				If [param include_internal] is [code]false[/code], the index won't take internal children into account, i.e. first non-internal child will have index of 0 (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
 		<method name="get_multiplayer_authority" qualifiers="const">
@@ -349,7 +349,7 @@
 			<return type="Node" />
 			<param index="0" name="path" type="NodePath" />
 			<description>
-				Similar to [method get_node], but does not log an error if [code]path[/code] does not point to a valid [Node].
+				Similar to [method get_node], but does not log an error if [param path] does not point to a valid [Node].
 			</description>
 		</method>
 		<method name="get_parent" qualifiers="const">
@@ -368,7 +368,7 @@
 			<return type="NodePath" />
 			<param index="0" name="node" type="Node" />
 			<description>
-				Returns the relative [NodePath] from this node to the specified [code]node[/code]. Both nodes must be in the same scene or the function will fail.
+				Returns the relative [NodePath] from this node to the specified [param node]. Both nodes must be in the same scene or the function will fail.
 			</description>
 		</method>
 		<method name="get_physics_process_delta_time" qualifiers="const">
@@ -432,7 +432,7 @@
 			<return type="bool" />
 			<param index="0" name="node" type="Node" />
 			<description>
-				Returns [code]true[/code] if [code]node[/code] has editable children enabled relative to this node. This method is only intended for use with editor tooling.
+				Returns [code]true[/code] if [param node] has editable children enabled relative to this node. This method is only intended for use with editor tooling.
 			</description>
 		</method>
 		<method name="is_greater_than" qualifiers="const">
@@ -561,7 +561,7 @@
 			<param index="1" name="args" type="Array" default="[]" />
 			<param index="2" name="parent_first" type="bool" default="false" />
 			<description>
-				Calls the given method (if present) with the arguments given in [code]args[/code] on this node and recursively on all its children. If the [code]parent_first[/code] argument is [code]true[/code], the method will be called on the current node first, then on all its children. If [code]parent_first[/code] is [code]false[/code], the children will be called first.
+				Calls the given method (if present) with the arguments given in [param args] on this node and recursively on all its children. If the [param parent_first] argument is [code]true[/code], the method will be called on the current node first, then on all its children. If [param parent_first] is [code]false[/code], the children will be called first.
 			</description>
 		</method>
 		<method name="propagate_notification">
@@ -610,7 +610,7 @@
 			<param index="1" name="keep_groups" type="bool" default="false" />
 			<description>
 				Replaces a node in a scene by the given one. Subscriptions that pass through this node will be lost.
-				If [code]keep_groups[/code] is [code]true[/code], the [code]node[/code] is added to the same groups that the replaced node is in.
+				If [param keep_groups] is [code]true[/code], the [param node] is added to the same groups that the replaced node is in.
 				[b]Note:[/b] The given node will become the new parent of any child nodes that the replaced node had.
 				[b]Note:[/b] The replaced node is not automatically freed, so you either need to keep it in a variable for later use or free it using [method Object.free].
 			</description>
@@ -625,7 +625,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. Returns [code]null[/code].
+				Sends a remote procedure call request for the given [param method] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. Returns [code]null[/code].
 				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [MultiplayerAPI]. You also need to keep track of the connection state, either by the [MultiplayerAPI] signals like [code]server_disconnected[/code] or by checking [code]get_multiplayer().peer.get_connection_status() == CONNECTION_CONNECTED[/code].
 			</description>
 		</method>
@@ -634,7 +634,7 @@
 			<param index="0" name="method" type="StringName" />
 			<param index="1" name="config" type="Variant" />
 			<description>
-				Changes the RPC mode for the given [code]method[/code] with the given [code]config[/code] which should be [code]null[/code] (to disable) or a [Dictionary] in the form:
+				Changes the RPC mode for the given [param method] with the given [param config] which should be [code]null[/code] (to disable) or a [Dictionary] in the form:
 				[codeblock]
 				{
 				    rpc_mode = MultiplayerAPI.RPCMode,
@@ -651,7 +651,7 @@
 			<param index="0" name="peer_id" type="int" />
 			<param index="1" name="method" type="StringName" />
 			<description>
-				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] (see [method MultiplayerPeer.set_target_peer]). Returns [code]null[/code].
+				Sends a [method rpc] to a specific peer identified by [param peer_id] (see [method MultiplayerPeer.set_target_peer]). Returns [code]null[/code].
 			</description>
 		</method>
 		<method name="set_display_folded">
@@ -666,7 +666,7 @@
 			<param index="0" name="node" type="Node" />
 			<param index="1" name="is_editable" type="bool" />
 			<description>
-				Sets the editable children state of [code]node[/code] relative to this node. This method is only intended for use with editor tooling.
+				Sets the editable children state of [param node] relative to this node. This method is only intended for use with editor tooling.
 			</description>
 		</method>
 		<method name="set_multiplayer_authority">
@@ -674,7 +674,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="recursive" type="bool" default="true" />
 			<description>
-				Sets the node's multiplayer authority to the peer with the given peer ID. The multiplayer authority is the peer that has authority over the node on the network. Useful in conjunction with [method rpc_config] and the [MultiplayerAPI]. Inherited from the parent node by default, which ultimately defaults to peer ID 1 (the server). If [code]recursive[/code], the given peer is recursively set as the authority for all children of this node.
+				Sets the node's multiplayer authority to the peer with the given peer ID. The multiplayer authority is the peer that has authority over the node on the network. Useful in conjunction with [method rpc_config] and the [MultiplayerAPI]. Inherited from the parent node by default, which ultimately defaults to peer ID 1 (the server). If [param recursive], the given peer is recursively set as the authority for all children of this node.
 			</description>
 		</method>
 		<method name="set_physics_process">
@@ -791,7 +791,7 @@
 			<param index="0" name="node" type="Node" />
 			<description>
 				Emitted when a child node is about to exit the scene tree, either because it is being removed or freed directly, or because this node is exiting the tree.
-				When this signal is received, the child [code]node[/code] is still in the tree and valid. This signal is emitted [i]after[/i] the child node's own [signal tree_exiting] and [constant NOTIFICATION_EXIT_TREE].
+				When this signal is received, the child [param node] is still in the tree and valid. This signal is emitted [i]after[/i] the child node's own [signal tree_exiting] and [constant NOTIFICATION_EXIT_TREE].
 			</description>
 		</signal>
 		<signal name="ready">

--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -15,14 +15,14 @@
 			<return type="void" />
 			<param index="0" name="ratio" type="Vector2" />
 			<description>
-				Multiplies the current scale by the [code]ratio[/code] vector.
+				Multiplies the current scale by the [param ratio] vector.
 			</description>
 		</method>
 		<method name="get_angle_to" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="point" type="Vector2" />
 			<description>
-				Returns the angle between the node and the [code]point[/code] in radians.
+				Returns the angle between the node and the [param point] in radians.
 				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/node2d_get_angle_to.png]Illustration of the returned angle.[/url]
 			</description>
 		</method>
@@ -37,14 +37,14 @@
 			<return type="void" />
 			<param index="0" name="offset" type="Vector2" />
 			<description>
-				Adds the [code]offset[/code] vector to the node's global position.
+				Adds the [param offset] vector to the node's global position.
 			</description>
 		</method>
 		<method name="look_at">
 			<return type="void" />
 			<param index="0" name="point" type="Vector2" />
 			<description>
-				Rotates the node so it points towards the [code]point[/code], which is expected to use global coordinates.
+				Rotates the node so it points towards the [param point], which is expected to use global coordinates.
 			</description>
 		</method>
 		<method name="move_local_x">
@@ -52,7 +52,7 @@
 			<param index="0" name="delta" type="float" />
 			<param index="1" name="scaled" type="bool" default="false" />
 			<description>
-				Applies a local translation on the node's X axis based on the [method Node._process]'s [code]delta[/code]. If [code]scaled[/code] is [code]false[/code], normalizes the movement.
+				Applies a local translation on the node's X axis based on the [method Node._process]'s [param delta]. If [param scaled] is [code]false[/code], normalizes the movement.
 			</description>
 		</method>
 		<method name="move_local_y">
@@ -60,7 +60,7 @@
 			<param index="0" name="delta" type="float" />
 			<param index="1" name="scaled" type="bool" default="false" />
 			<description>
-				Applies a local translation on the node's Y axis based on the [method Node._process]'s [code]delta[/code]. If [code]scaled[/code] is [code]false[/code], normalizes the movement.
+				Applies a local translation on the node's Y axis based on the [method Node._process]'s [param delta]. If [param scaled] is [code]false[/code], normalizes the movement.
 			</description>
 		</method>
 		<method name="rotate">
@@ -88,7 +88,7 @@
 			<return type="void" />
 			<param index="0" name="offset" type="Vector2" />
 			<description>
-				Translates the node by the given [code]offset[/code] in local coordinates.
+				Translates the node by the given [param offset] in local coordinates.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -113,9 +113,9 @@
 			<param index="0" name="target" type="Vector3" />
 			<param index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
 			<description>
-				Rotates the node so that the local forward axis (-Z) points toward the [code]target[/code] position.
-				The local up axis (+Y) points as close to the [code]up[/code] vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
-				The [code]target[/code] position cannot be the same as the node's position, the [code]up[/code] vector cannot be zero, and the direction from the node's position to the [code]target[/code] vector cannot be parallel to the [code]up[/code] vector.
+				Rotates the node so that the local forward axis (-Z) points toward the [param target] position.
+				The local up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
+				The [param target] position cannot be the same as the node's position, the [param up] vector cannot be zero, and the direction from the node's position to the [param target] vector cannot be parallel to the [param up] vector.
 				Operations take place in global space.
 			</description>
 		</method>
@@ -125,7 +125,7 @@
 			<param index="1" name="target" type="Vector3" />
 			<param index="2" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
 			<description>
-				Moves the node to the specified [code]position[/code], and then rotates the node to point toward the [code]target[/code] as per [method look_at]. Operations take place in global space.
+				Moves the node to the specified [param position], and then rotates the node to point toward the [param target] as per [method look_at]. Operations take place in global space.
 			</description>
 		</method>
 		<method name="orthonormalize">
@@ -138,14 +138,14 @@
 			<return type="bool" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if the property identified by [code]name[/code] can be reverted to a default value.
+				Returns [code]true[/code] if the property identified by [param name] can be reverted to a default value.
 			</description>
 		</method>
 		<method name="property_get_revert">
 			<return type="Variant" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the default value of the Node3D property with given [code]name[/code].
+				Returns the default value of the Node3D property with given [param name].
 			</description>
 		</method>
 		<method name="rotate">
@@ -245,14 +245,14 @@
 			<return type="Vector3" />
 			<param index="0" name="local_point" type="Vector3" />
 			<description>
-				Transforms [code]local_point[/code] from this node's local space to world space.
+				Transforms [param local_point] from this node's local space to world space.
 			</description>
 		</method>
 		<method name="to_local" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="global_point" type="Vector3" />
 			<description>
-				Transforms [code]global_point[/code] from world space to this node's local space.
+				Transforms [param global_point] from world space to this node's local space.
 			</description>
 		</method>
 		<method name="translate">
@@ -260,7 +260,7 @@
 			<param index="0" name="offset" type="Vector3" />
 			<description>
 				Changes the node's position by the given offset [Vector3].
-				Note that the translation [code]offset[/code] is affected by the node's scale, so if scaled by e.g. [code](10, 1, 1)[/code], a translation by an offset of [code](2, 0, 0)[/code] would actually add 20 ([code]2 * 10[/code]) to the X coordinate.
+				Note that the translation [param offset] is affected by the node's scale, so if scaled by e.g. [code](10, 1, 1)[/code], a translation by an offset of [code](2, 0, 0)[/code] would actually add 20 ([code]2 * 10[/code]) to the X coordinate.
 			</description>
 		</method>
 		<method name="translate_object_local">

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -113,7 +113,7 @@
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Gets the node name indicated by [code]idx[/code] (0 to [method get_name_count] - 1).
+				Gets the node name indicated by [param idx] (0 to [method get_name_count] - 1).
 				[codeblocks]
 				[gdscript]
 				var node_path = NodePath("Path2D/PathFollow2D/Sprite2D")
@@ -141,7 +141,7 @@
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Gets the resource or property name indicated by [code]idx[/code] (0 to [method get_subname_count]).
+				Gets the resource or property name indicated by [param idx] (0 to [method get_subname_count]).
 				[codeblocks]
 				[gdscript]
 				var node_path = NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path")

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -42,7 +42,7 @@
 			<return type="int" />
 			<param index="0" name="arguments" type="PackedStringArray" />
 			<description>
-				Creates a new instance of Godot that runs independently. The [code]arguments[/code] are used in the given order and separated by a space.
+				Creates a new instance of Godot that runs independently. The [param arguments] are used in the given order and separated by a space.
 				If the process creation succeeds, the method will return the new process ID, which you can use to monitor the process (and potentially terminate it with [method kill]). If the process creation fails, the method will return [code]-1[/code].
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>
@@ -53,8 +53,8 @@
 			<param index="1" name="arguments" type="PackedStringArray" />
 			<param index="2" name="open_console" type="bool" default="false" />
 			<description>
-				Creates a new process that runs independently of Godot. It will not terminate if Godot terminates. The path specified in [code]path[/code] must exist and be executable file or macOS .app bundle. Platform path resolution will be used. The [code]arguments[/code] are used in the given order and separated by a space.
-				On Windows, if [code]open_console[/code] is [code]true[/code] and the process is a console app, a new terminal window will be opened. This is ignored on other platforms.
+				Creates a new process that runs independently of Godot. It will not terminate if Godot terminates. The path specified in [param path] must exist and be executable file or macOS .app bundle. Platform path resolution will be used. The [param arguments] are used in the given order and separated by a space.
+				On Windows, if [param open_console] is [code]true[/code] and the process is a console app, a new terminal window will be opened. This is ignored on other platforms.
 				If the process creation succeeds, the method will return the new process ID, which you can use to monitor the process (and potentially terminate it with [method kill]). If the process creation fails, the method will return [code]-1[/code].
 				For example, running another instance of the project:
 				[codeblocks]
@@ -74,7 +74,7 @@
 			<return type="void" />
 			<param index="0" name="msec" type="int" />
 			<description>
-				Delays execution of the current thread by [code]msec[/code] milliseconds. [code]msec[/code] must be greater than or equal to [code]0[/code]. Otherwise, [method delay_msec] will do nothing and will print an error message.
+				Delays execution of the current thread by [param msec] milliseconds. [param msec] must be greater than or equal to [code]0[/code]. Otherwise, [method delay_msec] will do nothing and will print an error message.
 				[b]Note:[/b] [method delay_msec] is a [i]blocking[/i] way to delay code execution. To delay code execution in a non-blocking way, see [method SceneTree.create_timer]. Awaiting with [method SceneTree.create_timer] will delay the execution of code placed below the [code]await[/code] without affecting the rest of the project (or editor, for [EditorPlugin]s and [EditorScript]s).
 				[b]Note:[/b] When [method delay_msec] is called on the main thread, it will freeze the project and will prevent it from redrawing and registering input until the delay has passed. When using [method delay_msec] as part of an [EditorPlugin] or [EditorScript], it will freeze the editor but won't freeze the project if it is currently running (since the project is an independent child process).
 			</description>
@@ -83,7 +83,7 @@
 			<return type="void" />
 			<param index="0" name="usec" type="int" />
 			<description>
-				Delays execution of the current thread by [code]usec[/code] microseconds. [code]usec[/code] must be greater than or equal to [code]0[/code]. Otherwise, [method delay_usec] will do nothing and will print an error message.
+				Delays execution of the current thread by [param usec] microseconds. [param usec] must be greater than or equal to [code]0[/code]. Otherwise, [method delay_usec] will do nothing and will print an error message.
 				[b]Note:[/b] [method delay_usec] is a [i]blocking[/i] way to delay code execution. To delay code execution in a non-blocking way, see [method SceneTree.create_timer]. Awaiting with [method SceneTree.create_timer] will delay the execution of code placed below the [code]await[/code] without affecting the rest of the project (or editor, for [EditorPlugin]s and [EditorScript]s).
 				[b]Note:[/b] When [method delay_usec] is called on the main thread, it will freeze the project and will prevent it from redrawing and registering input until the delay has passed. When using [method delay_usec] as part of an [EditorPlugin] or [EditorScript], it will freeze the editor but won't freeze the project if it is currently running (since the project is an independent child process).
 			</description>
@@ -113,8 +113,8 @@
 			<param index="3" name="read_stderr" type="bool" default="false" />
 			<param index="4" name="open_console" type="bool" default="false" />
 			<description>
-				Executes a command. The file specified in [code]path[/code] must exist and be executable. Platform path resolution will be used. The [code]arguments[/code] are used in the given order and separated by a space. If an [code]output[/code] [Array] is provided, the complete shell output of the process will be appended as a single [String] element in [code]output[/code]. If [code]read_stderr[/code] is [code]true[/code], the output to the standard error stream will be included too.
-				On Windows, if [code]open_console[/code] is [code]true[/code] and the process is a console app, a new terminal window will be opened. This is ignored on other platforms.
+				Executes a command. The file specified in [param path] must exist and be executable. Platform path resolution will be used. The [param arguments] are used in the given order and separated by a space. If an [param output] [Array] is provided, the complete shell output of the process will be appended as a single [String] element in [param output]. If [param read_stderr] is [code]true[/code], the output to the standard error stream will be included too.
+				On Windows, if [param open_console] is [code]true[/code] and the process is a console app, a new terminal window will be opened. This is ignored on other platforms.
 				If the command is successfully executed, the method will return the exit code of the command, or [code]-1[/code] if it fails.
 				[b]Note:[/b] The Godot thread will pause its execution until the executed command terminates. Use [Thread] to create a separate thread that will not pause the Godot thread, or use [method create_process] to create a completely independent process.
 				For example, to retrieve a list of the working directory's contents:
@@ -140,9 +140,9 @@
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
-				[b]Note:[/b] To execute a Windows command interpreter built-in command, specify [code]cmd.exe[/code] in [code]path[/code], [code]/c[/code] as the first argument, and the desired command as the second argument.
-				[b]Note:[/b] To execute a PowerShell built-in command, specify [code]powershell.exe[/code] in [code]path[/code], [code]-Command[/code] as the first argument, and the desired command as the second argument.
-				[b]Note:[/b] To execute a Unix shell built-in command, specify shell executable name in [code]path[/code], [code]-c[/code] as the first argument, and the desired command as the second argument.
+				[b]Note:[/b] To execute a Windows command interpreter built-in command, specify [code]cmd.exe[/code] in [param path], [code]/c[/code] as the first argument, and the desired command as the second argument.
+				[b]Note:[/b] To execute a PowerShell built-in command, specify [code]powershell.exe[/code] in [param path], [code]-Command[/code] as the first argument, and the desired command as the second argument.
+				[b]Note:[/b] To execute a Unix shell built-in command, specify shell executable name in [param path], [code]-c[/code] as the first argument, and the desired command as the second argument.
 				[b]Note:[/b] On macOS, sandboxed applications are limited to run only embedded helper executables, specified during export.
 			</description>
 		</method>
@@ -238,7 +238,7 @@
 			<param index="0" name="variable" type="String" />
 			<description>
 				Returns the value of an environment variable. Returns an empty string if the environment variable doesn't exist.
-				[b]Note:[/b] Double-check the casing of [code]variable[/code]. Environment variable names are case-sensitive on all platforms except Windows.
+				[b]Note:[/b] Double-check the casing of [param variable]. Environment variable names are case-sensitive on all platforms except Windows.
 			</description>
 		</method>
 		<method name="get_executable_path" qualifiers="const">
@@ -408,7 +408,7 @@
 			<param index="1" name="bold" type="bool" default="false" />
 			<param index="2" name="italic" type="bool" default="false" />
 			<description>
-				Returns path to the system font file with [code]font_name[/code] and style. Return empty string if no matching fonts found.
+				Returns path to the system font file with [param font_name] and style. Return empty string if no matching fonts found.
 				[b]Note:[/b] This method is implemented on iOS, Linux, macOS and Windows.
 			</description>
 		</method>
@@ -451,8 +451,8 @@
 			<return type="bool" />
 			<param index="0" name="variable" type="String" />
 			<description>
-				Returns [code]true[/code] if the environment variable with the name [code]variable[/code] exists.
-				[b]Note:[/b] Double-check the casing of [code]variable[/code]. Environment variable names are case-sensitive on all platforms except Windows.
+				Returns [code]true[/code] if the environment variable with the name [param variable] exists.
+				[b]Note:[/b] Double-check the casing of [param variable]. Environment variable names are case-sensitive on all platforms except Windows.
 			</description>
 		</method>
 		<method name="has_feature" qualifiers="const">
@@ -482,7 +482,7 @@
 			<return type="bool" />
 			<param index="0" name="pid" type="int" />
 			<description>
-				Returns [code]true[/code] if the child process ID ([code]pid[/code]) is still running or [code]false[/code] if it has terminated.
+				Returns [code]true[/code] if the child process ID ([param pid]) is still running or [code]false[/code] if it has terminated.
 				Must be a valid ID generated from [method create_process].
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>
@@ -509,7 +509,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="pid" type="int" />
 			<description>
-				Kill (terminate) the process identified by the given process ID ([code]pid[/code]), e.g. the one returned by [method execute] in non-blocking mode. See also [method crash].
+				Kill (terminate) the process identified by the given process ID ([param pid]), e.g. the one returned by [method execute] in non-blocking mode. See also [method crash].
 				[b]Note:[/b] This method can also be used to kill processes that were not spawned by the game.
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>
@@ -538,7 +538,7 @@
 			<return type="void" />
 			<param index="0" name="tofile" type="String" default="&quot;&quot;" />
 			<description>
-				Shows all resources in the game. Optionally, the list can be written to a file by specifying a file path in [code]tofile[/code].
+				Shows all resources in the game. Optionally, the list can be written to a file by specifying a file path in [param tofile].
 			</description>
 		</method>
 		<method name="print_all_textures_by_size">
@@ -580,8 +580,8 @@
 			<param index="0" name="variable" type="String" />
 			<param index="1" name="value" type="String" />
 			<description>
-				Sets the value of the environment variable [code]variable[/code] to [code]value[/code]. The environment variable will be set for the Godot process and any process executed with [method execute] after running [method set_environment]. The environment variable will [i]not[/i] persist to processes run after the Godot process was terminated.
-				[b]Note:[/b] Double-check the casing of [code]variable[/code]. Environment variable names are case-sensitive on all platforms except Windows.
+				Sets the value of the environment variable [param variable] to [param value]. The environment variable will be set for the Godot process and any process executed with [method execute] after running [method set_environment]. The environment variable will [i]not[/i] persist to processes run after the Godot process was terminated.
+				[b]Note:[/b] Double-check the casing of [param variable]. Environment variable names are case-sensitive on all platforms except Windows.
 			</description>
 		</method>
 		<method name="set_restart_on_exit">
@@ -589,7 +589,7 @@
 			<param index="0" name="restart" type="bool" />
 			<param index="1" name="arguments" type="PackedStringArray" default="PackedStringArray()" />
 			<description>
-				If [code]restart[/code] is [code]true[/code], restarts the project automatically when it is exited with [method SceneTree.quit] or [constant Node.NOTIFICATION_WM_CLOSE_REQUEST]. Command line [code]arguments[/code] can be supplied. To restart the project with the same command line arguments as originally used to run the project, pass [method get_cmdline_args] as the value for [code]arguments[/code].
+				If [param restart] is [code]true[/code], restarts the project automatically when it is exited with [method SceneTree.quit] or [constant Node.NOTIFICATION_WM_CLOSE_REQUEST]. Command line [param arguments] can be supplied. To restart the project with the same command line arguments as originally used to run the project, pass [method get_cmdline_args] as the value for [param arguments].
 				[method set_restart_on_exit] can be used to apply setting changes that require a restart. See also [method is_restart_on_exit_set] and [method get_restart_on_exit_arguments].
 				[b]Note:[/b] This method is only effective on desktop platforms, and only when the project isn't started from the editor. It will have no effect on mobile and Web platforms, or when the project is started from the editor.
 				[b]Note:[/b] If the project process crashes or is [i]killed[/i] by the user (by sending [code]SIGKILL[/code] instead of the usual [code]SIGTERM[/code]), the project won't restart automatically.
@@ -606,7 +606,7 @@
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>
-				Enables backup saves if [code]enabled[/code] is [code]true[/code].
+				Enables backup saves if [param enabled] is [code]true[/code].
 			</description>
 		</method>
 		<method name="shell_open">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -39,7 +39,7 @@
 			<param index="0" name="property" type="StringName" />
 			<description>
 				Virtual method which can be overridden to customize the return value of [method get].
-				Returns the given property. Returns [code]null[/code] if the [code]property[/code] does not exist.
+				Returns the given property. Returns [code]null[/code] if the [param property] does not exist.
 			</description>
 		</method>
 		<method name="_get_property_list" qualifiers="virtual">
@@ -61,7 +61,7 @@
 			<return type="void" />
 			<param index="0" name="what" type="int" />
 			<description>
-				Called whenever the object receives a notification, which is identified in [code]what[/code] by a constant. The base [Object] has two constants [constant NOTIFICATION_POSTINITIALIZE] and [constant NOTIFICATION_PREDELETE], but subclasses such as [Node] define a lot more notifications which are also received by this method.
+				Called whenever the object receives a notification, which is identified in [param what] by a constant. The base [Object] has two constants [constant NOTIFICATION_POSTINITIALIZE] and [constant NOTIFICATION_PREDELETE], but subclasses such as [Node] define a lot more notifications which are also received by this method.
 			</description>
 		</method>
 		<method name="_set" qualifiers="virtual">
@@ -70,7 +70,7 @@
 			<param index="1" name="value" type="Variant" />
 			<description>
 				Virtual method which can be overridden to customize the return value of [method set].
-				Sets a property. Returns [code]true[/code] if the [code]property[/code] exists.
+				Sets a property. Returns [code]true[/code] if the [param property] exists.
 			</description>
 		</method>
 		<method name="_to_string" qualifiers="virtual">
@@ -85,14 +85,14 @@
 			<param index="0" name="signal" type="String" />
 			<param index="1" name="arguments" type="Array" default="[]" />
 			<description>
-				Adds a user-defined [code]signal[/code]. Arguments are optional, but can be added as an [Array] of dictionaries, each containing [code]name: String[/code] and [code]type: int[/code] (see [enum Variant.Type]) entries.
+				Adds a user-defined [param signal]. Arguments are optional, but can be added as an [Array] of dictionaries, each containing [code]name: String[/code] and [code]type: int[/code] (see [enum Variant.Type]) entries.
 			</description>
 		</method>
 		<method name="call" qualifiers="vararg">
 			<return type="Variant" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Calls the [code]method[/code] on the object and returns the result. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
+				Calls the [param method] on the object and returns the result. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
 				[codeblocks]
 				[gdscript]
 				var node = Node3D.new()
@@ -110,7 +110,7 @@
 			<return type="Variant" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Calls the [code]method[/code] on the object during idle time. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
+				Calls the [param method] on the object during idle time. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
 				[codeblocks]
 				[gdscript]
 				var node = Node3D.new()
@@ -129,7 +129,7 @@
 			<param index="0" name="method" type="StringName" />
 			<param index="1" name="arg_array" type="Array" />
 			<description>
-				Calls the [code]method[/code] on the object and returns the result. Contrarily to [method call], this method does not support a variable number of arguments but expects all parameters to be via a single [Array].
+				Calls the [param method] on the object and returns the result. Contrarily to [method call], this method does not support a variable number of arguments but expects all parameters to be via a single [Array].
 				[codeblocks]
 				[gdscript]
 				var node = Node3D.new()
@@ -154,7 +154,7 @@
 			<param index="1" name="callable" type="Callable" />
 			<param index="2" name="flags" type="int" default="0" />
 			<description>
-				Connects a [code]signal[/code] to a [code]callable[/code]. Use [code]flags[/code] to set deferred or one-shot connections. See [enum ConnectFlags] constants.
+				Connects a [param signal] to a [param callable]. Use [param flags] to set deferred or one-shot connections. See [enum ConnectFlags] constants.
 				A signal can only be connected once to a [Callable]. It will print an error if already connected, unless the signal was connected with [constant CONNECT_REFERENCE_COUNTED]. To avoid this, first, use [method is_connected] to check for existing connections.
 				If the callable's target is destroyed in the game's lifecycle, the connection will be lost.
 				[b]Examples with recommended syntax:[/b]
@@ -294,7 +294,7 @@
 			<param index="0" name="signal" type="StringName" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Disconnects a [code]signal[/code] from a given [code]callable[/code].
+				Disconnects a [param signal] from a given [param callable].
 				If you try to disconnect a connection that does not exist, the method will print an error. Use [method is_connected] to ensure that the connection exists.
 			</description>
 		</method>
@@ -302,7 +302,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Emits the given [code]signal[/code]. The signal must exist, so it should be a built-in signal of this class or one of its parent classes, or a user-defined signal. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
+				Emits the given [param signal]. The signal must exist, so it should be a built-in signal of this class or one of its parent classes, or a user-defined signal. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
 				[codeblocks]
 				[gdscript]
 				emit_signal("hit", "sword", 100)
@@ -325,7 +325,7 @@
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
 			<description>
-				Returns the [Variant] value of the given [code]property[/code]. If the [code]property[/code] doesn't exist, this will return [code]null[/code].
+				Returns the [Variant] value of the given [param property]. If the [param property] doesn't exist, this will return [code]null[/code].
 				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
 			</description>
 		</method>
@@ -366,8 +366,8 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="default" type="Variant" default="null" />
 			<description>
-				Returns the object's metadata entry for the given [code]name[/code].
-				Throws error if the entry does not exist, unless [code]default[/code] is not [code]null[/code] (in which case the default value will be returned).
+				Returns the object's metadata entry for the given [param name].
+				Throws error if the entry does not exist, unless [param default] is not [code]null[/code] (in which case the default value will be returned).
 			</description>
 		</method>
 		<method name="get_meta_list" qualifiers="const">
@@ -399,7 +399,7 @@
 			<return type="Array" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Returns an [Array] of connections for the given [code]signal[/code].
+				Returns an [Array] of connections for the given [param signal].
 			</description>
 		</method>
 		<method name="get_signal_list" qualifiers="const">
@@ -412,28 +412,28 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if a metadata entry is found with the given [code]name[/code].
+				Returns [code]true[/code] if a metadata entry is found with the given [param name].
 			</description>
 		</method>
 		<method name="has_method" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="method" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the object contains the given [code]method[/code].
+				Returns [code]true[/code] if the object contains the given [param method].
 			</description>
 		</method>
 		<method name="has_signal" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the given [code]signal[/code] exists.
+				Returns [code]true[/code] if the given [param signal] exists.
 			</description>
 		</method>
 		<method name="has_user_signal" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the given user-defined [code]signal[/code] exists. Only signals added using [method add_user_signal] are taken into account.
+				Returns [code]true[/code] if the given user-defined [param signal] exists. Only signals added using [method add_user_signal] are taken into account.
 			</description>
 		</method>
 		<method name="is_blocking_signals" qualifiers="const">
@@ -446,7 +446,7 @@
 			<return type="bool" />
 			<param index="0" name="class" type="String" />
 			<description>
-				Returns [code]true[/code] if the object inherits from the given [code]class[/code]. See also [method get_class].
+				Returns [code]true[/code] if the object inherits from the given [param class]. See also [method get_class].
 				[b]Note:[/b] [method is_class] does not take [code]class_name[/code] declarations into account. If the object has a [code]class_name[/code] defined, [method is_class] will return [code]false[/code] for that name.
 			</description>
 		</method>
@@ -455,7 +455,7 @@
 			<param index="0" name="signal" type="StringName" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Returns [code]true[/code] if a connection exists for a given [code]signal[/code] and [code]callable[/code].
+				Returns [code]true[/code] if a connection exists for a given [param signal] and [param callable].
 			</description>
 		</method>
 		<method name="is_queued_for_deletion" qualifiers="const">
@@ -470,7 +470,7 @@
 			<param index="1" name="reversed" type="bool" default="false" />
 			<description>
 				Send a given notification to the object, which will also trigger a call to the [method _notification] method of all classes that the object inherits from.
-				If [code]reversed[/code] is [code]true[/code], [method _notification] is called first on the object's own class, and then up to its successive parent classes. If [code]reversed[/code] is [code]false[/code], [method _notification] is called first on the highest ancestor ([Object] itself), and then down to its successive inheriting classes.
+				If [param reversed] is [code]true[/code], [method _notification] is called first on the object's own class, and then up to its successive parent classes. If [param reversed] is [code]false[/code], [method _notification] is called first on the highest ancestor ([Object] itself), and then down to its successive inheriting classes.
 			</description>
 		</method>
 		<method name="notify_property_list_changed">
@@ -491,7 +491,7 @@
 			<param index="0" name="property" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Assigns a new value to the given property. If the [code]property[/code] does not exist or the given value's type doesn't match, nothing will happen.
+				Assigns a new value to the given property. If the [param property] does not exist or the given value's type doesn't match, nothing will happen.
 				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
 			</description>
 		</method>
@@ -570,7 +570,7 @@
 			<param index="1" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Translates a message using translation catalogs configured in the Project Settings. An additional context could be used to specify the translation context.
-				Only works if message translation is enabled (which it is by default), otherwise it returns the [code]message[/code] unchanged. See [method set_message_translation].
+				Only works if message translation is enabled (which it is by default), otherwise it returns the [param message] unchanged. See [method set_message_translation].
 				See [url=$DOCS_URL/tutorials/i18n/internationalizing_games.html]Internationalizing games[/url] for examples of the usage of this method.
 			</description>
 		</method>
@@ -582,8 +582,8 @@
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Translates a message involving plurals using translation catalogs configured in the Project Settings. An additional context could be used to specify the translation context.
-				Only works if message translation is enabled (which it is by default), otherwise it returns the [code]message[/code] or [code]plural_message[/code] unchanged. See [method set_message_translation].
-				The number [code]n[/code] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
+				Only works if message translation is enabled (which it is by default), otherwise it returns the [param message] or [param plural_message] unchanged. See [method set_message_translation].
+				The number [param n] is the number or quantity of the plural object. It will be used to guide the translation system to fetch the correct plural form for the selected language.
 				[b]Note:[/b] Negative and floating-point values usually represent physical entities for which singular and plural don't clearly apply. In such cases, use [method tr].
 				See [url=$DOCS_URL/tutorials/i18n/localization_using_gettext.html]Localization using gettext[/url] for examples of the usage of this method.
 			</description>

--- a/doc/classes/OccluderInstance3D.xml
+++ b/doc/classes/OccluderInstance3D.xml
@@ -17,7 +17,7 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member bake_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member bake_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_bake_mask_value">
@@ -25,7 +25,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member bake_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member bake_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -17,7 +17,7 @@
 			<param index="1" name="label" type="String" />
 			<param index="2" name="id" type="int" default="-1" />
 			<description>
-				Adds an item, with a [code]texture[/code] icon, text [code]label[/code] and (optionally) [code]id[/code]. If no [code]id[/code] is passed, the item index will be used as the item's ID. New items are appended at the end.
+				Adds an item, with a [param texture] icon, text [param label] and (optionally) [param id]. If no [param id] is passed, the item index will be used as the item's ID. New items are appended at the end.
 			</description>
 		</method>
 		<method name="add_item">
@@ -25,14 +25,14 @@
 			<param index="0" name="label" type="String" />
 			<param index="1" name="id" type="int" default="-1" />
 			<description>
-				Adds an item, with text [code]label[/code] and (optionally) [code]id[/code]. If no [code]id[/code] is passed, the item index will be used as the item's ID. New items are appended at the end.
+				Adds an item, with text [param label] and (optionally) [param id]. If no [param id] is passed, the item index will be used as the item's ID. New items are appended at the end.
 			</description>
 		</method>
 		<method name="add_separator">
 			<return type="void" />
 			<param index="0" name="text" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a separator to the list of items. Separators help to group items, and can optionally be given a [code]text[/code] header. A separator also gets an index assigned, and is appended at the end of the item list.
+				Adds a separator to the list of items. Separators help to group items, and can optionally be given a [param text] header. A separator also gets an index assigned, and is appended at the end of the item list.
 			</description>
 		</method>
 		<method name="clear">
@@ -45,21 +45,21 @@
 			<return type="Texture2D" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the icon of the item at index [code]idx[/code].
+				Returns the icon of the item at index [param idx].
 			</description>
 		</method>
 		<method name="get_item_id" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the ID of the item at index [code]idx[/code].
+				Returns the ID of the item at index [param idx].
 			</description>
 		</method>
 		<method name="get_item_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns the index of the item with the given [code]id[/code].
+				Returns the index of the item with the given [param id].
 			</description>
 		</method>
 		<method name="get_item_metadata" qualifiers="const">
@@ -73,14 +73,14 @@
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the text of the item at index [code]idx[/code].
+				Returns the text of the item at index [param idx].
 			</description>
 		</method>
 		<method name="get_item_tooltip" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the tooltip of the item at index [code]idx[/code].
+				Returns the tooltip of the item at index [param idx].
 			</description>
 		</method>
 		<method name="get_popup" qualifiers="const">
@@ -117,7 +117,7 @@
 			<return type="bool" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at index [code]idx[/code] is disabled.
+				Returns [code]true[/code] if the item at index [param idx] is disabled.
 			</description>
 		</method>
 		<method name="is_item_separator" qualifiers="const">
@@ -130,7 +130,7 @@
 			<return type="void" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Removes the item at index [code]idx[/code].
+				Removes the item at index [param idx].
 			</description>
 		</method>
 		<method name="select">
@@ -146,7 +146,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="disabled" type="bool" />
 			<description>
-				Sets whether the item at index [code]idx[/code] is disabled.
+				Sets whether the item at index [param idx] is disabled.
 				Disabled items are drawn differently in the dropdown and are not selectable by the user. If the current selected item is set as disabled, it will remain selected.
 			</description>
 		</method>
@@ -155,7 +155,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="texture" type="Texture2D" />
 			<description>
-				Sets the icon of the item at index [code]idx[/code].
+				Sets the icon of the item at index [param idx].
 			</description>
 		</method>
 		<method name="set_item_id">
@@ -163,7 +163,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="id" type="int" />
 			<description>
-				Sets the ID of the item at index [code]idx[/code].
+				Sets the ID of the item at index [param idx].
 			</description>
 		</method>
 		<method name="set_item_metadata">
@@ -179,7 +179,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="text" type="String" />
 			<description>
-				Sets the text of the item at index [code]idx[/code].
+				Sets the text of the item at index [param idx].
 			</description>
 		</method>
 		<method name="set_item_tooltip">
@@ -187,7 +187,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="tooltip" type="String" />
 			<description>
-				Sets the tooltip of the item at index [code]idx[/code].
+				Sets the tooltip of the item at index [param idx].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -63,7 +63,7 @@
 			<return type="int" />
 			<param index="0" name="from" type="float" />
 			<description>
-				Cast a float value to an integer value, this method simply removes the number fractions (i.e. rounds [code]from[/code] towards zero), so for example [code]int(2.7)[/code] will be equals to 2, [code]int(0.1)[/code] will be equals to 0 and [code]int(-2.7)[/code] will be equals to -2. This operation is also called truncation.
+				Cast a float value to an integer value, this method simply removes the number fractions (i.e. rounds [param from] towards zero), so for example [code]int(2.7)[/code] will be equals to 2, [code]int(0.1)[/code] will be equals to 0 and [code]int(-2.7)[/code] will be equals to -2. This operation is also called truncation.
 			</description>
 		</constructor>
 	</constructors>


### PR DESCRIPTION
One of several commits to fix all of the class XML docs (see #64134, #64164, #64196, #64285).

(Edit: probably 2-3 more of these to finish them all.)