### PR TITLE
Remove `[Signal]` attribute from events

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -117,10 +117,6 @@ namespace Godot.SourceGenerators
             source.Append(symbol.NameWithTypeParameters());
             source.Append("\n{\n");
 
-            // TODO:
-            // The delegate name already needs to end with 'Signal' to avoid collision with the event name.
-            // Requiring SignalAttribute is redundant. Should we remove it to make declaration shorter?
-
             var members = symbol.GetMembers();
 
             var signalDelegateSymbols = members

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2257,7 +2257,7 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 		}
 
 		String delegate_name = p_isignal.proxy_name;
-		delegate_name += "Handler"; // Delegate name is [SignalName]Handler
+		delegate_name += "EventHandler"; // Delegate name is [SignalName]EventHandler
 
 		// Generate delegate
 		p_output.append(MEMBER_BEGIN "public delegate void ");
@@ -2271,7 +2271,7 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 		// If so, we could store the pointer we get from `data_unique_pointer()` instead of allocating StringName here.
 
 		// Generate event
-		p_output.append(MEMBER_BEGIN "[Signal]" MEMBER_BEGIN "public ");
+		p_output.append(MEMBER_BEGIN "public ");
 
 		if (p_itype.is_singleton) {
 			p_output.append("static ");

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
@@ -2,6 +2,6 @@ using System;
 
 namespace Godot
 {
-    [AttributeUsage(AttributeTargets.Delegate | AttributeTargets.Event)]
+    [AttributeUsage(AttributeTargets.Delegate)]
     public class SignalAttribute : Attribute { }
 }


### PR DESCRIPTION
- Remove event as a valid target of `SignalAttribute`.
- Stop adding the `[Signal]` attribute to events in bindings_generator.
- Make bindings_generator use the `EventHandler` suffix to be consistent with the C# source generator.
- Remove obsolete comment about the signal's delegate name (context: https://github.com/godotengine/godot/pull/64743#issuecomment-1226029104).

