### PR TITLE
Fix `EditorPropertyArray` to accept arrays with specific resource type

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -604,6 +604,10 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 
 			subtype_hint_string = p_hint_string.substr(hint_subtype_separator + 1, p_hint_string.size() - hint_subtype_separator - 1);
 			subtype = Variant::Type(subtype_string.to_int());
+		} else { // subType
+			subtype_hint = PROPERTY_HINT_RESOURCE_TYPE;
+			subtype = Variant::OBJECT;
+			subtype_hint_string = p_hint_string;
 		}
 	}
 }


### PR DESCRIPTION
Currently, it's not possible to pass the textures to a shader array uniform (at least with a simple drag & drop) using the inspector:

![image](https://user-images.githubusercontent.com/3036176/184529411-7fd37b8f-bf01-4426-9be8-24bb391b0cee.png)

After the fix, it's simple:

![image](https://user-images.githubusercontent.com/3036176/184529460-abba72d1-eb7f-4bca-ac5f-5a10abcb92df.png)
