### PR TITLE
Add GraphNode 'selected' and 'deselected' signals, simplify GraphEdit

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -265,6 +265,11 @@
 				Emitted when the GraphNode is requested to be closed. Happens on clicking the close button (see [member show_close]).
 			</description>
 		</signal>
+		<signal name="deselected">
+			<description>
+				Emitted when the GraphNode is deselected.
+			</description>
+		</signal>
 		<signal name="dragged">
 			<param index="0" name="from" type="Vector2" />
 			<param index="1" name="to" type="Vector2" />
@@ -286,6 +291,11 @@
 			<param index="0" name="new_minsize" type="Vector2" />
 			<description>
 				Emitted when the GraphNode is requested to be resized. Happens on dragging the resizer handle (see [member resizable]).
+			</description>
+		</signal>
+		<signal name="selected">
+			<description>
+				Emitted when the GraphNode is selected.
 			</description>
 		</signal>
 		<signal name="slot_updated">

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -186,6 +186,8 @@ private:
 	PackedVector2Array get_connection_line(const Vector2 &p_from, const Vector2 &p_to);
 	void _draw_connection_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_width, float p_zoom);
 
+	void _graph_node_selected(Node *p_gn);
+	void _graph_node_deselected(Node *p_gn);
 	void _graph_node_raised(Node *p_gn);
 	void _graph_node_moved(Node *p_gn);
 	void _graph_node_slot_updated(int p_index, Node *p_gn);

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -736,11 +736,12 @@ Vector2 GraphNode::get_position_offset() const {
 }
 
 void GraphNode::set_selected(bool p_selected) {
-	if (selected == p_selected) {
+	if (!is_selectable() || selected == p_selected) {
 		return;
 	}
 
 	selected = p_selected;
+	emit_signal(p_selected ? SNAME("selected") : SNAME("deselected"));
 	queue_redraw();
 }
 
@@ -1012,6 +1013,9 @@ bool GraphNode::is_draggable() {
 }
 
 void GraphNode::set_selectable(bool p_selectable) {
+	if (!p_selectable) {
+		set_selected(false);
+	}
 	selectable = p_selectable;
 }
 
@@ -1123,6 +1127,8 @@ void GraphNode::_bind_methods() {
 	ADD_GROUP("", "");
 
 	ADD_SIGNAL(MethodInfo("position_offset_changed"));
+	ADD_SIGNAL(MethodInfo("selected"));
+	ADD_SIGNAL(MethodInfo("deselected"));
 	ADD_SIGNAL(MethodInfo("slot_updated", PropertyInfo(Variant::INT, "idx")));
 	ADD_SIGNAL(MethodInfo("dragged", PropertyInfo(Variant::VECTOR2, "from"), PropertyInfo(Variant::VECTOR2, "to")));
 	ADD_SIGNAL(MethodInfo("raise_request"));


### PR DESCRIPTION
Make GraphEdit node selection signals more consistent whether node is selected through UI or through code.

Implementation details:
* Add "selected" and "deselected" signals on GraphNode.
* Update GraphNode.set_selcted() to
  * do redundancy check (if node is already in proper selection state);
  * fire corresponding signal.
* Update GraphEdit to subscribe to "selected" and "deselected" signals of each child GraphNode
  * on signal callback fire "node_selected" or "node_deselected" signals
* Remove logic to fire "node_selected" / "node_deselected" from GraphEdit code as it is now handled by GraphNode
* Move "selectable" logic from GraphEdit to GraphNode

That way proper signals are fired regardless of whether GraphNode is selected from UI, by setting it's "selected" property in the code, or by calling GraphEdit.set_selected(graph_node).

The patch is not compatible with 3.x branch because of renamed signals and type annotations introduced in 4.x version. Once merged I will do proper backport to 3.x branch.

Fixes #41799