### PR TITLE
Implementation of new Spatial Camera type: Oblique

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -319,6 +319,8 @@ void Projection::set_oblique(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_
 		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0 / p_aspect);
 	}
 
+	// real_t *columns = (real_t *)columns;
+
 	real_t sine, cotangent, deltaZ;
 	real_t radians = p_fovy_degrees / 2.0 * Math_PI / 180.0;
 
@@ -332,12 +334,12 @@ void Projection::set_oblique(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_
 
 	set_identity();
 
-	matrix[0][0] = cotangent / p_aspect;
-	matrix[1][1] = cotangent;
-	matrix[2][2] = -(p_z_far + p_z_near) / deltaZ;
-	matrix[2][3] = -1;
-	matrix[3][2] = -2 * p_z_near * p_z_far / deltaZ;
-	matrix[3][3] = 0;
+	columns[0][0] = cotangent / p_aspect;
+	columns[1][1] = cotangent;
+	columns[2][2] = -(p_z_far + p_z_near) / deltaZ;
+	columns[2][3] = -1;
+	columns[3][2] = -2 * p_z_near * p_z_far / deltaZ;
+	columns[3][3] = 0;
 
 	// Here goes oblique magic!
 	// Eric Lengyel Solution: http://terathon.com/code/oblique.html
@@ -348,24 +350,24 @@ void Projection::set_oblique(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_
 	q.x = ((
 		p_oblique_plane.x < 0 ? -1 :
 		p_oblique_plane.x > 0 ? +1 : 0
-		) + matrix[2][0]
-	) / matrix[0][0];
+		) + columns[2][0]
+	) / columns[0][0];
 
 	q.y = ((
 		p_oblique_plane.y < 0 ? -1 :
 		p_oblique_plane.y > 0 ? +1 : 0
-		) + matrix[2][1]
-	) / matrix[1][1];
+		) + columns[2][1]
+	) / columns[1][1];
 	/* clang-format on */
 
 	q.z = -1.0F;
-	q.w = (1.0F + matrix[2][2]) / matrix[3][2];
+	q.w = (1.0F + columns[2][2]) / columns[3][2];
 
 	Quaternion c = p_oblique_plane * (2.0F / p_oblique_plane.dot(q));
-	matrix[0][2] = c.x;
-	matrix[1][2] = c.y;
-	matrix[2][2] = c.z + 1.0F;
-	matrix[3][2] = c.w;
+	columns[0][2] = c.x;
+	columns[1][2] = c.y;
+	columns[2][2] = c.z + 1.0F;
+	columns[3][2] = c.w;
 }
 
 void Projection::set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample, real_t p_z_near, real_t p_z_far) {

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -33,6 +33,7 @@
 #include "core/math/aabb.h"
 #include "core/math/math_funcs.h"
 #include "core/math/plane.h"
+#include "core/math/quaternion.h"
 #include "core/math/rect2.h"
 #include "core/math/transform_3d.h"
 #include "core/string/ustring.h"
@@ -311,6 +312,60 @@ void Projection::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t 
 	cm.set_identity();
 	cm.columns[3][0] = modeltranslation;
 	*this = *this * cm;
+}
+
+void Projection::set_oblique(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, Quaternion p_oblique_plane, bool p_flip_fov) {
+	if (p_flip_fov) {
+		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0 / p_aspect);
+	}
+
+	real_t sine, cotangent, deltaZ;
+	real_t radians = p_fovy_degrees / 2.0 * Math_PI / 180.0;
+
+	deltaZ = p_z_far - p_z_near;
+	sine = Math::sin(radians);
+
+	if ((deltaZ == 0) || (sine == 0) || (p_aspect == 0)) {
+		return;
+	}
+	cotangent = Math::cos(radians) / sine;
+
+	set_identity();
+
+	matrix[0][0] = cotangent / p_aspect;
+	matrix[1][1] = cotangent;
+	matrix[2][2] = -(p_z_far + p_z_near) / deltaZ;
+	matrix[2][3] = -1;
+	matrix[3][2] = -2 * p_z_near * p_z_far / deltaZ;
+	matrix[3][3] = 0;
+
+	// Here goes oblique magic!
+	// Eric Lengyel Solution: http://terathon.com/code/oblique.html
+	// i < 0 ? -1 : (i > 0 ? +1 : 0) = sign()
+	Quaternion q;
+
+	/* clang-format off */
+	q.x = ((
+		p_oblique_plane.x < 0 ? -1 :
+		p_oblique_plane.x > 0 ? +1 : 0
+		) + matrix[2][0]
+	) / matrix[0][0];
+
+	q.y = ((
+		p_oblique_plane.y < 0 ? -1 :
+		p_oblique_plane.y > 0 ? +1 : 0
+		) + matrix[2][1]
+	) / matrix[1][1];
+	/* clang-format on */
+
+	q.z = -1.0F;
+	q.w = (1.0F + matrix[2][2]) / matrix[3][2];
+
+	Quaternion c = p_oblique_plane * (2.0F / p_oblique_plane.dot(q));
+	matrix[0][2] = c.x;
+	matrix[1][2] = c.y;
+	matrix[2][2] = c.z + 1.0F;
+	matrix[3][2] = c.w;
 }
 
 void Projection::set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample, real_t p_z_near, real_t p_z_far) {

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -31,6 +31,8 @@
 #ifndef PROJECTION_H
 #define PROJECTION_H
 
+#include "core/math/math_defs.h"
+#include "core/math/quaternion.h"
 #include "core/math/vector3.h"
 #include "core/math/vector4.h"
 
@@ -74,6 +76,7 @@ struct _NO_DISCARD_ Projection {
 	void set_light_atlas_rect(const Rect2 &p_rect);
 	void set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov = false);
 	void set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov, int p_eye, real_t p_intraocular_dist, real_t p_convergence_dist);
