### PR TITLE
Fix has_filter of AnimationNode not being called in scripts

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -107,7 +107,7 @@
 			</description>
 		</method>
 		<method name="has_filter" qualifiers="virtual">
-			<return type="String" />
+			<return type="bool" />
 			<description>
 				When inheriting from [AnimationRootNode], implement this virtual method to return whether the blend tree editor should display filter editing on this node.
 			</description>

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -357,6 +357,9 @@ bool AnimationNode::is_path_filtered(const NodePath &p_path) const {
 }
 
 bool AnimationNode::has_filter() const {
+	if (get_script_instance()) {
+		return get_script_instance()->call("has_filter");
+	}
 	return false;
 }
 
@@ -427,7 +430,7 @@ void AnimationNode::_bind_methods() {
 	}
 	BIND_VMETHOD(MethodInfo("process", PropertyInfo(Variant::REAL, "time"), PropertyInfo(Variant::BOOL, "seek")));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "get_caption"));
-	BIND_VMETHOD(MethodInfo(Variant::STRING, "has_filter"));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "has_filter"));
 
 	ADD_SIGNAL(MethodInfo("removed_from_graph"));
 


### PR DESCRIPTION
In godot 3.5, The `has_filter()` method was not called when implemented in a custom AnimationNode, making it impossible to have the "Edit Filter" button show up in the editor.