### PR TITLE
Avoid trying to load non-existent assembly

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -517,6 +517,10 @@ bool GDMono::_load_project_assembly() {
 								   .plus_file(assembly_name + ".dll");
 	assembly_path = ProjectSettings::get_singleton()->globalize_path(assembly_path);
 
+	if (!FileAccess::exists(assembly_path)) {
+		return false;
+	}
+
 	String loaded_assembly_path;
 	bool success = plugin_callbacks.LoadProjectAssemblyCallback(assembly_path.utf16(), &loaded_assembly_path);
 


### PR DESCRIPTION
If the project assembly does not exist, return `false` directly instead of trying to load it.
This prevents the `System.InvalidOperationException` thrown for failing to locate managed application. Fixes #64723.