### PR TITLE
Fixed lerp of Transform2D which caused losing of skew

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -272,32 +272,25 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, const 
 
 	real_t r1 = get_rotation();
 	real_t r2 = p_transform.get_rotation();
+	real_t k1 = Math::atan2(columns[1].x, columns[1].y);
+	real_t k2 = Math::atan2(p_transform.columns[1].x, p_transform.columns[1].y);
 
 	Size2 s1 = get_scale();
 	Size2 s2 = p_transform.get_scale();
 
-	//slerp rotation
-	Vector2 v1(Math::cos(r1), Math::sin(r1));
-	Vector2 v2(Math::cos(r2), Math::sin(r2));
-
-	real_t dot = v1.dot(v2);
-
-	dot = CLAMP(dot, -1.0f, 1.0f);
-
-	Vector2 v;
-
-	if (dot > 0.9995f) {
-		v = v1.lerp(v2, p_c).normalized(); //linearly interpolate to avoid numerical precision issues
-	} else {
-		real_t angle = p_c * Math::acos(dot);
-		Vector2 v3 = (v2 - v1 * dot).normalized();
-		v = v1 * Math::cos(angle) + v3 * Math::sin(angle);
-	}
+	// lerp
+	Vector2 p = p1.lerp(p2, p_c);
+	real_t r = lerp_angle(r1, r2, p_c);
+	real_t k = lerp_angle(k1, k2, p_c);
+	Vector2 s = s1.lerp(s2, p_c);
 
 	//construct matrix
-	Transform2D res(v.angle(), p1.lerp(p2, p_c));
-	res.scale_basis(s1.lerp(s2, p_c));
-	return res;
+	return Transform2D(
+			Math::cos(r) * s.x,
+			Math::sin(r) * s.x,
+			Math::sin(k) * s.y,
+			Math::cos(k) * s.y,
+			p.x, p.y);
 }
 
 void Transform2D::operator*=(const real_t p_val) {

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -110,6 +110,7 @@ struct _NO_DISCARD_ Transform2D {
 	Transform2D operator*(const real_t p_val) const;
 
 	Transform2D interpolate_with(const Transform2D &p_transform, const real_t p_c) const;
+	_FORCE_INLINE_ real_t lerp_angle(real_t p_a, real_t p_b, real_t p_weight) const;
 
 	_FORCE_INLINE_ Vector2 basis_xform(const Vector2 &p_vec) const;
 	_FORCE_INLINE_ Vector2 basis_xform_inv(const Vector2 &p_vec) const;
@@ -242,6 +243,16 @@ Vector<Vector2> Transform2D::xform_inv(const Vector<Vector2> &p_array) const {
 		w[i] = xform_inv(r[i]);
 	}
 	return array;
+}
+
+real_t Transform2D::lerp_angle(real_t p_a, real_t p_b, real_t p_weight) const {
+	real_t delta = p_b - p_a;
+	if (delta > Math_PI) {
+		delta -= Math_PI * 2;
+	} else if (delta < -Math_PI) {
+		delta += Math_PI * 2;
+	}
+	return p_a + delta * p_weight;
 }
 
 #endif // TRANSFORM_2D_H

--- a/tests/core/math/test_transform_2d.h
+++ b/tests/core/math/test_transform_2d.h
@@ -83,6 +83,38 @@ TEST_CASE("[Transform2D] rotation") {
 	CHECK(orig.rotated(phi) == R * orig);
 	CHECK(orig.rotated_local(phi) == orig * R);
 }
+
+Transform2D transform_from_array(real_t arr[]) {
+	return Transform2D(arr[0], Vector2(arr[1], arr[2]), arr[3], Vector2(arr[4], arr[5]));
+}
+
+void test_one_interpolation(real_t a[], real_t b[], real_t weight) {
+	Transform2D trans_a = transform_from_array(a);
+	Transform2D trans_b = transform_from_array(b);
+	Transform2D result = trans_a.interpolate_with(trans_b, weight);
+	Size2 result_scale = result.get_scale();
+	Size2 result_origin = result.get_origin();
+	real_t c[] = {
+		result.get_rotation(),
+		result_scale.x, result_scale.y,
+		result.get_skew(),
+		result_origin.x, result_origin.y
+	};
+	for (int i = 0; i < 6; ++i) {
+		CHECK(a[i] + weight * (b[i] - a[i]) == doctest::Approx(c[i]));
+	}
+}
+
+TEST_CASE("[Transform2D] interpolation") {
+	real_t cases[][6] = {
+		{ 1, 1, 1, 1, 0, 0 },
+		{ 1, 1, 1, 1, 0, 0 },
+		{ 1.5, 1, 2, 0, 10, 20 },
+		{ 0.5, 2, 3, 1, 15, 25 },
+	};
+	test_one_interpolation(cases[0], cases[1], 0.7);
+	test_one_interpolation(cases[2], cases[3], 0.4);
+}
 } // namespace TestTransform2D
 
 #endif // TEST_TRANSFORM_2D_H


### PR DESCRIPTION
This PR fixes #64252. With this PR, the test project produces correct result of ((1, 0), (1, 1), (0, 0)),