### PR TITLE
.NET: Change NETCore.App version detection to use highest match

### DIFF
--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -153,6 +153,7 @@ def find_app_host_version(dotnet_cmd, search_version_str):
     from distutils.version import LooseVersion
 
     search_version = LooseVersion(search_version_str)
+    found_match = False
 
     try:
         env = dict(os.environ, DOTNET_CLI_UI_LANGUAGE="en-US")
@@ -172,7 +173,10 @@ def find_app_host_version(dotnet_cmd, search_version_str):
             version = LooseVersion(version_str)
 
             if version >= search_version:
-                return version_str
+                search_version = version
+                found_match = True
+        if found_match:
+            return str(search_version)
     except (subprocess.CalledProcessError, OSError) as e:
         import sys
 


### PR DESCRIPTION
`libnethost.a` detection failed on my Linux system (Mageia 9, using Fedora 36
dotnet repos), because it used the first match which isn't the one matching
the rest of the SDK:
```
$ dotnet --list-runtimes
Microsoft.AspNetCore.App 3.1.28 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 6.0.8 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.NETCore.App 3.1.28 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
Microsoft.NETCore.App 6.0.5 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
Microsoft.NETCore.App 6.0.8 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```

No idea why I still have 6.0.5 installed but it should pick the highest I guess.

May fix #64765.