### PR TITLE
Fix various C# exceptions

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
@@ -16,7 +16,7 @@ namespace Godot.SourceGenerators
                 INamedTypeSymbol GetTypeByMetadataNameOrThrow(string fullyQualifiedMetadataName)
                 {
                     return compilation.GetTypeByMetadataName(fullyQualifiedMetadataName) ??
-                           throw new InvalidOperationException("Type not found: " + fullyQualifiedMetadataName);
+                           throw new InvalidOperationException($"Type not found: '{fullyQualifiedMetadataName}'.");
                 }
 
                 GodotObjectType = GetTypeByMetadataNameOrThrow("Godot.Object");

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/Utils/NotifyAwaiter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/Utils/NotifyAwaiter.cs
@@ -21,14 +21,14 @@ namespace GodotTools.IdeMessaging.Utils
         public void OnCompleted(Action continuation)
         {
             if (this.continuation != null)
-                throw new InvalidOperationException("This awaiter has already been listened");
+                throw new InvalidOperationException("This awaiter already has a continuation.");
             this.continuation = continuation;
         }
 
         public void SetResult(T result)
         {
             if (IsCompleted)
-                throw new InvalidOperationException("This awaiter is already completed");
+                throw new InvalidOperationException("This awaiter is already completed.");
 
             IsCompleted = true;
             this.result = result;
@@ -39,7 +39,7 @@ namespace GodotTools.IdeMessaging.Utils
         public void SetException(Exception exception)
         {
             if (IsCompleted)
-                throw new InvalidOperationException("This awaiter is already completed");
+                throw new InvalidOperationException("This awaiter is already completed.");
 
             IsCompleted = true;
             this.exception = exception;

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -15,7 +15,7 @@ namespace GodotTools.ProjectEditor
         public static ProjectRootElement GenGameProject(string name)
         {
             if (name.Length == 0)
-                throw new ArgumentException("Project name is empty", nameof(name));
+                throw new ArgumentException("Project name is empty.", nameof(name));
 
             var root = ProjectRootElement.Create(NewProjectFileOptions.None);
 
@@ -37,7 +37,7 @@ namespace GodotTools.ProjectEditor
         public static string GenAndSaveGameProject(string dir, string name)
         {
             if (name.Length == 0)
-                throw new ArgumentException("Project name is empty", nameof(name));
+                throw new ArgumentException("Project name is empty.", nameof(name));
 
             string path = Path.Combine(dir, name + ".csproj");
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -62,7 +62,7 @@ namespace GodotTools.Build
         private static bool Build(BuildInfo buildInfo)
         {
             if (_buildInProgress != null)
-                throw new InvalidOperationException("A build is already in progress");
+                throw new InvalidOperationException("A build is already in progress.");
 
             _buildInProgress = buildInfo;
 
@@ -111,7 +111,7 @@ namespace GodotTools.Build
         public static async Task<bool> BuildAsync(BuildInfo buildInfo)
         {
             if (_buildInProgress != null)
-                throw new InvalidOperationException("A build is already in progress");
+                throw new InvalidOperationException("A build is already in progress.");
 
             _buildInProgress = buildInfo;
 
@@ -157,7 +157,7 @@ namespace GodotTools.Build
         private static bool Publish(BuildInfo buildInfo)
         {
             if (_buildInProgress != null)
-                throw new InvalidOperationException("A build is already in progress");
+                throw new InvalidOperationException("A build is already in progress.");
 
             _buildInProgress = buildInfo;
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
@@ -120,13 +120,13 @@ namespace GodotTools.Build
         private void IssueActivated(int idx)
         {
             if (idx < 0 || idx >= _issuesList.ItemCount)
-                throw new IndexOutOfRangeException("Item list index out of range");
+                throw new ArgumentOutOfRangeException(nameof(idx), "Item list index out of range.");
 
             // Get correct issue idx from issue list
             int issueIndex = (int)_issuesList.GetItemMetadata(idx);
 
             if (issueIndex < 0 || issueIndex >= _issues.Count)
-                throw new IndexOutOfRangeException("Issue index out of range");
+                throw new InvalidOperationException("Issue index out of range.");
 
             BuildIssue issue = _issues[issueIndex];
 
@@ -293,7 +293,7 @@ namespace GodotTools.Build
         public void RestartBuild()
         {
             if (!HasBuildExited)
-                throw new InvalidOperationException("Build already started");
+                throw new InvalidOperationException("Build already started.");
 
             BuildManager.RestartBuild(this);
         }
@@ -301,7 +301,7 @@ namespace GodotTools.Build
         public void StopBuild()
         {
             if (!HasBuildExited)
-                throw new InvalidOperationException("Build is not in progress");
+                throw new InvalidOperationException("Build is not in progress.");
 
             BuildManager.StopBuild(this);
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/NuGetUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/NuGetUtils.cs
@@ -49,7 +49,7 @@ namespace GodotTools.Build
             {
                 // Check that the root node is the expected one
                 if (rootNode.Name != nuGetConfigRootName)
-                    throw new Exception("Invalid root Xml node for NuGet.Config. " +
+                    throw new FormatException("Invalid root Xml node for NuGet.Config. " +
                                         $"Expected '{nuGetConfigRootName}' got '{rootNode.Name}'.");
             }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -212,7 +212,7 @@ namespace GodotTools.Export
 
                     int clangExitCode = OS.ExecuteCommand(XcodeHelper.FindXcodeTool("clang"), clangArgs);
                     if (clangExitCode != 0)
-                        throw new Exception($"Command 'clang' exited with code: {clangExitCode}");
+                        throw new InvalidOperationException($"Command 'clang' exited with code: {clangExitCode}.");
 
                     objFilePathsForiOSArch[arch].Add(objFilePath);
                 }
@@ -318,7 +318,7 @@ MONO_AOT_MODE_LAST = 1000,
 
                 int arExitCode = OS.ExecuteCommand(XcodeHelper.FindXcodeTool("ar"), arArgs);
                 if (arExitCode != 0)
-                    throw new Exception($"Command 'ar' exited with code: {arExitCode}");
+                    throw new InvalidOperationException($"Command 'ar' exited with code: {arExitCode}.");
 
                 arFilePathsForAllArchs.Add(arOutputFilePath);
             }
@@ -336,7 +336,7 @@ MONO_AOT_MODE_LAST = 1000,
 
             int lipoExitCode = OS.ExecuteCommand(XcodeHelper.FindXcodeTool("lipo"), lipoArgs);
             if (lipoExitCode != 0)
-                throw new Exception($"Command 'lipo' exited with code: {lipoExitCode}");
+                throw new InvalidOperationException($"Command 'lipo' exited with code: {lipoExitCode}.");
 
             // TODO: Add the AOT lib and interpreter libs as device only to suppress warnings when targeting the simulator
 
@@ -436,7 +436,7 @@ MONO_AOT_MODE_LAST = 1000,
                 }
                 else if (!Directory.Exists(androidToolchain))
                 {
-                    throw new FileNotFoundException("Android toolchain not found: " + androidToolchain);
+                    throw new FileNotFoundException($"Android toolchain not found: '{androidToolchain}'.");
                 }
 
                 var androidToolPrefixes = new Dictionary<string, string>
@@ -533,12 +533,12 @@ MONO_AOT_MODE_LAST = 1000,
                 Console.WriteLine($"Running: \"{process.StartInfo.FileName}\" {process.StartInfo.Arguments}");
 
                 if (!process.Start())
-                    throw new Exception("Failed to start process for Mono AOT compiler");
+                    throw new InvalidOperationException("Failed to start process for Mono AOT compiler.");
 
                 process.WaitForExit();
 
                 if (process.ExitCode != 0)
-                    throw new Exception($"Mono AOT compiler exited with code: {process.ExitCode}");
+                    throw new InvalidOperationException($"Mono AOT compiler exited with code: {process.ExitCode}.");
             }
         }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -98,16 +98,16 @@ namespace GodotTools.Export
                 return;
 
             if (!DeterminePlatformFromFeatures(features, out string platform))
-                throw new NotSupportedException("Target platform not supported");
+                throw new NotSupportedException("Target platform not supported.");
 
             if (!new[] { OS.Platforms.Windows, OS.Platforms.LinuxBSD, OS.Platforms.MacOS }
                     .Contains(platform))
             {
-                throw new NotImplementedException("Target platform not yet implemented");
+                throw new NotImplementedException("Target platform not yet implemented.");
             }
 
             string outputDir = new FileInfo(path).Directory?.FullName ??
-                               throw new FileNotFoundException("Output base directory not found");
+                               throw new FileNotFoundException("Output base directory not found.");
 
             string buildConfig = isDebug ? "ExportDebug" : "ExportRelease";
 
@@ -131,7 +131,7 @@ namespace GodotTools.Export
             if (!BuildManager.PublishProjectBlocking(buildConfig, platform,
                     runtimeIdentifier, publishOutputTempDir))
             {
-                throw new Exception("Failed to build project");
+                throw new InvalidOperationException("Failed to build project.");
             }
 
             string soExt = ridOS switch

--- a/modules/mono/editor/GodotTools/GodotTools/Export/XcodeHelper.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/XcodeHelper.cs
@@ -16,7 +16,7 @@ namespace GodotTools.Export
                     _XcodePath = FindXcode();
 
                     if (_XcodePath == null)
-                        throw new Exception("Could not find Xcode");
+                        throw new FileNotFoundException("Could not find Xcode.");
                 }
 
                 return _XcodePath;

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -342,7 +342,7 @@ namespace GodotTools
                 DotNetSolution.MigrateFromOldConfigNames(GodotSharpDirs.ProjectSlnPath);
 
                 var msbuildProject = ProjectUtils.Open(GodotSharpDirs.ProjectCsProjPath)
-                                     ?? throw new Exception("Cannot open C# project");
+                                     ?? throw new InvalidOperationException("Cannot open C# project.");
 
                 // NOTE: The order in which changes are made to the project is important
 

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -153,7 +153,7 @@ namespace GodotTools.Ides
                 }
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(nameof(editorId));
             }
         }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/Rider/RiderPathLocator.cs
@@ -42,7 +42,7 @@ namespace GodotTools.Ides.Rider
                 {
                     return CollectAllRiderPathsLinux();
                 }
-                throw new Exception("Unexpected OS.");
+                throw new InvalidOperationException("Unexpected OS.");
             }
             catch (Exception e)
             {
@@ -216,7 +216,7 @@ namespace GodotTools.Ides.Rider
                 return "../../build.txt";
             if (OS.IsMacOS)
                 return "Contents/Resources/build.txt";
-            throw new Exception("Unknown OS.");
+            throw new InvalidOperationException("Unknown OS.");
         }
 
         [SupportedOSPlatform("windows")]

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/Internal.cs
@@ -74,11 +74,11 @@ namespace GodotTools.Internals
         internal static unsafe void Initialize(IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
         {
             if (initialized)
-                throw new InvalidOperationException("Already initialized");
+                throw new InvalidOperationException("Already initialized.");
             initialized = true;
 
             if (unmanagedCallbacksSize != sizeof(InternalUnmanagedCallbacks))
-                throw new ArgumentException("Unmanaged callbacks size mismatch");
+                throw new ArgumentException("Unmanaged callbacks size mismatch.", nameof(unmanagedCallbacksSize));
 
             _unmanagedCallbacks = Unsafe.AsRef<InternalUnmanagedCallbacks>((void*)unmanagedCallbacks);
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -257,7 +257,7 @@ namespace GodotTools.Utils
             using Process process = Process.Start(startInfo);
 
             if (process == null)
-                throw new Exception("No process was started");
+                throw new InvalidOperationException("No process was started.");
 
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();

--- a/modules/mono/glue/GodotSharp/GodotPlugins/Main.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/Main.cs
@@ -153,7 +153,7 @@ namespace GodotPlugins
                 string assemblyPath = new(nAssemblyPath);
 
                 if (_editorApiAssembly == null)
-                    throw new InvalidOperationException("The Godot editor API assembly is not loaded");
+                    throw new InvalidOperationException("The Godot editor API assembly is not loaded.");
 
                 var (assembly, _) = LoadPlugin(assemblyPath);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -145,6 +145,9 @@ namespace Godot
         /// Gets the position of one of the 8 endpoints of the <see cref="AABB"/>.
         /// </summary>
         /// <param name="idx">Which endpoint to get.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="idx"/> is less than 0 or greater than 7.
+        /// </exception>
         /// <returns>An endpoint of the <see cref="AABB"/>.</returns>
         public Vector3 GetEndpoint(int idx)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -510,7 +510,7 @@ namespace Godot.Collections
             if (_convertToVariantCallback == null || _convertToManagedCallback == null)
             {
                 throw new InvalidOperationException(
-                    $"The array element type is not supported for conversion to Variant: '{typeof(T).FullName}'");
+                    $"The array element type is not supported for conversion to Variant: '{typeof(T).FullName}'.");
             }
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -148,6 +148,9 @@ namespace Godot
         /// Access whole columns in the form of <see cref="Vector3"/>.
         /// </summary>
         /// <param name="column">Which column vector.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="column"/> is not 0, 1, 2 or 3.
+        /// </exception>
         /// <value>The basis column.</value>
         public Vector3 this[int column]
         {
@@ -366,8 +369,8 @@ namespace Godot
         /// but are more efficient for some internal calculations.
         /// </summary>
         /// <param name="index">Which row.</param>
-        /// <exception cref="IndexOutOfRangeException">
-        /// Thrown when the <paramref name="index"/> is not 0, 1 or 2.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0, 1 or 2.
         /// </exception>
         /// <returns>One of <c>Row0</c>, <c>Row1</c>, or <c>Row2</c>.</returns>
         public Vector3 GetRow(int index)
@@ -391,8 +394,8 @@ namespace Godot
         /// </summary>
         /// <param name="index">Which row.</param>
         /// <param name="value">The vector to set the row to.</param>
-        /// <exception cref="IndexOutOfRangeException">
-        /// Thrown when the <paramref name="index"/> is not 0, 1 or 2.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0, 1 or 2.
         /// </exception>
         public void SetRow(int index, Vector3 value)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -595,7 +595,7 @@ namespace Godot
         /// </summary>
         /// <param name="rgba">A string for the HTML hexadecimal representation of this color.</param>
         /// <exception name="ArgumentOutOfRangeException">
-        /// Thrown when the given <paramref name="rgba"/> color code is invalid.
+        /// <paramref name="rgba"/> color code is invalid.
         /// </exception>
         private static Color FromHTML(string rgba)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -171,7 +171,7 @@ namespace Godot.Collections
             var self = (godot_dictionary)NativeValue;
 
             if (NativeFuncs.godotsharp_dictionary_contains_key(ref self, variantKey).ToBool())
-                throw new ArgumentException("An element with the same key already exists", nameof(key));
+                throw new ArgumentException("An element with the same key already exists.", nameof(key));
 
             godot_variant variantValue = (godot_variant)value.NativeVar;
             NativeFuncs.godotsharp_dictionary_add(ref self, variantKey, variantValue);
@@ -381,13 +381,13 @@ namespace Godot.Collections
             if (_convertKeyToVariantCallback == null || _convertKeyToManagedCallback == null)
             {
                 throw new InvalidOperationException(
-                    $"The dictionary key type is not supported for conversion to Variant: '{typeof(TKey).FullName}'");
+                    $"The dictionary key type is not supported for conversion to Variant: '{typeof(TKey).FullName}'.");
             }
 
             if (_convertValueToVariantCallback == null || _convertValueToManagedCallback == null)
             {
                 throw new InvalidOperationException(
-                    $"The dictionary value type is not supported for conversion to Variant: '{typeof(TValue).FullName}'");
+                    $"The dictionary value type is not supported for conversion to Variant: '{typeof(TValue).FullName}'.");
             }
         }
 
