### PR TITLE
Tweak StringName highlighting color

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -646,13 +646,13 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 		node_path_color = Color(0.72, 0.77, 0.49);
 		node_ref_color = Color(0.39, 0.76, 0.35);
 		annotation_color = Color(1.0, 0.7, 0.45);
-		string_name_color = Color(1.0, 0.66, 0.72);
+		string_name_color = Color(1.0, 0.76, 0.65);
 	} else {
 		function_definition_color = Color(0, 0.6, 0.6);
 		node_path_color = Color(0.18, 0.55, 0);
 		node_ref_color = Color(0.0, 0.5, 0);
 		annotation_color = Color(0.8, 0.37, 0);
-		string_name_color = Color(0.8, 0.46, 0.52);
+		string_name_color = Color(0.8, 0.56, 0.45);
 	}
 
 	EDITOR_DEF("text_editor/theme/highlighting/gdscript/function_definition_color", function_definition_color);


### PR DESCRIPTION
The StringName default color is difficult to distinguish from the control flow color

![image](https://user-images.githubusercontent.com/85438892/186525816-4be4c7e7-0ca8-47e7-b651-efe228bc7d22.png)

The PR tweaks the color a bit to make it more discernible (updated):

![image](https://user-images.githubusercontent.com/85438892/186530797-884f2734-8910-49dd-ae25-58a0974d4914.png)
