### PR TITLE
[3.x] Add Selected Collision Group in TileSet Editor

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -3566,36 +3566,36 @@ void TilesetEditorContext::_get_property_list(List<PropertyInfo> *p_list) const 
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("options_step")));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("options_separation")));
 	}
-	if (tileset_editor->get_current_tile() >= 0 && !tileset.is_null()) {
-		int id = tileset_editor->get_current_tile();
-		p_list->push_back(PropertyInfo(Variant::NIL, GNAME("Selected Tile", "tile_"), PROPERTY_HINT_NONE, "tile_", PROPERTY_USAGE_GROUP));
-		p_list->push_back(PropertyInfo(Variant::STRING, PNAME("tile_name")));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("tile_texture"), PROPERTY_HINT_RESOURCE_TYPE, "Texture"));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("tile_normal_map"), PROPERTY_HINT_RESOURCE_TYPE, "Texture"));
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_tex_offset")));
-		p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("tile_material"), PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial"));
-		p_list->push_back(PropertyInfo(Variant::COLOR, PNAME("tile_modulate")));
-		p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_tile_mode"), PROPERTY_HINT_ENUM, "SINGLE_TILE,AUTO_TILE,ATLAS_TILE"));
-		if (tileset->tile_get_tile_mode(id) == TileSet::AUTO_TILE) {
-			p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_autotile_bitmask_mode"), PROPERTY_HINT_ENUM, "2x2,3x3 (minimal),3x3"));
-			p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_subtile_size")));
-			p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_subtile_spacing"), PROPERTY_HINT_RANGE, "0, 1024, 1"));
-			p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_autotile_fallback_mode"), PROPERTY_HINT_ENUM, "Auto,Icon"));
-		} else if (tileset->tile_get_tile_mode(id) == TileSet::ATLAS_TILE) {
-			p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_subtile_size")));
-			p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_subtile_spacing"), PROPERTY_HINT_RANGE, "0, 1024, 1"));
-		}
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_occluder_offset")));
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_navigation_offset")));
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_shape_offset"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_shape_transform"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_z_index"), PROPERTY_HINT_RANGE, itos(VS::CANVAS_ITEM_Z_MIN) + "," + itos(VS::CANVAS_ITEM_Z_MAX) + ",1"));
-	}
 	if (tileset_editor->edit_mode == TileSetEditor::EDITMODE_COLLISION && tileset_editor->edited_collision_shape.is_valid()) {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("selected_collision"), PROPERTY_HINT_RESOURCE_TYPE, tileset_editor->edited_collision_shape->get_class()));
 		if (tileset_editor->edited_collision_shape.is_valid()) {
+			p_list->push_back(PropertyInfo(Variant::NIL, GNAME("Collision Options", "selected_collision_"), PROPERTY_HINT_NONE, "selected_collision_", PROPERTY_USAGE_GROUP));
 			p_list->push_back(PropertyInfo(Variant::BOOL, PNAME("selected_collision_one_way"), PROPERTY_HINT_NONE));
 			p_list->push_back(PropertyInfo(Variant::REAL, PNAME("selected_collision_one_way_margin"), PROPERTY_HINT_NONE));
+		}
+		if (tileset_editor->get_current_tile() >= 0 && !tileset.is_null()) {
+			int id = tileset_editor->get_current_tile();
+			p_list->push_back(PropertyInfo(Variant::NIL, GNAME("Selected Tile", "tile_"), PROPERTY_HINT_NONE, "tile_", PROPERTY_USAGE_GROUP));
+			p_list->push_back(PropertyInfo(Variant::STRING, PNAME("tile_name")));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("tile_texture"), PROPERTY_HINT_RESOURCE_TYPE, "Texture"));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("tile_normal_map"), PROPERTY_HINT_RESOURCE_TYPE, "Texture"));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_tex_offset")));
+			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("tile_material"), PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial"));
+			p_list->push_back(PropertyInfo(Variant::COLOR, PNAME("tile_modulate")));
+			p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_tile_mode"), PROPERTY_HINT_ENUM, "SINGLE_TILE,AUTO_TILE,ATLAS_TILE"));
+			if (tileset->tile_get_tile_mode(id) == TileSet::AUTO_TILE) {
+				p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_autotile_bitmask_mode"), PROPERTY_HINT_ENUM, "2x2,3x3 (minimal),3x3"));
+				p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_subtile_size")));
+				p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_subtile_spacing"), PROPERTY_HINT_RANGE, "0, 1024, 1"));
+			} else if (tileset->tile_get_tile_mode(id) == TileSet::ATLAS_TILE) {
+				p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_subtile_size")));
+				p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_subtile_spacing"), PROPERTY_HINT_RANGE, "0, 1024, 1"));
+			}
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_occluder_offset")));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_navigation_offset")));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_shape_offset"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+			p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("tile_shape_transform"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
+			p_list->push_back(PropertyInfo(Variant::INT, PNAME("tile_z_index"), PROPERTY_HINT_RANGE, itos(VS::CANVAS_ITEM_Z_MIN) + "," + itos(VS::CANVAS_ITEM_Z_MAX) + ",1"));
 		}
 	}
 	if (tileset_editor->edit_mode == TileSetEditor::EDITMODE_NAVIGATION && tileset_editor->edited_navigation_shape.is_valid()) {
@@ -3605,6 +3605,7 @@ void TilesetEditorContext::_get_property_list(List<PropertyInfo> *p_list) const 
 		p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("selected_occlusion"), PROPERTY_HINT_RESOURCE_TYPE, tileset_editor->edited_occlusion_shape->get_class()));
 	}
 	if (!tileset.is_null()) {
+		p_list->push_back(PropertyInfo(Variant::NIL, GNAME("TileSet", "tileset"), PROPERTY_HINT_NONE, "tileset", PROPERTY_USAGE_CATEGORY));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("tileset_script"), PROPERTY_HINT_RESOURCE_TYPE, "Script"));
 	}
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4660 (only for 3.x).

Makes the extra Selected Collision property names readable by putting them in their own group if they exist.
Also moves the **TileSet** **Script** property down to its own category to make it look better.
| Before | After |
| --- | --- |
![Before](https://user-images.githubusercontent.com/66727710/186927936-e8f2465a-9ab3-4409-8799-3275a07d0b07.png) | ![After](https://user-images.githubusercontent.com/66727710/186927399-ebef564c-7197-4d17-b7c6-e5e494ddf3b5.png) |