### PR TITLE
[doc] Use "param" instead of "code" to refer to parameters (7)

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -37,7 +37,7 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Constructs a pure rotation basis matrix, rotated around the given [code]axis[/code] by [code]angle[/code] (in radians). The axis must be a normalized vector.
+				Constructs a pure rotation basis matrix, rotated around the given [param axis] by [param angle] (in radians). The axis must be a normalized vector.
 			</description>
 		</constructor>
 		<constructor name="Basis">
@@ -115,7 +115,7 @@
 			<return type="bool" />
 			<param index="0" name="b" type="Basis" />
 			<description>
-				Returns [code]true[/code] if this basis and [code]b[/code] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
+				Returns [code]true[/code] if this basis and [param b] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
 			</description>
 		</method>
 		<method name="looking_at" qualifiers="static">
@@ -123,8 +123,8 @@
 			<param index="0" name="target" type="Vector3" />
 			<param index="1" name="up" type="Vector3" default="Vector3(0, 1, 0)" />
 			<description>
-				Creates a Basis with a rotation such that the forward axis (-Z) points towards the [code]target[/code] position.
-				The up axis (+Y) points as close to the [code]up[/code] vector as possible while staying perpendicular to the forward axis. The resulting Basis is orthonormalized. The [code]target[/code] and [code]up[/code] vectors cannot be zero, and cannot be parallel to each other.
+				Creates a Basis with a rotation such that the forward axis (-Z) points towards the [param target] position.
+				The up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the forward axis. The resulting Basis is orthonormalized. The [param target] and [param up] vectors cannot be zero, and cannot be parallel to each other.
 			</description>
 		</method>
 		<method name="orthonormalized" qualifiers="const">
@@ -138,7 +138,7 @@
 			<param index="0" name="axis" type="Vector3" />
 			<param index="1" name="angle" type="float" />
 			<description>
-				Introduce an additional rotation around the given axis by [code]angle[/code] (in radians). The axis must be a normalized vector.
+				Introduce an additional rotation around the given axis by [param angle] (in radians). The axis must be a normalized vector.
 			</description>
 		</method>
 		<method name="scaled" qualifiers="const">

--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -27,7 +27,7 @@
 			<param index="0" name="image" type="Image" />
 			<param index="1" name="threshold" type="float" default="0.1" />
 			<description>
-				Creates a bitmap that matches the given image dimensions, every element of the bitmap is set to [code]false[/code] if the alpha value of the image at that position is equal to [code]threshold[/code] or less, and [code]true[/code] in other case.
+				Creates a bitmap that matches the given image dimensions, every element of the bitmap is set to [code]false[/code] if the alpha value of the image at that position is equal to [param threshold] or less, and [code]true[/code] in other case.
 			</description>
 		</method>
 		<method name="get_bit" qualifiers="const">
@@ -54,7 +54,7 @@
 			<param index="0" name="pixels" type="int" />
 			<param index="1" name="rect" type="Rect2" />
 			<description>
-				Applies morphological dilation or erosion to the bitmap. If [code]pixels[/code] is positive, dilation is applied to the bitmap. If [code]pixels[/code] is negative, erosion is applied to the bitmap. [code]rect[/code] defines the area where the morphological operation is applied. Pixels located outside the [code]rect[/code] are unaffected by [method grow_mask].
+				Applies morphological dilation or erosion to the bitmap. If [param pixels] is positive, dilation is applied to the bitmap. If [param pixels] is negative, erosion is applied to the bitmap. [param rect] defines the area where the morphological operation is applied. Pixels located outside the [param rect] are unaffected by [method grow_mask].
 			</description>
 		</method>
 		<method name="opaque_to_polygons" qualifiers="const">
@@ -67,14 +67,14 @@
 				[codeblock]
 				Rect2(Vector2(), get_size())
 				[/codeblock]
-				[code]epsilon[/code] is passed to RDP to control how accurately the polygons cover the bitmap: a lower [code]epsilon[/code] corresponds to more points in the polygons.
+				[param epsilon] is passed to RDP to control how accurately the polygons cover the bitmap: a lower [param epsilon] corresponds to more points in the polygons.
 			</description>
 		</method>
 		<method name="resize">
 			<return type="void" />
 			<param index="0" name="new_size" type="Vector2" />
 			<description>
-				Resizes the image to [code]new_size[/code].
+				Resizes the image to [param new_size].
 			</description>
 		</method>
 		<method name="set_bit">

--- a/doc/classes/BoneMap.xml
+++ b/doc/classes/BoneMap.xml
@@ -14,7 +14,7 @@
 			<return type="StringName" />
 			<param index="0" name="skeleton_bone_name" type="StringName" />
 			<description>
-				Returns a profile bone name having [code]skeleton_bone_name[/code]. If not found, an empty [StringName] will be returned.
+				Returns a profile bone name having [param skeleton_bone_name]. If not found, an empty [StringName] will be returned.
 				In the retargeting process, the returned bone name is the bone name of the target skeleton.
 			</description>
 		</method>
@@ -22,7 +22,7 @@
 			<return type="StringName" />
 			<param index="0" name="profile_bone_name" type="StringName" />
 			<description>
-				Returns a skeleton bone name is mapped to [code]profile_bone_name[/code].
+				Returns a skeleton bone name is mapped to [param profile_bone_name].
 				In the retargeting process, the returned bone name is the bone name of the source skeleton.
 			</description>
 		</method>
@@ -31,7 +31,7 @@
 			<param index="0" name="profile_bone_name" type="StringName" />
 			<param index="1" name="skeleton_bone_name" type="StringName" />
 			<description>
-				Maps a skeleton bone name to [code]profile_bone_name[/code].
+				Maps a skeleton bone name to [param profile_bone_name].
 				In the retargeting process, the setting bone name is the bone name of the source skeleton.
 			</description>
 		</method>

--- a/doc/classes/BoxContainer.xml
+++ b/doc/classes/BoxContainer.xml
@@ -14,7 +14,7 @@
 			<return type="Control" />
 			<param index="0" name="begin" type="bool" />
 			<description>
-				Adds a [Control] node to the box as a spacer. If [code]begin[/code] is [code]true[/code], it will insert the [Control] node in front of all other children.
+				Adds a [Control] node to the box as a spacer. If [param begin] is [code]true[/code], it will insert the [Control] node in front of all other children.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -54,7 +54,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="method" type="StringName" />
 			<description>
-				Creates a new [Callable] for the method called [code]method[/code] in the specified [code]object[/code].
+				Creates a new [Callable] for the method called [param method] in the specified [param object].
 			</description>
 		</constructor>
 	</constructors>

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -14,7 +14,7 @@
 			<return type="void" />
 			<param index="0" name="enable_next" type="bool" default="true" />
 			<description>
-				If this is the current camera, remove it from being current. If [code]enable_next[/code] is [code]true[/code], request to make the next camera current, if any.
+				If this is the current camera, remove it from being current. If [param enable_next] is [code]true[/code], request to make the next camera current, if any.
 			</description>
 		</method>
 		<method name="get_camera_rid" qualifiers="const">
@@ -33,7 +33,7 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member cull_mask] is enabled, given a [code]layer_number[/code] between 1 and 20.
+				Returns whether or not the specified layer of the [member cull_mask] is enabled, given a [param layer_number] between 1 and 20.
 			</description>
 		</method>
 		<method name="get_frustum" qualifiers="const">
@@ -81,7 +81,7 @@
 			<param index="0" name="screen_point" type="Vector2" />
 			<param index="1" name="z_depth" type="float" />
 			<description>
-				Returns the 3D point in world space that maps to the given 2D coordinate in the [Viewport] rectangle on a plane that is the given [code]z_depth[/code] distance into the scene away from the camera.
+				Returns the 3D point in world space that maps to the given 2D coordinate in the [Viewport] rectangle on a plane that is the given [param z_depth] distance into the scene away from the camera.
 			</description>
 		</method>
 		<method name="project_ray_normal" qualifiers="const">
@@ -103,7 +103,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member cull_mask], given a [code]layer_number[/code] between 1 and 20.
+				Based on [param value], enables or disables the specified layer in the [member cull_mask], given a [param layer_number] between 1 and 20.
 			</description>
 		</method>
 		<method name="set_frustum">
@@ -113,7 +113,7 @@
 			<param index="2" name="z_near" type="float" />
 			<param index="3" name="z_far" type="float" />
 			<description>
-				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [code]size[/code], an [code]offset[/code], and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space units. See also [member frustum_offset].
+				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [param size], an [param offset], and the [param z_near] and [param z_far] clip planes in world space units. See also [member frustum_offset].
 			</description>
 		</method>
 		<method name="set_orthogonal">
@@ -122,7 +122,7 @@
 			<param index="1" name="z_near" type="float" />
 			<param index="2" name="z_far" type="float" />
 			<description>
-				Sets the camera projection to orthogonal mode (see [constant PROJECTION_ORTHOGONAL]), by specifying a [code]size[/code], and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space units. (As a hint, 2D games often use this projection, with values specified in pixels.)
+				Sets the camera projection to orthogonal mode (see [constant PROJECTION_ORTHOGONAL]), by specifying a [param size], and the [param z_near] and [param z_far] clip planes in world space units. (As a hint, 2D games often use this projection, with values specified in pixels.)
 			</description>
 		</method>
 		<method name="set_perspective">
@@ -131,7 +131,7 @@
 			<param index="1" name="z_near" type="float" />
 			<param index="2" name="z_far" type="float" />
 			<description>
-				Sets the camera projection to perspective mode (see [constant PROJECTION_PERSPECTIVE]), by specifying a [code]fov[/code] (field of view) angle in degrees, and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space units.
+				Sets the camera projection to perspective mode (see [constant PROJECTION_PERSPECTIVE]), by specifying a [param fov] (field of view) angle in degrees, and the [param z_near] and [param z_far] clip planes in world space units.
 			</description>
 		</method>
 		<method name="unproject_position" qualifiers="const">

--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -15,7 +15,7 @@
 			<return type="void" />
 			<param index="0" name="feed" type="CameraFeed" />
 			<description>
-				Adds the camera [code]feed[/code] to the camera server.
+				Adds the camera [param feed] to the camera server.
 			</description>
 		</method>
 		<method name="feeds">
@@ -28,7 +28,7 @@
 			<return type="CameraFeed" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the [CameraFeed] corresponding to the camera with the given [code]index[/code].
+				Returns the [CameraFeed] corresponding to the camera with the given [param index].
 			</description>
 		</method>
 		<method name="get_feed_count">
@@ -41,7 +41,7 @@
 			<return type="void" />
 			<param index="0" name="feed" type="CameraFeed" />
 			<description>
-				Removes the specified camera [code]feed[/code].
+				Removes the specified camera [param feed].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -44,7 +44,7 @@
 			<param index="6" name="width" type="float" default="1.0" />
 			<param index="7" name="antialiased" type="bool" default="false" />
 			<description>
-				Draws a unfilled arc between the given angles. The larger the value of [code]point_count[/code], the smoother the curve. See also [method draw_circle].
+				Draws a unfilled arc between the given angles. The larger the value of [param point_count], the smoother the curve. See also [method draw_circle].
 			</description>
 		</method>
 		<method name="draw_char" qualifiers="const">
@@ -137,8 +137,8 @@
 			<param index="5" name="pixel_range" type="float" default="4.0" />
 			<description>
 				Draws a textured rectangle region of the multi-channel signed distance field texture at a given position, optionally modulated by a color. See [member FontFile.multichannel_signed_distance_field] for more information and caveats about MSDF font rendering.
-				If [code]outline[/code] is positive, each alpha channel value of pixel in region is set to maximum value of true distance in the [code]outline[/code] radius.
-				Value of the [code]pixel_range[/code] should the same that was used during distance field texture generation.
+				If [param outline] is positive, each alpha channel value of pixel in region is set to maximum value of true distance in the [param outline] radius.
+				Value of the [param pixel_range] should the same that was used during distance field texture generation.
 			</description>
 		</method>
 		<method name="draw_multiline">
@@ -147,7 +147,7 @@
 			<param index="1" name="color" type="Color" />
 			<param index="2" name="width" type="float" default="1.0" />
 			<description>
-				Draws multiple disconnected lines with a uniform [code]color[/code]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline] instead.
+				Draws multiple disconnected lines with a uniform [param color]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline] instead.
 			</description>
 		</method>
 		<method name="draw_multiline_colors">
@@ -156,7 +156,7 @@
 			<param index="1" name="colors" type="PackedColorArray" />
 			<param index="2" name="width" type="float" default="1.0" />
 			<description>
-				Draws multiple disconnected lines with a uniform [code]width[/code] and segment-by-segment coloring. Colors assigned to line segments match by index between [code]points[/code] and [code]colors[/code]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline_colors] instead.
+				Draws multiple disconnected lines with a uniform [param width] and segment-by-segment coloring. Colors assigned to line segments match by index between [param points] and [param colors]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline_colors] instead.
 			</description>
 		</method>
 		<method name="draw_multiline_string" qualifiers="const">
@@ -174,7 +174,7 @@
 			<param index="10" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="11" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Breaks [code]text[/code] to the lines and draws it using the specified [code]font[/code] at the [code]position[/code] (top-left corner). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
+				Breaks [param text] into lines and draws it using the specified [param font] at the [param pos] (top-left corner). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 			</description>
 		</method>
 		<method name="draw_multiline_string_outline" qualifiers="const">
@@ -193,7 +193,7 @@
 			<param index="11" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="12" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Breaks [code]text[/code] to the lines and draws text outline using the specified [code]font[/code] at the [code]position[/code] (top-left corner). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
+				Breaks [param text] to the lines and draws text outline using the specified [param font] at the [param pos] (top-left corner). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 			</description>
 		</method>
 		<method name="draw_multimesh">
@@ -221,7 +221,7 @@
 			<param index="2" name="width" type="float" default="1.0" />
 			<param index="3" name="antialiased" type="bool" default="false" />
 			<description>
