### PR TITLE
Rename Label & RichTextLabel.`percent_visible` to `visible_ratio`

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -61,10 +61,6 @@
 			Limits the lines of text the node shows on screen.
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="2" />
-		<member name="percent_visible" type="float" setter="set_percent_visible" getter="get_percent_visible" default="1.0">
-			The fraction of characters to display, relative to the total number of characters (see [method get_total_character_count]). If set to [code]1.0[/code], all characters are displayed. If set to [code]0.5[/code], only half of the characters will be displayed. This can be useful when animating the text appearing in a dialog box.
-			[b]Note:[/b] Setting this property updates [member visible_characters] accordingly.
-		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="4" />
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="TextServer.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
@@ -89,10 +85,14 @@
 		</member>
 		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" default="-1">
 			The number of characters to display. If set to [code]-1[/code], all characters are displayed. This can be useful when animating the text appearing in a dialog box.
-			[b]Note:[/b] Setting this property updates [member percent_visible] accordingly.
+			[b]Note:[/b] Setting this property updates [member visible_ratio] accordingly.
 		</member>
 		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
-			Sets the clipping behavior when [member visible_characters] or [member percent_visible] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
+			Sets the clipping behavior when [member visible_characters] or [member visible_ratio] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
+		</member>
+		<member name="visible_ratio" type="float" setter="set_visible_ratio" getter="get_visible_ratio" default="1.0">
+			The fraction of characters to display, relative to the total number of characters (see [method get_total_character_count]). If set to [code]1.0[/code], all characters are displayed. If set to [code]0.5[/code], only half of the characters will be displayed. This can be useful when animating the text appearing in a dialog box.
+			[b]Note:[/b] Setting this property updates [member visible_characters] accordingly.
 		</member>
 	</members>
 	<theme_items>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -480,10 +480,6 @@
 		<member name="override_selected_font_color" type="bool" setter="set_override_selected_font_color" getter="is_overriding_selected_font_color" default="false">
 			If [code]true[/code], the label uses the custom font color.
 		</member>
-		<member name="percent_visible" type="float" setter="set_percent_visible" getter="get_percent_visible" default="1.0">
-			The fraction of characters to display, relative to the total number of characters (see [method get_total_character_count]). If set to [code]1.0[/code], all characters are displayed. If set to [code]0.5[/code], only half of the characters will be displayed. This can be useful when animating the text appearing in a dialog box.
-			[b]Note:[/b] Setting this property updates [member visible_characters] accordingly.
-		</member>
 		<member name="progress_bar_delay" type="int" setter="set_progress_bar_delay" getter="get_progress_bar_delay" default="1000">
 			The delay after which the loading progress bar is displayed, in milliseconds. Set to [code]-1[/code] to disable progress bar entirely.
 			[b]Note:[/b] Progress bar is displayed only if [member threaded] is enabled.
@@ -521,10 +517,14 @@
 		</member>
 		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" default="-1">
 			The number of characters to display. If set to [code]-1[/code], all characters are displayed. This can be useful when animating the text appearing in a dialog box.
-			[b]Note:[/b] Setting this property updates [member percent_visible] accordingly.
+			[b]Note:[/b] Setting this property updates [member visible_ratio] accordingly.
 		</member>
 		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
-			Sets the clipping behavior when [member visible_characters] or [member percent_visible] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
+			Sets the clipping behavior when [member visible_characters] or [member visible_ratio] is set. See [enum TextServer.VisibleCharactersBehavior] for more info.
+		</member>
+		<member name="visible_ratio" type="float" setter="set_visible_ratio" getter="get_visible_ratio" default="1.0">
+			The fraction of characters to display, relative to the total number of characters (see [method get_total_character_count]). If set to [code]1.0[/code], all characters are displayed. If set to [code]0.5[/code], only half of the characters will be displayed. This can be useful when animating the text appearing in a dialog box.
+			[b]Note:[/b] Setting this property updates [member visible_characters] accordingly.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1606,13 +1606,13 @@
 			Displays glyphs that are mapped to the first [member Label.visible_characters] or [member RichTextLabel.visible_characters] characters from the beginning of the text.
 		</constant>
 		<constant name="VC_GLYPHS_AUTO" value="2" enum="VisibleCharactersBehavior">
-			Displays [member Label.percent_visible] or [member RichTextLabel.percent_visible] glyphs, starting from the left or from the right, depending on [member Control.layout_direction] value.
+			Displays [member Label.visible_ratio] or [member RichTextLabel.visible_ratio] glyphs, starting from the left or from the right, depending on [member Control.layout_direction] value.
 		</constant>
 		<constant name="VC_GLYPHS_LTR" value="3" enum="VisibleCharactersBehavior">
