### PR TITLE
Unify node casing adjustment

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5555,19 +5555,7 @@ bool CanvasItemEditorViewport::_cyclical_dependency_exists(const String &p_targe
 void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &path, const Point2 &p_point) {
 	// Adjust casing according to project setting. The file name is expected to be in snake_case, but will work for others.
 	String name = path.get_file().get_basename();
-	switch (ProjectSettings::get_singleton()->get("editor/node_naming/name_casing").operator int()) {
-		case NAME_CASING_PASCAL_CASE:
-			name = name.capitalize().replace(" ", "");
-			break;
-		case NAME_CASING_CAMEL_CASE:
-			name = name.capitalize().replace(" ", "");
-			name[0] = name.to_lower()[0];
-			break;
-		case NAME_CASING_SNAKE_CASE:
-			name = name.capitalize().replace(" ", "_").to_lower();
-			break;
-	}
-	child->set_name(name);
+	child->set_name(Node::adjust_name_casing(name));
 
 	Ref<Texture2D> texture = ResourceCache::get_ref(path);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3964,19 +3964,7 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 
 			// Adjust casing according to project setting. The file name is expected to be in snake_case, but will work for others.
 			String name = path.get_file().get_basename();
-			switch (ProjectSettings::get_singleton()->get("editor/node_naming/name_casing").operator int()) {
-				case NAME_CASING_PASCAL_CASE:
-					name = name.capitalize().replace(" ", "");
-					break;
-				case NAME_CASING_CAMEL_CASE:
-					name = name.capitalize().replace(" ", "");
-					name[0] = name.to_lower()[0];
-					break;
-				case NAME_CASING_SNAKE_CASE:
-					name = name.capitalize().replace(" ", "_").to_lower();
-					break;
-			}
-			mesh_instance->set_name(name);
+			mesh_instance->set_name(Node::adjust_name_casing(name));
 
 			instantiated_scene = mesh_instance;
 		} else {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -948,6 +948,21 @@ String Node::validate_child_name(Node *p_child) {
 }
 #endif
 
+String Node::adjust_name_casing(const String &p_name) {
+	switch (GLOBAL_GET("editor/node_naming/name_casing").operator int()) {
+		case NAME_CASING_PASCAL_CASE:
+			return p_name.capitalize().replace(" ", "");
+		case NAME_CASING_CAMEL_CASE: {
+			String name = p_name.capitalize().replace(" ", "");
+			name[0] = name.to_lower()[0];
+			return name;
+		}
+		case NAME_CASING_SNAKE_CASE:
+			return p_name.capitalize().replace(" ", "_").to_lower();
+	}
+	return p_name;
+}
+
 void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 	/* Make sure the name is unique */
 
@@ -1021,19 +1036,8 @@ void Node::_generate_serial_child_name(const Node *p_child, StringName &name) co
 		//no name and a new name is needed, create one.
 
 		name = p_child->get_class();
-		// Adjust casing according to project setting. The current type name is expected to be in PascalCase.
-		switch (ProjectSettings::get_singleton()->get("editor/node_naming/name_casing").operator int()) {
-			case NAME_CASING_PASCAL_CASE:
-				break;
-			case NAME_CASING_CAMEL_CASE: {
-				String n = name;
-				n[0] = n.to_lower()[0];
-				name = n;
-			} break;
-			case NAME_CASING_SNAKE_CASE:
-				name = String(name).camelcase_to_underscore(true);
-				break;
-		}
+		// Adjust casing according to project setting.
+		name = adjust_name_casing(name);
 	}
 
 	//quickly test if proposed name exists

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -459,6 +459,7 @@ public:
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);
 #endif
+	static String adjust_name_casing(const String &p_name);
 
 	void queue_delete();
 


### PR DESCRIPTION
I noticed that `"editor/node_naming/name_casing"` is accessed in 3 different places, so I moved it to a single method.