### PR TITLE
Improve performance of screen_get_dpi() in Javascript

### DIFF
--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -336,26 +336,12 @@ const GodotDisplay = {
 	$GodotDisplay__deps: ['$GodotConfig', '$GodotRuntime', '$GodotDisplayCursor', '$GodotEventListeners', '$GodotDisplayScreen', '$GodotDisplayVK'],
 	$GodotDisplay: {
 		window_icon: '',
-		findDPI: function () {
-			function testDPI(dpi) {
-				return window.matchMedia(`(max-resolution: ${dpi}dpi)`).matches;
-			}
-			function bisect(low, high, func) {
-				const mid = parseInt(((high - low) / 2) + low, 10);
-				if (high - low <= 1) {
-					return func(high) ? high : low;
-				}
-				if (func(mid)) {
-					return bisect(low, mid, func);
-				}
-				return bisect(mid, high, func);
-			}
-			try {
-				const dpi = bisect(0, 800, testDPI);
-				return dpi >= 96 ? dpi : 96;
-			} catch (e) {
-				return 96;
-			}
+		getDPI: function () {
+			// devicePixelRatio is given in dppx
+			// https://drafts.csswg.org/css-values/#resolution
+			// > due to the 1:96 fixed ratio of CSS *in* to CSS *px*, 1dppx is equivalent to 96dpi.
+			const dpi = Math.round(window.devicePixelRatio * 96);
+			return dpi >= 96 ? dpi : 96;
 		},
 	},
 
@@ -461,7 +447,7 @@ const GodotDisplay = {
 
 	godot_js_display_screen_dpi_get__sig: 'i',
 	godot_js_display_screen_dpi_get: function () {
-		return GodotDisplay.findDPI();
+		return GodotDisplay.getDPI();
 	},
 
 	godot_js_display_pixel_ratio_get__sig: 'f',


### PR DESCRIPTION
Replace a bisect with a single multiplication when calling
screen_get_dpi() in Javascript

This change is compatible with `3.x`.

Tested the value of
window.matchMedia(`(resolution:${(window.devicePixelRatio*96).toFixed(100)}dpi)`).matches
which is true except for values that cause a lot of rounding errors
(e.g. dpr : 0.3  => resolution: 28.799999999999997dpi)

Even in these cases the value matches the result of the previous
`findDPI()` method.

See also:

http://jsbench.github.io/#9fa2ce9499a06417c7432a23ce4c28d5
https://github.com/godotengine/godot/commit/6cff589b5bd483b563fe465bde74ca94902aab41#r81273660

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
