### PR TITLE
Make audio thread control flags safe

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -168,9 +168,8 @@ Error AudioDriverALSA::init() {
 		return ERR_CANT_OPEN;
 	}
 
-	active = false;
-	thread_exited = false;
-	exit_thread = false;
+	active.clear();
+	exit_thread.clear();
 
 	Error err = init_device();
 	if (err == OK) {
@@ -183,11 +182,11 @@ Error AudioDriverALSA::init() {
 void AudioDriverALSA::thread_func(void *p_udata) {
 	AudioDriverALSA *ad = static_cast<AudioDriverALSA *>(p_udata);
 
-	while (!ad->exit_thread) {
+	while (!ad->exit_thread.is_set()) {
 		ad->lock();
 		ad->start_counting_ticks();
 
-		if (!ad->active) {
+		if (!ad->active.is_set()) {
 			for (uint64_t i = 0; i < ad->period_size * ad->channels; i++) {
 				ad->samples_out.write[i] = 0;
 			}
@@ -203,7 +202,7 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 		int todo = ad->period_size;
 		int total = 0;
 
-		while (todo && !ad->exit_thread) {
+		while (todo && !ad->exit_thread.is_set()) {
 			int16_t *src = (int16_t *)ad->samples_out.ptr();
 			int wrote = snd_pcm_writei(ad->pcm_handle, (void *)(src + (total * ad->channels)), todo);
 
@@ -222,8 +221,8 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 				wrote = snd_pcm_recover(ad->pcm_handle, wrote, 0);
 				if (wrote < 0) {
 					ERR_PRINT("ALSA: Failed and can't recover: " + String(snd_strerror(wrote)));
-					ad->active = false;
-					ad->exit_thread = true;
+					ad->active.clear();
+					ad->exit_thread.set();
 				}
 			}
 		}
@@ -241,8 +240,8 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 
 				err = ad->init_device();
 				if (err != OK) {
-					ad->active = false;
-					ad->exit_thread = true;
+					ad->active.clear();
+					ad->exit_thread.set();
 				}
 			}
 		}
@@ -250,12 +249,10 @@ void AudioDriverALSA::thread_func(void *p_udata) {
 		ad->stop_counting_ticks();
 		ad->unlock();
 	}
-
-	ad->thread_exited = true;
 }
 
 void AudioDriverALSA::start() {
-	active = true;
+	active.set();
 }
 
 int AudioDriverALSA::get_mix_rate() const {
@@ -327,7 +324,7 @@ void AudioDriverALSA::finish_device() {
 }
 
 void AudioDriverALSA::finish() {
-	exit_thread = true;
+	exit_thread.set();
 	thread.wait_to_finish();
 
 	finish_device();

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -35,6 +35,7 @@
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
+#include "core/templates/safe_refcount.h"
 #include "servers/audio_server.h"
 
 #include "asound-so_wrap.h"
@@ -64,9 +65,8 @@ class AudioDriverALSA : public AudioDriver {
 	snd_pcm_uframes_t period_size;
 	int channels = 0;
 
-	bool active = false;
-	bool thread_exited = false;
-	mutable bool exit_thread = false;
+	SafeFlag active;
+	SafeFlag exit_thread;
 
 public:
 	const char *get_name() const {

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -79,7 +79,7 @@ void MIDIDriverALSAMidi::thread_func(void *p_udata) {
 	int expected_size = 255;
 	int bytes = 0;
 
-	while (!md->exit_thread) {
+	while (!md->exit_thread.is_set()) {
 		int ret;
 
 		md->lock();
@@ -149,14 +149,14 @@ Error MIDIDriverALSAMidi::open() {
 	}
 	snd_device_name_free_hint(hints);
 
-	exit_thread = false;
+	exit_thread.clear();
 	thread.start(MIDIDriverALSAMidi::thread_func, this);
 
 	return OK;
 }
 
 void MIDIDriverALSAMidi::close() {
-	exit_thread = true;
+	exit_thread.set();
 	thread.wait_to_finish();
 
 	for (int i = 0; i < connected_inputs.size(); i++) {
@@ -193,7 +193,7 @@ PackedStringArray MIDIDriverALSAMidi::get_connected_inputs() {
 }
 
 MIDIDriverALSAMidi::MIDIDriverALSAMidi() {
-	exit_thread = false;
+	exit_thread.clear();
 }
 
 MIDIDriverALSAMidi::~MIDIDriverALSAMidi() {

--- a/drivers/alsamidi/midi_driver_alsamidi.h
+++ b/drivers/alsamidi/midi_driver_alsamidi.h
@@ -36,6 +36,7 @@
 #include "core/os/midi_driver.h"
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
+#include "core/templates/safe_refcount.h"
 #include "core/templates/vector.h"
 
 #include "../alsa/asound-so_wrap.h"
@@ -47,7 +48,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 
 	Vector<snd_rawmidi_t *> connected_inputs;
 
-	bool exit_thread;
+	SafeFlag exit_thread;
 
 	static void thread_func(void *p_udata);
 

--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -215,6 +215,7 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 	}
 
 	ad->lock();
+	ad->start_counting_ticks();
 
 	AudioBufferList bufferList;
 	bufferList.mNumberBuffers = 1;
@@ -237,6 +238,7 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 		ERR_PRINT("AudioUnitRender failed, code: " + itos(result));
 	}
 
+	ad->stop_counting_ticks();
 	ad->unlock();
 
 	return result;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -285,9 +285,8 @@ Error AudioDriverPulseAudio::init() {
 		return ERR_CANT_OPEN;
 	}
 
-	active = false;
-	thread_exited = false;
-	exit_thread = false;
+	active.clear();
+	exit_thread.clear();
 
 	mix_rate = GLOBAL_GET("audio/driver/mix_rate");
 
@@ -384,7 +383,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 	size_t avail_bytes = 0;
 	uint64_t default_device_msec = OS::get_singleton()->get_ticks_msec();
 
-	while (!ad->exit_thread) {
+	while (!ad->exit_thread.is_set()) {
 		size_t read_bytes = 0;
 		size_t written_bytes = 0;
 
@@ -392,7 +391,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			ad->lock();
 			ad->start_counting_ticks();
 
-			if (!ad->active) {
+			if (!ad->active.is_set()) {
 				ad->samples_out.fill(0);
 			} else {
 				ad->audio_server_process(ad->buffer_frames, ad->samples_in.ptrw());
@@ -462,8 +461,8 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 				err = ad->init_device();
 				if (err != OK) {
-					ad->active = false;
-					ad->exit_thread = true;
+					ad->active.clear();
+					ad->exit_thread.set();
 					break;
 				}
 			}
@@ -501,8 +500,8 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 					Error err = ad->init_device();
 					if (err != OK) {
 						ERR_PRINT("PulseAudio: init_device error");
-						ad->active = false;
-						ad->exit_thread = true;
+						ad->active.clear();
+						ad->exit_thread.set();
 						break;
 					}
 
@@ -555,8 +554,8 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 
 					err = ad->capture_init_device();
 					if (err != OK) {
-						ad->active = false;
-						ad->exit_thread = true;
+						ad->active.clear();
+						ad->exit_thread.set();
 						break;
 					}
 				}
@@ -571,12 +570,10 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 			OS::get_singleton()->delay_usec(1000);
 		}
 	}
-
-	ad->thread_exited = true;
 }
 
 void AudioDriverPulseAudio::start() {
-	active = true;
+	active.set();
 }
 
 int AudioDriverPulseAudio::get_mix_rate() const {
@@ -661,7 +658,7 @@ void AudioDriverPulseAudio::finish() {
 		return;
 	}
 
-	exit_thread = true;
+	exit_thread.set();
 	thread.wait_to_finish();
 
 	finish_device();

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -35,6 +35,7 @@
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
+#include "core/templates/safe_refcount.h"
 #include "servers/audio_server.h"
 
 #include "pulse-so_wrap.h"
@@ -70,9 +71,8 @@ class AudioDriverPulseAudio : public AudioDriver {
 	Array pa_devices;
 	Array pa_rec_devices;
 
-	bool active = false;
-	bool thread_exited = false;
-	mutable bool exit_thread = false;
+	SafeFlag active;
+	SafeFlag exit_thread;
 
 	float latency = 0;
 

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -35,6 +35,7 @@
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
+#include "core/templates/safe_refcount.h"
 #include "servers/audio_server.h"
 
 #include <audioclient.h>
@@ -48,7 +49,7 @@ class AudioDriverWASAPI : public AudioDriver {
 		IAudioClient *audio_client = nullptr;
 		IAudioRenderClient *render_client = nullptr;
 		IAudioCaptureClient *capture_client = nullptr;
-		bool active = false;
+		SafeFlag active;
 
 		WORD format_tag = 0;
 		WORD bits_per_sample = 0;
@@ -76,8 +77,7 @@ class AudioDriverWASAPI : public AudioDriver {
 	float real_latency = 0.0;
 	bool using_audio_client_3 = false;
 
-	bool thread_exited = false;
-	mutable bool exit_thread = false;
+	SafeFlag exit_thread;
 
 	static _FORCE_INLINE_ void write_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i, int32_t sample);
 	static _FORCE_INLINE_ int32_t read_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i);

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -38,9 +38,8 @@ const char *AudioDriverXAudio2::get_name() const {
 }
 
 Error AudioDriverXAudio2::init() {
-	active = false;
-	thread_exited = false;
-	exit_thread = false;
+	active.clear();
+	exit_thread.clear();
 	pcm_open = false;
 	samples_in = nullptr;
 
@@ -86,17 +85,19 @@ Error AudioDriverXAudio2::init() {
 void AudioDriverXAudio2::thread_func(void *p_udata) {
 	AudioDriverXAudio2 *ad = static_cast<AudioDriverXAudio2 *>(p_udata);
 
-	while (!ad->exit_thread) {
-		if (!ad->active) {
+	while (!ad->exit_thread.is_set()) {
+		if (!ad->active.is_set()) {
 			for (int i = 0; i < AUDIO_BUFFERS; i++) {
 				ad->xaudio_buffer[i].Flags = XAUDIO2_END_OF_STREAM;
 			}
 
 		} else {
 			ad->lock();
+			ad->start_counting_ticks();
 
 			ad->audio_server_process(ad->buffer_size, ad->samples_in);
 
+			ad->stop_counting_ticks();
 			ad->unlock();
 
 			for (unsigned int i = 0; i < ad->buffer_size * ad->channels; i++) {
@@ -117,12 +118,10 @@ void AudioDriverXAudio2::thread_func(void *p_udata) {
 			}
 		}
 	}
-
-	ad->thread_exited = true;
 }
 
 void AudioDriverXAudio2::start() {
-	active = true;
+	active.set();
 	HRESULT hr = source_voice->Start(0);
 	ERR_FAIL_COND_MSG(hr != S_OK, "Error starting XAudio2 driver. Error code: " + itos(hr) + ".");
 }
@@ -154,7 +153,7 @@ void AudioDriverXAudio2::unlock() {
 }
 
 void AudioDriverXAudio2::finish() {
-	exit_thread = true;
+	exit_thread.set();
 	thread.wait_to_finish();
 
 	if (source_voice) {

--- a/drivers/xaudio2/audio_driver_xaudio2.h
+++ b/drivers/xaudio2/audio_driver_xaudio2.h
@@ -33,6 +33,7 @@
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
+#include "core/templates/safe_refcount.h"
 #include "servers/audio_server.h"
 
 #include <mmsystem.h>
@@ -77,9 +78,8 @@ class AudioDriverXAudio2 : public AudioDriver {
 
 	int channels = 0;
 
-	bool active = false;
-	bool thread_exited = false;
-	mutable bool exit_thread = false;
+	SafeFlag active;
+	SafeFlag exit_thread;
 	bool pcm_open = false;
 
 	WAVEFORMATEX wave_format = { 0 };

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -35,6 +35,7 @@
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
+#include "core/templates/safe_refcount.h"
 
 class AudioDriverDummy : public AudioDriver {
 	Thread thread;
@@ -50,9 +51,8 @@ class AudioDriverDummy : public AudioDriver {
 
 	int channels;
 
-	bool active;
-	bool thread_exited;
-	mutable bool exit_thread;
+	SafeFlag active;
+	SafeFlag exit_thread;
 
 	bool use_threads = true;
 


### PR DESCRIPTION
- ...plus remove the unused `thread_exited`.
- ...plus add missing calls to `start`/`stop_counting_ticks()`.

**UPDATE:** Version for 3.x submitted as #64608.