### PR TITLE
[GDExtension] Skip unset getter/setter/index fields in class property

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -871,9 +871,18 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 					Dictionary d2;
 					d2["type"] = get_property_info_type_name(F);
 					d2["name"] = String(property_name);
-					d2["setter"] = ClassDB::get_property_setter(class_name, F.name);
-					d2["getter"] = ClassDB::get_property_getter(class_name, F.name);
-					d2["index"] = ClassDB::get_property_index(class_name, F.name);
+					StringName setter = ClassDB::get_property_setter(class_name, F.name);
+					if (!(setter == "")) {
+						d2["setter"] = setter;
+					}
+					StringName getter = ClassDB::get_property_getter(class_name, F.name);
+					if (!(getter == "")) {
+						d2["getter"] = getter;
+					}
+					int index = ClassDB::get_property_index(class_name, F.name);
+					if (index != -1) {
+						d2["index"] = index;
+					}
 					properties.push_back(d2);
 				}
 


### PR DESCRIPTION
There is no reason to have `"index": -1` or `"setter": ""`/`"getter": ""` fields in `extension_api.json`

before:
```python
{
    "name": "AnimationPlayer",
    [...]
    "properties": [
        {
            "type": "float",
            "name": "current_animation_length",
            "setter": "",
            "getter": "get_current_animation_length",
            "index": -1
        },
```
after:
```python
{
    "name": "AnimationPlayer",
    [...]
    "properties": [
        {
            "type": "float",
            "name": "current_animation_length",
            "getter": "get_current_animation_length",
        },
```

BTW I had to use the ugly `!(setter == "")` because `StringName` [doesn't support operator!= with `char *`](https://github.com/godotengine/godot/blob/7c7ce7dcd7430d8503d6f74bb49c68892bc31dca/core/string/string_name.h#L102-L104), do you think we should add it instead ?