### PR TITLE
Fix the wrong determination of code paths not returning and unreachable code caused by 'continue'

### DIFF
--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -72,7 +72,7 @@ String GDScriptWarning::get_message() const {
 		} break;
 		case UNREACHABLE_CODE: {
 			CHECK_SYMBOLS(1);
-			return "Unreachable code (statement after return) in function '" + symbols[0] + "()'.";
+			return "Unreachable code (statement after return or continue) in function '" + symbols[0] + "()'.";
 		} break;
 		case UNREACHABLE_PATTERN: {
 			return "Unreachable pattern (pattern after wildcard or bind).";

--- a/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_continue.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_continue.gd
@@ -1,0 +1,9 @@
+func test():
+    var x := 10
+    match x:
+        0:
+            continue
+            print_debug("Error: print after continue")
+        _:
+            continue
+            print_debug("Error: print after continue")

--- a/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_continue.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_continue.out
@@ -1,0 +1,9 @@
+GDTEST_OK
+>> WARNING
+>> Line: 6
+>> UNREACHABLE_CODE
+>> Unreachable code (statement after return or continue) in function 'test()'.
+>> WARNING
+>> Line: 9
+>> UNREACHABLE_CODE
+>> Unreachable code (statement after return or continue) in function 'test()'.

--- a/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_return.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_return.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 7
 >> UNREACHABLE_CODE
->> Unreachable code (statement after return) in function 'test()'.
+>> Unreachable code (statement after return or continue) in function 'test()'.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Related to #64181.
This pull request fixes the following:
1. The GDScript parser failed to determine unreachable code (including 'return' statements) caused by 'continue'.
2. The parser did not correctly determine 'continue' statements that lead to a 'return' in a 'match' block.

![image](https://user-images.githubusercontent.com/88014292/185782892-c7845457-6892-4b74-8549-26a649afc9d1.png)
