### PR TITLE
Add `texel_scale` property to LightmapGI

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -65,6 +65,9 @@
 			The quality preset to use when baking lightmaps. This affects bake times, but output file sizes remain mostly identical across quality levels.
 			To further speed up bake times, decrease [member bounces], disable [member use_denoiser] and increase the lightmap texel size on 3D scenes in the Import doc.
 		</member>
+		<member name="texel_scale" type="float" setter="set_texel_scale" getter="get_texel_scale" default="1.0">
+			Scales the lightmap texel density of all meshes for the current bake. This is a multiplier that builds upon the existing lightmap texel size defined in each imported 3D scene, along with the per-mesh density multiplier (which is designed to be used when the same mesh is used at different scales). Lower values will result in faster bake times.
+		</member>
 		<member name="use_denoiser" type="bool" setter="set_use_denoiser" getter="is_using_denoiser" default="true">
 			If [code]true[/code], uses a GPU-based denoising algorithm on the generated lightmap. This eliminates most noise within the generated lightmap at the cost of longer bake times. File sizes are generally not impacted significantly by the use of a denoiser, although lossless compression may do a better job at compressing a denoised image.
 		</member>

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -107,6 +107,9 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 			case LightmapGI::BAKE_ERROR_TEXTURE_SIZE_TOO_SMALL: {
 				EditorNode::get_singleton()->show_warning(TTR("Maximum texture size is too small for the lightmap images."));
 			} break;
+			case LightmapGI::BAKE_ERROR_LIGHTMAP_TOO_SMALL: {
+				EditorNode::get_singleton()->show_warning(TTR("Failed creating lightmap images. Make sure all meshes selected to bake have `lightmap_size_hint` value set high enough, and `texel_scale` value of LightmapGI is not too low."));
+			} break;
 			default: {
 			} break;
 		}

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -142,6 +142,7 @@ public:
 		BAKE_ERROR_CANT_CREATE_IMAGE,
 		BAKE_ERROR_USER_ABORTED,
 		BAKE_ERROR_TEXTURE_SIZE_TOO_SMALL,
+		BAKE_ERROR_LIGHTMAP_TOO_SMALL,
 	};
 
 	enum EnvironmentMode {
@@ -158,6 +159,7 @@ private:
 	int bounces = 3;
 	float bounce_indirect_energy = 1.0;
 	float bias = 0.0005;
+	float texel_scale = 1.0;
 	int max_texture_size = 16384;
 	bool interior = false;
 	EnvironmentMode environment_mode = ENVIRONMENT_MODE_SCENE;
@@ -283,6 +285,9 @@ public:
 
 	void set_bias(float p_bias);
 	float get_bias() const;
+
+	void set_texel_scale(float p_multiplier);
+	float get_texel_scale() const;
 
 	void set_max_texture_size(int p_size);
 	int get_max_texture_size() const;


### PR DESCRIPTION
This PR adds `texel_scale` property to `LightmapGI`.
Closes godotengine/godot-proposals#3893.

----
Side notes:

1. This patch also adds `BakeError:BAKE_ERROR_LIGHTMAP_TOO_SMALL` together with a new warning message. I'm unable to generate `editor/translations/editor.pot` by using `extract.py` due to message duplicate error (`editor.pot` becomes empty). I have read the README files and contribution docs, but still don't know what exactly to do when adding new messages. As I'm not sure if the new BakeError (along with the new message) will be accepted, I decided to submit this potentially unfinished PR.

2. The new BakeError should help in other lightbaking cases (errors or incorrect user input) that result in an incorrect image size (width or height equal to zero). In such cases the editor should display a warning instead of freezing.