### PR TITLE
Fix ReflectionProbe ambient color properties appearing when they shouldn't

### DIFF
--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -179,11 +179,12 @@ AABB ReflectionProbe::get_aabb() const {
 }
 
 void ReflectionProbe::_validate_property(PropertyInfo &property) const {
-	if (property.name == "interior/ambient_color" || property.name == "interior/ambient_color_energy") {
+	if (property.name == "ambient_color" || property.name == "ambient_color_energy") {
 		if (ambient_mode != AMBIENT_COLOR) {
 			property.usage = PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL;
 		}
 	}
+
 	VisualInstance3D::_validate_property(property);
 }
 


### PR DESCRIPTION
`_validate_property()` didn't have properties renamed when they were changed not to include slashes.