### PR TITLE
Add `minimum_character_count` to SpinBox

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -59,6 +59,9 @@
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true" keywords="readonly, disabled, enabled">
 			If [code]true[/code], the [SpinBox] will be editable. Otherwise, it will be read only.
 		</member>
+		<member name="minimum_character_count" type="int" setter="set_minimum_character_count" getter="get_minimum_character_count" default="-1">
+			Determines the minimum width of the [SpinBox] by overriding the [theme_item LineEdit.minimum_character_width] property of the internal [LineEdit]. If [code]-1[/code], the size will be adjusted automatically to match the longest possible text length from the range of available values.
+		</member>
 		<member name="prefix" type="String" setter="set_prefix" getter="get_prefix" default="&quot;&quot;">
 			Adds the specified prefix string before the numerical value of the [SpinBox].
 		</member>

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -78,6 +78,7 @@ class SpinBox : public Range {
 	String last_text_value;
 	double custom_arrow_step = 0.0;
 	bool custom_arrow_round = false;
+	int minimum_character_count = -1;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
@@ -102,6 +103,7 @@ class SpinBox : public Range {
 
 	inline void _compute_sizes();
 	inline int _get_widest_button_icon_width();
+	void _adjust_character_count();
 
 	struct ThemeCache {
 		Ref<Texture2D> up_icon;
@@ -171,6 +173,9 @@ public:
 
 	void set_prefix(const String &p_prefix);
 	String get_prefix() const;
+
+	void set_minimum_character_count(int p_count);
+	int get_minimum_character_count() const;
 
 	void set_update_on_text_changed(bool p_enabled);
 	bool get_update_on_text_changed() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4138

Defaults to auto-adjust, but it doesn't seem to work well. I'm using the `minimum_character_width` theme property of LineEdit and it tends to make the SpinBox wider than necessary. Also determining the longest possible string is a bit tricky. But other than that, the feature is functional.