### PR TITLE
Improve SplitContainer minimum size splitting

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -98,11 +98,10 @@ void SplitContainer::_resort() {
 	// Compute the final middle separation
 	middle_sep = no_offset_middle_sep;
 	if (!collapsed) {
-		int clamped_split_offset = CLAMP(split_offset, ms_first[axis] - no_offset_middle_sep, (get_size()[axis] - ms_second[axis] - sep) - no_offset_middle_sep);
-		middle_sep += clamped_split_offset;
+		int clamped_split_offset = CLAMP(split_offset, ms_first[axis] - no_offset_middle_sep, get_size()[axis] - ms_second[axis] - sep);
+		middle_sep = MAX(middle_sep, clamped_split_offset);
 		if (should_clamp_split_offset) {
 			split_offset = clamped_split_offset;
-
 			should_clamp_split_offset = false;
 		}
 	}


### PR DESCRIPTION
When its child's minimum size changed, SplitContainer would always re-adjust its split position. Basically the size was added to the split offset, which was rather bad.

Here's the old behavior:
![godot_LYzRPaaGL8](https://user-images.githubusercontent.com/2223172/185771602-be91c617-cc5d-4098-ab28-cc042f5a900d.gif)

After my changes, if the child control grows, it will no longer push the splitter unless its bigger than the current split position.
![godot windows tools 64_3A6RMDisQQ](https://user-images.githubusercontent.com/2223172/185771622-63b7541e-81d8-4432-8cd5-0896b00f1a3a.gif)

Fixes #43749
Mitigates #64273 (the import dock could still be thinner probably)
