### PR TITLE
Fix Viewport size change not updating textures

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -801,6 +801,10 @@ void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override,
 
 	update_canvas_items();
 
+	for (ViewportTexture *E : viewport_textures) {
+		E->emit_changed();
+	}
+
 	emit_signal(SNAME("size_changed"));
 }
 


### PR DESCRIPTION
Fixes this bug:
![iNXynJNBNW](https://user-images.githubusercontent.com/2223172/185947752-458e4843-f1cf-4f52-8086-e3a5b8996fe5.gif)
Test script (3.x):
```GDScript
func _ready() -> void:
	yield(get_tree().create_timer(1), "timeout")
	$Viewport.size *= 2
	yield(get_tree().create_timer(1), "timeout")
	$PanelContainer/Sprite.update()
```
After fix:
![IwIxfvvSxk](https://user-images.githubusercontent.com/2223172/185947906-c61a5516-e69e-4620-8419-25b8317bda5a.gif)

Originally discovered in 3.x, but the bug also exists on master.

Here's code for 3.x branch:
```C++
for (Set<ViewportTexture *>::Element *E = viewport_textures.front(); E; E = E->next()) {
	E->get()->emit_changed();
}
```