### PR TITLE
Bind Physics Interpolation functions in VisualServer

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -45,6 +45,14 @@
 				Once finished with your RID, you will want to free the RID using the VisualServer's [method free_rid] static method.
 			</description>
 		</method>
+		<method name="camera_reset_physics_interpolation">
+			<return type="void" />
+			<argument index="0" name="camera" type="RID" />
+			<description>
+				Prevents physics interpolation for the current physics tick.
+				This is useful when moving a [Camera] to a new location, to give an instantaneous change rather than interpolation from the previous location.
+			</description>
+		</method>
 		<method name="camera_set_cull_mask">
 			<return type="void" />
 			<argument index="0" name="camera" type="RID" />
@@ -70,6 +78,14 @@
 			<argument index="4" name="z_far" type="float" />
 			<description>
 				Sets camera to use frustum projection. This mode allows adjusting the [code]offset[/code] argument to create "tilted frustum" effects.
+			</description>
+		</method>
+		<method name="camera_set_interpolated">
+			<return type="void" />
+			<argument index="0" name="camera" type="RID" />
+			<argument index="1" name="interpolated" type="bool" />
+			<description>
+				Turns on and off physics interpolation for the [Camera].
 			</description>
 		</method>
 		<method name="camera_set_orthogonal">
@@ -1404,6 +1420,14 @@
 				Sets a material that will override the material for all surfaces on the mesh associated with this instance. Equivalent to [member GeometryInstance.material_override].
 			</description>
 		</method>
+		<method name="instance_reset_physics_interpolation">
+			<return type="void" />
+			<argument index="0" name="instance" type="RID" />
+			<description>
+				Prevents physics interpolation for the current physics tick.
+				This is useful when moving an instance to a new location, to give an instantaneous change rather than interpolation from the previous location.
+			</description>
+		</method>
 		<method name="instance_set_base">
 			<return type="void" />
 			<argument index="0" name="instance" type="RID" />
@@ -1443,6 +1467,14 @@
 			<argument index="1" name="margin" type="float" />
 			<description>
 				Sets a margin to increase the size of the AABB when culling objects from the view frustum. This allows you to avoid culling objects that fall outside the view frustum. Equivalent to [member GeometryInstance.extra_cull_margin].
+			</description>
+		</method>
+		<method name="instance_set_interpolated">
+			<return type="void" />
+			<argument index="0" name="instance" type="RID" />
+			<argument index="1" name="interpolated" type="bool" />
+			<description>
+				Turns on and off physics interpolation for the instance.
 			</description>
 		</method>
 		<method name="instance_set_layer_mask">
@@ -2115,6 +2147,15 @@
 				Returns the [Transform2D] of the specified instance. For use when the multimesh is set to use 2D transforms.
 			</description>
 		</method>
+		<method name="multimesh_instance_reset_physics_interpolation">
+			<return type="void" />
+			<argument index="0" name="multimesh" type="RID" />
+			<argument index="1" name="index" type="int" />
+			<description>
+				Prevents physics interpolation for the specified instance during the current physics tick.
+				This is useful when moving an instance to a new location, to give an instantaneous change rather than interpolation from the previous location.
+			</description>
+		</method>
 		<method name="multimesh_instance_set_color">
 			<return type="void" />
 			<argument index="0" name="multimesh" type="RID" />
@@ -2163,12 +2204,39 @@
 				[Transform] is stored as 12 floats, [Transform2D] is stored as 8 floats, [code]COLOR_8BIT[/code] / [code]CUSTOM_DATA_8BIT[/code] is stored as 1 float (4 bytes as is) and [code]COLOR_FLOAT[/code] / [code]CUSTOM_DATA_FLOAT[/code] is stored as 4 floats.
 			</description>
 		</method>
+		<method name="multimesh_set_as_bulk_array_interpolated">
+			<return type="void" />
+			<argument index="0" name="multimesh" type="RID" />
+			<argument index="1" name="array" type="PoolRealArray" />
+			<argument index="2" name="array_previous" type="PoolRealArray" />
+			<description>
+				Alternative version of [method multimesh_set_as_bulk_array] for use with physics interpolation.
+				Takes both an array of current data and an array of data for the previous physics tick.
+			</description>
+		</method>
 		<method name="multimesh_set_mesh">
 			<return type="void" />
 			<argument index="0" name="multimesh" type="RID" />
 			<argument index="1" name="mesh" type="RID" />
 			<description>
 				Sets the mesh to be drawn by the multimesh. Equivalent to [member MultiMesh.mesh].
