### PR TITLE
Add type icons to editor docs' hierarchy

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -239,6 +239,27 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum) {
 	class_desc->pop();
 }
 
+void EditorHelp::_add_type_icon(const String &p_type, int p_size) {
+	Ref<Texture2D> icon;
+	if (has_theme_icon(p_type, SNAME("EditorIcons"))) {
+		icon = get_theme_icon(p_type, SNAME("EditorIcons"));
+	} else if (ClassDB::class_exists(p_type) && ClassDB::is_parent_class(p_type, "Object")) {
+		icon = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
+	} else {
+		icon = get_theme_icon(SNAME("ArrowRight"), SNAME("EditorIcons"));
+	}
+
+	Vector2i size = Vector2i(icon->get_width(), icon->get_height());
+	if (p_size > 0) {
+		// Ensures icon scales proportionally on both axis, based on icon height.
+		float ratio = p_size / float(size.height);
+		size.width *= ratio;
+		size.height *= ratio;
+	}
+
+	class_desc->add_image(icon, size.width, size.height);
+}
+
 String EditorHelp::_fix_constant(const String &p_constant) const {
 	if (p_constant.strip_edges() == "4294967295") {
 		return "0xFFFFFFFF";
@@ -530,22 +551,13 @@ void EditorHelp::_update_doc() {
 
 	DocData::ClassDoc cd = doc->class_list[edited_class]; // Make a copy, so we can sort without worrying.
 
-	Ref<Texture2D> icon;
-	if (has_theme_icon(edited_class, SNAME("EditorIcons"))) {
-		icon = get_theme_icon(edited_class, SNAME("EditorIcons"));
-	} else if (ClassDB::class_exists(edited_class) && ClassDB::is_parent_class(edited_class, "Object")) {
-		icon = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
-	} else {
-		icon = get_theme_icon(SNAME("ArrowRight"), SNAME("EditorIcons"));
-	}
-
 	// Class name
 	section_line.push_back(Pair<String, int>(TTR("Top"), 0));
 	class_desc->push_font(doc_title_font);
 	class_desc->push_font_size(doc_title_font_size);
 	class_desc->push_color(title_color);
 	class_desc->add_text(TTR("Class:") + " ");
-	class_desc->add_image(icon, icon->get_width(), icon->get_height());
+	_add_type_icon(edited_class, doc_title_font_size);
 	class_desc->add_text(" ");
 	class_desc->push_color(headline_color);
 	_add_text(edited_class);
@@ -566,6 +578,8 @@ void EditorHelp::_update_doc() {
 		String inherits = cd.inherits;
 
 		while (!inherits.is_empty()) {
+			_add_type_icon(inherits);
+			class_desc->add_text(" "); // Extra space, otherwise icon borrows hyperlink from _add_type().
 			_add_type(inherits);
 
 			inherits = doc->class_list[inherits].inherits;
@@ -597,7 +611,8 @@ void EditorHelp::_update_doc() {
 				if (prev) {
 					class_desc->add_text(" , ");
 				}
-
+				_add_type_icon(E.value.name);
+				class_desc->add_text(" "); // Extra space, otherwise icon borrows hyperlink from _add_type().
 				_add_type(E.value.name);
 				prev = true;
 			}

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -153,6 +153,7 @@ class EditorHelp : public VBoxContainer {
 
 	//void _button_pressed(int p_idx);
 	void _add_type(const String &p_type, const String &p_enum = String());
+	void _add_type_icon(const String &p_type, int p_size = 0);
 	void _add_method(const DocData::MethodDoc &p_method, bool p_overview = true);
 
 	void _add_bulletpoint();


### PR DESCRIPTION
The "_Inherits_" and "_Inherited by_" section of the docs now display the icon of each Object type on their side. Icons are one of those important "little things" that help with memorization and learning if used appropriately.

![image](https://user-images.githubusercontent.com/66727710/186499520-34dc24d3-5b59-4e60-8fb8-7c57a10918ca.png)

It's very pleasing most of the times but for the sake of completeness I need to show the worst case scenario:
![image](https://user-images.githubusercontent.com/66727710/186499996-b4d48118-ccd4-4901-8cb7-f1206b09a0ed.png)

Even if it can be certainly improved upon, this is certainly an upgrade from the raw wall of hyperlink text