### PR TITLE
Add Open Documentation button to signals

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -177,7 +177,8 @@ class ConnectionsDock : public VBoxContainer {
 	//Right-click Pop-up Menu Options.
 	enum SignalMenuOption {
 		CONNECT,
-		DISCONNECT_ALL
+		DISCONNECT_ALL,
+		OPEN_DOCUMENTATION,
 	};
 
 	enum SlotMenuOption {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -919,7 +919,6 @@ void EditorProperty::menu_option(int p_option) {
 		} break;
 		case MENU_OPEN_DOCUMENTATION: {
 			ScriptEditor::get_singleton()->goto_help(doc_path);
-			EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
 		} break;
 	}
 }


### PR DESCRIPTION
Adds an Open Documentation button to the context menu of signals in the Node dock.

![image](https://user-images.githubusercontent.com/67974470/185768321-fd10666a-778e-4976-a778-f7ee8539f129.png)

Related to https://github.com/godotengine/godot/pull/59680, where an Open Documentation button was added to the context menu of properties in the inspector.