### PR TITLE
Remove Inspector tooltip hack that never actually worked

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -44,12 +44,6 @@
 				Gets the edited property. If your editor is for a single property (added via [method EditorInspectorPlugin._parse_property]), then this will return the property.
 			</description>
 		</method>
-		<method name="get_tooltip_text" qualifiers="const">
-			<return type="String" />
-			<description>
-				Must be implemented to provide a custom tooltip to the property editor.
-			</description>
-		</method>
 		<method name="set_bottom_editor">
 			<return type="void" />
 			<param index="0" name="editor" type="Control" />

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -896,12 +896,7 @@ static Control *make_help_bit(const String &p_text, bool p_property) {
 }
 
 Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
-	tooltip_text = p_text;
 	return make_help_bit(p_text, true);
-}
-
-String EditorProperty::get_tooltip_text() const {
-	return tooltip_text;
 }
 
 void EditorProperty::menu_option(int p_option) {
@@ -951,7 +946,6 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_edited_property"), &EditorProperty::get_edited_property);
 	ClassDB::bind_method(D_METHOD("get_edited_object"), &EditorProperty::get_edited_object);
 
-	ClassDB::bind_method(D_METHOD("get_tooltip_text"), &EditorProperty::get_tooltip_text);
 	ClassDB::bind_method(D_METHOD("update_property"), &EditorProperty::update_property);
 
 	ClassDB::bind_method(D_METHOD("add_focusable", "control"), &EditorProperty::add_focusable);
@@ -1129,7 +1123,6 @@ void EditorInspectorCategory::_notification(int p_what) {
 }
 
 Control *EditorInspectorCategory::make_custom_tooltip(const String &p_text) const {
-	tooltip_text = p_text;
 	return make_help_bit(p_text, false);
 }
 
@@ -1146,14 +1139,6 @@ Size2 EditorInspectorCategory::get_minimum_size() const {
 	ms.height += get_theme_constant(SNAME("v_separation"), SNAME("Tree"));
 
 	return ms;
-}
-
-void EditorInspectorCategory::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_tooltip_text"), &EditorInspectorCategory::get_tooltip_text);
-}
-
-String EditorInspectorCategory::get_tooltip_text() const {
-	return tooltip_text;
 }
 
 EditorInspectorCategory::EditorInspectorCategory() {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -117,8 +117,6 @@ private:
 	Control *bottom_editor = nullptr;
 	PopupMenu *menu = nullptr;
 
-	mutable String tooltip_text;
-
 	HashMap<StringName, Variant> cache;
 
 	GDVIRTUAL0(_update_property)
@@ -199,8 +197,6 @@ public:
 	void set_object_and_property(Object *p_object, const StringName &p_property);
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
 
-	String get_tooltip_text() const;
-
 	void set_draw_top_bg(bool p_draw) { draw_top_bg = p_draw; }
 
 	bool can_revert_to_default() const { return can_revert; }
@@ -254,17 +250,12 @@ class EditorInspectorCategory : public Control {
 	Ref<Texture2D> icon;
 	String label;
 
-	mutable String tooltip_text;
-
 protected:
 	void _notification(int p_what);
-	static void _bind_methods();
 
 public:
 	virtual Size2 get_minimum_size() const override;
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
-
-	String get_tooltip_text() const;
 
 	EditorInspectorCategory();
 };

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1709,15 +1709,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 								is_tooltip_shown = true;
 							}
 						} else {
-							Variant t = gui.tooltip_popup->call("get_tooltip_text");
-
-							if (t.get_type() == Variant::STRING) {
-								if (tooltip == String(t)) {
-									is_tooltip_shown = true;
-								}
-							} else {
-								is_tooltip_shown = true; // Nothing to compare against, likely using custom control, so if it changes there is nothing we can do.
-							}
+							is_tooltip_shown = true; // Nothing to compare against, likely using custom control, so if it changes there is nothing we can do.
 						}
 					} else {
 						_gui_cancel_tooltip();


### PR DESCRIPTION
While discussing https://github.com/godotengine/godot/pull/64885 we discovered a method called `get_tooltip_text` defined on `EditorProperty` and `EditorInspectorCategory` which conflicted with the rename we were trying to make. Upon further investigation, I've uncovered that this method is not functioning as expected and never was.

Since this is a hack, and it has been 4 years since it was added, and nobody noticed any issues or fixed it since, I think it's safe to remove it now. If in the future someone decides that this should be reverted and fixed instead, just make sure you call the method on the tooltip owner, not on the tooltip popup wrapper (more explanation below). But IMO if this is supposed to solve some issue which has gone unnoticed all this time, it should be implemented using the existing tooltip methods of `Control` rather than an editor-specific hack.

-----

**The problem.**

In 2018, the relevant code [was added](https://github.com/godotengine/godot/commit/336db8bcd1ab9f08009efc58896510b66f5fe561#diff-7d37141bff1285fa01a0530677bdd0e2d07f1a3d6a9644b7eb5555807b8445c0) via a direct commit by @reduz. Since there was not PR, I guess it wasn't tested properly. The intention seems to be to allow for Inspector-spawned tooltips, which are custom tooltips with rich text content, to benefit from the system in Viewport which somehow optimizes its behavior based on the fact that the displayed text is the same as control's desired tooltip text.

It seems if the text differs, the tooltip is not considered as "displayed" and is properly updated. If it matches perfectly, then the tooltip is not touched. This already worked with default text-based tooltips, but for custom tooltips it was virtually impossible to detect if the content matches or not. The aforementioned commit could've introduced some general control method for that, but instead it added an inspector hack, which is only exposed via `EditorProperty` (and `EditorInspectorCategory` is not exposed itself, so that one stays internal).

The issue here is that the method is called on `gui.tooltip_popup`, which, in it's original version, is the `Control` node returned by `make_custom_tooltip` or a `TooltipPanel` generated by the Viewport on the fly. Neither of those two have the `get_tooltip_text` method, because that method is defined on controls that spawn tooltips, not on tooltips themselves, nor on the `TooltipPanel`. In theory the `Control` returned by `make_custom_tooltip` could implement this method, but this is not documented anywhere, and this is not done by the existing code that attempts to use this system. So it's broken whichever way you spin it.

In the `master` version there is another node in between, `PopupPanel`, a window, which makes it completely impossible to hack into this hacky solution.

**The fix.**

The fix is simple, `_gui_get_tooltip` can return the tooltip owner, which is the control that can have this method implemented. If the code is adjusted to do this, the call for `get_tooltip_text` can be made from the owner, and it will be actually utilized.

But IMO since this is a hack to begin with, and nobody noticed that it's not working in practice, I'd say it's time to remove it. If we were to fix it and make it work, existing Control methods should be used. Custom tooltips require `hint_tooltip` to contain some text anyway (which is a bug, but helpful in this case), so this property can be used, for example. Worst case scenario, this should be reimplemented not as a hack, but as a proper method of `Control`, which is properly documented and available to every control, not just some parts of the editor.