### PR TITLE
ci: add Python static analysis check via mypy

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install -qq dos2unix recode clang-format-13 libxml2-utils python3-pip moreutils
           sudo update-alternatives --remove-all clang-format || true
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
-          sudo pip3 install black==22.3.0 pygments pytest
+          sudo pip3 install black==22.3.0 pygments pytest==7.1.2 mypy==0.971
 
       - name: File formatting checks (file_format.sh)
         run: |
@@ -40,6 +40,10 @@ jobs:
       - name: Python style checks via black (black_format.sh)
         run: |
           bash ./misc/scripts/black_format.sh
+
+      - name: Python scripts static analysis (mypy_check.sh)
+        run: |
+          bash ./misc/scripts/mypy_check.sh
 
       - name: Python builders checks via pytest (pytest_builders.sh)
         run: |

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -2,6 +2,7 @@
 
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 """
+import zlib
 
 from platform_methods import subprocess_main
 
@@ -33,7 +34,6 @@ def make_certs_header(target, source, env):
     g = open(dst, "w", encoding="utf-8")
     buf = f.read()
     decomp_size = len(buf)
-    import zlib
 
     # Use maximum zlib compression level to further reduce file size
     # (at the cost of initial build times).
@@ -208,7 +208,7 @@ def make_license_header(target, source, env):
 
     from collections import OrderedDict
 
-    projects = OrderedDict()
+    projects: dict = OrderedDict()
     license_list = []
 
     with open(src_copyright, "r", encoding="utf-8") as copyright_file:
@@ -230,7 +230,7 @@ def make_license_header(target, source, env):
                 part = {}
                 reader.next_line()
 
-    data_list = []
+    data_list: list = []
     for project in iter(projects.values()):
         for part in project:
             part["file_index"] = len(data_list)

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -16,7 +16,7 @@ def make_default_controller_mappings(target, source, env):
     g.write('#include "core/input/default_controller_mappings.h"\n')
 
     # ensure mappings have a consistent order
-    platform_mappings = OrderedDict()
+    platform_mappings: dict = OrderedDict()
     for src_path in source:
         with open(src_path, "r") as f:
             # read mapping file and skip header

--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -60,7 +60,7 @@ BASE_STRINGS = [
 ## <xml-line-number-hack from="https://stackoverflow.com/a/36430270/10846399">
 import sys
 
-sys.modules["_elementtree"] = None
+sys.modules["_elementtree"] = None  # type: ignore
 import xml.etree.ElementTree as ET
 
 ## override the parser to get the line number

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import tempfile
 import uuid
+import zlib
 from platform_methods import subprocess_main
 
 
@@ -28,7 +29,6 @@ def make_doc_header(target, source, env):
 
     buf = (docbegin + buf + docend).encode("utf-8")
     decomp_size = len(buf)
-    import zlib
 
     # Use maximum zlib compression level to further reduce file size
     # (at the cost of initial build times).
@@ -87,9 +87,6 @@ def make_translations_header(target, source, env, category):
     g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
     g.write("#ifndef _{}_TRANSLATIONS_H\n".format(category.upper()))
     g.write("#define _{}_TRANSLATIONS_H\n".format(category.upper()))
-
-    import zlib
-    import os.path
 
     sorted_paths = sorted(source, key=lambda path: os.path.splitext(os.path.basename(path))[0])
 

--- a/editor/translations/extract.py
+++ b/editor/translations/extract.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+from typing import Dict, Tuple
 
 
 class Message:
@@ -42,7 +43,7 @@ class Message:
         return "\n".join(lines)
 
 
-messages_map = {}  # (id, context) -> Message.
+messages_map: Dict[Tuple[str, str], Message] = {}  # (id, context) -> Message.
 
 line_nb = False
 
@@ -51,11 +52,11 @@ for arg in sys.argv[1:]:
         print("Enabling line numbers in the context locations.")
         line_nb = True
     else:
-        os.sys.exit("Non supported argument '" + arg + "'. Aborting.")
+        sys.exit("Non supported argument '" + arg + "'. Aborting.")
 
 
 if not os.path.exists("editor"):
-    os.sys.exit("ERROR: This script should be started from the root of the git repo.")
+    sys.exit("ERROR: This script should be started from the root of the git repo.")
 
 
 matches = []

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -3,6 +3,10 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+import os.path
+
+from typing import Optional
+
 from platform_methods import subprocess_main
 
 
@@ -30,7 +34,7 @@ class GLES3HeaderStruct:
         self.specialization_values = []
 
 
-def include_file_in_gles3_header(filename, header_data, depth):
+def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, depth: int):
     fs = open(filename, "r")
     line = fs.readline()
 
@@ -90,8 +94,6 @@ def include_file_in_gles3_header(filename, header_data, depth):
 
         while line.find("#include ") != -1:
             includeline = line.replace("#include ", "").strip()[1:-1]
-
-            import os.path
 
             included_file = os.path.relpath(os.path.dirname(filename) + "/" + includeline)
             if not included_file in header_data.vertex_included_files and header_data.reading == "vertex":
@@ -182,7 +184,7 @@ def include_file_in_gles3_header(filename, header_data, depth):
     return header_data
 
 
-def build_gles3_header(filename, include, class_suffix, header_data=None):
+def build_gles3_header(filename: str, include: str, class_suffix: str, header_data: Optional[GLES3HeaderStruct] = None):
     header_data = header_data or GLES3HeaderStruct()
     include_file_in_gles3_header(filename, header_data, 0)
 

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -4,13 +4,15 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 
 """
 import os.path
