### PR TITLE
Add `session-id` CLI Argument to Allow for Debugger Session Identification

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -79,6 +79,10 @@ uint32_t Engine::get_frame_delay() const {
 	return _frame_delay;
 }
 
+void Engine::set_session_id(uint8_t p_session_id) {
+	_session_id = p_session_id;
+}
+
 void Engine::set_time_scale(double p_scale) {
 	_time_scale = p_scale;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -71,6 +71,8 @@ private:
 	uint64_t _process_frames = 0;
 	bool _in_physics = false;
 
+	uint8_t _session_id = 1;
+
 	List<Singleton> singletons;
 	HashMap<StringName, Object *> singleton_ptrs;
 
@@ -119,6 +121,9 @@ public:
 	void set_frame_delay(uint32_t p_msec);
 	uint32_t get_frame_delay() const;
 
+	void set_session_id(uint8_t p_id);
+	uint8_t get_session_id() const { return _session_id; }
+
 	void add_singleton(const Singleton &p_singleton);
 	void get_singletons(List<Singleton> *p_singletons);
 	bool has_singleton(const StringName &p_name) const;
@@ -127,17 +132,29 @@ public:
 	bool is_singleton_user_created(const StringName &p_name) const;
 
 #ifdef TOOLS_ENABLED
-	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }
-	_FORCE_INLINE_ bool is_editor_hint() const { return editor_hint; }
+	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) {
+		editor_hint = p_enabled;
+	}
+	_FORCE_INLINE_ bool is_editor_hint() const {
+		return editor_hint;
+	}
 
-	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) { project_manager_hint = p_enabled; }
-	_FORCE_INLINE_ bool is_project_manager_hint() const { return project_manager_hint; }
+	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) {
+		project_manager_hint = p_enabled;
+	}
+	_FORCE_INLINE_ bool is_project_manager_hint() const {
+		return project_manager_hint;
+	}
 #else
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) {}
-	_FORCE_INLINE_ bool is_editor_hint() const { return false; }
+	_FORCE_INLINE_ bool is_editor_hint() const {
+		return false;
+	}
 
 	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) {}
-	_FORCE_INLINE_ bool is_project_manager_hint() const { return false; }
+	_FORCE_INLINE_ bool is_project_manager_hint() const {
+		return false;
+	}
 #endif
 
 	Dictionary get_version_info() const;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2162,6 +2162,14 @@ bool Engine::is_in_physics_frame() const {
 	return ::Engine::get_singleton()->is_in_physics_frame();
 }
 
+void Engine::set_session_id(int p_session_id) {
+	::Engine::get_singleton()->set_session_id(p_session_id);
+}
+
+int Engine::get_session_id() const {
+	return ::Engine::get_singleton()->get_session_id();
+}
+
 bool Engine::has_singleton(const StringName &p_name) const {
 	return ::Engine::get_singleton()->has_singleton(p_name);
 }
@@ -2258,6 +2266,9 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_architecture_name"), &Engine::get_architecture_name);
 
 	ClassDB::bind_method(D_METHOD("is_in_physics_frame"), &Engine::is_in_physics_frame);
+
+	ClassDB::bind_method(D_METHOD("get_session_id"), &Engine::get_session_id);
+	ClassDB::bind_method(D_METHOD("set_session_id", "p_session_id"), &Engine::set_session_id);
 
 	ClassDB::bind_method(D_METHOD("has_singleton", "name"), &Engine::has_singleton);
 	ClassDB::bind_method(D_METHOD("get_singleton", "name"), &Engine::get_singleton_object);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -664,6 +664,9 @@ public:
 
 	bool is_in_physics_frame() const;
 
+	void set_session_id(int p_session_id);
+	int get_session_id() const;
+
 	bool has_singleton(const StringName &p_name) const;
 	Object *get_singleton_object(const StringName &p_name) const;
 	void register_singleton(const StringName &p_name, Object *p_object);

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -131,14 +131,6 @@
 				Session ids are generally assigned to values between 1 and 4, with 1 being the default value.
 			</description>
 		</method>
-		<method name="set_session_id">
-			<return type="void" />
-			<argument index="0" name="p_session_id" type="int" />
-			<description>
-				Assigns a session id to the current engine instance, which happens at launch by supplying [code]--session-id[/code] to the executable.
-				This is used by Godot's multiple-instance debugger so that each engine instance can be differentiated from one another.
-			</description>
-		</method>
 		<method name="get_singleton" qualifiers="const">
 			<return type="Object" />
 			<param index="0" name="name" type="StringName" />
@@ -229,6 +221,14 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="instance" type="Object" />
 			<description>