-				Draws interconnected line segments with a uniform [code]color[/code] and [code]width[/code] and optional antialiasing. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw disconnected lines, use [method draw_multiline] instead. See also [method draw_polygon].
+				Draws interconnected line segments with a uniform [param color] and [param width] and optional antialiasing. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw disconnected lines, use [method draw_multiline] instead. See also [method draw_polygon].
 			</description>
 		</method>
 		<method name="draw_polyline_colors">
@@ -231,7 +231,7 @@
 			<param index="2" name="width" type="float" default="1.0" />
 			<param index="3" name="antialiased" type="bool" default="false" />
 			<description>
-				Draws interconnected line segments with a uniform [code]width[/code] and segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between [code]points[/code] and [code]colors[/code]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw disconnected lines, use [method draw_multiline_colors] instead. See also [method draw_polygon].
+				Draws interconnected line segments with a uniform [param width] and segment-by-segment coloring, and optional antialiasing. Colors assigned to line segments match by index between [param points] and [param colors]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw disconnected lines, use [method draw_multiline_colors] instead. See also [method draw_polygon].
 			</description>
 		</method>
 		<method name="draw_primitive">
@@ -252,8 +252,8 @@
 			<param index="2" name="filled" type="bool" default="true" />
 			<param index="3" name="width" type="float" default="1.0" />
 			<description>
-				Draws a rectangle. If [code]filled[/code] is [code]true[/code], the rectangle will be filled with the [code]color[/code] specified. If [code]filled[/code] is [code]false[/code], the rectangle will be drawn as a stroke with the [code]color[/code] and [code]width[/code] specified.
-				[b]Note:[/b] [code]width[/code] is only effective if [code]filled[/code] is [code]false[/code].
+				Draws a rectangle. If [param filled] is [code]true[/code], the rectangle will be filled with the [param color] specified. If [param filled] is [code]false[/code], the rectangle will be drawn as a stroke with the [param color] and [param width] specified.
+				[b]Note:[/b] [param width] is only effective if [param filled] is [code]false[/code].
 			</description>
 		</method>
 		<method name="draw_set_transform">
@@ -285,7 +285,7 @@
 			<param index="8" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="9" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Draws [code]text[/code] using the specified [code]font[/code] at the [code]position[/code] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
+				Draws [param text] using the specified [param font] at the [param pos] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 				[b]Example using the default project font:[/b]
 				[codeblocks]
 				[gdscript]
@@ -322,7 +322,7 @@
 			<param index="9" name="direction" type="int" enum="TextServer.Direction" default="0" />
 			<param index="10" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
-				Draws [code]text[/code] outline using the specified [code]font[/code] at the [code]position[/code] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [code]modulate[/code]. If [code]clip_w[/code] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
+				Draws [param text] outline using the specified [param font] at the [param pos] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
 			</description>
 		</method>
 		<method name="draw_style_box">
@@ -350,7 +350,7 @@
 			<param index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
 			<param index="4" name="transpose" type="bool" default="false" />
 			<description>
-				Draws a textured rectangle at a given position, optionally modulated by a color. If [code]transpose[/code] is [code]true[/code], the texture will have its X and Y coordinates swapped.
+				Draws a textured rectangle at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped.
 			</description>
 		</method>
 		<method name="draw_texture_rect_region">
@@ -362,7 +362,7 @@
 			<param index="4" name="transpose" type="bool" default="false" />
 			<param index="5" name="clip_uv" type="bool" default="true" />
 			<description>
-				Draws a textured rectangle region at a given position, optionally modulated by a color. If [code]transpose[/code] is [code]true[/code], the texture will have its X and Y coordinates swapped.
+				Draws a textured rectangle region at a given position, optionally modulated by a color. If [param transpose] is [code]true[/code], the texture will have its X and Y coordinates swapped.
 			</description>
 		</method>
 		<method name="force_update_transform">
@@ -472,28 +472,28 @@
 			<return type="Vector2" />
 			<param index="0" name="screen_point" type="Vector2" />
 			<description>
-				Assigns [code]screen_point[/code] as this node's new local transform.
+				Assigns [param screen_point] as this node's new local transform.
 			</description>
 		</method>
 		<method name="make_input_local" qualifiers="const">
 			<return type="InputEvent" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Transformations issued by [code]event[/code]'s inputs are applied in local space instead of global space.
+				Transformations issued by [param event]'s inputs are applied in local space instead of global space.
 			</description>
 		</method>
 		<method name="set_notify_local_transform">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If [code]enable[/code] is [code]true[/code], this node will receive [constant NOTIFICATION_LOCAL_TRANSFORM_CHANGED] when its local transform changes.
+				If [param enable] is [code]true[/code], this node will receive [constant NOTIFICATION_LOCAL_TRANSFORM_CHANGED] when its local transform changes.
 			</description>
 		</method>
 		<method name="set_notify_transform">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
-				If [code]enable[/code] is [code]true[/code], this node will receive [constant NOTIFICATION_TRANSFORM_CHANGED] when its global transform changes.
+				If [param enable] is [code]true[/code], this node will receive [constant NOTIFICATION_TRANSFORM_CHANGED] when its global transform changes.
 			</description>
 		</method>
 		<method name="show">

--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -19,7 +19,7 @@
 			<return type="float" />
 			<param index="0" name="up_direction" type="Vector2" default="Vector2(0, -1)" />
 			<description>
-				Returns the floor's collision angle at the last collision point according to [code]up_direction[/code], which is [code]Vector2.UP[/code] by default. This value is always positive and only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+				Returns the floor's collision angle at the last collision point according to [param up_direction], which is [code]Vector2.UP[/code] by default. This value is always positive and only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="get_floor_normal" qualifiers="const">

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -20,7 +20,7 @@
 			<return type="float" />
 			<param index="0" name="up_direction" type="Vector3" default="Vector3(0, 1, 0)" />
 			<description>
-				Returns the floor's collision angle at the last collision point according to [code]up_direction[/code], which is [code]Vector3.UP[/code] by default. This value is always positive and only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
+				Returns the floor's collision angle at the last collision point according to [param up_direction], which is [code]Vector3.UP[/code] by default. This value is always positive and only valid after calling [method move_and_slide] and when [method is_on_floor] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="get_floor_normal" qualifiers="const">

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -13,14 +13,14 @@
 			<return type="bool" />
 			<param index="0" name="class" type="StringName" />
 			<description>
-				Returns [code]true[/code] if you can instance objects from the specified [code]class[/code], [code]false[/code] in other case.
+				Returns [code]true[/code] if you can instance objects from the specified [param class], [code]false[/code] in other case.
 			</description>
 		</method>
 		<method name="class_exists" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="class" type="StringName" />
 			<description>
-				Returns whether the specified [code]class[/code] is available or not.
+				Returns whether the specified [param class] is available or not.
 			</description>
 		</method>
 		<method name="class_get_enum_constants" qualifiers="const">
@@ -29,7 +29,7 @@
 			<param index="1" name="enum" type="StringName" />
 			<param index="2" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns an array with all the keys in [code]enum[/code] of [code]class[/code] or its ancestry.
+				Returns an array with all the keys in [param enum] of [param class] or its ancestry.
 			</description>
 		</method>
 		<method name="class_get_enum_list" qualifiers="const">
@@ -37,7 +37,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns an array with all the enums of [code]class[/code] or its ancestry.
+				Returns an array with all the enums of [param class] or its ancestry.
 			</description>
 		</method>
 		<method name="class_get_integer_constant" qualifiers="const">
@@ -45,7 +45,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="name" type="StringName" />
 			<description>
-				Returns the value of the integer constant [code]name[/code] of [code]class[/code] or its ancestry. Always returns 0 when the constant could not be found.
+				Returns the value of the integer constant [param name] of [param class] or its ancestry. Always returns 0 when the constant could not be found.
 			</description>
 		</method>
 		<method name="class_get_integer_constant_enum" qualifiers="const">
@@ -54,7 +54,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns which enum the integer constant [code]name[/code] of [code]class[/code] or its ancestry belongs to.
+				Returns which enum the integer constant [param name] of [param class] or its ancestry belongs to.
 			</description>
 		</method>
 		<method name="class_get_integer_constant_list" qualifiers="const">
@@ -62,7 +62,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns an array with the names all the integer constants of [code]class[/code] or its ancestry.
+				Returns an array with the names all the integer constants of [param class] or its ancestry.
 			</description>
 		</method>
 		<method name="class_get_method_list" qualifiers="const">
@@ -70,7 +70,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns an array with all the methods of [code]class[/code] or its ancestry if [code]no_inheritance[/code] is [code]false[/code]. Every element of the array is a [Dictionary] with the following keys: [code]args[/code], [code]default_args[/code], [code]flags[/code], [code]id[/code], [code]name[/code], [code]return: (class_name, hint, hint_string, name, type, usage)[/code].
+				Returns an array with all the methods of [param class] or its ancestry if [param no_inheritance] is [code]false[/code]. Every element of the array is a [Dictionary] with the following keys: [code]args[/code], [code]default_args[/code], [code]flags[/code], [code]id[/code], [code]name[/code], [code]return: (class_name, hint, hint_string, name, type, usage)[/code].
 				[b]Note:[/b] In exported release builds the debug info is not available, so the returned dictionaries will contain only method names.
 			</description>
 		</method>
@@ -79,7 +79,7 @@
 			<param index="0" name="object" type="Object" />
 			<param index="1" name="property" type="StringName" />
 			<description>
-				Returns the value of [code]property[/code] of [code]class[/code] or its ancestry.
+				Returns the value of [param property] of [param object] or its ancestry.
 			</description>
 		</method>
 		<method name="class_get_property_list" qualifiers="const">
@@ -87,7 +87,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns an array with all the properties of [code]class[/code] or its ancestry if [code]no_inheritance[/code] is [code]false[/code].
+				Returns an array with all the properties of [param class] or its ancestry if [param no_inheritance] is [code]false[/code].
 			</description>
 		</method>
 		<method name="class_get_signal" qualifiers="const">
@@ -95,7 +95,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="signal" type="StringName" />
 			<description>
-				Returns the [code]signal[/code] data of [code]class[/code] or its ancestry. The returned value is a [Dictionary] with the following keys: [code]args[/code], [code]default_args[/code], [code]flags[/code], [code]id[/code], [code]name[/code], [code]return: (class_name, hint, hint_string, name, type, usage)[/code].
+				Returns the [param signal] data of [param class] or its ancestry. The returned value is a [Dictionary] with the following keys: [code]args[/code], [code]default_args[/code], [code]flags[/code], [code]id[/code], [code]name[/code], [code]return: (class_name, hint, hint_string, name, type, usage)[/code].
 			</description>
 		</method>
 		<method name="class_get_signal_list" qualifiers="const">
@@ -103,7 +103,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns an array with all the signals of [code]class[/code] or its ancestry if [code]no_inheritance[/code] is [code]false[/code]. Every element of the array is a [Dictionary] as described in [method class_get_signal].
+				Returns an array with all the signals of [param class] or its ancestry if [param no_inheritance] is [code]false[/code]. Every element of the array is a [Dictionary] as described in [method class_get_signal].
 			</description>
 		</method>
 		<method name="class_has_enum" qualifiers="const">
@@ -112,7 +112,7 @@
 			<param index="1" name="name" type="StringName" />
 			<param index="2" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns whether [code]class[/code] or its ancestry has an enum called [code]name[/code] or not.
+				Returns whether [param class] or its ancestry has an enum called [param name] or not.
 			</description>
 		</method>
 		<method name="class_has_integer_constant" qualifiers="const">
@@ -120,7 +120,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="name" type="StringName" />
 			<description>
-				Returns whether [code]class[/code] or its ancestry has an integer constant called [code]name[/code] or not.
+				Returns whether [param class] or its ancestry has an integer constant called [param name] or not.
 			</description>
 		</method>
 		<method name="class_has_method" qualifiers="const">
@@ -129,7 +129,7 @@
 			<param index="1" name="method" type="StringName" />
 			<param index="2" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns whether [code]class[/code] (or its ancestry if [code]no_inheritance[/code] is [code]false[/code]) has a method called [code]method[/code] or not.
+				Returns whether [param class] (or its ancestry if [param no_inheritance] is [code]false[/code]) has a method called [param method] or not.
 			</description>
 		</method>
 		<method name="class_has_signal" qualifiers="const">
@@ -137,7 +137,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="signal" type="StringName" />
 			<description>
-				Returns whether [code]class[/code] or its ancestry has a signal called [code]signal[/code] or not.
+				Returns whether [param class] or its ancestry has a signal called [param signal] or not.
 			</description>
 		</method>
 		<method name="class_set_property" qualifiers="const">
@@ -146,7 +146,7 @@
 			<param index="1" name="property" type="StringName" />
 			<param index="2" name="value" type="Variant" />
 			<description>
-				Sets [code]property[/code] value of [code]class[/code] to [code]value[/code].
+				Sets [param property] value of [param object] to [param value].
 			</description>
 		</method>
 		<method name="get_class_list" qualifiers="const">
@@ -159,28 +159,28 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="class" type="StringName" />
 			<description>
-				Returns the names of all the classes that directly or indirectly inherit from [code]class[/code].
+				Returns the names of all the classes that directly or indirectly inherit from [param class].
 			</description>
 		</method>
 		<method name="get_parent_class" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="class" type="StringName" />
 			<description>
-				Returns the parent class of [code]class[/code].
+				Returns the parent class of [param class].
 			</description>
 		</method>
 		<method name="instantiate" qualifiers="const">
 			<return type="Variant" />
 			<param index="0" name="class" type="StringName" />
 			<description>
-				Creates an instance of [code]class[/code].
+				Creates an instance of [param class].
 			</description>
 		</method>
 		<method name="is_class_enabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="class" type="StringName" />
 			<description>
-				Returns whether this [code]class[/code] is enabled or not.
+				Returns whether this [param class] is enabled or not.
 			</description>
 		</method>
 		<method name="is_parent_class" qualifiers="const">
@@ -188,7 +188,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="inherits" type="StringName" />
 			<description>
-				Returns whether [code]inherits[/code] is an ancestor of [code]class[/code] or not.
+				Returns whether [param inherits] is an ancestor of [param class] or not.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -14,22 +14,22 @@
 			<return type="void" />
 			<param index="0" name="replace" type="bool" />
 			<description>