+			</description>
+		</method>
+		<method name="multimesh_set_physics_interpolated">
+			<return type="void" />
+			<argument index="0" name="multimesh" type="RID" />
+			<argument index="1" name="interpolated" type="bool" />
+			<description>
+				Turns on and off physics interpolation for the [MultiMesh].
+			</description>
+		</method>
+		<method name="multimesh_set_physics_interpolation_quality">
+			<return type="void" />
+			<argument index="0" name="multimesh" type="RID" />
+			<argument index="1" name="quality" type="int" enum="VisualServer.MultimeshPhysicsInterpolationQuality" />
+			<description>
+				Sets the physics interpolation quality for the [MultiMesh].
+				A value of [code]0[/code] gives fast but low quality interpolation, a value of [code]1[/code] gives slower but higher quality interpolation.
 			</description>
 		</method>
 		<method name="multimesh_set_visible_instances">
@@ -3800,6 +3868,12 @@
 		</constant>
 		<constant name="MULTIMESH_CUSTOM_DATA_FLOAT" value="2" enum="MultimeshCustomDataFormat">
 			MultiMesh custom data uses a float per component.
+		</constant>
+		<constant name="MULTIMESH_INTERP_QUALITY_FAST" value="0" enum="MultimeshPhysicsInterpolationQuality">
+			MultiMesh physics interpolation favours speed over quality.
+		</constant>
+		<constant name="MULTIMESH_INTERP_QUALITY_HIGH" value="1" enum="MultimeshPhysicsInterpolationQuality">
+			MultiMesh physics interpolation favours quality over speed.
 		</constant>
 		<constant name="REFLECTION_PROBE_UPDATE_ONCE" value="0" enum="ReflectionProbeUpdateMode">
 			Reflection probe will update reflections once and then stop.

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -219,7 +219,7 @@ void MultiMesh::set_visible_instance_count(int p_count) {
 
 void MultiMesh::set_physics_interpolation_quality(PhysicsInterpolationQuality p_quality) {
 	_physics_interpolation_quality = p_quality;
-	VisualServer::get_singleton()->multimesh_set_physics_interpolation_quality(multimesh, (int)p_quality);
+	VisualServer::get_singleton()->multimesh_set_physics_interpolation_quality(multimesh, (VS::MultimeshPhysicsInterpolationQuality)p_quality);
 }
 
 int MultiMesh::get_visible_instance_count() const {

--- a/servers/visual/rasterizer.cpp
+++ b/servers/visual/rasterizer.cpp
@@ -466,11 +466,11 @@ void RasterizerStorage::multimesh_set_physics_interpolated(RID p_multimesh, bool
 	}
 }
 
-void RasterizerStorage::multimesh_set_physics_interpolation_quality(RID p_multimesh, int p_quality) {
+void RasterizerStorage::multimesh_set_physics_interpolation_quality(RID p_multimesh, VS::MultimeshPhysicsInterpolationQuality p_quality) {
 	ERR_FAIL_COND((p_quality < 0) || (p_quality > 1));
 	MMInterpolator *mmi = _multimesh_get_interpolator(p_multimesh);
 	if (mmi) {
-		mmi->quality = p_quality;
+		mmi->quality = (int)p_quality;
 	}
 }
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -389,7 +389,7 @@ public:
 
 	virtual void multimesh_set_as_bulk_array_interpolated(RID p_multimesh, const PoolVector<float> &p_array, const PoolVector<float> &p_array_prev);
 	virtual void multimesh_set_physics_interpolated(RID p_multimesh, bool p_interpolated);
-	virtual void multimesh_set_physics_interpolation_quality(RID p_multimesh, int p_quality);
+	virtual void multimesh_set_physics_interpolation_quality(RID p_multimesh, VS::MultimeshPhysicsInterpolationQuality p_quality);
 	virtual void multimesh_instance_reset_physics_interpolation(RID p_multimesh, int p_index);
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -286,7 +286,7 @@ public:
 
 	BIND3(multimesh_set_as_bulk_array_interpolated, RID, const PoolVector<float> &, const PoolVector<float> &)
 	BIND2(multimesh_set_physics_interpolated, RID, bool)
-	BIND2(multimesh_set_physics_interpolation_quality, RID, int)
+	BIND2(multimesh_set_physics_interpolation_quality, RID, MultimeshPhysicsInterpolationQuality)
 	BIND2(multimesh_instance_reset_physics_interpolation, RID, int)
 
 	BIND2(multimesh_set_visible_instances, RID, int)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -209,7 +209,7 @@ public:
 
 	FUNC3(multimesh_set_as_bulk_array_interpolated, RID, const PoolVector<float> &, const PoolVector<float> &)
 	FUNC2(multimesh_set_physics_interpolated, RID, bool)
-	FUNC2(multimesh_set_physics_interpolation_quality, RID, int)
+	FUNC2(multimesh_set_physics_interpolation_quality, RID, MultimeshPhysicsInterpolationQuality)
 	FUNC2(multimesh_instance_reset_physics_interpolation, RID, int)
 
 	FUNC2(multimesh_set_visible_instances, RID, int)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1932,6 +1932,10 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("multimesh_set_visible_instances", "multimesh", "visible"), &VisualServer::multimesh_set_visible_instances);
 	ClassDB::bind_method(D_METHOD("multimesh_get_visible_instances", "multimesh"), &VisualServer::multimesh_get_visible_instances);
 	ClassDB::bind_method(D_METHOD("multimesh_set_as_bulk_array", "multimesh", "array"), &VisualServer::multimesh_set_as_bulk_array);
+	ClassDB::bind_method(D_METHOD("multimesh_set_as_bulk_array_interpolated", "multimesh", "array", "array_previous"), &VisualServer::multimesh_set_as_bulk_array_interpolated);
+	ClassDB::bind_method(D_METHOD("multimesh_set_physics_interpolated", "multimesh", "interpolated"), &VisualServer::multimesh_set_physics_interpolated);
+	ClassDB::bind_method(D_METHOD("multimesh_set_physics_interpolation_quality", "multimesh", "quality"), &VisualServer::multimesh_set_physics_interpolation_quality);
+	ClassDB::bind_method(D_METHOD("multimesh_instance_reset_physics_interpolation", "multimesh", "index"), &VisualServer::multimesh_instance_reset_physics_interpolation);
 #ifndef _3D_DISABLED
 	ClassDB::bind_method(D_METHOD("immediate_create"), &VisualServer::immediate_create);
 	ClassDB::bind_method(D_METHOD("immediate_begin", "immediate", "primitive", "texture"), &VisualServer::immediate_begin, DEFVAL(RID()));
@@ -2060,6 +2064,8 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &VisualServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &VisualServer::camera_set_frustum);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &VisualServer::camera_set_transform);
+	ClassDB::bind_method(D_METHOD("camera_set_interpolated", "camera", "interpolated"), &VisualServer::camera_set_interpolated);
+	ClassDB::bind_method(D_METHOD("camera_reset_physics_interpolation", "camera"), &VisualServer::camera_reset_physics_interpolation);
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &VisualServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &VisualServer::camera_set_environment);
 	ClassDB::bind_method(D_METHOD("camera_set_use_vertical_aspect", "camera", "enable"), &VisualServer::camera_set_use_vertical_aspect);
