### PR TITLE
[GDExtension] Fix `_property_can_revert` and `_property_get_revert` methods using incorrect string type.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -519,7 +519,7 @@ void Object::validate_property(PropertyInfo &p_property) const {
 	_validate_propertyv(p_property);
 }
 
-bool Object::property_can_revert(const String &p_name) const {
+bool Object::property_can_revert(const StringName &p_name) const {
 	if (script_instance) {
 		if (script_instance->property_can_revert(p_name)) {
 			return true;
@@ -543,7 +543,7 @@ bool Object::property_can_revert(const String &p_name) const {
 	return _property_can_revertv(p_name);
 }
 
-Variant Object::property_get_revert(const String &p_name) const {
+Variant Object::property_get_revert(const StringName &p_name) const {
 	Variant ret;
 
 	if (script_instance) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -805,8 +805,8 @@ public:
 
 	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
 	void validate_property(PropertyInfo &p_property) const;
-	bool property_can_revert(const String &p_name) const;
-	Variant property_get_revert(const String &p_name) const;
+	bool property_can_revert(const StringName &p_name) const;
+	Variant property_get_revert(const StringName &p_name) const;
 
 	bool has_method(const StringName &p_method) const;
 	void get_method_list(List<MethodInfo> *p_list) const;

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -113,11 +113,11 @@ class SectionedInspectorFilter : public Object {
 		}
 	}
 
-	bool property_can_revert(const String &p_name) {
+	bool property_can_revert(const StringName &p_name) {
 		return edited->property_can_revert(section + "/" + p_name);
 	}
 
-	Variant property_get_revert(const String &p_name) {
+	Variant property_get_revert(const StringName &p_name) {
 		return edited->property_get_revert(section + "/" + p_name);
 	}
 


### PR DESCRIPTION
GDExtension method signatures use `StringName` instead of `String` (which is also consistent with other similar methods).