### PR TITLE
Fix external Material for invalid Material

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -986,6 +986,11 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 					if (mat.is_valid()) {
 						String mat_id = mat->get_meta("import_id", mat->get_name());
 
+						if (mat_id.is_empty() && mat->has_meta("unique_id")) {
+							mat_id = mat->get_meta("unique_id");
+							mat->remove_meta("unique_id");
+						}
+
 						if (!mat_id.is_empty() && p_material_data.has(mat_id)) {
 							Dictionary matdata = p_material_data[mat_id];
 							{

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -148,6 +148,8 @@ void SceneImportSettings::_fill_material(Tree *p_tree, const Ref<Material> &p_ma
 	} else if (!p_material->get_name().is_empty()) {
 		import_id = p_material->get_name();
 		has_import_id = true;
+	} else if (p_material->has_meta("unique_id")) {
+		import_id = p_material->get_meta("unique_id");
 	} else {
 		import_id = "@MATERIAL:" + itos(material_set.size() - 1);
 	}

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2948,6 +2948,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> state) {
 				} else {
 					Ref<StandardMaterial3D> mat3d;
 					mat3d.instantiate();
+					mat3d->set_meta("unique_id", vformat("%s@%s", import_mesh->get_name(), itos(j)));
 					if (has_vertex_color) {
 						mat3d->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 					}


### PR DESCRIPTION
## Closes https://github.com/godotengine/godot/issues/64853

"Use External" works for Imported Assets (Blender, GLTF) even without a Material to replace.
The Implementation requires the importer to assign a unique "filler_id" as meta data to a Material if the Material does not have a valid import id or name.

I could not find a solution without edits in Importers because the Materials have no identification to find the right external Material to replace.

_Bugsquad edit: fixes: https://github.com/godotengine/godot/issues/64970_