### PR TITLE
[3.x] Fix incorrect Camera3D size documentation

### DIFF
--- a/doc/classes/Camera.xml
+++ b/doc/classes/Camera.xml
@@ -179,7 +179,7 @@
 			The camera's projection mode. In [constant PROJECTION_PERSPECTIVE] mode, objects' Z distance from the camera's local space scales their perceived size.
 		</member>
 		<member name="size" type="float" setter="set_size" getter="get_size" default="1.0">
-			The camera's size measured as 1/2 the width or height. Only applicable in orthogonal and frustum modes. Since [member keep_aspect] locks on axis, [code]size[/code] sets the other axis' size length.
+			The camera's size in meters measured as the diameter of the width or height, depending on [member keep_aspect]. Only applicable in orthogonal and frustum modes.
 		</member>
 		<member name="v_offset" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
 			The vertical (Y) offset of the camera viewport.


### PR DESCRIPTION
This PR is a manual backport of #64407 due to the Camera -> Camera3D rename.