### PR TITLE
Let platforms override the sizing of Vulkan swapchain and window

### DIFF
--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -266,6 +266,8 @@ protected:
 
 	Error _get_preferred_validation_layers(uint32_t *count, const char *const **names);
 
+	virtual VkExtent2D _compute_swapchain_extent(const VkSurfaceCapabilitiesKHR &p_surf_capabilities, int *p_window_width, int *p_window_height) const;
+
 public:
 	// Extension calls.
 	VkResult vkCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass);


### PR DESCRIPTION
In certain proprietary platforms the standard algorithm to determine window and swapchain size may not be a good fit. For instance, the platform abstraction may work better by using a fixed swapchain size and then using some native mechanism to display only the relevant portion.

This PR moves the current algorithm to a virtual method so platform abstractions are free to do it differently, without affecting the current behavior for the rest of platforms at all.