### PR TITLE
Fix tileset image and background sometimes disappearing

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -127,8 +127,8 @@ void TileAtlasView::_update_zoom_and_panning(bool p_zoom_on_mouse_pos) {
 	}
 
 	// Update the backgrounds.
-	background_left->update();
-	background_right->update();
+	background_left->set_size(base_tiles_root_control->get_custom_minimum_size());
+	background_right->set_size(alternative_tiles_root_control->get_custom_minimum_size());
 
 	// Zoom on the position.
 	if (p_zoom_on_mouse_pos) {
@@ -374,13 +374,11 @@ void TileAtlasView::_draw_alternatives() {
 
 void TileAtlasView::_draw_background_left() {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
-	background_left->set_size(base_tiles_root_control->get_custom_minimum_size());
 	background_left->draw_texture_rect(texture, Rect2(Vector2(), background_left->get_size()), true);
 }
 
 void TileAtlasView::_draw_background_right() {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
-	background_right->set_size(alternative_tiles_root_control->get_custom_minimum_size());
 	background_right->draw_texture_rect(texture, Rect2(Vector2(), background_right->get_size()), true);
 }
 
@@ -404,23 +402,6 @@ void TileAtlasView::set_atlas_source(TileSet *p_tile_set, TileSetAtlasSource *p_
 
 	// Update everything.
 	_update_zoom_and_panning();
-
-	// Change children control size.
-	Size2i base_tiles_control_size = _compute_base_tiles_control_size();
-	for (int i = 0; i < base_tiles_drawing_root->get_child_count(); i++) {
-		Control *control = Object::cast_to<Control>(base_tiles_drawing_root->get_child(i));
-		if (control) {
-			control->set_size(base_tiles_control_size);
-		}
-	}
-
-	Size2i alternative_control_size = _compute_alternative_tiles_control_size();
-	for (int i = 0; i < alternative_tiles_drawing_root->get_child_count(); i++) {
-		Control *control = Object::cast_to<Control>(alternative_tiles_drawing_root->get_child(i));
-		if (control) {
-			control->set_size(alternative_control_size);
-		}
-	}
 
 	// Update.
 	base_tiles_draw->update();
@@ -613,7 +594,7 @@ TileAtlasView::TileAtlasView() {
 
 	background_left = memnew(Control);
 	background_left->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-	background_left->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	background_left->set_anchors_and_offsets_preset(Control::PRESET_TOP_LEFT);
 	background_left->set_texture_repeat(TextureRepeat::TEXTURE_REPEAT_ENABLED);
 	background_left->connect("draw", callable_mp(this, &TileAtlasView::_draw_background_left));
 	base_tiles_root_control->add_child(background_left);
@@ -651,23 +632,26 @@ TileAtlasView::TileAtlasView() {
 
 	alternative_tiles_root_control = memnew(Control);
 	alternative_tiles_root_control->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+	alternative_tiles_root_control->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	alternative_tiles_root_control->connect("gui_input", callable_mp(this, &TileAtlasView::_alternative_tiles_root_control_gui_input));
 	right_vbox->add_child(alternative_tiles_root_control);
 
 	background_right = memnew(Control);
 	background_right->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
+	background_right->set_anchors_and_offsets_preset(Control::PRESET_TOP_LEFT);
 	background_right->set_texture_repeat(TextureRepeat::TEXTURE_REPEAT_ENABLED);
 	background_right->connect("draw", callable_mp(this, &TileAtlasView::_draw_background_right));
-
 	alternative_tiles_root_control->add_child(background_right);
 
 	alternative_tiles_drawing_root = memnew(Control);
 	alternative_tiles_drawing_root->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
+	alternative_tiles_drawing_root->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	alternative_tiles_drawing_root->set_texture_filter(TEXTURE_FILTER_NEAREST);
 	alternative_tiles_root_control->add_child(alternative_tiles_drawing_root);
 
 	alternatives_draw = memnew(Control);
 	alternatives_draw->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
+	alternatives_draw->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	alternatives_draw->connect("draw", callable_mp(this, &TileAtlasView::_draw_alternatives));
 	alternative_tiles_drawing_root->add_child(alternatives_draw);
 }

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -136,6 +136,7 @@ public:
 		} else {
 			base_tiles_root_control->add_child(p_control);
 		}
+		p_control->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 		p_control->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 	};
 
@@ -149,6 +150,7 @@ public:
 		} else {
 			alternative_tiles_root_control->add_child(p_control);
 		}
+		p_control->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 		p_control->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 	};
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2524,7 +2524,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tile_atlas_view->add_control_over_atlas_tiles(tile_atlas_control);
 
 	tile_atlas_control_unscaled = memnew(Control);
-	tile_atlas_control_unscaled->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	tile_atlas_control_unscaled->connect("draw", callable_mp(this, &TileSetAtlasSourceEditor::_tile_atlas_control_unscaled_draw));
 	tile_atlas_view->add_control_over_atlas_tiles(tile_atlas_control_unscaled, false);
 	tile_atlas_control_unscaled->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
@@ -2541,7 +2540,6 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tile_atlas_view->add_control_over_alternative_tiles(alternative_tiles_control);
 
 	alternative_tiles_control_unscaled = memnew(Control);
-	alternative_tiles_control_unscaled->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	alternative_tiles_control_unscaled->connect("draw", callable_mp(this, &TileSetAtlasSourceEditor::_tile_alternatives_control_unscaled_draw));
 	tile_atlas_view->add_control_over_alternative_tiles(alternative_tiles_control_unscaled, false);
 	alternative_tiles_control_unscaled->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);


### PR DESCRIPTION
Fixes #63070 and fixes #61470 (which are duplicates, I believe)

This fixes the bug causing the tileset image and background from disappearing in some cases.

Actually, there were two issues occurring:
- The image disappeared because the `*_tiles_drawing_root` children were clipped because they were not set to the correct size (they were not using the zoom), I fixed it by not setting their size at all, now their size is inferred correctly using their parent.
- The background disappeared because it had some kind of weird size dependency with its parent, causing it to shrink multiple times when zooming out once, I fixed it by changing its anchor from `PRESET_FULL_RECT` to `PRESET_TOP_LEFT`, and setting their size in the `_update_zoom_and_panning` method instead of the draw method.