### PR TITLE
[doc] Use "param" instead of "code" to refer to parameters (6)

### DIFF
--- a/doc/classes/EditorCommandPalette.xml
+++ b/doc/classes/EditorCommandPalette.xml
@@ -33,10 +33,10 @@
 			<param index="3" name="shortcut_text" type="String" default="&quot;None&quot;" />
 			<description>
 				Adds a custom command to EditorCommandPalette.
-				- [code]command_name[/code]: [String] (Name of the [b]Command[/b]. This is displayed to the user.)
-				- [code]key_name[/code]: [String] (Name of the key for a particular [b]Command[/b]. This is used to uniquely identify the [b]Command[/b].)
-				- [code]binded_callable[/code]: [Callable] (Callable of the [b]Command[/b]. This will be executed when the [b]Command[/b] is selected.)
-				- [code]shortcut_text[/code]: [String] (Shortcut text of the [b]Command[/b] if available.)
+				- [param command_name]: [String] (Name of the [b]Command[/b]. This is displayed to the user.)
+				- [param key_name]: [String] (Name of the key for a particular [b]Command[/b]. This is used to uniquely identify the [b]Command[/b].)
+				- [param binded_callable]: [Callable] (Callable of the [b]Command[/b]. This will be executed when the [b]Command[/b] is selected.)
+				- [param shortcut_text]: [String] (Shortcut text of the [b]Command[/b] if available.)
 			</description>
 		</method>
 		<method name="remove_command">
@@ -44,7 +44,7 @@
 			<param index="0" name="key_name" type="String" />
 			<description>
 				Removes the custom command from EditorCommandPalette.
-				- [code]key_name[/code]: [String] (Name of the key for a particular [b]Command[/b].)
+				- [param key_name]: [String] (Name of the key for a particular [b]Command[/b].)
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorDebuggerPlugin.xml
+++ b/doc/classes/EditorDebuggerPlugin.xml
@@ -42,7 +42,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Registers a message capture with given [code]name[/code]. If [code]name[/code] is "my_message" then messages starting with "my_message:" will be called with the given callable.
+				Registers a message capture with given [param name]. If [param name] is "my_message" then messages starting with "my_message:" will be called with the given callable.
 				Callable must accept a message string and a data array as argument. If the message and data are valid then callable must return [code]true[/code] otherwise [code]false[/code].
 			</description>
 		</method>
@@ -51,7 +51,7 @@
 			<param index="0" name="message" type="String" />
 			<param index="1" name="data" type="Array" />
 			<description>
-				Sends a message with given [code]message[/code] and [code]data[/code] array.
+				Sends a message with given [param message] and [param data] array.
 			</description>
 		</method>
 		<method name="unregister_message_capture">

--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -17,7 +17,7 @@
 			<param index="2" name="path" type="String" />
 			<param index="3" name="flags" type="int" />
 			<description>
-				Virtual method to be overridden by the user. It is called when the export starts and provides all information about the export. [code]features[/code] is the list of features for the export, [code]is_debug[/code] is [code]true[/code] for debug builds, [code]path[/code] is the target path for the exported project. [code]flags[/code] is only used when running a runnable profile, e.g. when using native run on Android.
+				Virtual method to be overridden by the user. It is called when the export starts and provides all information about the export. [param features] is the list of features for the export, [param is_debug] is [code]true[/code] for debug builds, [param path] is the target path for the exported project. [param flags] is only used when running a runnable profile, e.g. when using native run on Android.
 			</description>
 		</method>
 		<method name="_export_end" qualifiers="virtual">
@@ -32,7 +32,7 @@
 			<param index="1" name="type" type="String" />
 			<param index="2" name="features" type="PackedStringArray" />
 			<description>
-				Virtual method to be overridden by the user. Called for each exported file, providing arguments that can be used to identify the file. [code]path[/code] is the path of the file, [code]type[/code] is the [Resource] represented by the file (e.g. [PackedScene]) and [code]features[/code] is the list of features for the export.
+				Virtual method to be overridden by the user. Called for each exported file, providing arguments that can be used to identify the file. [param path] is the path of the file, [param type] is the [Resource] represented by the file (e.g. [PackedScene]) and [param features] is the list of features for the export.
 				Calling [method skip] inside this callback will make the file not included in the export.
 			</description>
 		</method>
@@ -42,14 +42,14 @@
 			<param index="1" name="file" type="PackedByteArray" />
 			<param index="2" name="remap" type="bool" />
 			<description>
-				Adds a custom file to be exported. [code]path[/code] is the virtual path that can be used to load the file, [code]file[/code] is the binary data of the file. If [code]remap[/code] is [code]true[/code], file will not be exported, but instead remapped to the given [code]path[/code].
+				Adds a custom file to be exported. [param path] is the virtual path that can be used to load the file, [param file] is the binary data of the file. If [param remap] is [code]true[/code], file will not be exported, but instead remapped to the given [param path].
 			</description>
 		</method>
 		<method name="add_ios_bundle_file">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Adds an iOS bundle file from the given [code]path[/code] to the exported project.
+				Adds an iOS bundle file from the given [param path] to the exported project.
 			</description>
 		</method>
 		<method name="add_ios_cpp_code">
@@ -93,14 +93,14 @@
 			<return type="void" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Adds a static lib from the given [code]path[/code] to the iOS project.
+				Adds a static lib from the given [param path] to the iOS project.
 			</description>
 		</method>
 		<method name="add_macos_plugin_file">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Adds file or directory matching [code]path[/code] to [code]PlugIns[/code] directory of macOS app bundle.
+				Adds file or directory matching [param path] to [code]PlugIns[/code] directory of macOS app bundle.
 				[b]Note:[/b] This is useful only for macOS exports.
 			</description>
 		</method>
@@ -110,7 +110,7 @@
 			<param index="1" name="tags" type="PackedStringArray" />
 			<param index="2" name="target" type="String" />
 			<description>
-				Adds a shared object or a directory containing only shared objects with the given [code]tags[/code] and destination [code]path[/code].
+				Adds a shared object or a directory containing only shared objects with the given [param tags] and destination [param path].
 				[b]Note:[/b] In case of macOS exports, those shared objects will be added to [code]Frameworks[/code] directory of app bundle.
 				In case of a directory code-sign will error if you place non code object in directory.
 			</description>

--- a/doc/classes/EditorFeatureProfile.xml
+++ b/doc/classes/EditorFeatureProfile.xml
@@ -14,21 +14,21 @@
 			<return type="String" />
 			<param index="0" name="feature" type="int" enum="EditorFeatureProfile.Feature" />
 			<description>
-				Returns the specified [code]feature[/code]'s human-readable name.
+				Returns the specified [param feature]'s human-readable name.
 			</description>
 		</method>
 		<method name="is_class_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="class_name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the class specified by [code]class_name[/code] is disabled. When disabled, the class won't appear in the Create New Node dialog.
+				Returns [code]true[/code] if the class specified by [param class_name] is disabled. When disabled, the class won't appear in the Create New Node dialog.
 			</description>
 		</method>
 		<method name="is_class_editor_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="class_name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if editing for the class specified by [code]class_name[/code] is disabled. When disabled, the class will still appear in the Create New Node dialog but the inspector will be read-only when selecting a node that extends the class.
+				Returns [code]true[/code] if editing for the class specified by [param class_name] is disabled. When disabled, the class will still appear in the Create New Node dialog but the inspector will be read-only when selecting a node that extends the class.
 			</description>
 		</method>
 		<method name="is_class_property_disabled" qualifiers="const">
@@ -36,14 +36,14 @@
 			<param index="0" name="class_name" type="StringName" />
 			<param index="1" name="property" type="StringName" />
 			<description>
-				Returns [code]true[/code] if [code]property[/code] is disabled in the class specified by [code]class_name[/code]. When a property is disabled, it won't appear in the inspector when selecting a node that extends the class specified by [code]class_name[/code].
+				Returns [code]true[/code] if [param property] is disabled in the class specified by [param class_name]. When a property is disabled, it won't appear in the inspector when selecting a node that extends the class specified by [param class_name].
 			</description>
 		</method>
 		<method name="is_feature_disabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="feature" type="int" enum="EditorFeatureProfile.Feature" />
 			<description>
-				Returns [code]true[/code] if the [code]feature[/code] is disabled. When a feature is disabled, it will disappear from the editor entirely.
+				Returns [code]true[/code] if the [param feature] is disabled. When a feature is disabled, it will disappear from the editor entirely.
 			</description>
 		</method>
 		<method name="load_from_file">
@@ -65,7 +65,7 @@
 			<param index="0" name="class_name" type="StringName" />
 			<param index="1" name="disable" type="bool" />
 			<description>
-				If [code]disable[/code] is [code]true[/code], disables the class specified by [code]class_name[/code]. When disabled, the class won't appear in the Create New Node dialog.
+				If [param disable] is [code]true[/code], disables the class specified by [param class_name]. When disabled, the class won't appear in the Create New Node dialog.
 			</description>
 		</method>
 		<method name="set_disable_class_editor">
@@ -73,7 +73,7 @@
 			<param index="0" name="class_name" type="StringName" />
 			<param index="1" name="disable" type="bool" />
 			<description>
-				If [code]disable[/code] is [code]true[/code], disables editing for the class specified by [code]class_name[/code]. When disabled, the class will still appear in the Create New Node dialog but the inspector will be read-only when selecting a node that extends the class.
+				If [param disable] is [code]true[/code], disables editing for the class specified by [param class_name]. When disabled, the class will still appear in the Create New Node dialog but the inspector will be read-only when selecting a node that extends the class.
 			</description>
 		</method>
 		<method name="set_disable_class_property">
@@ -82,7 +82,7 @@
 			<param index="1" name="property" type="StringName" />
 			<param index="2" name="disable" type="bool" />
 			<description>
-				If [code]disable[/code] is [code]true[/code], disables editing for [code]property[/code] in the class specified by [code]class_name[/code]. When a property is disabled, it won't appear in the inspector when selecting a node that extends the class specified by [code]class_name[/code].
+				If [param disable] is [code]true[/code], disables editing for [param property] in the class specified by [param class_name]. When a property is disabled, it won't appear in the inspector when selecting a node that extends the class specified by [param class_name].
 			</description>
 		</method>
 		<method name="set_disable_feature">
@@ -90,7 +90,7 @@
 			<param index="0" name="feature" type="int" enum="EditorFeatureProfile.Feature" />
 			<param index="1" name="disable" type="bool" />
 			<description>
-				If [code]disable[/code] is [code]true[/code], disables the editor feature specified in [code]feature[/code]. When a feature is disabled, it will disappear from the editor entirely.
+				If [param disable] is [code]true[/code], disables the editor feature specified in [param feature]. When a feature is disabled, it will disappear from the editor entirely.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -13,9 +13,9 @@
 			<param index="0" name="filter" type="String" />
 			<param index="1" name="description" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a comma-delimited file name [code]filter[/code] option to the [EditorFileDialog] with an optional [code]description[/code], which restricts what files can be picked.
-				A [code]filter[/code] should be of the form [code]"filename.extension"[/code], where filename and extension can be [code]*[/code] to match any string. Filters starting with [code].[/code] (i.e. empty filenames) are not allowed.
-				For example, a [code]filter[/code] of [code]"*.tscn, *.scn"[/code] and a [code]description[/code] of [code]"Scenes"[/code] results in filter text "Scenes (*.tscn, *.scn)".
+				Adds a comma-delimited file name [param filter] option to the [EditorFileDialog] with an optional [param description], which restricts what files can be picked.
+				A [param filter] should be of the form [code]"filename.extension"[/code], where filename and extension can be [code]*[/code] to match any string. Filters starting with [code].[/code] (i.e. empty filenames) are not allowed.
+				For example, a [param filter] of [code]"*.tscn, *.scn"[/code] and a [param description] of [code]"Scenes"[/code] results in filter text "Scenes (*.tscn, *.scn)".
 			</description>
 		</method>
 		<method name="clear_filters">

--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -27,7 +27,7 @@
 			<return type="EditorFileSystemDirectory" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Returns a view into the filesystem at [code]path[/code].
+				Returns a view into the filesystem at [param path].
 			</description>
 		</method>
 		<method name="get_scanning_progress" qualifiers="const">

--- a/doc/classes/EditorFileSystemDirectory.xml
+++ b/doc/classes/EditorFileSystemDirectory.xml
@@ -13,21 +13,21 @@
 			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the index of the directory with name [code]name[/code] or [code]-1[/code] if not found.
+				Returns the index of the directory with name [param name] or [code]-1[/code] if not found.
 			</description>
 		</method>
 		<method name="find_file_index" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the index of the file with name [code]name[/code] or [code]-1[/code] if not found.
+				Returns the index of the file with name [param name] or [code]-1[/code] if not found.
 			</description>
 		</method>
 		<method name="get_file" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the name of the file at index [code]idx[/code].
+				Returns the name of the file at index [param idx].
 			</description>
 		</method>
 		<method name="get_file_count" qualifiers="const">
@@ -40,35 +40,35 @@
 			<return type="bool" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the file at index [code]idx[/code] imported properly.
+				Returns [code]true[/code] if the file at index [param idx] imported properly.
 			</description>
 		</method>
 		<method name="get_file_path" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the path to the file at index [code]idx[/code].
+				Returns the path to the file at index [param idx].
 			</description>
 		</method>
 		<method name="get_file_script_class_extends" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the base class of the script class defined in the file at index [code]idx[/code]. If the file doesn't define a script class using the [code]class_name[/code] syntax, this will return an empty string.
+				Returns the base class of the script class defined in the file at index [param idx]. If the file doesn't define a script class using the [code]class_name[/code] syntax, this will return an empty string.
 			</description>
 		</method>
 		<method name="get_file_script_class_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the name of the script class defined in the file at index [code]idx[/code]. If the file doesn't define a script class using the [code]class_name[/code] syntax, this will return an empty string.
+				Returns the name of the script class defined in the file at index [param idx]. If the file doesn't define a script class using the [code]class_name[/code] syntax, this will return an empty string.
 			</description>
 		</method>
 		<method name="get_file_type" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the resource type of the file at index [code]idx[/code]. This returns a string such as [code]"Resource"[/code] or [code]"GDScript"[/code], [i]not[/i] a file extension such as [code]".gd"[/code].
+				Returns the resource type of the file at index [param idx]. This returns a string such as [code]"Resource"[/code] or [code]"GDScript"[/code], [i]not[/i] a file extension such as [code]".gd"[/code].
 			</description>
 		</method>
 		<method name="get_name">
@@ -93,7 +93,7 @@
 			<return type="EditorFileSystemDirectory" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the subdirectory at index [code]idx[/code].
+				Returns the subdirectory at index [param idx].
 			</description>
 		</method>
 		<method name="get_subdir_count" qualifiers="const">

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -217,7 +217,7 @@
 			<param index="3" name="platform_variants" type="Array" />
 			<param index="4" name="gen_files" type="Array" />
 			<description>
-				Imports [code]source_file[/code] into [code]save_path[/code] with the import [code]options[/code] specified. The [code]platform_variants[/code] and [code]gen_files[/code] arrays will be modified by this function.
+				Imports [param source_file] into [param save_path] with the import [param options] specified. The [param platform_variants] and [param gen_files] arrays will be modified by this function.
 				This method must be overridden to do the actual importing work. See this class' description for an example of overriding this method.
 			</description>
 		</method>

--- a/doc/classes/EditorInspectorPlugin.xml
+++ b/doc/classes/EditorInspectorPlugin.xml
@@ -27,7 +27,7 @@
 			<return type="void" />
 			<param index="0" name="object" type="Object" />
 			<description>
-				Called to allow adding controls at the beginning of the property list for [code]object[/code].
+				Called to allow adding controls at the beginning of the property list for [param object].
 			</description>
 		</method>
 		<method name="_parse_category" qualifiers="virtual">
@@ -35,14 +35,14 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="category" type="String" />
 			<description>
-				Called to allow adding controls at the beginning of a category in the property list for [code]object[/code].
+				Called to allow adding controls at the beginning of a category in the property list for [param object].
 			</description>
 		</method>
 		<method name="_parse_end" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="object" type="Object" />
 			<description>
-				Called to allow adding controls at the end of the property list for [code]object[/code].
+				Called to allow adding controls at the end of the property list for [param object].
 			</description>
 		</method>
 		<method name="_parse_group" qualifiers="virtual">
@@ -50,7 +50,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="group" type="String" />
 			<description>
-				Called to allow adding controls at the beginning of a group or a sub-group in the property list for [code]object[/code].
+				Called to allow adding controls at the beginning of a group or a sub-group in the property list for [param object].
 			</description>
 		</method>
 		<method name="_parse_property" qualifiers="virtual">
@@ -63,7 +63,7 @@
 			<param index="5" name="usage_flags" type="int" />
 			<param index="6" name="wide" type="bool" />
 			<description>
-				Called to allow adding property-specific editors to the property list for [code]object[/code]. The added editor control must extend [EditorProperty]. Returning [code]true[/code] removes the built-in editor for this property, otherwise allows to insert a custom editor before the built-in one.
+				Called to allow adding property-specific editors to the property list for [param object]. The added editor control must extend [EditorProperty]. Returning [code]true[/code] removes the built-in editor for this property, otherwise allows to insert a custom editor before the built-in one.
 			</description>
 		</method>
 		<method name="add_custom_control">
@@ -79,7 +79,7 @@
 			<param index="1" name="editor" type="Control" />
 			<param index="2" name="add_to_end" type="bool" default="false" />
 			<description>
-				Adds a property editor for an individual property. The [code]editor[/code] control must extend [EditorProperty].
+				Adds a property editor for an individual property. The [param editor] control must extend [EditorProperty].
 			</description>
 		</method>
 		<method name="add_property_editor_for_multiple_properties">
