### PR TITLE
Add "Check debug output for more details." to export result dialog when there are no explicit error messages

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -89,7 +89,7 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err) 
 	}
 	p_log->add_newline();
 
-	if (msg_count) {
+	if (msg_count > 0) {
 		p_log->push_table(2);
 		p_log->set_table_column_expand(0, false);
 		p_log->set_table_column_expand(1, true);
@@ -129,8 +129,11 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err) 
 		}
 		p_log->pop();
 		p_log->add_newline();
+	} else {
+		p_log->add_text(TTR("Check debug output for more details."));
+		p_log->add_newline();
 	}
-	p_log->add_newline();
+
 	return has_messages;
 }
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/64630 for other changes

![image](https://user-images.githubusercontent.com/14253836/185684546-62d46d8d-510c-4679-8289-cf8c9c4ce17d.png)

PATCH for 3.x cherry pick
---

Note:

- The first part of this patch is already part of 4.0, so omitted from the PR itself
- The change to the `if` statement was omitted in the patch for simplicity, since the behavior is the same.

```diff
From bf754df13afcfa7ec14cdb4bbe6cdbf97b06ba6b Mon Sep 17 00:00:00 2001
From: Nathan Franke <me@nathan.sh>
Date: Fri, 19 Aug 2022 13:01:17 -0500
Subject: [PATCH] add "Check debug output for more details." to export dialog

---
 editor/editor_export.cpp | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)

diff --git a/editor/editor_export.cpp b/editor/editor_export.cpp
index 8c7f30e78e..f867df3150 100644
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -251,6 +251,7 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err)
                p_log->add_text(TTR("Failed."));
                has_messages = true;
        }
+       p_log->add_newline();
 
        if (msg_count) {
                p_log->push_table(2);
@@ -292,8 +293,11 @@ bool EditorExportPlatform::fill_log_messages(RichTextLabel *p_log, Error p_err)
                }
                p_log->pop();
                p_log->add_newline();
+       } else {
+               p_log->add_text(TTR("Check debug output for more details."));
+               p_log->add_newline();
        }
-       p_log->add_newline();
+
        return has_messages;
 }
 
-- 
2.37.2
```
