### PR TITLE
Make C# source generators incremental

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -8,7 +8,7 @@ namespace Godot.SourceGenerators
     public static class Common
     {
         public static void ReportNonPartialGodotScriptClass(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             ClassDeclarationSyntax cds, INamedTypeSymbol symbol
         )
         {
@@ -32,11 +32,12 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportNonPartialGodotScriptOuterClass(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
+            Compilation compilation,
             TypeDeclarationSyntax outerTypeDeclSyntax
         )
         {
-            var outerSymbol = context.Compilation
+            var outerSymbol = compilation
                 .GetSemanticModel(outerTypeDeclSyntax.SyntaxTree)
                 .GetDeclaredSymbol(outerTypeDeclSyntax);
 
@@ -64,7 +65,7 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportExportedMemberIsStatic(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             ISymbol exportedMemberSymbol
         )
         {
@@ -91,7 +92,7 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportExportedMemberTypeNotSupported(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             ISymbol exportedMemberSymbol
         )
         {
@@ -117,7 +118,7 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportExportedMemberIsReadOnly(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             ISymbol exportedMemberSymbol
         )
         {
@@ -145,7 +146,7 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportExportedMemberIsWriteOnly(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             ISymbol exportedMemberSymbol
         )
         {
@@ -169,7 +170,7 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportExportedMemberIsIndexer(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             ISymbol exportedMemberSymbol
         )
         {
@@ -195,7 +196,7 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportSignalDelegateMissingSuffix(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             INamedTypeSymbol delegateSymbol)
         {
             var locations = delegateSymbol.Locations;
@@ -220,7 +221,7 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportSignalParameterTypeNotSupported(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             IParameterSymbol parameterSymbol)
         {
             var locations = parameterSymbol.Locations;
@@ -244,7 +245,7 @@ namespace Godot.SourceGenerators
         }
 
         public static void ReportSignalDelegateSignatureMustReturnVoid(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             INamedTypeSymbol delegateSymbol)
         {
             var locations = delegateSymbol.Locations;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -3,25 +3,26 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Godot.SourceGenerators
 {
     static class ExtensionMethods
     {
         public static bool TryGetGlobalAnalyzerProperty(
-            this GeneratorExecutionContext context, string property, out string? value
-        ) => context.AnalyzerConfigOptions.GlobalOptions
-            .TryGetValue("build_property." + property, out value);
+            this AnalyzerConfigOptionsProvider provider, string property, out string? value
+        ) => provider.GlobalOptions.TryGetValue("build_property." + property, out value);
 
-        public static bool AreGodotSourceGeneratorsDisabled(this GeneratorExecutionContext context)
+        public static bool AreGodotSourceGeneratorsDisabled(this AnalyzerConfigOptionsProvider context)
             => context.TryGetGlobalAnalyzerProperty("GodotSourceGenerators", out string? toggle) &&
                toggle != null &&
                toggle.Equals("disabled", StringComparison.OrdinalIgnoreCase);
 
-        public static bool IsGodotToolsProject(this GeneratorExecutionContext context)
+        public static bool IsGodotToolsProject(this AnalyzerConfigOptionsProvider context)
             => context.TryGetGlobalAnalyzerProperty("IsGodotToolsProject", out string? toggle) &&
                toggle != null &&
                toggle.Equals("true", StringComparison.OrdinalIgnoreCase);
@@ -69,19 +70,17 @@ namespace Godot.SourceGenerators
 
             string? godotClassName = null;
 
-            if (godotClassNameAttr is { ConstructorArguments: { Length: > 0 } })
+            if (godotClassNameAttr is { ConstructorArguments.Length: > 0 })
                 godotClassName = godotClassNameAttr.ConstructorArguments[0].Value?.ToString();
 
             return godotClassName ?? nativeType.Name;
         }
 
-        private static bool IsGodotScriptClass(
-            this ClassDeclarationSyntax cds, Compilation compilation,
+        public static bool IsGodotScriptClass(
+            this ClassDeclarationSyntax cds, SemanticModel sm,
             out INamedTypeSymbol? symbol
         )
         {
-            var sm = compilation.GetSemanticModel(cds.SyntaxTree);
-
             var classTypeSymbol = sm.GetDeclaredSymbol(cds);
 
             if (classTypeSymbol?.BaseType == null
@@ -95,16 +94,22 @@ namespace Godot.SourceGenerators
             return true;
         }
 
-        public static IEnumerable<(ClassDeclarationSyntax cds, INamedTypeSymbol symbol)> SelectGodotScriptClasses(
-            this IEnumerable<ClassDeclarationSyntax> source,
-            Compilation compilation
-        )
+        public static IncrementalValuesProvider<GodotClassData> CreateValuesProviderForGodotClasses(this SyntaxValueProvider provider, Func<SyntaxNode, CancellationToken, bool>? customPredicate = null, Func<GeneratorSyntaxContext, CancellationToken, GodotClassData>? customTransform = null)
         {
-            foreach (var cds in source)
-            {
-                if (cds.IsGodotScriptClass(compilation, out var symbol))
-                    yield return (cds, symbol!);
-            }
+            return provider.CreateSyntaxProvider(
+                // By default select class declarations that inherit from something
+                // since Godot classes must at least inherit from Godot.Object
+                predicate: customPredicate ?? (static (s, _) => s is ClassDeclarationSyntax { BaseList.Types.Count: > 0 }),
+                // Filter out non-Godot classes and retrieve the symbol
+                transform: customTransform ?? (static (ctx, _) =>
+                {
+                    var cds = (ClassDeclarationSyntax)ctx.Node;
+                    if (!cds.IsGodotScriptClass(ctx.SemanticModel, out var symbol))
+                        return default;
+
+                    return new GodotClassData(cds, symbol);
+                })
+            ).Where(static x => x.Symbol is not null);
         }
 
         public static bool IsNested(this TypeDeclarationSyntax cds)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
@@ -20,7 +20,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClassData.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClassData.cs
@@ -1,0 +1,17 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Godot.SourceGenerators
+{
+    public readonly struct GodotClassData
+    {
+        public GodotClassData(ClassDeclarationSyntax cds, INamedTypeSymbol symbol)
+        {
+            DeclarationSyntax = cds;
+            Symbol = symbol;
+        }
+
+        public ClassDeclarationSyntax DeclarationSyntax { get; }
+        public INamedTypeSymbol Symbol { get; }
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
@@ -5,17 +5,23 @@ using Microsoft.CodeAnalysis.Text;
 namespace Godot.SourceGenerators
 {
     [Generator]
-    public class GodotPluginsInitializerGenerator : ISourceGenerator
+    public class GodotPluginsInitializerGenerator : IIncrementalGenerator
     {
-        public void Initialize(GeneratorInitializationContext context)
+        public void Initialize(IncrementalGeneratorInitializationContext context)
         {
+            var isGodotToolsProject = context.AnalyzerConfigOptionsProvider.Select((provider, _) => provider.IsGodotToolsProject());
+
+            context.RegisterSourceOutput(isGodotToolsProject, static (spc, source) =>
+            {
+                if (source)
+                    return;
+
+                Execute(spc);
+            });
         }
 
-        public void Execute(GeneratorExecutionContext context)
+        private static void Execute(SourceProductionContext context)
         {
-            if (context.IsGodotToolsProject())
-                return;
-
             string source =
                 @"using System;
 using System.Runtime.InteropServices;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -1,55 +1,62 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Godot.SourceGenerators
 {
     [Generator]
-    public class ScriptMethodsGenerator : ISourceGenerator
+    public class ScriptMethodsGenerator : IIncrementalGenerator
     {
-        public void Initialize(GeneratorInitializationContext context)
+        public void Initialize(IncrementalGeneratorInitializationContext context)
         {
+            var areGodotSourceGeneratorsDisabled = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => provider.AreGodotSourceGeneratorsDisabled());
+
+            var godotClasses = context.SyntaxProvider.CreateValuesProviderForGodotClasses();
+
+            var values = areGodotSourceGeneratorsDisabled
+                .Combine(context.CompilationProvider)
+                .Combine(godotClasses.Collect());
+
+            context.RegisterSourceOutput(values, static (spc, source) =>
+            {
+                (bool areGodotSourceGeneratorsDisabled, Compilation compilation) = source.Left;
+                var godotClasses = source.Right;
+
+                if (areGodotSourceGeneratorsDisabled)
+                    return;
+
+                Execute(spc, compilation, godotClasses);
+            });
         }
 
-        public void Execute(GeneratorExecutionContext context)
+        private static void Execute(SourceProductionContext context, Compilation compilation, ImmutableArray<GodotClassData> godotClassDatas)
         {
-            if (context.AreGodotSourceGeneratorsDisabled())
-                return;
+            INamedTypeSymbol[] godotClasses = godotClassDatas.Where(x =>
+            {
+                // Report and skip non-partial classes
+                if (x.DeclarationSyntax.IsPartial())
+                {
+                    if (x.DeclarationSyntax.IsNested() && !x.DeclarationSyntax.AreAllOuterTypesPartial(out var typeMissingPartial))
+                    {
+                        Common.ReportNonPartialGodotScriptOuterClass(context, compilation, typeMissingPartial);
+                        return false;
+                    }
 
-            INamedTypeSymbol[] godotClasses = context
-                .Compilation.SyntaxTrees
-                .SelectMany(tree =>
-                    tree.GetRoot().DescendantNodes()
-                        .OfType<ClassDeclarationSyntax>()
-                        .SelectGodotScriptClasses(context.Compilation)
-                        // Report and skip non-partial classes
-                        .Where(x =>
-                        {
-                            if (x.cds.IsPartial())
-                            {
-                                if (x.cds.IsNested() && !x.cds.AreAllOuterTypesPartial(out var typeMissingPartial))
-                                {
-                                    Common.ReportNonPartialGodotScriptOuterClass(context, typeMissingPartial!);
-                                    return false;
-                                }
+                    return true;
+                }
 
-                                return true;
-                            }
-
-                            Common.ReportNonPartialGodotScriptClass(context, x.cds, x.symbol);
-                            return false;
-                        })
-                        .Select(x => x.symbol)
-                )
+                Common.ReportNonPartialGodotScriptClass(context, x.DeclarationSyntax, x.Symbol);
+                return false;
+            }).Select(x => x.Symbol)
                 .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
                 .ToArray();
 
             if (godotClasses.Length > 0)
             {
-                var typeCache = new MarshalUtils.TypeCache(context.Compilation);
+                var typeCache = new MarshalUtils.TypeCache(compilation);
 
                 foreach (var godotClass in godotClasses)
                 {
@@ -73,7 +80,7 @@ namespace Godot.SourceGenerators
         }
 
         private static void VisitGodotScriptClass(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             MarshalUtils.TypeCache typeCache,
             INamedTypeSymbol symbol
         )

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -1,55 +1,62 @@
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Godot.SourceGenerators
 {
     [Generator]
-    public class ScriptPropertiesGenerator : ISourceGenerator
+    public class ScriptPropertiesGenerator : IIncrementalGenerator
     {
-        public void Initialize(GeneratorInitializationContext context)
+        public void Initialize(IncrementalGeneratorInitializationContext context)
         {
+            var areGodotSourceGeneratorsDisabled = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => provider.AreGodotSourceGeneratorsDisabled());
+
+            var godotClasses = context.SyntaxProvider.CreateValuesProviderForGodotClasses();
+
+            var values = areGodotSourceGeneratorsDisabled
+                .Combine(context.CompilationProvider)
+                .Combine(godotClasses.Collect());
+
+            context.RegisterSourceOutput(values, static (spc, source) =>
+            {
+                (bool areGodotSourceGeneratorsDisabled, Compilation compilation) = source.Left;
+                var godotClasses = source.Right;
+
+                if (areGodotSourceGeneratorsDisabled)
+                    return;
+
+                Execute(spc, compilation, godotClasses);
+            });
         }
 
-        public void Execute(GeneratorExecutionContext context)
+        private static void Execute(SourceProductionContext context, Compilation compilation, ImmutableArray<GodotClassData> godotClassDatas)
         {
-            if (context.AreGodotSourceGeneratorsDisabled())
-                return;
+            INamedTypeSymbol[] godotClasses = godotClassDatas.Where(x =>
+            {
+                // Report and skip non-partial classes
+                if (x.DeclarationSyntax.IsPartial())
+                {
+                    if (x.DeclarationSyntax.IsNested() && !x.DeclarationSyntax.AreAllOuterTypesPartial(out var typeMissingPartial))
+                    {
+                        Common.ReportNonPartialGodotScriptOuterClass(context, compilation, typeMissingPartial);
+                        return false;
+                    }
 
-            INamedTypeSymbol[] godotClasses = context
-                .Compilation.SyntaxTrees
-                .SelectMany(tree =>
-                    tree.GetRoot().DescendantNodes()
-                        .OfType<ClassDeclarationSyntax>()
-                        .SelectGodotScriptClasses(context.Compilation)
-                        // Report and skip non-partial classes
-                        .Where(x =>
-                        {
-                            if (x.cds.IsPartial())
-                            {
-                                if (x.cds.IsNested() && !x.cds.AreAllOuterTypesPartial(out var typeMissingPartial))
-                                {
-                                    Common.ReportNonPartialGodotScriptOuterClass(context, typeMissingPartial!);
-                                    return false;
-                                }
+                    return true;
+                }
 
-                                return true;
-                            }
-
-                            Common.ReportNonPartialGodotScriptClass(context, x.cds, x.symbol);
-                            return false;
-                        })
-                        .Select(x => x.symbol)
-                )
+                Common.ReportNonPartialGodotScriptClass(context, x.DeclarationSyntax, x.Symbol);
+                return false;
+            }).Select(x => x.Symbol)
                 .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
                 .ToArray();
 
             if (godotClasses.Length > 0)
             {
-                var typeCache = new MarshalUtils.TypeCache(context.Compilation);
+                var typeCache = new MarshalUtils.TypeCache(compilation);
 
                 foreach (var godotClass in godotClasses)
                 {
@@ -59,7 +66,7 @@ namespace Godot.SourceGenerators
         }
 
         private static void VisitGodotScriptClass(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             MarshalUtils.TypeCache typeCache,
             INamedTypeSymbol symbol
         )
@@ -386,7 +393,7 @@ namespace Godot.SourceGenerators
         }
 
         private static PropertyInfo? DeterminePropertyInfo(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             MarshalUtils.TypeCache typeCache,
             ISymbol memberSymbol,
             MarshalType marshalType

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
@@ -1,55 +1,62 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Godot.SourceGenerators
 {
     [Generator]
-    public class ScriptSerializationGenerator : ISourceGenerator
+    public class ScriptSerializationGenerator : IIncrementalGenerator
     {
-        public void Initialize(GeneratorInitializationContext context)
+        public void Initialize(IncrementalGeneratorInitializationContext context)
         {
+            var areGodotSourceGeneratorsDisabled = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => provider.AreGodotSourceGeneratorsDisabled());
+
+            var godotClasses = context.SyntaxProvider.CreateValuesProviderForGodotClasses();
+
+            var values = areGodotSourceGeneratorsDisabled
+                .Combine(context.CompilationProvider)
+                .Combine(godotClasses.Collect());
+
+            context.RegisterSourceOutput(values, static (spc, source) =>
+            {
+                (bool areGodotSourceGeneratorsDisabled, Compilation compilation) = source.Left;
+                var godotClasses = source.Right;
+
+                if (areGodotSourceGeneratorsDisabled)
+                    return;
+
+                Execute(spc, compilation, godotClasses);
+            });
         }
 
-        public void Execute(GeneratorExecutionContext context)
+        private static void Execute(SourceProductionContext context, Compilation compilation, ImmutableArray<GodotClassData> godotClassDatas)
         {
-            if (context.AreGodotSourceGeneratorsDisabled())
-                return;
+            INamedTypeSymbol[] godotClasses = godotClassDatas.Where(x =>
+            {
+                // Report and skip non-partial classes
+                if (x.DeclarationSyntax.IsPartial())
+                {
+                    if (x.DeclarationSyntax.IsNested() && !x.DeclarationSyntax.AreAllOuterTypesPartial(out var typeMissingPartial))
+                    {
+                        Common.ReportNonPartialGodotScriptOuterClass(context, compilation, typeMissingPartial);
+                        return false;
+                    }
 
-            INamedTypeSymbol[] godotClasses = context
-                .Compilation.SyntaxTrees
-                .SelectMany(tree =>
-                    tree.GetRoot().DescendantNodes()
-                        .OfType<ClassDeclarationSyntax>()
-                        .SelectGodotScriptClasses(context.Compilation)
-                        // Report and skip non-partial classes
-                        .Where(x =>
-                        {
-                            if (x.cds.IsPartial())
-                            {
-                                if (x.cds.IsNested() && !x.cds.AreAllOuterTypesPartial(out var typeMissingPartial))
-                                {
-                                    Common.ReportNonPartialGodotScriptOuterClass(context, typeMissingPartial!);
-                                    return false;
-                                }
+                    return true;
+                }
 
-                                return true;
-                            }
-
-                            Common.ReportNonPartialGodotScriptClass(context, x.cds, x.symbol);
-                            return false;
-                        })
-                        .Select(x => x.symbol)
-                )
+                Common.ReportNonPartialGodotScriptClass(context, x.DeclarationSyntax, x.Symbol);
+                return false;
+            }).Select(x => x.Symbol)
                 .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
                 .ToArray();
 
             if (godotClasses.Length > 0)
             {
-                var typeCache = new MarshalUtils.TypeCache(context.Compilation);
+                var typeCache = new MarshalUtils.TypeCache(compilation);
 
                 foreach (var godotClass in godotClasses)
                 {
@@ -59,7 +66,7 @@ namespace Godot.SourceGenerators
         }
 
         private static void VisitGodotScriptClass(
-            GeneratorExecutionContext context,
+            SourceProductionContext context,
             MarshalUtils.TypeCache typeCache,
             INamedTypeSymbol symbol
         )

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/Common.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/Common.cs
@@ -6,7 +6,7 @@ namespace Godot.SourceGenerators.Internal;
 internal static class Common
 {
     public static void ReportNonPartialUnmanagedCallbacksClass(
-        GeneratorExecutionContext context,
+        SourceProductionContext context,
         ClassDeclarationSyntax cds, INamedTypeSymbol symbol
     )
     {
@@ -30,11 +30,12 @@ internal static class Common
     }
 
     public static void ReportNonPartialUnmanagedCallbacksOuterClass(
-        GeneratorExecutionContext context,
+        SourceProductionContext context,
+        Compilation compilation,
         TypeDeclarationSyntax outerTypeDeclSyntax
     )
     {
-        var outerSymbol = context.Compilation
+        var outerSymbol = compilation
             .GetSemanticModel(outerTypeDeclSyntax.SyntaxTree)
             .GetDeclaredSymbol(outerTypeDeclSyntax);
 

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/ExtensionMethods.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/ExtensionMethods.cs
@@ -12,45 +12,33 @@ internal static class ExtensionMethods
         => symbol.GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.IsGenerateUnmanagedCallbacksAttribute() ?? false);
 
-    private static bool HasGenerateUnmanagedCallbacksAttribute(
-        this ClassDeclarationSyntax cds, Compilation compilation,
+    public static bool HasGenerateUnmanagedCallbacksAttribute(
+        this ClassDeclarationSyntax cds, SemanticModel sm,
         out INamedTypeSymbol? symbol
     )
     {
-        var sm = compilation.GetSemanticModel(cds.SyntaxTree);
-
-        var classTypeSymbol = sm.GetDeclaredSymbol(cds);
-        if (classTypeSymbol == null)
+        foreach (var attrListSyntax in cds.AttributeLists)
         {
-            symbol = null;
-            return false;
+            foreach (var attrSyntax in attrListSyntax.Attributes)
+            {
+                if (sm.GetSymbolInfo(attrSyntax).Symbol is not IMethodSymbol attrSymbol)
+                    continue;
+
+                INamedTypeSymbol attrTypeSymbol = attrSymbol.ContainingType;
+                if (!attrTypeSymbol.IsGenerateUnmanagedCallbacksAttribute())
+                    continue;
+
+                symbol = sm.GetDeclaredSymbol(cds);
+                return symbol != null;
+            }
         }
 
-        if (!classTypeSymbol.GetAttributes()
-                .Any(a => a.AttributeClass?.IsGenerateUnmanagedCallbacksAttribute() ?? false))
-        {
-            symbol = null;
-            return false;
-        }
-
-        symbol = classTypeSymbol;
-        return true;
+        symbol = null;
+        return false;
     }
 
-    private static bool IsGenerateUnmanagedCallbacksAttribute(this INamedTypeSymbol symbol)
+    public static bool IsGenerateUnmanagedCallbacksAttribute(this INamedTypeSymbol symbol)
         => symbol.ToString() == GeneratorClasses.GenerateUnmanagedCallbacksAttr;
-
-    public static IEnumerable<(ClassDeclarationSyntax cds, INamedTypeSymbol symbol)> SelectUnmanagedCallbacksClasses(
-        this IEnumerable<ClassDeclarationSyntax> source,
-        Compilation compilation
-    )
-    {
-        foreach (var cds in source)
-        {
-            if (cds.HasGenerateUnmanagedCallbacksAttribute(compilation, out var symbol))
-                yield return (cds, symbol!);
-        }
-    }
 
     public static bool IsNested(this TypeDeclarationSyntax cds)
         => cds.Parent is TypeDeclarationSyntax;

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/Godot.SourceGenerators.Internal.csproj
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/Godot.SourceGenerators.Internal.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Switch to incremental source generators to increase their performance as they are executed in steps and avoid re-doing work.

### TODO
- [ ] I am not convinced that the way I'm reading the analyzer properties is the best way to do it since the syntax step is still going to be executed regardless of the properties' values.
- [ ] I haven't tested them thoroughly and I'd like to make sure I didn't introduce a regression before marking the PR out of draft.

_Production edit: closes godotengine/godot-roadmap#50_