### PR TITLE
Rename `str2var` to `str_to_var` and similar

### DIFF
--- a/core/math/audio_frame.h
+++ b/core/math/audio_frame.h
@@ -48,7 +48,7 @@ static inline float undenormalise(volatile float f) {
 }
 
 static const float AUDIO_PEAK_OFFSET = 0.0000000001f;
-static const float AUDIO_MIN_PEAK_DB = -200.0f; // linear2db(AUDIO_PEAK_OFFSET)
+static const float AUDIO_MIN_PEAK_DB = -200.0f; // linear_to_db(AUDIO_PEAK_OFFSET)
 
 struct AudioFrame {
 	//left and right samples

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -229,11 +229,11 @@ public:
 		return value;
 	}
 
-	static _ALWAYS_INLINE_ double deg2rad(double p_y) { return p_y * (Math_PI / 180.0); }
-	static _ALWAYS_INLINE_ float deg2rad(float p_y) { return p_y * (float)(Math_PI / 180.0); }
+	static _ALWAYS_INLINE_ double deg_to_rad(double p_y) { return p_y * (Math_PI / 180.0); }
+	static _ALWAYS_INLINE_ float deg_to_rad(float p_y) { return p_y * (float)(Math_PI / 180.0); }
 
-	static _ALWAYS_INLINE_ double rad2deg(double p_y) { return p_y * (180.0 / Math_PI); }
-	static _ALWAYS_INLINE_ float rad2deg(float p_y) { return p_y * (float)(180.0 / Math_PI); }
+	static _ALWAYS_INLINE_ double rad_to_deg(double p_y) { return p_y * (180.0 / Math_PI); }
+	static _ALWAYS_INLINE_ float rad_to_deg(float p_y) { return p_y * (float)(180.0 / Math_PI); }
 
 	static _ALWAYS_INLINE_ double lerp(double p_from, double p_to, double p_weight) { return p_from + (p_to - p_from) * p_weight; }
 	static _ALWAYS_INLINE_ float lerp(float p_from, float p_to, float p_weight) { return p_from + (p_to - p_from) * p_weight; }
@@ -331,11 +331,11 @@ public:
 	static _ALWAYS_INLINE_ double move_toward(double p_from, double p_to, double p_delta) { return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta; }
 	static _ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) { return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta; }
 
-	static _ALWAYS_INLINE_ double linear2db(double p_linear) { return Math::log(p_linear) * 8.6858896380650365530225783783321; }
-	static _ALWAYS_INLINE_ float linear2db(float p_linear) { return Math::log(p_linear) * (float)8.6858896380650365530225783783321; }
+	static _ALWAYS_INLINE_ double linear_to_db(double p_linear) { return Math::log(p_linear) * 8.6858896380650365530225783783321; }
+	static _ALWAYS_INLINE_ float linear_to_db(float p_linear) { return Math::log(p_linear) * (float)8.6858896380650365530225783783321; }
 
-	static _ALWAYS_INLINE_ double db2linear(double p_db) { return Math::exp(p_db * 0.11512925464970228420089957273422); }
-	static _ALWAYS_INLINE_ float db2linear(float p_db) { return Math::exp(p_db * (float)0.11512925464970228420089957273422); }
+	static _ALWAYS_INLINE_ double db_to_linear(double p_db) { return Math::exp(p_db * 0.11512925464970228420089957273422); }
+	static _ALWAYS_INLINE_ float db_to_linear(float p_db) { return Math::exp(p_db * (float)0.11512925464970228420089957273422); }
 
 	static _ALWAYS_INLINE_ double round(double p_val) { return ::round(p_val); }
 	static _ALWAYS_INLINE_ float round(float p_val) { return ::roundf(p_val); }

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -255,7 +255,7 @@ void Projection::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t 
 	}
 
 	real_t sine, cotangent, deltaZ;
-	real_t radians = Math::deg2rad(p_fovy_degrees / 2.0);
+	real_t radians = Math::deg_to_rad(p_fovy_degrees / 2.0);
 
 	deltaZ = p_z_far - p_z_near;
 	sine = Math::sin(radians);
@@ -282,7 +282,7 @@ void Projection::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t 
 
 	real_t left, right, modeltranslation, ymax, xmax, frustumshift;
 
-	ymax = p_z_near * tan(Math::deg2rad(p_fovy_degrees / 2.0));
+	ymax = p_z_near * tan(Math::deg_to_rad(p_fovy_degrees / 2.0));
 	xmax = ymax * p_aspect;
 	frustumshift = (p_intraocular_dist / 2.0) * p_z_near / p_convergence_dist;
 