+	void set_oblique(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, Quaternion p_oblique_plane, bool p_flip_fov = false);
 	void set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample, real_t p_z_near, real_t p_z_far);
 	void set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar);
 	void set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov = false);

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -116,6 +116,28 @@
 				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [param size], an [param offset], and the [param z_near] and [param z_far] clip planes in world space units. See also [member frustum_offset].
 			</description>
 		</method>
+		<method name="set_oblique">
+			<return type="void" />
+			<param index="0" name="fov" type="float" />
+			<param index="1" name="oblique_data" type="Dictionary" />
+			<param index="2" name="z_near" type="float" />
+			<param index="3" name="z_far" type="float" />
+			<description>
+				Sets the camera projection to perspective with oblique near clipping (see [constant PROJECTION_OBLIQUE]), by specifying a [code]fov[/code] (field of view) angle in degrees, the [code]oblique_data[/code] used to transform the projection frustum, and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space before transformation.
+				[b]Note:[/b] [code]oblique_data[/code] is a dictionary containing the following fields:
+				[code]camera_gt[/code]: The camera global transform.
+				[code]normal[/code]: The desired normal vector of the plane.
+				[code]position[/code]: The world-space position of the plane relative to the camera
+				[code]offset[/code]: An adjustable offset for the oblique plane distance value
+			</description>
+		</method>
+		<method name="set_oblique_plane_from_transform">
+			<return type="void" />
+			<param index="0" name="oblique_transform" type="Transform3D" />
+			<description>
+				Sets the Oblique_normal and oblique_position values of an oblique projection camera using a the origin and upward vector of the transform argument. For ease of using plane meshes as portals and mirrors.
+			</description>
+		</method>
 		<method name="set_orthogonal">
 			<return type="void" />
 			<param index="0" name="size" type="float" />
@@ -190,6 +212,15 @@
 		<member name="near" type="float" setter="set_near" getter="get_near" default="0.05">
 			The distance to the near culling boundary for this camera relative to its local Z axis.
 		</member>
+		<member name="oblique_normal" type="Vector3" setter="set_oblique_normal" getter="get_oblique_normal" default="Vector3(0, 1, 0)">
+			The desired normal vector of the world space plane used by an oblique camera as an oblique near clipping plane.
+		</member>
+		<member name="oblique_offset" type="float" setter="set_oblique_offset" getter="get_oblique_offset" default="0.0">
+			The an offset value for the oblique plane along it's forward vector.
+		</member>
+		<member name="oblique_position" type="Vector3" setter="set_oblique_position" getter="get_oblique_position" default="Vector3(0, 0, 0)">
+			The world space position of the plane used by an oblique camera as an oblique near clipping plane.
+		</member>
 		<member name="projection" type="int" setter="set_projection" getter="get_projection" enum="Camera3D.ProjectionType" default="0">
 			The camera's projection mode. In [constant PROJECTION_PERSPECTIVE] mode, objects' Z distance from the camera's local space scales their perceived size.
 		</member>
@@ -209,6 +240,9 @@
 		</constant>
 		<constant name="PROJECTION_FRUSTUM" value="2" enum="ProjectionType">
 			Frustum projection. This mode allows adjusting [member frustum_offset] to create "tilted frustum" effects.
