### PR TITLE
Hide MenuButton / OptionButton popup on click if it's already visible.

### DIFF
--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -80,6 +80,11 @@ void EditorPath::_add_children_to_popup(Object *p_obj, int p_depth) {
 }
 
 void EditorPath::_show_popup() {
+	if (sub_objects_menu->is_visible()) {
+		sub_objects_menu->hide();
+		return;
+	}
+
 	sub_objects_menu->clear();
 
 	Size2 size = get_size();

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -86,6 +86,11 @@ void MenuButton::_popup_visibility_changed(bool p_visible) {
 }
 
 void MenuButton::pressed() {
+	if (popup->is_visible()) {
+		popup->hide();
+		return;
+	}
+
 	emit_signal(SNAME("about_to_popup"));
 	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 
@@ -105,11 +110,7 @@ void MenuButton::pressed() {
 		popup->set_current_index(0);
 	}
 
-	if (popup->is_visible()) {
-		popup->hide();
-	} else {
-		popup->popup();
-	}
+	popup->popup();
 }
 
 void MenuButton::gui_input(const Ref<InputEvent> &p_event) {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -198,6 +198,11 @@ void OptionButton::_selected(int p_which) {
 }
 
 void OptionButton::pressed() {
+	if (popup->is_visible()) {
+		popup->hide();
+		return;
+	}
+
 	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 	popup->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));


### PR DESCRIPTION
Prevents popups from staying open and jumping around when rapid clicking on the Button control.

TODO:

- [x] Test with embedded windows.
- [x] Test on Windows.
- [x] Test on Linux/X11.
- [x] Test on macOS.