@@ -88,7 +88,7 @@
 			<param index="1" name="properties" type="PackedStringArray" />
 			<param index="2" name="editor" type="Control" />
 			<description>
-				Adds an editor that allows modifying multiple properties. The [code]editor[/code] control must extend [EditorProperty].
+				Adds an editor that allows modifying multiple properties. The [param editor] control must extend [EditorProperty].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -149,7 +149,7 @@
 			<param index="1" name="for_property" type="String" default="&quot;&quot;" />
 			<param index="2" name="inspector_only" type="bool" default="false" />
 			<description>
-				Shows the given property on the given [code]object[/code] in the editor's Inspector dock. If [code]inspector_only[/code] is [code]true[/code], plugins will not attempt to edit [code]object[/code].
+				Shows the given property on the given [param object] in the editor's Inspector dock. If [param inspector_only] is [code]true[/code], plugins will not attempt to edit [param object].
 			</description>
 		</method>
 		<method name="is_playing_scene" qualifiers="const">
@@ -162,7 +162,7 @@
 			<return type="bool" />
 			<param index="0" name="plugin" type="String" />
 			<description>
-				Returns [code]true[/code] if the specified [code]plugin[/code] is enabled. The plugin name is the same as its directory name.
+				Returns [code]true[/code] if the specified [param plugin] is enabled. The plugin name is the same as its directory name.
 			</description>
 		</method>
 		<method name="make_mesh_previews">
@@ -217,21 +217,21 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="with_preview" type="bool" default="true" />
 			<description>
-				Saves the scene as a file at [code]path[/code].
+				Saves the scene as a file at [param path].
 			</description>
 		</method>
 		<method name="select_file">
 			<return type="void" />
 			<param index="0" name="file" type="String" />
 			<description>
-				Selects the file, with the path provided by [code]file[/code], in the FileSystem dock.
+				Selects the file, with the path provided by [param file], in the FileSystem dock.
 			</description>
 		</method>
 		<method name="set_main_screen_editor">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Sets the editor's current main screen to the one specified in [code]name[/code]. [code]name[/code] must match the text of the tab in question exactly ([code]2D[/code], [code]3D[/code], [code]Script[/code], [code]AssetLib[/code]).
+				Sets the editor's current main screen to the one specified in [param name]. [param name] must match the text of the tab in question exactly ([code]2D[/code], [code]3D[/code], [code]Script[/code], [code]AssetLib[/code]).
 			</description>
 		</method>
 		<method name="set_plugin_enabled">

--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -16,9 +16,9 @@
 			<param index="2" name="restore" type="Variant" />
 			<param index="3" name="cancel" type="bool" />
 			<description>
-				Override this method to commit a handle being edited (handles must have been previously added by [method add_handles]). This usually means creating an [UndoRedo] action for the change, using the current handle value as "do" and the [code]restore[/code] argument as "undo".
-				If the [code]cancel[/code] argument is [code]true[/code], the [code]restore[/code] value should be directly set, without any [UndoRedo] action.
-				The [code]secondary[/code] argument is [code]true[/code] when the committed handle is secondary (see [method add_handles] for more information).
+				Override this method to commit a handle being edited (handles must have been previously added by [method add_handles]). This usually means creating an [UndoRedo] action for the change, using the current handle value as "do" and the [param restore] argument as "undo".
+				If the [param cancel] argument is [code]true[/code], the [param restore] value should be directly set, without any [UndoRedo] action.
+				The [param secondary] argument is [code]true[/code] when the committed handle is secondary (see [method add_handles] for more information).
 			</description>
 		</method>
 		<method name="_commit_subgizmos" qualifiers="virtual">
@@ -27,8 +27,8 @@
 			<param index="1" name="restores" type="Transform3D[]" />
 			<param index="2" name="cancel" type="bool" />
 			<description>
-				Override this method to commit a group of subgizmos being edited (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). This usually means creating an [UndoRedo] action for the change, using the current transforms as "do" and the [code]restore[/code] transforms as "undo".
-				If the [code]cancel[/code] argument is [code]true[/code], the [code]restore[/code] transforms should be directly set, without any [UndoRedo] action.
+				Override this method to commit a group of subgizmos being edited (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). This usually means creating an [UndoRedo] action for the change, using the current transforms as "do" and the [param restores] transforms as "undo".
+				If the [param cancel] argument is [code]true[/code], the [param restores] transforms should be directly set, without any [UndoRedo] action.
 			</description>
 		</method>
 		<method name="_get_handle_name" qualifiers="virtual const">
@@ -37,7 +37,7 @@
 			<param index="1" name="secondary" type="bool" />
 			<description>
 				Override this method to return the name of an edited handle (handles must have been previously added by [method add_handles]). Handles can be named for reference to the user when editing.
-				The [code]secondary[/code] argument is [code]true[/code] when the requested handle is secondary (see [method add_handles] for more information).
+				The [param secondary] argument is [code]true[/code] when the requested handle is secondary (see [method add_handles] for more information).
 			</description>
 		</method>
 		<method name="_get_handle_value" qualifiers="virtual const">
@@ -46,7 +46,7 @@
 			<param index="1" name="secondary" type="bool" />
 			<description>
 				Override this method to return the current value of a handle. This value will be requested at the start of an edit and used as the [code]restore[/code] argument in [method _commit_handle].
-				The [code]secondary[/code] argument is [code]true[/code] when the requested handle is secondary (see [method add_handles] for more information).
+				The [param secondary] argument is [code]true[/code] when the requested handle is secondary (see [method add_handles] for more information).
 			</description>
 		</method>
 		<method name="_get_subgizmo_transform" qualifiers="virtual const">
@@ -62,7 +62,7 @@
 			<param index="1" name="secondary" type="bool" />
 			<description>
 				Override this method to return [code]true[/code] whenever the given handle should be highlighted in the editor.
-				The [code]secondary[/code] argument is [code]true[/code] when the requested handle is secondary (see [method add_handles] for more information).
+				The [param secondary] argument is [code]true[/code] when the requested handle is secondary (see [method add_handles] for more information).
 			</description>
 		</method>
 		<method name="_redraw" qualifiers="virtual">
@@ -78,8 +78,8 @@
 			<param index="2" name="camera" type="Camera3D" />
 			<param index="3" name="point" type="Vector2" />
 			<description>
-				Override this method to update the node properties when the user drags a gizmo handle (previously added with [method add_handles]). The provided [code]point[/code] is the mouse position in screen coordinates and the [code]camera[/code] can be used to convert it to raycasts.
-				The [code]secondary[/code] argument is [code]true[/code] when the edited handle is secondary (see [method add_handles] for more information).
+				Override this method to update the node properties when the user drags a gizmo handle (previously added with [method add_handles]). The provided [param point] is the mouse position in screen coordinates and the [param camera] can be used to convert it to raycasts.
+				The [param secondary] argument is [code]true[/code] when the edited handle is secondary (see [method add_handles] for more information).
 			</description>
 		</method>
 		<method name="_set_subgizmo_transform" qualifiers="virtual">
@@ -87,7 +87,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="transform" type="Transform3D" />
 			<description>
-				Override this method to update the node properties during subgizmo editing (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). The [code]transform[/code] is given in the Node3D's local coordinate system.
+				Override this method to update the node properties during subgizmo editing (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). The [param transform] is given in the Node3D's local coordinate system.
 			</description>
 		</method>
 		<method name="_subgizmos_intersect_frustum" qualifiers="virtual const">
@@ -95,7 +95,7 @@
 			<param index="0" name="camera" type="Camera3D" />
 			<param index="1" name="frustum" type="Plane[]" />
 			<description>
-				Override this method to allow selecting subgizmos using mouse drag box selection. Given a [code]camera[/code] and a [code]frustum[/code], this method should return which subgizmos are contained within the frustum. The [code]frustum[/code] argument consists of an [code]Array[/code] with all the [code]Plane[/code]s that make up the selection frustum. The returned value should contain a list of unique subgizmo identifiers, which can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos].
+				Override this method to allow selecting subgizmos using mouse drag box selection. Given a [param camera] and a [param frustum], this method should return which subgizmos are contained within the frustum. The [param frustum] argument consists of an [code]Array[/code] with all the [code]Plane[/code]s that make up the selection frustum. The returned value should contain a list of unique subgizmo identifiers, which can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos].
 			</description>
 		</method>
 		<method name="_subgizmos_intersect_ray" qualifiers="virtual const">
@@ -103,14 +103,14 @@
 			<param index="0" name="camera" type="Camera3D" />
 			<param index="1" name="point" type="Vector2" />
 			<description>
-				Override this method to allow selecting subgizmos using mouse clicks. Given a [code]camera[/code] and a [code]point[/code] in screen coordinates, this method should return which subgizmo should be selected. The returned value should be a unique subgizmo identifier, which can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos].
+				Override this method to allow selecting subgizmos using mouse clicks. Given a [param camera] and a [param point] in screen coordinates, this method should return which subgizmo should be selected. The returned value should be a unique subgizmo identifier, which can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos].
 			</description>
 		</method>
 		<method name="add_collision_segments">
 			<return type="void" />
 			<param index="0" name="segments" type="PackedVector3Array" />
 			<description>
-				Adds the specified [code]segments[/code] to the gizmo's collision shape for picking. Call this method during [method _redraw].
+				Adds the specified [param segments] to the gizmo's collision shape for picking. Call this method during [method _redraw].
 			</description>
 		</method>
 		<method name="add_collision_triangles">
@@ -128,8 +128,8 @@
 			<param index="3" name="billboard" type="bool" default="false" />
 			<param index="4" name="secondary" type="bool" default="false" />
 			<description>
-				Adds a list of handles (points) which can be used to edit the properties of the gizmo's Node3D. The [code]ids[/code] argument can be used to specify a custom identifier for each handle, if an empty [code]Array[/code] is passed, the ids will be assigned automatically from the [code]handles[/code] argument order.
-				The [code]secondary[/code] argument marks the added handles as secondary, meaning they will normally have less selection priority than regular handles. When the user is holding the shift key secondary handles will switch to have higher priority than regular handles. This change in priority can be used to place multiple handles at the same point while still giving the user control on their selection.
+				Adds a list of handles (points) which can be used to edit the properties of the gizmo's Node3D. The [param ids] argument can be used to specify a custom identifier for each handle, if an empty [code]Array[/code] is passed, the ids will be assigned automatically from the [param handles] argument order.
+				The [param secondary] argument marks the added handles as secondary, meaning they will normally have less selection priority than regular handles. When the user is holding the shift key secondary handles will switch to have higher priority than regular handles. This change in priority can be used to place multiple handles at the same point while still giving the user control on their selection.
 				There are virtual methods which will be called upon editing of these handles. Call this method during [method _redraw].
 			</description>
 		</method>
@@ -150,7 +150,7 @@
 			<param index="2" name="transform" type="Transform3D" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)" />
 			<param index="3" name="skeleton" type="SkinReference" default="null" />
 			<description>
-				Adds a mesh to the gizmo with the specified [code]material[/code], local [code]transform[/code] and [code]skeleton[/code]. Call this method during [method _redraw].
+				Adds a mesh to the gizmo with the specified [param material], local [param transform] and [param skeleton]. Call this method during [method _redraw].
 			</description>
 		</method>
 		<method name="add_unscaled_billboard">
@@ -204,7 +204,7 @@
 			<return type="void" />
 			<param index="0" name="node" type="Node" />
 			<description>
-				Sets the reference [Node3D] node for the gizmo. [code]node[/code] must inherit from [Node3D].
+				Sets the reference [Node3D] node for the gizmo. [param node] must inherit from [Node3D].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorNode3DGizmoPlugin.xml
+++ b/doc/classes/EditorNode3DGizmoPlugin.xml
@@ -25,9 +25,9 @@
 			<param index="3" name="restore" type="Variant" />
 			<param index="4" name="cancel" type="bool" />
 			<description>
-				Override this method to commit a handle being edited (handles must have been previously added by [method EditorNode3DGizmo.add_handles] during [method _redraw]). This usually means creating an [UndoRedo] action for the change, using the current handle value as "do" and the [code]restore[/code] argument as "undo".
-				If the [code]cancel[/code] argument is [code]true[/code], the [code]restore[/code] value should be directly set, without any [UndoRedo] action.
-				The [code]secondary[/code] argument is [code]true[/code] when the committed handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information).
+				Override this method to commit a handle being edited (handles must have been previously added by [method EditorNode3DGizmo.add_handles] during [method _redraw]). This usually means creating an [UndoRedo] action for the change, using the current handle value as "do" and the [param restore] argument as "undo".
+				If the [param cancel] argument is [code]true[/code], the [param restore] value should be directly set, without any [UndoRedo] action.
+				The [param secondary] argument is [code]true[/code] when the committed handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information).
 				Called for this plugin's active gizmos.
 			</description>
 		</method>
@@ -38,8 +38,8 @@
 			<param index="2" name="restores" type="Transform3D[]" />
 			<param index="3" name="cancel" type="bool" />
 			<description>
-				Override this method to commit a group of subgizmos being edited (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). This usually means creating an [UndoRedo] action for the change, using the current transforms as "do" and the [code]restore[/code] transforms as "undo".
-				If the [code]cancel[/code] argument is [code]true[/code], the [code]restore[/code] transforms should be directly set, without any [UndoRedo] action. As with all subgizmo methods, transforms are given in local space respect to the gizmo's Node3D. Called for this plugin's active gizmos.
+				Override this method to commit a group of subgizmos being edited (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). This usually means creating an [UndoRedo] action for the change, using the current transforms as "do" and the [param restores] transforms as "undo".
+				If the [param cancel] argument is [code]true[/code], the [param restores] transforms should be directly set, without any [UndoRedo] action. As with all subgizmo methods, transforms are given in local space respect to the gizmo's Node3D. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_create_gizmo" qualifiers="virtual const">
@@ -61,7 +61,7 @@
 			<param index="1" name="handle_id" type="int" />
 			<param index="2" name="secondary" type="bool" />
 			<description>
-				Override this method to provide gizmo's handle names. The [code]secondary[/code] argument is [code]true[/code] when the requested handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information). Called for this plugin's active gizmos.
+				Override this method to provide gizmo's handle names. The [param secondary] argument is [code]true[/code] when the requested handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information). Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_get_handle_value" qualifiers="virtual const">
@@ -71,7 +71,7 @@
 			<param index="2" name="secondary" type="bool" />
 			<description>
 				Override this method to return the current value of a handle. This value will be requested at the start of an edit and used as the [code]restore[/code] argument in [method _commit_handle].
-				The [code]secondary[/code] argument is [code]true[/code] when the requested handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information).
+				The [param secondary] argument is [code]true[/code] when the requested handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information).
 				Called for this plugin's active gizmos.
 			</description>
 		</method>
@@ -103,7 +103,7 @@
 			<param index="1" name="handle_id" type="int" />
 			<param index="2" name="secondary" type="bool" />
 			<description>
-				Override this method to return [code]true[/code] whenever to given handle should be highlighted in the editor. The [code]secondary[/code] argument is [code]true[/code] when the requested handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information). Called for this plugin's active gizmos.
+				Override this method to return [code]true[/code] whenever to given handle should be highlighted in the editor. The [param secondary] argument is [code]true[/code] when the requested handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information). Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_is_selectable_when_hidden" qualifiers="virtual const">
@@ -127,8 +127,8 @@
 			<param index="3" name="camera" type="Camera3D" />
 			<param index="4" name="screen_pos" type="Vector2" />
 			<description>
-				Override this method to update the node's properties when the user drags a gizmo handle (previously added with [method EditorNode3DGizmo.add_handles]). The provided [code]point[/code] is the mouse position in screen coordinates and the [code]camera[/code] can be used to convert it to raycasts.
-				The [code]secondary[/code] argument is [code]true[/code] when the edited handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information).
+				Override this method to update the node's properties when the user drags a gizmo handle (previously added with [method EditorNode3DGizmo.add_handles]). The provided [param screen_pos] is the mouse position in screen coordinates and the [param camera] can be used to convert it to raycasts.
+				The [param secondary] argument is [code]true[/code] when the edited handle is secondary (see [method EditorNode3DGizmo.add_handles] for more information).
 				Called for this plugin's active gizmos.
 			</description>
 		</method>
@@ -138,7 +138,7 @@
 			<param index="1" name="subgizmo_id" type="int" />
 			<param index="2" name="transform" type="Transform3D" />
 			<description>
-				Override this method to update the node properties during subgizmo editing (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). The [code]transform[/code] is given in the Node3D's local coordinate system.  Called for this plugin's active gizmos.
+				Override this method to update the node properties during subgizmo editing (see [method _subgizmos_intersect_ray] and [method _subgizmos_intersect_frustum]). The [param transform] is given in the Node3D's local coordinate system.  Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_subgizmos_intersect_frustum" qualifiers="virtual const">
@@ -147,7 +147,7 @@
 			<param index="1" name="camera" type="Camera3D" />
 			<param index="2" name="frustum_planes" type="Plane[]" />
 			<description>
-				Override this method to allow selecting subgizmos using mouse drag box selection. Given a [code]camera[/code] and a [code]frustum[/code], this method should return which subgizmos are contained within the frustum. The [code]frustum[/code] argument consists of an [code]Array[/code] with all the [code]Plane[/code]s that make up the selection frustum. The returned value should contain a list of unique subgizmo identifiers, these identifiers can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos].  Called for this plugin's active gizmos.
+				Override this method to allow selecting subgizmos using mouse drag box selection. Given a [param camera] and [param frustum_planes], this method should return which subgizmos are contained within the frustums. The [param frustum_planes] argument consists of an [code]Array[/code] with all the [code]Plane[/code]s that make up the selection frustum. The returned value should contain a list of unique subgizmo identifiers, these identifiers can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos].  Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="_subgizmos_intersect_ray" qualifiers="virtual const">
@@ -156,7 +156,7 @@
 			<param index="1" name="camera" type="Camera3D" />
 			<param index="2" name="screen_pos" type="Vector2" />
 			<description>
