### PR TITLE
Fix input map settings theming

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -1061,6 +1061,9 @@ void ActionMapEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			action_list_search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+			if (!actions_cache.is_empty()) {
+				update_action_list();
+			}
 		} break;
 	}
 }


### PR DESCRIPTION
Currently, it does not update when theme is changed, which leads to the results like:

![image](https://user-images.githubusercontent.com/3036176/186588832-78541088-8270-410a-9c7d-90b470a487e0.png)
