### PR TITLE
Warn when connecting from CollisionObject with `input_pickable` disabled

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -478,6 +478,7 @@ void CollisionObject2D::set_pickable(bool p_enabled) {
 
 	pickable = p_enabled;
 	_update_pickable();
+	update_configuration_warnings();
 }
 
 bool CollisionObject2D::is_pickable() const {
@@ -559,6 +560,18 @@ TypedArray<String> CollisionObject2D::get_configuration_warnings() const {
 
 	if (shapes.is_empty()) {
 		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape."));
+	}
+
+	if (!pickable) {
+		List<Connection> connections;
+		get_signal_connection_list("mouse_entered", &connections);
+		get_signal_connection_list("mouse_exited", &connections);
+		get_signal_connection_list("mouse_shape_entered", &connections);
+		get_signal_connection_list("mouse_shape_exited", &connections);
+
+		if (connections.size() > 0) {
+			warnings.push_back(RTR("This node's mouse signals are connected, but the mouse cannot interact with this node.\nConsider enabling input_pickable to allow this functionality."));
+		}
 	}
 
 	return warnings;

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -417,6 +417,7 @@ void CollisionObject3D::_on_transform_changed() {
 void CollisionObject3D::set_ray_pickable(bool p_ray_pickable) {
 	ray_pickable = p_ray_pickable;
 	_update_pickable();
+	update_configuration_warnings();
 }
 
 bool CollisionObject3D::is_ray_pickable() const {
@@ -692,6 +693,18 @@ TypedArray<String> CollisionObject3D::get_configuration_warnings() const {
 
 	if (shapes.is_empty()) {
 		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape3D or CollisionPolygon3D as a child to define its shape."));
+	}
+
+	if (!ray_pickable) {
+		List<Connection> connections;
+		get_signal_connection_list("mouse_entered", &connections);
+		get_signal_connection_list("mouse_exited", &connections);
+		get_signal_connection_list("mouse_shape_entered", &connections);
+		get_signal_connection_list("mouse_shape_exited", &connections);
+
+		if (connections.size() > 0) {
+			warnings.push_back(RTR("This node's mouse signals are connected, but the mouse cannot interact with this node.\nConsider enabling input_ray_pickable to allow this functionality."));
+		}
 	}
 
 	return warnings;


### PR DESCRIPTION
Partially(?) closes https://github.com/godotengine/godot-proposals/issues/2441.

A configuration warning is issued, if any of the mouse signals are connected when `input_pickable` is disabled.
![Configuration warning](https://user-images.githubusercontent.com/66727710/185808768-93c1fc0f-1eda-4592-9c13-faedd82f4485.png)
Applies also for **CollisionObject3D** and `input_ray_pickable`.

~On the technical side, and this is... TOTALLY very invasive... To do the "_connect on warning_" properly, **Object**::`connect` had been turned into **virtual** function. If this change or behaviour is undesired, I can strip it away and only keep the configuration warning, which should be enough for most people, anyhow?~