### PR TITLE
External OpenXR Loader support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -171,6 +171,7 @@ opts.Add(EnumVariable("float", "Floating-point precision", "32", ("32", "64")))
 opts.Add(EnumVariable("optimize", "Optimization type", "speed", ("speed", "size", "none")))
 opts.Add(BoolVariable("production", "Set defaults to build Godot for use in production", False))
 opts.Add(EnumVariable("lto", "Link-time optimization (for production buids)", "none", ("none", "thin", "full")))
+opts.Add("external_openxr_loader", "Path to an external OpenXR loader library", "")
 
 # Components
 opts.Add(BoolVariable("deprecated", "Enable compatibility code for deprecated and removed features", True))
@@ -473,6 +474,9 @@ if selected_platform in platform_list:
         'Building for platform "%s", architecture "%s", %s, target "%s".'
         % (selected_platform, env["arch"], "editor" if env["tools"] else "template", env["target"])
     )
+
+    if env["external_openxr_loader"] != "":
+        env.AppendUnique(LIBS=[File(env["external_openxr_loader"])])
 
     # Set our C and C++ standard requirements.
     # C++17 is required as we need guaranteed copy elision as per GH-36436.

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -22,6 +22,9 @@ env_openxr.Prepend(
     ]
 )
 
+if env["platform"] == "android":
+    env_openxr.AppendUnique(CPPDEFINES=["XR_OS_ANDROID", "XR_USE_PLATFORM_ANDROID"])
+
 # may need to check and set:
 # - XR_USE_TIMESPEC
 
@@ -31,7 +34,6 @@ env_thirdparty.AppendUnique(CPPDEFINES=["DISABLE_STD_FILESYSTEM"])
 
 if env["platform"] == "android":
     # may need to set OPENXR_ANDROID_VERSION_SUFFIX
-    env_thirdparty.AppendUnique(CPPDEFINES=["XR_OS_ANDROID", "XR_USE_PLATFORM_ANDROID"])
     env_thirdparty.AppendUnique(CPPDEFINES=["JSON_USE_EXCEPTION=0"])
 
     # may need to include java parts of the openxr loader
@@ -46,10 +48,9 @@ elif env["platform"] == "linuxbsd":
 elif env["platform"] == "windows":
     env_thirdparty.AppendUnique(CPPDEFINES=["XR_OS_WINDOWS", "NOMINMAX", "XR_USE_PLATFORM_WIN32"])
 
-env_khrloader = env_thirdparty.Clone()
-if "-fno-exceptions" in env_khrloader["CXXFLAGS"]:
-    env_khrloader["CXXFLAGS"].remove("-fno-exceptions")
-env_khrloader.Append(CPPPATH=[thirdparty_dir + "/src/loader"])
+if "-fno-exceptions" in env_thirdparty["CXXFLAGS"]:
+    env_thirdparty["CXXFLAGS"].remove("-fno-exceptions")
+env_thirdparty.Append(CPPPATH=[thirdparty_dir + "/src/loader"])
 
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/xr_generated_dispatch_table.c")
 
@@ -67,28 +68,31 @@ if env["external_openxr_loader"] != "":
     env_thirdparty.AppendUnique(LIBS=[File(env["external_openxr_loader"])])
 else:
     if env["platform"] == "android":
