### PR TITLE
Fix crash when mesh skin data is invalid

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1230,6 +1230,10 @@ Array RenderingServer::_get_array_from_surface(uint32_t p_format, Vector<uint8_t
 
 			} break;
 			case RS::ARRAY_WEIGHTS: {
+				if (sr == nullptr) {
+					ERR_PRINT_ONCE("Invalid skin data for array weights.");
+					break;
+				}
 				uint32_t bone_count = (p_format & ARRAY_FLAG_USE_8_BONE_WEIGHTS) ? 8 : 4;
 
 				Vector<float> arr;
@@ -1249,6 +1253,10 @@ Array RenderingServer::_get_array_from_surface(uint32_t p_format, Vector<uint8_t
 
 			} break;
 			case RS::ARRAY_BONES: {
+				if (sr == nullptr) {
+					ERR_PRINT_ONCE("Invalid skin data for array bones.");
+					break;
+				}
 				uint32_t bone_count = (p_format & ARRAY_FLAG_USE_8_BONE_WEIGHTS) ? 8 : 4;
 
 				Vector<int> arr;


### PR DESCRIPTION
This commit fixes immediate crash on the --headless Godot instance when trying to perform create_convex_shape() on a mesh where there is no skin data information.

It's related to #64816 and I'm unsure if it's acceptable fix, I think we want to have such error prints and do some minimal sanity check in those places to prevent the crash and I think it might be mergable because of that.

At the same time I don't feel like it fixes the #64816 because most likely it's treating the symptoms not the cause

This work was kindly sponsored by The Mirror