### PR TITLE
Ignore class's property array when generating extension_api.json (not…

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -52,6 +52,9 @@ static String get_type_name(const PropertyInfo &p_info) {
 	if (p_info.type == Variant::INT && (p_info.usage & (PROPERTY_USAGE_CLASS_IS_BITFIELD))) {
 		return String("bitfield::") + String(p_info.class_name);
 	}
+	if (p_info.type == Variant::INT && (p_info.usage & PROPERTY_USAGE_ARRAY)) {
+		return "int";
+	}
 	if (p_info.class_name != StringName()) {
 		return p_info.class_name;
 	}
@@ -840,11 +843,15 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 				List<PropertyInfo> property_list;
 				ClassDB::get_property_list(class_name, &property_list, true);
 				for (const PropertyInfo &F : property_list) {
-					if (F.usage & PROPERTY_USAGE_CATEGORY || F.usage & PROPERTY_USAGE_GROUP || F.usage & PROPERTY_USAGE_SUBGROUP) {
+					if (F.usage & PROPERTY_USAGE_CATEGORY || F.usage & PROPERTY_USAGE_GROUP || F.usage & PROPERTY_USAGE_SUBGROUP || (F.type == Variant::NIL && F.usage & PROPERTY_USAGE_ARRAY)) {
 						continue; //not real properties
 					}
 					if (F.name.begins_with("_")) {
 						continue; //hidden property
+					}
+					if (F.name.find("/") >= 0) {
+						// Ignore properties with '/' (slash) in the name. These are only meant for use in the inspector.
+						continue;
 					}
 					StringName property_name = F.name;
 					Dictionary d2;


### PR DESCRIPTION
fix #64426
fix #63066

I've copied the code from the [mono's bindings_generator.cpp](https://github.com/godotengine/godot/blob/eda6800f5dc01981f3626580d91a619b496acb5f/modules/mono/editor/bindings_generator.cpp#L2768) (I'm not sure why the `F.type == Variant::NIL` part is needed given `PropertyInfo::add_property_array` always set the type to `Variant::NIL`)

In the long run, we should probably replace this by a proper factorization (for instance adding a `PropertyInfo::is_fake_property` method) as there is multiple places where this `E.usage & PROPERTY_USAGE_CATEGORY ||  ...` pattern is used (sometime without the check to `PROPERTY_USAGE_ARRAY` and no comment to easily understand if it is a desired behavior ^^)

EDIT: I've also included a commit that filter out the properties with `/` in there name (this also comes from [mono's bindings_generator.cpp](https://github.com/godotengine/godot/blob/eda6800f5dc01981f3626580d91a619b496acb5f/modules/mono/editor/bindings_generator.cpp#L2772-L2775) ) as they are also not real properties (if you ask me, in the long run we should have a dedicated `PROPERTY_...` for this kind of "editor only" property). Tell me you'd rather have it as a separate PR ;-)