### PR TITLE
Clamp Label's `percent_visible` properly between 0 and 1.0

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -481,7 +481,7 @@
 			If [code]true[/code], the label uses the custom font color.
 		</member>
 		<member name="percent_visible" type="float" setter="set_percent_visible" getter="get_percent_visible" default="1.0">
-			The range of characters to display, as a [float] between 0.0 and 1.0. When assigned an out of range value, it's the same as assigning 1.0.
+			The range of characters to display, as a [float] between 0.0 and 1.0.
 			[b]Note:[/b] Setting this property updates [member visible_characters] based on current [method get_total_character_count].
 		</member>
 		<member name="progress_bar_delay" type="int" setter="set_progress_bar_delay" getter="get_progress_bar_delay" default="1000">

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -764,13 +764,17 @@ int Label::get_visible_characters() const {
 
 void Label::set_percent_visible(float p_percent) {
 	if (percent_visible != p_percent) {
-		if (p_percent < 0 || p_percent >= 1) {
+		if (percent_visible >= 1.0) {
 			visible_chars = -1;
-			percent_visible = 1;
+			percent_visible = 1.0;
+		} else if (percent_visible < 0.0) {
+			visible_chars = 0;
+			percent_visible = 0.0;
 		} else {
 			visible_chars = get_total_character_count() * p_percent;
 			percent_visible = p_percent;
 		}
+
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			dirty = true;
 		}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4912,15 +4912,19 @@ void RichTextLabel::set_percent_visible(float p_percent) {
 	if (percent_visible != p_percent) {
 		_stop_thread();
 
-		if (p_percent < 0 || p_percent >= 1) {
+		if (percent_visible >= 1.0) {
 			visible_characters = -1;
-			percent_visible = 1;
+			percent_visible = 1.0;
+		} else if (percent_visible < 0.0) {
+			visible_characters = 0;
+			percent_visible = 0.0;
 		} else {
 			visible_characters = get_total_character_count() * p_percent;
 			percent_visible = p_percent;
 		}
+
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
-			main->first_invalid_line.store(0); //invalidate ALL
+			main->first_invalid_line.store(0); // Invalidate ALL.
 			_validate_line_caches();
 		}
 		update();


### PR DESCRIPTION

While making https://github.com/godotengine/godot/pull/64665, I noticed a very peculiar line:
> The range of characters to display, as a [float] between 0.0 and 1.0. **When assigned an out of range value, it's the same as assigning 1.0.**

I thought to myself that this behaviour was very nonsensical, but perhaps it was later documented to avoid breaking compatibility? Either way, this PR just clamps `percent_visible` between 0 and 1.0 as should probably be expected.

Also applies to **RichTextLabel**.