### PR TITLE
Add spacing after newline on editor warning tooltip

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -278,7 +278,19 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 				warning_icon = SNAME("NodeWarnings4Plus");
 			}
 
-			item->add_button(0, get_theme_icon(warning_icon, SNAME("EditorIcons")), BUTTON_WARNING, false, TTR("Node configuration warning:") + "\n" + warning);
+			// Improve looks on tooltip, extra spacing on non-bullet point newlines.
+			const String bullet_point = String::utf8("•  ");
+			int next_newline = 0;
+			while (next_newline != -1) {
+				next_newline = warning.find("\n", next_newline + 2);
+				if (warning.substr(next_newline + 1, bullet_point.length()) != bullet_point) {
+					warning = warning.insert(next_newline + 1, "    ");
+				}
+			}
+
+			String newline = (num_warnings == 1 ? "\n" : "\n\n");
+
+			item->add_button(0, get_theme_icon(warning_icon, SNAME("EditorIcons")), BUTTON_WARNING, false, TTR("Node configuration warning:") + newline + warning);
 		}
 
 		if (p_node->is_unique_name_in_owner()) {


### PR DESCRIPTION
While making https://github.com/godotengine/godot/pull/64702, something very minute to most bothered me...
Adds 4 spaces after every newline that isn't followed up by a bullet point, so that the tooltip looks much tidier.

| Before | After
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/66727710/185927821-14175cb9-3b8c-45f1-b7ea-b95e4ea4dac7.png) | ![After](https://user-images.githubusercontent.com/66727710/185926344-ef7805b4-3c02-42d6-96e5-b5f83160f386.png) | 

Because of the simple implementation, it may not look as nice if a different font were to be used, but even then, it shouldn't be by much.