-				Override this method to define how the selected entry should be inserted. If [code]replace[/code] is true, any existing text should be replaced.
+				Override this method to define how the selected entry should be inserted. If [param replace] is true, any existing text should be replaced.
 			</description>
 		</method>
 		<method name="_filter_code_completion_candidates" qualifiers="virtual const">
 			<return type="Array" />
 			<param index="0" name="candidates" type="Dictionary[]" />
 			<description>
-				Override this method to define what items in [code]candidates[/code] should be displayed.
-				Both [code]candidates[/code] and the return is a [Array] of [Dictionary], see [method get_code_completion_option] for [Dictionary] content.
+				Override this method to define what items in [param candidates] should be displayed.
+				Both [param candidates] and the return is a [Array] of [Dictionary], see [method get_code_completion_option] for [Dictionary] content.
 			</description>
 		</method>
 		<method name="_request_code_completion" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="force" type="bool" />
 			<description>
-				Override this method to define what happens when the user requests code completion. If [code]force[/code] is true, any checks should be bypassed.
+				Override this method to define what happens when the user requests code completion. If [param force] is true, any checks should be bypassed.
 			</description>
 		</method>
 		<method name="add_auto_brace_completion_pair">
@@ -123,7 +123,7 @@
 			<return type="void" />
 			<param index="0" name="replace" type="bool" default="false" />
 			<description>
-				Inserts the selected entry into the text. If [code]replace[/code] is true, any existing text is replaced rather then merged.
+				Inserts the selected entry into the text. If [param replace] is true, any existing text is replaced rather then merged.
 			</description>
 		</method>
 		<method name="do_indent">
@@ -155,7 +155,7 @@
 			<return type="String" />
 			<param index="0" name="open_key" type="String" />
 			<description>
-				Gets the matching auto brace close key for [code]open_key[/code].
+				Gets the matching auto brace close key for [param open_key].
 			</description>
 		</method>
 		<method name="get_bookmarked_lines" qualifiers="const">
@@ -174,7 +174,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Gets the completion option at [code]index[/code]. The return [Dictionary] has the following key-values:
+				Gets the completion option at [param index]. The return [Dictionary] has the following key-values:
 				[code]kind[/code]: [enum CodeCompletionKind]
 				[code]display_text[/code]: Text that is shown on the autocomplete menu.
 				[code]insert_text[/code]: Text that is to be inserted when this item is selected.
@@ -207,7 +207,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<description>
-				If [code]line[/code] [code]column[/code] is in a string or comment, returns the end position of the region. If not or no end could be found, both [Vector2] values will be [code]-1[/code].
+				If [param line] [param column] is in a string or comment, returns the end position of the region. If not or no end could be found, both [Vector2] values will be [code]-1[/code].
 			</description>
 		</method>
 		<method name="get_delimiter_start_key" qualifiers="const">
@@ -222,7 +222,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" />
 			<description>
-				If [code]line[/code] [code]column[/code] is in a string or comment, returns the start position of the region. If not or no start could be found, both [Vector2] values will be [code]-1[/code].
+				If [param line] [param column] is in a string or comment, returns the start position of the region. If not or no start could be found, both [Vector2] values will be [code]-1[/code].
 			</description>
 		</method>
 		<method name="get_executing_lines" qualifiers="const">
@@ -253,28 +253,28 @@
 			<return type="bool" />
 			<param index="0" name="close_key" type="String" />
 			<description>
-				Returns [code]true[/code] if close key [code]close_key[/code] exists.
+				Returns [code]true[/code] if close key [param close_key] exists.
 			</description>
 		</method>
 		<method name="has_auto_brace_completion_open_key" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="open_key" type="String" />
 			<description>
-				Returns [code]true[/code] if open key [code]open_key[/code] exists.
+				Returns [code]true[/code] if open key [param open_key] exists.
 			</description>
 		</method>
 		<method name="has_comment_delimiter" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="start_key" type="String" />
 			<description>
-				Returns [code]true[/code] if comment [code]start_key[/code] exists.
+				Returns [code]true[/code] if comment [param start_key] exists.
 			</description>
 		</method>
 		<method name="has_string_delimiter" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="start_key" type="String" />
 			<description>
-				Returns [code]true[/code] if string [code]start_key[/code] exists.
+				Returns [code]true[/code] if string [param start_key] exists.
 			</description>
 		</method>
 		<method name="indent_lines">
@@ -288,7 +288,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" default="-1" />
 			<description>
-				Returns delimiter index if [code]line[/code] [code]column[/code] is in a comment. If [code]column[/code] is not provided, will return delimiter index if the entire [code]line[/code] is a comment. Otherwise [code]-1[/code].
+				Returns delimiter index if [param line] [param column] is in a comment. If [param column] is not provided, will return delimiter index if the entire [param line] is a comment. Otherwise [code]-1[/code].
 			</description>
 		</method>
 		<method name="is_in_string" qualifiers="const">
@@ -296,7 +296,7 @@
 			<param index="0" name="line" type="int" />
 			<param index="1" name="column" type="int" default="-1" />
 			<description>
-				Returns the delimiter index if [code]line[/code] [code]column[/code] is in a string. If [code]column[/code] is not provided, will return the delimiter index if the entire [code]line[/code] is a string. Otherwise [code]-1[/code].
+				Returns the delimiter index if [param line] [param column] is in a string. If [param column] is not provided, will return the delimiter index if the entire [param line] is a string. Otherwise [code]-1[/code].
 			</description>
 		</method>
 		<method name="is_line_bookmarked" qualifiers="const">
@@ -331,21 +331,21 @@
 			<return type="void" />
 			<param index="0" name="start_key" type="String" />
 			<description>
-				Removes the comment delimiter with [code]start_key[/code].
+				Removes the comment delimiter with [param start_key].
 			</description>
 		</method>
 		<method name="remove_string_delimiter">
 			<return type="void" />
 			<param index="0" name="start_key" type="String" />
 			<description>
-				Removes the string delimiter with [code]start_key[/code].
+				Removes the string delimiter with [param start_key].
 			</description>
 		</method>
 		<method name="request_code_completion">
 			<return type="void" />
 			<param index="0" name="force" type="bool" default="false" />
 			<description>
-				Emits [signal code_completion_requested], if [code]force[/code] is true will bypass all checks. Otherwise will check that the caret is in a word or in front of a prefix. Will ignore the request if all current options are of type file path, node path or signal.
+				Emits [signal code_completion_requested], if [param force] is true will bypass all checks. Otherwise will check that the caret is in a word or in front of a prefix. Will ignore the request if all current options are of type file path, node path or signal.
 			</description>
 		</method>
 		<method name="set_code_completion_selected_index">
@@ -430,7 +430,7 @@
 			<return type="void" />
 			<param index="0" name="force" type="bool" />
 			<description>
-				Submits all completion options added with [method add_code_completion_option]. Will try to force the autoccomplete menu to popup, if [code]force[/code] is [code]true[/code].
+				Submits all completion options added with [method add_code_completion_option]. Will try to force the autoccomplete menu to popup, if [param force] is [code]true[/code].
 				[b]Note:[/b] This will replace all current candidates.
 			</description>
 		</method>

--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -16,7 +16,7 @@
 			<param index="1" name="event" type="InputEvent" />
 			<param index="2" name="shape_idx" type="int" />
 			<description>
-				Accepts unhandled [InputEvent]s. [code]shape_idx[/code] is the child index of the clicked [Shape2D]. Connect to the [code]input_event[/code] signal to easily pick up these events.
+				Accepts unhandled [InputEvent]s. [param shape_idx] is the child index of the clicked [Shape2D]. Connect to the [code]input_event[/code] signal to easily pick up these events.
 				[b]Note:[/b] [method _input_event] requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</method>
@@ -31,14 +31,14 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_layer] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_layer] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_collision_mask_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
@@ -51,7 +51,7 @@
 			<return type="float" />
 			<param index="0" name="owner_id" type="int" />
 			<description>
-				Returns the [code]one_way_collision_margin[/code] of the shape owner identified by given [code]owner_id[/code].
+				Returns the [code]one_way_collision_margin[/code] of the shape owner identified by given [param owner_id].
 			</description>
 		</method>
 		<method name="get_shape_owners">
@@ -86,7 +86,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_layer], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member collision_layer], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_collision_mask_value">
@@ -94,7 +94,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="shape_find_owner" qualifiers="const">
@@ -177,7 +177,7 @@
 			<param index="0" name="owner_id" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				If [code]enable[/code] is [code]true[/code], collisions for the shape owner originating from this [CollisionObject2D] will not be reported to collided with [CollisionObject2D]s.
+				If [param enable] is [code]true[/code], collisions for the shape owner originating from this [CollisionObject2D] will not be reported to collided with [CollisionObject2D]s.
 			</description>
 		</method>
 		<method name="shape_owner_set_one_way_collision_margin">
@@ -185,7 +185,7 @@
 			<param index="0" name="owner_id" type="int" />
 			<param index="1" name="margin" type="float" />
 			<description>
-				Sets the [code]one_way_collision_margin[/code] of the shape owner identified by given [code]owner_id[/code] to [code]margin[/code] pixels.
+				Sets the [code]one_way_collision_margin[/code] of the shape owner identified by given [param owner_id] to [param margin] pixels.
 			</description>
 		</method>
 		<method name="shape_owner_set_transform">
@@ -237,13 +237,13 @@
 		<signal name="mouse_shape_entered">
 			<param index="0" name="shape_idx" type="int" />
 			<description>
-				Emitted when the mouse pointer enters any of this object's shapes or moves from one shape to another. [code]shape_idx[/code] is the child index of the newly entered [Shape2D]. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
+				Emitted when the mouse pointer enters any of this object's shapes or moves from one shape to another. [param shape_idx] is the child index of the newly entered [Shape2D]. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</signal>
 		<signal name="mouse_shape_exited">
 			<param index="0" name="shape_idx" type="int" />
 			<description>
-				Emitted when the mouse pointer exits any of this object's shapes. [code]shape_idx[/code] is the child index of the exited [Shape2D]. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
+				Emitted when the mouse pointer exits any of this object's shapes. [param shape_idx] is the child index of the exited [Shape2D]. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -17,7 +17,7 @@
 			<param index="3" name="normal" type="Vector3" />
 			<param index="4" name="shape_idx" type="int" />
 			<description>
-				Receives unhandled [InputEvent]s. [code]position[/code] is the location in world space of the mouse pointer on the surface of the shape with index [code]shape_idx[/code] and [code]normal[/code] is the normal vector of the surface at that point. Connect to the [signal input_event] signal to easily pick up these events.
+				Receives unhandled [InputEvent]s. [param position] is the location in world space of the mouse pointer on the surface of the shape with index [param shape_idx] and [param normal] is the normal vector of the surface at that point. Connect to the [signal input_event] signal to easily pick up these events.
 				[b]Note:[/b] [method _input_event] requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</method>
@@ -32,14 +32,14 @@
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_layer] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_layer] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_collision_mask_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
+				Returns whether or not the specified layer of the [member collision_mask] is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">
@@ -73,7 +73,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_layer], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member collision_layer], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_collision_mask_value">
@@ -81,7 +81,7 @@
 			<param index="0" name="layer_number" type="int" />
 			<param index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member collision_mask], given a [code]layer_number[/code] between 1 and 32.
+				Based on [param value], enables or disables the specified layer in the [member collision_mask], given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
 		<method name="shape_find_owner" qualifiers="const">
@@ -195,7 +195,7 @@
 			<param index="3" name="normal" type="Vector3" />
 			<param index="4" name="shape_idx" type="int" />
 			<description>
-				Emitted when the object receives an unhandled [InputEvent]. [code]position[/code] is the location in world space of the mouse pointer on the surface of the shape with index [code]shape_idx[/code] and [code]normal[/code] is the normal vector of the surface at that point.
+				Emitted when the object receives an unhandled [InputEvent]. [param position] is the location in world space of the mouse pointer on the surface of the shape with index [param shape_idx] and [param normal] is the normal vector of the surface at that point.
 			</description>
 		</signal>
 		<signal name="mouse_entered">

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -57,7 +57,7 @@
 			<param index="0" name="code" type="String" />
 			<param index="1" name="alpha" type="float" />
 			<description>
-				Constructs a [Color] either from an HTML color code or from a standardized color name, with [code]alpha[/code] on the range of 0 to 1. Supported color names are the same as the constants.
+				Constructs a [Color] either from an HTML color code or from a standardized color name, with [param alpha] on the range of 0 to 1. Supported color names are the same as the constants.
 			</description>
 		</constructor>
 		<constructor name="Color">
@@ -121,7 +121,7 @@
 			<param index="0" name="min" type="Color" default="Color(0, 0, 0, 0)" />
 			<param index="1" name="max" type="Color" default="Color(1, 1, 1, 1)" />
 			<description>
-				Returns a new color with all components clamped between the components of [code]min[/code] and [code]max[/code], by running [method @GlobalScope.clamp] on each component.
+				Returns a new color with all components clamped between the components of [param min] and [param max], by running [method @GlobalScope.clamp] on each component.
 			</description>
 		</method>
 		<method name="darkened" qualifiers="const">
@@ -154,7 +154,7 @@
 			<param index="2" name="v" type="float" />
 			<param index="3" name="alpha" type="float" default="1.0" />
 			<description>
