### PR TITLE
Rename `CanvasItem.update()` to `queue_redraw()`

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Base class of anything 2D. Canvas items are laid out in a tree; children inherit and extend their parent's transform. [CanvasItem] is extended by [Control] for anything GUI-related, and by [Node2D] for anything related to the 2D engine.
-		Any [CanvasItem] can draw. For this, [method update] is called by the engine, then [constant NOTIFICATION_DRAW] will be received on idle time to request redraw. Because of this, canvas items don't need to be redrawn on every frame, improving the performance significantly. Several functions for drawing on the [CanvasItem] are provided (see [code]draw_*[/code] functions). However, they can only be used inside [method _draw], its corresponding [method Object._notification] or methods connected to the [signal draw] signal.
+		Any [CanvasItem] can draw. For this, [method queue_redraw] is called by the engine, then [constant NOTIFICATION_DRAW] will be received on idle time to request redraw. Because of this, canvas items don't need to be redrawn on every frame, improving the performance significantly. Several functions for drawing on the [CanvasItem] are provided (see [code]draw_*[/code] functions). However, they can only be used inside [method _draw], its corresponding [method Object._notification] or methods connected to the [signal draw] signal.
 		Canvas items are drawn in tree order. By default, children are on top of their parents so a root [CanvasItem] will be drawn behind everything. This behavior can be changed on a per-item basis.
 		A [CanvasItem] can also be hidden, which will also hide its children. It provides many ways to change parameters such as modulation (for itself and its children) and self modulation (only for itself), as well as its blend mode.
 		Ultimately, a transform notification can be requested, which will notify the node that its global position changed in case the parent tree changed.
@@ -20,7 +20,7 @@
 		<method name="_draw" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				Called when [CanvasItem] has been requested to redraw (when [method update] is called, either manually or by the engine).
+				Called when [CanvasItem] has been requested to redraw (after [method queue_redraw] is called, either manually or by the engine).
 				Corresponds to the [constant NOTIFICATION_DRAW] notification in [method Object._notification].
 			</description>
 		</method>
@@ -500,6 +500,12 @@
 				Transformations issued by [param event]'s inputs are applied in local space instead of global space.
 			</description>
 		</method>
+		<method name="queue_redraw">
+			<return type="void" />
+			<description>
+				Queues the [CanvasItem] to redraw. During idle time, if [CanvasItem] is visible, [constant NOTIFICATION_DRAW] is sent and [method _draw] is called. This only occurs [b]once[/b] per frame, even if this method has been called multiple times.
+			</description>
+		</method>
 		<method name="set_notify_local_transform">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
@@ -518,12 +524,6 @@
 			<return type="void" />
 			<description>
 				Show the [CanvasItem] if it's currently hidden. This is equivalent to setting [member visible] to [code]true[/code]. For controls that inherit [Popup], the correct way to make them visible is to call one of the multiple [code]popup*()[/code] functions instead.
-			</description>
-		</method>
-		<method name="update">
-			<return type="void" />
-			<description>
-				Queues the [CanvasItem] to redraw. During idle time, if [CanvasItem] is visible, [constant NOTIFICATION_DRAW] is sent and [method _draw] is called. This only occurs [b]once[/b] per frame, even if this method has been called multiple times.
 			</description>
 		</method>
 	</methods>

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -648,7 +648,7 @@ void AnimationBezierTrackEdit::set_animation_and_track(const Ref<Animation> &p_a
 	animation = p_animation;
 	read_only = p_read_only;
 	selected_track = p_track;
-	update();
+	queue_redraw();
 }
 
 Size2 AnimationBezierTrackEdit::get_minimum_size() const {
@@ -691,11 +691,11 @@ void AnimationBezierTrackEdit::_play_position_draw() {
 
 void AnimationBezierTrackEdit::set_play_position(real_t p_pos) {
 	play_position_pos = p_pos;
-	play_position->update();
+	play_position->queue_redraw();
 }
 
 void AnimationBezierTrackEdit::update_play_position() {
-	play_position->update();
+	play_position->queue_redraw();
 }
 
 void AnimationBezierTrackEdit::set_root(Node *p_root) {
@@ -734,12 +734,12 @@ void AnimationBezierTrackEdit::set_filtered(bool p_filtered) {
 			}
 		}
 	}
-	update();
+	queue_redraw();
 }
 
 void AnimationBezierTrackEdit::_zoom_changed() {
-	update();
-	play_position->update();
+	queue_redraw();
+	play_position->queue_redraw();
 }
 
 void AnimationBezierTrackEdit::_update_locked_tracks_after(int p_track) {
@@ -787,7 +787,7 @@ String AnimationBezierTrackEdit::get_tooltip(const Point2 &p_pos) const {
 void AnimationBezierTrackEdit::_clear_selection() {
 	selection.clear();
 	emit_signal(SNAME("clear_selection"));
-	update();
+	queue_redraw();
 }
 
 void AnimationBezierTrackEdit::_change_selected_keys_handle_mode(Animation::HandleMode p_mode, bool p_auto) {
@@ -819,7 +819,7 @@ void AnimationBezierTrackEdit::_select_at_anim(const Ref<Animation> &p_anim, int
 
 	selection.insert(IntPair(p_track, idx));
 	emit_signal(SNAME("select_key"), idx, true, p_track);
-	update();
+	queue_redraw();
 }
 
 void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
@@ -909,7 +909,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			v_scroll = (maximum_value + minimum_value) / 2.0;
 			v_zoom = (maximum_value - minimum_value) / ((get_size().height - timeline->get_size().height) * 0.9);
 
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		} else if (ED_GET_SHORTCUT("animation_bezier_editor/select_all_keys")->matches_event(p_event)) {
@@ -917,13 +917,13 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				selection.insert(IntPair(edit_points[i].track, edit_points[i].key));
 			}
 
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		} else if (ED_GET_SHORTCUT("animation_bezier_editor/deselect_all_keys")->matches_event(p_event)) {
 			selection.clear();
 
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		}
@@ -1024,7 +1024,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 								}
 							}
 						}
-						update();
+						queue_redraw();
 						return;
 					} else if (I.key == VISIBILITY_ICON) {
 						if (hidden_tracks.has(track)) {
@@ -1054,7 +1054,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 							solo_track = -1;
 						}
 
-						update();
+						queue_redraw();
 						return;
 					} else if (I.key == SOLO_ICON) {
 						if (solo_track == track) {
@@ -1076,7 +1076,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 							set_animation_and_track(animation, track, read_only);
 							solo_track = track;
 						}
-						update();
+						queue_redraw();
 						return;
 					}
 					return;
@@ -1098,7 +1098,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 						} else {
 							selection.insert(pair);
 						}
-						update();
+						queue_redraw();
 						select_single_attempt = IntPair(-1, -1);
 					} else if (selection.has(pair)) {
 						moving_selection_attempt = true;
@@ -1110,7 +1110,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 						moving_handle_right = animation->bezier_track_get_key_out_handle(pair.first, pair.second);
 						moving_selection_offset = Vector2();
 						select_single_attempt = pair;
-						update();
+						queue_redraw();
 					} else {
 						moving_selection_attempt = true;
 						moving_selection = true;
@@ -1135,7 +1135,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					moving_handle_track = edit_points[i].track;
 					moving_handle_left = animation->bezier_track_get_key_in_handle(edit_points[i].track, edit_points[i].key);
 					moving_handle_right = animation->bezier_track_get_key_out_handle(edit_points[i].track, edit_points[i].key);
-					update();
+					queue_redraw();
 					return;
 				}
 
@@ -1145,7 +1145,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					moving_handle_track = edit_points[i].track;
 					moving_handle_left = animation->bezier_track_get_key_in_handle(edit_points[i].track, edit_points[i].key);
 					moving_handle_right = animation->bezier_track_get_key_out_handle(edit_points[i].track, edit_points[i].key);
-					update();
+					queue_redraw();
 					return;
 				}
 			}
@@ -1186,7 +1186,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			moving_selection_from_track = selected_track;
 			moving_selection_offset = Vector2();
 			select_single_attempt = IntPair(-1, -1);
-			update();
+			queue_redraw();
 
 			return;
 		}
@@ -1258,7 +1258,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 		box_selecting_attempt = false;
 		box_selecting = false;
-		update();
+		queue_redraw();
 	}
 
 	if (moving_selection_attempt && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
@@ -1376,7 +1376,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			moving_selection_attempt = false;
-			update();
+			queue_redraw();
 		}
 	}
 
@@ -1397,7 +1397,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		additional_moving_handle_lefts.clear();
 		additional_moving_handle_rights.clear();
 
-		update();
+		queue_redraw();
 	}
 
 	if (box_selecting_attempt && mm.is_valid()) {
@@ -1412,7 +1412,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			//avoid cursor from going too above, so it does not lose focus with viewport
 			warp_mouse(Vector2(get_local_mouse_position().x, 0));
 		}
-		update();
+		queue_redraw();
 	}
 
 	if ((moving_handle == 1 || moving_handle == -1) && mm.is_valid()) {
@@ -1461,7 +1461,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				moving_handle_left = -moving_handle_right;
 			}
 		}
-		update();
+		queue_redraw();
 	}
 
 	if ((moving_handle == -1 || moving_handle == 1) && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
@@ -1478,7 +1478,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 			undo_redo->commit_action();
 			moving_handle = 0;
-			update();
+			queue_redraw();
 		}
 	}
 }
@@ -1491,7 +1491,7 @@ void AnimationBezierTrackEdit::_pan_callback(Vector2 p_scroll_vec) {
 	v_scroll += p_scroll_vec.y * v_zoom;
 	v_scroll = CLAMP(v_scroll, -100000, 100000);
 	timeline->set_value(timeline->get_value() - p_scroll_vec.x / timeline->get_zoom_scale());
-	update();
+	queue_redraw();
 }
 
 void AnimationBezierTrackEdit::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt) {
@@ -1511,7 +1511,7 @@ void AnimationBezierTrackEdit::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_or
 		}
 	}
 	v_scroll = v_scroll + (p_origin.y - get_size().y / 2.0) * (v_zoom - v_zoom_orig);
-	update();
+	queue_redraw();
 }
 
 void AnimationBezierTrackEdit::_menu_selected(int p_index) {
@@ -1541,7 +1541,7 @@ void AnimationBezierTrackEdit::_menu_selected(int p_index) {
 				undo_redo->add_do_method(animation.ptr(), "track_insert_key", selected_track, time, new_point);
 				undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", selected_track, time);
 				undo_redo->commit_action();
-				update();
+				queue_redraw();
 			}
 		} break;
 		case MENU_KEY_DUPLICATE: {
@@ -1624,7 +1624,7 @@ void AnimationBezierTrackEdit::duplicate_selection() {
 		selection.insert(IntPair(track, existing_idx));
 	}
 
-	update();
+	queue_redraw();
 }
 
 void AnimationBezierTrackEdit::delete_selection() {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1399,8 +1399,8 @@ public:
 };
 
 void AnimationTimelineEdit::_zoom_changed(double) {
-	update();
-	play_position->update();
+	queue_redraw();
+	play_position->queue_redraw();
 	emit_signal(SNAME("zoom_changed"));
 }
 
@@ -1430,7 +1430,7 @@ void AnimationTimelineEdit::_anim_length_changed(double p_new_len) {
 	undo_redo->add_undo_method(animation.ptr(), "set_length", animation->get_length());
 	undo_redo->commit_action();
 	editing = false;
-	update();
+	queue_redraw();
 
 	emit_signal(SNAME("length_changed"), p_new_len);
 }
@@ -1703,7 +1703,7 @@ void AnimationTimelineEdit::set_animation(const Ref<Animation> &p_animation, boo
 		add_track->hide();
 		play_position->hide();
 	}
-	update();
+	queue_redraw();
 	update_values();
 }
 
@@ -1731,7 +1731,7 @@ void AnimationTimelineEdit::set_track_edit(AnimationTrackEdit *p_track_edit) {
 
 void AnimationTimelineEdit::set_play_position(float p_pos) {
 	play_position_pos = p_pos;
-	play_position->update();
+	play_position->queue_redraw();
 }
 
 float AnimationTimelineEdit::get_play_position() const {
@@ -1739,7 +1739,7 @@ float AnimationTimelineEdit::get_play_position() const {
 }
 
 void AnimationTimelineEdit::update_play_position() {
-	play_position->update();
+	play_position->queue_redraw();
 }
 
 void AnimationTimelineEdit::update_values() {
@@ -1853,9 +1853,9 @@ void AnimationTimelineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		if (dragging_hsize) {
 			int ofs = mm->get_position().x - dragging_hsize_from;
 			name_limit = dragging_hsize_at + ofs;
-			update();
+			queue_redraw();
 			emit_signal(SNAME("name_limit_changed"));
-			play_position->update();
+			play_position->queue_redraw();
 		}
 		if (dragging_timeline) {
 			int x = mm->get_position().x - get_name_limit();
@@ -1898,7 +1898,7 @@ void AnimationTimelineEdit::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origi
 void AnimationTimelineEdit::set_use_fps(bool p_use_fps) {
 	use_fps = p_use_fps;
 	update_values();
-	update();
+	queue_redraw();
 }
 
 bool AnimationTimelineEdit::is_using_fps() const {
@@ -2292,13 +2292,13 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_ENTER:
 			hovered = true;
-			update();
+			queue_redraw();
 			break;
 		case NOTIFICATION_MOUSE_EXIT:
 			hovered = false;
 			// When the mouse cursor exits the track, we're no longer hovering any keyframe.
 			hovering_key_idx = -1;
-			update();
+			queue_redraw();
 			[[fallthrough]];
 		case NOTIFICATION_DRAG_END: {
 			cancel_drop();
@@ -2491,7 +2491,7 @@ void AnimationTrackEdit::set_animation_and_track(const Ref<Animation> &p_animati
 	read_only = p_read_only;
 
 	track = p_track;
-	update();
+	queue_redraw();
 
 	ERR_FAIL_INDEX(track, animation->get_track_count());
 
@@ -2553,11 +2553,11 @@ void AnimationTrackEdit::_play_position_draw() {
 
 void AnimationTrackEdit::set_play_position(float p_pos) {
 	play_position_pos = p_pos;
-	play_position->update();
+	play_position->queue_redraw();
 }
 
 void AnimationTrackEdit::update_play_position() {
-	play_position->update();
+	play_position->queue_redraw();
 }
 
 void AnimationTrackEdit::set_root(Node *p_root) {
@@ -2565,8 +2565,8 @@ void AnimationTrackEdit::set_root(Node *p_root) {
 }
 
 void AnimationTrackEdit::_zoom_changed() {
-	update();
-	play_position->update();
+	queue_redraw();
+	play_position->queue_redraw();
 }
 
 void AnimationTrackEdit::_path_submitted(const String &p_text) {
@@ -2811,7 +2811,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				undo_redo->add_do_method(animation.ptr(), "track_set_enabled", track, !animation->track_is_enabled(track));
 				undo_redo->add_undo_method(animation.ptr(), "track_set_enabled", track, animation->track_is_enabled(track));
 				undo_redo->commit_action();
-				update();
+				queue_redraw();
 				accept_event();
 			}
 
@@ -3090,7 +3090,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 				if (hovering_key_idx != previous_hovering_key_idx) {
 					// Required to draw keyframe hover feedback on the correct keyframe.
-					update();
+					queue_redraw();
 				}
 			}
 		}
@@ -3156,7 +3156,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 		dropping_at = 1;
 	}
 
-	const_cast<AnimationTrackEdit *>(this)->update();
+	const_cast<AnimationTrackEdit *>(this)->queue_redraw();
 	const_cast<AnimationTrackEdit *>(this)->emit_signal(SNAME("drop_attempted"), track);
 
 	return true;
@@ -3202,7 +3202,7 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 			undo_redo->add_do_method(animation.ptr(), "value_track_set_update_mode", track, update_mode);
 			undo_redo->add_undo_method(animation.ptr(), "value_track_set_update_mode", track, animation->value_track_get_update_mode(track));
 			undo_redo->commit_action();
-			update();
+			queue_redraw();
 
 		} break;
 		case MENU_INTERPOLATION_NEAREST:
@@ -3215,7 +3215,7 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 			undo_redo->add_do_method(animation.ptr(), "track_set_interpolation_type", track, interp_mode);
 			undo_redo->add_undo_method(animation.ptr(), "track_set_interpolation_type", track, animation->track_get_interpolation_type(track));
 			undo_redo->commit_action();
-			update();
+			queue_redraw();
 		} break;
 		case MENU_LOOP_WRAP:
 		case MENU_LOOP_CLAMP: {
@@ -3224,7 +3224,7 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 			undo_redo->add_do_method(animation.ptr(), "track_set_interpolation_loop_wrap", track, loop_wrap);
 			undo_redo->add_undo_method(animation.ptr(), "track_set_interpolation_loop_wrap", track, animation->track_get_interpolation_loop_wrap(track));
 			undo_redo->commit_action();
-			update();
+			queue_redraw();
 
 		} break;
 		case MENU_KEY_INSERT: {
@@ -3247,13 +3247,13 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 void AnimationTrackEdit::cancel_drop() {
 	if (dropping_at != 0) {
 		dropping_at = 0;
-		update();
+		queue_redraw();
 	}
 }
 
 void AnimationTrackEdit::set_in_group(bool p_enable) {
 	in_group = p_enable;
-	update();
+	queue_redraw();
 }
 
 void AnimationTrackEdit::append_to_selection(const Rect2 &p_box, bool p_deselection) {
@@ -3399,7 +3399,7 @@ void AnimationTrackEditGroup::set_type_and_name(const Ref<Texture2D> &p_type, co
 	icon = p_type;
 	node_name = p_name;
 	node = p_node;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -3419,11 +3419,11 @@ void AnimationTrackEditGroup::set_timeline(AnimationTimelineEdit *p_timeline) {
 
 void AnimationTrackEditGroup::set_root(Node *p_root) {
 	root = p_root;
-	update();
+	queue_redraw();
 }
 
 void AnimationTrackEditGroup::_zoom_changed() {
-	update();
+	queue_redraw();
 }
 
 void AnimationTrackEditGroup::_bind_methods() {
@@ -4645,18 +4645,18 @@ void AnimationTrackEditor::_update_tracks() {
 
 void AnimationTrackEditor::_redraw_tracks() {
 	for (int i = 0; i < track_edits.size(); i++) {
-		track_edits[i]->update();
+		track_edits[i]->queue_redraw();
 	}
 }
 
 void AnimationTrackEditor::_redraw_groups() {
 	for (int i = 0; i < groups.size(); i++) {
-		groups[i]->update();
+		groups[i]->queue_redraw();
 	}
 }
 
 void AnimationTrackEditor::_sync_animation_change() {
-	bezier_edit->update();
+	bezier_edit->queue_redraw();
 }
 
 void AnimationTrackEditor::_animation_changed() {
@@ -4669,12 +4669,12 @@ void AnimationTrackEditor::_animation_changed() {
 	}
 
 	if (key_edit && key_edit->setting) {
-		// If editing a key, just update the edited track, makes refresh less costly.
+		// If editing a key, just redraw the edited track, makes refresh less costly.
 		if (key_edit->track < track_edits.size()) {
 			if (animation->track_get_type(key_edit->track) == Animation::TYPE_BEZIER) {
-				bezier_edit->update();
+				bezier_edit->queue_redraw();
 			} else {
-				track_edits[key_edit->track]->update();
+				track_edits[key_edit->track]->queue_redraw();
 			}
 		}
 		return;
@@ -4713,7 +4713,7 @@ void AnimationTrackEditor::_update_step_spinbox() {
 }
 
 void AnimationTrackEditor::_animation_update() {
-	timeline->update();
+	timeline->queue_redraw();
 	timeline->update_values();
 
 	bool same = true;
@@ -4742,7 +4742,7 @@ void AnimationTrackEditor::_animation_update() {
 		_update_tracks();
 	}
 
-	bezier_edit->update();
+	bezier_edit->queue_redraw();
 
 	_update_step_spinbox();
 	emit_signal(SNAME("animation_step_changed"), animation->get_step());
@@ -5000,7 +5000,7 @@ void AnimationTrackEditor::_timeline_value_changed(double) {
 	}
 	_redraw_groups();
 
-	bezier_edit->update();
+	bezier_edit->queue_redraw();
 	bezier_edit->update_play_position();
 }
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -197,7 +197,7 @@ void AnimationTrackEditAudio::_preview_changed(ObjectID p_which) {
 	Ref<AudioStream> stream = object->call("get_stream");
 
 	if (stream.is_valid() && stream->get_instance_id() == p_which) {
-		update();
+		queue_redraw();
 	}
 }
 
@@ -799,7 +799,7 @@ void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
 	for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
 		Ref<AudioStream> stream = get_animation()->audio_track_get_key_stream(get_track(), i);
 		if (stream.is_valid() && stream->get_instance_id() == p_which) {
-			update();
+			queue_redraw();
 			return;
 		}
 	}
@@ -1026,7 +1026,7 @@ void AnimationTrackEditTypeAudio::drop_data(const Point2 &p_point, const Variant
 			get_undo_redo()->add_undo_method(get_animation().ptr(), "track_remove_key_at_time", get_track(), ofs);
 			get_undo_redo()->commit_action();
 
-			update();
+			queue_redraw();
 			return;
 		}
 	}
@@ -1086,7 +1086,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 	if (len_resizing && mm.is_valid()) {
 		len_resizing_rel += mm->get_relative().x;
 		len_resizing_start = mm->is_shift_pressed();
-		update();
+		queue_redraw();
 		accept_event();
 		return;
 	}
@@ -1097,7 +1097,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 		len_resizing_start = mb->is_shift_pressed();
 		len_resizing_from_px = mb->get_position().x;
 		len_resizing_rel = 0;
-		update();
+		queue_redraw();
 		accept_event();
 		return;
 	}
@@ -1120,7 +1120,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		len_resizing_index = -1;
-		update();
+		queue_redraw();
 		accept_event();
 		return;
 	}

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1092,7 +1092,7 @@ void CodeTextEditor::trim_trailing_whitespace() {
 
 	if (trimed_whitespace) {
 		text_editor->end_complex_operation();
-		text_editor->update();
+		text_editor->queue_redraw();
 	}
 }
 
@@ -1110,7 +1110,7 @@ void CodeTextEditor::insert_final_newline() {
 		text_editor->set_line(final_line, line);
 
 		text_editor->end_complex_operation();
-		text_editor->update();
+		text_editor->queue_redraw();
 	}
 }
 
@@ -1154,7 +1154,7 @@ void CodeTextEditor::convert_indent_to_spaces() {
 	if (changed_indentation) {
 		text_editor->set_caret_column(cursor_column);
 		text_editor->end_complex_operation();
-		text_editor->update();
+		text_editor->queue_redraw();
 	}
 }
 
@@ -1203,7 +1203,7 @@ void CodeTextEditor::convert_indent_to_tabs() {
 	if (changed_indentation) {
 		text_editor->set_caret_column(cursor_column);
 		text_editor->end_complex_operation();
-		text_editor->update();
+		text_editor->queue_redraw();
 	}
 }
 
@@ -1295,7 +1295,7 @@ void CodeTextEditor::move_lines_up() {
 		text_editor->set_caret_line(next_id);
 	}
 	text_editor->end_complex_operation();
-	text_editor->update();
+	text_editor->queue_redraw();
 }
 
 void CodeTextEditor::move_lines_down() {
@@ -1341,7 +1341,7 @@ void CodeTextEditor::move_lines_down() {
 		text_editor->set_caret_line(next_id);
 	}
 	text_editor->end_complex_operation();
-	text_editor->update();
+	text_editor->queue_redraw();
 }
 
 void CodeTextEditor::_delete_line(int p_line) {
@@ -1418,7 +1418,7 @@ void CodeTextEditor::duplicate_selection() {
 	}
 
 	text_editor->end_complex_operation();
-	text_editor->update();
+	text_editor->queue_redraw();
 }
 
 void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
@@ -1495,7 +1495,7 @@ void CodeTextEditor::toggle_inline_comment(const String &delimiter) {
 		text_editor->set_caret_column(col);
 	}
 	text_editor->end_complex_operation();
-	text_editor->update();
+	text_editor->queue_redraw();
 }
 
 void CodeTextEditor::goto_line(int p_line) {

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -92,7 +92,7 @@ String EditorPerformanceProfiler::_create_label(float p_value, Performance::Moni
 }
 
 void EditorPerformanceProfiler::_monitor_select() {
-	monitor_draw->update();
+	monitor_draw->queue_redraw();
 }
 
 void EditorPerformanceProfiler::_monitor_draw() {
@@ -283,12 +283,12 @@ void EditorPerformanceProfiler::_marker_input(const Ref<InputEvent> &p_event) {
 					float spacing = float(point_sep) / float(columns);
 					marker_frame = (rect.size.x - point.x) / spacing;
 				}
-				monitor_draw->update();
+				monitor_draw->queue_redraw();
 				return;
 			}
 		}
 		marker_key = "";
-		monitor_draw->update();
+		monitor_draw->queue_redraw();
 	}
 }
 
@@ -308,7 +308,7 @@ void EditorPerformanceProfiler::reset() {
 	_build_monitor_tree();
 	marker_key = "";
 	marker_frame = 0;
-	monitor_draw->update();
+	monitor_draw->queue_redraw();
 }
 
 void EditorPerformanceProfiler::update_monitors(const Vector<StringName> &p_names) {
@@ -357,7 +357,7 @@ void EditorPerformanceProfiler::add_profile_frame(const Vector<float> &p_values)
 		E.value.update_value(data);
 	}
 	marker_frame++;
-	monitor_draw->update();
+	monitor_draw->queue_redraw();
 }
 
 List<float> *EditorPerformanceProfiler::get_monitor_data(const StringName &p_name) {

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -318,7 +318,7 @@ void EditorProfiler::_update_plot() {
 	graph_texture->update(img);
 
 	graph->set_texture(graph_texture);
-	graph->update();
+	graph->queue_redraw();
 }
 
 void EditorProfiler::_update_frame() {
@@ -421,7 +421,7 @@ void EditorProfiler::_graph_tex_draw() {
 
 void EditorProfiler::_graph_tex_mouse_exit() {
 	hover_metric = -1;
-	graph->update();
+	graph->queue_redraw();
 }
 
 void EditorProfiler::_cursor_metric_changed(double) {
@@ -429,7 +429,7 @@ void EditorProfiler::_cursor_metric_changed(double) {
 		return;
 	}
 
-	graph->update();
+	graph->queue_redraw();
 	_update_frame();
 }
 
@@ -480,13 +480,13 @@ void EditorProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 			}
 		}
 
-		graph->update();
+		graph->queue_redraw();
 	}
 }
 
 void EditorProfiler::disable_seeking() {
 	seeking = false;
-	graph->update();
+	graph->queue_redraw();
 }
 
 void EditorProfiler::_combo_changed(int) {

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -312,7 +312,7 @@ void EditorVisualProfiler::_update_plot() {
 	graph_texture->update(img);
 
 	graph->set_texture(graph_texture);
-	graph->update();
+	graph->queue_redraw();
 }
 
 void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
@@ -489,7 +489,7 @@ void EditorVisualProfiler::_graph_tex_draw() {
 
 void EditorVisualProfiler::_graph_tex_mouse_exit() {
 	hover_metric = -1;
-	graph->update();
+	graph->queue_redraw();
 }
 
 void EditorVisualProfiler::_cursor_metric_changed(double) {
@@ -497,7 +497,7 @@ void EditorVisualProfiler::_cursor_metric_changed(double) {
 		return;
 	}
 
-	graph->update();
+	graph->queue_redraw();
 	_update_frame();
 }
 
@@ -613,7 +613,7 @@ void EditorVisualProfiler::_graph_tex_input(const Ref<InputEvent> &p_ev) {
 			}
 		}
 
-		graph->update();
+		graph->queue_redraw();
 	}
 }
 
