### PR TITLE
Reverse Camera2D.`rotating` to `ignore_rotation`

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -124,6 +124,9 @@
 		<member name="editor_draw_screen" type="bool" setter="set_screen_drawing_enabled" getter="is_screen_drawing_enabled" default="true">
 			If [code]true[/code], draws the camera's screen rectangle in the editor.
 		</member>
+		<member name="ignore_rotation" type="bool" setter="set_ignore_rotation" getter="is_ignoring_rotation" default="true">
+			If [code]true[/code], the camera's rendered view is not affected by its [member Node2D.rotation] and [member Node2D.global_rotation].
+		</member>
 		<member name="limit_bottom" type="int" setter="set_limit" getter="get_limit" default="10000000">
 			Bottom scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
 		</member>
@@ -146,9 +149,6 @@
 		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="Camera2D.Camera2DProcessCallback" default="1">
 			The camera's process callback. See [enum Camera2DProcessCallback].
-		</member>
-		<member name="rotating" type="bool" setter="set_rotating" getter="is_rotating" default="false">
-			If [code]true[/code], the camera view rotates with the target.
 		</member>
 		<member name="smoothing_enabled" type="bool" setter="set_enable_follow_smoothing" getter="is_follow_smoothing_enabled" default="false">
 			If [code]true[/code], the camera smoothly moves towards the target at [member smoothing_speed].

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -172,7 +172,7 @@ Transform2D Camera2D::get_camera_transform() {
 	Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5 * zoom_scale) : Point2());
 
 	real_t angle = get_global_rotation();
-	if (rotating) {
+	if (!ignore_rotation) {
 		screen_offset = screen_offset.rotated(angle);
 	}
 
@@ -204,7 +204,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 	Transform2D xform;
 	xform.scale_basis(zoom_scale);
-	if (rotating) {
+	if (!ignore_rotation) {
 		xform.set_rotation(angle);
 	}
 	xform.set_origin(screen_rect.position);
@@ -363,15 +363,15 @@ Camera2D::AnchorMode Camera2D::get_anchor_mode() const {
 	return anchor_mode;
 }
 
-void Camera2D::set_rotating(bool p_rotating) {
-	rotating = p_rotating;
+void Camera2D::set_ignore_rotation(bool p_ignore) {
+	ignore_rotation = p_ignore;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
 	smoothed_camera_pos = old_smoothed_camera_pos;
 }
 
-bool Camera2D::is_rotating() const {
-	return rotating;
+bool Camera2D::is_ignoring_rotation() const {
+	return ignore_rotation;
 }
 
 void Camera2D::set_process_callback(Camera2DProcessCallback p_mode) {
@@ -668,8 +668,8 @@ void Camera2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_anchor_mode", "anchor_mode"), &Camera2D::set_anchor_mode);
 	ClassDB::bind_method(D_METHOD("get_anchor_mode"), &Camera2D::get_anchor_mode);
 
-	ClassDB::bind_method(D_METHOD("set_rotating", "rotating"), &Camera2D::set_rotating);
-	ClassDB::bind_method(D_METHOD("is_rotating"), &Camera2D::is_rotating);
+	ClassDB::bind_method(D_METHOD("set_ignore_rotation", "ignore"), &Camera2D::set_ignore_rotation);
+	ClassDB::bind_method(D_METHOD("is_ignoring_rotation"), &Camera2D::is_ignoring_rotation);
 
 	ClassDB::bind_method(D_METHOD("_update_scroll"), &Camera2D::_update_scroll);
 
@@ -733,7 +733,7 @@ void Camera2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "anchor_mode", PROPERTY_HINT_ENUM, "Fixed TopLeft,Drag Center"), "set_anchor_mode", "get_anchor_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rotating"), "set_rotating", "is_rotating");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_rotation"), "set_ignore_rotation", "is_ignoring_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "current"), "set_current", "is_current");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "zoom", PROPERTY_HINT_LINK), "set_zoom", "get_zoom");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "custom_viewport", PROPERTY_HINT_RESOURCE_TYPE, "Viewport", PROPERTY_USAGE_NONE), "set_custom_viewport", "get_custom_viewport");

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -63,7 +63,7 @@ protected:
 	Vector2 zoom = Vector2(1, 1);
 	Vector2 zoom_scale = Vector2(1, 1);
 	AnchorMode anchor_mode = ANCHOR_MODE_DRAG_CENTER;
-	bool rotating = false;
+	bool ignore_rotation = true;
 	bool current = false;
 	real_t smoothing = 5.0;
 	bool smoothing_enabled = false;
@@ -109,8 +109,8 @@ public:
 	void set_anchor_mode(AnchorMode p_anchor_mode);
 	AnchorMode get_anchor_mode() const;
 
-	void set_rotating(bool p_rotating);
-	bool is_rotating() const;
+	void set_ignore_rotation(bool p_ignore);
+	bool is_ignoring_rotation() const;
 
 	void set_limit(Side p_side, int p_limit);
 	int get_limit(Side p_side) const;


### PR DESCRIPTION
As partially brought up in https://github.com/godotengine/godot/issues/54161#issuecomment-981074755.

`rotating` is misleading, as **Camera2D** is affected by `rotation` and `global_rotation` like any other **Node2D**.

This PR reverses the boolean outright, and makes it clearer the **Camera2D**'s view *ignores* its own `rotation` when it is now enabled.

~This PR has been refactored. It used to simply rename `rotating` to `rotating_view`~.