@@ -2136,6 +2142,8 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_set_scenario", "instance", "scenario"), &VisualServer::instance_set_scenario);
 	ClassDB::bind_method(D_METHOD("instance_set_layer_mask", "instance", "mask"), &VisualServer::instance_set_layer_mask);
 	ClassDB::bind_method(D_METHOD("instance_set_transform", "instance", "transform"), &VisualServer::instance_set_transform);
+	ClassDB::bind_method(D_METHOD("instance_set_interpolated", "instance", "interpolated"), &VisualServer::instance_set_interpolated);
+	ClassDB::bind_method(D_METHOD("instance_reset_physics_interpolation", "instance"), &VisualServer::instance_reset_physics_interpolation);
 	ClassDB::bind_method(D_METHOD("instance_attach_object_instance_id", "instance", "id"), &VisualServer::instance_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("instance_set_blend_shape_weight", "instance", "shape", "weight"), &VisualServer::instance_set_blend_shape_weight);
 	ClassDB::bind_method(D_METHOD("instance_set_surface_material", "instance", "surface", "material"), &VisualServer::instance_set_surface_material);
@@ -2487,6 +2495,8 @@ void VisualServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(MULTIMESH_CUSTOM_DATA_NONE);
 	BIND_ENUM_CONSTANT(MULTIMESH_CUSTOM_DATA_8BIT);
 	BIND_ENUM_CONSTANT(MULTIMESH_CUSTOM_DATA_FLOAT);
