### PR TITLE
Expose the collider's RID in `RayCast2D` and `RayCast3D`

### DIFF
--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -47,6 +47,12 @@
 				Returns the first object that the ray intersects, or [code]null[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
+		<method name="get_collider_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the first object that the ray intersects, or an empty [RID] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+			</description>
+		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -48,6 +48,12 @@
 				Returns the first object that the ray intersects, or [code]null[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
 			</description>
 		</method>
+		<method name="get_collider_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the first object that the ray intersects, or an empty [RID] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+			</description>
+		</method>
 		<method name="get_collider_shape" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -82,6 +82,10 @@ Object *RayCast2D::get_collider() const {
 	return ObjectDB::get_instance(against);
 }
 
+RID RayCast2D::get_collider_rid() const {
+	return against_rid;
+}
+
 int RayCast2D::get_collider_shape() const {
 	return against_shape;
 }
@@ -203,12 +207,14 @@ void RayCast2D::_update_raycast_state() {
 	if (dss->intersect_ray(ray_params, rr)) {
 		collided = true;
 		against = rr.collider_id;
+		against_rid = rr.rid;
 		collision_point = rr.position;
 		collision_normal = rr.normal;
 		against_shape = rr.shape;
 	} else {
 		collided = false;
 		against = ObjectID();
+		against_rid = RID();
 		against_shape = 0;
 	}
 
@@ -321,6 +327,7 @@ void RayCast2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_raycast_update"), &RayCast2D::force_raycast_update);
 
 	ClassDB::bind_method(D_METHOD("get_collider"), &RayCast2D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider_rid"), &RayCast2D::get_collider_rid);
 	ClassDB::bind_method(D_METHOD("get_collider_shape"), &RayCast2D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collision_point"), &RayCast2D::get_collision_point);
 	ClassDB::bind_method(D_METHOD("get_collision_normal"), &RayCast2D::get_collision_normal);

--- a/scene/2d/ray_cast_2d.h
+++ b/scene/2d/ray_cast_2d.h
@@ -41,6 +41,7 @@ class RayCast2D : public Node2D {
 	bool enabled = true;
 	bool collided = false;
 	ObjectID against;
+	RID against_rid;
 	int against_shape = 0;
 	Vector2 collision_point;
 	Vector2 collision_normal;
@@ -91,6 +92,7 @@ public:
 
 	bool is_colliding() const;
 	Object *get_collider() const;
+	RID get_collider_rid() const;
 	int get_collider_shape() const;
 	Vector2 get_collision_point() const;
 	Vector2 get_collision_normal() const;

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -88,6 +88,10 @@ Object *RayCast3D::get_collider() const {
 	return ObjectDB::get_instance(against);
 }
 
+RID RayCast3D::get_collider_rid() const {
+	return against_rid;
+}
+
 int RayCast3D::get_collider_shape() const {
 	return against_shape;
 }
@@ -224,12 +228,14 @@ void RayCast3D::_update_raycast_state() {
 	if (dss->intersect_ray(ray_params, rr)) {
 		collided = true;
 		against = rr.collider_id;
+		against_rid = rr.rid;
 		collision_point = rr.position;
 		collision_normal = rr.normal;
 		against_shape = rr.shape;
 	} else {
 		collided = false;
 		against = ObjectID();
+		against_rid = RID();
 		against_shape = 0;
 	}
 }
@@ -302,6 +308,7 @@ void RayCast3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_raycast_update"), &RayCast3D::force_raycast_update);
 
 	ClassDB::bind_method(D_METHOD("get_collider"), &RayCast3D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_collider_rid"), &RayCast3D::get_collider_rid);
 	ClassDB::bind_method(D_METHOD("get_collider_shape"), &RayCast3D::get_collider_shape);
 	ClassDB::bind_method(D_METHOD("get_collision_point"), &RayCast3D::get_collision_point);
 	ClassDB::bind_method(D_METHOD("get_collision_normal"), &RayCast3D::get_collision_normal);

--- a/scene/3d/ray_cast_3d.h
+++ b/scene/3d/ray_cast_3d.h
@@ -41,6 +41,7 @@ class RayCast3D : public Node3D {
 	bool enabled = true;
 	bool collided = false;
 	ObjectID against;
+	RID against_rid;
 	int against_shape = 0;
 	Vector3 collision_point;
 	Vector3 collision_normal;
@@ -113,6 +114,7 @@ public:
 	void force_raycast_update();
 	bool is_colliding() const;
 	Object *get_collider() const;
+	RID get_collider_rid() const;
 	int get_collider_shape() const;
 	Vector3 get_collision_point() const;
 	Vector3 get_collision_normal() const;


### PR DESCRIPTION
Create and expose the method `get_collider_rid` in `RayCast2D` and `Raycast3D`.

> This method returns the `RID` of the first object that the ray intersects, or an empty `RID` if no object is intersecting the fay (i.e. `is_colliding` returns `false`).

---

Tried to ask on Rocket if that should be exposed, but got no reply. Since it's quite straightforward, I decided to open the PR anyway. The logic here is methods like [`Physics2DDirectSpaceState.intersect_ray`](https://docs.godotengine.org/en/stable/classes/class_physics2ddirectspacestate.html?highlight=intersect_ray#class-physics2ddirectspacestate-method-intersect-ray) and objects like [`KinematicCollision2D`](https://docs.godotengine.org/en/latest/classes/class_kinematiccollision2d.html?highlight=get_collider_rid#class-kinematiccollision2d-method-get-collider-rid) all expose a way to get the colliding object's RID. So it would seem normal to me that the `RayCast2D` and `RayCast3D` nodes do the same. Especially because that information is needed to e.g. call [`TileMap.get_coords_for_body_rid`](https://docs.godotengine.org/en/latest/classes/class_tilemap.html?highlight=tilemap#class-tilemap-method-get-coords-for-body-rid).  

Sorry if this shouldn't be opened because of the freeze or if there's a reason I don't understand for not exposing this piece of info to the scripting side.  

❤️ 