### PR TITLE
Rename every instance of `caret_blink_speed` to `caret_blink_interval`

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -647,9 +647,9 @@
 			The monitor to display the project on when starting the project from the editor.
 		</member>
 		<member name="text_editor/appearance/caret/caret_blink" type="bool" setter="" getter="">
-			If [code]true[/code], makes the caret blink according to [member text_editor/appearance/caret/caret_blink_speed]. Disabling this setting can improve battery life on laptops if you spend long amounts of time in the script editor, since it will reduce the frequency at which the editor needs to be redrawn.
+			If [code]true[/code], makes the caret blink according to [member text_editor/appearance/caret/caret_blink_interval]. Disabling this setting can improve battery life on laptops if you spend long amounts of time in the script editor, since it will reduce the frequency at which the editor needs to be redrawn.
 		</member>
-		<member name="text_editor/appearance/caret/caret_blink_speed" type="float" setter="" getter="">
+		<member name="text_editor/appearance/caret/caret_blink_interval" type="float" setter="" getter="">
 			The interval at which to blink the caret (in seconds). See also [member text_editor/appearance/caret/caret_blink].
 		</member>
 		<member name="text_editor/appearance/caret/highlight_all_occurrences" type="bool" setter="" getter="">

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -144,7 +144,7 @@
 		<member name="caret_blink" type="bool" setter="set_caret_blink_enabled" getter="is_caret_blink_enabled" default="false">
 			If [code]true[/code], the caret (text cursor) blinks.
 		</member>
-		<member name="caret_blink_speed" type="float" setter="set_caret_blink_speed" getter="get_caret_blink_speed" default="0.65">
+		<member name="caret_blink_interval" type="float" setter="set_caret_blink_interval" getter="get_caret_blink_interval" default="0.65">
 			Duration (in seconds) of a caret's blinking cycle.
 		</member>
 		<member name="caret_column" type="int" setter="set_caret_column" getter="get_caret_column" default="0">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -915,7 +915,7 @@
 		<member name="caret_blink" type="bool" setter="set_caret_blink_enabled" getter="is_caret_blink_enabled" default="false">
 			Sets if the caret should blink.
 		</member>
