### PR TITLE
`SceneTreeDock` Allow/fix toggling unique name in owner for all selected nodes

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1068,24 +1068,61 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 		} break;
 		case TOOL_TOGGLE_SCENE_UNIQUE_NAME: {
-			List<Node *> selection = editor_selection->get_selected_node_list();
-			List<Node *>::Element *e = selection.front();
-			if (e) {
-				Ref<EditorUndoRedoManager> undo_redo = editor_data->get_undo_redo();
-				Node *node = e->get();
-				bool enabled = node->is_unique_name_in_owner();
-				if (!enabled && get_tree()->get_edited_scene_root()->get_node_or_null(UNIQUE_NODE_PREFIX + String(node->get_name())) != nullptr) {
-					accept->set_text(TTR("Another node already uses this unique name in the scene."));
+			// Enabling/disabling based on the same node based on which the checkbox in the menu is checked/unchecked.
+			List<Node *>::Element *first_selected = editor_selection->get_selected_node_list().front();
+			if (first_selected == nullptr) {
+				return;
+			}
+			bool enabling = !first_selected->get()->is_unique_name_in_owner();
+
+			List<Node *> full_selection = editor_selection->get_full_selected_node_list();
+			Ref<EditorUndoRedoManager> undo_redo = editor_data->get_undo_redo();
+
+			if (enabling) {
+				Vector<Node *> new_unique_nodes;
+				Vector<StringName> new_unique_names;
+				Vector<StringName> cant_be_set_unique_names;
+
+				for (Node *node : full_selection) {
+					if (node->is_unique_name_in_owner()) {
+						continue;
+					}
+					StringName name = node->get_name();
+					if (new_unique_names.find(name) != -1 || get_tree()->get_edited_scene_root()->get_node_or_null(UNIQUE_NODE_PREFIX + String(name)) != nullptr) {
+						cant_be_set_unique_names.push_back(name);
+					} else {
+						new_unique_nodes.push_back(node);
+						new_unique_names.push_back(name);
+					}
+				}
+
+				if (new_unique_nodes.size()) {
+					undo_redo->create_action(TTR("Enable Scene Unique Name(s)"));
+					for (Node *node : new_unique_nodes) {
+						undo_redo->add_do_method(node, "set_unique_name_in_owner", true);
+						undo_redo->add_undo_method(node, "set_unique_name_in_owner", false);
+					}
+					undo_redo->commit_action();
+				}
+
+				if (cant_be_set_unique_names.size()) {
+					String popup_text = TTR("Unique names already used by another node in the scene:");
+					popup_text += "\n";
+					for (StringName name : cant_be_set_unique_names) {
+						popup_text += "\n" + String(name);
+					}
+					accept->set_text(popup_text);
 					accept->popup_centered();
-					return;
 				}
-				if (!enabled) {
-					undo_redo->create_action(TTR("Enable Scene Unique Name"));
-				} else {
-					undo_redo->create_action(TTR("Disable Scene Unique Name"));
+			} else { // Disabling.
+				undo_redo->create_action(TTR("Disable Scene Unique Name(s)"));
+				for (Node *node : full_selection) {
+					if (!node->is_unique_name_in_owner()) {
+						continue;
+					}
+					undo_redo->add_do_method(node, "set_unique_name_in_owner", false);
+					undo_redo->add_undo_method(node, "set_unique_name_in_owner", true);
 				}
-				undo_redo->add_do_method(node, "set_unique_name_in_owner", !enabled);
-				undo_redo->add_undo_method(node, "set_unique_name_in_owner", enabled);
 				undo_redo->commit_action();
 			}
 		} break;
@@ -2821,14 +2858,26 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_separator();
 			menu->add_icon_shortcut(get_theme_icon(SNAME("CopyNodePath"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/copy_node_path"), TOOL_COPY_NODE_PATH);
 		}
+	}
 
-		if (selection[0]->get_owner() == EditorNode::get_singleton()->get_edited_scene()) {
-			// Only for nodes owned by the edited scene root.
+	if (profile_allow_editing) {
+		// Allow multi-toggling scene unique names but only if all selected nodes are owned by the edited scene root.
+		bool all_owned = true;
+		for (Node *node : full_selection) {
+			if (node->get_owner() != EditorNode::get_singleton()->get_edited_scene()) {
+				all_owned = false;
+				break;
+			}
+		}
+		if (all_owned) {
 			menu->add_separator();
 			menu->add_icon_check_item(get_theme_icon(SNAME("SceneUniqueName"), SNAME("EditorIcons")), TTR("Access as Scene Unique Name"), TOOL_TOGGLE_SCENE_UNIQUE_NAME);
+			// Checked based on `selection[0]` because `full_selection` has undesired ordering.
 			menu->set_item_checked(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), selection[0]->is_unique_name_in_owner());
 		}
+	}
 
+	if (selection.size() == 1) {
 		bool is_external = (!selection[0]->get_scene_file_path().is_empty());
 		if (is_external) {
 			bool is_inherited = selection[0]->get_scene_inherited_state() != nullptr;


### PR DESCRIPTION
Makes the _"Access as Scene Unique Name"_ RMB menu option be shown if all selected nodes are owned by the currently edited scene. Selecting/disabling based on the value for first node in selection (based on which the menu option currently has checked/unchecked icon).
When enabling it tries to enable scene unique names for nodes one by one according to the order in the full selection obtained from the editor. Note that it may result in somehow unexpected results based on how selection was made, e.g.:


|1|![godot windows tools 64_t7uyrCjd0I](https://user-images.githubusercontent.com/9283098/184879304-185d2813-bc64-4de5-88e9-fb9644f3ed0e.png)|![godot windows tools 64_xf3AXs274h](https://user-images.githubusercontent.com/9283098/184879423-d9a8967c-00bf-450c-9e5f-77e559095b63.png)|
|-|-|-|
|2|![mHqktFVfQc](https://user-images.githubusercontent.com/9283098/184879308-c6750280-e80b-473f-80b7-7466b7b673ca.png)|![mHqktFVfQc](https://user-images.githubusercontent.com/9283098/184879517-6250674e-70e1-416b-8d83-5d837632a7c9.png)|
|3|![HTnJQMwfca](https://user-images.githubusercontent.com/9283098/184879311-bbd6dc6e-8533-4691-9009-4ab85fe3d3fe.png)|![H9dN3coq6w](https://user-images.githubusercontent.com/9283098/184879535-e25a3160-f420-4cea-8777-224dc3901adf.png)|


But I don't think it's a big issue as in most cases I'd expect users won't be trying to enable it for nodes with the same name anyway.

Fixes #64380.

I've actually firstly "fixed it" to make it handle multi selection to only then notice this menu option was never designed to be shown for multi selection. But, oh well, since I've already made it handle multi selection then I guess a bugfix by enhacement it is. :slightly_smiling_face:

And to make things clear, because of the bugs it could have been shown for multi selection:
- in `master` if there was a node in the selection (different than the scene root) for which all other nodes in the selection was descendant in the tree:
![ZEsoVrKpQU](https://user-images.githubusercontent.com/9283098/184873555-a4bfd601-979b-4dd1-b9b9-68c5e95cc369.png)![7UP4dEMgbN](https://user-images.githubusercontent.com/9283098/184873561-552fa7cd-046e-44e9-99d9-89487cb30c54.png)
- in `3.5`/`3.x`: any multi-selection not including the edited scene's root:
![Xblm4OqYLf](https://user-images.githubusercontent.com/9283098/184874422-7d3c6014-a357-4652-bdde-b010a91058fe.png)![H28LUgZ7uK](https://user-images.githubusercontent.com/9283098/184874426-c13479e9-05d8-4e21-8917-d6f429b05fca.png)




