### PR TITLE
C#: Use custom project setting for C# project files name

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -722,19 +722,24 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 	GDMonoAssembly *proj_assembly = gdmono->get_project_assembly();
 
 	String appname = ProjectSettings::get_singleton()->get("application/config/name");
-	String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-	if (appname_safe.empty()) {
-		appname_safe = "UnnamedProject";
+	String assembly_name = ProjectSettings::get_singleton()->get_setting("mono/project/assembly_name");
+
+	if (assembly_name.empty()) {
+		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
+		if (appname_safe.empty()) {
+			appname_safe = "UnnamedProject";
+		}
+		assembly_name = appname_safe;
 	}
 
-	appname_safe += ".dll";
+	assembly_name += ".dll";
 
 	if (proj_assembly) {
 		String proj_asm_path = proj_assembly->get_path();
 
 		if (!FileAccess::exists(proj_asm_path)) {
 			// Maybe it wasn't loaded from the default path, so check this as well
-			proj_asm_path = GodotSharpDirs::get_res_temp_assemblies_dir().plus_file(appname_safe);
+			proj_asm_path = GodotSharpDirs::get_res_temp_assemblies_dir().plus_file(assembly_name);
 			if (!FileAccess::exists(proj_asm_path))
 				return false; // No assembly to load
 		}
@@ -742,7 +747,7 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 		if (FileAccess::get_modified_time(proj_asm_path) <= proj_assembly->get_modified_time())
 			return false; // Already up to date
 	} else {
-		if (!FileAccess::exists(GodotSharpDirs::get_res_temp_assemblies_dir().plus_file(appname_safe)))
+		if (!FileAccess::exists(GodotSharpDirs::get_res_temp_assemblies_dir().plus_file(assembly_name)))
 			return false; // No assembly to load
 	}
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -231,7 +231,7 @@ namespace GodotTools.Export
                 RunLipo(new[] {CompileForArch("arm64"), CompileForArch("x86_64")}, libFilePath);
             }
 
-            string projectAssemblyName = GodotSharpEditor.ProjectAssemblyName;
+            string projectAssemblyName = GodotSharpDirs.ProjectAssemblyName;
             string libAotName = $"lib-aot-{projectAssemblyName}";
 
             string libAotXcFrameworkPath = Path.Combine(aotTempDir, $"{libAotName}.xcframework");

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -167,7 +167,7 @@ namespace GodotTools.Export
 
             var assemblies = new Godot.Collections.Dictionary<string, string>();
 
-            string projectDllName = GodotSharpEditor.ProjectAssemblyName;
+            string projectDllName = GodotSharpDirs.ProjectAssemblyName;
             string projectDllSrcDir = Path.Combine(GodotSharpDirs.ResTempAssembliesBaseDir, buildConfig);
             string projectDllSrcPath = Path.Combine(projectDllSrcDir, $"{projectDllName}.dll");
 

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -39,18 +39,6 @@ namespace GodotTools
 
         public bool SkipBuildBeforePlaying { get; set; } = false;
 
