### PR TITLE
Fix GPUParticles2D ignoring AtlasTexture region

### DIFF
--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -82,6 +82,8 @@ private:
 
 	void _attach_sub_emitter();
 
+	void _texture_changed();
+
 protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;


### PR DESCRIPTION
Fixes #13923.
Also fixes GPUParticles2D's texture not updating in some cases.