### PR TITLE
Sync C# cubic interpolation with core

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -498,6 +498,15 @@ namespace Godot
             );
         }
 
+        internal Basis Lerp(Basis to, real_t weight)
+        {
+            Basis b = this;
+            b.Row0 = Row0.Lerp(to.Row0, weight);
+            b.Row1 = Row1.Lerp(to.Row1, weight);
+            b.Row2 = Row2.Lerp(to.Row2, weight);
+            return b;
+        }
+
         /// <summary>
         /// Returns the orthonormalized version of the basis matrix (useful to
         /// call occasionally to avoid rounding errors for orthogonal matrices).

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -175,7 +175,8 @@ namespace Godot
         }
 
         /// <summary>
-        /// Cubic interpolates between two values by a normalized value with pre and post values.
+        /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
+        /// with pre and post values.
         /// </summary>
         /// <param name="from">The start value for interpolation.</param>
         /// <param name="to">The destination value for interpolation.</param>
@@ -190,6 +191,33 @@ namespace Godot
                             (-pre + to) * weight +
                             (2.0f * pre - 5.0f * from + 4.0f * to - post) * (weight * weight) +
                             (-pre + 3.0f * from - 3.0f * to + post) * (weight * weight * weight));
+        }
+
+        /// <summary>
+        /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
+        /// with pre and post values.
+        /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
+        /// by the time values.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="pre">The value which before "from" value for interpolation.</param>
+        /// <param name="post">The value which after "to" value for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="toT"></param>
+        /// <param name="preT"></param>
+        /// <param name="postT"></param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static real_t CubicInterpolateInTime(real_t from, real_t to, real_t pre, real_t post, real_t weight, real_t toT, real_t preT, real_t postT)
+        {
+            /* Barry-Goldman method */
+            real_t t = Lerp(0.0f, toT, weight);
+            real_t a1 = Lerp(pre, from, preT == 0 ? 0.0f : (t - preT) / -preT);
+            real_t a2 = Lerp(from, to, toT == 0 ? 0.5f : t / toT);
+            real_t a3 = Lerp(to, post, postT - toT == 0 ? 1.0f : (t - toT) / (postT - toT));
+            real_t b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0f : (t - preT) / (toT - preT));
+            real_t b2 = Lerp(a2, a3, postT == 0 ? 1.0f : t / postT);
+            return Lerp(b1, b2, toT == 0 ? 0.5f : t / toT);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -194,6 +194,33 @@ namespace Godot
         }
 
         /// <summary>
+        /// Cubic interpolates between two rotation values with shortest path
+        /// by the factor defined in <paramref name="weight"/> with pre and post values.
+        /// See also <see cref="LerpAngle"/>.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="pre">The value which before "from" value for interpolation.</param>
+        /// <param name="post">The value which after "to" value for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static real_t CubicInterpolateAngle(real_t from, real_t to, real_t pre, real_t post, real_t weight)
+        {
+            real_t fromRot = from % Mathf.Tau;
+
+            real_t preDiff = (pre - fromRot) % Mathf.Tau;
+            real_t preRot = fromRot + (2.0f * preDiff) % Mathf.Tau - preDiff;
+
+            real_t toDiff = (to - fromRot) % Mathf.Tau;
+            real_t toRot = fromRot + (2.0f * toDiff) % Mathf.Tau - toDiff;
+
+            real_t postDiff = (post - toRot) % Mathf.Tau;
+            real_t postRot = toRot + (2.0f * postDiff) % Mathf.Tau - postDiff;
+
+            return CubicInterpolate(fromRot, toRot, preRot, postRot, weight);
+        }
+
+        /// <summary>
         /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
         /// with pre and post values.
         /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
@@ -218,6 +245,39 @@ namespace Godot
             real_t b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0f : (t - preT) / (toT - preT));
             real_t b2 = Lerp(a2, a3, postT == 0 ? 1.0f : t / postT);
             return Lerp(b1, b2, toT == 0 ? 0.5f : t / toT);
