### PR TITLE
C#: Add grouping attributes for properties.

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
@@ -5,6 +5,9 @@ namespace Godot.SourceGenerators
         public const string Object = "Godot.Object";
         public const string AssemblyHasScriptsAttr = "Godot.AssemblyHasScriptsAttribute";
         public const string ExportAttr = "Godot.ExportAttribute";
+        public const string ExportCategoryAttr = "Godot.ExportCategoryAttribute";
+        public const string ExportGroupAttr = "Godot.ExportGroupAttribute";
+        public const string ExportSubgroupAttr = "Godot.ExportSubgroupAttribute";
         public const string SignalAttr = "Godot.SignalAttribute";
         public const string GodotClassNameAttr = "Godot.GodotClassName";
         public const string SystemFlagsAttr = "System.FlagsAttribute";

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportCategoryAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportCategoryAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Define a new category for the following exported properties. This helps to organize properties in the Inspector dock.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ExportCategoryAttribute : Attribute
+    {
+        private string name;
+
+        /// <summary>
+        /// Define a new category for the following exported properties.
+        /// </summary>
+        /// <param name="name">The name of the category.</param>
+        public ExportCategoryAttribute(string name)
+        {
+            this.name = name;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportGroupAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportGroupAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Define a new group for the following exported properties. This helps to organize properties in the Inspector dock.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ExportGroupAttribute : Attribute
+    {
+        private string name;
+        private string prefix;
+
+        /// <summary>
+        /// Define a new group for the following exported properties.
+        /// </summary>
+        /// <param name="name">The name of the group.</param>
+        /// <param name="prefix">If provided, the group would make group to only consider properties that have this prefix.</param>
+        public ExportGroupAttribute(string name, string prefix = "")
+        {
+            this.name = name;
+            this.prefix = prefix;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportSubgroupAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportSubgroupAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Define a new subgroup for the following exported properties. This helps to organize properties in the Inspector dock.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ExportSubgroupAttribute : Attribute
+    {
+        private string name;
+        private string prefix;
+
+        /// <summary>
+        /// Define a new subgroup for the following exported properties. This helps to organize properties in the Inspector dock.
+        /// </summary>
+        /// <param name="name">The name of the subgroup.</param>
+        /// <param name="prefix">If provided, the subgroup would make group to only consider properties that have this prefix.</param>
+        public ExportSubgroupAttribute(string name, string prefix = "")
+        {
+            this.name = name;
+            this.prefix = prefix;
+        }
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -53,6 +53,9 @@
     <Compile Include="Core\Array.cs" />
     <Compile Include="Core\Attributes\AssemblyHasScriptsAttribute.cs" />
     <Compile Include="Core\Attributes\ExportAttribute.cs" />
+    <Compile Include="Core\Attributes\ExportCategoryAttribute.cs" />
+    <Compile Include="Core\Attributes\ExportGroupAttribute.cs" />
+    <Compile Include="Core\Attributes\ExportSubgroupAttribute.cs" />
     <Compile Include="Core\Attributes\RPCAttribute.cs" />
     <Compile Include="Core\Attributes\ScriptPathAttribute.cs" />
     <Compile Include="Core\Attributes\SignalAttribute.cs" />


### PR DESCRIPTION
This is C# implementation of #62707.



Note: At present the source generator will generate all properties first and then fields. It won't keep in order when using both fields and properties. This can be improved in future.

### Example

```C#
[ExportCategory("My Category")]

[Export] int aNumber;

[ExportGroup("My Group", "my")]

[Export] bool myToggle;
[Export] int myNumber;

[ExportCategory("Your Category")]

[ExportGroup("Your Group")]

[Export] bool yourToggle;
[Export] int yourNumber;

[ExportSubgroup("Your Subgroup", "yourSub")]

[Export] string yourSubIdentifier;
[Export] Vector2 anotherProp;
[Export] int yourSubInt;
```


![Inspector](https://user-images.githubusercontent.com/12966814/185975622-7f0a50a8-29b0-4140-a1b9-e7daac7ef643.png)
