### PR TITLE
Rename Polygon2D.`invert_enable` to end with "d"

### DIFF
--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -79,10 +79,10 @@
 		<member name="internal_vertex_count" type="int" setter="set_internal_vertex_count" getter="get_internal_vertex_count" default="0">
 		</member>
 		<member name="invert_border" type="float" setter="set_invert_border" getter="get_invert_border" default="100.0">
-			Added padding applied to the bounding box when using [code]invert[/code]. Setting this value too small may result in a "Bad Polygon" error.
+			Added padding applied to the bounding box when [member invert_enabled] is set to [code]true[/code]. Setting this value too small may result in a "Bad Polygon" error.
 		</member>
-		<member name="invert_enable" type="bool" setter="set_invert" getter="get_invert" default="false">
-			If [code]true[/code], polygon will be inverted, containing the area outside the defined points and extending to the [code]invert_border[/code].
+		<member name="invert_enabled" type="bool" setter="set_invert_enabled" getter="get_invert_enabled" default="false">
+			If [code]true[/code], the polygon will be inverted, containing the area outside the defined points and extending to the [member invert_border].
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The offset applied to each vertex.

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1008,6 +1008,7 @@ static const char *gdscript_properties_renames[][2] = {
 	{ "gravity_vec", "gravity_direction" }, // Area2D
 	{ "hseparation", "h_separation" }, // Theme
 	{ "iterations_per_second", "physics_ticks_per_second" }, // Engine
+	{ "invert_enable", "invert_enabled" }, // Polygon2D
 	{ "margin_bottom", "offset_bottom" }, // Control broke NinePatchRect, StyleBox
 	{ "margin_left", "offset_left" }, // Control broke NinePatchRect, StyleBox
 	{ "margin_right", "offset_right" }, // Control broke NinePatchRect, StyleBox
@@ -1089,6 +1090,7 @@ static const char *csharp_properties_renames[][2] = {
 	{ "GravityVec", "GravityDirection" }, // Area2D
 	{ "Hseparation", "HSeparation" }, // Theme
 	{ "IterationsPerSecond", "PhysicsTicksPerSecond" }, // Engine
+	{ "InvertEnable", "InvertEnabled" }, // Polygon2D
 	{ "MarginBottom", "OffsetBottom" }, // Control broke NinePatchRect, StyleBox
 	{ "MarginLeft", "OffsetLeft" }, // Control broke NinePatchRect, StyleBox
 	{ "MarginRight", "OffsetRight" }, // Control broke NinePatchRect, StyleBox

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -602,8 +602,8 @@ void Polygon2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_scale", "texture_scale"), &Polygon2D::set_texture_scale);
 	ClassDB::bind_method(D_METHOD("get_texture_scale"), &Polygon2D::get_texture_scale);
 
-	ClassDB::bind_method(D_METHOD("set_invert", "invert"), &Polygon2D::set_invert);
-	ClassDB::bind_method(D_METHOD("get_invert"), &Polygon2D::get_invert);
+	ClassDB::bind_method(D_METHOD("set_invert_enabled", "invert"), &Polygon2D::set_invert);
+	ClassDB::bind_method(D_METHOD("get_invert_enabled"), &Polygon2D::get_invert);
 
 	ClassDB::bind_method(D_METHOD("set_antialiased", "antialiased"), &Polygon2D::set_antialiased);
 	ClassDB::bind_method(D_METHOD("get_antialiased"), &Polygon2D::get_antialiased);
@@ -646,7 +646,7 @@ void Polygon2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "skeleton", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton2D"), "set_skeleton", "get_skeleton");
 
 	ADD_GROUP("Invert", "invert_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "invert_enable"), "set_invert", "get_invert");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "invert_enabled"), "set_invert_enabled", "get_invert_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "invert_border", PROPERTY_HINT_RANGE, "0.1,16384,0.1,suffix:px"), "set_invert_border", "get_invert_border");
 
 	ADD_GROUP("Data", "");


### PR DESCRIPTION
Oops! All bikeshedding!
Similar to https://github.com/godotengine/godot/pull/64355.

**Polygon2D**.`invert_enable` -> `invert_enabled`

Also affects the setters and getters, which are now named in full instead of cutting "enabled" off.

Updates old leftover documentation slightly, as well.