+from typing import Optional, Iterable
+
 from platform_methods import subprocess_main
 
 
-def generate_inline_code(input_lines, insert_newline=True):
+def generate_inline_code(input_lines: Iterable[str], insert_newline: bool = True):
     """Take header data and generate inline code
 
-    :param: list input_lines: values for shared inline code
+    :param: input_lines: values for shared inline code
     :return: str - generated inline value
     """
     output = []
@@ -40,7 +42,7 @@ class RDHeaderStruct:
         self.compute_offset = 0
 
 
-def include_file_in_rd_header(filename, header_data, depth):
+def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth: int) -> RDHeaderStruct:
     fs = open(filename, "r")
     line = fs.readline()
 
@@ -112,7 +114,7 @@ def include_file_in_rd_header(filename, header_data, depth):
     return header_data
 
 
-def build_rd_header(filename, header_data=None):
+def build_rd_header(filename: str, header_data: Optional[RDHeaderStruct] = None) -> None:
     header_data = header_data or RDHeaderStruct()
     include_file_in_rd_header(filename, header_data, 0)
 
@@ -171,7 +173,7 @@ class RAWHeaderStruct:
         self.code = ""
 
 
-def include_file_in_raw_header(filename, header_data, depth):
+def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, depth: int) -> None:
     fs = open(filename, "r")
     line = fs.readline()
 
@@ -191,7 +193,7 @@ def include_file_in_raw_header(filename, header_data, depth):
     fs.close()
 
 
-def build_raw_header(filename, header_data=None):
+def build_raw_header(filename: str, header_data: Optional[RAWHeaderStruct] = None):
     header_data = header_data or RAWHeaderStruct()
     include_file_in_raw_header(filename, header_data, 0)
 

--- a/methods.py
+++ b/methods.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 import glob
 import subprocess
 from collections import OrderedDict
@@ -663,7 +662,6 @@ def detect_visual_c_compiler_version(tools_env):
         if vc_x86_amd64_compiler_detection_index > -1 and (
             vc_chosen_compiler_index == -1 or vc_chosen_compiler_index > vc_x86_amd64_compiler_detection_index
         ):
-            vc_chosen_compiler_index = vc_x86_amd64_compiler_detection_index
             vc_chosen_compiler_str = "x86_amd64"
 
     return vc_chosen_compiler_str
@@ -781,7 +779,7 @@ def generate_vs_project(env, num_jobs):
                     f'bin\\godot.windows.{config}{dev}.{plat_id}{f".{name}" if name else ""}.exe'
                     for config in ModuleConfigs.CONFIGURATIONS
                     for plat_id in ModuleConfigs.PLATFORM_IDS
-                    for dev in ModuleConfig.DEV_SUFFIX
+                    for dev in ModuleConfigs.DEV_SUFFIX
                 ]
                 self.arg_dict["cpppaths"] += ModuleConfigs.for_every_variant(env["CPPPATH"] + [includes])
                 self.arg_dict["cppdefines"] += ModuleConfigs.for_every_variant(env["CPPDEFINES"] + defines)

--- a/misc/scripts/mypy.ini
+++ b/misc/scripts/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+ignore_missing_imports = true
+disallow_any_generics = True
+pretty = True
+show_column_numbers = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+
+namespace_packages = True
+explicit_package_bases = True

--- a/misc/scripts/mypy_check.sh
+++ b/misc/scripts/mypy_check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+echo -e "Python: mypy static analysis..."
+mypy --config-file=./misc/scripts/mypy.ini .

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -5,6 +5,7 @@ import os.path
 import shlex
 import subprocess
 from dataclasses import dataclass
