### PR TITLE
Add `RandomNumberGenerator.create_from_seed()` static method

### DIFF
--- a/core/math/random_number_generator.cpp
+++ b/core/math/random_number_generator.cpp
@@ -30,7 +30,16 @@
 
 #include "random_number_generator.h"
 
+Ref<RandomNumberGenerator> RandomNumberGenerator::create_from_seed(const uint64_t p_seed) {
+	Ref<RandomNumberGenerator> rng;
+	rng.instantiate();
+	rng->set_seed(p_seed);
+	return rng;
+}
+
 void RandomNumberGenerator::_bind_methods() {
+	ClassDB::bind_static_method("RandomNumberGenerator", D_METHOD("create_from_seed", "seed"), &RandomNumberGenerator::create_from_seed);
+
 	ClassDB::bind_method(D_METHOD("set_seed", "seed"), &RandomNumberGenerator::set_seed);
 	ClassDB::bind_method(D_METHOD("get_seed"), &RandomNumberGenerator::get_seed);
 

--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -43,6 +43,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static Ref<RandomNumberGenerator> create_from_seed(const uint64_t p_seed);
+
 	_FORCE_INLINE_ void set_seed(uint64_t p_seed) { randbase.seed(p_seed); }
 	_FORCE_INLINE_ uint64_t get_seed() { return randbase.get_seed(); }
 

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -19,6 +19,13 @@
 		<link title="Random number generation">$DOCS_URL/tutorials/math/random_number_generation.html</link>
 	</tutorials>
 	<methods>
+		<method name="create_from_seed" qualifiers="static">
+			<return type="RandomNumberGenerator" />
+			<param index="0" name="seed" type="int" />
+			<description>
+				Creates a new [RandomNumberGenerator] with a given [param seed].
+			</description>
+		</method>
 		<method name="randf">
 			<return type="float" />
 			<description>


### PR DESCRIPTION
Adds a static method to RandomNumberGenerator: `create_from_seed(seed: int)`. This can be used to create a RandomNumberGenerator with a seed in one line.