### PR TITLE
Improved performance of `String.repeat()`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3451,18 +3451,19 @@ String String::replacen(const String &p_key, const String &p_with) const {
 String String::repeat(int p_count) const {
 	ERR_FAIL_COND_V_MSG(p_count < 0, "", "Parameter count should be a positive number.");
 
-	String new_string;
-	const char32_t *src = this->get_data();
+	int len = length();
+	String new_string = *this;
+	new_string.resize(p_count * len + 1);
 
-	new_string.resize(length() * p_count + 1);
-	new_string[length() * p_count] = 0;
-
-	for (int i = 0; i < p_count; i++) {
-		for (int j = 0; j < length(); j++) {
-			new_string[i * length() + j] = src[j];
-		}
+	char32_t *dst = new_string.ptrw();
+	int offset = 1;
+	int stride = 1;
+	while (offset < p_count) {
+		memcpy(dst + offset * len, dst, stride * len * sizeof(char32_t));
+		offset += stride;
+		stride = MIN(stride * 2, p_count - offset);
 	}
-
+	dst[p_count * len] = _null;
 	return new_string;
 }
 


### PR DESCRIPTION
I was interested in implementing `Array.repeat` for my game so I looked into whether the method is already optimized in `String.repeat`; it wasn't, and also, it didn't avoid expensive computations in simple cases.

Optimization is like [the fast power algorithm](https://en.wikipedia.org/wiki/Exponentiation_by_squaring#With_constant_auxiliary_memory) but with string concatenation via memcpy. Scales much better with big strings or more repeats.
Benchmark (updated):

Test | Before | After
--- | --- | ---
len 1, x4 | 6.826ms | 4.946ms
len 1, x40 | 25.656ms | 5.388ms
len 1, x400 | 188.476ms | 7.304ms
len 1, x4000 | 1764.399ms | 8.035ms
len 6, x4 | 13.289ms | 5.610ms
len 6, x40 | 99.884ms | 7.016ms
len 6, x400 | 941.088ms | 6.594ms
len 45, x4 | 66.852ms | 6.724ms
len 45, x40 | 638.473ms | 6.383ms
len 250, x4 | 381.928ms | 7.406ms