-		<member name="caret_blink_speed" type="float" setter="set_caret_blink_speed" getter="get_caret_blink_speed" default="0.65">
+		<member name="caret_blink_interval" type="float" setter="set_caret_blink_interval" getter="get_caret_blink_interval" default="0.65">
 			Duration (in seconds) of a caret's blinking cycle.
 		</member>
 		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="true">

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1001,7 +1001,7 @@ void CodeTextEditor::update_editor_settings() {
 	// Appearance: Caret
 	text_editor->set_caret_type((TextEdit::CaretType)EditorSettings::get_singleton()->get("text_editor/appearance/caret/type").operator int());
 	text_editor->set_caret_blink_enabled(EditorSettings::get_singleton()->get("text_editor/appearance/caret/caret_blink"));
-	text_editor->set_caret_blink_speed(EditorSettings::get_singleton()->get("text_editor/appearance/caret/caret_blink_speed"));
+	text_editor->set_caret_blink_interval(EditorSettings::get_singleton()->get("text_editor/appearance/caret/caret_blink_interval"));
 	text_editor->set_highlight_current_line(EditorSettings::get_singleton()->get("text_editor/appearance/caret/highlight_current_line"));
 	text_editor->set_highlight_all_occurrences(EditorSettings::get_singleton()->get("text_editor/appearance/caret/highlight_all_occurrences"));
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -510,7 +510,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Appearance: Caret
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/caret/type", 0, "Line,Block")
 	_initial_set("text_editor/appearance/caret/caret_blink", true);
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/appearance/caret/caret_blink_speed", 0.5, "0.1,10,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/appearance/caret/caret_blink_interval", 0.5, "0.1,10,0.01")
 	_initial_set("text_editor/appearance/caret/highlight_current_line", true);
 	_initial_set("text_editor/appearance/caret/highlight_all_occurrences", true);
 

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -242,11 +242,11 @@ static const char *gdscript_function_renames[][2] = {
 	{ "commit_handle", "_commit_handle" }, // EditorNode3DGizmo
 	{ "convex_hull_2d", "convex_hull" }, // Geometry2D
 	{ "create_gizmo", "_create_gizmo" }, // EditorNode3DGizmoPlugin
-	{ "cursor_get_blink_speed", "get_caret_blink_speed" }, // TextEdit
+	{ "cursor_get_blink_speed", "get_caret_blink_interval" }, // TextEdit
 	{ "cursor_get_column", "get_caret_column" }, // TextEdit
 	{ "cursor_get_line", "get_caret_line" }, // TextEdit
 	{ "cursor_set_blink_enabled", "set_caret_blink_enabled" }, // TextEdit
-	{ "cursor_set_blink_speed", "set_caret_blink_speed" }, // TextEdit
+	{ "cursor_set_blink_speed", "set_caret_blink_interval" }, // TextEdit
 	{ "cursor_set_column", "set_caret_column" }, // TextEdit
 	{ "cursor_set_line", "set_caret_line" }, // TextEdit
 	{ "damped_spring_joint_create", "joint_make_damped_spring" }, // PhysicsServer2D
@@ -667,11 +667,11 @@ static const char *csharp_function_renames[][2] = {
 	{ "ClipPolylineWithPolygon2d", "ClipPolylineWithPolygon" }, //Geometry2D
 	{ "CommitHandle", "_CommitHandle" }, // EditorNode3DGizmo
 	{ "ConvexHull2d", "ConvexHull" }, // Geometry2D
-	{ "CursorGetBlinkSpeed", "GetCaretBlinkSpeed" }, // TextEdit
+	{ "CursorGetBlinkSpeed", "GetCaretBlinkInterval" }, // TextEdit
 	{ "CursorGetColumn", "GetCaretColumn" }, // TextEdit
 	{ "CursorGetLine", "GetCaretLine" }, // TextEdit
 	{ "CursorSetBlinkEnabled", "SetCaretBlinkEnabled" }, // TextEdit
-	{ "CursorSetBlinkSpeed", "SetCaretBlinkSpeed" }, // TextEdit
+	{ "CursorSetBlinkSpeed", "SetCaretBlinkInterval" }, // TextEdit
 	{ "CursorSetColumn", "SetCaretColumn" }, // TextEdit
 	{ "CursorSetLine", "SetCaretLine" }, // TextEdit
 	{ "DampedSpringJointCreate", "JointMakeDampedSpring" }, // PhysicsServer2D
@@ -1023,6 +1023,7 @@ static const char *gdscript_properties_renames[][2] = {
 	//	{ "filename", "scene_file_path" }, // Node
 	{ "as_normalmap", "as_normal_map" }, // NoiseTexture
 	{ "bbcode_text", "text" }, // RichTextLabel
+	{ "caret_blink_speed", "caret_blink_interval" }, // TextEdit, LineEdit
 	{ "caret_moving_by_right_click", "caret_move_on_right_click" }, // TextEdit
 	{ "caret_position", "caret_column" }, // LineEdit
 	{ "check_vadjust", "check_v_adjust" }, // Theme
@@ -1117,6 +1118,7 @@ static const char *csharp_properties_renames[][2] = {
 	//	{ "Znear", "Near" }, // Camera3D
 	{ "AsNormalmap", "AsNormalMap" }, // NoiseTexture
 	{ "BbcodeText", "Text" }, // RichTextLabel
+	{ "CaretBlinkSpeed", "CaretBlinkInterval" }, // TextEdit, LineEdit
 	{ "CaretMovingByRightClick", "CaretMoveOnRightClick" }, // TextEdit
 	{ "CaretPosition", "CaretColumn" }, // LineEdit
 	{ "CheckVadjust", "CheckVAdjust" }, // Theme

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -734,7 +734,7 @@ void LineEdit::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (Engine::get_singleton()->is_editor_hint() && !get_tree()->is_node_being_edited(this)) {
 				set_caret_blink_enabled(EDITOR_GET("text_editor/appearance/caret/caret_blink"));
-				set_caret_blink_speed(EDITOR_GET("text_editor/appearance/caret/caret_blink_speed"));
+				set_caret_blink_interval(EDITOR_GET("text_editor/appearance/caret/caret_blink_interval"));
 
 				if (!EditorSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed))) {
 					EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &LineEdit::_editor_settings_changed));
@@ -777,7 +777,7 @@ void LineEdit::_notification(int p_what) {
 			if (caret_blinking) {
 				caret_blink_timer += get_process_delta_time();
 
-				if (caret_blink_timer >= caret_blink_speed) {
+				if (caret_blink_timer >= caret_blink_interval) {
 					caret_blink_timer = 0.0;
 					_toggle_draw_caret();
 				}
@@ -1392,13 +1392,13 @@ void LineEdit::set_caret_force_displayed(const bool p_enabled) {
 	queue_redraw();
 }
 
-float LineEdit::get_caret_blink_speed() const {
-	return caret_blink_speed;
+float LineEdit::get_caret_blink_interval() const {
+	return caret_blink_interval;
 }
 
-void LineEdit::set_caret_blink_speed(const float p_speed) {
-	ERR_FAIL_COND(p_speed <= 0);
-	caret_blink_speed = p_speed;
+void LineEdit::set_caret_blink_interval(const float p_interval) {
+	ERR_FAIL_COND(p_interval <= 0);
+	caret_blink_interval = p_interval;
 }
 
 void LineEdit::_reset_caret_blink_timer() {
@@ -2037,7 +2037,7 @@ PopupMenu *LineEdit::get_menu() const {
 void LineEdit::_editor_settings_changed() {
 #ifdef TOOLS_ENABLED
 	set_caret_blink_enabled(EDITOR_GET("text_editor/appearance/caret/caret_blink"));
-	set_caret_blink_speed(EDITOR_GET("text_editor/appearance/caret/caret_blink_speed"));
+	set_caret_blink_interval(EDITOR_GET("text_editor/appearance/caret/caret_blink_interval"));
 #endif
 }
 
@@ -2274,7 +2274,7 @@ Key LineEdit::_get_menu_action_accelerator(const String &p_action) {
 }
 
 void LineEdit::_validate_property(PropertyInfo &p_property) const {
-	if (!caret_blink_enabled && p_property.name == "caret_blink_speed") {
+	if (!caret_blink_enabled && p_property.name == "caret_blink_interval") {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
@@ -2317,8 +2317,8 @@ void LineEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_caret_mid_grapheme_enabled"), &LineEdit::is_caret_mid_grapheme_enabled);
 	ClassDB::bind_method(D_METHOD("set_caret_force_displayed", "enabled"), &LineEdit::set_caret_force_displayed);
 	ClassDB::bind_method(D_METHOD("is_caret_force_displayed"), &LineEdit::is_caret_force_displayed);
-	ClassDB::bind_method(D_METHOD("set_caret_blink_speed", "blink_speed"), &LineEdit::set_caret_blink_speed);
-	ClassDB::bind_method(D_METHOD("get_caret_blink_speed"), &LineEdit::get_caret_blink_speed);
+	ClassDB::bind_method(D_METHOD("set_caret_blink_interval", "interval"), &LineEdit::set_caret_blink_interval);
+	ClassDB::bind_method(D_METHOD("get_caret_blink_interval"), &LineEdit::get_caret_blink_interval);
 	ClassDB::bind_method(D_METHOD("set_max_length", "chars"), &LineEdit::set_max_length);
 	ClassDB::bind_method(D_METHOD("get_max_length"), &LineEdit::get_max_length);
 	ClassDB::bind_method(D_METHOD("insert_text_at_caret", "text"), &LineEdit::insert_text_at_caret);
@@ -2419,7 +2419,7 @@ void LineEdit::_bind_methods() {
 
 	ADD_GROUP("Caret", "caret_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_blink"), "set_caret_blink_enabled", "is_caret_blink_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "caret_blink_speed", PROPERTY_HINT_RANGE, "0.1,10,0.01"), "set_caret_blink_speed", "get_caret_blink_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "caret_blink_interval", PROPERTY_HINT_RANGE, "0.1,10,0.01"), "set_caret_blink_interval", "get_caret_blink_interval");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "caret_column", PROPERTY_HINT_RANGE, "0,1000,1,or_greater"), "set_caret_column", "get_caret_column");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_force_displayed"), "set_caret_force_displayed", "is_caret_force_displayed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_mid_grapheme"), "set_caret_mid_grapheme_enabled", "is_caret_mid_grapheme_enabled");

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -170,7 +170,7 @@ private:
 	bool caret_blink_enabled = false;
 	bool caret_force_displayed = false;
 	bool draw_caret = true;
-	float caret_blink_speed = 0.65;
+	float caret_blink_interval = 0.65;
 	double caret_blink_timer = 0.0;
 	bool caret_blinking = false;
 
@@ -311,8 +311,8 @@ public:
 	bool is_caret_blink_enabled() const;
 	void set_caret_blink_enabled(const bool p_enabled);
 
-	float get_caret_blink_speed() const;
-	void set_caret_blink_speed(const float p_speed);
+	float get_caret_blink_interval() const;
+	void set_caret_blink_interval(const float p_interval);
 
 	void set_caret_force_displayed(const bool p_enabled);
 	bool is_caret_force_displayed() const;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3990,13 +3990,13 @@ bool TextEdit::is_caret_blink_enabled() const {
 	return caret_blink_enabled;
 }
 
-float TextEdit::get_caret_blink_speed() const {
+float TextEdit::get_caret_blink_interval() const {
 	return caret_blink_timer->get_wait_time();
 }
 
-void TextEdit::set_caret_blink_speed(const float p_speed) {
-	ERR_FAIL_COND(p_speed <= 0);
-	caret_blink_timer->set_wait_time(p_speed);
+void TextEdit::set_caret_blink_interval(const float p_interval) {
+	ERR_FAIL_COND(p_interval <= 0);
+	caret_blink_timer->set_wait_time(p_interval);
 }
 
 void TextEdit::set_move_caret_on_right_click_enabled(const bool p_enabled) {
@@ -5294,8 +5294,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_caret_blink_enabled", "enable"), &TextEdit::set_caret_blink_enabled);
 	ClassDB::bind_method(D_METHOD("is_caret_blink_enabled"), &TextEdit::is_caret_blink_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_caret_blink_speed", "blink_speed"), &TextEdit::set_caret_blink_speed);
-	ClassDB::bind_method(D_METHOD("get_caret_blink_speed"), &TextEdit::get_caret_blink_speed);
+	ClassDB::bind_method(D_METHOD("set_caret_blink_interval", "interval"), &TextEdit::set_caret_blink_interval);
+	ClassDB::bind_method(D_METHOD("get_caret_blink_interval"), &TextEdit::get_caret_blink_interval);
 
 	ClassDB::bind_method(D_METHOD("set_move_caret_on_right_click_enabled", "enable"), &TextEdit::set_move_caret_on_right_click_enabled);
 	ClassDB::bind_method(D_METHOD("is_move_caret_on_right_click_enabled"), &TextEdit::is_move_caret_on_right_click_enabled);
@@ -5524,7 +5524,7 @@ void TextEdit::_bind_methods() {
 	ADD_GROUP("Caret", "caret_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "caret_type", PROPERTY_HINT_ENUM, "Line,Block"), "set_caret_type", "get_caret_type");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_blink"), "set_caret_blink_enabled", "is_caret_blink_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "caret_blink_speed", PROPERTY_HINT_RANGE, "0.1,10,0.01,suffix:s"), "set_caret_blink_speed", "get_caret_blink_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "caret_blink_interval", PROPERTY_HINT_RANGE, "0.1,10,0.01,suffix:s"), "set_caret_blink_interval", "get_caret_blink_interval");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_move_on_right_click"), "set_move_caret_on_right_click_enabled", "is_move_caret_on_right_click_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "caret_mid_grapheme"), "set_caret_mid_grapheme_enabled", "is_caret_mid_grapheme_enabled");
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -762,8 +762,8 @@ public:
 	void set_caret_blink_enabled(const bool p_enabled);
 	bool is_caret_blink_enabled() const;
 
-	void set_caret_blink_speed(const float p_speed);
-	float get_caret_blink_speed() const;
+	void set_caret_blink_interval(const float p_interval);
+	float get_caret_blink_interval() const;
 
 	void set_move_caret_on_right_click_enabled(const bool p_enabled);
 	bool is_move_caret_on_right_click_enabled() const;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -2714,15 +2714,15 @@ TEST_CASE("[SceneTree][TextEdit] caret") {
 	text_edit->set_caret_blink_enabled(true);
 	CHECK(text_edit->is_caret_blink_enabled());
 
-	text_edit->set_caret_blink_speed(10);
-	CHECK(text_edit->get_caret_blink_speed() == 10);
+	text_edit->set_caret_blink_interval(10);
+	CHECK(text_edit->get_caret_blink_interval() == 10);
 
 	ERR_PRINT_OFF;
-	text_edit->set_caret_blink_speed(-1);
-	CHECK(text_edit->get_caret_blink_speed() == 10);
+	text_edit->set_caret_blink_interval(-1);
+	CHECK(text_edit->get_caret_blink_interval() == 10);
 
-	text_edit->set_caret_blink_speed(0);
-	CHECK(text_edit->get_caret_blink_speed() == 10);
+	text_edit->set_caret_blink_interval(0);
+	CHECK(text_edit->get_caret_blink_interval() == 10);
 	ERR_PRINT_ON;
 
 	text_edit->set_caret_type(TextEdit::CaretType::CARET_TYPE_LINE);


### PR DESCRIPTION
As brought up in https://github.com/godotengine/godot/issues/54161#issuecomment-1175135591 and https://github.com/godotengine/godot/issues/54161#issuecomment-1175247779.

~This PR was renaming it to caret_blink_rate~
~While none of the comments mentioned "rate", I chose it because the Windows settings and registry call it **CursorBlinkRate**. I was about to rename it to `caret_blink_time`, but just as I was creating this Pull Request, I realised how much better `caret_blink_rate` rolls off the tongue, especially because it can't be confused for the internal `caret_blink_timer` variable.~

It's been changed in the **editor settings**, and in the **LineEdit** and **TextEdit** classes.
Affects setters and getters, and passed parameters, too.