### PR TITLE
Patch glslang to avoid build errors on certain platforms

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -195,6 +195,7 @@ Files extracted from upstream source:
   to `glslang/build_info.h`
 - `LICENSE.txt`
 - Unnecessary files like `CMakeLists.txt`, `*.m4` and `updateGrammar` removed.
+- Patch in `patches/unused_cleanup.diff` must be applied.
 
 
 ## graphite

--- a/thirdparty/glslang/glslang/OSDependent/Unix/ossource.cpp
+++ b/thirdparty/glslang/glslang/OSDependent/Unix/ossource.cpp
@@ -66,43 +66,6 @@ static void DetachThreadLinux(void *)
 }
 
 //
-// Registers cleanup handler, sets cancel type and state, and executes the thread specific
-// cleanup handler.  This function will be called in the Standalone.cpp for regression
-// testing.  When OpenGL applications are run with the driver code, Linux OS does the
-// thread cleanup.
-//
-void OS_CleanupThreadData(void)
-{
-#if defined(__ANDROID__) || defined(__Fuchsia__)
-    DetachThreadLinux(NULL);
-#else
-    int old_cancel_state, old_cancel_type;
-    void *cleanupArg = NULL;
-
-    //
-    // Set thread cancel state and push cleanup handler.
-    //
-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_cancel_state);
-    pthread_cleanup_push(DetachThreadLinux, (void *) cleanupArg);
-
-    //
-    // Put the thread in deferred cancellation mode.
-    //
-    pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, &old_cancel_type);
-
-    //
-    // Pop cleanup handler and execute it prior to unregistering the cleanup handler.
-    //
-    pthread_cleanup_pop(1);
-
-    //
-    // Restore the thread's previous cancellation mode.
-    //
-    pthread_setcanceltype(old_cancel_state, NULL);
-#endif
-}
-
-//
 // Thread Local Storage Operations
 //
 inline OS_TLSIndex PthreadKeyToTLSIndex(pthread_key_t key)

--- a/thirdparty/glslang/glslang/OSDependent/osinclude.h
+++ b/thirdparty/glslang/glslang/OSDependent/osinclude.h
@@ -54,8 +54,6 @@ void ReleaseGlobalLock();
 
 typedef unsigned int (*TThreadEntrypoint)(void*);
 
-void OS_CleanupThreadData(void);
-
 void OS_DumpMemoryCounters();
 
 } // end namespace glslang

--- a/thirdparty/glslang/patches/unused_cleanup.diff
+++ b/thirdparty/glslang/patches/unused_cleanup.diff
@@ -1,0 +1,61 @@
+diff --git a/thirdparty/glslang/glslang/OSDependent/Unix/ossource.cpp b/thirdparty/glslang/glslang/OSDependent/Unix/ossource.cpp
+index 81da99c2c4..1cbd616e98 100644
+--- a/thirdparty/glslang/glslang/OSDependent/Unix/ossource.cpp
++++ b/thirdparty/glslang/glslang/OSDependent/Unix/ossource.cpp
+@@ -65,43 +65,6 @@ static void DetachThreadLinux(void *)
+     DetachThread();
+ }
+ 
+-//
+-// Registers cleanup handler, sets cancel type and state, and executes the thread specific
+-// cleanup handler.  This function will be called in the Standalone.cpp for regression
+-// testing.  When OpenGL applications are run with the driver code, Linux OS does the
+-// thread cleanup.
+-//
+-void OS_CleanupThreadData(void)
+-{
+-#if defined(__ANDROID__) || defined(__Fuchsia__)
+-    DetachThreadLinux(NULL);
+-#else
+-    int old_cancel_state, old_cancel_type;
+-    void *cleanupArg = NULL;
+-
+-    //
+-    // Set thread cancel state and push cleanup handler.
+-    //
+-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_cancel_state);
+-    pthread_cleanup_push(DetachThreadLinux, (void *) cleanupArg);
+-
+-    //
+-    // Put the thread in deferred cancellation mode.
+-    //
+-    pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, &old_cancel_type);
+-
+-    //
+-    // Pop cleanup handler and execute it prior to unregistering the cleanup handler.
+-    //
+-    pthread_cleanup_pop(1);
+-
+-    //
+-    // Restore the thread's previous cancellation mode.
+-    //
+-    pthread_setcanceltype(old_cancel_state, NULL);
+-#endif
+-}
+-
+ //
+ // Thread Local Storage Operations
+ //
+diff --git a/thirdparty/glslang/glslang/OSDependent/osinclude.h b/thirdparty/glslang/glslang/OSDependent/osinclude.h
+index 218abe4f23..fcfeff2cc4 100644
+--- a/thirdparty/glslang/glslang/OSDependent/osinclude.h
++++ b/thirdparty/glslang/glslang/OSDependent/osinclude.h
+@@ -54,8 +54,6 @@ void ReleaseGlobalLock();
+ 
+ typedef unsigned int (*TThreadEntrypoint)(void*);
+ 
+-void OS_CleanupThreadData(void);
+-
+ void OS_DumpMemoryCounters();
+ 
+ } // end namespace glslang


### PR DESCRIPTION
This PR removes an unused function in _glslang_ that causes build errors on certain platforms. The reason is that `PTHREAD_CANCEL_ENABLE` is not available on every dev environment. Since it's unused, the simplest thing is just to get rid of it, isn't it?

The corresponding patch has been submitted to upstream in https://github.com/KhronosGroup/glslang/pull/2997.