-				Override this method to allow selecting subgizmos using mouse clicks. Given a [code]camera[/code] and a [code]point[/code] in screen coordinates, this method should return which subgizmo should be selected. The returned value should be a unique subgizmo identifier, which can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos]. Called for this plugin's active gizmos.
+				Override this method to allow selecting subgizmos using mouse clicks. Given a [param camera] and a [param screen_pos] in screen coordinates, this method should return which subgizmo should be selected. The returned value should be a unique subgizmo identifier, which can have any non-negative value and will be used in other virtual methods like [method _get_subgizmo_transform] or [method _commit_subgizmos]. Called for this plugin's active gizmos.
 			</description>
 		</method>
 		<method name="add_material">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -100,7 +100,7 @@
 			<param index="0" name="viewport_camera" type="Camera3D" />
 			<param index="1" name="event" type="InputEvent" />
 			<description>
-				Called when there is a root node in the current edited scene, [method _handles] is implemented and an [InputEvent] happens in the 3D viewport. Intercepts the [InputEvent], if [code]return true[/code] [EditorPlugin] consumes the [code]event[/code], otherwise forwards [code]event[/code] to other Editor classes. Example:
+				Called when there is a root node in the current edited scene, [method _handles] is implemented and an [InputEvent] happens in the 3D viewport. Intercepts the [InputEvent], if [code]return true[/code] [EditorPlugin] consumes the [param event], otherwise forwards [param event] to other Editor classes. Example:
 				[codeblocks]
 				[gdscript]
 				# Prevents the InputEvent to reach other Editor classes.
@@ -182,7 +182,7 @@
 			<return type="bool" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Called when there is a root node in the current edited scene, [method _handles] is implemented and an [InputEvent] happens in the 2D viewport. Intercepts the [InputEvent], if [code]return true[/code] [EditorPlugin] consumes the [code]event[/code], otherwise forwards [code]event[/code] to other Editor classes. Example:
+				Called when there is a root node in the current edited scene, [method _handles] is implemented and an [InputEvent] happens in the 2D viewport. Intercepts the [InputEvent], if [code]return true[/code] [EditorPlugin] consumes the [param event], otherwise forwards [param event] to other Editor classes. Example:
 				[codeblocks]
 				[gdscript]
 				# Prevents the InputEvent to reach other Editor classes.
@@ -351,7 +351,7 @@
 			<return type="void" />
 			<param index="0" name="configuration" type="ConfigFile" />
 			<description>
-				Restore the plugin GUI layout and data saved by [method _get_window_layout]. This method is called for every plugin on editor startup. Use the provided [code]configuration[/code] file to read your saved data.
+				Restore the plugin GUI layout and data saved by [method _get_window_layout]. This method is called for every plugin on editor startup. Use the provided [param configuration] file to read your saved data.
 				[codeblock]
 				func _set_window_layout(configuration):
 				    $Window.position = configuration.get_value("MyPlugin", "window_position", Vector2())
@@ -364,7 +364,7 @@
 			<param index="0" name="name" type="String" />
 			<param index="1" name="path" type="String" />
 			<description>
-				Adds a script at [code]path[/code] to the Autoload list as [code]name[/code].
+				Adds a script at [param path] to the Autoload list as [param name].
 			</description>
 		</method>
 		<method name="add_control_to_bottom_panel">
@@ -429,7 +429,7 @@
 			<param index="1" name="first_priority" type="bool" default="false" />
 			<description>
 				Registers a new [EditorImportPlugin]. Import plugins are used to import custom and unsupported assets as a custom [Resource] type.
-				If [code]first_priority[/code] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
+				If [param first_priority] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 				[b]Note:[/b] If you want to import custom 3D asset formats use [method add_scene_format_importer_plugin] instead.
 				See [method add_inspector_plugin] for an example of how to register a plugin.
 			</description>
@@ -460,7 +460,7 @@
 			<param index="1" name="first_priority" type="bool" default="false" />
 			<description>
 				Registers a new [EditorSceneFormatImporter]. Scene importers are used to import custom 3D asset formats as scenes.
-				If [code]first_priority[/code] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
+				If [param first_priority] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 			</description>
 		</method>
 		<method name="add_scene_post_import_plugin">
@@ -469,7 +469,7 @@
 			<param index="1" name="first_priority" type="bool" default="false" />
 			<description>
 				Add a [EditorScenePostImportPlugin]. These plugins allow customizing the import process of 3D assets by adding new options to the import dialogs.
-				If [code]first_priority[/code] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
+				If [param first_priority] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 			</description>
 		</method>
 		<method name="add_spatial_gizmo_plugin">
@@ -485,7 +485,7 @@
 			<param index="0" name="name" type="String" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Adds a custom menu item to [b]Project &gt; Tools[/b] named [code]name[/code]. When clicked, the provided [code]callable[/code] will be called.
+				Adds a custom menu item to [b]Project &gt; Tools[/b] named [param name]. When clicked, the provided [param callable] will be called.
 			</description>
 		</method>
 		<method name="add_tool_submenu_item">
@@ -493,7 +493,7 @@
 			<param index="0" name="name" type="String" />
 			<param index="1" name="submenu" type="PopupMenu" />
 			<description>
-				Adds a custom [PopupMenu] submenu under [b]Project &gt; Tools &gt;[/b] [code]name[/code]. Use [code]remove_tool_menu_item(name)[/code] on plugin clean up to remove the menu.
+				Adds a custom [PopupMenu] submenu under [b]Project &gt; Tools &gt;[/b] [param name]. Use [code]remove_tool_menu_item(name)[/code] on plugin clean up to remove the menu.
 			</description>
 		</method>
 		<method name="add_translation_parser_plugin">
@@ -560,7 +560,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Removes an Autoload [code]name[/code] from the list.
+				Removes an Autoload [param name] from the list.
 			</description>
 		</method>
 		<method name="remove_control_from_bottom_panel">
@@ -645,7 +645,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Removes a menu [code]name[/code] from [b]Project &gt; Tools[/b].
+				Removes a menu [param name] from [b]Project &gt; Tools[/b].
 			</description>
 		</method>
 		<method name="remove_translation_parser_plugin">

--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -29,7 +29,7 @@
 			<param index="2" name="field" type="StringName" default="&amp;&quot;&quot;" />
 			<param index="3" name="changing" type="bool" default="false" />
 			<description>
-				If one or several properties have changed, this must be called. [code]field[/code] is used in case your editor can modify fields separately (as an example, Vector3.x). The [code]changing[/code] argument avoids the editor requesting this property to be refreshed (leave as [code]false[/code] if unsure).
+				If one or several properties have changed, this must be called. [param field] is used in case your editor can modify fields separately (as an example, Vector3.x). The [param changing] argument avoids the editor requesting this property to be refreshed (leave as [code]false[/code] if unsure).
 			</description>
 		</method>
 		<method name="get_edited_object">
@@ -54,7 +54,7 @@
 			<return type="void" />
 			<param index="0" name="editor" type="Control" />
 			<description>
-				Puts the [code]editor[/code] control below the property label. The control must be previously added using [method Node.add_child].
+				Puts the [param editor] control below the property label. The control must be previously added using [method Node.add_child].
 			</description>
 		</method>
 		<method name="update_property">

--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -21,7 +21,7 @@
 			<return type="void" />
 			<param index="0" name="menu_node" type="Object" />
 			<description>
-				This virtual method is called when updating the context menu of [EditorResourcePicker]. Implement this method to override the "New ..." items with your own options. [code]menu_node[/code] is a reference to the [PopupMenu] node.
+				This virtual method is called when updating the context menu of [EditorResourcePicker]. Implement this method to override the "New ..." items with your own options. [param menu_node] is a reference to the [PopupMenu] node.
 				[b]Note:[/b] Implement [method _handle_menu_selected] to handle these custom items.
 			</description>
 		</method>
@@ -64,7 +64,7 @@
 			<param index="0" name="resource" type="Resource" />
 			<param index="1" name="edit" type="bool" />
 			<description>
-				Emitted when the resource value was set and user clicked to edit it. When [code]edit[/code] is [code]true[/code], the signal was caused by the context menu "Edit" option.
+				Emitted when the resource value was set and user clicked to edit it. When [param edit] is [code]true[/code], the signal was caused by the context menu "Edit" option.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/EditorResourcePreview.xml
+++ b/doc/classes/EditorResourcePreview.xml
@@ -31,8 +31,8 @@
 			<param index="2" name="receiver_func" type="StringName" />
 			<param index="3" name="userdata" type="Variant" />
 			<description>
-				Queue the [code]resource[/code] being edited for preview. Once the preview is ready, the [code]receiver[/code]'s [code]receiver_func[/code] will be called. The [code]receiver_func[/code] must take the following four arguments: [String] path, [Texture2D] preview, [Texture2D] thumbnail_preview, [Variant] userdata. [code]userdata[/code] can be anything, and will be returned when [code]receiver_func[/code] is called.
-				[b]Note:[/b] If it was not possible to create the preview the [code]receiver_func[/code] will still be called, but the preview will be null.
+				Queue the [param resource] being edited for preview. Once the preview is ready, the [param receiver]'s [param receiver_func] will be called. The [param receiver_func] must take the following four arguments: [String] path, [Texture2D] preview, [Texture2D] thumbnail_preview, [Variant] userdata. [param userdata] can be anything, and will be returned when [param receiver_func] is called.
+				[b]Note:[/b] If it was not possible to create the preview the [param receiver_func] will still be called, but the preview will be null.
 			</description>
 		</method>
 		<method name="queue_resource_preview">
@@ -42,8 +42,8 @@
 			<param index="2" name="receiver_func" type="StringName" />
 			<param index="3" name="userdata" type="Variant" />
 			<description>
-				Queue a resource file located at [code]path[/code] for preview. Once the preview is ready, the [code]receiver[/code]'s [code]receiver_func[/code] will be called. The [code]receiver_func[/code] must take the following four arguments: [String] path, [Texture2D] preview, [Texture2D] thumbnail_preview, [Variant] userdata. [code]userdata[/code] can be anything, and will be returned when [code]receiver_func[/code] is called.
-				[b]Note:[/b] If it was not possible to create the preview the [code]receiver_func[/code] will still be called, but the preview will be null.
+				Queue a resource file located at [param path] for preview. Once the preview is ready, the [param receiver]'s [param receiver_func] will be called. The [param receiver_func] must take the following four arguments: [String] path, [Texture2D] preview, [Texture2D] thumbnail_preview, [Variant] userdata. [param userdata] can be anything, and will be returned when [param receiver_func] is called.
+				[b]Note:[/b] If it was not possible to create the preview the [param receiver_func] will still be called, but the preview will be null.
 			</description>
 		</method>
 		<method name="remove_preview_generator">
@@ -58,7 +58,7 @@
 		<signal name="preview_invalidated">
 			<param index="0" name="path" type="String" />
 			<description>
-				Emitted if a preview was invalidated (changed). [code]path[/code] corresponds to the path of the preview.
+				Emitted if a preview was invalidated (changed). [param path] corresponds to the path of the preview.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/EditorResourcePreviewGenerator.xml
+++ b/doc/classes/EditorResourcePreviewGenerator.xml
@@ -47,7 +47,7 @@
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
 			<description>
-				Returns [code]true[/code] if your generator supports the resource of type [code]type[/code].
+				Returns [code]true[/code] if your generator supports the resource of type [param type].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -44,7 +44,7 @@
 			<return type="void" />
 			<param index="0" name="node" type="Node" />
 			<description>
-				Adds [code]node[/code] as a child of the root node in the editor context.
+				Adds [param node] as a child of the root node in the editor context.
 				[b]Warning:[/b] The implementation of this method is currently disabled.
 			</description>
 		</method>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -74,14 +74,14 @@
 			<return type="bool" />
 			<param index="0" name="setting_prefix" type="String" />
 			<description>
-				Checks if any settings with the prefix [code]setting_prefix[/code] exist in the set of changed settings. See also [method get_changed_settings].
+				Checks if any settings with the prefix [param setting_prefix] exist in the set of changed settings. See also [method get_changed_settings].
 			</description>
 		</method>
 		<method name="erase">
 			<return type="void" />
 			<param index="0" name="property" type="String" />
 			<description>
-				Erases the setting whose name is specified by [code]property[/code].
+				Erases the setting whose name is specified by [param property].
 			</description>
 		</method>
 		<method name="get_changed_settings" qualifiers="const">
@@ -102,7 +102,7 @@
 			<param index="1" name="key" type="String" />
 			<param index="2" name="default" type="Variant" default="null" />
 			<description>
-				Returns project-specific metadata for the [code]section[/code] and [code]key[/code] specified. If the metadata doesn't exist, [code]default[/code] will be returned instead. See also [method set_project_metadata].
+				Returns project-specific metadata for the [param section] and [param key] specified. If the metadata doesn't exist, [param default] will be returned instead. See also [method set_project_metadata].
 			</description>
 		</method>
 		<method name="get_recent_dirs" qualifiers="const">
@@ -115,14 +115,14 @@
 			<return type="Variant" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the value of the setting specified by [code]name[/code]. This is equivalent to using [method Object.get] on the EditorSettings instance.
+				Returns the value of the setting specified by [param name]. This is equivalent to using [method Object.get] on the EditorSettings instance.
 			</description>
 		</method>
 		<method name="has_setting" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if the setting specified by [code]name[/code] exists, [code]false[/code] otherwise.
+				Returns [code]true[/code] if the setting specified by [param name] exists, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="mark_setting_changed">
@@ -136,14 +136,14 @@
 			<return type="bool" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns [code]true[/code] if the setting specified by [code]name[/code] can have its value reverted to the default value, [code]false[/code] otherwise. When this method returns [code]true[/code], a Revert button will display next to the setting in the Editor Settings.
+				Returns [code]true[/code] if the setting specified by [param name] can have its value reverted to the default value, [code]false[/code] otherwise. When this method returns [code]true[/code], a Revert button will display next to the setting in the Editor Settings.
 			</description>
 		</method>
 		<method name="property_get_revert">
 			<return type="Variant" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Returns the default value of the setting specified by [code]name[/code]. This is the value that would be applied when clicking the Revert button in the Editor Settings.
+				Returns the default value of the setting specified by [param name]. This is the value that would be applied when clicking the Revert button in the Editor Settings.
 			</description>
 		</method>
 		<method name="set_builtin_action_override">
@@ -151,7 +151,7 @@
 			<param index="0" name="name" type="String" />
 			<param index="1" name="actions_list" type="Array" />
 			<description>
-				Overrides the built-in editor action [code]name[/code] with the input actions defined in [code]actions_list[/code].
+				Overrides the built-in editor action [param name] with the input actions defined in [param actions_list].
 			</description>
 		</method>
 		<method name="set_favorites">
@@ -167,7 +167,7 @@
 			<param index="1" name="value" type="Variant" />
 			<param index="2" name="update_current" type="bool" />
 			<description>
-				Sets the initial value of the setting specified by [code]name[/code] to [code]value[/code]. This is used to provide a value for the Revert button in the Editor Settings. If [code]update_current[/code] is true, the current value of the setting will be set to [code]value[/code] as well.
+				Sets the initial value of the setting specified by [param name] to [param value]. This is used to provide a value for the Revert button in the Editor Settings. If [param update_current] is true, the current value of the setting will be set to [param value] as well.
 			</description>
 		</method>
 		<method name="set_project_metadata">
@@ -176,7 +176,7 @@
 			<param index="1" name="key" type="String" />
 			<param index="2" name="data" type="Variant" />
 			<description>
-				Sets project-specific metadata with the [code]section[/code], [code]key[/code] and [code]data[/code] specified. This metadata is stored outside the project folder and therefore won't be checked into version control. See also [method get_project_metadata].
+				Sets project-specific metadata with the [param section], [param key] and [param data] specified. This metadata is stored outside the project folder and therefore won't be checked into version control. See also [method get_project_metadata].
 			</description>
 		</method>
 		<method name="set_recent_dirs">
@@ -191,7 +191,7 @@
 			<param index="0" name="name" type="String" />
 			<param index="1" name="value" type="Variant" />
 			<description>
-				Sets the [code]value[/code] of the setting specified by [code]name[/code]. This is equivalent to using [method Object.set] on the EditorSettings instance.
+				Sets the [param value] of the setting specified by [param name]. This is equivalent to using [method Object.set] on the EditorSettings instance.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -123,7 +123,7 @@
 			<return type="Object" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns a global singleton with given [code]name[/code]. Often used for plugins, e.g. GodotPayments.
+				Returns a global singleton with given [param name]. Often used for plugins, e.g. GodotPayments.
 			</description>
 		</method>
 		<method name="get_singleton_list" qualifiers="const">
@@ -175,7 +175,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if a singleton with given [code]name[/code] exists in global scope.
+				Returns [code]true[/code] if a singleton with given [param name] exists in global scope.
 			</description>
 		</method>
 		<method name="is_editor_hint" qualifiers="const">

--- a/doc/classes/EngineDebugger.xml
+++ b/doc/classes/EngineDebugger.xml
@@ -41,7 +41,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="data" type="Array" />
 			<description>
-				Calls the [code]add[/code] callable of the profiler with given [code]name[/code] and [code]data[/code].
+				Calls the [code]add[/code] callable of the profiler with given [param name] and [param data].
 			</description>
 		</method>
 		<method name="profiler_enable">
@@ -50,7 +50,7 @@
 			<param index="1" name="enable" type="bool" />
 			<param index="2" name="arguments" type="Array" default="[]" />
 			<description>
