### PR TITLE
Add Node selector on Texture2D drag 'n' drop (in 3D)

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -187,6 +187,11 @@ private:
 	double gpu_time_history[FRAME_TIME_HISTORY];
 	int gpu_time_history_index;
 
+	// The type of node that will be created when dropping texture into the viewport.
+	String default_texture_node_type;
+	// Node types that are available to select from when dropping texture into viewport.
+	Vector<String> texture_node_types;
+
 	int index;
 	ViewType view_type;
 	void _menu_option(int p_option);
@@ -195,6 +200,9 @@ private:
 	AABB *preview_bounds = nullptr;
 	Vector<String> selected_files;
 	AcceptDialog *accept = nullptr;
+	AcceptDialog *resource_type_selector = nullptr;
+	VBoxContainer *button_container = nullptr;
+	Ref<ButtonGroup> button_group;
 
 	Node *target_node = nullptr;
 	Point2 drop_pos;
@@ -403,14 +411,23 @@ private:
 
 	Node *_sanitize_preview_node(Node *p_node) const;
 
+	void _on_select_type(Object *selected);
+	void _on_change_type_confirmed();
+	void _on_change_type_closed();
+	Node *_make_texture_node_type(String texture_node_type);
+
 	void _create_preview_node(const Vector<String> &files) const;
 	void _remove_preview_node();
 	bool _apply_preview_material(ObjectID p_target, const Point2 &p_point) const;
 	void _reset_preview_material() const;
 	void _remove_preview_material();
 	bool _cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node);
+	bool _only_packed_scenes_selected() const;
+	void _create_nodes(Node *parent, Node *child, String &path, const Point2 &p_point);
 	bool _create_instance(Node *parent, String &path, const Point2 &p_point);
 	void _perform_drop_data();
+	void _show_resource_type_selector();
+	void _create_resource_type_selector();
 
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);


### PR DESCRIPTION
Implements something like https://github.com/godotengine/godot-proposals/discussions/5210.

Implements the same Node type selector menu present in 2D when dragging **Texture2D** resources into the viewport, but for 3D. When holding ALT, the default "override texture" behaviour is... overridden.

![Showcase](https://i.gyazo.com/ecb1ff1527ec1c4b3b37c9d4ac7e959b.gif)

The following Nodes are present in the selection:
- **Sprite3D**;
- **CPUParticles3D**;
- **GPUParticles3D**;
- **Decal** _(very neat actually)_;
- **SpotLight3D**;
- **OmniLight3D**;

Draft because it's currently very iffy. It only works if you **begin** dragging while holding ALT, the original code from the 2D equivalent is actually annoyingly messy and disorganised... etc. etc.. It just doesn't work nicely enough now. Maybe in a future PR this "Node Type Menu" thing should be unified....