### PR TITLE
Allow using integer varyings with `flat` interpolation modifier

### DIFF
--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -206,17 +206,19 @@
 		</constant>
 		<constant name="VARYING_TYPE_FLOAT" value="0" enum="VaryingType">
 		</constant>
-		<constant name="VARYING_TYPE_VECTOR_2D" value="1" enum="VaryingType">
+		<constant name="VARYING_TYPE_INT" value="1" enum="VaryingType">
 		</constant>
-		<constant name="VARYING_TYPE_VECTOR_3D" value="2" enum="VaryingType">
+		<constant name="VARYING_TYPE_VECTOR_2D" value="2" enum="VaryingType">
 		</constant>
-		<constant name="VARYING_TYPE_VECTOR_4D" value="3" enum="VaryingType">
+		<constant name="VARYING_TYPE_VECTOR_3D" value="3" enum="VaryingType">
 		</constant>
-		<constant name="VARYING_TYPE_COLOR" value="4" enum="VaryingType">
+		<constant name="VARYING_TYPE_VECTOR_4D" value="4" enum="VaryingType">
 		</constant>
-		<constant name="VARYING_TYPE_TRANSFORM" value="5" enum="VaryingType">
+		<constant name="VARYING_TYPE_BOOLEAN" value="5" enum="VaryingType">
 		</constant>
-		<constant name="VARYING_TYPE_MAX" value="6" enum="VaryingType">
+		<constant name="VARYING_TYPE_TRANSFORM" value="6" enum="VaryingType">
+		</constant>
+		<constant name="VARYING_TYPE_MAX" value="7" enum="VaryingType">
 		</constant>
 		<constant name="NODE_ID_INVALID" value="-1">
 		</constant>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4312,6 +4312,9 @@ void VisualShaderEditor::_update_varying_tree() {
 				case VisualShader::VARYING_TYPE_FLOAT:
 					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")));
 					break;
+				case VisualShader::VARYING_TYPE_INT:
+					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("int"), SNAME("EditorIcons")));
+					break;
 				case VisualShader::VARYING_TYPE_VECTOR_2D:
 					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")));
 					break;
@@ -4321,8 +4324,8 @@ void VisualShaderEditor::_update_varying_tree() {
 				case VisualShader::VARYING_TYPE_VECTOR_4D:
 					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector4"), SNAME("EditorIcons")));
 					break;
-				case VisualShader::VARYING_TYPE_COLOR:
-					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")));
+				case VisualShader::VARYING_TYPE_BOOLEAN:
+					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")));
 					break;
 				case VisualShader::VARYING_TYPE_TRANSFORM:
 					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")));
@@ -4963,10 +4966,11 @@ VisualShaderEditor::VisualShaderEditor() {
 		varying_type = memnew(OptionButton);
 		hb->add_child(varying_type);
 		varying_type->add_item("Float");
+		varying_type->add_item("Int");
 		varying_type->add_item("Vector2");
 		varying_type->add_item("Vector3");
 		varying_type->add_item("Vector4");
-		varying_type->add_item("Color");
+		varying_type->add_item("Boolean");
 		varying_type->add_item("Transform");
 
 		varying_name = memnew(LineEdit);
@@ -5759,10 +5763,11 @@ public:
 
 		Ref<Texture2D> type_icon[] = {
 			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
 			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
 			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
 			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector4"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
 			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
 		};
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -79,10 +79,11 @@ public:
 
 	enum VaryingType {
 		VARYING_TYPE_FLOAT,
+		VARYING_TYPE_INT,
 		VARYING_TYPE_VECTOR_2D,
 		VARYING_TYPE_VECTOR_3D,
 		VARYING_TYPE_VECTOR_4D,
-		VARYING_TYPE_COLOR,
+		VARYING_TYPE_BOOLEAN,
 		VARYING_TYPE_TRANSFORM,
 		VARYING_TYPE_MAX,
 	};
@@ -828,7 +829,6 @@ public:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
-	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
 	VisualShaderNodeVaryingSetter();


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/64798 + Also added to visual shader
