### PR TITLE
[doc] Use "param" instead of "code" to refer to parameters (8)

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -16,7 +16,7 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Returns the absolute value of a [Variant] parameter [code]x[/code] (i.e. non-negative value). Variant types [int], [float] (real), [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
+				Returns the absolute value of a [Variant] parameter [param x] (i.e. non-negative value). Variant types [int], [float] (real), [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
 				[codeblock]
 				var a = abs(-1)
 				# a is 1
@@ -42,7 +42,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the absolute value of float parameter [code]x[/code] (i.e. positive value).
+				Returns the absolute value of float parameter [param x] (i.e. positive value).
 				[codeblock]
 				# a is 1.2
 				var a = absf(-1.2)
@@ -53,7 +53,7 @@
 			<return type="int" />
 			<param index="0" name="x" type="int" />
 			<description>
-				Returns the absolute value of int parameter [code]x[/code] (i.e. positive value).
+				Returns the absolute value of int parameter [param x] (i.e. positive value).
 				[codeblock]
 				# a is 1
 				var a = absi(-1)
@@ -64,7 +64,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the arc cosine of [code]x[/code] in radians. Use to get the angle of cosine [code]x[/code]. [code]x[/code] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method acos] will return [constant @GDScript.NAN].
+				Returns the arc cosine of [param x] in radians. Use to get the angle of cosine [param x]. [param x] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method acos] will return [constant @GDScript.NAN].
 				[codeblock]
 				# c is 0.523599 or 30 degrees if converted with rad2deg(c)
 				var c = acos(0.866025)
@@ -75,7 +75,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the arc sine of [code]x[/code] in radians. Use to get the angle of sine [code]x[/code]. [code]x[/code] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method asin] will return [constant @GDScript.NAN].
+				Returns the arc sine of [param x] in radians. Use to get the angle of sine [param x]. [param x] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method asin] will return [constant @GDScript.NAN].
 				[codeblock]
 				# s is 0.523599 or 30 degrees if converted with rad2deg(s)
 				var s = asin(0.5)
@@ -86,12 +86,12 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the arc tangent of [code]x[/code] in radians. Use it to get the angle from an angle's tangent in trigonometry.
+				Returns the arc tangent of [param x] in radians. Use it to get the angle from an angle's tangent in trigonometry.
 				The method cannot know in which quadrant the angle should fall. See [method atan2] if you have both [code]y[/code] and [code]x[/code].
 				[codeblock]
 				var a = atan(0.5) # a is 0.463648
 				[/codeblock]
-				If [code]x[/code] is between [code]-PI / 2[/code] and [code]PI / 2[/code] (inclusive), [code]atan(tan(x))[/code] is equal to [code]x[/code].
+				If [param x] is between [code]-PI / 2[/code] and [code]PI / 2[/code] (inclusive), [code]atan(tan(x))[/code] is equal to [param x].
 			</description>
 		</method>
 		<method name="atan2">
@@ -114,7 +114,7 @@
 			<param index="3" name="end" type="float" />
 			<param index="4" name="t" type="float" />
 			<description>
