### PR TITLE
Remove mentions of the Server platform from the Mono module

### DIFF
--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -3,11 +3,11 @@ import os.path
 
 
 def is_desktop(platform):
-    return platform in ["windows", "macos", "linuxbsd", "server", "uwp", "haiku"]
+    return platform in ["windows", "macos", "linuxbsd", "uwp", "haiku"]
 
 
 def is_unix_like(platform):
-    return platform in ["macos", "linuxbsd", "server", "android", "haiku", "ios"]
+    return platform in ["macos", "linuxbsd", "android", "haiku", "ios"]
 
 
 def module_supports_tools_on(platform):
@@ -132,7 +132,6 @@ def determine_runtime_identifier(env):
         "windows": "win",
         "macos": "osx",
         "linuxbsd": "linux",
-        "server": "linux",  # FIXME: Is server linux only, or also macos?
     }
 
     # .NET RID architectures: x86, x64, arm, or arm64

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -1,6 +1,6 @@
-# Prior to .NET Core, we supported these: ["windows", "macos", "linuxbsd", "server", "android", "haiku", "javascript", "ios"]
+# Prior to .NET Core, we supported these: ["windows", "macos", "linuxbsd", "android", "haiku", "javascript", "ios"]
 # Eventually support for each them should be added back (except Haiku if not supported by .NET Core)
-supported_platforms = ["windows", "macos", "linuxbsd", "server"]
+supported_platforms = ["windows", "macos", "linuxbsd"]
 
 
 def can_build(env, platform):

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -77,7 +77,6 @@
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'windows' ">GODOT_WINDOWS;GODOT_PC</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'linuxbsd' ">GODOT_LINUXBSD;GODOT_PC</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'macos' ">GODOT_OSX;GODOT_MACOS;GODOT_PC</GodotPlatformConstants>
-    <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'server' ">GODOT_SERVER;GODOT_PC</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'uwp' ">GODOT_UWP;GODOT_PC</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'haiku' ">GODOT_HAIKU;GODOT_PC</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'android' ">GODOT_ANDROID;GODOT_MOBILE</GodotPlatformConstants>

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -588,7 +588,6 @@ MONO_AOT_MODE_LAST = 1000,
                     return $"{platform}-{arch}";
                 }
                 case OS.Platforms.LinuxBSD:
-                case OS.Platforms.Server:
                 {
                     string arch = bits == "64" ? "x86_64" : "i686";
                     return $"linux-{arch}";

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -100,7 +100,7 @@ namespace GodotTools.Export
             if (!DeterminePlatformFromFeatures(features, out string platform))
                 throw new NotSupportedException("Target platform not supported");
 
-            if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS, OS.Platforms.Server }
+            if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS }
                     .Contains(platform))
             {
                 throw new NotImplementedException("Target platform not yet implemented");

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -23,7 +23,6 @@ namespace GodotTools.Utils
             public const string FreeBSD = "FreeBSD";
             public const string NetBSD = "NetBSD";
             public const string BSD = "BSD";
-            public const string Server = "Server";
             public const string UWP = "UWP";
             public const string Haiku = "Haiku";
             public const string Android = "Android";
@@ -36,7 +35,6 @@ namespace GodotTools.Utils
             public const string Windows = "windows";
             public const string MacOS = "macos";
             public const string LinuxBSD = "linuxbsd";
-            public const string Server = "server";
             public const string UWP = "uwp";
             public const string Haiku = "haiku";
             public const string Android = "android";
@@ -65,7 +63,6 @@ namespace GodotTools.Utils
             ["LinuxBSD"] = Platforms.LinuxBSD,
             // "X11" for compatibility, temporarily, while we are on an outdated branch
             ["X11"] = Platforms.LinuxBSD,
-            ["Server"] = Platforms.Server,
             ["UWP"] = Platforms.UWP,
             ["Haiku"] = Platforms.Haiku,
             ["Android"] = Platforms.Android,
@@ -81,7 +78,6 @@ namespace GodotTools.Utils
             [Names.FreeBSD] = Platforms.LinuxBSD,
             [Names.NetBSD] = Platforms.LinuxBSD,
             [Names.BSD] = Platforms.LinuxBSD,
-            [Names.Server] = Platforms.Server,
             [Names.UWP] = Platforms.UWP,
             [Names.Haiku] = Platforms.Haiku,
             [Names.Android] = Platforms.Android,
@@ -98,7 +94,6 @@ namespace GodotTools.Utils
             // instead of `linux` in the runtime identifier. This would be a problem as
             // Godot has a single export profile for both, named LinuxBSD.
             [Platforms.LinuxBSD] = DotNetOS.Linux,
-            [Platforms.Server] = DotNetOS.Linux,
             [Platforms.UWP] = DotNetOS.Win10,
             [Platforms.Android] = DotNetOS.Android,
             [Platforms.iOS] = DotNetOS.iOS,
@@ -129,13 +124,12 @@ namespace GodotTools.Utils
             new[] { Names.Linux, Names.FreeBSD, Names.NetBSD, Names.BSD };
 
         private static readonly IEnumerable<string> UnixLikePlatforms =
-            new[] { Names.MacOS, Names.Server, Names.Haiku, Names.Android, Names.iOS }
+            new[] { Names.MacOS, Names.Haiku, Names.Android, Names.iOS }
                 .Concat(LinuxBSDPlatforms).ToArray();
 
         private static readonly Lazy<bool> _isWindows = new(() => IsOS(Names.Windows));
         private static readonly Lazy<bool> _isMacOS = new(() => IsOS(Names.MacOS));
         private static readonly Lazy<bool> _isLinuxBSD = new(() => IsAnyOS(LinuxBSDPlatforms));
-        private static readonly Lazy<bool> _isServer = new(() => IsOS(Names.Server));
         private static readonly Lazy<bool> _isUWP = new(() => IsOS(Names.UWP));
         private static readonly Lazy<bool> _isHaiku = new(() => IsOS(Names.Haiku));
         private static readonly Lazy<bool> _isAndroid = new(() => IsOS(Names.Android));
@@ -148,8 +142,6 @@ namespace GodotTools.Utils
         [SupportedOSPlatformGuard("osx")] public static bool IsMacOS => _isMacOS.Value;
 
         [SupportedOSPlatformGuard("linux")] public static bool IsLinuxBSD => _isLinuxBSD.Value;
-
-        [SupportedOSPlatformGuard("linux")] public static bool IsServer => _isServer.Value;
 
         [SupportedOSPlatformGuard("windows")] public static bool IsUWP => _isUWP.Value;
 


### PR DESCRIPTION
The `server` platform does not exist in the master branch anymore.