### PR TITLE
Improve the UX of ViewportTexture in the editor

### DIFF
--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -17,6 +17,7 @@
 	<members>
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
+			[b]Note:[/b] In the editor, it is automatically updated when the target viewport's node path changes due to renaming or moving the viewport or its ancestors. At runtime, it may not be able to automatically update due to the inability to determine the scene root.
 		</member>
 	</members>
 </class>

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -4001,7 +4001,6 @@ void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
 	Ref<ViewportTexture> vt;
 	vt.instantiate();
 	vt->set_viewport_path_in_scene(get_tree()->get_edited_scene_root()->get_path_to(to_node));
-	vt->setup_local_to_scene();
 
 	emit_changed(get_edited_property(), vt);
 	update_property();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -72,9 +72,8 @@ void ViewportTexture::setup_local_to_scene() {
 
 	if (vp) {
 		vp->viewport_textures.erase(this);
+		vp = nullptr;
 	}
-
-	vp = nullptr;
 
 	if (loc_scene->is_ready()) {
 		_setup_local_to_scene(loc_scene);
@@ -91,8 +90,24 @@ void ViewportTexture::set_viewport_path_in_scene(const NodePath &p_path) {
 
 	path = p_path;
 
-	if (get_local_scene()) {
+	if (vp) {
+		vp->viewport_textures.erase(this);
+		vp = nullptr;
+	}
+
+	if (proxy_ph.is_valid()) {
+		RS::get_singleton()->free(proxy_ph);
+	}
+	if (proxy.is_valid()) {
+		RS::get_singleton()->free(proxy);
+	}
+	proxy_ph = RID();
+	proxy = RID();
+
+	if (get_local_scene() && !path.is_empty()) {
 		setup_local_to_scene();
+	} else {
+		emit_changed();
 	}
 }
 
@@ -171,6 +186,8 @@ void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {
 		proxy = RS::get_singleton()->texture_proxy_create(vp->texture_rid);
 	}
 	vp_pending = false;
+
+	emit_changed();
 }
 
 void ViewportTexture::_bind_methods() {
@@ -433,9 +450,28 @@ int Viewport::_sub_window_find(Window *p_window) {
 	return -1;
 }
 
+void Viewport::_update_viewport_path() {
+	if (viewport_textures.is_empty()) {
+		return;
+	}
+
+	Node *scene_root = get_scene_file_path().is_empty() ? get_owner() : this;
+	if (!scene_root && is_inside_tree()) {
+		scene_root = get_tree()->get_edited_scene_root();
+	}
+	if (scene_root && (scene_root == this || scene_root->is_ancestor_of(this))) {
+		NodePath path_in_scene = scene_root->get_path_to(this);
+		for (ViewportTexture *E : viewport_textures) {
+			E->path = path_in_scene;
+		}
+	}
+}
+
 void Viewport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			_update_viewport_path();
+
 			if (get_parent()) {
 				parent = get_parent()->get_viewport();
 				RenderingServer::get_singleton()->viewport_set_parent_viewport(viewport, parent->get_viewport_rid());
@@ -526,6 +562,10 @@ void Viewport::_notification(int p_what) {
 
 			RS::get_singleton()->viewport_set_active(viewport, false);
 			RenderingServer::get_singleton()->viewport_set_parent_viewport(viewport, RID());
+		} break;
+
+		case NOTIFICATION_PATH_RENAMED: {
+			_update_viewport_path();
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -317,6 +317,8 @@ private:
 	Ref<ViewportTexture> default_texture;
 	HashSet<ViewportTexture *> viewport_textures;
 
+	void _update_viewport_path();
+
 	SDFOversize sdf_oversize = SDF_OVERSIZE_120_PERCENT;
 	SDFScale sdf_scale = SDF_SCALE_50_PERCENT;
 


### PR DESCRIPTION
The associated `ViewportTexture`s will update the `viewport_path` in time when the `Viewport`'s nodepath is changed (caused by renaming the nodes or moving in the SceneTree dock).

![0](https://user-images.githubusercontent.com/30386067/236878481-1678e1fd-2eae-4545-8a0a-09e28e4fdf68.gif)

If the target `Viewport` is changed by resetting the `viewport_path`, the `ViewportTexture`s will be re-setup and emit `changed` signal in time.

![1](https://user-images.githubusercontent.com/30386067/236878550-7fde5460-7929-4666-b75e-18a5c88c6339.gif)


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->














