### PR TITLE
[Superseded by #77154] Rework Particle Turbulence

### DIFF
--- a/doc/classes/ParticleProcessMaterial.xml
+++ b/doc/classes/ParticleProcessMaterial.xml
@@ -286,7 +286,7 @@
 		</member>
 		<member name="turbulence_influence_max" type="float" setter="set_param_max" getter="get_param_max" default="0.1">
 			Minimum turbulence influence on each particle.
-			 The actual amount of turbulence influence on each particle is calculated as a random value between [member turbulence_influence_min] and [member turbulence_influence_max] and multiplied by the amount of turbulence influence from [member turbulence_influence_over_life].
+			The actual amount of turbulence influence on each particle is calculated as a random value between [member turbulence_influence_min] and [member turbulence_influence_max] and multiplied by the amount of turbulence influence from [member turbulence_influence_over_life].
 		</member>
 		<member name="turbulence_influence_min" type="float" setter="set_param_min" getter="get_param_min" default="0.1">
 			Maximum turbulence influence on each particle.
@@ -296,26 +296,27 @@
 			Each particle's amount of turbulence will be influenced along this [CurveTexture] over its life time.
 		</member>
 		<member name="turbulence_initial_displacement_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
-			Maximum displacement of each particles spawn position by the turbulence.
+			Maximum displacement of each particle's spawn position by the turbulence.
 			The actual amount of displacement will be a factor of the underlying turbulence multiplied by a random value between [member turbulence_initial_displacement_min] and [member turbulence_initial_displacement_max].
 		</member>
 		<member name="turbulence_initial_displacement_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
-			Minimum displacement of each particles spawn position by the turbulence.
+			Minimum displacement of each particle's spawn position by the turbulence.
 			The actual amount of displacement will be a factor of the underlying turbulence multiplied by a random value between [member turbulence_initial_displacement_min] and [member turbulence_initial_displacement_max].
 		</member>
 		<member name="turbulence_noise_scale" type="float" setter="set_turbulence_noise_scale" getter="get_turbulence_noise_scale" default="9.0">
 			This value controls the overall scale/frequency of the turbulence noise pattern.
 			A small scale will result in smaller features with more detail while a high scale will result in smoother noise with larger features.
 		</member>
-		<member name="turbulence_noise_speed" type="Vector3" setter="set_turbulence_noise_speed" getter="get_turbulence_noise_speed" default="Vector3(0.5, 0.5, 0.5)">
-			The movement speed of the turbulence pattern. This changes how quickly the noise changes over time.
-			A value of [code]Vector3(0.0, 0.0, 0.0)[/code] will freeze the turbulence pattern in place.
+		<member name="turbulence_noise_speed" type="Vector3" setter="set_turbulence_noise_speed" getter="get_turbulence_noise_speed" default="Vector3(0.0, 0.0, 0.0)">
+			A scrolling velocity for the turbulence field. This sets a directional trend for the pattern to move in over time.
+			The default value of [code]Vector3(0, 0, 0)[/code] turns off the scrolling.
 		</member>
 		<member name="turbulence_noise_speed_random" type="float" setter="set_turbulence_noise_speed_random" getter="get_turbulence_noise_speed_random" default="0.0">
-			Use to influence the noise speed in a random pattern. This helps to break up visible movement patterns.
+			The in-place rate of change of the turbulence field. This defines how quickly the noise pattern varies over time.
+			A value of 0.0 will result in a fixed pattern.
 		</member>
 		<member name="turbulence_noise_strength" type="float" setter="set_turbulence_noise_strength" getter="get_turbulence_noise_strength" default="1.0">
-			The turbulence noise strength. Increasing this will result in a stronger, more contrasting, noise pattern.
+			The turbulence noise strength. Increasing this will result in a stronger, more contrasting, flow pattern.
 		</member>
 	</members>
 	<constants>

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -315,53 +315,76 @@ void ParticleProcessMaterial::_update_shader() {
 
 		//functions for 3D noise / turbulence
 		code += "\n\n";
-		code += "// 3D Noise with friendly permission by Inigo Quilez\n";
-		code += "vec3 hash_noise( vec3 p ) {\n";
-		code += "	p *= mat3(vec3(127.1, 311.7, -53.7), vec3(269.5, 183.3, 77.1), vec3(-301.7, 27.3, 215.3));\n";
-		code += "	return 2.0 * fract(fract(p)*4375.55) -1.;\n";
+		code += "vec4 grad(vec4 p) {\n";
+		code += "	p = fract(vec4(\n";
+		code += "		dot(p, vec4(0.143081, 0.001724, 0.280166, 0.262771)),\n";
+		code += "		dot(p, vec4(0.645401, -0.047791, -0.146698, 0.595016)),\n";
+		code += "		dot(p, vec4(-0.499665, -0.095734, 0.425674, -0.207367)),\n";
+		code += "		dot(p, vec4(-0.013596, -0.848588, 0.423736, 0.17044))));\n";
+		code += "	return fract((p.xyzw * p.yzwx) * 2365.952041) * 2.0 - 1.0;\n";
 		code += "}\n";
-		code += "\n";
-		code += "float noise( vec3 p) {\n";
-		code += "	vec3 i = floor(p);;\n";
-		code += "	vec3 f = fract(p);\n ";
-		code += "	vec3 u = f * f * (3.0 - 2.0 * f);\n";
-		code += "\n";
-		code += "	return 2.0*mix( mix( mix( dot( hash_noise( i + vec3(0.0,0.0,0.0) ), f - vec3(0.0,0.0,0.0) ), dot( hash_noise( i + vec3(1.0,0.0,0.0) ), f - vec3(1.0,0.0,0.0) ), u.x),\n";
-		code += "			mix( dot( hash_noise( i + vec3(0.0,1.0,0.0) ), f - vec3(0.0,1.0,0.0) ), dot( hash_noise( i + vec3(1.0,1.0,0.0) ), f - vec3(1.0,1.0,0.0) ), u.x), u.y),\n";
-		code += "		mix( mix( dot( hash_noise( i + vec3(0.0,0.0,1.0) ), f - vec3(0.0,0.0,1.0) ), dot( hash_noise( i + vec3(1.0,0.0,1.0) ), f - vec3(1.0,0.0,1.0) ), u.x),\n";
-		code += "			mix( dot( hash_noise( i + vec3(0.0,1.0,1.0) ), f - vec3(0.0,1.0,1.0) ), dot( hash_noise( i + vec3(1.0,1.0,1.0) ), f - vec3(1.0,1.0,1.0) ), u.x), u.y), u.z);\n";
+		code += "float noise(vec4 coord) {\n";
+		code += "	// Domain rotation to improve the look of XYZ slices + animation patterns.\n";
+		code += "	coord = vec4(\n";
+		code += "		coord.xyz + dot(coord, vec4(vec3(-0.1666667), -0.5)),\n";
+		code += "		dot(coord, vec4(0.5)));\n\n";
+		code += "	vec4 base = floor(coord), delta = coord - base;\n\n";
+		code += "	vec4 grad_0000 = grad(base + vec4(0.0, 0.0, 0.0, 0.0)), grad_1000 = grad(base + vec4(1.0, 0.0, 0.0, 0.0));\n";
+		code += "	vec4 grad_0100 = grad(base + vec4(0.0, 1.0, 0.0, 0.0)), grad_1100 = grad(base + vec4(1.0, 1.0, 0.0, 0.0));\n";
+		code += "	vec4 grad_0010 = grad(base + vec4(0.0, 0.0, 1.0, 0.0)), grad_1010 = grad(base + vec4(1.0, 0.0, 1.0, 0.0));\n";
+		code += "	vec4 grad_0110 = grad(base + vec4(0.0, 1.0, 1.0, 0.0)), grad_1110 = grad(base + vec4(1.0, 1.0, 1.0, 0.0));\n";
+		code += "	vec4 grad_0001 = grad(base + vec4(0.0, 0.0, 0.0, 1.0)), grad_1001 = grad(base + vec4(1.0, 0.0, 0.0, 1.0));\n";
+		code += "	vec4 grad_0101 = grad(base + vec4(0.0, 1.0, 0.0, 1.0)), grad_1101 = grad(base + vec4(1.0, 1.0, 0.0, 1.0));\n";
+		code += "	vec4 grad_0011 = grad(base + vec4(0.0, 0.0, 1.0, 1.0)), grad_1011 = grad(base + vec4(1.0, 0.0, 1.0, 1.0));\n";
+		code += "	vec4 grad_0111 = grad(base + vec4(0.0, 1.0, 1.0, 1.0)), grad_1111 = grad(base + vec4(1.0, 1.0, 1.0, 1.0));\n\n";
+		code += "	vec4 result_0123 = vec4(\n";
+		code += "		dot(delta - vec4(0.0, 0.0, 0.0, 0.0), grad_0000), dot(delta - vec4(1.0, 0.0, 0.0, 0.0), grad_1000),\n";
+		code += "		dot(delta - vec4(0.0, 1.0, 0.0, 0.0), grad_0100), dot(delta - vec4(1.0, 1.0, 0.0, 0.0), grad_1100));\n";
+		code += "	vec4 result_4567 = vec4(\n";
+		code += "		dot(delta - vec4(0.0, 0.0, 1.0, 0.0), grad_0010), dot(delta - vec4(1.0, 0.0, 1.0, 0.0), grad_1010),\n";
+		code += "		dot(delta - vec4(0.0, 1.0, 1.0, 0.0), grad_0110), dot(delta - vec4(1.0, 1.0, 1.0, 0.0), grad_1110));\n";
+		code += "	vec4 result_89AB = vec4(\n";
+		code += "		dot(delta - vec4(0.0, 0.0, 0.0, 1.0), grad_0001), dot(delta - vec4(1.0, 0.0, 0.0, 1.0), grad_1001),\n";
+		code += "		dot(delta - vec4(0.0, 1.0, 0.0, 1.0), grad_0101), dot(delta - vec4(1.0, 1.0, 0.0, 1.0), grad_1101));\n";
+		code += "	vec4 result_CDEF = vec4(\n";
+		code += "		dot(delta - vec4(0.0, 0.0, 1.0, 1.0), grad_0011), dot(delta - vec4(1.0, 0.0, 1.0, 1.0), grad_1011),\n";
+		code += "		dot(delta - vec4(0.0, 1.0, 1.0, 1.0), grad_0111), dot(delta - vec4(1.0, 1.0, 1.0, 1.0), grad_1111));\n\n";
+		code += "	vec4 fade = delta * delta * delta * (10.0 + delta * (-15.0 + delta * 6.0));\n";
+		code += "	vec4 result_W0 = mix(result_0123, result_89AB, fade.w), result_W1 = mix(result_4567, result_CDEF, fade.w);\n";
+		code += "	vec4 result_WZ = mix(result_W0, result_W1, fade.z);\n";
+		code += "	vec2 result_WZY = mix(result_WZ.xy, result_WZ.zw, fade.y);\n";
+		code += "	return mix(result_WZY.x, result_WZY.y, fade.x);\n";
 		code += "}\n\n";
-		code += "// Curl 3D and noise_3d function with friendly permission by Isaac Cohen\n";
-		code += "vec3 noise_3d(vec3 p) {\n";
+		code += "// Curl 3D and three-noise function with friendly permission by Isaac Cohen.\n";
+		code += "// Modified to accept 4D noise.\n";
+		code += "vec3 noise_3x(vec4 p) {\n";
 		code += "	float s = noise(p);\n";
-		code += "	float s1 = noise(vec3(p.y - 19.1, p.z + 33.4, p.x + 47.2));\n";
-		code += "   float s2 = noise(vec3(p.z + 74.2, p.x - 124.5, p.y + 99.4));\n";
+		code += "	float s1 = noise(p + vec4(vec3(0.0), 1.7320508 * 2048.333333));\n";
+		code += "	float s2 = noise(p - vec4(vec3(0.0), 1.7320508 * 2048.333333));\n";
 		code += "	vec3 c = vec3(s, s1, s2);\n";
 		code += "	return c;\n";
-		code += "}\n\n";
-		code += "vec3 curl_3d(vec3 p, float c) {\n";
-		code += "	float epsilon = 0.001 + c;\n";
-		code += "	vec3 dx = vec3(epsilon, 0.0, 0.0);\n";
-		code += "	vec3 dy = vec3(0.0, epsilon, 0.0);\n";
-		code += "	vec3 dz = vec3(0.0, 0.0, epsilon);\n";
-		code += "	vec3 x0 = noise_3d(p - dx).xyz;\n";
-		code += "	vec3 x1 = noise_3d(p + dx).xyz;\n";
-		code += "	vec3 y0 = noise_3d(p - dy).xyz;\n";
-		code += "	vec3 y1 = noise_3d(p + dy).xyz;\n";
-		code += "	vec3 z0 = noise_3d(p - dz).xyz;\n";
-		code += "	vec3 z1 = noise_3d(p + dz).xyz;\n";
-		code += "	float x = y1.z - y0.z - z1.y + z0.y;\n";
-		code += "	float y = z1.x - z0.x - x1.z + x0.z;\n";
-		code += "	float z = x1.y - x0.y - y1.x + y0.x;\n";
-		code += "	float divisor = 1.0 / (2.0 * epsilon);\n";
-		code += "	return vec3(normalize(vec3(x, y, z) * divisor));\n";
 		code += "}\n";
-		code += "vec3 get_noise_direction(vec3 pos, vec3 emission_pos, vec3 time_noise) {\n";
+		code += "vec3 curl_3d(vec4 p, float c) {\n";
+		code += "	float epsilon = 0.001 + c;\n";
+		code += "	vec4 dx = vec4(epsilon, 0.0, 0.0, 0.0);\n";
+		code += "	vec4 dy = vec4(0.0, epsilon, 0.0, 0.0);\n";
+		code += "	vec4 dz = vec4(0.0, 0.0, epsilon, 0.0);\n";
+		code += "	vec3 x0 = noise_3x(p - dx).xyz;\n";
+		code += "	vec3 x1 = noise_3x(p + dx).xyz;\n";
+		code += "	vec3 y0 = noise_3x(p - dy).xyz;\n";
+		code += "	vec3 y1 = noise_3x(p + dy).xyz;\n";
+		code += "	vec3 z0 = noise_3x(p - dz).xyz;\n";
+		code += "	vec3 z1 = noise_3x(p + dz).xyz;\n";
+		code += "	float x = (y1.z - y0.z) - (z1.y - z0.y);\n";
+		code += "	float y = (z1.x - z0.x) - (x1.z - x0.z);\n";
+		code += "	float z = (x1.y - x0.y) - (y1.x - y0.x);\n";
+		code += "	return normalize(vec3(x, y, z));\n";
+		code += "}\n";
+		code += "vec3 get_noise_direction(vec3 pos) {\n";
 		code += "	float adj_contrast = max((turbulence_noise_strength - 1.0), 0.0) * 70.0;\n";
-		code += "	vec3 noise_time = (vec3(TIME) * turbulence_noise_speed) + time_noise;\n";
-		code += "	vec3 noise_pos = (pos * turbulence_noise_scale) - emission_pos;\n";
-		code += "	vec3 diff = pos - emission_pos;\n";
-		code += "	vec3 noise_direction = curl_3d(noise_pos + noise_time - diff, adj_contrast);\n";
+		code += "	vec4 noise_time = TIME * vec4(turbulence_noise_speed, turbulence_noise_speed_random);\n";
+		code += "	vec4 noise_pos = vec4(pos * turbulence_noise_scale, 0.0);\n";
+		code += "	vec3 noise_direction = curl_3d(noise_pos + noise_time, adj_contrast);\n";
 		code += "	noise_direction = mix(0.9 * noise_direction, noise_direction, turbulence_noise_strength - 9.0);\n";
 		code += "	return noise_direction;\n";
 		code += "}\n";
@@ -551,12 +574,7 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "	if (RESTART_VELOCITY) VELOCITY = (EMISSION_TRANSFORM * vec4(VELOCITY, 0.0)).xyz;\n";
 	// Apply noise/turbulence: initial displacement.
 	if (turbulence_enabled) {
-		if (get_turbulence_noise_speed_random() >= 0.0) {
-			code += "	vec3 time_noise = noise_3d( vec3(TIME) * turbulence_noise_speed_random ) * -turbulence_noise_speed;\n";
-		} else {
-			code += "	const vec3 time_noise = vec3(0.0);\n";
-		}
-		code += "	vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz, EMISSION_TRANSFORM[3].xyz, time_noise);\n";
+		code += "	vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz);\n";
 		code += "	float turb_init_displacement = mix(turbulence_initial_displacement_min, turbulence_initial_displacement_max, rand_from_seed(alt_seed));";
 		code += "	TRANSFORM[3].xyz += noise_direction * turb_init_displacement;\n";
 	}
@@ -692,12 +710,7 @@ void ParticleProcessMaterial::_update_shader() {
 			code += "	const float turbulence_influence = 1.0;\n";
 		}
 		code += "	\n";
-		if (get_turbulence_noise_speed_random() >= 0.0) {
-			code += "	vec3 time_noise = noise_3d( vec3(TIME) * turbulence_noise_speed_random ) * -turbulence_noise_speed;\n";
-		} else {
-			code += "	const vec3 time_noise = vec3(0.0);\n";
-		}
-		code += "	vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz, EMISSION_TRANSFORM[3].xyz, time_noise);\n";
+		code += "	vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz);\n";
 		// If collision happened, turbulence is no longer applied.
 		// We don't need this check when the collision mode is "hide on contact",
 		// as the particle will be hidden anyway.
@@ -1745,7 +1758,7 @@ void ParticleProcessMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "turbulence_noise_strength", PROPERTY_HINT_RANGE, "0,20,0.01"), "set_turbulence_noise_strength", "get_turbulence_noise_strength");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "turbulence_noise_scale", PROPERTY_HINT_RANGE, "0,10,0.01"), "set_turbulence_noise_scale", "get_turbulence_noise_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "turbulence_noise_speed"), "set_turbulence_noise_speed", "get_turbulence_noise_speed");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "turbulence_noise_speed_random", PROPERTY_HINT_RANGE, "0,10,0.01"), "set_turbulence_noise_speed_random", "get_turbulence_noise_speed_random");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "turbulence_noise_speed_random", PROPERTY_HINT_RANGE, "0,4,0.01"), "set_turbulence_noise_speed_random", "get_turbulence_noise_speed_random");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "turbulence_influence_min", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_min", "get_param_min", PARAM_TURB_VEL_INFLUENCE);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "turbulence_influence_max", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_param_max", "get_param_max", PARAM_TURB_VEL_INFLUENCE);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "turbulence_initial_displacement_min", PROPERTY_HINT_RANGE, "-100,100,0.1"), "set_param_min", "get_param_min", PARAM_TURB_INIT_DISPLACEMENT);


