### PR TITLE
Add `includeInternal` to C# NodeExtensions and avoid printing errors in `GetChildOrNull`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -241,7 +241,7 @@
 			<description>
 				Returns a child node by its index (see [method get_child_count]). This method is often used for iterating all children of a node.
 				Negative indices access the children from the last one.
-				If [param include_internal] is [code]true[/code], internal children are skipped (see [code]internal[/code] parameter in [method add_child]).
+				If [param include_internal] is [code]false[/code], internal children are skipped (see [code]internal[/code] parameter in [method add_child]).
 				To access a child node via its name, use [method get_node].
 			</description>
 		</method>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -93,8 +93,12 @@ namespace Godot
         /// Negative indices access the children from the last one.
         /// To access a child node via its name, use <see cref="GetNode"/>.
         /// </summary>
-        /// <seealso cref="GetChildOrNull{T}(int)"/>
+        /// <seealso cref="GetChildOrNull{T}(int, bool)"/>
         /// <param name="idx">Child index.</param>
+        /// <param name="includeInternal">
+        /// If <see langword="false"/>, internal children are skipped (see <c>internal</c>
+        /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
+        /// </param>
         /// <exception cref="InvalidCastException">
         /// Thrown when the given the fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
@@ -102,9 +106,9 @@ namespace Godot
         /// <returns>
         /// The child <see cref="Node"/> at the given index <paramref name="idx"/>.
         /// </returns>
-        public T GetChild<T>(int idx) where T : class
+        public T GetChild<T>(int idx, bool includeInternal = false) where T : class
         {
-            return (T)(object)GetChild(idx);
+            return (T)(object)GetChild(idx, includeInternal);
         }
 
         /// <summary>
@@ -113,15 +117,19 @@ namespace Godot
         /// Negative indices access the children from the last one.
         /// To access a child node via its name, use <see cref="GetNode"/>.
         /// </summary>
-        /// <seealso cref="GetChild{T}(int)"/>
+        /// <seealso cref="GetChild{T}(int, bool)"/>
         /// <param name="idx">Child index.</param>
+        /// <param name="includeInternal">
+        /// If <see langword="false"/>, internal children are skipped (see <c>internal</c>
+        /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
+        /// </param>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>
         /// The child <see cref="Node"/> at the given index <paramref name="idx"/>, or <see langword="null"/> if not found.
         /// </returns>
-        public T GetChildOrNull<T>(int idx) where T : class
+        public T GetChildOrNull<T>(int idx, bool includeInternal = false) where T : class
         {
-            return GetChild(idx) as T;
+            return GetChild(idx, includeInternal) as T;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -129,7 +129,8 @@ namespace Godot
         /// </returns>
         public T GetChildOrNull<T>(int idx, bool includeInternal = false) where T : class
         {
-            return GetChild(idx, includeInternal) as T;
+            int count = GetChildCount(includeInternal);
+            return idx >= -count && idx < count ? GetChild(idx, includeInternal) as T : null;
         }
 
         /// <summary>


### PR DESCRIPTION
- Node methods in C# extended to use generics now have the optional parameter `includeInternal` like their non-generic equivalents (added to core in #30391). Also fixes a typo in the `Node.xml` documentation.
- Avoid printing an error in `GetChildOrNull` when the given index is out of range, similar to how the LINQ `ElementAtOrDefault` method works (fixes #57128).