### PR TITLE
Display tooltip instantly on warning button press in Scene Tree Editor

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -936,6 +936,12 @@
 				If [param keep_offsets] is [code]true[/code], control's anchors will be updated instead of offsets.
 			</description>
 		</method>
+		<method name="show_tooltip">
+			<return type="void" />
+			<description>
+				Forces the the tooltip to display instantly, regardless of the [code]gui/timers/tooltip_delay_sec[/code] option in Project Settings, and even if [member mouse_filter] is set to [constant MOUSE_FILTER_IGNORE]. See [member hint_tooltip].
+			</description>
+		</method>
 		<method name="update_minimum_size">
 			<return type="void" />
 			<description>

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -126,13 +126,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		}
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_WARNING) {
-		String config_err = n->get_configuration_warnings_as_string();
-		if (config_err.is_empty()) {
-			return;
-		}
-		config_err = config_err.word_wrap(80);
-		warning->set_text(config_err);
-		warning->popup_centered();
+		show_tooltip();
 
 	} else if (p_id == BUTTON_SIGNALS) {
 		editor_selection->clear();
@@ -1317,10 +1311,6 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 
 	error = memnew(AcceptDialog);
 	add_child(error);
-
-	warning = memnew(AcceptDialog);
-	add_child(warning);
-	warning->set_title(TTR("Node Configuration Warning!"));
 
 	last_hash = 0;
 	blocked = 0;

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -64,7 +64,6 @@ class SceneTreeEditor : public Control {
 	String filter;
 
 	AcceptDialog *error = nullptr;
-	AcceptDialog *warning = nullptr;
 
 	bool auto_expand_selected = true;
 	bool connect_to_script_mode = false;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3041,6 +3041,13 @@ Control *Control::make_custom_tooltip(const String &p_text) const {
 	return nullptr;
 }
 
+void Control::show_tooltip() {
+	Viewport *viewport = get_viewport();
+	if (viewport) {
+		viewport->_gui_force_show_tooltip();
+	}
+}
+
 // Base object overrides.
 
 void Control::add_child_notify(Node *p_child) {
@@ -3366,6 +3373,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tooltip", "tooltip"), &Control::set_tooltip);
 	ClassDB::bind_method(D_METHOD("get_tooltip", "at_position"), &Control::get_tooltip, DEFVAL(Point2()));
 	ClassDB::bind_method(D_METHOD("_get_tooltip"), &Control::_get_tooltip);
+	ClassDB::bind_method(D_METHOD("show_tooltip"), &Control::show_tooltip);
 
 	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Control::set_default_cursor_shape);
 	ClassDB::bind_method(D_METHOD("get_default_cursor_shape"), &Control::get_default_cursor_shape);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -608,6 +608,7 @@ public:
 	void set_tooltip(const String &p_tooltip);
 	virtual String get_tooltip(const Point2 &p_pos) const;
 	virtual Control *make_custom_tooltip(const String &p_text) const;
+	void show_tooltip();
 
 	Control() {}
 };

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1266,6 +1266,10 @@ void Viewport::_gui_show_tooltip() {
 	gui.tooltip_popup->child_controls_changed();
 }
 
+void Viewport::_gui_force_show_tooltip() {
+	gui.tooltip_forced = true;
+}
+
 bool Viewport::_gui_call_input(Control *p_control, const Ref<InputEvent> &p_input) {
 	bool stopped = false;
 	Ref<InputEvent> ev = p_input;
@@ -1706,6 +1710,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 						} else if (gui.tooltip_label) {
 							if (tooltip == gui.tooltip_label->get_text()) {
 								is_tooltip_shown = true;
+							} else {
+								// Text is different, refresh tooltip instantly.
+								gui.tooltip_forced = true;
 							}
 						} else {
 							Variant t = gui.tooltip_popup->call("get_tooltip_text");
@@ -1730,9 +1737,14 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					}
 					gui.tooltip_control = over;
 					gui.tooltip_pos = over->get_screen_transform().xform(pos);
-					gui.tooltip_timer = get_tree()->create_timer(gui.tooltip_delay);
-					gui.tooltip_timer->set_ignore_time_scale(true);
-					gui.tooltip_timer->connect("timeout", callable_mp(this, &Viewport::_gui_show_tooltip));
+					if (gui.tooltip_forced) {
+						gui.tooltip_forced = false;
+						_gui_show_tooltip();
+					} else {
+						gui.tooltip_timer = get_tree()->create_timer(gui.tooltip_delay);
+						gui.tooltip_timer->set_ignore_time_scale(true);
+						gui.tooltip_timer->connect("timeout", callable_mp(this, &Viewport::_gui_show_tooltip));
+					}
 				}
 			}
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -369,6 +369,7 @@ private:
 		ObjectID drag_preview_id;
 		Ref<SceneTreeTimer> tooltip_timer;
 		double tooltip_delay = 0.0;
+		bool tooltip_forced = false;
 		Transform2D focus_inv_xform;
 		bool roots_order_dirty = false;
 		List<Control *> roots;
@@ -416,6 +417,7 @@ private:
 	String _gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Control **r_tooltip_owner = nullptr);
 	void _gui_cancel_tooltip();
 	void _gui_show_tooltip();
+	void _gui_force_show_tooltip();
 
 	void _gui_remove_control(Control *p_control);
 	void _gui_hide_control(Control *p_control);


### PR DESCRIPTION
This PR replaces the **AcceptDialog** warning in favour of showing the warning tooltip instantly when the Tree button is pressed.
![Showcase](https://i.gyazo.com/e1e813056b55cf8a791ecfa05df6e89a.gif)
I personally find it so much more lovely. Definitely faster than clicking to display the warning in a popup and then closing it by pressing OK.

Requires https://github.com/godotengine/godot/pull/64796 to be merged first.
With very wide **Tree**s, it may not behave as expected until https://github.com/godotengine/godot/pull/64771 is adjusted and merged first.