### PR TITLE
[3.x] Fix axis mapped to DPad buttons not releasing opposite button

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -847,11 +847,9 @@ void InputDefault::joy_axis(int p_device, int p_axis, float p_value) {
 		}
 
 		bool pressed = map.value > 0.5;
-		if (pressed == joy_buttons_pressed.has(_combine_device(map.index, p_device))) {
-			// Button already pressed or released; so ignore.
-			return;
+		if (pressed != joy_buttons_pressed.has(_combine_device(map.index, p_device))) {
+			_button_event(p_device, map.index, pressed);
 		}
-		_button_event(p_device, map.index, pressed);
 
 		// Ensure opposite D-Pad button is also released.
 		switch (map.index) {
@@ -998,7 +996,7 @@ InputDefault::JoyEvent InputDefault::_get_mapped_axis_event(const JoyDeviceMappi
 				value = -value;
 			}
 			if (binding.input.axis.range == FULL_AXIS ||
-					(binding.input.axis.range == POSITIVE_HALF_AXIS && value > 0) ||
+					(binding.input.axis.range == POSITIVE_HALF_AXIS && value >= 0) ||
 					(binding.input.axis.range == NEGATIVE_HALF_AXIS && value < 0)) {
 				event.type = binding.outputType;
 				float shifted_positive_value = 0;


### PR DESCRIPTION
3.x version of #64531.
