### PR TITLE
C#: Use pattern matching to simplify `Equals`

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/GodotIdeMetadata.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/GodotIdeMetadata.cs
@@ -25,10 +25,7 @@ namespace GodotTools.IdeMessaging
 
         public override bool Equals(object obj)
         {
-            if (obj is GodotIdeMetadata metadata)
-                return metadata == this;
-
-            return false;
+            return obj is GodotIdeMetadata metadata && metadata == this;
         }
 
         public bool Equals(GodotIdeMetadata other)

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
@@ -27,15 +27,13 @@ namespace GodotTools.Build
 
         public override bool Equals(object? obj)
         {
-            if (obj is BuildInfo other)
-                return other.Solution == Solution &&
-                       other.Configuration == Configuration && other.RuntimeIdentifier == RuntimeIdentifier &&
-                       other.PublishOutputDir == PublishOutputDir && other.Restore == Restore &&
-                       other.Rebuild == Rebuild && other.OnlyClean == OnlyClean &&
-                       other.CustomProperties == CustomProperties &&
-                       other.LogsDirPath == LogsDirPath;
-
-            return false;
+            return obj is BuildInfo other &&
+                other.Solution == Solution &&
+                other.Configuration == Configuration && other.RuntimeIdentifier == RuntimeIdentifier &&
+                other.PublishOutputDir == PublishOutputDir && other.Restore == Restore &&
+                other.Rebuild == Rebuild && other.OnlyClean == OnlyClean &&
+                other.CustomProperties == CustomProperties &&
+                other.LogsDirPath == LogsDirPath;
         }
 
         public override int GetHashCode()

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/AABB.cs
@@ -697,12 +697,7 @@ namespace Godot
         /// <returns>Whether or not the AABB and the object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is AABB)
-            {
-                return Equals((AABB)obj);
-            }
-
-            return false;
+            return obj is AABB other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -892,12 +892,7 @@ namespace Godot
         /// <returns>Whether or not the basis matrix and the object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Basis)
-            {
-                return Equals((Basis)obj);
-            }
-
-            return false;
+            return obj is Basis other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -1151,12 +1151,7 @@ namespace Godot
         /// <returns>Whether or not the color and the other object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Color)
-            {
-                return Equals((Color)obj);
-            }
-
-            return false;
+            return obj is Color other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
@@ -121,8 +121,8 @@ namespace Godot
 
             var sb = new StringBuilder();
 
-            if (methodBase is MethodInfo)
-                sb.AppendTypeName(((MethodInfo)methodBase).ReturnType);
+            if (methodBase is MethodInfo methodInfo)
+                sb.AppendTypeName(methodInfo.ReturnType);
 
             sb.Append(methodBase.DeclaringType?.FullName ?? "<unknown>");
             sb.Append('.');

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -353,12 +353,7 @@ namespace Godot
         /// <returns>Whether or not the plane and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Plane)
-            {
-                return Equals((Plane)obj);
-            }
-
-            return false;
+            return obj is Plane other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -812,11 +812,7 @@ namespace Godot
         /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Projection)
-            {
-                return Equals((Projection)obj);
-            }
-            return false;
+            return obj is Projection other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -589,12 +589,7 @@ namespace Godot
         /// <returns>Whether or not the quaternion and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Quaternion)
-            {
-                return Equals((Quaternion)obj);
-            }
-
-            return false;
+            return obj is Quaternion other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -426,12 +426,7 @@ namespace Godot
         /// <returns>Whether or not the rect and the other object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Rect2)
-            {
-                return Equals((Rect2)obj);
-            }
-
-            return false;
+            return obj is Rect2 other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2i.cs
@@ -426,12 +426,7 @@ namespace Godot
         /// <returns>Whether or not the rect and the other object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Rect2i)
-            {
-                return Equals((Rect2i)obj);
-            }
-
-            return false;
+            return obj is Rect2i other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -602,7 +602,7 @@ namespace Godot
         /// <returns>Whether or not the transform and the object are exactly equal.</returns>
         public override bool Equals(object obj)
         {
-            return obj is Transform2D transform2D && Equals(transform2D);
+            return obj is Transform2D other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -579,12 +579,7 @@ namespace Godot
         /// <returns>Whether or not the transform and the object are exactly equal.</returns>
         public override readonly bool Equals(object obj)
         {
-            if (obj is Transform3D)
-            {
-                return Equals((Transform3D)obj);
-            }
-
-            return false;
+            return obj is Transform3D other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -935,11 +935,7 @@ namespace Godot
         /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Vector2)
-            {
-                return Equals((Vector2)obj);
-            }
-            return false;
+            return obj is Vector2 other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -685,12 +685,7 @@ namespace Godot
         /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Vector2i)
-            {
-                return Equals((Vector2i)obj);
-            }
-
-            return false;
+            return obj is Vector2i other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -1004,12 +1004,7 @@ namespace Godot
         /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Vector3)
-            {
-                return Equals((Vector3)obj);
-            }
-
-            return false;
+            return obj is Vector3 other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -695,12 +695,7 @@ namespace Godot
         /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Vector3i)
-            {
-                return Equals((Vector3i)obj);
-            }
-
-            return false;
+            return obj is Vector3i other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -766,12 +766,7 @@ namespace Godot
         /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Vector4)
-            {
-                return Equals((Vector4)obj);
-            }
-
-            return false;
+            return obj is Vector4 other && Equals(other);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4i.cs
@@ -649,12 +649,7 @@ namespace Godot
         /// <returns>Whether or not the vector and the object are equal.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is Vector4i)
-            {
-                return Equals((Vector4i)obj);
-            }
-
-            return false;
+            return obj is Vector4i other && Equals(other);
         }
 
         /// <summary>


### PR DESCRIPTION
- Simplify and unify `Equals` implementation of C# struct types (some were using pattern matching and others weren't, now they all are).
- Also add pattern matching to replace a cast in `DebuggingUtils`.
