### PR TITLE
[3.5] Fix NavigationObstacle nodes not registering to default navigation map

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -139,7 +139,12 @@ void NavigationObstacle2D::set_navigation(Navigation2D *p_nav) {
 	}
 
 	navigation = p_nav;
-	Navigation2DServer::get_singleton()->agent_set_map(agent, navigation == nullptr ? RID() : navigation->get_rid());
+
+	if (navigation != nullptr) {
+		Navigation2DServer::get_singleton()->agent_set_map(agent, navigation->get_rid());
+	} else if (parent_node2d && parent_node2d->is_inside_tree()) {
+		Navigation2DServer::get_singleton()->agent_set_map(agent, parent_node2d->get_world_2d()->get_navigation_map());
+	}
 }
 
 void NavigationObstacle2D::set_navigation_node(Node *p_nav) {

--- a/scene/3d/navigation_obstacle.cpp
+++ b/scene/3d/navigation_obstacle.cpp
@@ -145,7 +145,12 @@ void NavigationObstacle::set_navigation(Navigation *p_nav) {
 	}
 
 	navigation = p_nav;
-	NavigationServer::get_singleton()->agent_set_map(agent, navigation == nullptr ? RID() : navigation->get_rid());
+
+	if (navigation != nullptr) {
+		NavigationServer::get_singleton()->agent_set_map(agent, navigation->get_rid());
+	} else if (parent_spatial && parent_spatial->is_inside_tree()) {
+		NavigationServer::get_singleton()->agent_set_map(agent, parent_spatial->get_world()->get_navigation_map());
+	}
 }
 
 void NavigationObstacle::set_navigation_node(Node *p_nav) {


### PR DESCRIPTION
Fix NavigationObstacle nodes not registering to default navigation map.

Godot 3.5 has still the old navigation node and if this node was not available there was no fallback to the default navigation map.

Fixes #64185.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
