### PR TITLE
C#: Preserve order of exported fields/categories

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -275,5 +275,13 @@ namespace Godot.SourceGenerators
                 yield return new GodotFieldData(field, marshalType.Value);
             }
         }
+
+        public static string Path(this Location location)
+            => location.SourceTree?.GetLineSpan(location.SourceSpan).Path
+            ?? location.GetLineSpan().Path;
+
+        public static int StartLine(this Location location)
+            => location.SourceTree?.GetLineSpan(location.SourceSpan).StartLinePosition.Line
+            ?? location.GetLineSpan().StartLinePosition.Line;
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotMemberData.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotMemberData.cs
@@ -59,4 +59,26 @@ namespace Godot.SourceGenerators
         public IFieldSymbol FieldSymbol { get; }
         public MarshalType Type { get; }
     }
+
+    public struct GodotPropertyOrFieldData
+    {
+        public GodotPropertyOrFieldData(ISymbol symbol, MarshalType type)
+        {
+            Symbol = symbol;
+            Type = type;
+        }
+
+        public GodotPropertyOrFieldData(GodotPropertyData propertyData)
+            : this(propertyData.PropertySymbol, propertyData.Type)
+        {
+        }
+
+        public GodotPropertyOrFieldData(GodotFieldData fieldData)
+            : this(fieldData.FieldSymbol, fieldData.Type)
+        {
+        }
+
+        public ISymbol Symbol { get; }
+        public MarshalType Type { get; }
+    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -225,28 +225,21 @@ namespace Godot.SourceGenerators
                     .Append(dictionaryType)
                     .Append("();\n");
 
-                foreach (var property in godotClassProperties)
+                // To retain the definition order (and display categories correctly), we want to
+                //  iterate over fields and properties at the same time, sorted by line number.
+                var godotClassPropertiesAndFields = Enumerable.Empty<GodotPropertyOrFieldData>()
+                    .Concat(godotClassProperties.Select(propertyData => new GodotPropertyOrFieldData(propertyData)))
+                    .Concat(godotClassFields.Select(fieldData => new GodotPropertyOrFieldData(fieldData)))
+                    .OrderBy(data => data.Symbol.Locations[0].Path())
+                    .ThenBy(data => data.Symbol.Locations[0].StartLine());
+
+                foreach (var member in godotClassPropertiesAndFields)
                 {
-                    foreach (var groupingInfo in DetermineGroupingPropertyInfo(property.PropertySymbol))
+                    foreach (var groupingInfo in DetermineGroupingPropertyInfo(member.Symbol))
                         AppendGroupingPropertyInfo(source, groupingInfo);
 
                     var propertyInfo = DeterminePropertyInfo(context, typeCache,
-                        property.PropertySymbol, property.Type);
-
-                    if (propertyInfo == null)
-                        continue;
-
-                    AppendPropertyInfo(source, propertyInfo.Value);
-                }
-
-                foreach (var field in godotClassFields)
-                {
-
-                    foreach (var groupingInfo in DetermineGroupingPropertyInfo(field.FieldSymbol))
-                        AppendGroupingPropertyInfo(source, groupingInfo);
-
-                    var propertyInfo = DeterminePropertyInfo(context, typeCache,
-                        field.FieldSymbol, field.Type);
+                        member.Symbol, member.Type);
 
                     if (propertyInfo == null)
                         continue;


### PR DESCRIPTION
This is a follow-up to #64742. Went with the most straightforward way, we only need to match the declaration order when we generate `GetGodotPropertyList()`. Everything else is untouched.  

Here's an example code and a screenshot of what it looks like in the inspector.

```cs
public partial class Sandbox : Node2D
{
    [Export]
    private string stringField = string.Empty;

    [ExportCategory("My Category")]

    [Export(PropertyHint.File)]
    public string FileProperty { get; set; }

    [ExportGroup("My Group")]

    [ExportSubgroup("My Subgroup 1")]

    [Export(PropertyHint.Range, "0,10")]
    public int RangeProperty { get; set; }

    [ExportSubgroup("My Subgroup 2")]

    [Export(PropertyHint.Range, "10,100")]
    public int rangeField;
}
```
![image](https://user-images.githubusercontent.com/437025/186515019-dcb5f140-b88e-45bb-b0e6-52c88f374281.png)
