### PR TITLE
Prevent HTTPRequest from polling invalid client

### DIFF
--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -94,6 +94,10 @@ Error HTTPClientTCP::connect_to_host(const String &p_host, int p_port, bool p_ss
 	} else {
 		// Host contains hostname and needs to be resolved to IP.
 		resolving = IP::get_singleton()->resolve_hostname_queue_item(server_host);
+		if (resolving == IP::RESOLVER_INVALID_ID) {
+			status = STATUS_CANT_RESOLVE;
+			return ERR_CANT_RESOLVE;
+		}
 		status = STATUS_RESOLVING;
 	}
 


### PR DESCRIPTION
Somewhat fixes https://github.com/godotengine/godot/issues/60602

The reason why the error mentioned in the issue typically shows up in the first place is because **HTTPRequest** keeps polling its associated client. However, as a result of exceeding the maximum DNS requests, the client's resolving id is INVALID, but nothing seems to be done on the **HTTPRequest**'s side to handle it, because the **HTTPRequest** doesn't know this happened.

Now, only this error show up (no edit on my part, this is appropriate):
![image](https://user-images.githubusercontent.com/66727710/184724516-271a1964-3536-47f4-9ea6-27f9ccdd07bd.png)

**HTTPClientTCP**.`connect_to_host()` now returns **ERR_CANT_RESOLVE** if the maximum number of DNS queries has been reached, ~and so does **HTTPRequest**.`request()`.~

~Need to update documentation, but I know **ERR_BUSY** isn't the most ideal error code (it's already used, too). I need someone to suggest an alternative.~