### PR TITLE
Consolidate the fact that `Input` is meant to be final

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -767,9 +767,6 @@ Point2i Input::warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, con
 	return rel_warped;
 }
 
-void Input::iteration(float p_step) {
-}
-
 void Input::action_press(const StringName &p_action, float p_strength) {
 	Action action;
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -114,6 +114,15 @@ private:
 
 	int mouse_from_touch_index = -1;
 
+	struct VibrationInfo {
+		float weak_magnitude;
+		float strong_magnitude;
+		float duration; // Duration in seconds
+		uint64_t timestamp;
+	};
+
+	HashMap<int, VibrationInfo> joy_vibration;
+
 	struct VelocityTrack {
 		uint64_t last_tick = 0;
 		Vector2 velocity;
@@ -226,15 +235,6 @@ private:
 	EventDispatchFunc event_dispatch_function = nullptr;
 
 protected:
-	struct VibrationInfo {
-		float weak_magnitude;
-		float strong_magnitude;
-		float duration; // Duration in seconds
-		uint64_t timestamp;
-	};
-
-	HashMap<int, VibrationInfo> joy_vibration;
-
 	static void _bind_methods();
 
 public:
@@ -294,8 +294,6 @@ public:
 
 	void action_press(const StringName &p_action, float p_strength = 1.f);
 	void action_release(const StringName &p_action);
-
-	void iteration(float p_step);
 
 	void set_emulate_touch_from_mouse(bool p_emulate);
 	bool is_emulating_touch_from_mouse() const;


### PR DESCRIPTION
In Godot 4.0, `Input` is meant to be an OS-agnostic hub for input related operations. It's no longer meant to be overridden by platform implementations.

This reverts #38034 and removes the `iteration()` method.