### PR TITLE
Revert the architecture values update made to the Android export logic

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -588,9 +588,9 @@ zip_fileinfo EditorExportPlatformAndroid::get_zip_fileinfo() {
 
 Vector<String> EditorExportPlatformAndroid::get_abis() {
 	Vector<String> abis;
-	abis.push_back("arm32");
-	abis.push_back("arm64");
-	abis.push_back("x86_32");
+	abis.push_back("armeabi-v7a");
+	abis.push_back("arm64-v8a");
+	abis.push_back("x86");
 	abis.push_back("x86_64");
 	return abis;
 }
@@ -1710,7 +1710,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 		const String abi = abis[i];
 		// All Android devices supporting Vulkan run 64-bit Android,
 		// so there is usually no point in exporting for 32-bit Android.
-		const bool is_default = abi == "arm64";
+		const bool is_default = abi == "arm64-v8a";
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("%s/%s", PNAME("architectures"), abi)), is_default));
 	}
 


### PR DESCRIPTION
Revert some of the changes in #55778

The abi values in the Android export logic are only exposed to the gradle build system, which expects the values to match the Android ones.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