+		</constant>
+		<constant name="PROJECTION_OBLIQUE" value="3" enum="ProjectionType">
+			Oblique Near Plane projection. This mode allows adjusting the near clipping plane to align with a given world plane.
 		</constant>
 		<constant name="KEEP_WIDTH" value="0" enum="KeepAspect">
 			Preserves the horizontal aspect ratio; also known as Vert- scaling. This is usually the best option for projects running in portrait mode, as taller aspect ratios will benefit from a wider vertical FOV.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -131,6 +131,20 @@
 				Sets camera to use frustum projection. This mode allows adjusting the [param offset] argument to create "tilted frustum" effects.
 			</description>
 		</method>
+		<method name="camera_set_oblique">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="fovy_degrees" type="float" />
+			<param index="2" name="camera_gt" type="Transform3D" />
+			<param index="3" name="oblique_normal" type="Vector3" />
+			<param index="4" name="oblique_position" type="Vector3" />
+			<param index="5" name="oblique_offset" type="float" />
+			<param index="6" name="z_near" type="float" />
+			<param index="7" name="z_far" type="float" />
+			<description>
+				Sets camera to use oblique projection. This mode allows adjusting the [code]normal[/code], [code]position[/code], and [code]offset[/code] arguments to create an oblique near clipping plane.
+			</description>
+		</method>
 		<method name="camera_set_orthogonal">
 			<return type="void" />
 			<param index="0" name="camera" type="RID" />

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1941,6 +1941,26 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			Vector3 tup(0, up.y + hsize / 2, side.z);
 			ADD_TRIANGLE(tup + offset, side + up + offset, nside + up + offset);
 		} break;
+		case Camera3D::PROJECTION_OBLIQUE: {
+			// The real FOV is halved for accurate representation
+			float fov = camera->get_fov() / 2.0;
+
+			Vector3 side = Vector3(Math::sin(Math::deg_to_rad(fov)), 0, -Math::cos(Math::deg_to_rad(fov)));
+			Vector3 nside = side;
+			nside.x = -nside.x;
+			Vector3 up = Vector3(0, side.x, 0);
+
+			ADD_TRIANGLE(Vector3(), side + up, side - up);
+			ADD_TRIANGLE(Vector3(), nside + up, nside - up);
+			ADD_TRIANGLE(Vector3(), side + up, nside + up);
+			ADD_TRIANGLE(Vector3(), side - up, nside - up);
+
+			handles.push_back(side);
+			side.x *= 0.25;
+			nside.x *= 0.25;
+			Vector3 tup(0, up.y * 3 / 2, side.z);
+			ADD_TRIANGLE(tup, side + up, nside + up);
+		} break;
 	}
 
 #undef ADD_TRIANGLE

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -43,7 +43,8 @@ public:
 	enum ProjectionType {
 		PROJECTION_PERSPECTIVE,
 		PROJECTION_ORTHOGONAL,
-		PROJECTION_FRUSTUM
+		PROJECTION_FRUSTUM,
+		PROJECTION_OBLIQUE
 	};
 
 	enum KeepAspect {
@@ -64,7 +65,10 @@ private:
 
 	ProjectionType mode = PROJECTION_PERSPECTIVE;
 
-	real_t fov = 75.0;
+	real_t fov = 0.0;
+	Vector3 oblique_normal;
+	Vector3 oblique_position;
+	real_t oblique_offset;
 	real_t size = 1.0;
 	Vector2 frustum_offset;
 	real_t near = 0.05;
@@ -112,6 +116,7 @@ public:
 	};
 
 	void set_perspective(real_t p_fovy_degrees, real_t p_z_near, real_t p_z_far);
+	void set_oblique(real_t p_fovy_degrees, const Dictionary &p_oblique_data, real_t p_z_near, real_t p_z_far);
 	void set_orthogonal(real_t p_size, real_t p_z_near, real_t p_z_far);
 	void set_frustum(real_t p_size, Vector2 p_offset, real_t p_z_near, real_t p_z_far);
 	void set_projection(Camera3D::ProjectionType p_mode);
@@ -124,6 +129,9 @@ public:
 	RID get_camera() const;
 
 	real_t get_fov() const;
+	Vector3 get_oblique_normal() const;
+	Vector3 get_oblique_position() const;
+	real_t get_oblique_offset() const;
 	real_t get_size() const;
 	real_t get_far() const;
 	real_t get_near() const;
