### PR TITLE
Fix some bugs in `SplitContainer`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6330,6 +6330,7 @@ EditorNode::EditorNode() {
 	left_l_vsplit->add_child(dock_slot[DOCK_SLOT_LEFT_BL]);
 
 	left_r_hsplit = memnew(HSplitContainer);
+	left_r_hsplit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	left_l_hsplit->add_child(left_r_hsplit);
 	left_r_vsplit = memnew(VSplitContainer);
 	left_r_hsplit->add_child(left_r_vsplit);
@@ -6339,6 +6340,7 @@ EditorNode::EditorNode() {
 	left_r_vsplit->add_child(dock_slot[DOCK_SLOT_LEFT_BR]);
 
 	main_hsplit = memnew(HSplitContainer);
+	main_hsplit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	left_r_hsplit->add_child(main_hsplit);
 	VBoxContainer *center_vb = memnew(VBoxContainer);
 	main_hsplit->add_child(center_vb);
@@ -6444,7 +6446,6 @@ EditorNode::EditorNode() {
 		dock_slot[i]->set_drag_to_rearrange_enabled(true);
 		dock_slot[i]->set_tabs_rearrange_group(1);
 		dock_slot[i]->connect("tab_changed", callable_mp(this, &EditorNode::_dock_tab_changed));
-		dock_slot[i]->set_use_hidden_tabs_for_min_size(true);
 	}
 
 	dock_drag_timer = memnew(Timer);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1055,7 +1055,6 @@ ProjectExportDialog::ProjectExportDialog() {
 	// Subsections.
 
 	sections = memnew(TabContainer);
-	sections->set_use_hidden_tabs_for_min_size(true);
 	sections->set_theme_type_variation("TabContainerOdd");
 	settings_vb->add_child(sections);
 	sections->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -45,6 +45,7 @@ public:
 
 private:
 	bool should_clamp_split_offset = false;
+	int prev_split_offset_origin = INT_MAX;
 	int split_offset = 0;
 	int middle_sep = 0;
 	bool vertical = false;


### PR DESCRIPTION
According to the expand flag of the child controls, the position of the origin.

| expand flag |             1st=`false`       |                  1st=`true`        |
| :---------: | :---------------------------: | :--------------------------------: |
| 2nd=`false` | The end of 1st's minimum rect | The begin of 2nd's minimum rect    |
| 2nd=`true`  | Same as above                 | The middle of the container's rect |

`split_offset_origin`/`prev_split_offset_origin` will record the  position of the origin of `split_offset`, and their sign show which side of the container the origin is relative to.

~~Fix #64851, fix #64866.~~
Fix #43749, fix #64273.

Can replace the role of `use_hidden_tabs_for_min_size` (introduced by #25353) when the `TabContainer` has a `SplitContainer` type ancestor. This will prevent #64273 from appearing.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