+from typing import Optional, List
 
 
 def find_dotnet_cli():
@@ -150,10 +151,7 @@ def find_any_msbuild_tool(mono_prefix):
     return None
 
 
-def run_msbuild(tools: ToolsLocation, sln: str, msbuild_args: [str] = None):
-    if msbuild_args is None:
-        msbuild_args = []
-
+def run_msbuild(tools: ToolsLocation, sln: str, msbuild_args: Optional[List[str]] = None):
     using_msbuild_mono = False
 
     # Preference order: dotnet CLI > Standalone MSBuild > Mono's MSBuild
@@ -169,7 +167,7 @@ def run_msbuild(tools: ToolsLocation, sln: str, msbuild_args: [str] = None):
 
     args += [sln]
 
-    if len(msbuild_args) > 0:
+    if msbuild_args:
         args += msbuild_args
 
     print("Running MSBuild: ", " ".join(shlex.quote(arg) for arg in args), flush=True)

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -3,6 +3,11 @@ import sys
 import platform
 import subprocess
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -17,8 +22,6 @@ def can_build():
 
 
 def get_opts():
-    from SCons.Variables import BoolVariable, EnumVariable
-
     return [
         ("ANDROID_SDK_ROOT", "Path to the Android SDK", get_env_android_sdk_root()),
         ("ndk_platform", 'Target platform (android-<api>, e.g. "android-24")', "android-24"),
@@ -74,7 +77,7 @@ def install_ndk_if_needed(env):
     env["ANDROID_NDK_ROOT"] = get_android_ndk_root(env)
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     if env["arch"] not in supported_arches:

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -2,6 +2,11 @@ import os
 import sys
 from methods import detect_darwin_sdk_path
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -42,7 +47,7 @@ def get_flags():
     ]
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -4,6 +4,11 @@ import sys
 from methods import get_compiler_version, using_gcc
 from platform_methods import detect_arch
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -55,7 +60,7 @@ def get_flags():
     ]
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
     if env["arch"] not in supported_arches:

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -3,6 +3,11 @@ import sys
 from methods import detect_darwin_sdk_path
 from platform_methods import detect_arch
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -72,7 +77,7 @@ def get_mvk_sdk_path():
     return os.path.join(os.path.join(dirname, ver_file), "MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/")
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -3,6 +3,11 @@ import os
 import sys
 from platform_methods import detect_arch
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -39,7 +44,7 @@ def get_flags():
     ]
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32"]
     if env["arch"] not in supported_arches:
@@ -83,7 +88,7 @@ def configure(env):
     env.AppendUnique(CCFLAGS=["/utf-8"])
 
     # ANGLE
-    angle_root = os.getenv("ANGLE_SRC_PATH")
+    angle_root = os.environ["ANGLE_SRC_PATH"]
     env.Prepend(CPPPATH=[angle_root + "/include"])
     jobs = str(env.GetOption("num_jobs"))
     angle_build_cmd = (
@@ -94,7 +99,7 @@ def configure(env):
         + " /p:Configuration=Release /p:Platform="
     )
 
-    if os.path.isfile(str(os.getenv("ANGLE_SRC_PATH")) + "/winrt/10/src/angle.sln"):
+    if os.path.isfile(f"{angle_root}/winrt/10/src/angle.sln"):
         env["build_angle"] = True
 
     ## Architecture

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -11,6 +11,10 @@ from emscripten_helpers import (
 )
 from methods import get_compiler_version
 from SCons.Util import WhereIs
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
 
 
 def is_active():
@@ -60,7 +64,7 @@ def get_flags():
     ]
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["wasm32"]
     if env["arch"] not in supported_arches:

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -4,6 +4,11 @@ import subprocess
 import sys
 from platform_methods import detect_arch
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 # To match other platforms
 STACK_SIZE = 8388608
 
@@ -588,7 +593,7 @@ def configure_mingw(env):
     env.Append(BUILDERS={"RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")})
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     if env["arch"] not in supported_arches:


### PR DESCRIPTION
I've noticed that there are now type annotation in various Python scripts across the codebase, but the type annotations by themselves are useless if they are not enforced.
Thus I added [mypy](https://github.com/python/mypy) into the CI pipeline which should check their validity. There were some errors in there, so:
- the easy errors are fixed
- `type: ignore` was added in cases where there's no straightforward fix
- ~some complex cases were downgraded (eg. in `make_method_signature()`) as there was no way this annotation could ever worked~
- added a few new annotations here and there.