### PR TITLE
Fix VisualScript editor crash when deleting selected nodes

### DIFF
--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -1888,7 +1888,7 @@ void VisualScriptEditor::_on_nodes_delete(const Array &p_nodes) {
 			}
 		}
 	} else {
-		for (int i = 0; i < graph->get_child_count(); i++) {
+		for (int i = 0; i < p_nodes.size(); i++) {
 			to_erase.push_back(p_nodes[i].operator String().to_int());
 		}
 	}


### PR DESCRIPTION
Fixes #64662.
Regression from #61145.

This doesn't seem needed in `master` as the original #61112 didn't change VisualScript.