### PR TITLE
Remove unused Create Signal Callbacks editor setting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -578,8 +578,6 @@
 		</member>
 		<member name="text_editor/theme/line_spacing" type="int" setter="" getter="">
 		</member>
-		<member name="text_editor/tools/create_signal_callbacks" type="bool" setter="" getter="">
-		</member>
 		<member name="text_editor/tools/sort_members_outline_alphabetically" type="bool" setter="" getter="">
 		</member>
 	</members>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -467,7 +467,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/files/auto_reload_scripts_on_external_change", false);
 
 	// Tools
-	_initial_set("text_editor/tools/create_signal_callbacks", true);
 	_initial_set("text_editor/tools/sort_members_outline_alphabetically", false);
 
 	// Cursor


### PR DESCRIPTION
This setting wasn't referred to anywhere. It also has no equivalent in `master`.