### PR TITLE
[3.x] Remove Inspector tooltip hack that never actually worked

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -38,12 +38,6 @@
 				Gets the edited property. If your editor is for a single property (added via [method EditorInspectorPlugin.parse_property]), then this will return the property.
 			</description>
 		</method>
-		<method name="get_tooltip_text" qualifiers="const">
-			<return type="String" />
-			<description>
-				Must be implemented to provide a custom tooltip to the property editor.
-			</description>
-		</method>
 		<method name="set_bottom_editor">
 			<return type="void" />
 			<argument index="0" name="editor" type="Control" />

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -699,7 +699,6 @@ void EditorProperty::_update_pin_flags() {
 }
 
 Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
-	tooltip_text = p_text;
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
 	help_bit->add_style_override("panel", get_stylebox("panel", "TooltipPanel"));
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
@@ -719,10 +718,6 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 	}
 
 	return help_bit;
-}
-
-String EditorProperty::get_tooltip_text() const {
-	return tooltip_text;
 }
 
 void EditorProperty::_bind_methods() {
@@ -751,8 +746,6 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_menu_option", "option"), &EditorProperty::_menu_option);
 	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &EditorProperty::_unhandled_key_input);
 	ClassDB::bind_method(D_METHOD("_focusable_focused"), &EditorProperty::_focusable_focused);
-
-	ClassDB::bind_method(D_METHOD("get_tooltip_text"), &EditorProperty::get_tooltip_text);
 
 	ClassDB::bind_method(D_METHOD("add_focusable", "control"), &EditorProperty::add_focusable);
 	ClassDB::bind_method(D_METHOD("set_bottom_editor", "editor"), &EditorProperty::set_bottom_editor);
@@ -979,7 +972,6 @@ void EditorInspectorCategory::_notification(int p_what) {
 }
 
 Control *EditorInspectorCategory::make_custom_tooltip(const String &p_text) const {
-	tooltip_text = p_text;
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
 	help_bit->add_style_override("panel", get_stylebox("panel", "TooltipPanel"));
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
@@ -1013,14 +1005,6 @@ Size2 EditorInspectorCategory::get_minimum_size() const {
 	ms.height += get_constant("vseparation", "Tree");
 
 	return ms;
-}
-
-void EditorInspectorCategory::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_tooltip_text"), &EditorInspectorCategory::get_tooltip_text);
-}
-
-String EditorInspectorCategory::get_tooltip_text() const {
-	return tooltip_text;
 }
 
 EditorInspectorCategory::EditorInspectorCategory() {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -108,8 +108,6 @@ private:
 	Control *bottom_editor;
 	PopupMenu *menu;
 
-	mutable String tooltip_text;
-
 	void _update_pin_flags();
 
 protected:
@@ -175,8 +173,6 @@ public:
 	void set_object_and_property(Object *p_object, const StringName &p_property);
 	virtual Control *make_custom_tooltip(const String &p_text) const;
 
-	String get_tooltip_text() const;
-
 	void set_draw_top_bg(bool p_draw) { draw_top_bg = p_draw; }
 
 	bool can_revert_to_default() const { return can_revert; }
@@ -218,17 +214,13 @@ class EditorInspectorCategory : public Control {
 	Ref<Texture> icon;
 	String label;
 	Color bg_color;
-	mutable String tooltip_text;
 
 protected:
 	void _notification(int p_what);
-	static void _bind_methods();
 
 public:
 	virtual Size2 get_minimum_size() const;
 	virtual Control *make_custom_tooltip(const String &p_text) const;
-
-	String get_tooltip_text() const;
 
 	EditorInspectorCategory();
 };

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2236,8 +2236,6 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 						if (tooltip == gui.tooltip_label->get_text()) {
 							is_tooltip_shown = true;
 						}
-					} else if (tooltip == String(gui.tooltip_popup->call("get_tooltip_text"))) {
-						is_tooltip_shown = true;
 					}
 				} else {
 					_gui_cancel_tooltip();


### PR DESCRIPTION
Backport of https://github.com/godotengine/godot/pull/64928. We agreed since this is broken it's okay to completely remove it, even though this technically affects public API. The method wasn't doing anything before, so it should not be breaking anything for anyone.