-				Returns the point at the given [code]t[/code] on a one-dimnesional [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by the given [code]control_1[/code], [code]control_2[/code], and [code]end[/code] points.
+				Returns the point at the given [param t] on a one-dimnesional [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by the given [param control_1], [param control_2], and [param end] points.
 			</description>
 		</method>
 		<method name="bytes2var">
@@ -137,7 +137,7 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Rounds [code]x[/code] upward (towards positive infinity), returning the smallest whole number that is not less than [code]x[/code]. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
+				Rounds [param x] upward (towards positive infinity), returning the smallest whole number that is not less than [param x]. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
 				[codeblock]
 				var i = ceil(1.45) # i is 2.0
 				i = ceil(1.001)    # i is 2.0
@@ -150,7 +150,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Rounds [code]x[/code] upward (towards positive infinity), returning the smallest whole number that is not less than [code]x[/code].
+				Rounds [param x] upward (towards positive infinity), returning the smallest whole number that is not less than [param x].
 				A type-safe version of [method ceil], specialzied in floats.
 			</description>
 		</method>
@@ -158,7 +158,7 @@
 			<return type="int" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Rounds [code]x[/code] upward (towards positive infinity), returning the smallest whole number that is not less than [code]x[/code].
+				Rounds [param x] upward (towards positive infinity), returning the smallest whole number that is not less than [param x].
 				A type-safe version of [method ceil] that returns integer.
 			</description>
 		</method>
@@ -168,7 +168,7 @@
 			<param index="1" name="min" type="Variant" />
 			<param index="2" name="max" type="Variant" />
 			<description>
-				Clamps the [Variant] [code]value[/code] and returns a value not less than [code]min[/code] and not more than [code]max[/code]. Variant types [int], [float] (real), [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
+				Clamps the [Variant] [param value] and returns a value not less than [param min] and not more than [param max]. Variant types [int], [float] (real), [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
 				[codeblock]
 				var a = clamp(-10, -1, 5)
 				# a is -1
@@ -196,7 +196,7 @@
 			<param index="1" name="min" type="float" />
 			<param index="2" name="max" type="float" />
 			<description>
-				Clamps the float [code]value[/code] and returns a value not less than [code]min[/code] and not more than [code]max[/code].
+				Clamps the float [param value] and returns a value not less than [param min] and not more than [param max].
 				[codeblock]
 				var speed = 42.1
 				# a is 20.0
@@ -214,7 +214,7 @@
 			<param index="1" name="min" type="int" />
 			<param index="2" name="max" type="int" />
 			<description>
-				Clamps the integer [code]value[/code] and returns a value not less than [code]min[/code] and not more than [code]max[/code].
+				Clamps the integer [param value] and returns a value not less than [param min] and not more than [param max].
 				[codeblock]
 				var speed = 42
 				# a is 20
@@ -230,7 +230,7 @@
 			<return type="float" />
 			<param index="0" name="angle_rad" type="float" />
 			<description>
-				Returns the cosine of angle [code]angle_rad[/code] in radians.
+				Returns the cosine of angle [param angle_rad] in radians.
 				[codeblock]
 				cos(PI * 2)      # Returns 1.0
 				cos(PI)          # Returns -1.0
@@ -242,7 +242,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the hyperbolic cosine of [code]x[/code] in radians.
+				Returns the hyperbolic cosine of [param x] in radians.
 				[codeblock]
 				# Prints 1.543081
 				print(cosh(1))
@@ -257,7 +257,7 @@
 			<param index="3" name="post" type="float" />
 			<param index="4" name="weight" type="float" />
 			<description>
-				Cubic interpolates between two values by the factor defined in [code]weight[/code] with pre and post values.
+				Cubic interpolates between two values by the factor defined in [param weight] with pre and post values.
 			</description>
 		</method>
 		<method name="db2linear">
@@ -283,7 +283,7 @@
 			<param index="0" name="x" type="float" />
 			<param index="1" name="curve" type="float" />
 			<description>
-				Returns an "eased" value of [code]x[/code] based on an easing function defined with [code]curve[/code]. This easing function is based on an exponent. The [code]curve[/code] can be any floating-point number, with specific values leading to the following behaviors:
+				Returns an "eased" value of [param x] based on an easing function defined with [param curve]. This easing function is based on an exponent. The [param curve] can be any floating-point number, with specific values leading to the following behaviors:
 				[codeblock]
 				- Lower than -1.0 (exclusive): Ease in-out
 				- 1.0: Linear
@@ -308,7 +308,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				The natural exponential function. It raises the mathematical constant [b]e[/b] to the power of [code]x[/code] and returns it.
+				The natural exponential function. It raises the mathematical constant [b]e[/b] to the power of [param x] and returns it.
 				[b]e[/b] has an approximate value of 2.71828, and can be obtained with [code]exp(1)[/code].
 				For exponents to other bases use the method [method pow].
 				[codeblock]
@@ -320,7 +320,7 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Rounds [code]x[/code] downward (towards negative infinity), returning the largest whole number that is not more than [code]x[/code]. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
+				Rounds [param x] downward (towards negative infinity), returning the largest whole number that is not more than [param x]. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
 				[codeblock]
 				# a is 2.0
 				var a = floor(2.99)
@@ -335,7 +335,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Rounds [code]x[/code] downward (towards negative infinity), returning the largest whole number that is not more than [code]x[/code].
+				Rounds [param x] downward (towards negative infinity), returning the largest whole number that is not more than [param x].
 				A type-safe version of [method floor], specialzied in floats.
 			</description>
 		</method>
@@ -343,7 +343,7 @@
 			<return type="int" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Rounds [code]x[/code] downward (towards negative infinity), returning the largest whole number that is not more than [code]x[/code].
+				Rounds [param x] downward (towards negative infinity), returning the largest whole number that is not more than [param x].
 				Equivalent of doing [code]int(x)[/code].
 			</description>
 		</method>
@@ -352,7 +352,7 @@
 			<param index="0" name="x" type="float" />
 			<param index="1" name="y" type="float" />
 			<description>
-				Returns the floating-point remainder of [code]x/y[/code], keeping the sign of [code]x[/code].
+				Returns the floating-point remainder of [code]x/y[/code], keeping the sign of [param x].
 				[codeblock]
 				# Remainder is 1.5
 				var remainder = fmod(7, 5.5)
@@ -397,7 +397,7 @@
 			<return type="Object" />
 			<param index="0" name="instance_id" type="int" />
 			<description>
-				Returns the Object that corresponds to [code]instance_id[/code]. All Objects have a unique instance ID.
+				Returns the Object that corresponds to [param instance_id]. All Objects have a unique instance ID.
 				[codeblock]
 				var foo = "bar"
 				func _ready():
@@ -413,7 +413,7 @@
 			<param index="1" name="to" type="float" />
 			<param index="2" name="weight" type="float" />
 			<description>
-				Returns an interpolation or extrapolation factor considering the range specified in [code]from[/code] and [code]to[/code], and the interpolated value specified in [code]weight[/code]. The returned value will be between [code]0.0[/code] and [code]1.0[/code] if [code]weight[/code] is between [code]from[/code] and [code]to[/code] (inclusive). If [code]weight[/code] is located outside this range, then an extrapolation factor will be returned (return value lower than [code]0.0[/code] or greater than [code]1.0[/code]). Use [method clamp] on the result of [method inverse_lerp] if this is not desired.
+				Returns an interpolation or extrapolation factor considering the range specified in [param from] and [param to], and the interpolated value specified in [param weight]. The returned value will be between [code]0.0[/code] and [code]1.0[/code] if [param weight] is between [param from] and [param to] (inclusive). If [param weight] is located outside this range, then an extrapolation factor will be returned (return value lower than [code]0.0[/code] or greater than [code]1.0[/code]). Use [method clamp] on the result of [method inverse_lerp] if this is not desired.
 				[codeblock]
 				# The interpolation ratio in the `lerp()` call below is 0.75.
 				var middle = lerp(20, 30, 0.75)
@@ -430,8 +430,8 @@
 			<param index="0" name="a" type="float" />
 			<param index="1" name="b" type="float" />
 			<description>
-				Returns [code]true[/code] if [code]a[/code] and [code]b[/code] are approximately equal to each other.
-				Here, approximately equal means that [code]a[/code] and [code]b[/code] are within a small internal epsilon of each other, which scales with the magnitude of the numbers.
+				Returns [code]true[/code] if [param a] and [param b] are approximately equal to each other.
+				Here, approximately equal means that [param a] and [param b] are within a small internal epsilon of each other, which scales with the magnitude of the numbers.
 				Infinity values of the same sign are considered equal.
 			</description>
 		</method>
@@ -439,35 +439,35 @@
 			<return type="bool" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns whether [code]x[/code] is an infinity value (either positive infinity or negative infinity).
+				Returns whether [param x] is an infinity value (either positive infinity or negative infinity).
 			</description>
 		</method>
 		<method name="is_instance_id_valid">
 			<return type="bool" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns [code]true[/code] if the Object that corresponds to [code]instance_id[/code] is a valid object (e.g. has not been deleted from memory). All Objects have a unique instance ID.
+				Returns [code]true[/code] if the Object that corresponds to [param id] is a valid object (e.g. has not been deleted from memory). All Objects have a unique instance ID.
 			</description>
 		</method>
 		<method name="is_instance_valid">
 			<return type="bool" />
 			<param index="0" name="instance" type="Variant" />
 			<description>
-				Returns whether [code]instance[/code] is a valid object (e.g. has not been deleted from memory).
+				Returns whether [param instance] is a valid object (e.g. has not been deleted from memory).
 			</description>
 		</method>
 		<method name="is_nan">
 			<return type="bool" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns whether [code]x[/code] is a NaN ("Not a Number" or invalid) value.
+				Returns whether [param x] is a NaN ("Not a Number" or invalid) value.
 			</description>
 		</method>
 		<method name="is_zero_approx">
 			<return type="bool" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns [code]true[/code] if [code]x[/code] is zero or almost zero.
+				Returns [code]true[/code] if [param x] is zero or almost zero.
 				This method is faster than using [method is_equal_approx] with one value as zero.
 			</description>
 		</method>
@@ -477,8 +477,8 @@
 			<param index="1" name="to" type="Variant" />
 			<param index="2" name="weight" type="Variant" />
 			<description>
-				Linearly interpolates between two values by the factor defined in [code]weight[/code]. To perform interpolation, [code]weight[/code] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. Use [method clamp] on the result of [method lerp] if this is not desired.
-				Both [code]from[/code] and [code]to[/code] must have matching types. Supported types: [float], [Vector2], [Vector3], [Vector4], [Color], [Quaternion], [Basis].
+				Linearly interpolates between two values by the factor defined in [param weight]. To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. Use [method clamp] on the result of [method lerp] if this is not desired.
+				Both [param from] and [param to] must have matching types. Supported types: [float], [Vector2], [Vector3], [Vector4], [Color], [Quaternion], [Basis].
 				[codeblock]
 				lerp(0, 4, 0.75) # Returns 3.0
 				[/codeblock]
@@ -503,7 +503,7 @@
 				    rotation = lerp_angle(min_angle, max_angle, elapsed)
 				    elapsed += delta
 				[/codeblock]
-				[b]Note:[/b] This method lerps through the shortest path between [code]from[/code] and [code]to[/code]. However, when these two angles are approximately [code]PI + k * TAU[/code] apart for any integer [code]k[/code], it's not obvious which way they lerp due to floating-point precision errors. For example, [code]lerp_angle(0, PI, weight)[/code] lerps counter-clockwise, while [code]lerp_angle(0, PI + 5 * TAU, weight)[/code] lerps clockwise.
+				[b]Note:[/b] This method lerps through the shortest path between [param from] and [param to]. However, when these two angles are approximately [code]PI + k * TAU[/code] apart for any integer [code]k[/code], it's not obvious which way they lerp due to floating-point precision errors. For example, [code]lerp_angle(0, PI, weight)[/code] lerps counter-clockwise, while [code]lerp_angle(0, PI + 5 * TAU, weight)[/code] lerps clockwise.
 			</description>
 		</method>
 		<method name="lerpf">
@@ -512,7 +512,7 @@
 			<param index="1" name="to" type="float" />
 			<param index="2" name="weight" type="float" />
 			<description>
-				Linearly interpolates between two values by the factor defined in [code]weight[/code]. To perform interpolation, [code]weight[/code] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i].
+				Linearly interpolates between two values by the factor defined in [param weight]. To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i].
 				[codeblock]
 				lerp(0, 4, 0.75) # Returns 3.0
 				[/codeblock]
@@ -616,8 +616,8 @@
 			<param index="1" name="to" type="float" />
 			<param index="2" name="delta" type="float" />
 			<description>
-				Moves [code]from[/code] toward [code]to[/code] by the [code]delta[/code] value.
-				Use a negative [code]delta[/code] value to move away.
+				Moves [param from] toward [param to] by the [param delta] value.
+				Use a negative [param delta] value to move away.
 				[codeblock]
 				move_toward(5, 10, 4) # Returns 9
 				move_toward(10, 5, 4) # Returns 6
@@ -629,7 +629,7 @@
 			<return type="int" />
 			<param index="0" name="value" type="int" />
 			<description>
-				Returns the nearest equal or larger power of 2 for integer [code]value[/code].
+				Returns the nearest equal or larger power of 2 for integer [param value].
 				In other words, returns the smallest value [code]a[/code] where [code]a = pow(2, n)[/code] such that [code]value &lt;= a[/code] for some non-negative integer [code]n[/code].
 				[codeblock]
 				nearest_po2(3) # Returns 4
@@ -639,7 +639,7 @@
 				nearest_po2(0) # Returns 0 (this may not be what you expect)
 				nearest_po2(-1) # Returns 0 (this may not be what you expect)
 				[/codeblock]
-				[b]Warning:[/b] Due to the way it is implemented, this function returns [code]0[/code] rather than [code]1[/code] for non-positive values of [code]value[/code] (in reality, 1 is the smallest integer power of 2).
+				[b]Warning:[/b] Due to the way it is implemented, this function returns [code]0[/code] rather than [code]1[/code] for non-positive values of [param value] (in reality, 1 is the smallest integer power of 2).
 			</description>
 		</method>
 		<method name="pingpong">
@@ -647,7 +647,7 @@
 			<param index="0" name="value" type="float" />
 			<param index="1" name="length" type="float" />
 			<description>
-				Returns the [code]value[/code] wrapped between [code]0[/code] and the [code]length[/code]. If the limit is reached, the next value the function returned is decreased to the [code]0[/code] side or increased to the [code]length[/code] side (like a triangle wave). If [code]length[/code] is less than zero, it becomes positive.
+				Returns the [param value] wrapped between [code]0[/code] and the [param length]. If the limit is reached, the next value the function returned is decreased to the [code]0[/code] side or increased to the [param length] side (like a triangle wave). If [param length] is less than zero, it becomes positive.
 				[codeblock]
 				pingpong(-3.0, 3.0) # Returns 3
 				pingpong(-2.0, 3.0) # Returns 2
@@ -689,7 +689,7 @@
 			<param index="0" name="base" type="float" />
 			<param index="1" name="exp" type="float" />
 			<description>
-				Returns the result of [code]base[/code] raised to the power of [code]exp[/code].
+				Returns the result of [param base] raised to the power of [param exp].
 				[codeblock]
 				pow(2, 5) # Returns 32
 				[/codeblock]
@@ -786,7 +786,7 @@
 			<return type="PackedInt64Array" />
 			<param index="0" name="seed" type="int" />
 			<description>
-				Random from seed: pass a [code]seed[/code], and an array with both number and new seed is returned. "Seed" here refers to the internal state of the pseudo random number generator. The internal state of the current implementation is 64 bits.
+				Random from seed: pass a [param seed], and an array with both number and new seed is returned. "Seed" here refers to the internal state of the pseudo random number generator. The internal state of the current implementation is 64 bits.
 			</description>
 		</method>
 		<method name="randf">
@@ -803,7 +803,7 @@
 			<param index="0" name="from" type="float" />
 			<param index="1" name="to" type="float" />
 			<description>
-				Returns a random floating point value on the interval between [code]from[/code] and [code]to[/code] (inclusive).
+				Returns a random floating point value on the interval between [param from] and [param to] (inclusive).
 				[codeblock]
 				prints(randf_range(-10, 10), randf_range(-10, 10)) # Prints e.g. -3.844535 7.45315
 				[/codeblock]
@@ -814,7 +814,7 @@
 			<param index="0" name="mean" type="float" />
 			<param index="1" name="deviation" type="float" />
 			<description>
-				Returns a normally-distributed pseudo-random floating point value using Box-Muller transform with the specified [code]mean[/code] and a standard [code]deviation[/code]. This is also called Gaussian distribution.
+				Returns a normally-distributed pseudo-random floating point value using Box-Muller transform with the specified [param mean] and a standard [param deviation]. This is also called Gaussian distribution.
 			</description>
 		</method>
 		<method name="randi">
@@ -834,7 +834,7 @@
 			<param index="0" name="from" type="int" />
 			<param index="1" name="to" type="int" />
 			<description>
-				Returns a random signed 32-bit integer between [code]from[/code] and [code]to[/code] (inclusive). If [code]to[/code] is lesser than [code]from[/code], they are swapped.
+				Returns a random signed 32-bit integer between [param from] and [param to] (inclusive). If [param to] is lesser than [param from], they are swapped.
 				[codeblock]
 				print(randi_range(0, 1)) # Prints 0 or 1
 				print(randi_range(-10, 1000)) # Prints any number from -10 to 1000
@@ -855,7 +855,7 @@
 			<param index="3" name="ostart" type="float" />
 			<param index="4" name="ostop" type="float" />
 			<description>
-				Maps a [code]value[/code] from range [code][istart, istop][/code] to [code][ostart, ostop][/code]. See also [method lerp] and [method inverse_lerp]. If [code]value[/code] is outside [code][istart, istop][/code], then the resulting value will also be outside [code][ostart, ostop][/code]. Use [method clamp] on the result of [method range_lerp] if this is not desired.
+				Maps a [param value] from range [code][istart, istop][/code] to [code][ostart, ostop][/code]. See also [method lerp] and [method inverse_lerp]. If [param value] is outside [code][istart, istop][/code], then the resulting value will also be outside [code][ostart, ostop][/code]. Use [method clamp] on the result of [method range_lerp] if this is not desired.
 				[codeblock]
 				range_lerp(75, 0, 100, -1, 1) # Returns 0.5
 				[/codeblock]
@@ -879,7 +879,7 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Rounds [code]x[/code] to the nearest whole number, with halfway cases rounded away from zero. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
+				Rounds [param x] to the nearest whole number, with halfway cases rounded away from zero. Supported types: [int], [float], [Vector2], [Vector3], [Vector4].
 				[codeblock]
 				round(2.4) # Returns 2
 				round(2.5) # Returns 3
@@ -893,7 +893,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Rounds [code]x[/code] to the nearest whole number, with halfway cases rounded away from zero.
+				Rounds [param x] to the nearest whole number, with halfway cases rounded away from zero.
 				A type-safe version of [method round], specialzied in floats.
 			</description>
 		</method>
@@ -901,7 +901,7 @@
 			<return type="int" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Rounds [code]x[/code] to the nearest whole number, with halfway cases rounded away from zero.
+				Rounds [param x] to the nearest whole number, with halfway cases rounded away from zero.
 				A type-safe version of [method round] that returns integer.
 			</description>
 		</method>
@@ -919,7 +919,7 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Returns the sign of [code]x[/code] as same type of [Variant] as [code]x[/code] with each component being -1, 0 and 1 for each negative, zero and positive values respectivelu. Variant types [int], [float] (real), [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
+				Returns the sign of [param x] as same type of [Variant] as [param x] with each component being -1, 0 and 1 for each negative, zero and positive values respectivelu. Variant types [int], [float] (real), [Vector2], [Vector2i], [Vector3] and [Vector3i] are supported.
 				[codeblock]
 				sign(-6.0) # Returns -1
 				sign(0.0)  # Returns 0
@@ -933,7 +933,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the sign of [code]x[/code] as a float: -1.0 or 1.0. Returns 0.0 if [code]x[/code] is 0.
+				Returns the sign of [param x] as a float: -1.0 or 1.0. Returns 0.0 if [param x] is 0.
 				[codeblock]
 				sign(-6.0) # Returns -1.0
 				sign(0.0)  # Returns 0.0
@@ -945,7 +945,7 @@
 			<return type="int" />
 			<param index="0" name="x" type="int" />
 			<description>
-				Returns the sign of [code]x[/code] as an integer: -1 or 1. Returns 0 if [code]x[/code] is 0.
+				Returns the sign of [param x] as an integer: -1 or 1. Returns 0 if [param x] is 0.
 				[codeblock]
 				sign(-6) # Returns -1
 				sign(0)  # Returns 0
@@ -957,7 +957,7 @@
 			<return type="float" />
 			<param index="0" name="angle_rad" type="float" />
 			<description>
-				Returns the sine of angle [code]angle_rad[/code] in radians.
+				Returns the sine of angle [param angle_rad] in radians.
 				[codeblock]
 				sin(0.523599)    # Returns 0.5
 				sin(deg2rad(90)) # Returns 1.0
@@ -968,7 +968,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the hyperbolic sine of [code]x[/code].
+				Returns the hyperbolic sine of [param x].
 				[codeblock]
 				var a = log(2.0) # Returns 0.693147
 				sinh(a) # Returns 0.75
@@ -981,8 +981,8 @@
 			<param index="1" name="to" type="float" />
 			<param index="2" name="x" type="float" />
 			<description>
-				Returns the result of smoothly interpolating the value of [code]x[/code] between [code]0[/code] and [code]1[/code], based on the where [code]x[/code] lies with respect to the edges [code]from[/code] and [code]to[/code].
-				The return value is [code]0[/code] if [code]x &lt;= from[/code], and [code]1[/code] if [code]x &gt;= to[/code]. If [code]x[/code] lies between [code]from[/code] and [code]to[/code], the returned value follows an S-shaped curve that maps [code]x[/code] between [code]0[/code] and [code]1[/code].
+				Returns the result of smoothly interpolating the value of [param x] between [code]0[/code] and [code]1[/code], based on the where [param x] lies with respect to the edges [param from] and [param to].
+				The return value is [code]0[/code] if [code]x &lt;= from[/code], and [code]1[/code] if [code]x &gt;= to[/code]. If [param x] lies between [param from] and [param to], the returned value follows an S-shaped curve that maps [param x] between [code]0[/code] and [code]1[/code].
 				This S-shaped curve is the cubic Hermite interpolator, given by [code]f(y) = 3*y^2 - 2*y^3[/code] where [code]y = (x-from) / (to-from)[/code].
 				[codeblock]
 				smoothstep(0, 2, -5.0) # Returns 0.0
@@ -999,7 +999,7 @@
 			<param index="0" name="x" type="float" />
 			<param index="1" name="step" type="float" />
 			<description>
-				Snaps float value [code]x[/code] to a given [code]step[/code]. This can also be used to round a floating point number to an arbitrary number of decimals.
+				Snaps float value [param x] to a given [param step]. This can also be used to round a floating point number to an arbitrary number of decimals.
 				[codeblock]
 				snapped(100, 32) # Returns 96
 				snapped(3.14159, 0.01) # Returns 3.14
@@ -1011,11 +1011,11 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the square root of [code]x[/code], where [code]x[/code] is a non-negative number.
+				Returns the square root of [param x], where [param x] is a non-negative number.
 				[codeblock]
 				sqrt(9) # Returns 3
 				[/codeblock]
-				[b]Note:[/b] Negative values of [code]x[/code] return NaN. If you need negative inputs, use [code]System.Numerics.Complex[/code] in C#.
+				[b]Note:[/b] Negative values of [param x] return NaN. If you need negative inputs, use [code]System.Numerics.Complex[/code] in C#.
 			</description>
 		</method>
 		<method name="step_decimals">
@@ -1055,7 +1055,7 @@
 			<return type="float" />
 			<param index="0" name="angle_rad" type="float" />
 			<description>
-				Returns the tangent of angle [code]angle_rad[/code] in radians.
+				Returns the tangent of angle [param angle_rad] in radians.
 				[codeblock]
 				tan(deg2rad(45)) # Returns 1
 				[/codeblock]
@@ -1065,7 +1065,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the hyperbolic tangent of [code]x[/code].
+				Returns the hyperbolic tangent of [param x].
 				[codeblock]
 				var a = log(2.0) # Returns 0.693147
 				tanh(a)      # Returns 0.6
@@ -1107,7 +1107,7 @@
 			<return type="String" />
 			<param index="0" name="variable" type="Variant" />
 			<description>
-				Converts a Variant [code]variable[/code] to a formatted string that can later be parsed using [method str2var].
+				Converts a Variant [param variable] to a formatted string that can later be parsed using [method str2var].
 				[codeblock]
 				a = { "a": 1, "b": 2 }
 				print(var2str(a))
@@ -1135,7 +1135,7 @@
 			<param index="1" name="min" type="Variant" />
 			<param index="2" name="max" type="Variant" />
 			<description>
-				Wraps the [Variant] [code]value[/code] between [code]min[/code] and [code]max[/code].
+				Wraps the [Variant] [param value] between [param min] and [param max].
 				Usable for creating loop-alike behavior or infinite surfaces.
 				Variant types [int] and [float] (real) are supported. If any of the argument is [float] the result will be [float], otherwise it is [int].
 				[codeblock]
@@ -1156,7 +1156,7 @@
 			<param index="1" name="min" type="float" />
 			<param index="2" name="max" type="float" />
 			<description>
-				Wraps float [code]value[/code] between [code]min[/code] and [code]max[/code].
+				Wraps float [param value] between [param min] and [param max].
 				Usable for creating loop-alike behavior or infinite surfaces.
 				[codeblock]
 				# Infinite loop between 5.0 and 9.9
@@ -1170,7 +1170,7 @@
 				# Infinite rotation (in radians)
 				angle = wrapf(angle + 0.1, -PI, PI)
 				[/codeblock]
-				[b]Note:[/b] If [code]min[/code] is [code]0[/code], this is equivalent to [method fposmod], so prefer using that instead.
+				[b]Note:[/b] If [param min] is [code]0[/code], this is equivalent to [method fposmod], so prefer using that instead.
 				[code]wrapf[/code] is more flexible than using the [method fposmod] approach by giving the user control over the minimum value.
 			</description>
 		</method>
@@ -1180,7 +1180,7 @@
 			<param index="1" name="min" type="int" />
 			<param index="2" name="max" type="int" />
 			<description>
-				Wraps integer [code]value[/code] between [code]min[/code] and [code]max[/code].
+				Wraps integer [param value] between [param min] and [param max].
 				Usable for creating loop-alike behavior or infinite surfaces.
 				[codeblock]
 				# Infinite loop between 5 and 9

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -195,21 +195,21 @@
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="to" type="Vector3" />
 			<description>
-				Returns [code]true[/code] if the [AABB] intersects the line segment between [code]from[/code] and [code]to[/code].
+				Returns [code]true[/code] if the [AABB] intersects the line segment between [param from] and [param to].
 			</description>
 		</method>
 		<method name="is_equal_approx" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="aabb" type="AABB" />
 			<description>
-				Returns [code]true[/code] if this [AABB] and [code]aabb[/code] are approximately equal, by calling [method @GlobalScope.is_equal_approx] on each component.
+				Returns [code]true[/code] if this [AABB] and [param aabb] are approximately equal, by calling [method @GlobalScope.is_equal_approx] on each component.
 			</description>
 		</method>
 		<method name="merge" qualifiers="const">
 			<return type="AABB" />
 			<param index="0" name="with" type="AABB" />
 			<description>
-				Returns a larger [AABB] that contains both this [AABB] and [code]with[/code].
+				Returns a larger [AABB] that contains both this [AABB] and [param with].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AESContext.xml
+++ b/doc/classes/AESContext.xml
@@ -98,15 +98,15 @@
 			<param index="1" name="key" type="PackedByteArray" />
 			<param index="2" name="iv" type="PackedByteArray" default="PackedByteArray()" />
 			<description>
-				Start the AES context in the given [code]mode[/code]. A [code]key[/code] of either 16 or 32 bytes must always be provided, while an [code]iv[/code] (initialization vector) of exactly 16 bytes, is only needed when [code]mode[/code] is either [constant MODE_CBC_ENCRYPT] or [constant MODE_CBC_DECRYPT].
+				Start the AES context in the given [param mode]. A [param key] of either 16 or 32 bytes must always be provided, while an [param iv] (initialization vector) of exactly 16 bytes, is only needed when [param mode] is either [constant MODE_CBC_ENCRYPT] or [constant MODE_CBC_DECRYPT].
 			</description>
 		</method>
 		<method name="update">
 			<return type="PackedByteArray" />
 			<param index="0" name="src" type="PackedByteArray" />
 			<description>
-				Run the desired operation for this AES context. Will return a [PackedByteArray] containing the result of encrypting (or decrypting) the given [code]src[/code]. See [method start] for mode of operation.
-				[b]Note:[/b] The size of [code]src[/code] must be a multiple of 16. Apply some padding if needed.
+				Run the desired operation for this AES context. Will return a [PackedByteArray] containing the result of encrypting (or decrypting) the given [param src]. See [method start] for mode of operation.
+				[b]Note:[/b] The size of [param src] must be a multiple of 16. Apply some padding if needed.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -33,8 +33,8 @@
 			<param index="1" name="position" type="Vector2" />
 			<param index="2" name="weight_scale" type="float" default="1.0" />
 			<description>
-				Adds a new point at the given position with the given identifier. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 0.0 or greater.
-				The [code]weight_scale[/code] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point. Thus, all else being equal, the algorithm prefers points with lower [code]weight_scale[/code]s to form a path.
+				Adds a new point at the given position with the given identifier. The [param id] must be 0 or larger, and the [param weight_scale] must be 0.0 or greater.
+				The [param weight_scale] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point. Thus, all else being equal, the algorithm prefers points with lower [param weight_scale]s to form a path.
 				[codeblocks]
 				[gdscript]
 				var astar = AStar2D.new()
@@ -45,7 +45,7 @@
 				astar.AddPoint(1, new Vector2(1, 0), 4); // Adds the point (1, 0) with weight_scale 4 and id 1
 				[/csharp]
 				[/codeblocks]
-				If there already exists a point for the given [code]id[/code], its position and weight scale are updated to the given values.
+				If there already exists a point for the given [param id], its position and weight scale are updated to the given values.
 			</description>
 		</method>
 		<method name="are_points_connected" qualifiers="const">
@@ -54,7 +54,7 @@
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="bidirectional" type="bool" default="true" />
 			<description>
-				Returns whether there is a connection/segment between the given points. If [code]bidirectional[/code] is [code]false[/code], returns whether movement from [code]id[/code] to [code]to_id[/code] is possible through this segment.
+				Returns whether there is a connection/segment between the given points. If [param bidirectional] is [code]false[/code], returns whether movement from [param id] to [param to_id] is possible through this segment.
 			</description>
 		</method>
 		<method name="clear">
@@ -69,7 +69,7 @@
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="bidirectional" type="bool" default="true" />
 			<description>
-				Creates a segment between the given points. If [code]bidirectional[/code] is [code]false[/code], only movement from [code]id[/code] to [code]to_id[/code] is allowed, not the reverse direction.
+				Creates a segment between the given points. If [param bidirectional] is [code]false[/code], only movement from [param id] to [param to_id] is allowed, not the reverse direction.
 				[codeblocks]
 				[gdscript]
 				var astar = AStar2D.new()
@@ -92,7 +92,7 @@
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="bidirectional" type="bool" default="true" />
 			<description>
-				Deletes the segment between the given points. If [code]bidirectional[/code] is [code]false[/code], only movement from [code]id[/code] to [code]to_id[/code] is prevented, and a unidirectional segment possibly remains.
+				Deletes the segment between the given points. If [param bidirectional] is [code]false[/code], only movement from [param id] to [param to_id] is prevented, and a unidirectional segment possibly remains.
 			</description>
 		</method>
 		<method name="get_available_point_id" qualifiers="const">
@@ -106,15 +106,15 @@
 			<param index="0" name="to_position" type="Vector2" />
 			<param index="1" name="include_disabled" type="bool" default="false" />
 			<description>
-				Returns the ID of the closest point to [code]to_position[/code], optionally taking disabled points into account. Returns [code]-1[/code] if there are no points in the points pool.
-				[b]Note:[/b] If several points are the closest to [code]to_position[/code], the one with the smallest ID will be returned, ensuring a deterministic result.
+				Returns the ID of the closest point to [param to_position], optionally taking disabled points into account. Returns [code]-1[/code] if there are no points in the points pool.
+				[b]Note:[/b] If several points are the closest to [param to_position], the one with the smallest ID will be returned, ensuring a deterministic result.
 			</description>
 		</method>
 		<method name="get_closest_position_in_segment" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="to_position" type="Vector2" />
 			<description>
-				Returns the closest position to [code]to_position[/code] that resides inside a segment between two connected points.
+				Returns the closest position to [param to_position] that resides inside a segment between two connected points.
 				[codeblocks]
 				[gdscript]
 				var astar = AStar2D.new()
@@ -236,21 +236,21 @@
 			<return type="Vector2" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns the position of the point associated with the given [code]id[/code].
+				Returns the position of the point associated with the given [param id].
 			</description>
 		</method>
 		<method name="get_point_weight_scale" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns the weight scale of the point associated with the given [code]id[/code].
+				Returns the weight scale of the point associated with the given [param id].
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns whether a point associated with the given [code]id[/code] exists.
+				Returns whether a point associated with the given [param id] exists.
 			</description>
 		</method>
 		<method name="is_point_disabled" qualifiers="const">
@@ -264,14 +264,14 @@
 			<return type="void" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Removes the point associated with the given [code]id[/code] from the points pool.
+				Removes the point associated with the given [param id] from the points pool.
 			</description>
 		</method>
 		<method name="reserve_space">
 			<return type="void" />
 			<param index="0" name="num_nodes" type="int" />
 			<description>
-				Reserves space internally for [code]num_nodes[/code] points, useful if you're adding a known large number of points at once, for a grid for instance. New capacity must be greater or equals to old capacity.
+				Reserves space internally for [param num_nodes] points, useful if you're adding a known large number of points at once, for a grid for instance. New capacity must be greater or equals to old capacity.
 			</description>
 		</method>
 		<method name="set_point_disabled">
@@ -287,7 +287,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the [code]position[/code] for the point with the given [code]id[/code].
+				Sets the [param position] for the point with the given [param id].
 			</description>
 		</method>
 		<method name="set_point_weight_scale">
@@ -295,7 +295,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="weight_scale" type="float" />
 			<description>
-				Sets the [code]weight_scale[/code] for the point with the given [code]id[/code]. The [code]weight_scale[/code] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point.
+				Sets the [param weight_scale] for the point with the given [param id]. The [param weight_scale] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -62,8 +62,8 @@
 			<param index="1" name="position" type="Vector3" />
 			<param index="2" name="weight_scale" type="float" default="1.0" />
 			<description>
-				Adds a new point at the given position with the given identifier. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 0.0 or greater.
-				The [code]weight_scale[/code] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point. Thus, all else being equal, the algorithm prefers points with lower [code]weight_scale[/code]s to form a path.
+				Adds a new point at the given position with the given identifier. The [param id] must be 0 or larger, and the [param weight_scale] must be 0.0 or greater.
+				The [param weight_scale] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point. Thus, all else being equal, the algorithm prefers points with lower [param weight_scale]s to form a path.
 				[codeblocks]
 				[gdscript]
 				var astar = AStar3D.new()
@@ -74,7 +74,7 @@
 				astar.AddPoint(1, new Vector3(1, 0, 0), 4); // Adds the point (1, 0, 0) with weight_scale 4 and id 1
 				[/csharp]
 				[/codeblocks]
-				If there already exists a point for the given [code]id[/code], its position and weight scale are updated to the given values.
+				If there already exists a point for the given [param id], its position and weight scale are updated to the given values.
 			</description>
 		</method>
 		<method name="are_points_connected" qualifiers="const">
@@ -83,7 +83,7 @@
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="bidirectional" type="bool" default="true" />
 			<description>
-				Returns whether the two given points are directly connected by a segment. If [code]bidirectional[/code] is [code]false[/code], returns whether movement from [code]id[/code] to [code]to_id[/code] is possible through this segment.
+				Returns whether the two given points are directly connected by a segment. If [param bidirectional] is [code]false[/code], returns whether movement from [param id] to [param to_id] is possible through this segment.
 			</description>
 		</method>
 		<method name="clear">
@@ -98,7 +98,7 @@
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="bidirectional" type="bool" default="true" />
 			<description>
-				Creates a segment between the given points. If [code]bidirectional[/code] is [code]false[/code], only movement from [code]id[/code] to [code]to_id[/code] is allowed, not the reverse direction.
+				Creates a segment between the given points. If [param bidirectional] is [code]false[/code], only movement from [param id] to [param to_id] is allowed, not the reverse direction.
 				[codeblocks]
 				[gdscript]
 				var astar = AStar3D.new()
@@ -121,7 +121,7 @@
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="bidirectional" type="bool" default="true" />
 			<description>
-				Deletes the segment between the given points. If [code]bidirectional[/code] is [code]false[/code], only movement from [code]id[/code] to [code]to_id[/code] is prevented, and a unidirectional segment possibly remains.
+				Deletes the segment between the given points. If [param bidirectional] is [code]false[/code], only movement from [param id] to [param to_id] is prevented, and a unidirectional segment possibly remains.
 			</description>
 		</method>
 		<method name="get_available_point_id" qualifiers="const">
@@ -135,15 +135,15 @@
 			<param index="0" name="to_position" type="Vector3" />
 			<param index="1" name="include_disabled" type="bool" default="false" />
 			<description>
-				Returns the ID of the closest point to [code]to_position[/code], optionally taking disabled points into account. Returns [code]-1[/code] if there are no points in the points pool.
-				[b]Note:[/b] If several points are the closest to [code]to_position[/code], the one with the smallest ID will be returned, ensuring a deterministic result.
+				Returns the ID of the closest point to [param to_position], optionally taking disabled points into account. Returns [code]-1[/code] if there are no points in the points pool.
+				[b]Note:[/b] If several points are the closest to [param to_position], the one with the smallest ID will be returned, ensuring a deterministic result.
 			</description>
 		</method>
 		<method name="get_closest_position_in_segment" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="to_position" type="Vector3" />
 			<description>
-				Returns the closest position to [code]to_position[/code] that resides inside a segment between two connected points.
+				Returns the closest position to [param to_position] that resides inside a segment between two connected points.
 				[codeblocks]
 				[gdscript]
 				var astar = AStar3D.new()
@@ -263,21 +263,21 @@
 			<return type="Vector3" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns the position of the point associated with the given [code]id[/code].
+				Returns the position of the point associated with the given [param id].
 			</description>
 		</method>
 		<method name="get_point_weight_scale" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns the weight scale of the point associated with the given [code]id[/code].
+				Returns the weight scale of the point associated with the given [param id].
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Returns whether a point associated with the given [code]id[/code] exists.
+				Returns whether a point associated with the given [param id] exists.
 			</description>
 		</method>
 		<method name="is_point_disabled" qualifiers="const">
@@ -291,14 +291,14 @@
 			<return type="void" />
 			<param index="0" name="id" type="int" />
 			<description>
-				Removes the point associated with the given [code]id[/code] from the points pool.
+				Removes the point associated with the given [param id] from the points pool.
 			</description>
 		</method>
 		<method name="reserve_space">
 			<return type="void" />
 			<param index="0" name="num_nodes" type="int" />
 			<description>
-				Reserves space internally for [code]num_nodes[/code] points, useful if you're adding a known large number of points at once, for a grid for instance. New capacity must be greater or equals to old capacity.
+				Reserves space internally for [param num_nodes] points, useful if you're adding a known large number of points at once, for a grid for instance. New capacity must be greater or equals to old capacity.
 			</description>
 		</method>
 		<method name="set_point_disabled">
@@ -314,7 +314,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the [code]position[/code] for the point with the given [code]id[/code].
+				Sets the [param position] for the point with the given [param id].
 			</description>
 		</method>
 		<method name="set_point_weight_scale">
@@ -322,7 +322,7 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="weight_scale" type="float" />
 			<description>
-				Sets the [code]weight_scale[/code] for the point with the given [code]id[/code]. The [code]weight_scale[/code] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point.
+				Sets the [param weight_scale] for the point with the given [param id]. The [param weight_scale] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -15,8 +15,8 @@
 			<param index="1" name="right" type="bool" default="false" />
 			<param index="2" name="action" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a button with label [code]text[/code] and a custom [code]action[/code] to the dialog and returns the created button. [code]action[/code] will be passed to the [signal custom_action] signal when pressed.
-				If [code]true[/code], [code]right[/code] will place the button to the right of any sibling buttons.
+				Adds a button with label [param text] and a custom [param action] to the dialog and returns the created button. [param action] will be passed to the [signal custom_action] signal when pressed.
+				If [code]true[/code], [param right] will place the button to the right of any sibling buttons.
 				You can use [method remove_button] method to remove a button created with this method from the dialog.
 			</description>
 		</method>
@@ -24,7 +24,7 @@
 			<return type="Button" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Adds a button with label [code]name[/code] and a cancel action to the dialog and returns the created button.
+				Adds a button with label [param name] and a cancel action to the dialog and returns the created button.
 				You can use [method remove_button] method to remove a button created with this method from the dialog.
 			</description>
 		</method>
@@ -53,7 +53,7 @@
 			<return type="void" />
 			<param index="0" name="button" type="Control" />
 			<description>
-				Removes the [code]button[/code] from the dialog. Does NOT free the [code]button[/code]. The [code]button[/code] must be a [Button] added with [method add_button] or [method add_cancel_button] method. After removal, pressing the [code]button[/code] will no longer emit this dialog's [signal custom_action] or [signal cancelled] signals.
+				Removes the [param button] from the dialog. Does NOT free the [param button]. The [param button] must be a [Button] added with [method add_button] or [method add_cancel_button] method. After removal, pressing the [param button] will no longer emit this dialog's [signal custom_action] or [signal cancelled] signals.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -17,7 +17,7 @@
 			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
 			<param index="1" name="backwards" type="bool" default="false" />
 			<description>
-				Plays the animation named [code]anim[/code]. If no [code]anim[/code] is provided, the current animation is played. If [code]backwards[/code] is [code]true[/code], the animation will be played in reverse.
+				Plays the animation named [param anim]. If no [param anim] is provided, the current animation is played. If [code]backwards[/code] is [code]true[/code], the animation will be played in reverse.
 			</description>
 		</method>
 		<method name="stop">

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -20,7 +20,7 @@
 			<return type="void" />
 			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
-				Plays the animation named [code]anim[/code]. If no [code]anim[/code] is provided, the current animation is played.
+				Plays the animation named [param anim]. If no [param anim] is provided, the current animation is played.
 			</description>
 		</method>
 		<method name="stop">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -44,7 +44,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
-				Returns the animation name at the key identified by [code]key_idx[/code]. The [code]track_idx[/code] must be the index of an Animation Track.
+				Returns the animation name at the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
 			</description>
 		</method>
 		<method name="animation_track_insert_key">
@@ -53,7 +53,7 @@
 			<param index="1" name="time" type="float" />
 			<param index="2" name="animation" type="StringName" />
 			<description>
-				Inserts a key with value [code]animation[/code] at the given [code]time[/code] (in seconds). The [code]track_idx[/code] must be the index of an Animation Track.
+				Inserts a key with value [param animation] at the given [param time] (in seconds). The [param track_idx] must be the index of an Animation Track.
 			</description>
 		</method>
 		<method name="animation_track_set_key_animation">
@@ -62,7 +62,7 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="animation" type="StringName" />
 			<description>
-				Sets the key identified by [code]key_idx[/code] to value [code]animation[/code]. The [code]track_idx[/code] must be the index of an Animation Track.
+				Sets the key identified by [param key_idx] to value [param animation]. The [param track_idx] must be the index of an Animation Track.
 			</description>
 		</method>
 		<method name="audio_track_get_key_end_offset" qualifiers="const">
@@ -70,7 +70,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
-				Returns the end offset of the key identified by [code]key_idx[/code]. The [code]track_idx[/code] must be the index of an Audio Track.
+				Returns the end offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
 				End offset is the number of seconds cut off at the ending of the audio stream.
 			</description>
 		</method>
@@ -79,7 +79,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
-				Returns the start offset of the key identified by [code]key_idx[/code]. The [code]track_idx[/code] must be the index of an Audio Track.
+				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
 				Start offset is the number of seconds cut off at the beginning of the audio stream.
 			</description>
 		</method>
@@ -88,7 +88,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
-				Returns the audio stream of the key identified by [code]key_idx[/code]. The [code]track_idx[/code] must be the index of an Audio Track.
+				Returns the audio stream of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
 			</description>
 		</method>
 		<method name="audio_track_insert_key">
@@ -99,8 +99,8 @@
 			<param index="3" name="start_offset" type="float" default="0" />
 			<param index="4" name="end_offset" type="float" default="0" />
 			<description>
-				Inserts an Audio Track key at the given [code]time[/code] in seconds. The [code]track_idx[/code] must be the index of an Audio Track.
-				[code]stream[/code] is the [AudioStream] resource to play. [code]start_offset[/code] is the number of seconds cut off at the beginning of the audio stream, while [code]end_offset[/code] is at the ending.
+				Inserts an Audio Track key at the given [param time] in seconds. The [param track_idx] must be the index of an Audio Track.
+				[param stream] is the [AudioStream] resource to play. [param start_offset] is the number of seconds cut off at the beginning of the audio stream, while [param end_offset] is at the ending.
 			</description>
 		</method>
 		<method name="audio_track_set_key_end_offset">
@@ -109,7 +109,7 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="offset" type="float" />
 			<description>
-				Sets the end offset of the key identified by [code]key_idx[/code] to value [code]offset[/code]. The [code]track_idx[/code] must be the index of an Audio Track.
+				Sets the end offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Audio Track.
 			</description>
 		</method>
 		<method name="audio_track_set_key_start_offset">
@@ -118,7 +118,7 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="offset" type="float" />
 			<description>
-				Sets the start offset of the key identified by [code]key_idx[/code] to value [code]offset[/code]. The [code]track_idx[/code] must be the index of an Audio Track.
+				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Audio Track.
 			</description>
 		</method>
 		<method name="audio_track_set_key_stream">
@@ -127,7 +127,7 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="stream" type="Resource" />
 			<description>
-				Sets the stream of the key identified by [code]key_idx[/code] to value [code]stream[/code]. The [code]track_idx[/code] must be the index of an Audio Track.
+				Sets the stream of the key identified by [param key_idx] to value [param stream]. The [param track_idx] must be the index of an Audio Track.
 			</description>
 		</method>
 		<method name="bezier_track_get_key_handle_mode" qualifiers="const">
@@ -135,7 +135,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
-				Returns the handle mode of the key identified by [code]index[/code]. See [enum HandleMode] for possible values. The [code]track_idx[/code] must be the index of a Bezier Track.
+				Returns the handle mode of the key identified by [param key_idx]. See [enum HandleMode] for possible values. The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="bezier_track_get_key_in_handle" qualifiers="const">
@@ -143,7 +143,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
-				Returns the in handle of the key identified by [code]key_idx[/code]. The [code]track_idx[/code] must be the index of a Bezier Track.
+				Returns the in handle of the key identified by [param key_idx]. The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="bezier_track_get_key_out_handle" qualifiers="const">
@@ -151,7 +151,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
-				Returns the out handle of the key identified by [code]key_idx[/code]. The [code]track_idx[/code] must be the index of a Bezier Track.
+				Returns the out handle of the key identified by [param key_idx]. The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="bezier_track_get_key_value" qualifiers="const">
@@ -159,7 +159,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
-				Returns the value of the key identified by [code]key_idx[/code]. The [code]track_idx[/code] must be the index of a Bezier Track.
+				Returns the value of the key identified by [param key_idx]. The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="bezier_track_insert_key">
@@ -171,8 +171,8 @@
 			<param index="4" name="out_handle" type="Vector2" default="Vector2(0, 0)" />
 			<param index="5" name="handle_mode" type="int" enum="Animation.HandleMode" default="1" />
 			<description>
-				Inserts a Bezier Track key at the given [code]time[/code] in seconds. The [code]track_idx[/code] must be the index of a Bezier Track.
-				[code]in_handle[/code] is the left-side weight of the added Bezier curve point, [code]out_handle[/code] is the right-side one, while [code]value[/code] is the actual value at this point.
+				Inserts a Bezier Track key at the given [param time] in seconds. The [param track_idx] must be the index of a Bezier Track.
+				[param in_handle] is the left-side weight of the added Bezier curve point, [param out_handle] is the right-side one, while [param value] is the actual value at this point.
 			</description>
 		</method>
 		<method name="bezier_track_interpolate" qualifiers="const">
@@ -180,7 +180,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="time" type="float" />
 			<description>
-				Returns the interpolated value at the given [code]time[/code] (in seconds). The [code]track_idx[/code] must be the index of a Bezier Track.
+				Returns the interpolated value at the given [param time] (in seconds). The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="bezier_track_set_key_handle_mode">
@@ -190,7 +190,7 @@
 			<param index="2" name="key_handle_mode" type="int" enum="Animation.HandleMode" />
 			<param index="3" name="balanced_value_time_ratio" type="float" default="1.0" />
 			<description>
-				Changes the handle mode of the keyframe at the given [code]index[/code]. See [enum HandleMode] for possible values. The [code]track_idx[/code] must be the index of a Bezier Track.
+				Changes the handle mode of the keyframe at the given [param key_idx]. See [enum HandleMode] for possible values. The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="bezier_track_set_key_in_handle">
@@ -200,7 +200,7 @@
 			<param index="2" name="in_handle" type="Vector2" />
 			<param index="3" name="balanced_value_time_ratio" type="float" default="1.0" />
 			<description>
-				Sets the in handle of the key identified by [code]key_idx[/code] to value [code]in_handle[/code]. The [code]track_idx[/code] must be the index of a Bezier Track.
+				Sets the in handle of the key identified by [param key_idx] to value [param in_handle]. The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="bezier_track_set_key_out_handle">
@@ -210,7 +210,7 @@
 			<param index="2" name="out_handle" type="Vector2" />
 			<param index="3" name="balanced_value_time_ratio" type="float" default="1.0" />
 			<description>
-				Sets the out handle of the key identified by [code]key_idx[/code] to value [code]out_handle[/code]. The [code]track_idx[/code] must be the index of a Bezier Track.
+				Sets the out handle of the key identified by [param key_idx] to value [param out_handle]. The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="bezier_track_set_key_value">
@@ -219,7 +219,7 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="value" type="float" />
 			<description>
-				Sets the value of the key identified by [code]key_idx[/code] to the given value. The [code]track_idx[/code] must be the index of a Bezier Track.
+				Sets the value of the key identified by [param key_idx] to the given value. The [param track_idx] must be the index of a Bezier Track.
 			</description>
 		</method>
 		<method name="blend_shape_track_insert_key">
@@ -249,7 +249,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="to_animation" type="Animation" />
 			<description>
-				Adds a new track that is a copy of the given track from [code]to_animation[/code].
+				Adds a new track that is a copy of the given track from [param to_animation].
 			</description>
 		</method>
 		<method name="find_track" qualifiers="const">
@@ -335,7 +335,7 @@
 			<return type="bool" />
 			<param index="0" name="track_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the track at [code]idx[/code] wraps the interpolation loop. New tracks wrap the interpolation loop by default.
+				Returns [code]true[/code] if the track at [param track_idx] wraps the interpolation loop. New tracks wrap the interpolation loop by default.
 			</description>
 		</method>
 		<method name="track_get_interpolation_type" qualifiers="const">
@@ -410,7 +410,7 @@
 			<return type="bool" />
 			<param index="0" name="track_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if the track at index [code]idx[/code] is enabled.
+				Returns [code]true[/code] if the track at index [param track_idx] is enabled.
 			</description>
 		</method>
 		<method name="track_is_imported" qualifiers="const">
@@ -432,7 +432,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="to_idx" type="int" />
 			<description>
-				Changes the index position of track [code]idx[/code] to the one defined in [code]to_idx[/code].
+				Changes the index position of track [param track_idx] to the one defined in [param to_idx].
 			</description>
 		</method>
 		<method name="track_move_up">
@@ -455,7 +455,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="time" type="float" />
 			<description>
-				Removes a key at [code]time[/code] in a given track.
+				Removes a key at [param time] in a given track.
 			</description>
 		</method>
 		<method name="track_set_enabled">
@@ -479,7 +479,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="interpolation" type="bool" />
 			<description>
-				If [code]true[/code], the track at [code]idx[/code] wraps the interpolation loop.
+				If [code]true[/code], the track at [param track_idx] wraps the interpolation loop.
 			</description>
 		</method>
 		<method name="track_set_interpolation_type">
@@ -531,7 +531,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="with_idx" type="int" />
 			<description>
-				Swaps the track [code]idx[/code]'s index position with the track [code]with_idx[/code].
+				Swaps the track [param track_idx]'s index position with the track [param with_idx].
 			</description>
 		</method>
 		<method name="value_track_get_key_indices" qualifiers="const">
@@ -555,7 +555,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="time_sec" type="float" />
 			<description>
-				Returns the interpolated value at the given time (in seconds). The [code]track_idx[/code] must be the index of a value track.
+				Returns the interpolated value at the given time (in seconds). The [param track_idx] must be the index of a value track.
 			</description>
 		</method>
 		<method name="value_track_set_update_mode">

--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -55,7 +55,7 @@
 			<param index="1" name="seek" type="bool" />
 			<param index="2" name="seek_root" type="bool" />
 			<description>
-				User-defined callback called when a custom node is processed. The [code]time[/code] parameter is a relative delta, unless [code]seek[/code] is [code]true[/code], in which case it is absolute.
+				User-defined callback called when a custom node is processed. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute.
 				Here, call the [method blend_input], [method blend_node] or [method blend_animation] functions. You can also use [method get_parameter] and [method set_parameter] to modify local memory.
 				This function should return the time left for the current animation to finish (if unsure, pass the value from the main blend being called).
 			</description>
@@ -77,7 +77,7 @@
 			<param index="5" name="blend" type="float" />
 			<param index="6" name="pingponged" type="int" default="0" />
 			<description>
-				Blend an animation by [code]blend[/code] amount (name must be valid in the linked [AnimationPlayer]). A [code]time[/code] and [code]delta[/code] may be passed, as well as whether [code]seek[/code] happened.
+				Blend an animation by [param blend] amount (name must be valid in the linked [AnimationPlayer]). A [param time] and [param delta] may be passed, as well as whether [param seeked] happened.
 			</description>
 		</method>
 		<method name="blend_input">
@@ -90,7 +90,7 @@
 			<param index="5" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
 			<param index="6" name="sync" type="bool" default="true" />
 			<description>
-				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. The [code]time[/code] parameter is a relative delta, unless [code]seek[/code] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
+				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
 			</description>
 		</method>
 		<method name="blend_node">

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -19,7 +19,7 @@
 			<param index="1" name="pos" type="float" />
 			<param index="2" name="at_index" type="int" default="-1" />
 			<description>
-				Adds a new point that represents a [code]node[/code] on the virtual axis at a given position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code], the point is inserted at the end of the blend points array.
+				Adds a new point that represents a [param node] on the virtual axis at a given position set by [param pos]. You can insert it at a specific index using the [param at_index] argument. If you use the default value for [param at_index], the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="get_blend_point_count" qualifiers="const">
@@ -32,21 +32,21 @@
 			<return type="AnimationRootNode" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Returns the [AnimationNode] referenced by the point at index [code]point[/code].
+				Returns the [AnimationNode] referenced by the point at index [param point].
 			</description>
 		</method>
 		<method name="get_blend_point_position" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Returns the position of the point at index [code]point[/code].
+				Returns the position of the point at index [param point].
 			</description>
 		</method>
 		<method name="remove_blend_point">
 			<return type="void" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Removes the point at index [code]point[/code] from the blend axis.
+				Removes the point at index [param point] from the blend axis.
 			</description>
 		</method>
 		<method name="set_blend_point_node">
@@ -54,7 +54,7 @@
 			<param index="0" name="point" type="int" />
 			<param index="1" name="node" type="AnimationRootNode" />
 			<description>
-				Changes the [AnimationNode] referenced by the point at index [code]point[/code].
+				Changes the [AnimationNode] referenced by the point at index [param point].
 			</description>
 		</method>
 		<method name="set_blend_point_position">
@@ -62,7 +62,7 @@
 			<param index="0" name="point" type="int" />
 			<param index="1" name="pos" type="float" />
 			<description>
-				Updates the position of the point at index [code]point[/code] on the blend axis.
+				Updates the position of the point at index [param point] on the blend axis.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -19,7 +19,7 @@
 			<param index="1" name="pos" type="Vector2" />
 			<param index="2" name="at_index" type="int" default="-1" />
 			<description>
-				Adds a new point that represents a [code]node[/code] at the position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code], the point is inserted at the end of the blend points array.
+				Adds a new point that represents a [param node] at the position set by [param pos]. You can insert it at a specific index using the [param at_index] argument. If you use the default value for [param at_index], the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="add_triangle">
@@ -29,7 +29,7 @@
 			<param index="2" name="z" type="int" />
 			<param index="3" name="at_index" type="int" default="-1" />
 			<description>
-				Creates a new triangle using three points [code]x[/code], [code]y[/code], and [code]z[/code]. Triangles can overlap. You can insert the triangle at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code], the point is inserted at the end of the blend points array.
+				Creates a new triangle using three points [param x], [param y], and [param z]. Triangles can overlap. You can insert the triangle at a specific index using the [param at_index] argument. If you use the default value for [param at_index], the point is inserted at the end of the blend points array.
 			</description>
 		</method>
 		<method name="get_blend_point_count" qualifiers="const">
