### PR TITLE
[3.x] Fix issue with `get_current_dir()` returning the wrong path on Android

### DIFF
--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -134,6 +134,20 @@ String DirAccessJAndroid::get_drive(int p_drive) {
 	}
 }
 
+String DirAccessJAndroid::get_current_dir() {
+	String base = _get_root_path();
+	String bd = current_dir;
+	if (base != "") {
+		bd = current_dir.replace_first(base, "");
+	}
+
+	if (bd.begins_with("/")) {
+		return _get_root_string() + bd.substr(1, bd.length());
+	} else {
+		return _get_root_string() + bd;
+	}
+}
+
 Error DirAccessJAndroid::change_dir(String p_dir) {
 	String new_dir = get_absolute_path(p_dir);
 	if (new_dir == current_dir) {

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -69,6 +69,7 @@ public:
 	virtual String get_drive(int p_drive) override;
 
 	virtual Error change_dir(String p_dir) override; ///< can be relative or absolute, return false on success
+	virtual String get_current_dir() override; ///< return current dir location
 
 	virtual bool file_exists(String p_file) override;
 	virtual bool dir_exists(String p_dir) override;


### PR DESCRIPTION
Fix #64074

In the process, also address a runtime crash issue on the `3.x` branch introduced in #61316

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