-				Constructs a color from an [url=https://en.wikipedia.org/wiki/HSL_and_HSV]HSV profile[/url]. [code]h[/code] (hue), [code]s[/code] (saturation), and [code]v[/code] (value) are typically between 0 and 1.
+				Constructs a color from an [url=https://en.wikipedia.org/wiki/HSL_and_HSV]HSV profile[/url]. [param h] (hue), [param s] (saturation), and [param v] (value) are typically between 0 and 1.
 				[codeblocks]
 				[gdscript]
 				var color = Color.from_hsv(0.58, 0.5, 0.79, 0.8)
@@ -172,7 +172,7 @@
 			<param index="2" name="l" type="float" />
 			<param index="3" name="alpha" type="float" default="1.0" />
 			<description>
-				Constructs a color from an [url=https://bottosson.github.io/posts/colorpicker/]OK HSL profile[/url]. [code]h[/code] (hue), [code]s[/code] (saturation), and [code]v[/code] (value) are typically between 0 and 1.
+				Constructs a color from an [url=https://bottosson.github.io/posts/colorpicker/]OK HSL profile[/url]. [param h] (hue), [param s] (saturation), and [param l] (lightness) are typically between 0 and 1.
 				[codeblocks]
 				[gdscript]
 				var color = Color.from_ok_hsl(0.58, 0.5, 0.79, 0.8)
@@ -237,9 +237,9 @@
 			<return type="Color" />
 			<param index="0" name="rgba" type="String" />
 			<description>
-				Returns a new color from [code]rgba[/code], an HTML hexadecimal color string. [code]rgba[/code] is not case sensitive, and may be prefixed with a '#' character.
-				[code]rgba[/code] must be a valid three-digit or six-digit hexadecimal color string, and may contain an alpha channel value. If [code]rgba[/code] does not contain an alpha channel value, an alpha channel value of 1.0 is applied.
-				If [code]rgba[/code] is invalid a Color(0.0, 0.0, 0.0, 1.0) is returned.
+				Returns a new color from [param rgba], an HTML hexadecimal color string. [param rgba] is not case sensitive, and may be prefixed with a '#' character.
+				[param rgba] must be a valid three-digit or six-digit hexadecimal color string, and may contain an alpha channel value. If [param rgba] does not contain an alpha channel value, an alpha channel value of 1.0 is applied.
+				If [param rgba] is invalid a Color(0.0, 0.0, 0.0, 1.0) is returned.
 				[b]Note:[/b] This method is not implemented in C#, but the same functionality is provided in the class constructor.
 				[codeblocks]
 				[gdscript]
@@ -257,7 +257,7 @@
 			<return type="bool" />
 			<param index="0" name="color" type="String" />
 			<description>
-				Returns [code]true[/code] if [code]color[/code] is a valid HTML hexadecimal color string. [code]color[/code] is not case sensitive, and may be prefixed with a '#' character.
+				Returns [code]true[/code] if [param color] is a valid HTML hexadecimal color string. [param color] is not case sensitive, and may be prefixed with a '#' character.
 				For a string to be valid it must be three-digit or six-digit hexadecimal, and may contain an alpha channel value.
 				[codeblocks]
 				[gdscript]
@@ -299,7 +299,7 @@
 			<return type="bool" />
 			<param index="0" name="to" type="Color" />
 			<description>
-				Returns [code]true[/code] if this color and [code]color[/code] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
+				Returns [code]true[/code] if this color and [param to] are approximately equal, by running [method @GlobalScope.is_equal_approx] on each component.
 			</description>
 		</method>
 		<method name="lerp" qualifiers="const">
@@ -307,7 +307,7 @@
 			<param index="0" name="to" type="Color" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the linear interpolation with another color. The interpolation factor [code]weight[/code] is between 0 and 1.
+				Returns the linear interpolation with another color. The interpolation factor [param weight] is between 0 and 1.
 				[codeblocks]
 				[gdscript]
 				var c1 = Color(1.0, 0.0, 0.0)
@@ -420,7 +420,7 @@
 			<param index="0" name="with_alpha" type="bool" default="true" />
 			<description>
 				Returns the color converted to an HTML hexadecimal color string in RGBA format (ex: [code]ff34f822[/code]).
-				Setting [code]with_alpha[/code] to [code]false[/code] excludes alpha from the hexadecimal string (and uses RGB instead of RGBA format).
+				Setting [param with_alpha] to [code]false[/code] excludes alpha from the hexadecimal string (and uses RGB instead of RGBA format).
 				[codeblocks]
 				[gdscript]
 				var color = Color(1, 1, 1, 0.5)

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -132,7 +132,7 @@
 			<param index="1" name="key" type="String" />
 			<param index="2" name="default" type="Variant" default="null" />
 			<description>
-				Returns the current value for the specified section and key. If either the section or the key do not exist, the method returns the fallback [code]default[/code] value. If [code]default[/code] is not specified or set to [code]null[/code], an error is also raised.
+				Returns the current value for the specified section and key. If either the section or the key do not exist, the method returns the fallback [param default] value. If [param default] is not specified or set to [code]null[/code], an error is also raised.
 			</description>
 		</method>
 		<method name="has_section" qualifiers="const">
@@ -165,7 +165,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="key" type="PackedByteArray" />
 			<description>
-				Loads the encrypted config file specified as a parameter, using the provided [code]key[/code] to decrypt it. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
+				Loads the encrypted config file specified as a parameter, using the provided [param key] to decrypt it. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>
@@ -174,7 +174,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="password" type="String" />
 			<description>
-				Loads the encrypted config file specified as a parameter, using the provided [code]password[/code] to decrypt it. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
+				Loads the encrypted config file specified as a parameter, using the provided [param password] to decrypt it. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>
@@ -199,7 +199,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="key" type="PackedByteArray" />
 			<description>
-				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [code]key[/code] to encrypt it. The output file uses an INI-style structure.
+				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param key] to encrypt it. The output file uses an INI-style structure.
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>
@@ -208,7 +208,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="password" type="String" />
 			<description>
-				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [code]password[/code] to encrypt it. The output file uses an INI-style structure.
+				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param password] to encrypt it. The output file uses an INI-style structure.
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -27,7 +27,7 @@
 			<param index="0" name="at_position" type="Vector2" />
 			<param index="1" name="data" type="Variant" />
 			<description>
-				Godot calls this method to test if [code]data[/code] from a control's [method _get_drag_data] can be dropped at [code]position[/code]. [code]position[/code] is local to this control.
+				Godot calls this method to test if [param data] from a control's [method _get_drag_data] can be dropped at [param at_position]. [param at_position] is local to this control.
 				This method should only be used to test the data. Process the data in [method _drop_data].
 				[codeblocks]
 				[gdscript]
@@ -52,7 +52,7 @@
 			<param index="0" name="at_position" type="Vector2" />
 			<param index="1" name="data" type="Variant" />
 			<description>
-				Godot calls this method to pass you the [code]data[/code] from a control's [method _get_drag_data] result. Godot first calls [method _can_drop_data] to test if [code]data[/code] is allowed to drop at [code]position[/code] where [code]position[/code] is local to this control.
+				Godot calls this method to pass you the [param data] from a control's [method _get_drag_data] result. Godot first calls [method _can_drop_data] to test if [param data] is allowed to drop at [param at_position] where [param at_position] is local to this control.
 				[codeblocks]
 				[gdscript]
 				func _can_drop_data(position, data):
@@ -77,7 +77,7 @@
 			<return type="Variant" />
 			<param index="0" name="at_position" type="Vector2" />
 			<description>
-				Godot calls this method to get data that can be dragged and dropped onto controls that expect drop data. Returns [code]null[/code] if there is no data to drag. Controls that want to receive drop data should implement [method _can_drop_data] and [method _drop_data]. [code]position[/code] is local to this control. Drag may be forced with [method force_drag].
+				Godot calls this method to get data that can be dragged and dropped onto controls that expect drop data. Returns [code]null[/code] if there is no data to drag. Controls that want to receive drop data should implement [method _can_drop_data] and [method _drop_data]. [param at_position] is local to this control. Drag may be forced with [method force_drag].
 				A preview that will follow the mouse that should represent the data can be set with [method set_drag_preview]. A good time to set the preview is in this method.
 				[codeblocks]
 				[gdscript]
@@ -145,7 +145,7 @@
 			<return type="bool" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Virtual method to be implemented by the user. Returns whether the given [code]point[/code] is inside this control.
+				Virtual method to be implemented by the user. Returns whether the given [param position] is inside this control.
 				If not overridden, default behavior is checking if the point is within control's Rect.
 				[b]Note:[/b] If you want to check if a point is inside the control, you can use [code]get_rect().has_point(point)[/code].
 			</description>
@@ -154,7 +154,7 @@
 			<return type="Object" />
 			<param index="0" name="for_text" type="String" />
 			<description>
-				Virtual method to be implemented by the user. Returns a [Control] node that should be used as a tooltip instead of the default one. The [code]for_text[/code] includes the contents of the [member hint_tooltip] property.
+				Virtual method to be implemented by the user. Returns a [Control] node that should be used as a tooltip instead of the default one. The [param for_text] includes the contents of the [member hint_tooltip] property.
 				The returned node must be of type [Control] or Control-derived. It can have child nodes of any type. It is freed when the tooltip disappears, so make sure you always provide a new instance (if you want to use a pre-existing node from your scene tree, you can duplicate it and pass the duplicated instance). When [code]null[/code] or a non-Control node is returned, the default tooltip will be used instead.
 				The returned node will be added as child to a [PopupPanel], so you should only provide the contents of that panel. That [PopupPanel] can be themed using [method Theme.set_stylebox] for the type [code]"TooltipPanel"[/code] (see [member hint_tooltip] for an example).
 				[b]Note:[/b] The tooltip is shrunk to minimal size. If you want to ensure it's fully visible, you might want to set its [member custom_minimum_size] to some non-zero value.
@@ -201,7 +201,7 @@
 			<param index="1" name="text" type="String" />
 			<description>
 				User defined BiDi algorithm override function.
-				Returns [code]Array[/code] of [code]Vector2i[/code] text ranges, in the left-to-right order. Ranges should cover full source [code]text[/code] without overlaps. BiDi algorithm will be used on each range separately.
+				Returns [code]Array[/code] of [code]Vector2i[/code] text ranges, in the left-to-right order. Ranges should cover full source [param text] without overlaps. BiDi algorithm will be used on each range separately.
 			</description>
 		</method>
 		<method name="accept_event">
@@ -215,7 +215,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="color" type="Color" />
 			<description>
-				Creates a local override for a theme [Color] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_color_override].
+				Creates a local override for a theme [Color] with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_color_override].
 				See also [method get_theme_color].
 				[b]Example of overriding a label's color and resetting it later:[/b]
 				[codeblocks]
@@ -243,7 +243,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="constant" type="int" />
 			<description>
-				Creates a local override for a theme constant with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_constant_override].
+				Creates a local override for a theme constant with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_constant_override].
 				See also [method get_theme_constant].
 			</description>
 		</method>
@@ -252,7 +252,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="font" type="Font" />
 			<description>
-				Creates a local override for a theme [Font] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_font_override].
+				Creates a local override for a theme [Font] with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_font_override].
 				See also [method get_theme_font].
 			</description>
 		</method>
@@ -261,7 +261,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="font_size" type="int" />
 			<description>
-				Creates a local override for a theme font size with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_font_size_override].
+				Creates a local override for a theme font size with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_font_size_override].
 				See also [method get_theme_font_size].
 			</description>
 		</method>
@@ -270,7 +270,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="texture" type="Texture2D" />
 			<description>
-				Creates a local override for a theme icon with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_icon_override].
+				Creates a local override for a theme icon with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_icon_override].
 				See also [method get_theme_icon].
 			</description>
 		</method>
@@ -279,7 +279,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="stylebox" type="StyleBox" />
 			<description>
-				Creates a local override for a theme [StyleBox] with the specified [code]name[/code]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_stylebox_override].
+				Creates a local override for a theme [StyleBox] with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_stylebox_override].
 				See also [method get_theme_stylebox].
 				[b]Example of modifying a property in a StyleBox by duplicating it:[/b]
 				[codeblocks]
@@ -337,7 +337,7 @@
 			<param index="0" name="data" type="Variant" />
 			<param index="1" name="preview" type="Control" />
 			<description>
-				Forces drag and bypasses [method _get_drag_data] and [method set_drag_preview] by passing [code]data[/code] and [code]preview[/code]. Drag will start even if the mouse is neither over nor pressed on this control.
+				Forces drag and bypasses [method _get_drag_data] and [method set_drag_preview] by passing [param data] and [param preview]. Drag will start even if the mouse is neither over nor pressed on this control.
 				The methods [method _can_drop_data] and [method _drop_data] must be implemented on controls that want to receive drop data.
 			</description>
 		</method>
@@ -435,7 +435,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns a [Color] from the first matching [Theme] in the tree if that [Theme] has a color item with the specified [code]name[/code] and [code]theme_type[/code]. If [code]theme_type[/code] is omitted the class name of the current control is used as the type, or [member theme_type_variation] if it is defined. If the type is a class name its parent classes are also checked, in order of inheritance. If the type is a variation its base types are checked, in order of dependency, then the control's class name and its parent classes are checked.
+				Returns a [Color] from the first matching [Theme] in the tree if that [Theme] has a color item with the specified [param name] and [param theme_type]. If [param theme_type] is omitted the class name of the current control is used as the type, or [member theme_type_variation] if it is defined. If the type is a class name its parent classes are also checked, in order of inheritance. If the type is a variation its base types are checked, in order of dependency, then the control's class name and its parent classes are checked.
 				For the current control its local overrides are considered first (see [method add_theme_color_override]), then its assigned [member theme]. After the current control, each parent control and its assigned [member theme] are considered; controls without a [member theme] assigned are skipped. If no matching [Theme] is found in the tree, a custom project [Theme] (see [member ProjectSettings.gui/theme/custom]) and the default [Theme] are used.
 				[codeblocks]
 				[gdscript]
@@ -462,7 +462,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns a constant from the first matching [Theme] in the tree if that [Theme] has a constant item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns a constant from the first matching [Theme] in the tree if that [Theme] has a constant item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -492,7 +492,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns a [Font] from the first matching [Theme] in the tree if that [Theme] has a font item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns a [Font] from the first matching [Theme] in the tree if that [Theme] has a font item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -501,7 +501,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns a font size from the first matching [Theme] in the tree if that [Theme] has a font size item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns a font size from the first matching [Theme] in the tree if that [Theme] has a font size item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -510,7 +510,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns an icon from the first matching [Theme] in the tree if that [Theme] has an icon item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns an icon from the first matching [Theme] in the tree if that [Theme] has an icon item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -519,7 +519,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns a [StyleBox] from the first matching [Theme] in the tree if that [Theme] has a stylebox item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns a [StyleBox] from the first matching [Theme] in the tree if that [Theme] has a stylebox item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -565,7 +565,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a color item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a color item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -573,7 +573,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if there is a local override for a theme [Color] with the specified [code]name[/code] in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme [Color] with the specified [param name] in this [Control] node.
 				See [method add_theme_color_override].
 			</description>
 		</method>