-			Displays [member Label.percent_visible] or [member RichTextLabel.percent_visible] glyphs, starting from the left.
+			Displays [member Label.visible_ratio] or [member RichTextLabel.visible_ratio] glyphs, starting from the left.
 		</constant>
 		<constant name="VC_GLYPHS_RTL" value="4" enum="VisibleCharactersBehavior">
-			Displays [member Label.percent_visible] or [member RichTextLabel.percent_visible] glyphs, starting from the right.
+			Displays [member Label.visible_ratio] or [member RichTextLabel.visible_ratio] glyphs, starting from the right.
 		</constant>
 		<constant name="OVERRUN_NO_TRIMMING" value="0" enum="OverrunBehavior">
 			No text trimming is performed.

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -279,8 +279,8 @@ void Label::_notification(int p_what) {
 				return; // Nothing new.
 			}
 			xl_text = new_text;
-			if (percent_visible < 1) {
-				visible_chars = get_total_character_count() * percent_visible;
+			if (visible_ratio < 1) {
+				visible_chars = get_total_character_count() * visible_ratio;
 			}
 			dirty = true;
 
@@ -348,7 +348,7 @@ void Label::_notification(int p_what) {
 				total_h += TS->shaped_text_get_size(lines_rid[i]).y + line_spacing;
 				total_glyphs += TS->shaped_text_get_glyph_count(lines_rid[i]) + TS->shaped_text_get_ellipsis_glyph_count(lines_rid[i]);
 			}
-			int visible_glyphs = total_glyphs * percent_visible;
+			int visible_glyphs = total_glyphs * visible_ratio;
 			int processed_glyphs = 0;
 			total_h += style->get_margin(SIDE_TOP) + style->get_margin(SIDE_BOTTOM);
 
@@ -652,8 +652,8 @@ void Label::set_text(const String &p_string) {
 	text = p_string;
 	xl_text = atr(p_string);
 	dirty = true;
-	if (percent_visible < 1) {
-		visible_chars = get_total_character_count() * percent_visible;
+	if (visible_ratio < 1) {
+		visible_chars = get_total_character_count() * visible_ratio;
 	}
 	update();
 	update_minimum_size();
@@ -771,9 +771,9 @@ void Label::set_visible_characters(int p_amount) {
 	if (visible_chars != p_amount) {
 		visible_chars = p_amount;
 		if (get_total_character_count() > 0) {
-			percent_visible = (float)p_amount / (float)get_total_character_count();
+			visible_ratio = (float)p_amount / (float)get_total_character_count();
 		} else {
-			percent_visible = 1.0;
+			visible_ratio = 1.0;
 		}
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			dirty = true;
@@ -786,17 +786,17 @@ int Label::get_visible_characters() const {
 	return visible_chars;
 }
 
-void Label::set_percent_visible(float p_percent) {
-	if (percent_visible != p_percent) {
-		if (percent_visible >= 1.0) {
+void Label::set_visible_ratio(float p_ratio) {
+	if (visible_ratio != p_ratio) {
+		if (visible_ratio >= 1.0) {
 			visible_chars = -1;
-			percent_visible = 1.0;
-		} else if (percent_visible < 0.0) {
+			visible_ratio = 1.0;
+		} else if (visible_ratio < 0.0) {
 			visible_chars = 0;
-			percent_visible = 0.0;
+			visible_ratio = 0.0;
 		} else {
-			visible_chars = get_total_character_count() * p_percent;
-			percent_visible = p_percent;
+			visible_chars = get_total_character_count() * p_ratio;
+			visible_ratio = p_ratio;
 		}
 
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
@@ -806,8 +806,8 @@ void Label::set_percent_visible(float p_percent) {
 	}
 }
 
-float Label::get_percent_visible() const {
-	return percent_visible;
+float Label::get_visible_ratio() const {
+	return visible_ratio;
 }
 
 TextServer::VisibleCharactersBehavior Label::get_visible_characters_behavior() const {
@@ -889,8 +889,8 @@ void Label::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_visible_characters"), &Label::get_visible_characters);
 	ClassDB::bind_method(D_METHOD("get_visible_characters_behavior"), &Label::get_visible_characters_behavior);
 	ClassDB::bind_method(D_METHOD("set_visible_characters_behavior", "behavior"), &Label::set_visible_characters_behavior);
-	ClassDB::bind_method(D_METHOD("set_percent_visible", "percent_visible"), &Label::set_percent_visible);
-	ClassDB::bind_method(D_METHOD("get_percent_visible"), &Label::get_percent_visible);
+	ClassDB::bind_method(D_METHOD("set_visible_ratio", "ratio"), &Label::set_visible_ratio);
+	ClassDB::bind_method(D_METHOD("get_visible_ratio"), &Label::get_visible_ratio);
 	ClassDB::bind_method(D_METHOD("set_lines_skipped", "lines_skipped"), &Label::set_lines_skipped);
 	ClassDB::bind_method(D_METHOD("get_lines_skipped"), &Label::get_lines_skipped);
 	ClassDB::bind_method(D_METHOD("set_max_lines_visible", "lines_visible"), &Label::set_max_lines_visible);
@@ -911,10 +911,10 @@ void Label::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "lines_skipped", PROPERTY_HINT_RANGE, "0,999,1"), "set_lines_skipped", "get_lines_skipped");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_lines_visible", PROPERTY_HINT_RANGE, "-1,999,1"), "set_max_lines_visible", "get_max_lines_visible");
 
-	// Note: "visible_characters" and "percent_visible" should be set after "text" to be correctly applied.
+	// Note: "visible_characters" and "visible_ratio" should be set after "text" to be correctly applied.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visible_characters", PROPERTY_HINT_RANGE, "-1,128000,1"), "set_visible_characters", "get_visible_characters");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visible_characters_behavior", PROPERTY_HINT_ENUM, "Characters Before Shaping,Characters After Shaping,Glyphs (Layout Direction),Glyphs (Left-to-Right),Glyphs (Right-to-Left)"), "set_visible_characters_behavior", "get_visible_characters_behavior");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "percent_visible", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_percent_visible", "get_percent_visible");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "visible_ratio", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_visible_ratio", "get_visible_ratio");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -59,10 +59,9 @@ private:
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 	Array st_args;
 
-	float percent_visible = 1.0;
-
 	TextServer::VisibleCharactersBehavior visible_chars_behavior = TextServer::VC_CHARS_BEFORE_SHAPING;
 	int visible_chars = -1;
+	float visible_ratio = 1.0;
 	int lines_skipped = 0;
 	int max_lines_visible = -1;
 
@@ -110,21 +109,21 @@ public:
 	void set_uppercase(bool p_uppercase);
 	bool is_uppercase() const;
 
-	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
 	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);
+	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
 
 	void set_visible_characters(int p_amount);
 	int get_visible_characters() const;
 	int get_total_character_count() const;
+
+	void set_visible_ratio(float p_ratio);
+	float get_visible_ratio() const;
 
 	void set_clip_text(bool p_clip);
 	bool is_clipping_text() const;
 
 	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
 	TextServer::OverrunBehavior get_text_overrun_behavior() const;
-
-	void set_percent_visible(float p_percent);
-	float get_percent_visible() const;
 
 	void set_lines_skipped(int p_lines);
 	int get_lines_skipped() const;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -742,7 +742,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	bool trim_glyphs_ltr = (visible_characters >= 0) && ((visible_chars_behavior == TextServer::VC_GLYPHS_LTR) || ((visible_chars_behavior == TextServer::VC_GLYPHS_AUTO) && !lrtl));
 	bool trim_glyphs_rtl = (visible_characters >= 0) && ((visible_chars_behavior == TextServer::VC_GLYPHS_RTL) || ((visible_chars_behavior == TextServer::VC_GLYPHS_AUTO) && lrtl));
 	int total_glyphs = (trim_glyphs_ltr || trim_glyphs_rtl) ? get_total_glyph_count() : 0;
-	int visible_glyphs = total_glyphs * percent_visible;
+	int visible_glyphs = total_glyphs * visible_ratio;
 
 	Vector<int> list_index;
 	Vector<ItemList *> list_items;
@@ -4940,19 +4940,19 @@ TextServer::AutowrapMode RichTextLabel::get_autowrap_mode() const {
 	return autowrap_mode;
 }
 
-void RichTextLabel::set_percent_visible(float p_percent) {
-	if (percent_visible != p_percent) {
+void RichTextLabel::set_visible_ratio(float p_ratio) {
+	if (visible_ratio != p_ratio) {
 		_stop_thread();
 
-		if (percent_visible >= 1.0) {
+		if (visible_ratio >= 1.0) {
 			visible_characters = -1;
-			percent_visible = 1.0;
-		} else if (percent_visible < 0.0) {
+			visible_ratio = 1.0;
+		} else if (visible_ratio < 0.0) {
 			visible_characters = 0;
-			percent_visible = 0.0;
+			visible_ratio = 0.0;
 		} else {
-			visible_characters = get_total_character_count() * p_percent;
-			percent_visible = p_percent;
+			visible_characters = get_total_character_count() * p_ratio;
+			visible_ratio = p_ratio;
 		}
 
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
@@ -4963,8 +4963,8 @@ void RichTextLabel::set_percent_visible(float p_percent) {
 	}
 }
 
-float RichTextLabel::get_percent_visible() const {
-	return percent_visible;
+float RichTextLabel::get_visible_ratio() const {
+	return visible_ratio;
 }
 
 void RichTextLabel::set_effects(Array p_effects) {
@@ -5139,8 +5139,8 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_visible_characters_behavior"), &RichTextLabel::get_visible_characters_behavior);
 	ClassDB::bind_method(D_METHOD("set_visible_characters_behavior", "behavior"), &RichTextLabel::set_visible_characters_behavior);
 
-	ClassDB::bind_method(D_METHOD("set_percent_visible", "percent_visible"), &RichTextLabel::set_percent_visible);
-	ClassDB::bind_method(D_METHOD("get_percent_visible"), &RichTextLabel::get_percent_visible);
+	ClassDB::bind_method(D_METHOD("set_visible_ratio", "ratio"), &RichTextLabel::set_visible_ratio);
+	ClassDB::bind_method(D_METHOD("get_visible_ratio"), &RichTextLabel::get_visible_ratio);
 
 	ClassDB::bind_method(D_METHOD("get_character_line", "character"), &RichTextLabel::get_character_line);
 	ClassDB::bind_method(D_METHOD("get_character_paragraph", "character"), &RichTextLabel::get_character_paragraph);
@@ -5189,10 +5189,10 @@ void RichTextLabel::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hint_underlined"), "set_hint_underline", "is_hint_underlined");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autowrap_mode", PROPERTY_HINT_ENUM, "Off,Arbitrary,Word,Word (Smart)"), "set_autowrap_mode", "get_autowrap_mode");
 
-	// Note: "visible_characters" and "percent_visible" should be set after "text" to be correctly applied.
+	// Note: "visible_characters" and "visible_ratio" should be set after "text" to be correctly applied.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visible_characters", PROPERTY_HINT_RANGE, "-1,128000,1"), "set_visible_characters", "get_visible_characters");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visible_characters_behavior", PROPERTY_HINT_ENUM, "Characters Before Shaping,Characters After Shaping,Glyphs (Layout Direction),Glyphs (Left-to-Right),Glyphs (Right-to-Left)"), "set_visible_characters_behavior", "get_visible_characters_behavior");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "percent_visible", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_percent_visible", "get_percent_visible");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "visible_ratio", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_visible_ratio", "get_visible_ratio");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "context_menu_enabled"), "set_context_menu_enabled", "is_context_menu_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_keys_enabled"), "set_shortcut_keys_enabled", "is_shortcut_keys_enabled");
@@ -5264,11 +5264,11 @@ void RichTextLabel::set_visible_characters(int p_visible) {
 
 		visible_characters = p_visible;
 		if (p_visible == -1) {
-			percent_visible = 1;
+			visible_ratio = 1;
 		} else {
 			int total_char_count = get_total_character_count();
 			if (total_char_count > 0) {
-				percent_visible = (float)p_visible / (float)total_char_count;
+				visible_ratio = (float)p_visible / (float)total_char_count;
 			}
 		}
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -440,7 +440,7 @@ private:
 	void _menu_option(int p_option);
 
 	int visible_characters = -1;
-	float percent_visible = 1.0;
+	float visible_ratio = 1.0;
 	TextServer::VisibleCharactersBehavior visible_chars_behavior = TextServer::VC_CHARS_BEFORE_SHAPING;
 
 	bool _is_click_inside_selection() const;
@@ -660,8 +660,8 @@ public:
 	int get_total_character_count() const;
 	int get_total_glyph_count() const;
 
-	void set_percent_visible(float p_percent);
-	float get_percent_visible() const;
+	void set_visible_ratio(float p_ratio);
+	float get_visible_ratio() const;
 
 	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
 	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4978.

For **Label** & **RichTextLabel**:
`percent_visible` -> `visible_ratio`

This way its meaning is much clearer, and now the property can more tidily be organised with the similar `visible_characters`.
![image](https://user-images.githubusercontent.com/66727710/185760843-69ab1fb4-58ec-423e-bba6-d4c842599031.png)

Also updates the Documentation of both `visible_characters` and `visible_ratio` considerably, to better describe what they do and improve consistency between the two Classes.
![image](https://user-images.githubusercontent.com/66727710/185760895-373c00fb-4b86-4a4a-bfc5-a3247d5d4b8c.png)

