### PR TITLE
Make `Menu/OptionButton` item auto-highlight behave better

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -64,6 +64,8 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 
 	bool button_masked = mouse_button.is_valid() && (mouse_button_to_mask(mouse_button->get_button_index()) & button_mask) != MouseButton::NONE;
 	if (button_masked || ui_accept) {
+		was_mouse_pressed = button_masked;
+
 		on_action_event(p_event);
 		return;
 	}
@@ -415,6 +417,10 @@ bool BaseButton::_is_focus_owner_in_shortcut_context() const {
 
 	// If the context is valid and the viewport focus is valid, check if the context is the focus or is a parent of it.
 	return ctx_node && vp_focus && (ctx_node == vp_focus || ctx_node->is_ancestor_of(vp_focus));
+}
+
+bool BaseButton::_was_pressed_by_mouse() const {
+	return was_mouse_pressed;
 }
 
 void BaseButton::_bind_methods() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -49,6 +49,7 @@ private:
 	MouseButton button_mask = MouseButton::MASK_LEFT;
 	bool toggle_mode = false;
 	bool shortcut_in_tooltip = true;
+	bool was_mouse_pressed = false;
 	bool keep_pressed_outside = false;
 	Ref<Shortcut> shortcut;
 	ObjectID shortcut_context;
@@ -81,6 +82,7 @@ protected:
 	void _notification(int p_what);
 
 	bool _is_focus_owner_in_shortcut_context() const;
+	bool _was_pressed_by_mouse() const;
 
 	GDVIRTUAL0(_pressed)
 	GDVIRTUAL1(_toggled, bool)

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -99,9 +99,7 @@ void MenuButton::pressed() {
 	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), size));
 
 	// If not triggered by the mouse, start the popup with its first item selected.
-	if (popup->get_item_count() > 0 &&
-			((get_action_mode() == ActionMode::ACTION_MODE_BUTTON_PRESS && Input::get_singleton()->is_action_just_pressed("ui_accept")) ||
-					(get_action_mode() == ActionMode::ACTION_MODE_BUTTON_RELEASE && Input::get_singleton()->is_action_just_released("ui_accept")))) {
+	if (popup->get_item_count() > 0 && !_was_pressed_by_mouse()) {
 		popup->set_current_index(0);
 	}
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -204,8 +204,7 @@ void OptionButton::pressed() {
 
 	// If not triggered by the mouse, start the popup with the checked item selected.
 	if (popup->get_item_count() > 0) {
-		if ((get_action_mode() == ActionMode::ACTION_MODE_BUTTON_PRESS && Input::get_singleton()->is_action_just_pressed("ui_accept")) ||
-				(get_action_mode() == ActionMode::ACTION_MODE_BUTTON_RELEASE && Input::get_singleton()->is_action_just_released("ui_accept"))) {
+		if (!_was_pressed_by_mouse()) {
 			popup->set_current_index(current > -1 ? current : 0);
 		} else {
 			popup->scroll_to_item(current > -1 ? current : 0);


### PR DESCRIPTION
This fixes some stuff with the auto-highlight feature for the `Menu/OptionButton` nodes. Now, it checks if the mouse was actually used, instead of just relying on the "ui_accept" event. With that, triggering the buttons with a shortcut should also trigger the auto-highlight as well.