### PR TITLE
Don't emit configuration warning change signals if the node can't be seen in the scene tree dock

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2709,12 +2709,28 @@ String Node::get_configuration_warnings_as_string() const {
 	return all_warnings;
 }
 
+#ifdef TOOLS_ENABLED
+inline bool can_node_be_seen_in_editor(Node &node) {
+	if (!node.is_inside_tree()) {
+		return false;
+	}
+	const Node *edited_scene_root = node.get_tree()->get_edited_scene_root();
+	if (edited_scene_root == nullptr) {
+		return false;
+	}
+	if (edited_scene_root == &node) {
+		return true;
+	}
+	// Not sure why `is_ancestor_of` is required
+	return edited_scene_root->is_ancestor_of(&node) && node.get_owner() == edited_scene_root;
+}
+#endif
+
 void Node::update_configuration_warnings() {
 #ifdef TOOLS_ENABLED
-	if (!is_inside_tree()) {
-		return;
-	}
-	if (get_tree()->get_edited_scene_root() && (get_tree()->get_edited_scene_root() == this || get_tree()->get_edited_scene_root()->is_ancestor_of(this))) {
+	// One reason to do this is if you have lots of nodes procedurally generated, or any nodes part of a tool.
+	// It would emit many signals that would lead to nothing being done or flood the message queue unnecessarily.
+	if (can_node_be_seen_in_editor(*this)) {
 		get_tree()->emit_signal(SceneStringNames::get_singleton()->node_configuration_warning_changed, this);
 	}
 #endif


### PR DESCRIPTION
When working with a large number of nodes, too many of those signals get fired unnecessarily, which can lead to performance issues or even crashes.

Details in https://github.com/Zylann/godot_voxel/issues/422#issuecomment-1214155587

I have other ideas to eliminate this kind of problem completely: remove those signals, instead increment a version number which can get polled by visible nodes of the scene tree dock (never more than a few dozen). But that's a larger change that could be done later?

Similar issues occur with "internal" shader materials and editor tools, which I wish to solve with polling as well, but that will be for later.