### PR TITLE
Use histogram for averaging in auto exposure

### DIFF
--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -86,7 +86,7 @@ private:
 
 	enum LuminanceReduceMode {
 		LUMINANCE_REDUCE_READ,
-		LUMINANCE_REDUCE,
+		//LUMINANCE_REDUCE,
 		LUMINANCE_REDUCE_WRITE,
 		LUMINANCE_REDUCE_MAX
 	};
@@ -233,7 +233,7 @@ public:
 	void fsr_upscale(RID p_source_rd_texture, RID p_secondary_texture, RID p_destination_texture, const Size2i &p_internal_size, const Size2i &p_size, float p_fsr_upscale_sharpness);
 	void taa_resolve(RID p_frame, RID p_temp, RID p_depth, RID p_velocity, RID p_prev_velocity, RID p_history, Size2 p_resolution, float p_z_near, float p_z_far);
 
-	void luminance_reduction(RID p_source_texture, const Size2i p_source_size, const Vector<RID> p_reduce, RID p_prev_luminance, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
+	void luminance_reduction(RID p_source_texture, const Size2i p_source_size, RID p_target, RID p_prev_luminance, RID p_histogram, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
 	void luminance_reduction_raster(RID p_source_texture, const Size2i p_source_size, const Vector<RID> p_reduce, Vector<RID> p_fb, RID p_prev_luminance, float p_min_luminance, float p_max_luminance, float p_adjust, bool p_set = false);
 
 	void roughness_limit(RID p_source_normal, RID p_roughness, const Size2i &p_size, float p_curve);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -527,6 +527,8 @@ private:
 		struct Luminance {
 			Vector<RID> reduce;
 			RID current;
+			RID histogram;
+			RID last_frame;
 
 			// used only on mobile renderer
 			Vector<RID> fb;

--- a/servers/rendering/renderer_rd/shaders/luminance_reduce.glsl
+++ b/servers/rendering/renderer_rd/shaders/luminance_reduce.glsl
@@ -4,28 +4,27 @@
 
 #VERSION_DEFINES
 
-#define BLOCK_SIZE 8
+#define BLOCK_SIZE 16
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = BLOCK_SIZE, local_size_z = 1) in;
 
-shared float tmp_data[BLOCK_SIZE * BLOCK_SIZE];
-
-#ifdef READ_TEXTURE
-
-//use for main texture
+// Use for reading from screen and from previous luminance.
 layout(set = 0, binding = 0) uniform sampler2D source_texture;
 
+#ifdef READ_TEXTURE
+layout(set = 1, binding = 0) buffer restrict writeonly Histogram {
+	uint data[256];
+}
+histogram;
+shared uint tmp_data[BLOCK_SIZE * BLOCK_SIZE];
 #else
 
-//use for intermediate textures
-layout(r32f, set = 0, binding = 0) uniform restrict readonly image2D source_luminance;
-
-#endif
-
-layout(r32f, set = 1, binding = 0) uniform restrict writeonly image2D dest_luminance;
-
-#ifdef WRITE_LUMINANCE
-layout(set = 2, binding = 0) uniform sampler2D prev_luminance;
+layout(set = 1, binding = 0) buffer restrict Histogram {
+	uint data[256];
+}
+histogram;
+layout(r32f, set = 2, binding = 0) uniform restrict writeonly image2D dest_luminance;
+shared float tmp_data[BLOCK_SIZE * BLOCK_SIZE];
 #endif
 
 layout(push_constant, std430) uniform Params {
@@ -37,46 +36,65 @@ layout(push_constant, std430) uniform Params {
 }
 params;
 
+uint color_to_histogram_bin(vec3 p_color) {
+	float lum = dot(p_color, vec3(0.2125, 0.7154, 0.0721));
+
+	// Purposfully use big epsilon to capture values near zero and round down.
+	if (lum < 0.005) {
+		return 0;
+	}
+
+	float log_lum = clamp((log2(lum) - params.min_luminance) * params.max_luminance, 0.0, 1.0);
+
+	// Map [0, 1] to [1, 255]. The zeroth bin is handled by the epsilon check above.
+	return uint(log_lum * 254.0 + 1.0);
+}
+
 void main() {
-	uint t = gl_LocalInvocationID.y * BLOCK_SIZE + gl_LocalInvocationID.x;
 	ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
 
-	if (any(lessThan(pos, params.source_size))) {
 #ifdef READ_TEXTURE
-		vec3 v = texelFetch(source_texture, pos, 0).rgb;
-		tmp_data[t] = max(v.r, max(v.g, v.b));
-#else
-		tmp_data[t] = imageLoad(source_luminance, pos).r;
-#endif
-	} else {
-		tmp_data[t] = 0.0;
+	tmp_data[gl_LocalInvocationIndex] = 0;
+
+	groupMemoryBarrier();
+	barrier();
+
+	if (any(lessThan(pos, params.source_size))) {
+		vec3 col = texelFetch(source_texture, pos, 0).rgb;
+		uint idx = color_to_histogram_bin(col);
+		atomicAdd(tmp_data[idx], 1);
 	}
 
 	groupMemoryBarrier();
 	barrier();
 
-	uint size = (BLOCK_SIZE * BLOCK_SIZE) >> 1;
+	atomicAdd(histogram.data[gl_LocalInvocationIndex], tmp_data[gl_LocalInvocationIndex]);
+#else
+	uint count = histogram.data[gl_LocalInvocationIndex];
+	tmp_data[gl_LocalInvocationIndex] = float(count) * float(gl_LocalInvocationIndex); // assign more weight to higher values
 
-	do {
-		if (t < size) {
-			tmp_data[t] += tmp_data[t + size];
+	groupMemoryBarrier();
+	barrier();
+
+	for (uint size = (BLOCK_SIZE * BLOCK_SIZE) >> 1; size >= 1; size >>= 1) {
+		if (gl_LocalInvocationIndex < size) {
+			tmp_data[gl_LocalInvocationIndex] += tmp_data[gl_LocalInvocationIndex + size];
 		}
 		groupMemoryBarrier();
 		barrier();
-
-		size >>= 1;
-	} while (size >= 1);
-
-	if (t == 0) {
-		//compute rect size
-		ivec2 rect_size = min(params.source_size - pos, ivec2(BLOCK_SIZE));
-		float avg = tmp_data[0] / float(rect_size.x * rect_size.y);
-		//float avg = tmp_data[0] / float(BLOCK_SIZE*BLOCK_SIZE);
-		pos /= ivec2(BLOCK_SIZE);
-#ifdef WRITE_LUMINANCE
-		float prev_lum = texelFetch(prev_luminance, ivec2(0, 0), 0).r; //1 pixel previous exposure
-		avg = clamp(prev_lum + (avg - prev_lum) * params.exposure_adjust, params.min_luminance, params.max_luminance);
-#endif
-		imageStore(dest_luminance, pos, vec4(avg));
 	}
+
+	histogram.data[gl_LocalInvocationIndex] = 0;
+
+	if (gl_LocalInvocationIndex == 0) {
+		float weighted_log_average = (tmp_data[0] / max((params.source_size.x * params.source_size.y) - float(count), 1.0)) - 1.0;
+
+		// Map from our histogram space to actual luminance
+		float weighted_average = exp2(((weighted_log_average / 254.0) * params.max_luminance) + params.min_luminance);
+
+		float prev_lum = texelFetch(source_texture, ivec2(0, 0), 0).r; //1 pixel previous exposure
+		weighted_average = prev_lum + (weighted_average - prev_lum) * params.exposure_adjust;
+		imageStore(dest_luminance, ivec2(0, 0), vec4(weighted_average));
+	}
+#endif
 }


### PR DESCRIPTION
This changes the approach we use to calculate average screen luminance from one where we simply average the luminance of all the pixels on screen to one where we bucket luminance values into a histogram and calculate a weighted average from the histogram. This approach is both more robust and faster than our old approach (although a simple averaged screen luminance could be more optimized than what we use). 

I used the approach from https://www.alextardif.com/HistogramLuminance.html which resulted in a 2X performance improvement for auto exposure (from 170 us to 80 us on a mobile RTX 3050)

Opening as draft for now as I need to come back to this after physical light units is merged and the rendering reorganization is finished. I want to explore different weighting methods and see if some of the benefits here can be carried over to the mobile renderer.

Reference for future: https://knarkowicz.wordpress.com/2016/01/09/automatic-exposure/

- *Production edit: This partially addresses https://github.com/godotengine/godot-proposals/issues/3080.*