@@ -42,14 +42,14 @@
 			<return type="AnimationRootNode" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Returns the [AnimationRootNode] referenced by the point at index [code]point[/code].
+				Returns the [AnimationRootNode] referenced by the point at index [param point].
 			</description>
 		</method>
 		<method name="get_blend_point_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Returns the position of the point at index [code]point[/code].
+				Returns the position of the point at index [param point].
 			</description>
 		</method>
 		<method name="get_triangle_count" qualifiers="const">
@@ -63,21 +63,21 @@
 			<param index="0" name="triangle" type="int" />
 			<param index="1" name="point" type="int" />
 			<description>
-				Returns the position of the point at index [code]point[/code] in the triangle of index [code]triangle[/code].
+				Returns the position of the point at index [param point] in the triangle of index [param triangle].
 			</description>
 		</method>
 		<method name="remove_blend_point">
 			<return type="void" />
 			<param index="0" name="point" type="int" />
 			<description>
-				Removes the point at index [code]point[/code] from the blend space.
+				Removes the point at index [param point] from the blend space.
 			</description>
 		</method>
 		<method name="remove_triangle">
 			<return type="void" />
 			<param index="0" name="triangle" type="int" />
 			<description>
-				Removes the triangle at index [code]triangle[/code] from the blend space.
+				Removes the triangle at index [param triangle] from the blend space.
 			</description>
 		</method>
 		<method name="set_blend_point_node">
