### PR TITLE
Unify PathFollower's h/v offsets to a single Vector2/3

### DIFF
--- a/doc/classes/PathFollow2D.xml
+++ b/doc/classes/PathFollow2D.xml
@@ -15,9 +15,6 @@
 			The points along the [Curve2D] of the [Path2D] are precomputed before use, for faster calculations. The point at the requested offset is then calculated interpolating between two adjacent cached points. This may present a problem if the curve makes sharp turns, as the cached points may not follow the curve closely enough.
 			There are two answers to this problem: either increase the number of cached points and increase memory consumption, or make a cubic interpolation between two points at the cost of (slightly) slower calculations.
 		</member>
-		<member name="h_offset" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">
-			The node's offset along the curve.
-		</member>
 		<member name="lookahead" type="float" setter="set_lookahead" getter="get_lookahead" default="4.0">
 			How far to look ahead of the curve to calculate the tangent if the node is rotating. E.g. shorter lookaheads will lead to faster rotations.
 		</member>
@@ -30,11 +27,11 @@
 		<member name="progress_ratio" type="float" setter="set_progress_ratio" getter="get_progress_ratio" default="0.0">
 			The distance along the path as a number in the range 0.0 (for the first vertex) to 1.0 (for the last). This is just another way of expressing the progress within the path, as the offset supplied is multiplied internally by the path's length.
 		</member>
+		<member name="relative_offset" type="Vector2" setter="set_relative_offset" getter="get_relative_offset" default="Vector2(0, 0)">
+			The node's offset position parallel and perpendicular to the curve."
+		</member>
 		<member name="rotates" type="bool" setter="set_rotates" getter="is_rotating" default="true">
 			If [code]true[/code], this node rotates to follow the path, with the +X direction facing forward on the path.
-		</member>
-		<member name="v_offset" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
-			The node's offset perpendicular to the curve.
 		</member>
 	</members>
 </class>

--- a/doc/classes/PathFollow3D.xml
+++ b/doc/classes/PathFollow3D.xml
@@ -15,9 +15,6 @@
 			The points along the [Curve3D] of the [Path3D] are precomputed before use, for faster calculations. The point at the requested offset is then calculated interpolating between two adjacent cached points. This may present a problem if the curve makes sharp turns, as the cached points may not follow the curve closely enough.
 			There are two answers to this problem: either increase the number of cached points and increase memory consumption, or make a cubic interpolation between two points at the cost of (slightly) slower calculations.
 		</member>
-		<member name="h_offset" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">
-			The node's offset along the curve.
-		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="true">
 			If [code]true[/code], any offset outside the path's length will wrap around, instead of stopping at the ends. Use it for cyclic paths.
 		</member>
@@ -27,11 +24,11 @@
 		<member name="progress_ratio" type="float" setter="set_progress_ratio" getter="get_progress_ratio" default="0.0">
 			The distance from the first vertex, considering 0.0 as the first vertex and 1.0 as the last. This is just another way of expressing the progress within the path, as the progress supplied is multiplied internally by the path's length.
 		</member>
+		<member name="relative_offset" type="Vector3" setter="set_relative_offset" getter="get_relative_offset" default="Vector3(0, 0, 0)">
+			The node's offset position parallel, perpendicular, and to the side of the curve.
+		</member>
 		<member name="rotation_mode" type="int" setter="set_rotation_mode" getter="get_rotation_mode" enum="PathFollow3D.RotationMode" default="3">
 			Allows or forbids rotation on one or more axes, depending on the [enum RotationMode] constants being used.
-		</member>
-		<member name="v_offset" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
-			The node's offset perpendicular to the curve.
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -209,14 +209,13 @@ void PathFollow2D::_update_transform() {
 
 		Vector2 normal_of_curve = -tangent_to_curve.orthogonal();
 
-		pos += tangent_to_curve * h_offset;
-		pos += normal_of_curve * v_offset;
+		pos += tangent_to_curve * relative_offset.x;
+		pos += normal_of_curve * relative_offset.y;
 
 		set_rotation(tangent_to_curve.angle());
 
 	} else {
-		pos.x += h_offset;
-		pos.y += v_offset;
+		pos += relative_offset;
 	}
 
 	set_position(pos);