-				Calls the [code]toggle[/code] callable of the profiler with given [code]name[/code] and [code]arguments[/code]. Enables/Disables the same profiler depending on [code]enable[/code] argument.
+				Calls the [code]toggle[/code] callable of the profiler with given [param name] and [param arguments]. Enables/Disables the same profiler depending on [code]enable[/code] argument.
 			</description>
 		</method>
 		<method name="register_message_capture">
@@ -58,7 +58,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
-				Registers a message capture with given [code]name[/code]. If [code]name[/code] is "my_message" then messages starting with "my_message:" will be called with the given callable.
+				Registers a message capture with given [param name]. If [param name] is "my_message" then messages starting with "my_message:" will be called with the given callable.
 				Callable must accept a message string and a data array as argument. If the message and data are valid then callable must return [code]true[/code] otherwise [code]false[/code].
 			</description>
 		</method>
@@ -67,7 +67,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="profiler" type="EngineProfiler" />
 			<description>
-				Registers a profiler with the given [code]name[/code]. See [EngineProfiler] for more information.
+				Registers a profiler with the given [param name]. See [EngineProfiler] for more information.
 			</description>
 		</method>
 		<method name="send_message">
@@ -75,21 +75,21 @@
 			<param index="0" name="message" type="String" />
 			<param index="1" name="data" type="Array" />
 			<description>
-				Sends a message with given [code]message[/code] and [code]data[/code] array.
+				Sends a message with given [param message] and [param data] array.
 			</description>
 		</method>
 		<method name="unregister_message_capture">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Unregisters the message capture with given [code]name[/code].
+				Unregisters the message capture with given [param name].
 			</description>
 		</method>
 		<method name="unregister_profiler">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Unregisters a profiler with given [code]name[/code].
+				Unregisters a profiler with given [param name].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EngineProfiler.xml
+++ b/doc/classes/EngineProfiler.xml
@@ -32,7 +32,7 @@
 			<param index="0" name="enable" type="bool" />
 			<param index="1" name="options" type="Array" />
 			<description>
-				Called when the profiler is enabled/disabled, along with a set of [code]options[/code].
+				Called when the profiler is enabled/disabled, along with a set of [param options].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -22,7 +22,7 @@
 			<return type="float" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the intensity of the glow level [code]idx[/code].
+				Returns the intensity of the glow level [param idx].
 			</description>
 		</method>
 		<method name="set_glow_level">
@@ -30,7 +30,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="intensity" type="float" />
 			<description>
-				Sets the intensity of the glow level [code]idx[/code]. A value above [code]0.0[/code] enables the level. Each level relies on the previous level. This means that enabling higher glow levels will slow down the glow effect rendering, even if previous levels aren't enabled.
+				Sets the intensity of the glow level [param idx]. A value above [code]0.0[/code] enables the level. Each level relies on the previous level. This means that enabling higher glow levels will slow down the glow effect rendering, even if previous levels aren't enabled.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -80,7 +80,7 @@
 			<param index="1" name="input_names" type="PackedStringArray" default="PackedStringArray()" />
 			<description>
 				Parses the expression and returns an [enum Error] code.
-				You can optionally specify names of variables that may appear in the expression with [code]input_names[/code], so that you can bind them when it gets executed.
+				You can optionally specify names of variables that may appear in the expression with [param input_names], so that you can bind them when it gets executed.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -118,21 +118,21 @@
 			<param index="0" name="skip_cr" type="bool" default="false" />
 			<description>
 				Returns the whole file as a [String]. Text is interpreted as being UTF-8 encoded.
-				If [code]skip_cr[/code] is [code]true[/code], carriage return characters ([code]\r[/code], CR) will be ignored when parsing the UTF-8, so that only line feed characters ([code]\n[/code], LF) represent a new line (Unix convention).
+				If [param skip_cr] is [code]true[/code], carriage return characters ([code]\r[/code], CR) will be ignored when parsing the UTF-8, so that only line feed characters ([code]\n[/code], LF) represent a new line (Unix convention).
 			</description>
 		</method>
 		<method name="get_buffer" qualifiers="const">
 			<return type="PackedByteArray" />
 			<param index="0" name="length" type="int" />
 			<description>
-				Returns next [code]length[/code] bytes of the file as a [PackedByteArray].
+				Returns next [param length] bytes of the file as a [PackedByteArray].
 			</description>
 		</method>
 		<method name="get_csv_line" qualifiers="const">
 			<return type="PackedStringArray" />
 			<param index="0" name="delim" type="String" default="&quot;,&quot;" />
 			<description>
-				Returns the next value of the file in CSV (Comma-Separated Values) format. You can pass a different delimiter [code]delim[/code] to use other than the default [code]","[/code] (comma). This delimiter must be one-character long, and cannot be a double quotation mark.
+				Returns the next value of the file in CSV (Comma-Separated Values) format. You can pass a different delimiter [param delim] to use other than the default [code]","[/code] (comma). This delimiter must be one-character long, and cannot be a double quotation mark.
 				Text is interpreted as being UTF-8 encoded. Text values must be enclosed in double quotes if they include the delimiter character. Double quotes within a text value can be escaped by doubling their occurrence.
 				For example, the following CSV lines are valid and will be properly parsed as two strings each:
 				[codeblock]
@@ -185,7 +185,7 @@
 			<return type="int" />
 			<param index="0" name="file" type="String" />
 			<description>
-				Returns the last time the [code]file[/code] was modified in Unix timestamp format or returns a [String] "ERROR IN [code]file[/code]". This Unix timestamp can be converted to another format using the [Time] singleton.
+				Returns the last time the [param file] was modified in Unix timestamp format or returns a [String] "ERROR IN [code]file[/code]". This Unix timestamp can be converted to another format using the [Time] singleton.
 			</description>
 		</method>
 		<method name="get_pascal_string">
@@ -230,7 +230,7 @@
 			<return type="Variant" />
 			<param index="0" name="allow_objects" type="bool" default="false" />
 			<description>
-				Returns the next [Variant] value from the file. If [code]allow_objects[/code] is [code]true[/code], decoding objects is allowed.
+				Returns the next [Variant] value from the file. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
@@ -297,7 +297,7 @@
 			<param index="0" name="value" type="int" />
 			<description>
 				Stores an integer as 16 bits in the file.
-				[b]Note:[/b] The [code]value[/code] should lie in the interval [code][0, 2^16 - 1][/code]. Any other value will overflow and wrap around.
+				[b]Note:[/b] The [param value] should lie in the interval [code][0, 2^16 - 1][/code]. Any other value will overflow and wrap around.
 				To store a signed integer, use [method store_64] or store a signed integer from the interval [code][-2^15, 2^15 - 1][/code] (i.e. keeping one bit for the signedness) and compute its sign manually when reading. For example:
 				[codeblocks]
 				[gdscript]
@@ -340,7 +340,7 @@
 			<param index="0" name="value" type="int" />
 			<description>
 				Stores an integer as 32 bits in the file.
-				[b]Note:[/b] The [code]value[/code] should lie in the interval [code][0, 2^32 - 1][/code]. Any other value will overflow and wrap around.
+				[b]Note:[/b] The [param value] should lie in the interval [code][0, 2^32 - 1][/code]. Any other value will overflow and wrap around.
 				To store a signed integer, use [method store_64], or convert it manually (see [method store_16] for an example).
 			</description>
 		</method>
@@ -349,7 +349,7 @@
 			<param index="0" name="value" type="int" />
 			<description>
 				Stores an integer as 64 bits in the file.
-				[b]Note:[/b] The [code]value[/code] must lie in the interval [code][-2^63, 2^63 - 1][/code] (i.e. be a valid [int] value).
+				[b]Note:[/b] The [param value] must lie in the interval [code][-2^63, 2^63 - 1][/code] (i.e. be a valid [int] value).
 			</description>
 		</method>
 		<method name="store_8">
@@ -357,7 +357,7 @@
 			<param index="0" name="value" type="int" />
 			<description>
 				Stores an integer as 8 bits in the file.
-				[b]Note:[/b] The [code]value[/code] should lie in the interval [code][0, 255][/code]. Any other value will overflow and wrap around.
+				[b]Note:[/b] The [param value] should lie in the interval [code][0, 255][/code]. Any other value will overflow and wrap around.
 				To store a signed integer, use [method store_64], or convert it manually (see [method store_16] for an example).
 			</description>
 		</method>
@@ -373,7 +373,7 @@
 			<param index="0" name="values" type="PackedStringArray" />
 			<param index="1" name="delim" type="String" default="&quot;,&quot;" />
 			<description>
-				Store the given [PackedStringArray] in the file as a line formatted in the CSV (Comma-Separated Values) format. You can pass a different delimiter [code]delim[/code] to use other than the default [code]","[/code] (comma). This delimiter must be one-character long.
+				Store the given [PackedStringArray] in the file as a line formatted in the CSV (Comma-Separated Values) format. You can pass a different delimiter [param delim] to use other than the default [code]","[/code] (comma). This delimiter must be one-character long.
 				Text will be encoded as UTF-8.
 			</description>
 		</method>
@@ -395,7 +395,7 @@
 			<return type="void" />
 			<param index="0" name="line" type="String" />
 			<description>
-				Appends [code]line[/code] to the file followed by a line return character ([code]\n[/code]), encoding the text as UTF-8.
+				Appends [param line] to the file followed by a line return character ([code]\n[/code]), encoding the text as UTF-8.
 			</description>
 		</method>
 		<method name="store_pascal_string">
@@ -417,7 +417,7 @@
 			<return type="void" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Appends [code]string[/code] to the file without a line return, encoding the text as UTF-8.
+				Appends [param string] to the file without a line return, encoding the text as UTF-8.
 				[b]Note:[/b] This method is intended to be used to write text files. The string is stored as a UTF-8 encoded buffer without string length or terminating zero, which means that it can't be loaded back easily. If you want to store a retrievable string in a binary file, consider using [method store_pascal_string] instead. For retrieving strings from a text file, you can use [code]get_buffer(length).get_string_from_utf8()[/code] (if you know the length) or [method get_as_text].
 			</description>
 		</method>
@@ -426,7 +426,7 @@
 			<param index="0" name="value" type="Variant" />
 			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
-				Stores any Variant value in the file. If [code]full_objects[/code] is [code]true[/code], encoding objects is allowed (and can potentially include code).
+				Stores any Variant value in the file. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
 				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object._get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags.
 			</description>
 		</method>

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -14,9 +14,9 @@
 			<param index="0" name="filter" type="String" />
 			<param index="1" name="description" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a comma-delimited file name [code]filter[/code] option to the [FileDialog] with an optional [code]description[/code], which restricts what files can be picked.
-				A [code]filter[/code] should be of the form [code]"filename.extension"[/code], where filename and extension can be [code]*[/code] to match any string. Filters starting with [code].[/code] (i.e. empty filenames) are not allowed.
-				For example, a [code]filter[/code] of [code]"*.png, *.jpg"[/code] and a [code]description[/code] of [code]"Images"[/code] results in filter text "Images (*.png, *.jpg)".
+				Adds a comma-delimited file name [param filter] option to the [FileDialog] with an optional [param description], which restricts what files can be picked.
+				A [param filter] should be of the form [code]"filename.extension"[/code], where filename and extension can be [code]*[/code] to match any string. Filters starting with [code].[/code] (i.e. empty filenames) are not allowed.
+				For example, a [param filter] of [code]"*.png, *.jpg"[/code] and a [param description] of [code]"Images"[/code] results in filter text "Images (*.png, *.jpg)".
 			</description>
 		</method>
 		<method name="clear_filters">

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -17,7 +17,7 @@
 			<param index="3" name="font_size" type="int" />
 			<param index="4" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw a single Unicode character [code]char[/code] into a canvas item using the font, at a given position, with [code]modulate[/code] color. [code]position[/code] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
+				Draw a single Unicode character [param char] into a canvas item using the font, at a given position, with [param modulate] color. [param pos] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 				[b]Note:[/b] Do not use this function to draw strings character by character, use [method draw_string] or [TextLine] instead.
 			</description>
 		</method>
@@ -30,7 +30,7 @@
 			<param index="4" name="size" type="int" default="-1" />
 			<param index="5" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Draw a single Unicode character [code]char[/code] outline into a canvas item using the font, at a given position, with [code]modulate[/code] color and [code]size[/code] outline size. [code]position[/code] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
+				Draw a single Unicode character [param char] outline into a canvas item using the font, at a given position, with [param modulate] color and [param size] outline size. [param pos] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 				[b]Note:[/b] Do not use this function to draw strings character by character, use [method draw_string] or [TextLine] instead.
 			</description>
 		</method>
@@ -49,7 +49,7 @@
 			<param index="10" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="11" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Breaks [code]text[/code] to the lines using rules specified by [code]flags[/code] and draws it into a canvas item using the font, at a given position, with [code]modulate[/code] color, optionally clipping the width and aligning horizontally. [code]position[/code] specifies the baseline of the first line, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
+				Breaks [param text] into lines using rules specified by [param brk_flags] and draws it into a canvas item using the font, at a given position, with [param modulate] color, optionally clipping the width and aligning horizontally. [param pos] specifies the baseline of the first line, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 				See also [method CanvasItem.draw_multiline_string].
 			</description>
 		</method>
@@ -69,7 +69,7 @@
 			<param index="11" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="12" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Breaks [code]text[/code] to the lines using rules specified by [code]flags[/code] and draws text outline into a canvas item using the font, at a given position, with [code]modulate[/code] color and [code]size[/code] outline size, optionally clipping the width and aligning horizontally. [code]position[/code] specifies the baseline of the first line, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
+				Breaks [param text] to the lines using rules specified by [param brk_flags] and draws text outline into a canvas item using the font, at a given position, with [param modulate] color and [param size] outline size, optionally clipping the width and aligning horizontally. [param pos] specifies the baseline of the first line, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 				See also [method CanvasItem.draw_multiline_string_outline].
 			</description>
 		</method>
@@ -86,7 +86,7 @@
 			<param index="8" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="9" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Draw [code]text[/code] into a canvas item using the font, at a given position, with [code]modulate[/code] color, optionally clipping the width and aligning horizontally. [code]position[/code] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
+				Draw [param text] into a canvas item using the font, at a given position, with [param modulate] color, optionally clipping the width and aligning horizontally. [param pos] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 				See also [method CanvasItem.draw_string].
 			</description>
 		</method>
@@ -104,7 +104,7 @@
 			<param index="9" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="10" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Draw [code]text[/code] outline into a canvas item using the font, at a given position, with [code]modulate[/code] color and [code]size[/code] outline size, optionally clipping the width and aligning horizontally. [code]position[/code] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
+				Draw [param text] outline into a canvas item using the font, at a given position, with [param modulate] color and [param size] outline size, optionally clipping the width and aligning horizontally. [param pos] specifies the baseline, not the top. To draw from the top, [i]ascent[/i] must be added to the Y axis.
 				See also [method CanvasItem.draw_string_outline].
 			</description>
 		</method>
@@ -274,7 +274,7 @@
 			<return type="bool" />
 			<param index="0" name="char" type="int" />
 			<description>
-				Returns [code]true[/code] if a Unicode [code]char[/code] is available in the font.
+				Returns [code]true[/code] if a Unicode [param char] is available in the font.
 			</description>
 		</method>
 		<method name="is_language_supported" qualifiers="const">

--- a/doc/classes/FontFile.xml
+++ b/doc/classes/FontFile.xml
@@ -142,7 +142,7 @@
 			<param index="1" name="char" type="int" />
 			<param index="2" name="variation_selector" type="int" />
 			<description>
-				Returns the glyph index of a [code]char[/code], optionally modified by the [code]variation_selector[/code].
+				Returns the glyph index of a [param char], optionally modified by the [param variation_selector].
 			</description>
 		</method>
 		<method name="get_glyph_list" qualifiers="const">
@@ -210,7 +210,7 @@
 			<return type="bool" />
 			<param index="0" name="language" type="String" />
 			<description>
-				Returns [code]true[/code] if support override is enabled for the [code]language[/code].
+				Returns [code]true[/code] if support override is enabled for the [param language].
 			</description>
 		</method>
 		<method name="get_language_support_overrides" qualifiers="const">
@@ -223,7 +223,7 @@
 			<return type="bool" />
 			<param index="0" name="script" type="String" />
 			<description>
-				Returns [code]true[/code] if support override is enabled for the [code]script[/code].
+				Returns [code]true[/code] if support override is enabled for the [param script].
 			</description>
 		</method>
 		<method name="get_script_support_overrides" qualifiers="const">
@@ -283,7 +283,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Loads an AngelCode BMFont (.fnt, .font) bitmap font from file [code]path[/code].
+				Loads an AngelCode BMFont (.fnt, .font) bitmap font from file [param path].
 				[b]Warning:[/b] This method should only be used in the editor or in cases when you need to load external fonts at run-time, such as fonts located at the [code]user://[/code] directory.
 			</description>
 		</method>
@@ -291,7 +291,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Loads a TrueType (.ttf), OpenType (.otf), WOFF (.woff), WOFF2 (.woff2) or Type 1 (.pfb, .pfm) dynamic font from file [code]path[/code].
+				Loads a TrueType (.ttf), OpenType (.otf), WOFF (.woff), WOFF2 (.woff2) or Type 1 (.pfb, .pfm) dynamic font from file [param path].
 				[b]Warning:[/b] This method should only be used in the editor or in cases when you need to load external fonts at run-time, such as fonts located at the [code]user://[/code] directory.
 			</description>
 		</method>

--- a/doc/classes/FontVariation.xml
+++ b/doc/classes/FontVariation.xml
@@ -32,7 +32,7 @@
 			<param index="0" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="1" name="value" type="int" />
 			<description>
