### PR TITLE
Add and expose a method for getting a list of script documentation in the Script class

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -127,6 +127,116 @@ PropertyInfo Script::get_class_category() const {
 
 #endif // TOOLS_ENABLED
 
+TypedArray<Dictionary> Script::_get_script_documentation_list() {
+#ifdef TOOLS_ENABLED
+	Vector<DocData::ClassDoc> classes = get_documentation();
+	TypedArray<Dictionary> doc_dicts;
+	for (int idx = 0; idx < classes.size(); idx++) {
+		DocData::ClassDoc p_class = classes[idx];
+		Dictionary dict;
+		dict["name"] = p_class.name;
+		dict["inherits"] = p_class.inherits;
+		dict["brief_description"] = p_class.brief_description.strip_edges();
+		dict["description"] = p_class.description.strip_edges();
+
+		TypedArray<Dictionary> tutorials;
+		for (int i = 0; i < p_class.tutorials.size(); i++) {
+			Dictionary tutorial;
+			tutorial["title"] = p_class.tutorials[i].title;
+			tutorial["link"] = p_class.tutorials[i].link;
+			tutorials.append(tutorial);
+		}
+		dict["tutorials"] = tutorials;
+
+		TypedArray<Dictionary> enums;
+		for (const KeyValue<String, String> &E : p_class.enums) {
+			Dictionary _enum;
+			_enum["name"] = E.key;
+			_enum["description"] = E.value;
+			enums.append(_enum);
+		}
+		dict["enums"] = enums;
+
+		TypedArray<Dictionary> constants;
+		for (int i = 0; i < p_class.constants.size(); i++) {
+			Dictionary constant;
+			constant["name"] = p_class.constants[i].name;
+			constant["value"] = p_class.constants[i].value;
+			constant["enumeration"] = p_class.constants[i].enumeration;
+			constant["description"] = p_class.constants[i].description.strip_edges();
+			constants.append(constant);
+		}
+		dict["constants"] = constants;
+
+		TypedArray<Dictionary> signals;
+		for (int i = 0; i < p_class.signals.size(); i++) {
+			Dictionary signal;
+			signal["name"] = p_class.signals[i].name;
+			signal["return_type"] = p_class.signals[i].return_type;
+			signal["qualifiers"] = p_class.signals[i].qualifiers;
+			signal["description"] = p_class.signals[i].description.strip_edges();
+
+			TypedArray<Dictionary> arguments;
+			for (int j = 0; j < p_class.signals[i].arguments.size(); j++) {
+				Dictionary argument;
+				argument["name"] = p_class.signals[i].arguments[j].name;
+				if (p_class.signals[i].arguments[j].type != "") {
+					argument["type"] = p_class.signals[i].arguments[j].type;
+				} else {
+					argument["type"] = "Variant";
+				}
+				argument["default_value"] = p_class.signals[i].arguments[j].default_value;
+				arguments.push_back(argument);
+			}
+			signal["arguments"] = arguments;
+			signals.append(signal);
+		}
+		dict["signals"] = signals;
+
+		TypedArray<Dictionary> variables;
+		for (int i = 0; i < p_class.properties.size(); i++) {
+			Dictionary var;
+			var["name"] = p_class.properties[i].name;
+			var["type"] = p_class.properties[i].type;
+			var["enumeration"] = p_class.properties[i].enumeration;
+			var["description"] = p_class.properties[i].description.strip_edges();
+			var["default_value"] = p_class.properties[i].default_value;
+			var["setter"] = p_class.properties[i].setter;
+			var["getter"] = p_class.properties[i].getter;
+			variables.append(var);
+		}
+		dict["variables"] = variables;
+
+		TypedArray<Dictionary> methods;
+		for (int i = 0; i < p_class.methods.size(); i++) {
+			Dictionary method;
+			method["name"] = p_class.methods[i].name;
+			method["return_type"] = p_class.methods[i].return_type;
+			method["qualifiers"] = p_class.methods[i].qualifiers;
+			method["description"] = p_class.methods[i].description.strip_edges();
+
+			TypedArray<Dictionary> arguments;
+			for (int j = 0; j < p_class.methods[i].arguments.size(); j++) {
+				Dictionary argument;
+				argument["name"] = p_class.methods[i].arguments[j].name;
+				argument["type"] = p_class.methods[i].arguments[j].type;
+				argument["default_value"] = p_class.methods[i].arguments[j].default_value;
+				arguments.push_back(argument);
+			}
+			method["arguments"] = arguments;
+			methods.append(method);
+		}
+		dict["methods"] = methods;
+
+		doc_dicts.append(dict);
+	}
+
+	return doc_dicts;
+#endif // TOOLS_ENABLED
+
+	return TypedArray<Dictionary>();
+}
+
 void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &Script::can_instantiate);
 	//ClassDB::bind_method(D_METHOD("instance_create","base_object"),&Script::instance_create);
