### PR TITLE
[3.x] Add theme item cache to `Control`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -475,6 +475,7 @@ void Control::_update_canvas_item_transform() {
 void Control::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_ENTER_TREE: {
+			_invalidate_theme_cache();
 		} break;
 		case NOTIFICATION_POST_ENTER_TREE: {
 			data.minimum_size_valid = false;
@@ -624,6 +625,7 @@ void Control::_notification(int p_notification) {
 
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
+			_invalidate_theme_cache();
 			minimum_size_changed();
 			update();
 		} break;
@@ -894,9 +896,15 @@ Ref<Texture> Control::get_icon(const StringName &p_name, const StringName &p_the
 		}
 	}
 
+	if (data.theme_icon_cache.has(p_theme_type) && data.theme_icon_cache[p_theme_type].has(p_name)) {
+		return data.theme_icon_cache[p_theme_type][p_name];
+	}
+
 	List<StringName> theme_types;
 	_get_theme_type_dependencies(p_theme_type, &theme_types);
-	return get_theme_item_in_types<Ref<Texture>>(data.theme_owner, Theme::DATA_TYPE_ICON, p_name, theme_types);
+	Ref<Texture> icon = get_theme_item_in_types<Ref<Texture>>(data.theme_owner, Theme::DATA_TYPE_ICON, p_name, theme_types);
+	data.theme_icon_cache[p_theme_type][p_name] = icon;
+	return icon;
 }
 
 Ref<Shader> Control::get_shader(const StringName &p_name, const StringName &p_theme_type) const {
@@ -949,9 +957,15 @@ Ref<StyleBox> Control::get_stylebox(const StringName &p_name, const StringName &
 		}
 	}
 
+	if (data.theme_style_cache.has(p_theme_type) && data.theme_style_cache[p_theme_type].has(p_name)) {
+		return data.theme_style_cache[p_theme_type][p_name];
+	}
+
 	List<StringName> theme_types;
 	_get_theme_type_dependencies(p_theme_type, &theme_types);
-	return get_theme_item_in_types<Ref<StyleBox>>(data.theme_owner, Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
+	Ref<StyleBox> style = get_theme_item_in_types<Ref<StyleBox>>(data.theme_owner, Theme::DATA_TYPE_STYLEBOX, p_name, theme_types);
+	data.theme_style_cache[p_theme_type][p_name] = style;
+	return style;
 }
 
 Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_theme_type) const {
@@ -962,9 +976,15 @@ Ref<Font> Control::get_font(const StringName &p_name, const StringName &p_theme_
 		}
 	}
 
+	if (data.theme_font_cache.has(p_theme_type) && data.theme_font_cache[p_theme_type].has(p_name)) {
+		return data.theme_font_cache[p_theme_type][p_name];
+	}
+
 	List<StringName> theme_types;
 	_get_theme_type_dependencies(p_theme_type, &theme_types);
-	return get_theme_item_in_types<Ref<Font>>(data.theme_owner, Theme::DATA_TYPE_FONT, p_name, theme_types);
+	Ref<Font> font = get_theme_item_in_types<Ref<Font>>(data.theme_owner, Theme::DATA_TYPE_FONT, p_name, theme_types);
+	data.theme_font_cache[p_theme_type][p_name] = font;
+	return font;
 }
 
 Color Control::get_color(const StringName &p_name, const StringName &p_theme_type) const {
@@ -975,9 +995,15 @@ Color Control::get_color(const StringName &p_name, const StringName &p_theme_typ
 		}
 	}
 
+	if (data.theme_color_cache.has(p_theme_type) && data.theme_color_cache[p_theme_type].has(p_name)) {
+		return data.theme_color_cache[p_theme_type][p_name];
+	}
+
 	List<StringName> theme_types;
 	_get_theme_type_dependencies(p_theme_type, &theme_types);
-	return get_theme_item_in_types<Color>(data.theme_owner, Theme::DATA_TYPE_COLOR, p_name, theme_types);
+	Color color = get_theme_item_in_types<Color>(data.theme_owner, Theme::DATA_TYPE_COLOR, p_name, theme_types);
+	data.theme_color_cache[p_theme_type][p_name] = color;
+	return color;
 }
 
 int Control::get_constant(const StringName &p_name, const StringName &p_theme_type) const {
@@ -988,9 +1014,15 @@ int Control::get_constant(const StringName &p_name, const StringName &p_theme_ty
 		}
 	}
 