@@ -246,7 +245,7 @@ bool PathFollow2D::get_cubic_interpolation() const {
 }
 
 void PathFollow2D::_validate_property(PropertyInfo &p_property) const {
-	if (p_property.name == "offset") {
+	if (p_property.name == "progress") {
 		real_t max = 10000.0;
 		if (path && path->get_curve().is_valid()) {
 			max = path->get_curve()->get_baked_length();
@@ -272,11 +271,8 @@ void PathFollow2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_progress", "progress"), &PathFollow2D::set_progress);
 	ClassDB::bind_method(D_METHOD("get_progress"), &PathFollow2D::get_progress);
 
-	ClassDB::bind_method(D_METHOD("set_h_offset", "h_offset"), &PathFollow2D::set_h_offset);
-	ClassDB::bind_method(D_METHOD("get_h_offset"), &PathFollow2D::get_h_offset);
-
-	ClassDB::bind_method(D_METHOD("set_v_offset", "v_offset"), &PathFollow2D::set_v_offset);
-	ClassDB::bind_method(D_METHOD("get_v_offset"), &PathFollow2D::get_v_offset);
+	ClassDB::bind_method(D_METHOD("set_relative_offset", "offset"), &PathFollow2D::set_relative_offset);
+	ClassDB::bind_method(D_METHOD("get_relative_offset"), &PathFollow2D::get_relative_offset);
 
 	ClassDB::bind_method(D_METHOD("set_progress_ratio", "ratio"), &PathFollow2D::set_progress_ratio);
 	ClassDB::bind_method(D_METHOD("get_progress_ratio"), &PathFollow2D::get_progress_ratio);
@@ -295,8 +291,7 @@ void PathFollow2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress", PROPERTY_HINT_RANGE, "0,10000,0.01,or_less,or_greater,suffix:px"), "set_progress", "get_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001,or_less,or_greater", PROPERTY_USAGE_EDITOR), "set_progress_ratio", "get_progress_ratio");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "h_offset"), "set_h_offset", "get_h_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_offset"), "set_v_offset", "get_v_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "relative_offset"), "set_relative_offset", "get_relative_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rotates"), "set_rotates", "is_rotating");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cubic_interp"), "set_cubic_interpolation", "get_cubic_interpolation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
@@ -324,26 +319,15 @@ void PathFollow2D::set_progress(real_t p_progress) {
 	}
 }
 
