### PR TITLE
Improve default `OS`'s CPU count getter

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -38,6 +38,7 @@
 #include "core/version_generated.gen.h"
 
 #include <stdarg.h>
+#include <thread>
 
 OS *OS::singleton = nullptr;
 uint64_t OS::target_ticks = 0;
@@ -321,7 +322,7 @@ String OS::get_unique_id() const {
 }
 
 int OS::get_processor_count() const {
-	return 1;
+	return std::thread::hardware_concurrency();
 }
 
 String OS::get_processor_name() const {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -503,10 +503,6 @@ bool OS_Unix::set_environment(const String &p_var, const String &p_value) const 
 	return setenv(p_var.utf8().get_data(), p_value.utf8().get_data(), /* overwrite: */ true) == 0;
 }
 
-int OS_Unix::get_processor_count() const {
-	return sysconf(_SC_NPROCESSORS_CONF);
-}
-
 String OS_Unix::get_user_data_dir() const {
 	String appname = get_safe_dir_name(ProjectSettings::get_singleton()->get("application/config/name"));
 	if (!appname.is_empty()) {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -84,8 +84,6 @@ public:
 	virtual bool set_environment(const String &p_var, const String &p_value) const override;
 	virtual String get_locale() const override;
 
-	virtual int get_processor_count() const override;
-
 	virtual void initialize_debugging() override;
 
 	virtual String get_executable_path() const override;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -870,17 +870,6 @@ BOOL is_wow64() {
 	return wow64;
 }
 
-int OS_Windows::get_processor_count() const {
-	SYSTEM_INFO sysinfo;
-	if (is_wow64()) {
-		GetNativeSystemInfo(&sysinfo);
-	} else {
-		GetSystemInfo(&sysinfo);
-	}
-
-	return sysinfo.dwNumberOfProcessors;
-}
-
 String OS_Windows::get_processor_name() const {
 	const String id = "Hardware\\Description\\System\\CentralProcessor\\0";
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -174,7 +174,6 @@ public:
 
 	virtual String get_locale() const override;
 
-	virtual int get_processor_count() const override;
 	virtual String get_processor_name() const override;
 
 	virtual uint64_t get_embedded_pck_offset() const override;


### PR DESCRIPTION
Probably this allows to get rid of the OS-specific implementations in some/all platforms, but that's another story...
