### PR TITLE
workaround for angle project issue 7245, safari, iOS

### DIFF
--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -211,7 +211,7 @@ VERTEX_SHADER_CODE
 
 	xform = transpose(xform);
 
-	out_velocity_active.a = mix(0.0, 1.0, shader_active);
+	out_velocity_active.a = float(shader_active);
 
 	out_xform_1 = xform[0];
 	out_xform_2 = xform[1];


### PR DESCRIPTION
Workaround for an angle limitation on safari on iOS, and Macos (confirmed on both host platforms).

This fix makes particles render properly on safari.  

Works around [this](https://bugs.chromium.org/p/angleproject/issues/detail?id=7245&q=mix%20boolean&can=2) reported angle issue (also seems like a problem on angle's vulkan backend).