@@ -556,7 +556,7 @@ namespace Godot.Collections
             var self = (godot_dictionary)_underlyingDict.NativeValue;
 
             if (NativeFuncs.godotsharp_dictionary_contains_key(ref self, variantKey).ToBool())
-                throw new ArgumentException("An element with the same key already exists", nameof(key));
+                throw new ArgumentException("An element with the same key already exists.", nameof(key));
 
             using var variantValue = _convertValueToVariantCallback(value);
             NativeFuncs.godotsharp_dictionary_add(ref self, variantKey, variantValue);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DisposablesTracker.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DisposablesTracker.cs
@@ -83,13 +83,13 @@ namespace Godot
         public static void UnregisterGodotObject(Object godotObject, WeakReference<Object> weakReferenceToSelf)
         {
             if (!GodotObjectInstances.TryRemove(weakReferenceToSelf, out _))
-                throw new ArgumentException("Godot Object not registered", nameof(weakReferenceToSelf));
+                throw new ArgumentException("Godot Object not registered.", nameof(weakReferenceToSelf));
         }
 
         public static void UnregisterDisposable(WeakReference<IDisposable> weakReference)
         {
             if (!OtherInstances.TryRemove(weakReference, out _))
-                throw new ArgumentException("Disposable not registered", nameof(weakReference));
+                throw new ArgumentException("Disposable not registered.", nameof(weakReference));
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -36,7 +36,7 @@ namespace Godot
         /// <seealso cref="GetNodeOrNull{T}(NodePath)"/>
         /// <param name="path">The path to the node to fetch.</param>
         /// <exception cref="InvalidCastException">
-        /// Thrown when the given the fetched node can't be casted to the given type <typeparamref name="T"/>.
+        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>
@@ -100,7 +100,7 @@ namespace Godot
         /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
         /// </param>
         /// <exception cref="InvalidCastException">
-        /// Thrown when the given the fetched node can't be casted to the given type <typeparamref name="T"/>.
+        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>
@@ -142,7 +142,7 @@ namespace Godot
         /// </summary>
         /// <seealso cref="GetOwnerOrNull{T}"/>
         /// <exception cref="InvalidCastException">
-        /// Thrown when the given the fetched node can't be casted to the given type <typeparamref name="T"/>.
+        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>
@@ -176,7 +176,7 @@ namespace Godot
         /// </summary>
         /// <seealso cref="GetParentOrNull{T}"/>
         /// <exception cref="InvalidCastException">
-        /// Thrown when the given the fetched node can't be casted to the given type <typeparamref name="T"/>.
+        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
@@ -11,7 +11,7 @@ namespace Godot
         /// </summary>
         /// <seealso cref="InstantiateOrNull{T}(GenEditState)"/>
         /// <exception cref="InvalidCastException">
-        /// Thrown when the given the instantiated node can't be casted to the given type <typeparamref name="T"/>.
+        /// The instantiated node can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
         /// <returns>The instantiated scene.</returns>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
@@ -19,7 +19,7 @@ namespace Godot
         /// Returns an empty resource if no <see cref="ResourceFormatLoader"/> could handle the file.
         /// </summary>
         /// <exception cref="InvalidCastException">
-        /// Thrown when the given the loaded resource can't be casted to the given type <typeparamref name="T"/>.
+        /// The loaded resource can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
         public static T Load<T>(string path, string typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : class

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -22,11 +22,11 @@ namespace Godot.NativeInterop
         public static void Initialize(IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
         {
             if (initialized)
-                throw new InvalidOperationException("Already initialized");
+                throw new InvalidOperationException("Already initialized.");
             initialized = true;
 
             if (unmanagedCallbacksSize != sizeof(UnmanagedCallbacks))
-                throw new ArgumentException("Unmanaged callbacks size mismatch");
+                throw new ArgumentException("Unmanaged callbacks size mismatch.", nameof(unmanagedCallbacksSize));
 
             _unmanagedCallbacks = Unsafe.AsRef<UnmanagedCallbacks>((void*)unmanagedCallbacks);
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.exceptions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Object.exceptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 #nullable enable
 
@@ -60,19 +61,22 @@ namespace Godot
             {
                 get
                 {
-                    string s = base.Message;
-
-                    if (string.IsNullOrEmpty(s))
+                    StringBuilder sb;
+                    if (string.IsNullOrEmpty(base.Message))
                     {
-                        s = Arg_NativeConstructorNotFoundException;
+                        sb = new(Arg_NativeConstructorNotFoundException);
+                    }
+                    else
+                    {
+                        sb = new(base.Message);
                     }
 
                     if (!string.IsNullOrEmpty(_nativeClassName))
                     {
-                        s += " " + string.Format("(Class '{0}')", _nativeClassName);
+                        sb.Append($" (Method '{_nativeClassName}')");
                     }
 
-                    return s;
+                    return sb.ToString();
                 }
             }
         }
@@ -115,19 +119,22 @@ namespace Godot
             {
                 get
                 {
-                    string s = base.Message;
-
-                    if (string.IsNullOrEmpty(s))
+                    StringBuilder sb;
+                    if (string.IsNullOrEmpty(base.Message))
                     {
-                        s = Arg_NativeMethodBindNotFoundException;
+                        sb = new(Arg_NativeMethodBindNotFoundException);
+                    }
+                    else
+                    {
+                        sb = new(base.Message);
                     }
 
                     if (!string.IsNullOrEmpty(_nativeMethodName))
                     {
-                        s += " " + string.Format("(Method '{0}')", _nativeMethodName);
+                        sb.Append($" (Method '{_nativeMethodName}')");
                     }
 
-                    return s;
+                    return sb.ToString();
                 }
             }
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -649,6 +649,9 @@ namespace Godot
         /// Access whole columns in the form of <see cref="Vector4"/>.
         /// </summary>
         /// <param name="column">Which column vector.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="column"/> is not 0, 1, 2 or 3.
+        /// </exception>
         public Vector4 this[int column]
         {
             get
@@ -664,7 +667,7 @@ namespace Godot
                     case 3:
                         return w;
                     default:
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(column));
                 }
             }
             set
@@ -684,7 +687,7 @@ namespace Godot
                         w = value;
                         return;
                     default:
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(column));
                 }
             }
         }