@@ -85,7 +85,7 @@
 			<param index="0" name="point" type="int" />
 			<param index="1" name="node" type="AnimationRootNode" />
 			<description>
-				Changes the [AnimationNode] referenced by the point at index [code]point[/code].
+				Changes the [AnimationNode] referenced by the point at index [param point].
 			</description>
 		</method>
 		<method name="set_blend_point_position">
@@ -93,7 +93,7 @@
 			<param index="0" name="point" type="int" />
 			<param index="1" name="pos" type="Vector2" />
 			<description>
-				Updates the position of the point at index [code]point[/code] on the blend axis.
+				Updates the position of the point at index [param point] on the blend axis.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeBlendTree.xml
+++ b/doc/classes/AnimationNodeBlendTree.xml
@@ -17,7 +17,7 @@
 			<param index="1" name="node" type="AnimationNode" />
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Adds an [AnimationNode] at the given [code]position[/code]. The [code]name[/code] is used to identify the created sub-node later.
+				Adds an [AnimationNode] at the given [param position]. The [param name] is used to identify the created sub-node later.
 			</description>
 		</method>
 		<method name="connect_node">
@@ -26,7 +26,7 @@
 			<param index="1" name="input_index" type="int" />
 			<param index="2" name="output_node" type="StringName" />
 			<description>
