### PR TITLE
Fix warp_mouse for transient windows, fix mouse jumping around when spinbox released

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -105,8 +105,9 @@ void SpinBox::_range_click_timeout() {
 void SpinBox::_release_mouse() {
 	if (drag.enabled) {
 		drag.enabled = false;
-		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_HIDDEN);
 		warp_mouse(drag.capture_pos);
+		Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1103,7 +1103,7 @@ Vector2 Viewport::get_mouse_position() const {
 
 void Viewport::warp_mouse(const Vector2 &p_position) {
 	Transform2D xform = get_screen_transform();
-	Vector2 gpos = xform.xform(p_position).round();
+	Vector2 gpos = xform.xform(p_position);
 	Input::get_singleton()->warp_mouse(gpos);
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -563,7 +563,7 @@ public:
 	bool is_input_disabled() const;
 
 	Vector2 get_mouse_position() const;
-	void warp_mouse(const Vector2 &p_position);
+	virtual void warp_mouse(const Vector2 &p_position);
 
 	void set_physics_object_picking(bool p_enable);
 	bool get_physics_object_picking();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -974,6 +974,18 @@ DisplayServer::WindowID Window::get_window_id() const {
 	return window_id;
 }
 
+void Window::warp_mouse(const Vector2 &p_position) {
+	Transform2D xform = get_screen_transform();
+	Vector2 gpos = xform.xform(p_position);
+
+	if (transient_parent && !transient_parent->is_embedding_subwindows()) {
+		Transform2D window_trans = Transform2D().translated(get_position() + (transient_parent->get_visible_rect().size - transient_parent->get_real_size()));
+		gpos = window_trans.xform(gpos);
+	}
+
+	Input::get_singleton()->warp_mouse(gpos);
+}
+
 void Window::set_wrap_controls(bool p_enable) {
 	wrap_controls = p_enable;
 	if (wrap_controls) {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -239,6 +239,8 @@ public:
 	void set_use_font_oversampling(bool p_oversampling);
 	bool is_using_font_oversampling() const;
 
+	void warp_mouse(const Vector2 &p_position) override;
+
 	void set_wrap_controls(bool p_enable);
 	bool is_wrapping_controls() const;
 	void child_controls_changed();


### PR DESCRIPTION
### Problem

When using the spinbox on a transient window, releasing the mouse after a drag (to increase/decrease value) put the cursor in the wrong place.

https://user-images.githubusercontent.com/11915892/185417242-548f91ca-99eb-402c-8c4e-5b5f616dbaa9.mp4

At the same time, i also fixed a small annoyance: when releasing after drag, the cursor jumped around instead of appearing directly at the correct position

https://user-images.githubusercontent.com/11915892/185417021-ac2f2326-4621-4830-ac3e-62d53c7e0838.mp4

(Those 2 problems where notices on Linux(Ubuntu) + X11, i don't know about the other os)

### Reproduce the problems

To reproduce the problems, you need to create a simple editor plugin : 
```gdscript
@tool
extends EditorPlugin

func _enter_tree():
	add_tool_menu_item("Test", test_panel.bind())
	
func _exit_tree():
	remove_tool_menu_item("Test")

func test_panel() -> void:
	var res_test = load("res://test.tscn")
	
	var window := Window.new()
	window.title = "Testing"
	window.wrap_controls = true
	window.transient = true
	window.always_on_top = false
	window.exclusive = true
	window.popup_window = true
	
	window.disable_3d = true
	
	var instance = res_test.instantiate()
	
	window.add_child(instance)
	window.min_size = instance.custom_minimum_size

	var base_control := get_editor_interface().get_base_control()
	base_control.add_child(window)
	window.popup_centered(window.min_size)
```
Then just create a simple test scene with a spinbox inside it, then try to drag to change the spinbox's value

### Fix

The proposed fix in this commit fixes both of those problems, but changing warp_mouse to a virtual function will decrease performance a bit, but i seemed like the cleanest approach.