### PR DESCRIPTION
After encountering the latest Alpha snapshot and discovering @RPicster's great efforts on the Particle Turbulence PR, I found some areas for improvement and rework, to hopefully start this feature off on the best footing possible for the upcoming 4.0 release. (Updated description here following discussions further down)

The current implementation merged in #55387 uses directionally-scrolling 3D noise to create an evolving pattern in 3D. This is problematic because it forces the consideration of a scrolling direction, which creates unavoidable and often unfitting bias in resulting patterns. The included speed-random parameter is poised as a means to conceal these effects, but it's only a moderately-effective patch on top of a problem that doesn't need to exist in the first place. This PR replaces the scrolling 3D noise with 4D noise which varies in place over time.

Further, the included formula for curl noise is highly complex and is based on axis-biased arithmetic of uncertain mathematical origin. ~~This PR replaces it with a more concise solution that uses fewer noise calls while also producing more natural effects.~~

~~These changes do break turbulence configs made using the existing dev snapshots!~~

### [NEW] Full change set:

- Replaced 3D noise with 4D noise to enable in-place pattern variation.
- Changed `turbulence_noise_speed_random` so that it controls the noise evolution instead (pending feedback on desired implementation).

### [OLD] Full change set:

- Exchanged scrolling 3D noise pattern variation approach with 4D noise that evolves in place, producing more convincing effects through more intuitive configuration. Replaced `turbulence_noise_speed` (vec3) with `turbulence_noise_evolution_speed` (float). ~~2D particles use evolving 3D noise.~~
  - I can also re-add `turbulence_noise_speed` (vec3) if it is decided that the scrolling is useful -- perhaps as `turbulence_noise_directional_trend` to be more explicit about its purpose and effect.
