### PR TITLE
Fix: Disabling warnings for GDScript does not work

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -471,7 +471,9 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 	} else if (p_msg == "error") {
 		DebuggerMarshalls::OutputError oe;
 		ERR_FAIL_COND_MSG(oe.deserialize(p_data) == false, "Failed to deserialize error message");
-
+		if (oe.warning && !ProjectSettings::get_singleton()->get_setting("debug/gdscript/warnings/enable")) {
+			return;
+		}
 		// Format time.
 		Array time_vals;
 		time_vals.push_back(oe.hr);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Closes: #64559