### PR TITLE
Fix Quaternion Tween and add Easing baker to AnimationTrackEditor

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -112,10 +112,11 @@ Quaternion Quaternion::exp() const {
 	Quaternion src = *this;
 	Vector3 src_v = Vector3(src.x, src.y, src.z);
 	real_t theta = src_v.length();
-	if (theta < CMP_EPSILON) {
+	src_v = src_v.normalized();
+	if (theta < CMP_EPSILON || !src_v.is_normalized()) {
 		return Quaternion(0, 0, 0, 1);
 	}
-	return Quaternion(src_v.normalized(), theta);
+	return Quaternion(src_v, theta);
 }
 
 Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) const {

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -32,6 +32,7 @@
 #define ANIMATION_TRACK_EDITOR_H
 
 #include "editor/editor_data.h"
+#include "editor/editor_properties.h"
 #include "editor/editor_spin_slider.h"
 #include "editor/property_selector.h"
 
@@ -450,6 +451,12 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	////////////// edit menu stuff
 
+	ConfirmationDialog *bake_dialog = nullptr;
+	CheckBox *bake_trs = nullptr;
+	CheckBox *bake_blendshape = nullptr;
+	CheckBox *bake_value = nullptr;
+	SpinBox *bake_fps = nullptr;
+
 	ConfirmationDialog *optimize_dialog = nullptr;
 	SpinBox *optimize_linear_error = nullptr;
 	SpinBox *optimize_angular_error = nullptr;
@@ -462,6 +469,11 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	ConfirmationDialog *scale_dialog = nullptr;
 	SpinBox *scale = nullptr;
+
+	ConfirmationDialog *ease_dialog = nullptr;
+	OptionButton *transition_selection = nullptr;
+	OptionButton *ease_selection = nullptr;
+	SpinBox *ease_fps = nullptr;
 
 	void _select_all_tracks_for_copy();
 
@@ -520,6 +532,8 @@ public:
 		EDIT_SCALE_SELECTION,
 		EDIT_SCALE_FROM_CURSOR,
 		EDIT_SCALE_CONFIRM,
+		EDIT_EASE_SELECTION,
+		EDIT_EASE_CONFIRM,
 		EDIT_DUPLICATE_SELECTION,
 		EDIT_DUPLICATE_TRANSPOSED,
 		EDIT_ADD_RESET_KEY,
@@ -528,6 +542,8 @@ public:
 		EDIT_GOTO_NEXT_STEP_TIMELINE_ONLY, // Next step without updating animation.
 		EDIT_GOTO_PREV_STEP,
 		EDIT_APPLY_RESET,
+		EDIT_BAKE_ANIMATION,
+		EDIT_BAKE_ANIMATION_CONFIRM,
 		EDIT_OPTIMIZE_ANIMATION,
 		EDIT_OPTIMIZE_ANIMATION_CONFIRM,
 		EDIT_CLEAN_UP_ANIMATION,

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -479,12 +479,8 @@ Variant Tween::interpolate_variant(Variant p_initial_val, Variant p_delta_val, f
 		case Variant::QUATERNION: {
 			Quaternion i = p_initial_val;
 			Quaternion d = p_delta_val;
-			Quaternion r;
-
-			APPLY_EQUATION(x);
-			APPLY_EQUATION(y);
-			APPLY_EQUATION(z);
-			APPLY_EQUATION(w);
+			Quaternion r = i * d;
+			r = i.slerp(r, run_equation(p_trans, p_ease, p_time, 0.0, 1.0, p_duration));
 			return r;
 		}
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/61938263/185772227-cfed7e12-2812-42de-af25-155b9c2d7597.mp4

To improve editing of non-Bezier track animations, add the feature of baking Easing by Tween to the AnimationTrackEditor.

Especially, the ValueTrack has EasingCurve, but the TRS3D track does not have EasingCurve. Is this due to performance reasons or compression tracks @reduz? Well, it is possible to use tween interpolation as an alternative feature from EasingCurve.

The main use case for this feature is to easily add animation to simple skeleton models such as weapons or GUI objects or something. For smoothing in character animation, Cubic interpolation improved with #63380 and #63602 is more appropriate.

---

In addition, Quaternion tween was completely broken, so this PR fixed it with using slerp internally. Also, `Quaternion::exp()` checking algorithm had a problem, which has been fixed.