### PR TITLE
Fix MenuBar not processing shortcuts.

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -859,6 +859,7 @@ void MenuBar::get_translatable_strings(List<String> *p_strings) const {
 }
 
 MenuBar::MenuBar() {
+	set_process_shortcut_input(true);
 }
 
 MenuBar::~MenuBar() {


### PR DESCRIPTION
Fix `MenuBar` not processing shortcuts. Regression from #63950

_Fixes https://github.com/godotengine/godot/issues/64614_