### PR TITLE
Fix issue with `get_current_dir()` returning the wrong path on Android

### DIFF
--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -135,6 +135,20 @@ String DirAccessJAndroid::get_drive(int p_drive) {
 	}
 }
 
+String DirAccessJAndroid::get_current_dir(bool p_include_drive) const {
+	String base = _get_root_path();
+	String bd = current_dir;
+	if (!base.is_empty()) {
+		bd = current_dir.replace_first(base, "");
+	}
+
+	if (bd.begins_with("/")) {
+		return _get_root_string() + bd.substr(1, bd.length());
+	} else {
+		return _get_root_string() + bd;
+	}
+}
+
 Error DirAccessJAndroid::change_dir(String p_dir) {
 	String new_dir = get_absolute_path(p_dir);
 	if (new_dir == current_dir) {

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -67,6 +67,7 @@ public:
 
 	virtual int get_drive_count() override;
 	virtual String get_drive(int p_drive) override;
+	virtual String get_current_dir(bool p_include_drive = true) const override; ///< return current dir location
 
 	virtual Error change_dir(String p_dir) override; ///< can be relative or absolute, return false on success
 


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/64074

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
