### PR TITLE
Avoid warnings about cursor shape change not supported

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1875,7 +1875,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 		}
 
-		DisplayServer::get_singleton()->cursor_set_shape(ds_cursor_shape);
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {
+			DisplayServer::get_singleton()->cursor_set_shape(ds_cursor_shape);
+		}
 	}
 
 	Ref<InputEventScreenTouch> touch_event = p_event;
@@ -2684,7 +2686,9 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 					DisplayServer::CURSOR_FDIAGSIZE
 				};
 
-				DisplayServer::get_singleton()->cursor_set_shape(shapes[resize]);
+				if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {
+					DisplayServer::get_singleton()->cursor_set_shape(shapes[resize]);
+				}
 
 				return true; // Reserved for showing the resize cursor.
 			}

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -349,7 +349,9 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 			_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_ENTER);
 			emit_signal(SNAME("mouse_entered"));
 			notification(NOTIFICATION_VP_MOUSE_ENTER);
-			DisplayServer::get_singleton()->cursor_set_shape(DisplayServer::CURSOR_ARROW); //restore cursor shape
+			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {
+				DisplayServer::get_singleton()->cursor_set_shape(DisplayServer::CURSOR_ARROW); //restore cursor shape
+			}
 		} break;
 		case DisplayServer::WINDOW_EVENT_MOUSE_EXIT: {
 			notification(NOTIFICATION_VP_MOUSE_EXIT);


### PR DESCRIPTION
The goal is that at least the core of the engine doesn't try to change cursor shapes unless the display server reports to support such feature. Otherwise, many warnings are printed on platforms that don't feature mouse support but still get mouse events from touch-to-mouse emulation. I believe the warnings are fine, as they give notice about the caller not being aware enough about the possibilities of the platform it's running on. Therefore, the proper fix is to make the core of the engine gain that awareness.

I've excluded the editor from this PR, because the editor can just assume the platforms where it can run have a minimum set of features and the core is the piece of the engine that faces real uncertainty about the underlying platform. That may be debatable, though. In any case, this PR has already a point by itself.