### PR TITLE
Add new highlighting color for function definition overrides

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -49,6 +49,7 @@ private:
 
 	HashMap<StringName, Color> keywords;
 	HashMap<StringName, Color> member_keywords;
+	HashMap<StringName, Color> function_keywords;
 	HashSet<StringName> global_functions;
 
 	enum Type {
@@ -74,6 +75,7 @@ private:
 	Color function_color;
 	Color global_function_color;
 	Color function_definition_color;
+	Color function_definition_override_color;
 	Color built_in_type_color;
 	Color number_color;
 	Color member_color;


### PR DESCRIPTION
This PR adds a new **highlight color** for when a function definition in a **Script** is actually overriding a function defined either in the inherited **Script** or base class.

I feel like this is going to be immensely useful. Whole branches of **Scripts** are prone get kind of large, and it's difficult to keep track of the options available to you. I find overriding functions to be a very powerful concept in general, but in practice most users only make use of them to override function callbacks.

It's also a clever reminder to new and returning users of **Godot 4** to put `super._ready()` in `_ready()`. I know I have...

![image](https://user-images.githubusercontent.com/66727710/185796001-6e93101b-1920-4fbc-88e9-d66ba1f62813.png)

The actual color could be developed upon, but I think a **blue-to-purplish** hue by default would suit them nicely, similar to what has been done in https://github.com/godotengine/godot/pull/64651.

