### PR TITLE
Decrease editor shadow maximum distance to match DirectionalLight3D default

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7607,7 +7607,7 @@ void Node3DEditor::_load_default_preview_settings() {
 	environ_tonemap_button->set_pressed(true);
 	environ_ao_button->set_pressed(false);
 	environ_gi_button->set_pressed(false);
-	sun_max_distance->set_value(250);
+	sun_max_distance->set_value(100);
 
 	sun_color->set_pick_color(Color(1, 1, 1));
 	sun_energy->set_value(1.0);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/49736 (can be merged independently).

This improves shadow texel density, leading to improved visual quality (and higher performance in large scenes, as fewer objects will be included in the shadow map).