@@ -694,6 +697,9 @@ namespace Godot
         /// </summary>
         /// <param name="column">Which column vector.</param>
         /// <param name="row">Which row of the column.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="column"/> or <paramref name="row"/> are not 0, 1, 2 or 3.
+        /// </exception>
         public real_t this[int column, int row]
         {
             get
@@ -709,7 +715,7 @@ namespace Godot
                     case 3:
                         return w[row];
                     default:
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(column));
                 }
             }
             set
@@ -729,7 +735,7 @@ namespace Godot
                         w[row] = value;
                         return;
                     default:
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(column));
                 }
             }
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -47,6 +47,9 @@ namespace Godot
         /// <summary>
         /// Access quaternion components using their index.
         /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0, 1, 2 or 3.
+        /// </exception>
         /// <value>
         /// <c>[0]</c> is equivalent to <see cref="x"/>,
         /// <c>[1]</c> is equivalent to <see cref="y"/>,
@@ -170,7 +173,7 @@ namespace Godot
 #if DEBUG
             if (!IsNormalized())
             {
-                throw new InvalidOperationException("Quaternion is not normalized");
+                throw new InvalidOperationException("Quaternion is not normalized.");
             }
 #endif
             var basis = new Basis(this);
@@ -186,7 +189,7 @@ namespace Godot
 #if DEBUG
             if (!IsNormalized())
             {
-                throw new InvalidOperationException("Quaternion is not normalized");
+                throw new InvalidOperationException("Quaternion is not normalized.");
             }
 #endif
             return new Quaternion(-x, -y, -z, w);