-				Connects the output of an [AnimationNode] as input for another [AnimationNode], at the input port specified by [code]input_index[/code].
+				Connects the output of an [AnimationNode] as input for another [AnimationNode], at the input port specified by [param input_index].
 			</description>
 		</method>
 		<method name="disconnect_node">
@@ -41,21 +41,21 @@
 			<return type="AnimationNode" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the sub-node with the specified [code]name[/code].
+				Returns the sub-node with the specified [param name].
 			</description>
 		</method>
 		<method name="get_node_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the position of the sub-node with the specified [code]name[/code].
+				Returns the position of the sub-node with the specified [param name].
 			</description>
 		</method>
 		<method name="has_node" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if a sub-node with specified [code]name[/code] exists.
+				Returns [code]true[/code] if a sub-node with specified [param name] exists.
 			</description>
 		</method>
 		<method name="remove_node">

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -27,7 +27,7 @@
 			<param index="1" name="node" type="AnimationNode" />
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Adds a new node to the graph. The [code]position[/code] is used for display in the editor.
+				Adds a new node to the graph. The [param position] is used for display in the editor.
 			</description>
 		</method>
 		<method name="add_transition">

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -20,21 +20,21 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="library" type="AnimationLibrary" />
 			<description>
-				Adds [code]library[/code] to the animation player, under the key [code]name[/code].
+				Adds [param library] to the animation player, under the key [param name].
 			</description>
 		</method>
 		<method name="advance">
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
 			<description>
-				Shifts position in the animation timeline and immediately updates the animation. [code]delta[/code] is the time in seconds to shift. Events between the current frame and [code]delta[/code] are handled.
+				Shifts position in the animation timeline and immediately updates the animation. [param delta] is the time in seconds to shift. Events between the current frame and [param delta] are handled.
 			</description>
 		</method>
 		<method name="animation_get_next" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="anim_from" type="StringName" />
 			<description>
-				Returns the key of the animation which is queued to play after the [code]anim_from[/code] animation.
+				Returns the key of the animation which is queued to play after the [param anim_from] animation.
 			</description>
 		</method>
 		<method name="animation_set_next">
@@ -42,7 +42,7 @@
 			<param index="0" name="anim_from" type="StringName" />
 			<param index="1" name="anim_to" type="StringName" />
 			<description>
-				Triggers the [code]anim_to[/code] animation when the [code]anim_from[/code] animation completes.
+				Triggers the [param anim_to] animation when the [param anim_from] animation completes.
 			</description>
 		</method>
 		<method name="clear_caches">
@@ -61,28 +61,28 @@
 			<return type="StringName" />
 			<param index="0" name="animation" type="Animation" />
 			<description>
-				Returns the key of [code]animation[/code] or an empty [StringName] if not found.
+				Returns the key of [param animation] or an empty [StringName] if not found.
 			</description>
 		</method>
 		<method name="find_animation_library" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="animation" type="Animation" />
 			<description>
-				Returns the key for the [AnimationLibrary] that contains [code]animation[/code] or an empty [StringName] if not found.
+				Returns the key for the [AnimationLibrary] that contains [param animation] or an empty [StringName] if not found.
 			</description>
 		</method>
 		<method name="get_animation" qualifiers="const">
 			<return type="Animation" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the [Animation] with key [code]name[/code] or [code]null[/code] if not found.
