### PR TITLE
Clarify the `Line2D`, `Curve2D/3D` documentation and fix parameter names

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -15,10 +15,10 @@
 			<param index="0" name="position" type="Vector2" />
 			<param index="1" name="in" type="Vector2" default="Vector2(0, 0)" />
 			<param index="2" name="out" type="Vector2" default="Vector2(0, 0)" />
-			<param index="3" name="at_position" type="int" default="-1" />
+			<param index="3" name="index" type="int" default="-1" />
 			<description>
-				Adds a point to a curve at [param position] relative to the [Curve2D]'s position, with control points [param in] and [param out].
-				If [param at_position] is given, the point is inserted before the point number [param at_position], moving that point (and every point after) after the inserted point. If [param at_position] is not given, or is an illegal value ([code]at_position &lt;0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
+				Adds a point with the specified [param position] relative to the curve's own position, with control points [param in] and [param out]. Appends the new point at the end of the point list.
+				If [param index] is given, the new point is inserted before the existing point identified by index [param index]. Every existing point starting from [param index] is shifted further down the list of points. The index must be greater than or equal to [code]0[/code] and must not exceed the number of existing points in the line. See [member point_count].
 			</description>
 		</method>
 		<method name="clear_points">

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -15,10 +15,10 @@
 			<param index="0" name="position" type="Vector3" />
 			<param index="1" name="in" type="Vector3" default="Vector3(0, 0, 0)" />
 			<param index="2" name="out" type="Vector3" default="Vector3(0, 0, 0)" />
-			<param index="3" name="at_position" type="int" default="-1" />
+			<param index="3" name="index" type="int" default="-1" />
 			<description>
-				Adds a point to a curve at [param position] relative to the [Curve3D]'s position, with control points [param in] and [param out].
-				If [param at_position] is given, the point is inserted before the point number [param at_position], moving that point (and every point after) after the inserted point. If [param at_position] is not given, or is an illegal value ([code]at_position &lt;0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
+				Adds a point with the specified [param position] relative to the curve's own position, with control points [param in] and [param out]. Appends the new point at the end of the point list.
+				If [param index] is given, the new point is inserted before the existing point identified by index [param index]. Every existing point starting from [param index] is shifted further down the list of points. The index must be greater than or equal to [code]0[/code] and must not exceed the number of existing points in the line. See [member point_count].
 			</description>
 		</method>
 		<method name="clear_points">

--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -14,10 +14,10 @@
 		<method name="add_point">
 			<return type="void" />
 			<param index="0" name="position" type="Vector2" />
-			<param index="1" name="at_position" type="int" default="-1" />
+			<param index="1" name="index" type="int" default="-1" />
 			<description>
-				Adds a point at the [param position]. Appends the point at the end of the line.
-				If [param at_position] is given, the point is inserted before the point number [param at_position], moving that point (and every point after) after the inserted point. If [param at_position] is not given, or is an illegal value ([code]at_position &lt; 0[/code] or [code]at_position &gt;= [method get_point_count][/code]), the point will be appended at the end of the point list.
+				Adds a point with the specified [param position] relative to the line's own position. Appends the new point at the end of the point list.
+				If [param index] is given, the new point is inserted before the existing point identified by index [param index]. Every existing point starting from [param index] is shifted further down the list of points. The index must be greater than or equal to [code]0[/code] and must not exceed the number of existing points in the line. See [method get_point_count].
 			</description>
 		</method>
 		<method name="clear_points">
@@ -29,29 +29,29 @@
 		<method name="get_point_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the Line2D's amount of points.
+				Returns the amount of points in the line.
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
 			<return type="Vector2" />
-			<param index="0" name="i" type="int" />
+			<param index="0" name="index" type="int" />
 			<description>
-				Returns point [param i]'s position.
+				Returns the position of the point at index [param index].
 			</description>
 		</method>
 		<method name="remove_point">
 			<return type="void" />
-			<param index="0" name="i" type="int" />
+			<param index="0" name="index" type="int" />
 			<description>
-				Removes the point at index [param i] from the line.
+				Removes the point at index [param index] from the line.
 			</description>
 		</method>
 		<method name="set_point_position">
 			<return type="void" />
-			<param index="0" name="i" type="int" />
+			<param index="0" name="index" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Overwrites the position in point [param i] with the supplied [param position].
+				Overwrites the position of the point at index [param index] with the supplied [param position].
 			</description>
 		</method>
 	</methods>

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -346,13 +346,13 @@ void Line2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_points", "points"), &Line2D::set_points);
 	ClassDB::bind_method(D_METHOD("get_points"), &Line2D::get_points);
 
-	ClassDB::bind_method(D_METHOD("set_point_position", "i", "position"), &Line2D::set_point_position);
-	ClassDB::bind_method(D_METHOD("get_point_position", "i"), &Line2D::get_point_position);
+	ClassDB::bind_method(D_METHOD("set_point_position", "index", "position"), &Line2D::set_point_position);
+	ClassDB::bind_method(D_METHOD("get_point_position", "index"), &Line2D::get_point_position);
 
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Line2D::get_point_count);
 
-	ClassDB::bind_method(D_METHOD("add_point", "position", "at_position"), &Line2D::add_point, DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("remove_point", "i"), &Line2D::remove_point);
+	ClassDB::bind_method(D_METHOD("add_point", "position", "index"), &Line2D::add_point, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("remove_point", "index"), &Line2D::remove_point);
 
 	ClassDB::bind_method(D_METHOD("clear_points"), &Line2D::clear_points);
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1167,7 +1167,7 @@ void Curve2D::_get_property_list(List<PropertyInfo> *p_list) const {
 void Curve2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Curve2D::get_point_count);
 	ClassDB::bind_method(D_METHOD("set_point_count", "count"), &Curve2D::set_point_count);
-	ClassDB::bind_method(D_METHOD("add_point", "position", "in", "out", "at_position"), &Curve2D::add_point, DEFVAL(Vector2()), DEFVAL(Vector2()), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("add_point", "position", "in", "out", "index"), &Curve2D::add_point, DEFVAL(Vector2()), DEFVAL(Vector2()), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("set_point_position", "idx", "position"), &Curve2D::set_point_position);
 	ClassDB::bind_method(D_METHOD("get_point_position", "idx"), &Curve2D::get_point_position);
 	ClassDB::bind_method(D_METHOD("set_point_in", "idx", "position"), &Curve2D::set_point_in);
@@ -1972,7 +1972,7 @@ void Curve3D::_get_property_list(List<PropertyInfo> *p_list) const {
 void Curve3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_count"), &Curve3D::get_point_count);
 	ClassDB::bind_method(D_METHOD("set_point_count", "count"), &Curve3D::set_point_count);
-	ClassDB::bind_method(D_METHOD("add_point", "position", "in", "out", "at_position"), &Curve3D::add_point, DEFVAL(Vector3()), DEFVAL(Vector3()), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("add_point", "position", "in", "out", "index"), &Curve3D::add_point, DEFVAL(Vector3()), DEFVAL(Vector3()), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("set_point_position", "idx", "position"), &Curve3D::set_point_position);
 	ClassDB::bind_method(D_METHOD("get_point_position", "idx"), &Curve3D::get_point_position);
 	ClassDB::bind_method(D_METHOD("set_point_tilt", "idx", "tilt"), &Curve3D::set_point_tilt);


### PR DESCRIPTION
I noticed a [badly formatted method reference](https://user-images.githubusercontent.com/11782833/184655534-e875ada6-f95a-4102-9272-5563c66cb153.png) at first, and then trying to read the whole thing got confused by the wording too. So I've fixed the language to clarify both the logic of this function, as well as cross-reference, as well as parameter names across several related methods of the class.

The issue was apparently identified the moment this argument was added in https://github.com/godotengine/godot/pull/27805, but it was never fixed since.

This fix also applies to `3.x`, but it doesn't have the `[param foo]` syntax (yet?) so it cannot be easily cherrypicked.