### PR TITLE
Account for TreeItem's Cell icon and center the text Popup vertically

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3591,12 +3591,17 @@ bool Tree::edit_selected() {
 	} else if (c.mode == TreeItem::CELL_MODE_STRING || c.mode == TreeItem::CELL_MODE_RANGE) {
 		Rect2 popup_rect;
 
-		Vector2 ofs(0, (text_editor->get_size().height - rect.size.height) / 2);
+		Vector2 ofs(0, Math::floor((text_editor->get_size().height - rect.size.height) / 2)); // "floor()" centers vertically.
 
 		Point2i textedpos = get_screen_position() + rect.position - ofs;
 		cache.text_editor_position = textedpos;
 		popup_rect.position = textedpos;
 		popup_rect.size = rect.size;
+
+		// Account for icon.
+		popup_rect.position.x += c.get_icon_size().x;
+		popup_rect.size.x -= c.get_icon_size().x;
+
 		text_editor->clear();
 		text_editor->set_text(c.mode == TreeItem::CELL_MODE_STRING ? c.text : String::num(c.val, Math::range_step_decimals(c.step)));
 		text_editor->select_all();


### PR DESCRIPTION
This PR... does this:

![Showcase](https://i.gyazo.com/4e5eca8262e85d1750931c3296354039.gif)

Accounts for the icon to the side. _(I don't know if this should be optional or not)_.

Also centers the Tree's popup vertically, in such a way that it doesn't look like the text jumps one pixel up when inputting.

| Before | After |
| -- | -- |
| ![Before](https://user-images.githubusercontent.com/66727710/185154472-8f77dd64-7bdc-4382-87ce-c4e958cee74d.png) | ![After](https://user-images.githubusercontent.com/66727710/185173699-f4f9119f-e1d5-4542-b5e2-16ae94bd61e9.png)

