### PR TITLE
SystemFont.font_names - break out of font search loop after first match

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2808,6 +2808,8 @@ void SystemFont::_update_base_font() {
 		file->set_oversampling(oversampling);
 
 		base_font = file;
+
+		break;
 	}
 
 	if (base_font.is_valid()) {


### PR DESCRIPTION
The documentation for the `font_names` property reads:

> Array of font family names to search, first matching font found is used.

Current behavior selects the last matching font name in the list.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
