### PR TITLE
Replace AABB/Rect2/Rect2i has_no_* methods with has_* methods

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2671,7 +2671,7 @@ void Image::blit_rect(const Ref<Image> &p_src, const Rect2i &p_src_rect, const P
 	Rect2i src_rect;
 	Rect2i dest_rect;
 	_get_clipped_src_and_dest_rects(p_src, p_src_rect, p_dest, src_rect, dest_rect);
-	if (src_rect.has_no_area() || dest_rect.has_no_area()) {
+	if (!src_rect.has_area() || !dest_rect.has_area()) {
 		return;
 	}
 
@@ -2717,7 +2717,7 @@ void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, co
 	Rect2i src_rect;
 	Rect2i dest_rect;
 	_get_clipped_src_and_dest_rects(p_src, p_src_rect, p_dest, src_rect, dest_rect);
-	if (src_rect.has_no_area() || dest_rect.has_no_area()) {
+	if (!src_rect.has_area() || !dest_rect.has_area()) {
 		return;
 	}
 
@@ -2762,7 +2762,7 @@ void Image::blend_rect(const Ref<Image> &p_src, const Rect2i &p_src_rect, const 
 	Rect2i src_rect;
 	Rect2i dest_rect;
 	_get_clipped_src_and_dest_rects(p_src, p_src_rect, p_dest, src_rect, dest_rect);
-	if (src_rect.has_no_area() || dest_rect.has_no_area()) {
+	if (!src_rect.has_area() || !dest_rect.has_area()) {
 		return;
 	}
 
@@ -2802,7 +2802,7 @@ void Image::blend_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, c
 	Rect2i src_rect;
 	Rect2i dest_rect;
 	_get_clipped_src_and_dest_rects(p_src, p_src_rect, p_dest, src_rect, dest_rect);
-	if (src_rect.has_no_area() || dest_rect.has_no_area()) {
+	if (!src_rect.has_area() || !dest_rect.has_area()) {
 		return;
 	}
 
@@ -2862,7 +2862,7 @@ void Image::fill_rect(const Rect2i &p_rect, const Color &p_color) {
 	ERR_FAIL_COND_MSG(!_can_modify(format), "Cannot fill rect in compressed or custom image formats.");
 
 	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect.abs());
-	if (r.has_no_area()) {
+	if (!r.has_area()) {
 		return;
 	}
 

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -47,12 +47,12 @@ struct _NO_DISCARD_ AABB {
 	Vector3 size;
 
 	real_t get_volume() const;
-	_FORCE_INLINE_ bool has_no_volume() const {
-		return (size.x <= 0 || size.y <= 0 || size.z <= 0);
+	_FORCE_INLINE_ bool has_volume() const {
+		return size.x > 0.0f && size.y > 0.0f && size.z > 0.0f;
 	}
 
-	_FORCE_INLINE_ bool has_no_surface() const {
-		return (size.x <= 0 && size.y <= 0 && size.z <= 0);
+	_FORCE_INLINE_ bool has_surface() const {
+		return size.x > 0.0f || size.y > 0.0f || size.z > 0.0f;
 	}
 
 	const Vector3 &get_position() const { return position; }

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -140,8 +140,8 @@ struct _NO_DISCARD_ Rect2 {
 				((p_rect.position.y + p_rect.size.y) <= (position.y + size.y));
 	}
 
-	_FORCE_INLINE_ bool has_no_area() const {
-		return (size.x <= 0 || size.y <= 0);
+	_FORCE_INLINE_ bool has_area() const {
+		return size.x > 0.0f && size.y > 0.0f;
 	}
 
 	// Returns the instersection between two Rect2s or an empty Rect2 if there is no intersection

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -83,8 +83,8 @@ struct _NO_DISCARD_ Rect2i {
 				((p_rect.position.y + p_rect.size.y) <= (position.y + size.y));
 	}
 
-	_FORCE_INLINE_ bool has_no_area() const {
-		return (size.x <= 0 || size.y <= 0);
+	_FORCE_INLINE_ bool has_area() const {
+		return size.x > 0 && size.y > 0;
 	}
 
 	// Returns the instersection between two Rect2is or an empty Rect2i if there is no intersection

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1650,7 +1650,7 @@ static void _register_variant_builtin_methods() {
 
 	bind_method(Rect2, get_center, sarray(), varray());
 	bind_method(Rect2, get_area, sarray(), varray());
-	bind_method(Rect2, has_no_area, sarray(), varray());
+	bind_method(Rect2, has_area, sarray(), varray());
 	bind_method(Rect2, has_point, sarray("point"), varray());
 	bind_method(Rect2, is_equal_approx, sarray("rect"), varray());
 	bind_method(Rect2, intersects, sarray("b", "include_borders"), varray(false));
@@ -1667,7 +1667,7 @@ static void _register_variant_builtin_methods() {
 
 	bind_method(Rect2i, get_center, sarray(), varray());
 	bind_method(Rect2i, get_area, sarray(), varray());
-	bind_method(Rect2i, has_no_area, sarray(), varray());
+	bind_method(Rect2i, has_area, sarray(), varray());
 	bind_method(Rect2i, has_point, sarray("point"), varray());
 	bind_method(Rect2i, intersects, sarray("b"), varray());
 	bind_method(Rect2i, encloses, sarray("b"), varray());

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1938,8 +1938,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(AABB, abs, sarray(), varray());
 	bind_method(AABB, get_center, sarray(), varray());
 	bind_method(AABB, get_volume, sarray(), varray());
-	bind_method(AABB, has_no_volume, sarray(), varray());
-	bind_method(AABB, has_no_surface, sarray(), varray());
+	bind_method(AABB, has_volume, sarray(), varray());
+	bind_method(AABB, has_surface, sarray(), varray());
 	bind_method(AABB, has_point, sarray("point"), varray());
 	bind_method(AABB, is_equal_approx, sarray("aabb"), varray());
 	bind_method(AABB, intersects, sarray("with"), varray());

--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -142,24 +142,24 @@
 				Returns a copy of the [AABB] grown a given number of units towards all the sides.
 			</description>
 		</method>
-		<method name="has_no_surface" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the [AABB] is empty.
-			</description>
-		</method>
-		<method name="has_no_volume" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the [AABB] is flat or empty.
-			</description>
-		</method>
 		<method name="has_point" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector3" />
 			<description>
 				Returns [code]true[/code] if the [AABB] contains a point. Points on the faces of the AABB are considered included, though float-point precision errors may impact the accuracy of such checks.
 				[b]Note:[/b] This method is not reliable for [AABB] with a [i]negative size[/i]. Use [method abs] to get a positive sized equivalent [AABB] to check for contained points.
+			</description>
+		</method>
+		<method name="has_surface" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the [AABB] has a surface or a length, and [code]false[/code] if the [AABB] is empty (all components of [member size] are zero or negative).
+			</description>
+		</method>
+		<method name="has_volume" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the [AABB] has a volume, and [code]false[/code] if the [AABB] is flat, empty, or has a negative [member size].
 			</description>
 		</method>
 		<method name="intersection" qualifiers="const">

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -93,7 +93,7 @@
 		<method name="get_area" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the area of the [Rect2]. See also [method has_no_area].
+				Returns the area of the [Rect2]. See also [method has_area].
 			</description>
 		</method>
 		<method name="get_center" qualifiers="const">
@@ -127,11 +127,10 @@
 				Returns a copy of the [Rect2] grown by the specified [param amount] on the specified [enum Side].
 			</description>
 		</method>
-		<method name="has_no_area" qualifiers="const">
+		<method name="has_area" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the [Rect2] is flat or empty, [code]false[/code] otherwise. See also [method get_area].
-				[b]Note:[/b] If the [Rect2] has a negative size and is not flat or empty, [method has_no_area] will return [code]true[/code].
+				Returns [code]true[/code] if the [Rect2] has area, and [code]false[/code] if the [Rect2] is linear, empty, or has a negative [member size]. See also [method get_area].
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -90,7 +90,7 @@
 		<method name="get_area" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the area of the [Rect2i]. See also [method has_no_area].
+				Returns the area of the [Rect2i]. See also [method has_area].
 			</description>
 		</method>
 		<method name="get_center" qualifiers="const">
@@ -125,11 +125,10 @@
 				Returns a copy of the [Rect2i] grown by the specified [param amount] on the specified [enum Side].
 			</description>
 		</method>
-		<method name="has_no_area" qualifiers="const">
+		<method name="has_area" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the [Rect2i] is flat or empty, [code]false[/code] otherwise. See also [method get_area].
-				[b]Note:[/b] If the [Rect2i] has a negative size and is not flat or empty, [method has_no_area] will return [code]true[/code].
+				Returns [code]true[/code] if the [Rect2i] has area, and [code]false[/code] if the [Rect2i] is linear, empty, or has a negative [member size]. See also [method get_area].
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -260,7 +260,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 		}
 		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
 			const AABB &bone = p_surface.bone_aabbs[i];
-			if (!bone.has_no_volume()) {
+			if (bone.has_volume()) {
 				mesh->bone_aabbs.write[i].merge_with(bone);
 			}
 		}

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -1172,7 +1172,7 @@ HashMap<Vector2i, TileMapCell> TileMapEditorTilesPlugin::_draw_bucket_fill(Vecto
 			TypedArray<Vector2i> to_check;
 			if (source_cell.source_id == TileSet::INVALID_SOURCE) {
 				Rect2i rect = tile_map->get_used_rect();
-				if (rect.has_no_area()) {
+				if (!rect.has_area()) {
 					rect = Rect2i(p_coords, Vector2i(1, 1));
 				}
 				for (int x = boundaries.position.x; x < boundaries.get_end().x; x++) {
@@ -2558,7 +2558,7 @@ RBSet<Vector2i> TileMapEditorTerrainsPlugin::_get_cells_for_bucket_fill(Vector2i
 		TypedArray<Vector2i> to_check;
 		if (source_cell.source_id == TileSet::INVALID_SOURCE) {
 			Rect2i rect = tile_map->get_used_rect();
-			if (rect.has_no_area()) {
+			if (!rect.has_area()) {
 				rect = Rect2i(p_coords, Vector2i(1, 1));
 			}
 			for (int x = boundaries.position.x; x < boundaries.get_end().x; x++) {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -133,15 +133,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the area of the <see cref="AABB"/>.
-        /// </summary>
-        /// <returns>The area.</returns>
-        public real_t GetArea()
-        {
-            return _size.x * _size.y * _size.z;
-        }
-
-        /// <summary>
         /// Gets the position of one of the 8 endpoints of the <see cref="AABB"/>.
         /// </summary>
         /// <param name="idx">Which endpoint to get.</param>
@@ -321,6 +312,15 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the volume of the <see cref="AABB"/>.
+        /// </summary>
+        /// <returns>The volume.</returns>
+        public real_t GetVolume()
+        {
+            return _size.x * _size.y * _size.z;
+        }
+
+        /// <summary>
         /// Returns a copy of the <see cref="AABB"/> grown a given amount of units towards all the sides.
         /// </summary>
         /// <param name="by">The amount to grow by.</param>
@@ -337,30 +337,6 @@ namespace Godot
             res._size.z += 2.0f * by;
 
             return res;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="AABB"/> is flat or empty,
-        /// or <see langword="false"/> otherwise.
-        /// </summary>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="AABB"/> has area.
-        /// </returns>
-        public bool HasNoArea()
-        {
-            return _size.x <= 0f || _size.y <= 0f || _size.z <= 0f;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="AABB"/> has no surface (no size),
-        /// or <see langword="false"/> otherwise.
-        /// </summary>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="AABB"/> has area.
-        /// </returns>
-        public bool HasNoSurface()
-        {
-            return _size.x <= 0f && _size.y <= 0f && _size.z <= 0f;
         }
 
         /// <summary>
@@ -387,6 +363,34 @@ namespace Godot
                 return false;
 
             return true;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the <see cref="AABB"/>
+        /// has a surface or a length, and <see langword="false"/>
+        /// if the <see cref="AABB"/> is empty (all components
+        /// of <see cref="Size"/> are zero or negative).
+        /// </summary>
+        /// <returns>
+        /// A <see langword="bool"/> for whether or not the <see cref="AABB"/> has surface.
+        /// </returns>
+        public bool HasSurface()
+        {
+            return _size.x > 0.0f || _size.y > 0.0f || _size.z > 0.0f;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the <see cref="AABB"/> has
+        /// area, and <see langword="false"/> if the <see cref="AABB"/>
+        /// is linear, empty, or has a negative <see cref="Size"/>.
+        /// See also <see cref="GetVolume"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see langword="bool"/> for whether or not the <see cref="AABB"/> has volume.
+        /// </returns>
+        public bool HasVolume()
+        {
+            return _size.x > 0.0f && _size.y > 0.0f && _size.z > 0.0f;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -234,15 +234,17 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rect2"/> is flat or empty,
-        /// or <see langword="false"/> otherwise.
+        /// Returns <see langword="true"/> if the <see cref="Rect2"/> has
+        /// area, and <see langword="false"/> if the <see cref="Rect2"/>
+        /// is linear, empty, or has a negative <see cref="Size"/>.
+        /// See also <see cref="GetArea"/>.
         /// </summary>
         /// <returns>
         /// A <see langword="bool"/> for whether or not the <see cref="Rect2"/> has area.
         /// </returns>
-        public bool HasNoArea()
+        public bool HasArea()
         {
-            return _size.x <= 0 || _size.y <= 0;
+            return _size.x > 0.0f && _size.y > 0.0f;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -236,15 +236,17 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rect2i"/> is flat or empty,
-        /// or <see langword="false"/> otherwise.
+        /// Returns <see langword="true"/> if the <see cref="Rect2i"/> has
+        /// area, and <see langword="false"/> if the <see cref="Rect2i"/>
+        /// is linear, empty, or has a negative <see cref="Size"/>.
+        /// See also <see cref="GetArea"/>.
         /// </summary>
         /// <returns>
         /// A <see langword="bool"/> for whether or not the <see cref="Rect2i"/> has area.
         /// </returns>
-        public bool HasNoArea()
+        public bool HasArea()
         {
-            return _size.x <= 0 || _size.y <= 0;
+            return _size.x > 0 && _size.y > 0;
         }
 
         /// <summary>

--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -572,12 +572,8 @@ void NavigationMeshGenerator::_build_recast_navigation_mesh(
 	cfg.bmax[2] = bmax[2];
 
 	AABB baking_aabb = p_nav_mesh->get_filter_baking_aabb();
-
-	bool aabb_has_no_volume = baking_aabb.has_no_volume();
-
-	if (!aabb_has_no_volume) {
+	if (baking_aabb.has_volume()) {
 		Vector3 baking_aabb_offset = p_nav_mesh->get_filter_baking_aabb_offset();
-
 		cfg.bmin[0] = baking_aabb.position[0] + baking_aabb_offset.x;
 		cfg.bmin[1] = baking_aabb.position[1] + baking_aabb_offset.y;
 		cfg.bmin[2] = baking_aabb.position[2] + baking_aabb_offset.z;

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -1015,7 +1015,7 @@ Rect2i DisplayServerX11::screen_get_usable_rect(int p_screen) const {
 								Rect2i left_rect(pos.x, pos.y + left_start_y, left, left_end_y - left_start_y);
 								if (left_rect.size.x > 0) {
 									Rect2i intersection = rect.intersection(left_rect);
-									if (!intersection.has_no_area() && intersection.size.x < rect.size.x) {
+									if (intersection.has_area() && intersection.size.x < rect.size.x) {
 										rect.position.x = left_rect.size.x;
 										rect.size.x = rect.size.x - intersection.size.x;
 									}
@@ -1024,7 +1024,7 @@ Rect2i DisplayServerX11::screen_get_usable_rect(int p_screen) const {
 								Rect2i right_rect(pos.x + size.x - right, pos.y + right_start_y, right, right_end_y - right_start_y);
 								if (right_rect.size.x > 0) {
 									Rect2i intersection = rect.intersection(right_rect);
-									if (!intersection.has_no_area() && right_rect.size.x < rect.size.x) {
+									if (intersection.has_area() && right_rect.size.x < rect.size.x) {
 										rect.size.x = intersection.position.x - rect.position.x;
 									}
 								}
@@ -1032,7 +1032,7 @@ Rect2i DisplayServerX11::screen_get_usable_rect(int p_screen) const {
 								Rect2i top_rect(pos.x + top_start_x, pos.y, top_end_x - top_start_x, top);
 								if (top_rect.size.y > 0) {
 									Rect2i intersection = rect.intersection(top_rect);
-									if (!intersection.has_no_area() && intersection.size.y < rect.size.y) {
+									if (intersection.has_area() && intersection.size.y < rect.size.y) {
 										rect.position.y = top_rect.size.y;
 										rect.size.y = rect.size.y - intersection.size.y;
 									}
@@ -1041,7 +1041,7 @@ Rect2i DisplayServerX11::screen_get_usable_rect(int p_screen) const {
 								Rect2i bottom_rect(pos.x + bottom_start_x, pos.y + size.y - bottom, bottom_end_x - bottom_start_x, bottom);
 								if (bottom_rect.size.y > 0) {
 									Rect2i intersection = rect.intersection(bottom_rect);
-									if (!intersection.has_no_area() && right_rect.size.y < rect.size.y) {
+									if (intersection.has_area() && right_rect.size.y < rect.size.y) {
 										rect.size.y = intersection.position.y - rect.position.y;
 									}
 								}

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -67,7 +67,7 @@ bool TextureButton::has_point(const Point2 &p_point) const {
 		Rect2 rect = Rect2();
 		Size2 mask_size = click_mask->get_size();
 
-		if (_position_rect.has_no_area()) {
+		if (!_position_rect.has_area()) {
 			rect.size = mask_size;
 		} else if (_tile) {
 			// if the stretch mode is tile we offset the point to keep it inside the mask size

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -94,7 +94,7 @@ void TextureRect::_notification(int p_what) {
 
 			Ref<AtlasTexture> p_atlas = texture;
 
-			if (p_atlas.is_valid() && region.has_no_area()) {
+			if (p_atlas.is_valid() && !region.has_area()) {
 				Size2 scale_size(size.width / texture->get_width(), size.height / texture->get_height());
 
 				offset.width += hflip ? p_atlas->get_margin().get_position().width * scale_size.width * 2 : 0;
@@ -104,10 +104,10 @@ void TextureRect::_notification(int p_what) {
 			size.width *= hflip ? -1.0f : 1.0f;
 			size.height *= vflip ? -1.0f : 1.0f;
 
-			if (region.has_no_area()) {
-				draw_texture_rect(texture, Rect2(offset, size), tile);
-			} else {
+			if (region.has_area()) {
 				draw_texture_rect_region(texture, Rect2(offset, size), region);
+			} else {
+				draw_texture_rect(texture, Rect2(offset, size), tile);
 			}
 		} break;
 	}

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -425,7 +425,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 		}
 		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
 			const AABB &bone = p_surface.bone_aabbs[i];
-			if (!bone.has_no_volume()) {
+			if (bone.has_volume()) {
 				mesh->bone_aabbs.write[i].merge_with(bone);
 			}
 		}

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1563,7 +1563,7 @@ void RendererSceneCull::_update_instance(Instance *p_instance) {
 		}
 	}
 
-	if (p_instance->aabb.has_no_surface()) {
+	if (!p_instance->aabb.has_surface()) {
 		return;
 	}
 

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -94,7 +94,7 @@ TEST_CASE("[AABB] Volume getters") {
 			Math::is_equal_approx(aabb.get_volume(), 120),
 			"get_volume() should return the expected value with positive size.");
 	CHECK_MESSAGE(
-			!aabb.has_no_volume(),
+			aabb.has_volume(),
 			"Non-empty volumetric AABB should have a volume.");
 
 	aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(-4, 5, 6));
@@ -114,27 +114,32 @@ TEST_CASE("[AABB] Volume getters") {
 
 	aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 0, 6));
 	CHECK_MESSAGE(
-			aabb.has_no_volume(),
+			!aabb.has_volume(),
 			"Non-empty flat AABB should not have a volume.");
 
 	CHECK_MESSAGE(
-			AABB().has_no_volume(),
+			!AABB().has_volume(),
 			"Empty AABB should not have a volume.");
 }
 
 TEST_CASE("[AABB] Surface getters") {
 	AABB aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6));
 	CHECK_MESSAGE(
-			!aabb.has_no_surface(),
+			aabb.has_surface(),
 			"Non-empty volumetric AABB should have an surface.");
 
 	aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 0, 6));
 	CHECK_MESSAGE(
-			!aabb.has_no_surface(),
+			aabb.has_surface(),
 			"Non-empty flat AABB should have a surface.");
 
+	aabb = AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 0, 0));
 	CHECK_MESSAGE(
-			AABB().has_no_surface(),
+			aabb.has_surface(),
+			"Non-empty linear AABB should have a surface.");
+
+	CHECK_MESSAGE(
+			!AABB().has_surface(),
 			"Empty AABB should not have an surface.");
 }
 

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -118,17 +118,17 @@ TEST_CASE("[Rect2] Area getters") {
 			"get_area() should return the expected value.");
 
 	CHECK_MESSAGE(
-			!Rect2(0, 100, 1280, 720).has_no_area(),
-			"has_no_area() should return the expected value on Rect2 with an area.");
+			Rect2(0, 100, 1280, 720).has_area(),
+			"has_area() should return the expected value on Rect2 with an area.");
 	CHECK_MESSAGE(
-			Rect2(0, 100, 0, 500).has_no_area(),
-			"has_no_area() should return the expected value on Rect2 with no area.");
+			!Rect2(0, 100, 0, 500).has_area(),
+			"has_area() should return the expected value on Rect2 with no area.");
 	CHECK_MESSAGE(
-			Rect2(0, 100, 500, 0).has_no_area(),
-			"has_no_area() should return the expected value on Rect2 with no area.");
+			!Rect2(0, 100, 500, 0).has_area(),
+			"has_area() should return the expected value on Rect2 with no area.");
 	CHECK_MESSAGE(
-			Rect2(0, 100, 0, 0).has_no_area(),
-			"has_no_area() should return the expected value on Rect2 with no area.");
+			!Rect2(0, 100, 0, 0).has_area(),
+			"has_area() should return the expected value on Rect2 with no area.");
 }
 
 TEST_CASE("[Rect2] Absolute coordinates") {

--- a/tests/core/math/test_rect2i.h
+++ b/tests/core/math/test_rect2i.h
@@ -118,17 +118,17 @@ TEST_CASE("[Rect2i] Area getters") {
 			"get_area() should return the expected value.");
 
 	CHECK_MESSAGE(
-			!Rect2i(0, 100, 1280, 720).has_no_area(),
-			"has_no_area() should return the expected value on Rect2i with an area.");
+			Rect2i(0, 100, 1280, 720).has_area(),
+			"has_area() should return the expected value on Rect2i with an area.");
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 0, 500).has_no_area(),
-			"has_no_area() should return the expected value on Rect2i with no area.");
+			!Rect2i(0, 100, 0, 500).has_area(),
+			"has_area() should return the expected value on Rect2i with no area.");
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 500, 0).has_no_area(),
-			"has_no_area() should return the expected value on Rect2i with no area.");
+			!Rect2i(0, 100, 500, 0).has_area(),
+			"has_area() should return the expected value on Rect2i with no area.");
 	CHECK_MESSAGE(
-			Rect2i(0, 100, 0, 0).has_no_area(),
-			"has_no_area() should return the expected value on Rect2i with no area.");
+			!Rect2i(0, 100, 0, 0).has_area(),
+			"has_area() should return the expected value on Rect2i with no area.");
 }
 
 TEST_CASE("[Rect2i] Absolute coordinates") {


### PR DESCRIPTION
This PR does the following:

* AABB: Replace `has_no_volume` with `has_volume` (the bool is inverted)
* AABB: Replace `has_no_surface` with `has_surface` (the bool is inverted)
* Rect2: Replace  `has_no_area` with `has_area` (the bool is inverted)
* Rect2i: Replace  `has_no_area` with `has_area` (the bool is inverted)
* Improve the documentation of these methods to be more clear and concise.

While working on #64416, I figured this would make sense to change, because otherwise we end up with double negatives.