### PR TITLE
Warn users about unsafe usage of `InputEvent`

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -878,6 +878,31 @@ void Input::parse_input_event(const Ref<InputEvent> &p_event) {
 
 	ERR_FAIL_COND(p_event.is_null());
 
+#ifdef DEBUG_ENABLED
+	uint64_t curr_frame = Engine::get_singleton()->get_process_frames();
+	if (curr_frame != last_parsed_frame) {
+		frame_parsed_events.clear();
+		last_parsed_frame = curr_frame;
+		frame_parsed_events.insert(p_event);
+	} else if (frame_parsed_events.has(p_event)) {
+		// It would be technically safe to send the same event in cases such as:
+		// - After an explicit flush.
+		// - In platforms using buffering when agile flushing is enabled, after one of the mid-frame flushes.
+		// - If platform doesn't use buffering and event accumulation is disabled.
+		// - If platform doesn't use buffering and the event type is not accumulable.
+		// However, it wouldn't be reasonable to ask users to remember the full ruleset and be aware at all times
+		// of the possibilites of the target platform, project settings and engine internals, which may change
+		// without prior notice.
+		// Therefore, the guideline is, "don't send the same event object more than once per frame".
+		WARN_PRINT_ONCE(
+				"An input event object is being parsed more than once in the same frame, which is unsafe.\n"
+				"If you are generating events in a script, you have to instantiate a new event instead of sending the same one more than once, unless the original one was sent on an earlier frame.\n"
+				"You can call duplicate() on the event to get a new instance with identical values.");
+	} else {
+		frame_parsed_events.insert(p_event);
+	}
+#endif
+
 	if (use_accumulated_input) {
 		if (buffered_events.is_empty() || !buffered_events.back()->get()->accumulate(p_event)) {
 			buffered_events.push_back(p_event);

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -222,6 +222,10 @@ private:
 	void _parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated);
 
 	List<Ref<InputEvent>> buffered_events;
+#ifdef DEBUG_ENABLED
+	HashSet<Ref<InputEvent>> frame_parsed_events;
+	uint64_t last_parsed_frame = UINT64_MAX;
+#endif
 
 	friend class DisplayServer;
 


### PR DESCRIPTION
Depending on many factors, sending the same input event object to the engine more than once may work as expected or not. Since the user is not (and should not be) expected to be aware of the multiple cases, this PR finally introduces a user-facing guideline that user's usage pattern is checked against to show a warning if not followed.

Plase see the big comment in the code for further details.

This addresses the part of #64176 due to the former lack of transparency about this.

Version for 3.x submitted as #64424.

**UPDATE:** For the sake of completeness, I'm sharing further thoughts on this. In 4.0 we have an opportunity to change how things work. I mean, we could just have a non-ref-counted `InputEvent` and copy any event sent to `Input.parse_input_event()`. That would also avoid other unstable behaviors not addressed here, like modifying an input event object once sent, which will still behave differently under different OS, project settings, etc. That'd be work for a separate PR, in any case. @godotengine/input, @godotengine/core, thoughts?