### PR TITLE
Fix arg naming in ResourceFormatSaver extension

### DIFF
--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -70,7 +70,7 @@ void ResourceFormatSaver::get_recognized_extensions(const Ref<Resource> &p_resou
 }
 
 void ResourceFormatSaver::_bind_methods() {
-	GDVIRTUAL_BIND(_save, "path", "resource", "flags");
+	GDVIRTUAL_BIND(_save, "resource", "path", "flags");
 	GDVIRTUAL_BIND(_recognize, "resource");
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
 }

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -26,8 +26,8 @@
 		</method>
 		<method name="_save" qualifiers="virtual">
 			<return type="int" />
-			<param index="0" name="path" type="Resource" />
-			<param index="1" name="resource" type="String" />
+			<param index="0" name="resource" type="Resource" />
+			<param index="1" name="path" type="String" />
 			<param index="2" name="flags" type="int" />
 			<description>
 				Saves the given resource object to a file at the target [param path]. [param flags] is a bitmask composed with [enum ResourceSaver.SaverFlags] constants.


### PR DESCRIPTION
When these arguments were swapped, the change to the binding (and therefore documentation) was missed.

Impact: This results in incorrect argument naming in the generated API and therefore the code in `godot-cpp`.