-				Sets the spacing for [code]type[/code] (see [enum TextServer.SpacingType]) to [code]value[/code] in pixels (not relative to the font size).
+				Sets the spacing for [code]type[/code] (see [enum TextServer.SpacingType]) to [param value] in pixels (not relative to the font size).
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -26,7 +26,7 @@
 			<param index="3" name="custom" type="Color" />
 			<param index="4" name="flags" type="int" />
 			<description>
-				Emits a single particle. Whether [code]xform[/code], [code]velocity[/code], [code]color[/code] and [code]custom[/code] are applied depends on the value of [code]flags[/code]. See [enum EmitFlags].
+				Emits a single particle. Whether [param xform], [param velocity], [param color] and [param custom] are applied depends on the value of [param flags]. See [enum EmitFlags].
 			</description>
 		</method>
 		<method name="restart">

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -26,14 +26,14 @@
 			<param index="3" name="custom" type="Color" />
 			<param index="4" name="flags" type="int" />
 			<description>
-				Emits a single particle. Whether [code]xform[/code], [code]velocity[/code], [code]color[/code] and [code]custom[/code] are applied depends on the value of [code]flags[/code]. See [enum EmitFlags].
+				Emits a single particle. Whether [param xform], [param velocity], [param color] and [param custom] are applied depends on the value of [param flags]. See [enum EmitFlags].
 			</description>
 		</method>
 		<method name="get_draw_pass_mesh" qualifiers="const">
 			<return type="Mesh" />
 			<param index="0" name="pass" type="int" />
 			<description>
-				Returns the [Mesh] that is drawn at index [code]pass[/code].
+				Returns the [Mesh] that is drawn at index [param pass].
 			</description>
 		</method>
 		<method name="restart">
@@ -47,7 +47,7 @@
 			<param index="0" name="pass" type="int" />
 			<param index="1" name="mesh" type="Mesh" />
 			<description>
-				Sets the [Mesh] that is drawn at index [code]pass[/code].
+				Sets the [Mesh] that is drawn at index [param pass].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/GPUParticlesCollisionSDF3D.xml
+++ b/doc/classes/GPUParticlesCollisionSDF3D.xml
@@ -18,7 +18,7 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member bake_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member bake_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_bake_mask_value">
@@ -26,7 +26,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member bake_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member bake_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -14,8 +14,8 @@
 			<param index="0" name="polygon_a" type="PackedVector2Array" />
 			<param index="1" name="polygon_b" type="PackedVector2Array" />
 			<description>
-				Clips [code]polygon_a[/code] against [code]polygon_b[/code] and returns an array of clipped polygons. This performs [constant OPERATION_DIFFERENCE] between polygons. Returns an empty array if [code]polygon_b[/code] completely overlaps [code]polygon_a[/code].
-				If [code]polygon_b[/code] is enclosed by [code]polygon_a[/code], returns an outer polygon (boundary) and inner polygon (hole) which could be distinguished by calling [method is_polygon_clockwise].
+				Clips [param polygon_a] against [param polygon_b] and returns an array of clipped polygons. This performs [constant OPERATION_DIFFERENCE] between polygons. Returns an empty array if [param polygon_b] completely overlaps [param polygon_a].
+				If [param polygon_b] is enclosed by [param polygon_a], returns an outer polygon (boundary) and inner polygon (hole) which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
 		<method name="clip_polyline_with_polygon">
@@ -23,7 +23,7 @@
 			<param index="0" name="polyline" type="PackedVector2Array" />
 			<param index="1" name="polygon" type="PackedVector2Array" />
 			<description>
-				Clips [code]polyline[/code] against [code]polygon[/code] and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE] between the polyline and the polygon. This operation can be thought of as cutting a line with a closed shape.
+				Clips [param polyline] against [param polygon] and returns an array of clipped polylines. This performs [constant OPERATION_DIFFERENCE] between the polyline and the polygon. This operation can be thought of as cutting a line with a closed shape.
 			</description>
 		</method>
 		<method name="convex_hull">
@@ -38,7 +38,7 @@
 			<param index="0" name="polygon_a" type="PackedVector2Array" />
 			<param index="1" name="polygon_b" type="PackedVector2Array" />
 			<description>
-				Mutually excludes common area defined by intersection of [code]polygon_a[/code] and [code]polygon_b[/code] (see [method intersect_polygons]) and returns an array of excluded polygons. This performs [constant OPERATION_XOR] between polygons. In other words, returns all but common area between polygons.
+				Mutually excludes common area defined by intersection of [param polygon_a] and [param polygon_b] (see [method intersect_polygons]) and returns an array of excluded polygons. This performs [constant OPERATION_XOR] between polygons. In other words, returns all but common area between polygons.
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
@@ -48,7 +48,7 @@
 			<param index="1" name="s1" type="Vector2" />
 			<param index="2" name="s2" type="Vector2" />
 			<description>
-				Returns the 2D point on the 2D segment ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point will always be inside the specified segment.
+				Returns the 2D point on the 2D segment ([param s1], [param s2]) that is closest to [param point]. The returned point will always be inside the specified segment.
 			</description>
 		</method>
 		<method name="get_closest_point_to_segment_uncapped">
@@ -57,7 +57,7 @@
 			<param index="1" name="s1" type="Vector2" />
 			<param index="2" name="s2" type="Vector2" />
 			<description>
-				Returns the 2D point on the 2D line defined by ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point can be inside the segment ([code]s1[/code], [code]s2[/code]) or outside of it, i.e. somewhere on the line extending from the segment.
+				Returns the 2D point on the 2D line defined by ([param s1], [param s2]) that is closest to [param point]. The returned point can be inside the segment ([param s1], [param s2]) or outside of it, i.e. somewhere on the line extending from the segment.
 			</description>
 		</method>
 		<method name="get_closest_points_between_segments">
@@ -67,7 +67,7 @@
 			<param index="2" name="p2" type="Vector2" />
 			<param index="3" name="q2" type="Vector2" />
 			<description>