@@ -132,6 +140,10 @@ public:
 	ProjectionType get_projection() const;
 
 	void set_fov(real_t p_fov);
+	void set_oblique_normal(Vector3 p_oblique_normal);
+	void set_oblique_position(Vector3 p_oblique_position);
+	void set_oblique_offset(real_t p_oblique_offset);
+	void set_oblique_plane_from_transform(Transform3D p_oblique_plane_transform);
 	void set_size(real_t p_size);
 	void set_far(real_t p_far);
 	void set_near(real_t p_near);

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -66,10 +66,12 @@ public:
 		enum Type {
 			PERSPECTIVE,
 			ORTHOGONAL,
-			FRUSTUM
+			FRUSTUM,
+			OBLIQUE
 		};
 		Type type;
 		float fov;
+		Plane oblique_plane;
 		float znear, zfar;
 		float size;
 		Vector2 offset;
@@ -98,6 +100,7 @@ public:
 	virtual void camera_initialize(RID p_rid);
 
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
+	virtual void camera_set_oblique(RID p_camera, float p_fovy_degrees, const Transform3D &p_camera_gt, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -41,6 +41,7 @@ public:
 	virtual void camera_initialize(RID p_rid) = 0;
 
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_oblique(RID p_camera, float p_fovy_degrees, const Transform3D &p_camera_gt, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -565,6 +565,7 @@ public:
 
 	FUNCRIDSPLIT(camera)
 	FUNC4(camera_set_perspective, RID, float, float, float)
+	FUNC8(camera_set_oblique, RID, float, const Transform3D &, const Vector3 &, const Vector3 &, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
 	FUNC2(camera_set_transform, RID, const Transform3D &)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2170,6 +2170,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("camera_create"), &RenderingServer::camera_create);
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
+	ClassDB::bind_method(D_METHOD("camera_set_oblique", "camera", "fovy_degrees", "camera_gt", "oblique_normal", "oblique_position", "oblique_offset", "z_near", "z_far"), &RenderingServer::camera_set_oblique);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -768,6 +768,7 @@ public:
 
 	virtual RID camera_create() = 0;
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_oblique(RID p_camera, float p_fovy_degrees, const Transform3D &p_camera_gt, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;


### PR DESCRIPTION
allows the specification of a world plane for near clipping;
applies matrix manipulation to generate oblique near plane.

A partial solution to this proposal: https://github.com/godotengine/godot-proposals/issues/2713
**Note: It is by no means a complete solution and should not necessarily be taken as a reason to close the proposal. This PR is merely a straightforward solution for implementing the need for oblique clipping planes to implement a portal mechanic.

Not exactly what is requested, but this implementation covers essentially the most common case the exposed camera matrix would be used for according to the community. At least until more common uses of an exposed matrix are determined to push for a more broad solution.

Thus, this feature is necessary for implementing a 'portal' effect based on the most popular feature tutorials. For example, this often cited video by Sebastian Lague:
https://www.youtube.com/watch?v=cWpFZbjtSQg

Benefits of this solution...
Uses the function 'set_oblique_plane_from_transform' to convert the origin and forward vector into a camera-space Plane normal and distance-offset. Or alternatively, the position and normal can be provided independently of each other.

Exposes member variables in the editor for the plane normal, position, and offset data which supports editing of the plane in world space providing an easy way to visualize the clipping plane by making adjustments in the inspector.

Portal Effect using perspective camera...
![image](https://user-images.githubusercontent.com/40372043/186676583-f66ce91e-9316-46a3-855a-cae4271ef395.png)
Each portal has a camera which displays on the alternate portal's display. The perspective camera can't see through the obstacle its parent portal is placed on (its position is relative to the player's position and the other portal).

Portal Effect using Oblique camera...
![image](https://user-images.githubusercontent.com/40372043/186613846-8f3dcaa6-d65e-4830-b00f-278bed4d3eed.png)
The oblique camera uses the portal's global transform to adjust the camera's near clipping plane to be parallel with the portals facing direction. Thus, obstacles between the camera and portal are no longer visible.

Oblique Camera Member Variables...
![image](https://user-images.githubusercontent.com/40372043/186613913-19198a0b-611f-41cd-9fcf-6adcb6f9f512.png)

[Simple Video Demonstration](https://youtu.be/PipVd6wRnMk)

**Note: If it is not clear using some metrics I'm not familiar with, this is the `master` branch target for previously made `3.x` PR https://github.com/godotengine/godot/pull/56664

- *Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/501.*