### PR TITLE
fix for mouse events propagation after capturing mouse

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -473,12 +473,7 @@ void Viewport::_notification(int p_what) {
 #endif // _3D_DISABLED
 		} break;
 
-		case NOTIFICATION_VP_MOUSE_ENTER: {
-			gui.mouse_in_viewport = true;
-		} break;
-
 		case NOTIFICATION_VP_MOUSE_EXIT: {
-			gui.mouse_in_viewport = false;
 			_drop_physics_mouseover();
 			_drop_mouse_over();
 			// When the mouse exits the viewport, we want to end mouse_over, but
@@ -1659,10 +1654,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 		}
 
-		Control *over = nullptr;
-		if (gui.mouse_in_viewport) {
-			over = gui_find_control(mpos);
-		}
+		Control *over = gui_find_control(mpos);
 
 		if (over != gui.mouse_over) {
 			_drop_mouse_over();

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -348,7 +348,6 @@ private:
 		// info used when this is a window
 
 		bool forced_mouse_focus = false; //used for menu buttons
-		bool mouse_in_viewport = true;
 		bool key_event_accepted = false;
 		Control *mouse_focus = nullptr;
 		Control *last_mouse_focus = nullptr;


### PR DESCRIPTION
When mouse is outside the window when Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED) is called, then after calling Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE) gui is not propagating some of the mouse events: buttons are not highlighted when mouse is hovering over them and some signals like mouse_entered/mouse_exited are not called.

This commit fixes this issue by removing redundant check in viewport - if viewport is receiving mouse movement events that means mouse must be inside the viewport so there is no need for such check.
It also removes gui.mouse_in_viewport member variable since it's not reliable - it's not updated at the time of mouse capturing.

closes #64438

This work was kindly sponsored by The Mirror