### PR TITLE
Simplify title of Create/Change Node Dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -38,7 +38,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 
-void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_select_type, const String &p_select_name) {
+void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_current_type, const String &p_current_name) {
 	_fill_type_list();
 
 	icon_fallback = search_options->has_theme_icon(base_type, SNAME("EditorIcons")) ? base_type : "Object";
@@ -50,18 +50,14 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	}
 
 	if (p_replace_mode) {
-		search_box->set_text(p_select_type);
+		search_box->set_text(p_current_type);
 	}
 
 	search_box->grab_focus();
 	_update_search();
 
 	if (p_replace_mode) {
-		if (!p_select_name.is_empty()) {
-			set_title(vformat(TTR("Convert %s from %s"), p_select_name, p_select_type));
-		} else {
-			set_title(vformat(TTR("Convert %s"), p_select_type));
-		}
+		set_title(vformat(TTR("Change Type of \"%s\""), p_current_name));
 		set_ok_button_text(TTR("Change"));
 	} else {
 		set_title(vformat(TTR("Create New %s"), base_type));

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -120,7 +120,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type) { preferred_search_result_type = p_preferred_type; }
 	String get_preferred_search_result_type() { return preferred_search_result_type; }
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_select_type = "Node", const String &p_select_name = "");
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_current_type = "", const String &p_current_name = "");
 
 	CreateDialog();
 };


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/37168
This is more similar to what is suggested here: https://github.com/godotengine/godot/issues/36831#issuecomment-595663000

I don't think it's necessary to have the current node type in the dialog. This is already filled in the search bar, and naturally leads the user to the next step. When I first opened the dialog following the other PR, I found it confusing to differentiate between my node name and the node type, as KoBeWi noted here: https://github.com/godotengine/godot/pull/37168#pullrequestreview-1079588109

((
**Edit, after merge**: Elaborating on this above paragraph, KoBeWi noted the title for changing the type of a CollisionShape2D node with the default name was `Convert CollisionShape2D from CollisionShape2D`, which is pretty confusing.
))

The create dialog in replace mode now always has the title `Change type of "%s"`, where `%s` is either "MyNodeName" or "MyVisualScript.vs".

![image](https://user-images.githubusercontent.com/14253836/186040966-af83e975-0342-402a-985d-02685248da6e.png)
![image](https://user-images.githubusercontent.com/14253836/186041078-14a2624d-f696-4e00-a2ed-80330f648f63.png)
