### PR TITLE
[Windows] Improve build environment detection, add support for Windows on ARM.

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -191,11 +191,11 @@ String Engine::get_architecture_name() const {
 #elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
 	return "x86_32";
 
-#elif defined(__aarch64__) || defined(_M_ARM64)
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 	return "arm64";
 
-#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7S__)
-	return "armv7";
+#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7S__) || defined(_M_ARM)
+	return "arm32";
 
 #elif defined(__riscv)
 #if __riscv_xlen == 8

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,5 +1,8 @@
 def can_build(env, platform):
     # Depends on Embree library, which only supports x86_64 and arm64.
+    if platform == "windows":
+        return env["arch"] == "x86_64"  # TODO build for Windows on ARM
+
     return env["arch"] in ["x86_64", "arm64"]
 
 

--- a/platform/windows/crash_handler_windows.cpp
+++ b/platform/windows/crash_handler_windows.cpp
@@ -173,10 +173,18 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	frame.AddrStack.Mode = AddrModeFlat;
 	frame.AddrFrame.Mode = AddrModeFlat;
 
-#ifdef _M_X64
+#if defined(_M_X64)
 	frame.AddrPC.Offset = context->Rip;
 	frame.AddrStack.Offset = context->Rsp;
 	frame.AddrFrame.Offset = context->Rbp;
+#elif defined(_M_ARM64) || defined(_M_ARM64EC)
+	frame.AddrPC.Offset = context->Pc;
+	frame.AddrStack.Offset = context->Sp;
+	frame.AddrFrame.Offset = context->Fp;
+#elif defined(_M_ARM)
+	frame.AddrPC.Offset = context->Pc;
+	frame.AddrStack.Offset = context->Sp;
+	frame.AddrFrame.Offset = context->R11;
 #else
 	frame.AddrPC.Offset = context->Eip;
 	frame.AddrStack.Offset = context->Esp;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -123,7 +123,7 @@ bool EditorExportPlatformWindows::get_export_option_visibility(const EditorExpor
 
 void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_options) {
 	EditorExportPlatformPC::get_export_options(r_options);
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32"), "x86_64"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm64"), "x86_64"));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "codesign/enable"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "codesign/identity_type", PROPERTY_HINT_ENUM, "Select automatically,Use PKCS12 file (specify *.PFX/*.P12 file),Use certificate store (specify SHA1 hash)"), 0));

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -345,6 +345,9 @@ File extracted from upstream release tarball:
 - Added 2 files `godot_core_mbedtls_platform.c` and `godot_core_mbedtls_config.h`
   providing configuration for light bundling with core.
 
+Some changes have been made in order to fix Windows on ARM build errors.
+They are marked with `// -- GODOT start --` and `// -- GODOT end --`
+
 
 ## meshoptimizer
 
@@ -374,6 +377,9 @@ Files extracted from upstream repository:
 - `minimp3.h`
 - `minimp3_ex.h`
 - `LICENSE`
+
+Some changes have been made in order to fix Windows on ARM build errors.
+They are marked with `// -- GODOT start --` and `// -- GODOT end --`
 
 
 ## miniupnpc

--- a/thirdparty/mbedtls/library/timing.c
+++ b/thirdparty/mbedtls/library/timing.c
@@ -195,8 +195,10 @@ unsigned long mbedtls_timing_hardclock( void )
 #endif /* !HAVE_HARDCLOCK && MBEDTLS_HAVE_ASM &&
           __GNUC__ && __ia64__ */
 
-#if !defined(HAVE_HARDCLOCK) && defined(_MSC_VER) && \
+// -- GODOT start --
+#if !defined(HAVE_HARDCLOCK) && defined(_WIN32) && \
     !defined(EFIX64) && !defined(EFI32)
+// -- GODOT end --
 
 #define HAVE_HARDCLOCK
 

--- a/thirdparty/minimp3/minimp3.h
+++ b/thirdparty/minimp3/minimp3.h
@@ -1566,7 +1566,18 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
 
 #else /* MINIMP3_FLOAT_OUTPUT */
 
+// -- GODOT start --
+#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM))
+            static f4 g_scale;
+            g_scale = vsetq_lane_f32(1.0f/32768.0f, g_scale, 0);
+            g_scale = vsetq_lane_f32(1.0f/32768.0f, g_scale, 1);
+            g_scale = vsetq_lane_f32(1.0f/32768.0f, g_scale, 2);
+            g_scale = vsetq_lane_f32(1.0f/32768.0f, g_scale, 3);
+#else
             static const f4 g_scale = { 1.0f/32768.0f, 1.0f/32768.0f, 1.0f/32768.0f, 1.0f/32768.0f };
+#endif
+// -- GODOT end --
+
             a = VMUL(a, g_scale);
             b = VMUL(b, g_scale);
 #if HAVE_SSE
@@ -1813,7 +1824,19 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
     int aligned_count = num_samples & ~7;
     for(; i < aligned_count; i += 8)
     {
+
+// -- GODOT start --
+#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM))
+            static f4 g_scale;
+            g_scale = vsetq_lane_f32(32768.0f, g_scale, 0);
+            g_scale = vsetq_lane_f32(32768.0f, g_scale, 1);
+            g_scale = vsetq_lane_f32(32768.0f, g_scale, 2);
+            g_scale = vsetq_lane_f32(32768.0f, g_scale, 3);
+#else
         static const f4 g_scale = { 32768.0f, 32768.0f, 32768.0f, 32768.0f };
+#endif
+// -- GODOT end --
+
         f4 a = VMUL(VLD(&in[i  ]), g_scale);
         f4 b = VMUL(VLD(&in[i+4]), g_scale);
 #if HAVE_SSE


### PR DESCRIPTION
- Adds support for Windows on ARM builds (MSVC and MinGW).
- 32-bit ARM is also supported by the build system, but not tested (are there any 32-bit ARM Windows devices at all?).
- Improves build environment detection.

Supported build option:

- Running from MSVC environment: architecture is detected automatically, mismatching `arch` flag cause error.
- Running from MSYS2 target specific environment: architecture is detected automatically, mismatching `arch` flag cause error.
- Running for generic terminal: any `arch` can be set.
   - Installed MSVC is detected automatically.
   - MinGW compilers should be in `PATH` or `MINGW_PREFIX` should be set (points to the MinGW installation root, replaces `MINGW_PREFIX32` and `MINGW_PREFIX64`).

Known limitation:
- It's impossible to build from base `MSYS` environment, target specific environment should be used instead (`MINGW32`, `MINGW64`, `CLANG32` and, `CLANG64`). Seems like there is some issue with MSYS2 path translation and compilers can't access temporary folder, unlikely fixable.
- If VS is installed, it's still necessary to use `use_mingw`, even if running from MSYS environment, SCons seems to be doing compilers detection before calling anything from `detect.py`.

TODO:

- [x] Cleanup.
- [x] Use readable error messages.
- [x] Mark changes in the third-party libraries.
- [x] Automatically detect `use_llvm` values based on MSYS2 environment type and available compiles in the path/prefix.

Fixes #64904