@@ -224,11 +227,11 @@ namespace Godot
 #if DEBUG
             if (!IsNormalized())
             {
-                throw new InvalidOperationException("Quaternion is not normalized");
+                throw new InvalidOperationException("Quaternion is not normalized.");
             }
             if (!to.IsNormalized())
             {
-                throw new ArgumentException("Argument is not normalized", nameof(to));
+                throw new ArgumentException("Argument is not normalized.", nameof(to));
             }
 #endif
 
@@ -388,7 +391,7 @@ namespace Godot
 #if DEBUG
             if (!axis.IsNormalized())
             {
-                throw new ArgumentException("Argument is not normalized", nameof(axis));
+                throw new ArgumentException("Argument is not normalized.", nameof(axis));
             }
 #endif
 
@@ -444,7 +447,7 @@ namespace Godot
 #if DEBUG
             if (!quaternion.IsNormalized())
             {
-                throw new InvalidOperationException("Quaternion is not normalized");
+                throw new InvalidOperationException("Quaternion is not normalized.");
             }
 #endif
             var u = new Vector3(quaternion.x, quaternion.y, quaternion.z);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -75,6 +75,9 @@ namespace Godot
         /// The third column is the <see cref="origin"/> vector.
         /// </summary>
         /// <param name="column">Which column vector.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="column"/> is not 0, 1 or 2.
