### PR TITLE
Extract editor color map and simplify SVG color conversion

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6227,6 +6227,7 @@ EditorNode::EditorNode() {
 	add_child(editor_export);
 
 	// Exporters might need the theme.
+	EditorColorMap::create();
 	theme = create_custom_theme();
 
 	register_exporters();

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -32,7 +32,6 @@
 
 #include "core/error/error_macros.h"
 #include "core/io/resource_loader.h"
-#include "core/variant/dictionary.h"
 #include "editor/editor_fonts.h"
 #include "editor/editor_icons.gen.h"
 #include "editor/editor_scale.h"
@@ -42,6 +41,118 @@
 #ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
 #endif
+
+HashMap<Color, Color> EditorColorMap::editor_color_map;
+
+void EditorColorMap::add_color_pair(const String p_from_color, const String p_to_color) {
+	editor_color_map[Color::html(p_from_color)] = Color::html(p_to_color);
+}
+
+void EditorColorMap::create() {
+	// Some of the colors below are listed for completeness sake.
+	// This can be a basis for proper palette validation later.
+
+	// Convert:    FROM       TO
+	add_color_pair("#478cbf", "#478cbf"); // Godot Blue
+	add_color_pair("#414042", "#414042"); // Godot Gray
+
+	add_color_pair("#ffffff", "#414141"); // Pure white
+	add_color_pair("#000000", "#bfbfbf"); // Pure black
+	// Keep pure RGB colors as is, but list them for explicitly.
+	add_color_pair("#ff0000", "#ff0000"); // Pure red
+	add_color_pair("#00ff00", "#00ff00"); // Pure green
+	add_color_pair("#0000ff", "#0000ff"); // Pure blue
+
+	// GUI Colors
+	add_color_pair("#e0e0e0", "#5a5a5a"); // Common icon color
+	add_color_pair("#fefefe", "#fefefe"); // Forced light color
+	add_color_pair("#808080", "#808080"); // GUI disabled color
+	add_color_pair("#b3b3b3", "#363636"); // GUI disabled light color
+	add_color_pair("#699ce8", "#699ce8"); // GUI highlight color
+	add_color_pair("#f9f9f9", "#606060"); // Scrollbar grabber highlight color
+
+	add_color_pair("#c38ef1", "#a85de9"); // Animation
+	add_color_pair("#fc7f7f", "#cd3838"); // Spatial
+	add_color_pair("#8da5f3", "#3d64dd"); // 2D
+	add_color_pair("#4b70ea", "#1a3eac"); // 2D Dark
+	add_color_pair("#8eef97", "#2fa139"); // Control
+
+	add_color_pair("#5fb2ff", "#0079f0"); // Selection (blue)
+	add_color_pair("#003e7a", "#2b74bb"); // Selection (darker blue)
+	add_color_pair("#f7f5cf", "#615f3a"); // Gizmo (yellow)
+
+	// Rainbow
+	add_color_pair("#ff4545", "#ff2929"); // Red
+	add_color_pair("#ffe345", "#ffe337"); // Yellow
+	add_color_pair("#80ff45", "#74ff34"); // Green
+	add_color_pair("#45ffa2", "#2cff98"); // Aqua
+	add_color_pair("#45d7ff", "#22ccff"); // Blue
+	add_color_pair("#8045ff", "#702aff"); // Purple
+	add_color_pair("#ff4596", "#ff2781"); // Pink
+
+	// Audio gradients
+	add_color_pair("#e1da5b", "#d6cf4b"); // Yellow
+
+	add_color_pair("#62aeff", "#1678e0"); // Frozen gradient top
+	add_color_pair("#75d1e6", "#41acc5"); // Frozen gradient middle
+	add_color_pair("#84ffee", "#49ccba"); // Frozen gradient bottom
+
+	add_color_pair("#f70000", "#c91616"); // Color track red
+	add_color_pair("#eec315", "#d58c0b"); // Color track orange
+	add_color_pair("#dbee15", "#b7d10a"); // Color track yellow
+	add_color_pair("#288027", "#218309"); // Color track green
+
+	// Resource groups
+	add_color_pair("#ffca5f", "#fea900"); // Mesh resource (orange)
+	add_color_pair("#2998ff", "#68b6ff"); // Shape resource (blue)
+	add_color_pair("#a2d2ff", "#4998e3"); // Shape resource (light blue)
+
+	// Animation editor tracks
+	// The property track icon color is set by the common icon color.
+	add_color_pair("#ea7940", "#bd5e2c"); // 3D Position track
+	add_color_pair("#ff2b88", "#bd165f"); // 3D Rotation track
+	add_color_pair("#eac840", "#bd9d1f"); // 3D Scale track
+	add_color_pair("#3cf34e", "#16a827"); // Call Method track
+	add_color_pair("#2877f6", "#236be6"); // Bezier Curve track
+	add_color_pair("#eae440", "#9f9722"); // Audio Playback track
+	add_color_pair("#a448f0", "#9853ce"); // Animation Playback track
+	add_color_pair("#5ad5c4", "#0a9c88"); // Blend Shape track
+
+	// Control layouts
+	add_color_pair("#d6d6d6", "#474747"); // Highlighted part
+	add_color_pair("#474747", "#d6d6d6"); // Background part
+	add_color_pair("#919191", "#6e6e6e"); // Border part
+
+	// TileSet editor icons
+	add_color_pair("#fce00e", "#aa8d24"); // New Single Tile
+	add_color_pair("#0e71fc", "#0350bd"); // New Autotile
+	add_color_pair("#c6ced4", "#828f9b"); // New Atlas
+
+	// Visual script
+	add_color_pair("#41ecad", "#25e3a0"); // VisualScript variant
+	add_color_pair("#6f91f0", "#6d8eeb"); // VisualScript bool
+	add_color_pair("#5abbef", "#4fb2e9"); // VisualScript int
+	add_color_pair("#35d4f4", "#27ccf0"); // VisualScript float
+	add_color_pair("#4593ec", "#4690e7"); // VisualScript String
+	add_color_pair("#ac73f1", "#ad76ee"); // VisualScript Vector2
+	add_color_pair("#f1738f", "#ee758e"); // VisualScript Rect2
+	add_color_pair("#de66f0", "#dc6aed"); // VisualScript Vector3
+	add_color_pair("#b9ec41", "#96ce1a"); // VisualScript Transform2D
+	add_color_pair("#f74949", "#f77070"); // VisualScript Plane
+	add_color_pair("#ec418e", "#ec69a3"); // VisualScript Quat
+	add_color_pair("#ee5677", "#ee7991"); // VisualScript AABB
+	add_color_pair("#e1ec41", "#b2bb19"); // VisualScript Basis
+	add_color_pair("#f68f45", "#f49047"); // VisualScript Transform
+	add_color_pair("#417aec", "#6993ec"); // VisualScript NodePath
+	add_color_pair("#41ec80", "#2ce573"); // VisualScript RID
+	add_color_pair("#55f3e3", "#12d5c3"); // VisualScript Object
+	add_color_pair("#54ed9e", "#57e99f"); // VisualScript Dictionary
+	// Visual shaders
+	add_color_pair("#77ce57", "#67c046"); // Vector funcs
+	add_color_pair("#ea686c", "#d95256"); // Vector transforms
+	add_color_pair("#eac968", "#d9b64f"); // Textures and cubemaps
+	add_color_pair("#cf68ea", "#c050dd"); // Functions and expressions
+}
 
 static Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true) {
 	Ref<StyleBoxTexture> style(memnew(StyleBoxTexture));
@@ -113,7 +224,7 @@ static Ref<Texture2D> flip_icon(Ref<Texture2D> p_texture, bool p_flip_y = false,
 
 #ifdef MODULE_SVG_ENABLED
 // See also `generate_icon()` in `scene/resources/default_theme.cpp`.
-static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color, float p_scale = EDSCALE, float p_saturation = 1.0, Dictionary p_convert_colors = Dictionary()) {
+static Ref<ImageTexture> editor_generate_icon(int p_index, float p_scale, float p_saturation, const HashMap<Color, Color> &p_convert_colors = HashMap<Color, Color>()) {
 	Ref<Image> img = memnew(Image);
 
 	// Upsample icon generation only if the editor scale isn't an integer multiplier.
@@ -121,8 +232,7 @@ static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color,
 	// with integer editor scales.
 	const bool upsample = !Math::is_equal_approx(Math::round(p_scale), p_scale);
 	ImageLoaderSVG img_loader;
-	img_loader.set_replace_colors(p_convert_colors);
-	img_loader.create_image_from_string(img, editor_icons_sources[p_index], p_scale, upsample, p_convert_color);
+	img_loader.create_image_from_string(img, editor_icons_sources[p_index], p_scale, upsample, p_convert_colors);
 	if (p_saturation != 1.0) {
 		img->adjust_bcs(1.0, 1.0, p_saturation);
 	}
@@ -132,126 +242,18 @@ static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color,
 }
 #endif
 
-#ifndef ADD_CONVERT_COLOR
-#define ADD_CONVERT_COLOR(dictionary, old_color, new_color) dictionary[Color::html(old_color)] = Color::html(new_color)
-#endif
-
 void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = true, int p_thumb_size = 32, bool p_only_thumbs = false, float p_icon_saturation = 1.0) {
 #ifdef MODULE_SVG_ENABLED
-	// The default icon theme is designed to be used for a dark theme.
-	// This dictionary stores Color values to convert to other colors
-	// for better readability on a light theme.
-	// Godot Color values are used to avoid the ambiguity of strings
-	// (where "#ffffff", "fff", and "white" are all equivalent).
-	Dictionary dark_icon_color_dictionary;
+	HashMap<Color, Color> icon_color_map;
 
 	// The names of the icons to never convert, even if one of their colors
 	// are contained in the dictionary above.
 	HashSet<StringName> exceptions;
 
-	// Some of the colors below are listed for completeness sake.
-	// This can be a basis for proper palette validation later.
 	if (!p_dark_theme) {
-		// Convert color:                             FROM       TO
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#478cbf", "#478cbf"); // Godot Blue
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#414042", "#414042"); // Godot Gray
-
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ffffff", "#414141"); // Pure white
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#000000", "#bfbfbf"); // Pure black
-		// Keep pure RGB colors as is, but list them for explicitly.
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ff0000", "#ff0000"); // Pure red
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#00ff00", "#00ff00"); // Pure green
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#0000ff", "#0000ff"); // Pure blue
-
-		// GUI Colors
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#e0e0e0", "#5a5a5a"); // Common icon color
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#fefefe", "#fefefe"); // Forced light color
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#808080", "#808080"); // GUI disabled color
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#b3b3b3", "#363636"); // GUI disabled light color
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#699ce8", "#699ce8"); // GUI highlight color
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#f9f9f9", "#606060"); // Scrollbar grabber highlight color
-
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#c38ef1", "#a85de9"); // Animation
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#fc7f7f", "#cd3838"); // Spatial
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#8da5f3", "#3d64dd"); // 2D
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#4b70ea", "#1a3eac"); // 2D Dark
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#8eef97", "#2fa139"); // Control
-
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#5fb2ff", "#0079f0"); // Selection (blue)
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#003e7a", "#2b74bb"); // Selection (darker blue)
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#f7f5cf", "#615f3a"); // Gizmo (yellow)
-
-		// Rainbow
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ff4545", "#ff2929"); // Red
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ffe345", "#ffe337"); // Yellow
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#80ff45", "#74ff34"); // Green
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#45ffa2", "#2cff98"); // Aqua
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#45d7ff", "#22ccff"); // Blue
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#8045ff", "#702aff"); // Purple
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ff4596", "#ff2781"); // Pink
-
-		// Audio gradients
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#e1da5b", "#d6cf4b"); // Yellow
-
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#62aeff", "#1678e0"); // Frozen gradient top
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#75d1e6", "#41acc5"); // Frozen gradient middle
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#84ffee", "#49ccba"); // Frozen gradient bottom
-
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#f70000", "#c91616"); // Color track red
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#eec315", "#d58c0b"); // Color track orange
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#dbee15", "#b7d10a"); // Color track yellow
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#288027", "#218309"); // Color track green
-
-		// Resource groups
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ffca5f", "#fea900"); // Mesh resource (orange)
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#2998ff", "#68b6ff"); // Shape resource (blue)
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#a2d2ff", "#4998e3"); // Shape resource (light blue)
-
-		// Animation editor tracks
-		// The property track icon color is set by the common icon color.
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ea7940", "#bd5e2c"); // 3D Position track
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ff2b88", "#bd165f"); // 3D Rotation track
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#eac840", "#bd9d1f"); // 3D Scale track
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#3cf34e", "#16a827"); // Call Method track
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#2877f6", "#236be6"); // Bezier Curve track
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#eae440", "#9f9722"); // Audio Playback track
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#a448f0", "#9853ce"); // Animation Playback track
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#5ad5c4", "#0a9c88"); // Blend Shape track
-
-		// Control layouts
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#d6d6d6", "#474747"); // Highlighted part
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#474747", "#d6d6d6"); // Background part
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#919191", "#6e6e6e"); // Border part
-
-		// TileSet editor icons
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#fce00e", "#aa8d24"); // New Single Tile
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#0e71fc", "#0350bd"); // New Autotile
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#c6ced4", "#828f9b"); // New Atlas
-
-		// Visual script
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#41ecad", "#25e3a0"); // VisualScript variant
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#6f91f0", "#6d8eeb"); // VisualScript bool
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#5abbef", "#4fb2e9"); // VisualScript int
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#35d4f4", "#27ccf0"); // VisualScript float
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#4593ec", "#4690e7"); // VisualScript String
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ac73f1", "#ad76ee"); // VisualScript Vector2
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#f1738f", "#ee758e"); // VisualScript Rect2
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#de66f0", "#dc6aed"); // VisualScript Vector3
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#b9ec41", "#96ce1a"); // VisualScript Transform2D
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#f74949", "#f77070"); // VisualScript Plane
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ec418e", "#ec69a3"); // VisualScript Quat
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ee5677", "#ee7991"); // VisualScript AABB
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#e1ec41", "#b2bb19"); // VisualScript Basis
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#f68f45", "#f49047"); // VisualScript Transform
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#417aec", "#6993ec"); // VisualScript NodePath
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#41ec80", "#2ce573"); // VisualScript RID
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#55f3e3", "#12d5c3"); // VisualScript Object
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#54ed9e", "#57e99f"); // VisualScript Dictionary
-		// Visual shaders
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#77ce57", "#67c046"); // Vector funcs
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ea686c", "#d95256"); // Vector transforms
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#eac968", "#d9b64f"); // Textures and cubemaps
-		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#cf68ea", "#c050dd"); // Functions and expressions
+		for (KeyValue<Color, Color> &E : EditorColorMap::get()) {
+			icon_color_map[E.key] = E.value;
+		}
 
 		exceptions.insert("EditorPivot");
 		exceptions.insert("EditorHandle");
@@ -291,18 +293,18 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 	const Color error_color = p_theme->get_color(SNAME("error_color"), SNAME("Editor"));
 	const Color success_color = p_theme->get_color(SNAME("success_color"), SNAME("Editor"));
 	const Color warning_color = p_theme->get_color(SNAME("warning_color"), SNAME("Editor"));
-	dark_icon_color_dictionary[Color::html("#ff5f5f")] = error_color;
-	dark_icon_color_dictionary[Color::html("#5fff97")] = success_color;
-	dark_icon_color_dictionary[Color::html("#ffdd65")] = warning_color;
+	icon_color_map[Color::html("#ff5f5f")] = error_color;
+	icon_color_map[Color::html("#5fff97")] = success_color;
+	icon_color_map[Color::html("#ffdd65")] = warning_color;
 
 	// Use the accent color for some icons (checkbox, radio, toggle, etc.).
-	Dictionary accent_color_icon_color_dictionary;
+	HashMap<Color, Color> accent_color_map;
 	HashSet<StringName> accent_color_icons;
 
 	const Color accent_color = p_theme->get_color(SNAME("accent_color"), SNAME("Editor"));
-	accent_color_icon_color_dictionary[Color::html("699ce8")] = accent_color;
+	accent_color_map[Color::html("699ce8")] = accent_color;
 	if (accent_color.get_luminance() > 0.75) {
-		accent_color_icon_color_dictionary[Color::html("ffffff")] = Color(0.2, 0.2, 0.2);
+		accent_color_map[Color::html("ffffff")] = Color(0.2, 0.2, 0.2);
 	}
 
 	accent_color_icons.insert("GuiChecked");
@@ -318,7 +320,7 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 			Ref<ImageTexture> icon;
 
 			if (accent_color_icons.has(editor_icons_names[i])) {
-				icon = editor_generate_icon(i, true, EDSCALE, 1.0, accent_color_icon_color_dictionary);
+				icon = editor_generate_icon(i, EDSCALE, 1.0, accent_color_map);
 			} else {
 				float saturation = p_icon_saturation;
 
@@ -327,7 +329,11 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 				}
 
 				const int is_exception = exceptions.has(editor_icons_names[i]);
-				icon = editor_generate_icon(i, !is_exception, EDSCALE, saturation, dark_icon_color_dictionary);
+				if (is_exception) {
+					icon = editor_generate_icon(i, EDSCALE, saturation);
+				} else {
+					icon = editor_generate_icon(i, EDSCALE, saturation, icon_color_map);
+				}
 			}
 
 			p_theme->set_icon(editor_icons_names[i], SNAME("EditorIcons"), icon);
@@ -342,7 +348,13 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		for (int i = 0; i < editor_bg_thumbs_count; i++) {
 			const int index = editor_bg_thumbs_indices[i];
 			const int is_exception = exceptions.has(editor_icons_names[index]);
-			const Ref<ImageTexture> icon = editor_generate_icon(index, !p_dark_theme && !is_exception, scale, force_filter, dark_icon_color_dictionary);
+
+			Ref<ImageTexture> icon;
+			if (!p_dark_theme && !is_exception) {
+				icon = editor_generate_icon(index, scale, force_filter, icon_color_map);
+			} else {
+				icon = editor_generate_icon(index, scale, force_filter);
+			}
 
 			p_theme->set_icon(editor_icons_names[index], SNAME("EditorIcons"), icon);
 		}
@@ -351,7 +363,13 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		for (int i = 0; i < editor_md_thumbs_count; i++) {
 			const int index = editor_md_thumbs_indices[i];
 			const bool is_exception = exceptions.has(editor_icons_names[index]);
-			const Ref<ImageTexture> icon = editor_generate_icon(index, !p_dark_theme && !is_exception, scale, force_filter, dark_icon_color_dictionary);
+
+			Ref<ImageTexture> icon;
+			if (!p_dark_theme && !is_exception) {
+				icon = editor_generate_icon(index, scale, force_filter, icon_color_map);
+			} else {
+				icon = editor_generate_icon(index, scale, force_filter);
+			}
 
 			p_theme->set_icon(editor_icons_names[index], SNAME("EditorIcons"), icon);
 		}

--- a/editor/editor_themes.h
+++ b/editor/editor_themes.h
@@ -34,6 +34,20 @@
 #include "scene/resources/texture.h"
 #include "scene/resources/theme.h"
 
+// The default icon theme is designed to be used for a dark theme. This map stores
+// Color values to convert to other colors for better readability on a light theme.
+class EditorColorMap {
+	// Godot Color values are used to avoid the ambiguity of strings
+	// (where "#ffffff", "fff", and "white" are all equivalent).
+	static HashMap<Color, Color> editor_color_map;
+
+public:
+	static void create();
+	static void add_color_pair(const String p_from_color, const String p_to_color);
+
+	static HashMap<Color, Color> &get() { return editor_color_map; };
+};
+
 Ref<Theme> create_editor_theme(Ref<Theme> p_theme = nullptr);
 
 Ref<Theme> create_custom_theme(Ref<Theme> p_theme = nullptr);

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -34,13 +34,10 @@
 #include "core/io/image_loader.h"
 
 class ImageLoaderSVG : public ImageFormatLoader {
-	Dictionary replace_colors;
-	void _replace_color_property(const String &p_prefix, String &r_string);
+	void _replace_color_property(const HashMap<Color, Color> &p_color_map, const String &p_prefix, String &r_string);
 
 public:
-	// Called by the editor to handle theme icon colors.
-	void set_replace_colors(Dictionary p_replace_colors) { replace_colors = p_replace_colors; }
-	void create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, bool p_convert_color);
+	void create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, const HashMap<Color, Color> &p_color_map);
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, bool p_force_linear, float p_scale) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -84,7 +84,7 @@ static Ref<ImageTexture> generate_icon(int p_index) {
 	// with integer scales.
 	const bool upsample = !Math::is_equal_approx(Math::round(scale), scale);
 	ImageLoaderSVG img_loader;
-	img_loader.create_image_from_string(img, default_theme_icons_sources[p_index], scale, upsample, false);
+	img_loader.create_image_from_string(img, default_theme_icons_sources[p_index], scale, upsample, HashMap<Color, Color>());
 #endif
 
 	return ImageTexture::create_from_image(img);


### PR DESCRIPTION
A stepping stone for https://github.com/godotengine/godot-proposals/issues/5034 and a bit of refactoring that we will need in future for icon testing/validation (see https://github.com/godotengine/godot/issues/56790).

Extracts the editor color map from a utility method in editor themes to a dedicated class, making it accessible throughout the editor. The map is stored as a hash map instead of a dictionary (we don't need any interop with the file system or public API, so why was it a dict to begin with?). I didn't move it out of `editor_themes.h/cpp`, because it is still mostly relevant together with the theme, but I can change that.

The SVG module is simplified a bit. Previously the conversion table was set as a class member, but this was done before every conversion anyway, and it was only used in the editor code. So this is a parameter of the parser method now. I'm not happy that the editor is allocating a new loader for every icon, this is probably slow and inefficient, but this can be fixed later. Functionally, passing the color map as a parameter of the parser function makes no difference, and allows to avoid polluting the class state for subsequent calls, which is important for the aforementioned proposal.

_This work is kindly sponsored by the **[Dialogic](https://github.com/coppolaemilio/dialogic)** project._