### PR TITLE
Document that `Area` only works with box shapes

### DIFF
--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -4,7 +4,7 @@
 		3D area for detection and physics and audio influence.
 	</brief_description>
 	<description>
-		3D area that detects [CollisionObject3D] nodes overlapping, entering, or exiting. Can also alter or override local physics parameters (gravity, damping) and route audio to custom audio buses.
+		3D area that detects [CollisionObject3D] nodes overlapping, entering, or exiting. Area only work with collision shapes of the type BOX, other types like Trimesh or Concave shape will not work. Can also alter or override local physics parameters (gravity, damping) and route audio to custom audio buses.
 	</description>
 	<tutorials>
 		<link title="3D Platformer Demo">https://godotengine.org/asset-library/asset/125</link>


### PR DESCRIPTION
I am posting here the changes as requested here: https://github.com/godotengine/godot/pull/64613

Other types of collision shapes not show any warning in the editor, but not work if added.
I lost various hours to find this, changed layers collision...etc and when I change the collision shape to BOX worked.
I reported here also: https://github.com/godotengine/godot/issues/64615

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
