### PR TITLE
Fix TextEdit::gutters_width Incorrect Value

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4786,6 +4786,9 @@ void TextEdit::add_gutter(int p_at) {
 	}
 
 	text.add_gutter(p_at);
+
+	_update_gutter_width();
+
 	emit_signal(SNAME("gutter_added"));
 	update();
 }
@@ -4796,6 +4799,9 @@ void TextEdit::remove_gutter(int p_gutter) {
 	gutters.remove_at(p_gutter);
 
 	text.remove_gutter(p_gutter);
+
+	_update_gutter_width();
+
 	emit_signal(SNAME("gutter_removed"));
 	update();
 }

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3245,7 +3245,7 @@ TEST_CASE("[SceneTree][CodeEdit] symbol lookup") {
 		code_edit->set_text("this is some text");
 
 		Point2 caret_pos = code_edit->get_caret_draw_pos();
-		caret_pos.x += 58;
+		caret_pos.x += 60;
 		SEND_GUI_MOUSE_BUTTON_EVENT(code_edit, caret_pos, MouseButton::NONE, MouseButton::NONE, Key::NONE);
 		CHECK(code_edit->get_text_for_symbol_lookup() == "this is s" + String::chr(0xFFFF) + "ome text");
 

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -3388,6 +3388,8 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 	SUBCASE("[TextEdit] gutter add and remove") {
 		text_edit->add_gutter();
 		CHECK(text_edit->get_gutter_count() == 1);
+		CHECK(text_edit->get_gutter_width(0) == 24);
+		CHECK(text_edit->get_total_gutter_width() == 24 + 2);
 		SIGNAL_CHECK("gutter_added", empty_signal_args);
 
 		text_edit->set_gutter_name(0, "test_gutter");
@@ -3395,39 +3397,43 @@ TEST_CASE("[SceneTree][TextEdit] gutters") {
 
 		text_edit->set_gutter_width(0, 10);
 		CHECK(text_edit->get_gutter_width(0) == 10);
-		CHECK(text_edit->get_total_gutter_width() > 10);
-		CHECK(text_edit->get_total_gutter_width() < 20);
+		CHECK(text_edit->get_total_gutter_width() == 10 + 2);
 
 		text_edit->add_gutter(-100);
 		text_edit->set_gutter_width(1, 10);
-		CHECK(text_edit->get_total_gutter_width() > 20);
-		CHECK(text_edit->get_total_gutter_width() < 30);
+		CHECK(text_edit->get_gutter_width(1) == 10);
+		CHECK(text_edit->get_total_gutter_width() == 20 + 2);
 		CHECK(text_edit->get_gutter_count() == 2);
 		CHECK(text_edit->get_gutter_name(0) == "test_gutter");
 		SIGNAL_CHECK("gutter_added", empty_signal_args);
 
 		text_edit->set_gutter_draw(1, false);
-		CHECK(text_edit->get_total_gutter_width() > 10);
-		CHECK(text_edit->get_total_gutter_width() < 20);
+		CHECK(text_edit->get_total_gutter_width() == 10 + 2);
 
 		text_edit->add_gutter(100);
 		CHECK(text_edit->get_gutter_count() == 3);
+		CHECK(text_edit->get_gutter_width(2) == 24);
+		CHECK(text_edit->get_total_gutter_width() == 34 + 2);
 		CHECK(text_edit->get_gutter_name(0) == "test_gutter");
 		SIGNAL_CHECK("gutter_added", empty_signal_args);
 
 		text_edit->add_gutter(0);
 		CHECK(text_edit->get_gutter_count() == 4);
+		CHECK(text_edit->get_gutter_width(0) == 24);
+		CHECK(text_edit->get_total_gutter_width() == 58 + 2);
 		CHECK(text_edit->get_gutter_name(1) == "test_gutter");
 		SIGNAL_CHECK("gutter_added", empty_signal_args);
 
 		text_edit->remove_gutter(2);
 		CHECK(text_edit->get_gutter_name(1) == "test_gutter");
 		CHECK(text_edit->get_gutter_count() == 3);
+		CHECK(text_edit->get_total_gutter_width() == 58 + 2);
 		SIGNAL_CHECK("gutter_removed", empty_signal_args);
 
 		text_edit->remove_gutter(0);
 		CHECK(text_edit->get_gutter_name(0) == "test_gutter");
 		CHECK(text_edit->get_gutter_count() == 2);
+		CHECK(text_edit->get_total_gutter_width() == 34 + 2);
 		SIGNAL_CHECK("gutter_removed", empty_signal_args);
 
 		ERR_PRINT_OFF;


### PR DESCRIPTION
### Summary

#### Bug

When adding & removing a gutter to a `TextEdit`, the total gutter width returned by `TextEdit::get_total_gutter_width` (GDScript) returns the incorrect value.

#### Platform

Windows 10

#### Godot Version

4.x [master](https://github.com/godotengine/godot/commit/6e390fa9abf2101f8772c4ef6694471153105636)

###### Before Add

![image](https://user-images.githubusercontent.com/25569850/186882589-407cad57-717b-4179-9514-8b535bbe8768.png)

###### After Add

![image](https://user-images.githubusercontent.com/25569850/186882681-58135836-191e-4787-b493-7437f414adde.png)

#### Fix

When adding & removing a gutter, `TextEdit::_update_gutter_width` is now called to ensure `TextEdit::gutters_width` has the correct value.

###### After Add

![image](https://user-images.githubusercontent.com/25569850/186881786-1e5ac7b7-4175-41ca-bf42-f4465355590d.png)

###### After Remove

![image](https://user-images.githubusercontent.com/25569850/186882006-ee7b9f83-69d2-48d7-87cc-af8556708711.png)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
