### PR TITLE
Fix using Resource objects as keys in the `tres` format

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1846,6 +1846,9 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 			List<Variant> keys;
 			d.get_key_list(&keys);
 			for (const Variant &E : keys) {
+				// Of course keys should also be cached, after all we can't prevent users from using resources as keys, right?
+				// See also ResourceFormatSaverBinaryInstance::_find_resources (when p_variant is of type Variant::DICTIONARY)
+				_find_resources(E);
 				Variant v = d[E];
 				_find_resources(v);
 			}


### PR DESCRIPTION
Version of Godot based on: 
    `v4.0.alpha.custom_build [14f8a54a3]`

The changed files are as follows:
    `godot\scene\resources\resource_format_text.cpp`

The problem solved is as follows:
> Fixes #57506 

The minimal case that can be tested is as follows:
    `https://github.com/godotengine/godot/files/7977119/ResourcesTest.zip`

Precautions:
    `ResourceSaver.save`: now the `first` parameter is `resource` and the `second` is `path`, the code in this case is just the opposite.

Roughly the process of solving the problem:

After many tests, the execution process of saving resources is roughly as follows:
```c++
ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, BitField<SaverFlags> p_flags);
ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags);
ResourceFormatSaverX->save(p_resource, path, p_flag);
ResourceFormatSaverX::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags);
ResourceFormatSaverXInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags);
ResourceFormatSaverXInstance::_find_resources(const Variant &p_variant, bool p_main);
	--> Variant value = res->get(E.name);
 	--> Object::get(const StringName &p_name, bool *r_valid) const;
	--> script_instance->get(p_name, ret); --> OK
```
And the member variables in the script_instance of the incoming p_resource all exist, that is to say, they are the same in terms of parameters.

But I noticed that after the execution of 
```c++
_find_resources(p_resource, true);
```
in
```c++
ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags);
```
The value of `load_steps` is significantly different(compared to `ResourceFormatSaverBinaryInstance`), and `saved_resources` does not save the resource of the key-value pair with resource as the key. But `ResourceFormatSaverBinaryInstance` doesn't have this problem.

So I checked
```c++
ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant, bool p_main);
```
And found that the key is also cached in the case where p_variant is Variant::DICTIONARY.

So I guess the problem with `ResourceFormatSaverTextInstance` is that it doesn't cache the key.


