### PR TITLE
Fix MenuBar minimum size adding unnecessary extra spacing after the last item.

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -749,7 +749,6 @@ Size2 MenuBar::get_minimum_size() const {
 	}
 
 	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
-	int hsep = get_theme_constant(SNAME("h_separation"));
 
 	Vector2 size;
 	for (int i = 0; i < menu_cache.size(); i++) {
@@ -758,7 +757,10 @@ Size2 MenuBar::get_minimum_size() const {
 		}
 		Size2 sz = menu_cache[i].text_buf->get_size() + style->get_minimum_size();
 		size.y = MAX(size.y, sz.y);
-		size.x += sz.x + hsep;
+		size.x += sz.x;
+	}
+	if (menu_cache.size() > 1) {
+		size.x += get_theme_constant(SNAME("h_separation")) * (menu_cache.size() - 1);
 	}
 	return size;
 }


### PR DESCRIPTION
Before:
<img width="269" alt="Screenshot 2022-08-19 at 17 12 35" src="https://user-images.githubusercontent.com/7645683/185637762-fff37a02-03b1-4db0-bbee-cbc896073c36.png">

After:
<img width="269" alt="Screenshot 2022-08-19 at 17 09 04" src="https://user-images.githubusercontent.com/7645683/185637576-8241c973-603c-44be-ab17-7748e3835bba.png">