+        /// </exception>
         public Vector2 this[int column]
         {
             get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -32,6 +32,9 @@ namespace Godot
         /// The fourth column is the <see cref="origin"/> vector.
         /// </summary>
         /// <param name="column">Which column vector.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="column"/> is not 0, 1, 2 or 3.
+        /// </exception>
         public Vector3 this[int column]
         {
             get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -39,8 +39,8 @@ namespace Godot
         /// <summary>
         /// Access vector components using their index.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException">
-        /// Thrown when the given the <paramref name="index"/> is not 0 or 1.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0 or 1.
         /// </exception>
         /// <value>
         /// <c>[0]</c> is equivalent to <see cref="x"/>,
@@ -479,7 +479,7 @@ namespace Godot
 #if DEBUG
             if (!normal.IsNormalized())
             {
-                throw new ArgumentException("Argument is not normalized", nameof(normal));
+                throw new ArgumentException("Argument is not normalized.", nameof(normal));
             }
 #endif
             return (2 * Dot(normal) * normal) - this;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -39,8 +39,8 @@ namespace Godot
         /// <summary>
         /// Access vector components using their index.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException">
-        /// Thrown when the given the <paramref name="index"/> is not 0 or 1.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0 or 1.
         /// </exception>
         /// <value>
         /// <c>[0]</c> is equivalent to <see cref="x"/>,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -48,8 +48,8 @@ namespace Godot
         /// <summary>
         /// Access vector components using their index.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException">
-        /// Thrown when the given the <paramref name="index"/> is not 0, 1 or 2.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0, 1 or 2.
         /// </exception>
         /// <value>
         /// <c>[0]</c> is equivalent to <see cref="x"/>,
@@ -497,7 +497,7 @@ namespace Godot
 #if DEBUG
             if (!normal.IsNormalized())
             {
-                throw new ArgumentException("Argument is not normalized", nameof(normal));
+                throw new ArgumentException("Argument is not normalized.", nameof(normal));
             }
 #endif
             return (2.0f * Dot(normal) * normal) - this;
@@ -515,7 +515,7 @@ namespace Godot
 #if DEBUG
             if (!axis.IsNormalized())
             {
-                throw new ArgumentException("Argument is not normalized", nameof(axis));
+                throw new ArgumentException("Argument is not normalized.", nameof(axis));
             }
 #endif
             return new Basis(axis, angle) * this;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -48,8 +48,8 @@ namespace Godot
         /// <summary>
         /// Access vector components using their <paramref name="index"/>.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException">
-        /// Thrown when the given the <paramref name="index"/> is not 0, 1 or 2.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0, 1 or 2.
         /// </exception>
         /// <value>
         /// <c>[0]</c> is equivalent to <see cref="x"/>,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -57,8 +57,8 @@ namespace Godot
         /// <summary>
         /// Access vector components using their index.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException">
-        /// Thrown when the given the <paramref name="index"/> is not 0, 1, 2 or 3.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0, 1, 2 or 3.
         /// </exception>
         /// <value>
         /// <c>[0]</c> is equivalent to <see cref="x"/>,
@@ -81,7 +81,7 @@ namespace Godot
                     case 3:
                         return w;
                     default:
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(index));
                 }
             }
             set