+	if (data.theme_constant_cache.has(p_theme_type) && data.theme_constant_cache[p_theme_type].has(p_name)) {
+		return data.theme_constant_cache[p_theme_type][p_name];
+	}
+
 	List<StringName> theme_types;
 	_get_theme_type_dependencies(p_theme_type, &theme_types);
-	return get_theme_item_in_types<int>(data.theme_owner, Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
+	int constant = get_theme_item_in_types<int>(data.theme_owner, Theme::DATA_TYPE_CONSTANT, p_name, theme_types);
+	data.theme_constant_cache[p_theme_type][p_name] = constant;
+	return constant;
 }
 
 bool Control::has_icon_override(const StringName &p_name) const {
@@ -2091,6 +2123,14 @@ void Control::_propagate_theme_changed(CanvasItem *p_at, Control *p_owner, bool 
 
 void Control::_theme_changed() {
 	_propagate_theme_changed(this, this, false);
+}
+
+void Control::_invalidate_theme_cache() {
+	data.theme_icon_cache.clear();
+	data.theme_style_cache.clear();
+	data.theme_font_cache.clear();
+	data.theme_color_cache.clear();
+	data.theme_constant_cache.clear();
 }
 
 void Control::set_theme(const Ref<Theme> &p_theme) {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -204,6 +204,12 @@ private:
 		HashMap<StringName, Color> color_override;
 		HashMap<StringName, int> constant_override;
 
+		mutable HashMap<StringName, HashMap<StringName, Ref<Texture>>> theme_icon_cache;
+		mutable HashMap<StringName, HashMap<StringName, Ref<StyleBox>>> theme_style_cache;
+		mutable HashMap<StringName, HashMap<StringName, Ref<Font>>> theme_font_cache;
+		mutable HashMap<StringName, HashMap<StringName, Color>> theme_color_cache;
+		mutable HashMap<StringName, HashMap<StringName, int>> theme_constant_cache;
+
 	} data;
 
 	void _window_find_focus_neighbour(const Vector2 &p_dir, Node *p_at, const Point2 *p_points, float p_min, float &r_closest_dist, Control **r_closest);
@@ -216,6 +222,7 @@ private:
 
 	void _propagate_theme_changed(CanvasItem *p_at, Control *p_owner, bool p_assign = true);
 	void _theme_changed();
+	void _invalidate_theme_cache();
 
 	void _change_notify_margins();
 	void _update_minimum_size();


### PR DESCRIPTION
Back port of https://github.com/godotengine/godot/pull/64314 

Part of a few PRs to address: https://github.com/godotengine/godot/issues/64241

To quick and dirty benchmark an affected control function say `get_color`, you can add the following tool script to any Control node.  This will give you a run_toggle flag in the inspector, and will print the execution time in millis to the editor console.

![image](https://user-images.githubusercontent.com/323868/184396421-e22c1a45-2af3-4d9b-aca0-f41450726936.png)


```gdscript
tool
extends Control

export var run_toggle := false

func _ready():
	pass # Replace with function body.


# Called every frame. 'delta' is the elapsed time since the previous frame.
func _process(delta):
	if(run_toggle):
		run_toggle = false
		var cpu_start_time := OS.get_ticks_msec()
		for i in range(100000):
			get_color("error_color", "SomeClass")
		var cpu_end_time := OS.get_ticks_msec()
		print("Time in millis: " + String( cpu_end_time - cpu_start_time))
```

The performance increase will be dependent on any particular project.  As the complexity of theme computation in a project will differ in each project and on any particular scene tree...  But  the following lines are expensive due to complexity and memory allocations in the `List<>` itself and what ends up getting populated in the `theme_types` list:

```c++
	List<StringName> theme_types;
	_get_theme_type_dependencies(p_theme_type, &theme_types);
```

The cache in this PR avoids this hotspot, and in our project, the timing from the above gdscript tool results on average a 6x speedup improvement in most of the affected control functions:

With the cache:

![image](https://user-images.githubusercontent.com/323868/184397600-8c1dfd44-252c-433b-8f61-816d3a0288bf.png)

Without any caching:

![image](https://user-images.githubusercontent.com/323868/184397719-df045d4e-2ac4-45c3-ae8e-b41ccc85ed76.png)

The above were tested in editor with `release_debug`.  The actual improvements in our project are even higher (roughly 10-20x), when benchmarked outside of gdscript when called from c++ (which we can't really provide a MRP for) and on non-editor pure release builds.  