+        }
+
+        /// <summary>
+        /// Cubic interpolates between two rotation values with shortest path
+        /// by the factor defined in <paramref name="weight"/> with pre and post values.
+        /// See also <see cref="LerpAngle"/>.
+        /// It can perform smoother interpolation than <see cref="CubicInterpolateAngle"/>
+        /// by the time values.
+        /// </summary>
+        /// <param name="from">The start value for interpolation.</param>
+        /// <param name="to">The destination value for interpolation.</param>
+        /// <param name="pre">The value which before "from" value for interpolation.</param>
+        /// <param name="post">The value which after "to" value for interpolation.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="toT"></param>
+        /// <param name="preT"></param>
+        /// <param name="postT"></param>
+        /// <returns>The resulting value of the interpolation.</returns>
+        public static real_t CubicInterpolateAngleInTime(real_t from, real_t to, real_t pre, real_t post, real_t weight,
+                    real_t toT, real_t preT, real_t postT)
+        {
+            real_t fromRot = from % Mathf.Tau;
+
+            real_t preDiff = (pre - fromRot) % Mathf.Tau;
+            real_t preRot = fromRot + (2.0f * preDiff) % Mathf.Tau - preDiff;
+
+            real_t toDiff = (to - fromRot) % Mathf.Tau;
+            real_t toRot = fromRot + (2.0f * toDiff) % Mathf.Tau - toDiff;
+
+            real_t postDiff = (post - toRot) % Mathf.Tau;
+            real_t postRot = toRot + (2.0f * postDiff) % Mathf.Tau - postDiff;
+
+            return CubicInterpolateInTime(fromRot, toRot, preRot, postRot, weight, toT, preT, postT);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -292,6 +292,17 @@ namespace Godot
         /// <returns>The resulting quaternion of the interpolation.</returns>
         public Quaternion Slerpni(Quaternion to, real_t weight)
         {
+#if DEBUG
+            if (!IsNormalized())
+            {
+                throw new InvalidOperationException("Quaternion is not normalized");
+            }
+            if (!to.IsNormalized())
+            {
+                throw new ArgumentException("Argument is not normalized", nameof(to));
+            }
+#endif
+
             real_t dot = Dot(to);
 
             if (Mathf.Abs(dot) > 0.9999f)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -158,6 +158,22 @@ namespace Godot
             return (x * b.x) + (y * b.y) + (z * b.z) + (w * b.w);
         }
 
+        public real_t GetAngle()
+        {
+            return 2 * Mathf.Acos(w);
+        }
+
+        public Vector3 GetAxis()
+        {
+            if (Mathf.Abs(w) > 1 - Mathf.Epsilon)
+            {
+                return new Vector3(x, y, z);
+            }
+
+            real_t r = 1 / Mathf.Sqrt(1 - w * w);
+            return new Vector3(x * r, y * r, z * r);
+        }
+
         /// <summary>
         /// Returns Euler angles (in the YXZ convention: when decomposing,
         /// first Z, then X, and Y last) corresponding to the rotation

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -158,6 +158,18 @@ namespace Godot
             return (x * b.x) + (y * b.y) + (z * b.z) + (w * b.w);
         }
 
