### PR TITLE
Add startup benchmarking support

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -33,7 +33,9 @@
 #include "core/authors.gen.h"
 #include "core/config/project_settings.h"
 #include "core/donors.gen.h"
+#include "core/io/json.h"
 #include "core/license.gen.h"
+#include "core/os/os.h"
 #include "core/version.h"
 
 void Engine::set_physics_ticks_per_second(int p_ips) {
@@ -305,6 +307,43 @@ Engine *Engine::get_singleton() {
 
 Engine::Engine() {
 	singleton = this;
+}
+
+void Engine::startup_begin() {
+	startup_benchmark_total_from = OS::get_singleton()->get_ticks_usec();
+}
+
+void Engine::startup_benchmark_begin_measure(const String &p_what) {
+	startup_benchmark_section = p_what;
+	startup_benchmark_from = OS::get_singleton()->get_ticks_usec();
+}
+void Engine::startup_benchmark_end_measure() {
+	uint64_t total = OS::get_singleton()->get_ticks_usec() - startup_benchmark_from;
+	double total_f = double(total) / double(1000000);
+
+	startup_benchmark_json[startup_benchmark_section] = total_f;
+}
+
+void Engine::startup_dump(const String &p_to_file) {
+	uint64_t total = OS::get_singleton()->get_ticks_usec() - startup_benchmark_total_from;
+	double total_f = double(total) / double(1000000);
+	startup_benchmark_json["total_time"] = total_f;
+
+	if (!p_to_file.is_empty()) {
+		Ref<FileAccess> f = FileAccess::open(p_to_file, FileAccess::WRITE);
+		if (f.is_valid()) {
+			Ref<JSON> json;
+			json.instantiate();
+			f->store_string(json->stringify(startup_benchmark_json, "\t", false, true));
+		}
+	} else {
+		List<Variant> keys;
+		startup_benchmark_json.get_key_list(&keys);
+		print_line("STARTUP BENCHMARK:");
+		for (const Variant &K : keys) {
+			print_line("\t-", K, ": ", startup_benchmark_json[K], +" sec.");
+		}
+	}
 }
 
 Engine::Singleton::Singleton(const StringName &p_name, Object *p_ptr, const StringName &p_class_name) :

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -79,6 +79,11 @@ private:
 	String write_movie_path;
 	String shader_cache_path;
 
+	Dictionary startup_benchmark_json;
+	String startup_benchmark_section;
+	uint64_t startup_benchmark_from = 0;
+	uint64_t startup_benchmark_total_from = 0;
+
 public:
 	static Engine *get_singleton();
 
@@ -150,6 +155,11 @@ public:
 	bool is_abort_on_gpu_errors_enabled() const;
 	bool is_validation_layers_enabled() const;
 	int32_t get_gpu_index() const;
+
+	void startup_begin();
+	void startup_benchmark_begin_measure(const String &p_what);
+	void startup_benchmark_end_measure();
+	void startup_dump(const String &p_to_file);
 
 	Engine();
 	virtual ~Engine() {}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1192,11 +1192,6 @@ void EditorFileSystem::scan_changes() {
 
 void EditorFileSystem::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			call_deferred(SNAME("scan")); //this should happen after every editor node entered the tree
-
-		} break;
-
 		case NOTIFICATION_EXIT_TREE: {
 			Thread &active_thread = thread.is_started() ? thread : thread_sources;
 			if (use_threads && active_thread.is_started()) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -682,6 +682,10 @@ private:
 	void _bottom_panel_switch(bool p_enable, int p_idx);
 	void _bottom_panel_raise_toggled(bool);
 
+	void _begin_first_scan();
+	bool use_startup_benchmark = false;
+	String startup_benchmark_file;
+
 protected:
 	friend class FileSystemDock;
 
@@ -816,6 +820,7 @@ public:
 
 	void _copy_warning(const String &p_str);
 
+	void set_use_startup_benchmark(bool p_use_startup_benchmark, const String &p_startup_benchmark_file);
 	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only);
 
 	Control *get_gui_base() { return gui_base; }


### PR DESCRIPTION
This adds support for benchmarking engine startup (and editor startup if used).
The goal is to use this in the benchmarking server to track improvements and changes to engine, editor, importer and scene loading startup times.

Example of how it looks:
```
$ godot -e --startup-benchmark myscene.tscn
STARTUP BENCHMARK:
	- core :  0.027352  sec.
	- servers :  0.649285  sec.
	- scene :  0.304407  sec.
	- editor :  6.370338  sec.
	- editor_scan_and_import :  1.884974  sec.
	- editor_load_scene :  2.611782  sec.
	- total_time :  15.153595  sec.
$ godot -e --startup-benchmark-file benchmark.json  myscene.tscn
$ cat benchmark.json
{
	"core": 0.042078,
	"servers": 0.622677,
	"scene": 0.299243,
	"editor": 6.58016,
	"editor_scan_and_import": 1.838239,
	"editor_load_scene": 0.194263,
	"total_time": 12.845866
}
```


