### PR TITLE
Add "Copy Name" option to signal menu

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -839,6 +839,9 @@ void ConnectionsDock::_handle_signal_menu_option(int p_option) {
 			disconnect_all_dialog->set_text(vformat(TTR("Are you sure you want to remove all connections from the \"%s\" signal?"), signal_name));
 			disconnect_all_dialog->popup_centered();
 		} break;
+		case COPY_NAME: {
+			DisplayServer::get_singleton()->clipboard_set(item->get_metadata(0).operator Dictionary()["name"]);
+		} break;
 	}
 }
 
@@ -1159,6 +1162,7 @@ ConnectionsDock::ConnectionsDock() {
 	signal_menu->connect("id_pressed", callable_mp(this, &ConnectionsDock::_handle_signal_menu_option));
 	signal_menu->add_item(TTR("Connect..."), CONNECT);
 	signal_menu->add_item(TTR("Disconnect All"), DISCONNECT_ALL);
+	signal_menu->add_item(TTR("Copy Name"), COPY_NAME);
 
 	slot_menu = memnew(PopupMenu);
 	add_child(slot_menu);

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -177,13 +177,14 @@ class ConnectionsDock : public VBoxContainer {
 	//Right-click Pop-up Menu Options.
 	enum SignalMenuOption {
 		CONNECT,
-		DISCONNECT_ALL
+		DISCONNECT_ALL,
+		COPY_NAME,
 	};
 
 	enum SlotMenuOption {
 		EDIT,
 		GO_TO_SCRIPT,
-		DISCONNECT
+		DISCONNECT,
 	};
 
 	Node *selected_node = nullptr;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2223172/185415761-0eae9add-c4a8-4307-866e-cc001ba8dea3.png)
It's sometimes useful when autocompletion fails you.