### PR TITLE
Make `_validate_property` a multilevel method

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -274,24 +274,24 @@ void InputEventWithModifiers::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "command_pressed"), "set_command_pressed", "is_command_pressed");
 }
 
-void InputEventWithModifiers::_validate_property(PropertyInfo &property) const {
+void InputEventWithModifiers::_validate_property(PropertyInfo &p_property) const {
 	if (store_command) {
 		// If we only want to Store "Command".
 #ifdef APPLE_STYLE_KEYS
 		// Don't store "Meta" on Mac.
-		if (property.name == "meta_pressed") {
-			property.usage ^= PROPERTY_USAGE_STORAGE;
+		if (p_property.name == "meta_pressed") {
+			p_property.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 #else
 		// Don't store "Ctrl".
-		if (property.name == "ctrl_pressed") {
-			property.usage ^= PROPERTY_USAGE_STORAGE;
+		if (p_property.name == "ctrl_pressed") {
+			p_property.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 #endif
 	} else {
 		// We don't want to store command, only ctrl or meta (on mac).
-		if (property.name == "command_pressed") {
-			property.usage ^= PROPERTY_USAGE_STORAGE;
+		if (p_property.name == "command_pressed") {
+			p_property.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 	}
 }

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -128,7 +128,7 @@ class InputEventWithModifiers : public InputEventFromWindow {
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_store_command(bool p_enabled);

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -981,7 +981,7 @@ void ClassDB::get_property_list(const StringName &p_class, List<PropertyInfo> *p
 			if (p_validator) {
 				// Making a copy as we may modify it.
 				PropertyInfo pi_mut = pi;
-				p_validator->_validate_property(pi_mut);
+				p_validator->validate_property(pi_mut);
 				p_list->push_back(pi_mut);
 			} else {
 				p_list->push_back(pi);
@@ -1022,7 +1022,7 @@ bool ClassDB::get_property_info(const StringName &p_class, const StringName &p_p
 		if (check->property_map.has(p_property)) {
 			PropertyInfo pinfo = check->property_map[p_property];
 			if (p_validator) {
-				p_validator->_validate_property(pinfo);
+				p_validator->validate_property(pinfo);
 			}
 			if (r_info) {
 				*r_info = pinfo;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -515,7 +515,8 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	}
 }
 
-void Object::_validate_property(PropertyInfo &property) const {
+void Object::validate_property(PropertyInfo &p_property) const {
+	_validate_propertyv(p_property);
 }
 
 bool Object::property_can_revert(const String &p_name) const {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -471,6 +471,15 @@ protected:                                                                      
 			m_inherits::_get_property_listv(p_list, p_reversed);                                                                                 \
 		}                                                                                                                                        \
 	}                                                                                                                                            \
+	_FORCE_INLINE_ void (Object::*_get_validate_property() const)(PropertyInfo & p_property) const {                                             \
+		return (void(Object::*)(PropertyInfo &) const) & m_class::_validate_property;                                                            \
+	}                                                                                                                                            \
+	virtual void _validate_propertyv(PropertyInfo &p_property) const override {                                                                  \
+		m_inherits::_validate_propertyv(p_property);                                                                                             \
+		if (m_class::_get_validate_property() != m_inherits::_get_validate_property()) {                                                         \
+			_validate_property(p_property);                                                                                                      \
+		}                                                                                                                                        \
+	}                                                                                                                                            \
 	_FORCE_INLINE_ bool (Object::*_get_property_can_revert() const)(const StringName &p_name) const {                                            \
 		return (bool(Object::*)(const StringName &) const) & m_class::_property_can_revert;                                                      \
 	}                                                                                                                                            \
@@ -637,6 +646,7 @@ protected:
 	virtual bool _setv(const StringName &p_name, const Variant &p_property) { return false; };
 	virtual bool _getv(const StringName &p_name, Variant &r_property) const { return false; };
 	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const {};
+	virtual void _validate_propertyv(PropertyInfo &p_property) const {};
 	virtual bool _property_can_revertv(const StringName &p_name) const { return false; };
 	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_property) const { return false; };
 	virtual void _notificationv(int p_notification, bool p_reversed) {}
@@ -645,6 +655,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_property) { return false; };
 	bool _get(const StringName &p_name, Variant &r_property) const { return false; };
 	void _get_property_list(List<PropertyInfo> *p_list) const {};
+	void _validate_property(PropertyInfo &p_property) const {};
 	bool _property_can_revert(const StringName &p_name) const { return false; };
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; };
 	void _notification(int p_notification) {}
@@ -660,6 +671,9 @@ protected:
 	}
 	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> *p_list) const {
 		return &Object::_get_property_list;
+	}
+	_FORCE_INLINE_ void (Object::*_get_validate_property() const)(PropertyInfo &p_property) const {
+		return &Object::_validate_property;
 	}
 	_FORCE_INLINE_ bool (Object::*_get_property_can_revert() const)(const StringName &p_name) const {
 		return &Object::_property_can_revert;
@@ -690,7 +704,6 @@ protected:
 	void _clear_internal_resource_paths(const Variant &p_var);
 
 	friend class ClassDB;
-	virtual void _validate_property(PropertyInfo &property) const;
 
 	void _disconnect(const StringName &p_signal, const Callable &p_callable, bool p_force = false);
 
@@ -791,6 +804,7 @@ public:
 	Variant get_indexed(const Vector<StringName> &p_names, bool *r_valid = nullptr) const;
 
 	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
+	void validate_property(PropertyInfo &p_property) const;
 	bool property_can_revert(const String &p_name) const;
 	Variant property_get_revert(const String &p_name) const;
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -584,15 +584,14 @@ bool CSGShape3D::is_calculating_tangents() const {
 	return calculate_tangents;
 }
 
-void CSGShape3D::_validate_property(PropertyInfo &property) const {
-	bool is_collision_prefixed = property.name.begins_with("collision_");
-	if ((is_collision_prefixed || property.name.begins_with("use_collision")) && is_inside_tree() && !is_root_shape()) {
+void CSGShape3D::_validate_property(PropertyInfo &p_property) const {
+	bool is_collision_prefixed = p_property.name.begins_with("collision_");
+	if ((is_collision_prefixed || p_property.name.begins_with("use_collision")) && is_inside_tree() && !is_root_shape()) {
 		//hide collision if not root
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	} else if (is_collision_prefixed && !bool(get("use_collision"))) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
-	GeometryInstance3D::_validate_property(property);
 }
 
 Array CSGShape3D::get_meshes() const {
@@ -2058,18 +2057,16 @@ void CSGPolygon3D::_notification(int p_what) {
 	}
 }
 
-void CSGPolygon3D::_validate_property(PropertyInfo &property) const {
-	if (property.name.begins_with("spin") && mode != MODE_SPIN) {
-		property.usage = PROPERTY_USAGE_NONE;
+void CSGPolygon3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name.begins_with("spin") && mode != MODE_SPIN) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-	if (property.name.begins_with("path") && mode != MODE_PATH) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name.begins_with("path") && mode != MODE_PATH) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-	if (property.name == "depth" && mode != MODE_DEPTH) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "depth" && mode != MODE_DEPTH) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-
-	CSGShape3D::_validate_property(property);
 }
 
 void CSGPolygon3D::_path_changed() {

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -117,7 +117,7 @@ protected:
 	friend class CSGCombiner3D;
 	CSGBrush *_get_brush();
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	Array get_meshes() const;
@@ -383,7 +383,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 
 public:

--- a/modules/noise/fastnoise_lite.cpp
+++ b/modules/noise/fastnoise_lite.cpp
@@ -476,24 +476,24 @@ void FastNoiseLite::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOMAIN_WARP_FRACTAL_INDEPENDENT);
 }
 
-void FastNoiseLite::_validate_property(PropertyInfo &property) const {
-	if (property.name.begins_with("cellular") && get_noise_type() != TYPE_CELLULAR) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void FastNoiseLite::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name.begins_with("cellular") && get_noise_type() != TYPE_CELLULAR) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		return;
 	}
 
-	if (property.name != "fractal_type" && property.name.begins_with("fractal") && get_fractal_type() == FRACTAL_NONE) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name != "fractal_type" && p_property.name.begins_with("fractal") && get_fractal_type() == FRACTAL_NONE) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		return;
 	}
 
-	if (property.name == "fractal_ping_pong_strength" && get_fractal_type() != FRACTAL_PING_PONG) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "fractal_ping_pong_strength" && get_fractal_type() != FRACTAL_PING_PONG) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		return;
 	}
 
-	if (property.name != "domain_warp_enabled" && property.name.begins_with("domain_warp") && !domain_warp_enabled) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name != "domain_warp_enabled" && p_property.name.begins_with("domain_warp") && !domain_warp_enabled) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		return;
 	}
 }

--- a/modules/noise/fastnoise_lite.h
+++ b/modules/noise/fastnoise_lite.h
@@ -92,7 +92,7 @@ public:
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 private:
 	_FastNoiseLite _noise;

--- a/modules/noise/noise_texture.cpp
+++ b/modules/noise/noise_texture.cpp
@@ -94,16 +94,16 @@ void NoiseTexture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "noise", PROPERTY_HINT_RESOURCE_TYPE, "Noise"), "set_noise", "get_noise");
 }
 