+			</description>
+		</method>
+		<method name="set_session_id">
+			<return type="void" />
+			<param index="0" name="p_session_id" type="int" />
+			<description>
+				Assigns a session id to the current engine instance, which happens at launch by supplying [code]--session-id[/code] to the executable.
+				This is used by Godot's multiple-instance debugger so that each engine instance can be differentiated from one another.
 			</description>
 		</method>
 		<method name="unregister_singleton">

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -119,6 +119,26 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_session_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the session id assigned via command line.
+
+				While using Godot's multiple-instance debugger, users can check the returned value to branch logic for their needs.
+				For example, the session id can be used to tell one instance to host a server while the others establish a peer connection. This is a nice quality of life feature for developers of multiplayer games where they might want to start a server and multiple clients simultaneously.
+				Or you could use session ids to branch between two different gameplay configurations such as character walk speeds or jump heights. This is a nice way to compare and contrast two drastically different gameplay scenarios for game testing.
+
+				Session ids are generally assigned to values between 1 and 4, with 1 being the default value.
+			</description>
+		</method>
+		<method name="set_session_id">
+			<return type="void" />
+			<argument index="0" name="p_session_id" type="int" />
+			<description>
+				Assigns a session id to the current engine instance, which happens at launch by supplying [code]--session-id[/code] to the executable.
+				This is used by Godot's multiple-instance debugger so that each engine instance can be differentiated from one another.
+			</description>
+		</method>
 		<method name="get_singleton" qualifiers="const">
 			<return type="Object" />
 			<param index="0" name="name" type="StringName" />

--- a/editor/editor_run.h
+++ b/editor/editor_run.h
@@ -47,6 +47,8 @@ private:
 	Status status;
 	String running_scene;
 
+	int append_session_identifiers_to_args(List<String> &p_to_append_to);
+
 public:
 	Status get_status() const;
 	String get_running_scene() const;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -178,6 +178,7 @@ static bool init_maximized = false;
 static bool init_windowed = false;
 static bool init_always_on_top = false;
 static bool init_use_custom_pos = false;
+static uint8_t init_session_id = 1;
 static Vector2 init_custom_pos;
 
 // Debug
@@ -1123,6 +1124,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			audio_driver = "Dummy";
 			display_driver = "headless";
 			main_args.push_back(I->get());
+		} else if (I->get() == "--session-id") {
+			if (I->next()) {
+				init_session_id = I->next()->get().to_int();
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing session id argument, aborting.");
+			}
 #endif
 		} else if (I->get() == "--path") { // set path of project to start or edit
 
@@ -1649,6 +1657,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF("debug/settings/stdout/print_fps", false);
 	GLOBAL_DEF("debug/settings/stdout/print_gpu_profile", false);
 	GLOBAL_DEF("debug/settings/stdout/verbose_stdout", false);
+
+	Engine::get_singleton()->set_session_id(init_session_id);
 
 	if (!OS::get_singleton()->_verbose_stdout) { // Not manually overridden.
 		OS::get_singleton()->_verbose_stdout = GLOBAL_GET("debug/settings/stdout/verbose_stdout");


### PR DESCRIPTION
As discussed in godotengine/godot-proposals#3357 , I have added the ability for Godot to be passed a session identifier which is then used by the debugger whenever there are multiple debugger sessions launched (`Debug > Multiple Instances` configuration larger than 1.)

The `Engine` class has been modified by adding two methods: `set_session_id` and `get_session_id`; For each one I've added the appropriate documentation for their purpose and utility. 

While using Godot's multiple-instance debugger, users can call `Engine::get_session_id` to branch logic for their needs. For example, the session id can be used to tell one instance to host a server while the others establish a peer connection. This is a nice quality of life feature for developers of multiplayer games where they might want to start a server and multiple clients simultaneously. Or you could use session ids to branch between two different gameplay configurations such as character walk speeds or jump heights. This is a nice way to compare and contrast two drastically different gameplay scenarios for game testing.

Here's a simplified idea on how this is supposed to be used within the editor.

```gdscript 
# ...

enum NetworkRole {
	SERVER,
	CLIENT
}

func _enter_tree():
	if "--server" in OS.get_cmdline_args() or Engine.get_session_id() == 1:
		print("Server Start")
		start_network(NetworkRole.SERVER)
	else:
		print("Client Start")
		start_network(NetworkRole.CLIENT, "127.0.0.1")

# ...
```

From here, assuming multiple instances have been enabled by the user, the debugger window will open two or more windows with one instance hosting a server while the others connect as peers. This is essential for quickly testing networked multiplayer games.

### Terminology Note

This patch refers to each Godot instance launched by the debugger as a "session", which is what they're called in the tabs above the debugger. However, in the `Debug` drop-down menu, these are referred as "instances". Since `get_instance_id` is already used extensively in the engine code, using the word `session` here seems appropriate. It might be worth considering changing the terminology in the debug menu to be consistent with the debugger tab at the bottom (i.e. `Run Multiple Sessions / Run X Sessions`.)