### PR TITLE
Fix `Menubar` having an unneeded extra separation space

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -760,6 +760,12 @@ Size2 MenuBar::get_minimum_size() const {
 		size.y = MAX(size.y, sz.y);
 		size.x += sz.x + hsep;
 	}
+
+	// Remove the last extraneous spacing.
+	if (size.x > 0) {
+		size.x -= hsep;
+	}
+
 	return size;
 }
 


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/30739239/185638029-73fb629e-c223-4c65-9997-7f04914e4058.png)