### PR TITLE
Implement a patch system.

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -102,6 +102,25 @@ void PackedData::add_pack_source(PackSource *p_source) {
 	}
 }
 
+uint8_t *PackedData::get_file_hash(const String &p_path) {
+	PathMD5 pmd5(p_path.md5_buffer());
+	HashMap<PathMD5, PackedFile, PathMD5>::Iterator E = files.find(pmd5);
+	if (!E) {
+		return nullptr;
+	}
+	if (E->value.offset == 0) {
+		return nullptr;
+	}
+
+	return E->value.md5;
+}
+
+void PackedData::clear() {
+	files.clear();
+	_free_packed_dirs(root);
+	root = memnew(PackedDir);
+}
+
 PackedData *PackedData::singleton = nullptr;
 
 PackedData::PackedData() {

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -111,12 +111,15 @@ private:
 public:
 	void add_pack_source(PackSource *p_source);
 	void add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted = false); // for PackSource
+	uint8_t *get_file_hash(const String &p_path);
 
 	void set_disabled(bool p_disabled) { disabled = p_disabled; }
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
 	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
+
+	void clear();
 
 	_FORCE_INLINE_ Ref<FileAccess> try_open_path(const String &p_path);
 	_FORCE_INLINE_ bool has_path(const String &p_path);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -992,9 +992,17 @@ void EditorNode::_fs_changed() {
 				export_preset->update_value_overrides();
 				if (export_defer.pack_only) { // Only export .pck or .zip data pack.
 					if (export_path.ends_with(".zip")) {
-						err = platform->export_zip(export_preset, export_defer.debug, export_path);
+						if (export_defer.patch) {
+							err = platform->export_zip_patch(export_preset, export_defer.debug, export_path);
+						} else {
+							err = platform->export_zip(export_preset, export_defer.debug, export_path);
+						}
 					} else if (export_path.ends_with(".pck")) {
-						err = platform->export_pack(export_preset, export_defer.debug, export_path);
+						if (export_defer.patch) {
+							err = platform->export_patch(export_preset, export_defer.debug, export_path);
+						} else {
+							err = platform->export_pack(export_preset, export_defer.debug, export_path);
+						}
 					} else {
 						ERR_PRINT(vformat("Export path \"%s\" doesn't end with a supported extension.", export_path));
 						err = FAILED;
@@ -4886,12 +4894,13 @@ void EditorNode::_begin_first_scan() {
 	requested_first_scan = true;
 }
 
-Error EditorNode::export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only, bool p_android_build_template) {
+Error EditorNode::export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only, bool p_android_build_template, bool p_patch) {
 	export_defer.preset = p_preset;
 	export_defer.path = p_path;
 	export_defer.debug = p_debug;
 	export_defer.pack_only = p_pack_only;
 	export_defer.android_build_template = p_android_build_template;
+	export_defer.patch = p_patch;
 	cmdline_export_mode = true;
 	return OK;
 }

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -254,6 +254,7 @@ private:
 		bool debug = false;
 		bool pack_only = false;
 		bool android_build_template = false;
+		bool patch = false;
 	} export_defer;
 
 	static EditorNode *singleton;
@@ -845,7 +846,7 @@ public:
 
 	void _copy_warning(const String &p_str);
 
-	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only, bool p_android_build_template);
+	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only, bool p_android_build_template, bool p_patch);
 	bool is_project_exporting() const;
 
 	Control *get_gui_base() { return gui_base; }

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -83,6 +83,9 @@ void EditorExport::_save() {
 		config->set_value(section, "include_filter", preset->get_include_filter());
 		config->set_value(section, "exclude_filter", preset->get_exclude_filter());
 		config->set_value(section, "export_path", preset->get_export_path());
+		config->set_value(section, "patches", preset->get_patches());
+		config->set_value(section, "disabled_patches", preset->get_disabled_patches());
+
 		config->set_value(section, "encryption_include_filters", preset->get_enc_in_filter());
 		config->set_value(section, "encryption_exclude_filters", preset->get_enc_ex_filter());
 		config->set_value(section, "encrypt_pck", preset->get_enc_pck());
@@ -293,6 +296,10 @@ void EditorExport::load_config() {
 		preset->set_exclude_filter(config->get_value(section, "exclude_filter"));
 		preset->set_export_path(config->get_value(section, "export_path", ""));
 		preset->set_script_export_mode(config->get_value(section, "script_export_mode", EditorExportPreset::MODE_SCRIPT_BINARY_TOKENS_COMPRESSED));
+
+		Vector<String> patches = config->get_value(section, "patches", Vector<String>());
+		Vector<String> disabled_patches = config->get_value(section, "disabled_patches", Vector<String>());
+		preset->set_patches(patches, disabled_patches);
 
 		if (config->has_section_key(section, "encrypt_pck")) {
 			preset->set_enc_pck(config->get_value(section, "encrypt_pck"));

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -100,8 +100,16 @@ private:
 	void _export_find_customized_resources(const Ref<EditorExportPreset> &p_preset, EditorFileSystemDirectory *p_dir, EditorExportPreset::FileExportMode p_mode, HashSet<String> &p_paths);
 	void _export_find_dependencies(const String &p_path, HashSet<String> &p_paths);
 
+	Error _load_patches(const Vector<String> &p_patches);
+	static bool _check_hash(const uint8_t *p_hash, const Vector<uint8_t> &p_data);
+
+	Error _save_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, EditorExportSaveFunction p_func, Vector<SharedObject> *p_so_files = nullptr, bool p_embed = false, int64_t *r_embedded_start = nullptr, int64_t *r_embedded_size = nullptr);
+	Error _save_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, EditorExportSaveFunction p_func);
+
 	static Error _save_pack_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
+	static Error _save_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
 	static Error _save_zip_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
+	static Error _save_zip_patch_file(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
 
 	void _edit_files_with_filter(Ref<DirAccess> &da, const Vector<String> &p_filters, HashSet<String> &r_list, bool exclude);
 	void _edit_filter_list(HashSet<String> &r_list, const String &p_filter, bool exclude);
@@ -248,7 +256,9 @@ public:
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const = 0;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) = 0;
 	virtual Error export_pack(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
+	virtual Error export_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 	virtual Error export_zip(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
+	virtual Error export_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0);
 	virtual void get_platform_features(List<String> *r_features) const = 0;
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) = 0;
 	virtual String get_debug_protocol() const { return "tcp://"; }

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -324,6 +324,67 @@ EditorExportPreset::FileExportMode EditorExportPreset::get_file_export_mode(cons
 	return p_default;
 }
 
+void EditorExportPreset::add_patch(const String &p_path, bool p_enabled, int p_at_pos) {
+	ERR_FAIL_COND_EDMSG(patches.has(p_path), vformat("Failed to add patch \"%s\". Patches must be unique.", p_path));
+
+	if (p_at_pos < 0) {
+		patches.push_back(p_path);
+	} else {
+		patches.insert(p_at_pos, p_path);
+	}
+
+	if (!p_enabled) {
+		disabled_patches.push_back(p_path);
+	}
+
+	EditorExport::singleton->save_presets();
+}
+
+void EditorExportPreset::set_patch(int p_index, const String &p_path, bool p_enabled) {
+	remove_patch(p_index);
+	add_patch(p_path, p_enabled, p_index);
+	EditorExport::singleton->save_presets();
+}
+
+String EditorExportPreset::get_patch(int p_index) {
+	ERR_FAIL_INDEX_V(p_index, patches.size(), String());
+	return patches[p_index];
+}
+
+void EditorExportPreset::remove_patch(int p_index) {
+	ERR_FAIL_INDEX(p_index, patches.size());
+	disabled_patches.erase(patches[p_index]);
+	patches.remove_at(p_index);
+	EditorExport::singleton->save_presets();
+}
+
+void EditorExportPreset::set_patches(const Vector<String> &p_patches, const Vector<String> &p_disabled_patches) {
+	patches = p_patches;
+	disabled_patches = p_disabled_patches;
+}
+
+Vector<String> EditorExportPreset::get_patches() const {
+	return patches;
+}
+
+Vector<String> EditorExportPreset::get_disabled_patches() const {
+	return disabled_patches;
+}
+
+bool EditorExportPreset::is_patch_enabled(const String &p_path) const {
+	return !disabled_patches.has(p_path);
+}
+
+Vector<String> EditorExportPreset::get_enabled_patches() const {
+	Vector<String> res;
+	for (const String &path : patches) {
+		if (is_patch_enabled(path)) {
+			res.push_back(path);
+		}
+	}
+	return res;
+}
+
 void EditorExportPreset::set_custom_features(const String &p_custom_features) {
 	custom_features = p_custom_features;
 	EditorExport::singleton->save_presets();

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -74,6 +74,9 @@ private:
 	bool advanced_options_enabled = false;
 	bool dedicated_server = false;
 
+	Vector<String> patches;
+	Vector<String> disabled_patches;
+
 	friend class EditorExport;
 	friend class EditorExportPlatform;
 
@@ -143,6 +146,16 @@ public:
 
 	void set_exclude_filter(const String &p_exclude);
 	String get_exclude_filter() const;
+
+	void add_patch(const String &p_path, bool p_enable = true, int p_at_pos = -1);
+	void set_patch(int p_index, const String &p_path, bool p_enable);
+	String get_patch(int p_index);
+	void remove_patch(int p_index);
+	void set_patches(const Vector<String> &p_patches, const Vector<String> &p_disabled_patches);
+	Vector<String> get_patches() const;
+	Vector<String> get_disabled_patches() const;
+	bool is_patch_enabled(const String &p_path) const;
+	Vector<String> get_enabled_patches() const;
 
 	void set_custom_features(const String &p_custom_features);
 	String get_custom_features() const;

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -105,6 +105,12 @@ class ProjectExportDialog : public ConfirmationDialog {
 	AcceptDialog *export_all_dialog = nullptr;
 
 	RBSet<String> feature_set;
+
+	Tree *patches = nullptr;
+	int patch_index = -1;
+	EditorFileDialog *patch_dialog = nullptr;
+	ConfirmationDialog *patch_erase = nullptr;
+
 	LineEdit *custom_features = nullptr;
 	RichTextLabel *custom_feature_display = nullptr;
 
@@ -119,6 +125,9 @@ class ProjectExportDialog : public ConfirmationDialog {
 	String default_filename;
 
 	bool exporting = false;
+
+	void _patch_selected(const String &p_path);
+	void _patch_deleted();
 
 	void _advanced_options_pressed();
 	void _runnable_pressed();
@@ -147,6 +156,9 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _check_propagated_to_item(Object *p_obj, int column);
 	void _tree_popup_edited(bool p_arrow_clicked);
 	void _set_file_export_mode(int p_id);
+
+	void _patch_button_clicked(Object *p_item, int p_column, int p_id, int p_mouse_button_index);
+	void _patch_edited();
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -626,6 +626,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("", "The target directory must exist.\n");
 	print_help_option("--export-debug <preset> <path>", "Export the project in debug mode using the given preset and output path. See --export-release description for other considerations.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--export-pack <preset> <path>", "Export the project data only using the given preset and output path. The <path> extension determines whether it will be in PCK or ZIP format.\n", CLI_OPTION_AVAILABILITY_EDITOR);
+	print_help_option("--export-patch <preset> <path>", "Export pack with changed files only. See --export-pack description for other considerations.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--install-android-build-template", "Install the Android build template. Used in conjunction with --export-release or --export-debug.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 #ifndef DISABLE_DEPRECATED
 	// Commands are long; split the description to a second line.
@@ -1441,7 +1442,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			wait_for_import = true;
 			quit_after = 1;
 		} else if (arg == "--export-release" || arg == "--export-debug" ||
-				arg == "--export-pack") { // Export project
+				arg == "--export-pack" || arg == "--export-patch") { // Export project
 			// Actually handling is done in start().
 			editor = true;
 			cmdline_tool = true;
@@ -3192,6 +3193,7 @@ int Main::start() {
 	bool export_debug = false;
 	bool export_pack_only = false;
 	bool install_android_build_template = false;
+	bool export_patch = false;
 #ifdef MODULE_GDSCRIPT_ENABLED
 	String gdscript_docs_path;
 #endif
@@ -3278,6 +3280,11 @@ int Main::start() {
 				editor = true;
 				_export_preset = E->next()->get();
 				export_pack_only = true;
+			} else if (E->get() == "--export-patch") {
+				editor = true;
+				_export_preset = E->next()->get();
+				export_pack_only = true;
+				export_patch = true;
 #endif
 			} else {
 				// The parameter does not match anything known, don't skip the next argument
@@ -3679,7 +3686,7 @@ int Main::start() {
 			sml->get_root()->add_child(editor_node);
 
 			if (!_export_preset.is_empty()) {
-				editor_node->export_preset(_export_preset, positional_arg, export_debug, export_pack_only, install_android_build_template);
+				editor_node->export_preset(_export_preset, positional_arg, export_debug, export_pack_only, install_android_build_template, export_patch);
 				game_path = ""; // Do not load anything.
 			}
 


### PR DESCRIPTION
This PR adds `Export As Patch` setting for exporting PCK/ZIP.

![as_patch](https://user-images.githubusercontent.com/3893594/185830099-a5e74a49-7df7-459a-915d-03d43b4448db.png)

When enabled, godot compare exported files and files in packs specified in the `Patches` tab. And exports only new/changed files.

![patches](https://user-images.githubusercontent.com/3893594/185830209-5073d563-c1dc-47de-8902-cbed72fc71a4.png)

Adds `--export-patch` option.

Proposal: https://github.com/godotengine/godot-proposals/issues/146