### PR TITLE
Add missing Vector4 and Vector4i Mono marshalling logic

### DIFF
--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -674,6 +674,8 @@ size_t variant_get_managed_unboxed_size(const ManagedType &p_type) {
 			RETURN_CHECK_FOR_STRUCT(Transform2D);
 			RETURN_CHECK_FOR_STRUCT(Vector3);
 			RETURN_CHECK_FOR_STRUCT(Vector3i);
+			RETURN_CHECK_FOR_STRUCT(Vector4);
+			RETURN_CHECK_FOR_STRUCT(Vector4i);
 			RETURN_CHECK_FOR_STRUCT(Basis);
 			RETURN_CHECK_FOR_STRUCT(Quaternion);
 			RETURN_CHECK_FOR_STRUCT(Transform3D);
@@ -779,6 +781,8 @@ void *variant_to_managed_unboxed(const Variant &p_var, const ManagedType &p_type
 			RETURN_CHECK_FOR_STRUCT(Transform2D);
 			RETURN_CHECK_FOR_STRUCT(Vector3);
 			RETURN_CHECK_FOR_STRUCT(Vector3i);
+			RETURN_CHECK_FOR_STRUCT(Vector4);
+			RETURN_CHECK_FOR_STRUCT(Vector4i);
 			RETURN_CHECK_FOR_STRUCT(Basis);
 			RETURN_CHECK_FOR_STRUCT(Quaternion);
 			RETURN_CHECK_FOR_STRUCT(Transform3D);
@@ -932,6 +936,8 @@ MonoObject *variant_to_mono_object(const Variant &p_var, const ManagedType &p_ty
 			RETURN_CHECK_FOR_STRUCT(Transform2D);
 			RETURN_CHECK_FOR_STRUCT(Vector3);
 			RETURN_CHECK_FOR_STRUCT(Vector3i);
+			RETURN_CHECK_FOR_STRUCT(Vector4);
+			RETURN_CHECK_FOR_STRUCT(Vector4i);
 			RETURN_CHECK_FOR_STRUCT(Basis);
 			RETURN_CHECK_FOR_STRUCT(Quaternion);
 			RETURN_CHECK_FOR_STRUCT(Transform3D);

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -1082,6 +1082,14 @@ Variant mono_object_to_variant_impl(MonoObject *p_obj, const ManagedType &p_type
 				return MARSHALLED_IN(Vector3i, unbox_addr<GDMonoMarshal::M_Vector3i>(p_obj));
 			}
 
+			if (vtclass == CACHED_CLASS(Vector4)) {
+				return MARSHALLED_IN(Vector4, unbox_addr<GDMonoMarshal::M_Vector4>(p_obj));
+			}
+
+			if (vtclass == CACHED_CLASS(Vector4i)) {
+				return MARSHALLED_IN(Vector4i, unbox_addr<GDMonoMarshal::M_Vector4i>(p_obj));
+			}
+
 			if (vtclass == CACHED_CLASS(Basis)) {
 				return MARSHALLED_IN(Basis, unbox_addr<GDMonoMarshal::M_Basis>(p_obj));
 			}


### PR DESCRIPTION
Mono marshalling is missing some crucial logic for `Vector4` and `Vector4i`. Changes from first commit specifically allow to marshall `Vector4` and `Vector4i` objects to Godot, without it all C# calls to native Godot classes will result in runtime errors (`Vector4` not recognised as a `Variant`).

Please note that while at this moment the error makes it impossible to properly use `Vector4` in C# code, the whole marshalling class will be removed with #64089 so it is a temporary fix.