### PR TITLE
Change Ref<T> to allow non const access to ptr

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -97,26 +97,15 @@ public:
 		return reference != p_r.reference;
 	}
 
-	_FORCE_INLINE_ T *operator->() {
+	_FORCE_INLINE_ T *operator*() const {
 		return reference;
 	}
 
-	_FORCE_INLINE_ T *operator*() {
+	_FORCE_INLINE_ T *operator->() const {
 		return reference;
 	}
 
-	_FORCE_INLINE_ const T *operator->() const {
-		return reference;
-	}
-
-	_FORCE_INLINE_ const T *ptr() const {
-		return reference;
-	}
-	_FORCE_INLINE_ T *ptr() {
-		return reference;
-	}
-
-	_FORCE_INLINE_ const T *operator*() const {
+	_FORCE_INLINE_ T *ptr() const {
 		return reference;
 	}
 


### PR DESCRIPTION
# Summary

This PR changes `Ref<T>` to allow non-const access to the referenced object even from a `const Ref<T>`.

Exactly as in `std::shared_ptr<T>`, the constness of the `Ref<T>` refers only to whether the pointer can be changed to point to something else.  The actual underlying object is not const because the pointer being managed is a non-const `T*`.  Due to restrictions with `RefCounted` (internal ref count), we cannot compile `Ref<const T>`, but that is ok because Godot is permissive when in doubt.  In Godot, a const object can just be passed as a `const T&` or `const T*` when this is truly needed.  

In practice, the following methods (and possibly more) already allowed non-const access to a `const Ref<T>`:

- `Ref<T>::operator=(const Ref<T>&)` turns a `const Ref` into a non-const `Ref`
- `Ref<T>(const Ref<T>&)` turns a `const Ref` into a non-const `Ref`
- `Ref<T>(const Variant&)` turns a `const Variant` containing a ref into a non-const `Ref`
- `Ref<T>::operator Variant() const` turns a `const Ref` into a Variant containing non-const `Ref`

# Problem being solved

In functions receiving a `const Ref<T>&`, the T object cannot be called on non-const methods.  That means it is frequently not usable by the function to which it is being passed.

This is shown in https://github.com/godotengine/godot-cpp/issues/693

It happens a lot on the Extension side because `const CLASS&` is the way the binding generator writes arguments and that is `const Ref<T>&` for reference counted types.

# godot-cpp

If this can be approved, a companion PR will make the equivalent changes in `godot-cpp`.