+	BIND_ENUM_CONSTANT(MULTIMESH_INTERP_QUALITY_FAST);
+	BIND_ENUM_CONSTANT(MULTIMESH_INTERP_QUALITY_HIGH);
 
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_UPDATE_ONCE);
 	BIND_ENUM_CONSTANT(REFLECTION_PROBE_UPDATE_ALWAYS);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -362,6 +362,11 @@ public:
 		MULTIMESH_CUSTOM_DATA_MAX,
 	};
 
+	enum MultimeshPhysicsInterpolationQuality {
+		MULTIMESH_INTERP_QUALITY_FAST,
+		MULTIMESH_INTERP_QUALITY_HIGH,
+	};
+
 	virtual void multimesh_allocate(RID p_multimesh, int p_instances, MultimeshTransformFormat p_transform_format, MultimeshColorFormat p_color_format, MultimeshCustomDataFormat p_data_format = MULTIMESH_CUSTOM_DATA_NONE) = 0;
 	virtual int multimesh_get_instance_count(RID p_multimesh) const = 0;
 
@@ -384,7 +389,7 @@ public:
 	// Interpolation
 	virtual void multimesh_set_as_bulk_array_interpolated(RID p_multimesh, const PoolVector<float> &p_array, const PoolVector<float> &p_array_prev) = 0;
 	virtual void multimesh_set_physics_interpolated(RID p_multimesh, bool p_interpolated) = 0;
-	virtual void multimesh_set_physics_interpolation_quality(RID p_multimesh, int p_quality) = 0;
+	virtual void multimesh_set_physics_interpolation_quality(RID p_multimesh, MultimeshPhysicsInterpolationQuality p_quality) = 0;
 	virtual void multimesh_instance_reset_physics_interpolation(RID p_multimesh, int p_index) = 0;
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible) = 0;
@@ -1235,6 +1240,7 @@ VARIANT_ENUM_CAST(VisualServer::Features);
 VARIANT_ENUM_CAST(VisualServer::MultimeshTransformFormat);
 VARIANT_ENUM_CAST(VisualServer::MultimeshColorFormat);
 VARIANT_ENUM_CAST(VisualServer::MultimeshCustomDataFormat);
+VARIANT_ENUM_CAST(VisualServer::MultimeshPhysicsInterpolationQuality);
 VARIANT_ENUM_CAST(VisualServer::LightBakeMode);
 VARIANT_ENUM_CAST(VisualServer::LightOmniShadowMode);
 VARIANT_ENUM_CAST(VisualServer::LightOmniShadowDetail);


### PR DESCRIPTION
To allow maximum flexibility in the initial rollout, VisualServer functions were not bound in order to prevent compatibility issues if the API changed.

These functions are now bound to allow direct use from the VisualServer.

Fixes #64905 .

## Defaults
Note that the default for instances is for interpolation to be **ON**.

I did experiment defaulting to off in the `VisualServer`, but given that the scene tree inheritance system defaults to on, it proved rather convoluted and buggy.
For regular nodes in the scene tree the _on_ default is not a problem, as they automatically send a `reset_physics_interpolation()` after adding to the tree, and will stay still with no further processing. However when using the `VisualServer` directly, users are responsible for either calling `reset_physics_interpolation()` on placement, or turning off interpolation for the instance using `instance_set_interpolated()` (or similar), if they are creating a non-moving instance.

Note also a source of confusion - despite the name, _physics interpolation_ is _not_ about interpolation of physics objects. This name was preferred by reviewers as being more beginner friendly, but the correct name is "fixed timestep interpolation", and it applies to nearly all visual instances, whether or not they are controlled by physics.

## Notes
* This was previously not bound deliberately, as the API functions here are subject to change based on feedback, and fixing any initial bugs which may have been compatibility breaking. This made physics interpolation temporarily not an option for the subset of users that are using `VisualServer` directly. This was of course annoying for this subset of users, but the benefit was this allows the underlying API to be changed without affecting user facing projects (as this was usually all handled through nodes).
* Hopefully this API is now stable, but should still be seen to some degree as _experimental_ and subject to change. Advanced users making use of this must be prepared for change until the API has been used significantly, however any changes should hopefully be minor and easy to fix in user code.
* Physics interpolation is not trivial to use directly through the `VisualServer`, aside from turning on and off interpolation for instances. The core scene tree code can be used as a guide, but beware, _here be dragons_. In particular for interpolation to work correctly there has to be a continuous stream of transform data, which can be complex in cases of for instance hidden / shown nodes. There is also no support in the `VisualServer` for `get_global_transform_interpolated()`. This is implemented totally as part of the scene tree to avoid stalls.
* This should probably not be cherry picked to 3.5 until it has been significantly tested in 3.6.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
