### PR TITLE
Hide properties that have no effect in SpriteBase3D inspector

### DIFF
--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -122,7 +122,7 @@
 			Represents the size of the [enum DrawFlags] enum.
 		</constant>
 		<constant name="ALPHA_CUT_DISABLED" value="0" enum="AlphaCutMode">
-			This mode performs standard alpha blending. It can display translucent areas, but transparency sorting issues may be visible when multiple transparent materials are overlapping.
+			This mode performs standard alpha blending. It can display translucent areas, but transparency sorting issues may be visible when multiple transparent materials are overlapping. [member GeometryInstance3D.cast_shadow] has no effect when this transparency mode is used; the [SpriteBase3D] will never cast shadows.
 		</constant>
 		<constant name="ALPHA_CUT_DISCARD" value="1" enum="AlphaCutMode">
 			This mode only allows fully transparent or fully opaque pixels. Harsh edges will be visible unless some form of screen-space antialiasing is enabled (see [member ProjectSettings.rendering/anti_aliasing/quality/screen_space_aa]). On the bright side, this mode doesn't suffer from transparency sorting issues when multiple transparent materials are overlapping. This mode is also known as [i]alpha testing[/i] or [i]1-bit transparency[/i].

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -452,8 +452,11 @@ bool SpriteBase3D::get_draw_flag(DrawFlags p_flag) const {
 
 void SpriteBase3D::set_alpha_cut_mode(AlphaCutMode p_mode) {
 	ERR_FAIL_INDEX(p_mode, ALPHA_CUT_MAX);
-	alpha_cut = p_mode;
-	_queue_redraw();
+	if (alpha_cut != p_mode) {
+		alpha_cut = p_mode;
+		_queue_redraw();
+		notify_property_list_changed();
+	}
 }
 
 SpriteBase3D::AlphaCutMode SpriteBase3D::get_alpha_cut_mode() const {
@@ -523,6 +526,18 @@ void SpriteBase3D::set_texture_filter(StandardMaterial3D::TextureFilter p_filter
 
 StandardMaterial3D::TextureFilter SpriteBase3D::get_texture_filter() const {
 	return texture_filter;
+}
+
+void SpriteBase3D::_validate_property(PropertyInfo &property) const {
+	if (property.name == "lod_bias" || property.name == "gi_lightmap_scale") {
+		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+
+	if (property.name == "cast_shadow" && alpha_cut == ALPHA_CUT_DISABLED) {
+		property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+
+	GeometryInstance3D::_validate_property(property);
 }
 
 void SpriteBase3D::_bind_methods() {
@@ -863,6 +878,8 @@ void Sprite3D::_validate_property(PropertyInfo &p_property) const {
 	if (!region && (p_property.name == "region_rect")) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
+
+	SpriteBase3D::_validate_property(p_property);
 }
 
 void Sprite3D::_bind_methods() {
@@ -989,6 +1006,8 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &p_property) const {
 		}
 		p_property.usage |= PROPERTY_USAGE_KEYING_INCREMENTS;
 	}
+
+	SpriteBase3D::_validate_property(p_property);
 }
 
 void AnimatedSprite3D::_notification(int p_what) {

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -102,6 +102,7 @@ protected:
 	Color _get_color_accum();
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual void _validate_property(PropertyInfo &property) const;
 	virtual void _draw() = 0;
 	void draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
@@ -193,7 +194,7 @@ protected:
 	virtual void _draw() override;
 	static void _bind_methods();
 
-	void _validate_property(PropertyInfo &p_property) const;
+	void _validate_property(PropertyInfo &p_property) const override;
 
 public:
 	void set_texture(const Ref<Texture2D> &p_texture);
@@ -253,7 +254,7 @@ protected:
 	virtual void _draw() override;
 	static void _bind_methods();
 	void _notification(int p_what);
-	void _validate_property(PropertyInfo &p_property) const;
+	void _validate_property(PropertyInfo &p_property) const override;
 
 public:
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/64449.

Sprite3D *can* contribute to GI if given a custom material, so the GI mode is still exposed (unlike for Label3D in https://github.com/godotengine/godot/pull/64449).

Parts of this PR can be remade for 3.x once we agree on this PR.