### PR TITLE
Expose NavigationMeshGenerator API for custom modules / addons / extentions

### DIFF
--- a/doc/classes/NavigationMeshGenerator.xml
+++ b/doc/classes/NavigationMeshGenerator.xml
@@ -28,5 +28,19 @@
 				Removes all polygons and vertices from the provided [param navigation_mesh] resource.
 			</description>
 		</method>
+		<method name="register_geometry_parser_3d">
+			<return type="void" />
+			<param index="0" name="geometry_parser" type="NavigationGeometryParser3D" />
+			<description>
+				Registers a navigation geometry parser to contribute geometry data from parser specified node class(es) for navmesh baking.
+			</description>
+		</method>
+		<method name="unregister_geometry_parser_3d">
+			<return type="void" />
+			<param index="0" name="geometry_parser" type="NavigationGeometryParser3D" />
+			<description>
+				Unregisters the specific navigation geometry parser.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/modules/navigation/config.py
+++ b/modules/navigation/config.py
@@ -4,3 +4,13 @@ def can_build(env, platform):
 
 def configure(env):
     pass
+
+
+def get_doc_classes():
+    return [
+        "NavigationGeometryParser3D",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/navigation/doc_classes/NavigationGeometryParser3D.xml
+++ b/modules/navigation/doc_classes/NavigationGeometryParser3D.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationGeometryParser3D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Parser to contribute a node's geometry data for [NavigationMesh] baking.
+	</brief_description>
+	<description>
+		Parser to contribute a node's geometry data for [NavigationMesh] baking. If a script extends this class and the function [method _parses_node] is overridden and returns [code]true[/code] the overridden function [method _parse_geometry] gets called and can be used to add custom geometry data for the [NavigationMesh] baking process.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_parse_geometry" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="node" type="Node" />
+			<param index="1" name="navigationmesh" type="NavigationMesh" />
+			<description>
+				Called when overridden and the [NavigationMeshGenerator] is parsing geometry for [NavigationMesh] baking. Custom 3D geometry can be added to the array's of [code]vertices[/code] and [code]indices[/code] with functions [method add_faces], [method add_mesh] or [method add_mesh_array] to be considered in the navmesh baking process.
+			</description>
+		</method>
+		<method name="_parses_node" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="node" type="Node" />
+			<description>
+				Called when parsing geometry nodes for navigationmesh baking. If [code]true[/code] will call [method _parse_geometry] with this node.
+			</description>
+		</method>
+		<method name="add_faces">
+			<return type="void" />
+			<param index="0" name="faces" type="PackedVector3Array" />
+			<param index="1" name="xform" type="Transform3D" />
+			<description>
+				Adds an array of vertex positions to the geometry data for navmesh baking to form triangulated faces. For each face the array must have three vertex positions in clockwise winding order. Since [NavigationMesh] resource have no transform all vertex positions need to be offset by the node's transform using the [code]xform[/code] parameter.
+			</description>
+		</method>
+		<method name="add_mesh">
+			<return type="void" />
+			<param index="0" name="mesh" type="Mesh" />
+			<param index="1" name="xform" type="Transform3D" />
+			<description>
+				Adds the geometry data of a [Mesh] resource to the navmesh baking data. The mesh must have valid triangulated mesh data to be considered. Since [NavigationMesh] resource have no transform all vertex positions need to be offset by the node's transform using the [code]xform[/code] parameter.
+			</description>
+		</method>
+		<method name="add_mesh_array">
+			<return type="void" />
+			<param index="0" name="mesh_array" type="Array" />
+			<param index="1" name="xform" type="Transform3D" />
+			<description>
+				Adds an [Array] the size of [constant Mesh.ARRAY_MAX] and with vertices at index [constant Mesh.ARRAY_VERTEX] and indices at index [constant Mesh.ARRAY_INDEX] to the navmesh baking data. The array must have valid triangulated mesh data to be considered. Since [NavigationMesh] resource have no transform all vertex positions need to be offset by the node's transform using the [code]xform[/code] parameter.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/navigation/geometry_parser/csgshape3d_navigation_geometry_parser_3d.h
+++ b/modules/navigation/geometry_parser/csgshape3d_navigation_geometry_parser_3d.h
@@ -1,0 +1,59 @@
+/*************************************************************************/
+/*  csgshape3d_navigation_geometry_parser_3d.h                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef CSGSHAPE3D_NAVIGATION_GEOMETRY_PARSER_3D_H
+#define CSGSHAPE3D_NAVIGATION_GEOMETRY_PARSER_3D_H
+
+#include "modules/csg/csg_shape.h"
+#include "modules/navigation/navigation_geometry_parser_3d.h"
+
+class CSGShape3DNavigationGeometryParser3D : public NavigationGeometryParser3D {
+public:
+	virtual bool parses_node(Node *p_node) override {
+		return (Object::cast_to<CSGShape3D>(p_node) != nullptr);
+	}
+
+	virtual void parse_geometry(Node *p_node, Ref<NavigationMesh> p_navigationmesh) override {
+		NavigationMesh::ParsedGeometryType parsed_geometry_type = p_navigationmesh->get_parsed_geometry_type();
+
+		if (Object::cast_to<CSGShape3D>(p_node) && parsed_geometry_type != NavigationMesh::PARSED_GEOMETRY_STATIC_COLLIDERS) {
+			CSGShape3D *csg_shape = Object::cast_to<CSGShape3D>(p_node);
+			Array meshes = csg_shape->get_meshes();
+			if (!meshes.is_empty()) {
+				Ref<Mesh> mesh = meshes[1];
+				if (mesh.is_valid()) {
+					add_mesh(mesh, csg_shape->get_global_transform());
+				}
+			}
+		}
+	}
+};
+
+#endif // CSGSHAPE3D_NAVIGATION_GEOMETRY_PARSER_3D_H

--- a/modules/navigation/geometry_parser/gridmap_navigation_geometry_parser_3d.h
+++ b/modules/navigation/geometry_parser/gridmap_navigation_geometry_parser_3d.h
@@ -1,0 +1,195 @@
+/*************************************************************************/
+/*  gridmap_navigation_geometry_parser_3d.h                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef GRIDMAP_NAVIGATION_GEOMETRY_PARSER_3D_H
+#define GRIDMAP_NAVIGATION_GEOMETRY_PARSER_3D_H
+
+#include "modules/gridmap/grid_map.h"
+#include "modules/navigation/navigation_geometry_parser_3d.h"
+
+#include "core/math/convex_hull.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/physics_body_3d.h"
+#include "scene/resources/box_shape_3d.h"
+#include "scene/resources/capsule_shape_3d.h"
+#include "scene/resources/concave_polygon_shape_3d.h"
+#include "scene/resources/convex_polygon_shape_3d.h"
+#include "scene/resources/cylinder_shape_3d.h"
+#include "scene/resources/height_map_shape_3d.h"
+#include "scene/resources/primitive_meshes.h"
+#include "scene/resources/shape_3d.h"
+#include "scene/resources/sphere_shape_3d.h"
+#include "scene/resources/world_boundary_shape_3d.h"
+
+class GridMap3DNavigationGeometryParser3D : public NavigationGeometryParser3D {
+public:
+	virtual bool parses_node(Node *p_node) override {
+		return (Object::cast_to<GridMap>(p_node) != nullptr);
+	}
+
+	virtual void parse_geometry(Node *p_node, Ref<NavigationMesh> p_navigationmesh) override {
+		GridMap *gridmap = Object::cast_to<GridMap>(p_node);
+		NavigationMesh::ParsedGeometryType parsed_geometry_type = p_navigationmesh->get_parsed_geometry_type();
+		uint32_t navigationmesh_collision_mask = p_navigationmesh->get_collision_mask();
+
+		if (gridmap) {
+			if (parsed_geometry_type != NavigationMesh::PARSED_GEOMETRY_STATIC_COLLIDERS) {
+				Array meshes = gridmap->get_meshes();
+				Transform3D xform = gridmap->get_global_transform();
+				for (int i = 0; i < meshes.size(); i += 2) {
+					Ref<Mesh> mesh = meshes[i + 1];
+					if (mesh.is_valid()) {
+						add_mesh(mesh, xform * (Transform3D)meshes[i]);
+					}
+				}
+			}
+
+			if (parsed_geometry_type != NavigationMesh::PARSED_GEOMETRY_MESH_INSTANCES && (gridmap->get_collision_layer() & navigationmesh_collision_mask)) {
+				Array shapes = gridmap->get_collision_shapes();
+				for (int i = 0; i < shapes.size(); i += 2) {
+					RID shape = shapes[i + 1];
+					PhysicsServer3D::ShapeType type = PhysicsServer3D::get_singleton()->shape_get_type(shape);
+					Variant data = PhysicsServer3D::get_singleton()->shape_get_data(shape);
+
+					switch (type) {
+						case PhysicsServer3D::SHAPE_SPHERE: {
+							real_t radius = data;
+							Array arr;
+							arr.resize(RS::ARRAY_MAX);
+							SphereMesh::create_mesh_array(arr, radius, radius * 2.0);
+							add_mesh_array(arr, shapes[i]);
+						} break;
+						case PhysicsServer3D::SHAPE_BOX: {
+							Vector3 extents = data;
+							Array arr;
+							arr.resize(RS::ARRAY_MAX);
+							BoxMesh::create_mesh_array(arr, extents * 2.0);
+							add_mesh_array(arr, shapes[i]);
+						} break;
+						case PhysicsServer3D::SHAPE_CAPSULE: {
+							Dictionary dict = data;
+							real_t radius = dict["radius"];
+							real_t height = dict["height"];
+							Array arr;
+							arr.resize(RS::ARRAY_MAX);
+							CapsuleMesh::create_mesh_array(arr, radius, height);
+							add_mesh_array(arr, shapes[i]);
+						} break;
+						case PhysicsServer3D::SHAPE_CYLINDER: {
+							Dictionary dict = data;
+							real_t radius = dict["radius"];
+							real_t height = dict["height"];
+							Array arr;
+							arr.resize(RS::ARRAY_MAX);
+							CylinderMesh::create_mesh_array(arr, radius, radius, height);
+							add_mesh_array(arr, shapes[i]);
+						} break;
+						case PhysicsServer3D::SHAPE_CONVEX_POLYGON: {
+							PackedVector3Array vertices = data;
+							Geometry3D::MeshData md;
+
+							Error err = ConvexHullComputer::convex_hull(vertices, md);
+
+							if (err == OK) {
+								PackedVector3Array faces;
+
+								for (uint32_t j = 0; j < md.faces.size(); ++j) {
+									const Geometry3D::MeshData::Face &face = md.faces[j];
+
+									for (uint32_t k = 2; k < face.indices.size(); ++k) {
+										faces.push_back(md.vertices[face.indices[0]]);
+										faces.push_back(md.vertices[face.indices[k - 1]]);
+										faces.push_back(md.vertices[face.indices[k]]);
+									}
+								}
+
+								add_faces(faces, shapes[i]);
+							}
+						} break;
+						case PhysicsServer3D::SHAPE_CONCAVE_POLYGON: {
+							Dictionary dict = data;
+							PackedVector3Array faces = Variant(dict["faces"]);
+							add_faces(faces, shapes[i]);
+						} break;
+						case PhysicsServer3D::SHAPE_HEIGHTMAP: {
+							Dictionary dict = data;
+							///< dict( int:"width", int:"depth",float:"cell_size", float_array:"heights"
+							int heightmap_depth = dict["depth"];
+							int heightmap_width = dict["width"];
+
+							if (heightmap_depth >= 2 && heightmap_width >= 2) {
+								const Vector<real_t> &map_data = dict["heights"];
+
+								Vector2 heightmap_gridsize(heightmap_width - 1, heightmap_depth - 1);
+								Vector2 start = heightmap_gridsize * -0.5;
+
+								Vector<Vector3> vertex_array;
+								vertex_array.resize((heightmap_depth - 1) * (heightmap_width - 1) * 6);
+								int map_data_current_index = 0;
+
+								for (int d = 0; d < heightmap_depth - 1; d++) {
+									for (int w = 0; w < heightmap_width - 1; w++) {
+										if (map_data_current_index + 1 + heightmap_depth < map_data.size()) {
+											float top_left_height = map_data[map_data_current_index];
+											float top_right_height = map_data[map_data_current_index + 1];
+											float bottom_left_height = map_data[map_data_current_index + heightmap_depth];
+											float bottom_right_height = map_data[map_data_current_index + 1 + heightmap_depth];
+
+											Vector3 top_left = Vector3(start.x + w, top_left_height, start.y + d);
+											Vector3 top_right = Vector3(start.x + w + 1.0, top_right_height, start.y + d);
+											Vector3 bottom_left = Vector3(start.x + w, bottom_left_height, start.y + d + 1.0);
+											Vector3 bottom_right = Vector3(start.x + w + 1.0, bottom_right_height, start.y + d + 1.0);
+
+											vertex_array.push_back(top_right);
+											vertex_array.push_back(bottom_left);
+											vertex_array.push_back(top_left);
+											vertex_array.push_back(top_right);
+											vertex_array.push_back(bottom_right);
+											vertex_array.push_back(bottom_left);
+										}
+										map_data_current_index += 1;
+									}
+								}
+								if (vertex_array.size() > 0) {
+									add_faces(vertex_array, shapes[i]);
+								}
+							}
+						} break;
+						default: {
+							WARN_PRINT("Unsupported collision shape type.");
+						} break;
+					}
+				}
+			}
+		}
+	}
+};
+
+#endif // GRIDMAP_NAVIGATION_GEOMETRY_PARSER_3D_H

--- a/modules/navigation/geometry_parser/meshinstance3d_navigation_geometry_parser_3d.h
+++ b/modules/navigation/geometry_parser/meshinstance3d_navigation_geometry_parser_3d.h
@@ -1,0 +1,56 @@
+/*************************************************************************/
+/*  meshinstance3d_navigation_geometry_parser_3d.h                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef MESHINSTANCE3D_NAVIGATION_GEOMETRY_PARSER_3D_H
+#define MESHINSTANCE3D_NAVIGATION_GEOMETRY_PARSER_3D_H
+
+#include "modules/navigation/navigation_geometry_parser_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+
+class MeshInstance3DNavigationGeometryParser3D : public NavigationGeometryParser3D {
+public:
+	virtual bool parses_node(Node *p_node) override {
+		return (Object::cast_to<MeshInstance3D>(p_node) != nullptr);
+	}
+
+	virtual void parse_geometry(Node *p_node, Ref<NavigationMesh> p_navigationmesh) override {
+		NavigationMesh::ParsedGeometryType parsed_geometry_type = p_navigationmesh->get_parsed_geometry_type();
+
+		if (Object::cast_to<MeshInstance3D>(p_node) && parsed_geometry_type != NavigationMesh::PARSED_GEOMETRY_STATIC_COLLIDERS) {
+			MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(p_node);
+			Ref<Mesh> mesh = mesh_instance->get_mesh();
+			if (mesh.is_valid()) {
+				add_mesh(mesh, mesh_instance->get_global_transform());
+			}
+		}
+	}
+};
+
+#endif // MESHINSTANCE3D_NAVIGATION_GEOMETRY_PARSER_3D_H

--- a/modules/navigation/geometry_parser/multimeshinstance3d_navigation_geometry_parser_3d.h
+++ b/modules/navigation/geometry_parser/multimeshinstance3d_navigation_geometry_parser_3d.h
@@ -1,0 +1,65 @@
+/*************************************************************************/
+/*  multimeshinstance3d_navigation_geometry_parser_3d.h                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef MULTIMESHINSTANCE3D_NAVIGATION_GEOMETRY_PARSER_3D_H
+#define MULTIMESHINSTANCE3D_NAVIGATION_GEOMETRY_PARSER_3D_H
+
+#include "modules/navigation/navigation_geometry_parser_3d.h"
+#include "scene/3d/multimesh_instance_3d.h"
+
+class MultiMeshInstance3DNavigationGeometryParser3D : public NavigationGeometryParser3D {
+public:
+	virtual bool parses_node(Node *p_node) override {
+		return (Object::cast_to<MultiMeshInstance3D>(p_node) != nullptr);
+	}
+
+	virtual void parse_geometry(Node *p_node, Ref<NavigationMesh> p_navigationmesh) override {
+		NavigationMesh::ParsedGeometryType parsed_geometry_type = p_navigationmesh->get_parsed_geometry_type();
+
+		if (Object::cast_to<MultiMeshInstance3D>(p_node) && parsed_geometry_type != NavigationMesh::PARSED_GEOMETRY_STATIC_COLLIDERS) {
+			MultiMeshInstance3D *multimesh_instance = Object::cast_to<MultiMeshInstance3D>(p_node);
+			Ref<MultiMesh> multimesh = multimesh_instance->get_multimesh();
+			if (multimesh.is_valid()) {
+				Ref<Mesh> mesh = multimesh->get_mesh();
+				if (mesh.is_valid()) {
+					int n = multimesh->get_visible_instance_count();
+					if (n == -1) {
+						n = multimesh->get_instance_count();
+					}
+					for (int i = 0; i < n; i++) {
+						add_mesh(mesh, multimesh_instance->get_global_transform() * multimesh->get_instance_transform(i));
+					}
+				}
+			}
+		}
+	}
+};
+
+#endif // MULTIMESHINSTANCE3D_NAVIGATION_GEOMETRY_PARSER_3D_H

--- a/modules/navigation/geometry_parser/staticbody3d_navigation_geometry_parser_3d.h
+++ b/modules/navigation/geometry_parser/staticbody3d_navigation_geometry_parser_3d.h
@@ -1,0 +1,189 @@
+/*************************************************************************/
+/*  staticbody3d_navigation_geometry_parser_3d.h                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef STATICBODY3D_NAVIGATION_GEOMETRY_PARSER_3D_H
+#define STATICBODY3D_NAVIGATION_GEOMETRY_PARSER_3D_H
+
+#include "modules/navigation/navigation_geometry_parser_3d.h"
+
+#include "core/math/convex_hull.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/physics_body_3d.h"
+#include "scene/resources/box_shape_3d.h"
+#include "scene/resources/capsule_shape_3d.h"
+#include "scene/resources/concave_polygon_shape_3d.h"
+#include "scene/resources/convex_polygon_shape_3d.h"
+#include "scene/resources/cylinder_shape_3d.h"
+#include "scene/resources/height_map_shape_3d.h"
+#include "scene/resources/primitive_meshes.h"
+#include "scene/resources/shape_3d.h"
+#include "scene/resources/sphere_shape_3d.h"
+#include "scene/resources/world_boundary_shape_3d.h"
+
+class StaticBody3DNavigationGeometryParser3D : public NavigationGeometryParser3D {
+public:
+	virtual bool parses_node(Node *p_node) override {
+		return (Object::cast_to<StaticBody3D>(p_node) != nullptr);
+	}
+
+	virtual void parse_geometry(Node *p_node, Ref<NavigationMesh> p_navigationmesh) override {
+		NavigationMesh::ParsedGeometryType parsed_geometry_type = p_navigationmesh->get_parsed_geometry_type();
+		uint32_t navigationmesh_collision_mask = p_navigationmesh->get_collision_mask();
+
+		if (Object::cast_to<StaticBody3D>(p_node) && parsed_geometry_type != NavigationMesh::PARSED_GEOMETRY_MESH_INSTANCES) {
+			StaticBody3D *static_body = Object::cast_to<StaticBody3D>(p_node);
+			if (static_body->get_collision_layer() & navigationmesh_collision_mask) {
+				List<uint32_t> shape_owners;
+				static_body->get_shape_owners(&shape_owners);
+				for (uint32_t shape_owner : shape_owners) {
+					const int shape_count = static_body->shape_owner_get_shape_count(shape_owner);
+					for (int i = 0; i < shape_count; i++) {
+						if (static_body->is_shape_owner_disabled(i)) {
+							continue;
+						}
+						Ref<Shape3D> s = static_body->shape_owner_get_shape(shape_owner, i);
+						if (s.is_null()) {
+							continue;
+						}
+
+						const Transform3D transform = static_body->get_global_transform() * static_body->shape_owner_get_transform(shape_owner);
+
+						BoxShape3D *box = Object::cast_to<BoxShape3D>(*s);
+						if (box) {
+							Array arr;
+							arr.resize(RS::ARRAY_MAX);
+							BoxMesh::create_mesh_array(arr, box->get_size());
+							add_mesh_array(arr, transform);
+						}
+
+						CapsuleShape3D *capsule = Object::cast_to<CapsuleShape3D>(*s);
+						if (capsule) {
+							Array arr;
+							arr.resize(RS::ARRAY_MAX);
+							CapsuleMesh::create_mesh_array(arr, capsule->get_radius(), capsule->get_height());
+							add_mesh_array(arr, transform);
+						}
+
+						CylinderShape3D *cylinder = Object::cast_to<CylinderShape3D>(*s);
+						if (cylinder) {
+							Array arr;
+							arr.resize(RS::ARRAY_MAX);
+							CylinderMesh::create_mesh_array(arr, cylinder->get_radius(), cylinder->get_radius(), cylinder->get_height());
+							add_mesh_array(arr, transform);
+						}
+
+						SphereShape3D *sphere = Object::cast_to<SphereShape3D>(*s);
+						if (sphere) {
+							Array arr;
+							arr.resize(RS::ARRAY_MAX);
+							SphereMesh::create_mesh_array(arr, sphere->get_radius(), sphere->get_radius() * 2.0);
+							add_mesh_array(arr, transform);
+						}
+
+						ConcavePolygonShape3D *concave_polygon = Object::cast_to<ConcavePolygonShape3D>(*s);
+						if (concave_polygon) {
+							add_faces(concave_polygon->get_faces(), transform);
+						}
+
+						ConvexPolygonShape3D *convex_polygon = Object::cast_to<ConvexPolygonShape3D>(*s);
+						if (convex_polygon) {
+							Vector<Vector3> varr = Variant(convex_polygon->get_points());
+							Geometry3D::MeshData md;
+
+							Error err = ConvexHullComputer::convex_hull(varr, md);
+
+							if (err == OK) {
+								PackedVector3Array faces;
+
+								for (uint32_t j = 0; j < md.faces.size(); ++j) {
+									const Geometry3D::MeshData::Face &face = md.faces[j];
+
+									for (uint32_t k = 2; k < face.indices.size(); ++k) {
+										faces.push_back(md.vertices[face.indices[0]]);
+										faces.push_back(md.vertices[face.indices[k - 1]]);
+										faces.push_back(md.vertices[face.indices[k]]);
+									}
+								}
+
+								add_faces(faces, transform);
+							}
+						}
+
+						HeightMapShape3D *heightmap_shape = Object::cast_to<HeightMapShape3D>(*s);
+						if (heightmap_shape) {
+							int heightmap_depth = heightmap_shape->get_map_depth();
+							int heightmap_width = heightmap_shape->get_map_width();
+
+							if (heightmap_depth >= 2 && heightmap_width >= 2) {
+								const Vector<real_t> &map_data = heightmap_shape->get_map_data();
+
+								Vector2 heightmap_gridsize(heightmap_width - 1, heightmap_depth - 1);
+								Vector2 start = heightmap_gridsize * -0.5;
+
+								Vector<Vector3> vertex_array;
+								vertex_array.resize((heightmap_depth - 1) * (heightmap_width - 1) * 6);
+								int map_data_current_index = 0;
+
+								for (int d = 0; d < heightmap_depth - 1; d++) {
+									for (int w = 0; w < heightmap_width - 1; w++) {
+										if (map_data_current_index + 1 + heightmap_depth < map_data.size()) {
+											float top_left_height = map_data[map_data_current_index];
+											float top_right_height = map_data[map_data_current_index + 1];
+											float bottom_left_height = map_data[map_data_current_index + heightmap_depth];
+											float bottom_right_height = map_data[map_data_current_index + 1 + heightmap_depth];
+
+											Vector3 top_left = Vector3(start.x + w, top_left_height, start.y + d);
+											Vector3 top_right = Vector3(start.x + w + 1.0, top_right_height, start.y + d);
+											Vector3 bottom_left = Vector3(start.x + w, bottom_left_height, start.y + d + 1.0);
+											Vector3 bottom_right = Vector3(start.x + w + 1.0, bottom_right_height, start.y + d + 1.0);
+
+											vertex_array.push_back(top_right);
+											vertex_array.push_back(bottom_left);
+											vertex_array.push_back(top_left);
+											vertex_array.push_back(top_right);
+											vertex_array.push_back(bottom_right);
+											vertex_array.push_back(bottom_left);
+										}
+										map_data_current_index += 1;
+									}
+								}
+								if (vertex_array.size() > 0) {
+									add_faces(vertex_array, transform);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+};
+
+#endif // STATICBODY3D_NAVIGATION_GEOMETRY_PARSER_3D_H

--- a/modules/navigation/navigation_geometry_parser_3d.cpp
+++ b/modules/navigation/navigation_geometry_parser_3d.cpp
@@ -1,0 +1,198 @@
+/*************************************************************************/
+/*  navigation_geometry_parser_3d.cpp                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef _3D_DISABLED
+
+#include "navigation_geometry_parser_3d.h"
+
+void NavigationGeometryParser3D::_add_vertex(const Vector3 &p_vec3) {
+	if (total_parsed_vertices == nullptr || total_parsed_indices == nullptr) {
+		return;
+	}
+	total_parsed_vertices->push_back(p_vec3.x);
+	total_parsed_vertices->push_back(p_vec3.y);
+	total_parsed_vertices->push_back(p_vec3.z);
+}
+
+void NavigationGeometryParser3D::_add_mesh(const Ref<Mesh> &p_mesh, const Transform3D &p_xform) {
+	if (total_parsed_vertices == nullptr || total_parsed_indices == nullptr) {
+		return;
+	}
+	int current_vertex_count;
+	for (int i = 0; i < p_mesh->get_surface_count(); i++) {
+		current_vertex_count = total_parsed_vertices->size() / 3;
+
+		if (p_mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
+			continue;
+		}
+
+		int index_count = 0;
+		if (p_mesh->surface_get_format(i) & Mesh::ARRAY_FORMAT_INDEX) {
+			index_count = p_mesh->surface_get_array_index_len(i);
+		} else {
+			index_count = p_mesh->surface_get_array_len(i);
+		}
+
+		ERR_CONTINUE((index_count == 0 || (index_count % 3) != 0));
+
+		int face_count = index_count / 3;
+
+		Array a = p_mesh->surface_get_arrays(i);
+
+		Vector<Vector3> mesh_vertices = a[Mesh::ARRAY_VERTEX];
+		const Vector3 *vr = mesh_vertices.ptr();
+
+		if (p_mesh->surface_get_format(i) & Mesh::ARRAY_FORMAT_INDEX) {
+			Vector<int> mesh_indices = a[Mesh::ARRAY_INDEX];
+			const int *ir = mesh_indices.ptr();
+
+			for (int j = 0; j < mesh_vertices.size(); j++) {
+				_add_vertex(p_xform.xform(vr[j]));
+			}
+
+			for (int j = 0; j < face_count; j++) {
+				// CCW
+				total_parsed_indices->push_back(current_vertex_count + (ir[j * 3 + 0]));
+				total_parsed_indices->push_back(current_vertex_count + (ir[j * 3 + 2]));
+				total_parsed_indices->push_back(current_vertex_count + (ir[j * 3 + 1]));
+			}
+		} else {
+			face_count = mesh_vertices.size() / 3;
+			for (int j = 0; j < face_count; j++) {
+				_add_vertex(p_xform.xform(vr[j * 3 + 0]));
+				_add_vertex(p_xform.xform(vr[j * 3 + 2]));
+				_add_vertex(p_xform.xform(vr[j * 3 + 1]));
+
+				total_parsed_indices->push_back(current_vertex_count + (j * 3 + 0));
+				total_parsed_indices->push_back(current_vertex_count + (j * 3 + 1));
+				total_parsed_indices->push_back(current_vertex_count + (j * 3 + 2));
+			}
+		}
+	}
+}
+
+void NavigationGeometryParser3D::_add_mesh_array(const Array &p_array, const Transform3D &p_xform) {
+	if (total_parsed_vertices == nullptr || total_parsed_indices == nullptr) {
+		return;
+	}
+	Vector<Vector3> mesh_vertices = p_array[Mesh::ARRAY_VERTEX];
+	const Vector3 *vr = mesh_vertices.ptr();
+
+	Vector<int> mesh_indices = p_array[Mesh::ARRAY_INDEX];
+	const int *ir = mesh_indices.ptr();
+
+	const int face_count = mesh_indices.size() / 3;
+	const int current_vertex_count = total_parsed_vertices->size() / 3;
+
+	for (int j = 0; j < mesh_vertices.size(); j++) {
+		_add_vertex(p_xform.xform(vr[j]));
+	}
+
+	for (int j = 0; j < face_count; j++) {
+		// CCW
+		total_parsed_indices->push_back(current_vertex_count + (ir[j * 3 + 0]));
+		total_parsed_indices->push_back(current_vertex_count + (ir[j * 3 + 2]));
+		total_parsed_indices->push_back(current_vertex_count + (ir[j * 3 + 1]));
+	}
+}
+
+void NavigationGeometryParser3D::_add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform) {
+	if (total_parsed_vertices == nullptr || total_parsed_indices == nullptr) {
+		return;
+	}
+	int face_count = p_faces.size() / 3;
+	int current_vertex_count = total_parsed_vertices->size() / 3;
+
+	for (int j = 0; j < face_count; j++) {
+		_add_vertex(p_xform.xform(p_faces[j * 3 + 0]));
+		_add_vertex(p_xform.xform(p_faces[j * 3 + 1]));
+		_add_vertex(p_xform.xform(p_faces[j * 3 + 2]));
+
+		total_parsed_indices->push_back(current_vertex_count + (j * 3 + 0));
+		total_parsed_indices->push_back(current_vertex_count + (j * 3 + 2));
+		total_parsed_indices->push_back(current_vertex_count + (j * 3 + 1));
+	}
+}
+
+bool NavigationGeometryParser3D::parses_node(Node *p_node) {
+	bool parses_this_node;
+	if (Object::cast_to<Node3D>(p_node) == nullptr) {
+		parses_this_node = false;
+		return parses_this_node;
+	}
+	if (GDVIRTUAL_CALL(_parses_node, p_node, parses_this_node)) {
+		return parses_this_node;
+	}
+
+	return false;
+}
+
+void NavigationGeometryParser3D::parse_node_geometry(const Transform3D &p_navmesh_transform, Ref<NavigationMesh> p_navigationmesh, Node *p_node, Vector<float> &p_vertices, Vector<int> &p_indices) {
+	// GDScript cannot use large vertices and indices vector array's passed by ref in a performant way without making slow copies
+	// to work around this issue we store vector array's internally and only expose add functions to scripting users
+	navmesh_transform = p_navmesh_transform;
+	total_parsed_vertices = &p_vertices;
+	total_parsed_indices = &p_indices;
+
+	parse_geometry(p_node, p_navigationmesh);
+
+	navmesh_transform = Transform3D();
+	total_parsed_vertices = nullptr;
+	total_parsed_indices = nullptr;
+}
+
+void NavigationGeometryParser3D::parse_geometry(Node *p_node, Ref<NavigationMesh> p_navigationmesh) {
+	if (GDVIRTUAL_CALL(_parse_geometry, p_node, p_navigationmesh)) {
+		return;
+	}
+}
+
+void NavigationGeometryParser3D::add_mesh(const Ref<Mesh> &p_mesh, const Transform3D &p_xform) {
+	_add_mesh(p_mesh, navmesh_transform * p_xform);
+}
+
+void NavigationGeometryParser3D::add_mesh_array(const Array &p_array, const Transform3D &p_xform) {
+	_add_mesh_array(p_array, navmesh_transform * p_xform);
+}
+
+void NavigationGeometryParser3D::add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform) {
+	_add_faces(p_faces, navmesh_transform * p_xform);
+}
+
+void NavigationGeometryParser3D::_bind_methods() {
+	GDVIRTUAL_BIND(_parses_node, "node");
+	GDVIRTUAL_BIND(_parse_geometry, "node", "navigationmesh")
+
+	ClassDB::bind_method(D_METHOD("add_mesh", "mesh", "xform"), &NavigationGeometryParser3D::add_mesh);
+	ClassDB::bind_method(D_METHOD("add_mesh_array", "mesh_array", "xform"), &NavigationGeometryParser3D::add_mesh_array);
+	ClassDB::bind_method(D_METHOD("add_faces", "faces", "xform"), &NavigationGeometryParser3D::add_faces);
+}
+
+#endif // _3D_DISABLED

--- a/modules/navigation/navigation_geometry_parser_3d.h
+++ b/modules/navigation/navigation_geometry_parser_3d.h
@@ -1,0 +1,70 @@
+/*************************************************************************/
+/*  navigation_geometry_parser_3d.h                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef NAVIGATION_GEOMETRY_PARSER_3D_H
+#define NAVIGATION_GEOMETRY_PARSER_3D_H
+
+#include "core/templates/vector.h"
+#include "scene/3d/node_3d.h"
+#include "scene/resources/navigation_mesh.h"
+
+class NavigationGeometryParser3D : public RefCounted {
+	GDCLASS(NavigationGeometryParser3D, RefCounted);
+	friend class NavigationMeshGenerator;
+
+protected:
+	static void _bind_methods();
+
+	GDVIRTUAL1RC(bool, _parses_node, Node *);
+
+	GDVIRTUAL2C(_parse_geometry, Node *, Ref<NavigationMesh>);
+
+private:
+	Transform3D navmesh_transform = Transform3D();
+	Vector<float> *total_parsed_vertices = nullptr;
+	Vector<int> *total_parsed_indices = nullptr;
+
+	void parse_node_geometry(const Transform3D &p_navmesh_transform, Ref<NavigationMesh> p_navigationmesh, Node *p_node, Vector<float> &p_vertices, Vector<int> &p_indices);
+
+	void _add_vertex(const Vector3 &p_vec3);
+	void _add_mesh(const Ref<Mesh> &p_mesh, const Transform3D &p_xform);
+	void _add_mesh_array(const Array &p_array, const Transform3D &p_xform);
+	void _add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform);
+
+public:
+	virtual bool parses_node(Node *p_node);
+	virtual void parse_geometry(Node *p_node, Ref<NavigationMesh> p_navigationmesh);
+
+	void add_mesh(const Ref<Mesh> &p_mesh, const Transform3D &p_xform);
+	void add_mesh_array(const Array &p_array, const Transform3D &p_xform);
+	void add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform);
+};
+
+#endif // NAVIGATION_GEOMETRY_PARSER_3D_H

--- a/modules/navigation/navigation_mesh_generator.h
+++ b/modules/navigation/navigation_mesh_generator.h
@@ -33,6 +33,8 @@
 
 #ifndef _3D_DISABLED
 
+#include "core/templates/local_vector.h"
+#include "navigation_geometry_parser_3d.h"
 #include "scene/3d/navigation_region_3d.h"
 
 #include <Recast.h>
@@ -46,6 +48,8 @@ class NavigationMeshGenerator : public Object {
 
 	static NavigationMeshGenerator *singleton;
 
+	LocalVector<Ref<NavigationGeometryParser3D>> geometry_3d_parsers;
+
 protected:
 	static void _bind_methods();
 
@@ -53,7 +57,7 @@ protected:
 	static void _add_mesh(const Ref<Mesh> &p_mesh, const Transform3D &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices);
 	static void _add_mesh_array(const Array &p_array, const Transform3D &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices);
 	static void _add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices);
-	static void _parse_geometry(const Transform3D &p_navmesh_transform, Node *p_node, Vector<float> &p_vertices, Vector<int> &p_indices, NavigationMesh::ParsedGeometryType p_generate_from, uint32_t p_collision_mask, bool p_recurse_children);
+	static void _parse_geometry_node(const Transform3D &p_navmesh_transform, Ref<NavigationMesh> p_navigationmesh, Node *p_node, Vector<float> &p_vertices, Vector<int> &p_indices, bool p_recurse_children);
 
 	static void _convert_detail_mesh_to_native_navigation_mesh(const rcPolyMeshDetail *p_detail_mesh, Ref<NavigationMesh> p_navigation_mesh);
 	static void _build_recast_navigation_mesh(
@@ -77,6 +81,11 @@ public:
 
 	void bake(Ref<NavigationMesh> p_navigation_mesh, Node *p_root_node);
 	void clear(Ref<NavigationMesh> p_navigation_mesh);
+
+	void register_geometry_parser_3d(const Ref<NavigationGeometryParser3D> &p_geometry_parser);
+	void unregister_geometry_parser_3d(const Ref<NavigationGeometryParser3D> &p_geometry_parser);
+
+	void cleanup() { geometry_3d_parsers.clear(); };
 };
 
 #endif


### PR DESCRIPTION
Implementation draft for proposal https://github.com/godotengine/godot-proposals/issues/5138 to open the `NavigationMeshGenerator` API and `NavigationMesh` baking for custom modules / addons / extentions and move the node type specific code to dedicated files.

Adds `NavigationGeometryParser3D` class.

This class can be extended and registered on the NavigationMeshGenerator singleton to contribute 3D geometry from specified node class(es) for navmesh baking.
```gdscript
var parser : NavigationGeometryParser3D = NavigationGeometryParser3D.new()
NavigationMeshGenerator.register_geometry_parser_3d(parser)
NavigationMeshGenerator.unregister_geometry_parser_3d(parser)
```
Modules can use the `parses_node(`) and `parse_geometry()` directly while scripts can override the underscore `_parses_node()` and `_parse_geometry()` functions. Since navmesh baking with ReCast requires specific, triangulated mesh data helper functions are exposed to add mesh resources or mesh arrays or single faces to the source geometry.

GDScript example with function override:

```gdscript
extends NavigationGeometryParser3D

func _parses_node(node : Node):
    # return true if this node wants to add baking geometry
    return node is CustomNode3D

func _parse_geometry(node: Node, navigationmesh : NavigationMesh):
    var mesh : Mesh = PlaneMesh.new()
    mesh.size = Vector2(10.0,10.0)
    var mesh_xfrom : Transform3D = node.global_transform
    add_mesh(mesh, mesh_xfrom)
    
    var mesh_array : Array = mesh.get_mesh_arrays()
    mesh_xfrom.origin.x += 5.0
    mesh_xfrom.origin.z += 5.0
    add_mesh_array(mesh_array, mesh_xfrom)
    
    mesh_xfrom.origin.x -= 10.0
    mesh_xfrom.origin.z -= 10.0
    var faces : PackedVector3Array = mesh.get_faces()
    add_faces(faces, mesh_xfrom)
```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
