### PR TITLE
Fix missing virtual in ScriptExtension

### DIFF
--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -62,6 +62,7 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_has_script_signal, "signal");
 	GDVIRTUAL_BIND(_get_script_signal_list);
 
+	GDVIRTUAL_BIND(_has_property_default_value, "property");
 	GDVIRTUAL_BIND(_get_property_default_value, "property");
 
 	GDVIRTUAL_BIND(_update_exports);

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -96,6 +96,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_has_property_default_value" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="property" type="StringName" />
+			<description>
+			</description>
+		</method>
 		<method name="_has_script_signal" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="signal" type="StringName" />


### PR DESCRIPTION
`_has_property_default_value` is a required virtual for `ScriptExtension` but it was not bound, and could
therefore not be implemented.  This was likely a typo/omission, since all analogous calls are bound.

Impact: this made it impossible to implement a `ScriptExtension` that runs without error.
