### PR TITLE
Fixed AnimationNode has_filter: binding & virtual

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -357,6 +357,10 @@ bool AnimationNode::is_path_filtered(const NodePath &p_path) const {
 }
 
 bool AnimationNode::has_filter() const {
+	if (get_script_instance()) {
+		return get_script_instance()->call("has_filter");
+	}
+
 	return false;
 }
 
@@ -427,7 +431,7 @@ void AnimationNode::_bind_methods() {
 	}
 	BIND_VMETHOD(MethodInfo("process", PropertyInfo(Variant::REAL, "time"), PropertyInfo(Variant::BOOL, "seek")));
 	BIND_VMETHOD(MethodInfo(Variant::STRING, "get_caption"));
-	BIND_VMETHOD(MethodInfo(Variant::STRING, "has_filter"));
+	BIND_VMETHOD(MethodInfo(Variant::BOOL, "has_filter"));
 
 	ADD_SIGNAL(MethodInfo("removed_from_graph"));
 


### PR DESCRIPTION
This tiny PR fixes AnimationNode.[has_filter](https://docs.godotengine.org/en/stable/classes/class_animationnode.html#class-animationnode-method-has-filter).

As of version 3.5 it has a wrong [binding](https://github.com/godotengine/godot/blob/1ea8b9d2b7da2285e890e087ff2b354e4d458b66/scene/animation/animation_tree.cpp#L430): `string` return value instead of `bool` and the method is not virtual as marked since it [doesn't](https://github.com/godotengine/godot/blob/1ea8b9d2b7da2285e890e087ff2b354e4d458b66/scene/animation/animation_tree.cpp#L360) call a script implementation if present (as all other virtual methods do, like [get_caption](https://github.com/godotengine/godot/blob/1ea8b9d2b7da2285e890e087ff2b354e4d458b66/scene/animation/animation_tree.cpp#L301).

Hence, this fix allows creating custom `AnimationNode` which filter capabilities. 
(which is a hard requirement for our project for which we are evaluating Godot as the engine atm).

P.S. The fix seems to be in line with the behavior in master (Godot 4.0): see [here](https://github.com/godotengine/godot/blob/0c5f254956f0115e363ce08045dd178dc30b54f8/scene/animation/animation_tree.h#L122) and [here](https://github.com/godotengine/godot/blob/0c5f254956f0115e363ce08045dd178dc30b54f8/scene/animation/animation_tree.cpp#L377))