### PR TITLE
Remove `String::erase` method declaration

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -373,8 +373,6 @@ public:
 	String plus_file(const String &p_file) const;
 	char32_t unicode_at(int p_idx) const;
 
-	void erase(int p_pos, int p_chars);
-
 	CharString ascii(bool p_allow_extended = false) const;
 	CharString utf8() const;
 	Error parse_utf8(const char *p_utf8, int p_len = -1, bool p_skip_cr = false);


### PR DESCRIPTION
It's just an old leftover, as discussed in the rocket chat.