@@ -582,7 +582,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a constant item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a constant item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -590,7 +590,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if there is a local override for a theme constant with the specified [code]name[/code] in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme constant with the specified [param name] in this [Control] node.
 				See [method add_theme_constant_override].
 			</description>
 		</method>
@@ -599,7 +599,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -607,7 +607,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if there is a local override for a theme [Font] with the specified [code]name[/code] in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme [Font] with the specified [param name] in this [Control] node.
 				See [method add_theme_font_override].
 			</description>
 		</method>
@@ -616,7 +616,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font size item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a font size item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -624,7 +624,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if there is a local override for a theme font size with the specified [code]name[/code] in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme font size with the specified [param name] in this [Control] node.
 				See [method add_theme_font_size_override].
 			</description>
 		</method>
@@ -633,7 +633,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if there is a matching [Theme] in the tree that has an icon item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has an icon item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -641,7 +641,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if there is a local override for a theme icon with the specified [code]name[/code] in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme icon with the specified [param name] in this [Control] node.
 				See [method add_theme_icon_override].
 			</description>
 		</method>
@@ -650,7 +650,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="theme_type" type="StringName" default="&quot;&quot;" />
 			<description>
-				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a stylebox item with the specified [code]name[/code] and [code]theme_type[/code].
+				Returns [code]true[/code] if there is a matching [Theme] in the tree that has a stylebox item with the specified [param name] and [param theme_type].
 				See [method get_theme_color] for details.
 			</description>
 		</method>
@@ -658,7 +658,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if there is a local override for a theme [StyleBox] with the specified [code]name[/code] in this [Control] node.
+				Returns [code]true[/code] if there is a local override for a theme [StyleBox] with the specified [param name] in this [Control] node.
 				See [method add_theme_stylebox_override].
 			</description>
 		</method>
