### PR TITLE
Use more explicit architecture compiler options on Linux

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -100,20 +100,31 @@ def configure(env: "SConsEnvironment"):
 
     ## Build type
 
-    # Cross-compilation
-    # TODO: Support cross-compilation on architectures other than x86.
-    host_is_64_bit = sys.maxsize > 2**32
-    if host_is_64_bit and env["arch"] == "x86_32":
-        env.Append(CCFLAGS=["-m32"])
-        env.Append(LINKFLAGS=["-m32"])
-    elif not host_is_64_bit and env["arch"] == "x86_64":
-        env.Append(CCFLAGS=["-m64"])
-        env.Append(LINKFLAGS=["-m64"])
-
     # CPU architecture flags.
-    if env["arch"] == "rv64":
+    # TODO: Support cross-compilation on architectures other than x86.
+    if env["arch"] == "x86_64":
+        # CFLAGS and CXXFLAGS have a lower priority than CCFLAGS, so don't use CCFLAGS, instead
+        # use duplicate CFLAGS and CXXFLAGS, allowing the user to override the arch flags if needed.
+        env.Prepend(CFLAGS=["-m64", "-march=x86-64"])
+        env.Prepend(CXXFLAGS=["-m64", "-march=x86-64"])
+        env.Prepend(LINKFLAGS=["-m64", "-march=x86-64"])
+    elif env["arch"] == "x86_32":
+        env.Prepend(CFLAGS=["-m32", "-march=i686"])
+        env.Prepend(CXXFLAGS=["-m32", "-march=i686"])
+        env.Prepend(LINKFLAGS=["-m32", "-march=i686"])
+    elif env["arch"] == "arm64":
+        env.Prepend(CFLAGS=["-march=armv8-a"])
+        env.Prepend(CXXFLAGS=["-march=armv8-a"])
+        env.Prepend(LINKFLAGS=["-march=armv8-a"])
+    elif env["arch"] == "arm32":
+        env.Prepend(CFLAGS=["-march=armv7-a"])
+        env.Prepend(CXXFLAGS=["-march=armv7-a"])
+        env.Prepend(LINKFLAGS=["-march=armv7-a"])
+    elif env["arch"] == "rv64":
         # G = General-purpose extensions, C = Compression extension (very common).
-        env.Append(CCFLAGS=["-march=rv64gc"])
+        env.Prepend(CFLAGS=["-march=rv64gc"])
+        env.Prepend(CXXFLAGS=["-march=rv64gc"])
+        env.Prepend(LINKFLAGS=["-march=rv64gc"])
 
     ## Compiler configuration
 


### PR DESCRIPTION
This PR takes a piece out of #55778. Specifically, this PR was driven by this review comment from @akien-mga:

<img width="920" alt="Screen Shot 2022-08-13 at 10 42 41 AM" src="https://user-images.githubusercontent.com/1646875/184501372-7e05a575-4a0e-43eb-891e-80cd5c536b7a.png">

I tested this PR on x86_64, arm64, and rv64 hosts & targets, and compiling x86_32 on x86_64.