### PR TITLE
Make Debugger/Misc LineEdits uneditable

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1959,15 +1959,18 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		info_left->set_columns(2);
 		misc->add_child(info_left);
 		clicked_ctrl = memnew(LineEdit);
+		clicked_ctrl->set_editable(false);
 		clicked_ctrl->set_h_size_flags(SIZE_EXPAND_FILL);
 		info_left->add_child(memnew(Label(TTR("Clicked Control:"))));
 		info_left->add_child(clicked_ctrl);
 		clicked_ctrl_type = memnew(LineEdit);
+		clicked_ctrl_type->set_editable(false);
 		info_left->add_child(memnew(Label(TTR("Clicked Control Type:"))));
 		info_left->add_child(clicked_ctrl_type);
 
 		scene_tree = memnew(SceneDebuggerTree);
 		live_edit_root = memnew(LineEdit);
+		live_edit_root->set_editable(false);
 		live_edit_root->set_h_size_flags(SIZE_EXPAND_FILL);
 
 		{


### PR DESCRIPTION
Makes these uneditable
![](https://chat.godotengine.org/file-upload/xSWuFafeaFcLnfynT/Clipboard%20-%2018%20sierpnia%202022%2016:13)
They are likely LineEdits to allow copying text, but there's no reason to edit them.