### PR TITLE
Add shuffle_custom method to Array

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -89,6 +89,30 @@ void Array::_unref() const {
 	_p = nullptr;
 }
 
+void Array::_internal_shuffle(const Callable &p_callable) {
+	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	const int n = _p->array.size();
+	if (n < 2) {
+		return;
+	}
+	bool use_default = p_callable.is_null();
+	Variant *data = _p->array.ptrw();
+	for (int i = n - 1; i >= 1; i--) {
+		Variant retv;
+		Callable::CallError ce;
+		if (use_default) {
+			retv = Math::rand();
+		} else {
+			p_callable.callp(nullptr, 0, retv, ce);
+		}
+		ERR_FAIL_COND_MSG(ce.error != Callable::CallError::CALL_OK, "Error calling method from 'shuffle_custom': " + Variant::get_callable_error_text(p_callable, nullptr, 0, ce));
+		const int j = (retv.operator unsigned int()) % (i + 1);
+		const Variant tmp = data[j];
+		data[j] = data[i];
+		data[i] = tmp;
+	}
+}
+
 Variant &Array::operator[](int p_idx) {
 	if (unlikely(_p->read_only)) {
 		*_p->read_only = _p->array[p_idx];
@@ -570,18 +594,11 @@ void Array::sort_custom(const Callable &p_callable) {
 }
 
 void Array::shuffle() {
-	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	const int n = _p->array.size();
-	if (n < 2) {
-		return;
-	}
-	Variant *data = _p->array.ptrw();
-	for (int i = n - 1; i >= 1; i--) {
-		const int j = Math::rand() % (i + 1);
-		const Variant tmp = data[j];
-		data[j] = data[i];
-		data[i] = tmp;
-	}
+	_internal_shuffle(Callable());
+}
+
+void Array::shuffle_custom(const Callable &p_callable) {
+	_internal_shuffle(p_callable);
 }
 
 int Array::bsearch(const Variant &p_value, bool p_before) {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -45,6 +45,7 @@ class Array {
 	mutable ArrayPrivate *_p;
 	void _ref(const Array &p_from) const;
 	void _unref() const;
+	void _internal_shuffle(const Callable &p_callable);
 
 protected:
 	bool _assign(const Array &p_array);
@@ -83,6 +84,7 @@ public:
 	void sort();
 	void sort_custom(const Callable &p_callable);
 	void shuffle();
+	void shuffle_custom(const Callable &p_callable);
 	int bsearch(const Variant &p_value, bool p_before = true);
 	int bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before = true);
 	void reverse();

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2054,6 +2054,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, sort, sarray(), varray());
 	bind_method(Array, sort_custom, sarray("func"), varray());
 	bind_method(Array, shuffle, sarray(), varray());
+	bind_method(Array, shuffle_custom, sarray("func"), varray());
 	bind_method(Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(Array, bsearch_custom, sarray("value", "func", "before"), varray(true));
 	bind_method(Array, reverse, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -533,6 +533,22 @@
 				Shuffles the array such that the items will have a random order. This method uses the global random number generator common to methods such as [method @GlobalScope.randi]. Call [method @GlobalScope.randomize] to ensure that a new seed will be used each time if you want non-reproducible shuffling.
 			</description>
 		</method>
+		<method name="shuffle_custom">
+			<return type="void" />
+			<param index="0" name="func" type="Callable" />
+			<description>
+				Shuffles the array using a custom method. The custom method receives no arguments and must return a random 32-bit unsigned integer between 0 and 4294967295. Use this when you don't want a randomization process to rely on global [RandomNumberGenerator].
+				[b]Note:[/b] To get predictable results, it is required to initialize any state of a custom random number generating method beforehand.
+				[codeblock]
+				func _ready():
+				    var arr = [1, 2, 3, 4, 5, 6, 7]
+				    var rng = RandomNumberGenerator.new()
+				    rng.seed = hash("Level_01")
+				    arr.shuffle_custom(rng.randi)
+				    print(arr) # Always prints [2, 3, 4, 7, 5, 1, 6] for the given seed
+				[/codeblock]
+			</description>
+		</method>
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
Alternative to #64318

Adds `void Array::shuffle_custom(const Callable &p_callable)`,
where p_callable is random number generating method

Pros:
- `shuffle_custom` is called upon object to be modified (easier to reason about, makes codebase a bit cleaner)
- User can in theory provide their implementation of custom method

Cons:
- There is no checking for validity of passed custom method (as in `Array::all`)
- User is responsible to init any state of this custom method himself

Example:
```
func _ready():
    var arr = [1, 2, 3, 4, 5, 6, 7]
    var rng = RandomNumberGenerator.new()
    rng.seed = hash("Level_01")
    arr.shuffle_custom(rng.randi)
    print(arr) # Always prints [2, 3, 4, 7, 5, 1, 6] for the given seed
```