### PR TITLE
Change default AnimatedTexture's `fps` to 0

### DIFF
--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -55,9 +55,9 @@
 		<member name="current_frame" type="int" setter="set_current_frame" getter="get_current_frame">
 			Sets the currently visible frame of the texture.
 		</member>
-		<member name="fps" type="float" setter="set_fps" getter="get_fps" default="4.0">
-			Animation speed in frames per second. This value defines the default time interval between two frames of the animation, and thus the overall duration of the animation loop based on the [member frames] property. A value of 0 means no predefined number of frames per second, the animation will play according to each frame's frame delay (see [method set_frame_delay]).
-			For example, an animation with 8 frames, no frame delay and a [code]fps[/code] value of 2 will run for 4 seconds, with each frame lasting 0.5 seconds.
+		<member name="fps" type="float" setter="set_fps" getter="get_fps" default="0.0">
+			The animation speed, in frames per second. This property does not include the additional delay that may have been set for each frame (see [method set_frame_delay]).
+			[b]Example:[/b] Any animation running at [code]4[/code] fps will switch frames every 0.25 seconds, while at [code]0.5[/code] fps it will switch every 2 seconds.
 		</member>
 		<member name="frames" type="int" setter="set_frames" getter="get_frames" default="1">
 			Number of frames to use in the animation. While you can create the frames independently with [method set_frame_texture], you need to set this value for the animation to take new frames into account. The maximum number of frames is [constant MAX_FRAMES].

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -930,7 +930,7 @@ private:
 	int current_frame = 0;
 	bool pause = false;
 	bool oneshot = false;
-	float fps = 4.0;
+	float fps = 0.0;
 
 	float time = 0.0;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4742.

Previously it was a somewhat arbitrary **4.0**. I can only speculate it was done to show the AnimatedTexture... animate as soon as its frames were added, but the documentation makes full note of the behaviour when `fps` is set to **0**, which is quite a bit more more noteworthy.