### PR TITLE
Add `FileAccess::get_access_type()`

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -115,6 +115,10 @@ FileAccess::CreateFunc FileAccess::get_create_func(AccessType p_access) {
 	return create_func[p_access];
 }
 
+FileAccess::AccessType FileAccess::get_access_type() const {
+	return _access_type;
+}
+
 String FileAccess::fix_path(const String &p_path) const {
 	//helper used by file accesses that use a single filesystem
 

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -60,6 +60,7 @@ public:
 	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) = 0;
 
 protected:
+	AccessType get_access_type() const;
 	String fix_path(const String &p_path) const;
 	virtual Error _open(const String &p_path, int p_mode_flags) = 0; ///< open a file
 	virtual uint64_t _get_modified_time(const String &p_file) = 0;


### PR DESCRIPTION
`DirAccess` already has it. File system abstraction for certain proprietary platforms need to query the access type to make wise decisions.