### PR TITLE
[3.x] Add Node editor description group

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3081,6 +3081,7 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_editor_description", "editor_description"), &Node::set_editor_description);
 	ClassDB::bind_method(D_METHOD("_get_editor_description"), &Node::get_editor_description);
+	ADD_GROUP("Editor Description", "editor_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_editor_description", "_get_editor_description");
 
 	ClassDB::bind_method(D_METHOD("_set_import_path", "import_path"), &Node::set_import_path);


### PR DESCRIPTION
Backport from 4.0.

As features are backported, that Node section there is starting to look a bit overwhelming.

![image](https://user-images.githubusercontent.com/66727710/184872981-2940c326-9cf5-4ef5-ac0a-31d869625b08.png)

Wished I could've done the same for those properties above, but their names are way too erratic.