+				Returns the [Animation] with key [param name] or [code]null[/code] if not found.
 			</description>
 		</method>
 		<method name="get_animation_library" qualifiers="const">
 			<return type="AnimationLibrary" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the first [AnimationLibrary] with key [code]name[/code] or [code]null[/code] if not found.
+				Returns the first [AnimationLibrary] with key [param name] or [code]null[/code] if not found.
 			</description>
 		</method>
 		<method name="get_animation_library_list" qualifiers="const">
@@ -121,14 +121,14 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the [AnimationPlayer] stores an [Animation] with key [code]name[/code].
+				Returns [code]true[/code] if the [AnimationPlayer] stores an [Animation] with key [param name].
 			</description>
 		</method>
 		<method name="has_animation_library" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the [AnimationPlayer] stores an [AnimationLibrary] with key [code]name[/code].
+				Returns [code]true[/code] if the [AnimationPlayer] stores an [AnimationLibrary] with key [param name].
 			</description>
 		</method>
 		<method name="is_playing" qualifiers="const">
@@ -144,8 +144,8 @@
 			<param index="2" name="custom_speed" type="float" default="1.0" />
 			<param index="3" name="from_end" type="bool" default="false" />
 			<description>
-				Plays the animation with key [code]name[/code]. Custom blend times and speed can be set. If [code]custom_speed[/code] is negative and [code]from_end[/code] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
-				The [AnimationPlayer] keeps track of its current or last played animation with [member assigned_animation]. If this method is called with that same animation [code]name[/code], or with no [code]name[/code] parameter, the assigned animation will resume playing if it was paused, or restart if it was stopped (see [method stop] for both pause and stop). If the animation was already playing, it will keep playing.
+				Plays the animation with key [param name]. Custom blend times and speed can be set. If [param custom_speed] is negative and [param from_end] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
+				The [AnimationPlayer] keeps track of its current or last played animation with [member assigned_animation]. If this method is called with that same animation [param name], or with no [param name] parameter, the assigned animation will resume playing if it was paused, or restart if it was stopped (see [method stop] for both pause and stop). If the animation was already playing, it will keep playing.
 				[b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].
 			</description>
 		</method>
@@ -154,7 +154,7 @@
 			<param index="0" name="name" type="StringName" default="&quot;&quot;" />
 			<param index="1" name="custom_blend" type="float" default="-1" />
 			<description>
-				Plays the animation with key [code]name[/code] in reverse.
+				Plays the animation with key [param name] in reverse.
 				This method is a shorthand for [method play] with [code]custom_speed = -1.0[/code] and [code]from_end = true[/code], so see its description for more information.
 			</description>
 		</method>
@@ -170,7 +170,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes the [AnimationLibrary] assosiated with the key [code]name[/code].
+				Removes the [AnimationLibrary] assosiated with the key [param name].
 			</description>
 		</method>
 		<method name="rename_animation_library">
@@ -178,7 +178,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="newname" type="StringName" />
 			<description>
-				Moves the [AnimationLibrary] associated with the key [code]name[/code] to the key [code]newname[/code].
+				Moves the [AnimationLibrary] associated with the key [param name] to the key [param newname].
 			</description>
 		</method>
 		<method name="seek">
@@ -186,7 +186,7 @@
 			<param index="0" name="seconds" type="float" />
 			<param index="1" name="update" type="bool" default="false" />
 			<description>
-				Seeks the animation to the [code]seconds[/code] point in time (in seconds). If [code]update[/code] is [code]true[/code], the animation updates too, otherwise it updates at process time. Events between the current frame and [code]seconds[/code] are skipped.
+				Seeks the animation to the [param seconds] point in time (in seconds). If [param update] is [code]true[/code], the animation updates too, otherwise it updates at process time. Events between the current frame and [param seconds] are skipped.
 				[b]Note:[/b] Seeking to the end of the animation doesn't emit [signal animation_finished]. If you want to skip animation and emit the signal, use [method advance].
 			</description>
 		</method>
@@ -203,8 +203,8 @@
 			<return type="void" />
 			<param index="0" name="reset" type="bool" default="true" />
 			<description>
-				Stops or pauses the currently playing animation. If [code]reset[/code] is [code]true[/code], the animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code].
-				If [code]reset[/code] is [code]false[/code], the [member current_animation_position] will be kept and calling [method play] or [method play_backwards] without arguments or with the same animation name as [member assigned_animation] will resume the animation.
+				Stops or pauses the currently playing animation. If [param reset] is [code]true[/code], the animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code].
+				If [param reset] is [code]false[/code], the [member current_animation_position] will be kept and calling [method play] or [method play_backwards] without arguments or with the same animation name as [member assigned_animation] will resume the animation.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -41,7 +41,7 @@
 			<description>
 				Returns [code]true[/code] if the given physics body intersects or overlaps this [Area2D], [code]false[/code] otherwise.
 				[b]Note:[/b] The result of this test is not immediate after moving objects. For performance, list of overlaps is updated once per frame and before the physics step. Consider using signals instead.
-				The [code]body[/code] argument can either be a [PhysicsBody2D] or a [TileMap] instance. While TileMaps are not physics bodies themselves, they register their tiles with collision shapes as a virtual physics body.
+				The [param body] argument can either be a [PhysicsBody2D] or a [TileMap] instance. While TileMaps are not physics bodies themselves, they register their tiles with collision shapes as a virtual physics body.
 			</description>
 		</method>
 	</methods>
@@ -99,14 +99,14 @@
 			<param index="0" name="area" type="Area2D" />
 			<description>
 				Emitted when another Area2D enters this Area2D. Requires [member monitoring] to be set to [code]true[/code].
-				[code]area[/code] the other Area2D.
+				[param area] the other Area2D.
 			</description>
 		</signal>
 		<signal name="area_exited">
 			<param index="0" name="area" type="Area2D" />
 			<description>
 				Emitted when another Area2D exits this Area2D. Requires [member monitoring] to be set to [code]true[/code].
-				[code]area[/code] the other Area2D.
+				[param area] the other Area2D.
 			</description>
 		</signal>
 		<signal name="area_shape_entered">
@@ -116,10 +116,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of another Area2D's [Shape2D]s enters one of this Area2D's [Shape2D]s. Requires [member monitoring] to be set to [code]true[/code].
-				[code]area_rid[/code] the [RID] of the other Area2D's [CollisionObject2D] used by the [PhysicsServer2D].
-				[code]area[/code] the other Area2D.
-				[code]area_shape_index[/code] the index of the [Shape2D] of the other Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]area.shape_owner_get_owner(area.shape_find_owner(area_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param area_rid] the [RID] of the other Area2D's [CollisionObject2D] used by the [PhysicsServer2D].
+				[param area] the other Area2D.
+				[param area_shape_index] the index of the [Shape2D] of the other Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]area.shape_owner_get_owner(area.shape_find_owner(area_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape2D] of this Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="area_shape_exited">
@@ -129,24 +129,24 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of another Area2D's [Shape2D]s exits one of this Area2D's [Shape2D]s. Requires [member monitoring] to be set to [code]true[/code].
-				[code]area_rid[/code] the [RID] of the other Area2D's [CollisionObject2D] used by the [PhysicsServer2D].
-				[code]area[/code] the other Area2D.
-				[code]area_shape_index[/code] the index of the [Shape2D] of the other Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]area.shape_owner_get_owner(area.shape_find_owner(area_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param area_rid] the [RID] of the other Area2D's [CollisionObject2D] used by the [PhysicsServer2D].
+				[param area] the other Area2D.
+				[param area_shape_index] the index of the [Shape2D] of the other Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]area.shape_owner_get_owner(area.shape_find_owner(area_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape2D] of this Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="body_entered">
 			<param index="0" name="body" type="Node2D" />
 			<description>
 				Emitted when a [PhysicsBody2D] or [TileMap] enters this Area2D. Requires [member monitoring] to be set to [code]true[/code]. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
 			</description>
 		</signal>
 		<signal name="body_exited">
 			<param index="0" name="body" type="Node2D" />
 			<description>
 				Emitted when a [PhysicsBody2D] or [TileMap] exits this Area2D. Requires [member monitoring] to be set to [code]true[/code]. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
@@ -156,10 +156,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of a [PhysicsBody2D] or [TileMap]'s [Shape2D]s enters one of this Area2D's [Shape2D]s. Requires [member monitoring] to be set to [code]true[/code]. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[code]body_rid[/code] the [RID] of the [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
-				[code]body[/code] the [Node], if it exists in the tree, of the [PhysicsBody2D] or [TileMap].
-				[code]body_shape_index[/code] the index of the [Shape2D] of the [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param body_rid] the [RID] of the [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
+				[param body] the [Node], if it exists in the tree, of the [PhysicsBody2D] or [TileMap].
+				[param body_shape_index] the index of the [Shape2D] of the [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape2D] of this Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -169,10 +169,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of a [PhysicsBody2D] or [TileMap]'s [Shape2D]s exits one of this Area2D's [Shape2D]s. Requires [member monitoring] to be set to [code]true[/code]. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[code]body_rid[/code] the [RID] of the [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
-				[code]body[/code] the [Node], if it exists in the tree, of the [PhysicsBody2D] or [TileMap].
-				[code]body_shape_index[/code] the index of the [Shape2D] of the [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape2D] of this Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param body_rid] the [RID] of the [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
+				[param body] the [Node], if it exists in the tree, of the [PhysicsBody2D] or [TileMap].
+				[param body_shape_index] the index of the [Shape2D] of the [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape2D] of this Area2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -39,7 +39,7 @@
 			<description>
 				Returns [code]true[/code] if the given physics body intersects or overlaps this [Area3D], [code]false[/code] otherwise.
 				[b]Note:[/b] The result of this test is not immediate after moving objects. For performance, list of overlaps is updated once per frame and before the physics step. Consider using signals instead.
-				The [code]body[/code] argument can either be a [PhysicsBody3D] or a [GridMap] instance. While GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body.
+				The [param body] argument can either be a [PhysicsBody3D] or a [GridMap] instance. While GridMaps are not physics body themselves, they register their tiles with collision shapes as a virtual physics body.
 			</description>
 		</method>
 	</methods>
@@ -118,14 +118,14 @@
 			<param index="0" name="area" type="Area3D" />
 			<description>
 				Emitted when another Area3D enters this Area3D. Requires [member monitoring] to be set to [code]true[/code].
-				[code]area[/code] the other Area3D.
+				[param area] the other Area3D.
 			</description>
 		</signal>
 		<signal name="area_exited">
 			<param index="0" name="area" type="Area3D" />
 			<description>
 				Emitted when another Area3D exits this Area3D. Requires [member monitoring] to be set to [code]true[/code].
-				[code]area[/code] the other Area3D.
+				[param area] the other Area3D.
 			</description>
 		</signal>
 		<signal name="area_shape_entered">
@@ -135,10 +135,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of another Area3D's [Shape3D]s enters one of this Area3D's [Shape3D]s. Requires [member monitoring] to be set to [code]true[/code].
-				[code]area_rid[/code] the [RID] of the other Area3D's [CollisionObject3D] used by the [PhysicsServer3D].
-				[code]area[/code] the other Area3D.
-				[code]area_shape_index[/code] the index of the [Shape3D] of the other Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]area.shape_owner_get_owner(area.shape_find_owner(area_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape3D] of this Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param area_rid] the [RID] of the other Area3D's [CollisionObject3D] used by the [PhysicsServer3D].
+				[param area] the other Area3D.
+				[param area_shape_index] the index of the [Shape3D] of the other Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]area.shape_owner_get_owner(area.shape_find_owner(area_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape3D] of this Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="area_shape_exited">
@@ -148,24 +148,24 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of another Area3D's [Shape3D]s exits one of this Area3D's [Shape3D]s. Requires [member monitoring] to be set to [code]true[/code].
-				[code]area_rid[/code] the [RID] of the other Area3D's [CollisionObject3D] used by the [PhysicsServer3D].
-				[code]area[/code] the other Area3D.
-				[code]area_shape_index[/code] the index of the [Shape3D] of the other Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]area.shape_owner_get_owner(area.shape_find_owner(area_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape3D] of this Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param area_rid] the [RID] of the other Area3D's [CollisionObject3D] used by the [PhysicsServer3D].
+				[param area] the other Area3D.
+				[param area_shape_index] the index of the [Shape3D] of the other Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]area.shape_owner_get_owner(area.shape_find_owner(area_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape3D] of this Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="body_entered">
 			<param index="0" name="body" type="Node3D" />
 			<description>
 				Emitted when a [PhysicsBody3D] or [GridMap] enters this Area3D. Requires [member monitoring] to be set to [code]true[/code]. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
 			</description>
 		</signal>
 		<signal name="body_exited">
 			<param index="0" name="body" type="Node3D" />
 			<description>
 				Emitted when a [PhysicsBody3D] or [GridMap] exits this Area3D. Requires [member monitoring] to be set to [code]true[/code]. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[code]body[/code] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody3D] or [GridMap].
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
@@ -175,10 +175,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of a [PhysicsBody3D] or [GridMap]'s [Shape3D]s enters one of this Area3D's [Shape3D]s. Requires [member monitoring] to be set to [code]true[/code]. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[code]body_rid[/code] the [RID] of the [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D].
-				[code]body[/code] the [Node], if it exists in the tree, of the [PhysicsBody3D] or [GridMap].
-				[code]body_shape_index[/code] the index of the [Shape3D] of the [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape3D] of this Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param body_rid] the [RID] of the [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D].
+				[param body] the [Node], if it exists in the tree, of the [PhysicsBody3D] or [GridMap].
+				[param body_shape_index] the index of the [Shape3D] of the [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape3D] of this Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 		<signal name="body_shape_exited">
@@ -188,10 +188,10 @@
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
 				Emitted when one of a [PhysicsBody3D] or [GridMap]'s [Shape3D]s enters one of this Area3D's [Shape3D]s. Requires [member monitoring] to be set to [code]true[/code]. [GridMap]s are detected if the [MeshLibrary] has Collision [Shape3D]s.
