### PR TITLE
Expose `set/get_tab_button_icon()` to scripting

### DIFF
--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -42,6 +42,13 @@
 				Returns [code]true[/code] if select with right mouse button is enabled.
 			</description>
 		</method>
+		<method name="get_tab_button_icon" qualifiers="const">
+			<return type="Texture" />
+			<argument index="0" name="tab_idx" type="int" />
+			<description>
+				Returns the button icon from the tab at index [code]tab_idx[/code].
+			</description>
+		</method>
 		<method name="get_tab_count" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -110,6 +117,14 @@
 				If [code]true[/code], enables selecting a tab with the right mouse button.
 			</description>
 		</method>
+		<method name="set_tab_button_icon">
+			<return type="void" />
+			<argument index="0" name="tab_idx" type="int" />
+			<argument index="1" name="icon" type="Texture" />
+			<description>
+				Sets the button icon from the tab at index [code]tab_idx[/code].
+			</description>
+		</method>
 		<method name="set_tab_disabled">
 			<return type="void" />
 			<argument index="0" name="tab_idx" type="int" />
@@ -169,7 +184,7 @@
 		<signal name="right_button_pressed">
 			<argument index="0" name="tab" type="int" />
 			<description>
-				Emitted when a tab is right-clicked.
+				Emitted when a tab's right button is pressed. See [method set_tab_button_icon].
 			</description>
 		</signal>
 		<signal name="tab_changed">

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -139,7 +139,7 @@ void Tabs::_gui_input(const Ref<InputEvent> &p_event) {
 
 		if (rb_pressing && !mb->is_pressed() && mb->get_button_index() == BUTTON_LEFT) {
 			if (rb_hover != -1) {
-				// Right mouse button pressed.
+				// Right tab button pressed.
 				emit_signal("right_button_pressed", rb_hover);
 			}
 
@@ -955,6 +955,8 @@ void Tabs::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tab_title", "tab_idx"), &Tabs::get_tab_title);
 	ClassDB::bind_method(D_METHOD("set_tab_icon", "tab_idx", "icon"), &Tabs::set_tab_icon);
 	ClassDB::bind_method(D_METHOD("get_tab_icon", "tab_idx"), &Tabs::get_tab_icon);
+	ClassDB::bind_method(D_METHOD("set_tab_button_icon", "tab_idx", "icon"), &Tabs::set_tab_right_button);
+	ClassDB::bind_method(D_METHOD("get_tab_button_icon", "tab_idx"), &Tabs::get_tab_right_button);
 	ClassDB::bind_method(D_METHOD("set_tab_disabled", "tab_idx", "disabled"), &Tabs::set_tab_disabled);
 	ClassDB::bind_method(D_METHOD("get_tab_disabled", "tab_idx"), &Tabs::get_tab_disabled);
 	ClassDB::bind_method(D_METHOD("remove_tab", "tab_idx"), &Tabs::remove_tab);


### PR DESCRIPTION
Fixes #64498.
Supersedes #64686.