### PR TITLE
Handle child control size changes in SplitContainer

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -95,11 +95,16 @@ void SplitContainer::_resort() {
 		no_offset_middle_sep = ms_first[axis];
 	}
 
-	// Compute the final middle separation
+	// Compute the final middle separation.
 	middle_sep = no_offset_middle_sep;
+	if (prev_no_offset_middle_sep != INT_MAX) {
+		split_offset -= middle_sep - prev_no_offset_middle_sep;
+	}
+	prev_no_offset_middle_sep = middle_sep;
+
 	if (!collapsed) {
-		int clamped_split_offset = CLAMP(split_offset, ms_first[axis] - no_offset_middle_sep, get_size()[axis] - ms_second[axis] - sep);
-		middle_sep = MAX(middle_sep, clamped_split_offset);
+		int clamped_split_offset = CLAMP(split_offset, ms_first[axis] - no_offset_middle_sep, (get_size()[axis] - ms_second[axis] - sep) - no_offset_middle_sep);
+		middle_sep += clamped_split_offset;
 		if (should_clamp_split_offset) {
 			split_offset = clamped_split_offset;
 			should_clamp_split_offset = false;

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -47,6 +47,7 @@ private:
 	bool should_clamp_split_offset = false;
 	int split_offset = 0;
 	int middle_sep = 0;
+	int prev_no_offset_middle_sep = INT_MAX;
 	bool vertical = false;
 	bool dragging = false;
 	int drag_from = 0;


### PR DESCRIPTION
Reverts #64676
Fixes #64785

This is an alternate fix that keeps #43749 fixed.