+        public Quaternion Exp()
+        {
+            Vector3 v = new Vector3(x, y, z);
+            real_t theta = v.Length();
+            v = v.Normalized();
+            if (theta < Mathf.Epsilon || !v.IsNormalized())
+            {
+                return new Quaternion(0, 0, 0, 1);
+            }
+            return new Quaternion(v, theta);
+        }
+
         public real_t GetAngle()
         {
             return 2 * Mathf.Acos(w);
@@ -215,6 +227,12 @@ namespace Godot
         public bool IsNormalized()
         {
             return Mathf.Abs(LengthSquared - 1) <= Mathf.Epsilon;
+        }
+
+        public Quaternion Log()
+        {
+            Vector3 v = GetAxis() * GetAngle();
+            return new Quaternion(v.x, v.y, v.z, 0);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -119,23 +119,9 @@ namespace Godot
         /// <returns>The interpolated transform.</returns>
         public Transform3D InterpolateWith(Transform3D transform, real_t weight)
         {
-            /* not sure if very "efficient" but good enough? */
-
-            Vector3 sourceScale = basis.Scale;
-            Quaternion sourceRotation = basis.GetRotationQuaternion();
-            Vector3 sourceLocation = origin;
-
-            Vector3 destinationScale = transform.basis.Scale;
-            Quaternion destinationRotation = transform.basis.GetRotationQuaternion();
-            Vector3 destinationLocation = transform.origin;
-
-            var interpolated = new Transform3D();
-            Quaternion quaternion = sourceRotation.Slerp(destinationRotation, weight).Normalized();
-            Vector3 scale = sourceScale.Lerp(destinationScale, weight);
-            interpolated.basis.SetQuaternionScale(quaternion, scale);
-            interpolated.origin = sourceLocation.Lerp(destinationLocation, weight);
-
-            return interpolated;
+            Basis retBasis = basis.Lerp(transform.basis, weight);
+            Vector3 retOrigin = origin.Lerp(transform.origin, weight);
+            return new Transform3D(retBasis, retOrigin);
         }
 
         /// <summary>
@@ -232,6 +218,34 @@ namespace Godot
         {
             Basis tmpBasis = Basis.FromScale(scale);
             return new Transform3D(basis * tmpBasis, origin);
+        }
+
+        /// <summary>
+        /// Returns a transform spherically interpolated between this transform and
+        /// another <paramref name="transform"/> by <paramref name="weight"/>.
+        /// </summary>
+        /// <param name="transform">The other transform.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <returns>The interpolated transform.</returns>
+        public Transform3D SphericalInterpolateWith(Transform3D transform, real_t weight)
+        {
+            /* not sure if very "efficient" but good enough? */
+
+            Vector3 sourceScale = basis.Scale;
+            Quaternion sourceRotation = basis.GetRotationQuaternion();
+            Vector3 sourceLocation = origin;
+
+            Vector3 destinationScale = transform.basis.Scale;
+            Quaternion destinationRotation = transform.basis.GetRotationQuaternion();
+            Vector3 destinationLocation = transform.origin;
+
+            var interpolated = new Transform3D();
+            Quaternion quaternion = sourceRotation.Slerp(destinationRotation, weight).Normalized();
+            Vector3 scale = sourceScale.Lerp(destinationScale, weight);
+            interpolated.basis.SetQuaternionScale(quaternion, scale);
+            interpolated.origin = sourceLocation.Lerp(destinationLocation, weight);
+
+            return interpolated;
         }
 
         private void SetLookAt(Vector3 eye, Vector3 target, Vector3 up)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -216,6 +216,29 @@ namespace Godot
         }
 
         /// <summary>
+        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+        /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
+        /// by the time values.
+        /// </summary>
+        /// <param name="b">The destination vector.</param>
+        /// <param name="preA">A vector before this vector.</param>
+        /// <param name="postB">A vector after <paramref name="b"/>.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="t"></param>
+        /// <param name="preAT"></param>
+        /// <param name="postBT"></param>
+        /// <returns>The interpolated vector.</returns>
+        public Vector2 CubicInterpolateInTime(Vector2 b, Vector2 preA, Vector2 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
+        {
+            return new Vector2
+            (
+                Mathf.CubicInterpolateInTime(x, b.x, preA.x, postB.x, weight, t, preAT, postBT),
+                Mathf.CubicInterpolateInTime(y, b.y, preA.y, postB.y, weight, t, preAT, postBT)
+            );
+        }
+
+        /// <summary>
         /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by this vector
         /// and the given <paramref name="control1"/>, <paramref name="control2"/> and <paramref name="end"/> points.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -209,6 +209,30 @@ namespace Godot
         }
 
         /// <summary>
+        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+        /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
+        /// by the time values.
+        /// </summary>
+        /// <param name="b">The destination vector.</param>
+        /// <param name="preA">A vector before this vector.</param>
+        /// <param name="postB">A vector after <paramref name="b"/>.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="t"></param>
+        /// <param name="preAT"></param>
+        /// <param name="postBT"></param>
+        /// <returns>The interpolated vector.</returns>
+        public Vector3 CubicInterpolateInTime(Vector3 b, Vector3 preA, Vector3 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
+        {
+            return new Vector3
+            (
+                Mathf.CubicInterpolateInTime(x, b.x, preA.x, postB.x, weight, t, preAT, postBT),
+                Mathf.CubicInterpolateInTime(y, b.y, preA.y, postB.y, weight, t, preAT, postBT),
+                Mathf.CubicInterpolateInTime(z, b.z, preA.z, postB.z, weight, t, preAT, postBT)
+            );
+        }
+
+        /// <summary>
         /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by this vector
         /// and the given <paramref name="control1"/>, <paramref name="control2"/> and <paramref name="end"/> points.
         /// </summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -193,6 +193,31 @@ namespace Godot
         }
 
         /// <summary>
+        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+        /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
+        /// by the time values.
+        /// </summary>
+        /// <param name="b">The destination vector.</param>
+        /// <param name="preA">A vector before this vector.</param>
+        /// <param name="postB">A vector after <paramref name="b"/>.</param>
+        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+        /// <param name="t"></param>
+        /// <param name="preAT"></param>
+        /// <param name="postBT"></param>
+        /// <returns>The interpolated vector.</returns>
+        public Vector4 CubicInterpolateInTime(Vector4 b, Vector4 preA, Vector4 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
+        {
+            return new Vector4
+            (
+                Mathf.CubicInterpolateInTime(x, b.x, preA.x, postB.x, weight, t, preAT, postBT),
+                Mathf.CubicInterpolateInTime(y, b.y, preA.y, postB.y, weight, t, preAT, postBT),
+                Mathf.CubicInterpolateInTime(y, b.z, preA.z, postB.z, weight, t, preAT, postBT),
+                Mathf.CubicInterpolateInTime(w, b.w, preA.w, postB.w, weight, t, preAT, postBT)
+            );
+        }
+
+        /// <summary>
         /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
         /// </summary>
         /// <param name="to">The other vector to point towards.</param>


### PR DESCRIPTION
Updates the C# implementation of cubic interpolation methods (mostly in Quaternion) with the latest changes implemented in core to keep C# in sync.

### Included changes

- Add missing check in `Quaternion.Slerpni`
- Fix `Transform3D` interpolation and add spherical interpolation (Follow up to #53684)
- Add `GetAngle` and `GetAxis` to Quaternion (Follow up to #54050 and #57675)
- Add `Exp` and `Log` to Quaternion (Follow up to #57675 and #64678)
- Fix `Quaternion.CubicSlerp` (Follow up to #63380)
- Rename and fix `Quaternion.SphericalCubicInterpolate` (Follow up to #63532 and #63593)
- Add `CubicInterpolateInTime` (Follow up to #63602)
- Add `CubicInterpolateAngle` (Follow up to #64924)

I made separate commits for each core PR but I can squash them if that's not useful.

### TODO

- [ ] Add missing documentation or leave for a separate PR? Note that core methods are not documented either so it'd be nice to document them too.