-        env_khrloader.Append(
-            CPPPATH=[thirdparty_dir + "/src/external/android-jni-wrappers", thirdparty_dir + "/src/external/jnipp"]
+        env_thirdparty.Append(
+            CPPPATH=[
+                thirdparty_dir + "/src/external/android-jni-wrappers",
+                thirdparty_dir + "/src/external/jnipp",
+            ]
         )
-        env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/external/jnipp/jnipp.cpp")
-        env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/android_utilities.cpp")
-        env_khrloader.add_source_files(
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/external/jnipp/jnipp.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/android_utilities.cpp")
+        env_thirdparty.add_source_files(
             khrloader_obj, thirdparty_dir + "/src/external/android-jni-wrappers/wrap/android.content.cpp"
         )
-        env_khrloader.add_source_files(
+        env_thirdparty.add_source_files(
             khrloader_obj, thirdparty_dir + "/src/external/android-jni-wrappers/wrap/android.database.cpp"
         )
-        env_khrloader.add_source_files(
+        env_thirdparty.add_source_files(
             khrloader_obj, thirdparty_dir + "/src/external/android-jni-wrappers/wrap/android.net.cpp"
         )
-    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/api_layer_interface.cpp")
-    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_core.cpp")
-    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_instance.cpp")
-    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger_recorders.cpp")
-    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger.cpp")
-    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/manifest_file.cpp")
-    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/runtime_interface.cpp")
-    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/xr_generated_loader.cpp")
+    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/api_layer_interface.cpp")
+    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_core.cpp")
+    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_instance.cpp")
+    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger_recorders.cpp")
+    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger.cpp")
+    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/manifest_file.cpp")
+    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/runtime_interface.cpp")
+    env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/xr_generated_loader.cpp")
     env.modules_sources += khrloader_obj
 
 env.modules_sources += thirdparty_obj
@@ -104,7 +108,6 @@ env_openxr.add_source_files(module_obj, "action_map/*.cpp")
 # We're a little more targeted with our extensions
 if env["platform"] == "android":
     env_openxr.add_source_files(module_obj, "extensions/openxr_android_extension.cpp")
-    env_openxr.AppendUnique(CPPDEFINES=["XR_OS_ANDROID", "XR_USE_PLATFORM_ANDROID"])
 if env["vulkan"]:
     env_openxr.add_source_files(module_obj, "extensions/openxr_vulkan_extension.cpp")
 

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -23,7 +23,21 @@ env_openxr.Prepend(
 )
 
 if env["platform"] == "android":
+    # may need to set OPENXR_ANDROID_VERSION_SUFFIX
     env_openxr.AppendUnique(CPPDEFINES=["XR_OS_ANDROID", "XR_USE_PLATFORM_ANDROID"])
+    env_openxr.AppendUnique(CPPDEFINES=["JSON_USE_EXCEPTION=0"])
+
+    # may need to include java parts of the openxr loader
+elif env["platform"] == "linuxbsd":
+    env_openxr.AppendUnique(CPPDEFINES=["XR_OS_LINUX"])
+
+    if env["x11"]:
+        env_openxr.AppendUnique(CPPDEFINES=["XR_USE_PLATFORM_XLIB"])
+
+    # FIXME: Review what needs to be set for Android and macOS.
+    env_openxr.AppendUnique(CPPDEFINES=["HAVE_SECURE_GETENV"])
+elif env["platform"] == "windows":
+    env_openxr.AppendUnique(CPPDEFINES=["XR_OS_WINDOWS", "NOMINMAX", "XR_USE_PLATFORM_WIN32"])
 
 # may need to check and set:
 # - XR_USE_TIMESPEC
@@ -31,22 +45,6 @@ if env["platform"] == "android":
 env_thirdparty = env_openxr.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.AppendUnique(CPPDEFINES=["DISABLE_STD_FILESYSTEM"])
-
-if env["platform"] == "android":
-    # may need to set OPENXR_ANDROID_VERSION_SUFFIX
-    env_thirdparty.AppendUnique(CPPDEFINES=["JSON_USE_EXCEPTION=0"])
-
-    # may need to include java parts of the openxr loader
-elif env["platform"] == "linuxbsd":
-    env_thirdparty.AppendUnique(CPPDEFINES=["XR_OS_LINUX"])
-
-    if env["x11"]:
-        env_thirdparty.AppendUnique(CPPDEFINES=["XR_USE_PLATFORM_XLIB"])
-
-    # FIXME: Review what needs to be set for Android and macOS.
-    env_thirdparty.AppendUnique(CPPDEFINES=["HAVE_SECURE_GETENV"])
-elif env["platform"] == "windows":
-    env_thirdparty.AppendUnique(CPPDEFINES=["XR_OS_WINDOWS", "NOMINMAX", "XR_USE_PLATFORM_WIN32"])
 
 if "-fno-exceptions" in env_thirdparty["CXXFLAGS"]:
     env_thirdparty["CXXFLAGS"].remove("-fno-exceptions")

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -9,6 +9,7 @@ env_openxr = env_modules.Clone()
 # Add in our Khronos OpenXR loader
 
 thirdparty_obj = []
+khrloader_obj = []
 thirdparty_dir = "#thirdparty/openxr"
 
 env_openxr.Prepend(
@@ -18,7 +19,6 @@ env_openxr.Prepend(
         thirdparty_dir + "/src",
         thirdparty_dir + "/src/common",
         thirdparty_dir + "/src/external/jsoncpp/include",
-        thirdparty_dir + "/src/loader",
     ]
 )
 
@@ -32,6 +32,7 @@ env_thirdparty.AppendUnique(CPPDEFINES=["DISABLE_STD_FILESYSTEM"])
 if env["platform"] == "android":
     # may need to set OPENXR_ANDROID_VERSION_SUFFIX
     env_thirdparty.AppendUnique(CPPDEFINES=["XR_OS_ANDROID", "XR_USE_PLATFORM_ANDROID"])
+    env_thirdparty.AppendUnique(CPPDEFINES=["JSON_USE_EXCEPTION=0"])
 
     # may need to include java parts of the openxr loader
 elif env["platform"] == "linuxbsd":
@@ -45,6 +46,11 @@ elif env["platform"] == "linuxbsd":
 elif env["platform"] == "windows":
     env_thirdparty.AppendUnique(CPPDEFINES=["XR_OS_WINDOWS", "NOMINMAX", "XR_USE_PLATFORM_WIN32"])
 
+env_khrloader = env_thirdparty.Clone()
+if "-fno-exceptions" in env_khrloader["CXXFLAGS"]:
+    env_khrloader["CXXFLAGS"].remove("-fno-exceptions")
+env_khrloader.Append(CPPPATH=[thirdparty_dir + "/src/loader"])
+
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/xr_generated_dispatch_table.c")
 
 # add in common files (hope these don't clash with us)
@@ -57,17 +63,33 @@ env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/external/
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/external/jsoncpp/src/lib_json/json_writer.cpp")
 
 # add in load
-if env["platform"] == "android":
-    env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/android_utilities.cpp")
-
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/api_layer_interface.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/loader_core.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/loader_instance.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/loader_logger_recorders.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/loader_logger.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/manifest_file.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/runtime_interface.cpp")
-env_thirdparty.add_source_files(thirdparty_obj, thirdparty_dir + "/src/loader/xr_generated_loader.cpp")
+if env["external_openxr_loader"] != "":
+    env_thirdparty.AppendUnique(LIBS=[File(env["external_openxr_loader"])])
+else:
+    if env["platform"] == "android":
+        env_khrloader.Append(
+            CPPPATH=[thirdparty_dir + "/src/external/android-jni-wrappers", thirdparty_dir + "/src/external/jnipp"]
+        )
+        env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/external/jnipp/jnipp.cpp")
+        env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/android_utilities.cpp")
+        env_khrloader.add_source_files(
+            khrloader_obj, thirdparty_dir + "/src/external/android-jni-wrappers/wrap/android.content.cpp"
+        )
+        env_khrloader.add_source_files(
+            khrloader_obj, thirdparty_dir + "/src/external/android-jni-wrappers/wrap/android.database.cpp"
+        )
+        env_khrloader.add_source_files(
+            khrloader_obj, thirdparty_dir + "/src/external/android-jni-wrappers/wrap/android.net.cpp"
+        )
+    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/api_layer_interface.cpp")
+    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_core.cpp")
+    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_instance.cpp")
+    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger_recorders.cpp")
+    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger.cpp")
+    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/manifest_file.cpp")
+    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/runtime_interface.cpp")
+    env_khrloader.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/xr_generated_loader.cpp")
+    env.modules_sources += khrloader_obj
 
 env.modules_sources += thirdparty_obj
 
@@ -82,6 +104,7 @@ env_openxr.add_source_files(module_obj, "action_map/*.cpp")
 # We're a little more targeted with our extensions
 if env["platform"] == "android":
     env_openxr.add_source_files(module_obj, "extensions/openxr_android_extension.cpp")
+    env_openxr.AppendUnique(CPPDEFINES=["XR_OS_ANDROID", "XR_USE_PLATFORM_ANDROID"])
 if env["vulkan"]:
     env_openxr.add_source_files(module_obj, "extensions/openxr_vulkan_extension.cpp")
 

--- a/modules/openxr/config.py
+++ b/modules/openxr/config.py
@@ -1,7 +1,5 @@
 def can_build(env, platform):
-    if (
-        platform == "linuxbsd" or platform == "windows"
-    ):  # or platform == "android" -- temporarily disabled android support
+    if platform == "linuxbsd" or platform == "windows" or platform == "android":
         return env["openxr"]
     else:
         # not supported on these platforms

--- a/modules/openxr/config.py
+++ b/modules/openxr/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    if platform == "linuxbsd" or platform == "windows" or platform == "android":
+    if platform in ("linuxbsd", "windows", "android"):
         return env["openxr"]
     else:
         # not supported on these platforms

--- a/modules/openxr/extensions/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/openxr_android_extension.cpp
@@ -29,7 +29,11 @@
 /*************************************************************************/
 
 #include "openxr_android_extension.h"
+#include "java_godot_wrapper.h"
+#include "os_android.h"
+#include "thread_jandroid.h"
 
+#include <jni.h>
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 
@@ -47,14 +51,13 @@ OpenXRAndroidExtension::OpenXRAndroidExtension(OpenXRAPI *p_openxr_api) :
 
 	// Initialize the loader
 	PFN_xrInitializeLoaderKHR xrInitializeLoaderKHR;
-	result = xrGetInstanceProcAddr(XR_NULL_HANDLE, "xrInitializeLoaderKHR", (PFN_xrVoidFunction *)(&xrInitializeLoaderKHR));
+	XrResult result = xrGetInstanceProcAddr(XR_NULL_HANDLE, "xrInitializeLoaderKHR", (PFN_xrVoidFunction *)(&xrInitializeLoaderKHR));
 	ERR_FAIL_COND_MSG(XR_FAILED(result), "Failed to retrieve pointer to xrInitializeLoaderKHR");
 
-	// TODO fix this code, this is still code from GDNative!
-	JNIEnv *env = android_api->godot_android_get_env();
+	JNIEnv *env = get_jni_env();
 	JavaVM *vm;
 	env->GetJavaVM(&vm);
-	jobject activity_object = env->NewGlobalRef(android_api->godot_android_get_activity());
+	jobject activity_object = env->NewGlobalRef(static_cast<OS_Android *>(OS::get_singleton())->get_godot_java()->get_activity());
 
 	XrLoaderInitInfoAndroidKHR loader_init_info_android = {
 		.type = XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR,

--- a/modules/openxr/extensions/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/openxr_vulkan_extension.cpp
@@ -47,6 +47,11 @@
 #include <windows.h>
 #endif
 
+#ifdef ANDROID_ENABLED
+// The jobject type from jni.h is used by openxr_platform.h on Android.
+#include <jni.h>
+#endif
+
 // include platform dependent structs
 #include <openxr/openxr_platform.h>
 

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+
 Import("env")
 
 android_files = [
@@ -74,3 +76,8 @@ if lib_arch_dir != "":
         str(env["ANDROID_NDK_ROOT"]) + "/sources/cxx-stl/llvm-libc++/libs/" + lib_arch_dir + "/libc++_shared.so"
     )
     env_android.Command(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
+
+    if env["external_openxr_loader"] != "":
+        openxr_loader_path = os.path.normpath(env["external_openxr_loader"])
+        openxr_loader_filename = openxr_loader_path.split(os.sep)[-1]
+        env_android.Command(out_dir + "/" + openxr_loader_filename, openxr_loader_path, Copy("$TARGET", "$SOURCE"))

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/ObjectWrapperBase.h
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/ObjectWrapperBase.h
@@ -1,0 +1,337 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+
+#pragma once
+#include <assert.h>
+#include <jni.h>
+#include <jnipp.h>
+
+namespace wrap {
+
+/*!
+ * Base class for types wrapping Java types.
+ *
+ * Derived types are encouraged to have a nested `struct Meta`, inheriting
+ * publicly from MetaBaseDroppable or MetaBase, with a singleton accessor named
+ * `data()`, and a private constructor (implemented in a .cpp file, not the
+ * header) that populates jni::method_t, jni::field_t, etc. members for each
+ * method, etc. of interest.
+ */
+class ObjectWrapperBase {
+  public:
+    /*!
+     * Default constructor.
+     */
+    ObjectWrapperBase() = default;
+
+    /*!
+     * Construct from a jni::Object.
+     */
+    explicit ObjectWrapperBase(jni::Object obj) : obj_(std::move(obj)) {}
+
+    /*!
+     * Construct from a nullptr.
+     */
+    explicit ObjectWrapperBase(std::nullptr_t const &) : obj_() {}
+
+    /*!
+     * Evaluate if this is non-null
+     */
+    explicit operator bool() const noexcept { return !obj_.isNull(); }
+
+    /*!
+     * Is this object null?
+     */
+    bool isNull() const noexcept { return obj_.isNull(); }
+
+    /*!
+     * Get the wrapped jni::Object
+     */
+    jni::Object &object() noexcept { return obj_; }
+
+    /*!
+     * Get the wrapped jni::Object (const overload)
+     */
+    jni::Object const &object() const noexcept { return obj_; }
+
+  private:
+    jni::Object obj_;
+};
+
+/*!
+ * Equality comparison for a wrapped Java object.
+ */
+static inline bool operator==(ObjectWrapperBase const &lhs,
+                              ObjectWrapperBase const &rhs) noexcept {
+    return lhs.object() == rhs.object();
+}
+
+/*!
+ * Inequality comparison for a wrapped Java object.
+ */
+static inline bool operator!=(ObjectWrapperBase const &lhs,
+                              ObjectWrapperBase const &rhs) noexcept {
+    return lhs.object() != rhs.object();
+}
+
+/*!
+ * Equality comparison between a wrapped Java object and @p nullptr.
+ */
+static inline bool operator==(ObjectWrapperBase const &obj,
+                              std::nullptr_t) noexcept {
+    return obj.isNull();
+}
+
+/*!
+ * Equality comparison between a wrapped Java object and @p nullptr.
+ */
+static inline bool operator==(std::nullptr_t,
+                              ObjectWrapperBase const &obj) noexcept {
+    return obj.isNull();
+}
+
+/*!
+ * Inequality comparison between a wrapped Java object and @p nullptr.
+ */
+static inline bool operator!=(ObjectWrapperBase const &obj,
+                              std::nullptr_t) noexcept {
+    return !(obj == nullptr);
+}
+
+/*!
+ * Inequality comparison between a wrapped Java object and @p nullptr.
+ */
+static inline bool operator!=(std::nullptr_t,
+                              ObjectWrapperBase const &obj) noexcept {
+    return !(obj == nullptr);
+}
+
+/*!
+ * Base class for Meta structs where you want the reference to the Class object
+ * to persist (indefinitely).
+ *
+ * Mostly for classes that would stick around anyway (e.g.
+ * @p java.lang.ClassLoader ) where many operations are on static
+ * methods/fields. Use of a non-static method or field does not require such a
+ * reference, use MetaBaseDroppable in those cases.
+ */
+class MetaBase {
+  public:
+    /*!
+     * Gets a reference to the class object.
+     *
+     * Unlike MetaBaseDroppable, here we know that the class object ref is
+     * alive.
+     */
+    jni::Class const &clazz() const noexcept { return clazz_; }
+    /*!
+     * Gets a reference to the class object.
+     *
+     * Provided here for parallel API to MetaBaseDroppable, despite being
+     * synonymous with clazz() here.
+     */
+    jni::Class const &classRef() const noexcept { return clazz_; }
+
+    /*!
+     * Get the class name, with namespaces delimited by `/`.
+     */
+    const char *className() const noexcept { return classname_; }
+
+  protected:
+    /*!
+     * Construct.
+     *
+     * @param classname The class name, fully qualified, with namespaces
+     * delimited by `/`.
+     * @param clazz The jclass object for the class in question, if known.
+     */
+    explicit MetaBase(const char *classname, jni::jclass clazz = nullptr)
+        : classname_(classname), clazz_() {
+        if (clazz != nullptr) {
+            // The 0 makes it a global ref.
+            clazz_ = jni::Class{clazz, 0};
+        } else {
+            clazz_ = jni::Class{classname};
+        }
+    }
+
+  private:
+    const char *classname_;
+    jni::Class clazz_;
+};
+
+/*!
+ * Base class for Meta structs where you don't need the reference to the Class
+ * object to persist. (This is most uses.)
+ */
+class MetaBaseDroppable {
+  public:
+    /*!
+     * Gets the class object.
+     *
+     * Works regardless of whether dropClassRef() has been called - it's just
+     * slower if it has.
+     */
+    jni::Class clazz() const {
+        if (clazz_.isNull()) {
+            return {classname_};
+        }
+        return clazz_;
+    }
+
+    /*!
+     * Get the class name, with namespaces delimited by `/`.
+     */
+    const char *className() const noexcept { return classname_; }
+
+    /*!
+     * May be called in/after the derived constructor, to drop the reference to
+     * the class object if it's no longer needed.
+     */
+    void dropClassRef() { clazz_ = jni::Class{}; }
+
+  protected:
+    /*!
+     * Construct.
+     *
+     * Once you are done constructing your derived struct, you may call
+     * dropClassRef() and still safely use non-static method and field IDs
+     * retrieved.
+     *
+     * @param classname The class name, fully qualified, with namespaces
+     * delimited by `/`.
+     * @param clazz The jclass object for the class in question, if known.
+     */
+    explicit MetaBaseDroppable(const char *classname,
+                               jni::jclass clazz = nullptr)
+        : classname_(classname), clazz_() {
+        if (clazz != nullptr) {
+            // The 0 makes it a global ref.
+            clazz_ = jni::Class{clazz, 0};
+        } else {
+            clazz_ = jni::Class{classname};
+        }
+    }
+
+    /*!
+     * Gets a reference to the class object, but is non-null only if it's still
+     * cached.
+     *
+     * Only for used in derived constructors/initializers, where you know you
+     * haven't dropped this yet.
+     */
+    jni::Class const &classRef() const { return clazz_; }
+
+  private:
+    const char *classname_;
+    jni::Class clazz_;
+};
+
+/*!
+ * Implementation namespace for these JNI wrappers.
+ *
+ * They can be ignored if you aren't adding/extending wrappers.
+ */
+namespace impl {
+/*!
+ * Type-aware wrapper for a field ID.
+ *
+ * This is a smarter alternative to just using jni::field_t since it avoids
+ * having to repeat the type in the accessor, without using any more storage.
+ *
+ * @see StaticFieldId for the equivalent for static fields.
+ * @see WrappedFieldId for the equivalent for structures that we wrap.
+ */
+template <typename T> struct FieldId {
+  public:
+    FieldId(jni::Class const &clazz, const char *name)
+        : id(clazz.getField<T>(name)) {}
+
+    const jni::field_t id;
+};
+
+/*!
+ * Get the value of field @p field in Java object @p obj.
+ *
+ * This is found by argument-dependent lookup and can be used unqualified.
+ *
+ * @relates FieldId
+ */
+template <typename T>
+static inline T get(FieldId<T> const &field, jni::Object const &obj) {
+    assert(!obj.isNull());
+    return obj.get<T>(field.id);
+}
+/*!
+ * Type-aware wrapper for a static field ID.
+ *
+ * This is a smarter alternative to just using jni::field_t since it avoids
+ * having to repeat the type in the accessor, without using any more storage.
+ *
+ * @see FieldId
+ */
+template <typename T> struct StaticFieldId {
+  public:
+    StaticFieldId(jni::Class const &clazz, const char *name)
+        : id(clazz.getStaticField<T>(name)) {}
+
+    const jni::field_t id;
+};
+
+/*!
+ * Get the value of static field @p field in Java type @p clazz.
+ *
+ * This is found by argument-dependent lookup and can be used unqualified.
+ *
+ * @relates FieldId
+ */
+template <typename T>
+static inline T get(StaticFieldId<T> const &field, jni::Class const &clazz) {
+    assert(!clazz.isNull());
+    return clazz.get<T>(field.id);
+}
+
+/*!
+ * Type-aware wrapper for a field ID of a wrapped structure type.
+ *
+ * This is a smarter alternative to just using jni::field_t since it avoids
+ * having to repeat the type in the accessor, without using any more storage.
+ *
+ * Requires that the structure wrapper provides
+ * `static constexpr const char *getTypeName() noexcept;`
+ *
+ * @see FieldId
+ */
+template <typename T> struct WrappedFieldId {
+  public:
+    WrappedFieldId(jni::Class const &clazz, const char *name)
+        : id(lookupField(clazz, name)) {}
+
+    const jni::field_t id;
+
+  private:
+    /*!
+     * Helper for field ID lookup, mostly to avoid calling c_str() on a string
+     * temporary.
+     */
+    static jni::field_t lookupField(jni::Class const &clazz, const char *name) {
+        std::string fullType = std::string("L") + T::getTypeName() + ";";
+        return clazz.getField(name, fullType.c_str());
+    }
+};
+
+/*!
+ * Get the value of field @p field in Java object @p obj.
+ *
+ * This is found by argument-dependent lookup and can be used unqualified.
+ *
+ * @relates WrappedFieldId
+ */
+template <typename T>
+static inline T get(WrappedFieldId<T> const &field, jni::Object const &obj) {
+    assert(!obj.isNull());
+    return T{obj.get<jni::Object>(field.id)};
+}
+} // namespace impl
+} // namespace wrap

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.content.cpp
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.content.cpp
@@ -1,0 +1,52 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+
+#include "android.content.h"
+
+namespace wrap {
+namespace android::content {
+Context::Meta::Meta(bool deferDrop)
+    : MetaBaseDroppable(Context::getTypeName()),
+      getContentResolver(classRef().getMethod(
+          "getContentResolver", "()Landroid/content/ContentResolver;")) {
+    if (!deferDrop) {
+        MetaBaseDroppable::dropClassRef();
+    }
+}
+ContentUris::Meta::Meta(bool deferDrop)
+    : MetaBaseDroppable(ContentUris::getTypeName()),
+      appendId(classRef().getStaticMethod(
+          "appendId",
+          "(Landroid/net/Uri$Builder;J)Landroid/net/Uri$Builder;")) {
+    if (!deferDrop) {
+        MetaBaseDroppable::dropClassRef();
+    }
+}
+ComponentName::Meta::Meta()
+    : MetaBase(ComponentName::getTypeName()),
+      init(classRef().getMethod("<init>",
+                                "(Ljava/lang/String;Ljava/lang/String;)V")),
+      init1(classRef().getMethod(
+          "<init>", "(Landroid/content/Context;Ljava/lang/String;)V")),
+      init2(classRef().getMethod(
+          "<init>", "(Landroid/content/Context;Ljava/lang/Class;)V")),
+      init3(classRef().getMethod("<init>", "(Landroid/os/Parcel;)V")) {}
+ContentResolver::Meta::Meta()
+    : MetaBaseDroppable(ContentResolver::getTypeName()),
+      query(classRef().getMethod(
+          "query",
+          "(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/"
+          "String;Ljava/lang/String;)Landroid/database/Cursor;")),
+      query1(classRef().getMethod(
+          "query", "(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/"
+                   "String;[Ljava/lang/String;Ljava/lang/String;Landroid/os/"
+                   "CancellationSignal;)Landroid/database/Cursor;")),
+      query2(classRef().getMethod(
+          "query",
+          "(Landroid/net/Uri;[Ljava/lang/String;Landroid/os/Bundle;Landroid/os/"
+          "CancellationSignal;)Landroid/database/Cursor;")) {
+    MetaBaseDroppable::dropClassRef();
+}
+} // namespace android::content
+} // namespace wrap

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.content.h
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.content.h
@@ -1,0 +1,296 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+
+#pragma once
+
+#include "ObjectWrapperBase.h"
+
+namespace wrap {
+namespace android::content {
+class ComponentName;
+class ContentResolver;
+class Context;
+} // namespace android::content
+
+namespace android::database {
+class Cursor;
+} // namespace android::database
+
+namespace android::net {
+class Uri;
+class Uri_Builder;
+} // namespace android::net
+
+} // namespace wrap
+
+namespace wrap {
+namespace android::content {
+/*!
+ * Wrapper for android.content.Context objects.
+ */
+class Context : public ObjectWrapperBase {
+  public:
+    using ObjectWrapperBase::ObjectWrapperBase;
+    static constexpr const char *getTypeName() noexcept {
+        return "android/content/Context";
+    }
+
+    /*!
+     * Wrapper for the getContentResolver method
+     *
+     * Java prototype:
+     * `public abstract android.content.ContentResolver getContentResolver();`
+     *
+     * JNI signature: ()Landroid/content/ContentResolver;
+     *
+     */
+    ContentResolver getContentResolver() const;
+
+    /*!
+     * Class metadata
+     */
+    struct Meta : public MetaBaseDroppable {
+        jni::method_t getContentResolver;
+
+        /*!
+         * Singleton accessor
+         */
+        static Meta &data(bool deferDrop = false) {
+            static Meta instance{deferDrop};
+            return instance;
+        }
+
+      private:
+        explicit Meta(bool deferDrop);
+    };
+};
+
+/*!
+ * Wrapper for android.content.ContentUris objects.
+ */
+class ContentUris : public ObjectWrapperBase {
+  public:
+    using ObjectWrapperBase::ObjectWrapperBase;
+    static constexpr const char *getTypeName() noexcept {
+        return "android/content/ContentUris";
+    }
+
+    /*!
+     * Wrapper for the appendId static method
+     *
+     * Java prototype:
+     * `public static android.net.Uri$Builder appendId(android.net.Uri$Builder,
+     * long);`
+     *
+     * JNI signature: (Landroid/net/Uri$Builder;J)Landroid/net/Uri$Builder;
+     *
+     */
+    static net::Uri_Builder appendId(net::Uri_Builder &uri_Builder,
+                                     long long longParam);
+
+    /*!
+     * Class metadata
+     */
+    struct Meta : public MetaBaseDroppable {
+        jni::method_t appendId;
+
+        /*!
+         * Singleton accessor
+         */
+        static Meta &data(bool deferDrop = false) {
+            static Meta instance{deferDrop};
+            return instance;
+        }
+
+      private:
+        explicit Meta(bool deferDrop);
+    };
+};
+
+/*!
+ * Wrapper for android.content.ComponentName objects.
+ */
+class ComponentName : public ObjectWrapperBase {
+  public:
+    using ObjectWrapperBase::ObjectWrapperBase;
+    static constexpr const char *getTypeName() noexcept {
+        return "android/content/ComponentName";
+    }
+
+    /*!
+     * Wrapper for a constructor
+     *
+     * Java prototype:
+     * `public android.content.ComponentName(java.lang.String,
+     * java.lang.String);`
+     *
+     * JNI signature: (Ljava/lang/String;Ljava/lang/String;)V
+     *
+     */
+    static ComponentName construct(std::string const &pkg,
+                                   std::string const &className);
+
+    /*!
+     * Wrapper for a constructor
+     *
+     * Java prototype:
+     * `public android.content.ComponentName(android.content.Context,
+     * java.lang.String);`
+     *
+     * JNI signature: (Landroid/content/Context;Ljava/lang/String;)V
+     *
+     */
+    static ComponentName construct(Context const &context,
+                                   std::string const &className);
+
+    /*!
+     * Wrapper for a constructor
+     *
+     * Java prototype:
+     * `public android.content.ComponentName(android.content.Context,
+     * java.lang.Class<?>);`
+     *
+     * JNI signature: (Landroid/content/Context;Ljava/lang/Class;)V
+     *
+     */
+    static ComponentName construct(Context const &context,
+                                   jni::Object const &cls);
+
+    /*!
+     * Wrapper for a constructor
+     *
+     * Java prototype:
+     * `public android.content.ComponentName(android.os.Parcel);`
+     *
+     * JNI signature: (Landroid/os/Parcel;)V
+     *
+     */
+    static ComponentName construct(jni::Object const &parcel);
+
+    /*!
+     * Class metadata
+     */
+    struct Meta : public MetaBase {
+        jni::method_t init;
+        jni::method_t init1;
+        jni::method_t init2;
+        jni::method_t init3;
+
+        /*!
+         * Singleton accessor
+         */
+        static Meta &data() {
+            static Meta instance{};
+            return instance;
+        }
+
+      private:
+        Meta();
+    };
+};
+
+/*!
+ * Wrapper for android.content.ContentResolver objects.
+ */
+class ContentResolver : public ObjectWrapperBase {
+  public:
+    using ObjectWrapperBase::ObjectWrapperBase;
+    static constexpr const char *getTypeName() noexcept {
+        return "android/content/ContentResolver";
+    }
+
+    /*!
+     * Wrapper for the query method - overload added in API level 1
+     *
+     * Java prototype:
+     * `public final android.database.Cursor query(android.net.Uri,
+     * java.lang.String[], java.lang.String, java.lang.String[],
+     * java.lang.String);`
+     *
+     * JNI signature:
+     * (Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;
+     *
+     */
+    database::Cursor query(net::Uri const &uri,
+                           jni::Array<std::string> const &projection,
+                           std::string const &selection,
+                           jni::Array<std::string> const &selectionArgs,
+                           std::string const &sortOrder);
+
+    /*!
+     * Wrapper for the query method - overload added in API level 1
+     *
+     * Java prototype:
+     * `public final android.database.Cursor query(android.net.Uri,
+     * java.lang.String[], java.lang.String, java.lang.String[],
+     * java.lang.String);`
+     *
+     * JNI signature:
+     * (Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;
+     *
+     * This is a way to call the main query() function without the three
+     * trailing optional arguments.
+     */
+    database::Cursor query(net::Uri const &uri,
+                           jni::Array<std::string> const &projection);
+
+    /*!
+     * Wrapper for the query method - overload added in API level 16
+     *
+     * Java prototype:
+     * `public final android.database.Cursor query(android.net.Uri,
+     * java.lang.String[], java.lang.String, java.lang.String[],
+     * java.lang.String, android.os.CancellationSignal);`
+     *
+     * JNI signature:
+     * (Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Landroid/os/CancellationSignal;)Landroid/database/Cursor;
+     *
+     */
+    database::Cursor query(net::Uri const &uri,
+                           jni::Array<std::string> const &projection,
+                           std::string const &selection,
+                           jni::Array<std::string> const &selectionArgs,
+                           std::string const &sortOrder,
+                           jni::Object const &cancellationSignal);
+
+    /*!
+     * Wrapper for the query method - overload added in API level 26
+     *
+     * Java prototype:
+     * `public final android.database.Cursor query(android.net.Uri,
+     * java.lang.String[], android.os.Bundle, android.os.CancellationSignal);`
+     *
+     * JNI signature:
+     * (Landroid/net/Uri;[Ljava/lang/String;Landroid/os/Bundle;Landroid/os/CancellationSignal;)Landroid/database/Cursor;
+     *
+     */
+    database::Cursor query(net::Uri const &uri,
+                           jni::Array<std::string> const &projection,
+                           jni::Object const &queryArgs,
+                           jni::Object const &cancellationSignal);
+
+    /*!
+     * Class metadata
+     */
+    struct Meta : public MetaBaseDroppable {
+        jni::method_t query;
+        jni::method_t query1;
+        jni::method_t query2;
+
+        /*!
+         * Singleton accessor
+         */
+        static Meta &data() {
+            static Meta instance{};
+            return instance;
+        }
+
+      private:
+        Meta();
+    };
+};
+
+} // namespace android::content
+} // namespace wrap
+#include "android.content.impl.h"

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.content.impl.h
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.content.impl.h
@@ -1,0 +1,91 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+// Inline implementations: do not include on its own!
+
+#pragma once
+
+#include "android.database.h"
+#include "android.net.h"
+#include <string>
+
+namespace wrap {
+namespace android::content {
+inline ContentResolver Context::getContentResolver() const {
+    assert(!isNull());
+    return ContentResolver(
+        object().call<jni::Object>(Meta::data().getContentResolver));
+}
+
+inline net::Uri_Builder ContentUris::appendId(net::Uri_Builder &uri_Builder,
+                                              long long longParam) {
+    auto &data = Meta::data(true);
+    auto ret = net::Uri_Builder(data.clazz().call<jni::Object>(
+        data.appendId, uri_Builder.object(), longParam));
+    data.dropClassRef();
+    return ret;
+}
+
+inline ComponentName ComponentName::construct(std::string const &pkg,
+                                              std::string const &className) {
+    return ComponentName(
+        Meta::data().clazz().newInstance(Meta::data().init, pkg, className));
+}
+
+inline ComponentName ComponentName::construct(Context const &context,
+                                              std::string const &className) {
+    return ComponentName(Meta::data().clazz().newInstance(
+        Meta::data().init1, context.object(), className));
+}
+
+inline ComponentName ComponentName::construct(Context const &context,
+                                              jni::Object const &cls) {
+    return ComponentName(Meta::data().clazz().newInstance(
+        Meta::data().init2, context.object(), cls));
+}
+
+inline ComponentName ComponentName::construct(jni::Object const &parcel) {
+    return ComponentName(
+        Meta::data().clazz().newInstance(Meta::data().init3, parcel));
+}
+
+inline database::Cursor ContentResolver::query(
+    net::Uri const &uri, jni::Array<std::string> const &projection,
+    std::string const &selection, jni::Array<std::string> const &selectionArgs,
+    std::string const &sortOrder) {
+    assert(!isNull());
+    return database::Cursor(
+        object().call<jni::Object>(Meta::data().query, uri.object(), projection,
+                                   selection, selectionArgs, sortOrder));
+}
+
+inline database::Cursor
+ContentResolver::query(net::Uri const &uri,
+                       jni::Array<std::string> const &projection) {
+    assert(!isNull());
+    return database::Cursor(
+        object().call<jni::Object>(Meta::data().query, uri.object(), projection,
+                                   nullptr, nullptr, nullptr));
+}
+
+inline database::Cursor ContentResolver::query(
+    net::Uri const &uri, jni::Array<std::string> const &projection,
+    std::string const &selection, jni::Array<std::string> const &selectionArgs,
+    std::string const &sortOrder, jni::Object const &cancellationSignal) {
+    assert(!isNull());
+    return database::Cursor(object().call<jni::Object>(
+        Meta::data().query1, uri.object(), projection, selection, selectionArgs,
+        sortOrder, cancellationSignal));
+}
+
+inline database::Cursor ContentResolver::query(
+    net::Uri const &uri, jni::Array<std::string> const &projection,
+    jni::Object const &queryArgs, jni::Object const &cancellationSignal) {
+    assert(!isNull());
+    return database::Cursor(
+        object().call<jni::Object>(Meta::data().query2, uri.object(),
+                                   projection, queryArgs, cancellationSignal));
+}
+
+} // namespace android::content
+} // namespace wrap

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.database.cpp
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.database.cpp
@@ -1,0 +1,22 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+
+#include "android.database.h"
+
+namespace wrap {
+namespace android::database {
+Cursor::Meta::Meta()
+    : MetaBaseDroppable(Cursor::getTypeName()),
+      getCount(classRef().getMethod("getCount", "()I")),
+      moveToFirst(classRef().getMethod("moveToFirst", "()Z")),
+      moveToNext(classRef().getMethod("moveToNext", "()Z")),
+      getColumnIndex(
+          classRef().getMethod("getColumnIndex", "(Ljava/lang/String;)I")),
+      getString(classRef().getMethod("getString", "(I)Ljava/lang/String;")),
+      getInt(classRef().getMethod("getInt", "(I)I")),
+      close(classRef().getMethod("close", "()V")) {
+    MetaBaseDroppable::dropClassRef();
+}
+} // namespace android::database
+} // namespace wrap

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.database.h
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.database.h
@@ -1,0 +1,125 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+
+#pragma once
+
+#include "ObjectWrapperBase.h"
+
+namespace wrap {
+namespace android::database {
+/*!
+ * Wrapper for android.database.Cursor objects.
+ */
+class Cursor : public ObjectWrapperBase {
+  public:
+    using ObjectWrapperBase::ObjectWrapperBase;
+    static constexpr const char *getTypeName() noexcept {
+        return "android/database/Cursor";
+    }
+
+    /*!
+     * Wrapper for the getCount method
+     *
+     * Java prototype:
+     * `public abstract int getCount();`
+     *
+     * JNI signature: ()I
+     *
+     */
+    int32_t getCount();
+
+    /*!
+     * Wrapper for the moveToFirst method
+     *
+     * Java prototype:
+     * `public abstract boolean moveToFirst();`
+     *
+     * JNI signature: ()Z
+     *
+     */
+    bool moveToFirst();
+
+    /*!
+     * Wrapper for the moveToNext method
+     *
+     * Java prototype:
+     * `public abstract boolean moveToNext();`
+     *
+     * JNI signature: ()Z
+     *
+     */
+    bool moveToNext();
+
+    /*!
+     * Wrapper for the getColumnIndex method
+     *
+     * Java prototype:
+     * `public abstract int getColumnIndex(java.lang.String);`
+     *
+     * JNI signature: (Ljava/lang/String;)I
+     *
+     */
+    int32_t getColumnIndex(std::string const &columnName);
+
+    /*!
+     * Wrapper for the getString method
+     *
+     * Java prototype:
+     * `public abstract java.lang.String getString(int);`
+     *
+     * JNI signature: (I)Ljava/lang/String;
+     *
+     */
+    std::string getString(int32_t column);
+
+    /*!
+     * Wrapper for the getInt method
+     *
+     * Java prototype:
+     * `public abstract int getInt(int);`
+     *
+     * JNI signature: (I)I
+     *
+     */
+    int32_t getInt(int32_t column);
+
+    /*!
+     * Wrapper for the close method
+     *
+     * Java prototype:
+     * `public abstract void close();`
+     *
+     * JNI signature: ()V
+     *
+     */
+    void close();
+
+    /*!
+     * Class metadata
+     */
+    struct Meta : public MetaBaseDroppable {
+        jni::method_t getCount;
+        jni::method_t moveToFirst;
+        jni::method_t moveToNext;
+        jni::method_t getColumnIndex;
+        jni::method_t getString;
+        jni::method_t getInt;
+        jni::method_t close;
+
+        /*!
+         * Singleton accessor
+         */
+        static Meta &data() {
+            static Meta instance{};
+            return instance;
+        }
+
+      private:
+        Meta();
+    };
+};
+
+} // namespace android::database
+} // namespace wrap
+#include "android.database.impl.h"

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.database.impl.h
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.database.impl.h
@@ -1,0 +1,48 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+// Inline implementations: do not include on its own!
+
+#pragma once
+
+#include <string>
+
+namespace wrap {
+namespace android::database {
+inline int32_t Cursor::getCount() {
+    assert(!isNull());
+    return object().call<int32_t>(Meta::data().getCount);
+}
+
+inline bool Cursor::moveToFirst() {
+    assert(!isNull());
+    return object().call<bool>(Meta::data().moveToFirst);
+}
+
+inline bool Cursor::moveToNext() {
+    assert(!isNull());
+    return object().call<bool>(Meta::data().moveToNext);
+}
+
+inline int32_t Cursor::getColumnIndex(std::string const &columnName) {
+    assert(!isNull());
+    return object().call<int32_t>(Meta::data().getColumnIndex, columnName);
+}
+
+inline std::string Cursor::getString(int32_t column) {
+    assert(!isNull());
+    return object().call<std::string>(Meta::data().getString, column);
+}
+
+inline int32_t Cursor::getInt(int32_t column) {
+    assert(!isNull());
+    return object().call<int32_t>(Meta::data().getInt, column);
+}
+
+inline void Cursor::close() {
+    assert(!isNull());
+    return object().call<void>(Meta::data().close);
+}
+
+} // namespace android::database
+} // namespace wrap

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.net.cpp
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.net.cpp
@@ -1,0 +1,27 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+
+#include "android.net.h"
+
+namespace wrap {
+namespace android::net {
+Uri::Meta::Meta()
+    : MetaBaseDroppable(Uri::getTypeName()),
+      toString(classRef().getMethod("toString", "()Ljava/lang/String;")) {
+    MetaBaseDroppable::dropClassRef();
+}
+Uri_Builder::Meta::Meta()
+    : MetaBaseDroppable(Uri_Builder::getTypeName()),
+      init(classRef().getMethod("<init>", "()V")),
+      scheme(classRef().getMethod(
+          "scheme", "(Ljava/lang/String;)Landroid/net/Uri$Builder;")),
+      authority(classRef().getMethod(
+          "authority", "(Ljava/lang/String;)Landroid/net/Uri$Builder;")),
+      appendPath(classRef().getMethod(
+          "appendPath", "(Ljava/lang/String;)Landroid/net/Uri$Builder;")),
+      build(classRef().getMethod("build", "()Landroid/net/Uri;")) {
+    MetaBaseDroppable::dropClassRef();
+}
+} // namespace android::net
+} // namespace wrap

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.net.h
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.net.h
@@ -1,0 +1,149 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+
+#pragma once
+
+#include "ObjectWrapperBase.h"
+
+namespace wrap {
+namespace android::net {
+class Uri;
+class Uri_Builder;
+} // namespace android::net
+
+} // namespace wrap
+
+namespace wrap {
+namespace android::net {
+/*!
+ * Wrapper for android.net.Uri objects.
+ */
+class Uri : public ObjectWrapperBase {
+  public:
+    using ObjectWrapperBase::ObjectWrapperBase;
+    static constexpr const char *getTypeName() noexcept {
+        return "android/net/Uri";
+    }
+
+    /*!
+     * Wrapper for the toString method
+     *
+     * Java prototype:
+     * `public abstract java.lang.String toString();`
+     *
+     * JNI signature: ()Ljava/lang/String;
+     *
+     */
+    std::string toString() const;
+
+    /*!
+     * Class metadata
+     */
+    struct Meta : public MetaBaseDroppable {
+        jni::method_t toString;
+
+        /*!
+         * Singleton accessor
+         */
+        static Meta &data() {
+            static Meta instance{};
+            return instance;
+        }
+
+      private:
+        Meta();
+    };
+};
+
+/*!
+ * Wrapper for android.net.Uri$Builder objects.
+ */
+class Uri_Builder : public ObjectWrapperBase {
+  public:
+    using ObjectWrapperBase::ObjectWrapperBase;
+    static constexpr const char *getTypeName() noexcept {
+        return "android/net/Uri$Builder";
+    }
+
+    /*!
+     * Wrapper for a constructor
+     *
+     * Java prototype:
+     * `public android.net.Uri$Builder();`
+     *
+     * JNI signature: ()V
+     *
+     */
+    static Uri_Builder construct();
+
+    /*!
+     * Wrapper for the scheme method
+     *
+     * Java prototype:
+     * `public android.net.Uri$Builder scheme(java.lang.String);`
+     *
+     * JNI signature: (Ljava/lang/String;)Landroid/net/Uri$Builder;
+     *
+     */
+    Uri_Builder &scheme(std::string const &stringParam);
+
+    /*!
+     * Wrapper for the authority method
+     *
+     * Java prototype:
+     * `public android.net.Uri$Builder authority(java.lang.String);`
+     *
+     * JNI signature: (Ljava/lang/String;)Landroid/net/Uri$Builder;
+     *
+     */
+    Uri_Builder &authority(std::string const &stringParam);
+
+    /*!
+     * Wrapper for the appendPath method
+     *
+     * Java prototype:
+     * `public android.net.Uri$Builder appendPath(java.lang.String);`
+     *
+     * JNI signature: (Ljava/lang/String;)Landroid/net/Uri$Builder;
+     *
+     */
+    Uri_Builder &appendPath(std::string const &stringParam);
+
+    /*!
+     * Wrapper for the build method
+     *
+     * Java prototype:
+     * `public android.net.Uri build();`
+     *
+     * JNI signature: ()Landroid/net/Uri;
+     *
+     */
+    Uri build();
+
+    /*!
+     * Class metadata
+     */
+    struct Meta : public MetaBaseDroppable {
+        jni::method_t init;
+        jni::method_t scheme;
+        jni::method_t authority;
+        jni::method_t appendPath;
+        jni::method_t build;
+
+        /*!
+         * Singleton accessor
+         */
+        static Meta &data() {
+            static Meta instance{};
+            return instance;
+        }
+
+      private:
+        Meta();
+    };
+};
+
+} // namespace android::net
+} // namespace wrap
+#include "android.net.impl.h"

--- a/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.net.impl.h
+++ b/thirdparty/openxr/src/external/android-jni-wrappers/wrap/android.net.impl.h
@@ -1,0 +1,45 @@
+// Copyright 2020-2021, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+// Author: Ryan Pavlik <ryan.pavlik@collabora.com>
+// Inline implementations: do not include on its own!
+
+#pragma once
+
+#include <string>
+
+namespace wrap {
+namespace android::net {
+inline std::string Uri::toString() const {
+    assert(!isNull());
+    return object().call<std::string>(Meta::data().toString);
+}
+
+inline Uri_Builder Uri_Builder::construct() {
+    return Uri_Builder(Meta::data().clazz().newInstance(Meta::data().init));
+}
+
+inline Uri_Builder &Uri_Builder::scheme(std::string const &stringParam) {
+    assert(!isNull());
+    object().call<jni::Object>(Meta::data().scheme, stringParam);
+    return *this;
+}
+
+inline Uri_Builder &Uri_Builder::authority(std::string const &stringParam) {
+    assert(!isNull());
+    object().call<jni::Object>(Meta::data().authority, stringParam);
+    return *this;
+}
+
+inline Uri_Builder &Uri_Builder::appendPath(std::string const &stringParam) {
+    assert(!isNull());
+    object().call<jni::Object>(Meta::data().appendPath, stringParam);
+    return *this;
+}
+
+inline Uri Uri_Builder::build() {
+    assert(!isNull());
+    return Uri(object().call<jni::Object>(Meta::data().build));
+}
+
+} // namespace android::net
+} // namespace wrap

--- a/thirdparty/openxr/src/external/jnipp/android/AndroidManifest.xml
+++ b/thirdparty/openxr/src/external/jnipp/android/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- BEGIN_INCLUDE(manifest) -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="jnipp"
+          android:versionCode="1"
+          android:versionName="1.0">
+</manifest>
+<!-- END_INCLUDE(manifest) -->

--- a/thirdparty/openxr/src/external/jnipp/jnipp.cpp
+++ b/thirdparty/openxr/src/external/jnipp/jnipp.cpp
@@ -1,0 +1,1626 @@
+#ifdef _WIN32
+# define WIN32_LEAN_AND_MEAN 1
+
+  // Windows Dependencies
+# include <windows.h>
+#else
+  // UNIX Dependencies
+# include <dlfcn.h>
+# include <unistd.h>
+# include <tuple>
+#endif
+
+// External Dependencies
+#include <jni.h>
+
+// Standard Dependencies
+#include <atomic>
+#include <string>
+
+// Local Dependencies
+#include "jnipp.h"
+
+namespace jni
+{
+    // Static Variables
+    static std::atomic_bool isVm(false);
+    static JavaVM* javaVm = nullptr;
+
+    static bool getEnv(JavaVM *vm, JNIEnv **env) {
+        return vm->GetEnv((void **)env, JNI_VERSION_1_2) == JNI_OK;
+    }
+
+    static bool isAttached(JavaVM *vm) {
+        JNIEnv *env = nullptr;
+        return getEnv(vm, &env);
+    }
+    /**
+        Maintains the lifecycle of a JNIEnv.
+     */
+    class ScopedEnv final
+    {
+    public:
+        ScopedEnv() noexcept : _vm(nullptr), _env(nullptr), _attached(false) {}
+        ~ScopedEnv();
+
+        void init(JavaVM* vm);
+        JNIEnv* get() const noexcept { return _env; }
+
+    private:
+        // Instance Variables
+        JavaVM* _vm;
+        JNIEnv* _env;
+        bool    _attached;    ///< Manually attached, as opposed to already attached.
+    };
+
+    ScopedEnv::~ScopedEnv()
+    {
+        if (_vm && _attached)
+            _vm->DetachCurrentThread();
+    }
+
+    void ScopedEnv::init(JavaVM* vm)
+    {
+        if (_env != nullptr)
+            return;
+
+        if (vm == nullptr)
+            throw InitializationException("JNI not initialized");
+
+        if (!getEnv(vm, &_env))
+        {
+#ifdef __ANDROID__
+            if (vm->AttachCurrentThread(&_env, nullptr) != 0)
+#else
+            if (vm->AttachCurrentThread((void**)&_env, nullptr) != 0)
+#endif
+                throw InitializationException("Could not attach JNI to thread");
+
+            _attached = true;
+        }
+
+        _vm = vm;
+    }
+
+    /*
+        Helper Functions
+     */
+
+#ifdef _WIN32
+
+    static bool fileExists(const std::string& filePath)
+    {
+        DWORD attr = ::GetFileAttributesA(filePath.c_str());
+
+        return attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY);
+    }
+
+#else
+
+     /**
+         Convert from a UTF-16 Java string to a UTF-32 string.
+      */
+    std::wstring toWString(const jchar* str, jsize length)
+    {
+        std::wstring result;
+
+        result.reserve(length);
+
+        for (jsize i = 0; i < length; ++i)
+        {
+            wchar_t ch = str[i];
+
+            // Check for a two-segment character.
+            if (ch >= wchar_t(0xD800) && ch <= wchar_t(0xDBFF)) {
+                if (i + 1 >= length)
+                    break;
+
+                // Create a single, 32-bit character.
+                ch = (ch - wchar_t(0xD800)) << 10;
+                ch += str[i++] - wchar_t(0x1DC00);
+            }
+
+            result += ch;
+        }
+
+        return result;
+    }
+
+    /**
+        Convert from a UTF-32 string to a UTF-16 Java string.
+     */
+    std::basic_string<jchar> toJString(const wchar_t* str, size_t length)
+    {
+        std::basic_string<jchar> result;
+
+        result.reserve(length * 2);    // Worst case scenario.
+
+        for (size_t i = 0; i < length; ++i)
+        {
+            wchar_t ch = str[i];
+
+            // Check for multi-byte UTF-16 character.
+            if (ch > wchar_t(0xFFFF)) {
+                ch -= uint32_t(0x10000);
+
+                // Add the first of the two-segment character.
+                result += jchar(0xD800 + (ch >> 10));
+                ch = wchar_t(0xDC00) + (ch & 0x03FF);
+            }
+
+            result += jchar(ch);
+        }
+
+        return result;
+    }
+
+#endif // _WIN32
+
+    JNIEnv* env()
+    {
+        static thread_local ScopedEnv env;
+
+        if (env.get() != nullptr && !isAttached(javaVm))
+        {
+            // we got detached, so clear it.
+            // will be re-populated from static javaVm below.
+            env = ScopedEnv{};
+        }
+
+        if (env.get() == nullptr)
+        {
+            env.init(javaVm);
+        }
+
+        return env.get();
+    }
+
+    static jclass findClass(const char* name)
+    {
+        jclass ref = env()->FindClass(name);
+
+        if (ref == nullptr)
+        {
+            env()->ExceptionClear();
+            throw NameResolutionException(name);
+        }
+
+        return ref;
+    }
+
+    static void handleJavaExceptions()
+    {
+        JNIEnv* env = jni::env();
+
+        jthrowable exception = env->ExceptionOccurred();
+
+        if (exception != nullptr)
+        {
+            Object obj(exception, Object::Temporary);
+
+            env->ExceptionClear();
+            std::string msg = obj.call<std::string>("toString");
+            throw InvocationException(msg.c_str());
+        }
+    }
+
+    static std::string toString(jobject handle, bool deleteLocal = true)
+    {
+        std::string result;
+
+        if (handle != nullptr)
+        {
+            JNIEnv* env = jni::env();
+
+            const char* chars = env->GetStringUTFChars(jstring(handle), nullptr);
+            result.assign(chars, env->GetStringUTFLength(jstring(handle)));
+            env->ReleaseStringUTFChars(jstring(handle), chars);
+
+            if (deleteLocal)
+                env->DeleteLocalRef(handle);
+        }
+
+        return result;
+    }
+
+    static std::wstring toWString(jobject handle, bool deleteLocal = true)
+    {
+        std::wstring result;
+
+        if (handle != nullptr)
+        {
+            JNIEnv* env = jni::env();
+
+            const jchar* chars = env->GetStringChars(jstring(handle), nullptr);
+#ifdef _WIN32
+            result.assign((const wchar_t*) chars, env->GetStringLength(jstring(handle)));
+#else
+            result = toWString(chars, env->GetStringLength(jstring(handle)));
+#endif
+            env->ReleaseStringChars(jstring(handle), chars);
+
+            if (deleteLocal)
+                env->DeleteLocalRef(handle);
+        }
+
+        return result;
+    }
+
+
+    /*
+        Stand-alone Function Implementations
+     */
+
+    void init(JNIEnv* env)
+    {
+        bool expected = false;
+
+        if (isVm.compare_exchange_strong(expected, true))
+        {
+            if (javaVm == nullptr && env->GetJavaVM(&javaVm) != 0)
+                throw InitializationException("Could not acquire Java VM");
+        }
+    }
+
+    void init(JavaVM* vm) {
+        bool expected = false;
+
+        if (isVm.compare_exchange_strong(expected, true))
+        {
+            javaVm = vm;
+        }
+    }
+    /*
+        Object Implementation
+     */
+
+    Object::Object() noexcept : _handle(nullptr), _class(nullptr), _isGlobal(false)
+    {
+    }
+
+    Object::Object(const Object& other) : _handle(nullptr), _class(nullptr), _isGlobal(!other.isNull())
+    {
+        if (!other.isNull())
+            _handle = env()->NewGlobalRef(other._handle);
+    }
+
+    Object::Object(Object&& other) noexcept : _handle(other._handle), _class(other._class), _isGlobal(other._isGlobal)
+    {
+        other._handle   = nullptr;
+        other._class    = nullptr;
+        other._isGlobal = false;
+    }
+
+    Object::Object(jobject ref, int scopeFlags) : _handle(ref), _class(nullptr), _isGlobal((scopeFlags & Temporary) == 0)
+    {
+        if (!_isGlobal)
+            return;
+
+        JNIEnv* env = jni::env();
+
+        _handle = env->NewGlobalRef(ref);
+
+        if (scopeFlags & DeleteLocalInput)
+            env->DeleteLocalRef(ref);
+    }
+
+    Object::~Object() noexcept
+    {
+        JNIEnv* env = jni::env();
+
+        if (_isGlobal)
+            env->DeleteGlobalRef(_handle);
+
+        if (_class != nullptr)
+            env->DeleteGlobalRef(_class);
+    }
+
+    Object& Object::operator=(const Object& other)
+    {
+        if (_handle != other._handle)
+        {
+            JNIEnv* env = jni::env();
+
+            // Ditch the old reference.
+            if (_isGlobal)
+                env->DeleteGlobalRef(_handle);
+            if (_class != nullptr)
+                env->DeleteGlobalRef(_class);
+
+            // Assign the new reference.
+            if ((_isGlobal = !other.isNull()) != false)
+                _handle = env->NewGlobalRef(other._handle);
+
+            _class = nullptr;
+        }
+
+        return *this;
+    }
+
+    bool Object::operator==(const Object& other) const
+    {
+        return env()->IsSameObject(_handle, other._handle) != JNI_FALSE;
+    }
+
+    Object& Object::operator=(Object&& other)
+    {
+        if (_handle != other._handle)
+        {
+            JNIEnv* env = jni::env();
+
+            // Ditch the old reference.
+            if (_isGlobal)
+                env->DeleteGlobalRef(_handle);
+            if (_class != nullptr)
+                env->DeleteGlobalRef(_class);
+
+            // Assign the new reference.
+            _handle   = other._handle;
+            _isGlobal = other._isGlobal;
+            _class    = other._class;
+
+            other._handle   = nullptr;
+            other._isGlobal = false;
+            other._class    = nullptr;
+        }
+
+        return *this;
+    }
+
+    bool Object::isNull() const noexcept
+    {
+        return _handle == nullptr || env()->IsSameObject(_handle, nullptr);
+    }
+
+    void Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<void> const&) const
+    {
+        env()->CallVoidMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+    }
+
+    bool Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<bool> const&) const
+    {
+        auto result = env()->CallBooleanMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return result != 0;
+    }
+
+    bool Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<bool> const&) const
+    {
+        return env()->GetBooleanField(_handle, field) != 0;
+    }
+
+    template <> void Object::set(field_t field, const bool& value)
+    {
+        env()->SetBooleanField(_handle, field, value);
+    }
+
+    byte_t Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<byte_t> const&) const
+    {
+        auto result = env()->CallByteMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    wchar_t Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<wchar_t> const&) const
+    {
+        auto result = env()->CallCharMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    short Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<short> const&) const
+    {
+        auto result = env()->CallShortMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    int Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<int> const&) const
+    {
+        auto result = env()->CallIntMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    long long Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<long long> const&) const
+    {
+        auto result = env()->CallLongMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    float Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<float> const&) const
+    {
+        auto result = env()->CallFloatMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    double Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<double> const&) const
+    {
+        auto result = env()->CallDoubleMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    std::string Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<std::string> const&) const
+    {
+        auto result = env()->CallObjectMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return toString(result);
+    }
+
+    std::wstring Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<std::wstring> const&) const
+    {
+        auto result = env()->CallObjectMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return toWString(result);
+    }
+
+    jni::Object Object::callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<jni::Object> const&) const
+    {
+        auto result = env()->CallObjectMethodA(_handle, method, (jvalue*) args);
+        handleJavaExceptions();
+        return Object(result, DeleteLocalInput);
+    }
+
+    byte_t Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<byte_t> const&) const
+    {
+        return env()->GetByteField(_handle, field);
+    }
+
+    wchar_t Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<wchar_t> const&) const
+    {
+        return env()->GetCharField(_handle, field);
+    }
+
+    short Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<short> const&) const
+    {
+        return env()->GetShortField(_handle, field);
+    }
+
+    int Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<int> const&) const
+    {
+        return env()->GetIntField(_handle, field);
+    }
+
+    long long Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<long long> const&) const
+    {
+        return env()->GetLongField(_handle, field);
+    }
+
+    float Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<float> const&) const
+    {
+        return env()->GetFloatField(_handle, field);
+    }
+
+    double Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<double> const&) const
+    {
+        return env()->GetDoubleField(_handle, field);
+    }
+
+    std::string Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<std::string> const&) const
+    {
+        return toString(env()->GetObjectField(_handle, field));
+    }
+
+    std::wstring Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<std::wstring> const&) const
+    {
+        return toWString(env()->GetObjectField(_handle, field));
+    }
+
+    Object Object::getFieldValue(field_t field, internal::ReturnTypeWrapper<Object> const&) const
+    {
+        return Object(env()->GetObjectField(_handle, field), DeleteLocalInput);
+    }
+
+    template <> void Object::set(field_t field, const byte_t& value)
+    {
+        env()->SetByteField(_handle, field, value);
+    }
+
+    template <> void Object::set(field_t field, const wchar_t& value)
+    {
+        env()->SetCharField(_handle, field, value);
+    }
+
+    template <> void Object::set(field_t field, const short& value)
+    {
+        env()->SetShortField(_handle, field, value);
+    }
+
+    template <> void Object::set(field_t field, const int& value)
+    {
+        env()->SetIntField(_handle, field, value);
+    }
+
+    template <> void Object::set(field_t field, const long long& value)
+    {
+        env()->SetLongField(_handle, field, value);
+    }
+
+    template <> void Object::set(field_t field, const float& value)
+    {
+        env()->SetFloatField(_handle, field, value);
+    }
+
+    template <> void Object::set(field_t field, const double& value)
+    {
+        env()->SetDoubleField(_handle, field, value);
+    }
+
+    template <> void Object::set(field_t field, const std::string& value)
+    {
+        JNIEnv* env = jni::env();
+
+        jobject handle = env->NewStringUTF(value.c_str());
+        env->SetObjectField(_handle, field, handle);
+        env->DeleteLocalRef(handle);
+    }
+
+    template <> void Object::set(field_t field, const std::wstring& value)
+    {
+        JNIEnv* env = jni::env();
+
+#ifdef _WIN32
+        jobject handle = env->NewString((const jchar*) value.c_str(), jsize(value.length()));
+#else
+        auto jstr = toJString(value.c_str(), value.length());
+        jobject handle = env->NewString(jstr.c_str(), jsize(jstr.length()));
+#endif
+        env->SetObjectField(_handle, field, handle);
+        env->DeleteLocalRef(handle);
+    }
+
+    template <> void Object::set(field_t field, const wchar_t* const& value)
+    {
+        JNIEnv* env = jni::env();
+#ifdef _WIN32
+        jobject handle = env->NewString((const jchar*) value, jsize(std::wcslen(value)));
+#else
+        auto jstr = toJString(value, std::wcslen(value));
+        jobject handle = env->NewString(jstr.c_str(), jsize(jstr.length()));
+#endif
+        env->SetObjectField(_handle, field, handle);
+        env->DeleteLocalRef(handle);
+    }
+
+    template <> void Object::set(field_t field, const char* const& value)
+    {
+        JNIEnv* env = jni::env();
+
+        jobject handle = env->NewStringUTF(value);
+        env->SetObjectField(_handle, field, handle);
+        env->DeleteLocalRef(handle);
+    }
+
+    template <> void Object::set(field_t field, const Object& value)
+    {
+        env()->SetObjectField(_handle, field, value.getHandle());
+    }
+
+    template <> void Object::set(field_t field, const Object* const& value)
+    {
+        env()->SetObjectField(_handle, field, value ? value->getHandle() : nullptr);
+    }
+
+    jclass Object::getClass() const
+    {
+        if (_class == nullptr)
+        {
+            JNIEnv* env = jni::env();
+
+            jclass classRef = env->GetObjectClass(_handle);
+            _class = jclass(env->NewGlobalRef(classRef));
+            env->DeleteLocalRef(classRef);
+        }
+
+        return _class;
+    }
+
+    method_t Object::getMethod(const char* name, const char* signature) const
+    {
+        return Class(getClass(), Temporary).getMethod(name, signature);
+    }
+
+    method_t Object::getMethod(const char* nameAndSignature) const
+    {
+        return Class(getClass(), Temporary).getMethod(nameAndSignature);
+    }
+
+    field_t Object::getField(const char* name, const char* signature) const
+    {
+        return Class(getClass(), Temporary).getField(name, signature);
+    }
+
+    jobject Object::makeLocalReference() const 
+    {
+        if (isNull())
+            return nullptr;
+        return env()->NewLocalRef(_handle);
+    }
+
+    /*
+        Class Implementation
+     */
+
+    Class::Class(const char* name) : Object(findClass(name), DeleteLocalInput)
+    {
+    }
+
+    Class::Class(jclass ref, int scopeFlags) : Object(ref, scopeFlags)
+    {
+    }
+
+    Object Class::newInstance() const
+    {
+        method_t constructor = getMethod("<init>", "()V");
+        jobject obj = env()->NewObject(getHandle(), constructor);
+
+        handleJavaExceptions();
+
+        return Object(obj, Object::DeleteLocalInput);
+    }
+
+    field_t Class::getField(const char* name, const char* signature) const
+    {
+        jfieldID id = env()->GetFieldID(getHandle(), name, signature);
+
+        if (id == nullptr)
+            throw NameResolutionException(name);
+
+        return id;
+    }
+
+    field_t Class::getStaticField(const char* name, const char* signature) const
+    {
+        jfieldID id = env()->GetStaticFieldID(getHandle(), name, signature);
+
+        if (id == nullptr)
+            throw NameResolutionException(name);
+
+        return id;
+    }
+
+    method_t Class::getMethod(const char* name, const char* signature) const
+    {
+        jmethodID id = env()->GetMethodID(getHandle(), name, signature);
+
+        if (id == nullptr)
+            throw NameResolutionException(name);
+
+        return id;
+    }
+
+
+    method_t Class::getMethod(const char* nameAndSignature) const
+    {
+        jmethodID id = nullptr;
+        const char* sig = std::strchr(nameAndSignature, '(');
+
+        if (sig != nullptr)
+            return getMethod(std::string(nameAndSignature, sig - nameAndSignature).c_str(), sig);
+
+        if (id == nullptr)
+            throw NameResolutionException(nameAndSignature);
+
+        return id;
+    }
+
+    method_t Class::getStaticMethod(const char* name, const char* signature) const
+    {
+        jmethodID id = env()->GetStaticMethodID(getHandle(), name, signature);
+
+        if (id == nullptr)
+            throw NameResolutionException(name);
+
+        return id;
+    }
+
+    method_t Class::getStaticMethod(const char* nameAndSignature) const
+    {
+        jmethodID id = nullptr;
+        const char* sig = std::strchr(nameAndSignature, '(');
+
+        if (sig != nullptr)
+            return getStaticMethod(std::string(nameAndSignature, sig - nameAndSignature).c_str(), sig);
+
+        if (id == nullptr)
+            throw NameResolutionException(nameAndSignature);
+
+        return id;
+    }
+
+    Class Class::getParent() const
+    {
+        return Class(env()->GetSuperclass(getHandle()), DeleteLocalInput);
+    }
+
+    std::string Class::getName() const
+    {
+        return Object::call<std::string>("getName");
+    }
+
+    template <> bool Class::get(field_t field) const
+    {
+        return env()->GetStaticBooleanField(getHandle(), field) != 0;
+    }
+
+    template <> byte_t Class::get(field_t field) const
+    {
+        return env()->GetStaticByteField(getHandle(), field);
+    }
+
+    template <> wchar_t Class::get(field_t field) const
+    {
+        return env()->GetStaticCharField(getHandle(), field);
+    }
+
+    template <> short Class::get(field_t field) const
+    {
+        return env()->GetStaticShortField(getHandle(), field);
+    }
+
+    template <> int Class::get(field_t field) const
+    {
+        return env()->GetStaticIntField(getHandle(), field);
+    }
+
+    template <> long long Class::get(field_t field) const
+    {
+        return env()->GetStaticLongField(getHandle(), field);
+    }
+
+    template <> float Class::get(field_t field) const
+    {
+        return env()->GetStaticFloatField(getHandle(), field);
+    }
+
+    template <> double Class::get(field_t field) const
+    {
+        return env()->GetStaticDoubleField(getHandle(), field);
+    }
+
+    template <> std::string Class::get(field_t field) const
+    {
+        return toString(env()->GetStaticObjectField(getHandle(), field));
+    }
+
+    template <> std::wstring Class::get(field_t field) const
+    {
+        return toWString(env()->GetStaticObjectField(getHandle(), field));
+    }
+
+    template <> Object Class::get(field_t field) const
+    {
+        return Object(env()->GetStaticObjectField(getHandle(), field), DeleteLocalInput);
+    }
+
+    template <> void Class::set(field_t field, const bool& value)
+    {
+        env()->SetStaticBooleanField(getHandle(), field, value);
+    }
+
+    template <> void Class::set(field_t field, const byte_t& value)
+    {
+        env()->SetStaticByteField(getHandle(), field, value);
+    }
+
+    template <> void Class::set(field_t field, const wchar_t& value)
+    {
+        env()->SetStaticCharField(getHandle(), field, value);
+    }
+
+    template <> void Class::set(field_t field, const short& value)
+    {
+        env()->SetStaticShortField(getHandle(), field, value);
+    }
+
+    template <> void Class::set(field_t field, const int& value)
+    {
+        env()->SetStaticIntField(getHandle(), field, value);
+    }
+
+    template <> void Class::set(field_t field, const long long& value)
+    {
+        env()->SetStaticLongField(getHandle(), field, value);
+    }
+
+    template <> void Class::set(field_t field, const float& value)
+    {
+        env()->SetStaticFloatField(getHandle(), field, value);
+    }
+
+    template <> void Class::set(field_t field, const double& value)
+    {
+        env()->SetStaticDoubleField(getHandle(), field, value);
+    }
+
+    template <> void Class::set(field_t field, const Object& value)
+    {
+        env()->SetStaticObjectField(getHandle(), field, value.getHandle());
+    }
+
+    template <> void Class::set(field_t field, const Object* const& value)
+    {
+        env()->SetStaticObjectField(getHandle(), field, value ? value->getHandle() : nullptr);
+    }
+
+    template <> void Class::set(field_t field, const std::string& value)
+    {
+        JNIEnv* env = jni::env();
+
+        jobject handle = env->NewStringUTF(value.c_str());
+        env->SetStaticObjectField(getHandle(), field, handle);
+        env->DeleteLocalRef(handle);
+    }
+
+    template <> void Class::set(field_t field, const std::wstring& value)
+    {
+        JNIEnv* env = jni::env();
+
+#ifdef _WIN32
+        jobject handle = env->NewString((const jchar*) value.c_str(), jsize(value.length()));
+#else
+        auto jstr = toJString(value.c_str(), value.length());
+        jobject handle = env->NewString(jstr.c_str(), jsize(jstr.length()));
+#endif
+        env->SetStaticObjectField(getHandle(), field, handle);
+        env->DeleteLocalRef(handle);
+    }
+
+    template <> void Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        env()->CallStaticVoidMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+    }
+
+    template <> bool Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticBooleanMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result != 0;
+    }
+
+    template <> byte_t Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticByteMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> wchar_t Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticCharMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> short Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticShortMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> int Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticIntMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> long long Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticLongMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> float Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticFloatMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> double Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticDoubleMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> std::string Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticObjectMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return toString(result);
+    }
+
+    template <> std::wstring Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticObjectMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return toWString(result);
+    }
+
+    template <> jni::Object Class::callStaticMethod(method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallStaticObjectMethodA(getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return Object(result, DeleteLocalInput);
+    }
+
+    template <> void Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        env()->CallNonvirtualVoidMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+    }
+
+    template <> bool Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualBooleanMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result != 0;
+    }
+
+    template <> byte_t Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualByteMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> wchar_t Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualCharMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> short Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualShortMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> int Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualIntMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> long long Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualLongMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <>  float Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualFloatMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> double Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualDoubleMethodA(obj, getHandle(), method, (jvalue*) args);
+        handleJavaExceptions();
+        return result;
+    }
+
+    template <> std::string Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualObjectMethodA(obj, getHandle(), method, (jvalue*)args);
+        handleJavaExceptions();
+        return toString(result);
+    }
+
+    template <> std::wstring Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualObjectMethodA(obj, getHandle(), method, (jvalue*)args);
+        handleJavaExceptions();
+        return toWString(result);
+    }
+
+    template <> Object Class::callExactMethod(jobject obj, method_t method, internal::value_t* args) const
+    {
+        auto result = env()->CallNonvirtualObjectMethodA(obj, getHandle(), method, (jvalue*)args);
+        handleJavaExceptions();
+        return Object(result, DeleteLocalInput);
+    }
+
+    Object Class::newObject(method_t constructor, internal::value_t* args) const
+    {
+        jobject ref = env()->NewObjectA(getHandle(), constructor, (jvalue*)args);
+        handleJavaExceptions();
+        return Object(ref, DeleteLocalInput);
+    }
+
+    /*
+        Enum Implementation
+     */
+
+    Enum::Enum(const char* name) : Class(name)
+    {
+        _name  = "L";
+        _name += name;
+        _name += ";";
+    }
+
+    Object Enum::get(const char* name) const
+    {
+        return Class::get<Object>(getStaticField(name, _name.c_str()));
+    }
+
+    /*
+        Array Implementation
+     */
+
+    template <> Array<bool>::Array(long length) : Object(env()->NewBooleanArray(length)), _length(length)
+    {
+    }
+
+    template <> Array<byte_t>::Array(long length) : Object(env()->NewByteArray(length)), _length(length)
+    {
+    }
+
+    template <> Array<wchar_t>::Array(long length) : Object(env()->NewCharArray(length)), _length(length)
+    {
+    }
+
+    template <> Array<short>::Array(long length) : Object(env()->NewShortArray(length)), _length(length)
+    {
+    }
+
+    template <> Array<int>::Array(long length) : Object(env()->NewIntArray(length)), _length(length)
+    {
+    }
+
+    template <> Array<long long>::Array(long length) : Object(env()->NewLongArray(length)), _length(length)
+    {
+    }
+
+    template <> Array<float>::Array(long length) : Object(env()->NewFloatArray(length)), _length(length)
+    {
+    }
+
+    template <> Array<double>::Array(long length) : Object(env()->NewDoubleArray(length)), _length(length)
+    {
+    }
+
+    template <> Array<std::string>::Array(long length) : Object(env()->NewObjectArray(length, Class("java/lang/String").getHandle(), nullptr)), _length(length)
+    {
+    }
+
+    template <> Array<std::wstring>::Array(long length) : Object(env()->NewObjectArray(length, Class("java/lang/String").getHandle(), nullptr)), _length(length)
+    {
+    }
+
+    template <> Array<Object>::Array(long length) : Object(env()->NewObjectArray(length, Class("java/lang/Object").getHandle(), nullptr)), _length(length)
+    {
+    }
+
+    template <> Array<Object>::Array(long length, const Class& type) : Object(env()->NewObjectArray(length, type.getHandle(), nullptr)), _length(length)
+    {
+    }
+
+    template <> bool Array<bool>::getElement(long index) const
+    {
+        jboolean output;
+        env()->GetBooleanArrayRegion(jbooleanArray(getHandle()), index, 1, &output);
+        handleJavaExceptions();
+        return output;
+    }
+
+    template <> byte_t Array<byte_t>::getElement(long index) const
+    {
+        jbyte output;
+        env()->GetByteArrayRegion(jbyteArray(getHandle()), index, 1, &output);
+        handleJavaExceptions();
+        return output;
+    }
+
+    template <> wchar_t Array<wchar_t>::getElement(long index) const
+    {
+        jchar output;
+        env()->GetCharArrayRegion(jcharArray(getHandle()), index, 1, &output);
+        handleJavaExceptions();
+        return output;
+    }
+
+    template <> short Array<short>::getElement(long index) const
+    {
+        jshort output;
+        env()->GetShortArrayRegion(jshortArray(getHandle()), index, 1, &output);
+        handleJavaExceptions();
+        return output;
+    }
+
+    template <> int Array<int>::getElement(long index) const
+    {
+        jint output;
+        env()->GetIntArrayRegion(jintArray(getHandle()), index, 1, &output);
+        handleJavaExceptions();
+        return output;
+    }
+
+    template <> long long Array<long long>::getElement(long index) const
+    {
+        jlong output;
+        env()->GetLongArrayRegion(jlongArray(getHandle()), index, 1, &output);
+        handleJavaExceptions();
+        return output;
+    }
+
+    template <> float Array<float>::getElement(long index) const
+    {
+        jfloat output;
+        env()->GetFloatArrayRegion(jfloatArray(getHandle()), index, 1, &output);
+        handleJavaExceptions();
+        return output;
+    }
+
+    template <> double Array<double>::getElement(long index) const
+    {
+        jdouble output;
+        env()->GetDoubleArrayRegion(jdoubleArray(getHandle()), index, 1, &output);
+        handleJavaExceptions();
+        return output;
+    }
+
+    template <> std::string Array<std::string>::getElement(long index) const
+    {
+        jobject output = env()->GetObjectArrayElement(jobjectArray(getHandle()), index);
+        handleJavaExceptions();
+        return toString(output);
+    }
+
+    template <> std::wstring Array<std::wstring>::getElement(long index) const
+    {
+        jobject output = env()->GetObjectArrayElement(jobjectArray(getHandle()), index);
+        handleJavaExceptions();
+        return toWString(output);
+    }
+
+    template <> Object Array<Object>::getElement(long index) const
+    {
+        jobject output = env()->GetObjectArrayElement(jobjectArray(getHandle()), index);
+        handleJavaExceptions();
+        return Object(output, DeleteLocalInput);
+    }
+
+    template <> void Array<bool>::setElement(long index, bool value)
+    {
+        jboolean jvalue = value;
+        env()->SetBooleanArrayRegion(jbooleanArray(getHandle()), index, 1, &jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<byte_t>::setElement(long index, byte_t value)
+    {
+        jbyte jvalue = value;
+        env()->SetByteArrayRegion(jbyteArray(getHandle()), index, 1, &jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<wchar_t>::setElement(long index, wchar_t value)
+    {
+        jchar jvalue = value;
+        env()->SetCharArrayRegion(jcharArray(getHandle()), index, 1, &jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<short>::setElement(long index, short value)
+    {
+        jshort jvalue = value;
+        env()->SetShortArrayRegion(jshortArray(getHandle()), index, 1, &jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<int>::setElement(long index, int value)
+    {
+        jint jvalue = value;
+        env()->SetIntArrayRegion(jintArray(getHandle()), index, 1, &jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<long long>::setElement(long index, long long value)
+    {
+        jlong jvalue = value;
+        env()->SetLongArrayRegion(jlongArray(getHandle()), index, 1, &jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<float>::setElement(long index, float value)
+    {
+        jfloat jvalue = value;
+        env()->SetFloatArrayRegion(jfloatArray(getHandle()), index, 1, &jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<double>::setElement(long index, double value)
+    {
+        jdouble jvalue = value;
+        env()->SetDoubleArrayRegion(jdoubleArray(getHandle()), index, 1, &jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<std::string>::setElement(long index, std::string value)
+    {
+        JNIEnv* env = jni::env();
+
+        jobject jvalue = env->NewStringUTF(value.c_str());;
+        env->SetObjectArrayElement(jobjectArray(getHandle()), index, jvalue);
+        env->DeleteLocalRef(jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<std::wstring>::setElement(long index, std::wstring value)
+    {
+        JNIEnv* env = jni::env();
+
+#ifdef _WIN32
+        jobject jvalue = env->NewString((const jchar*) value.c_str(), jsize(value.length()));
+#else
+        auto jstr = toJString(value.c_str(), value.length());
+        jobject jvalue = env->NewString(jstr.c_str(), jsize(jstr.length()));
+#endif
+        env->SetObjectArrayElement(jobjectArray(getHandle()), index, jvalue);
+        env->DeleteLocalRef(jvalue);
+        handleJavaExceptions();
+    }
+
+    template <> void Array<Object>::setElement(long index, Object value)
+    {
+        env()->SetObjectArrayElement(jobjectArray(getHandle()), index, value.getHandle());
+        handleJavaExceptions();
+    }
+
+    /*
+        Vm Implementation
+     */
+
+    typedef jint (JNICALL *CreateVm_t)(JavaVM**, void**, void*);
+
+#ifndef _WIN32
+    static bool fileExists(const std::string& filePath)
+    {
+        return access(filePath.c_str(), F_OK) != -1;
+    }
+
+    template <size_t N>
+    static ssize_t readlink_safe(const char *pathname, char (&output)[N]) {
+        auto len = readlink(pathname, output, N - 1);
+        if (len > 0) {
+            output[len] = '\0';
+        }
+        return len;
+    }
+
+    static std::pair<ssize_t, std::string>
+    readlink_as_string(const char *pathname) {
+        char buf[2048] = {};
+        auto len = readlink_safe(pathname, buf);
+        if (len <= 0) {
+            return {len, {}};
+        }
+        return {len, std::string{buf, static_cast<size_t>(len)}};
+    }
+    static std::string readlink_deep(const char *pathname) {
+        std::string prev{pathname};
+        ssize_t len = 0;
+        std::string next;
+        while (true) {
+            std::tie(len, next) = readlink_as_string(prev.c_str());
+            if (!next.empty()) {
+                prev = next;
+            } else {
+                return prev;
+            }
+        }
+    }
+
+    static std::string drop_path_components(const std::string & path, size_t num_components) {
+        size_t pos = std::string::npos;
+        size_t slash_pos = std::string::npos;
+        for (size_t i = 0; i < num_components; ++i) {
+            slash_pos = path.find_last_of('/', pos);
+            if (slash_pos == std::string::npos || slash_pos == 0) {
+                return {};
+            }
+            pos = slash_pos - 1;
+        }
+        return std::string{path.c_str(), slash_pos};
+    }
+#endif
+    static std::string detectJvmPath()
+    {
+        std::string result;
+
+#ifdef _WIN32
+
+        BYTE buffer[1024];
+        DWORD size = sizeof(buffer);
+        HKEY versionKey;
+
+        // Search via registry entries.
+        if (::RegOpenKeyA(HKEY_LOCAL_MACHINE, "Software\\JavaSoft\\Java Runtime Environment\\", &versionKey) == ERROR_SUCCESS)
+        {
+            if (::RegQueryValueEx(versionKey, "CurrentVersion", NULL, NULL, buffer, &size) == ERROR_SUCCESS)
+            {
+                HKEY libKey;
+
+                std::string keyName = std::string("Software\\JavaSoft\\Java Runtime Environment\\") + (const char*)buffer;
+
+                ::RegCloseKey(versionKey);
+
+                if (::RegOpenKeyA(HKEY_LOCAL_MACHINE, keyName.c_str(), &libKey) == ERROR_SUCCESS)
+                {
+                    size = sizeof(buffer);
+
+                    if (::RegQueryValueEx(libKey, "RuntimeLib", NULL, NULL, buffer, &size) == ERROR_SUCCESS)
+                    {
+                        result = (const char*)buffer;
+                    }
+
+                    ::RegCloseKey(libKey);
+                }
+            }
+        }
+
+        if (result.length() == 0)
+        {
+            // Could not locate via registry. Try the JAVA_HOME environment variable.
+            if ((size = ::GetEnvironmentVariableA("JAVA_HOME", (LPSTR) buffer, sizeof(buffer))) != 0)
+            {
+                std::string javaHome((const char*) buffer, size);
+
+                // Different installers put in different relative locations.
+                std::string options[] = {
+                    javaHome + "\\jre\\bin\\client\\jvm.dll",
+                    javaHome + "\\jre\\bin\\server\\jvm.dll",
+                    javaHome + "\\bin\\client\\jvm.dll",
+                    javaHome + "\\bin\\server\\jvm.dll"
+                };
+
+                for (auto const& i : options)
+                    if (fileExists(i))
+                        return i;
+            }
+        }
+
+#else
+
+        const char* javaHome = getenv("JAVA_HOME");
+        if (javaHome != nullptr) {
+            #ifdef __APPLE__
+            std::string libJvmPath = std::string(javaHome) + "/jre/lib/server/libjvm.dylib";
+            #else
+            std::string libJvmPath = std::string(javaHome) + "/jre/lib/amd64/server/libjvm.so";
+            #endif
+            result = libJvmPath;
+        } else {
+            std::string path = readlink_deep("/usr/bin/java");
+            if (!path.empty()) {
+                // drop bin and java
+                auto javaHome = drop_path_components(path, 2);
+                if (!javaHome.empty()) {
+                    std::string options[] = {
+                        javaHome + "/jre/lib/amd64/server/libjvm.so",
+                        javaHome + "/jre/lib/amd64/client/libjvm.so",
+                        javaHome + "/jre/lib/server/libjvm.so",
+                        javaHome + "/jre/lib/client/libjvm.so",
+                        javaHome + "/lib/server/libjvm.so",
+                        javaHome + "/lib/client/libjvm.so",
+                    };
+
+                    for (auto const &i : options) {
+                        fprintf(stderr, "trying %s\n", i.c_str());
+                        if (fileExists(i)) {
+                            return i;
+                        }
+                    }
+                }
+            }
+            // Best guess so far.
+            result = "/usr/lib/jvm/default-java/jre/lib/amd64/server/libjvm.so";
+        }
+
+#endif // _WIN32
+
+        return result;
+    }
+
+    Vm::Vm(const char* path_)
+    {
+        bool expected = false;
+
+        std::string path = path_ ? path_ : detectJvmPath();
+
+        if (path.length() == 0)
+            throw InitializationException("Could not locate Java Virtual Machine");
+        if (!isVm.compare_exchange_strong(expected, true))
+            throw InitializationException("Java Virtual Machine already initialized");
+
+        if (javaVm == nullptr)
+        {
+            JNIEnv* env;
+            JavaVMInitArgs args = {};
+            args.version = JNI_VERSION_1_2;
+
+#ifdef _WIN32
+
+            HMODULE lib = ::LoadLibraryA(path.c_str());
+
+            if (lib == NULL)
+            {
+                isVm.store(false);
+                throw InitializationException("Could not load JVM library");
+            }
+
+            CreateVm_t JNI_CreateJavaVM = (CreateVm_t) ::GetProcAddress(lib, "JNI_CreateJavaVM");
+
+            /**
+                Is your debugger catching an error here?  This is normal.  Just continue. The JVM
+                intentionally does this to test how the OS handles memory-reference exceptions.
+             */
+            if (JNI_CreateJavaVM == NULL || JNI_CreateJavaVM(&javaVm, (void**) &env, &args) != 0)
+            {
+                isVm.store(false);
+                ::FreeLibrary(lib);
+                throw InitializationException("Java Virtual Machine failed during creation");
+            }
+
+#else
+
+            void* lib = ::dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+
+            if (lib == NULL)
+            {
+                isVm.store(false);
+                throw InitializationException("Could not load JVM library");
+            }
+
+            CreateVm_t JNI_CreateJavaVM = (CreateVm_t) ::dlsym(lib, "JNI_CreateJavaVM");
+
+            if (JNI_CreateJavaVM == NULL || JNI_CreateJavaVM(&javaVm, (void**) &env, &args) != 0)
+            {
+                isVm.store(false);
+                ::dlclose(lib);
+                throw InitializationException("Java Virtual Machine failed during creation");
+            }
+
+#endif // _WIN32
+        }
+    }
+
+    Vm::~Vm()
+    {
+        /*
+            Note that you can't ever *really* unload the JavaVM. If you call
+            DestroyJavaVM(), you can't then call JNI_CreateJavaVM() again.
+            So, instead we just flag it as "gone".
+         */
+        isVm.store(false);
+    }
+
+    // Forward Declarations
+    JNIEnv* env();
+
+#ifndef _WIN32
+    extern std::basic_string<jchar> toJString(const wchar_t* str, size_t length);
+#endif
+
+    namespace internal
+    {
+        // Base Type Conversions
+        void valueArg(value_t* v, bool a)                   { ((jvalue*) v)->z = jboolean(a); }
+        void valueArg(value_t* v, byte_t a)                 { ((jvalue*) v)->b = a; }
+        void valueArg(value_t* v, wchar_t a)                { ((jvalue*) v)->c = jchar(a); }    // Note: Possible truncation.
+        void valueArg(value_t* v, short a)                  { ((jvalue*) v)->s = a; }
+        void valueArg(value_t* v, int a)                    { ((jvalue*) v)->i = a; }
+        void valueArg(value_t* v, long long a)              { ((jvalue*) v)->j = a; }
+        void valueArg(value_t* v, float a)                  { ((jvalue*) v)->f = a; }
+        void valueArg(value_t* v, double a)                 { ((jvalue*) v)->d = a; }
+        void valueArg(value_t* v, jobject a)                { ((jvalue*) v)->l = a; }
+        void valueArg(value_t* v, const Object& a)          { ((jvalue*) v)->l = a.getHandle(); }
+        void valueArg(value_t* v, const Object* const& a)   { ((jvalue*) v)->l = a ? a->getHandle() : nullptr; }
+
+        /*
+            Object Implementations
+         */
+
+        std::string valueSig(const Object* obj)
+        {
+            if (obj == nullptr || obj->isNull())
+                return "Ljava/lang/Object;";    // One can always hope...
+
+            std::string name = Class(obj->getClass(), Object::Temporary).getName();
+
+            // Change from "java.lang.Object" format to "java/lang/Object";
+            for (size_t i = 0; i < name.length(); ++i)
+                if (name[i] == '.')
+                    name[i] = '/';
+
+            return "L" + name + ";";
+        }
+
+        /*
+            String Implementations
+         */
+
+        void valueArg(value_t* v, const std::string& a)
+        {
+            ((jvalue*) v)->l = env()->NewStringUTF(a.c_str());
+        }
+
+        template <> void cleanupArg<std::string>(value_t* v)
+        {
+            env()->DeleteLocalRef(((jvalue*) v)->l);
+        }
+
+        void valueArg(value_t* v, const char* a)
+        {
+            ((jvalue*) v)->l = env()->NewStringUTF(a);
+        }
+
+        void valueArg(value_t* v, std::nullptr_t)
+        {
+            ((jvalue*) v)->l = nullptr;
+        }
+
+        template <> void cleanupArg<const char*>(value_t* v)
+        {
+            env()->DeleteLocalRef(((jvalue*) v)->l);
+        }
+#ifdef _WIN32
+
+        void valueArg(value_t* v, const std::wstring& a)
+        {
+            ((jvalue*) v)->l = env()->NewString((const jchar*) a.c_str(), jsize(a.length()));
+        }
+
+        void valueArg(value_t* v, const wchar_t* a)
+        {
+            ((jvalue*) v)->l = env()->NewString((const jchar*) a, jsize(std::wcslen(a)));
+        }
+#else
+
+        void valueArg(value_t* v, const std::wstring& a)
+        {
+            auto jstr = toJString(a.c_str(), a.length());
+            ((jvalue*) v)->l = env()->NewString(jstr.c_str(), jsize(jstr.length()));
+        }
+
+        void valueArg(value_t* v, const wchar_t* a)
+        {
+            auto jstr = toJString(a, std::wcslen(a));
+            ((jvalue*) v)->l = env()->NewString(jstr.c_str(), jsize(jstr.length()));
+        }
+
+#endif
+
+        template <> void cleanupArg<const std::wstring*>(value_t* v)
+        {
+            env()->DeleteLocalRef(((jvalue*) v)->l);
+        }
+
+        template <> void cleanupArg<const wchar_t*>(value_t* v)
+        {
+            env()->DeleteLocalRef(((jvalue*) v)->l);
+        }
+
+        long getArrayLength(jarray array)
+        {
+            return env()->GetArrayLength(array);
+        }
+    }
+}
+

--- a/thirdparty/openxr/src/external/jnipp/jnipp.h
+++ b/thirdparty/openxr/src/external/jnipp/jnipp.h
@@ -1,0 +1,1092 @@
+#ifndef _JNIPP_H_
+#define _JNIPP_H_ 1
+
+// Standard Dependencies
+#include <cstring>
+#include <stdexcept>        // For std::runtime_error
+#include <string>
+
+// Forward Declarations
+struct JNIEnv_;
+struct _JNIEnv;
+struct JavaVM_;
+struct _JavaVM;
+struct _jmethodID;
+struct _jfieldID;
+class  _jobject;
+class  _jclass;
+class  _jarray;
+
+namespace jni
+{
+    // JNI Base Types
+#ifdef __ANDROID__
+    typedef _JNIEnv     JNIEnv;
+    typedef _JavaVM JavaVM;
+#else
+    typedef JNIEnv_     JNIEnv;
+    typedef JavaVM_ JavaVM;
+#endif
+
+    typedef _jobject* jobject;
+    typedef _jclass* jclass;
+    typedef _jarray* jarray;
+
+    /**
+        You can save a method via its handle using Class::getMethod() if it is
+        going to be used often. This saves Object::call() from having to locate
+        the method each time by name.
+
+        Note that these handles are global and do not need to be deleted.
+     */
+    typedef _jmethodID* method_t;
+
+    /**
+        You can save a field via its handle using Class::getField() if it is
+        going to be used often. This saves Object::set() and Object::get() from
+        having to locate the field each time by name.
+
+        Note that these handles are global and do not need to be deleted.
+     */
+    typedef _jfieldID* field_t;
+
+    /**
+        Type used to denote the Java byte type.
+     */
+    typedef unsigned char byte_t;
+
+#ifdef JNIPP_EXCEPTION_CLASS
+
+    /**
+        Base class for thrown Exceptions.
+     */
+    typedef JNIPP_EXCEPTION_CLASS Exception;
+
+#else
+
+    /**
+        Base class for thrown Exceptions.
+     */
+    typedef std::runtime_error Exception;
+
+#endif // JNIPP_EXCEPTION_CLASS
+
+    // Foward Declarations
+    class Object;
+
+    /**
+        This namespace is for messy implementation details only. It is not a part
+        of the external API and is subject to change at any time. It is only in a
+        header file due to the fact it is required by some template functions.
+
+        Long story short...  this stuff be messy, yo.
+     */
+    namespace internal
+    {
+        /*
+            Signature Generation
+         */
+
+        inline std::string valueSig(const void*) { return "V"; }
+        inline std::string valueSig(const bool*) { return "Z"; }
+        inline std::string valueSig(const byte_t*) { return "B"; }
+        inline std::string valueSig(const wchar_t*) { return "C"; }
+        inline std::string valueSig(const short*) { return "S"; }
+        inline std::string valueSig(const int*) { return "I"; }
+        inline std::string valueSig(const long long*) { return "J"; }
+        inline std::string valueSig(const float*) { return "F"; }
+        inline std::string valueSig(const double*) { return "D"; }
+        inline std::string valueSig(const std::string*) { return "Ljava/lang/String;"; }
+        inline std::string valueSig(const std::wstring*) { return "Ljava/lang/String;"; }
+        inline std::string valueSig(const char* const*) { return "Ljava/lang/String;"; }
+        inline std::string valueSig(const wchar_t* const*) { return "Ljava/lang/String;"; }
+        std::string valueSig(const Object* obj);
+        inline std::string valueSig(const Object* const* obj) { return valueSig(obj ? *obj : nullptr); }
+
+        template <int n, class TArg>
+        inline std::string valueSig(const TArg(*arg)[n]) { return valueSig((const TArg* const*)arg); }
+
+        inline std::string sig() { return ""; }
+
+        template <class TArg, class... TArgs>
+        std::string sig(const TArg& arg, const TArgs&... args) {
+            return valueSig(&arg) + sig(args...);
+        }
+
+        /*
+            Argument Conversion
+         */
+
+        typedef long long value_t;
+
+        void valueArg(value_t* v, bool a);
+        void valueArg(value_t* v, byte_t a);
+        void valueArg(value_t* v, wchar_t a);
+        void valueArg(value_t* v, short a);
+        void valueArg(value_t* v, int a);
+        void valueArg(value_t* v, long long a);
+        void valueArg(value_t* v, float a);
+        void valueArg(value_t* v, double a);
+        void valueArg(value_t* v, jobject a);
+        void valueArg(value_t* v, const Object& a);
+        void valueArg(value_t* v, const Object* const& a);
+        void valueArg(value_t* v, const std::string& a);
+        void valueArg(value_t* v, const char* a);
+        void valueArg(value_t* v, const std::wstring& a);
+        void valueArg(value_t* v, const wchar_t* a);
+        void valueArg(value_t* v, std::nullptr_t);
+
+        inline void args(value_t*) {}
+
+        template <class TArg, class... TArgs>
+        void args(value_t* values, const TArg& arg, const TArgs&... args) {
+            valueArg(values, arg);
+            internal::args(values + 1, args...);
+        }
+
+        template <class TArg> void cleanupArg(value_t* /* value */) {}
+        template <>           void cleanupArg<std::string>(value_t* value);
+        template <>           void cleanupArg<std::wstring>(value_t* value);
+        template <>           void cleanupArg<const char*>(value_t* value);
+        template <>           void cleanupArg<const wchar_t*>(value_t* value);
+
+        template <class TArg = void, class... TArgs>
+        void cleanupArgs(value_t* values) {
+            cleanupArg<TArg>(values);
+            cleanupArgs<TArgs...>(values + 1);
+        }
+
+        template <>
+        inline void cleanupArgs<void>(value_t* /* values */) {}
+
+        template <class... TArgs>
+        class ArgArray
+        {
+        public:
+            ArgArray(const TArgs&... args) {
+                std::memset(this, 0, sizeof(ArgArray<TArgs...>));
+                internal::args(values, args...);
+            }
+
+            ~ArgArray() {
+                cleanupArgs<TArgs...>(values);
+            }
+
+            value_t values[sizeof...(TArgs)];
+        };
+
+        /* specialization for empty array - no args. Avoids "empty array" warning. */
+        template <>
+        class ArgArray<>
+        {
+        public:
+            ArgArray() {
+                std::memset(this, 0, sizeof(ArgArray<>));
+            }
+
+            ~ArgArray() {
+            }
+
+            value_t values[1];
+        };
+        long getArrayLength(jarray array);
+
+        /**
+         * @brief Used as a tag type for dispatching internally based on return type.
+         *
+         * @tparam T The type to wrap.
+         */
+        template<typename T>
+        struct ReturnTypeWrapper
+        {
+            using type = T;
+        };
+    }
+
+    /**
+        Initialises the Java Native Interface with the given JNIEnv handle, which
+        gets passed into a native function which is called from Java. This only
+        needs to be done once per process - further calls are no-ops.
+        \param env A JNI environment handle.
+     */
+    void init(JNIEnv* env);
+    /**
+        Initialises the Java Native Interface with the given JavaVM handle,
+        which may be accessible. This (or the other overload) only needs to be
+        done once per process - further calls are no-ops.
+        \param vm A JNI VM handle.
+     */
+    void init(JavaVM* vm);
+
+    /**
+        Get the appropriate JNI environment for this thread.
+     */
+    JNIEnv* env();
+
+    /**
+        Object corresponds with a `java.lang.Object` instance. With an Object,
+        you can then call Java methods, and access fields on the Object. To
+        instantiate an Object of a given class, use the `Class` class.
+     */
+    class Object
+    {
+    public:
+        /** Flags which can be passed to the Object constructor. */
+        enum ScopeFlags
+        {
+            Temporary = 1,    ///< Temporary object. Do not create a global reference.
+            DeleteLocalInput = 2     ///< The input reference is temporary and can be deleted.
+        };
+
+        /** Default constructor. Creates a `null` object. */
+        Object() noexcept;
+
+        /**
+            Copies a reference to another Object. Note that this is not a deep
+            copy operation, and both Objects will reference the same Java
+            Object.
+            \param other The Object to copy.
+         */
+        Object(const Object& other);
+
+        /**
+            Move constructor. Copies the Object reference from the supplied
+            Object, and then nulls the supplied Object reference.
+            \param other The Object to move.
+         */
+        Object(Object&& other) noexcept;
+
+        /**
+            Creates an Object from a local JNI reference.
+            \param ref The local JNI reference.
+            \param scopeFlags Bitmask of ScopeFlags values.
+         */
+        Object(jobject ref, int scopeFlags = 0);
+
+        /**
+            Destructor. Releases this reference on the Java Object so it can be
+            picked up by the garbage collector.
+         */
+        virtual ~Object() noexcept;
+
+        /**
+            Assignment operator. Copies the object reference from the supplied
+            Object. They will now both point to the same Java Object.
+            \param other The Object to copy.
+            \return This Object.
+         */
+        Object& operator=(const Object& other);
+
+        /**
+            Assignment operator. Moves the object reference from the supplied
+            Object to this one, and leaves the other one as a null.
+            \param other The Object to move.
+            \return This Object.
+         */
+        Object& operator=(Object&& other);
+
+        /**
+            Tells whether the two Objects refer to the same Java Object.
+            \param other the Object to compare with.
+            \return `true` if the same, `false` otherwise.
+         */
+        bool operator==(const Object& other) const;
+
+        /**
+            Tells whether the two Objects refer to the same Java Object.
+            \param other the Object to compare with.
+            \return `true` if the different, `false` otherwise.
+         */
+        bool operator!=(const Object& other) const { return !operator==(other); }
+
+        /**
+            Calls the given method on this Object. The method should have no
+            parameters. Note that the return type should be explicitly stated
+            in the function call.
+            \param method A method handle which applies to this Object.
+            \return The method's return value.
+         */
+        template <class TReturn>
+        TReturn call(method_t method) const { return callMethod(method, nullptr, internal::ReturnTypeWrapper<TReturn>{}); }
+
+        /**
+            Calls the method on this Object with the given name, and no arguments.
+            Note that the return type should be explicitly stated in the function
+            call.
+            \param name The name of the method to call (with optional signature).
+            \return The method's return value.
+         */
+        template <class TReturn>
+        TReturn call(const char* name) const {
+            if (std::strstr(name, "()"))
+                return call<TReturn>(getMethod(name));
+
+            // No signature supplied. Generate our own.
+            method_t method = getMethod(name, ("()" + internal::valueSig((TReturn*) nullptr)).c_str());
+            return call<TReturn>(method);
+        }
+
+        /**
+            Calls the method on this Object and supplies the given arguments.
+            Note that the return type should be explicitly stated in the function
+            call.
+            \param method The method to call.
+            \param args Arguments to supply to the method.
+            \return The method's return value.
+         */
+        template <class TReturn, class... TArgs>
+        TReturn call(method_t method, const TArgs&... args) const {
+            internal::ArgArray<TArgs...> transform(args...);
+            return callMethod(method, transform.values, internal::ReturnTypeWrapper<TReturn>{});
+        }
+
+        /**
+            Calls the method on this Object and supplies the given arguments.
+            Note that the return type should be explicitly stated in the function
+            call. The type signature of the method is calculated by the types of
+            the supplied arguments.
+            \param name The name of the method to call (and optional signature).
+            \param args Arguments to supply to the method.
+            \return The method's return value.
+         */
+        template <class TReturn, class... TArgs>
+        TReturn call(const char* name, const TArgs&... args) const {
+            if (std::strchr(name, '('))
+                return call<TReturn>(getMethod(name), args...);
+
+            std::string sig = "(" + internal::sig(args...) + ")" + internal::valueSig((TReturn*) nullptr);
+            method_t method = getMethod(name, sig.c_str());
+            return call<TReturn>(method, args...);
+        }
+
+        /**
+            Gets a field value from this Object. The field must belong to the
+            Object's class. Note that the field type should be explicitly stated
+            in the function call.
+            \param field Identifier for the field to retrieve.
+            \return The field's value.
+         */
+        template <class TType>
+        TType get(field_t field) const {
+            // If you get a compile error here, then you've asked for a type
+            // we don't know how to get from JNI directly.
+            return getFieldValue(field, internal::ReturnTypeWrapper<TType>{});
+        }
+
+        /**
+            Gets a field value from this Object. The field must belong to the
+            Object's class. Note that the field type should be explicitly stated
+            in the function call.
+            \param name The name of the field to retrieve.
+            \return The field's value.
+         */
+        template <class TType>
+        TType get(const char* name) const {
+            field_t field = getField(name, internal::valueSig((TType*) nullptr).c_str());
+            return get<TType>(field);
+        }
+
+        /**
+            Sets a field's value on this Object. The field must belong to the
+            Object's class, and the parameter's type should correspond to the
+            type of the field.
+            \param field The field to set the value to.
+            \param value The value to set.
+         */
+        template <class TType>
+        void set(field_t field, const TType& value);
+
+        /**
+            Sets a field's value on this Object. The field must belong to the
+            Object's class, and the parameter's type should correspond to the
+            type of the field.
+            \param name The name of the field to set the value to.
+            \param value The value to set.
+         */
+        template <class TType>
+        void set(const char* name, const TType& value) {
+            field_t field = getField(name, internal::valueSig((TType*) nullptr).c_str());
+            set(field, value);
+        }
+
+        /**
+            Tells whether this Object is currently a `null` pointer.
+            \return `true` if `null`, `false` if it references an object.
+         */
+        bool isNull() const noexcept;
+
+        /**
+            Gets a handle for this Object's class. Ideally, this should just return a Class,
+            but C++ won't let us do that that.
+            \return The Object's Class's handle.
+         */
+        jclass getClass() const;
+
+        /**
+            Gets the underlying JNI jobject handle.
+            \return The JNI handle.
+         */
+        jobject getHandle() const noexcept { return _handle; }
+
+        /**
+            Create a local reference for the underlying JNI handle.
+            \return The local reference.
+         */
+        jobject makeLocalReference() const;
+
+    private:
+        // Helper Functions
+        method_t getMethod(const char* name, const char* signature) const;
+        method_t getMethod(const char* nameAndSignature) const;
+        field_t getField(const char* name, const char* signature) const;
+
+        void callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<void> const&) const;
+        bool callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<bool> const&) const;
+        byte_t callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<byte_t> const&) const;
+        wchar_t callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<wchar_t> const&) const;
+        short callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<short> const&) const;
+        int callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<int> const&) const;
+        long long callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<long long> const&) const;
+        float callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<float> const&) const;
+        double callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<double> const&) const;
+        std::string callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<std::string> const&) const;
+        std::wstring callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<std::wstring> const&) const;
+        jni::Object callMethod(method_t method, internal::value_t* args, internal::ReturnTypeWrapper<jni::Object> const&) const;
+
+
+        void getFieldValue(field_t field, internal::ReturnTypeWrapper<void> const&) const;
+        bool getFieldValue(field_t field, internal::ReturnTypeWrapper<bool> const&) const;
+        byte_t getFieldValue(field_t field, internal::ReturnTypeWrapper<byte_t> const&) const;
+        wchar_t getFieldValue(field_t field, internal::ReturnTypeWrapper<wchar_t> const&) const;
+        short getFieldValue(field_t field, internal::ReturnTypeWrapper<short> const&) const;
+        int getFieldValue(field_t field, internal::ReturnTypeWrapper<int> const&) const;
+        long long getFieldValue(field_t field, internal::ReturnTypeWrapper<long long> const&) const;
+        float getFieldValue(field_t field, internal::ReturnTypeWrapper<float> const&) const;
+        double getFieldValue(field_t field, internal::ReturnTypeWrapper<double> const&) const;
+        std::string getFieldValue(field_t field, internal::ReturnTypeWrapper<std::string> const&) const;
+        std::wstring getFieldValue(field_t field, internal::ReturnTypeWrapper<std::wstring> const&) const;
+        jni::Object getFieldValue(field_t field, internal::ReturnTypeWrapper<jni::Object> const&) const;
+
+        // Instance Variables
+        jobject _handle;
+        mutable jclass _class;
+        bool _isGlobal;
+    };
+
+    /**
+        Class corresponds with `java.lang.Class`, and allows you to instantiate
+        Objects and get class members such as methods and fields.
+     */
+    class Class : protected Object
+    {
+    public:
+        /**
+            Creates a null class reference.
+         */
+        Class() : Object() {}
+
+        /**
+            Obtains a class reference to the Java class with the given qualified
+            name.
+            \param name The qualified class name (e.g. "java/lang/String").
+         */
+        Class(const char* name);
+
+        /**
+            Creates a Class object by JNI reference.
+            \param ref The JNI class reference.
+            \param scopeFlags Bitmask of Object::ScopeFlags.
+         */
+        Class(jclass ref, int scopeFlags = Temporary);
+
+        /**
+            Tells whether this Class is null or valid.
+            \return `true` if null, `false` if valid.
+         */
+        bool isNull() const noexcept { return Object::isNull(); }
+
+        /**
+            Creates a new instance of this Java class and returns a reference to
+            it. The item's parameterless constructor is called.
+            \return The created instance.
+         */
+        Object newInstance() const;
+
+        /**
+            Creates a new instance of this Java class and returns a reference to
+            it.
+            \param constructor The constructor to call.
+            \param args Arguments to supply to the constructor.
+            \return The created instance.
+         */
+        template <class... TArgs>
+        Object newInstance(method_t constructor, const TArgs&... args) const {
+            internal::ArgArray<TArgs...> transform(args...);
+            return newObject(constructor, transform.values);
+        }
+
+        /**
+            Creates a new instance of this Java class and returns a reference to
+            it. The constructor signature is determined by the supplied parameters,
+            and the parameters are then passed to the constructor.
+            \param args Arguments to supply to the constructor.
+            \return The created instance.
+         */
+        template <class... TArgs>
+        Object newInstance(const TArgs&... args) const {
+            method_t constructor = getMethod("<init>", ("(" + internal::sig(args...) + ")V").c_str());
+            return newInstance(constructor, args...);
+        }
+
+        /**
+            Gets a handle to the field with the given name and type signature.
+            This handle can then be stored so that the field does not need to
+            be looked up by name again. It does not need to be deleted.
+            \param name The name of the field.
+            \param signature The JNI type signature of the field.
+            \return The field ID.
+         */
+        field_t getField(const char* name, const char* signature) const;
+
+        /**
+            Gets a handle to the field with the given name and the supplied type.
+            This handle can then be stored so that the field does not need to
+            be looked up by name again. It does not need to be deleted.
+            \param name The name of the field.
+            \return The field ID.
+         */
+        template<typename TType>
+        field_t getField(const char* name) const {
+            return getField(name, internal::valueSig((TType*) nullptr).c_str());
+        }
+
+        /**
+            Gets a handle to the static field with the given name and type signature.
+            This handle can then be stored so that the field does not need to
+            be looked up by name again. It does not need to be deleted.
+            \param name The name of the field.
+            \param signature The JNI type signature of the field.
+            \return The field ID.
+         */
+        field_t getStaticField(const char* name, const char* signature) const;
+
+        /**
+            Gets a handle to the static field with the given name and the supplied type.
+            This handle can then be stored so that the field does not need to
+            be looked up by name again. It does not need to be deleted.
+            \param name The name of the field.
+            \return The field ID.
+         */
+        template<typename TType>
+        field_t getStaticField(const char* name) const {
+            return getStaticField(name, internal::valueSig((TType*)nullptr).c_str());
+        }
+
+        /**
+            Gets a handle to the method with the given name and signature.
+            This handle can then be stored so that the method does not need
+            to be looked up by name again. It does not need to be deleted.
+            \param name The name of the method.
+            \param signature The JNI method signature.
+            \return The method ID.
+         */
+        method_t getMethod(const char* name, const char* signature) const;
+
+        /**
+            Gets a handle to the method with the given name and signature.
+            This handle can then be stored so that the method does not need
+            to be looked up by name again. It does not need to be deleted.
+            \param nameAndSignature Name and signature identifier (e.g. "toString()Ljava/lang/String;").
+            \return The method ID.
+         */
+        method_t getMethod(const char* nameAndSignature) const;
+
+        /**
+            Gets a handle to the static method with the given name and signature.
+            This handle can then be stored so that the method does not need
+            to be looked up by name again. It does not need to be deleted.
+            \param name The name of the method.
+            \param signature The JNI method signature.
+            \return The method ID.
+         */
+        method_t getStaticMethod(const char* name, const char* signature) const;
+
+        /**
+            Gets a handle to the static method with the given name and signature.
+            This handle can then be stored so that the method does not need
+            to be looked up by name again. It does not need to be deleted.
+            \param nameAndSignature Name and signature identifier (e.g. "toString()Ljava/lang/String;").
+            \return The method ID.
+         */
+        method_t getStaticMethod(const char* nameAndSignature) const;
+
+        /**
+            Gets a handle to the constructor for this Class with the given
+            signature. Note that the return type should always be `void` ("V").
+            \param signature The JNI method signature for the constructor.
+            \return The constructor method ID.
+         */
+        method_t getConstructor(const char* signature) const { return getMethod("<init>", signature); }
+
+        /**
+            Gets the parent Class of this Class.
+            \return The parent class.
+         */
+        Class getParent() const;
+
+        /**
+            Gets the JNI-qualified name of this Class.
+            \return The Class name.
+         */
+        std::string getName() const;
+
+        /**
+            Calls a static method on this Class. The method should have no
+            parameters. Note that the return type should be explicitly stated
+            in the function call.
+            \param method A method handle which applies to this Object.
+            \return The method's return value.
+         */
+        template <class TReturn>
+        TReturn call(method_t method) const { return callStaticMethod<TReturn>(method, nullptr); }
+
+        /**
+            Calls a static method on this Class with the given name, and no arguments.
+            Note that the return type should be explicitly stated in the function
+            call.
+            \param name The name of the method to call.
+            \return The method's return value.
+         */
+        template <class TReturn>
+        TReturn call(const char* name) const {
+            method_t method = getStaticMethod(name, ("()" + internal::valueSig((TReturn*) nullptr)).c_str());
+            return call<TReturn>(method);
+        }
+
+        /**
+            Calls a static method on this Class and supplies the given arguments.
+            Note that the return type should be explicitly stated in the function
+            call.
+            \param method The method to call.
+            \param args Arguments to supply to the method.
+            \return The method's return value.
+         */
+        template <class TReturn, class... TArgs>
+        TReturn call(method_t method, const TArgs&... args) const {
+            internal::ArgArray<TArgs...> transform(args...);
+            return callStaticMethod<TReturn>(method, transform.values);
+        }
+
+        /**
+            Calls a static method on this Class and supplies the given arguments.
+            Note that the return type should be explicitly stated in the function
+            call. The type signature of the method is calculated by the types of
+            the supplied arguments.
+            \param name The name of the method to call.
+            \param args Arguments to supply to the method.
+            \return The method's return value.
+         */
+        template <class TReturn, class... TArgs>
+        TReturn call(const char* name, const TArgs&... args) const {
+            if (std::strchr(name, '('))
+                return call<TReturn>(getStaticMethod(name), args...);
+
+            std::string sig = "(" + internal::sig(args...) + ")" + internal::valueSig((TReturn*) nullptr);
+            method_t method = getStaticMethod(name, sig.c_str());
+            return call<TReturn>(method, args...);
+        }
+
+        /**
+            Calls a non-static method on this Class, applying it to the supplied
+            Object. The difference between this and Object.call() is that the
+            specific class implementation of the method is called, rather than
+            doing a virtual method lookup.
+            \param obj The Object to call the method on.
+            \param method The method to call.
+            \return The method's return value.
+         */
+        template <class TReturn>
+        TReturn call(const Object& obj, method_t method) const {
+            return callExactMethod<TReturn>(obj.getHandle(), method, nullptr);
+        }
+
+        /**
+            Calls a non-static method on this Class, applying it to the supplied
+            Object. The difference between this and Object.call() is that the
+            specific class implementation of the method is called, rather than
+            doing a virtual method lookup.
+            \param obj The Object to call the method on.
+            \param name The name of the method to call.
+            \return The method's return value.
+         */
+        template <class TReturn>
+        TReturn call(const Object& obj, const char* name) const {
+            method_t method = getMethod(name, ("()" + internal::valueSig((TReturn*) nullptr)).c_str());
+            return call<TReturn>(obj, method);
+        }
+        template <class TReturn>
+        TReturn call(const Object* obj, const char* name) const {
+            return call<TReturn>(obj, name);
+        }
+
+        /**
+            Calls a non-static method on this Class, applying it to the supplied
+            Object. The difference between this and Object.call() is that the
+            specific class implementation of the method is called, rather than
+            doing a virtual method lookup.
+            \param obj The Object to call the method on.
+            \param method The method to call.
+            \param args Arguments to pass to the method.
+            \return The method's return value.
+         */
+        template <class TReturn, class... TArgs>
+        TReturn call(const Object& obj, method_t method, const TArgs&... args) const {
+            internal::ArgArray<TArgs...> transform(args...);
+            return callExactMethod<TReturn>(obj.getHandle(), method, transform.values);
+        }
+        template <class TReturn, class... TArgs>
+        TReturn call(const Object* obj, method_t method, const TArgs&... args) const {
+            return call<TReturn>(*obj, method, args...);
+        }
+
+        /**
+            Calls a non-static method on this Class, applying it to the supplied
+            Object. The difference between this and Object.call() is that the
+            specific class implementation of the method is called, rather than
+            doing a virtual method lookup.
+            \param obj The Object to call the method on.
+            \param name The name of the method to call.
+            \param args Arguments to pass to the method.
+            \return The method's return value.
+         */
+        template <class TReturn, class... TArgs>
+        TReturn call(const Object& obj, const char* name, const TArgs&... args) const {
+            std::string sig = "(" + internal::sig(args...) + ")" + internal::valueSig((TReturn*) nullptr);
+            method_t method = getMethod(name, sig.c_str());
+            return call<TReturn>(obj, method, args...);
+        }
+        template <class TReturn, class... TArgs>
+        TReturn call(const Object* obj, const char* name, const TArgs&... args) const {
+            return call<TReturn>(*obj, name, args...);
+        }
+
+        /**
+            Gets a static field value from this Class. Note that the field type
+            should be explicitly stated in the function call.
+            \param field Identifier for the field to retrieve.
+            \return The field's value.
+         */
+        template <class TType>
+        TType get(field_t field) const;
+
+        /**
+            Gets a static field value from this Class. Note that the field type
+            should be explicitly stated in the function call.
+            \param name The name of the field to retrieve.
+            \return The field's value.
+         */
+        template <class TType>
+        TType get(const char* name) const {
+            field_t field = getStaticField(name, internal::valueSig((TType*) nullptr).c_str());
+            return get<TType>(field);
+        }
+
+        /**
+            Sets a static field's value on this Class. The parameter's type should
+            correspond to the type of the field.
+            \param field The field to set the value to.
+            \param value The value to set.
+         */
+        template <class TType>
+        void set(field_t field, const TType& value);
+
+        /**
+            Sets a static field's value on this Class. The parameter's type
+            should correspond to the type of the field.
+            \param name The name of the field to set the value to.
+            \param value The value to set.
+         */
+        template <class TType>
+        void set(const char* name, const TType& value) {
+            field_t field = getStaticField(name, internal::valueSig((TType*) nullptr).c_str());
+            set(field, value);
+        }
+
+        /**
+            Gets the underlying JNI jclass handle.
+            \return The JNI handle.
+         */
+        jclass getHandle() const noexcept { return jclass(Object::getHandle()); }
+
+    private:
+        // Helper Functions
+        template <class TType> TType callStaticMethod(method_t method, internal::value_t* values) const;
+        template <class TType> TType callExactMethod(jobject obj, method_t method, internal::value_t* values) const;
+        Object newObject(method_t constructor, internal::value_t* args) const;
+    };
+
+    /**
+        Convenience class for dealing with Java enums.
+     */
+    class Enum : protected Class
+    {
+    public:
+        /**
+            Loads the Enum with the given JNI-formatted name.
+            \param name The name of the enum.
+         */
+        Enum(const char* name);
+
+        /**
+            Gets the enum value with the given name.
+            \param name The name of the enum value.
+            \return The enum value identifier.
+         */
+        Object get(const char* name) const;
+
+    private:
+        // Instance Variables
+        std::string _name;
+    };
+
+    /**
+        Used to interact with native Java arrays. The element type can be any primitive
+        type, jni::Object, std::string or std::wstring.
+     */
+    template <class TElement>
+    class Array : public Object
+    {
+    public:
+        /**
+            Default constructor. Creates a null array reference.
+         */
+        Array() noexcept;
+
+        /**
+            Creates a Array object by JNI reference.
+            \param ref The JNI array reference.
+            \param scopeFlags Bitmask of Object::ScopeFlags.
+         */
+        Array(jarray ref, int scopeFlags = Temporary);
+
+        /**
+            Creates an Array of the given length. The elements are default initialised
+            to zero / null values.
+            \param length The Array length.
+         */
+        Array(long length);
+
+        /**
+            Creates an Array of the given length. A Class type is also specified, but can
+            be left null to default to "java.lang.Object".
+            \param length The Array length.
+            \param type The element type.
+
+         */
+        Array(long length, const Class& type);
+
+        /**
+            Copy constructor. Shares a reference to the Java array with the
+            copied Array object.
+            \param other The Array to copy.
+         */
+        Array(const Array<TElement>& other);
+
+        /**
+            Move constructor. Moves the array reference to the new Array, and leaves
+            the previous Array as a null reference.
+            \param other The Array to move.
+         */
+        Array(Array<TElement>&& other) noexcept;
+
+        /**
+            Assignment operator. Copies the array reference from the supplied
+            Array. They will now both point to the same Java array.
+            \param other The Array to copy.
+            \return This Array.
+         */
+        Array<TElement>& operator=(const Array<TElement>& other);
+
+        /**
+            Assignment operator. Moves the array reference from the supplied
+            Array to this one, and leaves the other one as a null.
+            \param other The Array to move.
+            \return This Array.
+         */
+        Array<TElement>& operator=(Array<TElement>&& other);
+
+        /**
+            Checks whether these Arrays both reference the same java array.
+            \param other The Array to compare with.
+            \return true if the same (or both null), false otherwise.
+         */
+        bool operator==(const Array<TElement>& other) const { return Object::operator==(other); }
+
+        /**
+            Checks whether these Arrays reference different the java arrays.
+            \param other The Array to compare with.
+            \return false if the same (or both null), true otherwise.
+         */
+        bool operator!=(const Array<TElement>& other) const { return !operator==(other); }
+
+        /**
+            Sets the element value at the given index in the Array.
+            \param index The zero-based index.
+            \param value The value to set.
+         */
+        void setElement(long index, TElement value);
+
+        /**
+            Gets the value at the given index within the Array.
+            \param index The zero-based index.
+            \return The element at the given index.
+         */
+        TElement getElement(long index) const;
+        TElement operator[](long index) const { return getElement(index); }
+
+        /**
+            Gets the length of this Array.
+            \return The array length.
+         */
+        long getLength() const;
+
+        /**
+            Gets the underlying JNI jarray handle.
+            \return The JNI handle.
+         */
+        jarray getHandle() const noexcept { return jarray(Object::getHandle()); }
+
+    private:
+        // Instance Variables
+        mutable long _length;   ///< Mutable as it may only finally get set in a getLength() call.
+    };
+
+    /**
+        When the application's entry point is in C++ rather than in Java, it will
+        need to spin up its own instance of the Java Virtual Machine (JVM) before
+        it can initialize the Java Native Interface. Vm is used to create and
+        destroy a running JVM instance.
+
+        It uses the RAII idiom, so when the destructor is called, the Vm is shut
+        down.
+
+        Note that currently only one instance is supported. Attempts to create
+        more will result in an InitializationException.
+     */
+    class Vm final
+    {
+    public:
+        /**
+            Starts the Java Virtual Machine.
+            \param path The path to the jvm.dll (or null for auto-detect).
+         */
+        Vm(const char* path = nullptr);
+
+        /** Destroys the running instance of the JVM. */
+        ~Vm();
+    };
+
+    /**
+        A Java method call threw an Exception.
+     */
+    class InvocationException : public Exception
+    {
+    public:
+        /**
+            Constructor with an error message.
+            \param msg Message to pass to the Exception.
+         */
+        InvocationException(const char* msg = "Java Exception detected") : Exception(msg) {}
+    };
+
+    /**
+        A supplied name or type signature could not be resolved.
+     */
+    class NameResolutionException : public Exception
+    {
+    public:
+        /**
+            Constructor with an error message.
+            \param name The name of the unresolved symbol.
+         */
+        NameResolutionException(const char* name) : Exception(name) {}
+    };
+
+    /**
+        The Java Native Interface was not properly initialized.
+     */
+    class InitializationException : public Exception
+    {
+    public:
+        /**
+            Constructor with an error message.
+            \param msg Message to pass to the Exception.
+         */
+        InitializationException(const char* msg) : Exception(msg) {}
+    };
+
+    /*
+        Array Implementation
+     */
+
+    template <class TElement>
+    Array<TElement>::Array() noexcept : Object(), _length(0)
+    {
+    }
+
+    template <class TElement>
+    Array<TElement>::Array(jarray ref, int scopeFlags) : Object((jobject) ref, scopeFlags), _length(-1)
+    {
+    }
+
+    template <class TElement>
+    Array<TElement>::Array(const Array<TElement>& other) : Object(other), _length(other._length)
+    {
+    }
+
+    template <class TElement>
+    Array<TElement>::Array(Array<TElement>&& other) noexcept : Object((Object&&)other), _length(other._length)
+    {
+        other._length = 0;
+    }
+
+    template <class TElement>
+    Array<TElement>& Array<TElement>::operator=(const Array<TElement>& other)
+    {
+        if (&other != this)
+        {
+            Object::operator=(other);
+            _length = other._length;
+        }
+
+        return *this;
+    }
+
+    template <class TElement>
+    Array<TElement>& Array<TElement>::operator=(Array<TElement>&& other)
+    {
+        if (&other != this)
+        {
+            Object::operator=((Object&&) other);
+            _length = other._length;
+
+            other._length = 0;
+        }
+
+        return *this;
+    }
+
+    template <class TElement>
+    long Array<TElement>::getLength() const
+    {
+        if (_length < 0)
+        {
+            _length = internal::getArrayLength(getHandle());
+        }
+
+        return _length;
+    }
+}
+
+#endif // _JNIPP_H_
+


### PR DESCRIPTION
Add support for using an external OpenXR loader library, instead of the built-in KHR loader.

This is required on the Meta Oculus Quest devices, where Meta uses a custom OpenXR
loader library. To use it, specify the loader library as a build parameter, e.g.:
scons platform=android android_arch=arm64v8 external_openxr_library=/path/to/libopenxr_loader.so

The change also adds support for building the KHR loader for Android, if an external loader
is not requested.

Tested with the Godot 4 OpenXR Demo on a Meta Quest 2.
