### PR TITLE
Make GraphNode::_validate_property protected so GraphNode can be inherited

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -32,9 +32,7 @@
 
 #include "core/string/translation.h"
 
-#ifdef TOOLS_ENABLED
 #include "graph_edit.h"
-#endif
 
 struct _MinSizeCache {
 	int min_size;
@@ -445,6 +443,7 @@ void GraphNode::_edit_set_position(const Point2 &p_position) {
 	}
 	set_position(p_position);
 }
+#endif
 
 void GraphNode::_validate_property(PropertyInfo &p_property) const {
 	GraphEdit *graph = Object::cast_to<GraphEdit>(get_parent());
@@ -454,7 +453,6 @@ void GraphNode::_validate_property(PropertyInfo &p_property) const {
 		}
 	}
 }
-#endif
 
 void GraphNode::set_slot(int p_idx, bool p_enable_left, int p_type_left, const Color &p_color_left, bool p_enable_right, int p_type_right, const Color &p_color_right, const Ref<Texture2D> &p_custom_left, const Ref<Texture2D> &p_custom_right, bool p_draw_stylebox) {
 	ERR_FAIL_COND_MSG(p_idx < 0, vformat("Cannot set slot with p_idx (%d) lesser than zero.", p_idx));

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -101,7 +101,6 @@ private:
 
 #ifdef TOOLS_ENABLED
 	void _edit_set_position(const Point2 &p_position) override;
-	void _validate_property(PropertyInfo &p_property) const;
 #endif
 
 protected:
@@ -112,6 +111,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	bool has_point(const Point2 &p_point) const override;


### PR DESCRIPTION
Since `_validate_property` became a multilevel method, the GDCLASS macro now tries to access the one from the parent class, which causes a compiling error if the parent class declares `_validate_property` as private. 
My module inherits from `GraphNode` and cannot compile since.
