### PR TITLE
Move `ShaderCreateDialog`'s `ShaderType` enum out of the header

### DIFF
--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -37,6 +37,13 @@
 #include "scene/resources/visual_shader.h"
 #include "servers/rendering/shader_types.h"
 
+enum ShaderType {
+	SHADER_TYPE_TEXT,
+	SHADER_TYPE_VISUAL,
+	SHADER_TYPE_INC,
+	SHADER_TYPE_MAX,
+};
+
 void ShaderCreateDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {

--- a/editor/shader_create_dialog.h
+++ b/editor/shader_create_dialog.h
@@ -44,13 +44,6 @@ class EditorFileDialog;
 class ShaderCreateDialog : public ConfirmationDialog {
 	GDCLASS(ShaderCreateDialog, ConfirmationDialog);
 
-	enum ShaderType {
-		SHADER_TYPE_TEXT,
-		SHADER_TYPE_VISUAL,
-		SHADER_TYPE_INC,
-		SHADER_TYPE_MAX,
-	};
-
 	struct ShaderTypeData {
 		List<String> extensions;
 		String default_extension;


### PR DESCRIPTION
This enum is an internal helper for this class, and is not needed in the header.

My main motivation for making this change is so that in a future PR we can move visual shaders to a module, and then we can control whether the `SHADER_TYPE_VISUAL` enum member is included without including `modules_enabled.gen.h` in the shader create dialog's header. However, I think this change stands well on its own, so that's why I'm opening this PR.