### PR TITLE
[3.x] `SpriteFramesEditor` Reallow deselecting frame with LMB press in select frames dialog

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -172,7 +172,7 @@ void SpriteFramesEditor::_sheet_preview_input(const Ref<InputEvent> &p_event) {
 				// Prevent double-toggling the same frame when moving the mouse when the mouse button is still held.
 				frames_toggled_by_mouse_hover.insert(idx);
 
-				if (mb->get_control()) {
+				if (frames_selected.has(idx)) {
 					frames_selected.erase(idx);
 				} else {
 					frames_selected.insert(idx);


### PR DESCRIPTION
Fixes #63811.

It got broken when cherry-picking, one line change (L127/R155) was incorrectly not picked:
https://github.com/godotengine/godot/commit/ad7a6102aed9ca25524d169570c29a599ab8e2a5#diff-3e7f486c64d2a3de1a4c3fcde4afc7705675df0adf3af634f78f67ebbaf4bddbL127-R156
https://github.com/godotengine/godot/commit/891681a5a328dd80630f1e75c7b8430d32125511#diff-3e7f486c64d2a3de1a4c3fcde4afc7705675df0adf3af634f78f67ebbaf4bddbR155-R156