@@ -685,42 +685,42 @@
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes a local override for a theme [Color] with the specified [code]name[/code] previously added by [method add_theme_color_override] or via the Inspector dock.
+				Removes a local override for a theme [Color] with the specified [param name] previously added by [method add_theme_color_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_constant_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes a local override for a theme constant with the specified [code]name[/code] previously added by [method add_theme_constant_override] or via the Inspector dock.
+				Removes a local override for a theme constant with the specified [param name] previously added by [method add_theme_constant_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_font_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes a local override for a theme [Font] with the specified [code]name[/code] previously added by [method add_theme_font_override] or via the Inspector dock.
+				Removes a local override for a theme [Font] with the specified [param name] previously added by [method add_theme_font_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_font_size_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes a local override for a theme font size with the specified [code]name[/code] previously added by [method add_theme_font_size_override] or via the Inspector dock.
+				Removes a local override for a theme font size with the specified [param name] previously added by [method add_theme_font_size_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_icon_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes a local override for a theme icon with the specified [code]name[/code] previously added by [method add_theme_icon_override] or via the Inspector dock.
+				Removes a local override for a theme icon with the specified [param name] previously added by [method add_theme_icon_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="remove_theme_stylebox_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes a local override for a theme [StyleBox] with the specified [code]name[/code] previously added by [method add_theme_stylebox_override] or via the Inspector dock.
+				Removes a local override for a theme [StyleBox] with the specified [param name] previously added by [method add_theme_stylebox_override] or via the Inspector dock.
 			</description>
 		</method>
 		<method name="reset_size">
@@ -736,9 +736,9 @@
 			<param index="2" name="keep_offset" type="bool" default="false" />
 			<param index="3" name="push_opposite_anchor" type="bool" default="true" />
 			<description>
-				Sets the anchor for the specified [enum Side] to [code]anchor[/code]. A setter method for [member anchor_bottom], [member anchor_left], [member anchor_right] and [member anchor_top].
-				If [code]keep_offset[/code] is [code]true[/code], offsets aren't updated after this operation.
-				If [code]push_opposite_anchor[/code] is [code]true[/code] and the opposite anchor overlaps this anchor, the opposite one will have its value overridden. For example, when setting left anchor to 1 and the right anchor has value of 0.5, the right anchor will also get value of 1. If [code]push_opposite_anchor[/code] was [code]false[/code], the left anchor would get value 0.5.
+				Sets the anchor for the specified [enum Side] to [param anchor]. A setter method for [member anchor_bottom], [member anchor_left], [member anchor_right] and [member anchor_top].
+				If [param keep_offset] is [code]true[/code], offsets aren't updated after this operation.
+				If [param push_opposite_anchor] is [code]true[/code] and the opposite anchor overlaps this anchor, the opposite one will have its value overridden. For example, when setting left anchor to 1 and the right anchor has value of 0.5, the right anchor will also get value of 1. If [param push_opposite_anchor] was [code]false[/code], the left anchor would get value 0.5.
 			</description>
 		</method>
 		<method name="set_anchor_and_offset">
@@ -765,8 +765,8 @@
 			<param index="0" name="preset" type="int" enum="Control.LayoutPreset" />
 			<param index="1" name="keep_offsets" type="bool" default="false" />
 			<description>
-				Sets the anchors to a [code]preset[/code] from [enum Control.LayoutPreset] enum. This is the code equivalent to using the Layout menu in the 2D editor.
-				If [code]keep_offsets[/code] is [code]true[/code], control's position will also be updated.
+				Sets the anchors to a [param preset] from [enum Control.LayoutPreset] enum. This is the code equivalent to using the Layout menu in the 2D editor.
+				If [param keep_offsets] is [code]true[/code], control's position will also be updated.
 			</description>
 		</method>
 		<method name="set_begin">
@@ -780,7 +780,7 @@
 			<return type="void" />
 			<param index="0" name="target" type="Object" />
 			<description>
-				Forwards the handling of this control's drag and drop to [code]target[/code] object.
+				Forwards the handling of this control's drag and drop to [param target] object.
 				Forwarding can be implemented in the target object similar to the methods [method _get_drag_data], [method _can_drop_data], and [method _drop_data] but with two differences:
 				1. The function name must be suffixed with [b]_fw[/b]
 				2. The function must take an extra argument that is the control doing the forwarding
@@ -887,7 +887,7 @@
 			<param index="0" name="side" type="int" enum="Side" />
 			<param index="1" name="neighbor" type="NodePath" />
 			<description>
-				Sets the anchor for the specified [enum Side] to the [Control] at [code]neighbor[/code] node path. A setter method for [member focus_neighbor_bottom], [member focus_neighbor_left], [member focus_neighbor_right] and [member focus_neighbor_top].
+				Sets the anchor for the specified [enum Side] to the [Control] at [param neighbor] node path. A setter method for [member focus_neighbor_bottom], [member focus_neighbor_left], [member focus_neighbor_right] and [member focus_neighbor_top].
 			</description>
 		</method>
 		<method name="set_global_position">
@@ -895,8 +895,8 @@
 			<param index="0" name="position" type="Vector2" />
 			<param index="1" name="keep_offsets" type="bool" default="false" />
 			<description>
-				Sets the [member global_position] to given [code]position[/code].
-				If [code]keep_offsets[/code] is [code]true[/code], control's anchors will be updated instead of offsets.
+				Sets the [member global_position] to given [param position].
+				If [param keep_offsets] is [code]true[/code], control's anchors will be updated instead of offsets.
 			</description>
 		</method>
 		<method name="set_offset">
@@ -904,7 +904,7 @@
 			<param index="0" name="side" type="int" enum="Side" />
 			<param index="1" name="offset" type="float" />
 			<description>
-				Sets the offset for the specified [enum Side] to [code]offset[/code]. A setter method for [member offset_bottom], [member offset_left], [member offset_right] and [member offset_top].
+				Sets the offset for the specified [enum Side] to [param offset]. A setter method for [member offset_bottom], [member offset_left], [member offset_right] and [member offset_top].
 			</description>
 		</method>
 		<method name="set_offsets_preset">
@@ -913,9 +913,9 @@
 			<param index="1" name="resize_mode" type="int" enum="Control.LayoutPresetMode" default="0" />
 			<param index="2" name="margin" type="int" default="0" />
 			<description>
-				Sets the offsets to a [code]preset[/code] from [enum Control.LayoutPreset] enum. This is the code equivalent to using the Layout menu in the 2D editor.
-				Use parameter [code]resize_mode[/code] with constants from [enum Control.LayoutPresetMode] to better determine the resulting size of the [Control]. Constant size will be ignored if used with presets that change size, e.g. [code]PRESET_LEFT_WIDE[/code].
-				Use parameter [code]margin[/code] to determine the gap between the [Control] and the edges.
+				Sets the offsets to a [param preset] from [enum Control.LayoutPreset] enum. This is the code equivalent to using the Layout menu in the 2D editor.
+				Use parameter [param resize_mode] with constants from [enum Control.LayoutPresetMode] to better determine the resulting size of the [Control]. Constant size will be ignored if used with presets that change size, e.g. [code]PRESET_LEFT_WIDE[/code].
+				Use parameter [param margin] to determine the gap between the [Control] and the edges.
 			</description>
 		</method>
 		<method name="set_position">
@@ -923,8 +923,8 @@
 			<param index="0" name="position" type="Vector2" />
 			<param index="1" name="keep_offsets" type="bool" default="false" />
 			<description>
-				Sets the [member position] to given [code]position[/code].
-				If [code]keep_offsets[/code] is [code]true[/code], control's anchors will be updated instead of offsets.
+				Sets the [member position] to given [param position].
+				If [param keep_offsets] is [code]true[/code], control's anchors will be updated instead of offsets.
 			</description>
 		</method>
 		<method name="set_size">
@@ -933,7 +933,7 @@
 			<param index="1" name="keep_offsets" type="bool" default="false" />
 			<description>
 				Sets the size (see [member size]).
-				If [code]keep_offsets[/code] is [code]true[/code], control's anchors will be updated instead of offsets.
+				If [param keep_offsets] is [code]true[/code], control's anchors will be updated instead of offsets.
 			</description>
 		</method>
 		<method name="update_minimum_size">
@@ -946,7 +946,7 @@
 			<return type="void" />
 			<param index="0" name="position" type="Vector2" />
 			<description>
-				Moves the mouse cursor to [code]position[/code], relative to [member position] of this [Control].
+				Moves the mouse cursor to [param position], relative to [member position] of this [Control].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Crypto.xml
+++ b/doc/classes/Crypto.xml
@@ -86,7 +86,7 @@
 			<param index="0" name="key" type="CryptoKey" />
 			<param index="1" name="ciphertext" type="PackedByteArray" />
 			<description>
-				Decrypt the given [code]ciphertext[/code] with the provided private [code]key[/code].
+				Decrypt the given [param ciphertext] with the provided private [param key].
 				[b]Note:[/b] The maximum size of accepted ciphertext is limited by the key size.
 			</description>
 		</method>
@@ -95,7 +95,7 @@
 			<param index="0" name="key" type="CryptoKey" />
 			<param index="1" name="plaintext" type="PackedByteArray" />
 			<description>
-				Encrypt the given [code]plaintext[/code] with the provided public [code]key[/code].
+				Encrypt the given [param plaintext] with the provided public [param key].
 				[b]Note:[/b] The maximum size of accepted plaintext is limited by the key size.
 			</description>
 		</method>
@@ -103,7 +103,7 @@
 			<return type="PackedByteArray" />
 			<param index="0" name="size" type="int" />
 			<description>
-				Generates a [PackedByteArray] of cryptographically secure random bytes with given [code]size[/code].
+				Generates a [PackedByteArray] of cryptographically secure random bytes with given [param size].
 			</description>
 		</method>
 		<method name="generate_rsa">
@@ -120,7 +120,7 @@
 			<param index="2" name="not_before" type="String" default="&quot;20140101000000&quot;" />
 			<param index="3" name="not_after" type="String" default="&quot;20340101000000&quot;" />
 			<description>
-				Generates a self-signed [X509Certificate] from the given [CryptoKey] and [code]issuer_name[/code]. The certificate validity will be defined by [code]not_before[/code] and [code]not_after[/code] (first valid date and last valid date). The [code]issuer_name[/code] must contain at least "CN=" (common name, i.e. the domain name), "O=" (organization, i.e. your company name), "C=" (country, i.e. 2 lettered ISO-3166 code of the country the organization is based in).
+				Generates a self-signed [X509Certificate] from the given [CryptoKey] and [param issuer_name]. The certificate validity will be defined by [param not_before] and [param not_after] (first valid date and last valid date). The [param issuer_name] must contain at least "CN=" (common name, i.e. the domain name), "O=" (organization, i.e. your company name), "C=" (country, i.e. 2 lettered ISO-3166 code of the country the organization is based in).
 				A small example to generate an RSA key and a X509 self-signed certificate.
 				[codeblocks]
 				[gdscript]
@@ -146,7 +146,7 @@
 			<param index="1" name="key" type="PackedByteArray" />
 			<param index="2" name="msg" type="PackedByteArray" />
 			<description>
-				Generates an [url=https://en.wikipedia.org/wiki/HMAC]HMAC[/url] digest of [code]msg[/code] using [code]key[/code]. The [code]hash_type[/code] parameter is the hashing algorithm that is used for the inner and outer hashes.
+				Generates an [url=https://en.wikipedia.org/wiki/HMAC]HMAC[/url] digest of [param msg] using [param key]. The [param hash_type] parameter is the hashing algorithm that is used for the inner and outer hashes.
 				Currently, only [constant HashingContext.HASH_SHA256] and [constant HashingContext.HASH_SHA1] are supported.
 			</description>
 		</method>
@@ -156,7 +156,7 @@
 			<param index="1" name="hash" type="PackedByteArray" />
 			<param index="2" name="key" type="CryptoKey" />
 			<description>
-				Sign a given [code]hash[/code] of type [code]hash_type[/code] with the provided private [code]key[/code].
+				Sign a given [param hash] of type [param hash_type] with the provided private [param key].
 			</description>
 		</method>
 		<method name="verify">
@@ -166,7 +166,7 @@
 			<param index="2" name="signature" type="PackedByteArray" />
 			<param index="3" name="key" type="CryptoKey" />
 			<description>
-				Verify that a given [code]signature[/code] for [code]hash[/code] of type [code]hash_type[/code] against the provided public [code]key[/code].
+				Verify that a given [param signature] for [param hash] of type [param hash_type] against the provided public [param key].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/CryptoKey.xml
+++ b/doc/classes/CryptoKey.xml
@@ -21,8 +21,8 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="public_only" type="bool" default="false" />
 			<description>
-				Loads a key from [code]path[/code]. If [code]public_only[/code] is [code]true[/code], only the public key will be loaded.
-				[b]Note:[/b] [code]path[/code] should be a "*.pub" file if [code]public_only[/code] is [code]true[/code], a "*.key" file otherwise.
+				Loads a key from [param path]. If [param public_only] is [code]true[/code], only the public key will be loaded.
+				[b]Note:[/b] [param path] should be a "*.pub" file if [param public_only] is [code]true[/code], a "*.key" file otherwise.
 			</description>
 		</method>
 		<method name="load_from_string">
@@ -30,7 +30,7 @@
 			<param index="0" name="string_key" type="String" />
 			<param index="1" name="public_only" type="bool" default="false" />
 			<description>
-				Loads a key from the given [code]string[/code]. If [code]public_only[/code] is [code]true[/code], only the public key will be loaded.
+				Loads a key from the given [param string_key]. If [param public_only] is [code]true[/code], only the public key will be loaded.
 			</description>
 		</method>
 		<method name="save">
@@ -38,15 +38,15 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="public_only" type="bool" default="false" />
 			<description>
-				Saves a key to the given [code]path[/code]. If [code]public_only[/code] is [code]true[/code], only the public key will be saved.
-				[b]Note:[/b] [code]path[/code] should be a "*.pub" file if [code]public_only[/code] is [code]true[/code], a "*.key" file otherwise.
+				Saves a key to the given [param path]. If [param public_only] is [code]true[/code], only the public key will be saved.
+				[b]Note:[/b] [param path] should be a "*.pub" file if [param public_only] is [code]true[/code], a "*.key" file otherwise.
 			</description>
 		</method>
 		<method name="save_to_string">
 			<return type="String" />
 			<param index="0" name="public_only" type="bool" default="false" />
 			<description>
-				Returns a string containing the key in PEM format. If [code]public_only[/code] is [code]true[/code], only the public key will be included.
+				Returns a string containing the key in PEM format. If [param public_only] is [code]true[/code], only the public key will be included.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Curve.xml
+++ b/doc/classes/Curve.xml
@@ -43,56 +43,56 @@
 			<return type="int" enum="Curve.TangentMode" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the left [enum TangentMode] for the point at [code]index[/code].
+				Returns the left [enum TangentMode] for the point at [param index].
 			</description>
 		</method>
 		<method name="get_point_left_tangent" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the left tangent angle (in degrees) for the point at [code]index[/code].
+				Returns the left tangent angle (in degrees) for the point at [param index].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the curve coordinates for the point at [code]index[/code].
+				Returns the curve coordinates for the point at [param index].
 			</description>
 		</method>
 		<method name="get_point_right_mode" qualifiers="const">
 			<return type="int" enum="Curve.TangentMode" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the right [enum TangentMode] for the point at [code]index[/code].
+				Returns the right [enum TangentMode] for the point at [param index].
 			</description>
 		</method>
 		<method name="get_point_right_tangent" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the right tangent angle (in degrees) for the point at [code]index[/code].
+				Returns the right tangent angle (in degrees) for the point at [param index].
 			</description>
 		</method>
 		<method name="interpolate" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="offset" type="float" />
 			<description>
-				Returns the Y value for the point that would exist at the X position [code]offset[/code] along the curve.
+				Returns the Y value for the point that would exist at the X position [param offset] along the curve.
 			</description>
 		</method>
 		<method name="interpolate_baked" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="offset" type="float" />
 			<description>
-				Returns the Y value for the point that would exist at the X position [code]offset[/code] along the curve using the baked cache. Bakes the curve's points if not already baked.
+				Returns the Y value for the point that would exist at the X position [param offset] along the curve using the baked cache. Bakes the curve's points if not already baked.
 			</description>
 		</method>
 		<method name="remove_point">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes the point at [code]index[/code] from the curve.
+				Removes the point at [param index] from the curve.
 			</description>
 		</method>
 		<method name="set_point_left_mode">
@@ -100,7 +100,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="mode" type="int" enum="Curve.TangentMode" />
 			<description>
-				Sets the left [enum TangentMode] for the point at [code]index[/code] to [code]mode[/code].
+				Sets the left [enum TangentMode] for the point at [param index] to [param mode].
 			</description>
 		</method>
 		<method name="set_point_left_tangent">
@@ -108,7 +108,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="tangent" type="float" />
 			<description>
-				Sets the left tangent angle for the point at [code]index[/code] to [code]tangent[/code].
+				Sets the left tangent angle for the point at [param index] to [param tangent].
 			</description>
 		</method>
 		<method name="set_point_offset">
@@ -124,7 +124,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="mode" type="int" enum="Curve.TangentMode" />
 			<description>
-				Sets the right [enum TangentMode] for the point at [code]index[/code] to [code]mode[/code].
+				Sets the right [enum TangentMode] for the point at [param index] to [param mode].
 			</description>
 		</method>
 		<method name="set_point_right_tangent">
@@ -132,7 +132,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="tangent" type="float" />
 			<description>
-				Sets the right tangent angle for the point at [code]index[/code] to [code]tangent[/code].
+				Sets the right tangent angle for the point at [param index] to [param tangent].
 			</description>
 		</method>
 		<method name="set_point_value">
@@ -140,7 +140,7 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="y" type="float" />
 			<description>
-				Assigns the vertical position [code]y[/code] to the point at [code]index[/code].
+				Assigns the vertical position [param y] to the point at [param index].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -17,8 +17,8 @@
 			<param index="2" name="out" type="Vector2" default="Vector2(0, 0)" />
 			<param index="3" name="at_position" type="int" default="-1" />
 			<description>
-				Adds a point to a curve at [code]position[/code] relative to the [Curve2D]'s position, with control points [code]in[/code] and [code]out[/code].
-				If [code]at_position[/code] is given, the point is inserted before the point number [code]at_position[/code], moving that point (and every point after) after the inserted point. If [code]at_position[/code] is not given, or is an illegal value ([code]at_position &lt;0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
+				Adds a point to a curve at [param position] relative to the [Curve2D]'s position, with control points [param in] and [param out].
+				If [param at_position] is given, the point is inserted before the point number [param at_position], moving that point (and every point after) after the inserted point. If [param at_position] is not given, or is an illegal value ([code]at_position &lt;0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
 			</description>
 		</method>
 		<method name="clear_points">
@@ -43,37 +43,37 @@
 			<return type="float" />
 			<param index="0" name="to_point" type="Vector2" />
 			<description>
-				Returns the closest offset to [code]to_point[/code]. This offset is meant to be used in [method interpolate_baked].
-				[code]to_point[/code] must be in this curve's local space.
+				Returns the closest offset to [param to_point]. This offset is meant to be used in [method interpolate_baked].
+				[param to_point] must be in this curve's local space.
 			</description>
 		</method>
 		<method name="get_closest_point" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="to_point" type="Vector2" />
 			<description>
-				Returns the closest baked point (in curve's local space) to [code]to_point[/code].
-				[code]to_point[/code] must be in this curve's local space.
+				Returns the closest baked point (in curve's local space) to [param to_point].
+				[param to_point] must be in this curve's local space.
 			</description>
 		</method>
 		<method name="get_point_in" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading to the vertex [code]idx[/code]. The returned position is relative to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point leading to the vertex [param idx]. The returned position is relative to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_out" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading out of the vertex [code]idx[/code]. The returned position is relative to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point leading out of the vertex [param idx]. The returned position is relative to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="interpolate" qualifiers="const">
@@ -81,8 +81,8 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the vertex [code]idx[/code] and the vertex [code]idx + 1[/code], where [code]t[/code] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [code]t[/code] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
-				If [code]idx[/code] is out of bounds it is truncated to the first or last vertex, and [code]t[/code] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position between the vertex [param idx] and the vertex [code]idx + 1[/code], where [param t] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
+				If [param idx] is out of bounds it is truncated to the first or last vertex, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="interpolate_baked" qualifiers="const">
@@ -90,8 +90,8 @@
 			<param index="0" name="offset" type="float" />
 			<param index="1" name="cubic" type="bool" default="false" />
 			<description>
-				Returns a point within the curve at position [code]offset[/code], where [code]offset[/code] is measured as a pixel distance along the curve.
-				To do that, it finds the two cached points where the [code]offset[/code] lies between, then interpolates the values. This interpolation is cubic if [code]cubic[/code] is set to [code]true[/code], or linear if set to [code]false[/code].
+				Returns a point within the curve at position [param offset], where [param offset] is measured as a pixel distance along the curve.
+				To do that, it finds the two cached points where the [param offset] lies between, then interpolates the values. This interpolation is cubic if [param cubic] is set to [code]true[/code], or linear if set to [code]false[/code].
 				Cubic interpolation tends to follow the curves better, but linear is faster (and often, precise enough).
 			</description>
 		</method>
@@ -99,14 +99,14 @@
 			<return type="Vector2" />
 			<param index="0" name="fofs" type="float" />
 			<description>
-				Returns the position at the vertex [code]fofs[/code]. It calls [method interpolate] using the integer part of [code]fofs[/code] as [code]idx[/code], and its fractional part as [code]t[/code].
+				Returns the position at the vertex [param fofs]. It calls [method interpolate] using the integer part of [param fofs] as [code]idx[/code], and its fractional part as [code]t[/code].
 			</description>
 		</method>
 		<method name="remove_point">
 			<return type="void" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Deletes the point [code]idx[/code] from the curve. Sends an error to the console if [code]idx[/code] is out of bounds.
+				Deletes the point [param idx] from the curve. Sends an error to the console if [param idx] is out of bounds.
 			</description>
 		</method>
 		<method name="set_point_in">
@@ -114,7 +114,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the position of the control point leading to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
+				Sets the position of the control point leading to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
 			</description>
 		</method>
 		<method name="set_point_out">
@@ -122,7 +122,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the position of the control point leading out of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
+				Sets the position of the control point leading out of the vertex [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
 			</description>
 		</method>
 		<method name="set_point_position">
@@ -130,7 +130,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the position for the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position for the vertex [param idx]. If the index is out of bounds, the function sends an error to the console.
 			</description>
 		</method>
 		<method name="tessellate" qualifiers="const">
@@ -140,8 +140,8 @@
 			<description>
 				Returns a list of points along the curve, with a curvature controlled point density. That is, the curvier parts will have more points than the straighter parts.
 				This approximation makes straight segments between each point, then subdivides those segments until the resulting shape is similar enough.
-				[code]max_stages[/code] controls how many subdivisions a curve segment may face before it is considered approximate enough. Each subdivision splits the segment in half, so the default 5 stages may mean up to 32 subdivisions per curve segment. Increase with care!
-				[code]tolerance_degrees[/code] controls how many degrees the midpoint of a segment may deviate from the real curve, before the segment has to be subdivided.
+				[param max_stages] controls how many subdivisions a curve segment may face before it is considered approximate enough. Each subdivision splits the segment in half, so the default 5 stages may mean up to 32 subdivisions per curve segment. Increase with care!
+				[param tolerance_degrees] controls how many degrees the midpoint of a segment may deviate from the real curve, before the segment has to be subdivided.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -17,8 +17,8 @@
 			<param index="2" name="out" type="Vector3" default="Vector3(0, 0, 0)" />
 			<param index="3" name="at_position" type="int" default="-1" />
 			<description>
-				Adds a point to a curve at [code]position[/code] relative to the [Curve3D]'s position, with control points [code]in[/code] and [code]out[/code].
-				If [code]at_position[/code] is given, the point is inserted before the point number [code]at_position[/code], moving that point (and every point after) after the inserted point. If [code]at_position[/code] is not given, or is an illegal value ([code]at_position &lt;0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
+				Adds a point to a curve at [param position] relative to the [Curve3D]'s position, with control points [param in] and [param out].
+				If [param at_position] is given, the point is inserted before the point number [param at_position], moving that point (and every point after) after the inserted point. If [param at_position] is not given, or is an illegal value ([code]at_position &lt;0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
 			</description>
 		</method>
 		<method name="clear_points">
@@ -56,44 +56,44 @@
 			<return type="float" />
 			<param index="0" name="to_point" type="Vector3" />
 			<description>
-				Returns the closest offset to [code]to_point[/code]. This offset is meant to be used in [method interpolate_baked] or [method interpolate_baked_up_vector].
-				[code]to_point[/code] must be in this curve's local space.
+				Returns the closest offset to [param to_point]. This offset is meant to be used in [method interpolate_baked] or [method interpolate_baked_up_vector].
+				[param to_point] must be in this curve's local space.
 			</description>
 		</method>
 		<method name="get_closest_point" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="to_point" type="Vector3" />
 			<description>
-				Returns the closest baked point (in curve's local space) to [code]to_point[/code].
-				[code]to_point[/code] must be in this curve's local space.
+				Returns the closest baked point (in curve's local space) to [param to_point].
+				[param to_point] must be in this curve's local space.
 			</description>
 		</method>
 		<method name="get_point_in" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading to the vertex [code]idx[/code]. The returned position is relative to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point leading to the vertex [param idx]. The returned position is relative to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_out" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading out of the vertex [code]idx[/code]. The returned position is relative to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point leading out of the vertex [param idx]. The returned position is relative to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_tilt" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the tilt angle in radians for the point [code]idx[/code]. If the index is out of bounds, the function sends an error to the console, and returns [code]0[/code].
+				Returns the tilt angle in radians for the point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code]0[/code].
 			</description>
 		</method>
 		<method name="interpolate" qualifiers="const">
@@ -101,8 +101,8 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the vertex [code]idx[/code] and the vertex [code]idx + 1[/code], where [code]t[/code] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [code]t[/code] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
-				If [code]idx[/code] is out of bounds it is truncated to the first or last vertex, and [code]t[/code] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position between the vertex [param idx] and the vertex [code]idx + 1[/code], where [param t] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
+				If [param idx] is out of bounds it is truncated to the first or last vertex, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="interpolate_baked" qualifiers="const">
@@ -110,8 +110,8 @@
 			<param index="0" name="offset" type="float" />
 			<param index="1" name="cubic" type="bool" default="false" />
 			<description>
-				Returns a point within the curve at position [code]offset[/code], where [code]offset[/code] is measured as a distance in 3D units along the curve.
-				To do that, it finds the two cached points where the [code]offset[/code] lies between, then interpolates the values. This interpolation is cubic if [code]cubic[/code] is set to [code]true[/code], or linear if set to [code]false[/code].
+				Returns a point within the curve at position [param offset], where [param offset] is measured as a distance in 3D units along the curve.
+				To do that, it finds the two cached points where the [param offset] lies between, then interpolates the values. This interpolation is cubic if [param cubic] is set to [code]true[/code], or linear if set to [code]false[/code].
 				Cubic interpolation tends to follow the curves better, but linear is faster (and often, precise enough).
 			</description>
 		</method>
@@ -120,8 +120,8 @@
 			<param index="0" name="offset" type="float" />
 			<param index="1" name="apply_tilt" type="bool" default="false" />
 			<description>
-				Returns an up vector within the curve at position [code]offset[/code], where [code]offset[/code] is measured as a distance in 3D units along the curve.
-				To do that, it finds the two cached up vectors where the [code]offset[/code] lies between, then interpolates the values. If [code]apply_tilt[/code] is [code]true[/code], an interpolated tilt is applied to the interpolated up vector.
+				Returns an up vector within the curve at position [param offset], where [param offset] is measured as a distance in 3D units along the curve.
+				To do that, it finds the two cached up vectors where the [param offset] lies between, then interpolates the values. If [param apply_tilt] is [code]true[/code], an interpolated tilt is applied to the interpolated up vector.
 				If the curve has no up vectors, the function sends an error to the console, and returns [code](0, 1, 0)[/code].
 			</description>
 		</method>
@@ -129,14 +129,14 @@
 			<return type="Vector3" />
 			<param index="0" name="fofs" type="float" />
 			<description>
-				Returns the position at the vertex [code]fofs[/code]. It calls [method interpolate] using the integer part of [code]fofs[/code] as [code]idx[/code], and its fractional part as [code]t[/code].
+				Returns the position at the vertex [param fofs]. It calls [method interpolate] using the integer part of [param fofs] as [code]idx[/code], and its fractional part as [code]t[/code].
 			</description>
 		</method>
 		<method name="remove_point">
 			<return type="void" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Deletes the point [code]idx[/code] from the curve. Sends an error to the console if [code]idx[/code] is out of bounds.
+				Deletes the point [param idx] from the curve. Sends an error to the console if [param idx] is out of bounds.
 			</description>
 		</method>
 		<method name="set_point_in">
@@ -144,7 +144,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position of the control point leading to the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
+				Sets the position of the control point leading to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
 			</description>
 		</method>
 		<method name="set_point_out">
@@ -152,7 +152,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position of the control point leading out of the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
+				Sets the position of the control point leading out of the vertex [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
 			</description>
 		</method>
 		<method name="set_point_position">
@@ -160,7 +160,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position for the vertex [code]idx[/code]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position for the vertex [param idx]. If the index is out of bounds, the function sends an error to the console.
 			</description>
 		</method>
 		<method name="set_point_tilt">
@@ -168,7 +168,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="tilt" type="float" />
 			<description>
-				Sets the tilt angle in radians for the point [code]idx[/code]. If the index is out of bounds, the function sends an error to the console.
+				Sets the tilt angle in radians for the point [param idx]. If the index is out of bounds, the function sends an error to the console.
 				The tilt controls the rotation along the look-at axis an object traveling the path would have. In the case of a curve controlling a [PathFollow3D], this tilt is an offset over the natural tilt the [PathFollow3D] calculates.
 			</description>
 		</method>
@@ -179,8 +179,8 @@
 			<description>
 				Returns a list of points along the curve, with a curvature controlled point density. That is, the curvier parts will have more points than the straighter parts.
 				This approximation makes straight segments between each point, then subdivides those segments until the resulting shape is similar enough.
-				[code]max_stages[/code] controls how many subdivisions a curve segment may face before it is considered approximate enough. Each subdivision splits the segment in half, so the default 5 stages may mean up to 32 subdivisions per curve segment. Increase with care!
-				[code]tolerance_degrees[/code] controls how many degrees the midpoint of a segment may deviate from the real curve, before the segment has to be subdivided.
+				[param max_stages] controls how many subdivisions a curve segment may face before it is considered approximate enough. Each subdivision splits the segment in half, so the default 5 stages may mean up to 32 subdivisions per curve segment. Increase with care!
+				[param tolerance_degrees] controls how many degrees the midpoint of a segment may deviate from the real curve, before the segment has to be subdivided.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/DTLSServer.xml
+++ b/doc/classes/DTLSServer.xml
@@ -152,14 +152,14 @@
 			<param index="1" name="certificate" type="X509Certificate" />
 			<param index="2" name="chain" type="X509Certificate" default="null" />
 			<description>
-				Setup the DTLS server to use the given [code]private_key[/code] and provide the given [code]certificate[/code] to clients. You can pass the optional [code]chain[/code] parameter to provide additional CA chain information along with the certificate.
+				Setup the DTLS server to use the given [param key] and provide the given [param certificate] to clients. You can pass the optional [param chain] parameter to provide additional CA chain information along with the certificate.
 			</description>
 		</method>
 		<method name="take_connection">
 			<return type="PacketPeerDTLS" />
 			<param index="0" name="udp_peer" type="PacketPeerUDP" />
 			<description>
-				Try to initiate the DTLS handshake with the given [code]udp_peer[/code] which must be already connected (see [method PacketPeerUDP.connect_to_host]).
+				Try to initiate the DTLS handshake with the given [param udp_peer] which must be already connected (see [method PacketPeerUDP.connect_to_host]).
 				[b]Note:[/b] You must check that the state of the return PacketPeerUDP is [constant PacketPeerDTLS.STATUS_HANDSHAKING], as it is normal that 50% of the new connections will be invalid due to cookie exchange.
 			</description>
 		</method>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -207,7 +207,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="deep" type="bool" default="false" />
 			<description>
-				Creates a copy of the dictionary, and returns it. The [code]deep[/code] parameter causes inner dictionaries and arrays to be copied recursively, but does not apply to objects.
+				Creates a copy of the dictionary, and returns it. The [param deep] parameter causes inner dictionaries and arrays to be copied recursively, but does not apply to objects.
 			</description>
 		</method>
 		<method name="erase">
@@ -296,7 +296,7 @@
 			<param index="0" name="dictionary" type="Dictionary" />
 			<param index="1" name="overwrite" type="bool" default="false" />
 			<description>
-				Adds elements from [code]dictionary[/code] to this [Dictionary]. By default, duplicate keys will not be copied over, unless [code]overwrite[/code] is [code]true[/code].
+				Adds elements from [param dictionary] to this [Dictionary]. By default, duplicate keys will not be copied over, unless [param overwrite] is [code]true[/code].
 			</description>
 		</method>
 		<method name="size" qualifiers="const">

--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -70,7 +70,7 @@
 			<param index="0" name="from" type="String" />
 			<param index="1" name="to" type="String" />
 			<description>
-				Copies the [code]from[/code] file to the [code]to[/code] destination. Both arguments should be paths to files, either relative or absolute. If the destination file exists and is not access-protected, it will be overwritten.
+				Copies the [param from] file to the [param to] destination. Both arguments should be paths to files, either relative or absolute. If the destination file exists and is not access-protected, it will be overwritten.
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>
@@ -188,7 +188,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Opens an existing directory of the filesystem. The [code]path[/code] argument can be within the project tree ([code]res://folder[/code]), the user directory ([code]user://folder[/code]) or an absolute path of the user filesystem (e.g. [code]/tmp/folder[/code] or [code]C:\tmp\folder[/code]).
+				Opens an existing directory of the filesystem. The [param path] argument can be within the project tree ([code]res://folder[/code]), the user directory ([code]user://folder[/code]) or an absolute path of the user filesystem (e.g. [code]/tmp/folder[/code] or [code]C:\tmp\folder[/code]).
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>
@@ -206,7 +206,7 @@
 			<param index="0" name="from" type="String" />
 			<param index="1" name="to" type="String" />
 			<description>
-				Renames (move) the [code]from[/code] file or directory to the [code]to[/code] destination. Both arguments should be paths to files or directories, either relative or absolute. If the destination file or directory exists and is not access-protected, it will be overwritten.
+				Renames (move) the [param from] file or directory to the [param to] destination. Both arguments should be paths to files or directories, either relative or absolute. If the destination file or directory exists and is not access-protected, it will be overwritten.
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -152,7 +152,7 @@
 			<param index="4" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="5" name="index" type="int" default="-1" />
 			<description>
-				Adds a new checkable item with text [code]label[/code] to the global menu with ID [code]menu_root[/code].
+				Adds a new checkable item with text [param label] to the global menu with ID [param menu_root].
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
@@ -171,7 +171,7 @@
 			<param index="5" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="6" name="index" type="int" default="-1" />
 			<description>
-				Adds a new checkable item with text [code]label[/code] and icon [code]icon[/code] to the global menu with ID [code]menu_root[/code].
+				Adds a new checkable item with text [param label] and icon [param icon] to the global menu with ID [param menu_root].
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
@@ -190,7 +190,7 @@
 			<param index="5" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="6" name="index" type="int" default="-1" />
 			<description>
-				Adds a new item with text [code]label[/code] and icon [code]icon[/code] to the global menu with ID [code]menu_root[/code].
+				Adds a new item with text [param label] and icon [param icon] to the global menu with ID [param menu_root].
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
@@ -209,7 +209,7 @@
 			<param index="5" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="6" name="index" type="int" default="-1" />
 			<description>
-				Adds a new radio-checkable item with text [code]label[/code] and icon [code]icon[/code] to the global menu with ID [code]menu_root[/code].
+				Adds a new radio-checkable item with text [param label] and icon [param icon] to the global menu with ID [param menu_root].
 				[b]Note:[/b] Radio-checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method global_menu_set_item_checked] for more info on how to control it.
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
@@ -228,7 +228,7 @@
 			<param index="4" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="5" name="index" type="int" default="-1" />
 			<description>
-				Adds a new item with text [code]label[/code] to the global menu with ID [code]menu_root[/code].
+				Adds a new item with text [param label] to the global menu with ID [param menu_root].
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
@@ -248,8 +248,8 @@
 			<param index="6" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="7" name="index" type="int" default="-1" />
 			<description>
-				Adds a new item with text [code]label[/code] to the global menu with ID [code]menu_root[/code].
-				Contrarily to normal binary items, multistate items can have more than two states, as defined by [code]max_states[/code]. Each press or activate of the item will increase the state by one. The default value is defined by [code]default_state[/code].
+				Adds a new item with text [param labe] to the global menu with ID [param menu_root].
+				Contrarily to normal binary items, multistate items can have more than two states, as defined by [param max_states]. Each press or activate of the item will increase the state by one. The default value is defined by [param default_state].
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
@@ -267,7 +267,7 @@
 			<param index="4" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="5" name="index" type="int" default="-1" />
 			<description>
-				Adds a new radio-checkable item with text [code]label[/code] to the global menu with ID [code]menu_root[/code].
+				Adds a new radio-checkable item with text [param label] to the global menu with ID [param menu_root].
 				[b]Note:[/b] Radio-checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method global_menu_set_item_checked] for more info on how to control it.
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
@@ -282,7 +282,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="index" type="int" default="-1" />
 			<description>
-				Adds a separator between items to the global menu with ID [code]menu_root[/code]. Separators also occupy an index.
+				Adds a separator between items to the global menu with ID [param menu_root]. Separators also occupy an index.
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
@@ -298,7 +298,7 @@
 			<param index="2" name="submenu" type="String" />
 			<param index="3" name="index" type="int" default="-1" />
 			<description>
-				Adds an item that will act as a submenu of the global menu [code]menu_root[/code]. The [code]submenu[/code] argument is the ID of the global menu root that will be shown when the item is clicked.
+				Adds an item that will act as a submenu of the global menu [param menu_root]. The [param submenu] argument is the ID of the global menu root that will be shown when the item is clicked.
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
@@ -311,7 +311,7 @@
 			<return type="void" />
 			<param index="0" name="menu_root" type="String" />
 			<description>
-				Removes all items from the global menu with ID [code]menu_root[/code].
+				Removes all items from the global menu with ID [param menu_root].
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
@@ -325,7 +325,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns the accelerator of the item at index [code]idx[/code]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
+				Returns the accelerator of the item at index [param idx]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -334,7 +334,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns the callback of the item at index [code]idx[/code].
+				Returns the callback of the item at index [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -343,7 +343,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns the icon of the item at index [code]idx[/code].
+				Returns the icon of the item at index [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -352,7 +352,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="tag" type="Variant" />
 			<description>
-				Returns the index of the item with the specified [code]tag[/code]. Index is automatically assigned to each item by the engine. Index can not be set manually.
+				Returns the index of the item with the specified [param tag]. Index is automatically assigned to each item by the engine. Index can not be set manually.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -361,7 +361,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="text" type="String" />
 			<description>
-				Returns the index of the item with the specified [code]text[/code]. Index is automatically assigned to each item by the engine. Index can not be set manually.
+				Returns the index of the item with the specified [param text]. Index is automatically assigned to each item by the engine. Index can not be set manually.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -388,7 +388,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns the submenu ID of the item at index [code]idx[/code]. See [method global_menu_add_submenu_item] for more info on how to add a submenu.
+				Returns the submenu ID of the item at index [param idx]. See [method global_menu_add_submenu_item] for more info on how to add a submenu.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -406,7 +406,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns the text of the item at index [code]idx[/code].
+				Returns the text of the item at index [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -415,7 +415,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns the tooltip associated with the specified index index [code]idx[/code].
+				Returns the tooltip associated with the specified index index [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -424,7 +424,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at index [code]idx[/code] is checkable in some way, i.e. if it has a checkbox or radio button.
+				Returns [code]true[/code] if the item at index [param idx] is checkable in some way, i.e. if it has a checkbox or radio button.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -433,7 +433,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at index [code]idx[/code] is checked.
+				Returns [code]true[/code] if the item at index [param idx] is checked.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -442,7 +442,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at index [code]idx[/code] is disabled. When it is disabled it can't be selected, or its action invoked.
+				Returns [code]true[/code] if the item at index [param idx] is disabled. When it is disabled it can't be selected, or its action invoked.
 				See [method global_menu_set_item_disabled] for more info on how to disable an item.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
@@ -452,7 +452,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the item at index [code]idx[/code] has radio button-style checkability.
+				Returns [code]true[/code] if the item at index [param idx] has radio button-style checkability.
 				[b]Note:[/b] This is purely cosmetic; you must add the logic for checking/unchecking items in radio groups.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
@@ -462,7 +462,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="idx" type="int" />
 			<description>
-				Removes the item at index [code]idx[/code] from the global menu [code]menu_root[/code].
+				Removes the item at index [param idx] from the global menu [param menu_root].
 				[b]Note:[/b] The indices of items after the removed item will be shifted by one.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
@@ -473,7 +473,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="keycode" type="int" enum="Key" />
 			<description>
-				Sets the accelerator of the item at index [code]idx[/code].
+				Sets the accelerator of the item at index [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -483,7 +483,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="callback" type="Callable" />
 			<description>
-				Sets the callback of the item at index [code]idx[/code]. Callback is emitted when an item is pressed or its accelerator is activated.
+				Sets the callback of the item at index [param idx]. Callback is emitted when an item is pressed or its accelerator is activated.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -493,7 +493,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="checkable" type="bool" />
 			<description>
-				Sets whether the item at index [code]idx[/code] has a checkbox. If [code]false[/code], sets the type of the item to plain text.
+				Sets whether the item at index [param idx] has a checkbox. If [code]false[/code], sets the type of the item to plain text.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -503,7 +503,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="checked" type="bool" />
 			<description>
-				Sets the checkstate status of the item at index [code]idx[/code].
+				Sets the checkstate status of the item at index [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -513,7 +513,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
-				Enables/disables the item at index [code]idx[/code]. When it is disabled, it can't be selected and its action can't be invoked.
+				Enables/disables the item at index [param idx]. When it is disabled, it can't be selected and its action can't be invoked.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -523,7 +523,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="icon" type="Texture2D" />
 			<description>
-				Replaces the [Texture2D] icon of the specified [code]idx[/code].
+				Replaces the [Texture2D] icon of the specified [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 				[b]Note:[/b] This method is not supported by macOS "_dock" menu items.
 			</description>
@@ -544,7 +544,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="checkable" type="bool" />
 			<description>
-				Sets the type of the item at the specified index [code]idx[/code] to radio button. If [code]false[/code], sets the type of the item to plain text
+				Sets the type of the item at the specified index [param idx] to radio button. If [code]false[/code], sets the type of the item to plain text
 				[b]Note:[/b] This is purely cosmetic; you must add the logic for checking/unchecking items in radio groups.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
@@ -565,7 +565,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="submenu" type="String" />
 			<description>
-				Sets the submenu of the item at index [code]idx[/code]. The submenu is the ID of a global menu root that would be shown when the item is clicked.
+				Sets the submenu of the item at index [param idx]. The submenu is the ID of a global menu root that would be shown when the item is clicked.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -585,7 +585,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="text" type="String" />
 			<description>
-				Sets the text of the item at index [code]idx[/code].
+				Sets the text of the item at index [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -595,7 +595,7 @@
 			<param index="1" name="idx" type="int" />
 			<param index="2" name="tooltip" type="String" />
 			<description>
-				Sets the [String] tooltip of the item at the specified index [code]idx[/code].
+				Sets the [String] tooltip of the item at the specified index [param idx].
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
@@ -626,7 +626,7 @@
 			<return type="int" enum="Key" />
 			<param index="0" name="keycode" type="int" enum="Key" />
 			<description>
-				Converts a physical (US QWERTY) [code]keycode[/code] to one in the active keyboard layout.
+				Converts a physical (US QWERTY) [param keycode] to one in the active keyboard layout.
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
@@ -641,7 +641,7 @@
 			<return type="String" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the ISO-639/BCP-47 language code of the keyboard layout at position [code]index[/code].
+				Returns the ISO-639/BCP-47 language code of the keyboard layout at position [param index].
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
@@ -649,7 +649,7 @@
 			<return type="String" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the localized name of the keyboard layout at position [code]index[/code].
+				Returns the localized name of the keyboard layout at position [param index].
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
@@ -692,7 +692,7 @@
 			<return type="int" />
 			<param index="0" name="screen" type="int" default="-1" />
 			<description>
-				Returns the dots per inch density of the specified screen. If [code]screen[/code] is [/code]SCREEN_OF_MAIN_WINDOW[/code] (the default value), a screen with the main window will be used.
+				Returns the dots per inch density of the specified screen. If [param screen] is [/code]SCREEN_OF_MAIN_WINDOW[/code] (the default value), a screen with the main window will be used.
 				[b]Note:[/b] On macOS, returned value is inaccurate if fractional display scaling mode is used.
 				[b]Note:[/b] On Android devices, the actual screen densities are grouped into six generalized densities:
 				[codeblock]
@@ -730,7 +730,7 @@
 			<return type="float" />
 			<param index="0" name="screen" type="int" default="-1" />
 			<description>
-				Returns the current refresh rate of the specified screen. If [code]screen[/code] is [constant SCREEN_OF_MAIN_WINDOW] (the default value), a screen with the main window will be used.
+				Returns the current refresh rate of the specified screen. If [param screen] is [constant SCREEN_OF_MAIN_WINDOW] (the default value), a screen with the main window will be used.
 				[b]Note:[/b] Returns [code]-1.0[/code] if the DisplayServer fails to find the refresh rate for the specified screen. On HTML5, [method screen_get_refresh_rate] will always return [code]-1.0[/code] as there is no way to retrieve the refresh rate on that platform.
 				To fallback to a default refresh rate if the method fails, try:
 				[codeblock]
@@ -842,7 +842,7 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="language" type="String" />
 			<description>
-				Returns an [PackedStringArray] of voice identifiers for the [code]language[/code].
+				Returns an [PackedStringArray] of voice identifiers for the [param language].
 				[b]Note:[/b] This method is implemented on Android, iOS, HTML5, Linux, macOS, and Windows.
 			</description>
 		</method>
@@ -896,13 +896,13 @@
 			<param index="5" name="utterance_id" type="int" default="0" />
 			<param index="6" name="interrupt" type="bool" default="false" />
 			<description>
-				Adds an utterance to the queue. If [code]interrupt[/code] is [code]true[/code], the queue is cleared first.
-				- [code]voice[/code] identifier is one of the [code]"id"[/code] values returned by [method tts_get_voices] or one of the values returned by [method tts_get_voices_for_language].
-				- [code]volume[/code] ranges from [code]0[/code] (lowest) to [code]100[/code] (highest).
-				- [code]pitch[/code] ranges from [code]0.0[/code] (lowest) to [code]2.0[/code] (highest), [code]1.0[/code] is default pitch for the current voice.
-				- [code]rate[/code] ranges from [code]0.1[/code] (lowest) to [code]10.0[/code] (highest), [code]1.0[/code] is a normal speaking rate. Other values act as a percentage relative.
-				- [code]utterance_id[/code] is passed as a parameter to the callback functions.
-				[b]Note:[/b] On Windows and Linux, utterance [code]text[/code] can use SSML markup. SSML support is engine and voice dependent. If the engine does not support SSML, you should strip out all XML markup before calling [method tts_speak].
+				Adds an utterance to the queue. If [param interrupt] is [code]true[/code], the queue is cleared first.
+				- [param voice] identifier is one of the [code]"id"[/code] values returned by [method tts_get_voices] or one of the values returned by [method tts_get_voices_for_language].
+				- [param volume] ranges from [code]0[/code] (lowest) to [code]100[/code] (highest).
+				- [param pitch] ranges from [code]0.0[/code] (lowest) to [code]2.0[/code] (highest), [code]1.0[/code] is default pitch for the current voice.
+				- [param rate] ranges from [code]0.1[/code] (lowest) to [code]10.0[/code] (highest), [code]1.0[/code] is a normal speaking rate. Other values act as a percentage relative.
+				- [param utterance_id] is passed as a parameter to the callback functions.
+				[b]Note:[/b] On Windows and Linux, utterance [param text] can use SSML markup. SSML support is engine and voice dependent. If the engine does not support SSML, you should strip out all XML markup before calling [method tts_speak].
 				[b]Note:[/b] The granularity of pitch, rate, and volume is engine and voice dependent. Values may be truncated.
 				[b]Note:[/b] This method is implemented on Android, iOS, HTML5, Linux, macOS, and Windows.
 			</description>
@@ -936,12 +936,12 @@
 			<param index="5" name="cursor_end" type="int" default="-1" />
 			<description>
 				Shows the virtual keyboard if the platform has one.
-				[code]existing_text[/code] parameter is useful for implementing your own [LineEdit] or [TextEdit], as it tells the virtual keyboard what text has already been typed (the virtual keyboard uses it for auto-correct and predictions).
-				[code]position[/code] parameter is the screen space [Rect2] of the edited text.
-				[code]type[/code] parameter allows configuring which type of virtual keyboard to show.
-				[code]max_length[/code] limits the number of characters that can be entered if different from [code]-1[/code].
-				[code]cursor_start[/code] can optionally define the current text cursor position if [code]cursor_end[/code] is not set.
-				[code]cursor_start[/code] and [code]cursor_end[/code] can optionally define the current text selection.
+				[param existing_text] parameter is useful for implementing your own [LineEdit] or [TextEdit], as it tells the virtual keyboard what text has already been typed (the virtual keyboard uses it for auto-correct and predictions).
+				[param position] parameter is the screen space [Rect2] of the edited text.
+				[param type] parameter allows configuring which type of virtual keyboard to show.
+				[param max_length] limits the number of characters that can be entered if different from [code]-1[/code].
+				[param cursor_start] can optionally define the current text cursor position if [param cursor_end] is not set.
+				[param cursor_start] and [param cursor_end] can optionally define the current text selection.
 				[b]Note:[/b] This method is implemented on Android, iOS and HTML5.
 			</description>
 		</method>
@@ -949,7 +949,7 @@
 			<return type="void" />
 			<param index="0" name="position" type="Vector2i" />
 			<description>
-				Sets the mouse cursor position to the given [code]position[/code] relative to an origin at the upper left corner of the currently focused game Window Manager window.
+				Sets the mouse cursor position to the given [param position] relative to an origin at the upper left corner of the currently focused game Window Manager window.
 			</description>
 		</method>
 		<method name="window_attach_instance_id">
@@ -988,7 +988,7 @@
 			<param index="0" name="flag" type="int" enum="DisplayServer.WindowFlags" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Returns the current value of the given window's [code]flag[/code].
+				Returns the current value of the given window's [param flag].
 			</description>
 		</method>
 		<method name="window_get_max_size" qualifiers="const">
@@ -1094,7 +1094,7 @@
 			<param index="1" name="enabled" type="bool" />
 			<param index="2" name="window_id" type="int" default="0" />
 			<description>
-				Enables or disables the given window's given [code]flag[/code]. See [enum WindowFlags] for possible values and their behavior.
+				Enables or disables the given window's given [param flag]. See [enum WindowFlags] for possible values and their behavior.
 			</description>
 		</method>
 		<method name="window_set_ime_active">
@@ -1137,7 +1137,7 @@
 			<param index="0" name="min_size" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the minimum size for the given window to [code]min_size[/code] (in pixels).
+				Sets the minimum size for the given window to [param min_size] (in pixels).
 				[b]Note:[/b] By default, the main window has a minimum size of [code]Vector2i(64, 64)[/code]. This prevents issues that can arise when the window is resized to a near-zero size.
 			</description>
 		</method>
@@ -1146,7 +1146,7 @@
 			<param index="0" name="mode" type="int" enum="DisplayServer.WindowMode" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets window mode for the given window to [code]mode[/code]. See [enum WindowMode] for possible values and how each mode behaves.
+				Sets window mode for the given window to [param mode]. See [enum WindowMode] for possible values and how each mode behaves.
 				[b]Note:[/b] Setting the window to fullscreen forcibly sets the borderless flag to [code]true[/code], so make sure to set it back to [code]false[/code] when not wanted.
 			</description>
 		</method>
@@ -1196,7 +1196,7 @@
 			<param index="0" name="position" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the position of the given window to [code]position[/code].
+				Sets the position of the given window to [param position].
 			</description>
 		</method>
 		<method name="window_set_rect_changed_callback">
@@ -1211,7 +1211,7 @@
 			<param index="0" name="size" type="Vector2i" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the size of the given window to [code]size[/code].
+				Sets the size of the given window to [param size].
 			</description>
 		</method>
 		<method name="window_set_title">
@@ -1219,7 +1219,7 @@
 			<param index="0" name="title" type="String" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Sets the title of the given window to [code]title[/code].
+				Sets the title of the given window to [param title].
 			</description>
 		</method>
 		<method name="window_set_transient">


### PR DESCRIPTION
One of several commits to fix all of the class XML docs (see #64134, #64164, #64196, #64285, #64319, #64328).

Note that `global_menu_add_multistate_item()` in DisplayServer has a parameter "labe" which should be "label". This will be fixed in a future PR.