@@ -144,6 +254,7 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_script_method_list"), &Script::_get_script_method_list);
 	ClassDB::bind_method(D_METHOD("get_script_signal_list"), &Script::_get_script_signal_list);
 	ClassDB::bind_method(D_METHOD("get_script_constant_map"), &Script::_get_script_constant_map);
+	ClassDB::bind_method(D_METHOD("get_script_documentation_list"), &Script::_get_script_documentation_list);
 	ClassDB::bind_method(D_METHOD("get_property_default_value", "property"), &Script::_get_property_default_value);
 
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -113,6 +113,7 @@ protected:
 	TypedArray<Dictionary> _get_script_property_list();
 	TypedArray<Dictionary> _get_script_method_list();
 	TypedArray<Dictionary> _get_script_signal_list();
+	TypedArray<Dictionary> _get_script_documentation_list();
 	Dictionary _get_script_constant_map();
 
 public:

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -43,6 +43,82 @@
 				Returns a dictionary containing constant names and their values.
 			</description>
 		</method>
+		<method name="get_script_documentation_list">
+			<return type="Dictionary[]" />
+			<description>
+				Returns an array of dictionary containing the documentation of this script and its subclasses.
+				Each dictionary contains the following structure:
+				[codeblock]
+				{
+				    "name": "",
+				    "inherits": "",
+				    "brief_description": "",
+				    "description": "",
+				    "tutorials": [
+				        {
+				            "title": "",
+				            "link": ""
+				        }
+				    ],
+				    "enums": [
+				        {
+				            "name": "",
+				            "description": ""
+				        }
+				    ],
+				    "constants": [
+				        {
+				            "name": "",
+				            "value": "",
+				            "enumeration": "",
+				            "description": ""
+				        }
+				    ],
+				    "signals": [
+				        {
+				            "name": "",
+				            "return_type": "",
+				            "qualifiers": "",
+				            "description": "",
+				            "arguments": [
+				                {
+				                    "name": "",
+				                    "type": "",
+				                    "default_value": ""
+				                }
+				            ]
+				        }
+				    ],
+				    "variables": [
+				        {
+				            "name": "",
+				            "type": "",
+				            "enumeration": "",
+				            "description": "",
+				            "default_value": "",
+				            "setter": "",
+				            "getter": ""
+				        }
+				    ],
+				    "methods": [
+				        {
+				            "name": "",
+				            "return_type": "",
+				            "qualifiers": "",
+				            "description": "",
+				            "arguments": [
+				                {
+				                    "name": "",
+				                    "type": "",
+				                    "default_value": ""
+				                }
+				            ]
+				        }
+				    ]
+				}
+				[/codeblock]
+			</description>
+		</method>
 		<method name="get_script_method_list">
 			<return type="Dictionary[]" />
 			<description>


### PR DESCRIPTION
Replace #62928 since I messed something up in the original PR.

Part modified from https://github.com/godotengine/godot/pull/39849 by @ThakeeNathees  
  
This allows users to access script documentation through scripts when `tools=yes`, making it easy to export script documentation to xml/json/bbcode/markdown etc, or create any tool based on it.  

Partial implementation https://github.com/godotengine/godot-proposals/issues/177

This should allow more freedom than exporting several preset document formats through the editor UI, allowing community to easily create various addons to export documents in different formats.

For example, here is a Json/Markdown documentation generator based on this PR: [Script Documentation Generator.zip](https://github.com/godotengine/godot/files/9364814/Script.Documentation.Generator.zip)

@akien-mga @YuriSizov 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