@@ -637,7 +637,7 @@ int EditorVisualProfiler::_get_cursor_index() const {
 
 void EditorVisualProfiler::disable_seeking() {
 	seeking = false;
-	graph->update();
+	graph->queue_redraw();
 }
 
 void EditorVisualProfiler::_combo_changed(int) {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -182,7 +182,7 @@ void EditorAudioBus::_notification(int p_what) {
 		case NOTIFICATION_DRAG_END: {
 			if (hovering_drop) {
 				hovering_drop = false;
-				update();
+				queue_redraw();
 			}
 		} break;
 	}
@@ -967,7 +967,7 @@ void EditorAudioBusDrop::_notification(int p_what) {
 		case NOTIFICATION_MOUSE_ENTER: {
 			if (!hovering_drop) {
 				hovering_drop = true;
-				update();
+				queue_redraw();
 			}
 		} break;
 
@@ -975,7 +975,7 @@ void EditorAudioBusDrop::_notification(int p_what) {
 		case NOTIFICATION_DRAG_END: {
 			if (hovering_drop) {
 				hovering_drop = false;
-				update();
+				queue_redraw();
 			}
 		} break;
 	}

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -231,7 +231,7 @@ void EditorProperty::_notification(int p_what) {
 				bottom_child_rect = bottom_rect;
 			}
 
-			update(); //need to redraw text
+			queue_redraw(); //need to redraw text
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -398,7 +398,7 @@ void EditorProperty::_notification(int p_what) {
 
 void EditorProperty::set_label(const String &p_label) {
 	label = p_label;
-	update();
+	queue_redraw();
 }
 
 String EditorProperty::get_label() const {
@@ -478,7 +478,7 @@ void EditorProperty::update_revert_and_pin_status() {
 		}
 		can_revert = new_can_revert;
 		pinned = new_pinned;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -499,7 +499,7 @@ bool EditorProperty::use_keying_next() const {
 
 void EditorProperty::set_checkable(bool p_checkable) {
 	checkable = p_checkable;
-	update();
+	queue_redraw();
 	queue_sort();
 }
 
@@ -509,7 +509,7 @@ bool EditorProperty::is_checkable() const {
 
 void EditorProperty::set_checked(bool p_checked) {
 	checked = p_checked;
-	update();
+	queue_redraw();
 }
 
 bool EditorProperty::is_checked() const {
@@ -518,18 +518,18 @@ bool EditorProperty::is_checked() const {
 
 void EditorProperty::set_draw_warning(bool p_draw_warning) {
 	draw_warning = p_draw_warning;
-	update();
+	queue_redraw();
 }
 
 void EditorProperty::set_keying(bool p_keying) {
 	keying = p_keying;
-	update();
+	queue_redraw();
 	queue_sort();
 }
 
 void EditorProperty::set_deletable(bool p_deletable) {
 	deletable = p_deletable;
-	update();
+	queue_redraw();
 	queue_sort();
 }
 
@@ -552,7 +552,7 @@ void EditorProperty::_focusable_focused(int p_index) {
 	bool already_selected = selected;
 	selected = true;
 	selected_focusable = p_index;
-	update();
+	queue_redraw();
 	if (!already_selected && selected) {
 		emit_signal(SNAME("selected"), property, selected_focusable);
 	}
@@ -571,7 +571,7 @@ void EditorProperty::select(int p_focusable) {
 		focusables[p_focusable]->grab_focus();
 	} else {
 		selected = true;
-		update();
+		queue_redraw();
 	}
 
 	if (!already_selected && selected) {
@@ -582,7 +582,7 @@ void EditorProperty::select(int p_focusable) {
 void EditorProperty::deselect() {
 	selected = false;
 	selected_focusable = -1;
-	update();
+	queue_redraw();
 }
 
 bool EditorProperty::is_selected() const {
@@ -608,25 +608,25 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 		bool new_keying_hover = keying_rect.has_point(mpos) && !button_left;
 		if (new_keying_hover != keying_hover) {
 			keying_hover = new_keying_hover;
-			update();
+			queue_redraw();
 		}
 
 		bool new_delete_hover = delete_rect.has_point(mpos) && !button_left;
 		if (new_delete_hover != delete_hover) {
 			delete_hover = new_delete_hover;
-			update();
+			queue_redraw();
 		}
 
 		bool new_revert_hover = revert_rect.has_point(mpos) && !button_left;
 		if (new_revert_hover != revert_hover) {
 			revert_hover = new_revert_hover;
-			update();
+			queue_redraw();
 		}
 
 		bool new_check_hover = check_rect.has_point(mpos) && !button_left;
 		if (new_check_hover != check_hover) {
 			check_hover = new_check_hover;
-			update();
+			queue_redraw();
 		}
 	}
 
@@ -641,7 +641,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 		if (!selected && selectable) {
 			selected = true;
 			emit_signal(SNAME("selected"), property, -1);
-			update();
+			queue_redraw();
 		}
 
 		if (keying_rect.has_point(mpos)) {
@@ -681,7 +681,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (check_rect.has_point(mpos)) {
 			checked = !checked;
-			update();
+			queue_redraw();
 			emit_signal(SNAME("property_checked"), property, checked);
 		}
 	} else if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
@@ -912,7 +912,7 @@ void EditorProperty::menu_option(int p_option) {
 		} break;
 		case MENU_PIN_VALUE: {
 			emit_signal(SNAME("property_pinned"), property, !pinned);
-			update();
+			queue_redraw();
 		} break;
 		case MENU_OPEN_DOCUMENTATION: {
 			ScriptEditor::get_singleton()->goto_help(doc_path);
@@ -1372,26 +1372,26 @@ void EditorInspectorSection::_notification(int p_what) {
 			}
 
 			dropping = children_can_drop;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAG_END: {
 			dropping = false;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_MOUSE_ENTER: {
 			if (dropping) {
 				dropping_unfold_timer->start();
 			}
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			if (dropping) {
 				dropping_unfold_timer->stop();
 			}
-			update();
+			queue_redraw();
 		} break;
 	}
 }
@@ -1477,7 +1477,7 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 			fold();
 		}
 	} else if (mb.is_valid() && !mb->is_pressed()) {
-		update();
+		queue_redraw();
 	}
 }
 
@@ -1494,7 +1494,7 @@ void EditorInspectorSection::unfold() {
 
 	object->editor_set_section_unfold(section, true);
 	vbox->show();
-	update();
+	queue_redraw();
 }
 
 void EditorInspectorSection::fold() {
@@ -1508,7 +1508,7 @@ void EditorInspectorSection::fold() {
 
 	object->editor_set_section_unfold(section, false);
 	vbox->hide();
-	update();
+	queue_redraw();
 }
 
 bool EditorInspectorSection::has_revertable_properties() const {
@@ -1523,7 +1523,7 @@ void EditorInspectorSection::property_can_revert_changed(const String &p_path, b
 		revertable_properties.erase(p_path);
 	}
 	if (has_revertable_properties() != had_revertable_properties) {
-		update();
+		queue_redraw();
 	}
 }
 
@@ -2052,8 +2052,8 @@ void EditorInspectorArray::_setup() {
 		ae.panel->set_drag_forwarding(this);
 		ae.panel->set_meta("index", begin_array_index + i);
 		ae.panel->set_tooltip_text(vformat(TTR("Element %d: %s%d*"), i, array_element_prefix, i));
-		ae.panel->connect("focus_entered", callable_mp((CanvasItem *)ae.panel, &PanelContainer::update));
-		ae.panel->connect("focus_exited", callable_mp((CanvasItem *)ae.panel, &PanelContainer::update));
+		ae.panel->connect("focus_entered", callable_mp((CanvasItem *)ae.panel, &PanelContainer::queue_redraw));
+		ae.panel->connect("focus_exited", callable_mp((CanvasItem *)ae.panel, &PanelContainer::queue_redraw));
 		ae.panel->connect("draw", callable_mp(this, &EditorInspectorArray::_panel_draw).bind(i));
 		ae.panel->connect("gui_input", callable_mp(this, &EditorInspectorArray::_panel_gui_input).bind(i));
 		ae.panel->add_theme_style_override(SNAME("panel"), i % 2 ? odd_style : even_style);
@@ -2155,7 +2155,7 @@ bool EditorInspectorArray::can_drop_data_fw(const Point2 &p_point, const Variant
 		return false;
 	}
 	// First, update drawing.
-	control_dropping->update();
+	control_dropping->queue_redraw();
 
 	if (p_data.get_type() != Variant::DICTIONARY) {
 		return false;
@@ -2206,14 +2206,14 @@ void EditorInspectorArray::_notification(int p_what) {
 			Dictionary dict = get_viewport()->gui_get_drag_data();
 			if (dict.has("type") && dict["type"] == "property_array_element" && String(dict["property_array_prefix"]) == array_element_prefix) {
 				dropping = true;
-				control_dropping->update();
+				control_dropping->queue_redraw();
 			}
 		} break;
 
 		case NOTIFICATION_DRAG_END: {
 			if (dropping) {
 				dropping = false;
-				control_dropping->update();
+				control_dropping->queue_redraw();
 			}
 		} break;
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4563,7 +4563,7 @@ void EditorNode::_dock_select_input(const Ref<InputEvent> &p_input) {
 		}
 
 		if (nrect != dock_select_rect_over_idx) {
-			dock_select->update();
+			dock_select->queue_redraw();
 			dock_select_rect_over_idx = nrect;
 		}
 
@@ -4589,7 +4589,7 @@ void EditorNode::_dock_select_input(const Ref<InputEvent> &p_input) {
 			dock_popup_selected_idx = nrect;
 			dock_slot[nrect]->set_current_tab(dock_slot[nrect]->get_tab_count() - 1);
 			dock_slot[nrect]->show();
-			dock_select->update();
+			dock_select->queue_redraw();
 
 			_update_dock_containers();
 
@@ -4601,7 +4601,7 @@ void EditorNode::_dock_select_input(const Ref<InputEvent> &p_input) {
 
 void EditorNode::_dock_popup_exit() {
 	dock_select_rect_over_idx = -1;
-	dock_select->update();
+	dock_select->queue_redraw();
 }
 
 void EditorNode::_dock_pre_popup(int p_which) {
@@ -4619,7 +4619,7 @@ void EditorNode::_dock_move_left() {
 	}
 	dock_slot[dock_popup_selected_idx]->move_child(current, prev->get_index());
 	dock_slot[dock_popup_selected_idx]->set_current_tab(dock_slot[dock_popup_selected_idx]->get_current_tab() - 1);
-	dock_select->update();
+	dock_select->queue_redraw();
 	_edit_current();
 	_save_docks();
 }
@@ -4632,7 +4632,7 @@ void EditorNode::_dock_move_right() {
 	}
 	dock_slot[dock_popup_selected_idx]->move_child(next, current->get_index());
 	dock_slot[dock_popup_selected_idx]->set_current_tab(dock_slot[dock_popup_selected_idx]->get_current_tab() + 1);
-	dock_select->update();
+	dock_select->queue_redraw();
 	_edit_current();
 	_save_docks();
 }

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -599,7 +599,7 @@ int EditorPlugin::update_overlays() const {
 		return count;
 	} else {
 		// This will update the normal viewport itself as well
-		CanvasItemEditor::get_singleton()->get_viewport_control()->update();
+		CanvasItemEditor::get_singleton()->get_viewport_control()->queue_redraw();
 		return 1;
 	}
 }

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -951,7 +951,7 @@ void EditorPropertyLayersGrid::gui_input(const Ref<InputEvent> &p_ev) {
 		bool expand_was_hovered = expand_hovered;
 		expand_hovered = expand_rect.has_point(mm->get_position());
 		if (expand_hovered != expand_was_hovered) {
-			update();
+			queue_redraw();
 		}
 
 		if (!expand_hovered) {
@@ -959,7 +959,7 @@ void EditorPropertyLayersGrid::gui_input(const Ref<InputEvent> &p_ev) {
 				if (flag_rects[i].has_point(mm->get_position())) {
 					// Used to highlight the hovered flag in the layers grid.
 					hovered_index = i;
-					update();
+					queue_redraw();
 					return;
 				}
 			}
@@ -968,7 +968,7 @@ void EditorPropertyLayersGrid::gui_input(const Ref<InputEvent> &p_ev) {
 		// Remove highlight when no square is hovered.
 		if (hovered_index != -1) {
 			hovered_index = -1;
-			update();
+			queue_redraw();
 		}
 
 		return;
@@ -986,11 +986,11 @@ void EditorPropertyLayersGrid::gui_input(const Ref<InputEvent> &p_ev) {
 			}
 
 			emit_signal(SNAME("flag_changed"), value);
-			update();
+			queue_redraw();
 		} else if (expand_hovered) {
 			expanded = !expanded;
 			update_minimum_size();
-			update();
+			queue_redraw();
 		}
 	}
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
@@ -1131,11 +1131,11 @@ void EditorPropertyLayersGrid::_notification(int p_what) {
 		case NOTIFICATION_MOUSE_EXIT: {
 			if (expand_hovered) {
 				expand_hovered = false;
-				update();
+				queue_redraw();
 			}
 			if (hovered_index != -1) {
 				hovered_index = -1;
-				update();
+				queue_redraw();
 			}
 		} break;
 	}
@@ -1143,7 +1143,7 @@ void EditorPropertyLayersGrid::_notification(int p_what) {
 
 void EditorPropertyLayersGrid::set_flag(uint32_t p_flag) {
 	value = p_flag;
-	update();
+	queue_redraw();
 }
 
 void EditorPropertyLayersGrid::_bind_methods() {
@@ -1276,7 +1276,7 @@ void EditorPropertyLayers::_menu_pressed(int p_menu) {
 	} else {
 		grid->value |= (1 << p_menu);
 	}
-	grid->update();
+	grid->queue_redraw();
 	layers->set_item_checked(layers->get_item_index(p_menu), grid->value & (1 << p_menu));
 	_grid_changed(grid->value);
 }
@@ -1523,13 +1523,13 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 
 			// Ensure the easing doesn't appear as being dragged
 			dragging = false;
-			easing_draw->update();
+			easing_draw->queue_redraw();
 		}
 
 		if (mb->get_button_index() == MouseButton::LEFT) {
 			dragging = mb->is_pressed();
 			// Update to display the correct dragging color
-			easing_draw->update();
+			easing_draw->queue_redraw();
 		}
 	}
 
@@ -1569,7 +1569,7 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 		val = CLAMP(val, -1'000'000, 1'000'000);
 
 		emit_changed(get_edited_property(), val);
-		easing_draw->update();
+		easing_draw->queue_redraw();
 	}
 }
 
@@ -1621,14 +1621,14 @@ void EditorPropertyEasing::_draw_easing() {
 }
 
 void EditorPropertyEasing::update_property() {
-	easing_draw->update();
+	easing_draw->queue_redraw();
 }
 
 void EditorPropertyEasing::_set_preset(int p_preset) {
 	static const float preset_value[EASING_MAX] = { 0.0, 1.0, 2.0, 0.5, -2.0, -0.5 };
 
 	emit_changed(get_edited_property(), preset_value[p_preset]);
-	easing_draw->update();
+	easing_draw->queue_redraw();
 }
 
 void EditorPropertyEasing::_setup_spin() {
@@ -1667,7 +1667,7 @@ void EditorPropertyEasing::_spin_focus_exited() {
 	spin->hide();
 	// Ensure the easing doesn't appear as being dragged
 	dragging = false;
-	easing_draw->update();
+	easing_draw->queue_redraw();
 }
 
 void EditorPropertyEasing::setup(bool p_positive_only, bool p_flip) {
@@ -3952,7 +3952,7 @@ void EditorPropertyResource::_update_property_bg() {
 	}
 
 	updating_theme = false;
-	update();
+	queue_redraw();
 }
 
 void EditorPropertyResource::_update_preferred_shader() {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -509,7 +509,7 @@ void EditorPropertyArray::_notification(int p_what) {
 			if (is_visible_in_tree()) {
 				if (_is_drop_valid(get_viewport()->gui_get_drag_data())) {
 					dropping = true;
-					edit->update();
+					edit->queue_redraw();
 				}
 			}
 		} break;
@@ -517,7 +517,7 @@ void EditorPropertyArray::_notification(int p_what) {
 		case NOTIFICATION_DRAG_END: {
 			if (dropping) {
 				dropping = false;
-				edit->update();
+				edit->queue_redraw();
 			}
 		} break;
 	}

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -775,14 +775,14 @@ void EditorResourcePicker::_notification(int p_what) {
 		case NOTIFICATION_DRAG_BEGIN: {
 			if (editable && _is_drop_valid(get_viewport()->gui_get_drag_data())) {
 				dropping = true;
-				assign_button->update();
+				assign_button->queue_redraw();
 			}
 		} break;
 
 		case NOTIFICATION_DRAG_END: {
 			if (dropping) {
 				dropping = false;
-				assign_button->update();
+				assign_button->queue_redraw();
 			}
 		} break;
 	}
@@ -1049,7 +1049,7 @@ void EditorAudioStreamPicker::_notification(int p_what) {
 					Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(audio_stream);
 					if (preview.is_valid()) {
 						if (preview->get_version() != last_preview_version) {
-							stream_preview_rect->update();
+							stream_preview_rect->queue_redraw();
 							last_preview_version = preview->get_version();
 						}
 					}
@@ -1083,10 +1083,10 @@ void EditorAudioStreamPicker::_notification(int p_what) {
 						}
 					}
 
-					stream_preview_rect->update();
+					stream_preview_rect->queue_redraw();
 				} else {
 					if (tagged_frame_offset_count != 0) {
-						stream_preview_rect->update();
+						stream_preview_rect->queue_redraw();
 					}
 					tagged_frame_offset_count = 0;
 				}
@@ -1107,7 +1107,7 @@ void EditorAudioStreamPicker::_update_resource() {
 		set_assign_button_min_size(Size2(1, font->get_height(font_size) * 1.5));
 	}
 
-	stream_preview_rect->update();
+	stream_preview_rect->queue_redraw();
 }
 
 void EditorAudioStreamPicker::_preview_draw() {

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -82,7 +82,7 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 					if (grabbing_spinner) {
 						Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 						Input::get_singleton()->warp_mouse(grabbing_spinner_mouse_pos);
-						update();
+						queue_redraw();
 					} else {
 						_focus_entered();
 					}
@@ -93,7 +93,7 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		} else if (mb->get_button_index() == MouseButton::WHEEL_UP || mb->get_button_index() == MouseButton::WHEEL_DOWN) {
 			if (grabber->is_visible()) {
-				call_deferred(SNAME("update"));
+				call_deferred(SNAME("queue_redraw"));
 			}
 		}
 	}
@@ -137,7 +137,7 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 			bool new_hover = (mm->get_position().x > updown_offset);
 			if (new_hover != hover_updown) {
 				hover_updown = new_hover;
-				update();
+				queue_redraw();
 			}
 		}
 	}
@@ -190,7 +190,7 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 		ERR_FAIL_COND(Math::is_zero_approx(scale_x));
 		float grabbing_ofs = (grabber->get_transform().xform(mm->get_position()).x - grabbing_from) / float(grabber_range) / scale_x;
 		set_as_ratio(grabbing_ratio + grabbing_ofs);
-		update();
+		queue_redraw();
 	}
 }
 
@@ -463,12 +463,12 @@ void EditorSpinSlider::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_ENTER: {
 			mouse_over_spin = true;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			mouse_over_spin = false;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {
@@ -498,7 +498,7 @@ Size2 EditorSpinSlider::get_minimum_size() const {
 
 void EditorSpinSlider::set_hide_slider(bool p_hide) {
 	hide_slider = p_hide;
-	update();
+	queue_redraw();
 }
 
 bool EditorSpinSlider::is_hiding_slider() const {
@@ -507,7 +507,7 @@ bool EditorSpinSlider::is_hiding_slider() const {
 
 void EditorSpinSlider::set_label(const String &p_label) {
 	label = p_label;
-	update();
+	queue_redraw();
 }
 
 String EditorSpinSlider::get_label() const {
@@ -516,7 +516,7 @@ String EditorSpinSlider::get_label() const {
 
 void EditorSpinSlider::set_suffix(const String &p_suffix) {
 	suffix = p_suffix;
-	update();
+	queue_redraw();
 }
 
 String EditorSpinSlider::get_suffix() const {
@@ -583,17 +583,17 @@ void EditorSpinSlider::_value_focus_exited() {
 
 void EditorSpinSlider::_grabber_mouse_entered() {
 	mouse_over_grabber = true;
-	update();
+	queue_redraw();
 }
 
 void EditorSpinSlider::_grabber_mouse_exited() {
 	mouse_over_grabber = false;
-	update();
+	queue_redraw();
 }
 
 void EditorSpinSlider::set_read_only(bool p_enable) {
 	read_only = p_enable;
-	update();
+	queue_redraw();
 }
 
 bool EditorSpinSlider::is_read_only() const {
@@ -602,7 +602,7 @@ bool EditorSpinSlider::is_read_only() const {
 
 void EditorSpinSlider::set_flat(bool p_enable) {
 	flat = p_enable;
-	update();
+	queue_redraw();
 }
 
 bool EditorSpinSlider::is_flat() const {

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -62,7 +62,7 @@ void EditorToaster::_notification(int p_what) {
 					if (toasts[element.key].remaining_time < 0) {
 						close(element.key);
 					}
-					element.key->update();
+					element.key->queue_redraw();
 				}
 			} else {
 				// Reset the timers when hovered.
@@ -71,7 +71,7 @@ void EditorToaster::_notification(int p_what) {
 						continue;
 					}
 					toasts[element.key].remaining_time = element.value.duration;
-					element.key->update();
+					element.key->queue_redraw();
 				}
 			}
 
@@ -101,7 +101,7 @@ void EditorToaster::_notification(int p_what) {
 			if (needs_update) {
 				_update_vbox_position();
 				_update_disable_notifications_button();
-				main_button->update();
+				main_button->queue_redraw();
 			}
 		} break;
 
@@ -132,8 +132,8 @@ void EditorToaster::_notification(int p_what) {
 			error_panel_style_progress->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")).lightened(0.03));
 			error_panel_style_progress->set_border_color(get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
-			main_button->update();
-			disable_notifications_button->update();
+			main_button->queue_redraw();
+			disable_notifications_button->queue_redraw();
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
@@ -334,7 +334,7 @@ void EditorToaster::_repop_old() {
 	if (needs_update) {
 		_update_vbox_position();
 		_update_disable_notifications_button();
-		main_button->update();
+		main_button->queue_redraw();
 	}
 }
 
@@ -389,7 +389,7 @@ Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_
 	_auto_hide_or_free_toasts();
 	_update_vbox_position();
 	_update_disable_notifications_button();
-	main_button->update();
+	main_button->queue_redraw();
 
 	return panel;
 }
@@ -438,7 +438,7 @@ void EditorToaster::_popup_str(String p_message, Severity p_severity, String p_t
 		_auto_hide_or_free_toasts();
 		_update_vbox_position();
 		_update_disable_notifications_button();
-		main_button->update();
+		main_button->queue_redraw();
 	}
 
 	// Retrieve the label back then update the text.

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -57,13 +57,13 @@ void AudioStreamImportSettings::_notification(int p_what) {
 			zoom_out->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
 			zoom_reset->set_icon(get_theme_icon(SNAME("ZoomReset"), SNAME("EditorIcons")));
 
-			_indicator->update();
-			_preview->update();
+			_indicator->queue_redraw();
+			_preview->queue_redraw();
 		} break;
 
 		case NOTIFICATION_PROCESS: {
 			_current = _player->get_playback_position();
-			_indicator->update();
+			_indicator->queue_redraw();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -167,7 +167,7 @@ void AudioStreamImportSettings::_draw_preview() {
 
 void AudioStreamImportSettings::_preview_changed(ObjectID p_which) {
 	if (stream.is_valid() && stream->get_instance_id() == p_which) {
-		_preview->update();
+		_preview->queue_redraw();
 	}
 }
 
@@ -179,8 +179,8 @@ void AudioStreamImportSettings::_preview_zoom_in() {
 	zoom_bar->set_page(page_size * 0.5);
 	zoom_bar->set_value(zoom_bar->get_value() + page_size * 0.25);
 
-	_preview->update();
-	_indicator->update();
+	_preview->queue_redraw();
+	_indicator->queue_redraw();
 }
 
 void AudioStreamImportSettings::_preview_zoom_out() {
@@ -191,8 +191,8 @@ void AudioStreamImportSettings::_preview_zoom_out() {
 	zoom_bar->set_page(MIN(zoom_bar->get_max(), page_size * 2.0));
 	zoom_bar->set_value(zoom_bar->get_value() - page_size * 0.5);
 
-	_preview->update();
-	_indicator->update();
+	_preview->queue_redraw();
+	_indicator->queue_redraw();
 }
 
 void AudioStreamImportSettings::_preview_zoom_reset() {
@@ -202,22 +202,22 @@ void AudioStreamImportSettings::_preview_zoom_reset() {
 	zoom_bar->set_max(stream->get_length());
 	zoom_bar->set_page(zoom_bar->get_max());
 	zoom_bar->set_value(0);
-	_preview->update();
-	_indicator->update();
+	_preview->queue_redraw();
+	_indicator->queue_redraw();
 }
 
 void AudioStreamImportSettings::_preview_zoom_offset_changed(double) {
-	_preview->update();
-	_indicator->update();
+	_preview->queue_redraw();
+	_indicator->queue_redraw();
 }
 
 void AudioStreamImportSettings::_audio_changed() {
 	if (!is_visible()) {
 		return;
 	}
-	_preview->update();
-	_indicator->update();
-	color_rect->update();
+	_preview->queue_redraw();
+	_indicator->queue_redraw();
+	color_rect->queue_redraw();
 }
 
 void AudioStreamImportSettings::_play() {
@@ -238,7 +238,7 @@ void AudioStreamImportSettings::_stop() {
 	_player->stop();
 	_play_button->set_icon(get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 	_current = 0;
-	_indicator->update();
+	_indicator->queue_redraw();
 	set_process(false);
 }
 
@@ -246,7 +246,7 @@ void AudioStreamImportSettings::_on_finished() {
 	_play_button->set_icon(get_theme_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
 	if (!_pausing) {
 		_current = 0;
-		_indicator->update();
+		_indicator->queue_redraw();
 	} else {
 		_pausing = false;
 	}
@@ -310,7 +310,7 @@ void AudioStreamImportSettings::_draw_indicator() {
 
 void AudioStreamImportSettings::_on_indicator_mouse_exited() {
 	_hovering_beat = -1;
-	_indicator->update();
+	_indicator->queue_redraw();
 }
 
 void AudioStreamImportSettings::_on_input_indicator(Ref<InputEvent> p_event) {
@@ -353,11 +353,11 @@ void AudioStreamImportSettings::_on_input_indicator(Ref<InputEvent> p_event) {
 				int new_hovering_beat = _get_beat_at_pos(mm->get_position().x);
 				if (new_hovering_beat != _hovering_beat) {
 					_hovering_beat = new_hovering_beat;
-					_indicator->update();
+					_indicator->queue_redraw();
 				}
 			} else if (_hovering_beat != -1) {
 				_hovering_beat = -1;
-				_indicator->update();
+				_indicator->queue_redraw();
 			}
 		}
 	}
@@ -391,7 +391,7 @@ void AudioStreamImportSettings::_seek_to(real_t p_x) {
 	_current = zoom_bar->get_value() + p_x / _preview->get_rect().size.x * zoom_bar->get_page();
 	_current = CLAMP(_current, 0, stream->get_length());
 	_player->seek(_current);
-	_indicator->update();
+	_indicator->queue_redraw();
 }
 
 void AudioStreamImportSettings::edit(const String &p_path, const String &p_importer, const Ref<AudioStream> &p_stream) {
@@ -410,9 +410,9 @@ void AudioStreamImportSettings::edit(const String &p_path, const String &p_impor
 
 	if (!stream.is_null()) {
 		stream->connect("changed", callable_mp(this, &AudioStreamImportSettings::_audio_changed));
-		_preview->update();
-		_indicator->update();
-		color_rect->update();
+		_preview->queue_redraw();
+		_indicator->queue_redraw();
+		color_rect->queue_redraw();
 	} else {
 		hide();
 	}
@@ -500,9 +500,9 @@ void AudioStreamImportSettings::_settings_changed() {
 
 	updating_settings = false;
 
-	_preview->update();
-	_indicator->update();
-	color_rect->update();
+	_preview->queue_redraw();
+	_indicator->queue_redraw();
+	color_rect->queue_redraw();
 }
 
 void AudioStreamImportSettings::_reimport() {

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -474,7 +474,7 @@ void DynamicFontImportSettings::_main_prop_changed(const String &p_edited_proper
 
 	font_preview_label->add_theme_font_override("font", font_preview);
 	font_preview_label->add_theme_font_size_override("font_size", 200 * EDSCALE);
-	font_preview_label->update();
+	font_preview_label->queue_redraw();
 }
 
 /*************************************************************************/
@@ -1096,7 +1096,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 	}
 	font_preview_label->add_theme_font_override("font", font_preview);
 	font_preview_label->add_theme_font_size_override("font_size", 200 * EDSCALE);
-	font_preview_label->update();
+	font_preview_label->queue_redraw();
 
 	_variations_validate();
 

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -120,7 +120,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && tool_select->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		blend_space_draw->update(); // why not
+		blend_space_draw->queue_redraw(); // why not
 
 		// try to see if a point can be selected
 		selected_point = -1;
@@ -167,7 +167,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 			dragging_selected_attempt = false;
 			dragging_selected = false;
-			blend_space_draw->update();
+			blend_space_draw->queue_redraw();
 		}
 	}
 
@@ -178,20 +178,20 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 		blend_pos += blend_space->get_min_space();
 
 		AnimationTreeEditor::get_singleton()->get_tree()->set(get_blend_position_path(), blend_pos);
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid() && !blend_space_draw->has_focus()) {
 		blend_space_draw->grab_focus();
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 
 	if (mm.is_valid() && dragging_selected_attempt) {
 		dragging_selected = true;
 		drag_ofs = ((mm->get_position() - drag_from) / blend_space_draw->get_size()) * ((blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, 0));
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 		_update_edited_point_pos();
 	}
 
@@ -202,7 +202,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 		AnimationTreeEditor::get_singleton()->get_tree()->set(get_blend_position_path(), blend_pos);
 
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 }
 
@@ -330,7 +330,7 @@ void AnimationNodeBlendSpace1DEditor::_update_space() {
 
 	snap_value->set_value(blend_space->get_snap());
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 
 	updating = false;
 }
@@ -355,7 +355,7 @@ void AnimationNodeBlendSpace1DEditor::_config_changed(double) {
 	undo_redo->commit_action();
 	updating = false;
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace1DEditor::_labels_changed(String) {
@@ -374,7 +374,7 @@ void AnimationNodeBlendSpace1DEditor::_labels_changed(String) {
 }
 
 void AnimationNodeBlendSpace1DEditor::_snap_toggled() {
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace1DEditor::_file_opened(const String &p_file) {
@@ -425,7 +425,7 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 	undo_redo->commit_action();
 	updating = false;
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace1DEditor::_add_animation_type(int p_index) {
@@ -443,7 +443,7 @@ void AnimationNodeBlendSpace1DEditor::_add_animation_type(int p_index) {
 	undo_redo->commit_action();
 	updating = false;
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace1DEditor::_tool_switch(int p_tool) {
@@ -456,7 +456,7 @@ void AnimationNodeBlendSpace1DEditor::_tool_switch(int p_tool) {
 	}
 
 	_update_tool_erase();
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace1DEditor::_update_edited_point_pos() {
@@ -517,7 +517,7 @@ void AnimationNodeBlendSpace1DEditor::_erase_selected() {
 
 		updating = false;
 
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 }
 
@@ -537,7 +537,7 @@ void AnimationNodeBlendSpace1DEditor::_edit_point_pos(double) {
 	undo_redo->commit_action();
 	updating = false;
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace1DEditor::_open_editor() {

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -52,7 +52,7 @@ bool AnimationNodeBlendSpace2DEditor::can_edit(const Ref<AnimationNode> &p_node)
 }
 
 void AnimationNodeBlendSpace2DEditor::_blend_space_changed() {
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
@@ -161,7 +161,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && tool_select->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		blend_space_draw->update(); //update anyway
+		blend_space_draw->queue_redraw(); //update anyway
 		//try to see if a point can be selected
 		selected_point = -1;
 		selected_triangle = -1;
@@ -201,7 +201,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && tool_triangle->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
-		blend_space_draw->update(); //update anyway
+		blend_space_draw->queue_redraw(); //update anyway
 		//try to see if a point can be selected
 		selected_point = -1;
 
@@ -260,7 +260,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 		}
 		dragging_selected_attempt = false;
 		dragging_selected = false;
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && tool_blend->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
@@ -271,14 +271,14 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 		AnimationTreeEditor::get_singleton()->get_tree()->set(get_blend_position_path(), blend_pos);
 
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid() && !blend_space_draw->has_focus()) {
 		blend_space_draw->grab_focus();
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 
 	if (mm.is_valid() && dragging_selected_attempt) {
@@ -286,17 +286,17 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 		if (!read_only) {
 			drag_ofs = ((mm->get_position() - drag_from) / blend_space_draw->get_size()) * (blend_space->get_max_space() - blend_space->get_min_space()) * Vector2(1, -1);
 		}
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 		_update_edited_point_pos();
 	}
 
 	if (mm.is_valid() && tool_triangle->is_pressed() && making_triangle.size()) {
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 
 	if (mm.is_valid() && !tool_triangle->is_pressed() && making_triangle.size()) {
 		making_triangle.clear();
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 
 	if (mm.is_valid() && tool_blend->is_pressed() && (mm->get_button_mask() & MouseButton::MASK_LEFT) != MouseButton::NONE) {
@@ -307,7 +307,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 		AnimationTreeEditor::get_singleton()->get_tree()->set(get_blend_position_path(), blend_pos);
 
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 }
 
@@ -359,7 +359,7 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 	undo_redo->commit_action();
 	updating = false;
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace2DEditor::_add_animation_type(int p_index) {
@@ -377,7 +377,7 @@ void AnimationNodeBlendSpace2DEditor::_add_animation_type(int p_index) {
 	undo_redo->commit_action();
 	updating = false;
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace2DEditor::_update_tool_erase() {
@@ -424,7 +424,7 @@ void AnimationNodeBlendSpace2DEditor::_tool_switch(int p_tool) {
 		tool_erase_sep->hide();
 	}
 	_update_tool_erase();
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
@@ -614,7 +614,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 }
 
 void AnimationNodeBlendSpace2DEditor::_snap_toggled() {
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace2DEditor::_update_space() {
@@ -647,7 +647,7 @@ void AnimationNodeBlendSpace2DEditor::_update_space() {
 	snap_x->set_value(blend_space->get_snap().x);
 	snap_y->set_value(blend_space->get_snap().y);
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 
 	updating = false;
 }
@@ -674,7 +674,7 @@ void AnimationNodeBlendSpace2DEditor::_config_changed(double) {
 	undo_redo->commit_action();
 	updating = false;
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace2DEditor::_labels_changed(String) {
@@ -716,7 +716,7 @@ void AnimationNodeBlendSpace2DEditor::_erase_selected() {
 		undo_redo->commit_action();
 		updating = false;
 
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	} else if (selected_triangle != -1) {
 		updating = true;
 		undo_redo->create_action(TTR("Remove BlendSpace2D Triangle"));
@@ -728,7 +728,7 @@ void AnimationNodeBlendSpace2DEditor::_erase_selected() {
 		undo_redo->commit_action();
 		updating = false;
 
-		blend_space_draw->update();
+		blend_space_draw->queue_redraw();
 	}
 }
 
@@ -767,7 +767,7 @@ void AnimationNodeBlendSpace2DEditor::_edit_point_pos(double) {
 	undo_redo->commit_action();
 	updating = false;
 
-	blend_space_draw->update();
+	blend_space_draw->queue_redraw();
 }
 
 void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -128,7 +128,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 					//travel
 					playback->travel(node_rects[i].node_name);
 				}
-				state_machine_draw->update();
+				state_machine_draw->queue_redraw();
 				return;
 			}
 
@@ -168,7 +168,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 				Ref<AnimationNode> anode = state_machine->get_node(selected_node);
 				EditorNode::get_singleton()->push_item(anode.ptr(), "", true);
-				state_machine_draw->update();
+				state_machine_draw->queue_redraw();
 				dragging_selected_attempt = true;
 				dragging_selected = false;
 				drag_from = mb->get_position();
@@ -228,7 +228,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			}
 		}
 
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 		_update_mode();
 	}
 
@@ -259,7 +259,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 		dragging_selected_attempt = false;
 		dragging_selected = false;
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 	}
 
 	// Connect nodes
@@ -296,7 +296,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			_open_menu(mb->get_position());
 		}
 		connecting_to_node = StringName();
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 	}
 
 	// Start box selecting
@@ -319,7 +319,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	// End box selecting
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed() && box_selecting) {
 		box_selecting = false;
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 		_update_mode();
 	}
 
@@ -335,7 +335,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	if (mm.is_valid() && connecting && !read_only) {
 		connecting_to = mm->get_position();
 		connecting_to_node = StringName();
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 
 		for (int i = node_rects.size() - 1; i >= 0; i--) { //inverse to draw order
 			if (node_rects[i].node_name != connecting_from && node_rects[i].node.has_point(connecting_to)) { //select node since nothing else was selected
@@ -382,7 +382,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			}
 		}
 
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 	}
 
 	// Move mouse while moving box select
@@ -412,7 +412,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			}
 		}
 
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 	}
 
 	if (mm.is_valid()) {
@@ -442,7 +442,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		if (new_over_node != over_node || new_over_node_what != over_node_what) {
 			over_node = new_over_node;
 			over_node_what = new_over_node_what;
-			state_machine_draw->update();
+			state_machine_draw->queue_redraw();
 		}
 
 		// set tooltip for transition
@@ -620,7 +620,7 @@ void AnimationNodeStateMachineEditor::_group_selected_nodes() {
 
 		selected_nodes.clear();
 		selected_nodes.insert(group_name);
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 		accept_event();
 		_update_mode();
 	}
@@ -721,7 +721,7 @@ void AnimationNodeStateMachineEditor::_ungroup_selected_nodes() {
 	if (find) {
 		selected_nodes = new_selected_nodes;
 		selected_node = StringName();
-		state_machine_draw->update();
+		state_machine_draw->queue_redraw();
 		accept_event();
 		_update_mode();
 	}
@@ -909,7 +909,7 @@ bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<Ani
 
 void AnimationNodeStateMachineEditor::_stop_connecting() {
 	connecting = false;
-	state_machine_draw->update();
+	state_machine_draw->queue_redraw();
 }
 
 void AnimationNodeStateMachineEditor::_delete_selected() {
@@ -1028,7 +1028,7 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 	undo_redo->commit_action();
 	updating = false;
 
-	state_machine_draw->update();
+	state_machine_draw->queue_redraw();
 }
 
 void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
@@ -1056,7 +1056,7 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 	undo_redo->commit_action();
 	updating = false;
 
-	state_machine_draw->update();
+	state_machine_draw->queue_redraw();
 }
 
 void AnimationNodeStateMachineEditor::_connect_to(int p_index) {
@@ -1475,7 +1475,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	v_scroll->set_value(state_machine->get_graph_offset().y);
 	updating = false;
 
-	state_machine_play_pos->update();
+	state_machine_play_pos->queue_redraw();
 }
 
 void AnimationNodeStateMachineEditor::_state_machine_pos_draw() {
@@ -1537,7 +1537,7 @@ void AnimationNodeStateMachineEditor::_update_graph() {
 
 	updating = true;
 
-	state_machine_draw->update();
+	state_machine_draw->queue_redraw();
 
 	updating = false;
 }
@@ -1609,34 +1609,34 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 				}
 
 				if (tidx == -1) { //missing transition, should redraw
-					state_machine_draw->update();
+					state_machine_draw->queue_redraw();
 					break;
 				}
 
 				if (transition_lines[i].disabled != state_machine->get_transition(tidx)->is_disabled()) {
-					state_machine_draw->update();
+					state_machine_draw->queue_redraw();
 					break;
 				}
 
 				if (transition_lines[i].auto_advance != state_machine->get_transition(tidx)->has_auto_advance()) {
-					state_machine_draw->update();
+					state_machine_draw->queue_redraw();
 					break;
 				}
 
 				if (transition_lines[i].advance_condition_name != state_machine->get_transition(tidx)->get_advance_condition_name()) {
-					state_machine_draw->update();
+					state_machine_draw->queue_redraw();
 					break;
 				}
 
 				if (transition_lines[i].mode != state_machine->get_transition(tidx)->get_switch_mode()) {
-					state_machine_draw->update();
+					state_machine_draw->queue_redraw();
 					break;
 				}
 
 				bool acstate = transition_lines[i].advance_condition_name != StringName() && bool(AnimationTreeEditor::get_singleton()->get_tree()->get(AnimationTreeEditor::get_singleton()->get_base_path() + String(transition_lines[i].advance_condition_name)));
 
 				if (transition_lines[i].advance_condition_state != acstate) {
-					state_machine_draw->update();
+					state_machine_draw->queue_redraw();
 					break;
 				}
 			}
@@ -1671,14 +1671,14 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 				}
 			}
 
-			//update if travel state changed
+			//redraw if travel state changed
 			if (!same_travel_path || last_active != is_playing || last_current_node != current_node || last_blend_from_node != blend_from_node) {
-				state_machine_draw->update();
+				state_machine_draw->queue_redraw();
 				last_travel_path = tp;
 				last_current_node = current_node;
 				last_active = is_playing;
 				last_blend_from_node = blend_from_node;
-				state_machine_play_pos->update();
+				state_machine_play_pos->queue_redraw();
 			}
 
 			{
@@ -1703,7 +1703,7 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 
 			if (last_play_pos != play_pos) {
 				last_play_pos = play_pos;
-				state_machine_play_pos->update();
+				state_machine_play_pos->queue_redraw();
 			}
 		} break;
 
@@ -1749,7 +1749,7 @@ void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 	name_edit_popup->hide();
 	updating = false;
 
-	state_machine_draw->update();
+	state_machine_draw->queue_redraw();
 }
 
 void AnimationNodeStateMachineEditor::_name_edited_focus_out() {
@@ -1766,7 +1766,7 @@ void AnimationNodeStateMachineEditor::_scroll_changed(double) {
 	}
 
 	state_machine->set_graph_offset(Vector2(h_scroll->get_value(), v_scroll->get_value()));
-	state_machine_draw->update();
+	state_machine_draw->queue_redraw();
 }
 
 void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action) {
@@ -1857,7 +1857,7 @@ void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action
 		selected_multi_transition = TransitionLine();
 	}
 
-	state_machine_draw->update();
+	state_machine_draw->queue_redraw();
 }
 
 void AnimationNodeStateMachineEditor::_update_mode() {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -487,21 +487,21 @@ void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 
 	if (k.is_valid()) {
 		if (k->get_keycode() == Key::CTRL || k->get_keycode() == Key::ALT || k->get_keycode() == Key::SHIFT) {
-			viewport->update();
+			viewport->queue_redraw();
 		}
 
 		if (k->is_pressed() && !k->is_ctrl_pressed() && !k->is_echo() && (grid_snap_active || _is_grid_visible())) {
 			if (multiply_grid_step_shortcut.is_valid() && multiply_grid_step_shortcut->matches_event(p_ev)) {
 				// Multiply the grid size
 				grid_step_multiplier = MIN(grid_step_multiplier + 1, 12);
-				viewport->update();
+				viewport->queue_redraw();
 			} else if (divide_grid_step_shortcut.is_valid() && divide_grid_step_shortcut->matches_event(p_ev)) {
 				// Divide the grid size
 				Point2 new_grid_step = grid_step * Math::pow(2.0, grid_step_multiplier - 1);
 				if (new_grid_step.x >= 1.0 && new_grid_step.y >= 1.0) {
 					grid_step_multiplier--;
 				}
-				viewport->update();
+				viewport->queue_redraw();
 			}
 		}
 	}
@@ -758,7 +758,7 @@ bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_po
 			}
 		}
 	}
-	viewport->update();
+	viewport->queue_redraw();
 	return still_selected;
 }
 
@@ -875,15 +875,15 @@ void CanvasItemEditor::_commit_canvas_item_state(List<CanvasItem *> p_canvas_ite
 			}
 		}
 	}
-	undo_redo->add_do_method(viewport, "update");
-	undo_redo->add_undo_method(viewport, "update");
+	undo_redo->add_do_method(viewport, "queue_redraw");
+	undo_redo->add_undo_method(viewport, "queue_redraw");
 	undo_redo->commit_action();
 }
 
 void CanvasItemEditor::_snap_changed() {
 	static_cast<SnapDialog *>(snap_dialog)->get_fields(grid_offset, grid_step, primary_grid_steps, snap_rotation_offset, snap_rotation_step, snap_scale_step);
 	grid_step_multiplier = 0;
-	viewport->update();
+	viewport->queue_redraw();
 }
 
 void CanvasItemEditor::_selection_result_pressed(int p_result) {
@@ -983,7 +983,7 @@ void CanvasItemEditor::_on_grid_menu_id_pressed(int p_id) {
 		case GRID_VISIBILITY_SHOW_WHEN_SNAPPING:
 		case GRID_VISIBILITY_HIDE:
 			grid_visibility = (GridVisibility)p_id;
-			viewport->update();
+			viewport->queue_redraw();
 			view_menu->get_popup()->hide();
 			return;
 	}
@@ -1010,7 +1010,7 @@ void CanvasItemEditor::_on_grid_menu_id_pressed(int p_id) {
 				break;
 		}
 	}
-	viewport->update();
+	viewport->queue_redraw();
 }
 
 bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_event) {
@@ -1105,7 +1105,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 			drag_to = xform.affine_inverse().xform(m->get_position());
 
 			dragged_guide_pos = xform.xform(snap_point(drag_to, SNAP_GRID | SNAP_PIXEL | SNAP_OTHER_NODES));
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 
@@ -1128,14 +1128,14 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 							undo_redo->create_action(TTR("Move Vertical Guide"));
 							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
 							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						} else {
 							vguides.push_back(edited.x);
 							undo_redo->create_action(TTR("Create Vertical Guide"));
 							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
 							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						}
 					} else {
@@ -1148,7 +1148,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", vguides);
 							}
 							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						}
 					}
@@ -1161,14 +1161,14 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 							undo_redo->create_action(TTR("Move Horizontal Guide"));
 							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
 							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						} else {
 							hguides.push_back(edited.y);
 							undo_redo->create_action(TTR("Create Horizontal Guide"));
 							undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
 							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						}
 					} else {
@@ -1181,7 +1181,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 								undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
 							}
 							undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
-							undo_redo->add_undo_method(viewport, "update");
+							undo_redo->add_undo_method(viewport, "queue_redraw");
 							undo_redo->commit_action();
 						}
 					}
@@ -1197,7 +1197,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 						undo_redo->add_do_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", hguides);
 						undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_vertical_guides_", prev_vguides);
 						undo_redo->add_undo_method(EditorNode::get_singleton()->get_edited_scene(), "set_meta", "_edit_horizontal_guides_", prev_hguides);
-						undo_redo->add_undo_method(viewport, "update");
+						undo_redo->add_undo_method(viewport, "queue_redraw");
 						undo_redo->commit_action();
 					}
 				}
@@ -1205,7 +1205,7 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 	}
@@ -1380,7 +1380,7 @@ bool CanvasItemEditor::_gui_input_pivot(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 	}
@@ -1430,7 +1430,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 				//Rotate the opposite way if the canvas item's compounded scale has an uneven number of negative elements
 				bool opposite = (canvas_item->get_global_transform().get_scale().sign().dot(canvas_item->get_transform().get_scale().sign()) == 0);
 				canvas_item->_edit_set_rotation(snap_angle(canvas_item->_edit_get_rotation() + (opposite ? -1 : 1) * (drag_from - drag_rotation_center).angle_to(drag_to - drag_rotation_center), canvas_item->_edit_get_rotation()));
-				viewport->update();
+				viewport->queue_redraw();
 			}
 			return true;
 		}
@@ -1463,7 +1463,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 	}
@@ -1625,7 +1625,7 @@ bool CanvasItemEditor::_gui_input_anchors(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 	}
@@ -1824,7 +1824,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 
@@ -1834,7 +1834,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 	}
@@ -1963,7 +1963,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 			}
 
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 
@@ -1971,7 +1971,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && b->is_pressed()) {
 			_restore_canvas_item_state(drag_selection);
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 	}
@@ -2096,7 +2096,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			snap_target[1] = SNAP_TARGET_NONE;
 
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 
@@ -2106,7 +2106,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			snap_target[0] = SNAP_TARGET_NONE;
 			snap_target[1] = SNAP_TARGET_NONE;
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 	}
@@ -2214,7 +2214,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			}
 			_reset_drag();
 		}
-		viewport->update();
+		viewport->queue_redraw();
 		return true;
 	}
 
@@ -2339,7 +2339,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				if (!b->is_shift_pressed()) {
 					// Clear the selection if not additive
 					editor_selection->clear();
-					viewport->update();
+					viewport->queue_redraw();
 					selected_from_canvas = true;
 				};
 
@@ -2415,21 +2415,21 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			}
 
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 
 		if (b.is_valid() && b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
 			// Cancel box selection
 			_reset_drag();
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 
 		if (m.is_valid()) {
 			// Update box selection
 			box_selecting_to = transform.affine_inverse().xform(m->get_position());
-			viewport->update();
+			viewport->queue_redraw();
 			return true;
 		}
 	}
@@ -2437,7 +2437,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 	if (k.is_valid() && k->is_pressed() && k->get_keycode() == Key::ESCAPE && drag_type == DRAG_NONE && tool == TOOL_SELECT) {
 		// Unselect everything
 		editor_selection->clear();
-		viewport->update();
+		viewport->queue_redraw();
 	}
 	return false;
 }
@@ -2463,12 +2463,12 @@ bool CanvasItemEditor::_gui_input_ruler_tool(const Ref<InputEvent> &p_event) {
 			ruler_tool_active = false;
 		}
 
-		viewport->update();
+		viewport->queue_redraw();
 		return true;
 	}
 
 	if (m.is_valid() && (ruler_tool_active || (grid_snap_active && previous_origin != ruler_tool_origin))) {
-		viewport->update();
+		viewport->queue_redraw();
 		return true;
 	}
 
