### PR TITLE
Add button to toggle Unique Name when renaming Node

### DIFF
--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -54,6 +54,7 @@ class SceneTreeEditor : public Control {
 		BUTTON_GROUPS = 7,
 		BUTTON_PIN = 8,
 		BUTTON_UNIQUE = 9,
+		BUTTON_UNIQUE_TOGGLE = 10,
 	};
 
 	Tree *tree = nullptr;
@@ -97,6 +98,9 @@ class SceneTreeEditor : public Control {
 	bool updating_tree = false;
 	bool show_enabled_subscene = false;
 
+	TreeItem *renaming_item;
+	void _begin_rename();
+	void _end_rename();
 	void _renamed();
 	UndoRedo *undo_redo = nullptr;
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1849,6 +1849,10 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 				p_item->set_meta("__focus_rect", Rect2(r.position, r.size));
 
+				if (popup_edited_item && popup_edited_item_col >= 0 && popup_edited_item_col <= columns.size()) {
+					_update_popup_editor_size();
+				}
+
 				if (select_mode != SELECT_ROW) {
 					if (rtl) {
 						r.position.x = get_size().width - r.position.x - r.size.x;
@@ -2759,7 +2763,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 	return item_h; // nothing found
 }
 
-void Tree::_text_editor_modal_close() {
+void Tree::_text_editor_modal_close_requested() {
 	if (Input::get_singleton()->is_key_pressed(Key::ESCAPE) ||
 			Input::get_singleton()->is_key_pressed(Key::KP_ENTER) ||
 			Input::get_singleton()->is_key_pressed(Key::ENTER)) {
@@ -2770,11 +2774,43 @@ void Tree::_text_editor_modal_close() {
 		return;
 	}
 
+	// Don't close when clicking cell buttons.
+	if (popup_edited_item && popup_edited_item_col >= 0 && popup_edited_item_col < popup_edited_item->cells.size()) {
+		TreeItem *item = popup_edited_item;
+		int item_column = popup_edited_item_col;
+
+		Rect2 focus_rect = item->get_meta("__focus_rect");
+		Vector2 mouse_position = get_local_mouse_position();
+
+		focus_rect.size.x = get_column_width(item_column);
+
+		//Rect2 button_rect = Rect2(0, 0, 240, 240);
+		if (focus_rect.has_point(mouse_position)) {
+			//WARN_PRINT("Point found");
+
+			Ref<InputEventMouseButton> mouse_button_event(memnew(InputEventMouseButton));
+
+			mouse_button_event->set_global_position(get_global_mouse_position());
+			mouse_button_event->set_position(get_local_mouse_position());
+			mouse_button_event->set_button_index(MouseButton::LEFT);
+			mouse_button_event->set_pressed(true);
+			gui_input(mouse_button_event);
+
+			mouse_button_event->set_pressed(false);
+			gui_input(mouse_button_event);
+
+			return;
+		}
+	}
+
+	//WARN_PRINT("Hide the popup");
+	popup_editor->hide();
+
 	_text_editor_submit(text_editor->get_text());
 }
 
 void Tree::_text_editor_submit(String p_text) {
-	popup_editor->hide();
+	//popup_editor->hide();
 
 	if (!popup_edited_item) {
 		return;
@@ -3621,12 +3657,40 @@ bool Tree::edit_selected() {
 		popup_editor->popup();
 		popup_editor->child_controls_changed();
 
+		//update();
+		//popup_editor->call_deferred("_update_popup_editor_size");
+
 		text_editor->grab_focus();
 
 		return true;
 	}
 
 	return false;
+}
+
+void Tree::_update_popup_editor_size() {
+	TreeItem *selected_item = popup_edited_item;
+	ERR_FAIL_COND_MSG(!selected_item, "Can't update size with no item selected.");
+	int selected_column = popup_edited_item_col;
+	ERR_FAIL_INDEX_MSG(selected_column, columns.size(), "Can't update size with no column selected.");
+
+	const TreeItem::Cell cell = selected_item->cells[selected_column];
+
+	Rect2i focus_rect = selected_item->get_meta("__focus_rect");
+
+	if (cell.mode == TreeItem::CELL_MODE_STRING || cell.mode == TreeItem::CELL_MODE_RANGE) {
+		Rect2 popup_rect;
+
+		Vector2 offset(0, (text_editor->get_size().height - focus_rect.size.height) / 2);
+
+		Point2i textedpos = get_screen_position() + focus_rect.position - offset;
+		cache.text_editor_position = textedpos;
+		popup_rect.position = textedpos;
+		popup_rect.size = focus_rect.size;
+
+		popup_editor->set_position(popup_rect.position);
+		popup_editor->set_size(popup_rect.size);
+	}
 }
 
 bool Tree::is_editing() {
@@ -4137,6 +4201,10 @@ TreeItem *Tree::get_edited() const {
 
 int Tree::get_edited_column() const {
 	return edited_col;
+}
+
+LineEdit *Tree::get_text_editor() const {
+	return text_editor;
 }
 
 TreeItem *Tree::get_next_selected(TreeItem *p_item) {
@@ -5018,8 +5086,16 @@ Tree::Tree() {
 	popup_menu->hide();
 	add_child(popup_menu, false, INTERNAL_MODE_FRONT);
 
-	popup_editor = memnew(Popup);
+	popup_editor = memnew(Window);
 	popup_editor->set_wrap_controls(true);
+
+	popup_editor->set_wrap_controls(true);
+	popup_editor->set_visible(false);
+	popup_editor->set_transient(true);
+	popup_editor->set_flag(Window::FLAG_BORDERLESS, true);
+	popup_editor->set_flag(Window::FLAG_RESIZE_DISABLED, true);
+	popup_editor->set_flag(Window::FLAG_POPUP, true);
+
 	add_child(popup_editor, false, INTERNAL_MODE_FRONT);
 	popup_editor_vb = memnew(VBoxContainer);
 	popup_editor->add_child(popup_editor_vb);
@@ -5048,7 +5124,7 @@ Tree::Tree() {
 	h_scroll->connect("value_changed", callable_mp(this, &Tree::_scroll_moved));
 	v_scroll->connect("value_changed", callable_mp(this, &Tree::_scroll_moved));
 	text_editor->connect("text_submitted", callable_mp(this, &Tree::_text_editor_submit));
-	popup_editor->connect("popup_hide", callable_mp(this, &Tree::_text_editor_modal_close));
+	popup_editor->connect("close_requested", callable_mp(this, &Tree::_text_editor_modal_close_requested));
 	popup_menu->connect("id_pressed", callable_mp(this, &Tree::popup_select));
 	value_editor->connect("value_changed", callable_mp(this, &Tree::value_editor_changed));
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -435,7 +435,7 @@ private:
 
 	VBoxContainer *popup_editor_vb = nullptr;
 
-	Popup *popup_editor = nullptr;
+	Window *popup_editor = nullptr;
 	LineEdit *text_editor = nullptr;
 	HSlider *value_editor = nullptr;
 	bool updating_value_editor = false;
@@ -461,7 +461,7 @@ private:
 	void select_single_item(TreeItem *p_selected, TreeItem *p_current, int p_col, TreeItem *p_prev = nullptr, bool *r_in_range = nullptr, bool p_force_deselect = false);
 	int propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int x_limit, bool p_double_click, TreeItem *p_item, MouseButton p_button, const Ref<InputEventWithModifiers> &p_mod);
 	void _text_editor_submit(String p_text);
-	void _text_editor_modal_close();
+	void _text_editor_modal_close_requested();
 	void value_editor_changed(double p_value);
 
 	void popup_select(int p_option);
@@ -670,6 +670,7 @@ public:
 
 	TreeItem *get_edited() const;
 	int get_edited_column() const;
+	LineEdit *get_text_editor() const;
 
 	void ensure_cursor_is_visible();
 
@@ -678,6 +679,7 @@ public:
 	int get_item_offset(TreeItem *p_item) const;
 	Rect2 get_item_rect(TreeItem *p_item, int p_column = -1, int p_button = -1) const;
 	bool edit_selected();
+	void _update_popup_editor_size();
 	bool is_editing();
 
 	// First item that starts with the text, from the current focused item down and wraps around.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4498.

This PR adds a Unique Name button while renaming a Node in the **Scene Tree Editor**, present to the side of the edited Node. When a Node is Unique, the toggle remains even when leaving the text editor and is highlighted more noticeably. 

![Showcase](https://gyazo.com/94dbeb751a7344072aabdc7091c045f2.gif)

Currently a draft because... *oh good Lord* do not look at the code. To get these features, the changes had to be very invasive and, in lack of better words, unpolished. (E.g. the **Popup** is now a simpler **Window**, otherwise clicking outside it would automatically close it). Submitting names with keys no longer even works anymore. But I may just be very stupid. Its implementation may likely be completely overhauled at some point down the line.