### PR TITLE
Improve string formatting (%f and %v) for inf and nan

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4637,15 +4637,18 @@ String String::sprintf(const Array &values, bool *error) const {
 					double value = values[value_index];
 					bool is_negative = (value < 0);
 					String str = String::num(ABS(value), min_decimals);
+					bool not_numeric = isinf(value) || isnan(value);
 
 					// Pad decimals out.
-					str = str.pad_decimals(min_decimals);
+					if (!not_numeric) {
+						str = str.pad_decimals(min_decimals);
+					}
 
 					int initial_len = str.length();
 
 					// Padding. Leave room for sign later if required.
 					int pad_chars_count = (is_negative || show_sign) ? min_chars - 1 : min_chars;
-					String pad_char = pad_with_zeros ? String("0") : String(" ");
+					String pad_char = (pad_with_zeros && !not_numeric) ? String("0") : String(" "); // Never pad NaN or inf with zeros
 					if (left_justified) {
 						str = str.rpad(pad_chars_count, pad_char);
 					} else {
@@ -4695,14 +4698,19 @@ String String::sprintf(const Array &values, bool *error) const {
 					String str = "(";
 					for (int i = 0; i < count; i++) {
 						double val = vec[i];
+						String number_str = String::num(ABS(val), min_decimals);
+						bool not_numeric = isinf(val) || isnan(val);
+
 						// Pad decimals out.
-						String number_str = String::num(ABS(val), min_decimals).pad_decimals(min_decimals);
+						if (!not_numeric) {
+							number_str = number_str.pad_decimals(min_decimals);
+						}
 
 						int initial_len = number_str.length();
 
 						// Padding. Leave room for sign later if required.
 						int pad_chars_count = val < 0 ? min_chars - 1 : min_chars;
-						String pad_char = pad_with_zeros ? String("0") : String(" ");
+						String pad_char = (pad_with_zeros && !not_numeric) ? String("0") : String(" "); // Never pad NaN or inf with zeros
 						if (left_justified) {
 							number_str = number_str.rpad(pad_chars_count, pad_char);
 						} else {

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -745,6 +745,14 @@ TEST_CASE("[String] sprintf") {
 	REQUIRE(error == false);
 	CHECK(output == String("fish   99.990000 frog"));
 
+	// Real (infinity) left-padded
+	format = "fish %11f frog";
+	args.clear();
+	args.push_back(INFINITY);
+	output = format.sprintf(args, &error);
+	REQUIRE(error == false);
+	CHECK(output == String("fish         inf frog"));
+
 	// Real right-padded.
 	format = "fish %-11f frog";
 	args.clear();
@@ -844,6 +852,14 @@ TEST_CASE("[String] sprintf") {
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
 	CHECK(output == String("fish (  19.990000,    1.000000,   -2.050000) frog"));
+
+	// Vector left-padded with inf/nan
+	format = "fish %11v frog";
+	args.clear();
+	args.push_back(Variant(Vector2(INFINITY, NAN)));
+	output = format.sprintf(args, &error);
+	REQUIRE(error == false);
+	CHECK(output == String("fish (        inf,         nan) frog"));
 
 	// Vector right-padded.
 	format = "fish %-11v frog";


### PR DESCRIPTION
Fixes #62908

When string formatting with %f or %v inf and nan has decimals added to them which doesn't make any sense. This pr changes the behaviour to always pad with empty spaces instead of zeros for those numbers.

Examples:
`print("1::'%s' 2::'%.2f' 3::'%.3f' 4::'%.4f' 5::'%f' 6::'%10f'" % [INF, INF, INF, INF, INF, INF])`
Previously gave:
`1::'inf' 2::'inf.00' 3::'inf.000' 4::'inf.0000' 5::'inf.000000' 6::'inf.000000'`
Now it gives:
![image](https://user-images.githubusercontent.com/19669673/186436016-72c150d5-4f1a-49f7-8e96-ee84f780a952.png)
It also works for vectors:
`print("%5v %10v" % [Vector2(INF, NAN), Vector2(INF, NAN)])`
![image](https://user-images.githubusercontent.com/19669673/186435899-a6674185-0764-4a8a-828b-4341096b4446.png)

When a min length is set it pads to the left (unless the - char is used) and the min decimal count is totally ignored for inf and nan. When its set to pad with zeros instead of spaces it still pads with spaces for inf and nan. This feels like the most logical behaviour imo but it can of course be changed depending on feedback.

Edit: Also added two testcases to verify this behaviour

3.x version: #64870