### PR TITLE
Hide properties that have no effect in Label3D inspector

### DIFF
--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -54,7 +54,8 @@
 			Font configuration used to display text.
 		</member>
 		<member name="font_size" type="int" setter="set_font_size" getter="get_font_size" default="32">
-			Font size of the [Label3D]'s text.
+			Font size of the [Label3D]'s text. To make the font look more detailed when up close, increase [member font_size] while decreasing [member pixel_size] at the same time.
+			Higher font sizes require more time to render new characters, which can cause stuttering during gameplay.
 		</member>
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="1">
 			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
@@ -86,7 +87,7 @@
 			Text outline size.
 		</member>
 		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.005">
-			The size of one pixel's width on the label to scale it in 3D.
+			The size of one pixel's width on the label to scale it in 3D. To make the font look more detailed when up close, increase [member font_size] while decreasing [member pixel_size] at the same time.
 		</member>
 		<member name="render_priority" type="int" setter="set_render_priority" getter="get_render_priority" default="0">
 			Sets the render priority for the text. Higher priority objects will be sorted in front of lower priority objects.
@@ -138,7 +139,7 @@
 			Represents the size of the [enum DrawFlags] enum.
 		</constant>
 		<constant name="ALPHA_CUT_DISABLED" value="0" enum="AlphaCutMode">
-			This mode performs standard alpha blending. It can display translucent areas, but transparency sorting issues may be visible when multiple transparent materials are overlapping.
+			This mode performs standard alpha blending. It can display translucent areas, but transparency sorting issues may be visible when multiple transparent materials are overlapping. [member GeometryInstance3D.cast_shadow] has no effect when this transparency mode is used; the [Label3D] will never cast shadows.
 		</constant>
 		<constant name="ALPHA_CUT_DISCARD" value="1" enum="AlphaCutMode">
 			This mode only allows fully transparent or fully opaque pixels. Harsh edges will be visible unless some form of screen-space antialiasing is enabled (see [member ProjectSettings.rendering/anti_aliasing/quality/screen_space_aa]). This mode is also known as [i]alpha testing[/i] or [i]1-bit transparency[/i].

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -163,7 +163,17 @@ void Label3D::_bind_methods() {
 }
 
 void Label3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "material_override" || property.name == "material_overlay") {
+	if (
+			property.name == "material_override" ||
+			property.name == "material_overlay" ||
+			property.name == "lod_bias" ||
+			property.name == "gi_mode" ||
+			property.name == "gi_lightmap_scale") {
+		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+
+	if (property.name == "cast_shadow" && alpha_cut == ALPHA_CUT_DISABLED) {
+		// Alpha-blended materials can't cast shadows.
 		property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
@@ -889,6 +899,7 @@ void Label3D::set_alpha_cut_mode(AlphaCutMode p_mode) {
 	if (alpha_cut != p_mode) {
 		alpha_cut = p_mode;
 		_queue_update();
+		notify_property_list_changed();
 	}
 }
 
@@ -927,7 +938,12 @@ Label3D::Label3D() {
 
 	mesh = RenderingServer::get_singleton()->mesh_create();
 
+	// Disable shadow casting by default to improve performance and avoid unintended visual artifacts.
 	set_cast_shadows_setting(SHADOW_CASTING_SETTING_OFF);
+
+	// Label3D can't contribute to GI in any way, so disable it to improve performance.
+	set_gi_mode(GI_MODE_DISABLED);
+
 	set_base(mesh);
 }
 


### PR DESCRIPTION
- Use the disabled GI mode as Label3D can't contribute to GI in any way. (Label3D can *receive* GI when its **Shaded** property is enabled, but this works even with the Disabled GI mode.)
- Improve Label3D class documentation.

Parts of this PR can be remade for `3.x` once we agree on this PR.