- Replaced the then-merged 3D curl formula with a simple and orientation-invariant `cross(noiseGradientA, noiseGradientB)` which produces a proper divergence-free flow field with many fewer steps.
-~~Added a separate 2D case which uses an even simpler `rotate90(noiseGradient)` formula (paraphrased code).~~
- Replaced displaced-sampling-based noise gradient (partial derivative vector) computation with single-evaluation analytic derivative sampling.
- Replaced Perlin noise algorithm with more-directionally-unbiased-looking Simplex noise. Simplex is also easier to calculate the analytic derivatives for.
  - I used two octaves of noise per each gradient computation to remove / vary up the straight line segments some of the particles were following in the single layers. It also increases variation.
- Adjusted the curve of `turbulence_noise_scale` as it's passed to the shader, to better reflect the description in the documentation. `shader_turbulence_noise_scale = 1.0 / turbulence_noise_scale;`
- Removed `turbulence_noise_speed_random` since it no longer has its necessary use case.
- ~~Removed `turbulence_noise_strength` since it had no effect on the particle update step, and its effect during the initialization step could be accomplished just the same by increasing `turbulence_initial_displacement_min` and `turbulence_initial_displacement_max`.~~ Determined that it does produce an effect and re-added corresponding functionality though a `turbulence_sharpness` parameter.
  - It was ~~also~~ previously used in the definition of `adj_contrast, which no longer plays a role now that the partial derivative vector is computed analytically.
- Changed existing formula for `turbulence_influence` (from values sampled according to `turbulence_influence_min` and `turbulence_influence_max`), which biases the result towards more influence, to do so more cleanly. [old](https://github.com/RPicster/godot/blob/9137ba79269cd957753fce8d783ffb01c8ac60fa/scene/resources/particles_material.cpp#L706), [new](https://github.com/KdotJPG/godot/blob/e33c4e1131bdb71ef5f5edcee8b73427e5ffdc94/scene/resources/particles_material.cpp#L848-L849) https://www.desmos.com/calculator/hmsaly3f4b
  - ~~I also adjusted the way the normalization happens so that the new vector is always the same length as the old.~~
- ~~Fixed the distance-from-center selection in the existing `EMISSION_SHAPE_SPHERE` code -- it needs to be passed through a cube-root for a proper uniform distribution that doesn't cluster at the center.~~
  - ~~This technically does change existing patterns, but I wouldn't generally expect it to break any. If I should revert it or implement it differently, just give me the word.~~

### ~~Motion to also remove Initial Displacement~~

~~Initial Displacement seems well-intentioned, but I haven't found any behavior in it that I couldn't replicate with the Emission Shape features. If there is consensus, I will update this PR with its removal. (@RPicster feel free to fill me in if I'm missing something.)~~

---

![image](https://user-images.githubusercontent.com/8829856/185583392-755d7cae-f32e-4b17-8c6b-2668f6389934.png)

---

All code added is ~~either MIT-licensed or~~ self-authored.