### PR TITLE
Enhance portability of threading

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -36,10 +36,7 @@
 #include "core/object/script_language.h"
 #include "core/templates/safe_refcount.h"
 
-Error (*Thread::set_name_func)(const String &) = nullptr;
-void (*Thread::set_priority_func)(Thread::Priority) = nullptr;
-void (*Thread::init_func)() = nullptr;
-void (*Thread::term_func)() = nullptr;
+Thread::PlatformFunctions Thread::platform_functions;
 
 uint64_t Thread::_thread_id_hash(const std::thread::id &p_t) {
 	static std::hash<std::thread::id> hasher;
@@ -49,30 +46,27 @@ uint64_t Thread::_thread_id_hash(const std::thread::id &p_t) {
 Thread::ID Thread::main_thread_id = _thread_id_hash(std::this_thread::get_id());
 thread_local Thread::ID Thread::caller_id = 0;
 
-void Thread::_set_platform_funcs(
-		Error (*p_set_name_func)(const String &),
-		void (*p_set_priority_func)(Thread::Priority),
-		void (*p_init_func)(),
-		void (*p_term_func)()) {
-	Thread::set_name_func = p_set_name_func;
-	Thread::set_priority_func = p_set_priority_func;
-	Thread::init_func = p_init_func;
-	Thread::term_func = p_term_func;
+void Thread::_set_platform_functions(const PlatformFunctions &p_functions) {
+	platform_functions = p_functions;
 }
 
 void Thread::callback(Thread *p_self, const Settings &p_settings, Callback p_callback, void *p_userdata) {
 	Thread::caller_id = _thread_id_hash(p_self->thread.get_id());
-	if (set_priority_func) {
-		set_priority_func(p_settings.priority);
+	if (platform_functions.set_priority) {
+		platform_functions.set_priority(p_settings.priority);
 	}
-	if (init_func) {
-		init_func();
+	if (platform_functions.init) {
+		platform_functions.init();
 	}
-	ScriptServer::thread_enter(); //scripts may need to attach a stack
-	p_callback(p_userdata);
+	ScriptServer::thread_enter(); // Scripts may need to attach a stack.
+	if (platform_functions.wrapper) {
+		platform_functions.wrapper(p_callback, p_userdata);
+	} else {
+		p_callback(p_userdata);
+	}
 	ScriptServer::thread_exit();
-	if (term_func) {
-		term_func();
+	if (platform_functions.term) {
+		platform_functions.term();
 	}
 }
 
@@ -105,8 +99,8 @@ void Thread::wait_to_finish() {
 }
 
 Error Thread::set_name(const String &p_name) {
-	if (set_name_func) {
-		return set_name_func(p_name);
+	if (platform_functions.set_name) {
+		return platform_functions.set_name(p_name);
 	}
 
 	return ERR_UNAVAILABLE;

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -63,6 +63,14 @@ public:
 		Settings() { priority = PRIORITY_NORMAL; }
 	};
 
+	struct PlatformFunctions {
+		Error (*set_name)(const String &) = nullptr;
+		void (*set_priority)(Thread::Priority) = nullptr;
+		void (*init)() = nullptr;
+		void (*wrapper)(Thread::Callback, void *) = nullptr;
+		void (*term)() = nullptr;
+	};
+
 private:
 	friend class Main;
 
@@ -76,17 +84,10 @@ private:
 
 	static void callback(Thread *p_self, const Settings &p_settings, Thread::Callback p_callback, void *p_userdata);
 
-	static Error (*set_name_func)(const String &);
-	static void (*set_priority_func)(Thread::Priority);
-	static void (*init_func)();
-	static void (*term_func)();
+	static PlatformFunctions platform_functions;
 
 public:
-	static void _set_platform_funcs(
-			Error (*p_set_name_func)(const String &),
-			void (*p_set_priority_func)(Thread::Priority),
-			void (*p_init_func)() = nullptr,
-			void (*p_term_func)() = nullptr);
+	static void _set_platform_functions(const PlatformFunctions &p_functions);
 
 	_FORCE_INLINE_ ID get_id() const { return id; }
 	// get the ID of the caller thread

--- a/drivers/unix/thread_posix.cpp
+++ b/drivers/unix/thread_posix.cpp
@@ -70,7 +70,7 @@ static Error set_name(const String &p_name) {
 }
 
 void init_thread_posix() {
-	Thread::_set_platform_funcs(&set_name, nullptr);
+	Thread::_set_platform_functions({ .set_name = set_name });
 }
 
 #endif // UNIX_ENABLED || PTHREAD_ENABLED

--- a/platform/android/thread_jandroid.cpp
+++ b/platform/android/thread_jandroid.cpp
@@ -63,7 +63,7 @@ static void term_thread() {
 void init_thread_jandroid(JavaVM *p_jvm, JNIEnv *p_env) {
 	java_vm = p_jvm;
 	env = p_env;
-	Thread::_set_platform_funcs(nullptr, nullptr, &init_thread, &term_thread);
+	Thread::_set_platform_functions({ .init = init_thread, .term = &term_thread });
 }
 
 void setup_android_thread() {


### PR DESCRIPTION
- Add a new thread function customizable per platform (needed for a certain one), which wraps the regular callback.
- Refactor the way to set the functions into a more elegant and convenient one.
- Stay way from abbrevs (😆), which is more Godot 4-ish (`Funcs` -> `Functions`).