### PR TITLE
Improve C# signal analyzer errors

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -192,7 +192,31 @@ namespace Godot.SourceGenerators
                 location?.SourceTree?.FilePath));
         }
 
-        public static void ReportSignalDelegateSignatureNotSupported(
+        public static void ReportSignalParameterTypeNotSupported(
+            GeneratorExecutionContext context,
+            IParameterSymbol parameterSymbol)
+        {
+            var locations = parameterSymbol.Locations;
+            var location = locations.FirstOrDefault(l => l.SourceTree != null) ?? locations.FirstOrDefault();
+
+            string message = "The parameter of the delegate signature of the signal " +
+                             $"is not supported: '{parameterSymbol.ToDisplayString()}'";
+
+            string description = $"{message}. Use supported types only or remove the '[Signal]' attribute.";
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(id: "GODOT-G0202",
+                    title: message,
+                    messageFormat: message,
+                    category: "Usage",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true,
+                    description),
+                location,
+                location?.SourceTree?.FilePath));
+        }
+
+        public static void ReportSignalDelegateSignatureMustReturnVoid(
             GeneratorExecutionContext context,
             INamedTypeSymbol delegateSymbol)
         {
@@ -200,12 +224,12 @@ namespace Godot.SourceGenerators
             var location = locations.FirstOrDefault(l => l.SourceTree != null) ?? locations.FirstOrDefault();
 
             string message = "The delegate signature of the signal " +
-                             $"is not supported: '{delegateSymbol.ToDisplayString()}'";
+                             $"must return void: '{delegateSymbol.ToDisplayString()}'";
 
-            string description = $"{message}. Use supported types only or remove the '[Signal]' attribute.";
+            string description = $"{message}. Return void or remove the '[Signal]' attribute.";
 
             context.ReportDiagnostic(Diagnostic.Create(
-                new DiagnosticDescriptor(id: "GODOT-G0202",
+                new DiagnosticDescriptor(id: "GODOT-G0203",
                     title: message,
                     messageFormat: message,
                     category: "Usage",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -148,8 +148,29 @@ namespace Godot.SourceGenerators
 
                 if (invokeMethodData == null)
                 {
-                    // TODO: Better error for incompatible signature. We should indicate incompatible argument types, as we do with exported properties.
-                    Common.ReportSignalDelegateSignatureNotSupported(context, signalDelegateSymbol);
+                    if (signalDelegateSymbol.DelegateInvokeMethod is IMethodSymbol methodSymbol)
+                    {
+                        foreach (var parameter in methodSymbol.Parameters)
+                        {
+                            if (parameter.RefKind != RefKind.None)
+                            {
+                                Common.ReportSignalParameterTypeNotSupported(context, parameter);
+                                continue;
+                            }
+
+                            var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(parameter.Type, typeCache);
+
+                            if (marshalType == null)
+                            {
+                                Common.ReportSignalParameterTypeNotSupported(context, parameter);
+                            }
+                        }
+
+                        if (!methodSymbol.ReturnsVoid)
+                        {
+                            Common.ReportSignalDelegateSignatureMustReturnVoid(context, signalDelegateSymbol);
+                        }
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
- Report the specific parameters that are not supported. (The messages might be a bit wordy, I'm open to suggestions).
- ~~Remove `AttributeTargets.Event` from `SignalAttribute` since declaring events as signal is no longer supported (see 97713ff77a339faa72d54bd596e3d8c2b8520ce0).~~ I removed this from the PR because the generated bindings use the attribute on events.

About this TODO:

https://github.com/godotengine/godot/blob/99548e521dc049b609347cd1fe38262d59d1b0d6/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs#L120-L122

It seems the suffix was `Signal` at one point but it's currently `EventHandler` which I don't think is redundant and it could be possible that an user declares a delegate with the `EventHandler` suffix that they don't want to expose as a signal. I decided not to touch the TODO comment but it seems incorrect right now.