@@ -2480,7 +2480,7 @@ bool CanvasItemEditor::_gui_input_hover(const Ref<InputEvent> &p_event) {
 	if (m.is_valid()) {
 		Point2 click = transform.affine_inverse().xform(m->get_position());
 
-		// Checks if the hovered items changed, update the viewport if so
+		// Checks if the hovered items changed, redraw the viewport if so
 		Vector<_SelectResult> hovering_results_items;
 		_get_canvas_items_at_pos(click, hovering_results_items);
 		hovering_results_items.sort();
@@ -2502,7 +2502,7 @@ bool CanvasItemEditor::_gui_input_hover(const Ref<InputEvent> &p_event) {
 			hovering_results_tmp.push_back(hover_result);
 		}
 
-		// Check if changed, if so, update.
+		// Check if changed, if so, redraw.
 		bool changed = false;
 		if (hovering_results_tmp.size() == hovering_results.size()) {
 			for (int i = 0; i < hovering_results_tmp.size(); i++) {
@@ -2519,7 +2519,7 @@ bool CanvasItemEditor::_gui_input_hover(const Ref<InputEvent> &p_event) {
 
 		if (changed) {
 			hovering_results = hovering_results_tmp;
-			viewport->update();
+			viewport->queue_redraw();
 		}
 
 		return true;
@@ -3827,7 +3827,7 @@ void CanvasItemEditor::_draw_viewport() {
 
 void CanvasItemEditor::update_viewport() {
 	_update_scrollbars();
-	viewport->update();
+	viewport->queue_redraw();
 }
 
 void CanvasItemEditor::set_current_tool(Tool p_tool) {
@@ -3895,7 +3895,7 @@ void CanvasItemEditor::_notification(int p_what) {
 				Transform2D xform = canvas_item->get_transform();
 
 				if (rect != se->prev_rect || xform != se->prev_xform) {
-					viewport->update();
+					viewport->queue_redraw();
 					se->prev_rect = rect;
 					se->prev_xform = xform;
 				}
@@ -3917,7 +3917,7 @@ void CanvasItemEditor::_notification(int p_what) {
 						se->prev_anchors[SIDE_RIGHT] = anchors[SIDE_RIGHT];
 						se->prev_anchors[SIDE_TOP] = anchors[SIDE_TOP];
 						se->prev_anchors[SIDE_BOTTOM] = anchors[SIDE_BOTTOM];
-						viewport->update();
+						viewport->queue_redraw();
 					}
 				}
 
@@ -3933,7 +3933,7 @@ void CanvasItemEditor::_notification(int p_what) {
 			for (KeyValue<BoneKey, BoneList> &E : bone_list) {
 				Object *b = ObjectDB::get_instance(E.key.from);
 				if (!b) {
-					viewport->update();
+					viewport->queue_redraw();
 					break;
 				}
 
@@ -3946,13 +3946,13 @@ void CanvasItemEditor::_notification(int p_what) {
 
 				if (global_xform != E.value.xform) {
 					E.value.xform = global_xform;
-					viewport->update();
+					viewport->queue_redraw();
 				}
 
 				Bone2D *bone = Object::cast_to<Bone2D>(b);
 				if (bone && bone->get_length() != E.value.length) {
 					E.value.length = bone->get_length();
-					viewport->update();
+					viewport->queue_redraw();
 				}
 			}
 		} break;
@@ -4106,7 +4106,7 @@ void CanvasItemEditor::_update_scroll(real_t) {
 
 	view_offset.x = h_scroll->get_value();
 	view_offset.y = v_scroll->get_value();
-	viewport->update();
+	viewport->queue_redraw();
 }
 
 void CanvasItemEditor::_zoom_on_position(real_t p_zoom, Point2 p_position) {
@@ -4148,12 +4148,12 @@ void CanvasItemEditor::_shortcut_zoom_set(real_t p_zoom) {
 
 void CanvasItemEditor::_button_toggle_smart_snap(bool p_status) {
 	smart_snap_active = p_status;
-	viewport->update();
+	viewport->queue_redraw();
 }
 
 void CanvasItemEditor::_button_toggle_grid_snap(bool p_status) {
 	grid_snap_active = p_status;
-	viewport->update();
+	viewport->queue_redraw();
 }
 
 void CanvasItemEditor::_button_override_camera(bool p_pressed) {
@@ -4174,7 +4174,7 @@ void CanvasItemEditor::_button_tool_select(int p_index) {
 
 	tool = (Tool)p_index;
 
-	viewport->update();
+	viewport->queue_redraw();
 	_update_cursor();
 }
 
@@ -4276,25 +4276,25 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			show_origin = !show_origin;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_ORIGIN);
 			view_menu->get_popup()->set_item_checked(idx, show_origin);
-			viewport->update();
+			viewport->queue_redraw();
 		} break;
 		case SHOW_VIEWPORT: {
 			show_viewport = !show_viewport;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_VIEWPORT);
 			view_menu->get_popup()->set_item_checked(idx, show_viewport);
-			viewport->update();
+			viewport->queue_redraw();
 		} break;
 		case SHOW_EDIT_LOCKS: {
 			show_edit_locks = !show_edit_locks;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_EDIT_LOCKS);
 			view_menu->get_popup()->set_item_checked(idx, show_edit_locks);
-			viewport->update();
+			viewport->queue_redraw();
 		} break;
 		case SHOW_TRANSFORMATION_GIZMOS: {
 			show_transformation_gizmos = !show_transformation_gizmos;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_TRANSFORMATION_GIZMOS);
 			view_menu->get_popup()->set_item_checked(idx, show_transformation_gizmos);
-			viewport->update();
+			viewport->queue_redraw();
 		} break;
 		case SNAP_USE_NODE_PARENT: {
 			snap_node_parent = !snap_node_parent;
@@ -4340,7 +4340,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			snap_relative = !snap_relative;
 			int idx = snap_config_menu->get_popup()->get_item_index(SNAP_RELATIVE);
 			snap_config_menu->get_popup()->set_item_checked(idx, snap_relative);
-			viewport->update();
+			viewport->queue_redraw();
 		} break;
 		case SNAP_USE_PIXEL: {
 			snap_pixel = !snap_pixel;
@@ -4370,20 +4370,20 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			show_helpers = !show_helpers;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_HELPERS);
 			view_menu->get_popup()->set_item_checked(idx, show_helpers);
-			viewport->update();
+			viewport->queue_redraw();
 		} break;
 		case SHOW_RULERS: {
 			show_rulers = !show_rulers;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_RULERS);
 			view_menu->get_popup()->set_item_checked(idx, show_rulers);
 			_update_scrollbars();
-			viewport->update();
+			viewport->queue_redraw();
 		} break;
 		case SHOW_GUIDES: {
 			show_guides = !show_guides;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_GUIDES);
 			view_menu->get_popup()->set_item_checked(idx, show_guides);
-			viewport->update();
+			viewport->queue_redraw();
 		} break;
 		case LOCK_SELECTED: {
 			undo_redo->create_action(TTR("Lock Selected"));
@@ -4403,8 +4403,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
 			}
-			undo_redo->add_do_method(viewport, "update");
-			undo_redo->add_undo_method(viewport, "update");
+			undo_redo->add_do_method(viewport, "queue_redraw");
+			undo_redo->add_undo_method(viewport, "queue_redraw");
 			undo_redo->commit_action();
 		} break;
 		case UNLOCK_SELECTED: {
@@ -4425,8 +4425,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				undo_redo->add_do_method(this, "emit_signal", "item_lock_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_lock_status_changed");
 			}
-			undo_redo->add_do_method(viewport, "update");
-			undo_redo->add_undo_method(viewport, "update");
+			undo_redo->add_do_method(viewport, "queue_redraw");
+			undo_redo->add_undo_method(viewport, "queue_redraw");
 			undo_redo->commit_action();
 		} break;
 		case GROUP_SELECTED: {
@@ -4447,8 +4447,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
 			}
-			undo_redo->add_do_method(viewport, "update");
-			undo_redo->add_undo_method(viewport, "update");
+			undo_redo->add_do_method(viewport, "queue_redraw");
+			undo_redo->add_undo_method(viewport, "queue_redraw");
 			undo_redo->commit_action();
 		} break;
 		case UNGROUP_SELECTED: {
@@ -4469,8 +4469,8 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				undo_redo->add_do_method(this, "emit_signal", "item_group_status_changed");
 				undo_redo->add_undo_method(this, "emit_signal", "item_group_status_changed");
 			}
-			undo_redo->add_do_method(viewport, "update");
-			undo_redo->add_undo_method(viewport, "update");
+			undo_redo->add_do_method(viewport, "queue_redraw");
+			undo_redo->add_undo_method(viewport, "queue_redraw");
 			undo_redo->commit_action();
 		} break;
 
@@ -4590,7 +4590,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 					undo_redo->add_do_method(root, "remove_meta", "_edit_vertical_guides_");
 					undo_redo->add_undo_method(root, "set_meta", "_edit_vertical_guides_", vguides);
 				}
-				undo_redo->add_undo_method(viewport, "update");
+				undo_redo->add_undo_method(viewport, "queue_redraw");
 				undo_redo->commit_action();
 			}
 
@@ -4704,7 +4704,7 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 			real_t scale_y = viewport->get_size().y / rect.size.y;
 			zoom = scale_x < scale_y ? scale_x : scale_y;
 			zoom *= 0.90;
-			viewport->update();
+			viewport->queue_redraw();
 			zoom_widget->set_zoom(zoom);
 			call_deferred(SNAME("_popup_callback"), VIEW_CENTER_TO_SELECTION);
 		}
@@ -4930,7 +4930,7 @@ void CanvasItemEditor::set_state(const Dictionary &p_state) {
 	if (update_scrollbars) {
 		_update_scrollbars();
 	}
-	viewport->update();
+	viewport->queue_redraw();
 }
 
 void CanvasItemEditor::add_control_to_menu_panel(Control *p_control) {
@@ -4980,7 +4980,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	editor_selection->add_editor_plugin(this);
-	editor_selection->connect("selection_changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
+	editor_selection->connect("selection_changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	editor_selection->connect("selection_changed", callable_mp(this, &CanvasItemEditor::_selection_changed));
 
 	SceneTreeDock::get_singleton()->connect("node_created", callable_mp(this, &CanvasItemEditor::_node_created));

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -87,7 +87,7 @@ void CurveEditor::set_curve(Ref<Curve> curve) {
 	_hover_point = -1;
 	_selected_tangent = TANGENT_NONE;
 
-	update();
+	queue_redraw();
 
 	// Note: if you edit a curve, then set another, and try to undo,
 	// it will normally apply on the previous curve, but you won't see it
@@ -311,7 +311,7 @@ void CurveEditor::on_preset_item_selected(int preset_id) {
 }
 
 void CurveEditor::_curve_changed() {
-	update();
+	queue_redraw();
 	// Point count can change in case of undo
 	if (_selected_point >= _curve_ref->get_point_count()) {
 		set_selected_point(-1);
@@ -512,14 +512,14 @@ void CurveEditor::toggle_linear(TangentIndex tangent) {
 void CurveEditor::set_selected_point(int index) {
 	if (index != _selected_point) {
 		_selected_point = index;
-		update();
+		queue_redraw();
 	}
 }
 
 void CurveEditor::set_hover_point_index(int index) {
 	if (index != _hover_point) {
 		_hover_point = index;
-		update();
+		queue_redraw();
 	}
 }
 

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -942,7 +942,7 @@ Size2 FontPreview::get_minimum_size() const {
 
 void FontPreview::set_data(const Ref<Font> &p_f) {
 	prev_font = p_f;
-	update();
+	queue_redraw();
 }
 
 FontPreview::FontPreview() {

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -50,7 +50,7 @@ void GradientEditor::_gradient_changed() {
 	Vector<Gradient::Point> points = gradient->get_points();
 	set_points(points);
 	set_interpolation_mode(gradient->get_interpolation_mode());
-	update();
+	queue_redraw();
 	editing = false;
 }
 
@@ -83,7 +83,7 @@ void GradientEditor::reverse_gradient() {
 	gradient->reverse();
 	set_points(gradient->get_points());
 	emit_signal(SNAME("ramp_changed"));
-	update();
+	queue_redraw();
 }
 
 GradientEditor::GradientEditor() {

--- a/editor/plugins/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.cpp
@@ -89,17 +89,17 @@ void GradientTexture2DEditorRect::gui_input(const Ref<InputEvent> &p_event) {
 
 void GradientTexture2DEditorRect::set_texture(Ref<GradientTexture2D> &p_texture) {
 	texture = p_texture;
-	texture->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
+	texture->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 }
 
 void GradientTexture2DEditorRect::set_snap_enabled(bool p_snap_enabled) {
 	snap_enabled = p_snap_enabled;
-	update();
+	queue_redraw();
 }
 
 void GradientTexture2DEditorRect::set_snap_size(float p_snap_size) {
 	snap_size = p_snap_size;
-	update();
+	queue_redraw();
 }
 
 void GradientTexture2DEditorRect::_notification(int p_what) {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -99,7 +99,7 @@ void ViewportRotationControl::_notification(int p_what) {
 			axis_colors.push_back(get_theme_color(SNAME("axis_x_color"), SNAME("Editor")));
 			axis_colors.push_back(get_theme_color(SNAME("axis_y_color"), SNAME("Editor")));
 			axis_colors.push_back(get_theme_color(SNAME("axis_z_color"), SNAME("Editor")));
-			update();
+			queue_redraw();
 
 			if (!is_connected("mouse_exited", callable_mp(this, &ViewportRotationControl::_on_mouse_exited))) {
 				connect("mouse_exited", callable_mp(this, &ViewportRotationControl::_on_mouse_exited));
@@ -247,13 +247,13 @@ void ViewportRotationControl::_update_focus() {
 	}
 
 	if (focused_axis != original_focus) {
-		update();
+		queue_redraw();
 	}
 }
 
 void ViewportRotationControl::_on_mouse_exited() {
 	focused_axis = -2;
-	update();
+	queue_redraw();
 }
 
 void ViewportRotationControl::set_viewport(Node3DEditorViewport *p_viewport) {
@@ -350,7 +350,7 @@ void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 		}
 
 		update_transform_gizmo_view();
-		rotation_control->update();
+		rotation_control->queue_redraw();
 		spatial_editor->update_grid();
 	}
 }
@@ -1614,7 +1614,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						}
 					}
 
-					surface->update();
+					surface->queue_redraw();
 				} else {
 					if (_edit.gizmo.is_valid()) {
 						_edit.gizmo->commit_handle(_edit.gizmo_handle, _edit.gizmo_handle_secondary, _edit.gizmo_initial_value, false);
@@ -1632,7 +1632,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						if (cursor.region_select) {
 							_select_region();
 							cursor.region_select = false;
-							surface->update();
+							surface->queue_redraw();
 						}
 					}
 
@@ -1657,7 +1657,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						_edit.mode = TRANSFORM_NONE;
 						set_message("");
 					}
-					surface->update();
+					surface->queue_redraw();
 				}
 
 			} break;
@@ -1741,7 +1741,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 				if (cursor.region_select) {
 					cursor.region_end = m->get_position();
-					surface->update();
+					surface->queue_redraw();
 					return;
 				}
 
@@ -2244,12 +2244,12 @@ void Node3DEditorViewport::set_freelook_active(bool active_now) {
 
 void Node3DEditorViewport::scale_fov(real_t p_fov_offset) {
 	cursor.fov_scale = CLAMP(cursor.fov_scale + p_fov_offset, 0.1, 2.5);
-	surface->update();
+	surface->queue_redraw();
 }
 
 void Node3DEditorViewport::reset_fov() {
 	cursor.fov_scale = 1.0;
-	surface->update();
+	surface->queue_redraw();
 }
 
 void Node3DEditorViewport::scale_cursor_distance(real_t scale) {
@@ -2268,7 +2268,7 @@ void Node3DEditorViewport::scale_cursor_distance(real_t scale) {
 	}
 
 	zoom_indicator_delay = ZOOM_FREELOOK_INDICATOR_DELAY_S;
-	surface->update();
+	surface->queue_redraw();
 }
 
 void Node3DEditorViewport::scale_freelook_speed(real_t scale) {
@@ -2281,7 +2281,7 @@ void Node3DEditorViewport::scale_freelook_speed(real_t scale) {
 	}
 
 	zoom_indicator_delay = ZOOM_FREELOOK_INDICATOR_DELAY_S;
-	surface->update();
+	surface->queue_redraw();
 }
 
 Point2i Node3DEditorViewport::_get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const {
@@ -2454,7 +2454,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 			if (zoom_indicator_delay > 0) {
 				zoom_indicator_delay -= delta;
 				if (zoom_indicator_delay <= 0) {
-					surface->update();
+					surface->queue_redraw();
 					zoom_limit_label->hide();
 				}
 			}
@@ -2472,7 +2472,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 					previewing = cam;
 					previewing->connect("tree_exited", callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 					RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), cam->get_camera());
-					surface->update();
+					surface->queue_redraw();
 				}
 			}
 
@@ -2538,13 +2538,13 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 			if (message_time > 0) {
 				if (message != last_message) {
-					surface->update();
+					surface->queue_redraw();
 					last_message = message;
 				}
 
 				message_time -= get_physics_process_delta_time();
 				if (message_time < 0) {
-					surface->update();
+					surface->queue_redraw();
 				}
 			}
 
@@ -3356,13 +3356,13 @@ void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 		if (!preview) {
 			preview_camera->hide();
 		}
-		surface->update();
+		surface->queue_redraw();
 
 	} else {
 		previewing = preview;
 		previewing->connect("tree_exiting", callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), preview->get_camera()); //replace
-		surface->update();
+		surface->queue_redraw();
 	}
 }
 
@@ -3384,7 +3384,7 @@ void Node3DEditorViewport::_toggle_cinema_preview(bool p_activate) {
 			preview_camera->show();
 		}
 		view_menu->show();
-		surface->update();
+		surface->queue_redraw();
 	}
 }
 
@@ -3619,7 +3619,7 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 			previewing = Object::cast_to<Camera3D>(pv);
 			previewing->connect("tree_exiting", callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 			RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), previewing->get_camera()); //replace
-			surface->update();
+			surface->queue_redraw();
 			preview_camera->set_pressed(true);
 			preview_camera->show();
 		}
@@ -4392,7 +4392,7 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 			}
 
 			spatial_editor->update_transform_gizmo();
-			surface->update();
+			surface->queue_redraw();
 
 		} break;
 
@@ -4491,7 +4491,7 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 			}
 
 			spatial_editor->update_transform_gizmo();
-			surface->update();
+			surface->queue_redraw();
 
 		} break;
 
@@ -4595,7 +4595,7 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 			}
 
 			spatial_editor->update_transform_gizmo();
-			surface->update();
+			surface->queue_redraw();
 
 		} break;
 		default: {
@@ -4608,7 +4608,7 @@ void Node3DEditorViewport::finish_transform() {
 	spatial_editor->update_transform_gizmo();
 	_edit.mode = TRANSFORM_NONE;
 	_edit.instant = false;
-	surface->update();
+	surface->queue_redraw();
 }
 
 // Register a shortcut and also add it as an input action with the same events.
@@ -5010,7 +5010,7 @@ void Node3DEditorViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 			hovering_v = mm->get_position().y > (mid_h - v_sep / 2) && mm->get_position().y < (mid_h + v_sep / 2);
 
 			if (was_hovering_h != hovering_h || was_hovering_v != hovering_v) {
-				update();
+				queue_redraw();
 			}
 		}
 
@@ -5019,14 +5019,14 @@ void Node3DEditorViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 			new_ratio = CLAMP(new_ratio, 40 / get_size().width, (get_size().width - 40) / get_size().width);
 			ratio_h = new_ratio;
 			queue_sort();
-			update();
+			queue_redraw();
 		}
 		if (dragging_v) {
 			real_t new_ratio = drag_begin_ratio.y + (mm->get_position().y - drag_begin_pos.y) / get_size().height;
 			new_ratio = CLAMP(new_ratio, 40 / get_size().height, (get_size().height - 40) / get_size().height);
 			ratio_v = new_ratio;
 			queue_sort();
-			update();
+			queue_redraw();
 		}
 	}
 }
@@ -5036,7 +5036,7 @@ void Node3DEditorViewportContainer::_notification(int p_what) {
 		case NOTIFICATION_MOUSE_ENTER:
 		case NOTIFICATION_MOUSE_EXIT: {
 			mouseover = (p_what == NOTIFICATION_MOUSE_ENTER);
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -7581,7 +7581,7 @@ void Node3DEditor::_preview_settings_changed() {
 		Transform3D t;
 		t.basis = Basis(Vector3(sun_rotation.x, sun_rotation.y, 0));
 		preview_sun->set_transform(t);
-		sun_direction->update();
+		sun_direction->queue_redraw();
 		preview_sun->set_param(Light3D::PARAM_ENERGY, sun_energy->get_value());
 		preview_sun->set_param(Light3D::PARAM_SHADOW_MAX_DISTANCE, sun_max_distance->get_value());
 		preview_sun->set_color(sun_color->get_pick_color());
@@ -7615,7 +7615,7 @@ void Node3DEditor::_load_default_preview_settings() {
 
 	sun_angle_altitude->set_value(-Math::rad_to_deg(sun_rotation.x));
 	sun_angle_azimuth->set_value(180.0 - Math::rad_to_deg(sun_rotation.y));
-	sun_direction->update();
+	sun_direction->queue_redraw();
 	environ_sky_color->set_pick_color(Color(0.385, 0.454, 0.55));
 	environ_ground_color->set_pick_color(Color(0.2, 0.169, 0.133));
 	environ_energy->set_value(1.0);

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -433,7 +433,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void update_surface() { surface->update(); }
+	void update_surface() { surface->queue_redraw(); }
 	void update_transform_gizmo_view();
 
 	void set_can_preview(Camera3D *p_preview);

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -155,8 +155,8 @@ void Polygon2DEditor::_sync_bones() {
 	undo_redo->add_undo_method(node, "_set_bones", prev_bones);
 	undo_redo->add_do_method(this, "_update_bone_list");
 	undo_redo->add_undo_method(this, "_update_bone_list");
-	undo_redo->add_do_method(uv_edit_draw, "update");
-	undo_redo->add_undo_method(uv_edit_draw, "update");
+	undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+	undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 	undo_redo->commit_action();
 }
 
@@ -195,11 +195,11 @@ void Polygon2DEditor::_update_bone_list() {
 		cb->connect("pressed", callable_mp(this, &Polygon2DEditor::_bone_paint_selected).bind(i));
 	}
 
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_bone_paint_selected(int p_index) {
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_uv_edit_mode_select(int p_mode) {
@@ -269,7 +269,7 @@ void Polygon2DEditor::_uv_edit_mode_select(int p_mode) {
 	}
 
 	uv_edit->set_size(uv_edit->get_size()); // Necessary readjustment of the popup window.
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_uv_edit_popup_hide() {
@@ -293,8 +293,8 @@ void Polygon2DEditor::_menu_option(int p_option) {
 				undo_redo->create_action(TTR("Create UV Map"));
 				undo_redo->add_do_method(node, "set_uv", points);
 				undo_redo->add_undo_method(node, "set_uv", uvs);
-				undo_redo->add_do_method(uv_edit_draw, "update");
-				undo_redo->add_undo_method(uv_edit_draw, "update");
+				undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+				undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 				undo_redo->commit_action();
 			}
 
@@ -314,8 +314,8 @@ void Polygon2DEditor::_menu_option(int p_option) {
 			undo_redo->create_action(TTR("Create UV Map"));
 			undo_redo->add_do_method(node, "set_uv", points);
 			undo_redo->add_undo_method(node, "set_uv", uvs);
-			undo_redo->add_do_method(uv_edit_draw, "update");
-			undo_redo->add_undo_method(uv_edit_draw, "update");
+			undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+			undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 			undo_redo->commit_action();
 		} break;
 		case UVEDIT_UV_TO_POLYGON: {
@@ -328,8 +328,8 @@ void Polygon2DEditor::_menu_option(int p_option) {
 			undo_redo->create_action(TTR("Create Polygon"));
 			undo_redo->add_do_method(node, "set_polygon", uvs);
 			undo_redo->add_undo_method(node, "set_polygon", points);
-			undo_redo->add_do_method(uv_edit_draw, "update");
-			undo_redo->add_undo_method(uv_edit_draw, "update");
+			undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+			undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 			undo_redo->commit_action();
 		} break;
 		case UVEDIT_UV_CLEAR: {
@@ -340,8 +340,8 @@ void Polygon2DEditor::_menu_option(int p_option) {
 			undo_redo->create_action(TTR("Create UV Map"));
 			undo_redo->add_do_method(node, "set_uv", Vector<Vector2>());
 			undo_redo->add_undo_method(node, "set_uv", uvs);
-			undo_redo->add_do_method(uv_edit_draw, "update");
-			undo_redo->add_undo_method(uv_edit_draw, "update");
+			undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+			undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 			undo_redo->commit_action();
 		} break;
 		case UVEDIT_GRID_SETTINGS: {
@@ -391,8 +391,8 @@ void Polygon2DEditor::_update_polygon_editing_state() {
 
 void Polygon2DEditor::_commit_action() {
 	// Makes that undo/redoing actions made outside of the UV editor still affect its polygon.
-	undo_redo->add_do_method(uv_edit_draw, "update");
-	undo_redo->add_undo_method(uv_edit_draw, "update");
+	undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+	undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 	undo_redo->add_do_method(CanvasItemEditor::get_singleton(), "update_viewport");
 	undo_redo->add_undo_method(CanvasItemEditor::get_singleton(), "update_viewport");
 	undo_redo->commit_action();
@@ -406,31 +406,31 @@ void Polygon2DEditor::_set_use_snap(bool p_use) {
 void Polygon2DEditor::_set_show_grid(bool p_show) {
 	snap_show_grid = p_show;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "show_grid", p_show);
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_off_x(real_t p_val) {
 	snap_offset.x = p_val;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_offset", snap_offset);
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_off_y(real_t p_val) {
 	snap_offset.y = p_val;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_offset", snap_offset);
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_step_x(real_t p_val) {
 	snap_step.x = p_val;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_step", snap_step);
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_set_snap_step_y(real_t p_val) {
 	snap_step.y = p_val;
 	EditorSettings::get_singleton()->set_project_metadata("polygon_2d_uv_editor", "snap_step", snap_step);
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_uv_mode(int p_mode) {
@@ -495,7 +495,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 						node->set_uv(points_prev);
 						node->set_internal_vertex_count(0);
 
-						uv_edit_draw->update();
+						uv_edit_draw->queue_redraw();
 					} else {
 						Vector2 tuv = mtx.affine_inverse().xform(snap_point(mb->get_position()));
 
@@ -514,8 +514,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 							undo_redo->add_undo_method(node, "_set_bones", uv_create_bones_prev);
 							undo_redo->add_do_method(this, "_update_polygon_editing_state");
 							undo_redo->add_undo_method(this, "_update_polygon_editing_state");
-							undo_redo->add_do_method(uv_edit_draw, "update");
-							undo_redo->add_undo_method(uv_edit_draw, "update");
+							undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+							undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 							undo_redo->commit_action();
 							uv_drag = false;
 							uv_create = false;
@@ -566,8 +566,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					undo_redo->add_undo_method(node, "set_internal_vertex_count", internal_vertices);
 					undo_redo->add_do_method(this, "_update_polygon_editing_state");
 					undo_redo->add_undo_method(this, "_update_polygon_editing_state");
-					undo_redo->add_do_method(uv_edit_draw, "update");
-					undo_redo->add_undo_method(uv_edit_draw, "update");
+					undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+					undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 					undo_redo->commit_action();
 				}
 
@@ -621,8 +621,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					undo_redo->add_undo_method(node, "set_internal_vertex_count", internal_vertices);
 					undo_redo->add_do_method(this, "_update_polygon_editing_state");
 					undo_redo->add_undo_method(this, "_update_polygon_editing_state");
-					undo_redo->add_do_method(uv_edit_draw, "update");
-					undo_redo->add_undo_method(uv_edit_draw, "update");
+					undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+					undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 					undo_redo->commit_action();
 				}
 
@@ -679,8 +679,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 								undo_redo->create_action(TTR("Add Custom Polygon"));
 								undo_redo->add_do_method(node, "set_polygons", polygons);
 								undo_redo->add_undo_method(node, "set_polygons", node->get_polygons());
-								undo_redo->add_do_method(uv_edit_draw, "update");
-								undo_redo->add_undo_method(uv_edit_draw, "update");
+								undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+								undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 								undo_redo->commit_action();
 							}
 
@@ -720,8 +720,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 						undo_redo->create_action(TTR("Remove Custom Polygon"));
 						undo_redo->add_do_method(node, "set_polygons", polygons);
 						undo_redo->add_undo_method(node, "set_polygons", node->get_polygons());
-						undo_redo->add_do_method(uv_edit_draw, "update");
-						undo_redo->add_undo_method(uv_edit_draw, "update");
+						undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+						undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 						undo_redo->commit_action();
 					}
 				}
@@ -748,15 +748,15 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 						undo_redo->create_action(TTR("Transform UV Map"));
 						undo_redo->add_do_method(node, "set_uv", node->get_uv());
 						undo_redo->add_undo_method(node, "set_uv", points_prev);
-						undo_redo->add_do_method(uv_edit_draw, "update");
-						undo_redo->add_undo_method(uv_edit_draw, "update");
+						undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+						undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 						undo_redo->commit_action();
 					} else if (uv_edit_mode[1]->is_pressed() && uv_move_current == UV_MODE_EDIT_POINT) { // Edit polygon.
 						undo_redo->create_action(TTR("Transform Polygon"));
 						undo_redo->add_do_method(node, "set_polygon", node->get_polygon());
 						undo_redo->add_undo_method(node, "set_polygon", points_prev);
-						undo_redo->add_do_method(uv_edit_draw, "update");
-						undo_redo->add_undo_method(uv_edit_draw, "update");
+						undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+						undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 						undo_redo->commit_action();
 					}
 
@@ -767,8 +767,8 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 					undo_redo->create_action(TTR("Paint Bone Weights"));
 					undo_redo->add_do_method(node, "set_bone_weights", bone_painting_bone, node->get_bone_weights(bone_painting_bone));
 					undo_redo->add_undo_method(node, "set_bone_weights", bone_painting_bone, prev_weights);
-					undo_redo->add_do_method(uv_edit_draw, "update");
-					undo_redo->add_undo_method(uv_edit_draw, "update");
+					undo_redo->add_do_method(uv_edit_draw, "queue_redraw");
+					undo_redo->add_undo_method(uv_edit_draw, "queue_redraw");
 					undo_redo->commit_action();
 					bone_painting = false;
 				}
@@ -780,7 +780,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 				node->set_bone_weights(bone_painting_bone, prev_weights);
 			}
 
-			uv_edit_draw->update();
+			uv_edit_draw->queue_redraw();
 		}
 	}
 
@@ -906,14 +906,14 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 				node->set_bone_weights(bone_painting_bone, painted_weights);
 			}
 
-			uv_edit_draw->update();
+			uv_edit_draw->queue_redraw();
 			CanvasItemEditor::get_singleton()->update_viewport();
 		} else if (polygon_create.size()) {
 			uv_create_to = mtx.affine_inverse().xform(mm->get_position());
-			uv_edit_draw->update();
+			uv_edit_draw->queue_redraw();
 		} else if (uv_mode == UV_MODE_PAINT_WEIGHT || uv_mode == UV_MODE_CLEAR_WEIGHT) {
 			bone_paint_pos = mm->get_position();
-			uv_edit_draw->update();
+			uv_edit_draw->queue_redraw();
 		}
 	}
 
@@ -954,7 +954,7 @@ void Polygon2DEditor::_uv_scroll_changed(real_t) {
 	uv_draw_ofs.x = uv_hscroll->get_value();
 	uv_draw_ofs.y = uv_vscroll->get_value();
 	uv_draw_zoom = uv_zoom->get_value();
-	uv_edit_draw->update();
+	uv_edit_draw->queue_redraw();
 }
 
 void Polygon2DEditor::_uv_draw() {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1124,15 +1124,15 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
 			tx->toggle_foldable_line(tx->get_caret_line());
-			tx->update();
+			tx->queue_redraw();
 		} break;
 		case EDIT_FOLD_ALL_LINES: {
 			tx->fold_all_lines();
-			tx->update();
+			tx->queue_redraw();
 		} break;
 		case EDIT_UNFOLD_ALL_LINES: {
 			tx->unfold_all_lines();
-			tx->update();
+			tx->queue_redraw();
 		} break;
 		case EDIT_TOGGLE_COMMENT: {
 			_edit_option_toggle_inline_comment();
@@ -1760,7 +1760,7 @@ void ScriptTextEditor::_color_changed(const Color &p_color) {
 	code_editor->get_text_editor()->begin_complex_operation();
 	code_editor->get_text_editor()->set_line(color_position.x, line_with_replaced_args);
 	code_editor->get_text_editor()->end_complex_operation();
-	code_editor->get_text_editor()->update();
+	code_editor->get_text_editor()->queue_redraw();
 }
 
 void ScriptTextEditor::_prepare_edit_menu() {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -182,27 +182,27 @@ void BoneTransformEditor::_update_properties() {
 				if (split[2] == "enabled") {
 					enabled_checkbox->set_read_only(E.usage & PROPERTY_USAGE_READ_ONLY);
 					enabled_checkbox->update_property();
-					enabled_checkbox->update();
+					enabled_checkbox->queue_redraw();
 				}
 				if (split[2] == "position") {
 					position_property->set_read_only(E.usage & PROPERTY_USAGE_READ_ONLY);
 					position_property->update_property();
-					position_property->update();
+					position_property->queue_redraw();
 				}
 				if (split[2] == "rotation") {
 					rotation_property->set_read_only(E.usage & PROPERTY_USAGE_READ_ONLY);
 					rotation_property->update_property();
-					rotation_property->update();
+					rotation_property->queue_redraw();
 				}
 				if (split[2] == "scale") {
 					scale_property->set_read_only(E.usage & PROPERTY_USAGE_READ_ONLY);
 					scale_property->update_property();
-					scale_property->update();
+					scale_property->queue_redraw();
 				}
 				if (split[2] == "rest") {
 					rest_matrix->set_read_only(E.usage & PROPERTY_USAGE_READ_ONLY);
 					rest_matrix->update_property();
-					rest_matrix->update();
+					rest_matrix->queue_redraw();
 				}
 			}
 		}

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -128,7 +128,7 @@ void Sprite2DEditor::_menu_option(int p_option) {
 
 			_update_mesh_data();
 			debug_uv_dialog->popup_centered();
-			debug_uv->update();
+			debug_uv->queue_redraw();
 
 		} break;
 		case MENU_OPTION_CONVERT_TO_POLYGON_2D: {
@@ -137,7 +137,7 @@ void Sprite2DEditor::_menu_option(int p_option) {
 
 			_update_mesh_data();
 			debug_uv_dialog->popup_centered();
-			debug_uv->update();
+			debug_uv->queue_redraw();
 		} break;
 		case MENU_OPTION_CREATE_COLLISION_POLY_2D: {
 			debug_uv_dialog->set_ok_button_text(TTR("Create CollisionPolygon2D"));
@@ -145,7 +145,7 @@ void Sprite2DEditor::_menu_option(int p_option) {
 
 			_update_mesh_data();
 			debug_uv_dialog->popup_centered();
-			debug_uv->update();
+			debug_uv->queue_redraw();
 
 		} break;
 		case MENU_OPTION_CREATE_LIGHT_OCCLUDER_2D: {
@@ -154,7 +154,7 @@ void Sprite2DEditor::_menu_option(int p_option) {
 
 			_update_mesh_data();
 			debug_uv_dialog->popup_centered();
-			debug_uv->update();
+			debug_uv->queue_redraw();
 
 		} break;
 	}
@@ -302,7 +302,7 @@ void Sprite2DEditor::_update_mesh_data() {
 		}
 	}
 
-	debug_uv->update();
+	debug_uv->queue_redraw();
 }
 
 void Sprite2DEditor::_create_node() {

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -182,7 +182,7 @@ void SpriteFramesEditor::_sheet_preview_input(const Ref<InputEvent> &p_event) {
 
 		if (last_frame_selected != idx || idx != -1) {
 			last_frame_selected = idx;
-			split_sheet_preview->update();
+			split_sheet_preview->queue_redraw();
 		}
 	}
 
@@ -208,7 +208,7 @@ void SpriteFramesEditor::_sheet_preview_input(const Ref<InputEvent> &p_event) {
 			}
 
 			last_frame_selected = idx;
-			split_sheet_preview->update();
+			split_sheet_preview->queue_redraw();
 		}
 	}
 }
@@ -307,7 +307,7 @@ void SpriteFramesEditor::_sheet_select_clear_all_frames() {
 		frames_selected.clear();
 	}
 
-	split_sheet_preview->update();
+	split_sheet_preview->queue_redraw();
 }
 
 void SpriteFramesEditor::_sheet_spin_changed(double p_value, int p_dominant_param) {
@@ -363,7 +363,7 @@ void SpriteFramesEditor::_sheet_spin_changed(double p_value, int p_dominant_para
 
 	frames_selected.clear();
 	last_frame_selected = -1;
-	split_sheet_preview->update();
+	split_sheet_preview->queue_redraw();
 }
 
 void SpriteFramesEditor::_prepare_sprite_sheet(const String &p_file) {

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -36,7 +36,7 @@ bool StyleBoxPreview::grid_preview_enabled = true;
 
 void StyleBoxPreview::_grid_preview_toggled(bool p_active) {
 	grid_preview_enabled = p_active;
-	preview->update();
+	preview->queue_redraw();
 }
 
 bool EditorInspectorPluginStyleBox::can_handle(Object *p_object) {
@@ -66,7 +66,7 @@ void StyleBoxPreview::edit(const Ref<StyleBox> &p_stylebox) {
 }
 
 void StyleBoxPreview::_sb_changed() {
-	preview->update();
+	preview->queue_redraw();
 }
 
 void StyleBoxPreview::_notification(int p_what) {

--- a/editor/plugins/sub_viewport_preview_editor_plugin.cpp
+++ b/editor/plugins/sub_viewport_preview_editor_plugin.cpp
@@ -39,7 +39,7 @@ void EditorInspectorPluginSubViewportPreview::parse_begin(Object *p_object) {
 
 	TexturePreview *sub_viewport_preview = memnew(TexturePreview(sub_viewport->get_texture(), false));
 	// Otherwise `sub_viewport_preview`'s `texture_display` doesn't update properly when `sub_viewport`'s size changes.
-	sub_viewport->connect("size_changed", callable_mp((CanvasItem *)sub_viewport_preview->get_texture_display(), &CanvasItem::update));
+	sub_viewport->connect("size_changed", callable_mp((CanvasItem *)sub_viewport_preview->get_texture_display(), &CanvasItem::queue_redraw));
 	add_custom_control(sub_viewport_preview);
 }
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -339,15 +339,15 @@ void TextEditor::_edit_option(int p_op) {
 		} break;
 		case EDIT_TOGGLE_FOLD_LINE: {
 			tx->toggle_foldable_line(tx->get_caret_line());
-			tx->update();
+			tx->queue_redraw();
 		} break;
 		case EDIT_FOLD_ALL_LINES: {
 			tx->fold_all_lines();
-			tx->update();
+			tx->queue_redraw();
 		} break;
 		case EDIT_UNFOLD_ALL_LINES: {
 			tx->unfold_all_lines();
-			tx->update();
+			tx->queue_redraw();
 		} break;
 		case EDIT_TRIM_TRAILING_WHITESAPCE: {
 			trim_trailing_whitespace();

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -53,7 +53,7 @@ void Texture3DEditor::_texture_changed() {
 	if (!is_visible()) {
 		return;
 	}
-	update();
+	queue_redraw();
 }
 
 void Texture3DEditor::_update_material() {
@@ -124,7 +124,7 @@ void Texture3DEditor::edit(Ref<Texture3D> p_texture) {
 		}
 
 		texture->connect("changed", callable_mp(this, &Texture3DEditor::_texture_changed));
-		update();
+		queue_redraw();
 		texture_rect->set_material(material);
 		setting = true;
 		layer->set_max(texture->get_depth() - 1);

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -64,7 +64,7 @@ void TextureLayeredEditor::_texture_changed() {
 	if (!is_visible()) {
 		return;
 	}
-	update();
+	queue_redraw();
 }
 
 void TextureLayeredEditor::_update_material() {
@@ -190,7 +190,7 @@ void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
 		}
 
 		texture->connect("changed", callable_mp(this, &TextureLayeredEditor::_texture_changed));
-		update();
+		queue_redraw();
 		texture_rect->set_material(materials[texture->get_layered_type()]);
 		setting = true;
 		if (texture->get_layered_type() == TextureLayered::LAYERED_TYPE_2D_ARRAY) {

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -381,8 +381,8 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 							}
 							undo_redo->add_do_method(this, "_update_rect");
 							undo_redo->add_undo_method(this, "_update_rect");
-							undo_redo->add_do_method(edit_draw, "update");
-							undo_redo->add_undo_method(edit_draw, "update");
+							undo_redo->add_do_method(edit_draw, "queue_redraw");
+							undo_redo->add_undo_method(edit_draw, "queue_redraw");
 							undo_redo->commit_action();
 							break;
 						}
@@ -455,8 +455,8 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 				}
 				undo_redo->add_do_method(this, "_update_rect");
 				undo_redo->add_undo_method(this, "_update_rect");
-				undo_redo->add_do_method(edit_draw, "update");
-				undo_redo->add_undo_method(edit_draw, "update");
+				undo_redo->add_do_method(edit_draw, "queue_redraw");
+				undo_redo->add_undo_method(edit_draw, "queue_redraw");
 				undo_redo->commit_action();
 				drag = false;
 				creating = false;
@@ -477,7 +477,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 				} else {
 					apply_rect(rect_prev);
 					rect = rect_prev;
-					edit_draw->update();
+					edit_draw->queue_redraw();
 					drag_index = -1;
 				}
 			}
@@ -546,7 +546,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					rect = Rect2(drag_from, Size2());
 					rect.expand_to(new_pos);
 					apply_rect(rect);
-					edit_draw->update();
+					edit_draw->queue_redraw();
 					return;
 				}
 
@@ -601,7 +601,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					} break;
 				}
 			}
-			edit_draw->update();
+			edit_draw->queue_redraw();
 		}
 	}
 
