### PR TITLE
Allow using numpad +/-/0 for editor zoom shortcuts

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1867,8 +1867,13 @@ void CodeTextEditor::update_toggle_scripts_button() {
 
 CodeTextEditor::CodeTextEditor() {
 	code_complete_func = nullptr;
-	ED_SHORTCUT("script_editor/zoom_in", TTR("Zoom In"), KeyModifierMask::CMD | Key::EQUAL);
-	ED_SHORTCUT("script_editor/zoom_out", TTR("Zoom Out"), KeyModifierMask::CMD | Key::MINUS);
+
+	ED_SHORTCUT_ARRAY("script_editor/zoom_in", TTR("Zoom In"),
+			{ int32_t(KeyModifierMask::CMD | Key::EQUAL), int32_t(KeyModifierMask::CMD | Key::KP_ADD) });
+
+	ED_SHORTCUT_ARRAY("script_editor/zoom_out", TTR("Zoom Out"),
+			{ int32_t(KeyModifierMask::CMD | Key::MINUS), int32_t(KeyModifierMask::CMD | Key::KP_SUBTRACT) });
+
 	ED_SHORTCUT_ARRAY("script_editor/reset_zoom", TTR("Reset Zoom"),
 			{ int32_t(KeyModifierMask::CMD | Key::KEY_0), int32_t(KeyModifierMask::CMD | Key::KP_0) });
 

--- a/editor/editor_zoom_widget.cpp
+++ b/editor/editor_zoom_widget.cpp
@@ -167,7 +167,10 @@ EditorZoomWidget::EditorZoomWidget() {
 	zoom_minus->set_flat(true);
 	add_child(zoom_minus);
 	zoom_minus->connect("pressed", callable_mp(this, &EditorZoomWidget::_button_zoom_minus));
-	zoom_minus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_minus", TTR("Zoom Out"), KeyModifierMask::CMD | Key::MINUS));
+
+	zoom_minus->set_shortcut(ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_minus", TTR("Zoom Out"),
+			{ int32_t(KeyModifierMask::CMD | Key::MINUS), int32_t(KeyModifierMask::CMD | Key::KP_SUBTRACT) }));
+
 	zoom_minus->set_shortcut_context(this);
 	zoom_minus->set_focus_mode(FOCUS_NONE);
 
@@ -189,7 +192,10 @@ EditorZoomWidget::EditorZoomWidget() {
 	zoom_plus->set_flat(true);
 	add_child(zoom_plus);
 	zoom_plus->connect("pressed", callable_mp(this, &EditorZoomWidget::_button_zoom_plus));
-	zoom_plus->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_plus", TTR("Zoom In"), KeyModifierMask::CMD | Key::EQUAL)); // Usually direct access key for PLUS
+
+	zoom_plus->set_shortcut(ED_SHORTCUT_ARRAY("canvas_item_editor/zoom_plus", TTR("Zoom In"),
+			{ int32_t(KeyModifierMask::CMD | Key::EQUAL), int32_t(KeyModifierMask::CMD | Key::KP_ADD) })); // Usually direct access key for PLUS
+
 	zoom_plus->set_shortcut_context(this);
 	zoom_plus->set_focus_mode(FOCUS_NONE);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7860,11 +7860,11 @@ Node3DEditor::Node3DEditor() {
 	preview_node = memnew(Node3D);
 	preview_bounds = AABB();
 
-	ED_SHORTCUT("spatial_editor/bottom_view", TTR("Bottom View"), KeyModifierMask::ALT + Key::KP_7);
+	ED_SHORTCUT("spatial_editor/bottom_view", TTR("Bottom View"), KeyModifierMask::ALT | Key::KP_7);
 	ED_SHORTCUT("spatial_editor/top_view", TTR("Top View"), Key::KP_7);
-	ED_SHORTCUT("spatial_editor/rear_view", TTR("Rear View"), KeyModifierMask::ALT + Key::KP_1);
+	ED_SHORTCUT("spatial_editor/rear_view", TTR("Rear View"), KeyModifierMask::ALT | Key::KP_1);
 	ED_SHORTCUT("spatial_editor/front_view", TTR("Front View"), Key::KP_1);
-	ED_SHORTCUT("spatial_editor/left_view", TTR("Left View"), KeyModifierMask::ALT + Key::KP_3);
+	ED_SHORTCUT("spatial_editor/left_view", TTR("Left View"), KeyModifierMask::ALT | Key::KP_3);
 	ED_SHORTCUT("spatial_editor/right_view", TTR("Right View"), Key::KP_3);
 	ED_SHORTCUT("spatial_editor/orbit_view_down", TTR("Orbit View Down"), Key::KP_2);
 	ED_SHORTCUT("spatial_editor/orbit_view_left", TTR("Orbit View Left"), Key::KP_4);
@@ -7875,12 +7875,18 @@ Node3DEditor::Node3DEditor() {
 	ED_SHORTCUT("spatial_editor/insert_anim_key", TTR("Insert Animation Key"), Key::K);
 	ED_SHORTCUT("spatial_editor/focus_origin", TTR("Focus Origin"), Key::O);
 	ED_SHORTCUT("spatial_editor/focus_selection", TTR("Focus Selection"), Key::F);
-	ED_SHORTCUT("spatial_editor/align_transform_with_view", TTR("Align Transform with View"), KeyModifierMask::ALT + KeyModifierMask::CMD + Key::M);
-	ED_SHORTCUT("spatial_editor/align_rotation_with_view", TTR("Align Rotation with View"), KeyModifierMask::ALT + KeyModifierMask::CMD + Key::F);
-	ED_SHORTCUT("spatial_editor/freelook_toggle", TTR("Toggle Freelook"), KeyModifierMask::SHIFT + Key::F);
-	ED_SHORTCUT("spatial_editor/decrease_fov", TTR("Decrease Field of View"), KeyModifierMask::CMD + Key::EQUAL); // Usually direct access key for `KEY_PLUS`.
-	ED_SHORTCUT("spatial_editor/increase_fov", TTR("Increase Field of View"), KeyModifierMask::CMD + Key::MINUS);
-	ED_SHORTCUT("spatial_editor/reset_fov", TTR("Reset Field of View to Default"), KeyModifierMask::CMD + Key::KEY_0);
+	ED_SHORTCUT("spatial_editor/align_transform_with_view", TTR("Align Transform with View"), KeyModifierMask::ALT | KeyModifierMask::CMD | Key::M);
+	ED_SHORTCUT("spatial_editor/align_rotation_with_view", TTR("Align Rotation with View"), KeyModifierMask::ALT | KeyModifierMask::CMD | Key::F);
+	ED_SHORTCUT("spatial_editor/freelook_toggle", TTR("Toggle Freelook"), KeyModifierMask::SHIFT | Key::F);
+
+	ED_SHORTCUT_ARRAY("spatial_editor/decrease_fov", TTR("Decrease Field of View"),
+			{ int32_t(KeyModifierMask::CMD | Key::EQUAL), int32_t(KeyModifierMask::CMD | Key::KP_ADD) }); // Usually direct access key for `KEY_PLUS`.
+
+	ED_SHORTCUT_ARRAY("spatial_editor/increase_fov", TTR("Increase Field of View"),
+			{ int32_t(KeyModifierMask::CMD | Key::MINUS), int32_t(KeyModifierMask::CMD | Key::KP_SUBTRACT) });
+
+	ED_SHORTCUT_ARRAY("spatial_editor/reset_fov", TTR("Reset Field of View to Default"),
+			{ int32_t(KeyModifierMask::CMD + Key::KEY_0), int32_t(KeyModifierMask::CMD | Key::KP_0) });
 
 	PopupMenu *p;
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/64215.

This applies to the 2D editor, 3D editor and script editor.

**Not tested yet**, so please test if you have time :slightly_smiling_face: