### PR TITLE
Rename Camera2D's `*_screen_center` and `*_position` to `get_screen_center_position` and `get_target_position`

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -7,7 +7,7 @@
 		Camera node for 2D scenes. It forces the screen (current layer) to scroll following this node. This makes it easier (and faster) to program scrollable scenes than manually changing the position of [CanvasItem]-based nodes.
 		Cameras register themselves in the nearest [Viewport] node (when ascending the tree). Only one camera can be active per viewport. If no viewport is available ascending the tree, the camera will register in the global viewport.
 		This node is intended to be a simple helper to get things going quickly, but more functionality may be desired to change how the camera works. To make your own custom camera node, inherit it from [Node2D] and change the transform of the canvas by setting [member Viewport.canvas_transform] in [Viewport] (you can obtain the current [Viewport] by using [method Node.get_viewport]).
-		Note that the [Camera2D] node's [code]position[/code] doesn't represent the actual position of the screen, which may differ due to applied smoothing or limits. You can use [method get_camera_screen_center] to get the real position.
+		Note that the [Camera2D] node's [code]position[/code] doesn't represent the actual position of the screen, which may differ due to applied smoothing or limits. You can use [method get_screen_center_position] to get the real position.
 	</description>
 	<tutorials>
 		<link title="2D Platformer Demo">https://godotengine.org/asset-library/asset/120</link>
@@ -27,20 +27,6 @@
 				Forces the camera to update scroll immediately.
 			</description>
 		</method>
-		<method name="get_camera_position" qualifiers="const">
-			<return type="Vector2" />
-			<description>
-				Returns the camera's [code]position[/code] (the tracked point the camera attempts to follow), relative to the origin.
-				[b]Note:[/b] The returned value is not the same as [member Node2D.position] or [member Node2D.global_position], as it is affected by the [code]drag[/code] properties.
-			</description>
-		</method>
-		<method name="get_camera_screen_center" qualifiers="const">
-			<return type="Vector2" />
-			<description>
-				Returns the location of the [Camera2D]'s screen-center, relative to the origin.
-				[b]Note:[/b] The real [code]position[/code] of the camera may be different, see [method get_camera_position].
-			</description>
-		</method>
 		<method name="get_drag_margin" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="margin" type="int" enum="Side" />
@@ -53,6 +39,20 @@
 			<param index="0" name="margin" type="int" enum="Side" />
 			<description>
 				Returns the camera limit for the specified [enum Side]. See also [member limit_bottom], [member limit_top], [member limit_left], and [member limit_right].
+			</description>
+		</method>
+		<method name="get_screen_center_position" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the center of the screen from this camera's point of view, in global coordinates.
+				[b]Note:[/b] The exact targeted position of the camera may be different. See [method get_target_position].
+			</description>
+		</method>
+		<method name="get_target_position" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns this camera's target position, in global coordinates.
+				[b]Note:[/b] The returned value is not the same as [member Node2D.global_position], as it is affected by the drag properties. It is also not the same as the current position if [member smoothing_enabled] is [code]true[/code] (see [method get_screen_center_position]).
 			</description>
 		</method>
 		<method name="reset_smoothing">

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -701,8 +701,8 @@ void Camera2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_drag_margin", "margin", "drag_margin"), &Camera2D::set_drag_margin);
 	ClassDB::bind_method(D_METHOD("get_drag_margin", "margin"), &Camera2D::get_drag_margin);
 
-	ClassDB::bind_method(D_METHOD("get_camera_position"), &Camera2D::get_camera_position);
-	ClassDB::bind_method(D_METHOD("get_camera_screen_center"), &Camera2D::get_camera_screen_center);
+	ClassDB::bind_method(D_METHOD("get_target_position"), &Camera2D::get_camera_position);
+	ClassDB::bind_method(D_METHOD("get_screen_center_position"), &Camera2D::get_camera_screen_center);
 
 	ClassDB::bind_method(D_METHOD("set_zoom", "zoom"), &Camera2D::set_zoom);
 	ClassDB::bind_method(D_METHOD("get_zoom"), &Camera2D::get_zoom);


### PR DESCRIPTION
As brought up in: https://github.com/godotengine/godot/issues/54161#issuecomment-1036072622, https://github.com/godotengine/godot/issues/54161#issuecomment-1036245261.

~I am fuming, how did I forget to write this sooner, dang it! I was the one complaining about it!~

These **Camera2D** properties have very confusing and redundant names. Most egregiously, last time I edited the documentation, I had to carefully tip-toe around `get_camera_position()` to make sure it wasn't being confused with Node2D.`position`. This PR attempts to address that.

`get_camera_screen_center` -> `get_screen_center_position`
`get_camera_position` -> `get_target_position`

Also improves the documentation of these two.


~Previously this PR was `get_camera_screen_center` -> `get_screen_center`~
**Note:** Unlike other PRs similarly to this, I left their internal names untouched. See https://github.com/godotengine/godot/pull/63773.