### PR TITLE
Fix undefined behavior in `String::operator+=(const String &)`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -531,10 +531,12 @@ String &String::operator+=(const String &p_str) {
 
 	resize(lhs_len + rhs_len + 1);
 
-	const char32_t *src = p_str.get_data();
+	const char32_t *src = p_str.ptr();
 	char32_t *dst = ptrw() + lhs_len;
 
-	memcpy(dst, src, (rhs_len + 1) * sizeof(char32_t));
+	// Don't copy the terminating null with `memcpy` to avoid undefined behavior when string is being added to itself (it would overlap the destination).
+	memcpy(dst, src, rhs_len * sizeof(char32_t));
+	*(dst + rhs_len) = _null;
 
 	return *this;
 }


### PR DESCRIPTION
`str += str` for non-empty `str` was resulting in undefined behavior as `memcpy` was used for overlapping memory blocks (original terminating null is at the copy destination).

Noticed because of [a failing check](https://github.com/godotengine/godot/runs/7863982789?check_suite_focus=true) in #64489 (see https://github.com/godotengine/godot/pull/64489#issuecomment-1218050500).