### PR TITLE
Disable shadow casting by default in GPUParticles3D and CPUParticles3D

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1656,6 +1656,10 @@ CPUParticles3D::CPUParticles3D() {
 
 	multimesh = RenderingServer::get_singleton()->multimesh_create();
 	RenderingServer::get_singleton()->multimesh_set_visible_instances(multimesh, 0);
+
+	// Disable shadow casting by default to improve performance.
+	set_cast_shadows_setting(SHADOW_CASTING_SETTING_OFF);
+
 	set_base(multimesh);
 
 	set_emitting(true);

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -617,6 +617,10 @@ void GPUParticles3D::_bind_methods() {
 GPUParticles3D::GPUParticles3D() {
 	particles = RS::get_singleton()->particles_create();
 	RS::get_singleton()->particles_set_mode(particles, RS::PARTICLES_MODE_3D);
+
+	// Disable shadow casting by default to improve performance.
+	set_cast_shadows_setting(SHADOW_CASTING_SETTING_OFF);
+
 	set_base(particles);
 	one_shot = false; // Needed so that set_emitting doesn't access uninitialized values
 	set_emitting(true);


### PR DESCRIPTION
This improves rendering performance when large amounts of particles are rendered, especially if they use detailed meshes like spheres.

See https://twitter.com/MagnusL3D/status/1559181271082885120, where disabling shadow casting on a particle system was found to double the framerate without changing its visuals in any way.

## Preview

### Before

![image](https://user-images.githubusercontent.com/180032/184682502-d5463006-b27e-4c7d-a7dc-5b3a24e6a1c0.png)

### After

![image](https://user-images.githubusercontent.com/180032/184682510-c3c88a05-620a-477f-87c3-f83222cd87f4.png)