### PR TITLE
Fix file URI format for language server

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -183,7 +183,7 @@ Dictionary GDScriptLanguageProtocol::initialize(const Dictionary &p_params) {
 	if (root_uri.length() && is_same_workspace) {
 		workspace->root_uri = root_uri;
 	} else {
-		workspace->root_uri = "file://" + workspace->root;
+		workspace->root_uri = "file:///" + workspace->root;
 
 		Dictionary params;
 		params["path"] = workspace->root;


### PR DESCRIPTION
This change allows internal document links in the `godot-tools` VSCode extension to function correctly in Godot 3.x.

It appears that this same change has already been done to `master`.

The problem here is that a file URI of the form `file://path` is never valid. It must be `file:/path` or `file:///path`. VSCode does not gracefully handle the incorrect URI, instead throwing a very unhelpful "Unable to open <file>" error.

<details>
<summary>The Unhelpful Error</summary>

![image](https://user-images.githubusercontent.com/18042232/185063033-a5459da6-672c-4507-ae51-a8fae86a302f.png)

</details>
