### PR TITLE
Hide prefix/suffix on SpinBox focus

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -41,12 +41,16 @@ Size2 SpinBox::get_minimum_size() const {
 
 void SpinBox::_value_changed(double p_value) {
 	String value = TS->format_number(String::num(get_value(), Math::range_step_decimals(get_step())));
-	if (!prefix.is_empty()) {
-		value = prefix + " " + value;
+
+	if (!line_edit->has_focus()) {
+		if (!prefix.is_empty()) {
+			value = prefix + " " + value;
+		}
+		if (!suffix.is_empty()) {
+			value += " " + suffix;
+		}
 	}
-	if (!suffix.is_empty()) {
-		value += " " + suffix;
-	}
+
 	line_edit->set_text(value);
 	Range::_value_changed(p_value);
 }
@@ -181,8 +185,14 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void SpinBox::_line_edit_focus_enter() {
+	int col = line_edit->get_caret_column();
+	_value_changed(0); // Update the LineEdit's text.
+	line_edit->set_caret_column(col);
+}
+
 void SpinBox::_line_edit_focus_exit() {
-	// discontinue because the focus_exit was caused by right-click context menu
+	// Discontinue because the focus_exit was caused by right-click context menu.
 	if (line_edit->is_menu_visible()) {
 		return;
 	}
@@ -338,6 +348,7 @@ SpinBox::SpinBox() {
 	line_edit->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 
 	line_edit->connect("text_submitted", callable_mp(this, &SpinBox::_text_submitted), CONNECT_DEFERRED);
+	line_edit->connect("focus_entered", callable_mp(this, &SpinBox::_line_edit_focus_enter), CONNECT_DEFERRED);
 	line_edit->connect("focus_exited", callable_mp(this, &SpinBox::_line_edit_focus_exit), CONNECT_DEFERRED);
 	line_edit->connect("gui_input", callable_mp(this, &SpinBox::_line_edit_input));
 

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -64,6 +64,7 @@ class SpinBox : public Range {
 		double diff_y = 0.0;
 	} drag;
 
+	void _line_edit_focus_enter();
 	void _line_edit_focus_exit();
 
 	inline void _adjust_width_for_icon(const Ref<Texture2D> &icon);


### PR DESCRIPTION
Simple change that makes editing the value easier:
![godot windows tools 64_2rERJjBTUI](https://user-images.githubusercontent.com/2223172/185107372-481f7756-7b60-4305-9284-428b74446b78.gif)

Minor caveats:
- seems like releasing focus is not possible if you don't have another Control that you can click; it just means that restoring prefix display might be somewhat difficult in some cases
- it is no longer possible to select text in unfocused SpinBox, because clicking it updates the text immediately. Double-click edit is still possible though