### PR TITLE
Fix Windows list dir handle leak

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -402,6 +402,8 @@ DirAccessWindows::DirAccessWindows() {
 }
 
 DirAccessWindows::~DirAccessWindows() {
+	list_dir_end();
+
 	memdelete(p);
 }
 


### PR DESCRIPTION
Fixes a handle leak on Windows when calling list_dir_begin() and forgetting to call list_dir_end(). For example, the code example in https://docs.godotengine.org/en/stable/classes/class_directory.html currently leaks the find handle every time it is called. This PR adds a call to list_dir_end() to the DirAccessWindows destructor, similar to other platform versions.  Probably should be cherry-picked to 3.x, or does this need a separate PR for a fix this simple?