### PR TITLE
Linux: Fix GNU ld detection for `pck_embed` linker script

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -387,7 +387,9 @@ def configure(env):
         import subprocess
         import re
 
-        linker_version_str = subprocess.check_output([env.subst(env["LINK"]), "-Wl,--version"]).decode("utf-8")
+        linker_version_str = subprocess.check_output(
+            [env.subst(env["LINK"]), "-Wl,--version"] + env.subst(env["LINKFLAGS"])
+        ).decode("utf-8")
         gnu_ld_version = re.search("^GNU ld [^$]*(\d+\.\d+)$", linker_version_str, re.MULTILINE)
         if not gnu_ld_version:
             print(


### PR DESCRIPTION
As discussed on #buildsystem with @raulsntos.

I'm not using the recently introduced `env["linker"] == "bfd"` because it can (and most of the time is) `"default"`, and default can be anything that `/bin/ld` points to (which usually is GNU bfd, but not always).