@@ -642,7 +642,7 @@ void TextureRegionEditor::_scroll_changed(float) {
 
 	draw_ofs.x = hscroll->get_value();
 	draw_ofs.y = vscroll->get_value();
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_set_snap_mode(int p_mode) {
@@ -658,37 +658,37 @@ void TextureRegionEditor::_set_snap_mode(int p_mode) {
 		_update_autoslice();
 	}
 
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_set_snap_off_x(float p_val) {
 	snap_offset.x = p_val;
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_set_snap_off_y(float p_val) {
 	snap_offset.y = p_val;
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_set_snap_step_x(float p_val) {
 	snap_step.x = p_val;
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_set_snap_step_y(float p_val) {
 	snap_step.y = p_val;
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_set_snap_sep_x(float p_val) {
 	snap_separation.x = p_val;
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_set_snap_sep_y(float p_val) {
 	snap_separation.y = p_val;
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
@@ -702,7 +702,7 @@ void TextureRegionEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
 	ofs = ofs / prev_zoom - ofs / draw_zoom;
 	draw_ofs = (draw_ofs + ofs).round();
 
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 void TextureRegionEditor::_zoom_in() {
@@ -933,7 +933,7 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		obj_styleBox = Ref<StyleBoxTexture>(nullptr);
 		atlas_tex = Ref<AtlasTexture>(nullptr);
 	}
-	edit_draw->update();
+	edit_draw->queue_redraw();
 	popup_centered_ratio(0.5);
 	request_center = true;
 }
@@ -963,7 +963,7 @@ void TextureRegionEditor::_edit_region() {
 		_zoom_reset();
 		hscroll->hide();
 		vscroll->hide();
-		edit_draw->update();
+		edit_draw->queue_redraw();
 		return;
 	}
 
@@ -979,7 +979,7 @@ void TextureRegionEditor::_edit_region() {
 	}
 
 	_update_rect();
-	edit_draw->update();
+	edit_draw->queue_redraw();
 }
 
 Vector2 TextureRegionEditor::snap_point(Vector2 p_target) const {

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -56,7 +56,7 @@ void ThemeEditorPreview::add_preview_overlay(Control *p_overlay) {
 void ThemeEditorPreview::_propagate_redraw(Control *p_at) {
 	p_at->notification(NOTIFICATION_THEME_CHANGED);
 	p_at->update_minimum_size();
-	p_at->update();
+	p_at->queue_redraw();
 	for (int i = 0; i < p_at->get_child_count(); i++) {
 		Control *a = Object::cast_to<Control>(p_at->get_child(i));
 		if (a) {
@@ -174,7 +174,7 @@ void ThemeEditorPreview::_gui_input_picker_overlay(const Ref<InputEvent> &p_even
 	if (mm.is_valid()) {
 		Vector2 mp = preview_content->get_local_mouse_position();
 		hovered_control = _find_hovered_control(preview_content, mp);
-		picker_overlay->update();
+		picker_overlay->queue_redraw();
 	}
 
 	// Forward input to the scroll container underneath to allow scrolling.
@@ -183,7 +183,7 @@ void ThemeEditorPreview::_gui_input_picker_overlay(const Ref<InputEvent> &p_even
 
 void ThemeEditorPreview::_reset_picker_overlay() {
 	hovered_control = nullptr;
-	picker_overlay->update();
+	picker_overlay->queue_redraw();
 }
 
 void ThemeEditorPreview::_notification(int p_what) {

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -404,12 +404,12 @@ void TileAtlasView::set_atlas_source(TileSet *p_tile_set, TileSetAtlasSource *p_
 	_update_zoom_and_panning();
 
 	// Update.
-	base_tiles_draw->update();
-	base_tiles_texture_grid->update();
-	base_tiles_shape_grid->update();
-	alternatives_draw->update();
-	background_left->update();
-	background_right->update();
+	base_tiles_draw->queue_redraw();
+	base_tiles_texture_grid->queue_redraw();
+	base_tiles_shape_grid->queue_redraw();
+	alternatives_draw->queue_redraw();
+	background_left->queue_redraw();
+	background_right->queue_redraw();
 }
 
 float TileAtlasView::get_zoom() const {
@@ -493,13 +493,13 @@ Rect2i TileAtlasView::get_alternative_tile_rect(const Vector2i p_coords, int p_a
 	return alternative_tiles_rect_cache[p_coords][p_alternative_tile];
 }
 
-void TileAtlasView::update() {
-	base_tiles_draw->update();
-	base_tiles_texture_grid->update();
-	base_tiles_shape_grid->update();
-	alternatives_draw->update();
-	background_left->update();
-	background_right->update();
+void TileAtlasView::queue_redraw() {
+	base_tiles_draw->queue_redraw();
+	base_tiles_texture_grid->queue_redraw();
+	base_tiles_shape_grid->queue_redraw();
+	alternatives_draw->queue_redraw();
+	background_left->queue_redraw();
+	background_right->queue_redraw();
 }
 
 void TileAtlasView::_notification(int p_what) {

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -154,8 +154,8 @@ public:
 		p_control->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 	};
 
-	// Update everything.
-	void update();
+	// Redraw everything.
+	void queue_redraw();
 
 	TileAtlasView();
 };

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -240,12 +240,12 @@ void GenericTilePolygonEditor::_base_control_draw() {
 
 void GenericTilePolygonEditor::_center_view() {
 	panning = Vector2();
-	base_control->update();
+	base_control->queue_redraw();
 	button_center_view->set_disabled(true);
 }
 
 void GenericTilePolygonEditor::_zoom_changed() {
-	base_control->update();
+	base_control->queue_redraw();
 }
 
 void GenericTilePolygonEditor::_advanced_menu_item_pressed(int p_item_pressed) {
@@ -266,26 +266,26 @@ void GenericTilePolygonEditor::_advanced_menu_item_pressed(int p_item_pressed) {
 				polygon.write[i] = polygon[i] * tile_set->get_tile_size();
 			}
 			undo_redo->add_do_method(this, "add_polygon", polygon);
-			undo_redo->add_do_method(base_control, "update");
+			undo_redo->add_do_method(base_control, "queue_redraw");
 			undo_redo->add_do_method(this, "emit_signal", "polygons_changed");
 			undo_redo->add_undo_method(this, "clear_polygons");
 			for (unsigned int i = 0; i < polygons.size(); i++) {
 				undo_redo->add_undo_method(this, "add_polygon", polygons[i]);
 			}
-			undo_redo->add_undo_method(base_control, "update");
+			undo_redo->add_undo_method(base_control, "queue_redraw");
 			undo_redo->add_undo_method(this, "emit_signal", "polygons_changed");
 			undo_redo->commit_action(true);
 		} break;
 		case CLEAR_TILE: {
 			undo_redo->create_action(TTR("Clear Polygons"));
 			undo_redo->add_do_method(this, "clear_polygons");
-			undo_redo->add_do_method(base_control, "update");
+			undo_redo->add_do_method(base_control, "queue_redraw");
 			undo_redo->add_do_method(this, "emit_signal", "polygons_changed");
 			undo_redo->add_undo_method(this, "clear_polygons");
 			for (unsigned int i = 0; i < polygons.size(); i++) {
 				undo_redo->add_undo_method(this, "add_polygon", polygons[i]);
 			}
-			undo_redo->add_undo_method(base_control, "update");
+			undo_redo->add_undo_method(base_control, "queue_redraw");
 			undo_redo->add_undo_method(this, "emit_signal", "polygons_changed");
 			undo_redo->commit_action(true);
 		} break;
@@ -318,12 +318,12 @@ void GenericTilePolygonEditor::_advanced_menu_item_pressed(int p_item_pressed) {
 				}
 				undo_redo->add_do_method(this, "set_polygon", i, new_polygon);
 			}
-			undo_redo->add_do_method(base_control, "update");
+			undo_redo->add_do_method(base_control, "queue_redraw");
 			undo_redo->add_do_method(this, "emit_signal", "polygons_changed");
 			for (unsigned int i = 0; i < polygons.size(); i++) {
 				undo_redo->add_undo_method(this, "set_polygon", polygons[i]);
 			}
-			undo_redo->add_undo_method(base_control, "update");
+			undo_redo->add_undo_method(base_control, "queue_redraw");
 			undo_redo->add_undo_method(this, "emit_signal", "polygons_changed");
 			undo_redo->commit_action(true);
 		} break;
@@ -491,9 +491,9 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 							undo_redo->add_do_method(this, "clear_polygons");
 						}
 						undo_redo->add_do_method(this, "add_polygon", in_creation_polygon);
-						undo_redo->add_do_method(base_control, "update");
+						undo_redo->add_do_method(base_control, "queue_redraw");
 						undo_redo->add_undo_method(this, "remove_polygon", added);
-						undo_redo->add_undo_method(base_control, "update");
+						undo_redo->add_undo_method(base_control, "queue_redraw");
 						undo_redo->commit_action(false);
 						emit_signal(SNAME("polygons_changed"));
 					} else {
@@ -539,8 +539,8 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 							undo_redo->add_do_method(this, "set_polygon", closest_polygon, polygons[closest_polygon]);
 							undo_redo->add_undo_method(this, "set_polygon", closest_polygon, old_polygon);
 						}
-						undo_redo->add_do_method(base_control, "update");
-						undo_redo->add_undo_method(base_control, "update");
+						undo_redo->add_do_method(base_control, "queue_redraw");
+						undo_redo->add_undo_method(base_control, "queue_redraw");
 						undo_redo->commit_action(false);
 						emit_signal(SNAME("polygons_changed"));
 					}
@@ -549,9 +549,9 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 				if (drag_type == DRAG_TYPE_DRAG_POINT) {
 					undo_redo->create_action(TTR("Edit Polygons"));
 					undo_redo->add_do_method(this, "set_polygon", drag_polygon_index, polygons[drag_polygon_index]);
-					undo_redo->add_do_method(base_control, "update");
+					undo_redo->add_do_method(base_control, "queue_redraw");
 					undo_redo->add_undo_method(this, "set_polygon", drag_polygon_index, drag_old_polygon);
-					undo_redo->add_undo_method(base_control, "update");
+					undo_redo->add_undo_method(base_control, "queue_redraw");
 					undo_redo->commit_action(false);
 					emit_signal(SNAME("polygons_changed"));
 				} else if (drag_type == DRAG_TYPE_CREATE_POINT) {
@@ -586,8 +586,8 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 							undo_redo->add_do_method(this, "set_polygon", closest_polygon, polygons[closest_polygon]);
 							undo_redo->add_undo_method(this, "set_polygon", closest_polygon, old_polygon);
 						}
-						undo_redo->add_do_method(base_control, "update");
-						undo_redo->add_undo_method(base_control, "update");
+						undo_redo->add_do_method(base_control, "queue_redraw");
+						undo_redo->add_undo_method(base_control, "queue_redraw");
 						undo_redo->commit_action(false);
 						emit_signal(SNAME("polygons_changed"));
 					} else {
@@ -611,7 +611,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 		}
 	}
 
-	base_control->update();
+	base_control->queue_redraw();
 }
 
 void GenericTilePolygonEditor::set_use_undo_redo(bool p_use_undo_redo) {
@@ -659,7 +659,7 @@ void GenericTilePolygonEditor::set_background(Ref<Texture2D> p_texture, Rect2 p_
 	background_v_flip = p_flip_v;
 	background_transpose = p_transpose;
 	background_modulate = p_modulate;
-	base_control->update();
+	base_control->queue_redraw();
 }
 
 int GenericTilePolygonEditor::get_polygon_count() {
@@ -672,13 +672,13 @@ int GenericTilePolygonEditor::add_polygon(Vector<Point2> p_polygon, int p_index)
 
 	if (p_index < 0) {
 		polygons.push_back(p_polygon);
-		base_control->update();
+		base_control->queue_redraw();
 		button_edit->set_pressed(true);
 		return polygons.size() - 1;
 	} else {
 		polygons.insert(p_index, p_polygon);
 		button_edit->set_pressed(true);
-		base_control->update();
+		base_control->queue_redraw();
 		return p_index;
 	}
 }
@@ -690,12 +690,12 @@ void GenericTilePolygonEditor::remove_polygon(int p_index) {
 	if (polygons.size() == 0) {
 		button_create->set_pressed(true);
 	}
-	base_control->update();
+	base_control->queue_redraw();
 }
 
 void GenericTilePolygonEditor::clear_polygons() {
 	polygons.clear();
-	base_control->update();
+	base_control->queue_redraw();
 }
 
 void GenericTilePolygonEditor::set_polygon(int p_polygon_index, Vector<Point2> p_polygon) {
@@ -703,7 +703,7 @@ void GenericTilePolygonEditor::set_polygon(int p_polygon_index, Vector<Point2> p
 	ERR_FAIL_COND(p_polygon.size() < 3);
 	polygons[p_polygon_index] = p_polygon;
 	button_edit->set_pressed(true);
-	base_control->update();
+	base_control->queue_redraw();
 }
 
 Vector<Point2> GenericTilePolygonEditor::get_polygon(int p_polygon_index) {
@@ -713,7 +713,7 @@ Vector<Point2> GenericTilePolygonEditor::get_polygon(int p_polygon_index) {
 
 void GenericTilePolygonEditor::set_polygons_color(Color p_color) {
 	polygon_color = p_color;
-	base_control->update();
+	base_control->queue_redraw();
 }
 
 void GenericTilePolygonEditor::set_multiple_polygon_mode(bool p_multiple_polygon_mode) {

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -351,7 +351,7 @@ void TileMapEditorTilesPlugin::_update_atlas_view() {
 
 	tile_atlas_view->set_atlas_source(*tile_map->get_tileset(), atlas_source, source_id);
 	TilesEditorPlugin::get_singleton()->synchronize_atlas_view(tile_atlas_view);
-	tile_atlas_control->update();
+	tile_atlas_control->queue_redraw();
 }
 
 void TileMapEditorTilesPlugin::_update_scenes_collection_view() {
@@ -1651,8 +1651,8 @@ void TileMapEditorTilesPlugin::_update_tileset_selection_from_selection_pattern(
 		}
 	}
 	_update_source_display();
-	tile_atlas_control->update();
-	alternative_tiles_control->update();
+	tile_atlas_control->queue_redraw();
+	alternative_tiles_control->queue_redraw();
 }
 
 void TileMapEditorTilesPlugin::_tile_atlas_control_draw() {
@@ -1736,7 +1736,7 @@ void TileMapEditorTilesPlugin::_tile_atlas_control_mouse_exited() {
 	hovered_tile.set_atlas_coords(TileSetSource::INVALID_ATLAS_COORDS);
 	hovered_tile.alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE;
 	tile_set_dragging_selection = false;
-	tile_atlas_control->update();
+	tile_atlas_control->queue_redraw();
 }
 
 void TileMapEditorTilesPlugin::_tile_atlas_control_gui_input(const Ref<InputEvent> &p_event) {
@@ -1780,8 +1780,8 @@ void TileMapEditorTilesPlugin::_tile_atlas_control_gui_input(const Ref<InputEven
 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
-		tile_atlas_control->update();
-		alternative_tiles_control->update();
+		tile_atlas_control->queue_redraw();
+		alternative_tiles_control->queue_redraw();
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -1841,7 +1841,7 @@ void TileMapEditorTilesPlugin::_tile_atlas_control_gui_input(const Ref<InputEven
 			}
 			tile_set_dragging_selection = false;
 		}
-		tile_atlas_control->update();
+		tile_atlas_control->queue_redraw();
 	}
 }
 
@@ -1895,7 +1895,7 @@ void TileMapEditorTilesPlugin::_tile_alternatives_control_mouse_exited() {
 	hovered_tile.set_atlas_coords(TileSetSource::INVALID_ATLAS_COORDS);
 	hovered_tile.alternative_tile = TileSetSource::INVALID_TILE_ALTERNATIVE;
 	tile_set_dragging_selection = false;
-	alternative_tiles_control->update();
+	alternative_tiles_control->queue_redraw();
 }
 
 void TileMapEditorTilesPlugin::_tile_alternatives_control_gui_input(const Ref<InputEvent> &p_event) {
@@ -1938,8 +1938,8 @@ void TileMapEditorTilesPlugin::_tile_alternatives_control_gui_input(const Ref<In
 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
-		tile_atlas_control->update();
-		alternative_tiles_control->update();
+		tile_atlas_control->queue_redraw();
+		alternative_tiles_control->queue_redraw();
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -1959,8 +1959,8 @@ void TileMapEditorTilesPlugin::_tile_alternatives_control_gui_input(const Ref<In
 			}
 			_update_selection_pattern_from_tileset_tiles_selection();
 		}
-		tile_atlas_control->update();
-		alternative_tiles_control->update();
+		tile_atlas_control->queue_redraw();
+		alternative_tiles_control->queue_redraw();
 	}
 }
 
@@ -3618,7 +3618,7 @@ void TileMapEditor::_tab_changed(int p_tab_id) {
 	}
 
 	// Graphical update.
-	tabs_data[tabs_bar->get_current_tab()].panel->update();
+	tabs_data[tabs_bar->get_current_tab()].panel->queue_redraw();
 	CanvasItemEditor::get_singleton()->update_viewport();
 }
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -624,8 +624,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		TileDataTextureOffsetEditor *tile_data_texture_offset_editor = memnew(TileDataTextureOffsetEditor);
 		tile_data_texture_offset_editor->hide();
 		tile_data_texture_offset_editor->setup_property_editor(Variant::VECTOR2, "texture_offset");
-		tile_data_texture_offset_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-		tile_data_texture_offset_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+		tile_data_texture_offset_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+		tile_data_texture_offset_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 		tile_data_editors["texture_offset"] = tile_data_texture_offset_editor;
 	}
 
@@ -634,8 +634,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		TileDataDefaultEditor *tile_data_modulate_editor = memnew(TileDataDefaultEditor());
 		tile_data_modulate_editor->hide();
 		tile_data_modulate_editor->setup_property_editor(Variant::COLOR, "modulate", "", Color(1.0, 1.0, 1.0, 1.0));
-		tile_data_modulate_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-		tile_data_modulate_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+		tile_data_modulate_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+		tile_data_modulate_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 		tile_data_editors["modulate"] = tile_data_modulate_editor;
 	}
 
@@ -644,8 +644,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		TileDataDefaultEditor *tile_data_z_index_editor = memnew(TileDataDefaultEditor());
 		tile_data_z_index_editor->hide();
 		tile_data_z_index_editor->setup_property_editor(Variant::INT, "z_index");
-		tile_data_z_index_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-		tile_data_z_index_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+		tile_data_z_index_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+		tile_data_z_index_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 		tile_data_editors["z_index"] = tile_data_z_index_editor;
 	}
 
@@ -654,8 +654,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		TileDataYSortEditor *tile_data_y_sort_editor = memnew(TileDataYSortEditor);
 		tile_data_y_sort_editor->hide();
 		tile_data_y_sort_editor->setup_property_editor(Variant::INT, "y_sort_origin");
-		tile_data_y_sort_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-		tile_data_y_sort_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+		tile_data_y_sort_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+		tile_data_y_sort_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 		tile_data_editors["y_sort_origin"] = tile_data_y_sort_editor;
 	}
 
@@ -665,8 +665,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 			TileDataOcclusionShapeEditor *tile_data_occlusion_shape_editor = memnew(TileDataOcclusionShapeEditor());
 			tile_data_occlusion_shape_editor->hide();
 			tile_data_occlusion_shape_editor->set_occlusion_layer(i);
-			tile_data_occlusion_shape_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-			tile_data_occlusion_shape_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+			tile_data_occlusion_shape_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+			tile_data_occlusion_shape_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 			tile_data_editors[vformat("occlusion_layer_%d", i)] = tile_data_occlusion_shape_editor;
 		}
 	}
@@ -680,8 +680,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	if (!tile_data_editors.has("terrain_set")) {
 		TileDataTerrainsEditor *tile_data_terrains_editor = memnew(TileDataTerrainsEditor);
 		tile_data_terrains_editor->hide();
-		tile_data_terrains_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-		tile_data_terrains_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+		tile_data_terrains_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+		tile_data_terrains_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 		tile_data_editors["terrain_set"] = tile_data_terrains_editor;
 	}
 
@@ -691,8 +691,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		TileDataDefaultEditor *tile_data_probability_editor = memnew(TileDataDefaultEditor());
 		tile_data_probability_editor->hide();
 		tile_data_probability_editor->setup_property_editor(Variant::FLOAT, "probability", "", 1.0);
-		tile_data_probability_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-		tile_data_probability_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+		tile_data_probability_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+		tile_data_probability_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 		tile_data_editors["probability"] = tile_data_probability_editor;
 	}
 
@@ -704,8 +704,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 			TileDataCollisionEditor *tile_data_collision_editor = memnew(TileDataCollisionEditor());
 			tile_data_collision_editor->hide();
 			tile_data_collision_editor->set_physics_layer(i);
-			tile_data_collision_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-			tile_data_collision_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+			tile_data_collision_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+			tile_data_collision_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 			tile_data_editors[vformat("physics_layer_%d", i)] = tile_data_collision_editor;
 		}
 	}
@@ -722,8 +722,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 			TileDataNavigationEditor *tile_data_navigation_editor = memnew(TileDataNavigationEditor());
 			tile_data_navigation_editor->hide();
 			tile_data_navigation_editor->set_navigation_layer(i);
-			tile_data_navigation_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-			tile_data_navigation_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+			tile_data_navigation_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+			tile_data_navigation_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 			tile_data_editors[vformat("navigation_layer_%d", i)] = tile_data_navigation_editor;
 		}
 	}
@@ -744,8 +744,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 			TileDataDefaultEditor *tile_data_custom_data_editor = memnew(TileDataDefaultEditor());
 			tile_data_custom_data_editor->hide();
 			tile_data_custom_data_editor->setup_property_editor(tile_set->get_custom_data_layer_type(i), vformat("custom_data_%d", i), tile_set->get_custom_data_layer_name(i));
-			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::update));
-			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::update));
+			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
+			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
 			tile_data_editors[vformat("custom_data_%d", i)] = tile_data_custom_data_editor;
 		}
 	}
@@ -872,10 +872,10 @@ void TileSetAtlasSourceEditor::_tile_data_editor_dropdown_button_pressed() {
 void TileSetAtlasSourceEditor::_tile_data_editors_tree_selected() {
 	tile_data_editors_popup->call_deferred(SNAME("hide"));
 	_update_current_tile_data_editor();
-	tile_atlas_control->update();
-	tile_atlas_control_unscaled->update();
-	alternative_tiles_control->update();
-	alternative_tiles_control_unscaled->update();
+	tile_atlas_control->queue_redraw();
+	tile_atlas_control_unscaled->queue_redraw();
+	alternative_tiles_control->queue_redraw();
+	alternative_tiles_control_unscaled->queue_redraw();
 }
 
 void TileSetAtlasSourceEditor::_update_atlas_view() {
@@ -923,11 +923,11 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 	tile_atlas_view->set_padding(Side::SIDE_RIGHT, texture_region_base_size_min);
 
 	// Redraw everything.
-	tile_atlas_control->update();
-	tile_atlas_control_unscaled->update();
-	alternative_tiles_control->update();
-	alternative_tiles_control_unscaled->update();
-	tile_atlas_view->update();
+	tile_atlas_control->queue_redraw();
+	tile_atlas_control_unscaled->queue_redraw();
+	alternative_tiles_control->queue_redraw();
+	alternative_tiles_control_unscaled->queue_redraw();
+	tile_atlas_view->queue_redraw();
 
 	// Synchronize atlas view.
 	TilesEditorPlugin::get_singleton()->synchronize_atlas_view(tile_atlas_view);
@@ -961,14 +961,14 @@ void TileSetAtlasSourceEditor::_update_toolbar() {
 
 void TileSetAtlasSourceEditor::_tile_atlas_control_mouse_exited() {
 	hovered_base_tile_coords = TileSetSource::INVALID_ATLAS_COORDS;
-	tile_atlas_control->update();
-	tile_atlas_control_unscaled->update();
-	tile_atlas_view->update();
+	tile_atlas_control->queue_redraw();
+	tile_atlas_control_unscaled->queue_redraw();
+	tile_atlas_view->queue_redraw();
 }
 
 void TileSetAtlasSourceEditor::_tile_atlas_view_transform_changed() {
-	tile_atlas_control->update();
-	tile_atlas_control_unscaled->update();
+	tile_atlas_control->queue_redraw();
+	tile_atlas_control_unscaled->queue_redraw();
 }
 
 void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEvent> &p_event) {
@@ -983,11 +983,11 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 		// Update only what's needed.
 		tile_set_changed_needs_update = false;
 
-		tile_atlas_control->update();
-		tile_atlas_control_unscaled->update();
-		alternative_tiles_control->update();
-		alternative_tiles_control_unscaled->update();
-		tile_atlas_view->update();
+		tile_atlas_control->queue_redraw();
+		tile_atlas_control_unscaled->queue_redraw();
+		alternative_tiles_control->queue_redraw();
+		alternative_tiles_control_unscaled->queue_redraw();
+		tile_atlas_view->queue_redraw();
 		return;
 	} else {
 		// Handle the event.
@@ -1132,11 +1132,11 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 			}
 
 			// Redraw for the hovered tile.
-			tile_atlas_control->update();
-			tile_atlas_control_unscaled->update();
-			alternative_tiles_control->update();
-			alternative_tiles_control_unscaled->update();
-			tile_atlas_view->update();
+			tile_atlas_control->queue_redraw();
+			tile_atlas_control_unscaled->queue_redraw();
+			alternative_tiles_control->queue_redraw();
+			alternative_tiles_control_unscaled->queue_redraw();
+			tile_atlas_view->queue_redraw();
 			return;
 		}
 
@@ -1283,11 +1283,11 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					// Left click released.
 					_end_dragging();
 				}
-				tile_atlas_control->update();
-				tile_atlas_control_unscaled->update();
-				alternative_tiles_control->update();
-				alternative_tiles_control_unscaled->update();
-				tile_atlas_view->update();
+				tile_atlas_control->queue_redraw();
+				tile_atlas_control_unscaled->queue_redraw();
+				alternative_tiles_control->queue_redraw();
+				alternative_tiles_control_unscaled->queue_redraw();
+				tile_atlas_view->queue_redraw();
 				return;
 			} else if (mb->get_button_index() == MouseButton::RIGHT) {
 				// Right click pressed.
@@ -1298,11 +1298,11 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					// Right click released.
 					_end_dragging();
 				}
-				tile_atlas_control->update();
-				tile_atlas_control_unscaled->update();
-				alternative_tiles_control->update();
-				alternative_tiles_control_unscaled->update();
-				tile_atlas_view->update();
+				tile_atlas_control->queue_redraw();
+				tile_atlas_control_unscaled->queue_redraw();
+				alternative_tiles_control->queue_redraw();
+				alternative_tiles_control_unscaled->queue_redraw();
+				tile_atlas_view->queue_redraw();
 				return;
 			}
 		}
@@ -1872,20 +1872,20 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_gui_input(const Ref<In
 		if (current_tile_data_editor) {
 			current_tile_data_editor->forward_painting_alternatives_gui_input(tile_atlas_view, tile_set_atlas_source, p_event);
 		}
-		tile_atlas_control->update();
-		tile_atlas_control_unscaled->update();
-		alternative_tiles_control->update();
-		alternative_tiles_control_unscaled->update();
-		tile_atlas_view->update();
+		tile_atlas_control->queue_redraw();
+		tile_atlas_control_unscaled->queue_redraw();
+		alternative_tiles_control->queue_redraw();
+		alternative_tiles_control_unscaled->queue_redraw();
+		tile_atlas_view->queue_redraw();
 		return;
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
-		tile_atlas_control->update();
-		tile_atlas_control_unscaled->update();
-		alternative_tiles_control->update();
-		alternative_tiles_control_unscaled->update();
+		tile_atlas_control->queue_redraw();
+		tile_atlas_control_unscaled->queue_redraw();
+		alternative_tiles_control->queue_redraw();
+		alternative_tiles_control_unscaled->queue_redraw();
 
 		if (drag_type == DRAG_TYPE_MAY_POPUP_MENU) {
 			if (Vector2(drag_start_mouse_pos).distance_to(alternative_tiles_control->get_local_mouse_position()) > 5.0 * EDSCALE) {
@@ -1942,19 +1942,19 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_gui_input(const Ref<In
 				drag_type = DRAG_TYPE_NONE;
 			}
 		}
-		tile_atlas_control->update();
-		tile_atlas_control_unscaled->update();
-		alternative_tiles_control->update();
-		alternative_tiles_control_unscaled->update();
+		tile_atlas_control->queue_redraw();
+		tile_atlas_control_unscaled->queue_redraw();
+		alternative_tiles_control->queue_redraw();
+		alternative_tiles_control_unscaled->queue_redraw();
 	}
 }
 
 void TileSetAtlasSourceEditor::_tile_alternatives_control_mouse_exited() {
 	hovered_alternative_tile_coords = Vector3i(TileSetSource::INVALID_ATLAS_COORDS.x, TileSetSource::INVALID_ATLAS_COORDS.y, TileSetSource::INVALID_TILE_ALTERNATIVE);
-	tile_atlas_control->update();
-	tile_atlas_control_unscaled->update();
-	alternative_tiles_control->update();
-	alternative_tiles_control_unscaled->update();
+	tile_atlas_control->queue_redraw();
+	tile_atlas_control_unscaled->queue_redraw();
+	alternative_tiles_control->queue_redraw();
+	alternative_tiles_control_unscaled->queue_redraw();
 }
 
 void TileSetAtlasSourceEditor::_tile_alternatives_control_draw() {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6263,7 +6263,7 @@ void VisualShaderNodePortPreview::setup(const Ref<VisualShader> &p_shader, Visua
 	type = p_type;
 	port = p_port;
 	node = p_node;
-	update();
+	queue_redraw();
 	_shader_changed();
 }
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -962,12 +962,12 @@ public:
 		switch (p_what) {
 			case NOTIFICATION_MOUSE_ENTER: {
 				hover = true;
-				update();
+				queue_redraw();
 			} break;
 
 			case NOTIFICATION_MOUSE_EXIT: {
 				hover = false;
-				update();
+				queue_redraw();
 			} break;
 
 			case NOTIFICATION_DRAW: {
@@ -1682,7 +1682,7 @@ void ProjectList::select_project(int p_index) {
 	_selected_project_paths.clear();
 
 	for (int i = 0; i < previous_selected_items.size(); ++i) {
-		previous_selected_items[i].control->update();
+		previous_selected_items[i].control->queue_redraw();
 	}
 
 	toggle_select(p_index);
@@ -1728,7 +1728,7 @@ void ProjectList::toggle_select(int p_index) {
 	} else {
 		_selected_project_paths.insert(item.path);
 	}
-	item.control->update();
+	item.control->queue_redraw();
 }
 
 void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
@@ -1860,7 +1860,7 @@ void ProjectManager::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			settings_hb->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT);
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1200,7 +1200,7 @@ void SceneTreeDock::_notification(int p_what) {
 			if (canvas_item_plugin) {
 				canvas_item_plugin->get_canvas_item_editor()->connect("item_lock_status_changed", Callable(scene_tree, "_update_tree"));
 				canvas_item_plugin->get_canvas_item_editor()->connect("item_group_status_changed", Callable(scene_tree, "_update_tree"));
-				scene_tree->connect("node_changed", callable_mp((CanvasItem *)canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), &CanvasItem::update));
+				scene_tree->connect("node_changed", callable_mp((CanvasItem *)canvas_item_plugin->get_canvas_item_editor()->get_viewport_control(), &CanvasItem::queue_redraw));
 			}
 
 			Node3DEditorPlugin *spatial_editor_plugin = Object::cast_to<Node3DEditorPlugin>(editor_data->get_editor("3D"));
@@ -2127,7 +2127,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 
 	// hack, force 2d editor viewport to refresh after deletion
 	if (CanvasItemEditor *editor = CanvasItemEditor::get_singleton()) {
-		editor->get_viewport_control()->update();
+		editor->get_viewport_control()->queue_redraw();
 	}
 
 	_push_item(nullptr);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -505,7 +505,7 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 
 	if (p_node->is_class("CanvasItem") || p_node->is_class("CanvasLayer") || p_node->is_class("Window")) {
 		visible = p_node->call("is_visible");
-		CanvasItemEditor::get_singleton()->get_viewport_control()->update();
+		CanvasItemEditor::get_singleton()->get_viewport_control()->queue_redraw();
 	} else if (p_node->is_class("Node3D")) {
 		visible = p_node->call("is_visible");
 	}

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -205,7 +205,7 @@ void AnimatedSprite2D::_notification(int p_what) {
 						}
 					}
 
-					update();
+					queue_redraw();
 
 					emit_signal(SceneStringNames::get_singleton()->frame_changed);
 				}
@@ -274,7 +274,7 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 
 	notify_property_list_changed();
 	_reset_timeout();
-	update();
+	queue_redraw();
 	update_configuration_warnings();
 }
 
@@ -304,7 +304,7 @@ void AnimatedSprite2D::set_frame(int p_frame) {
 
 	frame = p_frame;
 	_reset_timeout();
-	update();
+	queue_redraw();
 
 	emit_signal(SceneStringNames::get_singleton()->frame_changed);
 }
