### PR TITLE
Remove internal functions of named colors from the public API

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1835,10 +1835,6 @@ static void _register_variant_builtin_methods() {
 	bind_static_method(Color, hex64, sarray("hex"), varray());
 	bind_static_method(Color, html, sarray("rgba"), varray());
 	bind_static_method(Color, html_is_valid, sarray("color"), varray());
-	bind_static_method(Color, find_named_color, sarray("name"), varray());
-	bind_static_method(Color, get_named_color_count, sarray(), varray());
-	bind_static_method(Color, get_named_color_name, sarray("idx"), varray());
-	bind_static_method(Color, get_named_color, sarray("idx"), varray());
 	bind_static_method(Color, from_string, sarray("str", "default"), varray());
 	bind_static_method(Color, from_hsv, sarray("h", "s", "v", "alpha"), varray(1.0));
 	bind_static_method(Color, from_ok_hsl, sarray("h", "s", "l", "alpha"), varray(1.0));

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -141,17 +141,6 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="find_named_color" qualifiers="static">
-			<return type="int" />
-			<param index="0" name="name" type="String" />
-			<description>
-				Returns the index of a named color. Use [method get_named_color] to get the actual color.
-				[codeblock]
-				var idx = Color.find_named_color("khaki")
-				modulate = Color.get_named_color(idx)
-				[/codeblock]
-			</description>
-		</method>
 		<method name="from_hsv" qualifiers="static">
 			<return type="Color" />
 			<param index="0" name="h" type="float" />
@@ -209,26 +198,6 @@
 				Returns the luminance of the color in the [code][0.0, 1.0][/code] range.
 				This is useful when determining light or dark color. Colors with a luminance smaller than 0.5 can be generally considered dark.
 				[b]Note:[/b] [method get_luminance] relies on the colour being in the linear color space to return an accurate relative luminance value. If the color is in the sRGB color space, use [method srgb_to_linear] to convert it to the linear color space first.
-			</description>
-		</method>
-		<method name="get_named_color" qualifiers="static">
-			<return type="Color" />
-			<param index="0" name="idx" type="int" />
-			<description>
-				Returns a named color with the given index. You can get the index from [method find_named_color] or iteratively from [method get_named_color_count].
-			</description>
-		</method>
-		<method name="get_named_color_count" qualifiers="static">
-			<return type="int" />
-			<description>
-				Returns the number of available named colors.
-			</description>
-		</method>
-		<method name="get_named_color_name" qualifiers="static">
-			<return type="String" />
-			<param index="0" name="idx" type="int" />
-			<description>
-				Returns the name of a color with the given index. You can get the index from [method find_named_color] or iteratively from [method get_named_color_count].
 			</description>
 		</method>
 		<method name="hex" qualifiers="static">


### PR DESCRIPTION
The following static methods are internal and became available in the public API by accident\* (as I understand it):

* `find_named_color`;
* `get_named_color_count`;
* `get_named_color_name`;
* `get_named_color`.

I suggest to hide them and add the `get_named_colors` method or other (if needed).

---

\* - I think so, because IMO these are internal methods, I do not see cases of using these methods in user code, except for:

1. getting a random named color (`Color.get_named_color(randi() % Color.get_named_color_count())`), but for these purposes we can add a separate method;
2. getting a list of named colors, but for these purposes we can add a separate method or add the ability to get a list/values of constants via `ClassDB` universally, for any class, not just for `Color`.

`find_named_color` doesn't seem to be useful at all, since the id of a named color can only be used to get its name or color. Both options are useless:

```gdscript
get_named_color_name(find_named_color(name)) # ≈ name
get_named_color(find_named_color(name)) # Color(name) or Color.from_string(name, default)
```