@@ -816,7 +816,7 @@ real_t Projection::get_fov() const {
 	right_plane.normalize();
 
 	if ((matrix[8] == 0) && (matrix[9] == 0)) {
-		return Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
+		return Math::rad_to_deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
 	} else {
 		// our frustum is asymmetrical need to calculate the left planes angle separately..
 		Plane left_plane = Plane(matrix[3] + matrix[0],
@@ -825,7 +825,7 @@ real_t Projection::get_fov() const {
 				matrix[15] + matrix[12]);
 		left_plane.normalize();
 
-		return Math::rad2deg(Math::acos(Math::abs(left_plane.normal.x))) + Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x)));
+		return Math::rad_to_deg(Math::acos(Math::abs(left_plane.normal.x))) + Math::rad_to_deg(Math::acos(Math::abs(right_plane.normal.x)));
 	}
 }
 

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -96,7 +96,7 @@ struct Projection {
 	Projection jitter_offseted(const Vector2 &p_offset) const;
 
 	static real_t get_fovy(real_t p_fovx, real_t p_aspect) {
-		return Math::rad2deg(Math::atan(p_aspect * Math::tan(Math::deg2rad(p_fovx) * 0.5)) * 2.0);
+		return Math::rad_to_deg(Math::atan(p_aspect * Math::tan(Math::deg_to_rad(p_fovx) * 0.5)) * 2.0);
 	}
 
 	real_t get_z_far() const;

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -396,20 +396,20 @@ struct VariantUtilityFunctions {
 		return Math::move_toward(from, to, delta);
 	}
 
-	static inline double deg2rad(double angle_deg) {
-		return Math::deg2rad(angle_deg);
+	static inline double deg_to_rad(double angle_deg) {
+		return Math::deg_to_rad(angle_deg);
 	}
 
-	static inline double rad2deg(double angle_rad) {
-		return Math::rad2deg(angle_rad);
+	static inline double rad_to_deg(double angle_rad) {
+		return Math::rad_to_deg(angle_rad);
 	}
 
-	static inline double linear2db(double linear) {
-		return Math::linear2db(linear);
+	static inline double linear_to_db(double linear) {
+		return Math::linear_to_db(linear);
 	}
 
-	static inline double db2linear(double db) {
-		return Math::db2linear(db);
+	static inline double db_to_linear(double db) {
+		return Math::db_to_linear(db);
 	}
 
 	static inline Variant wrap(const Variant &p_x, const Variant &p_min, const Variant &p_max, Callable::CallError &r_error) {
@@ -837,13 +837,13 @@ struct VariantUtilityFunctions {
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 
-	static inline String var2str(const Variant &p_var) {
+	static inline String var_to_str(const Variant &p_var) {
 		String vars;
 		VariantWriter::write_to_string(p_var, vars);
 		return vars;
 	}
 
-	static inline Variant str2var(const String &p_var) {
+	static inline Variant str_to_var(const String &p_var) {
 		VariantParser::StreamString ss;
 		ss.s = p_var;
 
@@ -855,7 +855,7 @@ struct VariantUtilityFunctions {
 		return ret;
 	}
 
-	static inline PackedByteArray var2bytes(const Variant &p_var) {
+	static inline PackedByteArray var_to_bytes(const Variant &p_var) {
 		int len;
 		Error err = encode_variant(p_var, nullptr, len, false);
 		if (err != OK) {
@@ -875,7 +875,7 @@ struct VariantUtilityFunctions {
 		return barr;
 	}
 
-	static inline PackedByteArray var2bytes_with_objects(const Variant &p_var) {
+	static inline PackedByteArray var_to_bytes_with_objects(const Variant &p_var) {
 		int len;
 		Error err = encode_variant(p_var, nullptr, len, true);
 		if (err != OK) {
@@ -895,7 +895,7 @@ struct VariantUtilityFunctions {
 		return barr;
 	}
 
-	static inline Variant bytes2var(const PackedByteArray &p_arr) {
+	static inline Variant bytes_to_var(const PackedByteArray &p_arr) {
 		Variant ret;
 		{
 			const uint8_t *r = p_arr.ptr();
@@ -907,7 +907,7 @@ struct VariantUtilityFunctions {
 		return ret;
 	}
 
-	static inline Variant bytes2var_with_objects(const PackedByteArray &p_arr) {
+	static inline Variant bytes_to_var_with_objects(const PackedByteArray &p_arr) {
 		Variant ret;
 		{
 			const uint8_t *r = p_arr.ptr();
@@ -1428,10 +1428,10 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(smoothstep, sarray("from", "to", "x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(move_toward, sarray("from", "to", "delta"), Variant::UTILITY_FUNC_TYPE_MATH);
 
-	FUNCBINDR(deg2rad, sarray("deg"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(rad2deg, sarray("rad"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(linear2db, sarray("lin"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(db2linear, sarray("db"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(deg_to_rad, sarray("deg"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(rad_to_deg, sarray("rad"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(linear_to_db, sarray("lin"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(db_to_linear, sarray("db"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDVR3(wrap, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(wrapi, sarray("value", "min", "max"), Variant::UTILITY_FUNC_TYPE_MATH);
@@ -1479,14 +1479,14 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDVARARGV(push_error, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(push_warning, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(var2str, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(str2var, sarray("string"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(var_to_str, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(str_to_var, sarray("string"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(var2bytes, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(bytes2var, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(var_to_bytes, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(bytes_to_var, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
-	FUNCBINDR(var2bytes_with_objects, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
-	FUNCBINDR(bytes2var_with_objects, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(var_to_bytes_with_objects, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(bytes_to_var_with_objects, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
 	FUNCBINDR(hash, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -66,7 +66,7 @@
 			<description>
 				Returns the arc cosine of [param x] in radians. Use to get the angle of cosine [param x]. [param x] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method acos] will return [constant @GDScript.NAN].
 				[codeblock]
-				# c is 0.523599 or 30 degrees if converted with rad2deg(c)
+				# c is 0.523599 or 30 degrees if converted with rad_to_deg(c)
 				var c = acos(0.866025)
 				[/codeblock]
 			</description>
@@ -77,7 +77,7 @@
 			<description>
 				Returns the arc sine of [param x] in radians. Use to get the angle of sine [param x]. [param x] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method asin] will return [constant @GDScript.NAN].
 				[codeblock]
-				# s is 0.523599 or 30 degrees if converted with rad2deg(s)
+				# s is 0.523599 or 30 degrees if converted with rad_to_deg(s)
 				var s = asin(0.5)
 				[/codeblock]
 			</description>
@@ -117,15 +117,15 @@
 				Returns the point at the given [param t] on a one-dimnesional [url=https://en.wikipedia.org/wiki/B%C3%A9zier_curve]Bezier curve[/url] defined by the given [param control_1], [param control_2], and [param end] points.
 			</description>
 		</method>
-		<method name="bytes2var">
+		<method name="bytes_to_var">
 			<return type="Variant" />
 			<param index="0" name="bytes" type="PackedByteArray" />
 			<description>
 				Decodes a byte array back to a [Variant] value, without decoding objects.
-				[b]Note:[/b] If you need object deserialization, see [method bytes2var_with_objects].
+				[b]Note:[/b] If you need object deserialization, see [method bytes_to_var_with_objects].
 			</description>
 		</method>
-		<method name="bytes2var_with_objects">
+		<method name="bytes_to_var_with_objects">
 			<return type="Variant" />
 			<param index="0" name="bytes" type="PackedByteArray" />
 			<description>
@@ -232,9 +232,9 @@
 			<description>
 				Returns the cosine of angle [param angle_rad] in radians.
 				[codeblock]
-				cos(PI * 2)      # Returns 1.0
-				cos(PI)          # Returns -1.0
-				cos(deg2rad(90)) # Returns 0.0
+				cos(PI * 2)         # Returns 1.0
+				cos(PI)             # Returns -1.0
+				cos(deg_to_rad(90)) # Returns 0.0
 				[/codeblock]
 			</description>
 		</method>
@@ -275,21 +275,21 @@
 				It can perform smoother interpolation than [code]cubic_interpolate()[/code] by the time values.
 			</description>
 		</method>
-		<method name="db2linear">
+		<method name="db_to_linear">
 			<return type="float" />
 			<param index="0" name="db" type="float" />
 			<description>
 				Converts from decibels to linear energy (audio).
 			</description>
 		</method>
-		<method name="deg2rad">
+		<method name="deg_to_rad">
 			<return type="float" />
 			<param index="0" name="deg" type="float" />
 			<description>
 				Converts an angle expressed in degrees to radians.
 				[codeblock]
 				# r is 3.141593
-				var r = deg2rad(180)
+				var r = deg_to_rad(180)
 				[/codeblock]
 			</description>
 		</method>
@@ -513,8 +513,8 @@
 				extends Sprite
 				var elapsed = 0.0
 				func _process(delta):
-				    var min_angle = deg2rad(0.0)
-				    var max_angle = deg2rad(90.0)
+				    var min_angle = deg_to_rad(0.0)
+				    var max_angle = deg_to_rad(90.0)
 				    rotation = lerp_angle(min_angle, max_angle, elapsed)
 				    elapsed += delta
 				[/codeblock]
@@ -534,7 +534,7 @@
 				See also [method inverse_lerp] which performs the reverse of this operation. To perform eased interpolation with [method lerp], combine it with [method ease] or [method smoothstep].
 			</description>
 		</method>
-		<method name="linear2db">
+		<method name="linear_to_db">
 			<return type="float" />
 			<param index="0" name="lin" type="float" />
 			<description>
@@ -543,7 +543,7 @@
 				# "Slider" refers to a node that inherits Range such as HSlider or VSlider.
 				# Its range must be configured to go from 0 to 1.
 				# Change the bus name if you'd like to change the volume of a specific bus only.
-				AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear2db($Slider.value))
+				AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db($Slider.value))
 				[/codeblock]
 			</description>
 		</method>
@@ -787,13 +787,13 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="rad2deg">
+		<method name="rad_to_deg">
 			<return type="float" />
 			<param index="0" name="rad" type="float" />
 			<description>
 				Converts an angle expressed in radians to degrees.
 				[codeblock]
-				rad2deg(0.523599) # Returns 30
+				rad_to_deg(0.523599) # Returns 30
 				[/codeblock]
 			</description>
 		</method>
@@ -974,8 +974,8 @@
 			<description>
 				Returns the sine of angle [param angle_rad] in radians.
 				[codeblock]
-				sin(0.523599)    # Returns 0.5
-				sin(deg2rad(90)) # Returns 1.0
+				sin(0.523599)       # Returns 0.5
+				sin(deg_to_rad(90)) # Returns 1.0
 				[/codeblock]
 			</description>
 		</method>
@@ -1054,14 +1054,14 @@
 				Converts one or more arguments of any type to string in the best way possible.
 			</description>
 		</method>
-		<method name="str2var">
+		<method name="str_to_var">
 			<return type="Variant" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Converts a formatted string that was returned by [method var2str] to the original value.
+				Converts a formatted [param string] that was returned by [method var_to_str] to the original value.
 				[codeblock]
 				var a = '{ "a": 1, "b": 2 }'
-				var b = str2var(a)
+				var b = str_to_var(a)
 				print(b["a"]) # Prints 1
 				[/codeblock]
 			</description>
@@ -1072,7 +1072,7 @@
 			<description>
 				Returns the tangent of angle [param angle_rad] in radians.
 				[codeblock]
-				tan(deg2rad(45)) # Returns 1
+				tan(deg_to_rad(45)) # Returns 1
 				[/codeblock]
 			</description>
 		</method>
@@ -1103,29 +1103,29 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="var2bytes">
+		<method name="var_to_bytes">
 			<return type="PackedByteArray" />
 			<param index="0" name="variable" type="Variant" />
 			<description>
-				Encodes a [Variant] value to a byte array, without encoding objects. Deserialization can be done with [method bytes2var].
-				[b]Note:[/b] If you need object serialization, see [method var2bytes_with_objects].
+				Encodes a [Variant] value to a byte array, without encoding objects. Deserialization can be done with [method bytes_to_var].
+				[b]Note:[/b] If you need object serialization, see [method var_to_bytes_with_objects].
 			</description>
 		</method>
-		<method name="var2bytes_with_objects">
+		<method name="var_to_bytes_with_objects">
 			<return type="PackedByteArray" />
 			<param index="0" name="variable" type="Variant" />
 			<description>
-				Encodes a [Variant] value to a byte array. Encoding objects is allowed (and can potentially include code). Deserialization can be done with [method bytes2var_with_objects].
+				Encodes a [Variant] value to a byte array. Encoding objects is allowed (and can potentially include code). Deserialization can be done with [method bytes_to_var_with_objects].
 			</description>
 		</method>
-		<method name="var2str">
+		<method name="var_to_str">
 			<return type="String" />
 			<param index="0" name="variable" type="Variant" />
 			<description>
-				Converts a Variant [param variable] to a formatted string that can later be parsed using [method str2var].
+				Converts a Variant [param variable] to a formatted string that can later be parsed using [method str_to_var].
 				[codeblock]
 				a = { "a": 1, "b": 2 }
-				print(var2str(a))
+				print(var_to_str(a))
 				[/codeblock]
 				prints
 				[codeblock]

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -9,7 +9,7 @@
 		Canvas items are drawn in tree order. By default, children are on top of their parents so a root [CanvasItem] will be drawn behind everything. This behavior can be changed on a per-item basis.
 		A [CanvasItem] can also be hidden, which will also hide its children. It provides many ways to change parameters such as modulation (for itself and its children) and self modulation (only for itself), as well as its blend mode.
 		Ultimately, a transform notification can be requested, which will notify the node that its global position changed in case the parent tree changed.
-		[b]Note:[/b] Unless otherwise specified, all methods that have angle parameters must have angles specified as [i]radians[/i]. To convert degrees to radians, use [method @GlobalScope.deg2rad].
+		[b]Note:[/b] Unless otherwise specified, all methods that have angle parameters must have angles specified as [i]radians[/i]. To convert degrees to radians, use [method @GlobalScope.deg_to_rad].
 	</description>
 	<tutorials>
 		<link title="Viewport and canvas transforms">$DOCS_URL/tutorials/2d/2d_transforms.html</link>

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -6,7 +6,7 @@
 	<description>
 		Most basic 3D game object, with a 3D [Transform3D] and visibility settings. All other 3D game objects inherit from Node3D. Use [Node3D] as a parent node to move, scale, rotate and show/hide children in a 3D project.
 		Affine operations (rotate, scale, translate) happen in parent's local coordinate system, unless the [Node3D] object is set as top-level. Affine operations in this coordinate system correspond to direct affine operations on the [Node3D]'s transform. The word local below refers to this coordinate system. The coordinate system that is attached to the [Node3D] object itself is referred to as object-local coordinate system.
-		[b]Note:[/b] Unless otherwise specified, all methods that have angle parameters must have angles specified as [i]radians[/i]. To convert degrees to radians, use [method @GlobalScope.deg2rad].
+		[b]Note:[/b] Unless otherwise specified, all methods that have angle parameters must have angles specified as [i]radians[/i]. To convert degrees to radians, use [method @GlobalScope.deg_to_rad].
 	</description>
 	<tutorials>
 		<link title="Introduction to 3D">$DOCS_URL/tutorials/3d/introduction_to_3d.html</link>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -304,7 +304,7 @@
 			<return type="Vector2" />
 			<param index="0" name="angle" type="float" />
 			<description>
-				Returns the vector rotated by [param angle] (in radians). See also [method @GlobalScope.deg2rad].
+				Returns the vector rotated by [param angle] (in radians). See also [method @GlobalScope.deg_to_rad].
 			</description>
 		</method>
 		<method name="round" qualifiers="const">

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -648,7 +648,7 @@ void RasterizerSceneGLES3::_setup_sky(RID p_env, RID p_render_buffers, const Pag
 
 					float angular_diameter = light_storage->light_get_param(base, RS::LIGHT_PARAM_SIZE);
 					if (angular_diameter > 0.0) {
-						angular_diameter = Math::tan(Math::deg2rad(angular_diameter));
+						angular_diameter = Math::tan(Math::deg_to_rad(angular_diameter));
 					} else {
 						angular_diameter = 0.0;
 					}
@@ -1518,7 +1518,7 @@ void RasterizerSceneGLES3::_setup_lights(const RenderDataGLES3 *p_render_data, b
 				light_data.color[2] = linear_col.b;
 
 				float size = light_storage->light_get_param(base, RS::LIGHT_PARAM_SIZE);
-				light_data.size = 1.0 - Math::cos(Math::deg2rad(size)); //angle to cosine offset
+				light_data.size = 1.0 - Math::cos(Math::deg_to_rad(size)); //angle to cosine offset
 
 				light_data.specular = light_storage->light_get_param(base, RS::LIGHT_PARAM_SPECULAR);
 
@@ -1645,7 +1645,7 @@ void RasterizerSceneGLES3::_setup_lights(const RenderDataGLES3 *p_render_data, b
 		light_data.inv_spot_attenuation = 1.0f / light_storage->light_get_param(base, RS::LIGHT_PARAM_SPOT_ATTENUATION);
 
 		float spot_angle = light_storage->light_get_param(base, RS::LIGHT_PARAM_SPOT_ANGLE);
-		light_data.cos_spot_angle = Math::cos(Math::deg2rad(spot_angle));
+		light_data.cos_spot_angle = Math::cos(Math::deg_to_rad(spot_angle));
 
 		light_data.specular_amount = light_storage->light_get_param(base, RS::LIGHT_PARAM_SPECULAR) * 2.0;
 

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -318,7 +318,7 @@ AABB LightStorage::light_get_aabb(RID p_light) const {
 	switch (light->type) {
 		case RS::LIGHT_SPOT: {
 			float len = light->param[RS::LIGHT_PARAM_RANGE];
-			float size = Math::tan(Math::deg2rad(light->param[RS::LIGHT_PARAM_SPOT_ANGLE])) * len;
+			float size = Math::tan(Math::deg_to_rad(light->param[RS::LIGHT_PARAM_SPOT_ANGLE])) * len;
 			return AABB(Vector3(-size, -size, -len), Vector3(size * 2, size * 2, len));
 		};
 		case RS::LIGHT_OMNI: {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1458,7 +1458,7 @@ void EditorPropertyFloat::_value_changed(double val) {
 	}
 
 	if (angle_in_radians) {
-		val = Math::deg2rad(val);
+		val = Math::deg_to_rad(val);
 	}
 	emit_changed(get_edited_property(), val);
 }
@@ -1466,7 +1466,7 @@ void EditorPropertyFloat::_value_changed(double val) {
 void EditorPropertyFloat::update_property() {
 	double val = get_edited_object()->get(get_edited_property());
 	if (angle_in_radians) {
-		val = Math::rad2deg(val);
+		val = Math::rad_to_deg(val);
 	}
 	setting = true;
 	spin->set_value(val);
@@ -1988,9 +1988,9 @@ void EditorPropertyVector3::_value_changed(double val, const String &p_name) {
 	v3.y = spin[1]->get_value();
 	v3.z = spin[2]->get_value();
 	if (angle_in_radians) {
-		v3.x = Math::deg2rad(v3.x);
-		v3.y = Math::deg2rad(v3.y);
-		v3.z = Math::deg2rad(v3.z);
+		v3.x = Math::deg_to_rad(v3.x);
+		v3.y = Math::deg_to_rad(v3.y);
+		v3.z = Math::deg_to_rad(v3.z);
 	}
 	emit_changed(get_edited_property(), v3, p_name);
 }
@@ -2022,9 +2022,9 @@ void EditorPropertyVector3::_update_ratio() {
 
 void EditorPropertyVector3::update_using_vector(Vector3 p_vector) {
 	if (angle_in_radians) {
-		p_vector.x = Math::rad2deg(p_vector.x);
-		p_vector.y = Math::rad2deg(p_vector.y);
-		p_vector.z = Math::rad2deg(p_vector.z);
+		p_vector.x = Math::rad_to_deg(p_vector.x);
+		p_vector.y = Math::rad_to_deg(p_vector.y);
+		p_vector.z = Math::rad_to_deg(p_vector.z);
 	}
 	setting = true;
 	spin[0]->set_value(p_vector.x);
@@ -2039,9 +2039,9 @@ Vector3 EditorPropertyVector3::get_vector() {
 	v3.y = spin[1]->get_value();
 	v3.z = spin[2]->get_value();
 	if (angle_in_radians) {
-		v3.x = Math::deg2rad(v3.x);
-		v3.y = Math::deg2rad(v3.y);
-		v3.z = Math::deg2rad(v3.z);
+		v3.x = Math::deg_to_rad(v3.x);
+		v3.y = Math::deg_to_rad(v3.y);
+		v3.z = Math::deg_to_rad(v3.z);
 	}
 
 	return v3;
@@ -2643,9 +2643,9 @@ void EditorPropertyQuaternion::_custom_value_changed(double val) {
 	edit_euler.z = euler[2]->get_value();
 
 	Vector3 v;
-	v.x = Math::deg2rad(edit_euler.x);
-	v.y = Math::deg2rad(edit_euler.y);
-	v.z = Math::deg2rad(edit_euler.z);
+	v.x = Math::deg_to_rad(edit_euler.x);
+	v.y = Math::deg_to_rad(edit_euler.y);
+	v.z = Math::deg_to_rad(edit_euler.z);
 
 	Quaternion temp_q = Quaternion(v);
 	spin[0]->set_value(temp_q.x);
@@ -2685,9 +2685,9 @@ void EditorPropertyQuaternion::update_property() {
 	spin[3]->set_value(val.w);
 	if (!is_grabbing_euler()) {
 		Vector3 v = val.normalized().get_euler_yxz();
-		edit_euler.x = Math::rad2deg(v.x);
-		edit_euler.y = Math::rad2deg(v.y);
-		edit_euler.z = Math::rad2deg(v.z);
+		edit_euler.x = Math::rad_to_deg(v.x);
+		edit_euler.y = Math::rad_to_deg(v.y);
+		edit_euler.z = Math::rad_to_deg(v.z);
 		euler[0]->set_value(edit_euler.x);
 		euler[1]->set_value(edit_euler.y);
 		euler[2]->set_value(edit_euler.z);

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -131,7 +131,7 @@ Transform3D Collada::Node::compute_transform(const Collada &state) const {
 		switch (xf.op) {
 			case XForm::OP_ROTATE: {
 				if (xf.data.size() >= 4) {
-					xform_step.rotate(Vector3(xf.data[0], xf.data[1], xf.data[2]), Math::deg2rad(xf.data[3]));
+					xform_step.rotate(Vector3(xf.data[0], xf.data[1], xf.data[2]), Math::deg_to_rad(xf.data[3]));
 				}
 			} break;
 			case XForm::OP_SCALE: {

--- a/editor/import/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/post_import_plugin_skeleton_rest_fixer.cpp
@@ -324,7 +324,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 				Vector3 src_dir = src_tail - src_head;
 
 				// Rotate rest.
-				if (Math::abs(Math::rad2deg(src_dir.angle_to(prof_dir))) > float(p_options["retarget/rest_fixer/fix_silhouette/threshold"])) {
+				if (Math::abs(Math::rad_to_deg(src_dir.angle_to(prof_dir))) > float(p_options["retarget/rest_fixer/fix_silhouette/threshold"])) {
 					// Get rotation difference.
 					Vector3 up_vec; // Need to rotate other than roll axis.
 					switch (Vector3(abs(src_dir.x), abs(src_dir.y), abs(src_dir.z)).min_axis_index()) {

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -390,7 +390,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 		int first = 0;
 		int last = (frames / format_channels) - 1;
 		bool found = false;
-		float limit = Math::db2linear(TRIM_DB_LIMIT);
+		float limit = Math::db_to_linear(TRIM_DB_LIMIT);
 
 		for (int i = 0; i < data.size() / format_channels; i++) {
 			float ampChannelSum = 0;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -223,8 +223,8 @@ public:
 		grid_step_x->set_value(p_grid_step.x);
 		grid_step_y->set_value(p_grid_step.y);
 		primary_grid_steps->set_value(p_primary_grid_steps);
-		rotation_offset->set_value(Math::rad2deg(p_rotation_offset));
-		rotation_step->set_value(Math::rad2deg(p_rotation_step));
+		rotation_offset->set_value(Math::rad_to_deg(p_rotation_offset));
+		rotation_step->set_value(Math::rad_to_deg(p_rotation_step));
 		scale_step->set_value(p_scale_step);
 	}
 
@@ -232,8 +232,8 @@ public:
 		p_grid_offset = Point2(grid_offset_x->get_value(), grid_offset_y->get_value());
 		p_grid_step = Point2(grid_step_x->get_value(), grid_step_y->get_value());
 		p_primary_grid_steps = int(primary_grid_steps->get_value());
-		p_rotation_offset = Math::deg2rad(rotation_offset->get_value());
-		p_rotation_step = Math::deg2rad(rotation_step->get_value());
+		p_rotation_offset = Math::deg_to_rad(rotation_offset->get_value());
+		p_rotation_step = Math::deg_to_rad(rotation_step->get_value());
 		p_scale_step = scale_step->get_value();
 	}
 };
@@ -1447,7 +1447,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 						drag_selection,
 						vformat(TTR("Rotate CanvasItem \"%s\" to %d degrees"),
 								drag_selection[0]->get_name(),
-								Math::rad2deg(drag_selection[0]->_edit_get_rotation())),
+								Math::rad_to_deg(drag_selection[0]->_edit_get_rotation())),
 						true);
 			}
 
@@ -3676,7 +3676,7 @@ void CanvasItemEditor::_draw_transform_message() {
 		} break;
 
 		case DRAG_ROTATE: {
-			real_t delta = Math::rad2deg(current_transform.get_rotation() - original_transform.get_rotation());
+			real_t delta = Math::rad_to_deg(current_transform.get_rotation() - original_transform.get_rotation());
 			transform_message = TTR("Rotating:") + " " + FORMAT(delta) + String::utf8(" °");
 		} break;
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -215,7 +215,7 @@ private:
 	int primary_grid_steps = 8;
 	int grid_step_multiplier = 0;
 
-	real_t snap_rotation_step = Math::deg2rad(15.0);
+	real_t snap_rotation_step = Math::deg_to_rad(15.0);
 	real_t snap_rotation_offset = 0.0;
 	real_t snap_scale_step = 0.1f;
 	bool smart_snap_active = false;

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -179,8 +179,8 @@ MaterialEditor::MaterialEditor() {
 	viewport->add_child(box_instance);
 
 	Transform3D box_xform;
-	box_xform.basis.rotate(Vector3(1, 0, 0), Math::deg2rad(25.0));
-	box_xform.basis = box_xform.basis * Basis().rotated(Vector3(0, 1, 0), Math::deg2rad(-25.0));
+	box_xform.basis.rotate(Vector3(1, 0, 0), Math::deg_to_rad(25.0));
+	box_xform.basis = box_xform.basis * Basis().rotated(Vector3(0, 1, 0), Math::deg_to_rad(-25.0));
 	box_xform.basis.scale(Vector3(0.7, 0.7, 0.7));
 	box_xform.origin.y = 0.05;
 	box_instance->set_transform(box_xform);

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -77,8 +77,8 @@ void MeshEditor::edit(Ref<Mesh> p_mesh) {
 	mesh = p_mesh;
 	mesh_instance->set_mesh(mesh);
 
-	rot_x = Math::deg2rad(-15.0);
-	rot_y = Math::deg2rad(30.0);
+	rot_x = Math::deg_to_rad(-15.0);
+	rot_y = Math::deg_to_rad(30.0);
 	_update_rotation();
 
 	AABB aabb = mesh->get_aabb();

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1295,7 +1295,7 @@ static float _find_closest_angle_to_half_pi_arc(const Vector3 &p_from, const Vec
 
 	//min_p = p_arc_xform.affine_inverse().xform(min_p);
 	float a = (Math_PI * 0.5) - Vector2(min_p.x, -min_p.z).angle();
-	return Math::rad2deg(a);
+	return Math::rad_to_deg(a);
 }
 
 void Light3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) {
@@ -1421,8 +1421,8 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 		for (int i = 0; i < 120; i++) {
 			// Create a circle
-			const float ra = Math::deg2rad((float)(i * 3));
-			const float rb = Math::deg2rad((float)((i + 1) * 3));
+			const float ra = Math::deg_to_rad((float)(i * 3));
+			const float rb = Math::deg_to_rad((float)((i + 1) * 3));
 			const Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r;
 			const Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r;
 
@@ -1458,13 +1458,13 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		SpotLight3D *sl = Object::cast_to<SpotLight3D>(light);
 
 		float r = sl->get_param(Light3D::PARAM_RANGE);
-		float w = r * Math::sin(Math::deg2rad(sl->get_param(Light3D::PARAM_SPOT_ANGLE)));
-		float d = r * Math::cos(Math::deg2rad(sl->get_param(Light3D::PARAM_SPOT_ANGLE)));
+		float w = r * Math::sin(Math::deg_to_rad(sl->get_param(Light3D::PARAM_SPOT_ANGLE)));
+		float d = r * Math::cos(Math::deg_to_rad(sl->get_param(Light3D::PARAM_SPOT_ANGLE)));
 
 		for (int i = 0; i < 120; i++) {
 			// Draw a circle
-			const float ra = Math::deg2rad((float)(i * 3));
-			const float rb = Math::deg2rad((float)((i + 1) * 3));
+			const float ra = Math::deg_to_rad((float)(i * 3));
+			const float rb = Math::deg_to_rad((float)((i + 1) * 3));
 			const Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * w;
 			const Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * w;
 
@@ -1545,8 +1545,8 @@ void AudioStreamPlayer3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo
 	float closest_angle = 1e20;
 
 	for (int i = 0; i < 180; i++) {
-		float a = Math::deg2rad((float)i);
-		float an = Math::deg2rad((float)(i + 1));
+		float a = Math::deg_to_rad((float)i);
+		float an = Math::deg_to_rad((float)(i + 1));
 
 		Vector3 from(Math::sin(a), 0, -Math::cos(a));
 		Vector3 to(Math::sin(an), 0, -Math::cos(an));
@@ -1628,8 +1628,8 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 		for (int i = 0; i < 120; i++) {
 			// Create a circle.
-			const float ra = Math::deg2rad((float)(i * 3));
-			const float rb = Math::deg2rad((float)((i + 1) * 3));
+			const float ra = Math::deg_to_rad((float)(i * 3));
+			const float rb = Math::deg_to_rad((float)((i + 1) * 3));
 			const Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r;
 			const Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r;
 
@@ -1671,8 +1671,8 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	if (player->is_emission_angle_enabled()) {
 		const float pc = player->get_emission_angle();
-		const float ofs = -Math::cos(Math::deg2rad(pc));
-		const float radius = Math::sin(Math::deg2rad(pc));
+		const float ofs = -Math::cos(Math::deg_to_rad(pc));
+		const float radius = Math::sin(Math::deg_to_rad(pc));
 
 		Vector<Vector3> points_primary;
 		points_primary.resize(200);
@@ -1707,7 +1707,7 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(points_secondary, material_secondary);
 
 		Vector<Vector3> handles;
-		const float ha = Math::deg2rad(player->get_emission_angle());
+		const float ha = Math::deg_to_rad(player->get_emission_angle());
 		handles.push_back(Vector3(Math::sin(ha), 0, -Math::cos(ha)));
 		p_gizmo->add_handles(handles, get_material("handles"));
 	}
@@ -1872,7 +1872,7 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			// The real FOV is halved for accurate representation
 			float fov = camera->get_fov() / 2.0;
 
-			Vector3 side = Vector3(Math::sin(Math::deg2rad(fov)), 0, -Math::cos(Math::deg2rad(fov)));
+			Vector3 side = Vector3(Math::sin(Math::deg_to_rad(fov)), 0, -Math::cos(Math::deg_to_rad(fov)));
 			Vector3 nside = side;
 			nside.x = -nside.x;
 			Vector3 up = Vector3(0, side.x, 0);
@@ -2643,8 +2643,8 @@ void VehicleWheel3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	float r = car_wheel->get_radius();
 	const int skip = 10;
 	for (int i = 0; i <= 360; i += skip) {
-		float ra = Math::deg2rad((float)i);
-		float rb = Math::deg2rad((float)i + skip);
+		float ra = Math::deg_to_rad((float)i);
+		float rb = Math::deg_to_rad((float)i + skip);
 		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r;
 		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r;
 
@@ -3272,8 +3272,8 @@ void GPUParticlesCollision3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> points;
 
 		for (int i = 0; i <= 360; i++) {
-			float ra = Math::deg2rad((float)i);
-			float rb = Math::deg2rad((float)i + 1);
+			float ra = Math::deg_to_rad((float)i);
+			float rb = Math::deg_to_rad((float)i + 1);
 			Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r;
 			Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r;
 
@@ -4517,8 +4517,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> points;
 
 		for (int i = 0; i <= 360; i++) {
-			float ra = Math::deg2rad((float)i);
-			float rb = Math::deg2rad((float)i + 1);
+			float ra = Math::deg_to_rad((float)i);
+			float rb = Math::deg_to_rad((float)i + 1);
 			Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r;
 			Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r;
 
@@ -4589,8 +4589,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 		Vector3 d(0, height * 0.5 - radius, 0);
 		for (int i = 0; i < 360; i++) {
-			float ra = Math::deg2rad((float)i);
-			float rb = Math::deg2rad((float)i + 1);
+			float ra = Math::deg_to_rad((float)i);
+			float rb = Math::deg_to_rad((float)i + 1);
 			Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * radius;
 			Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * radius;
 
@@ -4660,8 +4660,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 		Vector3 d(0, height * 0.5, 0);
 		for (int i = 0; i < 360; i++) {
-			float ra = Math::deg2rad((float)i);
-			float rb = Math::deg2rad((float)i + 1);
+			float ra = Math::deg_to_rad((float)i);
+			float rb = Math::deg_to_rad((float)i + 1);
 			Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * radius;
 			Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * radius;
 
@@ -5203,8 +5203,8 @@ void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_ba
 
 	//swing
 	for (int i = 0; i < 360; i += 10) {
-		float ra = Math::deg2rad((float)i);
-		float rb = Math::deg2rad((float)i + 10);
+		float ra = Math::deg_to_rad((float)i);
+		float rb = Math::deg_to_rad((float)i + 10);
 		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * w;
 		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * w;
 
@@ -5221,12 +5221,12 @@ void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_ba
 	r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(1, 0, 0))).origin);
 
 	/// Twist
-	float ts = Math::rad2deg(p_twist);
+	float ts = Math::rad_to_deg(p_twist);
 	ts = MIN(ts, 720);
 
 	for (int i = 0; i < int(ts); i += 5) {
-		float ra = Math::deg2rad((float)i);
-		float rb = Math::deg2rad((float)i + 5);
+		float ra = Math::deg_to_rad((float)i);
+		float rb = Math::deg_to_rad((float)i + 5);
 		float c = i / 720.0;
 		float cn = (i + 5) / 720.0;
 		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * w * c;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -342,7 +342,7 @@ void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 		camera->set_global_transform(to_camera_transform(camera_cursor));
 
 		if (orthogonal) {
-			float half_fov = Math::deg2rad(get_fov()) / 2.0;
+			float half_fov = Math::deg_to_rad(get_fov()) / 2.0;
 			float height = 2.0 * cursor.distance * Math::tan(half_fov);
 			camera->set_orthogonal(height, get_znear(), get_zfar());
 		} else {
@@ -2144,7 +2144,7 @@ void Node3DEditorViewport::_nav_orbit(Ref<InputEventWithModifiers> p_event, cons
 	}
 
 	const real_t degrees_per_pixel = EditorSettings::get_singleton()->get("editors/3d/navigation_feel/orbit_sensitivity");
-	const real_t radians_per_pixel = Math::deg2rad(degrees_per_pixel);
+	const real_t radians_per_pixel = Math::deg_to_rad(degrees_per_pixel);
 	const bool invert_y_axis = EditorSettings::get_singleton()->get("editors/3d/navigation/invert_y_axis");
 	const bool invert_x_axis = EditorSettings::get_singleton()->get("editors/3d/navigation/invert_x_axis");
 
@@ -2177,7 +2177,7 @@ void Node3DEditorViewport::_nav_look(Ref<InputEventWithModifiers> p_event, const
 
 	// Scale mouse sensitivity with camera FOV scale when zoomed in to make it easier to point at things.
 	const real_t degrees_per_pixel = real_t(EditorSettings::get_singleton()->get("editors/3d/freelook/freelook_sensitivity")) * MIN(1.0, cursor.fov_scale);
-	const real_t radians_per_pixel = Math::deg2rad(degrees_per_pixel);
+	const real_t radians_per_pixel = Math::deg_to_rad(degrees_per_pixel);
 	const bool invert_y_axis = EditorSettings::get_singleton()->get("editors/3d/navigation/invert_y_axis");
 
 	// Note: do NOT assume the camera has the "current" transform, because it is interpolated and may have "lag".
@@ -4546,7 +4546,7 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 				break;
 			}
 
-			static const float orthogonal_threshold = Math::cos(Math::deg2rad(87.0f));
+			static const float orthogonal_threshold = Math::cos(Math::deg_to_rad(87.0f));
 			bool axis_is_orthogonal = ABS(plane.normal.dot(global_axis)) < orthogonal_threshold;
 
 			double angle = 0.0f;
@@ -4566,10 +4566,10 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 			if (_edit.snap || spatial_editor->is_snap_enabled()) {
 				snap = spatial_editor->get_rotate_snap();
 			}
-			angle = Math::rad2deg(angle) + snap * 0.5; //else it won't reach +180
+			angle = Math::rad_to_deg(angle) + snap * 0.5; //else it won't reach +180
 			angle -= Math::fmod(angle, snap);
 			set_message(vformat(TTR("Rotating %s degrees."), String::num(angle, snap_step_decimals)));
-			angle = Math::deg2rad(angle);
+			angle = Math::deg_to_rad(angle);
 
 			bool local_coords = (spatial_editor->are_local_coords_enabled() && _edit.plane != TRANSFORM_VIEW); // Disable local transformation for TRANSFORM_VIEW
 
@@ -5737,7 +5737,7 @@ void Node3DEditor::_xform_dialog_action() {
 
 	for (int i = 0; i < 3; i++) {
 		translate[i] = xform_translate[i]->get_text().to_float();
-		rotate[i] = Math::deg2rad(xform_rotate[i]->get_text().to_float());
+		rotate[i] = Math::deg_to_rad(xform_rotate[i]->get_text().to_float());
 		scale[i] = xform_scale[i]->get_text().to_float();
 	}
 
@@ -7623,10 +7623,10 @@ void Node3DEditor::_load_default_preview_settings() {
 	// On any not-tidally-locked planet, a sun would have an angular altitude
 	// of 60 degrees as the average of all points on the sphere at noon.
 	// The azimuth choice is arbitrary, but ideally shouldn't be on an axis.
-	sun_rotation = Vector2(-Math::deg2rad(60.0), Math::deg2rad(150.0));
+	sun_rotation = Vector2(-Math::deg_to_rad(60.0), Math::deg_to_rad(150.0));
 
-	sun_angle_altitude->set_value(-Math::rad2deg(sun_rotation.x));
-	sun_angle_azimuth->set_value(180.0 - Math::rad2deg(sun_rotation.y));
+	sun_angle_altitude->set_value(-Math::rad_to_deg(sun_rotation.x));
+	sun_angle_azimuth->set_value(180.0 - Math::rad_to_deg(sun_rotation.y));
 	sun_direction->update();
 	environ_sky_color->set_pick_color(Color(0.385, 0.454, 0.55));
 	environ_ground_color->set_pick_color(Color(0.2, 0.169, 0.133));
@@ -7669,8 +7669,8 @@ void Node3DEditor::_update_preview_environment() {
 		}
 	}
 
-	sun_angle_altitude->set_value(-Math::rad2deg(sun_rotation.x));
-	sun_angle_azimuth->set_value(180.0 - Math::rad2deg(sun_rotation.y));
+	sun_angle_altitude->set_value(-Math::rad_to_deg(sun_rotation.x));
+	sun_angle_azimuth->set_value(180.0 - Math::rad_to_deg(sun_rotation.y));
 
 	bool disable_env = world_env_count > 0 || environ_button->is_pressed();
 
@@ -7703,15 +7703,15 @@ void Node3DEditor::_sun_direction_input(const Ref<InputEvent> &p_event) {
 		sun_rotation.x += mm->get_relative().y * (0.02 * EDSCALE);
 		sun_rotation.y -= mm->get_relative().x * (0.02 * EDSCALE);
 		sun_rotation.x = CLAMP(sun_rotation.x, -Math_TAU / 4, Math_TAU / 4);
-		sun_angle_altitude->set_value(-Math::rad2deg(sun_rotation.x));
-		sun_angle_azimuth->set_value(180.0 - Math::rad2deg(sun_rotation.y));
+		sun_angle_altitude->set_value(-Math::rad_to_deg(sun_rotation.x));
+		sun_angle_azimuth->set_value(180.0 - Math::rad_to_deg(sun_rotation.y));
 		_preview_settings_changed();
 	}
 }
 
 void Node3DEditor::_sun_direction_angle_set() {
-	sun_rotation.x = Math::deg2rad(-sun_angle_altitude->get_value());
-	sun_rotation.y = Math::deg2rad(180.0 - sun_angle_azimuth->get_value());
+	sun_rotation.x = Math::deg_to_rad(-sun_angle_altitude->get_value());
+	sun_rotation.y = Math::deg_to_rad(180.0 - sun_angle_azimuth->get_value());
 	_preview_settings_changed();
 }
 

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -569,9 +569,23 @@ static const char *gdscript_function_renames[][2] = {
 	{ "to_utf8", "to_utf8_buffer" }, // String
 	{ "to_wchar", "to_utf32_buffer" }, // String // TODO - utf32 or utf16?
 
-	// Globals
+	// @GlobalScope
+	{ "bytes2var", "bytes_to_var" },
+	{ "bytes2var_with_objects", "bytes_to_var_with_objects" },
+	{ "db2linear", "db_to_linear" },
+	{ "deg2rad", "deg_to_rad" },
+	{ "linear2db", "linear_to_db" },
+	{ "rad2deg", "rad_to_deg" },
 	{ "rand_range", "randf_range" },
 	{ "stepify", "snapped" },
+	{ "str2var", "str_to_var" },
+	{ "var2str", "var_to_str" },
+	{ "var2bytes", "var_to_bytes" },
+	{ "var2bytes_with_objects", "var_to_bytes_with_objects" },
+
+	// @GDScript
+	{ "dict2inst", "dict_to_inst" },
+	{ "inst2dict", "inst_to_dict" },
 
 	{ nullptr, nullptr },
 };
@@ -958,9 +972,23 @@ static const char *csharp_function_renames[][2] = {
 	{ "ToUtf8", "ToUtf8Buffer" }, // String
 	{ "ToWchar", "ToUtf32Buffer" }, // String // TODO - utf32 or utf16?
 
-	// Globals
+	// @GlobalScope
+	{ "Bytes2Var", "BytesToVar" },
+	{ "Bytes2VarWithObjects", "BytesToVarWithObjects" },
+	{ "Db2Linear", "DbToLinear" },
+	{ "Deg2Rad", "DegToRad" },
+	{ "Linear2Db", "LinearToDb" },
+	{ "Rad2Deg", "RadToDeg" },
 	{ "RandRange", "RandfRange" },
 	{ "Stepify", "Snapped" },
+	{ "Str2Var", "StrToVar" },
+	{ "Var2Str", "VarToStr" },
+	{ "Var2Bytes", "VarToBytes" },
+	{ "Var2BytesWithObjects", "VarToBytesWithObjects" },
+
+	// @GDScript
+	{ "Dict2Inst", "DictToInst" },
+	{ "Inst2Dict", "InstToDict" },
 
 	{ nullptr, nullptr },
 };

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1838,7 +1838,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 			u_step *= curve_length / path_u_distance;
 		}
 		double v_step = 1.0 / shape_sides;
-		double spin_step = Math::deg2rad(spin_degrees / spin_sides);
+		double spin_step = Math::deg_to_rad(spin_degrees / spin_sides);
 		double extrusion_step = 1.0 / extrusions;
 		if (mode == MODE_PATH) {
 			if (path_joined) {
@@ -1902,7 +1902,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 			}
 		}
 
-		real_t angle_simplify_dot = Math::cos(Math::deg2rad(path_simplify_angle));
+		real_t angle_simplify_dot = Math::cos(Math::deg_to_rad(path_simplify_angle));
 		Vector3 previous_simplify_dir = Vector3(0, 0, 0);
 		int faces_combined = 0;
 

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -74,11 +74,11 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="dict2inst">
+		<method name="dict_to_inst">
 			<return type="Object" />
 			<param index="0" name="dictionary" type="Dictionary" />
 			<description>
-				Converts a dictionary (previously created with [method inst2dict]) back to an instance. Useful for deserializing.
+				Converts a [param dictionary] (previously created with [method inst_to_dict]) back to an Object instance. Useful for deserializing.
 			</description>
 		</method>
 		<method name="get_stack">
@@ -102,15 +102,15 @@
 				[b]Note:[/b] Not supported for calling from threads. Instead, this will return an empty array.
 			</description>
 		</method>
-		<method name="inst2dict">
+		<method name="inst_to_dict">
 			<return type="Dictionary" />
 			<param index="0" name="instance" type="Object" />
 			<description>
-				Returns the passed instance converted to a dictionary (useful for serializing).
+				Returns the passed [param instance] converted to a Dictionary (useful for serializing).
 				[codeblock]
 				var foo = "bar"
 				func _ready():
-				    var d = inst2dict(self)
+				    var d = inst_to_dict(self)
 				    print(d.keys())
 				    print(d.values())
 				[/codeblock]

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -262,7 +262,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		}
 	}
 
-	static inline void inst2dict(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void inst_to_dict(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 
 		if (p_args[0]->get_type() == Variant::NIL) {
@@ -329,7 +329,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		}
 	}
 
-	static inline void dict2inst(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void dict_to_inst(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 
 		if (p_args[0]->get_type() != Variant::DICTIONARY) {
@@ -653,8 +653,8 @@ void GDScriptUtilityFunctions::register_functions() {
 	REGISTER_VARARG_FUNC(str, true, Variant::STRING);
 	REGISTER_VARARG_FUNC(range, false, Variant::ARRAY);
 	REGISTER_CLASS_FUNC(load, false, "Resource", ARG("path", Variant::STRING));
-	REGISTER_FUNC(inst2dict, false, Variant::DICTIONARY, ARG("instance", Variant::OBJECT));
-	REGISTER_FUNC(dict2inst, false, Variant::OBJECT, ARG("dictionary", Variant::DICTIONARY));
+	REGISTER_FUNC(inst_to_dict, false, Variant::DICTIONARY, ARG("instance", Variant::OBJECT));
+	REGISTER_FUNC(dict_to_inst, false, Variant::OBJECT, ARG("dictionary", Variant::DICTIONARY));
 	REGISTER_FUNC_DEF(Color8, true, 255, Variant::COLOR, ARG("r8", Variant::INT), ARG("g8", Variant::INT), ARG("b8", Variant::INT), ARG("a8", Variant::INT));
 	REGISTER_VARARG_FUNC(print_debug, false, Variant::NIL);
 	REGISTER_FUNC_NO_ARGS(print_stack, false, Variant::NIL);

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5176,7 +5176,7 @@ Node3D *GLTFDocument::_generate_light(Ref<GLTFState> state, const GLTFNodeIndex 
 		SpotLight3D *light = memnew(SpotLight3D);
 		light->set_param(SpotLight3D::PARAM_ENERGY, intensity);
 		light->set_param(SpotLight3D::PARAM_RANGE, range);
-		light->set_param(SpotLight3D::PARAM_SPOT_ANGLE, Math::rad2deg(l->outer_cone_angle));
+		light->set_param(SpotLight3D::PARAM_SPOT_ANGLE, Math::rad_to_deg(l->outer_cone_angle));
 		light->set_color(l->color);
 
 		// Line of best fit derived from guessing, see https://www.desmos.com/calculator/biiflubp8b
@@ -5200,7 +5200,7 @@ Camera3D *GLTFDocument::_generate_camera(Ref<GLTFState> state, const GLTFNodeInd
 	Ref<GLTFCamera> c = state->cameras[gltf_node->camera];
 	camera->set_projection(c->get_perspective() ? Camera3D::PROJECTION_PERSPECTIVE : Camera3D::PROJECTION_ORTHOGONAL);
 	// GLTF spec (yfov) is in radians, Godot's camera (fov) is in degrees.
-	camera->set_fov(Math::rad2deg(c->get_fov()));
+	camera->set_fov(Math::rad_to_deg(c->get_fov()));
 	// GLTF spec (xmag and ymag) is a radius in meters, Godot's camera (size) is a diameter in meters.
 	camera->set_size(c->get_size_mag() * 2.0f);
 	camera->set_near(c->get_depth_near());
@@ -5215,7 +5215,7 @@ GLTFCameraIndex GLTFDocument::_convert_camera(Ref<GLTFState> state, Camera3D *p_
 	c.instantiate();
 	c->set_perspective(p_camera->get_projection() == Camera3D::ProjectionType::PROJECTION_PERSPECTIVE);
 	// GLTF spec (yfov) is in radians, Godot's camera (fov) is in degrees.
-	c->set_fov(Math::deg2rad(p_camera->get_fov()));
+	c->set_fov(Math::deg_to_rad(p_camera->get_fov()));
 	// GLTF spec (xmag and ymag) is a radius in meters, Godot's camera (size) is a diameter in meters.
 	c->set_size_mag(p_camera->get_size() * 0.5f);
 	c->set_depth_far(p_camera->get_far());
@@ -5246,7 +5246,7 @@ GLTFLightIndex GLTFDocument::_convert_light(Ref<GLTFState> state, Light3D *p_lig
 		SpotLight3D *light = cast_to<SpotLight3D>(p_light);
 		l->range = light->get_param(SpotLight3D::PARAM_RANGE);
 		l->intensity = light->get_param(SpotLight3D::PARAM_ENERGY);
-		l->outer_cone_angle = Math::deg2rad(light->get_param(SpotLight3D::PARAM_SPOT_ANGLE));
+		l->outer_cone_angle = Math::deg_to_rad(light->get_param(SpotLight3D::PARAM_SPOT_ANGLE));
 
 		// This equation is the inverse of the import equation (which has a desmos link).
 		float angle_ratio = 1 - (0.2 / (0.1 + light->get_param(SpotLight3D::PARAM_SPOT_ATTENUATION)));

--- a/modules/gltf/structures/gltf_camera.h
+++ b/modules/gltf/structures/gltf_camera.h
@@ -44,7 +44,7 @@ private:
 	// GLTF has no default camera values, they should always be specified in
 	// the GLTF file. Here we default to Godot's default camera settings.
 	bool perspective = true;
-	real_t fov = Math::deg2rad(75.0);
+	real_t fov = Math::deg_to_rad(75.0);
 	real_t size_mag = 0.5;
 	real_t depth_far = 4000.0;
 	real_t depth_near = 0.05;

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -62,7 +62,7 @@ void LightmapperRD::add_directional_light(bool p_static, const Vector3 &p_direct
 	l.color[2] = p_color.b;
 	l.energy = p_energy;
 	l.static_bake = p_static;
-	l.size = Math::tan(Math::deg2rad(p_angular_distance));
+	l.size = Math::tan(Math::deg_to_rad(p_angular_distance));
 	l.shadow_blur = p_shadow_blur;
 	lights.push_back(l);
 }
@@ -96,7 +96,7 @@ void LightmapperRD::add_spot_light(bool p_static, const Vector3 &p_position, con
 	l.direction[2] = p_direction.z;
 	l.range = p_range;
 	l.attenuation = p_attenuation;
-	l.cos_spot_angle = Math::cos(Math::deg2rad(p_spot_angle));
+	l.cos_spot_angle = Math::cos(Math::deg_to_rad(p_spot_angle));
 	l.inv_spot_attenuation = 1.0f / p_spot_attenuation;
 	l.color[0] = p_color.r;
 	l.color[1] = p_color.g;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -181,9 +181,9 @@ namespace Godot
                                 if (variantType == Variant.Type.Nil)
                                     return false;
 
-                                static byte[] Var2Bytes(in godot_variant var)
+                                static byte[] VarToBytes(in godot_variant var)
                                 {
-                                    NativeFuncs.godotsharp_var2bytes(var, false.ToGodotBool(), out var varBytes);
+                                    NativeFuncs.godotsharp_var_to_bytes(var, false.ToGodotBool(), out var varBytes);
                                     using (varBytes)
                                         return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
                                 }
@@ -192,7 +192,7 @@ namespace Godot
 
                                 var fieldValue = field.GetValue(target);
                                 using var fieldValueVariant = Marshaling.ConvertManagedObjectToVariant(fieldValue);
-                                byte[] valueBuffer = Var2Bytes(fieldValueVariant);
+                                byte[] valueBuffer = VarToBytes(fieldValueVariant);
                                 writer.Write(valueBuffer.Length);
                                 writer.Write(valueBuffer);
                             }
@@ -448,7 +448,7 @@ namespace Godot
 
                             FieldInfo? fieldInfo = targetType.GetField(name,
                                 BindingFlags.Instance | BindingFlags.Public);
-                            fieldInfo?.SetValue(recreatedTarget, GD.Bytes2Var(valueBuffer));
+                            fieldInfo?.SetValue(recreatedTarget, GD.BytesToVar(valueBuffer));
                         }
 
                         @delegate = Delegate.CreateDelegate(delegateType, recreatedTarget, methodInfo,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -21,10 +21,10 @@ namespace Godot
         /// <param name="bytes">Byte array that will be decoded to a <c>Variant</c>.</param>
         /// <param name="allowObjects">If objects should be decoded.</param>
         /// <returns>The decoded <c>Variant</c>.</returns>
-        public static Variant Bytes2Var(Span<byte> bytes, bool allowObjects = false)
+        public static Variant BytesToVar(Span<byte> bytes, bool allowObjects = false)
         {
             using var varBytes = Marshaling.ConvertSystemArrayToNativePackedByteArray(bytes);
-            NativeFuncs.godotsharp_bytes2var(varBytes, allowObjects.ToGodotBool(), out godot_variant ret);
+            NativeFuncs.godotsharp_bytes_to_var(varBytes, allowObjects.ToGodotBool(), out godot_variant ret);
             return Variant.CreateTakingOwnershipOfDisposableValue(ret);
         }
 
@@ -52,10 +52,10 @@ namespace Godot
         /// <summary>
         /// Converts from decibels to linear energy (audio).
         /// </summary>
-        /// <seealso cref="Linear2Db(real_t)"/>
+        /// <seealso cref="LinearToDb(real_t)"/>
         /// <param name="db">Decibels to convert.</param>
         /// <returns>Audio volume as linear energy.</returns>
-        public static real_t Db2Linear(real_t db)
+        public static real_t DbToLinear(real_t db)
         {
             return (real_t)Math.Exp(db * 0.11512925464970228420089957273422);
         }
@@ -115,18 +115,18 @@ namespace Godot
         /// Converts from linear energy to decibels (audio).
         /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
         /// </summary>
-        /// <seealso cref="Db2Linear(real_t)"/>
+        /// <seealso cref="DbToLinear(real_t)"/>
         /// <example>
         /// <code>
         /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
         /// // Its range must be configured to go from 0 to 1.
         /// // Change the bus name if you'd like to change the volume of a specific bus only.
-        /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.Linear2Db(slider.value));
+        /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.LinearToDb(slider.value));
         /// </code>
         /// </example>
         /// <param name="linear">The linear energy to convert.</param>
         /// <returns>Audio as decibels.</returns>
-        public static real_t Linear2Db(real_t linear)
+        public static real_t LinearToDb(real_t linear)
         {
             return (real_t)(Math.Log(linear) * 8.6858896380650365530225783783321);
         }
@@ -518,21 +518,21 @@ namespace Godot
         }
 
         /// <summary>
-        /// Converts a formatted string that was returned by <see cref="Var2Str(Variant)"/> to the original value.
+        /// Converts a formatted string that was returned by <see cref="VarToStr(Variant)"/> to the original value.
         /// </summary>
         /// <example>
         /// <code>
         /// string a = "{\"a\": 1, \"b\": 2 }";
-        /// var b = (Godot.Collections.Dictionary)GD.Str2Var(a);
+        /// var b = (Godot.Collections.Dictionary)GD.StrToVar(a);
         /// GD.Print(b["a"]); // Prints 1
         /// </code>
         /// </example>
         /// <param name="str">String that will be converted to Variant.</param>
         /// <returns>The decoded <c>Variant</c>.</returns>
-        public static Variant Str2Var(string str)
+        public static Variant StrToVar(string str)
         {
             using var godotStr = Marshaling.ConvertStringToNative(str);
-            NativeFuncs.godotsharp_str2var(godotStr, out godot_variant ret);
+            NativeFuncs.godotsharp_str_to_var(godotStr, out godot_variant ret);
             return Variant.CreateTakingOwnershipOfDisposableValue(ret);
         }
 
@@ -540,26 +540,26 @@ namespace Godot
         /// Encodes a <c>Variant</c> value to a byte array.
         /// If <paramref name="fullObjects"/> is <see langword="true"/> encoding objects is allowed
         /// (and can potentially include code).
-        /// Deserialization can be done with <see cref="Bytes2Var(Span{byte}, bool)"/>.
+        /// Deserialization can be done with <see cref="BytesToVar(Span{byte}, bool)"/>.
         /// </summary>
         /// <param name="var">Variant that will be encoded.</param>
         /// <param name="fullObjects">If objects should be serialized.</param>
         /// <returns>The <c>Variant</c> encoded as an array of bytes.</returns>
-        public static byte[] Var2Bytes(Variant var, bool fullObjects = false)
+        public static byte[] VarToBytes(Variant var, bool fullObjects = false)
         {
-            NativeFuncs.godotsharp_var2bytes((godot_variant)var.NativeVar, fullObjects.ToGodotBool(), out var varBytes);
+            NativeFuncs.godotsharp_var_to_bytes((godot_variant)var.NativeVar, fullObjects.ToGodotBool(), out var varBytes);
             using (varBytes)
                 return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
         }
 
         /// <summary>
         /// Converts a <c>Variant</c> <paramref name="var"/> to a formatted string that
-        /// can later be parsed using <see cref="Str2Var(string)"/>.
+        /// can later be parsed using <see cref="StrToVar(string)"/>.
         /// </summary>
         /// <example>
         /// <code>
         /// var a = new Godot.Collections.Dictionary { ["a"] = 1, ["b"] = 2 };
-        /// GD.Print(GD.Var2Str(a));
+        /// GD.Print(GD.VarToStr(a));
         /// // Prints
         /// // {
         /// //    "a": 1,
@@ -569,9 +569,9 @@ namespace Godot
         /// </example>
         /// <param name="var">Variant that will be converted to string.</param>
         /// <returns>The <c>Variant</c> encoded as a string.</returns>
-        public static string Var2Str(Variant var)
+        public static string VarToStr(Variant var)
         {
-            NativeFuncs.godotsharp_var2str((godot_variant)var.NativeVar, out godot_string ret);
+            NativeFuncs.godotsharp_var_to_str((godot_variant)var.NativeVar, out godot_string ret);
             using (ret)
                 return Marshaling.ConvertStringToManaged(ret);
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -35,9 +35,9 @@ namespace Godot
         public const real_t NaN = real_t.NaN;
 
         // 0.0174532924f and 0.0174532925199433
-        private const real_t _deg2RadConst = (real_t)0.0174532925199432957692369077M;
+        private const real_t _degToRadConst = (real_t)0.0174532925199432957692369077M;
         // 57.29578f and 57.2957795130823
-        private const real_t _rad2DegConst = (real_t)57.295779513082320876798154814M;
+        private const real_t _radToDegConst = (real_t)57.295779513082320876798154814M;
 
         /// <summary>
         /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
@@ -219,9 +219,9 @@ namespace Godot
         /// </summary>
         /// <param name="deg">An angle expressed in degrees.</param>
         /// <returns>The same angle expressed in radians.</returns>
-        public static real_t Deg2Rad(real_t deg)
+        public static real_t DegToRad(real_t deg)
         {
-            return deg * _deg2RadConst;
+            return deg * _degToRadConst;
         }
 
         /// <summary>
@@ -531,9 +531,9 @@ namespace Godot
         /// </summary>
         /// <param name="rad">An angle expressed in radians.</param>
         /// <returns>The same angle expressed in degrees.</returns>
-        public static real_t Rad2Deg(real_t rad)
+        public static real_t RadToDeg(real_t rad)
         {
-            return rad * _rad2DegConst;
+            return rad * _radToDegConst;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -461,7 +461,7 @@ namespace Godot.NativeInterop
 
         // GD, etc
 
-        internal static partial void godotsharp_bytes2var(in godot_packed_byte_array p_bytes,
+        internal static partial void godotsharp_bytes_to_var(in godot_packed_byte_array p_bytes,
             godot_bool p_allow_objects,
             out godot_variant r_ret);
 
@@ -504,12 +504,12 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_str(in godot_array p_what, out godot_string r_ret);
 
-        internal static partial void godotsharp_str2var(in godot_string p_str, out godot_variant r_ret);
+        internal static partial void godotsharp_str_to_var(in godot_string p_str, out godot_variant r_ret);
 
-        internal static partial void godotsharp_var2bytes(in godot_variant p_what, godot_bool p_full_objects,
+        internal static partial void godotsharp_var_to_bytes(in godot_variant p_what, godot_bool p_full_objects,
             out godot_packed_byte_array r_bytes);
 
-        internal static partial void godotsharp_var2str(in godot_variant p_var, out godot_string r_ret);
+        internal static partial void godotsharp_var_to_str(in godot_variant p_var, out godot_string r_ret);
 
         internal static partial void godotsharp_pusherror(in godot_string p_str);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -226,7 +226,7 @@ namespace Godot
             {
                 fovyDegrees = GetFovy(fovyDegrees, (real_t)1.0 / aspect);
             }
-            real_t radians = Mathf.Deg2Rad(fovyDegrees / (real_t)2.0);
+            real_t radians = Mathf.DegToRad(fovyDegrees / (real_t)2.0);
             real_t deltaZ = zFar - zNear;
             real_t sine = Mathf.Sin(radians);
 
@@ -256,7 +256,7 @@ namespace Godot
                 fovyDegrees = GetFovy(fovyDegrees, (real_t)1.0 / aspect);
             }
 
-            real_t ymax = zNear * Mathf.Tan(Mathf.Deg2Rad(fovyDegrees / (real_t)2.0));
+            real_t ymax = zNear * Mathf.Tan(Mathf.DegToRad(fovyDegrees / (real_t)2.0));
             real_t xmax = ymax * aspect;
             real_t frustumshift = (intraocularDist / (real_t)2.0) * zNear / convergenceDist;
             real_t left;
@@ -313,18 +313,18 @@ namespace Godot
             Plane rightPlane = new Plane(x.w - x.x, y.w - y.x, z.w - z.x, -w.w + w.x).Normalized();
             if (z.x == 0 && z.y == 0)
             {
-                return Mathf.Rad2Deg(Mathf.Acos(Mathf.Abs(rightPlane.Normal.x))) * (real_t)2.0;
+                return Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(rightPlane.Normal.x))) * (real_t)2.0;
             }
             else
             {
                 Plane leftPlane = new Plane(x.w + x.x, y.w + y.x, z.w + z.x, w.w + w.x).Normalized();
-                return Mathf.Rad2Deg(Mathf.Acos(Mathf.Abs(leftPlane.Normal.x))) + Mathf.Rad2Deg(Mathf.Acos(Mathf.Abs(rightPlane.Normal.x)));
+                return Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(leftPlane.Normal.x))) + Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(rightPlane.Normal.x)));
             }
         }
 
         public static real_t GetFovy(real_t fovx, real_t aspect)
         {
-            return Mathf.Rad2Deg(Mathf.Atan(aspect * Mathf.Tan(Mathf.Deg2Rad(fovx) * (real_t)0.5)) * (real_t)2.0);
+            return Mathf.RadToDeg(Mathf.Atan(aspect * Mathf.Tan(Mathf.DegToRad(fovx) * (real_t)0.5)) * (real_t)2.0);
         }
 
         public real_t GetLodMultiplier()

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1233,13 +1233,13 @@ void godotsharp_pushwarning(const godot_string *p_str) {
 	WARN_PRINT(*reinterpret_cast<const String *>(p_str));
 }
 
-void godotsharp_var2str(const godot_variant *p_var, godot_string *r_ret) {
+void godotsharp_var_to_str(const godot_variant *p_var, godot_string *r_ret) {
 	const Variant &var = *reinterpret_cast<const Variant *>(p_var);
 	String &vars = *memnew_placement(r_ret, String);
 	VariantWriter::write_to_string(var, vars);
 }
 
-void godotsharp_str2var(const godot_string *p_str, godot_variant *r_ret) {
+void godotsharp_str_to_var(const godot_string *p_str, godot_variant *r_ret) {
 	Variant ret;
 
 	VariantParser::StreamString ss;
@@ -1256,7 +1256,7 @@ void godotsharp_str2var(const godot_string *p_str, godot_variant *r_ret) {
 	memnew_placement(r_ret, Variant(ret));
 }
 
-void godotsharp_var2bytes(const godot_variant *p_var, bool p_full_objects, godot_packed_array *r_bytes) {
+void godotsharp_var_to_bytes(const godot_variant *p_var, bool p_full_objects, godot_packed_array *r_bytes) {
 	const Variant &var = *reinterpret_cast<const Variant *>(p_var);
 	PackedByteArray &bytes = *memnew_placement(r_bytes, PackedByteArray);
 
@@ -1268,7 +1268,7 @@ void godotsharp_var2bytes(const godot_variant *p_var, bool p_full_objects, godot
 	encode_variant(var, bytes.ptrw(), len, p_full_objects);
 }
 
-void godotsharp_bytes2var(const godot_packed_array *p_bytes, bool p_allow_objects, godot_variant *r_ret) {
+void godotsharp_bytes_to_var(const godot_packed_array *p_bytes, bool p_allow_objects, godot_variant *r_ret) {
 	const PackedByteArray *bytes = reinterpret_cast<const PackedByteArray *>(p_bytes);
 	Variant ret;
 	Error err = decode_variant(ret, bytes->ptr(), bytes->size(), nullptr, p_allow_objects);
@@ -1479,7 +1479,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_node_path_get_subname,
 	(void *)godotsharp_node_path_get_subname_count,
 	(void *)godotsharp_node_path_is_absolute,
-	(void *)godotsharp_bytes2var,
+	(void *)godotsharp_bytes_to_var,
 	(void *)godotsharp_convert,
 	(void *)godotsharp_hash,
 	(void *)godotsharp_instance_from_id,
@@ -1499,9 +1499,9 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_seed,
 	(void *)godotsharp_weakref,
 	(void *)godotsharp_str,
-	(void *)godotsharp_str2var,
-	(void *)godotsharp_var2bytes,
-	(void *)godotsharp_var2str,
+	(void *)godotsharp_str_to_var,
+	(void *)godotsharp_var_to_bytes,
+	(void *)godotsharp_var_to_str,
 	(void *)godotsharp_pusherror,
 	(void *)godotsharp_pushwarning,
 	(void *)godotsharp_object_to_string,

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -185,7 +185,7 @@ void AudioStreamPlayer2D::_update_panning() {
 		}
 
 		float multiplier = Math::pow(1.0f - dist / max_distance, attenuation);
-		multiplier *= Math::db2linear(volume_db); //also apply player volume!
+		multiplier *= Math::db_to_linear(volume_db); //also apply player volume!
 
 		float pan = relative_to_listener.x / screen_size.x;
 		// Don't let the panning effect extend (too far) beyond the screen.

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -745,12 +745,12 @@ void CPUParticles2D::_particles_process(double p_delta) {
 				p.start_color_rand = Color(1, 1, 1, 1);
 			}
 
-			real_t angle1_rad = direction.angle() + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
+			real_t angle1_rad = direction.angle() + Math::deg_to_rad((Math::randf() * 2.0 - 1.0) * spread);
 			Vector2 rot = Vector2(Math::cos(angle1_rad), Math::sin(angle1_rad));
 			p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], (real_t)Math::randf());
 
 			real_t base_angle = tex_angle * Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);
-			p.rotation = Math::deg2rad(base_angle);
+			p.rotation = Math::deg_to_rad(base_angle);
 
 			p.custom[0] = 0.0; // unused
 			p.custom[1] = 0.0; // phase [0..1]
@@ -912,7 +912,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			}
 			real_t base_angle = (tex_angle)*Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);
 			base_angle += p.custom[1] * lifetime * tex_angular_velocity * Math::lerp(parameters_min[PARAM_ANGULAR_VELOCITY], parameters_max[PARAM_ANGULAR_VELOCITY], rand_from_seed(alt_seed));
-			p.rotation = Math::deg2rad(base_angle); //angle
+			p.rotation = Math::deg_to_rad(base_angle); //angle
 			p.custom[2] = tex_anim_offset * Math::lerp(parameters_min[PARAM_ANIM_OFFSET], parameters_max[PARAM_ANIM_OFFSET], p.anim_offset_rand) + tv * tex_anim_speed * Math::lerp(parameters_min[PARAM_ANIM_SPEED], parameters_max[PARAM_ANIM_SPEED], rand_from_seed(alt_seed));
 		}
 		//apply color

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -373,9 +373,9 @@ private:
 	bool slide_on_ceiling = true;
 	int max_slides = 4;
 	int platform_layer = 0;
-	real_t floor_max_angle = Math::deg2rad((real_t)45.0);
+	real_t floor_max_angle = Math::deg_to_rad((real_t)45.0);
 	real_t floor_snap_length = 1;
-	real_t wall_min_slide_angle = Math::deg2rad((real_t)15.0);
+	real_t wall_min_slide_angle = Math::deg_to_rad((real_t)15.0);
 	Vector2 up_direction = Vector2(0.0, -1.0);
 	uint32_t platform_floor_layers = UINT32_MAX;
 	uint32_t platform_wall_layers = 0;

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -44,7 +44,7 @@ bool Bone2D::_set(const StringName &p_path, const Variant &p_value) {
 	} else if (path.begins_with("length")) {
 		set_length(p_value);
 	} else if (path.begins_with("bone_angle")) {
-		set_bone_angle(Math::deg2rad(real_t(p_value)));
+		set_bone_angle(Math::deg_to_rad(real_t(p_value)));
 	} else if (path.begins_with("default_length")) {
 		set_length(p_value);
 	}
@@ -66,7 +66,7 @@ bool Bone2D::_get(const StringName &p_path, Variant &r_ret) const {
 	} else if (path.begins_with("length")) {
 		r_ret = get_length();
 	} else if (path.begins_with("bone_angle")) {
-		r_ret = Math::rad2deg(get_bone_angle());
+		r_ret = Math::rad_to_deg(get_bone_angle());
 	} else if (path.begins_with("default_length")) {
 		r_ret = get_length();
 	}

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -149,7 +149,7 @@ void AudioStreamPlayer3D::_calc_reverb_vol(Area3D *area, Vector3 listener_area_p
 
 	if (uniformity > 0.0) {
 		float distance = listener_area_pos.length();
-		float attenuation = Math::db2linear(_get_attenuation_db(distance));
+		float attenuation = Math::db_to_linear(_get_attenuation_db(distance));
 
 		// Determine the fraction of sound that would come from each speaker if they were all driven uniformly.
 		float center_val[3] = { 0.5f, 0.25f, 0.16666f };
@@ -213,12 +213,12 @@ float AudioStreamPlayer3D::_get_attenuation_db(float p_distance) const {
 	float att = 0;
 	switch (attenuation_model) {
 		case ATTENUATION_INVERSE_DISTANCE: {
-			att = Math::linear2db(1.0 / ((p_distance / unit_size) + CMP_EPSILON));
+			att = Math::linear_to_db(1.0 / ((p_distance / unit_size) + CMP_EPSILON));
 		} break;
 		case ATTENUATION_INVERSE_SQUARE_DISTANCE: {
 			float d = (p_distance / unit_size);
 			d *= d;
-			att = Math::linear2db(1.0 / (d + CMP_EPSILON));
+			att = Math::linear_to_db(1.0 / (d + CMP_EPSILON));
 		} break;
 		case ATTENUATION_LOGARITHMIC: {
 			att = -20 * Math::log(p_distance / unit_size + CMP_EPSILON);
@@ -443,7 +443,7 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 			}
 		}
 
-		float multiplier = Math::db2linear(_get_attenuation_db(dist));
+		float multiplier = Math::db_to_linear(_get_attenuation_db(dist));
 		if (max_distance > 0) {
 			multiplier *= MAX(0, 1.0 - (dist / max_distance));
 		}
@@ -453,13 +453,13 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 		if (emission_angle_enabled) {
 			Vector3 listenertopos = global_pos - listener_node->get_global_transform().origin;
 			float c = listenertopos.normalized().dot(get_global_transform().basis.get_column(2).normalized()); //it's z negative
-			float angle = Math::rad2deg(Math::acos(c));
+			float angle = Math::rad_to_deg(Math::acos(c));
 			if (angle > emission_angle) {
 				db_att -= -emission_angle_filter_attenuation_db;
 			}
 		}
 
-		linear_attenuation = Math::db2linear(db_att);
+		linear_attenuation = Math::db_to_linear(db_att);
 		for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 			AudioServer::get_singleton()->set_playback_highshelf_params(playback, linear_attenuation, attenuation_filter_cutoff_hz);
 		}

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -766,13 +766,13 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			}
 
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-				real_t angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
+				real_t angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg_to_rad((Math::randf() * 2.0 - 1.0) * spread);
 				Vector3 rot = Vector3(Math::cos(angle1_rad), Math::sin(angle1_rad), 0.0);
 				p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], (real_t)Math::randf());
 			} else {
 				//initiate velocity spread in 3D
-				real_t angle1_rad = Math::deg2rad((Math::randf() * (real_t)2.0 - (real_t)1.0) * spread);
-				real_t angle2_rad = Math::deg2rad((Math::randf() * (real_t)2.0 - (real_t)1.0) * ((real_t)1.0 - flatness) * spread);
+				real_t angle1_rad = Math::deg_to_rad((Math::randf() * (real_t)2.0 - (real_t)1.0) * spread);
+				real_t angle2_rad = Math::deg_to_rad((Math::randf() * (real_t)2.0 - (real_t)1.0) * ((real_t)1.0 - flatness) * spread);
 
 				Vector3 direction_xz = Vector3(Math::sin(angle1_rad), 0, Math::cos(angle1_rad));
 				Vector3 direction_yz = Vector3(0, Math::sin(angle2_rad), Math::cos(angle2_rad));
@@ -796,7 +796,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			}
 
 			real_t base_angle = tex_angle * Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);
-			p.custom[0] = Math::deg2rad(base_angle); //angle
+			p.custom[0] = Math::deg_to_rad(base_angle); //angle
 			p.custom[1] = 0.0; //phase
 			p.custom[2] = tex_anim_offset * Math::lerp(parameters_min[PARAM_ANIM_OFFSET], parameters_max[PARAM_ANIM_OFFSET], p.anim_offset_rand); //animation offset (0-1)
 			p.transform = Transform3D();
@@ -1007,7 +1007,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			}
 			real_t base_angle = (tex_angle)*Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);
 			base_angle += p.custom[1] * lifetime * tex_angular_velocity * Math::lerp(parameters_min[PARAM_ANGULAR_VELOCITY], parameters_max[PARAM_ANGULAR_VELOCITY], rand_from_seed(alt_seed));
-			p.custom[0] = Math::deg2rad(base_angle); //angle
+			p.custom[0] = Math::deg_to_rad(base_angle); //angle
 			p.custom[2] = tex_anim_offset * Math::lerp(parameters_min[PARAM_ANIM_OFFSET], parameters_max[PARAM_ANIM_OFFSET], p.anim_offset_rand) + tv * tex_anim_speed * Math::lerp(parameters_min[PARAM_ANIM_SPEED], parameters_max[PARAM_ANIM_SPEED], rand_from_seed(alt_seed)); //angle
 		}
 		//apply color

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -149,7 +149,7 @@ AABB Light3D::get_aabb() const {
 
 	} else if (type == RenderingServer::LIGHT_SPOT) {
 		real_t len = param[PARAM_RANGE];
-		real_t size = Math::tan(Math::deg2rad(param[PARAM_SPOT_ANGLE])) * len;
+		real_t size = Math::tan(Math::deg_to_rad(param[PARAM_SPOT_ANGLE])) * len;
 		return AABB(Vector3(-size, -size, -len), Vector3(size * 2, size * 2, len));
 	}
 

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -2284,13 +2284,13 @@ bool PhysicalBone3D::ConeJointData::_set(const StringName &p_name, const Variant
 	}
 
 	if ("joint_constraints/swing_span" == p_name) {
-		swing_span = Math::deg2rad(real_t(p_value));
+		swing_span = Math::deg_to_rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->cone_twist_joint_set_param(j, PhysicsServer3D::CONE_TWIST_JOINT_SWING_SPAN, swing_span);
 		}
 
 	} else if ("joint_constraints/twist_span" == p_name) {
-		twist_span = Math::deg2rad(real_t(p_value));
+		twist_span = Math::deg_to_rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->cone_twist_joint_set_param(j, PhysicsServer3D::CONE_TWIST_JOINT_TWIST_SPAN, twist_span);
 		}
@@ -2326,9 +2326,9 @@ bool PhysicalBone3D::ConeJointData::_get(const StringName &p_name, Variant &r_re
 	}
 
 	if ("joint_constraints/swing_span" == p_name) {
-		r_ret = Math::rad2deg(swing_span);
+		r_ret = Math::rad_to_deg(swing_span);
 	} else if ("joint_constraints/twist_span" == p_name) {
-		r_ret = Math::rad2deg(twist_span);
+		r_ret = Math::rad_to_deg(twist_span);
 	} else if ("joint_constraints/bias" == p_name) {
 		r_ret = bias;
 	} else if ("joint_constraints/softness" == p_name) {
@@ -2364,13 +2364,13 @@ bool PhysicalBone3D::HingeJointData::_set(const StringName &p_name, const Varian
 		}
 
 	} else if ("joint_constraints/angular_limit_upper" == p_name) {
-		angular_limit_upper = Math::deg2rad(real_t(p_value));
+		angular_limit_upper = Math::deg_to_rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->hinge_joint_set_param(j, PhysicsServer3D::HINGE_JOINT_LIMIT_UPPER, angular_limit_upper);
 		}
 
 	} else if ("joint_constraints/angular_limit_lower" == p_name) {
-		angular_limit_lower = Math::deg2rad(real_t(p_value));
+		angular_limit_lower = Math::deg_to_rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->hinge_joint_set_param(j, PhysicsServer3D::HINGE_JOINT_LIMIT_LOWER, angular_limit_lower);
 		}
@@ -2408,9 +2408,9 @@ bool PhysicalBone3D::HingeJointData::_get(const StringName &p_name, Variant &r_r
 	if ("joint_constraints/angular_limit_enabled" == p_name) {
 		r_ret = angular_limit_enabled;
 	} else if ("joint_constraints/angular_limit_upper" == p_name) {
-		r_ret = Math::rad2deg(angular_limit_upper);
+		r_ret = Math::rad_to_deg(angular_limit_upper);
 	} else if ("joint_constraints/angular_limit_lower" == p_name) {
-		r_ret = Math::rad2deg(angular_limit_lower);
+		r_ret = Math::rad_to_deg(angular_limit_lower);
 	} else if ("joint_constraints/angular_limit_bias" == p_name) {
 		r_ret = angular_limit_bias;
 	} else if ("joint_constraints/angular_limit_softness" == p_name) {
@@ -2471,13 +2471,13 @@ bool PhysicalBone3D::SliderJointData::_set(const StringName &p_name, const Varia
 		}
 
 	} else if ("joint_constraints/angular_limit_upper" == p_name) {
-		angular_limit_upper = Math::deg2rad(real_t(p_value));
+		angular_limit_upper = Math::deg_to_rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_UPPER, angular_limit_upper);
 		}
 
 	} else if ("joint_constraints/angular_limit_lower" == p_name) {
-		angular_limit_lower = Math::deg2rad(real_t(p_value));
+		angular_limit_lower = Math::deg_to_rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->slider_joint_set_param(j, PhysicsServer3D::SLIDER_JOINT_ANGULAR_LIMIT_LOWER, angular_limit_lower);
 		}
@@ -2523,9 +2523,9 @@ bool PhysicalBone3D::SliderJointData::_get(const StringName &p_name, Variant &r_
 	} else if ("joint_constraints/linear_limit_damping" == p_name) {
 		r_ret = linear_limit_damping;
 	} else if ("joint_constraints/angular_limit_upper" == p_name) {
-		r_ret = Math::rad2deg(angular_limit_upper);
+		r_ret = Math::rad_to_deg(angular_limit_upper);
 	} else if ("joint_constraints/angular_limit_lower" == p_name) {
-		r_ret = Math::rad2deg(angular_limit_lower);
+		r_ret = Math::rad_to_deg(angular_limit_lower);
 	} else if ("joint_constraints/angular_limit_softness" == p_name) {
 		r_ret = angular_limit_softness;
 	} else if ("joint_constraints/angular_limit_restitution" == p_name) {
@@ -2649,13 +2649,13 @@ bool PhysicalBone3D::SixDOFJointData::_set(const StringName &p_name, const Varia
 		}
 
 	} else if ("angular_limit_upper" == var_name) {
-		axis_data[axis].angular_limit_upper = Math::deg2rad(real_t(p_value));
+		axis_data[axis].angular_limit_upper = Math::deg_to_rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(j, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_UPPER_LIMIT, axis_data[axis].angular_limit_upper);
 		}
 
 	} else if ("angular_limit_lower" == var_name) {
-		axis_data[axis].angular_limit_lower = Math::deg2rad(real_t(p_value));
+		axis_data[axis].angular_limit_lower = Math::deg_to_rad(real_t(p_value));
 		if (j.is_valid()) {
 			PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(j, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_LOWER_LIMIT, axis_data[axis].angular_limit_lower);
 		}
@@ -2765,9 +2765,9 @@ bool PhysicalBone3D::SixDOFJointData::_get(const StringName &p_name, Variant &r_
 	} else if ("angular_limit_enabled" == var_name) {
 		r_ret = axis_data[axis].angular_limit_enabled;
 	} else if ("angular_limit_upper" == var_name) {
-		r_ret = Math::rad2deg(axis_data[axis].angular_limit_upper);
+		r_ret = Math::rad_to_deg(axis_data[axis].angular_limit_upper);
 	} else if ("angular_limit_lower" == var_name) {
-		r_ret = Math::rad2deg(axis_data[axis].angular_limit_lower);
+		r_ret = Math::rad_to_deg(axis_data[axis].angular_limit_lower);
 	} else if ("angular_limit_softness" == var_name) {
 		r_ret = axis_data[axis].angular_limit_softness;
 	} else if ("angular_restitution" == var_name) {

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -414,8 +414,8 @@ private:
 	uint32_t platform_floor_layers = UINT32_MAX;
 	uint32_t platform_wall_layers = 0;
 	real_t floor_snap_length = 0.1;
-	real_t floor_max_angle = Math::deg2rad((real_t)45.0);
-	real_t wall_min_slide_angle = Math::deg2rad((real_t)15.0);
+	real_t floor_max_angle = Math::deg_to_rad((real_t)45.0);
+	real_t wall_min_slide_angle = Math::deg_to_rad((real_t)15.0);
 	Vector3 up_direction = Vector3(0.0, 1.0, 0.0);
 	Vector3 velocity;
 	Vector3 floor_normal;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1151,7 +1151,7 @@ void AnimationPlayer::_animation_update_transforms() {
 				}
 #endif
 
-				static_cast<Node2D *>(pa->object)->set_rotation(Math::deg2rad((double)pa->value_accum));
+				static_cast<Node2D *>(pa->object)->set_rotation(Math::deg_to_rad((double)pa->value_accum));
 			} break;
 			case SP_NODE2D_SCALE: {
 #ifdef DEBUG_ENABLED

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1528,7 +1528,7 @@ void AnimationTree::_process_graph(double p_delta) {
 							}
 						}
 
-						real_t db = Math::linear2db(MAX(blend, 0.00001));
+						real_t db = Math::linear_to_db(MAX(blend, 0.00001));
 						if (t->object->has_method(SNAME("set_unit_db"))) {
 							t->object->call(SNAME("set_unit_db"), db);
 						} else {

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -256,7 +256,7 @@ Vector<AudioFrame> AudioStreamPlayer::_get_volume_vector() {
 		channel_volume_db = AudioFrame(0, 0);
 	}
 
-	float volume_linear = Math::db2linear(volume_db);
+	float volume_linear = Math::db_to_linear(volume_db);
 
 	// Set the volume vector up according to the speaker mode and mix target.
 	// TODO do we need to scale the volume down when we output to more channels?

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -362,7 +362,7 @@ void VideoStreamPlayer::set_volume_db(float p_db) {
 	if (p_db < -79) {
 		set_volume(0);
 	} else {
-		set_volume(Math::db2linear(p_db));
+		set_volume(Math::db_to_linear(p_db));
 	}
 }
 
@@ -370,7 +370,7 @@ float VideoStreamPlayer::get_volume_db() const {
 	if (volume == 0) {
 		return -80;
 	} else {
-		return Math::linear2db(volume);
+		return Math::linear_to_db(volume);
 	}
 }
 

--- a/scene/resources/capsule_shape_3d.cpp
+++ b/scene/resources/capsule_shape_3d.cpp
@@ -40,8 +40,8 @@ Vector<Vector3> CapsuleShape3D::get_debug_mesh_lines() const {
 
 	Vector3 d(0, height * 0.5 - radius, 0);
 	for (int i = 0; i < 360; i++) {
-		float ra = Math::deg2rad((float)i);
-		float rb = Math::deg2rad((float)i + 1);
+		float ra = Math::deg_to_rad((float)i);
+		float rb = Math::deg_to_rad((float)i + 1);
 		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * radius;
 		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * radius;
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -763,7 +763,7 @@ void Curve2D::_bake_segment2d(RBMap<real_t, Vector2> &r_bake, real_t p_begin, re
 	Vector2 nb = (end - mid).normalized();
 	real_t dp = na.dot(nb);
 
-	if (dp < Math::cos(Math::deg2rad(p_tol))) {
+	if (dp < Math::cos(Math::deg_to_rad(p_tol))) {
 		r_bake[mp] = mid;
 	}
 
@@ -1352,7 +1352,7 @@ void Curve3D::_bake_segment3d(RBMap<real_t, Vector3> &r_bake, real_t p_begin, re
 	Vector3 nb = (end - mid).normalized();
 	real_t dp = na.dot(nb);
 
-	if (dp < Math::cos(Math::deg2rad(p_tol))) {
+	if (dp < Math::cos(Math::deg_to_rad(p_tol))) {
 		r_bake[mp] = mid;
 	}
 	if (p_depth < p_max_depth) {

--- a/scene/resources/cylinder_shape_3d.cpp
+++ b/scene/resources/cylinder_shape_3d.cpp
@@ -40,8 +40,8 @@ Vector<Vector3> CylinderShape3D::get_debug_mesh_lines() const {
 
 	Vector3 d(0, height * 0.5, 0);
 	for (int i = 0; i < 360; i++) {
-		float ra = Math::deg2rad((float)i);
-		float rb = Math::deg2rad((float)i + 1);
+		float ra = Math::deg_to_rad((float)i);
+		float rb = Math::deg_to_rad((float)i + 1);
 		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * radius;
 		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * radius;
 

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -301,9 +301,9 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 			}
 		}
 
-		float normal_merge_threshold = Math::cos(Math::deg2rad(p_normal_merge_angle));
-		float normal_pre_split_threshold = Math::cos(Math::deg2rad(MIN(180.0f, p_normal_split_angle * 2.0f)));
-		float normal_split_threshold = Math::cos(Math::deg2rad(p_normal_split_angle));
+		float normal_merge_threshold = Math::cos(Math::deg_to_rad(p_normal_merge_angle));
+		float normal_pre_split_threshold = Math::cos(Math::deg_to_rad(MIN(180.0f, p_normal_split_angle * 2.0f)));
+		float normal_split_threshold = Math::cos(Math::deg_to_rad(p_normal_split_angle));
 		const Vector3 *normals_ptr = normals.ptr();
 
 		HashMap<Vector3, LocalVector<Pair<int, int>>> unique_vertices;

--- a/scene/resources/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/skeleton_modification_2d_ccdik.cpp
@@ -52,9 +52,9 @@ bool SkeletonModification2DCCDIK::_set(const StringName &p_path, const Variant &
 		} else if (what == "enable_constraint") {
 			set_ccdik_joint_enable_constraint(which, p_value);
 		} else if (what == "constraint_angle_min") {
-			set_ccdik_joint_constraint_angle_min(which, Math::deg2rad(float(p_value)));
+			set_ccdik_joint_constraint_angle_min(which, Math::deg_to_rad(float(p_value)));
 		} else if (what == "constraint_angle_max") {
-			set_ccdik_joint_constraint_angle_max(which, Math::deg2rad(float(p_value)));
+			set_ccdik_joint_constraint_angle_max(which, Math::deg_to_rad(float(p_value)));
 		} else if (what == "constraint_angle_invert") {
 			set_ccdik_joint_constraint_angle_invert(which, p_value);
 		} else if (what == "constraint_in_localspace") {
@@ -96,9 +96,9 @@ bool SkeletonModification2DCCDIK::_get(const StringName &p_path, Variant &r_ret)
 		} else if (what == "enable_constraint") {
 			r_ret = get_ccdik_joint_enable_constraint(which);
 		} else if (what == "constraint_angle_min") {
-			r_ret = Math::rad2deg(get_ccdik_joint_constraint_angle_min(which));
+			r_ret = Math::rad_to_deg(get_ccdik_joint_constraint_angle_min(which));
 		} else if (what == "constraint_angle_max") {
-			r_ret = Math::rad2deg(get_ccdik_joint_constraint_angle_max(which));
+			r_ret = Math::rad_to_deg(get_ccdik_joint_constraint_angle_max(which));
 		} else if (what == "constraint_angle_invert") {
 			r_ret = get_ccdik_joint_constraint_angle_invert(which);
 		} else if (what == "constraint_in_localspace") {

--- a/scene/resources/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/skeleton_modification_2d_lookat.cpp
@@ -41,15 +41,15 @@ bool SkeletonModification2DLookAt::_set(const StringName &p_path, const Variant 
 	if (path.begins_with("enable_constraint")) {
 		set_enable_constraint(p_value);
 	} else if (path.begins_with("constraint_angle_min")) {
-		set_constraint_angle_min(Math::deg2rad(float(p_value)));
+		set_constraint_angle_min(Math::deg_to_rad(float(p_value)));
 	} else if (path.begins_with("constraint_angle_max")) {
-		set_constraint_angle_max(Math::deg2rad(float(p_value)));
+		set_constraint_angle_max(Math::deg_to_rad(float(p_value)));
 	} else if (path.begins_with("constraint_angle_invert")) {
 		set_constraint_angle_invert(p_value);
 	} else if (path.begins_with("constraint_in_localspace")) {
 		set_constraint_in_localspace(p_value);
 	} else if (path.begins_with("additional_rotation")) {
-		set_additional_rotation(Math::deg2rad(float(p_value)));
+		set_additional_rotation(Math::deg_to_rad(float(p_value)));
 	}
 
 #ifdef TOOLS_ENABLED
@@ -67,15 +67,15 @@ bool SkeletonModification2DLookAt::_get(const StringName &p_path, Variant &r_ret
 	if (path.begins_with("enable_constraint")) {
 		r_ret = get_enable_constraint();
 	} else if (path.begins_with("constraint_angle_min")) {
-		r_ret = Math::rad2deg(get_constraint_angle_min());
+		r_ret = Math::rad_to_deg(get_constraint_angle_min());
 	} else if (path.begins_with("constraint_angle_max")) {
-		r_ret = Math::rad2deg(get_constraint_angle_max());
+		r_ret = Math::rad_to_deg(get_constraint_angle_max());
 	} else if (path.begins_with("constraint_angle_invert")) {
 		r_ret = get_constraint_angle_invert();
 	} else if (path.begins_with("constraint_in_localspace")) {
 		r_ret = get_constraint_in_localspace();
 	} else if (path.begins_with("additional_rotation")) {
-		r_ret = Math::rad2deg(get_additional_rotation());
+		r_ret = Math::rad_to_deg(get_additional_rotation());
 	}
 
 #ifdef TOOLS_ENABLED

--- a/scene/resources/skeleton_modification_3d_ccdik.cpp
+++ b/scene/resources/skeleton_modification_3d_ccdik.cpp
@@ -50,9 +50,9 @@ bool SkeletonModification3DCCDIK::_set(const StringName &p_path, const Variant &
 		} else if (what == "enable_joint_constraint") {
 			set_ccdik_joint_enable_constraint(which, p_value);
 		} else if (what == "joint_constraint_angle_min") {
-			set_ccdik_joint_constraint_angle_min(which, Math::deg2rad(real_t(p_value)));
+			set_ccdik_joint_constraint_angle_min(which, Math::deg_to_rad(real_t(p_value)));
 		} else if (what == "joint_constraint_angle_max") {
-			set_ccdik_joint_constraint_angle_max(which, Math::deg2rad(real_t(p_value)));
+			set_ccdik_joint_constraint_angle_max(which, Math::deg_to_rad(real_t(p_value)));
 		} else if (what == "joint_constraint_angles_invert") {
 			set_ccdik_joint_constraint_invert(which, p_value);
 		}
@@ -79,9 +79,9 @@ bool SkeletonModification3DCCDIK::_get(const StringName &p_path, Variant &r_ret)
 		} else if (what == "enable_joint_constraint") {
 			r_ret = get_ccdik_joint_enable_constraint(which);
 		} else if (what == "joint_constraint_angle_min") {
-			r_ret = Math::rad2deg(get_ccdik_joint_constraint_angle_min(which));
+			r_ret = Math::rad_to_deg(get_ccdik_joint_constraint_angle_min(which));
 		} else if (what == "joint_constraint_angle_max") {
-			r_ret = Math::rad2deg(get_ccdik_joint_constraint_angle_max(which));
+			r_ret = Math::rad_to_deg(get_ccdik_joint_constraint_angle_max(which));
 		} else if (what == "joint_constraint_angles_invert") {
 			r_ret = get_ccdik_joint_constraint_invert(which);
 		}

--- a/scene/resources/skeleton_modification_3d_fabrik.cpp
+++ b/scene/resources/skeleton_modification_3d_fabrik.cpp
@@ -58,7 +58,7 @@ bool SkeletonModification3DFABRIK::_set(const StringName &p_path, const Variant 
 		} else if (what == "use_target_basis") {
 			set_fabrik_joint_use_target_basis(which, p_value);
 		} else if (what == "roll") {
-			set_fabrik_joint_roll(which, Math::deg2rad(real_t(p_value)));
+			set_fabrik_joint_roll(which, Math::deg_to_rad(real_t(p_value)));
 		}
 		return true;
 	}
@@ -91,7 +91,7 @@ bool SkeletonModification3DFABRIK::_get(const StringName &p_path, Variant &r_ret
 		} else if (what == "use_target_basis") {
 			r_ret = get_fabrik_joint_use_target_basis(which);
 		} else if (what == "roll") {
-			r_ret = Math::rad2deg(get_fabrik_joint_roll(which));
+			r_ret = Math::rad_to_deg(get_fabrik_joint_roll(which));
 		}
 		return true;
 	}

--- a/scene/resources/skeleton_modification_3d_jiggle.cpp
+++ b/scene/resources/skeleton_modification_3d_jiggle.cpp
@@ -58,7 +58,7 @@ bool SkeletonModification3DJiggle::_set(const StringName &p_path, const Variant 
 		} else if (what == "gravity") {
 			set_jiggle_joint_gravity(which, p_value);
 		} else if (what == "roll") {
-			set_jiggle_joint_roll(which, Math::deg2rad(real_t(p_value)));
+			set_jiggle_joint_roll(which, Math::deg_to_rad(real_t(p_value)));
 		}
 		return true;
 	} else {
@@ -98,7 +98,7 @@ bool SkeletonModification3DJiggle::_get(const StringName &p_path, Variant &r_ret
 		} else if (what == "gravity") {
 			r_ret = get_jiggle_joint_gravity(which);
 		} else if (what == "roll") {
-			r_ret = Math::rad2deg(get_jiggle_joint_roll(which));
+			r_ret = Math::rad_to_deg(get_jiggle_joint_roll(which));
 		}
 		return true;
 	} else {

--- a/scene/resources/skeleton_modification_3d_lookat.cpp
+++ b/scene/resources/skeleton_modification_3d_lookat.cpp
@@ -39,9 +39,9 @@ bool SkeletonModification3DLookAt::_set(const StringName &p_path, const Variant 
 		set_lock_rotation_plane(p_value);
 	} else if (p_path == "additional_rotation") {
 		Vector3 tmp = p_value;
-		tmp.x = Math::deg2rad(tmp.x);
-		tmp.y = Math::deg2rad(tmp.y);
-		tmp.z = Math::deg2rad(tmp.z);
+		tmp.x = Math::deg_to_rad(tmp.x);
+		tmp.y = Math::deg_to_rad(tmp.y);
+		tmp.z = Math::deg_to_rad(tmp.z);
 		set_additional_rotation(tmp);
 	}
 
@@ -55,9 +55,9 @@ bool SkeletonModification3DLookAt::_get(const StringName &p_path, Variant &r_ret
 		r_ret = get_lock_rotation_plane();
 	} else if (p_path == "additional_rotation") {
 		Vector3 tmp = get_additional_rotation();
-		tmp.x = Math::rad2deg(tmp.x);
-		tmp.y = Math::rad2deg(tmp.y);
-		tmp.z = Math::rad2deg(tmp.z);
+		tmp.x = Math::rad_to_deg(tmp.x);
+		tmp.y = Math::rad_to_deg(tmp.y);
+		tmp.z = Math::rad_to_deg(tmp.z);
 		r_ret = tmp;
 	}
 

--- a/scene/resources/skeleton_modification_3d_twoboneik.cpp
+++ b/scene/resources/skeleton_modification_3d_twoboneik.cpp
@@ -54,13 +54,13 @@ bool SkeletonModification3DTwoBoneIK::_set(const StringName &p_path, const Varia
 	} else if (path == "joint_one/bone_idx") {
 		set_joint_one_bone_idx(p_value);
 	} else if (path == "joint_one/roll") {
-		set_joint_one_roll(Math::deg2rad(real_t(p_value)));
+		set_joint_one_roll(Math::deg_to_rad(real_t(p_value)));
 	} else if (path == "joint_two/bone_name") {
 		set_joint_two_bone_name(p_value);
 	} else if (path == "joint_two/bone_idx") {
 		set_joint_two_bone_idx(p_value);
 	} else if (path == "joint_two/roll") {
-		set_joint_two_roll(Math::deg2rad(real_t(p_value)));
+		set_joint_two_roll(Math::deg_to_rad(real_t(p_value)));
 	}
 
 	return true;
@@ -88,13 +88,13 @@ bool SkeletonModification3DTwoBoneIK::_get(const StringName &p_path, Variant &r_
 	} else if (path == "joint_one/bone_idx") {
 		r_ret = get_joint_one_bone_idx();
 	} else if (path == "joint_one/roll") {
-		r_ret = Math::rad2deg(get_joint_one_roll());
+		r_ret = Math::rad_to_deg(get_joint_one_roll());
 	} else if (path == "joint_two/bone_name") {
 		r_ret = get_joint_two_bone_name();
 	} else if (path == "joint_two/bone_idx") {
 		r_ret = get_joint_two_bone_idx();
 	} else if (path == "joint_two/roll") {
-		r_ret = Math::rad2deg(get_joint_two_roll());
+		r_ret = Math::rad_to_deg(get_joint_two_roll());
 	}
 
 	return true;

--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -128,7 +128,7 @@ float ProceduralSkyMaterial::get_ground_energy() const {
 
 void ProceduralSkyMaterial::set_sun_angle_max(float p_angle) {
 	sun_angle_max = p_angle;
-	RS::get_singleton()->material_set_param(_get_material(), "sun_angle_max", Math::deg2rad(sun_angle_max));
+	RS::get_singleton()->material_set_param(_get_material(), "sun_angle_max", Math::deg_to_rad(sun_angle_max));
 }
 
 float ProceduralSkyMaterial::get_sun_angle_max() const {

--- a/scene/resources/sphere_shape_3d.cpp
+++ b/scene/resources/sphere_shape_3d.cpp
@@ -38,8 +38,8 @@ Vector<Vector3> SphereShape3D::get_debug_mesh_lines() const {
 	Vector<Vector3> points;
 
 	for (int i = 0; i <= 360; i++) {
-		float ra = Math::deg2rad((float)i);
-		float rb = Math::deg2rad((float)i + 1);
+		float ra = Math::deg_to_rad((float)i);
+		float rb = Math::deg_to_rad((float)i + 1);
 		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r;
 		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r;
 

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -782,7 +782,7 @@ void AudioStreamPlaybackRandomizer::start(float p_from_pos) {
 		float range_to = randomizer->random_volume_offset_db;
 
 		float volume_offset_db = range_from + Math::randf() * (range_to - range_from);
-		volume_scale = Math::db2linear(volume_offset_db);
+		volume_scale = Math::db_to_linear(volume_offset_db);
 	}
 
 	if (playing.is_valid()) {

--- a/servers/audio/effects/audio_effect_amplify.cpp
+++ b/servers/audio/effects/audio_effect_amplify.cpp
@@ -33,8 +33,8 @@
 void AudioEffectAmplifyInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
 	//multiply volume interpolating to avoid clicks if this changes
 	float volume_db = base->volume_db;
-	float vol = Math::db2linear(mix_volume_db);
-	float vol_inc = (Math::db2linear(volume_db) - vol) / float(p_frame_count);
+	float vol = Math::db_to_linear(mix_volume_db);
+	float vol_inc = (Math::db_to_linear(volume_db) - vol) / float(p_frame_count);
 
 	for (int i = 0; i < p_frame_count; i++) {
 		p_dst_frames[i] = p_src_frames[i] * vol;

--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -95,7 +95,7 @@ void AudioEffectChorusInstance::_process_chunk(const AudioFrame *p_src_frames, A
 
 		//vol modifier
 
-		AudioFrame vol_modifier = AudioFrame(base->wet, base->wet) * Math::db2linear(v.level);
+		AudioFrame vol_modifier = AudioFrame(base->wet, base->wet) * Math::db_to_linear(v.level);
 		vol_modifier.l *= CLAMP(1.0 - v.pan, 0, 1);
 		vol_modifier.r *= CLAMP(1.0 + v.pan, 0, 1);
 

--- a/servers/audio/effects/audio_effect_compressor.cpp
+++ b/servers/audio/effects/audio_effect_compressor.cpp
@@ -32,7 +32,7 @@
 #include "servers/audio_server.h"
 
 void AudioEffectCompressorInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
-	float threshold = Math::db2linear(base->threshold);
+	float threshold = Math::db_to_linear(base->threshold);
 	float sample_rate = AudioServer::get_singleton()->get_mix_rate();
 
 	float ratatcoef = exp(-1 / (0.00001f * sample_rate));
@@ -42,7 +42,7 @@ void AudioEffectCompressorInstance::process(const AudioFrame *p_src_frames, Audi
 	float atcoef = exp(-1 / (attime * sample_rate));
 	float relcoef = exp(-1 / (reltime * sample_rate));
 
-	float makeup = Math::db2linear(base->gain);
+	float makeup = Math::db_to_linear(base->gain);
 
 	float mix = base->mix;
 	float gr_meter_decay = exp(1 / (1 * sample_rate));
@@ -64,7 +64,7 @@ void AudioEffectCompressorInstance::process(const AudioFrame *p_src_frames, Audi
 
 		float peak = MAX(s.l, s.r);
 
-		float overdb = 2.08136898f * Math::linear2db(peak / threshold);
+		float overdb = 2.08136898f * Math::linear_to_db(peak / threshold);
 
 		if (overdb < 0.0) { //we only care about what goes over to compress
 			overdb = 0.0;
@@ -94,7 +94,7 @@ void AudioEffectCompressorInstance::process(const AudioFrame *p_src_frames, Audi
 		}
 
 		float gr = -overdb * (cratio - 1) / cratio;
-		float grv = Math::db2linear(gr);
+		float grv = Math::db_to_linear(gr);
 
 		runmax = maxover + relcoef * (runmax - maxover); // highest peak for setting att/rel decays in reltime
 		maxover = runmax;

--- a/servers/audio/effects/audio_effect_delay.cpp
+++ b/servers/audio/effects/audio_effect_delay.cpp
@@ -53,13 +53,13 @@ void AudioEffectDelayInstance::_process_chunk(const AudioFrame *p_src_frames, Au
 
 	float mix_rate = AudioServer::get_singleton()->get_mix_rate();
 
-	float tap_1_level_f = base->tap_1_active ? Math::db2linear(base->tap_1_level) : 0.0;
+	float tap_1_level_f = base->tap_1_active ? Math::db_to_linear(base->tap_1_level) : 0.0;
 	int tap_1_delay_frames = int((base->tap_1_delay_ms / 1000.0) * mix_rate);
 
-	float tap_2_level_f = base->tap_2_active ? Math::db2linear(base->tap_2_level) : 0.0;
+	float tap_2_level_f = base->tap_2_active ? Math::db_to_linear(base->tap_2_level) : 0.0;
 	int tap_2_delay_frames = int((base->tap_2_delay_ms / 1000.0) * mix_rate);
 
-	float feedback_level_f = base->feedback_active ? Math::db2linear(base->feedback_level) : 0.0;
+	float feedback_level_f = base->feedback_active ? Math::db_to_linear(base->feedback_level) : 0.0;
 	unsigned int feedback_delay_frames = int((base->feedback_delay_ms / 1000.0) * mix_rate);
 
 	AudioFrame tap1_vol = AudioFrame(tap_1_level_f, tap_1_level_f);

--- a/servers/audio/effects/audio_effect_distortion.cpp
+++ b/servers/audio/effects/audio_effect_distortion.cpp
@@ -41,8 +41,8 @@ void AudioEffectDistortionInstance::process(const AudioFrame *p_src_frames, Audi
 	float lpf_ic = 1.0 - lpf_c;
 
 	float drive_f = base->drive;
-	float pregain_f = Math::db2linear(base->pre_gain);
-	float postgain_f = Math::db2linear(base->post_gain);
+	float pregain_f = Math::db_to_linear(base->pre_gain);
+	float postgain_f = Math::db_to_linear(base->post_gain);
 
 	float atan_mult = pow(10, drive_f * drive_f * 3.0) - 1.0 + 0.001;
 	float atan_div = 1.0 / (atanf(atan_mult) * (1.0 + drive_f * 8));

--- a/servers/audio/effects/audio_effect_eq.cpp
+++ b/servers/audio/effects/audio_effect_eq.cpp
@@ -38,7 +38,7 @@ void AudioEffectEQInstance::process(const AudioFrame *p_src_frames, AudioFrame *
 	EQ::BandProcess *proc_r = bands[1].ptrw();
 	float *bgain = gains.ptrw();
 	for (int i = 0; i < band_count; i++) {
-		bgain[i] = Math::db2linear(base->gain[i]);
+		bgain[i] = Math::db_to_linear(base->gain[i]);
 	}
 
 	for (int i = 0; i < p_frame_count; i++) {

--- a/servers/audio/effects/audio_effect_limiter.cpp
+++ b/servers/audio/effects/audio_effect_limiter.cpp
@@ -32,11 +32,11 @@
 
 void AudioEffectLimiterInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
 	float threshdb = base->threshold;
-	float ceiling = Math::db2linear(base->ceiling);
+	float ceiling = Math::db_to_linear(base->ceiling);
 	float ceildb = base->ceiling;
-	float makeup = Math::db2linear(ceildb - threshdb);
+	float makeup = Math::db_to_linear(ceildb - threshdb);
 	float sc = -base->soft_clip;
-	float scv = Math::db2linear(sc);
+	float scv = Math::db_to_linear(sc);
 	float peakdb = ceildb + 25;
 	float scmult = Math::abs((ceildb - sc) / (peakdb - sc));
 
@@ -49,14 +49,14 @@ void AudioEffectLimiterInstance::process(const AudioFrame *p_src_frames, AudioFr
 		float sign1 = (spl1 < 0.0 ? -1.0 : 1.0);
 		float abs0 = Math::abs(spl0);
 		float abs1 = Math::abs(spl1);
-		float overdb0 = Math::linear2db(abs0) - ceildb;
-		float overdb1 = Math::linear2db(abs1) - ceildb;
+		float overdb0 = Math::linear_to_db(abs0) - ceildb;
+		float overdb1 = Math::linear_to_db(abs1) - ceildb;
 
 		if (abs0 > scv) {
-			spl0 = sign0 * (scv + Math::db2linear(overdb0 * scmult));
+			spl0 = sign0 * (scv + Math::db_to_linear(overdb0 * scmult));
 		}
 		if (abs1 > scv) {
-			spl1 = sign1 * (scv + Math::db2linear(overdb1 * scmult));
+			spl1 = sign1 * (scv + Math::db_to_linear(overdb1 * scmult));
 		}
 
 		spl0 = MIN(ceiling, Math::abs(spl0)) * (spl0 < 0.0 ? -1.0 : 1.0);

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -547,7 +547,7 @@ void AudioServer::_mix_step() {
 
 			AudioFrame peak = AudioFrame(0, 0);
 
-			float volume = Math::db2linear(bus->volume_db);
+			float volume = Math::db_to_linear(bus->volume_db);
 
 			if (solo_mode) {
 				if (!bus->soloed) {
@@ -573,12 +573,12 @@ void AudioServer::_mix_step() {
 				}
 			}
 
-			bus->channels.write[k].peak_volume = AudioFrame(Math::linear2db(peak.l + AUDIO_PEAK_OFFSET), Math::linear2db(peak.r + AUDIO_PEAK_OFFSET));
+			bus->channels.write[k].peak_volume = AudioFrame(Math::linear_to_db(peak.l + AUDIO_PEAK_OFFSET), Math::linear_to_db(peak.r + AUDIO_PEAK_OFFSET));
 
 			if (!bus->channels[k].used) {
 				//see if any audio is contained, because channel was not used
 
-				if (MAX(peak.r, peak.l) > Math::db2linear(channel_disable_threshold_db)) {
+				if (MAX(peak.r, peak.l) > Math::db_to_linear(channel_disable_threshold_db)) {
 					bus->channels.write[k].last_mix_with_audio = mix_frames;
 				} else if (mix_frames - bus->channels[k].last_mix_with_audio > channel_disable_frames) {
 					bus->channels.write[k].active = false;

--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -1218,7 +1218,7 @@ GodotPhysicsDirectSpaceState2D *GodotSpace2D::get_direct_state() {
 
 GodotSpace2D::GodotSpace2D() {
 	body_linear_velocity_sleep_threshold = GLOBAL_DEF("physics/2d/sleep_threshold_linear", 2.0);
-	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/2d/sleep_threshold_angular", Math::deg2rad(8.0));
+	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/2d/sleep_threshold_angular", Math::deg_to_rad(8.0));
 	body_time_to_sleep = GLOBAL_DEF("physics/2d/time_before_sleep", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/time_before_sleep", PropertyInfo(Variant::FLOAT, "physics/2d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
 

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -1249,7 +1249,7 @@ GodotPhysicsDirectSpaceState3D *GodotSpace3D::get_direct_state() {
 
 GodotSpace3D::GodotSpace3D() {
 	body_linear_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_linear", 0.1);
-	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_angular", Math::deg2rad(8.0));
+	body_angular_velocity_sleep_threshold = GLOBAL_DEF("physics/3d/sleep_threshold_angular", Math::deg_to_rad(8.0));
 	body_time_to_sleep = GLOBAL_DEF("physics/3d/time_before_sleep", 0.5);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/time_before_sleep", PropertyInfo(Variant::FLOAT, "physics/3d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"));
 

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -269,7 +269,7 @@ public:
 			//spot
 			radius *= shared->cone_overfit; // overfit icosphere
 
-			real_t len = Math::tan(Math::deg2rad(p_spot_aperture)) * radius;
+			real_t len = Math::tan(Math::deg_to_rad(p_spot_aperture)) * radius;
 			//approximate, probably better to use a cone support function
 			float max_d = -1e20;
 			float min_d = 1e20;
@@ -293,7 +293,7 @@ public:
 				float dist = base_plane.distance_to(Vector3());
 				if (dist >= 0 && dist < radius) {
 					//inside, check angle
-					float angle = Math::rad2deg(Math::acos((-xform.origin.normalized()).dot(-xform.basis.get_column(Vector3::AXIS_Z))));
+					float angle = Math::rad_to_deg(Math::acos((-xform.origin.normalized()).dot(-xform.basis.get_column(Vector3::AXIS_Z))));
 					e.touches_near = angle < p_spot_aperture * 1.05; //overfit aperture a little due to cone overfit
 				} else {
 					e.touches_near = false;

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -1604,7 +1604,7 @@ void SSEffects::screen_space_reflection(SSRRenderBuffers &p_ssr_buffers, const R
 			ScreenSpaceReflectionFilterPushConstant push_constant;
 			push_constant.view_index = v;
 			push_constant.orthogonal = p_projections[v].is_orthogonal();
-			push_constant.edge_tolerance = Math::sin(Math::deg2rad(15.0));
+			push_constant.edge_tolerance = Math::sin(Math::deg_to_rad(15.0));
 			push_constant.proj_info[0] = -2.0f / (p_screen_size.width * p_projections[v].matrix[0][0]);
 			push_constant.proj_info[1] = -2.0f / (p_screen_size.height * p_projections[v].matrix[1][1]);
 			push_constant.proj_info[2] = (1.0f - p_projections[v].matrix[0][2]) / p_projections[v].matrix[0][0];

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -1924,7 +1924,7 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 			lights[idx].has_shadow = RSG::light_storage->light_has_shadow(li->light);
 			lights[idx].attenuation = RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_ATTENUATION);
 			lights[idx].radius = RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_RANGE);
-			lights[idx].cos_spot_angle = Math::cos(Math::deg2rad(RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ANGLE)));
+			lights[idx].cos_spot_angle = Math::cos(Math::deg_to_rad(RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ANGLE)));
 			lights[idx].inv_spot_attenuation = 1.0f / RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ATTENUATION);
 
 			idx++;
@@ -2362,7 +2362,7 @@ void GI::SDFGI::render_static_lights(RID p_render_buffers, uint32_t p_cascade_co
 				lights[idx].has_shadow = RSG::light_storage->light_has_shadow(li->light);
 				lights[idx].attenuation = RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_ATTENUATION);
 				lights[idx].radius = RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_RANGE);
-				lights[idx].cos_spot_angle = Math::cos(Math::deg2rad(RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ANGLE)));
+				lights[idx].cos_spot_angle = Math::cos(Math::deg_to_rad(RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ANGLE)));
 				lights[idx].inv_spot_attenuation = 1.0f / RSG::light_storage->light_get_param(li->light, RS::LIGHT_PARAM_SPOT_ATTENUATION);
 
 				idx++;
@@ -2800,7 +2800,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 				l.color[1] = color.g;
 				l.color[2] = color.b;
 
-				l.cos_spot_angle = Math::cos(Math::deg2rad(RSG::light_storage->light_get_param(light, RS::LIGHT_PARAM_SPOT_ANGLE)));
+				l.cos_spot_angle = Math::cos(Math::deg_to_rad(RSG::light_storage->light_get_param(light, RS::LIGHT_PARAM_SPOT_ANGLE)));
 				l.inv_spot_attenuation = 1.0f / RSG::light_storage->light_get_param(light, RS::LIGHT_PARAM_SPOT_ATTENUATION);
 
 				Transform3D xform = p_scene_render->light_instance_get_base_transform(light_instance);

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1232,7 +1232,7 @@ void SkyRD::setup(RID p_env, RID p_render_buffers, const PagedArray<RID> &p_ligh
 						// I know tan(0) is 0, but let's not risk it with numerical precision.
 						// technically this will keep expanding until reaching the sun, but all we care
 						// is expand until we reach the radius of the near plane (there can't be more occluders than that)
-						angular_diameter = Math::tan(Math::deg2rad(angular_diameter));
+						angular_diameter = Math::tan(Math::deg_to_rad(angular_diameter));
 					} else {
 						angular_diameter = 0.0;
 					}

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1594,7 +1594,7 @@ void RendererCanvasRenderRD::light_update_shadow(RID p_rid, int p_shadow_index, 
 			real_t farp = p_far;
 			real_t aspect = 1.0;
 
-			real_t ymax = nearp * Math::tan(Math::deg2rad(fov * 0.5));
+			real_t ymax = nearp * Math::tan(Math::deg_to_rad(fov * 0.5));
 			real_t ymin = -ymax;
 			real_t xmin = ymin * aspect;
 			real_t xmax = ymax * aspect;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2862,7 +2862,7 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 
 				float size = light_storage->light_get_param(base, RS::LIGHT_PARAM_SIZE);
 
-				light_data.size = 1.0 - Math::cos(Math::deg2rad(size)); //angle to cosine offset
+				light_data.size = 1.0 - Math::cos(Math::deg_to_rad(size)); //angle to cosine offset
 
 				if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_PSSM_SPLITS) {
 					WARN_PRINT_ONCE("The DirectionalLight3D PSSM splits debug draw mode is not reimplemented yet.");
@@ -2877,7 +2877,7 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 					// I know tan(0) is 0, but let's not risk it with numerical precision.
 					// technically this will keep expanding until reaching the sun, but all we care
 					// is expand until we reach the radius of the near plane (there can't be more occluders than that)
-					angular_diameter = Math::tan(Math::deg2rad(angular_diameter));
+					angular_diameter = Math::tan(Math::deg_to_rad(angular_diameter));
 					if (light_storage->light_has_shadow(base) && light_storage->light_get_param(base, RS::LIGHT_PARAM_SHADOW_BLUR) > 0.0) {
 						// Only enable PCSS-like soft shadows if blurring is enabled.
 						// Otherwise, performance would decrease with no visual difference.
@@ -3092,7 +3092,7 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 
 		light_data.inv_spot_attenuation = 1.0f / light_storage->light_get_param(base, RS::LIGHT_PARAM_SPOT_ATTENUATION);
 		float spot_angle = light_storage->light_get_param(base, RS::LIGHT_PARAM_SPOT_ANGLE);
-		light_data.cos_spot_angle = Math::cos(Math::deg2rad(spot_angle));
+		light_data.cos_spot_angle = Math::cos(Math::deg_to_rad(spot_angle));
 
 		light_data.mask = light_storage->light_get_cull_mask(base);
 
@@ -3193,7 +3193,7 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 					// Only enable PCSS-like soft shadows if blurring is enabled.
 					// Otherwise, performance would decrease with no visual difference.
 					Projection cm = li->shadow_transform[0].camera;
-					float half_np = cm.get_z_near() * Math::tan(Math::deg2rad(spot_angle));
+					float half_np = cm.get_z_near() * Math::tan(Math::deg_to_rad(spot_angle));
 					light_data.soft_shadow_size = (size * 0.5 / radius) / (half_np / cm.get_z_near()) * rect.size.width;
 				} else {
 					light_data.soft_shadow_size = 0.0;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -352,7 +352,7 @@ AABB LightStorage::light_get_aabb(RID p_light) const {
 	switch (light->type) {
 		case RS::LIGHT_SPOT: {
 			float len = light->param[RS::LIGHT_PARAM_RANGE];
-			float size = Math::tan(Math::deg2rad(light->param[RS::LIGHT_PARAM_SPOT_ANGLE])) * len;
+			float size = Math::tan(Math::deg_to_rad(light->param[RS::LIGHT_PARAM_SPOT_ANGLE])) * len;
 			return AABB(Vector3(-size, -size, -len), Vector3(size * 2, size * 2, len));
 		};
 		case RS::LIGHT_OMNI: {

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2146,7 +2146,7 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 
 				if (soft_shadow_angle > 0.0) {
 					float z_range = (z_vec.dot(center) + radius + pancake_size) - z_min_cam;
-					soft_shadow_expand = Math::tan(Math::deg2rad(soft_shadow_angle)) * z_range;
+					soft_shadow_expand = Math::tan(Math::deg_to_rad(soft_shadow_angle)) * z_range;
 
 					x_max += soft_shadow_expand;
 					y_max += soft_shadow_expand;
@@ -3125,8 +3125,8 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 						float radius = RSG::light_storage->light_get_param(ins->base, RS::LIGHT_PARAM_RANGE);
 						float angle = RSG::light_storage->light_get_param(ins->base, RS::LIGHT_PARAM_SPOT_ANGLE);
 
-						float w = radius * Math::sin(Math::deg2rad(angle));
-						float d = radius * Math::cos(Math::deg2rad(angle));
+						float w = radius * Math::sin(Math::deg_to_rad(angle));
+						float d = radius * Math::cos(Math::deg_to_rad(angle));
 
 						Vector3 base = ins->transform.origin - ins->transform.basis.get_column(2).normalized() * d;
 

--- a/tests/core/math/test_quaternion.h
+++ b/tests/core/math/test_quaternion.h
@@ -41,9 +41,9 @@
 namespace TestQuaternion {
 
 Quaternion quat_euler_yxz_deg(Vector3 angle) {
-	double yaw = Math::deg2rad(angle[1]);
-	double pitch = Math::deg2rad(angle[0]);
-	double roll = Math::deg2rad(angle[2]);
+	double yaw = Math::deg_to_rad(angle[1]);
+	double pitch = Math::deg_to_rad(angle[0]);
+	double roll = Math::deg_to_rad(angle[2]);
 
 	// Generate YXZ (Z-then-X-then-Y) Quaternion using single-axis Euler
 	// constructor and quaternion product, both tested separately.
@@ -77,7 +77,7 @@ TEST_CASE("[Quaternion] Construct x,y,z,w") {
 
 TEST_CASE("[Quaternion] Construct AxisAngle 1") {
 	// Easy to visualize: 120 deg about X-axis.
-	Quaternion q(Vector3(1.0, 0.0, 0.0), Math::deg2rad(120.0));
+	Quaternion q(Vector3(1.0, 0.0, 0.0), Math::deg_to_rad(120.0));
 
 	// 0.866 isn't close enough; doctest::Approx doesn't cut much slack!
 	CHECK(q[0] == doctest::Approx(0.866025)); // Sine of half the angle.
@@ -88,7 +88,7 @@ TEST_CASE("[Quaternion] Construct AxisAngle 1") {
 
 TEST_CASE("[Quaternion] Construct AxisAngle 2") {
 	// Easy to visualize: 30 deg about Y-axis.
-	Quaternion q(Vector3(0.0, 1.0, 0.0), Math::deg2rad(30.0));
+	Quaternion q(Vector3(0.0, 1.0, 0.0), Math::deg_to_rad(30.0));
 
 	CHECK(q[0] == doctest::Approx(0.0));
 	CHECK(q[1] == doctest::Approx(0.258819)); // Sine of half the angle.
@@ -98,7 +98,7 @@ TEST_CASE("[Quaternion] Construct AxisAngle 2") {
 
 TEST_CASE("[Quaternion] Construct AxisAngle 3") {
 	// Easy to visualize: 60 deg about Z-axis.
-	Quaternion q(Vector3(0.0, 0.0, 1.0), Math::deg2rad(60.0));
+	Quaternion q(Vector3(0.0, 0.0, 1.0), Math::deg_to_rad(60.0));
 
 	CHECK(q[0] == doctest::Approx(0.0));
 	CHECK(q[1] == doctest::Approx(0.0));
@@ -109,7 +109,7 @@ TEST_CASE("[Quaternion] Construct AxisAngle 3") {
 TEST_CASE("[Quaternion] Construct AxisAngle 4") {
 	// More complex & hard to visualize, so test w/ data from online calculator.
 	Vector3 axis(1.0, 2.0, 0.5);
-	Quaternion q(axis.normalized(), Math::deg2rad(35.0));
+	Quaternion q(axis.normalized(), Math::deg_to_rad(35.0));
 
 	CHECK(q[0] == doctest::Approx(0.131239));
 	CHECK(q[1] == doctest::Approx(0.262478));
@@ -119,7 +119,7 @@ TEST_CASE("[Quaternion] Construct AxisAngle 4") {
 
 TEST_CASE("[Quaternion] Construct from Quaternion") {
 	Vector3 axis(1.0, 2.0, 0.5);
-	Quaternion q_src(axis.normalized(), Math::deg2rad(35.0));
+	Quaternion q_src(axis.normalized(), Math::deg_to_rad(35.0));
 	Quaternion q(q_src);
 
 	CHECK(q[0] == doctest::Approx(0.131239));
@@ -129,9 +129,9 @@ TEST_CASE("[Quaternion] Construct from Quaternion") {
 }
 
 TEST_CASE("[Quaternion] Construct Euler SingleAxis") {
-	double yaw = Math::deg2rad(45.0);
-	double pitch = Math::deg2rad(30.0);
-	double roll = Math::deg2rad(10.0);
+	double yaw = Math::deg_to_rad(45.0);
+	double pitch = Math::deg_to_rad(30.0);
+	double roll = Math::deg_to_rad(10.0);
 
 	Vector3 euler_y(0.0, yaw, 0.0);
 	Quaternion q_y(euler_y);
@@ -156,9 +156,9 @@ TEST_CASE("[Quaternion] Construct Euler SingleAxis") {
 }
 
 TEST_CASE("[Quaternion] Construct Euler YXZ dynamic axes") {
-	double yaw = Math::deg2rad(45.0);
-	double pitch = Math::deg2rad(30.0);
-	double roll = Math::deg2rad(10.0);
+	double yaw = Math::deg_to_rad(45.0);
+	double pitch = Math::deg_to_rad(30.0);
+	double roll = Math::deg_to_rad(10.0);
 
 	// Generate YXZ comparision data (Z-then-X-then-Y) using single-axis Euler
 	// constructor and quaternion product, both tested separately.
@@ -187,9 +187,9 @@ TEST_CASE("[Quaternion] Construct Euler YXZ dynamic axes") {
 }
 
 TEST_CASE("[Quaternion] Construct Basis Euler") {
-	double yaw = Math::deg2rad(45.0);
-	double pitch = Math::deg2rad(30.0);
-	double roll = Math::deg2rad(10.0);
+	double yaw = Math::deg_to_rad(45.0);
+	double pitch = Math::deg_to_rad(30.0);
+	double roll = Math::deg_to_rad(10.0);
 	Vector3 euler_yxz(pitch, yaw, roll);
 	Quaternion q_yxz(euler_yxz);
 	Basis basis_axes(euler_yxz);
@@ -199,7 +199,7 @@ TEST_CASE("[Quaternion] Construct Basis Euler") {
 
 TEST_CASE("[Quaternion] Construct Basis Axes") {
 	// Arbitrary Euler angles.
-	Vector3 euler_yxz(Math::deg2rad(31.41), Math::deg2rad(-49.16), Math::deg2rad(12.34));
+	Vector3 euler_yxz(Math::deg_to_rad(31.41), Math::deg_to_rad(-49.16), Math::deg_to_rad(12.34));
 	// Basis vectors from online calculation of rotation matrix.
 	Vector3 i_unit(0.5545787, 0.1823950, 0.8118957);
 	Vector3 j_unit(-0.5249245, 0.8337420, 0.1712555);
@@ -248,9 +248,9 @@ TEST_CASE("[Quaternion] Product (book)") {
 }
 
 TEST_CASE("[Quaternion] Product") {
-	double yaw = Math::deg2rad(45.0);
-	double pitch = Math::deg2rad(30.0);
-	double roll = Math::deg2rad(10.0);
+	double yaw = Math::deg_to_rad(45.0);
+	double pitch = Math::deg_to_rad(30.0);
+	double roll = Math::deg_to_rad(10.0);
 
 	Vector3 euler_y(0.0, yaw, 0.0);
 	Quaternion q_y(euler_y);
@@ -292,7 +292,7 @@ TEST_CASE("[Quaternion] Product") {
 TEST_CASE("[Quaternion] xform unit vectors") {
 	// Easy to visualize: 120 deg about X-axis.
 	// Transform the i, j, & k unit vectors.
-	Quaternion q(Vector3(1.0, 0.0, 0.0), Math::deg2rad(120.0));
+	Quaternion q(Vector3(1.0, 0.0, 0.0), Math::deg_to_rad(120.0));
 	Vector3 i_t = q.xform(Vector3(1.0, 0.0, 0.0));
 	Vector3 j_t = q.xform(Vector3(0.0, 1.0, 0.0));
 	Vector3 k_t = q.xform(Vector3(0.0, 0.0, 1.0));
@@ -305,7 +305,7 @@ TEST_CASE("[Quaternion] xform unit vectors") {
 	CHECK(k_t.length_squared() == doctest::Approx(1.0));
 
 	// Easy to visualize: 30 deg about Y-axis.
-	q = Quaternion(Vector3(0.0, 1.0, 0.0), Math::deg2rad(30.0));
+	q = Quaternion(Vector3(0.0, 1.0, 0.0), Math::deg_to_rad(30.0));
 	i_t = q.xform(Vector3(1.0, 0.0, 0.0));
 	j_t = q.xform(Vector3(0.0, 1.0, 0.0));
 	k_t = q.xform(Vector3(0.0, 0.0, 1.0));
@@ -318,7 +318,7 @@ TEST_CASE("[Quaternion] xform unit vectors") {
 	CHECK(k_t.length_squared() == doctest::Approx(1.0));
 
 	// Easy to visualize: 60 deg about Z-axis.
-	q = Quaternion(Vector3(0.0, 0.0, 1.0), Math::deg2rad(60.0));
+	q = Quaternion(Vector3(0.0, 0.0, 1.0), Math::deg_to_rad(60.0));
 	i_t = q.xform(Vector3(1.0, 0.0, 0.0));
 	j_t = q.xform(Vector3(0.0, 1.0, 0.0));
 	k_t = q.xform(Vector3(0.0, 0.0, 1.0));
@@ -333,7 +333,7 @@ TEST_CASE("[Quaternion] xform unit vectors") {
 
 TEST_CASE("[Quaternion] xform vector") {
 	// Arbitrary quaternion rotates an arbitrary vector.
-	Vector3 euler_yzx(Math::deg2rad(31.41), Math::deg2rad(-49.16), Math::deg2rad(12.34));
+	Vector3 euler_yzx(Math::deg_to_rad(31.41), Math::deg_to_rad(-49.16), Math::deg_to_rad(12.34));
 	Basis basis_axes(euler_yzx);
 	Quaternion q(basis_axes);
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5206.

As brought up in https://github.com/godotengine/godot/issues/54161#issuecomment-1198981759.

To make it short, the naming scheme with "2" in the middle is not always used across Godot (`String.int_to_bin()`), and it isn't proper English.

Affects the internal **Math** class, a good chunk of the audio filter code, and a lot of miscellaneous classes.

| Before | After|
| --------| ---------|
| `var2str` | `var_to_str`
| `str2var` | `str_to_var`
| `bytes2var` | `bytes_to_var`
| `bytes2var_with_objects` | `bytes_to_var_with_objects`
| `var2bytes` | `var_to_bytes`
| `var2bytes_with_objects` | `var_to_bytes_with_objects`
| `linear2db` | `linear_to_db`
| `db2linear` | `db_to_linear` 
| `deg2rad` | `deg_to_rad`
| `rad2deg` | `rad_to_deg`

Added later in this PR:
| Before | After |
| --- | --- |
| `dict2inst` | `dict_to_inst` |
| `inst2dict` | `inst_to_dict` |

I think it's worth noting, before merging this, that while testing I did find writing these methods to be much slower (_underscore, two characters, another underscore, and the Italian keyboard requires holding Shift to access the underscores_), although it may be a matter of getting used to it.