### PR TITLE
Restore ability to drag 'n' drop Mesh to Viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4113,6 +4113,7 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 						continue;
 					}
 					Ref<PackedScene> scn = res;
+					Ref<Mesh> mesh = res;
 					Ref<Material> mat = res;
 					Ref<Texture2D> tex = res;
 					if (scn.is_valid()) {
@@ -4131,6 +4132,8 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 
 						spatial_editor->set_preview_material(mat);
 						break;
+					} else if (mesh.is_valid()) {
+						// Let the mesh pass.
 					} else if (tex.is_valid()) {
 						Ref<StandardMaterial3D> new_mat = memnew(StandardMaterial3D);
 						new_mat->set_texture(BaseMaterial3D::TEXTURE_ALBEDO, tex);


### PR DESCRIPTION
While I was giving a shot at https://github.com/godotengine/godot-proposals/issues/5204, I noticed that you could no longer drop meshes. Somebody forgot a small check...

![Showcase](https://i.gyazo.com/7c5afddce145645cb61d0788f16a2460.gif)

_I don't know what else should be checked to make sure Meshes can be previewed? Is it even possible to result in a error? At worst it wouldn't display at all, or not import properly in the first place...?_