### PR TITLE
Fixed surface material overrides are not applied to the new mesh after changing mesh in the editor

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -106,7 +106,7 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 				preview_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 				int thumbnail_size = EditorSettings::get_singleton()->get("filesystem/file_dialog/thumbnail_size");
 				thumbnail_size *= EDSCALE;
-				assign_button->set_custom_minimum_size(Size2(MIN(1, assign_button_min_size.x), MIN(thumbnail_size, assign_button_min_size.y)));
+				assign_button->set_custom_minimum_size(Size2(MAX(1, assign_button_min_size.x), MAX(thumbnail_size, assign_button_min_size.y)));
 			}
 
 			preview_rect->set_texture(p_preview);

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -117,6 +117,12 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 		mesh->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance3D::_mesh_changed));
 		_mesh_changed();
 		set_base(mesh->get_rid());
+		int surface_count = mesh->get_surface_count();
+		for (int surface_index(0); surface_index < surface_count; ++surface_index) {
+			if (surface_override_materials[surface_index].is_valid()) {
+				RS::get_singleton()->instance_set_surface_override_material(get_instance(), surface_index, surface_override_materials[surface_index]->get_rid());
+			}
+		}
 	} else {
 		blend_shape_tracks.clear();
 		blend_shape_properties.clear();


### PR DESCRIPTION
Fixed #64163