-        public static string ProjectAssemblyName
-        {
-            get
-            {
-                string projectAssemblyName = (string)ProjectSettings.GetSetting("application/config/name");
-                projectAssemblyName = projectAssemblyName.ToSafeDirName();
-                if (string.IsNullOrEmpty(projectAssemblyName))
-                    projectAssemblyName = "UnnamedProject";
-                return projectAssemblyName;
-            }
-        }
-
         private bool CreateProjectSolution()
         {
             using (var pr = new EditorProgress("create_csharp_solution", "Generating solution...".TTR(), 3))
@@ -60,7 +48,7 @@ namespace GodotTools
                 string resourceDir = ProjectSettings.GlobalizePath("res://");
 
                 string path = resourceDir;
-                string name = ProjectAssemblyName;
+                string name = GodotSharpDirs.ProjectAssemblyName;
 
                 string guid = CsProjOperations.GenerateGameProject(path, name);
 
@@ -375,7 +363,8 @@ namespace GodotTools
         [UsedImplicitly]
         public bool OverridesExternalEditor()
         {
-            return (ExternalEditorId)_editorSettings.GetSetting("mono/editor/external_editor") != ExternalEditorId.None;
+            return (ExternalEditorId)_editorSettings.GetSetting("mono/editor/external_editor") !=
+                   ExternalEditorId.None;
         }
 
         public override bool Build()
@@ -396,7 +385,7 @@ namespace GodotTools
                 // NOTE: The order in which changes are made to the project is important
 
                 // Migrate to MSBuild project Sdks style if using the old style
-                ProjectUtils.MigrateToProjectSdksStyle(msbuildProject, ProjectAssemblyName);
+                ProjectUtils.MigrateToProjectSdksStyle(msbuildProject, GodotSharpDirs.ProjectAssemblyName);
 
                 ProjectUtils.EnsureGodotSdkIsUpToDate(msbuildProject);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -20,6 +20,7 @@ namespace GodotTools.Internals
         public static string MonoSolutionsDir => internal_MonoSolutionsDir();
         public static string BuildLogsDirs => internal_BuildLogsDirs();
 
+        public static string ProjectAssemblyName => internal_ProjectAssemblyName();
         public static string ProjectSlnPath => internal_ProjectSlnPath();
         public static string ProjectCsProjPath => internal_ProjectCsProjPath();
 
@@ -73,6 +74,9 @@ namespace GodotTools.Internals
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_BuildLogsDirs();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern string internal_ProjectAssemblyName();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string internal_ProjectSlnPath();

--- a/modules/mono/editor/editor_internal_calls.cpp
+++ b/modules/mono/editor/editor_internal_calls.cpp
@@ -107,6 +107,14 @@ MonoString *godot_icall_GodotSharpDirs_BuildLogsDirs() {
 #endif
 }
 
+MonoString *godot_icall_GodotSharpDirs_ProjectAssemblyName() {
+#ifdef TOOLS_ENABLED
+	return GDMonoMarshal::mono_string_from_godot(GodotSharpDirs::get_project_assembly_name());
+#else
+	return NULL;
+#endif
+}
+
 MonoString *godot_icall_GodotSharpDirs_ProjectSlnPath() {
 #ifdef TOOLS_ENABLED
 	return GDMonoMarshal::mono_string_from_godot(GodotSharpDirs::get_project_sln_path());
@@ -388,6 +396,7 @@ void register_editor_internal_calls() {
 	GDMonoUtils::add_internal_call("GodotTools.Internals.GodotSharpDirs::internal_MonoLogsDir", godot_icall_GodotSharpDirs_MonoLogsDir);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.GodotSharpDirs::internal_MonoSolutionsDir", godot_icall_GodotSharpDirs_MonoSolutionsDir);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.GodotSharpDirs::internal_BuildLogsDirs", godot_icall_GodotSharpDirs_BuildLogsDirs);
+	GDMonoUtils::add_internal_call("GodotTools.Internals.GodotSharpDirs::internal_ProjectAssemblyName", godot_icall_GodotSharpDirs_ProjectAssemblyName);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.GodotSharpDirs::internal_ProjectSlnPath", godot_icall_GodotSharpDirs_ProjectSlnPath);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.GodotSharpDirs::internal_ProjectCsProjPath", godot_icall_GodotSharpDirs_ProjectCsProjPath);
 	GDMonoUtils::add_internal_call("GodotTools.Internals.GodotSharpDirs::internal_DataEditorToolsDir", godot_icall_GodotSharpDirs_DataEditorToolsDir);

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -102,6 +102,7 @@ public:
 	String mono_solutions_dir;
 	String build_logs_dir;
 
+	String project_assembly_name;
 	String sln_filepath;
 	String csproj_filepath;
 
@@ -144,16 +145,35 @@ private:
 		mono_solutions_dir = mono_user_dir.plus_file("solutions");
 		build_logs_dir = mono_user_dir.plus_file("build_logs");
 
+		GLOBAL_DEF("mono/project/assembly_name", "");
+		GLOBAL_DEF("mono/project/solution_directory", "");
+		GLOBAL_DEF("mono/project/c#_project_directory", "");
+
 		String appname = ProjectSettings::get_singleton()->get("application/config/name");
 		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
 		if (appname_safe.empty()) {
 			appname_safe = "UnnamedProject";
 		}
 
-		String base_path = ProjectSettings::get_singleton()->globalize_path("res://");
+		project_assembly_name = ProjectSettings::get_singleton()->get("mono/project/assembly_name");
+		if (project_assembly_name.empty()) {
+			project_assembly_name = appname_safe;
+			ProjectSettings::get_singleton()->set("mono/project/assembly_name", project_assembly_name);
+		}
 
-		sln_filepath = base_path.plus_file(appname_safe + ".sln");
-		csproj_filepath = base_path.plus_file(appname_safe + ".csproj");
+		String sln_parent_dir = ProjectSettings::get_singleton()->get("mono/project/solution_directory");
+		if (sln_parent_dir.empty()) {
+			sln_parent_dir = "res://";
+		}
+
+		String csproj_parent_dir = ProjectSettings::get_singleton()->get("mono/project/c#_project_directory");
+		if (csproj_parent_dir.empty()) {
+			csproj_parent_dir = "res://";
+		}
+
+		sln_filepath = ProjectSettings::get_singleton()->globalize_path(sln_parent_dir).plus_file(project_assembly_name + ".sln");
+
+		csproj_filepath = ProjectSettings::get_singleton()->globalize_path(csproj_parent_dir).plus_file(project_assembly_name + ".csproj");
 #endif
 
 		String exe_dir = OS::get_singleton()->get_executable_path().get_base_dir();
@@ -286,6 +306,10 @@ String get_mono_solutions_dir() {
 
 String get_build_logs_dir() {
 	return _GodotSharpDirs::get_singleton().build_logs_dir;
+}
+
+String get_project_assembly_name() {
+	return _GodotSharpDirs::get_singleton().project_assembly_name;
 }
 
 String get_project_sln_path() {

--- a/modules/mono/godotsharp_dirs.h
+++ b/modules/mono/godotsharp_dirs.h
@@ -51,6 +51,7 @@ String get_mono_logs_dir();
 String get_mono_solutions_dir();
 String get_build_logs_dir();
 
+String get_project_assembly_name();
 String get_project_sln_path();
 String get_project_csproj_path();
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -987,13 +987,15 @@ bool GDMono::_load_project_assembly() {
 	if (project_assembly)
 		return true;
 
-	String appname = ProjectSettings::get_singleton()->get("application/config/name");
-	String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-	if (appname_safe.empty()) {
-		appname_safe = "UnnamedProject";
+	String assembly_name = ProjectSettings::get_singleton()->get("mono/project/assembly_name");
+
+	if (assembly_name.empty()) {
+		String appname = ProjectSettings::get_singleton()->get("application/config/name");
+		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
+		assembly_name = appname_safe;
 	}
 
-	bool success = load_assembly(appname_safe, &project_assembly);
+	bool success = load_assembly(assembly_name, &project_assembly);
 
 	if (success) {
 		mono_assembly_set_main(project_assembly->get_assembly());


### PR DESCRIPTION
Backports 9c698629499a9a8fffb74a3ec4c2bfac6b7a1484 to 3.x
Fixes #27030

An important difference from the `master` version is I renamed the settings to be more consistent with how we name C# settings in 3.x:

- `dotnet/project/assembly_name` → `mono/project/assembly_name`
- `dotnet/project/solution_directory` → `mono/project/solution_directory`
- `dotnet/project/c#_project_directory` → `mono/project/c#_project_directory`

Created as a draft since this is not in master yet (pending the merge of the `dotnet6` branch).