@@ -329,7 +329,7 @@ double AnimatedSprite2D::get_speed_scale() const {
 
 void AnimatedSprite2D::set_centered(bool p_center) {
 	centered = p_center;
-	update();
+	queue_redraw();
 	item_rect_changed();
 }
 
@@ -339,7 +339,7 @@ bool AnimatedSprite2D::is_centered() const {
 
 void AnimatedSprite2D::set_offset(const Point2 &p_offset) {
 	offset = p_offset;
-	update();
+	queue_redraw();
 	item_rect_changed();
 }
 
@@ -349,7 +349,7 @@ Point2 AnimatedSprite2D::get_offset() const {
 
 void AnimatedSprite2D::set_flip_h(bool p_flip) {
 	hflip = p_flip;
-	update();
+	queue_redraw();
 }
 
 bool AnimatedSprite2D::is_flipped_h() const {
@@ -358,7 +358,7 @@ bool AnimatedSprite2D::is_flipped_h() const {
 
 void AnimatedSprite2D::set_flip_v(bool p_flip) {
 	vflip = p_flip;
-	update();
+	queue_redraw();
 }
 
 bool AnimatedSprite2D::is_flipped_v() const {
@@ -368,7 +368,7 @@ bool AnimatedSprite2D::is_flipped_v() const {
 void AnimatedSprite2D::_res_changed() {
 	set_frame(frame);
 
-	update();
+	queue_redraw();
 }
 
 void AnimatedSprite2D::set_playing(bool p_playing) {
@@ -433,7 +433,7 @@ void AnimatedSprite2D::set_animation(const StringName &p_animation) {
 	_reset_timeout();
 	set_frame(0);
 	notify_property_list_changed();
-	update();
+	queue_redraw();
 }
 
 StringName AnimatedSprite2D::get_animation() const {

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -39,7 +39,7 @@ void Camera2D::_update_scroll() {
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		update(); //will just be drawn
+		queue_redraw(); //will just be drawn
 		return;
 	}
 
@@ -392,7 +392,7 @@ void Camera2D::_make_current(Object *p_which) {
 		current = true;
 		if (is_inside_tree()) {
 			get_viewport()->_camera_2d_set(this);
-			update();
+			queue_redraw();
 		}
 	} else {
 		current = false;
@@ -400,7 +400,7 @@ void Camera2D::_make_current(Object *p_which) {
 			if (get_viewport()->get_camera_2d() == this) {
 				get_viewport()->_camera_2d_set(nullptr);
 			}
-			update();
+			queue_redraw();
 		}
 	}
 }
@@ -461,7 +461,7 @@ bool Camera2D::is_limit_smoothing_enabled() const {
 void Camera2D::set_drag_margin(Side p_side, real_t p_drag_margin) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	drag_margin[p_side] = p_drag_margin;
-	update();
+	queue_redraw();
 }
 
 real_t Camera2D::get_drag_margin(Side p_side) const {
@@ -625,7 +625,7 @@ Node *Camera2D::get_custom_viewport() const {
 void Camera2D::set_screen_drawing_enabled(bool enable) {
 	screen_drawing_enabled = enable;
 #ifdef TOOLS_ENABLED
-	update();
+	queue_redraw();
 #endif
 }
 
@@ -636,7 +636,7 @@ bool Camera2D::is_screen_drawing_enabled() const {
 void Camera2D::set_limit_drawing_enabled(bool enable) {
 	limit_drawing_enabled = enable;
 #ifdef TOOLS_ENABLED
-	update();
+	queue_redraw();
 #endif
 }
 
@@ -647,7 +647,7 @@ bool Camera2D::is_limit_drawing_enabled() const {
 void Camera2D::set_margin_drawing_enabled(bool enable) {
 	margin_drawing_enabled = enable;
 #ifdef TOOLS_ENABLED
-	update();
+	queue_redraw();
 #endif
 }
 

--- a/scene/2d/canvas_group.cpp
+++ b/scene/2d/canvas_group.cpp
@@ -36,7 +36,7 @@ void CanvasGroup::set_fit_margin(real_t p_fit_margin) {
 	fit_margin = p_fit_margin;
 	RS::get_singleton()->canvas_item_set_canvas_group_mode(get_canvas_item(), RS::CANVAS_GROUP_MODE_TRANSPARENT, clear_margin, true, fit_margin, use_mipmaps);
 
-	update();
+	queue_redraw();
 }
 
 real_t CanvasGroup::get_fit_margin() const {
@@ -49,7 +49,7 @@ void CanvasGroup::set_clear_margin(real_t p_clear_margin) {
 	clear_margin = p_clear_margin;
 	RS::get_singleton()->canvas_item_set_canvas_group_mode(get_canvas_item(), RS::CANVAS_GROUP_MODE_TRANSPARENT, clear_margin, true, clear_margin, use_mipmaps);
 
-	update();
+	queue_redraw();
 }
 
 real_t CanvasGroup::get_clear_margin() const {

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -198,7 +198,7 @@ void CollisionPolygon2D::set_polygon(const Vector<Point2> &p_polygon) {
 		_build_polygon();
 		_update_in_shape_owner();
 	}
-	update();
+	queue_redraw();
 	update_configuration_warnings();
 }
 
@@ -213,7 +213,7 @@ void CollisionPolygon2D::set_build_mode(BuildMode p_mode) {
 		_build_polygon();
 		_update_in_shape_owner();
 	}
-	update();
+	queue_redraw();
 	update_configuration_warnings();
 }
 
@@ -264,7 +264,7 @@ TypedArray<String> CollisionPolygon2D::get_configuration_warnings() const {
 
 void CollisionPolygon2D::set_disabled(bool p_disabled) {
 	disabled = p_disabled;
-	update();
+	queue_redraw();
 	if (parent) {
 		parent->shape_owner_set_disabled(owner_id, p_disabled);
 	}
@@ -276,7 +276,7 @@ bool CollisionPolygon2D::is_disabled() const {
 
 void CollisionPolygon2D::set_one_way_collision(bool p_enable) {
 	one_way_collision = p_enable;
-	update();
+	queue_redraw();
 	if (parent) {
 		parent->shape_owner_set_one_way_collision(owner_id, p_enable);
 	}

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -36,7 +36,7 @@
 #include "scene/resources/convex_polygon_shape_2d.h"
 
 void CollisionShape2D::_shape_changed() {
-	update();
+	queue_redraw();
 }
 
 void CollisionShape2D::_update_in_shape_owner(bool p_xform_only) {
@@ -140,7 +140,7 @@ void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 		shape->disconnect("changed", callable_mp(this, &CollisionShape2D::_shape_changed));
 	}
 	shape = p_shape;
-	update();
+	queue_redraw();
 	if (parent) {
 		parent->shape_owner_clear_shapes(owner_id);
 		if (shape.is_valid()) {
@@ -192,7 +192,7 @@ TypedArray<String> CollisionShape2D::get_configuration_warnings() const {
 
 void CollisionShape2D::set_disabled(bool p_disabled) {
 	disabled = p_disabled;
-	update();
+	queue_redraw();
 	if (parent) {
 		parent->shape_owner_set_disabled(owner_id, p_disabled);
 	}
@@ -204,7 +204,7 @@ bool CollisionShape2D::is_disabled() const {
 
 void CollisionShape2D::set_one_way_collision(bool p_enable) {
 	one_way_collision = p_enable;
-	update();
+	queue_redraw();
 	if (parent) {
 		parent->shape_owner_set_one_way_collision(owner_id, p_enable);
 	}

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -102,7 +102,7 @@ private:
 	double inactive_time = 0.0;
 	double frame_remainder = 0.0;
 	int cycle = 0;
-	bool redraw = false;
+	bool do_redraw = false;
 
 	RID mesh;
 	RID multimesh;
@@ -186,7 +186,7 @@ private:
 
 	void _update_mesh_texture();
 
-	void _set_redraw(bool p_redraw);
+	void _set_do_redraw(bool p_do_redraw);
 
 	void _texture_changed();
 

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -99,7 +99,7 @@ void GPUParticles2D::set_visibility_rect(const Rect2 &p_visibility_rect) {
 
 	RS::get_singleton()->particles_set_custom_aabb(particles, aabb);
 
-	update();
+	queue_redraw();
 }
 
 void GPUParticles2D::set_use_local_coordinates(bool p_enable) {
@@ -141,7 +141,7 @@ void GPUParticles2D::set_process_material(const Ref<Material> &p_material) {
 void GPUParticles2D::set_trail_enabled(bool p_enabled) {
 	trail_enabled = p_enabled;
 	RS::get_singleton()->particles_set_trails(particles, trail_enabled, trail_length);
-	update();
+	queue_redraw();
 
 	RS::get_singleton()->particles_set_transform_align(particles, p_enabled ? RS::PARTICLES_TRANSFORM_ALIGN_Y_TO_VELOCITY : RS::PARTICLES_TRANSFORM_ALIGN_DISABLED);
 }
@@ -150,7 +150,7 @@ void GPUParticles2D::set_trail_length(double p_seconds) {
 	ERR_FAIL_COND(p_seconds < 0.001);
 	trail_length = p_seconds;
 	RS::get_singleton()->particles_set_trails(particles, trail_enabled, trail_length);
-	update();
+	queue_redraw();
 }
 
 void GPUParticles2D::set_trail_sections(int p_sections) {
@@ -158,7 +158,7 @@ void GPUParticles2D::set_trail_sections(int p_sections) {
 	ERR_FAIL_COND(p_sections > 128);
 
 	trail_sections = p_sections;
-	update();
+	queue_redraw();
 }
 
 void GPUParticles2D::set_trail_section_subdivisions(int p_subdivisions) {
@@ -166,13 +166,13 @@ void GPUParticles2D::set_trail_section_subdivisions(int p_subdivisions) {
 	ERR_FAIL_COND(p_subdivisions > 1024);
 
 	trail_section_subdivisions = p_subdivisions;
-	update();
+	queue_redraw();
 }
 
 #ifdef TOOLS_ENABLED
 void GPUParticles2D::set_show_visibility_rect(bool p_show_visibility_rect) {
 	show_visibility_rect = p_show_visibility_rect;
-	update();
+	queue_redraw();
 }
 #endif
 
@@ -333,7 +333,7 @@ Rect2 GPUParticles2D::capture_rect() const {
 void GPUParticles2D::set_texture(const Ref<Texture2D> &p_texture) {
 	texture = p_texture;
 	_update_collision_size();
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> GPUParticles2D::get_texture() const {

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -267,7 +267,7 @@ void PinJoint2D::_configure_joint(RID p_joint, PhysicsBody2D *body_a, PhysicsBod
 
 void PinJoint2D::set_softness(real_t p_softness) {
 	softness = p_softness;
-	update();
+	queue_redraw();
 	if (is_configured()) {
 		PhysicsServer2D::get_singleton()->pin_joint_set_param(get_joint(), PhysicsServer2D::PIN_JOINT_SOFTNESS, p_softness);
 	}
@@ -321,7 +321,7 @@ void GrooveJoint2D::_configure_joint(RID p_joint, PhysicsBody2D *body_a, Physics
 
 void GrooveJoint2D::set_length(real_t p_length) {
 	length = p_length;
-	update();
+	queue_redraw();
 }
 
 real_t GrooveJoint2D::get_length() const {
@@ -330,7 +330,7 @@ real_t GrooveJoint2D::get_length() const {
 
 void GrooveJoint2D::set_initial_offset(real_t p_initial_offset) {
 	initial_offset = p_initial_offset;
-	update();
+	queue_redraw();
 }
 
 real_t GrooveJoint2D::get_initial_offset() const {
@@ -387,7 +387,7 @@ void DampedSpringJoint2D::_configure_joint(RID p_joint, PhysicsBody2D *body_a, P
 
 void DampedSpringJoint2D::set_length(real_t p_length) {
 	length = p_length;
-	update();
+	queue_redraw();
 }
 
 real_t DampedSpringJoint2D::get_length() const {
@@ -396,7 +396,7 @@ real_t DampedSpringJoint2D::get_length() const {
 
 void DampedSpringJoint2D::set_rest_length(real_t p_rest_length) {
 	rest_length = p_rest_length;
-	update();
+	queue_redraw();
 	if (is_configured()) {
 		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_SPRING_REST_LENGTH, p_rest_length ? p_rest_length : length);
 	}
@@ -408,7 +408,7 @@ real_t DampedSpringJoint2D::get_rest_length() const {
 
 void DampedSpringJoint2D::set_stiffness(real_t p_stiffness) {
 	stiffness = p_stiffness;
-	update();
+	queue_redraw();
 	if (is_configured()) {
 		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_SPRING_STIFFNESS, p_stiffness);
 	}
@@ -420,7 +420,7 @@ real_t DampedSpringJoint2D::get_stiffness() const {
 
 void DampedSpringJoint2D::set_damping(real_t p_damping) {
 	damping = p_damping;
-	update();
+	queue_redraw();
 	if (is_configured()) {
 		PhysicsServer2D::get_singleton()->damped_spring_joint_set_param(get_joint(), PhysicsServer2D::DAMPED_SPRING_DAMPING, p_damping);
 	}

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -153,7 +153,7 @@ OccluderPolygon2D::~OccluderPolygon2D() {
 
 void LightOccluder2D::_poly_changed() {
 #ifdef DEBUG_ENABLED
-	update();
+	queue_redraw();
 #endif
 }
 
@@ -229,7 +229,7 @@ void LightOccluder2D::set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polyg
 	if (occluder_polygon.is_valid()) {
 		occluder_polygon->connect("changed", callable_mp(this, &LightOccluder2D::_poly_changed));
 	}
-	update();
+	queue_redraw();
 #endif
 }
 

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -76,7 +76,7 @@ bool Line2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toleranc
 
 void Line2D::set_points(const Vector<Vector2> &p_points) {
 	_points = p_points;
-	update();
+	queue_redraw();
 }
 
 void Line2D::set_width(float p_width) {
@@ -84,7 +84,7 @@ void Line2D::set_width(float p_width) {
 		p_width = 0.0;
 	}
 	_width = p_width;
-	update();
+	queue_redraw();
 }
 
 float Line2D::get_width() const {
@@ -104,7 +104,7 @@ void Line2D::set_curve(const Ref<Curve> &p_curve) {
 		_curve->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_curve_changed));
 	}
 
-	update();
+	queue_redraw();
 }
 
 Ref<Curve> Line2D::get_curve() const {
@@ -118,7 +118,7 @@ Vector<Vector2> Line2D::get_points() const {
 void Line2D::set_point_position(int i, Vector2 p_pos) {
 	ERR_FAIL_INDEX(i, _points.size());
 	_points.set(i, p_pos);
-	update();
+	queue_redraw();
 }
 
 Vector2 Line2D::get_point_position(int i) const {
@@ -134,7 +134,7 @@ void Line2D::clear_points() {
 	int count = _points.size();
 	if (count > 0) {
 		_points.clear();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -144,17 +144,17 @@ void Line2D::add_point(Vector2 p_pos, int p_atpos) {
 	} else {
 		_points.insert(p_atpos, p_pos);
 	}
-	update();
+	queue_redraw();
 }
 
 void Line2D::remove_point(int i) {
 	_points.remove_at(i);
-	update();
+	queue_redraw();
 }
 
 void Line2D::set_default_color(Color p_color) {
 	_default_color = p_color;
-	update();
+	queue_redraw();
 }
 
 Color Line2D::get_default_color() const {
@@ -174,7 +174,7 @@ void Line2D::set_gradient(const Ref<Gradient> &p_gradient) {
 		_gradient->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_gradient_changed));
 	}
 
-	update();
+	queue_redraw();
 }
 
 Ref<Gradient> Line2D::get_gradient() const {
@@ -183,7 +183,7 @@ Ref<Gradient> Line2D::get_gradient() const {
 
 void Line2D::set_texture(const Ref<Texture2D> &p_texture) {
 	_texture = p_texture;
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> Line2D::get_texture() const {
@@ -192,7 +192,7 @@ Ref<Texture2D> Line2D::get_texture() const {
 
 void Line2D::set_texture_mode(const LineTextureMode p_mode) {
 	_texture_mode = p_mode;
-	update();
+	queue_redraw();
 }
 
 Line2D::LineTextureMode Line2D::get_texture_mode() const {
@@ -201,7 +201,7 @@ Line2D::LineTextureMode Line2D::get_texture_mode() const {
 
 void Line2D::set_joint_mode(LineJointMode p_mode) {
 	_joint_mode = p_mode;
-	update();
+	queue_redraw();
 }
 
 Line2D::LineJointMode Line2D::get_joint_mode() const {
@@ -210,7 +210,7 @@ Line2D::LineJointMode Line2D::get_joint_mode() const {
 
 void Line2D::set_begin_cap_mode(LineCapMode p_mode) {
 	_begin_cap_mode = p_mode;
-	update();
+	queue_redraw();
 }
 
 Line2D::LineCapMode Line2D::get_begin_cap_mode() const {
@@ -219,7 +219,7 @@ Line2D::LineCapMode Line2D::get_begin_cap_mode() const {
 
 void Line2D::set_end_cap_mode(LineCapMode p_mode) {
 	_end_cap_mode = p_mode;
-	update();
+	queue_redraw();
 }
 
 Line2D::LineCapMode Line2D::get_end_cap_mode() const {
@@ -239,7 +239,7 @@ void Line2D::set_sharp_limit(float p_limit) {
 		p_limit = 0.f;
 	}
 	_sharp_limit = p_limit;
-	update();
+	queue_redraw();
 }
 
 float Line2D::get_sharp_limit() const {
@@ -248,7 +248,7 @@ float Line2D::get_sharp_limit() const {
 
 void Line2D::set_round_precision(int p_precision) {
 	_round_precision = MAX(1, p_precision);
-	update();
+	queue_redraw();
 }
 
 int Line2D::get_round_precision() const {
@@ -257,7 +257,7 @@ int Line2D::get_round_precision() const {
 
 void Line2D::set_antialiased(bool p_antialiased) {
 	_antialiased = p_antialiased;
-	update();
+	queue_redraw();
 }
 
 bool Line2D::get_antialiased() const {
@@ -334,11 +334,11 @@ void Line2D::_draw() {
 }
 
 void Line2D::_gradient_changed() {
-	update();
+	queue_redraw();
 }
 
 void Line2D::_curve_changed() {
-	update();
+	queue_redraw();
 }
 
 // static

--- a/scene/2d/marker_2d.cpp
+++ b/scene/2d/marker_2d.cpp
@@ -86,7 +86,7 @@ bool Marker2D::_edit_use_rect() const {
 void Marker2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -102,7 +102,7 @@ void Marker2D::_notification(int p_what) {
 
 void Marker2D::set_gizmo_extents(real_t p_extents) {
 	gizmo_extents = p_extents;
-	update();
+	queue_redraw();
 }
 
 real_t Marker2D::get_gizmo_extents() const {

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -61,7 +61,7 @@ void MeshInstance2D::_bind_methods() {
 
 void MeshInstance2D::set_mesh(const Ref<Mesh> &p_mesh) {
 	mesh = p_mesh;
-	update();
+	queue_redraw();
 }
 
 Ref<Mesh> MeshInstance2D::get_mesh() const {
@@ -73,13 +73,13 @@ void MeshInstance2D::set_texture(const Ref<Texture2D> &p_texture) {
 		return;
 	}
 	texture = p_texture;
-	update();
+	queue_redraw();
 	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 }
 
 void MeshInstance2D::set_normal_map(const Ref<Texture2D> &p_texture) {
 	normal_map = p_texture;
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> MeshInstance2D::get_normal_map() const {

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -61,7 +61,7 @@ void MultiMeshInstance2D::_bind_methods() {
 
 void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
 	multimesh = p_multimesh;
-	update();
+	queue_redraw();
 }
 
 Ref<MultiMesh> MultiMeshInstance2D::get_multimesh() const {
@@ -73,7 +73,7 @@ void MultiMeshInstance2D::set_texture(const Ref<Texture2D> &p_texture) {
 		return;
 	}
 	texture = p_texture;
-	update();
+	queue_redraw();
 	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 }
 
@@ -83,7 +83,7 @@ Ref<Texture2D> MultiMeshInstance2D::get_texture() const {
 
 void MultiMeshInstance2D::set_normal_map(const Ref<Texture2D> &p_texture) {
 	normal_map = p_texture;
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> MultiMeshInstance2D::get_normal_map() const {

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -374,7 +374,7 @@ void NavigationRegion2D::set_enabled(bool p_enabled) {
 
 #ifdef DEBUG_ENABLED
 	if (Engine::get_singleton()->is_editor_hint() || NavigationServer3D::get_singleton()->get_debug_enabled()) {
-		update();
+		queue_redraw();
 	}
 #endif // DEBUG_ENABLED
 }
@@ -551,7 +551,7 @@ Ref<NavigationPolygon> NavigationRegion2D::get_navigation_polygon() const {
 
 void NavigationRegion2D::_navpoly_changed() {
 	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint())) {
-		update();
+		queue_redraw();
 	}
 	if (navpoly.is_valid()) {
 		NavigationServer2D::get_singleton()->region_set_navpoly(region, navpoly);
@@ -561,7 +561,7 @@ void NavigationRegion2D::_navpoly_changed() {
 void NavigationRegion2D::_map_changed(RID p_map) {
 #ifdef DEBUG_ENABLED
 	if (is_inside_tree() && get_world_2d()->get_navigation_map() == p_map) {
-		update();
+		queue_redraw();
 	}
 #endif // DEBUG_ENABLED
 }

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -131,7 +131,7 @@ void Path2D::_curve_changed() {
 		return;
 	}
 
-	update();
+	queue_redraw();
 }
 
 void Path2D::set_curve(const Ref<Curve2D> &p_curve) {

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -97,7 +97,7 @@ void Polygon2D::_validate_property(PropertyInfo &p_property) const {
 }
 
 void Polygon2D::_skeleton_bone_setup_changed() {
-	update();
+	queue_redraw();
 }
 
 void Polygon2D::_notification(int p_what) {
@@ -375,7 +375,7 @@ void Polygon2D::_notification(int p_what) {
 void Polygon2D::set_polygon(const Vector<Vector2> &p_polygon) {
 	polygon = p_polygon;
 	rect_cache_dirty = true;
-	update();
+	queue_redraw();
 }
 
 Vector<Vector2> Polygon2D::get_polygon() const {
@@ -392,7 +392,7 @@ int Polygon2D::get_internal_vertex_count() const {
 
 void Polygon2D::set_uv(const Vector<Vector2> &p_uv) {
 	uv = p_uv;
-	update();
+	queue_redraw();
 }
 
 Vector<Vector2> Polygon2D::get_uv() const {
@@ -401,7 +401,7 @@ Vector<Vector2> Polygon2D::get_uv() const {
 
 void Polygon2D::set_polygons(const Array &p_polygons) {
 	polygons = p_polygons;
-	update();
+	queue_redraw();
 }
 
 Array Polygon2D::get_polygons() const {
@@ -410,7 +410,7 @@ Array Polygon2D::get_polygons() const {
 
 void Polygon2D::set_color(const Color &p_color) {
 	color = p_color;
-	update();
+	queue_redraw();
 }
 
 Color Polygon2D::get_color() const {
@@ -419,7 +419,7 @@ Color Polygon2D::get_color() const {
 
 void Polygon2D::set_vertex_colors(const Vector<Color> &p_colors) {
 	vertex_colors = p_colors;
-	update();
+	queue_redraw();
 }
 
 Vector<Color> Polygon2D::get_vertex_colors() const {
@@ -428,7 +428,7 @@ Vector<Color> Polygon2D::get_vertex_colors() const {
 
 void Polygon2D::set_texture(const Ref<Texture2D> &p_texture) {
 	texture = p_texture;
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> Polygon2D::get_texture() const {
@@ -437,7 +437,7 @@ Ref<Texture2D> Polygon2D::get_texture() const {
 
 void Polygon2D::set_texture_offset(const Vector2 &p_offset) {
 	tex_ofs = p_offset;
-	update();
+	queue_redraw();
 }
 
 Vector2 Polygon2D::get_texture_offset() const {
@@ -446,7 +446,7 @@ Vector2 Polygon2D::get_texture_offset() const {
 
 void Polygon2D::set_texture_rotation(real_t p_rot) {
 	tex_rot = p_rot;
-	update();
+	queue_redraw();
 }
 
 real_t Polygon2D::get_texture_rotation() const {
@@ -455,7 +455,7 @@ real_t Polygon2D::get_texture_rotation() const {
 
 void Polygon2D::set_texture_scale(const Size2 &p_scale) {
 	tex_scale = p_scale;
-	update();
+	queue_redraw();
 }
 
 Size2 Polygon2D::get_texture_scale() const {
@@ -464,7 +464,7 @@ Size2 Polygon2D::get_texture_scale() const {
 
 void Polygon2D::set_invert(bool p_invert) {
 	invert = p_invert;
-	update();
+	queue_redraw();
 	notify_property_list_changed();
 }
 
@@ -474,7 +474,7 @@ bool Polygon2D::get_invert() const {
 
 void Polygon2D::set_antialiased(bool p_antialiased) {
 	antialiased = p_antialiased;
-	update();
+	queue_redraw();
 }
 
 bool Polygon2D::get_antialiased() const {
@@ -483,7 +483,7 @@ bool Polygon2D::get_antialiased() const {
 
 void Polygon2D::set_invert_border(real_t p_invert_border) {
 	invert_border = p_invert_border;
-	update();
+	queue_redraw();
 }
 
 real_t Polygon2D::get_invert_border() const {
@@ -493,7 +493,7 @@ real_t Polygon2D::get_invert_border() const {
 void Polygon2D::set_offset(const Vector2 &p_offset) {
 	offset = p_offset;
 	rect_cache_dirty = true;
-	update();
+	queue_redraw();
 }
 
 Vector2 Polygon2D::get_offset() const {
@@ -533,13 +533,13 @@ void Polygon2D::clear_bones() {
 void Polygon2D::set_bone_weights(int p_index, const Vector<float> &p_weights) {
 	ERR_FAIL_INDEX(p_index, bone_weights.size());
 	bone_weights.write[p_index].weights = p_weights;
-	update();
+	queue_redraw();
 }
 
 void Polygon2D::set_bone_path(int p_index, const NodePath &p_path) {
 	ERR_FAIL_INDEX(p_index, bone_weights.size());
 	bone_weights.write[p_index].path = p_path;
-	update();
+	queue_redraw();
 }
 
 Array Polygon2D::_get_bones() const {
@@ -567,7 +567,7 @@ void Polygon2D::set_skeleton(const NodePath &p_skeleton) {
 		return;
 	}
 	skeleton = p_skeleton;
-	update();
+	queue_redraw();
 }
 
 NodePath Polygon2D::get_skeleton() const {

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -36,7 +36,7 @@
 void RayCast2D::set_target_position(const Vector2 &p_point) {
 	target_position = p_point;
 	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint())) {
-		update();
+		queue_redraw();
 	}
 }
 
@@ -100,7 +100,7 @@ Vector2 RayCast2D::get_collision_normal() const {
 
 void RayCast2D::set_enabled(bool p_enabled) {
 	enabled = p_enabled;
-	update();
+	queue_redraw();
 	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
 		set_physics_process_internal(p_enabled);
 	}
@@ -219,7 +219,7 @@ void RayCast2D::_update_raycast_state() {
 	}
 
 	if (prev_collision_state != collided) {
-		update();
+		queue_redraw();
 	}
 }
 

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -40,7 +40,7 @@
 void ShapeCast2D::set_target_position(const Vector2 &p_point) {
 	target_position = p_point;
 	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint())) {
-		update();
+		queue_redraw();
 	}
 }
 
@@ -132,7 +132,7 @@ real_t ShapeCast2D::get_closest_collision_unsafe_fraction() const {
 
 void ShapeCast2D::set_enabled(bool p_enabled) {
 	enabled = p_enabled;
-	update();
+	queue_redraw();
 	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
 		set_physics_process_internal(p_enabled);
 	}
@@ -152,7 +152,7 @@ void ShapeCast2D::set_shape(const Ref<Shape2D> &p_shape) {
 		shape_rid = shape->get_rid();
 	}
 	update_configuration_warnings();
-	update();
+	queue_redraw();
 }
 
 Ref<Shape2D> ShapeCast2D::get_shape() const {
@@ -182,7 +182,7 @@ bool ShapeCast2D::get_exclude_parent_body() const {
 }
 
 void ShapeCast2D::_redraw_shape() {
-	update();
+	queue_redraw();
 }
 
 void ShapeCast2D::_notification(int p_what) {
@@ -325,7 +325,7 @@ void ShapeCast2D::_update_shapecast_state() {
 	collided = !result.is_empty();
 
 	if (prev_collision_state != collided) {
-		update();
+		queue_redraw();
 	}
 }
 

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -126,7 +126,7 @@ void Bone2D::_notification(int p_what) {
 				return;
 			}
 
-			update();
+			queue_redraw();
 #endif // TOOLS_ENABLED
 		} break;
 
@@ -143,12 +143,12 @@ void Bone2D::_notification(int p_what) {
 				return;
 			}
 
-			update();
+			queue_redraw();
 
 			if (get_parent()) {
 				Bone2D *parent_bone = Object::cast_to<Bone2D>(get_parent());
 				if (parent_bone) {
-					parent_bone->update();
+					parent_bone->queue_redraw();
 				}
 			}
 #endif // TOOLS_ENABLED
@@ -365,7 +365,7 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 
 void Bone2D::_editor_set_show_bone_gizmo(bool p_show_gizmo) {
 	_editor_show_bone_gizmo = p_show_gizmo;
-	update();
+	queue_redraw();
 }
 
 bool Bone2D::_editor_get_show_bone_gizmo() const {
@@ -493,7 +493,7 @@ void Bone2D::set_length(real_t p_length) {
 	length = p_length;
 
 #ifdef TOOLS_ENABLED
-	update();
+	queue_redraw();
 #endif // TOOLS_ENABLED
 }
 
@@ -505,7 +505,7 @@ void Bone2D::set_bone_angle(real_t p_angle) {
 	bone_angle = p_angle;
 
 #ifdef TOOLS_ENABLED
-	update();
+	queue_redraw();
 #endif // TOOLS_ENABLED
 }
 

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -146,7 +146,7 @@ void Sprite2D::set_texture(const Ref<Texture2D> &p_texture) {
 		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Sprite2D::_texture_changed));
 	}
 
-	update();
+	queue_redraw();
 	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 	item_rect_changed();
 }
@@ -157,7 +157,7 @@ Ref<Texture2D> Sprite2D::get_texture() const {
 
 void Sprite2D::set_centered(bool p_center) {
 	centered = p_center;
-	update();
+	queue_redraw();
 	item_rect_changed();
 }
 
@@ -167,7 +167,7 @@ bool Sprite2D::is_centered() const {
 
 void Sprite2D::set_offset(const Point2 &p_offset) {
 	offset = p_offset;
-	update();
+	queue_redraw();
 	item_rect_changed();
 }
 
@@ -177,7 +177,7 @@ Point2 Sprite2D::get_offset() const {
 
 void Sprite2D::set_flip_h(bool p_flip) {
 	hflip = p_flip;
-	update();
+	queue_redraw();
 }
 
 bool Sprite2D::is_flipped_h() const {
@@ -186,7 +186,7 @@ bool Sprite2D::is_flipped_h() const {
 
 void Sprite2D::set_flip_v(bool p_flip) {
 	vflip = p_flip;
-	update();
+	queue_redraw();
 }
 
 bool Sprite2D::is_flipped_v() const {
@@ -199,7 +199,7 @@ void Sprite2D::set_region_enabled(bool p_region_enabled) {
 	}
 
 	region_enabled = p_region_enabled;
-	update();
+	queue_redraw();
 	notify_property_list_changed();
 }
 
@@ -225,7 +225,7 @@ Rect2 Sprite2D::get_region_rect() const {
 
 void Sprite2D::set_region_filter_clip_enabled(bool p_region_filter_clip_enabled) {
 	region_filter_clip_enabled = p_region_filter_clip_enabled;
-	update();
+	queue_redraw();
 }
 
 bool Sprite2D::is_region_filter_clip_enabled() const {
@@ -262,7 +262,7 @@ Vector2i Sprite2D::get_frame_coords() const {
 void Sprite2D::set_vframes(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of vframes cannot be smaller than 1.");
 	vframes = p_amount;
-	update();
+	queue_redraw();
 	item_rect_changed();
 	notify_property_list_changed();
 }
@@ -274,7 +274,7 @@ int Sprite2D::get_vframes() const {
 void Sprite2D::set_hframes(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of hframes cannot be smaller than 1.");
 	hframes = p_amount;
-	update();
+	queue_redraw();
 	item_rect_changed();
 	notify_property_list_changed();
 }
@@ -388,7 +388,7 @@ void Sprite2D::_texture_changed() {
 	// Changes to the texture need to trigger an update to make
 	// the editor redraw the sprite with the updated texture.
 	if (texture.is_valid()) {
-		update();
+		queue_redraw();
 	}
 }
 

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -34,7 +34,7 @@
 
 void TouchScreenButton::set_texture_normal(const Ref<Texture2D> &p_texture) {
 	texture_normal = p_texture;
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> TouchScreenButton::get_texture_normal() const {
@@ -43,7 +43,7 @@ Ref<Texture2D> TouchScreenButton::get_texture_normal() const {
 
 void TouchScreenButton::set_texture_pressed(const Ref<Texture2D> &p_texture_pressed) {
 	texture_pressed = p_texture_pressed;
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> TouchScreenButton::get_texture_pressed() const {
@@ -60,16 +60,16 @@ Ref<BitMap> TouchScreenButton::get_bitmask() const {
 
 void TouchScreenButton::set_shape(const Ref<Shape2D> &p_shape) {
 	if (shape.is_valid()) {
-		shape->disconnect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
+		shape->disconnect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 
 	shape = p_shape;
 
 	if (shape.is_valid()) {
-		shape->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
+		shape->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 
-	update();
+	queue_redraw();
 }
 
 Ref<Shape2D> TouchScreenButton::get_shape() const {
@@ -78,7 +78,7 @@ Ref<Shape2D> TouchScreenButton::get_shape() const {
 
 void TouchScreenButton::set_shape_centered(bool p_shape_centered) {
 	shape_centered = p_shape_centered;
-	update();
+	queue_redraw();
 }
 
 bool TouchScreenButton::is_shape_visible() const {
@@ -87,7 +87,7 @@ bool TouchScreenButton::is_shape_visible() const {
 
 void TouchScreenButton::set_shape_visible(bool p_shape_visible) {
 	shape_visible = p_shape_visible;
-	update();
+	queue_redraw();
 }
 
 bool TouchScreenButton::is_shape_centered() const {
@@ -140,7 +140,7 @@ void TouchScreenButton::_notification(int p_what) {
 			if (!Engine::get_singleton()->is_editor_hint() && !!DisplayServer::get_singleton()->screen_is_touchscreen(DisplayServer::get_singleton()->window_get_current_screen(get_viewport()->get_window_id())) && visibility == VISIBILITY_TOUCHSCREEN_ONLY) {
 				return;
 			}
-			update();
+			queue_redraw();
 
 			if (!Engine::get_singleton()->is_editor_hint()) {
 				set_process_input(is_visible_in_tree());
@@ -292,7 +292,7 @@ void TouchScreenButton::_press(int p_finger_pressed) {
 	}
 
 	emit_signal(SNAME("pressed"));
-	update();
+	queue_redraw();
 }
 
 void TouchScreenButton::_release(bool p_exiting_tree) {
@@ -311,7 +311,7 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 
 	if (!p_exiting_tree) {
 		emit_signal(SNAME("released"));
-		update();
+		queue_redraw();
 	}
 }
 
@@ -339,7 +339,7 @@ Rect2 TouchScreenButton::get_anchorable_rect() const {
 
 void TouchScreenButton::set_visibility_mode(VisibilityMode p_mode) {
 	visibility = p_mode;
-	update();
+	queue_redraw();
 }
 
 TouchScreenButton::VisibilityMode TouchScreenButton::get_visibility_mode() const {

--- a/scene/2d/visible_on_screen_notifier_2d.cpp
+++ b/scene/2d/visible_on_screen_notifier_2d.cpp
@@ -66,7 +66,7 @@ void VisibleOnScreenNotifier2D::set_rect(const Rect2 &p_rect) {
 	if (is_inside_tree()) {
 		RS::get_singleton()->canvas_item_set_visibility_notifier(get_canvas_item(), true, rect, callable_mp(this, &VisibleOnScreenNotifier2D::_visibility_enter), callable_mp(this, &VisibleOnScreenNotifier2D::_visibility_exit));
 	}
-	update();
+	queue_redraw();
 }
 
 Rect2 VisibleOnScreenNotifier2D::get_rect() const {

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -77,7 +77,7 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 			bool last_press_inside = status.pressing_inside;
 			status.pressing_inside = has_point(mouse_motion->get_position());
 			if (last_press_inside != status.pressing_inside) {
-				update();
+				queue_redraw();
 			}
 		}
 	}
@@ -87,32 +87,32 @@ void BaseButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_MOUSE_ENTER: {
 			status.hovering = true;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			status.hovering = false;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN:
 		case NOTIFICATION_SCROLL_BEGIN: {
 			if (status.press_attempt) {
 				status.press_attempt = false;
-				update();
+				queue_redraw();
 			}
 		} break;
 
 		case NOTIFICATION_FOCUS_ENTER: {
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_FOCUS_EXIT: {
 			if (status.press_attempt) {
 				status.press_attempt = false;
-				update();
+				queue_redraw();
 			} else if (status.hovering) {
-				update();
+				queue_redraw();
 			}
 		} break;
 
@@ -188,7 +188,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		emit_signal(SNAME("button_up"));
 	}
 
-	update();
+	queue_redraw();
 }
 
 void BaseButton::pressed() {
@@ -210,7 +210,7 @@ void BaseButton::set_disabled(bool p_disabled) {
 		status.press_attempt = false;
 		status.pressing_inside = false;
 	}
-	update();
+	queue_redraw();
 }
 
 bool BaseButton::is_disabled() const {
@@ -234,7 +234,7 @@ void BaseButton::set_pressed(bool p_pressed) {
 	}
 	_toggled(status.pressed);
 
-	update();
+	queue_redraw();
 }
 
 void BaseButton::set_pressed_no_signal(bool p_pressed) {
@@ -246,7 +246,7 @@ void BaseButton::set_pressed_no_signal(bool p_pressed) {
 	}
 	status.pressed = p_pressed;
 
-	update();
+	queue_redraw();
 }
 
 bool BaseButton::is_pressing() const {
@@ -385,7 +385,7 @@ void BaseButton::set_button_group(const Ref<ButtonGroup> &p_group) {
 		button_group->buttons.insert(this);
 	}
 
-	update(); //checkbox changes to radio if set a buttongroup
+	queue_redraw(); //checkbox changes to radio if set a buttongroup
 }
 
 Ref<ButtonGroup> BaseButton::get_button_group() const {

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -49,7 +49,7 @@ void Button::_set_internal_margin(Side p_side, float p_value) {
 void Button::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -57,14 +57,14 @@ void Button::_notification(int p_what) {
 			_shape();
 
 			update_minimum_size();
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 
 			update_minimum_size();
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -389,7 +389,7 @@ void Button::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 		overrun_behavior = p_behavior;
 		_shape();
 
-		update();
+		queue_redraw();
 		update_minimum_size();
 	}
 }
@@ -404,7 +404,7 @@ void Button::set_text(const String &p_text) {
 		xl_text = atr(text);
 		_shape();
 
-		update();
+		queue_redraw();
 		update_minimum_size();
 	}
 }
@@ -418,7 +418,7 @@ void Button::set_text_direction(Control::TextDirection p_text_direction) {
 	if (text_direction != p_text_direction) {
 		text_direction = p_text_direction;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -430,7 +430,7 @@ void Button::set_language(const String &p_language) {
 	if (language != p_language) {
 		language = p_language;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -441,7 +441,7 @@ String Button::get_language() const {
 void Button::set_icon(const Ref<Texture2D> &p_icon) {
 	if (icon != p_icon) {
 		icon = p_icon;
-		update();
+		queue_redraw();
 		update_minimum_size();
 	}
 }
@@ -453,7 +453,7 @@ Ref<Texture2D> Button::get_icon() const {
 void Button::set_expand_icon(bool p_enabled) {
 	if (expand_icon != p_enabled) {
 		expand_icon = p_enabled;
-		update();
+		queue_redraw();
 		update_minimum_size();
 	}
 }
@@ -465,7 +465,7 @@ bool Button::is_expand_icon() const {
 void Button::set_flat(bool p_enabled) {
 	if (flat != p_enabled) {
 		flat = p_enabled;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -476,7 +476,7 @@ bool Button::is_flat() const {
 void Button::set_clip_text(bool p_enabled) {
 	if (clip_text != p_enabled) {
 		clip_text = p_enabled;
-		update();
+		queue_redraw();
 		update_minimum_size();
 	}
 }
@@ -488,7 +488,7 @@ bool Button::get_clip_text() const {
 void Button::set_text_alignment(HorizontalAlignment p_alignment) {
 	if (alignment != p_alignment) {
 		alignment = p_alignment;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -499,7 +499,7 @@ HorizontalAlignment Button::get_text_alignment() const {
 void Button::set_icon_alignment(HorizontalAlignment p_alignment) {
 	icon_alignment = p_alignment;
 	update_minimum_size();
-	update();
+	queue_redraw();
 }
 
 HorizontalAlignment Button::get_icon_alignment() const {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -268,7 +268,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		if (is_code_completion_scroll_pressed && mb->get_button_index() == MouseButton::LEFT) {
 			is_code_completion_scroll_pressed = false;
-			update();
+			queue_redraw();
 			return;
 		}
 
@@ -281,13 +281,13 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				case MouseButton::WHEEL_UP: {
 					if (code_completion_current_selected > 0) {
 						code_completion_current_selected--;
-						update();
+						queue_redraw();
 					}
 				} break;
 				case MouseButton::WHEEL_DOWN: {
 					if (code_completion_current_selected < code_completion_options.size() - 1) {
 						code_completion_current_selected++;
-						update();
+						queue_redraw();
 					}
 				} break;
 				case MouseButton::LEFT: {
@@ -295,7 +295,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					if (mb->is_double_click()) {
 						confirm_code_completion();
 					}
-					update();
+					queue_redraw();
 				} break;
 				default:
 					break;
@@ -310,7 +310,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				is_code_completion_scroll_pressed = true;
 
 				_update_scroll_selected_line(mb->get_position().y);
-				update();
+				queue_redraw();
 			}
 
 			return;
@@ -384,12 +384,12 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		bool scroll_hovered = code_completion_scroll_rect.has_point(mpos);
 		if (is_code_completion_scroll_hovered != scroll_hovered) {
 			is_code_completion_scroll_hovered = scroll_hovered;
-			update();
+			queue_redraw();
 		}
 
 		if (is_code_completion_scroll_pressed) {
 			_update_scroll_selected_line(mpos.y);
-			update();
+			queue_redraw();
 			return;
 		}
 	}
@@ -448,7 +448,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			} else {
 				code_completion_current_selected = code_completion_options.size() - 1;
 			}
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		}
@@ -458,31 +458,31 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			} else {
 				code_completion_current_selected = 0;
 			}
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_page_up", true)) {
 			code_completion_current_selected = MAX(0, code_completion_current_selected - code_completion_max_lines);
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_page_down", true)) {
 			code_completion_current_selected = MIN(code_completion_options.size() - 1, code_completion_current_selected + code_completion_max_lines);
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_home", true)) {
 			code_completion_current_selected = 0;
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_end", true)) {
 			code_completion_current_selected = code_completion_options.size() - 1;
-			update();
+			queue_redraw();
 			accept_event();
 			return;
 		}
@@ -1106,7 +1106,7 @@ bool CodeEdit::is_auto_brace_completion_enabled() const {
 
 void CodeEdit::set_highlight_matching_braces_enabled(bool p_enabled) {
 	highlight_matching_braces_enabled = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool CodeEdit::is_highlight_matching_braces_enabled() const {
@@ -1265,7 +1265,7 @@ void CodeEdit::set_line_as_breakpoint(int p_line, bool p_breakpointed) {
 		breakpointed_lines.erase(p_line);
 	}
 	emit_signal(SNAME("breakpoint_toggled"), p_line);
-	update();
+	queue_redraw();
 }
 
 bool CodeEdit::is_line_breakpointed(int p_line) const {
@@ -1294,7 +1294,7 @@ PackedInt32Array CodeEdit::get_breakpointed_lines() const {
 void CodeEdit::set_line_as_bookmarked(int p_line, bool p_bookmarked) {
 	int mask = get_line_gutter_metadata(p_line, main_gutter);
 	set_line_gutter_metadata(p_line, main_gutter, p_bookmarked ? mask | MAIN_GUTTER_BOOKMARK : mask & ~MAIN_GUTTER_BOOKMARK);
-	update();
+	queue_redraw();
 }
 
 bool CodeEdit::is_line_bookmarked(int p_line) const {
@@ -1323,7 +1323,7 @@ PackedInt32Array CodeEdit::get_bookmarked_lines() const {
 void CodeEdit::set_line_as_executing(int p_line, bool p_executing) {
 	int mask = get_line_gutter_metadata(p_line, main_gutter);
 	set_line_gutter_metadata(p_line, main_gutter, p_executing ? mask | MAIN_GUTTER_EXECUTING : mask & ~MAIN_GUTTER_EXECUTING);
-	update();
+	queue_redraw();
 }
 
 bool CodeEdit::is_line_executing(int p_line) const {
@@ -1359,7 +1359,7 @@ bool CodeEdit::is_draw_line_numbers_enabled() const {
 
 void CodeEdit::set_line_numbers_zero_padded(bool p_zero_padded) {
 	p_zero_padded ? line_number_padding = "0" : line_number_padding = " ";
-	update();
+	queue_redraw();
 }
 
 bool CodeEdit::is_line_numbers_zero_padded() const {
@@ -1529,7 +1529,7 @@ void CodeEdit::fold_line(int p_line) {
 		set_caret_line(p_line, false, false);
 		set_caret_column(get_line(p_line).length(), false);
 	}
-	update();
+	queue_redraw();
 }
 
 void CodeEdit::unfold_line(int p_line) {
@@ -1552,14 +1552,14 @@ void CodeEdit::unfold_line(int p_line) {
 		}
 		_set_line_as_hidden(i, false);
 	}
-	update();
+	queue_redraw();
 }
 
 void CodeEdit::fold_all_lines() {
 	for (int i = 0; i < get_line_count(); i++) {
 		fold_line(i);
 	}
-	update();
+	queue_redraw();
 }
 
 void CodeEdit::unfold_all_lines() {
@@ -1765,12 +1765,12 @@ Point2 CodeEdit::get_delimiter_end_position(int p_line, int p_column) const {
 void CodeEdit::set_code_hint(const String &p_hint) {
 	code_hint = p_hint;
 	code_hint_xpos = -0xFFFF;
-	update();
+	queue_redraw();
 }
 
 void CodeEdit::set_code_hint_draw_below(bool p_below) {
 	code_hint_draw_below = p_below;
-	update();
+	queue_redraw();
 }
 
 /* Code Completion */
@@ -1929,7 +1929,7 @@ void CodeEdit::set_code_completion_selected_index(int p_index) {
 	}
 	ERR_FAIL_INDEX(p_index, code_completion_options.size());
 	code_completion_current_selected = p_index;
-	update();
+	queue_redraw();
 }
 
 void CodeEdit::confirm_code_completion(bool p_replace) {
@@ -2043,13 +2043,13 @@ void CodeEdit::cancel_code_completion() {
 	}
 	code_completion_forced = false;
 	code_completion_active = false;
-	update();
+	queue_redraw();
 }
 
 /* Line length guidelines */
 void CodeEdit::set_line_length_guidelines(TypedArray<int> p_guideline_columns) {
 	line_length_guideline_columns = p_guideline_columns;
-	update();
+	queue_redraw();
 }
 
 TypedArray<int> CodeEdit::get_line_length_guidelines() const {
@@ -2802,7 +2802,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		code_completion_longest_line = MIN(max_width, code_completion_max_width * font_size);
 		code_completion_current_selected = 0;
 		code_completion_active = true;
-		update();
+		queue_redraw();
 		return;
 	}
 
@@ -3052,7 +3052,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 	code_completion_longest_line = MIN(max_width, code_completion_max_width * font_size);
 	code_completion_current_selected = 0;
 	code_completion_active = true;
-	update();
+	queue_redraw();
 }
 
 void CodeEdit::_lines_edited_from(int p_from_line, int p_to_line) {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -303,7 +303,7 @@ void ColorPicker::set_edit_alpha(bool p_show) {
 	}
 
 	_update_color();
-	sample->update();
+	sample->queue_redraw();
 }
 
 bool ColorPicker::is_editing_alpha() const {
@@ -458,15 +458,15 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 
 	_update_text_value();
 
-	sample->update();
-	uv_edit->update();
-	w_edit->update();
+	sample->queue_redraw();
+	uv_edit->queue_redraw();
+	w_edit->queue_redraw();
 	for (int i = 0; i < current_slider_count; i++) {
-		sliders[i]->update();
+		sliders[i]->queue_redraw();
 	}
-	alpha_slider->update();
-	wheel->update();
-	wheel_uv->update();
+	alpha_slider->queue_redraw();
+	wheel->queue_redraw();
+	wheel_uv->queue_redraw();
 	updating = false;
 }
 
@@ -1359,7 +1359,7 @@ void ColorPickerButton::_about_to_popup() {
 
 void ColorPickerButton::_color_changed(const Color &p_color) {
 	color = p_color;
-	update();
+	queue_redraw();
 	emit_signal(SNAME("color_changed"), color);
 }
 
@@ -1439,7 +1439,7 @@ void ColorPickerButton::set_pick_color(const Color &p_color) {
 		picker->set_pick_color(p_color);
 	}
 
-	update();
+	queue_redraw();
 }
 
 Color ColorPickerButton::get_pick_color() const {

--- a/scene/gui/color_rect.cpp
+++ b/scene/gui/color_rect.cpp
@@ -35,7 +35,7 @@ void ColorRect::set_color(const Color &p_color) {
 		return;
 	}
 	color = p_color;
-	update();
+	queue_redraw();
 }
 
 Color ColorRect::get_color() const {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -713,7 +713,7 @@ void Control::set_anchor(Side p_side, real_t p_anchor, bool p_keep_offset, bool 
 		_size_changed();
 	}
 
-	update();
+	queue_redraw();
 }
 
 real_t Control::get_anchor(Side p_side) const {
@@ -1459,7 +1459,7 @@ void Control::set_scale(const Vector2 &p_scale) {
 	if (data.scale.y == 0) {
 		data.scale.y = CMP_EPSILON;
 	}
-	update();
+	queue_redraw();
 	_notify_transform();
 }
 
@@ -1473,7 +1473,7 @@ void Control::set_rotation(real_t p_radians) {
 	}
 
 	data.rotation = p_radians;
-	update();
+	queue_redraw();
 	_notify_transform();
 }
 
@@ -1487,7 +1487,7 @@ void Control::set_pivot_offset(const Vector2 &p_pivot) {
 	}
 
 	data.pivot_offset = p_pivot;
-	update();
+	queue_redraw();
 	_notify_transform();
 }
 
@@ -2240,7 +2240,7 @@ void Control::set_disable_visibility_clip(bool p_ignore) {
 		return;
 	}
 	data.disable_visibility_clip = p_ignore;
-	update();
+	queue_redraw();
 }
 
 bool Control::is_visibility_clip_disabled() const {
@@ -2252,7 +2252,7 @@ void Control::set_clip_contents(bool p_clip) {
 		return;
 	}
 	data.clip_contents = p_clip;
-	update();
+	queue_redraw();
 }
 
 bool Control::is_clipping_contents() {
@@ -3196,9 +3196,9 @@ void Control::_notification(int p_notification) {
 			// some parents need to know the order of the children to draw (like TabContainer)
 			// update if necessary
 			if (data.parent) {
-				data.parent->update();
+				data.parent->queue_redraw();
 			}
-			update();
+			queue_redraw();
 
 			if (data.RI) {
 				get_viewport()->_gui_set_root_order_dirty();
@@ -3225,19 +3225,19 @@ void Control::_notification(int p_notification) {
 
 		case NOTIFICATION_FOCUS_ENTER: {
 			emit_signal(SceneStringNames::get_singleton()->focus_entered);
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_FOCUS_EXIT: {
 			emit_signal(SceneStringNames::get_singleton()->focus_exited);
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
 			emit_signal(SceneStringNames::get_singleton()->theme_changed);
 			_invalidate_theme_cache();
 			update_minimum_size();
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -92,7 +92,7 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 		points.remove_at(grabbed);
 		grabbed = -1;
 		grabbing = false;
-		update();
+		queue_redraw();
 		emit_signal(SNAME("ramp_changed"));
 		accept_event();
 	}
@@ -112,7 +112,7 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 			points.remove_at(grabbed);
 			grabbed = -1;
 			grabbing = false;
-			update();
+			queue_redraw();
 			emit_signal(SNAME("ramp_changed"));
 			accept_event();
 		}
@@ -138,13 +138,13 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			emit_signal(SNAME("ramp_changed"));
-			update();
+			queue_redraw();
 		}
 	}
 
 	// Select.
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-		update();
+		queue_redraw();
 		int x = mb->get_position().x;
 		int total_w = get_size().width - get_size().height - draw_spacing;
 
@@ -214,7 +214,7 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 			grabbing = false;
 			emit_signal(SNAME("ramp_changed"));
 		}
-		update();
+		queue_redraw();
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
@@ -282,7 +282,7 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 		emit_signal(SNAME("ramp_changed"));
 
-		update();
+		queue_redraw();
 	}
 }
 
@@ -378,7 +378,7 @@ void GradientEdit::_color_changed(const Color &p_color) {
 		return;
 	}
 	points.write[grabbed].color = p_color;
-	update();
+	queue_redraw();
 	emit_signal(SNAME("ramp_changed"));
 }
 
@@ -393,7 +393,7 @@ void GradientEdit::set_ramp(const Vector<float> &p_offsets, const Vector<Color> 
 	}
 
 	points.sort();
-	update();
+	queue_redraw();
 }
 
 Vector<float> GradientEdit::get_offsets() const {

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -78,7 +78,7 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 	}
 
 	set_slot(idx, si.enable_left, si.type_left, si.color_left, si.enable_right, si.type_right, si.color_right, si.custom_slot_left, si.custom_slot_right, si.draw_stylebox);
-	update();
+	queue_redraw();
 	return true;
 }
 
@@ -288,7 +288,7 @@ void GraphNode::_resort() {
 		idx++;
 	}
 
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 }
 
@@ -416,7 +416,7 @@ void GraphNode::_notification(int p_what) {
 			_shape();
 
 			update_minimum_size();
-			update();
+			queue_redraw();
 		} break;
 	}
 }
@@ -475,7 +475,7 @@ void GraphNode::set_slot(int p_idx, bool p_enable_left, int p_type_left, const C
 	s.custom_slot_right = p_custom_right;
 	s.draw_stylebox = p_draw_stylebox;
 	slot_info[p_idx] = s;
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 
 	emit_signal(SNAME("slot_updated"), p_idx);
@@ -483,13 +483,13 @@ void GraphNode::set_slot(int p_idx, bool p_enable_left, int p_type_left, const C
 
 void GraphNode::clear_slot(int p_idx) {
 	slot_info.erase(p_idx);
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 }
 
 void GraphNode::clear_all_slots() {
 	slot_info.clear();
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 }
 
@@ -508,7 +508,7 @@ void GraphNode::set_slot_enabled_left(int p_idx, bool p_enable_left) {
 	}
 
 	slot_info[p_idx].enable_left = p_enable_left;
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 
 	emit_signal(SNAME("slot_updated"), p_idx);
@@ -522,7 +522,7 @@ void GraphNode::set_slot_type_left(int p_idx, int p_type_left) {
 	}
 
 	slot_info[p_idx].type_left = p_type_left;
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 
 	emit_signal(SNAME("slot_updated"), p_idx);
@@ -543,7 +543,7 @@ void GraphNode::set_slot_color_left(int p_idx, const Color &p_color_left) {
 	}
 
 	slot_info[p_idx].color_left = p_color_left;
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 
 	emit_signal(SNAME("slot_updated"), p_idx);
@@ -571,7 +571,7 @@ void GraphNode::set_slot_enabled_right(int p_idx, bool p_enable_right) {
 	}
 
 	slot_info[p_idx].enable_right = p_enable_right;
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 
 	emit_signal(SNAME("slot_updated"), p_idx);
@@ -585,7 +585,7 @@ void GraphNode::set_slot_type_right(int p_idx, int p_type_right) {
 	}
 
 	slot_info[p_idx].type_right = p_type_right;
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 
 	emit_signal(SNAME("slot_updated"), p_idx);
@@ -606,7 +606,7 @@ void GraphNode::set_slot_color_right(int p_idx, const Color &p_color_right) {
 	}
 
 	slot_info[p_idx].color_right = p_color_right;
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 
 	emit_signal(SNAME("slot_updated"), p_idx);
@@ -630,7 +630,7 @@ void GraphNode::set_slot_draw_stylebox(int p_idx, bool p_enable) {
 	ERR_FAIL_COND_MSG(p_idx < 0, vformat("Cannot set draw_stylebox for the slot with p_idx (%d) lesser than zero.", p_idx));
 
 	slot_info[p_idx].draw_stylebox = p_enable;
-	update();
+	queue_redraw();
 	connpos_dirty = true;
 
 	emit_signal(SNAME("slot_updated"), p_idx);
@@ -688,7 +688,7 @@ void GraphNode::set_title(const String &p_title) {
 	title = p_title;
 	_shape();
 
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -701,7 +701,7 @@ void GraphNode::set_text_direction(Control::TextDirection p_text_direction) {
 	if (text_direction != p_text_direction) {
 		text_direction = p_text_direction;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -713,7 +713,7 @@ void GraphNode::set_language(const String &p_language) {
 	if (language != p_language) {
 		language = p_language;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -728,7 +728,7 @@ void GraphNode::set_position_offset(const Vector2 &p_offset) {
 
 	position_offset = p_offset;
 	emit_signal(SNAME("position_offset_changed"));
-	update();
+	queue_redraw();
 }
 
 Vector2 GraphNode::get_position_offset() const {
@@ -741,7 +741,7 @@ void GraphNode::set_selected(bool p_selected) {
 	}
 
 	selected = p_selected;
-	update();
+	queue_redraw();
 }
 
 bool GraphNode::is_selected() {
@@ -766,7 +766,7 @@ void GraphNode::set_show_close_button(bool p_enable) {
 	}
 
 	show_close = p_enable;
-	update();
+	queue_redraw();
 }
 
 bool GraphNode::is_close_button_visible() const {
@@ -970,7 +970,7 @@ void GraphNode::set_overlay(Overlay p_overlay) {
 	}
 
 	overlay = p_overlay;
-	update();
+	queue_redraw();
 }
 
 GraphNode::Overlay GraphNode::get_overlay() const {
@@ -983,7 +983,7 @@ void GraphNode::set_comment(bool p_enable) {
 	}
 
 	comment = p_enable;
-	update();
+	queue_redraw();
 }
 
 bool GraphNode::is_comment() const {
@@ -996,7 +996,7 @@ void GraphNode::set_resizable(bool p_enable) {
 	}
 
 	resizable = p_enable;
-	update();
+	queue_redraw();
 }
 
 bool GraphNode::is_resizable() const {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -63,7 +63,7 @@ int ItemList::add_item(const String &p_item, const Ref<Texture2D> &p_texture, bo
 
 	_shape(items.size() - 1);
 
-	update();
+	queue_redraw();
 	shape_changed = true;
 	notify_property_list_changed();
 	return item_id;
@@ -76,7 +76,7 @@ int ItemList::add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable) {
 	items.push_back(item);
 	int item_id = items.size() - 1;
 
-	update();
+	queue_redraw();
 	shape_changed = true;
 	notify_property_list_changed();
 	return item_id;
@@ -94,7 +94,7 @@ void ItemList::set_item_text(int p_idx, const String &p_text) {
 
 	items.write[p_idx].text = p_text;
 	_shape(p_idx);
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -112,7 +112,7 @@ void ItemList::set_item_text_direction(int p_idx, Control::TextDirection p_text_
 	if (items[p_idx].text_direction != p_text_direction) {
 		items.write[p_idx].text_direction = p_text_direction;
 		_shape(p_idx);
-		update();
+		queue_redraw();
 	}
 }
 
@@ -129,7 +129,7 @@ void ItemList::set_item_language(int p_idx, const String &p_language) {
 	if (items[p_idx].language != p_language) {
 		items.write[p_idx].language = p_language;
 		_shape(p_idx);
-		update();
+		queue_redraw();
 	}
 }
 
@@ -162,7 +162,7 @@ void ItemList::set_item_tooltip(int p_idx, const String &p_tooltip) {
 	}
 
 	items.write[p_idx].tooltip = p_tooltip;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -182,7 +182,7 @@ void ItemList::set_item_icon(int p_idx, const Ref<Texture2D> &p_icon) {
 	}
 
 	items.write[p_idx].icon = p_icon;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -203,7 +203,7 @@ void ItemList::set_item_icon_transposed(int p_idx, const bool p_transposed) {
 	}
 
 	items.write[p_idx].icon_transposed = p_transposed;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -224,7 +224,7 @@ void ItemList::set_item_icon_region(int p_idx, const Rect2 &p_region) {
 	}
 
 	items.write[p_idx].icon_region = p_region;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -245,7 +245,7 @@ void ItemList::set_item_icon_modulate(int p_idx, const Color &p_modulate) {
 	}
 
 	items.write[p_idx].icon_modulate = p_modulate;
-	update();
+	queue_redraw();
 }
 
 Color ItemList::get_item_icon_modulate(int p_idx) const {
@@ -265,7 +265,7 @@ void ItemList::set_item_custom_bg_color(int p_idx, const Color &p_custom_bg_colo
 	}
 
 	items.write[p_idx].custom_bg = p_custom_bg_color;
-	update();
+	queue_redraw();
 }
 
 Color ItemList::get_item_custom_bg_color(int p_idx) const {
@@ -285,7 +285,7 @@ void ItemList::set_item_custom_fg_color(int p_idx, const Color &p_custom_fg_colo
 	}
 
 	items.write[p_idx].custom_fg = p_custom_fg_color;
-	update();
+	queue_redraw();
 }
 
 Color ItemList::get_item_custom_fg_color(int p_idx) const {
@@ -305,7 +305,7 @@ void ItemList::set_item_tag_icon(int p_idx, const Ref<Texture2D> &p_tag_icon) {
 	}
 
 	items.write[p_idx].tag_icon = p_tag_icon;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -340,7 +340,7 @@ void ItemList::set_item_disabled(int p_idx, bool p_disabled) {
 	}
 
 	items.write[p_idx].disabled = p_disabled;
-	update();
+	queue_redraw();
 }
 
 bool ItemList::is_item_disabled(int p_idx) const {
@@ -359,7 +359,7 @@ void ItemList::set_item_metadata(int p_idx, const Variant &p_metadata) {
 	}
 
 	items.write[p_idx].metadata = p_metadata;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -387,7 +387,7 @@ void ItemList::select(int p_idx, bool p_single) {
 			items.write[p_idx].selected = true;
 		}
 	}
-	update();
+	queue_redraw();
 }
 
 void ItemList::deselect(int p_idx) {
@@ -399,7 +399,7 @@ void ItemList::deselect(int p_idx) {
 	} else {
 		items.write[p_idx].selected = false;
 	}
-	update();
+	queue_redraw();
 }
 
 void ItemList::deselect_all() {
@@ -411,7 +411,7 @@ void ItemList::deselect_all() {
 		items.write[i].selected = false;
 	}
 	current = -1;
-	update();
+	queue_redraw();
 }
 
 bool ItemList::is_selected(int p_idx) const {
@@ -431,7 +431,7 @@ void ItemList::set_current(int p_current) {
 		select(p_current, true);
 	} else {
 		current = p_current;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -451,7 +451,7 @@ void ItemList::move_item(int p_from_idx, int p_to_idx) {
 	items.remove_at(p_from_idx);
 	items.insert(p_to_idx, item);
 
-	update();
+	queue_redraw();
 	shape_changed = true;
 	notify_property_list_changed();
 }
@@ -464,7 +464,7 @@ void ItemList::set_item_count(int p_count) {
 	}
 
 	items.resize(p_count);
-	update();
+	queue_redraw();
 	shape_changed = true;
 	notify_property_list_changed();
 }
@@ -480,7 +480,7 @@ void ItemList::remove_item(int p_idx) {
 	if (current == p_idx) {
 		current = -1;
 	}
-	update();
+	queue_redraw();
 	shape_changed = true;
 	defer_select_single = -1;
 	notify_property_list_changed();
@@ -490,7 +490,7 @@ void ItemList::clear() {
 	items.clear();
 	current = -1;
 	ensure_selected_visible = false;
-	update();
+	queue_redraw();
 	shape_changed = true;
 	defer_select_single = -1;
 	notify_property_list_changed();
@@ -504,7 +504,7 @@ void ItemList::set_fixed_column_width(int p_size) {
 	}
 
 	fixed_column_width = p_size;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -518,7 +518,7 @@ void ItemList::set_same_column_width(bool p_enable) {
 	}
 
 	same_column_width = p_enable;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -539,7 +539,7 @@ void ItemList::set_max_text_lines(int p_lines) {
 			}
 		}
 		shape_changed = true;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -555,7 +555,7 @@ void ItemList::set_max_columns(int p_amount) {
 	}
 
 	max_columns = p_amount;
-	update();
+	queue_redraw();
 	shape_changed = true;
 }
 
@@ -569,7 +569,7 @@ void ItemList::set_select_mode(SelectMode p_mode) {
 	}
 
 	select_mode = p_mode;
-	update();
+	queue_redraw();
 }
 
 ItemList::SelectMode ItemList::get_select_mode() const {
@@ -588,7 +588,7 @@ void ItemList::set_icon_mode(IconMode p_mode) {
 			}
 		}
 		shape_changed = true;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -602,7 +602,7 @@ void ItemList::set_fixed_icon_size(const Size2 &p_size) {
 	}
 
 	fixed_icon_size = p_size;
-	update();
+	queue_redraw();
 }
 
 Size2 ItemList::get_fixed_icon_size() const {
@@ -961,7 +961,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 void ItemList::ensure_current_is_visible() {
 	ensure_selected_visible = true;
-	update();
+	queue_redraw();
 }
 
 static Rect2 _adjust_to_max_size(Size2 p_size, Size2 p_max_size) {
@@ -984,7 +984,7 @@ void ItemList::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_RESIZED: {
 			shape_changed = true;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
@@ -994,7 +994,7 @@ void ItemList::_notification(int p_what) {
 				_shape(i);
 			}
 			shape_changed = true;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -1430,7 +1430,7 @@ void ItemList::_notification(int p_what) {
 }
 
 void ItemList::_scroll_changed(double) {
-	update();
+	queue_redraw();
 }
 
 int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
@@ -1505,7 +1505,7 @@ String ItemList::get_tooltip(const Point2 &p_pos) const {
 
 void ItemList::sort_items_by_text() {
 	items.sort();
-	update();
+	queue_redraw();
 	shape_changed = true;
 
 	if (select_mode == SELECT_SINGLE) {
@@ -1593,7 +1593,7 @@ void ItemList::set_auto_height(bool p_enable) {
 
 	auto_height = p_enable;
 	shape_changed = true;
-	update();
+	queue_redraw();
 }
 
 bool ItemList::has_auto_height() const {
@@ -1607,7 +1607,7 @@ void ItemList::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior)
 			items.write[i].text_buf->set_text_overrun_behavior(p_behavior);
 		}
 		shape_changed = true;
-		update();
+		queue_redraw();
 	}
 }
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -44,7 +44,7 @@ void Label::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
 
 	autowrap_mode = p_mode;
 	lines_dirty = true;
-	update();
+	queue_redraw();
 
 	if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		update_minimum_size();
@@ -63,7 +63,7 @@ void Label::set_uppercase(bool p_uppercase) {
 	uppercase = p_uppercase;
 	dirty = true;
 
-	update();
+	queue_redraw();
 }
 
 bool Label::is_uppercase() const {
@@ -284,11 +284,11 @@ void Label::_notification(int p_what) {
 			}
 			dirty = true;
 
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -544,7 +544,7 @@ void Label::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			font_dirty = true;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_RESIZED: {
@@ -623,7 +623,7 @@ void Label::set_horizontal_alignment(HorizontalAlignment p_alignment) {
 	}
 	horizontal_alignment = p_alignment;
 
-	update();
+	queue_redraw();
 }
 
 HorizontalAlignment Label::get_horizontal_alignment() const {
@@ -638,7 +638,7 @@ void Label::set_vertical_alignment(VerticalAlignment p_alignment) {
 	}
 
 	vertical_alignment = p_alignment;
-	update();
+	queue_redraw();
 }
 
 VerticalAlignment Label::get_vertical_alignment() const {
@@ -655,13 +655,13 @@ void Label::set_text(const String &p_string) {
 	if (visible_ratio < 1) {
 		visible_chars = get_total_character_count() * visible_ratio;
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
 void Label::_invalidate() {
 	font_dirty = true;
-	update();
+	queue_redraw();
 }
 
 void Label::set_label_settings(const Ref<LabelSettings> &p_settings) {
@@ -686,7 +686,7 @@ void Label::set_text_direction(Control::TextDirection p_text_direction) {
 	if (text_direction != p_text_direction) {
 		text_direction = p_text_direction;
 		font_dirty = true;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -694,7 +694,7 @@ void Label::set_structured_text_bidi_override(TextServer::StructuredTextParser p
 	if (st_parser != p_parser) {
 		st_parser = p_parser;
 		dirty = true;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -709,7 +709,7 @@ void Label::set_structured_text_bidi_override_options(Array p_args) {
 
 	st_args = p_args;
 	dirty = true;
-	update();
+	queue_redraw();
 }
 
 Array Label::get_structured_text_bidi_override_options() const {
@@ -724,7 +724,7 @@ void Label::set_language(const String &p_language) {
 	if (language != p_language) {
 		language = p_language;
 		dirty = true;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -738,7 +738,7 @@ void Label::set_clip_text(bool p_clip) {
 	}
 
 	clip = p_clip;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -753,7 +753,7 @@ void Label::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 
 	overrun_behavior = p_behavior;
 	lines_dirty = true;
-	update();
+	queue_redraw();
 	if (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		update_minimum_size();
 	}
@@ -778,7 +778,7 @@ void Label::set_visible_characters(int p_amount) {
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			dirty = true;
 		}
-		update();
+		queue_redraw();
 	}
 }
 
@@ -802,7 +802,7 @@ void Label::set_visible_ratio(float p_ratio) {
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			dirty = true;
 		}
-		update();
+		queue_redraw();
 	}
 }
 
@@ -818,7 +818,7 @@ void Label::set_visible_characters_behavior(TextServer::VisibleCharactersBehavio
 	if (visible_chars_behavior != p_behavior) {
 		visible_chars_behavior = p_behavior;
 		dirty = true;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -831,7 +831,7 @@ void Label::set_lines_skipped(int p_lines) {
 
 	lines_skipped = p_lines;
 	_update_visible();
-	update();
+	queue_redraw();
 }
 
 int Label::get_lines_skipped() const {
@@ -845,7 +845,7 @@ void Label::set_max_lines_visible(int p_lines) {
 
 	max_lines_visible = p_lines;
 	_update_visible();
-	update();
+	queue_redraw();
 }
 
 int Label::get_max_lines_visible() const {

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -51,7 +51,7 @@ void LineEdit::_swap_current_input_direction() {
 		input_direction = TEXT_DIRECTION_LTR;
 	}
 	set_caret_column(get_caret_column());
-	update();
+	queue_redraw();
 }
 
 void LineEdit::_move_caret_left(bool p_select, bool p_move_by_word) {
@@ -285,7 +285,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (!text.is_empty() && is_editable() && _is_over_clear_button(b->get_position())) {
 				clear_button_status.press_attempt = true;
 				clear_button_status.pressing_inside = true;
-				update();
+				queue_redraw();
 				return;
 			}
 
@@ -348,7 +348,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 
-			update();
+			queue_redraw();
 
 		} else {
 			if (selection.enabled && !pass && b->get_button_index() == MouseButton::LEFT && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIPBOARD_PRIMARY)) {
@@ -375,7 +375,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			show_virtual_keyboard();
 		}
 
-		update();
+		queue_redraw();
 	}
 
 	Ref<InputEventMouseMotion> m = p_event;
@@ -385,7 +385,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			bool last_press_inside = clear_button_status.pressing_inside;
 			clear_button_status.pressing_inside = clear_button_status.press_attempt && _is_over_clear_button(m->get_position());
 			if (last_press_inside != clear_button_status.pressing_inside) {
-				update();
+				queue_redraw();
 			}
 		}
 
@@ -613,7 +613,7 @@ void LineEdit::set_horizontal_alignment(HorizontalAlignment p_alignment) {
 
 	alignment = p_alignment;
 	_shape();
-	update();
+	queue_redraw();
 }
 
 HorizontalAlignment LineEdit::get_horizontal_alignment() const {
@@ -681,7 +681,7 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 			}
 			text_changed_dirty = true;
 		}
-		update();
+		queue_redraw();
 	}
 }
 
@@ -725,25 +725,25 @@ void LineEdit::_notification(int p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			placeholder_translated = atr(placeholder);
 			_shape();
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
 			window_has_focus = true;
 			draw_caret = true;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
 			window_has_focus = false;
 			draw_caret = false;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
@@ -1052,7 +1052,7 @@ void LineEdit::_notification(int p_what) {
 				_shape();
 				set_caret_column(caret_column); // Update scroll_offset
 
-				update();
+				queue_redraw();
 			}
 		} break;
 
@@ -1357,7 +1357,7 @@ bool LineEdit::is_caret_force_displayed() const {
 void LineEdit::set_caret_force_displayed(const bool p_enabled) {
 	caret_force_displayed = p_enabled;
 	set_caret_blink_enabled(caret_blink_enabled);
-	update();
+	queue_redraw();
 }
 
 float LineEdit::get_caret_blink_speed() const {
@@ -1374,7 +1374,7 @@ void LineEdit::_reset_caret_blink_timer() {
 		draw_caret = true;
 		if (has_focus()) {
 			caret_blink_timer = 0.0;
-			update();
+			queue_redraw();
 		}
 	}
 }
@@ -1382,7 +1382,7 @@ void LineEdit::_reset_caret_blink_timer() {
 void LineEdit::_toggle_draw_caret() {
 	draw_caret = !draw_caret;
 	if (is_visible_in_tree() && ((has_focus() && window_has_focus) || caret_force_displayed)) {
-		update();
+		queue_redraw();
 	}
 }
 
@@ -1425,7 +1425,7 @@ void LineEdit::set_text(String p_text) {
 	insert_text_at_caret(p_text);
 	_create_undo_state();
 
-	update();
+	queue_redraw();
 	caret_column = 0;
 	scroll_offset = 0.0;
 }
@@ -1445,7 +1445,7 @@ void LineEdit::set_text_direction(Control::TextDirection p_text_direction) {
 			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_LTR), text_direction == TEXT_DIRECTION_LTR);
 			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_RTL), text_direction == TEXT_DIRECTION_RTL);
 		}
-		update();
+		queue_redraw();
 	}
 }
 
@@ -1457,7 +1457,7 @@ void LineEdit::set_language(const String &p_language) {
 	if (language != p_language) {
 		language = p_language;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -1472,7 +1472,7 @@ void LineEdit::set_draw_control_chars(bool p_draw_control_chars) {
 			menu->set_item_checked(menu->get_item_index(MENU_DISPLAY_UCC), draw_control_chars);
 		}
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -1484,7 +1484,7 @@ void LineEdit::set_structured_text_bidi_override(TextServer::StructuredTextParse
 	if (st_parser != p_parser) {
 		st_parser = p_parser;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -1495,7 +1495,7 @@ TextServer::StructuredTextParser LineEdit::get_structured_text_bidi_override() c
 void LineEdit::set_structured_text_bidi_override_options(Array p_args) {
 	st_args = p_args;
 	_shape();
-	update();
+	queue_redraw();
 }
 
 Array LineEdit::get_structured_text_bidi_override_options() const {
@@ -1534,7 +1534,7 @@ void LineEdit::set_placeholder(String p_text) {
 	placeholder = p_text;
 	placeholder_translated = atr(placeholder);
 	_shape();
-	update();
+	queue_redraw();
 }
 
 String LineEdit::get_placeholder() const {
@@ -1614,7 +1614,7 @@ void LineEdit::set_caret_column(int p_column) {
 	}
 	scroll_offset = MIN(0, scroll_offset);
 
-	update();
+	queue_redraw();
 }
 
 int LineEdit::get_caret_column() const {
@@ -1660,7 +1660,7 @@ void LineEdit::clear_internal() {
 	undo_text = "";
 	text = "";
 	_shape();
-	update();
+	queue_redraw();
 }
 
 Size2 LineEdit::get_minimum_size() const {
@@ -1704,7 +1704,7 @@ void LineEdit::deselect() {
 	selection.enabled = false;
 	selection.creating = false;
 	selection.double_click = false;
-	update();
+	queue_redraw();
 }
 
 bool LineEdit::has_selection() const {
@@ -1768,7 +1768,7 @@ void LineEdit::select_all() {
 	selection.begin = 0;
 	selection.end = text.length();
 	selection.enabled = true;
-	update();
+	queue_redraw();
 }
 
 void LineEdit::set_editable(bool p_editable) {
@@ -1779,7 +1779,7 @@ void LineEdit::set_editable(bool p_editable) {
 	editable = p_editable;
 
 	update_minimum_size();
-	update();
+	queue_redraw();
 }
 
 bool LineEdit::is_editable() const {
@@ -1793,7 +1793,7 @@ void LineEdit::set_secret(bool p_secret) {
 
 	pass = p_secret;
 	_shape();
-	update();
+	queue_redraw();
 }
 
 bool LineEdit::is_secret() const {
@@ -1811,7 +1811,7 @@ void LineEdit::set_secret_character(const String &p_string) {
 
 	secret_character = p_string;
 	_shape();
-	update();
+	queue_redraw();
 }
 
 String LineEdit::get_secret_character() const {
@@ -1848,7 +1848,7 @@ void LineEdit::select(int p_from, int p_to) {
 	selection.end = p_to;
 	selection.creating = false;
 	selection.double_click = false;
-	update();
+	queue_redraw();
 }
 
 bool LineEdit::is_text_field() const {
@@ -2027,7 +2027,7 @@ void LineEdit::set_clear_button_enabled(bool p_enabled) {
 	clear_button_enabled = p_enabled;
 	_fit_to_width();
 	update_minimum_size();
-	update();
+	queue_redraw();
 }
 
 bool LineEdit::is_clear_button_enabled() const {
@@ -2104,7 +2104,7 @@ void LineEdit::set_right_icon(const Ref<Texture2D> &p_icon) {
 	right_icon = p_icon;
 	_fit_to_width();
 	update_minimum_size();
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> LineEdit::get_right_icon() {
@@ -2114,7 +2114,7 @@ Ref<Texture2D> LineEdit::get_right_icon() {
 void LineEdit::set_flat(bool p_enabled) {
 	if (flat != p_enabled) {
 		flat = p_enabled;
-		update();
+		queue_redraw();
 	}
 }
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -54,7 +54,7 @@ void LinkButton::set_text(const String &p_text) {
 	xl_text = atr(text);
 	_shape();
 	update_minimum_size();
-	update();
+	queue_redraw();
 }
 
 String LinkButton::get_text() const {
@@ -65,7 +65,7 @@ void LinkButton::set_structured_text_bidi_override(TextServer::StructuredTextPar
 	if (st_parser != p_parser) {
 		st_parser = p_parser;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -76,7 +76,7 @@ TextServer::StructuredTextParser LinkButton::get_structured_text_bidi_override()
 void LinkButton::set_structured_text_bidi_override_options(Array p_args) {
 	st_args = p_args;
 	_shape();
-	update();
+	queue_redraw();
 }
 
 Array LinkButton::get_structured_text_bidi_override_options() const {
@@ -88,7 +88,7 @@ void LinkButton::set_text_direction(Control::TextDirection p_text_direction) {
 	if (text_direction != p_text_direction) {
 		text_direction = p_text_direction;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -100,7 +100,7 @@ void LinkButton::set_language(const String &p_language) {
 	if (language != p_language) {
 		language = p_language;
 		_shape();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -114,7 +114,7 @@ void LinkButton::set_underline_mode(UnderlineMode p_underline_mode) {
 	}
 
 	underline_mode = p_underline_mode;
-	update();
+	queue_redraw();
 }
 
 LinkButton::UnderlineMode LinkButton::get_underline_mode() const {
@@ -131,17 +131,17 @@ void LinkButton::_notification(int p_what) {
 			xl_text = atr(text);
 			_shape();
 			update_minimum_size();
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 			update_minimum_size();
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAW: {

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -95,7 +95,7 @@ void MenuBar::gui_input(const Ref<InputEvent> &p_event) {
 			selected_menu = focused_menu;
 		}
 		if (selected_menu != old_sel) {
-			update();
+			queue_redraw();
 		}
 	}
 
@@ -143,7 +143,7 @@ void MenuBar::_open_popup(int p_index, bool p_focus_item) {
 		}
 	}
 
-	update();
+	queue_redraw();
 }
 
 void MenuBar::shortcut_input(const Ref<InputEvent> &p_event) {
@@ -212,7 +212,7 @@ void MenuBar::_popup_visibility_changed(bool p_visible) {
 		active_menu = -1;
 		focused_menu = -1;
 		set_process_internal(false);
-		update();
+		queue_redraw();
 		return;
 	}
 
@@ -337,7 +337,7 @@ void MenuBar::_update_menu() {
 		}
 	}
 	update_minimum_size();
-	update();
+	queue_redraw();
 }
 
 void MenuBar::_notification(int p_what) {
@@ -352,7 +352,7 @@ void MenuBar::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_MOUSE_EXIT: {
 			focused_menu = -1;
-			update();
+			queue_redraw();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
@@ -716,7 +716,7 @@ String MenuBar::get_language() const {
 void MenuBar::set_flat(bool p_enabled) {
 	if (flat != p_enabled) {
 		flat = p_enabled;
-		update();
+		queue_redraw();
 	}
 }
 

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -94,7 +94,7 @@ void NinePatchRect::set_texture(const Ref<Texture2D> &p_tex) {
 		return;
 	}
 	texture = p_tex;
-	update();
+	queue_redraw();
 	update_minimum_size();
 	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 }
@@ -111,7 +111,7 @@ void NinePatchRect::set_patch_margin(Side p_side, int p_size) {
 	}
 
 	margin[p_side] = p_size;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -140,7 +140,7 @@ void NinePatchRect::set_draw_center(bool p_enabled) {
 	}
 
 	draw_center = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool NinePatchRect::is_draw_center_enabled() const {
@@ -153,7 +153,7 @@ void NinePatchRect::set_h_axis_stretch_mode(AxisStretchMode p_mode) {
 	}
 
 	axis_h = p_mode;
-	update();
+	queue_redraw();
 }
 
 NinePatchRect::AxisStretchMode NinePatchRect::get_h_axis_stretch_mode() const {
@@ -166,7 +166,7 @@ void NinePatchRect::set_v_axis_stretch_mode(AxisStretchMode p_mode) {
 	}
 
 	axis_v = p_mode;
-	update();
+	queue_redraw();
 }
 
 NinePatchRect::AxisStretchMode NinePatchRect::get_v_axis_stretch_mode() const {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -296,7 +296,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 					mouse_over = i;
 					emit_signal(SNAME("id_focused"), i);
 					scroll_to_item(i);
-					control->update();
+					control->queue_redraw();
 					set_input_as_handled();
 					match_found = true;
 					break;
@@ -310,7 +310,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 						mouse_over = i;
 						emit_signal(SNAME("id_focused"), i);
 						scroll_to_item(i);
-						control->update();
+						control->queue_redraw();
 						set_input_as_handled();
 						break;
 					}
@@ -328,7 +328,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 					mouse_over = i;
 					emit_signal(SNAME("id_focused"), i);
 					scroll_to_item(i);
-					control->update();
+					control->queue_redraw();
 					set_input_as_handled();
 					match_found = true;
 					break;
@@ -342,7 +342,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 						mouse_over = i;
 						emit_signal(SNAME("id_focused"), i);
 						scroll_to_item(i);
-						control->update();
+						control->queue_redraw();
 						set_input_as_handled();
 						break;
 					}
@@ -463,7 +463,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (id < 0) {
 			mouse_over = -1;
-			control->update();
+			control->queue_redraw();
 			return;
 		}
 
@@ -474,7 +474,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (over != mouse_over) {
 			mouse_over = over;
-			control->update();
+			control->queue_redraw();
 		}
 	}
 
@@ -511,7 +511,7 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 				mouse_over = i;
 				emit_signal(SNAME("id_focused"), i);
 				scroll_to_item(i);
-				control->update();
+				control->queue_redraw();
 				set_input_as_handled();
 				break;
 			}
@@ -843,7 +843,7 @@ void PopupMenu::_notification(int p_what) {
 
 			child_controls_changed();
 			_menu_changed();
-			control->update();
+			control->queue_redraw();
 		} break;
 
 		case NOTIFICATION_WM_MOUSE_ENTER: {
@@ -853,7 +853,7 @@ void PopupMenu::_notification(int p_what) {
 		case NOTIFICATION_WM_MOUSE_EXIT: {
 			if (mouse_over >= 0 && (items[mouse_over].submenu.is_empty() || submenu_over != -1)) {
 				mouse_over = -1;
-				control->update();
+				control->queue_redraw();
 			}
 		} break;
 
@@ -881,7 +881,7 @@ void PopupMenu::_notification(int p_what) {
 			if (!is_visible()) {
 				if (mouse_over >= 0) {
 					mouse_over = -1;
-					control->update();
+					control->queue_redraw();
 				}
 
 				for (int i = 0; i < items.size(); i++) {
@@ -934,7 +934,7 @@ void PopupMenu::add_item(const String &p_label, int p_id, Key p_accel) {
 	ITEM_SETUP_WITH_ACCEL(p_label, p_id, p_accel);
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	notify_property_list_changed();
 	_menu_changed();
@@ -946,7 +946,7 @@ void PopupMenu::add_icon_item(const Ref<Texture2D> &p_icon, const String &p_labe
 	item.icon = p_icon;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	notify_property_list_changed();
 	_menu_changed();
@@ -958,7 +958,7 @@ void PopupMenu::add_check_item(const String &p_label, int p_id, Key p_accel) {
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -970,7 +970,7 @@ void PopupMenu::add_icon_check_item(const Ref<Texture2D> &p_icon, const String &
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 }
 
@@ -980,7 +980,7 @@ void PopupMenu::add_radio_check_item(const String &p_label, int p_id, Key p_acce
 	item.checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -992,7 +992,7 @@ void PopupMenu::add_icon_radio_check_item(const Ref<Texture2D> &p_icon, const St
 	item.checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1004,7 +1004,7 @@ void PopupMenu::add_multistate_item(const String &p_label, int p_max_states, int
 	item.state = p_default_state;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1023,7 +1023,7 @@ void PopupMenu::add_shortcut(const Ref<Shortcut> &p_shortcut, int p_id, bool p_g
 	ITEM_SETUP_WITH_SHORTCUT(p_shortcut, p_id, p_global);
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1034,7 +1034,7 @@ void PopupMenu::add_icon_shortcut(const Ref<Texture2D> &p_icon, const Ref<Shortc
 	item.icon = p_icon;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1045,7 +1045,7 @@ void PopupMenu::add_check_shortcut(const Ref<Shortcut> &p_shortcut, int p_id, bo
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1057,7 +1057,7 @@ void PopupMenu::add_icon_check_shortcut(const Ref<Texture2D> &p_icon, const Ref<
 	item.checkable_type = Item::CHECKABLE_TYPE_CHECK_BOX;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1068,7 +1068,7 @@ void PopupMenu::add_radio_check_shortcut(const Ref<Shortcut> &p_shortcut, int p_
 	item.checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1080,7 +1080,7 @@ void PopupMenu::add_icon_radio_check_shortcut(const Ref<Texture2D> &p_icon, cons
 	item.checkable_type = Item::CHECKABLE_TYPE_RADIO_BUTTON;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1093,7 +1093,7 @@ void PopupMenu::add_submenu_item(const String &p_label, const String &p_submenu,
 	item.submenu = p_submenu;
 	items.push_back(item);
 	_shape_item(items.size() - 1);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1116,7 +1116,7 @@ void PopupMenu::set_item_text(int p_idx, const String &p_text) {
 	items.write[p_idx].dirty = true;
 	_shape_item(p_idx);
 
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1130,7 +1130,7 @@ void PopupMenu::set_item_text_direction(int p_item, Control::TextDirection p_tex
 	if (items[p_item].text_direction != p_text_direction) {
 		items.write[p_item].text_direction = p_text_direction;
 		items.write[p_item].dirty = true;
-		control->update();
+		control->queue_redraw();
 	}
 }
 
@@ -1142,7 +1142,7 @@ void PopupMenu::set_item_language(int p_item, const String &p_language) {
 	if (items[p_item].language != p_language) {
 		items.write[p_item].language = p_language;
 		items.write[p_item].dirty = true;
-		control->update();
+		control->queue_redraw();
 	}
 }
 
@@ -1158,7 +1158,7 @@ void PopupMenu::set_item_icon(int p_idx, const Ref<Texture2D> &p_icon) {
 
 	items.write[p_idx].icon = p_icon;
 
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1175,7 +1175,7 @@ void PopupMenu::set_item_checked(int p_idx, bool p_checked) {
 
 	items.write[p_idx].checked = p_checked;
 
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1192,7 +1192,7 @@ void PopupMenu::set_item_id(int p_idx, int p_id) {
 
 	items.write[p_idx].id = p_id;
 
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1210,7 +1210,7 @@ void PopupMenu::set_item_accelerator(int p_idx, Key p_accel) {
 	items.write[p_idx].accel = p_accel;
 	items.write[p_idx].dirty = true;
 
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1226,7 +1226,7 @@ void PopupMenu::set_item_metadata(int p_idx, const Variant &p_meta) {
 	}
 
 	items.write[p_idx].metadata = p_meta;
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1242,7 +1242,7 @@ void PopupMenu::set_item_disabled(int p_idx, bool p_disabled) {
 	}
 
 	items.write[p_idx].disabled = p_disabled;
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1258,7 +1258,7 @@ void PopupMenu::set_item_submenu(int p_idx, const String &p_submenu) {
 	}
 
 	items.write[p_idx].submenu = p_submenu;
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1266,7 +1266,7 @@ void PopupMenu::set_item_submenu(int p_idx, const String &p_submenu) {
 void PopupMenu::toggle_item_checked(int p_idx) {
 	ERR_FAIL_INDEX(p_idx, items.size());
 	items.write[p_idx].checked = !items[p_idx].checked;
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1377,7 +1377,7 @@ void PopupMenu::set_item_as_separator(int p_idx, bool p_separator) {
 	}
 
 	items.write[p_idx].separator = p_separator;
-	control->update();
+	control->queue_redraw();
 }
 
 bool PopupMenu::is_item_separator(int p_idx) const {
@@ -1397,7 +1397,7 @@ void PopupMenu::set_item_as_checkable(int p_idx, bool p_checkable) {
 	}
 
 	items.write[p_idx].checkable_type = p_checkable ? Item::CHECKABLE_TYPE_CHECK_BOX : Item::CHECKABLE_TYPE_NONE;
-	control->update();
+	control->queue_redraw();
 	_menu_changed();
 }
 
@@ -1413,7 +1413,7 @@ void PopupMenu::set_item_as_radio_checkable(int p_idx, bool p_radio_checkable) {
 	}
 
 	items.write[p_idx].checkable_type = p_radio_checkable ? Item::CHECKABLE_TYPE_RADIO_BUTTON : Item::CHECKABLE_TYPE_NONE;
-	control->update();
+	control->queue_redraw();
 	_menu_changed();
 }
 
@@ -1428,7 +1428,7 @@ void PopupMenu::set_item_tooltip(int p_idx, const String &p_tooltip) {
 	}
 
 	items.write[p_idx].tooltip = p_tooltip;
-	control->update();
+	control->queue_redraw();
 	_menu_changed();
 }
 
@@ -1453,7 +1453,7 @@ void PopupMenu::set_item_shortcut(int p_idx, const Ref<Shortcut> &p_shortcut, bo
 		_ref_shortcut(items[p_idx].shortcut);
 	}
 
-	control->update();
+	control->queue_redraw();
 	_menu_changed();
 }
 
@@ -1468,7 +1468,7 @@ void PopupMenu::set_item_indent(int p_idx, int p_indent) {
 	}
 	items.write[p_idx].indent = p_indent;
 
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1484,7 +1484,7 @@ void PopupMenu::set_item_multistate(int p_idx, int p_state) {
 	}
 
 	items.write[p_idx].state = p_state;
-	control->update();
+	control->queue_redraw();
 	_menu_changed();
 }
 
@@ -1499,7 +1499,7 @@ void PopupMenu::set_item_shortcut_disabled(int p_idx, bool p_disabled) {
 	}
 
 	items.write[p_idx].shortcut_is_disabled = p_disabled;
-	control->update();
+	control->queue_redraw();
 	_menu_changed();
 }
 
@@ -1514,7 +1514,7 @@ void PopupMenu::toggle_item_multistate(int p_idx) {
 		items.write[p_idx].state = 0;
 	}
 
-	control->update();
+	control->queue_redraw();
 	_menu_changed();
 }
 
@@ -1552,7 +1552,7 @@ void PopupMenu::set_current_index(int p_idx) {
 		scroll_to_item(mouse_over);
 	}
 
-	control->update();
+	control->queue_redraw();
 }
 
 int PopupMenu::get_current_index() const {
@@ -1575,7 +1575,7 @@ void PopupMenu::set_item_count(int p_count) {
 		}
 	}
 
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	notify_property_list_changed();
 	_menu_changed();
@@ -1718,7 +1718,7 @@ void PopupMenu::remove_item(int p_idx) {
 	}
 
 	items.remove_at(p_idx);
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	_menu_changed();
 }
@@ -1732,7 +1732,7 @@ void PopupMenu::add_separator(const String &p_text, int p_id) {
 		sep.xl_text = atr(p_text);
 	}
 	items.push_back(sep);
-	control->update();
+	control->queue_redraw();
 	_menu_changed();
 }
 
@@ -1744,7 +1744,7 @@ void PopupMenu::clear() {
 	}
 	items.clear();
 	mouse_over = -1;
-	control->update();
+	control->queue_redraw();
 	child_controls_changed();
 	notify_property_list_changed();
 	_menu_changed();
@@ -1753,7 +1753,7 @@ void PopupMenu::clear() {
 void PopupMenu::_ref_shortcut(Ref<Shortcut> p_sc) {
 	if (!shortcut_refcount.has(p_sc)) {
 		shortcut_refcount[p_sc] = 1;
-		p_sc->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
+		p_sc->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	} else {
 		shortcut_refcount[p_sc] += 1;
 	}
@@ -1763,7 +1763,7 @@ void PopupMenu::_unref_shortcut(Ref<Shortcut> p_sc) {
 	ERR_FAIL_COND(!shortcut_refcount.has(p_sc));
 	shortcut_refcount[p_sc]--;
 	if (shortcut_refcount[p_sc] == 0) {
-		p_sc->disconnect("changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
+		p_sc->disconnect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 		shortcut_refcount.erase(p_sc);
 	}
 }

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -118,7 +118,7 @@ void ProgressBar::_notification(int p_what) {
 void ProgressBar::set_fill_mode(int p_fill) {
 	ERR_FAIL_INDEX(p_fill, FILL_MODE_MAX);
 	mode = (FillMode)p_fill;
-	update();
+	queue_redraw();
 }
 
 int ProgressBar::get_fill_mode() {
@@ -131,7 +131,7 @@ void ProgressBar::set_percent_visible(bool p_visible) {
 	}
 	percent_visible = p_visible;
 	update_minimum_size();
-	update();
+	queue_redraw();
 }
 
 bool ProgressBar::is_percent_visible() const {

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -46,7 +46,7 @@ void Range::_value_changed(double p_value) {
 void Range::_value_changed_notify() {
 	_value_changed(shared->val);
 	emit_signal(SNAME("value_changed"), shared->val);
-	update();
+	queue_redraw();
 }
 
 void Range::Shared::emit_value_changed() {
@@ -61,7 +61,7 @@ void Range::Shared::emit_value_changed() {
 
 void Range::_changed_notify(const char *p_what) {
 	emit_signal(SNAME("changed"));
-	update();
+	queue_redraw();
 }
 
 void Range::_validate_values() {

--- a/scene/gui/reference_rect.cpp
+++ b/scene/gui/reference_rect.cpp
@@ -51,7 +51,7 @@ void ReferenceRect::set_border_color(const Color &p_color) {
 	}
 
 	border_color = p_color;
-	update();
+	queue_redraw();
 }
 
 Color ReferenceRect::get_border_color() const {
@@ -65,7 +65,7 @@ void ReferenceRect::set_border_width(float p_width) {
 	}
 
 	border_width = width_max;
-	update();
+	queue_redraw();
 }
 
 float ReferenceRect::get_border_width() const {
@@ -78,7 +78,7 @@ void ReferenceRect::set_editor_only(const bool &p_enabled) {
 	}
 
 	editor_only = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool ReferenceRect::get_editor_only() const {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1621,7 +1621,7 @@ void RichTextLabel::_scroll_changed(double) {
 
 	scroll_updated = true;
 
-	update();
+	queue_redraw();
 }
 
 void RichTextLabel::_update_fx(RichTextLabel::ItemFrame *p_frame, double p_delta_time) {
@@ -1685,20 +1685,20 @@ void RichTextLabel::_notification(int p_what) {
 				meta_hovering = nullptr;
 				emit_signal(SNAME("meta_hover_ended"), current_meta);
 				current_meta = false;
-				update();
+				queue_redraw();
 			}
 		} break;
 
 		case NOTIFICATION_RESIZED: {
 			_stop_thread();
 			main->first_resized_line.store(0); //invalidate ALL
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
 			_stop_thread();
 			main->first_invalid_font_line.store(0); //invalidate ALL
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -1708,7 +1708,7 @@ void RichTextLabel::_notification(int p_what) {
 			}
 
 			main->first_invalid_line.store(0); //invalidate ALL
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_PREDELETE:
@@ -1720,11 +1720,11 @@ void RichTextLabel::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			_stop_thread();
 			main->first_invalid_line.store(0); //invalidate ALL
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -1806,7 +1806,7 @@ void RichTextLabel::_notification(int p_what) {
 				}
 				double dt = get_process_delta_time();
 				_update_fx(main, dt);
-				update();
+				queue_redraw();
 			}
 		} break;
 
@@ -1918,7 +1918,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 							if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIPBOARD_PRIMARY)) {
 								DisplayServer::get_singleton()->clipboard_set_primary(get_selected_text());
 							}
-							update();
+							queue_redraw();
 							break;
 						}
 					}
@@ -2084,7 +2084,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			selection.active = true;
-			update();
+			queue_redraw();
 		}
 
 		Variant meta;
@@ -2541,7 +2541,7 @@ void RichTextLabel::_thread_function(void *self) {
 	RichTextLabel *rtl = reinterpret_cast<RichTextLabel *>(self);
 	rtl->_process_line_caches();
 	rtl->updating.store(false);
-	rtl->call_deferred(SNAME("update"));
+	rtl->call_deferred(SNAME("queue_redraw"));
 }
 
 void RichTextLabel::_stop_thread() {
@@ -2562,7 +2562,7 @@ void RichTextLabel::set_threaded(bool p_threaded) {
 	if (threaded != p_threaded) {
 		_stop_thread();
 		threaded = p_threaded;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -2661,7 +2661,7 @@ bool RichTextLabel::_validate_line_caches() {
 		return false;
 	} else {
 		_process_line_caches();
-		update();
+		queue_redraw();
 		return true;
 	}
 }
@@ -2799,7 +2799,7 @@ void RichTextLabel::add_text(const String &p_text) {
 
 		pos = end + 1;
 	}
-	update();
+	queue_redraw();
 }
 
 void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline) {
@@ -2837,7 +2837,7 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 	if (fixed_width != -1) {
 		update_minimum_size();
 	}
-	update();
+	queue_redraw();
 }
 
 void RichTextLabel::_remove_item(Item *p_item, const int p_line, const int p_subitem_line) {
@@ -2918,7 +2918,7 @@ void RichTextLabel::add_newline() {
 	_add_item(item, false);
 	current_frame->lines.resize(current_frame->lines.size() + 1);
 	_invalidate_current_line(current_frame);
-	update();
+	queue_redraw();
 }
 
 bool RichTextLabel::remove_line(const int p_line) {
@@ -2957,7 +2957,7 @@ bool RichTextLabel::remove_line(const int p_line) {
 	}
 
 	main->first_invalid_line.store(0);
-	update();
+	queue_redraw();
 
 	return true;
 }
@@ -3386,7 +3386,7 @@ void RichTextLabel::set_tab_size(int p_spaces) {
 
 	tab_size = p_spaces;
 	main->first_resized_line.store(0);
-	update();
+	queue_redraw();
 }
 
 int RichTextLabel::get_tab_size() const {
@@ -3410,7 +3410,7 @@ void RichTextLabel::set_meta_underline(bool p_underline) {
 	}
 
 	underline_meta = p_underline;
-	update();
+	queue_redraw();
 }
 
 bool RichTextLabel::is_meta_underlined() const {
@@ -3419,7 +3419,7 @@ bool RichTextLabel::is_meta_underlined() const {
 
 void RichTextLabel::set_hint_underline(bool p_underline) {
 	underline_hint = p_underline;
-	update();
+	queue_redraw();
 }
 
 bool RichTextLabel::is_hint_underlined() const {
@@ -3445,7 +3445,7 @@ void RichTextLabel::set_scroll_active(bool p_active) {
 
 	scroll_active = p_active;
 	vscroll->set_drag_node_enabled(p_active);
-	update();
+	queue_redraw();
 }
 
 bool RichTextLabel::is_scroll_active() const {
@@ -4570,7 +4570,7 @@ bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p
 		if (!(p_search_previous && char_idx < 0) &&
 				_search_line(selection.from_frame, selection.from_line, p_string, char_idx, p_search_previous)) {
 			scroll_to_line(selection.from_frame->line + selection.from_line);
-			update();
+			queue_redraw();
 			return true;
 		}
 		char_idx = p_search_previous ? -1 : 0;
@@ -4595,7 +4595,7 @@ bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p
 				// Search for next element
 				if (_search_table(parent_table, parent_element, p_string, p_search_previous)) {
 					scroll_to_line(selection.from_frame->line + selection.from_line);
-					update();
+					queue_redraw();
 					return true;
 				}
 			}
@@ -4619,7 +4619,7 @@ bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p
 
 		if (_search_line(main, current_line, p_string, char_idx, p_search_previous)) {
 			scroll_to_line(current_line);
-			update();
+			queue_redraw();
 			return true;
 		}
 		p_search_previous ? current_line-- : current_line++;
@@ -4729,7 +4729,7 @@ String RichTextLabel::get_selected_text() const {
 
 void RichTextLabel::deselect() {
 	selection.active = false;
-	update();
+	queue_redraw();
 }
 
 void RichTextLabel::selection_copy() {
@@ -4784,7 +4784,7 @@ void RichTextLabel::select_all() {
 	selection.to_char = to_frame->lines[to_line].char_count;
 	selection.to_item = to_item;
 	selection.active = true;
-	update();
+	queue_redraw();
 }
 
 bool RichTextLabel::is_selection_enabled() const {
@@ -4872,7 +4872,7 @@ void RichTextLabel::set_text_direction(Control::TextDirection p_text_direction) 
 		text_direction = p_text_direction;
 		main->first_invalid_line.store(0); //invalidate ALL
 		_validate_line_caches();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -4883,7 +4883,7 @@ void RichTextLabel::set_structured_text_bidi_override(TextServer::StructuredText
 		st_parser = p_parser;
 		main->first_invalid_line.store(0); //invalidate ALL
 		_validate_line_caches();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -4898,7 +4898,7 @@ void RichTextLabel::set_structured_text_bidi_override_options(Array p_args) {
 		st_args = p_args;
 		main->first_invalid_line.store(0); //invalidate ALL
 		_validate_line_caches();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -4917,7 +4917,7 @@ void RichTextLabel::set_language(const String &p_language) {
 		language = p_language;
 		main->first_invalid_line.store(0); //invalidate ALL
 		_validate_line_caches();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -4932,7 +4932,7 @@ void RichTextLabel::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
 		autowrap_mode = p_mode;
 		main->first_invalid_line = 0; //invalidate ALL
 		_validate_line_caches();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -4959,7 +4959,7 @@ void RichTextLabel::set_visible_ratio(float p_ratio) {
 			main->first_invalid_line.store(0); // Invalidate ALL.
 			_validate_line_caches();
 		}
-		update();
+		queue_redraw();
 	}
 }
 
@@ -5259,7 +5259,7 @@ void RichTextLabel::set_visible_characters_behavior(TextServer::VisibleCharacter
 		visible_chars_behavior = p_behavior;
 		main->first_invalid_line.store(0); //invalidate ALL
 		_validate_line_caches();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -5280,7 +5280,7 @@ void RichTextLabel::set_visible_characters(int p_visible) {
 			main->first_invalid_line.store(0); //invalidate ALL
 			_validate_line_caches();
 		}
-		update();
+		queue_redraw();
 	}
 }
 

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -82,14 +82,14 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			if (ofs < decr_size) {
 				decr_active = true;
 				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
-				update();
+				queue_redraw();
 				return;
 			}
 
 			if (ofs > total - incr_size) {
 				incr_active = true;
 				set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
-				update();
+				queue_redraw();
 				return;
 			}
 
@@ -117,7 +117,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 				drag.active = true;
 				drag.pos_at_click = grabber_ofs + ofs;
 				drag.value_at_click = get_as_ratio();
-				update();
+				queue_redraw();
 			} else {
 				if (scrolling) {
 					target_scroll = CLAMP(target_scroll + get_page(), get_min(), get_max() - get_page());
@@ -137,7 +137,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			incr_active = false;
 			decr_active = false;
 			drag.active = false;
-			update();
+			queue_redraw();
 		}
 	}
 
@@ -177,7 +177,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 			if (new_hilite != highlight) {
 				highlight = new_hilite;
-				update();
+				queue_redraw();
 			}
 		}
 	}
@@ -408,7 +408,7 @@ void ScrollBar::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			highlight = HIGHLIGHT_NONE;
-			update();
+			queue_redraw();
 		} break;
 	}
 }

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -312,7 +312,7 @@ void ScrollContainer::_reposition_children() {
 		fit_child_in_rect(c, r);
 	}
 
-	update();
+	queue_redraw();
 }
 
 void ScrollContainer::_notification(int p_what) {

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -149,17 +149,17 @@ void Slider::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			update_minimum_size();
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_MOUSE_ENTER: {
 			mouse_inside = true;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			mouse_inside = false;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED:
@@ -232,7 +232,7 @@ void Slider::set_ticks(int p_count) {
 	}
 
 	ticks = p_count;
-	update();
+	queue_redraw();
 }
 
 int Slider::get_ticks() const {
@@ -249,7 +249,7 @@ void Slider::set_ticks_on_borders(bool _tob) {
 	}
 
 	ticks_on_borders = _tob;
-	update();
+	queue_redraw();
 }
 
 void Slider::set_editable(bool p_editable) {
@@ -258,7 +258,7 @@ void Slider::set_editable(bool p_editable) {
 	}
 
 	editable = p_editable;
-	update();
+	queue_redraw();
 }
 
 bool Slider::is_editable() const {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -238,7 +238,7 @@ void SpinBox::_notification(int p_what) {
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			_value_changed(0);
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -247,7 +247,7 @@ void SpinBox::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			update();
+			queue_redraw();
 		} break;
 	}
 }

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -124,7 +124,7 @@ void SplitContainer::_resort() {
 		}
 	}
 
-	update();
+	queue_redraw();
 }
 
 Size2 SplitContainer::get_minimum_size() const {
@@ -176,7 +176,7 @@ void SplitContainer::_notification(int p_what) {
 		case NOTIFICATION_MOUSE_EXIT: {
 			mouse_inside = false;
 			if (get_theme_constant(SNAME("autohide"))) {
-				update();
+				queue_redraw();
 			}
 		} break;
 
@@ -256,7 +256,7 @@ void SplitContainer::gui_input(const Ref<InputEvent> &p_event) {
 		if (mouse_inside != mouse_inside_state) {
 			mouse_inside = mouse_inside_state;
 			if (get_theme_constant(SNAME("autohide"))) {
-				update();
+				queue_redraw();
 			}
 		}
 
@@ -333,7 +333,7 @@ void SplitContainer::set_dragger_visibility(DraggerVisibility p_visibility) {
 
 	dragger_visibility = p_visibility;
 	queue_sort();
-	update();
+	queue_redraw();
 }
 
 SplitContainer::DraggerVisibility SplitContainer::get_dragger_visibility() const {

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -60,7 +60,7 @@ void SubViewportContainer::set_stretch(bool p_enable) {
 	stretch = p_enable;
 	update_minimum_size();
 	queue_sort();
-	update();
+	queue_redraw();
 }
 
 bool SubViewportContainer::is_stretch_enabled() const {
@@ -88,7 +88,7 @@ void SubViewportContainer::set_stretch_shrink(int p_shrink) {
 		c->set_size(get_size() / shrink);
 	}
 
-	update();
+	queue_redraw();
 }
 
 int SubViewportContainer::get_stretch_shrink() const {

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -129,39 +129,39 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				if (pos.x < decr->get_width()) {
 					if (highlight_arrow != 1) {
 						highlight_arrow = 1;
-						update();
+						queue_redraw();
 					}
 				} else if (pos.x < incr->get_width() + decr->get_width()) {
 					if (highlight_arrow != 0) {
 						highlight_arrow = 0;
-						update();
+						queue_redraw();
 					}
 				} else if (highlight_arrow != -1) {
 					highlight_arrow = -1;
-					update();
+					queue_redraw();
 				}
 			} else {
 				int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
 				if (pos.x > limit_minus_buttons + decr->get_width()) {
 					if (highlight_arrow != 1) {
 						highlight_arrow = 1;
-						update();
+						queue_redraw();
 					}
 				} else if (pos.x > limit_minus_buttons) {
 					if (highlight_arrow != 0) {
 						highlight_arrow = 0;
-						update();
+						queue_redraw();
 					}
 				} else if (highlight_arrow != -1) {
 					highlight_arrow = -1;
-					update();
+					queue_redraw();
 				}
 			}
 		}
 
 		if (get_viewport()->gui_is_dragging() && can_drop_data(pos, get_viewport()->gui_get_drag_data())) {
 			dragging_valid_tab = true;
-			update();
+			queue_redraw();
 		}
 
 		_update_hover();
@@ -177,7 +177,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				if (offset > 0) {
 					offset--;
 					_update_cache();
-					update();
+					queue_redraw();
 				}
 			}
 		}
@@ -187,7 +187,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				if (missing_right && offset < tabs.size()) {
 					offset++;
 					_update_cache();
-					update();
+					queue_redraw();
 				}
 			}
 		}
@@ -198,7 +198,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			rb_pressing = false;
-			update();
+			queue_redraw();
 		}
 
 		if (cb_pressing && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
@@ -207,7 +207,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			cb_pressing = false;
-			update();
+			queue_redraw();
 		}
 
 		if (mb->is_pressed() && (mb->get_button_index() == MouseButton::LEFT || (select_with_rmb && mb->get_button_index() == MouseButton::RIGHT))) {
@@ -222,14 +222,14 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 						if (missing_right) {
 							offset++;
 							_update_cache();
-							update();
+							queue_redraw();
 						}
 						return;
 					} else if (pos.x < incr->get_width() + decr->get_width()) {
 						if (offset > 0) {
 							offset--;
 							_update_cache();
-							update();
+							queue_redraw();
 						}
 						return;
 					}
@@ -239,14 +239,14 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 						if (missing_right) {
 							offset++;
 							_update_cache();
-							update();
+							queue_redraw();
 						}
 						return;
 					} else if (pos.x > limit) {
 						if (offset > 0) {
 							offset--;
 							_update_cache();
-							update();
+							queue_redraw();
 						}
 						return;
 					}
@@ -266,13 +266,13 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 
 				if (tabs[i].rb_rect.has_point(pos)) {
 					rb_pressing = true;
-					update();
+					queue_redraw();
 					return;
 				}
 
 				if (tabs[i].cb_rect.has_point(pos) && (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current))) {
 					cb_pressing = true;
-					update();
+					queue_redraw();
 					return;
 				}
 
@@ -317,7 +317,7 @@ void TabBar::_shape(int p_tab) {
 void TabBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED:
@@ -343,7 +343,7 @@ void TabBar::_notification(int p_what) {
 		case NOTIFICATION_DRAG_END: {
 			if (dragging_valid_tab) {
 				dragging_valid_tab = false;
-				update();
+				queue_redraw();
 			}
 		} break;
 
@@ -581,7 +581,7 @@ void TabBar::set_tab_count(int p_count) {
 		}
 	}
 
-	update();
+	queue_redraw();
 	update_minimum_size();
 	notify_property_list_changed();
 }
@@ -607,7 +607,7 @@ void TabBar::set_current_tab(int p_current) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 
 	emit_signal(SNAME("tab_changed"), p_current);
 }
@@ -647,7 +647,7 @@ void TabBar::set_tab_title(int p_tab, const String &p_title) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -663,7 +663,7 @@ void TabBar::set_tab_text_direction(int p_tab, Control::TextDirection p_text_dir
 	if (tabs[p_tab].text_direction != p_text_direction) {
 		tabs.write[p_tab].text_direction = p_text_direction;
 		_shape(p_tab);
-		update();
+		queue_redraw();
 	}
 }
 
@@ -683,7 +683,7 @@ void TabBar::set_tab_language(int p_tab, const String &p_language) {
 		if (scroll_to_selected) {
 			ensure_tab_visible(current);
 		}
-		update();
+		queue_redraw();
 		update_minimum_size();
 	}
 }
@@ -707,7 +707,7 @@ void TabBar::set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -730,7 +730,7 @@ void TabBar::set_tab_disabled(int p_tab, bool p_disabled) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -753,7 +753,7 @@ void TabBar::set_tab_hidden(int p_tab, bool p_hidden) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -776,7 +776,7 @@ void TabBar::set_tab_button_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -817,7 +817,7 @@ void TabBar::_update_hover() {
 		}
 
 		if (hover_buttons != -1) {
-			update();
+			queue_redraw();
 			break;
 		}
 	}
@@ -838,7 +838,7 @@ void TabBar::_update_hover() {
 		cb_hover = hover_buttons;
 
 		if (rb_hover != rb_hover_old || cb_hover != cb_hover_old) {
-			update();
+			queue_redraw();
 		}
 	}
 }
@@ -940,7 +940,7 @@ void TabBar::_on_mouse_exited() {
 	highlight_arrow = -1;
 	dragging_valid_tab = false;
 
-	update();
+	queue_redraw();
 }
 
 void TabBar::add_tab(const String &p_str, const Ref<Texture2D> &p_icon) {
@@ -955,7 +955,7 @@ void TabBar::add_tab(const String &p_str, const Ref<Texture2D> &p_icon) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 
 	if (tabs.size() == 1 && is_inside_tree()) {
@@ -974,7 +974,7 @@ void TabBar::clear_tabs() {
 	current = 0;
 	previous = 0;
 
-	update();
+	queue_redraw();
 	update_minimum_size();
 	notify_property_list_changed();
 }
@@ -1004,7 +1004,7 @@ void TabBar::remove_tab(int p_idx) {
 		}
 	}
 
-	update();
+	queue_redraw();
 	update_minimum_size();
 	notify_property_list_changed();
 
@@ -1152,7 +1152,7 @@ void TabBar::drop_data(const Point2 &p_point, const Variant &p_data) {
 					set_current_tab(hover_now);
 				} else {
 					_update_cache();
-					update();
+					queue_redraw();
 				}
 
 				update_minimum_size();
@@ -1188,7 +1188,7 @@ void TabBar::set_tab_alignment(AlignmentMode p_alignment) {
 	tab_alignment = p_alignment;
 
 	_update_cache();
-	update();
+	queue_redraw();
 }
 
 TabBar::AlignmentMode TabBar::get_tab_alignment() const {
@@ -1210,7 +1210,7 @@ void TabBar::set_clip_tabs(bool p_clip_tabs) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -1251,7 +1251,7 @@ void TabBar::move_tab(int p_from, int p_to) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	notify_property_list_changed();
 }
 
@@ -1337,7 +1337,7 @@ void TabBar::_ensure_no_over_offset() {
 
 	if (prev_offset != offset) {
 		_update_cache();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -1354,7 +1354,7 @@ void TabBar::ensure_tab_visible(int p_idx) {
 	if (p_idx < offset) {
 		offset = p_idx;
 		_update_cache();
-		update();
+		queue_redraw();
 
 		return;
 	}
@@ -1389,7 +1389,7 @@ void TabBar::ensure_tab_visible(int p_idx) {
 
 	if (prev_offset != offset) {
 		_update_cache();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -1416,7 +1416,7 @@ void TabBar::set_tab_close_display_policy(CloseButtonDisplayPolicy p_policy) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -1438,7 +1438,7 @@ void TabBar::set_max_tab_width(int p_width) {
 	if (scroll_to_selected) {
 		ensure_tab_visible(current);
 	}
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -98,7 +98,7 @@ void TabContainer::gui_input(const Ref<InputEvent> &p_event) {
 		if (pos.y > _get_top_margin()) {
 			if (menu_hovered) {
 				menu_hovered = false;
-				update();
+				queue_redraw();
 			}
 			return;
 		}
@@ -109,23 +109,23 @@ void TabContainer::gui_input(const Ref<InputEvent> &p_event) {
 				if (pos.x <= menu->get_width()) {
 					if (!menu_hovered) {
 						menu_hovered = true;
-						update();
+						queue_redraw();
 						return;
 					}
 				} else if (menu_hovered) {
 					menu_hovered = false;
-					update();
+					queue_redraw();
 				}
 			} else {
 				if (pos.x >= size.width - menu->get_width()) {
 					if (!menu_hovered) {
 						menu_hovered = true;
-						update();
+						queue_redraw();
 						return;
 					}
 				} else if (menu_hovered) {
 					menu_hovered = false;
-					update();
+					queue_redraw();
 				}
 			}
 
@@ -218,7 +218,7 @@ void TabContainer::_on_theme_changed() {
 	} else {
 		update_minimum_size();
 	}
-	update();
+	queue_redraw();
 
 	theme_changing = false;
 }
@@ -304,7 +304,7 @@ void TabContainer::_update_margins() {
 void TabContainer::_on_mouse_exited() {
 	if (menu_hovered) {
 		menu_hovered = false;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -502,7 +502,7 @@ void TabContainer::add_child_notify(Node *p_child) {
 
 	_update_margins();
 	if (get_tab_count() == 1) {
-		update();
+		queue_redraw();
 	}
 
 	p_child->connect("renamed", callable_mp(this, &TabContainer::_refresh_tab_names));
@@ -558,7 +558,7 @@ void TabContainer::remove_child_notify(Node *p_child) {
 
 	_update_margins();
 	if (get_tab_count() == 0) {
-		update();
+		queue_redraw();
 	}
 
 	p_child->remove_meta("_tab_name");
@@ -656,7 +656,7 @@ void TabContainer::set_tabs_visible(bool p_visible) {
 		}
 	}
 
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -838,7 +838,7 @@ void TabContainer::set_popup(Node *p_popup) {
 	popup_obj_id = popup_id;
 
 	if (had_popup != bool(popup)) {
-		update();
+		queue_redraw();
 		_update_margins();
 		if (!get_clip_tabs()) {
 			update_minimum_size();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -452,13 +452,13 @@ void TextEdit::_notification(int p_what) {
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
 			window_has_focus = true;
 			draw_caret = true;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
 			window_has_focus = false;
 			draw_caret = false;
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
@@ -1507,7 +1507,7 @@ void TextEdit::_notification(int p_what) {
 				}
 
 				text.invalidate_cache(caret.line, caret.column, true, t, structured_text_parser(st_parser, st_args, t));
-				update();
+				queue_redraw();
 			}
 		} break;
 
@@ -1696,7 +1696,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 						}
 						selection.selecting_line = prev_line;
 						selection.selecting_column = prev_col;
-						update();
+						queue_redraw();
 					} else {
 						if (caret.line < selection.selecting_line || (caret.line == selection.selecting_line && caret.column < selection.selecting_column)) {
 							if (selection.shiftclick_left) {
@@ -1718,7 +1718,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 							selection.active = false;
 						}
 
-						update();
+						queue_redraw();
 					}
 				} else if (drag_and_drop_selection_enabled && is_mouse_over_selection()) {
 					selection.selecting_mode = SelectionMode::SELECTION_MODE_NONE;
@@ -1746,7 +1746,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					last_dblclk = OS::get_singleton()->get_ticks_msec();
 					last_dblclk_pos = mb->get_position();
 				}
-				update();
+				queue_redraw();
 			}
 
 			if (is_middle_mouse_paste_enabled() && mb->get_button_index() == MouseButton::MIDDLE && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIPBOARD_PRIMARY)) {
@@ -1880,7 +1880,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		if (current_hovered_gutter != hovered_gutter) {
 			hovered_gutter = current_hovered_gutter;
-			update();
+			queue_redraw();
 		}
 
 		if (drag_action && can_drop_data(mpos, get_viewport()->gui_get_drag_data())) {
@@ -2146,7 +2146,7 @@ void TextEdit::_swap_current_input_direction() {
 		input_direction = TEXT_DIRECTION_LTR;
 	}
 	set_caret_column(caret.column);
-	update();
+	queue_redraw();
 }
 
 void TextEdit::_new_line(bool p_split_current_line, bool p_above) {
@@ -2527,7 +2527,7 @@ void TextEdit::_delete(bool p_word, bool p_all_to_right) {
 	}
 
 	_remove_text(caret.line, caret.column, next_line, next_column);
-	update();
+	queue_redraw();
 }
 
 void TextEdit::_move_caret_document_start(bool p_select) {
@@ -2816,7 +2816,7 @@ void TextEdit::set_editable(const bool p_editable) {
 
 	editable = p_editable;
 
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_editable() const {
@@ -2846,7 +2846,7 @@ void TextEdit::set_text_direction(Control::TextDirection p_text_direction) {
 			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_LTR), text_direction == TEXT_DIRECTION_LTR);
 			menu_dir->set_item_checked(menu_dir->get_item_index(MENU_DIR_RTL), text_direction == TEXT_DIRECTION_RTL);
 		}
-		update();
+		queue_redraw();
 	}
 }
 
@@ -2866,7 +2866,7 @@ void TextEdit::set_language(const String &p_language) {
 		text.set_direction_and_language(dir, (!language.is_empty()) ? language : TranslationServer::get_singleton()->get_tool_locale());
 		text.invalidate_all();
 		_update_placeholder();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -2880,7 +2880,7 @@ void TextEdit::set_structured_text_bidi_override(TextServer::StructuredTextParse
 		for (int i = 0; i < text.size(); i++) {
 			text.set(i, text[i], structured_text_parser(st_parser, st_args, text[i]));
 		}
-		update();
+		queue_redraw();
 	}
 }
 
@@ -2897,7 +2897,7 @@ void TextEdit::set_structured_text_bidi_override_options(Array p_args) {
 	for (int i = 0; i < text.size(); i++) {
 		text.set(i, text[i], structured_text_parser(st_parser, st_args, text[i]));
 	}
-	update();
+	queue_redraw();
 }
 
 Array TextEdit::get_structured_text_bidi_override_options() const {
@@ -2912,7 +2912,7 @@ void TextEdit::set_tab_size(const int p_size) {
 	text.set_tab_size(p_size);
 	text.invalidate_all_lines();
 	_update_placeholder();
-	update();
+	queue_redraw();
 }
 
 int TextEdit::get_tab_size() const {
@@ -2926,7 +2926,7 @@ void TextEdit::set_overtype_mode_enabled(const bool p_enabled) {
 	}
 
 	overtype_mode = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_overtype_mode_enabled() const {
@@ -3022,7 +3022,7 @@ void TextEdit::set_text(const String &p_text) {
 	set_caret_line(0);
 	set_caret_column(0);
 
-	update();
+	queue_redraw();
 	setting_text = false;
 	emit_signal(SNAME("text_set"));
 }
@@ -3050,7 +3050,7 @@ void TextEdit::set_placeholder(const String &p_text) {
 
 	placeholder_text = p_text;
 	_update_placeholder();
-	update();
+	queue_redraw();
 }
 
 String TextEdit::get_placeholder() const {
@@ -3149,7 +3149,7 @@ void TextEdit::insert_line_at(int p_at, const String &p_text) {
 			++selection.to_line;
 		}
 	}
-	update();
+	queue_redraw();
 }
 
 void TextEdit::insert_text_at_caret(const String &p_text) {
@@ -3166,7 +3166,7 @@ void TextEdit::insert_text_at_caret(const String &p_text) {
 
 	set_caret_line(new_line, false);
 	set_caret_column(new_column);
-	update();
+	queue_redraw();
 
 	if (had_selection) {
 		end_complex_operation();
@@ -3557,7 +3557,7 @@ void TextEdit::undo() {
 		set_caret_line(undo_stack_pos->get().from_line, false);
 		set_caret_column(undo_stack_pos->get().from_column);
 	}
-	update();
+	queue_redraw();
 }
 
 void TextEdit::redo() {
@@ -3592,7 +3592,7 @@ void TextEdit::redo() {
 	set_caret_line(undo_stack_pos->get().to_line, false);
 	set_caret_column(undo_stack_pos->get().to_column);
 	undo_stack_pos = undo_stack_pos->next();
-	update();
+	queue_redraw();
 }
 
 void TextEdit::clear_undo_history() {
@@ -3962,7 +3962,7 @@ void TextEdit::set_caret_type(CaretType p_type) {
 	}
 
 	caret_type = p_type;
-	update();
+	queue_redraw();
 }
 
 TextEdit::CaretType TextEdit::get_caret_type() const {
@@ -4217,7 +4217,7 @@ void TextEdit::select_all() {
 	selection.shiftclick_left = true;
 	set_caret_line(selection.to_line, false);
 	set_caret_column(selection.to_column, false);
-	update();
+	queue_redraw();
 }
 
 void TextEdit::select_word_under_caret() {
@@ -4312,7 +4312,7 @@ void TextEdit::select(int p_from_line, int p_from_column, int p_to_line, int p_t
 		selection.shiftclick_left = true;
 	}
 
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::has_selection() const {
@@ -4359,7 +4359,7 @@ int TextEdit::get_selection_to_column() const {
 
 void TextEdit::deselect() {
 	selection.active = false;
-	update();
+	queue_redraw();
 }
 
 void TextEdit::delete_selection() {
@@ -4372,7 +4372,7 @@ void TextEdit::delete_selection() {
 	_remove_text(selection.from_line, selection.from_column, selection.to_line, selection.to_column);
 	set_caret_line(selection.from_line, false, false);
 	set_caret_column(selection.from_column);
-	update();
+	queue_redraw();
 }
 
 /* Line wrapping. */
@@ -4464,7 +4464,7 @@ void TextEdit::set_scroll_past_end_of_file_enabled(const bool p_enabled) {
 	}
 
 	scroll_past_end_of_file_enabled = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_scroll_past_end_of_file_enabled() const {
@@ -4688,7 +4688,7 @@ void TextEdit::adjust_viewport_to_caret() {
 	}
 	h_scroll->set_value(caret.x_ofs);
 
-	update();
+	queue_redraw();
 }
 
 void TextEdit::center_viewport_to_caret() {
@@ -4741,7 +4741,7 @@ void TextEdit::center_viewport_to_caret() {
 	}
 	h_scroll->set_value(caret.x_ofs);
 
-	update();
+	queue_redraw();
 }
 
 /* Minimap */
@@ -4752,7 +4752,7 @@ void TextEdit::set_draw_minimap(bool p_enabled) {
 
 	draw_minimap = p_enabled;
 	_update_wrap_at_column();
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_drawing_minimap() const {
@@ -4766,7 +4766,7 @@ void TextEdit::set_minimap_width(int p_minimap_width) {
 
 	minimap_width = p_minimap_width;
 	_update_wrap_at_column();
-	update();
+	queue_redraw();
 }
 
 int TextEdit::get_minimap_width() const {
@@ -4787,7 +4787,7 @@ void TextEdit::add_gutter(int p_at) {
 
 	text.add_gutter(p_at);
 	emit_signal(SNAME("gutter_added"));
-	update();
+	queue_redraw();
 }
 
 void TextEdit::remove_gutter(int p_gutter) {
@@ -4797,7 +4797,7 @@ void TextEdit::remove_gutter(int p_gutter) {
 
 	text.remove_gutter(p_gutter);
 	emit_signal(SNAME("gutter_removed"));
-	update();
+	queue_redraw();
 }
 
 int TextEdit::get_gutter_count() const {
@@ -4822,7 +4822,7 @@ void TextEdit::set_gutter_type(int p_gutter, GutterType p_type) {
 	}
 
 	gutters.write[p_gutter].type = p_type;
-	update();
+	queue_redraw();
 }
 
 TextEdit::GutterType TextEdit::get_gutter_type(int p_gutter) const {
@@ -4870,7 +4870,7 @@ void TextEdit::set_gutter_clickable(int p_gutter, bool p_clickable) {
 	}
 
 	gutters.write[p_gutter].clickable = p_clickable;
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_gutter_clickable(int p_gutter) const {
@@ -4918,7 +4918,7 @@ void TextEdit::merge_gutters(int p_from_line, int p_to_line) {
 			text.set_line_gutter_clickable(p_to_line, i, true);
 		}
 	}
-	update();
+	queue_redraw();
 }
 
 void TextEdit::set_gutter_custom_draw(int p_gutter, const Callable &p_draw_callback) {
@@ -4929,7 +4929,7 @@ void TextEdit::set_gutter_custom_draw(int p_gutter, const Callable &p_draw_callb
 	}
 
 	gutters.write[p_gutter].custom_draw_callback = p_draw_callback;
-	update();
+	queue_redraw();
 }
 
 // Line gutters.
@@ -4954,7 +4954,7 @@ void TextEdit::set_line_gutter_text(int p_line, int p_gutter, const String &p_te
 	}
 
 	text.set_line_gutter_text(p_line, p_gutter, p_text);
-	update();
+	queue_redraw();
 }
 
 String TextEdit::get_line_gutter_text(int p_line, int p_gutter) const {
@@ -4972,7 +4972,7 @@ void TextEdit::set_line_gutter_icon(int p_line, int p_gutter, const Ref<Texture2
 	}
 
 	text.set_line_gutter_icon(p_line, p_gutter, p_icon);
-	update();
+	queue_redraw();
 }
 
 Ref<Texture2D> TextEdit::get_line_gutter_icon(int p_line, int p_gutter) const {
@@ -4990,7 +4990,7 @@ void TextEdit::set_line_gutter_item_color(int p_line, int p_gutter, const Color 
 	}
 
 	text.set_line_gutter_item_color(p_line, p_gutter, p_color);
-	update();
+	queue_redraw();
 }
 
 Color TextEdit::get_line_gutter_item_color(int p_line, int p_gutter) const {
@@ -5020,7 +5020,7 @@ void TextEdit::set_line_background_color(int p_line, const Color &p_color) {
 	}
 
 	text.set_line_background_color(p_line, p_color);
-	update();
+	queue_redraw();
 }
 
 Color TextEdit::get_line_background_color(int p_line) const {
@@ -5038,7 +5038,7 @@ void TextEdit::set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighte
 	if (syntax_highlighter.is_valid()) {
 		syntax_highlighter->set_text_edit(this);
 	}
-	update();
+	queue_redraw();
 }
 
 Ref<SyntaxHighlighter> TextEdit::get_syntax_highlighter() const {
@@ -5052,7 +5052,7 @@ void TextEdit::set_highlight_current_line(bool p_enabled) {
 	}
 
 	highlight_current_line = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_highlight_current_line_enabled() const {
@@ -5065,7 +5065,7 @@ void TextEdit::set_highlight_all_occurrences(const bool p_enabled) {
 	}
 
 	highlight_all_occurrences = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_highlight_all_occurrences_enabled() const {
@@ -5081,7 +5081,7 @@ void TextEdit::set_draw_control_chars(bool p_enabled) {
 		text.set_draw_control_chars(draw_control_chars);
 		text.invalidate_font();
 		_update_placeholder();
-		update();
+		queue_redraw();
 	}
 }
 
@@ -5095,7 +5095,7 @@ void TextEdit::set_draw_tabs(bool p_enabled) {
 	}
 
 	draw_tabs = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_drawing_tabs() const {
@@ -5108,7 +5108,7 @@ void TextEdit::set_draw_spaces(bool p_enabled) {
 	}
 
 	draw_spaces = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::is_drawing_spaces() const {
@@ -5560,7 +5560,7 @@ void TextEdit::_set_hiding_enabled(bool p_enabled) {
 		_unhide_all_lines();
 	}
 	hiding_enabled = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool TextEdit::_is_hiding_enabled() const {
@@ -5577,7 +5577,7 @@ void TextEdit::_unhide_all_lines() {
 		text.set_hidden(i, false);
 	}
 	_update_scrollbars();
-	update();
+	queue_redraw();
 }
 
 void TextEdit::_set_line_as_hidden(int p_line, bool p_hidden) {
@@ -5590,7 +5590,7 @@ void TextEdit::_set_line_as_hidden(int p_line, bool p_hidden) {
 	if (_is_hiding_enabled() || !p_hidden) {
 		text.set_hidden(p_line, p_hidden);
 	}
-	update();
+	queue_redraw();
 }
 
 // Symbol lookup.
@@ -5600,7 +5600,7 @@ void TextEdit::_set_symbol_lookup_word(const String &p_symbol) {
 	}
 
 	lookup_symbol_word = p_symbol;
-	update();
+	queue_redraw();
 }
 
 /* Text manipulation */
@@ -5985,14 +5985,14 @@ void TextEdit::_reset_caret_blink_timer() {
 	if (has_focus()) {
 		caret_blink_timer->stop();
 		caret_blink_timer->start();
-		update();
+		queue_redraw();
 	}
 }
 
 void TextEdit::_toggle_draw_caret() {
 	draw_caret = !draw_caret;
 	if (is_visible_in_tree() && has_focus() && window_has_focus) {
-		update();
+		queue_redraw();
 	}
 }
 
@@ -6054,7 +6054,7 @@ void TextEdit::_update_selection_mode_pointer() {
 
 	set_caret_line(line, false);
 	set_caret_column(col);
-	update();
+	queue_redraw();
 
 	click_select_held->start();
 }
@@ -6106,7 +6106,7 @@ void TextEdit::_update_selection_mode_word() {
 		DisplayServer::get_singleton()->clipboard_set_primary(get_selected_text());
 	}
 
-	update();
+	queue_redraw();
 
 	click_select_held->start();
 }
@@ -6137,7 +6137,7 @@ void TextEdit::_update_selection_mode_line() {
 		DisplayServer::get_singleton()->clipboard_set_primary(get_selected_text());
 	}
 
-	update();
+	queue_redraw();
 
 	click_select_held->start();
 }
@@ -6163,7 +6163,7 @@ void TextEdit::_post_shift_selection() {
 
 	if (selection.active && selection.selecting_mode == SelectionMode::SELECTION_MODE_SHIFT) {
 		select(selection.selecting_line, selection.selecting_column, caret.line, caret.column);
-		update();
+		queue_redraw();
 	}
 
 	selection.selecting_text = true;
@@ -6325,7 +6325,7 @@ void TextEdit::_scroll_moved(double p_to_val) {
 		caret.line_ofs = n_line;
 		caret.wrap_ofs = wi;
 	}
-	update();
+	queue_redraw();
 }
 
 double TextEdit::_get_visible_lines_offset() const {
@@ -6447,7 +6447,7 @@ void TextEdit::_update_minimap_hover() {
 		if (hovering_minimap) {
 			// Only redraw if the hovering status changed.
 			hovering_minimap = false;
-			update();
+			queue_redraw();
 		}
 
 		// Return early to avoid running the operations below when not needed.
@@ -6460,7 +6460,7 @@ void TextEdit::_update_minimap_hover() {
 	if (new_hovering_minimap != hovering_minimap) {
 		// Only redraw if the hovering status changed.
 		hovering_minimap = new_hovering_minimap;
-		update();
+		queue_redraw();
 	}
 }
 
@@ -6522,7 +6522,7 @@ void TextEdit::_update_gutter_width() {
 	if (gutters_width > 0) {
 		gutter_padding = 2;
 	}
-	update();
+	queue_redraw();
 }
 
 /* Syntax highlighting. */

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -299,7 +299,7 @@ void TextureButton::set_normal_texture(const Ref<Texture2D> &p_normal) {
 	}
 
 	normal = p_normal;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -309,7 +309,7 @@ void TextureButton::set_pressed_texture(const Ref<Texture2D> &p_pressed) {
 	}
 
 	pressed = p_pressed;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -319,7 +319,7 @@ void TextureButton::set_hover_texture(const Ref<Texture2D> &p_hover) {
 	}
 
 	hover = p_hover;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -329,7 +329,7 @@ void TextureButton::set_disabled_texture(const Ref<Texture2D> &p_disabled) {
 	}
 
 	disabled = p_disabled;
-	update();
+	queue_redraw();
 }
 
 void TextureButton::set_click_mask(const Ref<BitMap> &p_click_mask) {
@@ -337,7 +337,7 @@ void TextureButton::set_click_mask(const Ref<BitMap> &p_click_mask) {
 		return;
 	}
 	click_mask = p_click_mask;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -380,7 +380,7 @@ void TextureButton::set_ignore_texture_size(bool p_ignore) {
 
 	ignore_texture_size = p_ignore;
 	update_minimum_size();
-	update();
+	queue_redraw();
 }
 
 void TextureButton::set_stretch_mode(StretchMode p_stretch_mode) {
@@ -389,7 +389,7 @@ void TextureButton::set_stretch_mode(StretchMode p_stretch_mode) {
 	}
 
 	stretch_mode = p_stretch_mode;
-	update();
+	queue_redraw();
 }
 
 TextureButton::StretchMode TextureButton::get_stretch_mode() const {
@@ -402,7 +402,7 @@ void TextureButton::set_flip_h(bool p_flip) {
 	}
 
 	hflip = p_flip;
-	update();
+	queue_redraw();
 }
 
 bool TextureButton::is_flipped_h() const {
@@ -415,7 +415,7 @@ void TextureButton::set_flip_v(bool p_flip) {
 	}
 
 	vflip = p_flip;
-	update();
+	queue_redraw();
 }
 
 bool TextureButton::is_flipped_v() const {

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -38,7 +38,7 @@ void TextureProgressBar::set_under_texture(const Ref<Texture2D> &p_texture) {
 	}
 
 	under = p_texture;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -52,7 +52,7 @@ void TextureProgressBar::set_over_texture(const Ref<Texture2D> &p_texture) {
 	}
 
 	over = p_texture;
-	update();
+	queue_redraw();
 	if (under.is_null()) {
 		update_minimum_size();
 	}
@@ -70,7 +70,7 @@ void TextureProgressBar::set_stretch_margin(Side p_side, int p_size) {
 	}
 
 	stretch_margin[p_side] = p_size;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -85,7 +85,7 @@ void TextureProgressBar::set_nine_patch_stretch(bool p_stretch) {
 	}
 
 	nine_patch_stretch = p_stretch;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -113,7 +113,7 @@ void TextureProgressBar::set_progress_texture(const Ref<Texture2D> &p_texture) {
 	}
 
 	progress = p_texture;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -127,7 +127,7 @@ void TextureProgressBar::set_progress_offset(Point2 p_offset) {
 	}
 
 	progress_offset = p_offset;
-	update();
+	queue_redraw();
 }
 
 Point2 TextureProgressBar::get_progress_offset() const {
@@ -140,7 +140,7 @@ void TextureProgressBar::set_tint_under(const Color &p_tint) {
 	}
 
 	tint_under = p_tint;
-	update();
+	queue_redraw();
 }
 
 Color TextureProgressBar::get_tint_under() const {
@@ -153,7 +153,7 @@ void TextureProgressBar::set_tint_progress(const Color &p_tint) {
 	}
 
 	tint_progress = p_tint;
-	update();
+	queue_redraw();
 }
 
 Color TextureProgressBar::get_tint_progress() const {
@@ -166,7 +166,7 @@ void TextureProgressBar::set_tint_over(const Color &p_tint) {
 	}
 
 	tint_over = p_tint;
-	update();
+	queue_redraw();
 }
 
 Color TextureProgressBar::get_tint_over() const {
@@ -591,7 +591,7 @@ void TextureProgressBar::set_fill_mode(int p_fill) {
 	}
 
 	mode = (FillMode)p_fill;
-	update();
+	queue_redraw();
 }
 
 int TextureProgressBar::get_fill_mode() {
@@ -611,7 +611,7 @@ void TextureProgressBar::set_radial_initial_angle(float p_angle) {
 	}
 
 	rad_init_angle = p_angle;
-	update();
+	queue_redraw();
 }
 
 float TextureProgressBar::get_radial_initial_angle() {
@@ -626,7 +626,7 @@ void TextureProgressBar::set_fill_degrees(float p_angle) {
 	}
 
 	rad_max_degrees = angle_clamped;
-	update();
+	queue_redraw();
 }
 
 float TextureProgressBar::get_fill_degrees() {
@@ -639,7 +639,7 @@ void TextureProgressBar::set_radial_center_offset(const Point2 &p_off) {
 	}
 
 	rad_center_off = p_off;
-	update();
+	queue_redraw();
 }
 
 Point2 TextureProgressBar::get_radial_center_offset() {

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -150,7 +150,7 @@ void TextureRect::_bind_methods() {
 
 void TextureRect::_texture_changed() {
 	if (texture.is_valid()) {
-		update();
+		queue_redraw();
 		update_minimum_size();
 	}
 }
@@ -170,7 +170,7 @@ void TextureRect::set_texture(const Ref<Texture2D> &p_tex) {
 		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureRect::_texture_changed));
 	}
 
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -184,7 +184,7 @@ void TextureRect::set_ignore_texture_size(bool p_ignore) {
 	}
 
 	ignore_texture_size = p_ignore;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -198,7 +198,7 @@ void TextureRect::set_stretch_mode(StretchMode p_mode) {
 	}
 
 	stretch_mode = p_mode;
-	update();
+	queue_redraw();
 }
 
 TextureRect::StretchMode TextureRect::get_stretch_mode() const {
@@ -211,7 +211,7 @@ void TextureRect::set_flip_h(bool p_flip) {
 	}
 
 	hflip = p_flip;
-	update();
+	queue_redraw();
 }
 
 bool TextureRect::is_flipped_h() const {
@@ -224,7 +224,7 @@ void TextureRect::set_flip_v(bool p_flip) {
 	}
 
 	vflip = p_flip;
-	update();
+	queue_redraw();
 }
 
 bool TextureRect::is_flipped_v() const {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -126,13 +126,13 @@ void TreeItem::_change_tree(Tree *p_tree) {
 			tree->pressing_for_editor = false;
 		}
 
-		tree->update();
+		tree->queue_redraw();
 	}
 
 	tree = p_tree;
 
 	if (tree) {
-		tree->update();
+		tree->queue_redraw();
 		cells.resize(tree->columns.size());
 	}
 }
@@ -551,7 +551,7 @@ void TreeItem::set_collapsed(bool p_collapsed) {
 				select(tree->selected_col);
 			}
 
-			tree->update();
+			tree->queue_redraw();
 		}
 	}
 
@@ -569,7 +569,7 @@ void TreeItem::set_visible(bool p_visible) {
 	}
 	visible = p_visible;
 	if (tree) {
-		tree->update();
+		tree->queue_redraw();
 		_changed_notify();
 	}
 }
@@ -610,7 +610,7 @@ TreeItem *TreeItem::create_child(int p_idx) {
 	TreeItem *ti = memnew(TreeItem(tree));
 	if (tree) {
 		ti->cells.resize(tree->columns.size());
-		tree->update();
+		tree->queue_redraw();
 	}
 
 	TreeItem *l_prev = nullptr;
@@ -880,7 +880,7 @@ void TreeItem::move_before(TreeItem *p_item) {
 	p_item->prev = this;
 
 	if (tree && old_tree == tree) {
-		tree->update();
+		tree->queue_redraw();
 	}
 
 	validate_cache();
@@ -924,7 +924,7 @@ void TreeItem::move_after(TreeItem *p_item) {
 	}
 
 	if (tree && old_tree == tree) {
-		tree->update();
+		tree->queue_redraw();
 	}
 	validate_cache();
 }
@@ -939,7 +939,7 @@ void TreeItem::remove_child(TreeItem *p_item) {
 	p_item->parent = nullptr;
 
 	if (tree) {
-		tree->update();
+		tree->queue_redraw();
 	}
 	validate_cache();
 }
@@ -972,7 +972,7 @@ void TreeItem::set_as_cursor(int p_column) {
 	}
 	tree->selected_item = this;
 	tree->selected_col = p_column;
-	tree->update();
+	tree->queue_redraw();
 }
 
 void TreeItem::select(int p_column) {
@@ -2658,7 +2658,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 				cache.click_item = p_item;
 				cache.click_column = col;
 				cache.click_pos = click_pos;
-				update();
+				queue_redraw();
 				return -1;
 			}
 
@@ -2716,7 +2716,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 						emit_signal(SNAME("multi_selected"),p_item,col,true);
 					}
 					*/
-					update();
+					queue_redraw();
 				}
 			}
 		}
@@ -2935,7 +2935,7 @@ void Tree::_text_editor_submit(String p_text) {
 	}
 
 	item_edited(popup_edited_item_col, popup_edited_item);
-	update();
+	queue_redraw();
 }
 
 void Tree::value_editor_changed(double p_value) {
@@ -2952,7 +2952,7 @@ void Tree::value_editor_changed(double p_value) {
 	text_editor->set_text(String::num(c.val, Math::range_step_decimals(c.step)));
 
 	item_edited(popup_edited_item_col, popup_edited_item);
-	update();
+	queue_redraw();
 }
 
 void Tree::popup_select(int p_option) {
@@ -2966,7 +2966,7 @@ void Tree::popup_select(int p_option) {
 
 	popup_edited_item->cells.write[popup_edited_item_col].val = p_option;
 	//popup_edited_item->edited_signal.call( popup_edited_item_col );
-	update();
+	queue_redraw();
 	item_edited(popup_edited_item_col, popup_edited_item);
 }
 
@@ -2993,7 +2993,7 @@ void Tree::_go_left() {
 			selected_item->select(selected_col - 1);
 		}
 	}
-	update();
+	queue_redraw();
 	accept_event();
 	ensure_cursor_is_visible();
 }
@@ -3014,7 +3014,7 @@ void Tree::_go_right() {
 			selected_item->select(selected_col + 1);
 		}
 	}
-	update();
+	queue_redraw();
 	ensure_cursor_is_visible();
 	accept_event();
 }
@@ -3043,7 +3043,7 @@ void Tree::_go_up() {
 		}
 		selected_item = prev;
 		emit_signal(SNAME("cell_selected"));
-		update();
+		queue_redraw();
 	} else {
 		int col = selected_col < 0 ? 0 : selected_col;
 		while (prev && !prev->cells[col].selectable) {
@@ -3086,7 +3086,7 @@ void Tree::_go_down() {
 
 		selected_item = next;
 		emit_signal(SNAME("cell_selected"));
-		update();
+		queue_redraw();
 	} else {
 		int col = selected_col < 0 ? 0 : selected_col;
 
@@ -3196,7 +3196,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		if (select_mode == SELECT_MULTI) {
 			selected_item = next;
 			emit_signal(SNAME("cell_selected"));
-			update();
+			queue_redraw();
 		} else {
 			while (next && !next->cells[selected_col].selectable) {
 				next = next->get_next_visible();
@@ -3234,7 +3234,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		if (select_mode == SELECT_MULTI) {
 			selected_item = prev;
 			emit_signal(SNAME("cell_selected"));
-			update();
+			queue_redraw();
 		} else {
 			while (prev && !prev->cells[selected_col].selectable) {
 				prev = prev->get_prev_visible();
@@ -3358,11 +3358,11 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				if (drop_mode_flags) {
 					if (it != drop_mode_over) {
 						drop_mode_over = it;
-						update();
+						queue_redraw();
 					}
 					if (it && section != drop_mode_section) {
 						drop_mode_section = section;
-						update();
+						queue_redraw();
 					}
 				}
 
@@ -3371,14 +3371,14 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 				if (it != old_it || col != old_col) {
 					if (old_it && old_col >= old_it->cells.size()) {
-						// Columns may have changed since last update().
-						update();
+						// Columns may have changed since last redraw().
+						queue_redraw();
 					} else {
 						// Only need to update if mouse enters/exits a button
 						bool was_over_button = old_it && old_it->cells[old_col].custom_button;
 						bool is_over_button = it && it->cells[col].custom_button;
 						if (was_over_button || is_over_button) {
-							update();
+							queue_redraw();
 						}
 					}
 				}
@@ -3387,7 +3387,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 		// Update if mouse enters/exits columns
 		if (cache.hover_type != old_hover || cache.hover_index != old_index) {
-			update();
+			queue_redraw();
 		}
 
 		if (pressing_for_editor && popup_pressing_edited_item && (popup_pressing_edited_item->get_cell_mode(popup_pressing_edited_item_column) == TreeItem::CELL_MODE_RANGE)) {
@@ -3526,7 +3526,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			cache.click_id = -1;
 			cache.click_item = nullptr;
 			cache.click_column = 0;
-			update();
+			queue_redraw();
 			return;
 		}
 
@@ -3556,7 +3556,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 							if (pos.x < static_cast<real_t>(len)) {
 								cache.click_type = Cache::CLICK_TITLE;
 								cache.click_index = i;
-								update();
+								queue_redraw();
 								break;
 							}
 						}
@@ -3852,7 +3852,7 @@ void Tree::_notification(int p_what) {
 		case NOTIFICATION_MOUSE_EXIT: {
 			if (cache.hover_type != Cache::CLICK_NONE) {
 				cache.hover_type = Cache::CLICK_NONE;
-				update();
+				queue_redraw();
 			}
 		} break;
 
@@ -3868,7 +3868,7 @@ void Tree::_notification(int p_what) {
 			drop_mode_flags = 0;
 			scrolling = false;
 			set_physics_process_internal(false);
-			update();
+			queue_redraw();
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {
@@ -4110,7 +4110,7 @@ void Tree::item_changed(int p_column, TreeItem *p_item) {
 	if (p_item != nullptr && p_column >= 0 && p_column < p_item->cells.size()) {
 		p_item->cells.write[p_column].dirty = true;
 	}
-	update();
+	queue_redraw();
 }
 
 void Tree::item_selected(int p_column, TreeItem *p_item) {
@@ -4129,7 +4129,7 @@ void Tree::item_selected(int p_column, TreeItem *p_item) {
 	} else {
 		select_single_item(p_item, root, p_column);
 	}
-	update();
+	queue_redraw();
 }
 
 void Tree::item_deselected(int p_column, TreeItem *p_item) {
@@ -4144,7 +4144,7 @@ void Tree::item_deselected(int p_column, TreeItem *p_item) {
 	if (select_mode == SELECT_MULTI || select_mode == SELECT_SINGLE) {
 		p_item->cells.write[p_column].selected = false;
 	}
-	update();
+	queue_redraw();
 }
 
 void Tree::set_select_mode(SelectMode p_mode) {
@@ -4167,7 +4167,7 @@ void Tree::deselect_all() {
 	selected_item = nullptr;
 	selected_col = -1;
 
-	update();
+	queue_redraw();
 }
 
 bool Tree::is_anything_selected() {
@@ -4196,7 +4196,7 @@ void Tree::clear() {
 	popup_edited_item = nullptr;
 	popup_pressing_edited_item = nullptr;
 
-	update();
+	queue_redraw();
 };
 
 void Tree::set_hide_root(bool p_enabled) {
@@ -4205,7 +4205,7 @@ void Tree::set_hide_root(bool p_enabled) {
 	}
 
 	hide_root = p_enabled;
-	update();
+	queue_redraw();
 }
 
 bool Tree::is_root_hidden() const {
@@ -4223,7 +4223,7 @@ void Tree::set_column_custom_minimum_width(int p_column, int p_min_width) {
 		return;
 	}
 	columns.write[p_column].custom_min_width = p_min_width;
-	update();
+	queue_redraw();
 }
 
 void Tree::set_column_expand(int p_column, bool p_expand) {
@@ -4234,7 +4234,7 @@ void Tree::set_column_expand(int p_column, bool p_expand) {
 	}
 
 	columns.write[p_column].expand = p_expand;
-	update();
+	queue_redraw();
 }
 
 void Tree::set_column_expand_ratio(int p_column, int p_ratio) {
@@ -4245,7 +4245,7 @@ void Tree::set_column_expand_ratio(int p_column, int p_ratio) {
 	}
 
 	columns.write[p_column].expand_ratio = p_ratio;
-	update();
+	queue_redraw();
 }
 
 void Tree::set_column_clip_content(int p_column, bool p_fit) {
@@ -4256,7 +4256,7 @@ void Tree::set_column_clip_content(int p_column, bool p_fit) {
 	}
 
 	columns.write[p_column].clip_content = p_fit;
-	update();
+	queue_redraw();
 }
 
 bool Tree::is_column_expanding(int p_column) const {
@@ -4429,7 +4429,7 @@ void Tree::set_columns(int p_columns) {
 	if (selected_col >= p_columns) {
 		selected_col = p_columns - 1;
 	}
-	update();
+	queue_redraw();
 }
 
 int Tree::get_columns() const {
@@ -4437,7 +4437,7 @@ int Tree::get_columns() const {
 }
 
 void Tree::_scroll_moved(float) {
-	update();
+	queue_redraw();
 }
 
 Rect2 Tree::get_custom_popup_rect() const {
@@ -4582,7 +4582,7 @@ void Tree::set_column_titles_visible(bool p_show) {
 	}
 
 	show_column_titles = p_show;
-	update();
+	queue_redraw();
 }
 
 bool Tree::are_column_titles_visible() const {
@@ -4601,7 +4601,7 @@ void Tree::set_column_title(int p_column, const String &p_title) {
 	}
 	columns.write[p_column].title = p_title;
 	update_column(p_column);
-	update();
+	queue_redraw();
 }
 
 String Tree::get_column_title(int p_column) const {
@@ -4615,7 +4615,7 @@ void Tree::set_column_title_direction(int p_column, Control::TextDirection p_tex
 	if (columns[p_column].text_direction != p_text_direction) {
 		columns.write[p_column].text_direction = p_text_direction;
 		update_column(p_column);
-		update();
+		queue_redraw();
 	}
 }
 
@@ -4629,7 +4629,7 @@ void Tree::set_column_title_language(int p_column, const String &p_language) {
 	if (columns[p_column].language != p_language) {
 		columns.write[p_column].language = p_language;
 		update_column(p_column);
-		update();
+		queue_redraw();
 	}
 }
 
@@ -5027,7 +5027,7 @@ void Tree::set_hide_folding(bool p_hide) {
 	}
 
 	hide_folding = p_hide;
-	update();
+	queue_redraw();
 }
 
 bool Tree::is_folding_hidden() const {
@@ -5043,7 +5043,7 @@ void Tree::set_drop_mode_flags(int p_flags) {
 		drop_mode_over = nullptr;
 	}
 
-	update();
+	queue_redraw();
 }
 
 int Tree::get_drop_mode_flags() const {

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -213,7 +213,7 @@ void VideoStreamPlayer::set_expand(bool p_expand) {
 	}
 
 	expand = p_expand;
-	update();
+	queue_redraw();
 	update_minimum_size();
 }
 
@@ -261,7 +261,7 @@ void VideoStreamPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 		AudioServer::get_singleton()->unlock();
 	}
 
-	update();
+	queue_redraw();
 
 	if (!expand) {
 		update_minimum_size();

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -88,7 +88,7 @@ void CanvasItem::_handle_visibility_change(bool p_visible) {
 	notification(NOTIFICATION_VISIBILITY_CHANGED);
 
 	if (p_visible) {
-		update();
+		queue_redraw();
 	} else {
 		emit_signal(SceneStringNames::get_singleton()->hidden);
 	}
@@ -121,7 +121,7 @@ CanvasItem *CanvasItem::get_current_item_drawn() {
 	return current_item_drawn;
 }
 
-void CanvasItem::_update_callback() {
+void CanvasItem::_redraw_callback() {
 	if (!is_inside_tree()) {
 		pending_update = false;
 		return;
@@ -242,7 +242,7 @@ void CanvasItem::_enter_canvas() {
 	}
 
 	pending_update = false;
-	update();
+	queue_redraw();
 
 	notification(NOTIFICATION_ENTER_CANVAS);
 }
@@ -355,7 +355,7 @@ void CanvasItem::_window_visibility_changed() {
 	}
 }
 
-void CanvasItem::update() {
+void CanvasItem::queue_redraw() {
 	if (!is_inside_tree()) {
 		return;
 	}
@@ -365,7 +365,7 @@ void CanvasItem::update() {
 
 	pending_update = true;
 
-	MessageQueue::get_singleton()->push_call(this, SNAME("_update_callback"));
+	MessageQueue::get_singleton()->push_call(this, SNAME("_redraw_callback"));
 }
 
 void CanvasItem::set_modulate(const Color &p_modulate) {
@@ -438,7 +438,7 @@ int CanvasItem::get_light_mask() const {
 
 void CanvasItem::item_rect_changed(bool p_size_changed) {
 	if (p_size_changed) {
-		update();
+		queue_redraw();
 	}
 	emit_signal(SceneStringNames::get_singleton()->item_rect_changed);
 }
@@ -867,7 +867,7 @@ void CanvasItem::force_update_transform() {
 
 void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_top_level_raise_self"), &CanvasItem::_top_level_raise_self);
-	ClassDB::bind_method(D_METHOD("_update_callback"), &CanvasItem::_update_callback);
+	ClassDB::bind_method(D_METHOD("_redraw_callback"), &CanvasItem::_redraw_callback);
 
 #ifdef TOOLS_ENABLED
 	ClassDB::bind_method(D_METHOD("_edit_set_state", "state"), &CanvasItem::_edit_set_state);
@@ -896,7 +896,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("show"), &CanvasItem::show);
 	ClassDB::bind_method(D_METHOD("hide"), &CanvasItem::hide);
 
-	ClassDB::bind_method(D_METHOD("update"), &CanvasItem::update);
+	ClassDB::bind_method(D_METHOD("queue_redraw"), &CanvasItem::queue_redraw);
 
 	ClassDB::bind_method(D_METHOD("set_as_top_level", "enable"), &CanvasItem::set_as_top_level);
 	ClassDB::bind_method(D_METHOD("is_set_as_top_level"), &CanvasItem::is_set_as_top_level);
@@ -1100,7 +1100,7 @@ void CanvasItem::_update_texture_filter_changed(bool p_propagate) {
 		texture_filter_cache = RS::CanvasItemTextureFilter(texture_filter);
 	}
 	RS::get_singleton()->canvas_item_set_default_texture_filter(get_canvas_item(), texture_filter_cache);
-	update();
+	queue_redraw();
 
 	if (p_propagate) {
 		for (CanvasItem *E : children_items) {
@@ -1141,7 +1141,7 @@ void CanvasItem::_update_texture_repeat_changed(bool p_propagate) {
 		texture_repeat_cache = RS::CanvasItemTextureRepeat(texture_repeat);
 	}
 	RS::get_singleton()->canvas_item_set_default_texture_repeat(get_canvas_item(), texture_repeat_cache);
-	update();
+	queue_redraw();
 	if (p_propagate) {
 		for (CanvasItem *E : children_items) {
 			if (!E->top_level && E->texture_repeat == TEXTURE_REPEAT_PARENT_NODE) {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -110,7 +110,7 @@ private:
 	void _propagate_visibility_changed(bool p_parent_visible_in_tree);
 	void _handle_visibility_change(bool p_visible);
 
-	void _update_callback();
+	void _redraw_callback();
 
 	void _enter_canvas();
 	void _exit_canvas();
@@ -197,7 +197,7 @@ public:
 	void show();
 	void hide();
 
-	void update();
+	void queue_redraw();
 
 	void set_clip_children(bool p_enabled);
 	bool is_clipping_children() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1023,7 +1023,7 @@ void Viewport::_update_canvas_items(Node *p_node) {
 
 		CanvasItem *ci = Object::cast_to<CanvasItem>(p_node);
 		if (ci) {
-			ci->update();
+			ci->queue_redraw();
 		}
 	}
 
@@ -2197,7 +2197,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 	gui.key_focus = p_control;
 	emit_signal(SNAME("gui_focus_changed"), p_control);
 	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
-	p_control->update();
+	p_control->queue_redraw();
 }
 
 void Viewport::_gui_accept_event() {
@@ -2865,7 +2865,7 @@ void Viewport::gui_release_focus() {
 		Control *f = gui.key_focus;
 		gui.key_focus = nullptr;
 		f->notification(Control::NOTIFICATION_FOCUS_EXIT, true);
-		f->update();
+		f->queue_redraw();
 	}
 }
 

--- a/scene/resources/skeleton_modification_stack_2d.cpp
+++ b/scene/resources/skeleton_modification_stack_2d.cpp
@@ -138,7 +138,7 @@ void SkeletonModificationStack2D::set_editor_gizmos_dirty(bool p_dirty) {
 	if (!editor_gizmo_dirty && p_dirty) {
 		editor_gizmo_dirty = p_dirty;
 		if (skeleton) {
-			skeleton->update();
+			skeleton->queue_redraw();
 		}
 	} else {
 		editor_gizmo_dirty = p_dirty;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5190.

As brought up in https://github.com/godotengine/godot/issues/54161#issuecomment-962015533, https://github.com/godotengine/godot/issues/54161#issuecomment-1034903362 and [Should CanvasItem.`update()` be renamed to `request_redraw()` or  `redraw()`](https://github.com/godotengine/godot-proposals/discussions/5154).

Affects a lot of classes. This PR is absolutely, utterly **GARGANTUAN**.

I very thoroughly checked signal connections and deferred calls to this method, `add_do_method`/`add_undo_method` calls, and so on. Just a few comments have also been changed to say "redraw". It's ENTIRELY possible I still missed something, but the engine compiles, at least!

Also renames the internal `_update_callback()` to `_redraw_callback()` for consistency.

In **CPUParticles2D**, there was a private variable with the same name. For now, this has been renamed to `do_redraw`. It's either that, or something close. I haven't exactly understood what it's meant for.

~This PR was previously renaming it to redraw()~