-void PathFollow2D::set_h_offset(real_t p_h_offset) {
-	h_offset = p_h_offset;
+void PathFollow2D::set_relative_offset(Vector2 p_offset) {
+	relative_offset = p_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-real_t PathFollow2D::get_h_offset() const {
-	return h_offset;
-}
-
-void PathFollow2D::set_v_offset(real_t p_v_offset) {
-	v_offset = p_v_offset;
-	if (path) {
-		_update_transform();
-	}
-}
-
-real_t PathFollow2D::get_v_offset() const {
-	return v_offset;
+Vector2 PathFollow2D::get_relative_offset() const {
+	return relative_offset;
 }
 
 real_t PathFollow2D::get_progress() const {

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -66,8 +66,7 @@ public:
 private:
 	Path2D *path = nullptr;
 	real_t progress = 0.0;
-	real_t h_offset = 0.0;
-	real_t v_offset = 0.0;
+	Vector2 relative_offset = Vector2();
 	real_t lookahead = 4.0;
 	bool cubic = true;
 	bool loop = true;
@@ -85,11 +84,8 @@ public:
 	void set_progress(real_t p_progress);
 	real_t get_progress() const;
 
-	void set_h_offset(real_t p_h_offset);
-	real_t get_h_offset() const;
-
-	void set_v_offset(real_t p_v_offset);
-	real_t get_v_offset() const;
+	void set_relative_offset(Vector2 p_offset);
+	Vector2 get_relative_offset() const;
 
 	void set_progress_ratio(real_t p_ratio);
 	real_t get_progress_ratio() const;

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -239,7 +239,7 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 		t.basis.set_columns(sideways, up, forward);
 		t.basis.scale_local(scale);
 
-		t.origin = pos + sideways * h_offset + up * v_offset;
+		t.origin = pos + sideways * relative_offset.x + up * relative_offset.y + forward * relative_offset.z;
 	} else if (rotation_mode != ROTATION_NONE) {
 		// perform parallel transport
 		//
@@ -296,9 +296,9 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 			}
 		}
 
-		t.translate_local(Vector3(h_offset, v_offset, 0));
+		t.translate_local(relative_offset);
 	} else {
-		t.origin = pos + Vector3(h_offset, v_offset, 0);
+		t.origin = pos + relative_offset;
 	}
 
 	set_transform(t);
@@ -331,7 +331,7 @@ bool PathFollow3D::get_cubic_interpolation() const {
 }
 
 void PathFollow3D::_validate_property(PropertyInfo &p_property) const {
-	if (p_property.name == "offset") {
+	if (p_property.name == "progress") {
 		real_t max = 10000;
 		if (path && path->get_curve().is_valid()) {
 			max = path->get_curve()->get_baked_length();
@@ -362,11 +362,8 @@ void PathFollow3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_progress", "progress"), &PathFollow3D::set_progress);
 	ClassDB::bind_method(D_METHOD("get_progress"), &PathFollow3D::get_progress);
 
-	ClassDB::bind_method(D_METHOD("set_h_offset", "h_offset"), &PathFollow3D::set_h_offset);
-	ClassDB::bind_method(D_METHOD("get_h_offset"), &PathFollow3D::get_h_offset);
-
-	ClassDB::bind_method(D_METHOD("set_v_offset", "v_offset"), &PathFollow3D::set_v_offset);
-	ClassDB::bind_method(D_METHOD("get_v_offset"), &PathFollow3D::get_v_offset);
+	ClassDB::bind_method(D_METHOD("set_relative_offset", "offset"), &PathFollow3D::set_relative_offset);
+	ClassDB::bind_method(D_METHOD("get_relative_offset"), &PathFollow3D::get_relative_offset);
 
 	ClassDB::bind_method(D_METHOD("set_progress_ratio", "ratio"), &PathFollow3D::set_progress_ratio);
 	ClassDB::bind_method(D_METHOD("get_progress_ratio"), &PathFollow3D::get_progress_ratio);
@@ -382,8 +379,7 @@ void PathFollow3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress", PROPERTY_HINT_RANGE, "0,10000,0.01,or_less,or_greater,suffix:m"), "set_progress", "get_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001,or_less,or_greater", PROPERTY_USAGE_EDITOR), "set_progress_ratio", "get_progress_ratio");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "h_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_h_offset", "get_h_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_v_offset", "get_v_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "relative_offset"), "set_relative_offset", "get_relative_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rotation_mode", PROPERTY_HINT_ENUM, "None,Y,XY,XYZ,Oriented"), "set_rotation_mode", "get_rotation_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cubic_interp"), "set_cubic_interpolation", "get_cubic_interpolation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
@@ -418,26 +414,15 @@ void PathFollow3D::set_progress(real_t p_progress) {
 	}
 }
 
-void PathFollow3D::set_h_offset(real_t p_h_offset) {
-	h_offset = p_h_offset;
+void PathFollow3D::set_relative_offset(Vector3 p_offset) {
+	relative_offset = p_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-real_t PathFollow3D::get_h_offset() const {
-	return h_offset;
-}
-
-void PathFollow3D::set_v_offset(real_t p_v_offset) {
-	v_offset = p_v_offset;
-	if (path) {
-		_update_transform();
-	}
-}
-
-real_t PathFollow3D::get_v_offset() const {
-	return v_offset;
+Vector3 PathFollow3D::get_relative_offset() const {
+	return relative_offset;
 }
 
 real_t PathFollow3D::get_progress() const {

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -76,8 +76,7 @@ private:
 	Path3D *path = nullptr;
 	real_t prev_offset = 0.0; // Offset during the last _update_transform.
 	real_t progress = 0.0;
-	real_t h_offset = 0.0;
-	real_t v_offset = 0.0;
+	Vector3 relative_offset = Vector3();
 	bool cubic = true;
 	bool loop = true;
 	RotationMode rotation_mode = ROTATION_XYZ;
@@ -94,11 +93,8 @@ public:
 	void set_progress(real_t p_progress);
 	real_t get_progress() const;
 
-	void set_h_offset(real_t p_h_offset);
-	real_t get_h_offset() const;
-
-	void set_v_offset(real_t p_v_offset);
-	real_t get_v_offset() const;
+	void set_relative_offset(Vector3 p_offset);
+	Vector3 get_relative_offset() const;
 
 	void set_progress_ratio(real_t p_ratio);
 	real_t get_progress_ratio() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5104#issue-1331176699.

As brought up in https://github.com/godotengine/godot/issues/54161#issuecomment-1214453639.

If the original name of **PathFollower2D** and **PathFollower3D**'s `offset` is changed, it can be brought back to reunite two properties, as can be argued should've been the case quite some time ago.

And as a bonus, it's now a Vector3 for **PathFollower3D**!

For **PathFollower2D** and :
`h_offset` and `v_offset` -> Vector2 `relative_offset`
**PathFollower3D**
`h_offset` and `v_offset` -> Vector3 `relative_offset` (forward and back included)
![image](https://user-images.githubusercontent.com/66727710/186294450-3a51be87-5c5e-4299-b8fc-909fddcb0309.png)

~Depends on https://github.com/godotengine/godot/pull/64804 to be merged first.~