### PR TITLE
Avoid spurious alloc error in SPIRV-Reflect

### DIFF
--- a/thirdparty/spirv-reflect/patches/zero-calloc.patch
+++ b/thirdparty/spirv-reflect/patches/zero-calloc.patch
@@ -1,0 +1,28 @@
+diff --git a/thirdparty/spirv-reflect/spirv_reflect.c b/thirdparty/spirv-reflect/spirv_reflect.c
+index c174ae1900..11ccbdee3a 100644
+--- a/thirdparty/spirv-reflect/spirv_reflect.c
++++ b/thirdparty/spirv-reflect/spirv_reflect.c
+@@ -3322,12 +3322,18 @@ static SpvReflectResult ParseExecutionModes(
+     }
+     for (size_t entry_point_idx = 0; entry_point_idx < p_module->entry_point_count; ++entry_point_idx) {
+       SpvReflectEntryPoint* p_entry_point = &p_module->entry_points[entry_point_idx];
+-      p_entry_point->execution_modes =
+-          (SpvExecutionMode*)calloc(p_entry_point->execution_mode_count, sizeof(*p_entry_point->execution_modes));
+-      if (IsNull(p_entry_point->execution_modes)) {
+-        SafeFree(indices);
+-        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
++// -- GODOT begin --
++      if (p_entry_point->execution_mode_count > 0) {
++// -- GODOT end --
++        p_entry_point->execution_modes =
++            (SpvExecutionMode*)calloc(p_entry_point->execution_mode_count, sizeof(*p_entry_point->execution_modes));
++        if (IsNull(p_entry_point->execution_modes)) {
++          SafeFree(indices);
++          return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
++        }
++// -- GODOT begin --
+       }
++// -- GODOT end --
+     }
+ 
+     for (size_t node_idx = 0; node_idx < p_parser->node_count; ++node_idx) {

--- a/thirdparty/spirv-reflect/spirv_reflect.c
+++ b/thirdparty/spirv-reflect/spirv_reflect.c
@@ -3322,12 +3322,18 @@ static SpvReflectResult ParseExecutionModes(
     }
     for (size_t entry_point_idx = 0; entry_point_idx < p_module->entry_point_count; ++entry_point_idx) {
       SpvReflectEntryPoint* p_entry_point = &p_module->entry_points[entry_point_idx];
-      p_entry_point->execution_modes =
-          (SpvExecutionMode*)calloc(p_entry_point->execution_mode_count, sizeof(*p_entry_point->execution_modes));
-      if (IsNull(p_entry_point->execution_modes)) {
-        SafeFree(indices);
-        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+// -- GODOT begin --
+      if (p_entry_point->execution_mode_count > 0) {
+// -- GODOT end --
+        p_entry_point->execution_modes =
+            (SpvExecutionMode*)calloc(p_entry_point->execution_mode_count, sizeof(*p_entry_point->execution_modes));
+        if (IsNull(p_entry_point->execution_modes)) {
+          SafeFree(indices);
+          return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+// -- GODOT begin --
       }
+// -- GODOT end --
     }
 
     for (size_t node_idx = 0; node_idx < p_parser->node_count; ++node_idx) {


### PR DESCRIPTION
This patch has been submitted upstream (https://github.com/KhronosGroup/SPIRV-Reflect/pull/157).

Let me quote the description sent there:
> `calloc()` returns `NULL` in some implementations when given a size of zero. This PR adds a guard for a case where that can happen in a valid shader to avoid a falsey `SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED` result.

This PR fixes the issue in a proprietary platform where that was exactly the case.