### PR TITLE
Add a method for restarting the editor to `EditorInterface`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -206,6 +206,13 @@
 				Reloads the scene at the given path.
 			</description>
 		</method>
+		<method name="restart_editor">
+			<return type="void" />
+			<param index="0" name="save" type="bool" default="true" />
+			<description>
+				Restarts the editor. This closes the editor and then opens the same project. If [param save] is [code]true[/code], the project will be saved before restarting.
+			</description>
+		</method>
 		<method name="save_scene">
 			<return type="int" enum="Error" />
 			<description>

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -312,6 +312,13 @@ void EditorInterface::set_distraction_free_mode(bool p_enter) {
 	EditorNode::get_singleton()->set_distraction_free_mode(p_enter);
 }
 
+void EditorInterface::restart_editor(bool p_save) {
+	if (p_save) {
+		EditorNode::get_singleton()->save_all_scenes();
+	}
+	EditorNode::get_singleton()->restart_editor();
+}
+
 bool EditorInterface::is_distraction_free_mode_enabled() const {
 	return EditorNode::get_singleton()->is_distraction_free_mode_enabled();
 }
@@ -360,6 +367,7 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
 	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("restart_editor", "save"), &EditorInterface::restart_editor, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -116,6 +116,7 @@ public:
 
 	Error save_scene();
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);
+	void restart_editor(bool p_save = true);
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
 


### PR DESCRIPTION
I ran into a situation when I wanted to have an editor plugin restart the editor, but it seems there is currently no way to do this. The editor restarting functionality already exists in Godot, it's used for the "Save & Restart" buttons on Project Settings and Editor Settings menus, this PR just exposes this to editor plugins via `EditorInterface`.

This work was sponsored by The Mirror.