### PR TITLE
Remove `Node.remove_and_skip` method

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -577,12 +577,6 @@
 				Queues a node for deletion at the end of the current frame. When deleted, all of its child nodes will be deleted as well. This method ensures it's safe to delete the node, contrary to [method Object.free]. Use [method Object.is_queued_for_deletion] to check whether a node will be deleted at the end of the frame.
 			</description>
 		</method>
-		<method name="remove_and_skip">
-			<return type="void" />
-			<description>
-				Removes a node and sets all its children as children of the parent node (if it exists). All event subscriptions that pass by the removed node will be unsubscribed.
-			</description>
-		</method>
 		<method name="remove_child">
 			<return type="void" />
 			<param index="0" name="node" type="Node" />

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1907,43 +1907,6 @@ Ref<Tween> Node::create_tween() {
 	return tween;
 }
 
-void Node::remove_and_skip() {
-	ERR_FAIL_COND(!data.parent);
-
-	Node *new_owner = get_owner();
-
-	List<Node *> children;
-
-	while (true) {
-		bool clear = true;
-		for (int i = 0; i < data.children.size(); i++) {
-			Node *c_node = data.children[i];
-			if (!c_node->get_owner()) {
-				continue;
-			}
-
-			remove_child(c_node);
-			c_node->_propagate_replace_owner(this, nullptr);
-			children.push_back(c_node);
-			clear = false;
-			break;
-		}
-
-		if (clear) {
-			break;
-		}
-	}
-
-	while (!children.is_empty()) {
-		Node *c_node = children.front()->get();
-		data.parent->add_child(c_node);
-		c_node->_propagate_replace_owner(nullptr, new_owner);
-		children.pop_front();
-	}
-
-	data.parent->remove_child(this);
-}
-
 void Node::set_scene_file_path(const String &p_scene_file_path) {
 	data.scene_file_path = p_scene_file_path;
 }
@@ -2803,7 +2766,6 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_groups"), &Node::_get_groups);
 	ClassDB::bind_method(D_METHOD("set_owner", "owner"), &Node::set_owner);
 	ClassDB::bind_method(D_METHOD("get_owner"), &Node::get_owner);
-	ClassDB::bind_method(D_METHOD("remove_and_skip"), &Node::remove_and_skip);
 	ClassDB::bind_method(D_METHOD("get_index", "include_internal"), &Node::get_index, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("print_tree"), &Node::print_tree);
 	ClassDB::bind_method(D_METHOD("print_tree_pretty"), &Node::print_tree_pretty);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -356,7 +356,6 @@ public:
 	void set_unique_name_in_owner(bool p_enabled);
 	bool is_unique_name_in_owner() const;
 
-	void remove_and_skip();
 	int get_index(bool p_include_internal = true) const;
 
 	Ref<Tween> create_tween();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4049

Closes https://github.com/godotengine/godot/issues/56905 (I guess..?)

The method is obscure as it's not needed often, and it fails to communicate its purpose well. For the most part, it can be re-implemented in 4-5 simple lines of GDScript even if you do need it, which I assume most users never have. Basically it goes against a requirement proposals today need to fulfill.

Had a chat about whether we should rename or outright remove it, the sentiment seemed to be towards the latter. Probably best to discuss further.