### PR TITLE
Add option to remove underline in Editor Docs

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -525,6 +525,8 @@ void EditorHelp::_update_doc() {
 	method_line.clear();
 	section_line.clear();
 
+	class_desc->set_meta_underline(EditorSettings::get_singleton()->get_setting("text_editor/help/show_meta_underline"));
+
 	_update_theme();
 	String link_color_text = title_color.to_html(false);
 
@@ -1985,6 +1987,14 @@ void EditorHelp::_toggle_scripts_pressed() {
 	update_toggle_scripts_button();
 }
 
+void EditorHelp::_meta_hover_started(Variant p_meta) {
+	// TODO: Very cool meta tooltips.
+	class_desc->set_default_cursor_shape(CURSOR_POINTING_HAND);
+}
+void EditorHelp::_meta_hover_ended(Variant p_meta) {
+	class_desc->set_default_cursor_shape(CURSOR_ARROW);
+}
+
 void EditorHelp::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY:
@@ -2105,6 +2115,11 @@ EditorHelp::EditorHelp() {
 	class_desc->connect("meta_clicked", callable_mp(this, &EditorHelp::_class_desc_select));
 	class_desc->connect("gui_input", callable_mp(this, &EditorHelp::_class_desc_input));
 	class_desc->connect("resized", callable_mp(this, &EditorHelp::_class_desc_resized).bind(false));
+
+	// Change cursor shape, even if meta_underline is disabled.
+	class_desc->connect("meta_hover_started", callable_mp(this, &EditorHelp::_meta_hover_started)); //.unbind(1));
+	class_desc->connect("meta_hover_ended", callable_mp(this, &EditorHelp::_meta_hover_ended)); //.unbind(1));
+
 	_class_desc_resized(false);
 
 	// Added second so it opens at the bottom so it won't offset the entire widget.

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -175,6 +175,8 @@ class EditorHelp : public VBoxContainer {
 
 	String _fix_constant(const String &p_constant) const;
 	void _toggle_scripts_pressed();
+	void _meta_hover_started(Variant p_meta);
+	void _meta_hover_ended(Variant p_meta);
 
 	static Thread thread;
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -578,6 +578,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_source_font_size", 14, "8,48,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/help/help_title_font_size", 23, "8,48,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/help/class_reference_examples", 0, "GDScript,C#,GDScript and C#")
+	_initial_set("text_editor/help/show_meta_underline", true);
 
 	/* Editors */
 


### PR DESCRIPTION
The current Docs are certainly an improvement in style, but there's something that has always given me _enough_ of a headache to instead look up the Docs online, and I can't help but feel like the problem I personally have is much more pronounced for users that have trouble reading in general (poor vision, **dyslexia**...).

This PR adds a new **Editor Setting** "`text_editor/help/show_meta_underline`". This is enabled by default.

| On | Off |
| --- | --- |
| ![TopOn](https://user-images.githubusercontent.com/66727710/186546804-c554b274-6e71-4d8e-9a2d-f2abc6165d28.png) |  ![TopOff](https://user-images.githubusercontent.com/66727710/186546891-d945c1d4-6e57-4dbb-a43a-65fea7a64802.png) | 
| ![DescriptionOn](https://user-images.githubusercontent.com/66727710/186547058-4822ca35-8fc6-4676-a57c-0c755f6f62f0.png) | ![DescriptionOff](https://user-images.githubusercontent.com/66727710/186547003-0c65dfdf-c7a1-4db8-b50f-327cba28426c.png) |
| ![MethodsOn](https://user-images.githubusercontent.com/66727710/186547130-7886cec4-fe95-4a51-bd27-72184cba4b53.png) | ![MethodsOff](https://user-images.githubusercontent.com/66727710/186547179-84677ea5-0fc0-4a12-9839-08d2ddb490e9.png)


When disabled, it can definitely be said that the text becomes much cleaner to read. To further sell the deal, in this PR, meta words change cursor shape on hover, regardless of setting:

![HoverCursorShapeChange](https://gyazo.com/b1df65fe517d13e6fe4109b0ba78acf7.gif)
_(In the future, this may actually be useful to show meaningful tooltips in the Editor Documentation, too)_
