### PR TITLE
Optimized support function for large meshes

### DIFF
--- a/servers/physics_3d/godot_shape_3d.h
+++ b/servers/physics_3d/godot_shape_3d.h
@@ -277,6 +277,8 @@ public:
 
 struct GodotConvexPolygonShape3D : public GodotShape3D {
 	Geometry3D::MeshData mesh;
+	LocalVector<int> extreme_vertices;
+	LocalVector<LocalVector<int>> vertex_neighbors;
 
 	void _setup(const Vector<Vector3> &p_vertices);
 


### PR DESCRIPTION
This is the second piece of addressing #48587.  `get_support()` and `project_range()` are both currently implemented with full scans over all vertices.  For a large mesh, that's very slow.  I used the approach suggested in https://graphics.stanford.edu/courses/cs468-01-fall/Papers/cameron.pdf, which is to search along the surface, moving between adjacent vertices to increase the support value.

To make this fast, we want a good starting point to search from.  I precompute the extreme vertices along 26 directions.  That gives us a short list of vertices to start with, one of which should be close to the true support point.

To benchmark it, I measured the time for 1 million calls to `get_support()` along random directions.  I did that for meshes of varying size with the current implementation and with this PR.  Here are the times in seconds for 1 million calls, or equivalently the average time in microseconds for a single call.

|Vertices|Original|This PR|
|---|---|---|
|10|0.048|0.065|
|52|0.170|0.132|
|452|1.069|0.175|
|4986|10.614|0.344|

When combined with #63702, the total cost of collision detection scales very weakly with the number of vertices, roughly as O(sqrt(N)) in the limit of very large meshes.  For two meshes that each have several thousand vertices, the total time to compute a collision is measured in microseconds.