### PR TITLE
Remove copy constructors in C# structs

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -74,18 +74,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new <see cref="Projection"/> from an existing <see cref="Projection"/>.
-        /// </summary>
-        /// <param name="proj">The existing <see cref="Projection"/>.</param>
-        public Projection(Projection proj)
-        {
-            x = proj.x;
-            y = proj.y;
-            z = proj.z;
-            w = proj.w;
-        }
-
-        /// <summary>
         /// Constructs a new <see cref="Projection"/> from a <see cref="Transform3D"/>.
         /// </summary>
         /// <param name="transform">The <see cref="Transform3D"/>.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -358,15 +358,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a <see cref="Quaternion"/> from the given <see cref="Quaternion"/>.
-        /// </summary>
-        /// <param name="q">The existing quaternion.</param>
-        public Quaternion(Quaternion q)
-        {
-            this = q;
-        }
-
-        /// <summary>
         /// Constructs a <see cref="Quaternion"/> from the given <see cref="Basis"/>.
         /// </summary>
         /// <param name="basis">The <see cref="Basis"/> to construct from.</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -639,16 +639,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new <see cref="Vector2"/> from an existing <see cref="Vector2"/>.
-        /// </summary>
-        /// <param name="v">The existing <see cref="Vector2"/>.</param>
-        public Vector2(Vector2 v)
-        {
-            x = v.x;
-            y = v.y;
-        }
-
-        /// <summary>
         /// Creates a unit Vector2 rotated to the given angle. This is equivalent to doing
         /// <c>Vector2(Mathf.Cos(angle), Mathf.Sin(angle))</c> or <c>Vector2.Right.Rotated(angle)</c>.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -350,27 +350,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new <see cref="Vector2i"/> from an existing <see cref="Vector2i"/>.
-        /// </summary>
-        /// <param name="vi">The existing <see cref="Vector2i"/>.</param>
-        public Vector2i(Vector2i vi)
-        {
-            this.x = vi.x;
-            this.y = vi.y;
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Vector2i"/> from an existing <see cref="Vector2"/>
-        /// by rounding the components via <see cref="Mathf.RoundToInt(real_t)"/>.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector2"/> to convert.</param>
-        public Vector2i(Vector2 v)
-        {
-            this.x = Mathf.RoundToInt(v.x);
-            this.y = Mathf.RoundToInt(v.y);
-        }
-
-        /// <summary>
         /// Adds each component of the <see cref="Vector2i"/>
         /// with the components of the given <see cref="Vector2i"/>.
         /// </summary>
@@ -674,7 +653,10 @@ namespace Godot
         /// <param name="value">The vector to convert.</param>
         public static explicit operator Vector2i(Vector2 value)
         {
-            return new Vector2i(value);
+            return new Vector2i(
+                Mathf.RoundToInt(value.x),
+                Mathf.RoundToInt(value.y)
+            );
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -692,17 +692,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new <see cref="Vector3"/> from an existing <see cref="Vector3"/>.
-        /// </summary>
-        /// <param name="v">The existing <see cref="Vector3"/>.</param>
-        public Vector3(Vector3 v)
-        {
-            x = v.x;
-            y = v.y;
-            z = v.z;
-        }
-
-        /// <summary>
         /// Adds each component of the <see cref="Vector3"/>
         /// with the components of the given <see cref="Vector3"/>.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -330,29 +330,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new <see cref="Vector3i"/> from an existing <see cref="Vector3i"/>.
-        /// </summary>
-        /// <param name="vi">The existing <see cref="Vector3i"/>.</param>
-        public Vector3i(Vector3i vi)
-        {
-            this.x = vi.x;
-            this.y = vi.y;
-            this.z = vi.z;
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Vector3i"/> from an existing <see cref="Vector3"/>
-        /// by rounding the components via <see cref="Mathf.RoundToInt(real_t)"/>.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector3"/> to convert.</param>
-        public Vector3i(Vector3 v)
-        {
-            this.x = Mathf.RoundToInt(v.x);
-            this.y = Mathf.RoundToInt(v.y);
-            this.z = Mathf.RoundToInt(v.z);
-        }
-
-        /// <summary>
         /// Adds each component of the <see cref="Vector3i"/>
         /// with the components of the given <see cref="Vector3i"/>.
         /// </summary>
@@ -684,7 +661,11 @@ namespace Godot
         /// <param name="value">The vector to convert.</param>
         public static explicit operator Vector3i(Vector3 value)
         {
-            return new Vector3i(value);
+            return new Vector3i(
+                Mathf.RoundToInt(value.x),
+                Mathf.RoundToInt(value.y),
+                Mathf.RoundToInt(value.z)
+            );
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -477,18 +477,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new <see cref="Vector4"/> from an existing <see cref="Vector4"/>.
-        /// </summary>
-        /// <param name="v">The existing <see cref="Vector4"/>.</param>
-        public Vector4(Vector4 v)
-        {
-            x = v.x;
-            y = v.y;
-            z = v.z;
-            w = v.w;
-        }
-
-        /// <summary>
         /// Adds each component of the <see cref="Vector4"/>
         /// with the components of the given <see cref="Vector4"/>.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4i.cs
@@ -258,31 +258,6 @@ namespace Godot
         }
 
         /// <summary>
-        /// Constructs a new <see cref="Vector4i"/> from an existing <see cref="Vector4i"/>.
-        /// </summary>
-        /// <param name="vi">The existing <see cref="Vector4i"/>.</param>
-        public Vector4i(Vector4i vi)
-        {
-            this.x = vi.x;
-            this.y = vi.y;
-            this.z = vi.z;
-            this.w = vi.w;
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Vector4i"/> from an existing <see cref="Vector4"/>
-        /// by rounding the components via <see cref="Mathf.RoundToInt(real_t)"/>.
-        /// </summary>
-        /// <param name="v">The <see cref="Vector4"/> to convert.</param>
-        public Vector4i(Vector4 v)
-        {
-            this.x = Mathf.RoundToInt(v.x);
-            this.y = Mathf.RoundToInt(v.y);
-            this.z = Mathf.RoundToInt(v.z);
-            this.w = Mathf.RoundToInt(v.w);
-        }
-
-        /// <summary>
         /// Adds each component of the <see cref="Vector4i"/>
         /// with the components of the given <see cref="Vector4i"/>.
         /// </summary>
@@ -638,7 +613,12 @@ namespace Godot
         /// <param name="value">The vector to convert.</param>
         public static explicit operator Vector4i(Vector4 value)
         {
-            return new Vector4i(value);
+            return new Vector4i(
+                Mathf.RoundToInt(value.x),
+                Mathf.RoundToInt(value.y),
+                Mathf.RoundToInt(value.z),
+                Mathf.RoundToInt(value.w)
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
Copy constructors are not necessary in C# structs since they are ValueTypes.
Also removed the `Vector2i(Vector2 v);`, `Vector3i(Vector3 v);` and `Vector4i(Vector4 v);` constructors since an explicit conversion already exists.