-				Given the two 2D segments ([code]p1[/code], [code]q1[/code]) and ([code]p2[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PackedVector2Array] that contains this point on ([code]p1[/code], [code]q1[/code]) as well the accompanying point on ([code]p2[/code], [code]q2[/code]).
+				Given the two 2D segments ([param p1], [param q1]) and ([param p2], [param q2]), finds those two points on the two segments that are closest to each other. Returns a [PackedVector2Array] that contains this point on ([param p1], [param q1]) as well the accompanying point on ([param p2], [param q2]).
 			</description>
 		</method>
 		<method name="intersect_polygons">
@@ -75,7 +75,7 @@
 			<param index="0" name="polygon_a" type="PackedVector2Array" />
 			<param index="1" name="polygon_b" type="PackedVector2Array" />
 			<description>
-				Intersects [code]polygon_a[/code] with [code]polygon_b[/code] and returns an array of intersected polygons. This performs [constant OPERATION_INTERSECTION] between polygons. In other words, returns common area shared by polygons. Returns an empty array if no intersection occurs.
+				Intersects [param polygon_a] with [param polygon_b] and returns an array of intersected polygons. This performs [constant OPERATION_INTERSECTION] between polygons. In other words, returns common area shared by polygons. Returns an empty array if no intersection occurs.
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
@@ -84,7 +84,7 @@
 			<param index="0" name="polyline" type="PackedVector2Array" />
 			<param index="1" name="polygon" type="PackedVector2Array" />
 			<description>
-				Intersects [code]polyline[/code] with [code]polygon[/code] and returns an array of intersected polylines. This performs [constant OPERATION_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
+				Intersects [param polyline] with [param polygon] and returns an array of intersected polylines. This performs [constant OPERATION_INTERSECTION] between the polyline and the polygon. This operation can be thought of as chopping a line with a closed shape.
 			</description>
 		</method>
 		<method name="is_point_in_circle">
@@ -93,7 +93,7 @@
 			<param index="1" name="circle_position" type="Vector2" />
 			<param index="2" name="circle_radius" type="float" />
 			<description>
-				Returns [code]true[/code] if [code]point[/code] is inside the circle or if it's located exactly [i]on[/i] the circle's boundary, otherwise returns [code]false[/code].
+				Returns [code]true[/code] if [param point] is inside the circle or if it's located exactly [i]on[/i] the circle's boundary, otherwise returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_point_in_polygon">
@@ -101,14 +101,14 @@
 			<param index="0" name="point" type="Vector2" />
 			<param index="1" name="polygon" type="PackedVector2Array" />
 			<description>
-				Returns [code]true[/code] if [code]point[/code] is inside [code]polygon[/code] or if it's located exactly [i]on[/i] polygon's boundary, otherwise returns [code]false[/code].
+				Returns [code]true[/code] if [param point] is inside [param polygon] or if it's located exactly [i]on[/i] polygon's boundary, otherwise returns [code]false[/code].
 			</description>
 		</method>
 		<method name="is_polygon_clockwise">
 			<return type="bool" />
 			<param index="0" name="polygon" type="PackedVector2Array" />
 			<description>
-				Returns [code]true[/code] if [code]polygon[/code]'s vertices are ordered in clockwise order, otherwise returns [code]false[/code].
+				Returns [code]true[/code] if [param polygon]'s vertices are ordered in clockwise order, otherwise returns [code]false[/code].
 			</description>
 		</method>
 		<method name="line_intersects_line">
@@ -118,7 +118,7 @@
 			<param index="2" name="from_b" type="Vector2" />
 			<param index="3" name="dir_b" type="Vector2" />
 			<description>
-				Checks if the two lines ([code]from_a[/code], [code]dir_a[/code]) and ([code]from_b[/code], [code]dir_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
+				Checks if the two lines ([param from_a], [param dir_a]) and ([param from_b], [param dir_b]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
 				[b]Note:[/b] The lines are specified using direction vectors, not end points.
 			</description>
 		</method>
@@ -134,7 +134,7 @@
 			<param index="0" name="polygon_a" type="PackedVector2Array" />
 			<param index="1" name="polygon_b" type="PackedVector2Array" />
 			<description>
-				Merges (combines) [code]polygon_a[/code] and [code]polygon_b[/code] and returns an array of merged polygons. This performs [constant OPERATION_UNION] between polygons.
+				Merges (combines) [param polygon_a] and [param polygon_b] and returns an array of merged polygons. This performs [constant OPERATION_UNION] between polygons.
 				The operation may result in an outer polygon (boundary) and multiple inner polygons (holes) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
@@ -144,8 +144,8 @@
 			<param index="1" name="delta" type="float" />
 			<param index="2" name="join_type" type="int" enum="Geometry2D.PolyJoinType" default="0" />
 			<description>
-				Inflates or deflates [code]polygon[/code] by [code]delta[/code] units (pixels). If [code]delta[/code] is positive, makes the polygon grow outward. If [code]delta[/code] is negative, shrinks the polygon inward. Returns an array of polygons because inflating/deflating may result in multiple discrete polygons. Returns an empty array if [code]delta[/code] is negative and the absolute value of it approximately exceeds the minimum bounding rectangle dimensions of the polygon.
-				Each polygon's vertices will be rounded as determined by [code]join_type[/code], see [enum PolyJoinType].
+				Inflates or deflates [param polygon] by [param delta] units (pixels). If [param delta] is positive, makes the polygon grow outward. If [param delta] is negative, shrinks the polygon inward. Returns an array of polygons because inflating/deflating may result in multiple discrete polygons. Returns an empty array if [param delta] is negative and the absolute value of it approximately exceeds the minimum bounding rectangle dimensions of the polygon.
+				Each polygon's vertices will be rounded as determined by [param join_type], see [enum PolyJoinType].
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 				[b]Note:[/b] To translate the polygon's vertices specifically, multiply them to a [Transform2D]:
 				[codeblocks]
@@ -172,9 +172,9 @@
 			<param index="2" name="join_type" type="int" enum="Geometry2D.PolyJoinType" default="0" />
 			<param index="3" name="end_type" type="int" enum="Geometry2D.PolyEndType" default="3" />
 			<description>
-				Inflates or deflates [code]polyline[/code] by [code]delta[/code] units (pixels), producing polygons. If [code]delta[/code] is positive, makes the polyline grow outward. Returns an array of polygons because inflating/deflating may result in multiple discrete polygons. If [code]delta[/code] is negative, returns an empty array.
-				Each polygon's vertices will be rounded as determined by [code]join_type[/code], see [enum PolyJoinType].
-				Each polygon's endpoints will be rounded as determined by [code]end_type[/code], see [enum PolyEndType].
+				Inflates or deflates [param polyline] by [param delta] units (pixels), producing polygons. If [param delta] is positive, makes the polyline grow outward. Returns an array of polygons because inflating/deflating may result in multiple discrete polygons. If [param delta] is negative, returns an empty array.
+				Each polygon's vertices will be rounded as determined by [param join_type], see [enum PolyJoinType].
+				Each polygon's endpoints will be rounded as determined by [param end_type], see [enum PolyEndType].
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
@@ -185,7 +185,7 @@
 			<param index="2" name="b" type="Vector2" />
 			<param index="3" name="c" type="Vector2" />
 			<description>
-				Returns if [code]point[/code] is inside the triangle specified by [code]a[/code], [code]b[/code] and [code]c[/code].
+				Returns if [param point] is inside the triangle specified by [param a], [param b] and [param c].
 			</description>
 		</method>
 		<method name="segment_intersects_circle">
@@ -195,7 +195,7 @@
 			<param index="2" name="circle_position" type="Vector2" />
 			<param index="3" name="circle_radius" type="float" />
 			<description>
-				Given the 2D segment ([code]segment_from[/code], [code]segment_to[/code]), returns the position on the segment (as a number between 0 and 1) at which the segment hits the circle that is located at position [code]circle_position[/code] and has radius [code]circle_radius[/code]. If the segment does not intersect the circle, -1 is returned (this is also the case if the line extending the segment would intersect the circle, but the segment does not).
+				Given the 2D segment ([param segment_from], [param segment_to]), returns the position on the segment (as a number between 0 and 1) at which the segment hits the circle that is located at position [param circle_position] and has radius [param circle_radius]. If the segment does not intersect the circle, -1 is returned (this is also the case if the line extending the segment would intersect the circle, but the segment does not).
 			</description>
 		</method>
 		<method name="segment_intersects_segment">
@@ -205,21 +205,21 @@
 			<param index="2" name="from_b" type="Vector2" />
 			<param index="3" name="to_b" type="Vector2" />
 			<description>
-				Checks if the two segments ([code]from_a[/code], [code]to_a[/code]) and ([code]from_b[/code], [code]to_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
+				Checks if the two segments ([param from_a], [param to_a]) and ([param from_b], [param to_b]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
 		<method name="triangulate_delaunay">
 			<return type="PackedInt32Array" />
 			<param index="0" name="points" type="PackedVector2Array" />
 			<description>
-				Triangulates the area specified by discrete set of [code]points[/code] such that no point is inside the circumcircle of any resulting triangle. Returns a [PackedInt32Array] where each triangle consists of three consecutive point indices into [code]points[/code] (i.e. the returned array will have [code]n * 3[/code] elements, with [code]n[/code] being the number of found triangles). If the triangulation did not succeed, an empty [PackedInt32Array] is returned.
+				Triangulates the area specified by discrete set of [param points] such that no point is inside the circumcircle of any resulting triangle. Returns a [PackedInt32Array] where each triangle consists of three consecutive point indices into [param points] (i.e. the returned array will have [code]n * 3[/code] elements, with [code]n[/code] being the number of found triangles). If the triangulation did not succeed, an empty [PackedInt32Array] is returned.
 			</description>
 		</method>
 		<method name="triangulate_polygon">
 			<return type="PackedInt32Array" />
 			<param index="0" name="polygon" type="PackedVector2Array" />
 			<description>
-				Triangulates the polygon specified by the points in [code]polygon[/code]. Returns a [PackedInt32Array] where each triangle consists of three consecutive point indices into [code]polygon[/code] (i.e. the returned array will have [code]n * 3[/code] elements, with [code]n[/code] being the number of found triangles). Output triangles will always be counter clockwise, and the contour will be flipped if it's clockwise. If the triangulation did not succeed, an empty [PackedInt32Array] is returned.
+				Triangulates the polygon specified by the points in [param polygon]. Returns a [PackedInt32Array] where each triangle consists of three consecutive point indices into [param polygon] (i.e. the returned array will have [code]n * 3[/code] elements, with [code]n[/code] being the number of found triangles). Output triangles will always be counter clockwise, and the contour will be flipped if it's clockwise. If the triangulation did not succeed, an empty [PackedInt32Array] is returned.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -13,7 +13,7 @@
 			<return type="Array" />
 			<param index="0" name="extents" type="Vector3" />
 			<description>
-				Returns an array with 6 [Plane]s that describe the sides of a box centered at the origin. The box size is defined by [code]extents[/code], which represents one (positive) corner of the box (i.e. half its actual size).
+				Returns an array with 6 [Plane]s that describe the sides of a box centered at the origin. The box size is defined by [param extents], which represents one (positive) corner of the box (i.e. half its actual size).
 			</description>
 		</method>
 		<method name="build_capsule_planes">
@@ -24,7 +24,7 @@
 			<param index="3" name="lats" type="int" />
 			<param index="4" name="axis" type="int" enum="Vector3.Axis" default="2" />
 			<description>
-				Returns an array of [Plane]s closely bounding a faceted capsule centered at the origin with radius [code]radius[/code] and height [code]height[/code]. The parameter [code]sides[/code] defines how many planes will be generated for the side part of the capsule, whereas [code]lats[/code] gives the number of latitudinal steps at the bottom and top of the capsule. The parameter [code]axis[/code] describes the axis along which the capsule is oriented (0 for X, 1 for Y, 2 for Z).
+				Returns an array of [Plane]s closely bounding a faceted capsule centered at the origin with radius [param radius] and height [param height]. The parameter [param sides] defines how many planes will be generated for the side part of the capsule, whereas [param lats] gives the number of latitudinal steps at the bottom and top of the capsule. The parameter [param axis] describes the axis along which the capsule is oriented (0 for X, 1 for Y, 2 for Z).
 			</description>
 		</method>
 		<method name="build_cylinder_planes">
@@ -34,7 +34,7 @@
 			<param index="2" name="sides" type="int" />
 			<param index="3" name="axis" type="int" enum="Vector3.Axis" default="2" />
 			<description>
-				Returns an array of [Plane]s closely bounding a faceted cylinder centered at the origin with radius [code]radius[/code] and height [code]height[/code]. The parameter [code]sides[/code] defines how many planes will be generated for the round part of the cylinder. The parameter [code]axis[/code] describes the axis along which the cylinder is oriented (0 for X, 1 for Y, 2 for Z).
+				Returns an array of [Plane]s closely bounding a faceted cylinder centered at the origin with radius [param radius] and height [param height]. The parameter [param sides] defines how many planes will be generated for the round part of the cylinder. The parameter [param axis] describes the axis along which the cylinder is oriented (0 for X, 1 for Y, 2 for Z).
 			</description>
 		</method>
 		<method name="clip_polygon">
@@ -42,7 +42,7 @@
 			<param index="0" name="points" type="PackedVector3Array" />
 			<param index="1" name="plane" type="Plane" />
 			<description>
-				Clips the polygon defined by the points in [code]points[/code] against the [code]plane[/code] and returns the points of the clipped polygon.
+				Clips the polygon defined by the points in [param points] against the [param plane] and returns the points of the clipped polygon.
 			</description>
 		</method>
 		<method name="get_closest_point_to_segment">
@@ -51,7 +51,7 @@
 			<param index="1" name="s1" type="Vector3" />
 			<param index="2" name="s2" type="Vector3" />
 			<description>
-				Returns the 3D point on the 3D segment ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point will always be inside the specified segment.
+				Returns the 3D point on the 3D segment ([param s1], [param s2]) that is closest to [param point]. The returned point will always be inside the specified segment.
 			</description>
 		</method>
 		<method name="get_closest_point_to_segment_uncapped">
@@ -60,7 +60,7 @@
 			<param index="1" name="s1" type="Vector3" />
 			<param index="2" name="s2" type="Vector3" />
 			<description>
-				Returns the 3D point on the 3D line defined by ([code]s1[/code], [code]s2[/code]) that is closest to [code]point[/code]. The returned point can be inside the segment ([code]s1[/code], [code]s2[/code]) or outside of it, i.e. somewhere on the line extending from the segment.
+				Returns the 3D point on the 3D line defined by ([param s1], [param s2]) that is closest to [param point]. The returned point can be inside the segment ([param s1], [param s2]) or outside of it, i.e. somewhere on the line extending from the segment.
 			</description>
 		</method>
 		<method name="get_closest_points_between_segments">
@@ -70,7 +70,7 @@
 			<param index="2" name="q1" type="Vector3" />
 			<param index="3" name="q2" type="Vector3" />
 			<description>
-				Given the two 3D segments ([code]p1[/code], [code]p2[/code]) and ([code]q1[/code], [code]q2[/code]), finds those two points on the two segments that are closest to each other. Returns a [PackedVector3Array] that contains this point on ([code]p1[/code], [code]p2[/code]) as well the accompanying point on ([code]q1[/code], [code]q2[/code]).
+				Given the two 3D segments ([param p1], [param p2]) and ([param q1], [param q2]), finds those two points on the two segments that are closest to each other. Returns a [PackedVector3Array] that contains this point on ([param p1], [param p2]) as well the accompanying point on ([param q1], [param q2]).
 			</description>
 		</method>
 		<method name="ray_intersects_triangle">
@@ -81,7 +81,7 @@
 			<param index="3" name="b" type="Vector3" />
 			<param index="4" name="c" type="Vector3" />
 			<description>
-				Tests if the 3D ray starting at [code]from[/code] with the direction of [code]dir[/code] intersects the triangle specified by [code]a[/code], [code]b[/code] and [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, returns [code]null[/code].
+				Tests if the 3D ray starting at [param from] with the direction of [param dir] intersects the triangle specified by [param a], [param b] and [param c]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
 		<method name="segment_intersects_convex">
@@ -90,7 +90,7 @@
 			<param index="1" name="to" type="Vector3" />
 			<param index="2" name="planes" type="Array" />
 			<description>
-				Given a convex hull defined though the [Plane]s in the array [code]planes[/code], tests if the segment ([code]from[/code], [code]to[/code]) intersects with that hull. If an intersection is found, returns a [PackedVector3Array] containing the point the intersection and the hull's normal. Otherwise, returns an empty array.
+				Given a convex hull defined though the [Plane]s in the array [param planes], tests if the segment ([param from], [param to]) intersects with that hull. If an intersection is found, returns a [PackedVector3Array] containing the point the intersection and the hull's normal. Otherwise, returns an empty array.
 			</description>
 		</method>
 		<method name="segment_intersects_cylinder">
@@ -100,7 +100,7 @@
 			<param index="2" name="height" type="float" />
 			<param index="3" name="radius" type="float" />
 			<description>
-				Checks if the segment ([code]from[/code], [code]to[/code]) intersects the cylinder with height [code]height[/code] that is centered at the origin and has radius [code]radius[/code]. If no, returns an empty [PackedVector3Array]. If an intersection takes place, the returned array contains the point of intersection and the cylinder's normal at the point of intersection.
+				Checks if the segment ([param from], [param to]) intersects the cylinder with height [param height] that is centered at the origin and has radius [param radius]. If no, returns an empty [PackedVector3Array]. If an intersection takes place, the returned array contains the point of intersection and the cylinder's normal at the point of intersection.
 			</description>
 		</method>
 		<method name="segment_intersects_sphere">
@@ -110,7 +110,7 @@
 			<param index="2" name="sphere_position" type="Vector3" />
 			<param index="3" name="sphere_radius" type="float" />
 			<description>
-				Checks if the segment ([code]from[/code], [code]to[/code]) intersects the sphere that is located at [code]sphere_position[/code] and has radius [code]sphere_radius[/code]. If no, returns an empty [PackedVector3Array]. If yes, returns a [PackedVector3Array] containing the point of intersection and the sphere's normal at the point of intersection.
+				Checks if the segment ([param from], [param to]) intersects the sphere that is located at [param sphere_position] and has radius [param sphere_radius]. If no, returns an empty [PackedVector3Array]. If yes, returns a [PackedVector3Array] containing the point of intersection and the sphere's normal at the point of intersection.
 			</description>
 		</method>
 		<method name="segment_intersects_triangle">
@@ -121,7 +121,7 @@
 			<param index="3" name="b" type="Vector3" />
 			<param index="4" name="c" type="Vector3" />
 			<description>
-				Tests if the segment ([code]from[/code], [code]to[/code]) intersects the triangle [code]a[/code], [code]b[/code], [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, returns [code]null[/code].
+				Tests if the segment ([param from], [param to]) intersects the triangle [param a], [param b], [param c]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -22,14 +22,14 @@
 			<return type="Color" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Returns the color of the gradient color at index [code]point[/code].
+				Returns the color of the gradient color at index [param point].
 			</description>
 		</method>
 		<method name="get_offset">
 			<return type="float" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Returns the offset of the gradient color at index [code]point[/code].
+				Returns the offset of the gradient color at index [param point].
 			</description>
 		</method>
 		<method name="get_point_count" qualifiers="const">
@@ -42,14 +42,14 @@
 			<return type="Color" />
 			<param index="0" name="offset" type="float" />
 			<description>
-				Returns the interpolated color specified by [code]offset[/code].
+				Returns the interpolated color specified by [param offset].
 			</description>
 		</method>
 		<method name="remove_point">
 			<return type="void" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Removes the color at the index [code]point[/code].
+				Removes the color at the index [param point].
 			</description>
 		</method>
 		<method name="reverse">
@@ -63,7 +63,7 @@
 			<param index="0" name="point" type="int" />
 			<param index="1" name="color" type="Color" />
 			<description>
-				Sets the color of the gradient color at index [code]point[/code].
+				Sets the color of the gradient color at index [param point].
 			</description>
 		</method>
 		<method name="set_offset">
@@ -71,7 +71,7 @@
 			<param index="0" name="point" type="int" />
 			<param index="1" name="offset" type="float" />
 			<description>
-				Sets the offset for the gradient color at index [code]point[/code].
+				Sets the offset for the gradient color at index [param point].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -24,8 +24,8 @@
 			<param index="1" name="slot_index" type="int" />
 			<param index="2" name="mouse_position" type="Vector2" />
 			<description>
-				Returns whether the [code]mouse_position[/code] is in the input hot zone.
-				By default, a hot zone is a [Rect2] positioned such that its center is at [code]graph_node[/code].[method GraphNode.get_connection_input_position]([code]slot_index[/code]) (For output's case, call [method GraphNode.get_connection_output_position] instead). The hot zone's width is twice the Theme Property [code]port_grab_distance_horizontal[/code], and its height is twice the [code]port_grab_distance_vertical[/code].
+				Returns whether the [param mouse_position] is in the input hot zone.
+				By default, a hot zone is a [Rect2] positioned such that its center is at [param graph_node].[method GraphNode.get_connection_input_position]([param slot_index]) (For output's case, call [method GraphNode.get_connection_output_position] instead). The hot zone's width is twice the Theme Property [code]port_grab_distance_horizontal[/code], and its height is twice the [code]port_grab_distance_vertical[/code].
 				Below is a sample code to help get started:
 				[codeblock]
 				func _is_in_input_hotzone(graph_node, slot_index, mouse_position):
@@ -43,7 +43,7 @@
 			<param index="1" name="slot_index" type="int" />
 			<param index="2" name="mouse_position" type="Vector2" />
 			<description>
-				Returns whether the [code]mouse_position[/code] is in the output hot zone. For more information on hot zones, see [method _is_in_input_hotzone].
+				Returns whether the [param mouse_position] is in the output hot zone. For more information on hot zones, see [method _is_in_input_hotzone].
 				Below is a sample code to help get started:
 				[codeblock]
 				func _is_in_output_hotzone(graph_node, slot_index, mouse_position):
@@ -119,7 +119,7 @@
 			<param index="2" name="to" type="StringName" />
 			<param index="3" name="to_port" type="int" />
 			<description>
-				Create a connection between the [code]from_port[/code] slot of the [code]from[/code] GraphNode and the [code]to_port[/code] slot of the [code]to[/code] GraphNode. If the connection already exists, no connection is created.
+				Create a connection between the [param from_port] slot of the [param from] GraphNode and the [param to_port] slot of the [param to] GraphNode. If the connection already exists, no connection is created.
 			</description>
 		</method>
 		<method name="disconnect_node">
@@ -129,7 +129,7 @@
 			<param index="2" name="to" type="StringName" />
 			<param index="3" name="to_port" type="int" />
 			<description>
-				Removes the connection between the [code]from_port[/code] slot of the [code]from[/code] GraphNode and the [code]to_port[/code] slot of the [code]to[/code] GraphNode. If the connection does not exist, no connection is removed.
+				Removes the connection between the [param from_port] slot of the [param from] GraphNode and the [param to_port] slot of the [param to] GraphNode. If the connection does not exist, no connection is removed.
 			</description>
 		</method>
 		<method name="force_connection_drag_end">
@@ -145,7 +145,7 @@
 			<param index="0" name="from" type="Vector2" />
 			<param index="1" name="to" type="Vector2" />
 			<description>
-				Returns the points which would make up a connection between [code]from[/code] and [code]to[/code].
+				Returns the points which would make up a connection between [param from] and [param to].
 			</description>
 		</method>
 		<method name="get_connection_list" qualifiers="const">
@@ -168,7 +168,7 @@
 			<param index="2" name="to" type="StringName" />
 			<param index="3" name="to_port" type="int" />
 			<description>
-				Returns [code]true[/code] if the [code]from_port[/code] slot of the [code]from[/code] GraphNode is connected to the [code]to_port[/code] slot of the [code]to[/code] GraphNode.
+				Returns [code]true[/code] if the [param from_port] slot of the [param from] GraphNode is connected to the [param to_port] slot of the [param to] GraphNode.
 			</description>
 		</method>
 		<method name="is_valid_connection_type" qualifiers="const">
@@ -209,14 +209,14 @@
 			<param index="3" name="to_port" type="int" />
 			<param index="4" name="amount" type="float" />
 			<description>
-				Sets the coloration of the connection between [code]from[/code]'s [code]from_port[/code] and [code]to[/code]'s [code]to_port[/code] with the color provided in the [theme_item activity] theme property.
+				Sets the coloration of the connection between [param from]'s [param from_port] and [param to]'s [param to_port] with the color provided in the [theme_item activity] theme property.
 			</description>
 		</method>
 		<method name="set_selected">
 			<return type="void" />
 			<param index="0" name="node" type="Node" />
 			<description>
-				Sets the specified [code]node[/code] as the one selected.
+				Sets the specified [param node] as the one selected.
 			</description>
 		</method>
 	</methods>
@@ -305,7 +305,7 @@
 			<param index="2" name="to" type="StringName" />
 			<param index="3" name="to_slot" type="int" />
 			<description>
-				Emitted to the GraphEdit when the connection between the [code]from_slot[/code] slot of the [code]from[/code] GraphNode and the [code]to_slot[/code] slot of the [code]to[/code] GraphNode is attempted to be created.
+				Emitted to the GraphEdit when the connection between the [param from_slot] slot of the [param from] GraphNode and the [param to_slot] slot of the [param to] GraphNode is attempted to be created.
 			</description>
 		</signal>
 		<signal name="connection_to_empty">
@@ -333,7 +333,7 @@
 			<param index="2" name="to" type="StringName" />
 			<param index="3" name="to_slot" type="int" />
 			<description>
-				Emitted to the GraphEdit when the connection between [code]from_slot[/code] slot of [code]from[/code] GraphNode and [code]to_slot[/code] slot of [code]to[/code] GraphNode is attempted to be removed.
+				Emitted to the GraphEdit when the connection between [param from_slot] slot of [param from] GraphNode and [param to_slot] slot of [param to] GraphNode is attempted to be removed.
 			</description>
 		</signal>
 		<signal name="duplicate_nodes_request">
@@ -365,7 +365,7 @@
 		<signal name="popup_request">
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Emitted when a popup is requested. Happens on right-clicking in the GraphEdit. [code]position[/code] is the position of the mouse pointer when the signal is sent.
+				Emitted when a popup is requested. Happens on right-clicking in the GraphEdit. [param position] is the position of the mouse pointer when the signal is sent.
 			</description>
 		</signal>
 		<signal name="scroll_offset_changed">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -21,14 +21,14 @@
 			<return type="void" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Disables input and output slot whose index is [code]idx[/code].
+				Disables input and output slot whose index is [param idx].
 			</description>
 		</method>
 		<method name="get_connection_input_color">
 			<return type="Color" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the [Color] of the input connection [code]idx[/code].
+				Returns the [Color] of the input connection [param idx].
 			</description>
 		</method>
 		<method name="get_connection_input_count">
@@ -41,28 +41,28 @@
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the height of the input connection [code]idx[/code].
+				Returns the height of the input connection [param idx].
 			</description>
 		</method>
 		<method name="get_connection_input_position">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the input connection [code]idx[/code].
+				Returns the position of the input connection [param idx].
 			</description>
 		</method>
 		<method name="get_connection_input_type">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the type of the input connection [code]idx[/code].
+				Returns the type of the input connection [param idx].
 			</description>
 		</method>
 		<method name="get_connection_output_color">
 			<return type="Color" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the [Color] of the output connection [code]idx[/code].
+				Returns the [Color] of the output connection [param idx].
 			</description>
 		</method>
 		<method name="get_connection_output_count">
@@ -75,70 +75,70 @@
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the height of the output connection [code]idx[/code].
+				Returns the height of the output connection [param idx].
 			</description>
 		</method>
 		<method name="get_connection_output_position">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the output connection [code]idx[/code].
+				Returns the position of the output connection [param idx].
 			</description>
 		</method>
 		<method name="get_connection_output_type">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the type of the output connection [code]idx[/code].
+				Returns the type of the output connection [param idx].
 			</description>
 		</method>
 		<method name="get_slot_color_left" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the left (input) [Color] of the slot [code]idx[/code].
+				Returns the left (input) [Color] of the slot [param idx].
 			</description>
 		</method>
 		<method name="get_slot_color_right" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the right (output) [Color] of the slot [code]idx[/code].
+				Returns the right (output) [Color] of the slot [param idx].
 			</description>
 		</method>
 		<method name="get_slot_type_left" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the left (input) type of the slot [code]idx[/code].
+				Returns the left (input) type of the slot [param idx].
 			</description>
 		</method>
 		<method name="get_slot_type_right" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the right (output) type of the slot [code]idx[/code].
+				Returns the right (output) type of the slot [param idx].
 			</description>
 		</method>
 		<method name="is_slot_draw_stylebox" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns true if the background [StyleBox] of the slot [code]idx[/code] is drawn.
+				Returns true if the background [StyleBox] of the slot [param idx] is drawn.
 			</description>
 		</method>
 		<method name="is_slot_enabled_left" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if left (input) side of the slot [code]idx[/code] is enabled.
+				Returns [code]true[/code] if left (input) side of the slot [param idx] is enabled.
 			</description>
 		</method>
 		<method name="is_slot_enabled_right" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if right (output) side of the slot [code]idx[/code] is enabled.
+				Returns [code]true[/code] if right (output) side of the slot [param idx] is enabled.
 			</description>
 		</method>
 		<method name="set_slot">
@@ -154,11 +154,11 @@
 			<param index="8" name="custom_right" type="Texture2D" default="null" />
 			<param index="9" name="enable" type="bool" default="true" />
 			<description>
-				Sets properties of the slot with ID [code]idx[/code].
-				If [code]enable_left[/code]/[code]right[/code], a port will appear and the slot will be able to be connected from this side.
-				[code]type_left[/code]/[code]right[/code] is an arbitrary type of the port. Only ports with the same type values can be connected.
-				[code]color_left[/code]/[code]right[/code] is the tint of the port's icon on this side.
-				[code]custom_left[/code]/[code]right[/code] is a custom texture for this side's port.
+				Sets properties of the slot with ID [param idx].
+				If [param enable_left]/[param enable_right], a port will appear and the slot will be able to be connected from this side.
+				[param type_left]/[param type_right] is an arbitrary type of the port. Only ports with the same type values can be connected.
+				[param color_left]/[param color_right] is the tint of the port's icon on this side.
+				[param custom_left]/[param custom_right] is a custom texture for this side's port.
 				[b]Note:[/b] This method only sets properties of the slot. To create the slot, add a [Control]-derived child to the GraphNode.
 				Individual properties can be set using one of the [code]set_slot_*[/code] methods. You must enable at least one side of the slot to do so.
 			</description>
@@ -168,7 +168,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="color_left" type="Color" />
 			<description>
-				Sets the [Color] of the left (input) side of the slot [code]idx[/code] to [code]color_left[/code].
+				Sets the [Color] of the left (input) side of the slot [param idx] to [param color_left].
 			</description>
 		</method>
 		<method name="set_slot_color_right">
@@ -176,7 +176,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="color_right" type="Color" />
 			<description>
-				Sets the [Color] of the right (output) side of the slot [code]idx[/code] to [code]color_right[/code].
+				Sets the [Color] of the right (output) side of the slot [param idx] to [param color_right].
 			</description>
 		</method>
 		<method name="set_slot_draw_stylebox">
@@ -184,7 +184,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="draw_stylebox" type="bool" />
 			<description>
-				Toggles the background [StyleBox] of the slot [code]idx[/code].
+				Toggles the background [StyleBox] of the slot [param idx].
 			</description>
 		</method>
 		<method name="set_slot_enabled_left">
@@ -192,7 +192,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="enable_left" type="bool" />
 			<description>
-				Toggles the left (input) side of the slot [code]idx[/code]. If [code]enable_left[/code] is [code]true[/code], a port will appear on the left side and the slot will be able to be connected from this side.
+				Toggles the left (input) side of the slot [param idx]. If [param enable_left] is [code]true[/code], a port will appear on the left side and the slot will be able to be connected from this side.
 			</description>
 		</method>
 		<method name="set_slot_enabled_right">
@@ -200,7 +200,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="enable_right" type="bool" />
 			<description>
-				Toggles the right (output) side of the slot [code]idx[/code]. If [code]enable_right[/code] is [code]true[/code], a port will appear on the right side and the slot will be able to be connected from this side.
+				Toggles the right (output) side of the slot [param idx]. If [param enable_right] is [code]true[/code], a port will appear on the right side and the slot will be able to be connected from this side.
 			</description>
 		</method>
 		<method name="set_slot_type_left">
@@ -208,7 +208,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="type_left" type="int" />
 			<description>
-				Sets the left (input) type of the slot [code]idx[/code] to [code]type_left[/code].
+				Sets the left (input) type of the slot [param idx] to [param type_left].
 			</description>
 		</method>
 		<method name="set_slot_type_right">
@@ -216,7 +216,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="type_right" type="int" />
 			<description>
-				Sets the right (output) type of the slot [code]idx[/code] to [code]type_right[/code].
+				Sets the right (output) type of the slot [param idx] to [param type_right].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/HMACContext.xml
+++ b/doc/classes/HMACContext.xml
@@ -72,7 +72,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="data" type="PackedByteArray" />
 			<description>
-				Updates the message to be HMACed. This can be called multiple times before [method finish] is called to append [code]data[/code] to the message, but cannot be called until [method start] has been called.
+				Updates the message to be HMACed. This can be called multiple times before [method finish] is called to append [param data] to the message, but cannot be called until [method start] has been called.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -35,8 +35,8 @@
 			<description>
 				Connects to a host. This needs to be done before any requests are sent.
 				The host should not have http:// prepended but will strip the protocol identifier if provided.
-				If no [code]port[/code] is specified (or [code]-1[/code] is used), it is automatically set to 80 for HTTP and 443 for HTTPS (if [code]use_ssl[/code] is enabled).
-				[code]verify_host[/code] will check the SSL identity of the host if set to [code]true[/code].
+				If no [param port] is specified (or [code]-1[/code] is used), it is automatically set to 80 for HTTP and 443 for HTTPS (if [param use_ssl] is enabled).
+				[param verify_host] will check the SSL identity of the host if set to [code]true[/code].
 			</description>
 		</method>
 		<method name="get_response_body_length" qualifiers="const">
@@ -158,7 +158,7 @@
 				var result = new HTTPClient().Request(HTTPClient.Method.Post, "index.php", headers, queryString);
 				[/csharp]
 				[/codeblocks]
-				[b]Note:[/b] The [code]request_data[/code] parameter is ignored if [code]method[/code] is [constant HTTPClient.METHOD_GET]. This is because GET methods can't contain request data. As a workaround, you can pass request data as a query string in the URL. See [method String.uri_encode] for an example.
+				[b]Note:[/b] The [param body] parameter is ignored if [param method] is [constant HTTPClient.METHOD_GET]. This is because GET methods can't contain request data. As a workaround, you can pass request data as a query string in the URL. See [method String.uri_encode] for an example.
 			</description>
 		</method>
 		<method name="request_raw">
@@ -180,7 +180,7 @@
 			<param index="1" name="port" type="int" />
 			<description>
 				Sets the proxy server for HTTP requests.
-				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+				The proxy server is unset if [param host] is empty or [param port] is -1.
 			</description>
 		</method>
 		<method name="set_https_proxy">
@@ -189,7 +189,7 @@
 			<param index="1" name="port" type="int" />
 			<description>
 				Sets the proxy server for HTTPS requests.
-				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+				The proxy server is unset if [param host] is empty or [param port] is -1.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -195,7 +195,7 @@
 			<description>
 				Creates request on the underlying [HTTPClient]. If there is no configuration errors, it tries to connect using [method HTTPClient.connect_to_host] and passes parameters onto [method HTTPClient.request].
 				Returns [constant OK] if request is successfully created. (Does not imply that the server has responded), [constant ERR_UNCONFIGURED] if not in the tree, [constant ERR_BUSY] if still processing previous request, [constant ERR_INVALID_PARAMETER] if given string is not a valid URL format, or [constant ERR_CANT_CONNECT] if not using thread and the [HTTPClient] cannot connect to host.
-				[b]Note:[/b] When [code]method[/code] is [constant HTTPClient.METHOD_GET], the payload sent via [code]request_data[/code] might be ignored by the server or even cause the server to reject the request (check [url=https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1]RFC 7231 section 4.3.1[/url] for more details). As a workaround, you can send data as a query string in the URL (see [method String.uri_encode] for an example).
+				[b]Note:[/b] When [param method] is [constant HTTPClient.METHOD_GET], the payload sent via [param request_data] might be ignored by the server or even cause the server to reject the request (check [url=https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1]RFC 7231 section 4.3.1[/url] for more details). As a workaround, you can send data as a query string in the URL (see [method String.uri_encode] for an example).
 				[b]Note:[/b] It's recommended to use transport encryption (SSL/TLS) and to avoid sending sensitive information (such as login credentials) in HTTP GET URL parameters. Consider using HTTP POST requests or HTTP headers for such information instead.
 			</description>
 		</method>
@@ -217,7 +217,7 @@
 			<param index="1" name="port" type="int" />
 			<description>
 				Sets the proxy server for HTTP requests.
-				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+				The proxy server is unset if [param host] is empty or [param port] is -1.
 			</description>
 		</method>
 		<method name="set_https_proxy">
@@ -226,7 +226,7 @@
 			<param index="1" name="port" type="int" />
 			<description>
 				Sets the proxy server for HTTPS requests.
-				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+				The proxy server is unset if [param host] is empty or [param port] is -1.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/HashingContext.xml
+++ b/doc/classes/HashingContext.xml
@@ -71,14 +71,14 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="type" type="int" enum="HashingContext.HashType" />
 			<description>
-				Starts a new hash computation of the given [code]type[/code] (e.g. [constant HASH_SHA256] to start computation of a SHA-256).
+				Starts a new hash computation of the given [param type] (e.g. [constant HASH_SHA256] to start computation of a SHA-256).
 			</description>
 		</method>
 		<method name="update">
 			<return type="int" enum="Error" />
 			<param index="0" name="chunk" type="PackedByteArray" />
 			<description>
-				Updates the computation with the given [code]chunk[/code] of data.
+				Updates the computation with the given [param chunk] of data.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -26,7 +26,7 @@
 			<param index="1" name="src_rect" type="Rect2i" />
 			<param index="2" name="dst" type="Vector2i" />
 			<description>
-				Alpha-blends [code]src_rect[/code] from [code]src[/code] image to this image at coordinates [code]dest[/code], clipped accordingly to both image bounds. This image and [code]src[/code] image [b]must[/b] have the same format. [code]src_rect[/code] with not positive size is treated as empty.
+				Alpha-blends [param src_rect] from [param src] image to this image at coordinates [param dst], clipped accordingly to both image bounds. This image and [param src] image [b]must[/b] have the same format. [param src_rect] with not positive size is treated as empty.
 			</description>
 		</method>
 		<method name="blend_rect_mask">
@@ -36,7 +36,7 @@
 			<param index="2" name="src_rect" type="Rect2i" />
 			<param index="3" name="dst" type="Vector2i" />
 			<description>
-				Alpha-blends [code]src_rect[/code] from [code]src[/code] image to this image using [code]mask[/code] image at coordinates [code]dst[/code], clipped accordingly to both image bounds. Alpha channels are required for both [code]src[/code] and [code]mask[/code]. [code]dst[/code] pixels and [code]src[/code] pixels will blend if the corresponding mask pixel's alpha value is not 0. This image and [code]src[/code] image [b]must[/b] have the same format. [code]src[/code] image and [code]mask[/code] image [b]must[/b] have the same size (width and height) but they can have different formats. [code]src_rect[/code] with not positive size is treated as empty.
+				Alpha-blends [param src_rect] from [param src] image to this image using [param mask] image at coordinates [param dst], clipped accordingly to both image bounds. Alpha channels are required for both [param src] and [param mask]. [param dst] pixels and [param src] pixels will blend if the corresponding mask pixel's alpha value is not 0. This image and [param src] image [b]must[/b] have the same format. [param src] image and [param mask] image [b]must[/b] have the same size (width and height) but they can have different formats. [param src_rect] with not positive size is treated as empty.
 			</description>
 		</method>
 		<method name="blit_rect">
@@ -45,7 +45,7 @@
 			<param index="1" name="src_rect" type="Rect2i" />
 			<param index="2" name="dst" type="Vector2i" />
 			<description>
-				Copies [code]src_rect[/code] from [code]src[/code] image to this image at coordinates [code]dst[/code], clipped accordingly to both image bounds. This image and [code]src[/code] image [b]must[/b] have the same format. [code]src_rect[/code] with not positive size is treated as empty.
+				Copies [param src_rect] from [param src] image to this image at coordinates [param dst], clipped accordingly to both image bounds. This image and [param src] image [b]must[/b] have the same format. [param src_rect] with not positive size is treated as empty.
 			</description>
 		</method>
 		<method name="blit_rect_mask">
@@ -55,7 +55,7 @@
 			<param index="2" name="src_rect" type="Rect2i" />
 			<param index="3" name="dst" type="Vector2i" />
 			<description>
-				Blits [code]src_rect[/code] area from [code]src[/code] image to this image at the coordinates given by [code]dst[/code], clipped accordingly to both image bounds. [code]src[/code] pixel is copied onto [code]dst[/code] if the corresponding [code]mask[/code] pixel's alpha value is not 0. This image and [code]src[/code] image [b]must[/b] have the same format. [code]src[/code] image and [code]mask[/code] image [b]must[/b] have the same size (width and height) but they can have different formats. [code]src_rect[/code] with not positive size is treated as empty.
+				Blits [param src_rect] area from [param src] image to this image at the coordinates given by [param dst], clipped accordingly to both image bounds. [param src] pixel is copied onto [param dst] if the corresponding [param mask] pixel's alpha value is not 0. This image and [param src] image [b]must[/b] have the same format. [param src] image and [param mask] image [b]must[/b] have the same size (width and height) but they can have different formats. [param src_rect] with not positive size is treated as empty.
 			</description>
 		</method>
 		<method name="bump_map_to_normal_map">
@@ -108,7 +108,7 @@
 			<return type="void" />
 			<param index="0" name="src" type="Image" />
 			<description>
-				Copies [code]src[/code] image to this image.
+				Copies [param src] image to this image.
 			</description>
 		</method>
 		<method name="create">
@@ -118,7 +118,7 @@
 			<param index="2" name="use_mipmaps" type="bool" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<description>
-				Creates an empty image of given size and format. See [enum Format] constants. If [code]use_mipmaps[/code] is [code]true[/code] then generate mipmaps for this image. See the [method generate_mipmaps].
+				Creates an empty image of given size and format. See [enum Format] constants. If [param use_mipmaps] is [code]true[/code] then generate mipmaps for this image. See the [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="create_from_data">
@@ -129,7 +129,7 @@
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<param index="4" name="data" type="PackedByteArray" />
 			<description>
-				Creates a new image of given size and format. See [enum Format] constants. Fills the image with the given raw data. If [code]use_mipmaps[/code] is [code]true[/code] then loads mipmaps for this image from [code]data[/code]. See [method generate_mipmaps].
+				Creates a new image of given size and format. See [enum Format] constants. Fills the image with the given raw data. If [param use_mipmaps] is [code]true[/code] then loads mipmaps for this image from [param data]. See [method generate_mipmaps].
 			</description>
 		</method>
 		<method name="crop">
@@ -137,7 +137,7 @@
 			<param index="0" name="width" type="int" />
 			<param index="1" name="height" type="int" />
 			<description>
-				Crops the image to the given [code]width[/code] and [code]height[/code]. If the specified size is larger than the current size, the extra area is filled with black pixels.
+				Crops the image to the given [param width] and [param height]. If the specified size is larger than the current size, the extra area is filled with black pixels.
 			</description>
 		</method>
 		<method name="decompress">
@@ -163,7 +163,7 @@
 			<return type="void" />
 			<param index="0" name="color" type="Color" />
 			<description>
-				Fills the image with [code]color[/code].
+				Fills the image with [param color].
 			</description>
 		</method>
 		<method name="fill_rect">
@@ -171,7 +171,7 @@
 			<param index="0" name="rect" type="Rect2i" />
 			<param index="1" name="color" type="Color" />
 			<description>
-				Fills [code]rect[/code] with [code]color[/code].
+				Fills [param rect] with [param color].
 			</description>
 		</method>
 		<method name="fix_alpha_edges">
@@ -222,7 +222,7 @@
 			<return type="int" />
 			<param index="0" name="mipmap" type="int" />
 			<description>
-				Returns the offset where the image's mipmap with index [code]mipmap[/code] is stored in the [code]data[/code] dictionary.
+				Returns the offset where the image's mipmap with index [param mipmap] is stored in the [code]data[/code] dictionary.
 			</description>
 		</method>
 		<method name="get_pixel" qualifiers="const">
@@ -238,7 +238,7 @@
 			<return type="Color" />
 			<param index="0" name="point" type="Vector2i" />
 			<description>
-				Returns the color of the pixel at [code]point[/code].
+				Returns the color of the pixel at [param point].
 				This is the same as [method get_pixel], but with a [Vector2i] argument instead of two integer arguments.
 			</description>
 		</method>
@@ -246,7 +246,7 @@
 			<return type="Image" />
 			<param index="0" name="rect" type="Rect2i" />
 			<description>
-				Returns a new image that is a copy of the image's area specified with [code]rect[/code].
+				Returns a new image that is a copy of the image's area specified with [param rect].
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">
@@ -295,7 +295,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Loads an image from file [code]path[/code]. See [url=$DOCS_URL/tutorials/assets_pipeline/importing_images.html#supported-image-formats]Supported image formats[/url] for a list of supported image formats and limitations.
+				Loads an image from file [param path]. See [url=$DOCS_URL/tutorials/assets_pipeline/importing_images.html#supported-image-formats]Supported image formats[/url] for a list of supported image formats and limitations.
 				[b]Warning:[/b] This method should only be used in the editor or in cases when you need to load external images at run-time, such as images located at the [code]user://[/code] directory, and may not work in exported projects.
 				See also [ImageTexture] description for usage examples.
 			</description>
@@ -361,7 +361,7 @@
 			<param index="1" name="height" type="int" />
 			<param index="2" name="interpolation" type="int" enum="Image.Interpolation" default="1" />
 			<description>
-				Resizes the image to the given [code]width[/code] and [code]height[/code]. New pixels are calculated using the [code]interpolation[/code] mode defined via [enum Interpolation] constants.
+				Resizes the image to the given [param width] and [param height]. New pixels are calculated using the [param interpolation] mode defined via [enum Interpolation] constants.
 			</description>
 		</method>
 		<method name="resize_to_po2">
@@ -369,7 +369,7 @@
 			<param index="0" name="square" type="bool" default="false" />
 			<param index="1" name="interpolation" type="int" enum="Image.Interpolation" default="1" />
 			<description>
-				Resizes the image to the nearest power of 2 for the width and height. If [code]square[/code] is [code]true[/code] then set width and height to be the same. New pixels are calculated using the [code]interpolation[/code] mode defined via [enum Interpolation] constants.
+				Resizes the image to the nearest power of 2 for the width and height. If [param square] is [code]true[/code] then set width and height to be the same. New pixels are calculated using the [param interpolation] mode defined via [enum Interpolation] constants.
 			</description>
 		</method>
 		<method name="rgbe_to_srgb">
@@ -388,7 +388,7 @@
 			<return type="void" />
 			<param index="0" name="direction" type="int" enum="ClockDirection" />
 			<description>
-				Rotates the image in the specified [code]direction[/code] by [code]90[/code] degrees. The width and height of the image must be greater than [code]1[/code]. If the width and height are not equal, the image will be resized.
+				Rotates the image in the specified [param direction] by [code]90[/code] degrees. The width and height of the image must be greater than [code]1[/code]. If the width and height are not equal, the image will be resized.
 			</description>
 		</method>
 		<method name="save_exr" qualifiers="const">
@@ -396,7 +396,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="grayscale" type="bool" default="false" />
 			<description>
-				Saves the image as an EXR file to [code]path[/code]. If [code]grayscale[/code] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
+				Saves the image as an EXR file to [param path]. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
 				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
 			</description>
 		</method>
@@ -404,7 +404,7 @@
 			<return type="PackedByteArray" />
 			<param index="0" name="grayscale" type="bool" default="false" />
 			<description>
-				Saves the image as an EXR file to a byte array. If [code]grayscale[/code] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return an empty byte array if Godot was compiled without the TinyEXR module.
+				Saves the image as an EXR file to a byte array. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return an empty byte array if Godot was compiled without the TinyEXR module.
 				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return an empty byte array when it is called from an exported project.
 			</description>
 		</method>
@@ -413,7 +413,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="quality" type="float" default="0.75" />
 			<description>
-				Saves the image as a JPEG file to [code]path[/code] with the specified [code]quality[/code] between [code]0.01[/code] and [code]1.0[/code] (inclusive). Higher [code]quality[/code] values result in better-looking output at the cost of larger file sizes. Recommended [code]quality[/code] values are between [code]0.75[/code] and [code]0.90[/code]. Even at quality [code]1.00[/code], JPEG compression remains lossy.
+				Saves the image as a JPEG file to [param path] with the specified [param quality] between [code]0.01[/code] and [code]1.0[/code] (inclusive). Higher [param quality] values result in better-looking output at the cost of larger file sizes. Recommended [param quality] values are between [code]0.75[/code] and [code]0.90[/code]. Even at quality [code]1.00[/code], JPEG compression remains lossy.
 				[b]Note:[/b] JPEG does not save an alpha channel. If the [Image] contains an alpha channel, the image will still be saved, but the resulting JPEG file won't contain the alpha channel.
 			</description>
 		</method>
@@ -421,7 +421,7 @@
 			<return type="PackedByteArray" />
 			<param index="0" name="quality" type="float" default="0.75" />
 			<description>
-				Saves the image as a JPEG file to a byte array with the specified [code]quality[/code] between [code]0.01[/code] and [code]1.0[/code] (inclusive). Higher [code]quality[/code] values result in better-looking output at the cost of larger byte array sizes (and therefore memory usage). Recommended [code]quality[/code] values are between [code]0.75[/code] and [code]0.90[/code]. Even at quality [code]1.00[/code], JPEG compression remains lossy.
+				Saves the image as a JPEG file to a byte array with the specified [param quality] between [code]0.01[/code] and [code]1.0[/code] (inclusive). Higher [param quality] values result in better-looking output at the cost of larger byte array sizes (and therefore memory usage). Recommended [param quality] values are between [code]0.75[/code] and [code]0.90[/code]. Even at quality [code]1.00[/code], JPEG compression remains lossy.
 				[b]Note:[/b] JPEG does not save an alpha channel. If the [Image] contains an alpha channel, the image will still be saved, but the resulting byte array won't contain the alpha channel.
 			</description>
 		</method>
@@ -429,7 +429,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Saves the image as a PNG file to the file at [code]path[/code].
+				Saves the image as a PNG file to the file at [param path].
 			</description>
 		</method>
 		<method name="save_png_to_buffer" qualifiers="const">
@@ -444,7 +444,7 @@
 			<param index="1" name="lossy" type="bool" default="false" />
 			<param index="2" name="quality" type="float" default="0.75" />
 			<description>
-				Saves the image as a WebP (Web Picture) file to the file at [code]path[/code]. By default it will save lossless. If [code]lossy[/code] is true, the image will be saved lossy, using the [code]quality[/code] setting between 0.0 and 1.0 (inclusive).
+				Saves the image as a WebP (Web Picture) file to the file at [param path]. By default it will save lossless. If [param lossy] is true, the image will be saved lossy, using the [param quality] setting between 0.0 and 1.0 (inclusive).
 			</description>
 		</method>
 		<method name="save_webp_to_buffer" qualifiers="const">
@@ -452,7 +452,7 @@
 			<param index="0" name="lossy" type="bool" default="false" />
 			<param index="1" name="quality" type="float" default="0.75" />
 			<description>
-				Saves the image as a WebP (Web Picture) file to a byte array. By default it will save lossless. If [code]lossy[/code] is true, the image will be saved lossy, using the [code]quality[/code] setting between 0.0 and 1.0 (inclusive).
+				Saves the image as a WebP (Web Picture) file to a byte array. By default it will save lossless. If [param lossy] is true, the image will be saved lossy, using the [param quality] setting between 0.0 and 1.0 (inclusive).
 			</description>
 		</method>
 		<method name="set_pixel">
@@ -461,7 +461,7 @@
 			<param index="1" name="y" type="int" />
 			<param index="2" name="color" type="Color" />
 			<description>
-				Sets the [Color] of the pixel at [code](x, y)[/code] to [code]color[/code]. Example:
+				Sets the [Color] of the pixel at [code](x, y)[/code] to [param color]. Example:
 				[codeblocks]
 				[gdscript]
 				var img_width = 10
@@ -488,7 +488,7 @@
 			<param index="0" name="point" type="Vector2i" />
 			<param index="1" name="color" type="Color" />
 			<description>
-				Sets the [Color] of the pixel at [code]point[/code] to [code]color[/code]. Example:
+				Sets the [Color] of the pixel at [param point] to [param color]. Example:
 				[codeblocks]
 				[gdscript]
 				var img_width = 10

--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -29,8 +29,8 @@
 			<param index="6" name="flags" type="int" default="0" />
 			<description>
 				Creates a new surface, analogous to [method ArrayMesh.add_surface_from_arrays].
-				Surfaces are created to be rendered using a [code]primitive[/code], which may be any of the types defined in [enum Mesh.PrimitiveType]. (As a note, when using indices, it is recommended to only use points, lines, or triangles.) [method Mesh.get_surface_count] will become the [code]surf_idx[/code] for this new surface.
-				The [code]arrays[/code] argument is an array of arrays. See [enum Mesh.ArrayType] for the values used in this array. For example, [code]arrays[0][/code] is the array of vertices. That first vertex sub-array is always required; the others are optional. Adding an index array puts this function into "index mode" where the vertex and other arrays become the sources of data and the index array defines the vertex order. All sub-arrays must have the same length as the vertex array (or be an exact multiple of the vertex array's length, when multiple elements of a sub-array correspond to a single vertex) or be empty, except for [constant Mesh.ARRAY_INDEX] if it is used.
+				Surfaces are created to be rendered using a [param primitive], which may be any of the types defined in [enum Mesh.PrimitiveType]. (As a note, when using indices, it is recommended to only use points, lines, or triangles.) [method Mesh.get_surface_count] will become the [code]surf_idx[/code] for this new surface.
+				The [param arrays] argument is an array of arrays. See [enum Mesh.ArrayType] for the values used in this array. For example, [code]arrays[0][/code] is the array of vertices. That first vertex sub-array is always required; the others are optional. Adding an index array puts this function into "index mode" where the vertex and other arrays become the sources of data and the index array defines the vertex order. All sub-arrays must have the same length as the vertex array (or be an exact multiple of the vertex array's length, when multiple elements of a sub-array correspond to a single vertex) or be empty, except for [constant Mesh.ARRAY_INDEX] if it is used.
 			</description>
 		</method>
 		<method name="clear">
@@ -45,7 +45,7 @@
 			<param index="1" name="normal_split_angle" type="float" />
 			<description>
 				Generates all lods for this ImporterMesh.
-				[code]normal_merge_angle[/code] and [code]normal_split_angle[/code] are in degrees and used in the same way as the importer settings in [code]lods[/code]. As a good default, use 25 and 60 respectively.
+				[param normal_merge_angle] and [param normal_split_angle] are in degrees and used in the same way as the importer settings in [code]lods[/code]. As a good default, use 25 and 60 respectively.
 				The number of generated lods can be accessed using [method get_surface_lod_count], and each LOD is available in [method get_surface_lod_size] and [method get_surface_lod_indices].
 			</description>
 		</method>
@@ -80,7 +80,7 @@
 			<description>
 				Returns the mesh data represented by this [ImporterMesh] as a usable [ArrayMesh].
 				This method caches the returned mesh, and subsequent calls will return the cached data until [method clear] is called.
-				If not yet cached and [code]base_mesh[/code] is provided, [code]base_mesh[/code] will be used and mutated.
+				If not yet cached and [param base_mesh] is provided, [param base_mesh] will be used and mutated.
 			</description>
 		</method>
 		<method name="get_surface_arrays" qualifiers="const">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -58,7 +58,7 @@
 			<param index="1" name="exact_match" type="bool" default="false" />
 			<description>
 				Returns a value between 0 and 1 representing the raw intensity of the given action, ignoring the action's deadzone. In most cases, you should use [method get_action_strength] instead.
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="get_action_strength" qualifiers="const">
@@ -67,7 +67,7 @@
 			<param index="1" name="exact_match" type="bool" default="false" />
 			<description>
 				Returns a value between 0 and 1 representing the intensity of the given action. In a joypad, for example, the further away the axis (analog sticks or L2, R2 triggers) is from the dead zone, the closer the value will be to 1. If the action is mapped to a control that has no axis as the keyboard, the value returned will be 0 or 1.
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="get_axis" qualifiers="const">
@@ -180,7 +180,7 @@
 			<description>
 				Returns [code]true[/code] when the user starts pressing the action event, meaning it's [code]true[/code] only on the frame that the user pressed down the button.
 				This is useful for code that needs to run only once when an action is pressed, instead of every frame while it's pressed.
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 				[b]Note:[/b] Due to keyboard ghosting, [method is_action_just_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
 			</description>
 		</method>
@@ -190,7 +190,7 @@
 			<param index="1" name="exact_match" type="bool" default="false" />
 			<description>
 				Returns [code]true[/code] when the user stops pressing the action event, meaning it's [code]true[/code] only on the frame that the user released the button.
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="is_action_pressed" qualifiers="const">
@@ -199,7 +199,7 @@
 			<param index="1" name="exact_match" type="bool" default="false" />
 			<description>
 				Returns [code]true[/code] if you are pressing the action event. Note that if an action has multiple buttons assigned and more than one of them is pressed, releasing one button will release the action, even if some other button assigned to this action is still pressed.
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 				[b]Note:[/b] Due to keyboard ghosting, [method is_action_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
 			</description>
 		</method>
@@ -293,8 +293,8 @@
 			<param index="2" name="hotspot" type="Vector2" default="Vector2(0, 0)" />
 			<description>
 				Sets a custom mouse cursor image, which is only visible inside the game window. The hotspot can also be specified. Passing [code]null[/code] to the image parameter resets to the system cursor. See [enum CursorShape] for the list of shapes.
-				[code]image[/code]'s size must be lower than 256×256.
-				[code]hotspot[/code] must be within [code]image[/code]'s size.
+				[param image]'s size must be lower than 256×256.
+				[param hotspot] must be within [param image]'s size.
 				[b]Note:[/b] [AnimatedTexture]s aren't supported as custom mouse cursors. If using an [AnimatedTexture], only the first frame will be displayed.
 				[b]Note:[/b] Only images imported with the [b]Lossless[/b], [b]Lossy[/b] or [b]Uncompressed[/b] compression modes are supported. The [b]Video RAM[/b] compression mode can't be used for custom cursors.
 			</description>
@@ -339,7 +339,7 @@
 			<param index="2" name="strong_magnitude" type="float" />
 			<param index="3" name="duration" type="float" default="0" />
 			<description>
-				Starts to vibrate the joypad. Joypads usually come with two rumble motors, a strong and a weak one. [code]weak_magnitude[/code] is the strength of the weak motor (between 0 and 1) and [code]strong_magnitude[/code] is the strength of the strong motor (between 0 and 1). [code]duration[/code] is the duration of the effect in seconds (a duration of 0 will try to play the vibration indefinitely).
+				Starts to vibrate the joypad. Joypads usually come with two rumble motors, a strong and a weak one. [param weak_magnitude] is the strength of the weak motor (between 0 and 1) and [param strong_magnitude] is the strength of the strong motor (between 0 and 1). [param duration] is the duration of the effect in seconds (a duration of 0 will try to play the vibration indefinitely).
 				[b]Note:[/b] Not every hardware is compatible with long effect durations; it is recommended to restart an effect if it has to be played for more than a few seconds.
 			</description>
 		</method>

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -33,7 +33,7 @@
 			<param index="1" name="exact_match" type="bool" default="false" />
 			<description>
 				Returns a value between 0.0 and 1.0 depending on the given actions' state. Useful for getting the value of events of type [InputEventJoypadMotion].
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="is_action" qualifiers="const">
@@ -42,7 +42,7 @@
 			<param index="1" name="exact_match" type="bool" default="false" />
 			<description>
 				Returns [code]true[/code] if this input event matches a pre-defined action of any type.
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="is_action_pressed" qualifiers="const">
@@ -51,8 +51,8 @@
 			<param index="1" name="allow_echo" type="bool" default="false" />
 			<param index="2" name="exact_match" type="bool" default="false" />
 			<description>
-				Returns [code]true[/code] if the given action is being pressed (and is not an echo event for [InputEventKey] events, unless [code]allow_echo[/code] is [code]true[/code]). Not relevant for events of type [InputEventMouseMotion] or [InputEventScreenDrag].
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				Returns [code]true[/code] if the given action is being pressed (and is not an echo event for [InputEventKey] events, unless [param allow_echo] is [code]true[/code]). Not relevant for events of type [InputEventMouseMotion] or [InputEventScreenDrag].
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 				[b]Note:[/b] Due to keyboard ghosting, [method is_action_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
 			</description>
 		</method>
@@ -62,7 +62,7 @@
 			<param index="1" name="exact_match" type="bool" default="false" />
 			<description>
 				Returns [code]true[/code] if the given action is released (i.e. not pressed). Not relevant for events of type [InputEventMouseMotion] or [InputEventScreenDrag].
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="is_action_type" qualifiers="const">
@@ -82,8 +82,8 @@
 			<param index="0" name="event" type="InputEvent" />
 			<param index="1" name="exact_match" type="bool" default="true" />
 			<description>
-				Returns [code]true[/code] if the specified [code]event[/code] matches this event. Only valid for action events i.e key ([InputEventKey]), button ([InputEventMouseButton] or [InputEventJoypadButton]), axis [InputEventJoypadMotion] or action ([InputEventAction]) events.
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				Returns [code]true[/code] if the specified [param event] matches this event. Only valid for action events i.e key ([InputEventKey]), button ([InputEventMouseButton] or [InputEventJoypadButton]), axis [InputEventJoypadMotion] or action ([InputEventAction]) events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="is_pressed" qualifiers="const">
@@ -98,7 +98,7 @@
 			<param index="0" name="xform" type="Transform2D" />
 			<param index="1" name="local_ofs" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Returns a copy of the given input event which has been offset by [code]local_ofs[/code] and transformed by [code]xform[/code]. Relevant for events of type [InputEventMouseButton], [InputEventMouseMotion], [InputEventScreenTouch], [InputEventScreenDrag], [InputEventMagnifyGesture] and [InputEventPanGesture].
+				Returns a copy of the given input event which has been offset by [param local_ofs] and transformed by [param xform]. Relevant for events of type [InputEventMouseButton], [InputEventMouseMotion], [InputEventScreenTouch], [InputEventScreenDrag], [InputEventMagnifyGesture] and [InputEventPanGesture].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -69,7 +69,7 @@
 			<param index="0" name="action" type="StringName" />
 			<param index="1" name="deadzone" type="float" default="0.5" />
 			<description>
-				Adds an empty action to the [InputMap] with a configurable [code]deadzone[/code].
+				Adds an empty action to the [InputMap] with a configurable [param deadzone].
 				An [InputEvent] can then be added to this action with [method action_add_event].
 			</description>
 		</method>
@@ -87,7 +87,7 @@
 			<param index="2" name="exact_match" type="bool" default="false" />
 			<description>
 				Returns [code]true[/code] if the given event is part of an existing action. This method ignores keyboard modifiers if the given [InputEvent] is not pressed (for proper release detection). See [method action_has_event] if you don't want this behavior.
-				If [code]exact_match[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 			</description>
 		</method>
 		<method name="get_actions">

--- a/doc/classes/InstancePlaceholder.xml
+++ b/doc/classes/InstancePlaceholder.xml
@@ -30,7 +30,7 @@
 			<param index="0" name="with_order" type="bool" default="false" />
 			<description>
 				Returns the list of properties that will be applied to the node when [method create_instance] is called.
-				If [code]with_order[/code] is [code]true[/code], a key named [code].order[/code] (note the leading period) is added to the dictionary. This [code].order[/code] key is an [Array] of [String] property names specifying the order in which properties will be applied (with index 0 being the first).
+				If [param with_order] is [code]true[/code], a key named [code].order[/code] (note the leading period) is added to the dictionary. This [code].order[/code] key is an [Array] of [String] property names specifying the order in which properties will be applied (with index 0 being the first).
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
One of several commits to fix all of the class XML docs (see #64134, #64164, #64196, #64285, #64319).