### PR TITLE
Create a SVG default project icon in new projects

### DIFF
--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -6,20 +6,20 @@
 	<description>
 		A [Texture2D] based on an [Image]. For an image to be displayed, an [ImageTexture] has to be created from it using the [method create_from_image] method:
 		[codeblock]
-		var image = Image.load_from_file("res://icon.png")
+		var image = Image.load_from_file("res://icon.svg")
 		var texture = ImageTexture.create_from_image(image)
 		$Sprite2D.texture = texture
 		[/codeblock]
 		This way, textures can be created at run-time by loading images both from within the editor and externally.
 		[b]Warning:[/b] Prefer to load imported textures with [method @GDScript.load] over loading them from within the filesystem dynamically with [method Image.load], as it may not work in exported projects:
 		[codeblock]
-		var texture = load("res://icon.png")
+		var texture = load("res://icon.svg")
 		$Sprite2D.texture = texture
 		[/codeblock]
 		This is because images have to be imported as a [CompressedTexture2D] first to be loaded with [method @GDScript.load]. If you'd still like to load an image file just like any other [Resource], import it as an [Image] resource instead, and then load it normally using the [method @GDScript.load] method.
 		[b]Note:[/b] The image can be retrieved from an imported texture using the [method Texture2D.get_image] method, which returns a copy of the image:
 		[codeblock]
-		var texture = load("res://icon.png")
+		var texture = load("res://icon.svg")
 		var image : Image = texture.get_image()
 		[/codeblock]
 		An [ImageTexture] is not meant to be operated from within the editor interface directly, and is mostly useful for rendering images on screen dynamically via code. If you need to generate images procedurally from within the editor, consider saving and importing images as custom texture resources implementing a new [EditorImportPlugin].

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1849,14 +1849,14 @@ Ref<Theme> create_custom_theme(const Ref<Theme> p_theme) {
 	return theme;
 }
 
-Ref<ImageTexture> create_unscaled_default_project_icon() {
-#ifdef MODULE_SVG_ENABLED
+/**
+ * Returns the SVG code for the default project icon.
+ */
+String get_default_project_icon() {
 	for (int i = 0; i < editor_icons_count; i++) {
-		// ESCALE should never affect size of the icon
 		if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0) {
-			return editor_generate_icon(i, false, 1.0);
+			return String(editor_icons_sources[i]);
 		}
 	}
-#endif
-	return Ref<ImageTexture>(memnew(ImageTexture));
+	return String();
 }

--- a/editor/editor_themes.h
+++ b/editor/editor_themes.h
@@ -38,6 +38,6 @@ Ref<Theme> create_editor_theme(Ref<Theme> p_theme = nullptr);
 
 Ref<Theme> create_custom_theme(Ref<Theme> p_theme = nullptr);
 
-Ref<ImageTexture> create_unscaled_default_project_icon();
+String get_default_project_icon();
 
 #endif // EDITOR_THEMES_H

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -483,12 +483,20 @@ private:
 					project_features.sort();
 					initial_settings["application/config/features"] = project_features;
 					initial_settings["application/config/name"] = project_name->get_text().strip_edges();
-					initial_settings["application/config/icon"] = "res://icon.png";
+					initial_settings["application/config/icon"] = "res://icon.svg";
 
 					if (ProjectSettings::get_singleton()->save_custom(dir.plus_file("project.godot"), initial_settings, Vector<String>(), false) != OK) {
 						set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 					} else {
-						ResourceSaver::save(create_unscaled_default_project_icon(), dir.plus_file("icon.png"));
+						// Store default project icon in SVG format.
+						Error err;
+						Ref<FileAccess> fa_icon = FileAccess::open(dir.plus_file("icon.svg"), FileAccess::WRITE, &err);
+						fa_icon->store_string(get_default_project_icon());
+
+						if (err != OK) {
+							set_message(TTR("Couldn't create icon.svg in project path."), MESSAGE_ERROR);
+						}
+
 						EditorVCSInterface::create_vcs_metadata_files(EditorVCSInterface::VCSMetadata(vcs_metadata_selection->get_selected()), dir);
 					}
 				} else if (mode == MODE_INSTALL) {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/58059.

This allows the icon's scale to be changed using the `svg/scale` import option, including to scales greater than the default 128×128.

Project created with the new SVG icon: [example_project.zip](https://github.com/godotengine/godot/files/9385730/example_project.zip)