-				[code]body_rid[/code] the [RID] of the [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D].
-				[code]body[/code] the [Node], if it exists in the tree, of the [PhysicsBody3D] or [GridMap].
-				[code]body_shape_index[/code] the index of the [Shape3D] of the [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
-				[code]local_shape_index[/code] the index of the [Shape3D] of this Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
+				[param body_rid] the [RID] of the [PhysicsBody3D] or [MeshLibrary]'s [CollisionObject3D] used by the [PhysicsServer3D].
+				[param body] the [Node], if it exists in the tree, of the [PhysicsBody3D] or [GridMap].
+				[param body_shape_index] the index of the [Shape3D] of the [PhysicsBody3D] or [GridMap] used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param local_shape_index] the index of the [Shape3D] of this Area3D used by the [PhysicsServer3D]. Get the [CollisionShape3D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -201,7 +201,7 @@
 			<param index="0" name="value" type="Variant" />
 			<param index="1" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array.
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -211,7 +211,7 @@
 			<param index="1" name="func" type="Callable" />
 			<param index="2" name="before" type="bool" default="true" />
 			<description>
-				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search and a custom comparison method. Optionally, a [code]before[/code] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array. The custom method receives two arguments (an element from the array and the value searched for) and must return [code]true[/code] if the first argument is less than the second, and return [code]false[/code] otherwise.
+				Finds the index of an existing value (or the insertion index that maintains sorting order, if the value is not yet present in the array) using binary search and a custom comparison method. Optionally, a [param before] specifier can be passed. If [code]false[/code], the returned index comes after all existing entries of the value in the array. The custom method receives two arguments (an element from the array and the value searched for) and must return [code]true[/code] if the first argument is less than the second, and return [code]false[/code] otherwise.
 				[b]Note:[/b] Calling [method bsearch_custom] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
@@ -233,7 +233,7 @@
 			<param index="0" name="deep" type="bool" default="false" />
 			<description>
 				Returns a copy of the array.
-				If [code]deep[/code] is [code]true[/code], a deep copy is performed: all nested arrays and dictionaries are duplicated and will not be shared with the original array. If [code]false[/code], a shallow copy is made and references to the original nested arrays and dictionaries are kept, so that modifying a sub-array or dictionary in the copy will also impact those referenced in the source array.
+				If [param deep] is [code]true[/code], a deep copy is performed: all nested arrays and dictionaries are duplicated and will not be shared with the original array. If [code]false[/code], a shallow copy is made and references to the original nested arrays and dictionaries are kept, so that modifying a sub-array or dictionary in the copy will also impact those referenced in the source array.
 			</description>
 		</method>
 		<method name="erase">
@@ -399,7 +399,7 @@
 			<return type="Variant" />
 			<param index="0" name="position" type="int" />
 			<description>
-				Removes and returns the element of the array at index [code]position[/code]. If negative, [code]position[/code] is considered relative to the end of the array. Leaves the array untouched and returns [code]null[/code] if the array is empty or if it's accessed out of bounds. An error message is printed when the array is accessed out of bounds, but not when the array is empty.
+				Removes and returns the element of the array at index [param position]. If negative, [param position] is considered relative to the end of the array. Leaves the array untouched and returns [code]null[/code] if the array is empty or if it's accessed out of bounds. An error message is printed when the array is accessed out of bounds, but not when the array is empty.
 				[b]Note:[/b] On large arrays, this method can be slower than [method pop_back] as it will reindex the array's elements that are located after the removed element. The larger the array and the lower the index of the removed element, the slower [method pop_at] will be.
 			</description>
 		</method>
@@ -436,8 +436,8 @@
 			<param index="0" name="method" type="Callable" />
 			<param index="1" name="accum" type="Variant" default="null" />
 			<description>
-				Calls the provided [Callable] for each element in array and accumulates the result in [code]accum[/code].
-				The callable's method takes two arguments: the current value of [code]accum[/code] and the current array element. If [code]accum[/code] is [code]null[/code] (default value), the iteration will start from the second element, with the first one used as initial value of [code]accum[/code].
+				Calls the provided [Callable] for each element in array and accumulates the result in [param accum].
+				The callable's method takes two arguments: the current value of [param accum] and the current array element. If [param accum] is [code]null[/code] (default value), the iteration will start from the second element, with the first one used as initial value of [param accum].
 				[codeblock]
 				func _ready():
 				    print([1, 2, 3].reduce(sum, 10)) # Prints 16.
@@ -498,11 +498,11 @@
 			<param index="2" name="step" type="int" default="1" />
 			<param index="3" name="deep" type="bool" default="false" />
 			<description>
-				Returns the slice of the [Array], from [code]begin[/code] (inclusive) to [code]end[/code] (exclusive), as a new [Array].
-				The absolute value of [code]begin[/code] and [code]end[/code] will be clamped to the array size, so the default value for [code]end[/code] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
-				If either [code]begin[/code] or [code]end[/code] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
-				If specified, [code]step[/code] is the relative index between source elements. It can be negative, then [code]begin[/code] must be higher than [code]end[/code]. For example, [code][0, 1, 2, 3, 4, 5].slice(5, 1, -2)[/code] returns [code][5, 3][/code]).
-				If [code]deep[/code] is true, each element will be copied by value rather than by reference.
+				Returns the slice of the [Array], from [param begin] (inclusive) to [param end] (exclusive), as a new [Array].
+				The absolute value of [param begin] and [param end] will be clamped to the array size, so the default value for [param end] makes it slice to the size of the array by default (i.e. [code]arr.slice(1)[/code] is a shorthand for [code]arr.slice(1, arr.size())[/code]).
+				If either [param begin] or [param end] are negative, they will be relative to the end of the array (i.e. [code]arr.slice(0, -2)[/code] is a shorthand for [code]arr.slice(0, arr.size() - 2)[/code]).
+				If specified, [param step] is the relative index between source elements. It can be negative, then [param begin] must be higher than [param end]. For example, [code][0, 1, 2, 3, 4, 5].slice(5, 1, -2)[/code] returns [code][5, 3][/code]).
+				If [param deep] is true, each element will be copied by value rather than by reference.
 			</description>
 		</method>
 		<method name="sort">
@@ -562,56 +562,56 @@
 			<return type="bool" />
 			<param index="0" name="right" type="Array" />
 			<description>
-				Compares the left operand [Array] against the [code]right[/code] [Array]. Returns [code]true[/code] if the sizes or contents of the arrays are [i]not[/i] equal, [code]false[/code] otherwise.
+				Compares the left operand [Array] against the [param right] [Array]. Returns [code]true[/code] if the sizes or contents of the arrays are [i]not[/i] equal, [code]false[/code] otherwise.
 			</description>
 		</operator>
 		<operator name="operator +">
 			<return type="Array" />
 			<param index="0" name="right" type="Array" />
 			<description>
-				Concatenates two [Array]s together, with the [code]right[/code] [Array] being added to the end of the [Array] specified in the left operand. For example, [code][1, 2] + [3, 4][/code] results in [code][1, 2, 3, 4][/code].
+				Concatenates two [Array]s together, with the [param right] [Array] being added to the end of the [Array] specified in the left operand. For example, [code][1, 2] + [3, 4][/code] results in [code][1, 2, 3, 4][/code].
 			</description>
 		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="Array" />
 			<description>
-				Performs a comparison for each index between the left operand [Array] and the [code]right[/code] [Array], considering the highest common index of both arrays for this comparison: Returns [code]true[/code] on the first occurrence of an element that is less, or [code]false[/code] if the element is greater. Note that depending on the type of data stored, this function may be recursive. If all elements are equal, it compares the length of both arrays and returns [code]false[/code] if the left operand [Array] has less elements, otherwise it returns [code]true[/code].
+				Performs a comparison for each index between the left operand [Array] and the [param right] [Array], considering the highest common index of both arrays for this comparison: Returns [code]true[/code] on the first occurrence of an element that is less, or [code]false[/code] if the element is greater. Note that depending on the type of data stored, this function may be recursive. If all elements are equal, it compares the length of both arrays and returns [code]false[/code] if the left operand [Array] has less elements, otherwise it returns [code]true[/code].
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Array" />
 			<description>
-				Performs a comparison for each index between the left operand [Array] and the [code]right[/code] [Array], considering the highest common index of both arrays for this comparison: Returns [code]true[/code] on the first occurrence of an element that is less, or [code]false[/code] if the element is greater. Note that depending on the type of data stored, this function may be recursive. If all elements are equal, it compares the length of both arrays and returns [code]true[/code] if the left operand [Array] has less or the same number of elements, otherwise it returns [code]false[/code].
+				Performs a comparison for each index between the left operand [Array] and the [param right] [Array], considering the highest common index of both arrays for this comparison: Returns [code]true[/code] on the first occurrence of an element that is less, or [code]false[/code] if the element is greater. Note that depending on the type of data stored, this function may be recursive. If all elements are equal, it compares the length of both arrays and returns [code]true[/code] if the left operand [Array] has less or the same number of elements, otherwise it returns [code]false[/code].
 			</description>
 		</operator>
 		<operator name="operator ==">
 			<return type="bool" />
 			<param index="0" name="right" type="Array" />
 			<description>
-				Compares the left operand [Array] against the [code]right[/code] [Array]. Returns [code]true[/code] if the sizes and contents of the arrays are equal, [code]false[/code] otherwise.
+				Compares the left operand [Array] against the [param right] [Array]. Returns [code]true[/code] if the sizes and contents of the arrays are equal, [code]false[/code] otherwise.
 			</description>
 		</operator>
 		<operator name="operator &gt;">
 			<return type="bool" />
 			<param index="0" name="right" type="Array" />
 			<description>
-				Performs a comparison for each index between the left operand [Array] and the [code]right[/code] [Array], considering the highest common index of both arrays for this comparison: Returns [code]true[/code] on the first occurrence of an element that is greater, or [code]false[/code] if the element is less. Note that depending on the type of data stored, this function may be recursive. If all elements are equal, it compares the length of both arrays and returns [code]true[/code] if the [code]right[/code] [Array] has more elements, otherwise it returns [code]false[/code].
+				Performs a comparison for each index between the left operand [Array] and the [param right] [Array], considering the highest common index of both arrays for this comparison: Returns [code]true[/code] on the first occurrence of an element that is greater, or [code]false[/code] if the element is less. Note that depending on the type of data stored, this function may be recursive. If all elements are equal, it compares the length of both arrays and returns [code]true[/code] if the [param right] [Array] has more elements, otherwise it returns [code]false[/code].
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="Array" />
 			<description>
-				Performs a comparison for each index between the left operand [Array] and the [code]right[/code] [Array], considering the highest common index of both arrays for this comparison: Returns [code]true[/code] on the first occurrence of an element that is greater, or [code]false[/code] if the element is less. Note that depending on the type of data stored, this function may be recursive. If all elements are equal, it compares the length of both arrays and returns [code]true[/code] if the [code]right[/code] [Array] has more or the same number of elements, otherwise it returns [code]false[/code].
+				Performs a comparison for each index between the left operand [Array] and the [param right] [Array], considering the highest common index of both arrays for this comparison: Returns [code]true[/code] on the first occurrence of an element that is greater, or [code]false[/code] if the element is less. Note that depending on the type of data stored, this function may be recursive. If all elements are equal, it compares the length of both arrays and returns [code]true[/code] if the [param right] [Array] has more or the same number of elements, otherwise it returns [code]false[/code].
 			</description>
 		</operator>
 		<operator name="operator []">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns a reference to the element of type [Variant] at the specified location. Arrays start at index 0. [code]index[/code] can be a zero or positive value to start from the beginning, or a negative value to start from the end. Out-of-bounds array access causes a run-time error, which will result in an error being printed and the project execution pausing if run from the editor.
+				Returns a reference to the element of type [Variant] at the specified location. Arrays start at index 0. [param index] can be a zero or positive value to start from the beginning, or a negative value to start from the end. Out-of-bounds array access causes a run-time error, which will result in an error being printed and the project execution pausing if run from the editor.
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -66,8 +66,8 @@
 			<param index="4" name="compress_flags" type="int" default="0" />
 			<description>
 				Creates a new surface.
