### PR TITLE
[opengl3] Prevent viewport's render buffers getting out of sync with render target when resized by XR interface

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -176,7 +176,7 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 			// to compensate for the loss of sharpness.
 			const float texture_mipmap_bias = log2f(MIN(scaling_3d_scale, 1.0)) + p_viewport->texture_mipmap_bias;
 
-			p_viewport->render_buffers->configure(p_viewport->render_target, Size2i(render_width, render_height), Size2(width, height), p_viewport->fsr_sharpness, texture_mipmap_bias, p_viewport->msaa_3d, p_viewport->screen_space_aa, p_viewport->use_taa, p_viewport->use_debanding, p_viewport->get_view_count());
+			p_viewport->render_buffers->configure(p_viewport->render_target, Size2i(render_width, render_height), Size2(width, height), p_viewport->fsr_sharpness, texture_mipmap_bias, p_viewport->msaa_3d, p_viewport->screen_space_aa, p_viewport->use_taa, p_viewport->use_debanding, p_viewport->view_count);
 		}
 	}
 }
@@ -613,14 +613,7 @@ void RendererViewport::draw_viewports() {
 			if (xr_interface.is_valid()) {
 				// Override our size, make sure it matches our required size and is created as a stereo target
 				Size2 xr_size = xr_interface->get_render_target_size();
-
-				// Would have been nice if we could call viewport_set_size here,
-				// but alas that takes our RID and we now have our pointer,
-				// also we only check if view_count changes in render_target_set_size so we need to call that for this to reliably change
-				vp->occlusion_buffer_dirty = vp->occlusion_buffer_dirty || (vp->size != xr_size);
-				vp->size = xr_size;
-				uint32_t view_count = xr_interface->get_view_count();
-				RSG::texture_storage->render_target_set_size(vp->render_target, vp->size.x, vp->size.y, view_count);
+				_viewport_set_size(vp, xr_size.width, xr_size.height, xr_interface->get_view_count());
 
 				// Inform xr interface we're about to render its viewport, if this returns false we don't render
 				visible = xr_interface->pre_draw_viewport(vp->render_target);
@@ -767,7 +760,13 @@ void RendererViewport::viewport_set_use_xr(RID p_viewport, bool p_use_xr) {
 	}
 
 	viewport->use_xr = p_use_xr;
-	_configure_3d_render_buffers(viewport);
+
+	// Re-configure the 3D render buffers when disabling XR. They'll get
+	// re-configured when enabling XR in draw_viewports().
+	if (!p_use_xr) {
+		viewport->view_count = 1;
+		_configure_3d_render_buffers(viewport);
+	}
 }
 
 void RendererViewport::viewport_set_scaling_3d_mode(RID p_viewport, RS::ViewportScaling3DMode p_mode) {
@@ -813,34 +812,26 @@ void RendererViewport::viewport_set_scaling_3d_scale(RID p_viewport, float p_sca
 	_configure_3d_render_buffers(viewport);
 }
 
-uint32_t RendererViewport::Viewport::get_view_count() {
-	uint32_t view_count = 1;
-
-	if (use_xr && XRServer::get_singleton() != nullptr) {
-		Ref<XRInterface> xr_interface;
-
-		xr_interface = XRServer::get_singleton()->get_primary_interface();
-		if (xr_interface.is_valid()) {
-			view_count = xr_interface->get_view_count();
-		}
-	}
-
-	return view_count;
-}
-
 void RendererViewport::viewport_set_size(RID p_viewport, int p_width, int p_height) {
 	ERR_FAIL_COND(p_width < 0 && p_height < 0);
 
 	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_COND(!viewport);
 
-	viewport->size = Size2(p_width, p_height);
+	_viewport_set_size(viewport, p_width, p_height, viewport->view_count);
+}
 
-	uint32_t view_count = viewport->get_view_count();
-	RSG::texture_storage->render_target_set_size(viewport->render_target, p_width, p_height, view_count);
-	_configure_3d_render_buffers(viewport);
+void RendererViewport::_viewport_set_size(Viewport *p_viewport, int p_width, int p_height, uint32_t p_view_count) {
+	Size2i new_size(p_width, p_height);
+	if (p_viewport->size != new_size || p_viewport->view_count != p_view_count) {
+		p_viewport->size = new_size;
+		p_viewport->view_count = p_view_count;
 
-	viewport->occlusion_buffer_dirty = true;
+		RSG::texture_storage->render_target_set_size(p_viewport->render_target, p_width, p_height, p_view_count);
+		_configure_3d_render_buffers(p_viewport);
+
+		p_viewport->occlusion_buffer_dirty = true;
+	}
 }
 
 void RendererViewport::viewport_set_active(RID p_viewport, bool p_active) {
@@ -880,7 +871,7 @@ void RendererViewport::viewport_attach_to_screen(RID p_viewport, const Rect2 &p_
 		// If using OpenGL we can optimize this operation by rendering directly to system_fbo
 		// instead of rendering to fbo and copying to system_fbo after
 		if (RSG::rasterizer->is_low_end() && viewport->viewport_render_direct_to_screen) {
-			RSG::texture_storage->render_target_set_size(viewport->render_target, p_rect.size.x, p_rect.size.y, viewport->get_view_count());
+			RSG::texture_storage->render_target_set_size(viewport->render_target, p_rect.size.x, p_rect.size.y, viewport->view_count);
 			RSG::texture_storage->render_target_set_position(viewport->render_target, p_rect.position.x, p_rect.position.y);
 		}
 
@@ -890,7 +881,7 @@ void RendererViewport::viewport_attach_to_screen(RID p_viewport, const Rect2 &p_
 		// if render_direct_to_screen was used, reset size and position
 		if (RSG::rasterizer->is_low_end() && viewport->viewport_render_direct_to_screen) {
 			RSG::texture_storage->render_target_set_position(viewport->render_target, 0, 0);
-			RSG::texture_storage->render_target_set_size(viewport->render_target, viewport->size.x, viewport->size.y, viewport->get_view_count());
+			RSG::texture_storage->render_target_set_size(viewport->render_target, viewport->size.x, viewport->size.y, viewport->view_count);
 		}
 
 		viewport->viewport_to_screen_rect = Rect2();
@@ -909,7 +900,7 @@ void RendererViewport::viewport_set_render_direct_to_screen(RID p_viewport, bool
 	// if disabled, reset render_target size and position
 	if (!p_enable) {
 		RSG::texture_storage->render_target_set_position(viewport->render_target, 0, 0);
-		RSG::texture_storage->render_target_set_size(viewport->render_target, viewport->size.x, viewport->size.y, viewport->get_view_count());
+		RSG::texture_storage->render_target_set_size(viewport->render_target, viewport->size.x, viewport->size.y, viewport->view_count);
 	}
 
 	RSG::texture_storage->render_target_set_direct_to_screen(viewport->render_target, p_enable);
@@ -917,7 +908,7 @@ void RendererViewport::viewport_set_render_direct_to_screen(RID p_viewport, bool
 
 	// if attached to screen already, setup screen size and position, this needs to happen after setting flag to avoid an unnecessary buffer allocation
 	if (RSG::rasterizer->is_low_end() && viewport->viewport_to_screen_rect != Rect2() && p_enable) {
-		RSG::texture_storage->render_target_set_size(viewport->render_target, viewport->viewport_to_screen_rect.size.x, viewport->viewport_to_screen_rect.size.y, viewport->get_view_count());
+		RSG::texture_storage->render_target_set_size(viewport->render_target, viewport->viewport_to_screen_rect.size.x, viewport->viewport_to_screen_rect.size.y, viewport->view_count);
 		RSG::texture_storage->render_target_set_position(viewport->render_target, viewport->viewport_to_screen_rect.position.x, viewport->viewport_to_screen_rect.position.y);
 	}
 }

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -54,6 +54,7 @@ public:
 
 		Size2i internal_size;
 		Size2i size;
+		uint32_t view_count;
 		RID camera;
 		RID scenario;
 
@@ -150,6 +151,7 @@ public:
 		RendererScene::RenderInfo render_info;
 
 		Viewport() {
+			view_count = 1;
 			update_mode = RS::VIEWPORT_UPDATE_WHEN_VISIBLE;
 			clear_mode = RS::VIEWPORT_CLEAR_ALWAYS;
 			transparent_bg = false;
@@ -176,8 +178,6 @@ public:
 			time_gpu_begin = 0;
 			time_gpu_end = 0;
 		}
-
-		uint32_t get_view_count();
 	};
 
 	HashMap<String, RID> timestamp_vp_map;
@@ -196,6 +196,7 @@ public:
 
 private:
 	Vector<Viewport *> _sort_active_viewports();
+	void _viewport_set_size(Viewport *p_viewport, int p_width, int p_height, uint32_t p_view_count);
 	void _configure_3d_render_buffers(Viewport *p_viewport);
 	void _draw_3d(Viewport *p_viewport);
 	void _draw_viewport(Viewport *p_viewport);


### PR DESCRIPTION
I've been working on getting WebXR working with Godot 4 (see draft PR #64514), and I've encountered an issue where switching to XR leads to the viewport's render buffers getting out of sync with the render target in GLES3. This is because we need to run `_configure_3d_render_buffers()` after the render target has been resized, so that it uses the new texture from the render target - otherwise the render buffers still have the old texture attached.

There was this comment:

```
				// Would have been nice if we could call viewport_set_size here,
				// but alas that takes our RID and we now have our pointer,
				// also we only check if view_count changes in render_target_set_size so we need to call that for this to reliably change
```

`viewport_set_size()` calls to `_configure_3d_render_buffers()`, so if this code _did_ use `viewport_set_size()`, this problem wouldn't have existed! So, I made an private `_viewport_set_size()` that takes the `Viewport` pointer, which can be used here and by the public `viewport_set_size()`, reducing code duplication.

However, just this on its own would have led to `_configure_3d_render_buffers()` getting called every frame when using XR (which means destroying and re-creating the render buffers every frame) so I refactored a bunch of code to make it only resize the render target and call  `_configure_3d_render_buffers()` if the size or view count has actually changed. This is why the `RendererViewport::Viewport::get_view_count()` function has turned into the `RendererViewport::Viewport::view_count` variable.

Hopefully, that all makes sense! But I'd be happy to discuss further :-)