### PR TITLE
Overhaul CLI argument forwarding to processes started by the editor

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -166,10 +166,6 @@ bool OS::is_stdout_verbose() const {
 	return _verbose_stdout;
 }
 
-bool OS::is_single_window() const {
-	return _single_window;
-}
-
 bool OS::is_stdout_debug_enabled() const {
 	return _debug_stdout;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -52,7 +52,6 @@ class OS {
 	int low_processor_usage_mode_sleep_usec = 10000;
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
-	bool _single_window = false;
 	String _local_clipboard;
 	int _exit_code = EXIT_FAILURE; // unexpected exit is marked as failure
 	bool _allow_hidpi = false;
@@ -242,8 +241,6 @@ public:
 	bool is_stderr_enabled() const;
 	void set_stdout_enabled(bool p_enabled);
 	void set_stderr_enabled(bool p_enabled);
-
-	virtual bool is_single_window() const;
 
 	virtual void disable_crash_handler() {}
 	virtual bool is_disable_crash_handler() const { return false; }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1815,14 +1815,14 @@ void EditorNode::restart_editor() {
 
 	List<String> args;
 
+	for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_TOOL)) {
+		args.push_back(a);
+	}
+
 	args.push_back("--path");
 	args.push_back(ProjectSettings::get_singleton()->get_resource_path());
 
 	args.push_back("-e");
-
-	if (OS::get_singleton()->is_disable_crash_handler()) {
-		args.push_back("--disable-crash-handler");
-	}
 
 	if (!to_reopen.is_empty()) {
 		args.push_back(to_reopen);
@@ -3162,6 +3162,9 @@ void EditorNode::_discard_changes(const String &p_str) {
 			String exec = OS::get_singleton()->get_executable_path();
 
 			List<String> args;
+			for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_TOOL)) {
+				args.push_back(a);
+			}
 			args.push_back("--path");
 			args.push_back(exec.get_base_dir());
 			args.push_back("--project-manager");

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
+#include "main/main.h"
 #include "servers/display_server.h"
 
 EditorRun::Status EditorRun::get_status() const {
@@ -45,6 +46,10 @@ String EditorRun::get_running_scene() const {
 
 Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	List<String> args;
+
+	for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_PROJECT)) {
+		args.push_back(a);
+	}
 
 	String resource_path = ProjectSettings::get_singleton()->get_resource_path();
 	if (!resource_path.is_empty()) {
@@ -103,10 +108,6 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		// Fixed monitor ID
 		// There are 3 special options, so decrement the option ID by 3 to get the monitor ID
 		screen -= 3;
-	}
-
-	if (OS::get_singleton()->is_disable_crash_handler()) {
-		args.push_back("--disable-crash-handler");
 	}
 
 	Rect2 screen_rect;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -47,6 +47,7 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_themes.h"
 #include "editor/editor_vcs_interface.h"
+#include "main/main.h"
 #include "scene/gui/center_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/margin_container.h"
@@ -2109,26 +2110,14 @@ void ProjectManager::_open_selected_projects() {
 
 		List<String> args;
 
+		for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_TOOL)) {
+			args.push_back(a);
+		}
+
 		args.push_back("--path");
 		args.push_back(path);
 
 		args.push_back("--editor");
-
-		if (OS::get_singleton()->is_stdout_debug_enabled()) {
-			args.push_back("--debug");
-		}
-
-		if (OS::get_singleton()->is_stdout_verbose()) {
-			args.push_back("--verbose");
-		}
-
-		if (OS::get_singleton()->is_disable_crash_handler()) {
-			args.push_back("--disable-crash-handler");
-		}
-
-		if (OS::get_singleton()->is_single_window()) {
-			args.push_back("--single-window");
-		}
 
 		Error err = OS::get_singleton()->create_instance(args);
 		ERR_FAIL_COND(err);
@@ -2242,12 +2231,12 @@ void ProjectManager::_run_project_confirm() {
 
 		List<String> args;
 
+		for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_PROJECT)) {
+			args.push_back(a);
+		}
+
 		args.push_back("--path");
 		args.push_back(path);
-
-		if (OS::get_singleton()->is_disable_crash_handler()) {
-			args.push_back("--disable-crash-handler");
-		}
 
 		Error err = OS::get_singleton()->create_instance(args);
 		ERR_FAIL_COND(err);

--- a/main/main.h
+++ b/main/main.h
@@ -35,6 +35,9 @@
 #include "core/os/thread.h"
 #include "core/typedefs.h"
 
+template <class T>
+class Vector;
+
 class Main {
 	static void print_help(const char *p_binary);
 	static uint64_t last_ticks;
@@ -47,6 +50,14 @@ class Main {
 
 public:
 	static bool is_cmdline_tool();
+#ifdef TOOLS_ENABLED
+	enum CLIScope {
+		CLI_SCOPE_TOOL, // Editor and project manager.
+		CLI_SCOPE_PROJECT,
+	};
+	static const Vector<String> &get_forwardable_cli_arguments(CLIScope p_scope);
+#endif
+
 	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
 	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
 	static Error setup2(Thread::ID p_main_tid_override = 0);

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -98,7 +98,6 @@ public:
 	String get_user_data_dir() const override;
 
 	bool is_userfs_persistent() const override;
-	bool is_single_window() const override { return true; }
 
 	void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 


### PR DESCRIPTION
First, this reverts a the changes about making the editor forward certain CLI arguments to new processes (either a new instance of the editor itself, the project manager or the running project), such as those in b2d27214aa0bee3cf0dc091846bf087e007c9607, 2b292a1a2ad7c0a74ea186d9f53afa70b65d390f and 116f03a1b68ecc59f9755cd0219e256c63955f55.

Then, it adds a little framework that makes the management of argument forwarding more centralized, complete and maintainable.

P. S.: I said I would do this as a Saturday morning project, but it turned out to be a Saturday evening one.

**UPDATE:** Version for 3.5+ in #64375.