-				Surfaces are created to be rendered using a [code]primitive[/code], which may be any of the types defined in [enum Mesh.PrimitiveType]. (As a note, when using indices, it is recommended to only use points, lines, or triangles.) [method Mesh.get_surface_count] will become the [code]surf_idx[/code] for this new surface.
-				The [code]arrays[/code] argument is an array of arrays. See [enum Mesh.ArrayType] for the values used in this array. For example, [code]arrays[0][/code] is the array of vertices. That first vertex sub-array is always required; the others are optional. Adding an index array puts this function into "index mode" where the vertex and other arrays become the sources of data and the index array defines the vertex order. All sub-arrays must have the same length as the vertex array (or be an exact multiple of the vertex array's length, when multiple elements of a sub-array correspond to a single vertex) or be empty, except for [constant Mesh.ARRAY_INDEX] if it is used.
+				Surfaces are created to be rendered using a [param primitive], which may be any of the types defined in [enum Mesh.PrimitiveType]. (As a note, when using indices, it is recommended to only use points, lines, or triangles.) [method Mesh.get_surface_count] will become the [code]surf_idx[/code] for this new surface.
+				The [param arrays] argument is an array of arrays. See [enum Mesh.ArrayType] for the values used in this array. For example, [code]arrays[0][/code] is the array of vertices. That first vertex sub-array is always required; the others are optional. Adding an index array puts this function into "index mode" where the vertex and other arrays become the sources of data and the index array defines the vertex order. All sub-arrays must have the same length as the vertex array (or be an exact multiple of the vertex array's length, when multiple elements of a sub-array correspond to a single vertex) or be empty, except for [constant Mesh.ARRAY_INDEX] if it is used.
 			</description>
 		</method>
 		<method name="clear_blend_shapes">

--- a/doc/classes/AudioEffectCapture.xml
+++ b/doc/classes/AudioEffectCapture.xml
@@ -15,7 +15,7 @@
 			<return type="bool" />
 			<param index="0" name="frames" type="int" />
 			<description>
-				Returns [code]true[/code] if at least [code]frames[/code] audio frames are available to read in the internal ring buffer.
+				Returns [code]true[/code] if at least [param frames] audio frames are available to read in the internal ring buffer.
 			</description>
 		</method>
 		<method name="clear_buffer">
@@ -28,8 +28,8 @@
 			<return type="PackedVector2Array" />
 			<param index="0" name="frames" type="int" />
 			<description>
-				Gets the next [code]frames[/code] audio samples from the internal ring buffer.
-				Returns a [PackedVector2Array] containing exactly [code]frames[/code] audio samples if available, or an empty [PackedVector2Array] if insufficient data was available.
+				Gets the next [param frames] audio samples from the internal ring buffer.
+				Returns a [PackedVector2Array] containing exactly [param frames] audio samples if available, or an empty [PackedVector2Array] if insufficient data was available.
 			</description>
 		</method>
 		<method name="get_buffer_length_frames" qualifiers="const">

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -17,7 +17,7 @@
 			<return type="void" />
 			<param index="0" name="at_position" type="int" default="-1" />
 			<description>
-				Adds a bus at [code]at_position[/code].
+				Adds a bus at [param at_position].
 			</description>
 		</method>
 		<method name="add_bus_effect">
@@ -26,7 +26,7 @@
 			<param index="1" name="effect" type="AudioEffect" />
 			<param index="2" name="at_position" type="int" default="-1" />
 			<description>
-				Adds an [AudioEffect] effect to the bus [code]bus_idx[/code] at [code]at_position[/code].
+				Adds an [AudioEffect] effect to the bus [param bus_idx] at [param at_position].
 			</description>
 		</method>
 		<method name="capture_get_device_list">
@@ -45,7 +45,7 @@
 			<return type="int" />
 			<param index="0" name="bus_idx" type="int" />
 			<description>
-				Returns the amount of channels of the bus at index [code]bus_idx[/code].
+				Returns the amount of channels of the bus at index [param bus_idx].
 			</description>
 		</method>
 		<method name="get_bus_effect">
@@ -53,14 +53,14 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="effect_idx" type="int" />
 			<description>
-				Returns the [AudioEffect] at position [code]effect_idx[/code] in bus [code]bus_idx[/code].
+				Returns the [AudioEffect] at position [param effect_idx] in bus [param bus_idx].
 			</description>
 		</method>
 		<method name="get_bus_effect_count">
 			<return type="int" />
 			<param index="0" name="bus_idx" type="int" />
 			<description>
-				Returns the number of effects on the bus at [code]bus_idx[/code].
+				Returns the number of effects on the bus at [param bus_idx].
 			</description>
 		</method>
 		<method name="get_bus_effect_instance">
@@ -76,14 +76,14 @@
 			<return type="int" />
 			<param index="0" name="bus_name" type="StringName" />
 			<description>
-				Returns the index of the bus with the name [code]bus_name[/code].
+				Returns the index of the bus with the name [param bus_name].
 			</description>
 		</method>
 		<method name="get_bus_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="bus_idx" type="int" />
 			<description>
-				Returns the name of the bus with the index [code]bus_idx[/code].
+				Returns the name of the bus with the index [param bus_idx].
 			</description>
 		</method>
 		<method name="get_bus_peak_volume_left_db" qualifiers="const">
@@ -91,7 +91,7 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="channel" type="int" />
 			<description>
-				Returns the peak volume of the left speaker at bus index [code]bus_idx[/code] and channel index [code]channel[/code].
+				Returns the peak volume of the left speaker at bus index [param bus_idx] and channel index [param channel].
 			</description>
 		</method>
 		<method name="get_bus_peak_volume_right_db" qualifiers="const">
@@ -99,21 +99,21 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="channel" type="int" />
 			<description>
-				Returns the peak volume of the right speaker at bus index [code]bus_idx[/code] and channel index [code]channel[/code].
+				Returns the peak volume of the right speaker at bus index [param bus_idx] and channel index [param channel].
 			</description>
 		</method>
 		<method name="get_bus_send" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="bus_idx" type="int" />
 			<description>
-				Returns the name of the bus that the bus at index [code]bus_idx[/code] sends to.
+				Returns the name of the bus that the bus at index [param bus_idx] sends to.
 			</description>
 		</method>
 		<method name="get_bus_volume_db" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="bus_idx" type="int" />
 			<description>
-				Returns the volume of the bus at index [code]bus_idx[/code] in dB.
+				Returns the volume of the bus at index [param bus_idx] in dB.
 			</description>
 		</method>
 		<method name="get_device_list">
@@ -156,7 +156,7 @@
 			<return type="bool" />
 			<param index="0" name="bus_idx" type="int" />
 			<description>
-				If [code]true[/code], the bus at index [code]bus_idx[/code] is bypassing effects.
+				If [code]true[/code], the bus at index [param bus_idx] is bypassing effects.
 			</description>
 		</method>
 		<method name="is_bus_effect_enabled" qualifiers="const">
@@ -164,21 +164,21 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="effect_idx" type="int" />
 			<description>
-				If [code]true[/code], the effect at index [code]effect_idx[/code] on the bus at index [code]bus_idx[/code] is enabled.
+				If [code]true[/code], the effect at index [param effect_idx] on the bus at index [param bus_idx] is enabled.
 			</description>
 		</method>
 		<method name="is_bus_mute" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="bus_idx" type="int" />
 			<description>
-				If [code]true[/code], the bus at index [code]bus_idx[/code] is muted.
+				If [code]true[/code], the bus at index [param bus_idx] is muted.
 			</description>
 		</method>
 		<method name="is_bus_solo" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="bus_idx" type="int" />
 			<description>
-				If [code]true[/code], the bus at index [code]bus_idx[/code] is in solo mode.
+				If [code]true[/code], the bus at index [param bus_idx] is in solo mode.
 			</description>
 		</method>
 		<method name="lock">
@@ -193,14 +193,14 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="to_index" type="int" />
 			<description>
-				Moves the bus from index [code]index[/code] to index [code]to_index[/code].
+				Moves the bus from index [param index] to index [param to_index].
 			</description>
 		</method>
 		<method name="remove_bus">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Removes the bus at index [code]index[/code].
+				Removes the bus at index [param index].
 			</description>
 		</method>
 		<method name="remove_bus_effect">
@@ -208,7 +208,7 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="effect_idx" type="int" />
 			<description>
-				Removes the effect at index [code]effect_idx[/code] from the bus at index [code]bus_idx[/code].
+				Removes the effect at index [param effect_idx] from the bus at index [param bus_idx].
 			</description>
 		</method>
 		<method name="set_bus_bypass_effects">
@@ -216,7 +216,7 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], the bus at index [code]bus_idx[/code] is bypassing effects.
+				If [code]true[/code], the bus at index [param bus_idx] is bypassing effects.
 			</description>
 		</method>
 		<method name="set_bus_effect_enabled">
@@ -225,7 +225,7 @@
 			<param index="1" name="effect_idx" type="int" />
 			<param index="2" name="enabled" type="bool" />
 			<description>
-				If [code]true[/code], the effect at index [code]effect_idx[/code] on the bus at index [code]bus_idx[/code] is enabled.
+				If [code]true[/code], the effect at index [param effect_idx] on the bus at index [param bus_idx] is enabled.
 			</description>
 		</method>
 		<method name="set_bus_layout">
@@ -240,7 +240,7 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], the bus at index [code]bus_idx[/code] is muted.
+				If [code]true[/code], the bus at index [param bus_idx] is muted.
 			</description>
 		</method>
 		<method name="set_bus_name">
@@ -248,7 +248,7 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="name" type="String" />
 			<description>
-				Sets the name of the bus at index [code]bus_idx[/code] to [code]name[/code].
+				Sets the name of the bus at index [param bus_idx] to [param name].
 			</description>
 		</method>
 		<method name="set_bus_send">
@@ -256,7 +256,7 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="send" type="StringName" />
 			<description>
-				Connects the output of the bus at [code]bus_idx[/code] to the bus named [code]send[/code].
+				Connects the output of the bus at [param bus_idx] to the bus named [param send].
 			</description>
 		</method>
 		<method name="set_bus_solo">
@@ -264,7 +264,7 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				If [code]true[/code], the bus at index [code]bus_idx[/code] is in solo mode.
+				If [code]true[/code], the bus at index [param bus_idx] is in solo mode.
 			</description>
 		</method>
 		<method name="set_bus_volume_db">
@@ -272,7 +272,7 @@
 			<param index="0" name="bus_idx" type="int" />
 			<param index="1" name="volume_db" type="float" />
 			<description>
-				Sets the volume of the bus at index [code]bus_idx[/code] to [code]volume_db[/code].
+				Sets the volume of the bus at index [param bus_idx] to [param volume_db].
 			</description>
 		</method>
 		<method name="set_enable_tagging_used_audio_streams">
@@ -287,7 +287,7 @@
 			<param index="1" name="effect_idx" type="int" />
 			<param index="2" name="by_effect_idx" type="int" />
 			<description>
-				Swaps the position of two effects in bus [code]bus_idx[/code].
+				Swaps the position of two effects in bus [param bus_idx].
 			</description>
 		</method>
 		<method name="unlock">

--- a/doc/classes/AudioStreamGeneratorPlayback.xml
+++ b/doc/classes/AudioStreamGeneratorPlayback.xml
@@ -15,7 +15,7 @@
 			<return type="bool" />
 			<param index="0" name="amount" type="int" />
 			<description>
-				Returns [code]true[/code] if a buffer of the size [code]amount[/code] can be pushed to the audio sample data buffer without overflowing it, [code]false[/code] otherwise.
+				Returns [code]true[/code] if a buffer of the size [param amount] can be pushed to the audio sample data buffer without overflowing it, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="clear_buffer">

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -32,7 +32,7 @@
 			<return type="void" />
 			<param index="0" name="from_position" type="float" default="0.0" />
 			<description>
-				Plays the audio from the given [code]from_position[/code], in seconds.
+				Plays the audio from the given [param from_position], in seconds.
 			</description>
 		</method>
 		<method name="seek">

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -29,7 +29,7 @@
 			<return type="void" />
 			<param index="0" name="from_position" type="float" default="0.0" />
 			<description>
-				Plays the audio from the given position [code]from_position[/code], in seconds.
+				Plays the audio from the given position [param from_position], in seconds.
 			</description>
 		</method>
 		<method name="seek">

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -29,7 +29,7 @@
 			<return type="void" />
 			<param index="0" name="from_position" type="float" default="0.0" />
 			<description>
-				Plays the audio from the given position [code]from_position[/code], in seconds.
+				Plays the audio from the given position [param from_position], in seconds.
 			</description>
 		</method>
 		<method name="seek">

--- a/doc/classes/AudioStreamWAV.xml
+++ b/doc/classes/AudioStreamWAV.xml
@@ -14,8 +14,8 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Saves the AudioStreamWAV as a WAV file to [code]path[/code]. Samples with IMA ADPCM format can't be saved.
-				[b]Note:[/b] A [code].wav[/code] extension is automatically appended to [code]path[/code] if it is missing.
+				Saves the AudioStreamWAV as a WAV file to [param path]. Samples with IMA ADPCM format can't be saved.
+				[b]Note:[/b] A [code].wav[/code] extension is automatically appended to [param path] if it is missing.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -98,7 +98,7 @@
 		<signal name="toggled">
 			<param index="0" name="button_pressed" type="bool" />
 			<description>
-				Emitted when the button was just toggled between pressed and normal states (only if [member toggle_mode] is active). The new state is contained in the [code]button_pressed[/code] argument.
+				Emitted when the button was just toggled between pressed and normal states (only if [member toggle_mode] is active). The new state is contained in the [param button_pressed] argument.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -52,7 +52,7 @@
 			<param index="0" name="param" type="int" enum="BaseMaterial3D.TextureParam" />
 			<param index="1" name="texture" type="Texture2D" />
 			<description>
-				Sets the texture for the slot specified by [code]param[/code]. See [enum TextureParam] for available slots.
+				Sets the texture for the slot specified by [param param]. See [enum TextureParam] for available slots.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Last of the commits to fix all of the class XML docs (see #64134, #64164, #64196, #64285, #64319, #64328, #64331).
