### PR TITLE
Replace meta properties with regular properties in `Control`

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -170,6 +170,9 @@ private:
 
 		// Positioning and sizing.
 
+		LayoutMode stored_layout_mode = LayoutMode::LAYOUT_MODE_POSITION;
+		bool stored_use_custom_anchors = false;
+
 		real_t offset[4] = { 0.0, 0.0, 0.0, 0.0 };
 		real_t anchor[4] = { ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN, ANCHOR_BEGIN };
 		FocusMode focus_mode = FOCUS_NONE;
@@ -275,6 +278,7 @@ private:
 
 	void _set_layout_mode(LayoutMode p_mode);
 	LayoutMode _get_layout_mode() const;
+	LayoutMode _get_default_layout_mode() const;
 	void _set_anchors_layout_preset(int p_preset);
 	int _get_anchors_layout_preset() const;
 
@@ -318,6 +322,9 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	virtual void _validate_property(PropertyInfo &property) const override;
+
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 
 	// Internationalization.
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/61343. Supersedes https://github.com/godotengine/godot/pull/61529.

As discussed with @reduz, meta in this case is likely not needed and normal properties should be used. The logic should be overwise unchanged, including ignoring the stored value if it doesn't match the state of the control (e.g. it doesn't matter if the layout mode is stored as "anchors" if it's a child of a container, we just ignore it).

The property is now saved more often, but it shouldn't be a huge bother, as it is a property of the node after all, even if it's not relevant for the runtime.

-----

~I'll have to rebase this soon to update for the changes in property revert methods from https://github.com/godotengine/godot/pull/64334. But as far as this PR is concerned, this is a cosmetic change. Though some builds will fail, because I didn't update the documentation for temporarily bound methods. They'll soon be gone, so there is no point in doing that.~ Done