@@ -101,7 +101,7 @@ namespace Godot
                         w = value;
                         return;
                     default:
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(index));
                 }
             }
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4i.cs
@@ -57,8 +57,8 @@ namespace Godot
         /// <summary>
         /// Access vector components using their <paramref name="index"/>.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException">
-        /// Thrown when the given the <paramref name="index"/> is not 0, 1, 2 or 3.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is not 0, 1, 2 or 3.
         /// </exception>
         /// <value>
         /// <c>[0]</c> is equivalent to <see cref="x"/>,
@@ -81,7 +81,7 @@ namespace Godot
                     case 3:
                         return w;
                     default:
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(index));
                 }
             }
             set
@@ -101,7 +101,7 @@ namespace Godot
                         w = value;
                         return;
                     default:
-                        throw new IndexOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(index));
                 }
             }
         }


### PR DESCRIPTION
- Replace `IndexOutOfRangeException` with `ArgumentOutOfRangeException`.
- Replace `Exception` with a more specific exception.
- Add the parameter name to argument exception.
- Update documentation for methods that throw exceptions.
- Use `StringBuilder` to build exception messages.
- Ensure exception messages end with a period.

I couldn't think of a better exception than `InvalidOperationException` to replace `Exception` but I'm not sure it's the best option in all cases.