-void NoiseTexture::_validate_property(PropertyInfo &property) const {
-	if (property.name == "bump_strength") {
+void NoiseTexture::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "bump_strength") {
 		if (!as_normal_map) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "seamless_blend_skirt") {
+	if (p_property.name == "seamless_blend_skirt") {
 		if (!seamless) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 }

--- a/modules/noise/noise_texture.h
+++ b/modules/noise/noise_texture.h
@@ -75,7 +75,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_noise(Ref<Noise> p_noise);

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -512,32 +512,32 @@ Dictionary VisualScriptFunctionCall::_get_argument_cache() const {
 	return method_cache;
 }
 
-void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const {
-	if (property.name == "base_type") {
+void VisualScriptFunctionCall::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "base_type") {
 		if (call_mode != CALL_MODE_INSTANCE) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "base_script") {
+	if (p_property.name == "base_script") {
 		if (call_mode != CALL_MODE_INSTANCE) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
-	if (property.name == "basic_type") {
+	if (p_property.name == "basic_type") {
 		if (call_mode != CALL_MODE_BASIC_TYPE) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
-	if (property.name == "singleton") {
+	if (p_property.name == "singleton") {
 		if (call_mode != CALL_MODE_SINGLETON) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		} else {
 			List<Engine::Singleton> names;
 			Engine::get_singleton()->get_singletons(&names);
-			property.hint = PROPERTY_HINT_ENUM;
+			p_property.hint = PROPERTY_HINT_ENUM;
 			String sl;
 			for (const Engine::Singleton &E : names) {
 				if (!sl.is_empty()) {
@@ -545,41 +545,41 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 				}
 				sl += E.name;
 			}
-			property.hint_string = sl;
+			p_property.hint_string = sl;
 		}
 	}
 
-	if (property.name == "node_path") {
+	if (p_property.name == "node_path") {
 		if (call_mode != CALL_MODE_NODE_PATH) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		} else {
 			Node *bnode = _get_base_node();
 			if (bnode) {
-				property.hint_string = bnode->get_path(); //convert to long string
+				p_property.hint_string = bnode->get_path(); //convert to long string
 			}
 		}
 	}
 
-	if (property.name == "function") {
+	if (p_property.name == "function") {
 		if (call_mode == CALL_MODE_BASIC_TYPE) {
-			property.hint = PROPERTY_HINT_METHOD_OF_VARIANT_TYPE;
-			property.hint_string = Variant::get_type_name(basic_type);
+			p_property.hint = PROPERTY_HINT_METHOD_OF_VARIANT_TYPE;
+			p_property.hint_string = Variant::get_type_name(basic_type);
 
 		} else if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
-			property.hint = PROPERTY_HINT_METHOD_OF_SCRIPT;
-			property.hint_string = itos(get_visual_script()->get_instance_id());
+			p_property.hint = PROPERTY_HINT_METHOD_OF_SCRIPT;
+			p_property.hint_string = itos(get_visual_script()->get_instance_id());
 		} else if (call_mode == CALL_MODE_SINGLETON) {
 			Object *obj = Engine::get_singleton()->get_singleton_object(singleton);
 			if (obj) {
-				property.hint = PROPERTY_HINT_METHOD_OF_INSTANCE;
-				property.hint_string = itos(obj->get_instance_id());
+				p_property.hint = PROPERTY_HINT_METHOD_OF_INSTANCE;
+				p_property.hint_string = itos(obj->get_instance_id());
 			} else {
-				property.hint = PROPERTY_HINT_METHOD_OF_BASE_TYPE;
-				property.hint_string = base_type; //should be cached
+				p_property.hint = PROPERTY_HINT_METHOD_OF_BASE_TYPE;
+				p_property.hint_string = base_type; //should be cached
 			}
 		} else if (call_mode == CALL_MODE_INSTANCE) {
-			property.hint = PROPERTY_HINT_METHOD_OF_BASE_TYPE;
-			property.hint_string = base_type;
+			p_property.hint = PROPERTY_HINT_METHOD_OF_BASE_TYPE;
+			p_property.hint_string = base_type;
 
 			if (!base_script.is_empty()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
@@ -589,8 +589,8 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 				if (ResourceCache::has(base_script)) {
 					Ref<Script> script = ResourceCache::get_ref(base_script);
 					if (script.is_valid()) {
-						property.hint = PROPERTY_HINT_METHOD_OF_SCRIPT;
-						property.hint_string = itos(script->get_instance_id());
+						p_property.hint = PROPERTY_HINT_METHOD_OF_SCRIPT;
+						p_property.hint_string = itos(script->get_instance_id());
 					}
 				}
 			}
@@ -598,17 +598,17 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 		} else if (call_mode == CALL_MODE_NODE_PATH) {
 			Node *node = _get_base_node();
 			if (node) {
-				property.hint = PROPERTY_HINT_METHOD_OF_INSTANCE;
-				property.hint_string = itos(node->get_instance_id());
+				p_property.hint = PROPERTY_HINT_METHOD_OF_INSTANCE;
+				p_property.hint_string = itos(node->get_instance_id());
 			} else {
-				property.hint = PROPERTY_HINT_METHOD_OF_BASE_TYPE;
-				property.hint_string = get_base_type();
+				p_property.hint = PROPERTY_HINT_METHOD_OF_BASE_TYPE;
+				p_property.hint_string = get_base_type();
 			}
 		}
 	}
 
-	if (property.name == "use_default_args") {
-		property.hint = PROPERTY_HINT_RANGE;
+	if (p_property.name == "use_default_args") {
+		p_property.hint = PROPERTY_HINT_RANGE;
 
 		int mc = 0;
 
@@ -622,15 +622,15 @@ void VisualScriptFunctionCall::_validate_property(PropertyInfo &property) const 
 		}
 
 		if (mc == 0) {
-			property.usage = PROPERTY_USAGE_NONE; //do not show
+			p_property.usage = PROPERTY_USAGE_NONE; //do not show
 		} else {
-			property.hint_string = "0," + itos(mc) + ",1";
+			p_property.hint_string = "0," + itos(mc) + ",1";
 		}
 	}
 
-	if (property.name == "rpc_call_mode") {
+	if (p_property.name == "rpc_call_mode") {
 		if (call_mode == CALL_MODE_BASIC_TYPE) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 }
@@ -1290,47 +1290,47 @@ VisualScriptPropertySet::AssignOp VisualScriptPropertySet::get_assign_op() const
 	return assign_op;
 }
 
-void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
-	if (property.name == "base_type") {
+void VisualScriptPropertySet::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "base_type") {
 		if (call_mode != CALL_MODE_INSTANCE) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "base_script") {
+	if (p_property.name == "base_script") {
 		if (call_mode != CALL_MODE_INSTANCE) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
-	if (property.name == "basic_type") {
+	if (p_property.name == "basic_type") {
 		if (call_mode != CALL_MODE_BASIC_TYPE) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
-	if (property.name == "node_path") {
+	if (p_property.name == "node_path") {
 		if (call_mode != CALL_MODE_NODE_PATH) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		} else {
 			Node *bnode = _get_base_node();
 			if (bnode) {
-				property.hint_string = bnode->get_path(); //convert to long string
+				p_property.hint_string = bnode->get_path(); //convert to long string
 			}
 		}
 	}
 
-	if (property.name == "property") {
+	if (p_property.name == "property") {
 		if (call_mode == CALL_MODE_BASIC_TYPE) {
-			property.hint = PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE;
-			property.hint_string = Variant::get_type_name(basic_type);
+			p_property.hint = PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE;
+			p_property.hint_string = Variant::get_type_name(basic_type);
 
 		} else if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
-			property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
-			property.hint_string = itos(get_visual_script()->get_instance_id());
+			p_property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
+			p_property.hint_string = itos(get_visual_script()->get_instance_id());
 		} else if (call_mode == CALL_MODE_INSTANCE) {
-			property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
-			property.hint_string = base_type;
+			p_property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
+			p_property.hint_string = base_type;
 
 			if (!base_script.is_empty()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
@@ -1340,8 +1340,8 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 				if (ResourceCache::has(base_script)) {
 					Ref<Script> script = ResourceCache::get_ref(base_script);
 					if (script.is_valid()) {
-						property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
-						property.hint_string = itos(script->get_instance_id());
+						p_property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
+						p_property.hint_string = itos(script->get_instance_id());
 					}
 				}
 			}
@@ -1349,16 +1349,16 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 		} else if (call_mode == CALL_MODE_NODE_PATH) {
 			Node *node = _get_base_node();
 			if (node) {
-				property.hint = PROPERTY_HINT_PROPERTY_OF_INSTANCE;
-				property.hint_string = itos(node->get_instance_id());
+				p_property.hint = PROPERTY_HINT_PROPERTY_OF_INSTANCE;
+				p_property.hint_string = itos(node->get_instance_id());
 			} else {
-				property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
-				property.hint_string = get_base_type();
+				p_property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
+				p_property.hint_string = get_base_type();
 			}
 		}
 	}
 
-	if (property.name == "index") {
+	if (p_property.name == "index") {
 		Callable::CallError ce;
 		Variant v;
 		Variant::construct(type_cache.type, v, nullptr, 0, ce);
@@ -1369,11 +1369,11 @@ void VisualScriptPropertySet::_validate_property(PropertyInfo &property) const {
 			options += "," + E.name;
 		}
 
-		property.hint = PROPERTY_HINT_ENUM;
-		property.hint_string = options;
-		property.type = Variant::STRING;
+		p_property.hint = PROPERTY_HINT_ENUM;
+		p_property.hint_string = options;
+		p_property.type = Variant::STRING;
 		if (options.is_empty()) {
-			property.usage = PROPERTY_USAGE_NONE; //hide if type has no usable index
+			p_property.usage = PROPERTY_USAGE_NONE; //hide if type has no usable index
 		}
 	}
 }
@@ -1996,47 +1996,47 @@ StringName VisualScriptPropertyGet::get_index() const {
 	return index;
 }
 
-void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
-	if (property.name == "base_type") {
+void VisualScriptPropertyGet::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "base_type") {
 		if (call_mode != CALL_MODE_INSTANCE) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "base_script") {
+	if (p_property.name == "base_script") {
 		if (call_mode != CALL_MODE_INSTANCE) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
-	if (property.name == "basic_type") {
+	if (p_property.name == "basic_type") {
 		if (call_mode != CALL_MODE_BASIC_TYPE) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
-	if (property.name == "node_path") {
+	if (p_property.name == "node_path") {
 		if (call_mode != CALL_MODE_NODE_PATH) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		} else {
 			Node *bnode = _get_base_node();
 			if (bnode) {
-				property.hint_string = bnode->get_path(); //convert to long string
+				p_property.hint_string = bnode->get_path(); //convert to long string
 			}
 		}
 	}
 
-	if (property.name == "property") {
+	if (p_property.name == "property") {
 		if (call_mode == CALL_MODE_BASIC_TYPE) {
-			property.hint = PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE;
-			property.hint_string = Variant::get_type_name(basic_type);
+			p_property.hint = PROPERTY_HINT_PROPERTY_OF_VARIANT_TYPE;
+			p_property.hint_string = Variant::get_type_name(basic_type);
 
 		} else if (call_mode == CALL_MODE_SELF && get_visual_script().is_valid()) {
-			property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
-			property.hint_string = itos(get_visual_script()->get_instance_id());
+			p_property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
+			p_property.hint_string = itos(get_visual_script()->get_instance_id());
 		} else if (call_mode == CALL_MODE_INSTANCE) {
-			property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
-			property.hint_string = base_type;
+			p_property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
+			p_property.hint_string = base_type;
 
 			if (!base_script.is_empty()) {
 				if (!ResourceCache::has(base_script) && ScriptServer::edit_request_func) {
@@ -2046,24 +2046,24 @@ void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
 				if (ResourceCache::has(base_script)) {
 					Ref<Script> script = ResourceCache::get_ref(base_script);
 					if (script.is_valid()) {
-						property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
-						property.hint_string = itos(script->get_instance_id());
+						p_property.hint = PROPERTY_HINT_PROPERTY_OF_SCRIPT;
+						p_property.hint_string = itos(script->get_instance_id());
 					}
 				}
 			}
 		} else if (call_mode == CALL_MODE_NODE_PATH) {
 			Node *node = _get_base_node();
 			if (node) {
-				property.hint = PROPERTY_HINT_PROPERTY_OF_INSTANCE;
-				property.hint_string = itos(node->get_instance_id());
+				p_property.hint = PROPERTY_HINT_PROPERTY_OF_INSTANCE;
+				p_property.hint_string = itos(node->get_instance_id());
 			} else {
-				property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
-				property.hint_string = get_base_type();
+				p_property.hint = PROPERTY_HINT_PROPERTY_OF_BASE_TYPE;
+				p_property.hint_string = get_base_type();
 			}
 		}
 	}
 
-	if (property.name == "index") {
+	if (p_property.name == "index") {
 		Callable::CallError ce;
 		Variant v;
 		Variant::construct(type_cache, v, nullptr, 0, ce);
@@ -2074,11 +2074,11 @@ void VisualScriptPropertyGet::_validate_property(PropertyInfo &property) const {
 			options += "," + E.name;
 		}
 
-		property.hint = PROPERTY_HINT_ENUM;
-		property.hint_string = options;
-		property.type = Variant::STRING;
+		p_property.hint = PROPERTY_HINT_ENUM;
+		p_property.hint_string = options;
+		p_property.type = Variant::STRING;
 		if (options.is_empty()) {
-			property.usage = PROPERTY_USAGE_NONE; //hide if type has no usable index
+			p_property.usage = PROPERTY_USAGE_NONE; //hide if type has no usable index
 		}
 	}
 }
@@ -2322,9 +2322,9 @@ StringName VisualScriptEmitSignal::get_signal() const {
 	return name;
 }
 
-void VisualScriptEmitSignal::_validate_property(PropertyInfo &property) const {
-	if (property.name == "signal") {
-		property.hint = PROPERTY_HINT_ENUM;
+void VisualScriptEmitSignal::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "signal") {
+		p_property.hint = PROPERTY_HINT_ENUM;
 
 		List<StringName> sigs;
 		List<MethodInfo> base_sigs;
@@ -2349,7 +2349,7 @@ void VisualScriptEmitSignal::_validate_property(PropertyInfo &property) const {
 			ml += E.name;
 		}
 
-		property.hint_string = ml;
+		p_property.hint_string = ml;
 	}
 }
 

--- a/modules/visual_script/visual_script_func_nodes.h
+++ b/modules/visual_script/visual_script_func_nodes.h
@@ -75,7 +75,7 @@ private:
 	Dictionary _get_argument_cache() const;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 
@@ -187,7 +187,7 @@ private:
 	void _adjust_input_index(PropertyInfo &pinfo) const;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 
@@ -275,7 +275,7 @@ private:
 	void _adjust_input_index(PropertyInfo &pinfo) const;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 
@@ -330,7 +330,7 @@ private:
 	StringName name;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1299,8 +1299,8 @@ StringName VisualScriptVariableGet::get_variable() const {
 	return variable;
 }
 
-void VisualScriptVariableGet::_validate_property(PropertyInfo &property) const {
-	if (property.name == "var_name" && get_visual_script().is_valid()) {
+void VisualScriptVariableGet::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "var_name" && get_visual_script().is_valid()) {
 		Ref<VisualScript> vs = get_visual_script();
 		List<StringName> vars;
 		vs->get_variable_list(&vars);
@@ -1314,8 +1314,8 @@ void VisualScriptVariableGet::_validate_property(PropertyInfo &property) const {
 			vhint += E.operator String();
 		}
 
-		property.hint = PROPERTY_HINT_ENUM;
-		property.hint_string = vhint;
+		p_property.hint = PROPERTY_HINT_ENUM;
+		p_property.hint_string = vhint;
 	}
 }
 
@@ -1409,8 +1409,8 @@ StringName VisualScriptVariableSet::get_variable() const {
 	return variable;
 }
 
-void VisualScriptVariableSet::_validate_property(PropertyInfo &property) const {
-	if (property.name == "var_name" && get_visual_script().is_valid()) {
+void VisualScriptVariableSet::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "var_name" && get_visual_script().is_valid()) {
 		Ref<VisualScript> vs = get_visual_script();
 		List<StringName> vars;
 		vs->get_variable_list(&vars);
@@ -1424,8 +1424,8 @@ void VisualScriptVariableSet::_validate_property(PropertyInfo &property) const {
 			vhint += E.operator String();
 		}
 
-		property.hint = PROPERTY_HINT_ENUM;
-		property.hint_string = vhint;
+		p_property.hint = PROPERTY_HINT_ENUM;
+		p_property.hint_string = vhint;
 	}
 }
 
@@ -1533,11 +1533,11 @@ Variant VisualScriptConstant::get_constant_value() const {
 	return value;
 }
 
-void VisualScriptConstant::_validate_property(PropertyInfo &property) const {
-	if (property.name == "value") {
-		property.type = type;
+void VisualScriptConstant::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "value") {
+		p_property.type = type;
 		if (type == Variant::NIL) {
-			property.usage = PROPERTY_USAGE_NONE; //do not save if nil
+			p_property.usage = PROPERTY_USAGE_NONE; //do not save if nil
 		}
 	}
 }
@@ -1982,17 +1982,17 @@ VisualScriptNodeInstance *VisualScriptClassConstant::instantiate(VisualScriptIns
 	return instance;
 }
 
-void VisualScriptClassConstant::_validate_property(PropertyInfo &property) const {
-	if (property.name == "constant") {
+void VisualScriptClassConstant::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "constant") {
 		List<String> constants;
 		ClassDB::get_integer_constant_list(base_type, &constants, true);
 
-		property.hint_string = "";
+		p_property.hint_string = "";
 		for (const String &E : constants) {
-			if (!property.hint_string.is_empty()) {
-				property.hint_string += ",";
+			if (!p_property.hint_string.is_empty()) {
+				p_property.hint_string += ",";
 			}
-			property.hint_string += E;
+			p_property.hint_string += E;
 		}
 	}
 }
@@ -2115,21 +2115,21 @@ VisualScriptNodeInstance *VisualScriptBasicTypeConstant::instantiate(VisualScrip
 	return instance;
 }
 
-void VisualScriptBasicTypeConstant::_validate_property(PropertyInfo &property) const {
-	if (property.name == "constant") {
+void VisualScriptBasicTypeConstant::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "constant") {
 		List<StringName> constants;
 		Variant::get_constants_for_type(type, &constants);
 
 		if (constants.size() == 0) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 			return;
 		}
-		property.hint_string = "";
+		p_property.hint_string = "";
 		for (const StringName &E : constants) {
-			if (!property.hint_string.is_empty()) {
-				property.hint_string += ",";
+			if (!p_property.hint_string.is_empty()) {
+				p_property.hint_string += ",";
 			}
-			property.hint_string += String(E);
+			p_property.hint_string += String(E);
 		}
 	}
 }
@@ -2344,7 +2344,7 @@ VisualScriptEngineSingleton::TypeGuess VisualScriptEngineSingleton::guess_output
 	return tg;
 }
 
-void VisualScriptEngineSingleton::_validate_property(PropertyInfo &property) const {
+void VisualScriptEngineSingleton::_validate_property(PropertyInfo &p_property) const {
 	String cc;
 
 	List<Engine::Singleton> singletons;
@@ -2362,8 +2362,8 @@ void VisualScriptEngineSingleton::_validate_property(PropertyInfo &property) con
 		cc += E.name;
 	}
 
-	property.hint = PROPERTY_HINT_ENUM;
-	property.hint_string = cc;
+	p_property.hint = PROPERTY_HINT_ENUM;
+	p_property.hint_string = cc;
 }
 
 void VisualScriptEngineSingleton::_bind_methods() {
@@ -2525,9 +2525,9 @@ VisualScriptSceneNode::TypeGuess VisualScriptSceneNode::guess_output_type(TypeGu
 	return tg;
 }
 
-void VisualScriptSceneNode::_validate_property(PropertyInfo &property) const {
+void VisualScriptSceneNode::_validate_property(PropertyInfo &p_property) const {
 #ifdef TOOLS_ENABLED
-	if (property.name == "node_path") {
+	if (p_property.name == "node_path") {
 		Ref<Script> script = get_visual_script();
 		if (!script.is_valid()) {
 			return;
@@ -2552,7 +2552,7 @@ void VisualScriptSceneNode::_validate_property(PropertyInfo &property) const {
 			return;
 		}
 
-		property.hint_string = script_node->get_path();
+		p_property.hint_string = script_node->get_path();
 	}
 #endif
 }
@@ -2646,7 +2646,7 @@ VisualScriptSceneTree::TypeGuess VisualScriptSceneTree::guess_output_type(TypeGu
 	return tg;
 }
 
-void VisualScriptSceneTree::_validate_property(PropertyInfo &property) const {
+void VisualScriptSceneTree::_validate_property(PropertyInfo &p_property) const {
 }
 
 void VisualScriptSceneTree::_bind_methods() {
@@ -3757,9 +3757,9 @@ VisualScriptNodeInstance *VisualScriptInputAction::instantiate(VisualScriptInsta
 	return instance;
 }
 
-void VisualScriptInputAction::_validate_property(PropertyInfo &property) const {
-	if (property.name == "action") {
-		property.hint = PROPERTY_HINT_ENUM;
+void VisualScriptInputAction::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "action") {
+		p_property.hint = PROPERTY_HINT_ENUM;
 		String actions;
 
 		List<PropertyInfo> pinfo;
@@ -3785,7 +3785,7 @@ void VisualScriptInputAction::_validate_property(PropertyInfo &property) const {
 			actions += al[i];
 		}
 
-		property.hint_string = actions;
+		p_property.hint_string = actions;
 	}
 }
 
@@ -3935,7 +3935,7 @@ VisualScriptNodeInstance *VisualScriptDeconstruct::instantiate(VisualScriptInsta
 	return instance;
 }
 
-void VisualScriptDeconstruct::_validate_property(PropertyInfo &property) const {
+void VisualScriptDeconstruct::_validate_property(PropertyInfo &p_property) const {
 }
 
 void VisualScriptDeconstruct::_bind_methods() {

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -269,7 +269,7 @@ class VisualScriptVariableGet : public VisualScriptNode {
 	StringName variable;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:
@@ -301,7 +301,7 @@ class VisualScriptVariableSet : public VisualScriptNode {
 	StringName variable;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:
@@ -334,7 +334,7 @@ class VisualScriptConstant : public VisualScriptNode {
 	Variant value;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:
@@ -478,7 +478,7 @@ class VisualScriptClassConstant : public VisualScriptNode {
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	virtual int get_output_sequence_port_count() const override;
@@ -514,7 +514,7 @@ class VisualScriptBasicTypeConstant : public VisualScriptNode {
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	virtual int get_output_sequence_port_count() const override;
@@ -598,7 +598,7 @@ class VisualScriptEngineSingleton : public VisualScriptNode {
 	String singleton;
 
 protected:
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 
@@ -633,7 +633,7 @@ class VisualScriptSceneNode : public VisualScriptNode {
 	NodePath path;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:
@@ -665,7 +665,7 @@ class VisualScriptSceneTree : public VisualScriptNode {
 	GDCLASS(VisualScriptSceneTree, VisualScriptNode);
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:
@@ -1010,7 +1010,7 @@ public:
 	Mode mode;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 
@@ -1058,7 +1058,7 @@ class VisualScriptDeconstruct : public VisualScriptNode {
 	void _set_elem_cache(const Array &p_elements);
 	Array _get_elem_cache() const;
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 protected:
 	static void _bind_methods();

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -171,10 +171,10 @@ double VisualScriptYield::get_wait_time() {
 	return wait_time;
 }
 
-void VisualScriptYield::_validate_property(PropertyInfo &property) const {
-	if (property.name == "wait_time") {
+void VisualScriptYield::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "wait_time") {
 		if (yield_mode != YIELD_WAIT) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 }
@@ -417,26 +417,26 @@ VisualScriptYieldSignal::CallMode VisualScriptYieldSignal::get_call_mode() const
 	return call_mode;
 }
 
-void VisualScriptYieldSignal::_validate_property(PropertyInfo &property) const {
-	if (property.name == "base_type") {
+void VisualScriptYieldSignal::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "base_type") {
 		if (call_mode != CALL_MODE_INSTANCE) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "node_path") {
+	if (p_property.name == "node_path") {
 		if (call_mode != CALL_MODE_NODE_PATH) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		} else {
 			Node *bnode = _get_base_node();
 			if (bnode) {
-				property.hint_string = bnode->get_path(); //convert to long string
+				p_property.hint_string = bnode->get_path(); //convert to long string
 			}
 		}
 	}
 
-	if (property.name == "signal") {
-		property.hint = PROPERTY_HINT_ENUM;
+	if (p_property.name == "signal") {
+		p_property.hint = PROPERTY_HINT_ENUM;
 
 		List<MethodInfo> methods;
 
@@ -460,7 +460,7 @@ void VisualScriptYieldSignal::_validate_property(PropertyInfo &property) const {
 			ml += E;
 		}
 
-		property.hint_string = ml;
+		p_property.hint_string = ml;
 	}
 }
 

--- a/modules/visual_script/visual_script_yield_nodes.h
+++ b/modules/visual_script/visual_script_yield_nodes.h
@@ -50,7 +50,7 @@ private:
 	double wait_time;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 
@@ -103,7 +103,7 @@ private:
 	StringName _get_base_type() const;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -104,12 +104,12 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 	return Rect2(ofs, s);
 }
 
-void AnimatedSprite2D::_validate_property(PropertyInfo &property) const {
+void AnimatedSprite2D::_validate_property(PropertyInfo &p_property) const {
 	if (!frames.is_valid()) {
 		return;
 	}
-	if (property.name == "animation") {
-		property.hint = PROPERTY_HINT_ENUM;
+	if (p_property.name == "animation") {
+		p_property.hint = PROPERTY_HINT_ENUM;
 		List<StringName> names;
 		frames->get_animation_list(&names);
 		names.sort_custom<StringName::AlphCompare>();
@@ -118,33 +118,33 @@ void AnimatedSprite2D::_validate_property(PropertyInfo &property) const {
 
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			if (E->prev()) {
-				property.hint_string += ",";
+				p_property.hint_string += ",";
 			}
 
-			property.hint_string += String(E->get());
+			p_property.hint_string += String(E->get());
 			if (animation == E->get()) {
 				current_found = true;
 			}
 		}
 
 		if (!current_found) {
-			if (property.hint_string.is_empty()) {
-				property.hint_string = String(animation);
+			if (p_property.hint_string.is_empty()) {
+				p_property.hint_string = String(animation);
 			} else {
-				property.hint_string = String(animation) + "," + property.hint_string;
+				p_property.hint_string = String(animation) + "," + p_property.hint_string;
 			}
 		}
 	}
 
-	if (property.name == "frame") {
-		property.hint = PROPERTY_HINT_RANGE;
+	if (p_property.name == "frame") {
+		p_property.hint = PROPERTY_HINT_RANGE;
 		if (frames->has_animation(animation) && frames->get_frame_count(animation) > 0) {
-			property.hint_string = "0," + itos(frames->get_frame_count(animation) - 1) + ",1";
+			p_property.hint_string = "0," + itos(frames->get_frame_count(animation) - 1) + ",1";
 		} else {
 			// Avoid an error, `hint_string` is required for `PROPERTY_HINT_RANGE`.
-			property.hint_string = "0,0,1";
+			p_property.hint_string = "0,0,1";
 		}
-		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
 }
 

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -62,7 +62,7 @@ class AnimatedSprite2D : public Node2D {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 #ifdef TOOLS_ENABLED

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -498,8 +498,8 @@ StringName Area2D::get_audio_bus_name() const {
 	return "Master";
 }
 
-void Area2D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "audio_bus_name") {
+void Area2D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "audio_bus_name") {
 		String options;
 		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 			if (i > 0) {
@@ -509,28 +509,28 @@ void Area2D::_validate_property(PropertyInfo &property) const {
 			options += name;
 		}
 
-		property.hint_string = options;
-	} else if (property.name.begins_with("gravity") && property.name != "gravity_space_override") {
+		p_property.hint_string = options;
+	} else if (p_property.name.begins_with("gravity") && p_property.name != "gravity_space_override") {
 		if (gravity_space_override == SPACE_OVERRIDE_DISABLED) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		} else {
 			if (gravity_is_point) {
-				if (property.name == "gravity_direction") {
-					property.usage = PROPERTY_USAGE_NO_EDITOR;
+				if (p_property.name == "gravity_direction") {
+					p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 				}
 			} else {
-				if (property.name.begins_with("gravity_point_")) {
-					property.usage = PROPERTY_USAGE_NO_EDITOR;
+				if (p_property.name.begins_with("gravity_point_")) {
+					p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 				}
 			}
 		}
-	} else if (property.name.begins_with("linear_damp") && property.name != "linear_damp_space_override") {
+	} else if (p_property.name.begins_with("linear_damp") && p_property.name != "linear_damp_space_override") {
 		if (linear_damp_space_override == SPACE_OVERRIDE_DISABLED) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
-	} else if (property.name.begins_with("angular_damp") && property.name != "angular_damp_space_override") {
+	} else if (p_property.name.begins_with("angular_damp") && p_property.name != "angular_damp_space_override") {
 		if (angular_damp_space_override == SPACE_OVERRIDE_DISABLED) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 }

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -135,7 +135,7 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_gravity_space_override_mode(SpaceOverride p_mode);

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -323,8 +323,8 @@ bool AudioStreamPlayer2D::_is_active() const {
 	return active.is_set();
 }
 
-void AudioStreamPlayer2D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "bus") {
+void AudioStreamPlayer2D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "bus") {
 		String options;
 		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 			if (i > 0) {
@@ -334,7 +334,7 @@ void AudioStreamPlayer2D::_validate_property(PropertyInfo &property) const {
 			options += name;
 		}
 
-		property.hint_string = options;
+		p_property.hint_string = options;
 	}
 }
 

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -85,7 +85,7 @@ private:
 	float cached_global_panning_strength = 1.0f;
 
 protected:
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -655,9 +655,9 @@ bool Camera2D::is_margin_drawing_enabled() const {
 	return margin_drawing_enabled;
 }
 
-void Camera2D::_validate_property(PropertyInfo &property) const {
-	if (!smoothing_enabled && property.name == "smoothing_speed") {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void Camera2D::_validate_property(PropertyInfo &p_property) const {
+	if (!smoothing_enabled && p_property.name == "smoothing_speed") {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -100,7 +100,7 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_offset(const Vector2 &p_offset);

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -503,32 +503,32 @@ bool CPUParticles2D::get_split_scale() {
 	return split_scale;
 }
 
-void CPUParticles2D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "emission_sphere_radius" && (emission_shape != EMISSION_SHAPE_SPHERE && emission_shape != EMISSION_SHAPE_SPHERE_SURFACE)) {
-		property.usage = PROPERTY_USAGE_NONE;
+void CPUParticles2D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "emission_sphere_radius" && (emission_shape != EMISSION_SHAPE_SPHERE && emission_shape != EMISSION_SHAPE_SPHERE_SURFACE)) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_rect_extents" && emission_shape != EMISSION_SHAPE_RECTANGLE) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_rect_extents" && emission_shape != EMISSION_SHAPE_RECTANGLE) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if ((property.name == "emission_point_texture" || property.name == "emission_color_texture") && (emission_shape < EMISSION_SHAPE_POINTS)) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if ((p_property.name == "emission_point_texture" || p_property.name == "emission_color_texture") && (emission_shape < EMISSION_SHAPE_POINTS)) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_normals" && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_normals" && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_points" && emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_points" && emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_colors" && emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_colors" && emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-	if (property.name.begins_with("scale_curve_") && !split_scale) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name.begins_with("scale_curve_") && !split_scale) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -193,7 +193,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_emitting(bool p_emitting);

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -340,7 +340,7 @@ Ref<Texture2D> GPUParticles2D::get_texture() const {
 	return texture;
 }
 
-void GPUParticles2D::_validate_property(PropertyInfo &property) const {
+void GPUParticles2D::_validate_property(PropertyInfo &p_property) const {
 }
 
 void GPUParticles2D::emit_particle(const Transform2D &p_transform2d, const Vector2 &p_velocity2d, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) {

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -84,7 +84,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	void _update_collision_size();
 

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -227,9 +227,9 @@ real_t Light2D::get_shadow_smooth() const {
 	return shadow_smooth;
 }
 
-void Light2D::_validate_property(PropertyInfo &property) const {
-	if (!shadow && (property.name == "shadow_color" || property.name == "shadow_filter" || property.name == "shadow_filter_smooth" || property.name == "shadow_item_cull_mask")) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void Light2D::_validate_property(PropertyInfo &p_property) const {
+	if (!shadow && (p_property.name == "shadow_color" || p_property.name == "shadow_filter" || p_property.name == "shadow_filter_smooth" || p_property.name == "shadow_item_cull_mask")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/2d/light_2d.h
+++ b/scene/2d/light_2d.h
@@ -79,7 +79,7 @@ protected:
 	_FORCE_INLINE_ RID _get_light() const { return canvas_light; }
 	void _notification(int p_what);
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_enabled(bool p_enabled);

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -46,7 +46,7 @@ class NavigationObstacle2D : public Node {
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &p_property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 
 public:

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -245,14 +245,14 @@ bool PathFollow2D::get_cubic_interpolation() const {
 	return cubic;
 }
 
-void PathFollow2D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "offset") {
+void PathFollow2D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "offset") {
 		real_t max = 10000.0;
 		if (path && path->get_curve().is_valid()) {
 			max = path->get_curve()->get_baked_length();
 		}
 
-		property.hint_string = "0," + rtos(max) + ",0.01,or_lesser,or_greater";
+		p_property.hint_string = "0," + rtos(max) + ",0.01,or_lesser,or_greater";
 	}
 }
 

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -76,7 +76,7 @@ private:
 	void _update_transform();
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1062,10 +1062,10 @@ void RigidDynamicBody2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(CCD_MODE_CAST_SHAPE);
 }
 
-void RigidDynamicBody2D::_validate_property(PropertyInfo &property) const {
+void RigidDynamicBody2D::_validate_property(PropertyInfo &p_property) const {
 	if (center_of_mass_mode != CENTER_OF_MASS_MODE_CUSTOM) {
-		if (property.name == "center_of_mass") {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		if (p_property.name == "center_of_mass") {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 }
@@ -1776,14 +1776,14 @@ void CharacterBody2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(PLATFORM_VEL_ON_LEAVE_NEVER);
 }
 
-void CharacterBody2D::_validate_property(PropertyInfo &property) const {
+void CharacterBody2D::_validate_property(PropertyInfo &p_property) const {
 	if (motion_mode == MOTION_MODE_FLOATING) {
-		if (property.name.begins_with("floor_") || property.name == "up_direction" || property.name == "slide_on_ceiling") {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		if (p_property.name.begins_with("floor_") || p_property.name == "up_direction" || p_property.name == "slide_on_ceiling") {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	} else {
-		if (property.name == "wall_min_slide_angle") {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		if (p_property.name == "wall_min_slide_angle") {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 }

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -216,7 +216,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	GDVIRTUAL1(_integrate_forces, PhysicsDirectBodyState2D *)
 
@@ -450,7 +450,7 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 };
 
 VARIANT_ENUM_CAST(CharacterBody2D::MotionMode);

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -90,9 +90,9 @@ bool Polygon2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toler
 }
 #endif
 
-void Polygon2D::_validate_property(PropertyInfo &property) const {
-	if (!invert && property.name == "invert_border") {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void Polygon2D::_validate_property(PropertyInfo &p_property) const {
+	if (!invert && p_property.name == "invert_border") {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -77,7 +77,7 @@ class Polygon2D : public Node2D {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 #ifdef TOOLS_ENABLED

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -368,19 +368,19 @@ Rect2 Sprite2D::get_rect() const {
 	return Rect2(ofs, s);
 }
 
-void Sprite2D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "frame") {
-		property.hint = PROPERTY_HINT_RANGE;
-		property.hint_string = "0," + itos(vframes * hframes - 1) + ",1";
-		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+void Sprite2D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "frame") {
+		p_property.hint = PROPERTY_HINT_RANGE;
+		p_property.hint_string = "0," + itos(vframes * hframes - 1) + ",1";
+		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
 
-	if (property.name == "frame_coords") {
-		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+	if (p_property.name == "frame_coords") {
+		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
 
-	if (!region_enabled && (property.name == "region_rect" || property.name == "region_filter_clip")) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (!region_enabled && (p_property.name == "region_rect" || p_property.name == "region_filter_clip")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -64,7 +64,7 @@ protected:
 
 	static void _bind_methods();
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 #ifdef TOOLS_ENABLED

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -598,8 +598,8 @@ float Area3D::get_reverb_uniformity() const {
 	return reverb_uniformity;
 }
 
-void Area3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "audio_bus_name" || property.name == "reverb_bus_name") {
+void Area3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "audio_bus_name" || p_property.name == "reverb_bus_name") {
 		String options;
 		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 			if (i > 0) {
@@ -609,32 +609,30 @@ void Area3D::_validate_property(PropertyInfo &property) const {
 			options += name;
 		}
 
-		property.hint_string = options;
-	} else if (property.name.begins_with("gravity") && property.name != "gravity_space_override") {
+		p_property.hint_string = options;
+	} else if (p_property.name.begins_with("gravity") && p_property.name != "gravity_space_override") {
 		if (gravity_space_override == SPACE_OVERRIDE_DISABLED) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		} else {
 			if (gravity_is_point) {
-				if (property.name == "gravity_direction") {
-					property.usage = PROPERTY_USAGE_NO_EDITOR;
+				if (p_property.name == "gravity_direction") {
+					p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 				}
 			} else {
-				if (property.name.begins_with("gravity_point_")) {
-					property.usage = PROPERTY_USAGE_NO_EDITOR;
+				if (p_property.name.begins_with("gravity_point_")) {
+					p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 				}
 			}
 		}
-	} else if (property.name.begins_with("linear_damp") && property.name != "linear_damp_space_override") {
+	} else if (p_property.name.begins_with("linear_damp") && p_property.name != "linear_damp_space_override") {
 		if (linear_damp_space_override == SPACE_OVERRIDE_DISABLED) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
-	} else if (property.name.begins_with("angular_damp") && property.name != "angular_damp_space_override") {
+	} else if (p_property.name.begins_with("angular_damp") && p_property.name != "angular_damp_space_override") {
 		if (angular_damp_space_override == SPACE_OVERRIDE_DISABLED) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
-
-	CollisionObject3D::_validate_property(property);
 }
 
 void Area3D::_bind_methods() {

--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -141,7 +141,7 @@ private:
 	float reverb_amount = 0.0;
 	float reverb_uniformity = 0.0;
 
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	void _initialize_wind();
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -648,8 +648,8 @@ bool AudioStreamPlayer3D::_is_active() const {
 	return active.is_set();
 }
 
-void AudioStreamPlayer3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "bus") {
+void AudioStreamPlayer3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "bus") {
 		String options;
 		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 			if (i > 0) {
@@ -659,10 +659,8 @@ void AudioStreamPlayer3D::_validate_property(PropertyInfo &property) const {
 			options += name;
 		}
 
-		property.hint_string = options;
+		p_property.hint_string = options;
 	}
-
-	Node3D::_validate_property(property);
 }
 
 void AudioStreamPlayer3D::_bus_layout_changed() {

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -120,7 +120,7 @@ private:
 	float cached_global_panning_strength = 1.0f;
 
 protected:
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -30,8 +30,8 @@
 
 #include "bone_attachment_3d.h"
 
-void BoneAttachment3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "bone_name") {
+void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "bone_name") {
 		// Because it is a constant function, we cannot use the _get_skeleton_3d function.
 		const Skeleton3D *parent = nullptr;
 		if (use_external_skeleton) {
@@ -51,15 +51,13 @@ void BoneAttachment3D::_validate_property(PropertyInfo &property) const {
 				names += parent->get_bone_name(i);
 			}
 
-			property.hint = PROPERTY_HINT_ENUM;
-			property.hint_string = names;
+			p_property.hint = PROPERTY_HINT_ENUM;
+			p_property.hint_string = names;
 		} else {
-			property.hint = PROPERTY_HINT_NONE;
-			property.hint_string = "";
+			p_property.hint = PROPERTY_HINT_NONE;
+			p_property.hint_string = "";
 		}
 	}
-
-	Node3D::_validate_property(property);
 }
 
 bool BoneAttachment3D::_set(const StringName &p_path, const Variant &p_value) {

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -64,7 +64,7 @@ class BoneAttachment3D : public Node3D {
 	Skeleton3D *_get_skeleton3d();
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
 	void _get_property_list(List<PropertyInfo> *p_list) const;

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -71,8 +71,6 @@ void Camera3D::_validate_property(PropertyInfo &p_property) const {
 			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
-
-	Node3D::_validate_property(p_property);
 }
 
 void Camera3D::_update_camera() {

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -99,7 +99,7 @@ protected:
 	void _update_camera_mode();
 
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &p_property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -516,36 +516,34 @@ bool CPUParticles3D::get_split_scale() {
 	return split_scale;
 }
 
-void CPUParticles3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "emission_sphere_radius" && (emission_shape != EMISSION_SHAPE_SPHERE && emission_shape != EMISSION_SHAPE_SPHERE_SURFACE)) {
-		property.usage = PROPERTY_USAGE_NONE;
+void CPUParticles3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "emission_sphere_radius" && (emission_shape != EMISSION_SHAPE_SPHERE && emission_shape != EMISSION_SHAPE_SPHERE_SURFACE)) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_box_extents" && emission_shape != EMISSION_SHAPE_BOX) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_box_extents" && emission_shape != EMISSION_SHAPE_BOX) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if ((property.name == "emission_point_texture" || property.name == "emission_color_texture" || property.name == "emission_points") && (emission_shape != EMISSION_SHAPE_POINTS && (emission_shape != EMISSION_SHAPE_DIRECTED_POINTS))) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if ((p_property.name == "emission_point_texture" || p_property.name == "emission_color_texture" || p_property.name == "emission_points") && (emission_shape != EMISSION_SHAPE_POINTS && (emission_shape != EMISSION_SHAPE_DIRECTED_POINTS))) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_normals" && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_normals" && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name.begins_with("emission_ring_") && emission_shape != EMISSION_SHAPE_RING) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name.begins_with("emission_ring_") && emission_shape != EMISSION_SHAPE_RING) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name.begins_with("orbit_") && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name.begins_with("orbit_") && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name.begins_with("scale_curve_") && !split_scale) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name.begins_with("scale_curve_") && !split_scale) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-
-	Node3D::_validate_property(property);
 }
 
 static uint32_t idhash(uint32_t x) {

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -198,7 +198,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	AABB get_aabb() const override;

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -152,11 +152,10 @@ AABB Decal::get_aabb() const {
 	return aabb;
 }
 
-void Decal::_validate_property(PropertyInfo &property) const {
-	if (!distance_fade_enabled && (property.name == "distance_fade_begin" || property.name == "distance_fade_length")) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void Decal::_validate_property(PropertyInfo &p_property) const {
+	if (!distance_fade_enabled && (p_property.name == "distance_fade_begin" || p_property.name == "distance_fade_length")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
-	VisualInstance3D::_validate_property(property);
 }
 
 TypedArray<String> Decal::get_configuration_warnings() const {

--- a/scene/3d/decal.h
+++ b/scene/3d/decal.h
@@ -62,7 +62,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	virtual TypedArray<String> get_configuration_warnings() const override;

--- a/scene/3d/fog_volume.cpp
+++ b/scene/3d/fog_volume.cpp
@@ -45,12 +45,11 @@ void FogVolume::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "FogMaterial,ShaderMaterial"), "set_material", "get_material");
 }
 
-void FogVolume::_validate_property(PropertyInfo &property) const {
-	if (property.name == "extents" && shape == RS::FOG_VOLUME_SHAPE_WORLD) {
-		property.usage = PROPERTY_USAGE_NONE;
+void FogVolume::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "extents" && shape == RS::FOG_VOLUME_SHAPE_WORLD) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 		return;
 	}
-	VisualInstance3D::_validate_property(property);
 }
 
 void FogVolume::set_extents(const Vector3 &p_extents) {

--- a/scene/3d/fog_volume.h
+++ b/scene/3d/fog_volume.h
@@ -49,7 +49,7 @@ class FogVolume : public VisualInstance3D {
 protected:
 	_FORCE_INLINE_ RID _get_volume() { return volume; }
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_extents(const Vector3 &p_extents);

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -376,16 +376,14 @@ AABB GPUParticles3D::capture_aabb() const {
 	return RS::get_singleton()->particles_get_current_aabb(particles);
 }
 
-void GPUParticles3D::_validate_property(PropertyInfo &property) const {
-	if (property.name.begins_with("draw_pass_")) {
-		int index = property.name.get_slicec('_', 2).to_int() - 1;
+void GPUParticles3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name.begins_with("draw_pass_")) {
+		int index = p_property.name.get_slicec('_', 2).to_int() - 1;
 		if (index >= draw_passes.size()) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 			return;
 		}
 	}
-
-	GeometryInstance3D::_validate_property(property);
 }
 
 void GPUParticles3D::emit_particle(const Transform3D &p_transform, const Vector3 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) {

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -94,7 +94,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	AABB get_aabb() const override;

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -162,19 +162,19 @@ void Label3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(ALPHA_CUT_OPAQUE_PREPASS);
 }
 
-void Label3D::_validate_property(PropertyInfo &property) const {
+void Label3D::_validate_property(PropertyInfo &p_property) const {
 	if (
-			property.name == "material_override" ||
-			property.name == "material_overlay" ||
-			property.name == "lod_bias" ||
-			property.name == "gi_mode" ||
-			property.name == "gi_lightmap_scale") {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.name == "material_override" ||
+			p_property.name == "material_overlay" ||
+			p_property.name == "lod_bias" ||
+			p_property.name == "gi_mode" ||
+			p_property.name == "gi_lightmap_scale") {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "cast_shadow" && alpha_cut == ALPHA_CUT_DISABLED) {
+	if (p_property.name == "cast_shadow" && alpha_cut == ALPHA_CUT_DISABLED) {
 		// Alpha-blended materials can't cast shadows.
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -149,7 +149,7 @@ protected:
 
 	static void _bind_methods();
 
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	void _im_update();
 	void _font_changed();

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -223,21 +223,19 @@ bool Light3D::is_editor_only() const {
 	return editor_only;
 }
 
-void Light3D::_validate_property(PropertyInfo &property) const {
-	if (!shadow && (property.name == "shadow_bias" || property.name == "shadow_normal_bias" || property.name == "shadow_reverse_cull_face" || property.name == "shadow_transmittance_bias" || property.name == "shadow_fog_fade" || property.name == "shadow_opacity" || property.name == "shadow_blur" || property.name == "distance_fade_shadow")) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void Light3D::_validate_property(PropertyInfo &p_property) const {
+	if (!shadow && (p_property.name == "shadow_bias" || p_property.name == "shadow_normal_bias" || p_property.name == "shadow_reverse_cull_face" || p_property.name == "shadow_transmittance_bias" || p_property.name == "shadow_fog_fade" || p_property.name == "shadow_opacity" || p_property.name == "shadow_blur" || p_property.name == "distance_fade_shadow")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (get_light_type() != RS::LIGHT_DIRECTIONAL && property.name == "light_angular_distance") {
+	if (get_light_type() != RS::LIGHT_DIRECTIONAL && p_property.name == "light_angular_distance") {
 		// Angular distance is only used in DirectionalLight3D.
-		property.usage = PROPERTY_USAGE_NONE;
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (!distance_fade_enabled && (property.name == "distance_fade_begin" || property.name == "distance_fade_shadow" || property.name == "distance_fade_length")) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (!distance_fade_enabled && (p_property.name == "distance_fade_begin" || p_property.name == "distance_fade_shadow" || p_property.name == "distance_fade_length")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
-
-	VisualInstance3D::_validate_property(property);
 }
 
 void Light3D::_bind_methods() {
@@ -429,29 +427,27 @@ DirectionalLight3D::SkyMode DirectionalLight3D::get_sky_mode() const {
 	return sky_mode;
 }
 
-void DirectionalLight3D::_validate_property(PropertyInfo &property) const {
-	if (shadow_mode == SHADOW_ORTHOGONAL && (property.name == "directional_shadow_split_1" || property.name == "directional_shadow_blend_splits")) {
+void DirectionalLight3D::_validate_property(PropertyInfo &p_property) const {
+	if (shadow_mode == SHADOW_ORTHOGONAL && (p_property.name == "directional_shadow_split_1" || p_property.name == "directional_shadow_blend_splits")) {
 		// Split 2 and split blending are only used with the PSSM 2 Splits and PSSM 4 Splits shadow modes.
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if ((shadow_mode == SHADOW_ORTHOGONAL || shadow_mode == SHADOW_PARALLEL_2_SPLITS) && (property.name == "directional_shadow_split_2" || property.name == "directional_shadow_split_3")) {
+	if ((shadow_mode == SHADOW_ORTHOGONAL || shadow_mode == SHADOW_PARALLEL_2_SPLITS) && (p_property.name == "directional_shadow_split_2" || p_property.name == "directional_shadow_split_3")) {
 		// Splits 3 and 4 are only used with the PSSM 4 Splits shadow mode.
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "light_size" || property.name == "light_projector" || property.name == "light_specular") {
+	if (p_property.name == "light_size" || p_property.name == "light_projector" || p_property.name == "light_specular") {
 		// Not implemented in DirectionalLight3D (`light_size` is replaced by `light_angular_distance`).
-		property.usage = PROPERTY_USAGE_NONE;
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "distance_fade_enabled" || property.name == "distance_fade_begin" || property.name == "distance_fade_shadow" || property.name == "distance_fade_length") {
+	if (p_property.name == "distance_fade_enabled" || p_property.name == "distance_fade_begin" || p_property.name == "distance_fade_shadow" || p_property.name == "distance_fade_length") {
 		// Not relevant for DirectionalLight3D, as the light LOD system only pertains to point lights.
 		// For DirectionalLight3D, `directional_shadow_max_distance` can be used instead.
-		property.usage = PROPERTY_USAGE_NONE;
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-
-	Light3D::_validate_property(property);
 }
 
 void DirectionalLight3D::_bind_methods() {

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -93,7 +93,7 @@ protected:
 
 	static void _bind_methods();
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	Light3D(RenderingServer::LightType p_type);
 
@@ -171,7 +171,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_shadow_mode(ShadowMode p_mode);

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1410,17 +1410,16 @@ LightmapGI::GenerateProbes LightmapGI::get_generate_probes() const {
 	return gen_probes;
 }
 
-void LightmapGI::_validate_property(PropertyInfo &property) const {
-	if (property.name == "environment_custom_sky" && environment_mode != ENVIRONMENT_MODE_CUSTOM_SKY) {
-		property.usage = PROPERTY_USAGE_NONE;
+void LightmapGI::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "environment_custom_sky" && environment_mode != ENVIRONMENT_MODE_CUSTOM_SKY) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-	if (property.name == "environment_custom_color" && environment_mode != ENVIRONMENT_MODE_CUSTOM_COLOR) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "environment_custom_color" && environment_mode != ENVIRONMENT_MODE_CUSTOM_COLOR) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-	if (property.name == "environment_custom_energy" && environment_mode != ENVIRONMENT_MODE_CUSTOM_COLOR && environment_mode != ENVIRONMENT_MODE_CUSTOM_SKY) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "environment_custom_energy" && environment_mode != ENVIRONMENT_MODE_CUSTOM_COLOR && environment_mode != ENVIRONMENT_MODE_CUSTOM_SKY) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-	VisualInstance3D::_validate_property(property);
 }
 
 void LightmapGI::_bind_methods() {

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -216,7 +216,7 @@ private:
 	void _gen_new_positions_from_octree(const GenProbesOctree *p_cell, float p_cell_size, const Vector<Vector3> &probe_positions, LocalVector<Vector3> &new_probe_positions, HashMap<Vector3i, bool> &positions_used, const AABB &p_bounds);
 
 protected:
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 	void _notification(int p_what);
 

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -45,7 +45,7 @@ class NavigationObstacle3D : public Node {
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &p_property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 
 public:

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -879,21 +879,21 @@ NodePath Node3D::get_visibility_parent() const {
 	return visibility_parent_path;
 }
 
-void Node3D::_validate_property(PropertyInfo &property) const {
-	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_BASIS && property.name == "basis") {
-		property.usage = 0;
+void Node3D::_validate_property(PropertyInfo &p_property) const {
+	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_BASIS && p_property.name == "basis") {
+		p_property.usage = 0;
 	}
-	if (data.rotation_edit_mode == ROTATION_EDIT_MODE_BASIS && property.name == "scale") {
-		property.usage = 0;
+	if (data.rotation_edit_mode == ROTATION_EDIT_MODE_BASIS && p_property.name == "scale") {
+		p_property.usage = 0;
 	}
-	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_QUATERNION && property.name == "quaternion") {
-		property.usage = 0;
+	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_QUATERNION && p_property.name == "quaternion") {
+		p_property.usage = 0;
 	}
-	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && property.name == "rotation") {
-		property.usage = 0;
+	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && p_property.name == "rotation") {
+		p_property.usage = 0;
 	}
-	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && property.name == "rotation_order") {
-		property.usage = 0;
+	if (data.rotation_edit_mode != ROTATION_EDIT_MODE_EULER && p_property.name == "rotation_order") {
+		p_property.usage = 0;
 	}
 }
 

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -155,7 +155,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -330,16 +330,15 @@ bool PathFollow3D::get_cubic_interpolation() const {
 	return cubic;
 }
 
-void PathFollow3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "offset") {
+void PathFollow3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "offset") {
 		real_t max = 10000;
 		if (path && path->get_curve().is_valid()) {
 			max = path->get_curve()->get_baked_length();
 		}
 
-		property.hint_string = "0," + rtos(max) + ",0.01,or_lesser,or_greater";
+		p_property.hint_string = "0," + rtos(max) + ",0.01,or_lesser,or_greater";
 	}
-	Node3D::_validate_property(property);
 }
 
 TypedArray<String> PathFollow3D::get_configuration_warnings() const {

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -85,7 +85,7 @@ private:
 	void _update_transform(bool p_update_xyz_rot = true);
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1124,13 +1124,12 @@ void RigidDynamicBody3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DAMP_MODE_REPLACE);
 }
 
-void RigidDynamicBody3D::_validate_property(PropertyInfo &property) const {
+void RigidDynamicBody3D::_validate_property(PropertyInfo &p_property) const {
 	if (center_of_mass_mode != CENTER_OF_MASS_MODE_CUSTOM) {
-		if (property.name == "center_of_mass") {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		if (p_property.name == "center_of_mass") {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
-	PhysicsBody3D::_validate_property(property);
 }
 
 RigidDynamicBody3D::RigidDynamicBody3D() :
@@ -2022,13 +2021,12 @@ void CharacterBody3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(PLATFORM_VEL_ON_LEAVE_NEVER);
 }
 
-void CharacterBody3D::_validate_property(PropertyInfo &property) const {
+void CharacterBody3D::_validate_property(PropertyInfo &p_property) const {
 	if (motion_mode == MOTION_MODE_FLOATING) {
-		if (property.name.begins_with("floor_") || property.name == "up_direction" || property.name == "slide_on_ceiling") {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		if (p_property.name.begins_with("floor_") || p_property.name == "up_direction" || p_property.name == "slide_on_ceiling") {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
-	PhysicsBody3D::_validate_property(property);
 }
 
 CharacterBody3D::CharacterBody3D() :

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -226,7 +226,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	GDVIRTUAL1(_integrate_forces, PhysicsDirectBodyState3D *)
 
@@ -483,7 +483,7 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 };
 
 VARIANT_ENUM_CAST(CharacterBody3D::MotionMode);

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -178,13 +178,12 @@ AABB ReflectionProbe::get_aabb() const {
 	return aabb;
 }
 
-void ReflectionProbe::_validate_property(PropertyInfo &property) const {
-	if (property.name == "ambient_color" || property.name == "ambient_color_energy") {
+void ReflectionProbe::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "ambient_color" || p_property.name == "ambient_color_energy") {
 		if (ambient_mode != AMBIENT_COLOR) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
-	VisualInstance3D::_validate_property(property);
 }
 
 void ReflectionProbe::_bind_methods() {

--- a/scene/3d/reflection_probe.h
+++ b/scene/3d/reflection_probe.h
@@ -67,7 +67,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_intensity(float p_intensity);

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -176,39 +176,37 @@ void Skeleton3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-void Skeleton3D::_validate_property(PropertyInfo &property) const {
-	PackedStringArray split = property.name.split("/");
+void Skeleton3D::_validate_property(PropertyInfo &p_property) const {
+	PackedStringArray split = p_property.name.split("/");
 	if (split.size() == 3 && split[0] == "bones") {
 		if (split[2] == "rest") {
-			property.usage |= PROPERTY_USAGE_READ_ONLY;
+			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 		}
 		if (is_show_rest_only()) {
 			if (split[2] == "enabled") {
-				property.usage |= PROPERTY_USAGE_READ_ONLY;
+				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 			}
 			if (split[2] == "position") {
-				property.usage |= PROPERTY_USAGE_READ_ONLY;
+				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 			}
 			if (split[2] == "rotation") {
-				property.usage |= PROPERTY_USAGE_READ_ONLY;
+				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 			}
 			if (split[2] == "scale") {
-				property.usage |= PROPERTY_USAGE_READ_ONLY;
+				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 			}
 		} else if (!is_bone_enabled(split[1].to_int())) {
 			if (split[2] == "position") {
-				property.usage |= PROPERTY_USAGE_READ_ONLY;
+				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 			}
 			if (split[2] == "rotation") {
-				property.usage |= PROPERTY_USAGE_READ_ONLY;
+				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 			}
 			if (split[2] == "scale") {
-				property.usage |= PROPERTY_USAGE_READ_ONLY;
+				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 			}
 		}
 	}
-
-	Node3D::_validate_property(property);
 }
 
 void Skeleton3D::_update_process_order() {

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -156,7 +156,7 @@ protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
 	void _get_property_list(List<PropertyInfo> *p_list) const;
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -329,8 +329,8 @@ void FabrikInverseKinematic::_update_chain(const Skeleton3D *p_sk, ChainItem *p_
 	}
 }
 
-void SkeletonIK3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "root_bone" || property.name == "tip_bone") {
+void SkeletonIK3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "root_bone" || p_property.name == "tip_bone") {
 		if (skeleton) {
 			String names("--,");
 			for (int i = 0; i < skeleton->get_bone_count(); i++) {
@@ -340,15 +340,13 @@ void SkeletonIK3D::_validate_property(PropertyInfo &property) const {
 				names += skeleton->get_bone_name(i);
 			}
 
-			property.hint = PROPERTY_HINT_ENUM;
-			property.hint_string = names;
+			p_property.hint = PROPERTY_HINT_ENUM;
+			p_property.hint_string = names;
 		} else {
-			property.hint = PROPERTY_HINT_NONE;
-			property.hint_string = "";
+			p_property.hint = PROPERTY_HINT_NONE;
+			p_property.hint_string = "";
 		}
 	}
-
-	Node::_validate_property(property);
 }
 
 void SkeletonIK3D::_bind_methods() {

--- a/scene/3d/skeleton_ik_3d.h
+++ b/scene/3d/skeleton_ik_3d.h
@@ -137,7 +137,7 @@ class SkeletonIK3D : public Node {
 	FabrikInverseKinematic::Task *task = nullptr;
 
 protected:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 	virtual void _notification(int p_what);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -751,18 +751,16 @@ Rect2 Sprite3D::get_item_rect() const {
 	return Rect2(ofs, s);
 }
 
-void Sprite3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "frame") {
-		property.hint = PROPERTY_HINT_RANGE;
-		property.hint_string = "0," + itos(vframes * hframes - 1) + ",1";
-		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+void Sprite3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "frame") {
+		p_property.hint = PROPERTY_HINT_RANGE;
+		p_property.hint_string = "0," + itos(vframes * hframes - 1) + ",1";
+		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
 
-	if (property.name == "frame_coords") {
-		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+	if (p_property.name == "frame_coords") {
+		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
-
-	SpriteBase3D::_validate_property(property);
 }
 
 void Sprite3D::_bind_methods() {
@@ -1000,12 +998,12 @@ void AnimatedSprite3D::_draw() {
 	}
 }
 
-void AnimatedSprite3D::_validate_property(PropertyInfo &property) const {
+void AnimatedSprite3D::_validate_property(PropertyInfo &p_property) const {
 	if (!frames.is_valid()) {
 		return;
 	}
-	if (property.name == "animation") {
-		property.hint = PROPERTY_HINT_ENUM;
+	if (p_property.name == "animation") {
+		p_property.hint = PROPERTY_HINT_ENUM;
 		List<StringName> names;
 		frames->get_animation_list(&names);
 		names.sort_custom<StringName::AlphCompare>();
@@ -1014,36 +1012,34 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &property) const {
 
 		for (List<StringName>::Element *E = names.front(); E; E = E->next()) {
 			if (E->prev()) {
-				property.hint_string += ",";
+				p_property.hint_string += ",";
 			}
 
-			property.hint_string += String(E->get());
+			p_property.hint_string += String(E->get());
 			if (animation == E->get()) {
 				current_found = true;
 			}
 		}
 
 		if (!current_found) {
-			if (property.hint_string.is_empty()) {
-				property.hint_string = String(animation);
+			if (p_property.hint_string.is_empty()) {
+				p_property.hint_string = String(animation);
 			} else {
-				property.hint_string = String(animation) + "," + property.hint_string;
+				p_property.hint_string = String(animation) + "," + p_property.hint_string;
 			}
 		}
 	}
 
-	if (property.name == "frame") {
-		property.hint = PROPERTY_HINT_RANGE;
+	if (p_property.name == "frame") {
+		p_property.hint = PROPERTY_HINT_RANGE;
 		if (frames->has_animation(animation) && frames->get_frame_count(animation) > 0) {
-			property.hint_string = "0," + itos(frames->get_frame_count(animation) - 1) + ",1";
+			p_property.hint_string = "0," + itos(frames->get_frame_count(animation) - 1) + ",1";
 		} else {
 			// Avoid an error, `hint_string` is required for `PROPERTY_HINT_RANGE`.
-			property.hint_string = "0,0,1";
+			p_property.hint_string = "0,0,1";
 		}
-		property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
+		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
-
-	SpriteBase3D::_validate_property(property);
 }
 
 void AnimatedSprite3D::_notification(int p_what) {

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -174,7 +174,7 @@ protected:
 	virtual void _draw() override;
 	static void _bind_methods();
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_texture(const Ref<Texture2D> &p_texture);
@@ -229,7 +229,7 @@ protected:
 	virtual void _draw() override;
 	static void _bind_methods();
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -244,27 +244,25 @@ void XRNode3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("trigger_haptic_pulse", "action_name", "frequency", "amplitude", "duration_sec", "delay_sec"), &XRNode3D::trigger_haptic_pulse);
 };
 
-void XRNode3D::_validate_property(PropertyInfo &property) const {
+void XRNode3D::_validate_property(PropertyInfo &p_property) const {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);
 
-	if (property.name == "tracker") {
+	if (p_property.name == "tracker") {
 		PackedStringArray names = xr_server->get_suggested_tracker_names();
 		String hint_string;
 		for (const String &name : names) {
 			hint_string += name + ",";
 		}
-		property.hint_string = hint_string;
-	} else if (property.name == "pose") {
+		p_property.hint_string = hint_string;
+	} else if (p_property.name == "pose") {
 		PackedStringArray names = xr_server->get_suggested_pose_names(tracker_name);
 		String hint_string;
 		for (const String &name : names) {
 			hint_string += name + ",";
 		}
-		property.hint_string = hint_string;
+		p_property.hint_string = hint_string;
 	}
-
-	Node3D::_validate_property(property);
 }
 
 void XRNode3D::set_tracker(const StringName p_tracker_name) {

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -93,7 +93,7 @@ protected:
 	void _pose_changed(const Ref<XRPose> &p_pose);
 
 public:
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void set_tracker(const StringName p_tracker_name);
 	StringName get_tracker() const;
 

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -42,15 +42,14 @@ Ref<AnimationNode> AnimationNodeBlendSpace1D::get_child_by_name(const StringName
 	return get_blend_point_node(p_name.operator String().to_int());
 }
 
-void AnimationNodeBlendSpace1D::_validate_property(PropertyInfo &property) const {
-	if (property.name.begins_with("blend_point_")) {
-		String left = property.name.get_slicec('/', 0);
+void AnimationNodeBlendSpace1D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name.begins_with("blend_point_")) {
+		String left = p_property.name.get_slicec('/', 0);
 		int idx = left.get_slicec('_', 2).to_int();
 		if (idx >= blend_points_used) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
-	AnimationRootNode::_validate_property(property);
 }
 
 void AnimationNodeBlendSpace1D::_tree_changed() {

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -65,7 +65,7 @@ class AnimationNodeBlendSpace1D : public AnimationRootNode {
 protected:
 	bool sync = false;
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -566,18 +566,17 @@ String AnimationNodeBlendSpace2D::get_caption() const {
 	return "BlendSpace2D";
 }
 
-void AnimationNodeBlendSpace2D::_validate_property(PropertyInfo &property) const {
-	if (auto_triangles && property.name == "triangles") {
-		property.usage = PROPERTY_USAGE_NONE;
+void AnimationNodeBlendSpace2D::_validate_property(PropertyInfo &p_property) const {
+	if (auto_triangles && p_property.name == "triangles") {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-	if (property.name.begins_with("blend_point_")) {
-		String left = property.name.get_slicec('/', 0);
+	if (p_property.name.begins_with("blend_point_")) {
+		String left = p_property.name.get_slicec('/', 0);
 		int idx = left.get_slicec('_', 2).to_int();
 		if (idx >= blend_points_used) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
-	AnimationRootNode::_validate_property(property);
 }
 
 void AnimationNodeBlendSpace2D::set_auto_triangles(bool p_enable) {

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -90,7 +90,7 @@ protected:
 protected:
 	bool sync = false;
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -47,8 +47,8 @@ void AnimationNodeAnimation::get_parameter_list(List<PropertyInfo> *r_list) cons
 	r_list->push_back(PropertyInfo(Variant::FLOAT, time, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 }
 
-void AnimationNodeAnimation::_validate_property(PropertyInfo &property) const {
-	if (property.name == "animation" && get_editable_animation_list) {
+void AnimationNodeAnimation::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "animation" && get_editable_animation_list) {
 		Vector<String> names = get_editable_animation_list();
 		String anims;
 		for (int i = 0; i < names.size(); i++) {
@@ -58,8 +58,8 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &property) const {
 			anims += String(names[i]);
 		}
 		if (!anims.is_empty()) {
-			property.hint = PROPERTY_HINT_ENUM;
-			property.hint_string = anims;
+			p_property.hint = PROPERTY_HINT_ENUM;
+			p_property.hint_string = anims;
 		}
 	}
 }
@@ -768,18 +768,16 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_seek_
 	return rem;
 }
 
-void AnimationNodeTransition::_validate_property(PropertyInfo &property) const {
-	if (property.name.begins_with("input_")) {
-		String n = property.name.get_slicec('/', 0).get_slicec('_', 1);
+void AnimationNodeTransition::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name.begins_with("input_")) {
+		String n = p_property.name.get_slicec('/', 0).get_slicec('_', 1);
 		if (n != "count") {
 			int idx = n.to_int();
 			if (idx >= enabled_inputs) {
-				property.usage = PROPERTY_USAGE_NONE;
+				p_property.usage = PROPERTY_USAGE_NONE;
 			}
 		}
 	}
-
-	AnimationNode::_validate_property(property);
 }
 
 void AnimationNodeTransition::_bind_methods() {

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -67,7 +67,7 @@ public:
 	AnimationNodeAnimation();
 
 protected:
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 private:
@@ -304,7 +304,7 @@ class AnimationNodeTransition : public AnimationNodeSync {
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -174,8 +174,8 @@ bool AnimationPlayer::_get(const StringName &p_name, Variant &r_ret) const {
 	return true;
 }
 
-void AnimationPlayer::_validate_property(PropertyInfo &property) const {
-	if (property.name == "current_animation") {
+void AnimationPlayer::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "current_animation") {
 		List<String> names;
 
 		for (const KeyValue<StringName, AnimationData> &E : animation_set) {
@@ -191,10 +191,8 @@ void AnimationPlayer::_validate_property(PropertyInfo &property) const {
 			hint += E->get();
 		}
 
-		property.hint_string = hint;
+		p_property.hint_string = hint;
 	}
-
-	Node::_validate_property(property);
 }
 
 void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -311,7 +311,7 @@ private:
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -399,9 +399,9 @@ void AnimationNode::_set_filters(const Array &p_filters) {
 	}
 }
 
-void AnimationNode::_validate_property(PropertyInfo &property) const {
-	if (!has_filter() && (property.name == "filter_enabled" || property.name == "filters")) {
-		property.usage = PROPERTY_USAGE_NONE;
+void AnimationNode::_validate_property(PropertyInfo &p_property) const {
+	if (!has_filter() && (p_property.name == "filter_enabled" || p_property.name == "filters")) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -111,7 +111,7 @@ protected:
 
 	static void _bind_methods();
 
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	GDVIRTUAL0RC(Dictionary, _get_child_nodes)
 	GDVIRTUAL0RC(Array, _get_parameter_list)

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -283,8 +283,8 @@ Vector<AudioFrame> AudioStreamPlayer::_get_volume_vector() {
 	return volume_vector;
 }
 
-void AudioStreamPlayer::_validate_property(PropertyInfo &property) const {
-	if (property.name == "bus") {
+void AudioStreamPlayer::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "bus") {
 		String options;
 		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 			if (i > 0) {
@@ -294,10 +294,8 @@ void AudioStreamPlayer::_validate_property(PropertyInfo &property) const {
 			options += name;
 		}
 
-		property.hint_string = options;
+		p_property.hint_string = options;
 	}
-
-	Node::_validate_property(property);
 }
 
 void AudioStreamPlayer::_bus_layout_changed() {

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -72,7 +72,7 @@ private:
 	Vector<AudioFrame> _get_volume_vector();
 
 protected:
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -422,9 +422,9 @@ void Control::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-void Control::_validate_property(PropertyInfo &property) const {
+void Control::_validate_property(PropertyInfo &p_property) const {
 	// Update theme type variation options.
-	if (property.name == "theme_type_variation") {
+	if (p_property.name == "theme_type_variation") {
 		List<StringName> names;
 
 		// Only the default theme and the project theme are used for the list of options.
@@ -447,18 +447,18 @@ void Control::_validate_property(PropertyInfo &property) const {
 			unique_names.append(E);
 		}
 
-		property.hint_string = hint_string;
+		p_property.hint_string = hint_string;
 	}
 
-	if (property.name == "mouse_force_pass_scroll_events") {
+	if (p_property.name == "mouse_force_pass_scroll_events") {
 		// Disable force pass if the control is not stopping the event.
 		if (data.mouse_filter != MOUSE_FILTER_STOP) {
-			property.usage |= PROPERTY_USAGE_READ_ONLY;
+			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 		}
 	}
 
-	if (property.name == "scale") {
-		property.hint = PROPERTY_HINT_LINK;
+	if (p_property.name == "scale") {
+		p_property.hint = PROPERTY_HINT_LINK;
 	}
 
 	// Validate which positioning properties should be displayed depending on the parent and the layout mode.
@@ -467,33 +467,33 @@ void Control::_validate_property(PropertyInfo &property) const {
 		// If there is no parent, display both anchor and container options.
 
 		// Set the layout mode to be disabled with the proper value.
-		if (property.name == "layout_mode") {
-			property.hint_string = "Position,Anchors,Container,Uncontrolled";
-			property.usage |= PROPERTY_USAGE_READ_ONLY;
+		if (p_property.name == "layout_mode") {
+			p_property.hint_string = "Position,Anchors,Container,Uncontrolled";
+			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 		}
 
 		// Use the layout mode to display or hide advanced anchoring properties.
 		bool use_custom_anchors = _get_anchors_layout_preset() == -1; // Custom "preset".
-		if (!use_custom_anchors && (property.name.begins_with("anchor_") || property.name.begins_with("offset_") || property.name.begins_with("grow_"))) {
-			property.usage ^= PROPERTY_USAGE_EDITOR;
+		if (!use_custom_anchors && (p_property.name.begins_with("anchor_") || p_property.name.begins_with("offset_") || p_property.name.begins_with("grow_"))) {
+			p_property.usage ^= PROPERTY_USAGE_EDITOR;
 		}
 	} else if (Object::cast_to<Container>(parent_node)) {
 		// If the parent is a container, display only container-related properties.
-		if (property.name.begins_with("anchor_") || property.name.begins_with("offset_") || property.name.begins_with("grow_") || property.name == "anchors_preset" ||
-				property.name == "position" || property.name == "rotation" || property.name == "scale" || property.name == "size" || property.name == "pivot_offset") {
-			property.usage ^= PROPERTY_USAGE_EDITOR;
+		if (p_property.name.begins_with("anchor_") || p_property.name.begins_with("offset_") || p_property.name.begins_with("grow_") || p_property.name == "anchors_preset" ||
+				p_property.name == "position" || p_property.name == "rotation" || p_property.name == "scale" || p_property.name == "size" || p_property.name == "pivot_offset") {
+			p_property.usage ^= PROPERTY_USAGE_EDITOR;
 
-		} else if (property.name == "layout_mode") {
+		} else if (p_property.name == "layout_mode") {
 			// Set the layout mode to be disabled with the proper value.
-			property.hint_string = "Position,Anchors,Container,Uncontrolled";
-			property.usage |= PROPERTY_USAGE_READ_ONLY;
-		} else if (property.name == "size_flags_horizontal" || property.name == "size_flags_vertical") {
+			p_property.hint_string = "Position,Anchors,Container,Uncontrolled";
+			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
+		} else if (p_property.name == "size_flags_horizontal" || p_property.name == "size_flags_vertical") {
 			// Filter allowed size flags based on the parent container configuration.
 			Container *parent_container = Object::cast_to<Container>(parent_node);
 			Vector<int> size_flags;
-			if (property.name == "size_flags_horizontal") {
+			if (p_property.name == "size_flags_horizontal") {
 				size_flags = parent_container->get_allowed_size_flags_horizontal();
-			} else if (property.name == "size_flags_vertical") {
+			} else if (p_property.name == "size_flags_vertical") {
 				size_flags = parent_container->get_allowed_size_flags_vertical();
 			}
 
@@ -522,30 +522,30 @@ void Control::_validate_property(PropertyInfo &property) const {
 			}
 
 			if (hint_string.is_empty()) {
-				property.hint_string = "";
-				property.usage |= PROPERTY_USAGE_READ_ONLY;
+				p_property.hint_string = "";
+				p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 			} else {
-				property.hint_string = hint_string;
+				p_property.hint_string = hint_string;
 			}
 		}
 	} else {
 		// If the parent is NOT a container or not a control at all, display only anchoring-related properties.
-		if (property.name.begins_with("size_flags_")) {
-			property.usage ^= PROPERTY_USAGE_EDITOR;
+		if (p_property.name.begins_with("size_flags_")) {
+			p_property.usage ^= PROPERTY_USAGE_EDITOR;
 
-		} else if (property.name == "layout_mode") {
+		} else if (p_property.name == "layout_mode") {
 			// Set the layout mode to be enabled with proper options.
-			property.hint_string = "Position,Anchors";
+			p_property.hint_string = "Position,Anchors";
 		}
 
 		// Use the layout mode to display or hide advanced anchoring properties.
 		bool use_anchors = _get_layout_mode() == LayoutMode::LAYOUT_MODE_ANCHORS;
-		if (!use_anchors && property.name == "anchors_preset") {
-			property.usage ^= PROPERTY_USAGE_EDITOR;
+		if (!use_anchors && p_property.name == "anchors_preset") {
+			p_property.usage ^= PROPERTY_USAGE_EDITOR;
 		}
 		bool use_custom_anchors = use_anchors && _get_anchors_layout_preset() == -1; // Custom "preset".
-		if (!use_custom_anchors && (property.name.begins_with("anchor_") || property.name.begins_with("offset_") || property.name.begins_with("grow_"))) {
-			property.usage ^= PROPERTY_USAGE_EDITOR;
+		if (!use_custom_anchors && (p_property.name.begins_with("anchor_") || p_property.name.begins_with("offset_") || p_property.name.begins_with("grow_"))) {
+			p_property.usage ^= PROPERTY_USAGE_EDITOR;
 		}
 	}
 
@@ -555,13 +555,13 @@ void Control::_validate_property(PropertyInfo &property) const {
 	}
 	bool property_is_managed_by_container = false;
 	for (unsigned i = 0; i < properties_managed_by_container_count; i++) {
-		property_is_managed_by_container = properties_managed_by_container[i] == property.name;
+		property_is_managed_by_container = properties_managed_by_container[i] == p_property.name;
 		if (property_is_managed_by_container) {
 			break;
 		}
 	}
 	if (property_is_managed_by_container) {
-		property.usage |= PROPERTY_USAGE_READ_ONLY;
+		p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 	}
 }
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -317,7 +317,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	// Internationalization.
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -446,12 +446,11 @@ void GraphNode::_edit_set_position(const Point2 &p_position) {
 	set_position(p_position);
 }
 
-void GraphNode::_validate_property(PropertyInfo &property) const {
-	Control::_validate_property(property);
+void GraphNode::_validate_property(PropertyInfo &p_property) const {
 	GraphEdit *graph = Object::cast_to<GraphEdit>(get_parent());
 	if (graph) {
-		if (property.name == "position") {
-			property.usage |= PROPERTY_USAGE_READ_ONLY;
+		if (p_property.name == "position") {
+			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 		}
 	}
 }

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -101,7 +101,7 @@ private:
 
 #ifdef TOOLS_ENABLED
 	void _edit_set_position(const Point2 &p_position) override;
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 #endif
 
 protected:

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2224,9 +2224,9 @@ Key LineEdit::_get_menu_action_accelerator(const String &p_action) {
 	}
 }
 
-void LineEdit::_validate_property(PropertyInfo &property) const {
-	if (!caret_blink_enabled && property.name == "caret_blink_speed") {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void LineEdit::_validate_property(PropertyInfo &p_property) const {
+	if (!caret_blink_enabled && p_property.name == "caret_blink_speed") {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -221,7 +221,7 @@ protected:
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -471,9 +471,9 @@ void OptionButton::get_translatable_strings(List<String> *p_strings) const {
 	popup->get_translatable_strings(p_strings);
 }
 
-void OptionButton::_validate_property(PropertyInfo &property) const {
-	if (property.name == "text" || property.name == "icon") {
-		property.usage = PROPERTY_USAGE_NONE;
+void OptionButton::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "text" || p_property.name == "icon") {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -58,7 +58,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -79,7 +79,7 @@ class VideoStreamPlayer : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_notification);
-	void _validate_property(PropertyInfo &p_property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	Size2 get_minimum_size() const override;

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -286,9 +286,9 @@ void CanvasLayer::_update_follow_viewport(bool p_force_exit) {
 	}
 }
 
-void CanvasLayer::_validate_property(PropertyInfo &property) const {
-	if (!follow_viewport && property.name == "follow_viewport_scale") {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void CanvasLayer::_validate_property(PropertyInfo &p_property) const {
+	if (!follow_viewport && p_property.name == "follow_viewport_scale") {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -64,7 +64,7 @@ class CanvasLayer : public Node {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_layer(int p_xform);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3953,9 +3953,9 @@ void Viewport::_bind_methods() {
 	BIND_ENUM_CONSTANT(VRS_MAX);
 }
 
-void Viewport::_validate_property(PropertyInfo &property) const {
-	if (vrs_mode != VRS_TEXTURE && (property.name == "vrs_texture")) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void Viewport::_validate_property(PropertyInfo &p_property) const {
+	if (vrs_mode != VRS_TEXTURE && (p_property.name == "vrs_texture")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -709,7 +709,7 @@ public:
 	bool is_using_xr();
 #endif // _3D_DISABLED
 
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	Viewport();
 	~Viewport();
 };

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1510,8 +1510,8 @@ bool Window::is_auto_translating() const {
 	return auto_translate;
 }
 
-void Window::_validate_property(PropertyInfo &property) const {
-	if (property.name == "theme_type_variation") {
+void Window::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "theme_type_variation") {
 		List<StringName> names;
 
 		// Only the default theme and the project theme are used for the list of options.
@@ -1534,7 +1534,7 @@ void Window::_validate_property(PropertyInfo &property) const {
 			unique_names.append(E);
 		}
 
-		property.hint_string = hint_string;
+		p_property.hint_string = hint_string;
 	}
 }
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -158,7 +158,7 @@ protected:
 	virtual Size2 _get_contents_minimum_size() const;
 	static void _bind_methods();
 	void _notification(int p_what);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;

--- a/scene/resources/bone_map.cpp
+++ b/scene/resources/bone_map.cpp
@@ -167,7 +167,7 @@ void BoneMap::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("profile_updated"));
 }
 
-void BoneMap::_validate_property(PropertyInfo &property) const {
+void BoneMap::_validate_property(PropertyInfo &p_property) const {
 	//
 }
 

--- a/scene/resources/bone_map.h
+++ b/scene/resources/bone_map.h
@@ -45,7 +45,7 @@ class BoneMap : public Resource {
 protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	static void _bind_methods();
 

--- a/scene/resources/camera_effects.cpp
+++ b/scene/resources/camera_effects.cpp
@@ -145,11 +145,11 @@ void CameraEffects::_update_override_exposure() {
 
 // Private methods, constructor and destructor
 
-void CameraEffects::_validate_property(PropertyInfo &property) const {
-	if ((!dof_blur_far_enabled && (property.name == "dof_blur_far_distance" || property.name == "dof_blur_far_transition")) ||
-			(!dof_blur_near_enabled && (property.name == "dof_blur_near_distance" || property.name == "dof_blur_near_transition")) ||
-			(!override_exposure_enabled && property.name == "override_exposure")) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void CameraEffects::_validate_property(PropertyInfo &p_property) const {
+	if ((!dof_blur_far_enabled && (p_property.name == "dof_blur_far_distance" || p_property.name == "dof_blur_far_transition")) ||
+			(!dof_blur_near_enabled && (p_property.name == "dof_blur_near_distance" || p_property.name == "dof_blur_near_transition")) ||
+			(!override_exposure_enabled && p_property.name == "override_exposure")) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/resources/camera_effects.h
+++ b/scene/resources/camera_effects.h
@@ -59,7 +59,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	virtual RID get_rid() const override;

--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -227,9 +227,9 @@ bool CanvasItemMaterial::get_particles_anim_loop() const {
 	return particles_anim_loop;
 }
 
-void CanvasItemMaterial::_validate_property(PropertyInfo &property) const {
-	if (property.name.begins_with("particles_anim_") && !particles_animation) {
-		property.usage = PROPERTY_USAGE_NONE;
+void CanvasItemMaterial::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name.begins_with("particles_anim_") && !particles_animation) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 

--- a/scene/resources/canvas_item_material.h
+++ b/scene/resources/canvas_item_material.h
@@ -117,7 +117,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_blend_mode(BlendMode p_blend_mode);

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1037,46 +1037,46 @@ void Environment::_update_adjustment() {
 
 // Private methods, constructor and destructor
 
-void Environment::_validate_property(PropertyInfo &property) const {
-	if (property.name == "sky" || property.name == "sky_custom_fov" || property.name == "sky_rotation" || property.name == "ambient_light_sky_contribution") {
+void Environment::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "sky" || p_property.name == "sky_custom_fov" || p_property.name == "sky_rotation" || p_property.name == "ambient_light_sky_contribution") {
 		if (bg_mode != BG_SKY && ambient_source != AMBIENT_SOURCE_SKY && reflection_source != REFLECTION_SOURCE_SKY) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "fog_aerial_perspective") {
+	if (p_property.name == "fog_aerial_perspective") {
 		if (bg_mode != BG_SKY) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "tonemap_white" && tone_mapper == TONE_MAPPER_LINEAR) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "tonemap_white" && tone_mapper == TONE_MAPPER_LINEAR) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "glow_intensity" && glow_blend_mode == GLOW_BLEND_MODE_MIX) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "glow_intensity" && glow_blend_mode == GLOW_BLEND_MODE_MIX) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "glow_mix" && glow_blend_mode != GLOW_BLEND_MODE_MIX) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "glow_mix" && glow_blend_mode != GLOW_BLEND_MODE_MIX) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "background_color") {
+	if (p_property.name == "background_color") {
 		if (bg_mode != BG_COLOR && ambient_source != AMBIENT_SOURCE_COLOR) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "background_canvas_max_layer") {
+	if (p_property.name == "background_canvas_max_layer") {
 		if (bg_mode != BG_CANVAS) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
-	if (property.name == "background_camera_feed_id") {
+	if (p_property.name == "background_camera_feed_id") {
 		if (bg_mode != BG_CAMERA_FEED) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 
@@ -1107,8 +1107,8 @@ void Environment::_validate_property(PropertyInfo &property) const {
 		String prefix = String(*prefixes);
 
 		String enabled = prefix + "enabled";
-		if (property.name.begins_with(prefix) && property.name != enabled && !bool(get(enabled))) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		if (p_property.name.begins_with(prefix) && p_property.name != enabled && !bool(get(enabled))) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 			return;
 		}
 
@@ -1120,8 +1120,8 @@ void Environment::_validate_property(PropertyInfo &property) const {
 		while (*prefixes) {
 			String prefix = String(*prefixes);
 
-			if (property.name.begins_with(prefix)) {
-				property.usage = PROPERTY_USAGE_NO_EDITOR;
+			if (p_property.name.begins_with(prefix)) {
+				p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 				return;
 			}
 

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -211,7 +211,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 #ifndef DISABLE_DEPRECATED
 	// Kept for compatibility from 3.x to 4.0.
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -71,12 +71,12 @@ RID Material::get_rid() const {
 	return material;
 }
 
-void Material::_validate_property(PropertyInfo &property) const {
-	if (!_can_do_next_pass() && property.name == "next_pass") {
-		property.usage = PROPERTY_USAGE_NONE;
+void Material::_validate_property(PropertyInfo &p_property) const {
+	if (!_can_do_next_pass() && p_property.name == "next_pass") {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
-	if (!_can_use_render_priority() && property.name == "render_priority") {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (!_can_use_render_priority() && p_property.name == "render_priority") {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 
@@ -1867,61 +1867,61 @@ void BaseMaterial3D::_validate_high_end(const String &text, PropertyInfo &proper
 	}
 }
 
-void BaseMaterial3D::_validate_property(PropertyInfo &property) const {
-	_validate_feature("normal", FEATURE_NORMAL_MAPPING, property);
-	_validate_feature("emission", FEATURE_EMISSION, property);
-	_validate_feature("rim", FEATURE_RIM, property);
-	_validate_feature("clearcoat", FEATURE_CLEARCOAT, property);
-	_validate_feature("anisotropy", FEATURE_ANISOTROPY, property);
-	_validate_feature("ao", FEATURE_AMBIENT_OCCLUSION, property);
-	_validate_feature("heightmap", FEATURE_HEIGHT_MAPPING, property);
-	_validate_feature("subsurf_scatter", FEATURE_SUBSURFACE_SCATTERING, property);
-	_validate_feature("backlight", FEATURE_BACKLIGHT, property);
-	_validate_feature("refraction", FEATURE_REFRACTION, property);
-	_validate_feature("detail", FEATURE_DETAIL, property);
+void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
+	_validate_feature("normal", FEATURE_NORMAL_MAPPING, p_property);
+	_validate_feature("emission", FEATURE_EMISSION, p_property);
+	_validate_feature("rim", FEATURE_RIM, p_property);
+	_validate_feature("clearcoat", FEATURE_CLEARCOAT, p_property);
+	_validate_feature("anisotropy", FEATURE_ANISOTROPY, p_property);
+	_validate_feature("ao", FEATURE_AMBIENT_OCCLUSION, p_property);
+	_validate_feature("heightmap", FEATURE_HEIGHT_MAPPING, p_property);
+	_validate_feature("subsurf_scatter", FEATURE_SUBSURFACE_SCATTERING, p_property);
+	_validate_feature("backlight", FEATURE_BACKLIGHT, p_property);
+	_validate_feature("refraction", FEATURE_REFRACTION, p_property);
+	_validate_feature("detail", FEATURE_DETAIL, p_property);
 
-	_validate_high_end("refraction", property);
-	_validate_high_end("subsurf_scatter", property);
-	_validate_high_end("heightmap", property);
+	_validate_high_end("refraction", p_property);
+	_validate_high_end("subsurf_scatter", p_property);
+	_validate_high_end("heightmap", p_property);
 
-	if (property.name.begins_with("particles_anim_") && billboard_mode != BILLBOARD_PARTICLES) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name.begins_with("particles_anim_") && billboard_mode != BILLBOARD_PARTICLES) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "billboard_keep_scale" && billboard_mode == BILLBOARD_DISABLED) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "billboard_keep_scale" && billboard_mode == BILLBOARD_DISABLED) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "grow_amount" && !grow_enabled) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "grow_amount" && !grow_enabled) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "point_size" && !flags[FLAG_USE_POINT_SIZE]) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "point_size" && !flags[FLAG_USE_POINT_SIZE]) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "proximity_fade_distance" && !proximity_fade_enabled) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "proximity_fade_distance" && !proximity_fade_enabled) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "msdf_pixel_range" && !flags[FLAG_ALBEDO_TEXTURE_MSDF]) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "msdf_pixel_range" && !flags[FLAG_ALBEDO_TEXTURE_MSDF]) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (property.name == "msdf_outline_size" && !flags[FLAG_ALBEDO_TEXTURE_MSDF]) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if (p_property.name == "msdf_outline_size" && !flags[FLAG_ALBEDO_TEXTURE_MSDF]) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if ((property.name == "distance_fade_max_distance" || property.name == "distance_fade_min_distance") && distance_fade == DISTANCE_FADE_DISABLED) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if ((p_property.name == "distance_fade_max_distance" || p_property.name == "distance_fade_min_distance") && distance_fade == DISTANCE_FADE_DISABLED) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if ((property.name == "uv1_triplanar_sharpness" || property.name == "uv1_world_triplanar") && !flags[FLAG_UV1_USE_TRIPLANAR]) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if ((p_property.name == "uv1_triplanar_sharpness" || p_property.name == "uv1_world_triplanar") && !flags[FLAG_UV1_USE_TRIPLANAR]) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if ((property.name == "uv2_triplanar_sharpness" || property.name == "uv2_world_triplanar") && !flags[FLAG_UV2_USE_TRIPLANAR]) {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	if ((p_property.name == "uv2_triplanar_sharpness" || p_property.name == "uv2_world_triplanar") && !flags[FLAG_UV2_USE_TRIPLANAR]) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
 	// you can only enable anti-aliasing (in materials) on alpha scissor and alpha hash
@@ -1930,96 +1930,96 @@ void BaseMaterial3D::_validate_property(PropertyInfo &property) const {
 	const bool alpha_aa_enabled = (alpha_antialiasing_mode != ALPHA_ANTIALIASING_OFF) && can_select_aa;
 
 	// alpha scissor slider isn't needed when alpha antialiasing is enabled
-	if (property.name == "alpha_scissor_threshold" && transparency != TRANSPARENCY_ALPHA_SCISSOR) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "alpha_scissor_threshold" && transparency != TRANSPARENCY_ALPHA_SCISSOR) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
 	// alpha hash scale slider is only needed if transparency is alpha hash
-	if (property.name == "alpha_hash_scale" && transparency != TRANSPARENCY_ALPHA_HASH) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "alpha_hash_scale" && transparency != TRANSPARENCY_ALPHA_HASH) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "alpha_antialiasing_mode" && !can_select_aa) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "alpha_antialiasing_mode" && !can_select_aa) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
 	// we can't choose an antialiasing mode if alpha isn't possible
-	if (property.name == "alpha_antialiasing_edge" && !alpha_aa_enabled) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "alpha_antialiasing_edge" && !alpha_aa_enabled) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "blend_mode" && alpha_aa_enabled) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "blend_mode" && alpha_aa_enabled) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if ((property.name == "heightmap_min_layers" || property.name == "heightmap_max_layers") && !deep_parallax) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if ((p_property.name == "heightmap_min_layers" || p_property.name == "heightmap_max_layers") && !deep_parallax) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (flags[FLAG_SUBSURFACE_MODE_SKIN] && (property.name == "subsurf_scatter_transmittance_color" || property.name == "subsurf_scatter_transmittance_texture")) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (flags[FLAG_SUBSURFACE_MODE_SKIN] && (p_property.name == "subsurf_scatter_transmittance_color" || p_property.name == "subsurf_scatter_transmittance_texture")) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
 	if (orm) {
-		if (property.name == "shading_mode") {
+		if (p_property.name == "shading_mode") {
 			// Vertex not supported in ORM mode, since no individual roughness.
-			property.hint_string = "Unshaded,Per-Pixel";
+			p_property.hint_string = "Unshaded,Per-Pixel";
 		}
-		if (property.name.begins_with("roughness") || property.name.begins_with("metallic") || property.name.begins_with("ao_texture")) {
-			property.usage = PROPERTY_USAGE_NONE;
+		if (p_property.name.begins_with("roughness") || p_property.name.begins_with("metallic") || p_property.name.begins_with("ao_texture")) {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 
 	} else {
-		if (property.name == "orm_texture") {
-			property.usage = PROPERTY_USAGE_NONE;
+		if (p_property.name == "orm_texture") {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
 	if (shading_mode != SHADING_MODE_PER_PIXEL) {
 		if (shading_mode != SHADING_MODE_PER_VERTEX) {
 			//these may still work per vertex
-			if (property.name.begins_with("ao")) {
-				property.usage = PROPERTY_USAGE_NONE;
+			if (p_property.name.begins_with("ao")) {
+				p_property.usage = PROPERTY_USAGE_NONE;
 			}
-			if (property.name.begins_with("emission")) {
-				property.usage = PROPERTY_USAGE_NONE;
-			}
-
-			if (property.name.begins_with("metallic")) {
-				property.usage = PROPERTY_USAGE_NONE;
-			}
-			if (property.name.begins_with("rim")) {
-				property.usage = PROPERTY_USAGE_NONE;
+			if (p_property.name.begins_with("emission")) {
+				p_property.usage = PROPERTY_USAGE_NONE;
 			}
 
-			if (property.name.begins_with("roughness")) {
-				property.usage = PROPERTY_USAGE_NONE;
+			if (p_property.name.begins_with("metallic")) {
+				p_property.usage = PROPERTY_USAGE_NONE;
+			}
+			if (p_property.name.begins_with("rim")) {
+				p_property.usage = PROPERTY_USAGE_NONE;
 			}
 
-			if (property.name.begins_with("subsurf_scatter")) {
-				property.usage = PROPERTY_USAGE_NONE;
+			if (p_property.name.begins_with("roughness")) {
+				p_property.usage = PROPERTY_USAGE_NONE;
+			}
+
+			if (p_property.name.begins_with("subsurf_scatter")) {
+				p_property.usage = PROPERTY_USAGE_NONE;
 			}
 		}
 
 		//these definitely only need per pixel
-		if (property.name.begins_with("anisotropy")) {
-			property.usage = PROPERTY_USAGE_NONE;
+		if (p_property.name.begins_with("anisotropy")) {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 
-		if (property.name.begins_with("clearcoat")) {
-			property.usage = PROPERTY_USAGE_NONE;
+		if (p_property.name.begins_with("clearcoat")) {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 
-		if (property.name.begins_with("normal")) {
-			property.usage = PROPERTY_USAGE_NONE;
+		if (p_property.name.begins_with("normal")) {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 
-		if (property.name.begins_with("backlight")) {
-			property.usage = PROPERTY_USAGE_NONE;
+		if (p_property.name.begins_with("backlight")) {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 
-		if (property.name.begins_with("transmittance")) {
-			property.usage = PROPERTY_USAGE_NONE;
+		if (p_property.name.begins_with("transmittance")) {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 }

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -54,7 +54,7 @@ protected:
 	virtual bool _can_do_next_pass() const;
 	virtual bool _can_use_render_priority() const;
 
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	GDVIRTUAL0RC(RID, _get_shader_rid)
 	GDVIRTUAL0RC(Shader::Mode, _get_shader_mode)
@@ -553,7 +553,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	virtual bool _can_do_next_pass() const override { return true; }
 	virtual bool _can_use_render_priority() const override { return true; }
 

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -660,17 +660,17 @@ void NavigationMesh::_bind_methods() {
 	BIND_ENUM_CONSTANT(SOURCE_GEOMETRY_MAX);
 }
 
-void NavigationMesh::_validate_property(PropertyInfo &property) const {
-	if (property.name == "geometry_collision_mask") {
+void NavigationMesh::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "geometry_collision_mask") {
 		if (parsed_geometry_type == PARSED_GEOMETRY_MESH_INSTANCES) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 			return;
 		}
 	}
 
-	if (property.name == "geometry_source_group_name") {
+	if (p_property.name == "geometry_source_group_name") {
 		if (source_geometry_mode == SOURCE_GEOMETRY_NAVMESH_CHILDREN) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 			return;
 		}
 	}

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -60,7 +60,7 @@ class NavigationMesh : public Resource {
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -1386,54 +1386,54 @@ RID ParticlesMaterial::get_shader_rid() const {
 	return shader_map[current_key].shader;
 }
 
-void ParticlesMaterial::_validate_property(PropertyInfo &property) const {
-	if (property.name == "emission_sphere_radius" && (emission_shape != EMISSION_SHAPE_SPHERE && emission_shape != EMISSION_SHAPE_SPHERE_SURFACE)) {
-		property.usage = PROPERTY_USAGE_NONE;
+void ParticlesMaterial::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "emission_sphere_radius" && (emission_shape != EMISSION_SHAPE_SPHERE && emission_shape != EMISSION_SHAPE_SPHERE_SURFACE)) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_box_extents" && emission_shape != EMISSION_SHAPE_BOX) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_box_extents" && emission_shape != EMISSION_SHAPE_BOX) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if ((property.name == "emission_point_texture" || property.name == "emission_color_texture") && (emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS)) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if ((p_property.name == "emission_point_texture" || p_property.name == "emission_color_texture") && (emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS)) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_normal_texture" && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_normal_texture" && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "emission_point_count" && (emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS)) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "emission_point_count" && (emission_shape != EMISSION_SHAPE_POINTS && emission_shape != EMISSION_SHAPE_DIRECTED_POINTS)) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name.begins_with("emission_ring_") && emission_shape != EMISSION_SHAPE_RING) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name.begins_with("emission_ring_") && emission_shape != EMISSION_SHAPE_RING) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "sub_emitter_frequency" && sub_emitter_mode != SUB_EMITTER_CONSTANT) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "sub_emitter_frequency" && sub_emitter_mode != SUB_EMITTER_CONSTANT) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name == "sub_emitter_amount_at_end" && sub_emitter_mode != SUB_EMITTER_AT_END) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name == "sub_emitter_amount_at_end" && sub_emitter_mode != SUB_EMITTER_AT_END) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (property.name.begins_with("orbit_") && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		property.usage = PROPERTY_USAGE_NONE;
+	if (p_property.name.begins_with("orbit_") && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
 	if (!turbulence_enabled) {
-		if (property.name == "turbulence_noise_strength" ||
-				property.name == "turbulence_noise_scale" ||
-				property.name == "turbulence_noise_speed" ||
-				property.name == "turbulence_noise_speed_random" ||
-				property.name == "turbulence_influence_over_life" ||
-				property.name == "turbulence_influence_min" ||
-				property.name == "turbulence_influence_max" ||
-				property.name == "turbulence_initial_displacement_min" ||
-				property.name == "turbulence_initial_displacement_max") {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		if (p_property.name == "turbulence_noise_strength" ||
+				p_property.name == "turbulence_noise_scale" ||
+				p_property.name == "turbulence_noise_speed" ||
+				p_property.name == "turbulence_noise_speed_random" ||
+				p_property.name == "turbulence_influence_over_life" ||
+				p_property.name == "turbulence_influence_min" ||
+				p_property.name == "turbulence_influence_max" ||
+				p_property.name == "turbulence_initial_displacement_min" ||
+				p_property.name == "turbulence_initial_displacement_max") {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 		}
 	}
 }

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -307,7 +307,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_direction(Vector3 p_direction);

--- a/scene/resources/skeleton_profile.cpp
+++ b/scene/resources/skeleton_profile.cpp
@@ -121,26 +121,26 @@ bool SkeletonProfile::_get(const StringName &p_path, Variant &r_ret) const {
 	return true;
 }
 
-void SkeletonProfile::_validate_property(PropertyInfo &property) const {
+void SkeletonProfile::_validate_property(PropertyInfo &p_property) const {
 	if (is_read_only) {
-		if (property.name == ("group_size") || property.name == ("bone_size") || property.name == ("root_bone") || property.name == ("scale_base_bone")) {
-			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		if (p_property.name == ("group_size") || p_property.name == ("bone_size") || p_property.name == ("root_bone") || p_property.name == ("scale_base_bone")) {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 			return;
 		}
 	}
 
-	if (property.name == ("root_bone") || property.name == ("scale_base_bone")) {
+	if (p_property.name == ("root_bone") || p_property.name == ("scale_base_bone")) {
 		String hint = "";
 		for (int i = 0; i < bones.size(); i++) {
 			hint += i == 0 ? String(bones[i].bone_name) : "," + String(bones[i].bone_name);
 		}
-		property.hint_string = hint;
+		p_property.hint_string = hint;
 	}
 
-	PackedStringArray split = property.name.split("/");
+	PackedStringArray split = p_property.name.split("/");
 	if (split.size() == 3 && split[0] == "bones") {
 		if (split[2] == "bone_tail" && get_tail_direction(split[1].to_int()) != TAIL_DIRECTION_SPECIFIC_CHILD) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 }

--- a/scene/resources/skeleton_profile.h
+++ b/scene/resources/skeleton_profile.h
@@ -72,7 +72,7 @@ protected:
 
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	static void _bind_methods();
 

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -842,9 +842,9 @@ float StyleBoxFlat::get_style_margin(Side p_side) const {
 	return border_width[p_side];
 }
 
-void StyleBoxFlat::_validate_property(PropertyInfo &property) const {
-	if (!anti_aliased && property.name == "anti_aliasing_size") {
-		property.usage = PROPERTY_USAGE_NO_EDITOR;
+void StyleBoxFlat::_validate_property(PropertyInfo &p_property) const {
+	if (!anti_aliased && p_property.name == "anti_aliasing_size") {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -166,7 +166,7 @@ class StyleBoxFlat : public StyleBox {
 protected:
 	virtual float get_style_margin(Side p_side) const override;
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_bg_color(const Color &p_color);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1038,7 +1038,7 @@ void CompressedTexture2D::reload_from_file() {
 	load(path);
 }
 
-void CompressedTexture2D::_validate_property(PropertyInfo &property) const {
+void CompressedTexture2D::_validate_property(PropertyInfo &p_property) const {
 }
 
 void CompressedTexture2D::_bind_methods() {
@@ -1394,7 +1394,7 @@ void CompressedTexture3D::reload_from_file() {
 	load(path);
 }
 
-void CompressedTexture3D::_validate_property(PropertyInfo &property) const {
+void CompressedTexture3D::_validate_property(PropertyInfo &p_property) const {
 }
 
 void CompressedTexture3D::_bind_methods() {
@@ -2789,12 +2789,12 @@ bool AnimatedTexture::is_pixel_opaque(int p_x, int p_y) const {
 	return true;
 }
 
-void AnimatedTexture::_validate_property(PropertyInfo &property) const {
-	String prop = property.name;
+void AnimatedTexture::_validate_property(PropertyInfo &p_property) const {
+	String prop = p_property.name;
 	if (prop.begins_with("frame_")) {
 		int frame = prop.get_slicec('/', 0).get_slicec('_', 1).to_int();
 		if (frame >= frame_count) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 }
@@ -3214,7 +3214,7 @@ void CompressedTextureLayered::reload_from_file() {
 	load(path);
 }
 
-void CompressedTextureLayered::_validate_property(PropertyInfo &property) const {
+void CompressedTextureLayered::_validate_property(PropertyInfo &p_property) const {
 }
 
 void CompressedTextureLayered::_bind_methods() {

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -251,7 +251,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	static Ref<Image> load_image_from_file(Ref<FileAccess> p_file, int p_size_limit);
@@ -506,7 +506,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	Image::Format get_format() const override;
@@ -651,7 +651,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	Image::Format get_format() const override;
@@ -940,7 +940,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_frames(int p_frames);

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -3302,11 +3302,11 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-void TileSet::_validate_property(PropertyInfo &property) const {
-	if (property.name == "tile_layout" && tile_shape == TILE_SHAPE_SQUARE) {
-		property.usage ^= PROPERTY_USAGE_READ_ONLY;
-	} else if (property.name == "tile_offset_axis" && tile_shape == TILE_SHAPE_SQUARE) {
-		property.usage ^= PROPERTY_USAGE_READ_ONLY;
+void TileSet::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "tile_layout" && tile_shape == TILE_SHAPE_SQUARE) {
+		p_property.usage ^= PROPERTY_USAGE_READ_ONLY;
+	} else if (p_property.name == "tile_offset_axis" && tile_shape == TILE_SHAPE_SQUARE) {
+		p_property.usage ^= PROPERTY_USAGE_READ_ONLY;
 	}
 }
 

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -295,7 +295,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
-	virtual void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 private:
 	// --- TileSet data ---

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3153,8 +3153,8 @@ String VisualShaderNodeInput::get_input_index_name(int p_index) const {
 	return "";
 }
 
-void VisualShaderNodeInput::_validate_property(PropertyInfo &property) const {
-	if (property.name == "input_name") {
+void VisualShaderNodeInput::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "input_name") {
 		String port_list;
 
 		int idx = 0;
@@ -3172,7 +3172,7 @@ void VisualShaderNodeInput::_validate_property(PropertyInfo &property) const {
 		if (port_list.is_empty()) {
 			port_list = RTR("None");
 		}
-		property.hint_string = port_list;
+		p_property.hint_string = port_list;
 	}
 }
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -428,7 +428,7 @@ public:
 
 protected:
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	virtual int get_input_port_count() const override;

--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -272,11 +272,11 @@ float AudioEffectChorus::get_dry() const {
 	return dry;
 }
 
-void AudioEffectChorus::_validate_property(PropertyInfo &property) const {
-	if (property.name.begins_with("voice/")) {
-		int voice_idx = property.name.get_slice("/", 1).to_int();
+void AudioEffectChorus::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name.begins_with("voice/")) {
+		int voice_idx = p_property.name.get_slice("/", 1).to_int();
 		if (voice_idx > voice_count) {
-			property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 }

--- a/servers/audio/effects/audio_effect_chorus.h
+++ b/servers/audio/effects/audio_effect_chorus.h
@@ -96,7 +96,7 @@ private:
 	float dry;
 
 protected:
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 

--- a/servers/audio/effects/audio_effect_compressor.cpp
+++ b/servers/audio/effects/audio_effect_compressor.cpp
@@ -184,15 +184,15 @@ StringName AudioEffectCompressor::get_sidechain() const {
 	return sidechain;
 }
 
-void AudioEffectCompressor::_validate_property(PropertyInfo &property) const {
-	if (property.name == "sidechain") {
+void AudioEffectCompressor::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "sidechain") {
 		String buses = "";
 		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 			buses += ",";
 			buses += AudioServer::get_singleton()->get_bus_name(i);
 		}
 
-		property.hint_string = buses;
+		p_property.hint_string = buses;
 	}
 }
 

--- a/servers/audio/effects/audio_effect_compressor.h
+++ b/servers/audio/effects/audio_effect_compressor.h
@@ -61,7 +61,7 @@ class AudioEffectCompressor : public AudioEffect {
 	StringName sidechain;
 
 protected:
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
 public:

--- a/servers/audio/effects/audio_effect_filter.h
+++ b/servers/audio/effects/audio_effect_filter.h
@@ -98,9 +98,9 @@ VARIANT_ENUM_CAST(AudioEffectFilter::FilterDB)
 class AudioEffectLowPassFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectLowPassFilter, AudioEffectFilter);
 
-	void _validate_property(PropertyInfo &property) const override {
-		if (property.name == "gain") {
-			property.usage = PROPERTY_USAGE_NONE;
+	void _validate_property(PropertyInfo &p_property) const {
+		if (p_property.name == "gain") {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
@@ -111,9 +111,9 @@ public:
 
 class AudioEffectHighPassFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectHighPassFilter, AudioEffectFilter);
-	void _validate_property(PropertyInfo &property) const override {
-		if (property.name == "gain") {
-			property.usage = PROPERTY_USAGE_NONE;
+	void _validate_property(PropertyInfo &p_property) const {
+		if (p_property.name == "gain") {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 
@@ -124,9 +124,9 @@ public:
 
 class AudioEffectBandPassFilter : public AudioEffectFilter {
 	GDCLASS(AudioEffectBandPassFilter, AudioEffectFilter);
-	void _validate_property(PropertyInfo &property) const override {
-		if (property.name == "gain") {
-			property.usage = PROPERTY_USAGE_NONE;
+	void _validate_property(PropertyInfo &p_property) const {
+		if (p_property.name == "gain") {
+			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}
 


### PR DESCRIPTION
Supersedes a part of https://github.com/godotengine/godot/pull/57654. Makes `_validate_property` a multilevel method, meaning that it will be automatically called on every class in the inheritance chain. Extending classes can override parent behavior.

I didn't touch the hack that https://github.com/godotengine/godot/pull/57654 removed as well, since that was a point of disagreement in the comments. If still desired, this can be fixed with a follow-up PR.

This PR is a bit beefier because I have also renamed every `property` to `p_property` to follow our codestyle.

-----

This PR is a requirement to make `_validate_property` exposed to the API, but it doesn't touch that yet. I'm not sure how to properly pass `PropertyInfo` to the extension API. Probably needs some conversion to a struct and instead of the PropertyInfo being changed in place in the public API the method must return a new struct (or Dictionary in case of GDScript). But I'm not confident in how to make that happen yet.

Still, being multilevel means that it will eventually work with user scripts and extension code.