### PR TITLE
[Net] Expose get_remote_address/get_remote_port.

### DIFF
--- a/modules/enet/doc_classes/ENetPacketPeer.xml
+++ b/modules/enet/doc_classes/ENetPacketPeer.xml
@@ -18,6 +18,18 @@
 				Returns the number of channels allocated for communication with peer.
 			</description>
 		</method>
+		<method name="get_remote_address" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the IP address of this peer.
+			</description>
+		</method>
+		<method name="get_remote_port" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the remote port of this peer.
+			</description>
+		</method>
 		<method name="get_state" qualifiers="const">
 			<return type="int" enum="ENetPacketPeer.PeerState" />
 			<description>

--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -206,6 +206,8 @@ void ENetPacketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("send", "channel", "packet", "flags"), &ENetPacketPeer::_send);
 	ClassDB::bind_method(D_METHOD("throttle_configure", "interval", "acceleration", "deceleration"), &ENetPacketPeer::throttle_configure);
 	ClassDB::bind_method(D_METHOD("set_timeout", "timeout", "timeout_min", "timeout_max"), &ENetPacketPeer::set_timeout);
+	ClassDB::bind_method(D_METHOD("get_remote_address"), &ENetPacketPeer::get_remote_address);
+	ClassDB::bind_method(D_METHOD("get_remote_port"), &ENetPacketPeer::get_remote_port);
 	ClassDB::bind_method(D_METHOD("get_statistic", "statistic"), &ENetPacketPeer::get_statistic);
 	ClassDB::bind_method(D_METHOD("get_state"), &ENetPacketPeer::get_state);
 	ClassDB::bind_method(D_METHOD("get_channels"), &ENetPacketPeer::get_channels);


### PR DESCRIPTION
Which was not properly exposed to ClassDB after the refactoring.