### PR TITLE
Added property to find the number of ticks of the slider automatically.

### DIFF
--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -10,11 +10,11 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="find_ticks" type="bool" setter="set_find_ticks" getter="is_finding_ticks" default="false">
-			If [code]true[/code], the number of ticks will be found from the number of steps. The steps will be reduced if the ticks cannot be aligned on the grabber.
-		</member>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
 			If [code]true[/code], the slider can be interacted with. If [code]false[/code], the value can be changed only by code.
+		</member>
+		<member name="find_ticks" type="bool" setter="set_find_ticks" getter="is_finding_ticks" default="false">
+			If [code]true[/code], the number of ticks will be found from the number of steps. The steps will be reduced if the ticks cannot be aligned on the grabber.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="scrollable" type="bool" setter="set_scrollable" getter="is_scrollable" default="true">

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -10,8 +10,8 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="adjust_step" type="bool" setter="set_adjust_step" getter="is_adjusting_step" default="false">
-			If [code]true[/code], the number of ticks will be calculated from the number of steps. The steps will be reduced if the ticks cannot be aligned on the grabber.
+		<member name="find_ticks" type="bool" setter="set_find_ticks" getter="is_finding_ticks" default="false">
+			If [code]true[/code], the number of ticks will be found from the number of steps. The steps will be reduced if the ticks cannot be aligned on the grabber.
 		</member>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
 			If [code]true[/code], the slider can be interacted with. If [code]false[/code], the value can be changed only by code.

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -10,6 +10,9 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="adjust_step" type="bool" setter="set_adjust_step" getter="is_adjusting_step" default="false">
+			If [code]true[/code], the number of ticks will be calculated from the number of steps. The steps will be reduced if the ticks cannot be aligned on the grabber.
+		</member>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
 			If [code]true[/code], the slider can be interacted with. If [code]false[/code], the value can be changed only by code.
 		</member>

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -188,21 +188,18 @@ void Slider::_notification(int p_what) {
 			RID ci = get_canvas_item();
 			Size2i size = get_size();
 			double ratio = Math::is_nan(get_as_ratio()) ? 0 : get_as_ratio();
-			
+
 			if (adjust_step) {
 				float step = get_step(), dist = get_max() - get_min();
 				int idist = dist;
-
 				if (step > dist) {
 					ticks = 0;
 					WARN_PRINT_ONCE("The step must be less than or equal to : " + itos(dist));
-				}
-				else if (step == dist || step < 1) { ticks = 0; }
-				else if (step >= 1) {
-
+				} else if (step == dist || step < 1) {
+					ticks = 0;
+				} else if (step >= 1) {
 					if (!Math::is_equal_approx(Math::fmod(dist, step), 0)) {
 						List<int> factors = List<int>();
-						
 						for (int i = Math::sqrt(dist); i > 0; i--) { // find all divisors of the distance
 							if (idist % i == 0) {
 								factors.push_back(i);
@@ -210,7 +207,6 @@ void Slider::_notification(int p_what) {
 							}
 						}
 						factors.sort();
-
 						for (int i = factors.size() - 1; i >= 0; i--) {
 							if (step >= factors[i]) {
 								set_step(factors[i]);

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -190,17 +190,23 @@ void Slider::_notification(int p_what) {
 			double ratio = Math::is_nan(get_as_ratio()) ? 0 : get_as_ratio();
 			
 			if (adjust_step) {
-				float step = get_step(), min = get_min(), max = get_max();
-				int imax = get_max();
-				if (step > min && step < max) {
+				float step = get_step(), dist = get_max() - get_min();
+				int idist = dist;
 
-					if (!Math::is_equal_approx(Math::fmod(max, min), 0)) {
+				if (step > dist) {
+					ticks = 0;
+					WARN_PRINT_ONCE("The step must be less than or equal to : " + itos(dist));
+				}
+				else if (step == dist || step < 1) { ticks = 0; }
+				else if (step >= 1) {
+
+					if (!Math::is_equal_approx(Math::fmod(dist, step), 0)) {
 						List<int> factors = List<int>();
 						
-						for (int i = Math::sqrt(max); i > 0; i--) {
-							if (imax % i == 0) {
+						for (int i = Math::sqrt(dist); i > 0; i--) { // find all divisors of the distance
+							if (idist % i == 0) {
 								factors.push_back(i);
-								factors.push_back(imax / i);
+								factors.push_back(idist / i);
 							}
 						}
 						factors.sort();
@@ -212,7 +218,7 @@ void Slider::_notification(int p_what) {
 							}
 						}
 					}
-					ticks = get_max() / get_step() + 1;
+					ticks = (get_max() - get_min()) / get_step() + 1;
 				}
 			}
 

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -189,7 +189,7 @@ void Slider::_notification(int p_what) {
 			Size2i size = get_size();
 			double ratio = Math::is_nan(get_as_ratio()) ? 0 : get_as_ratio();
 
-			if (adjust_step) {
+			if (find_ticks) {
 				float step = get_step(), dist = get_max() - get_min();
 				int idist = dist;
 				if (step > dist) {
@@ -314,17 +314,17 @@ void Slider::set_ticks_on_borders(bool _tob) {
 	queue_redraw();
 }
 
-void Slider::set_adjust_step(bool p_adjust) {
-	if (adjust_step == p_adjust) {
+void Slider::set_find_ticks(bool p_find_ticks) {
+	if (find_ticks == p_find_ticks) {
 		return;
 	}
 
-	adjust_step = p_adjust;
+	find_ticks = p_find_ticks;
 	update();
 }
 
-bool Slider::is_adjusting_step() const {
-	return adjust_step;
+bool Slider::is_finding_ticks() const {
+	return find_ticks;
 }
 
 void Slider::set_editable(bool p_editable) {
@@ -355,8 +355,8 @@ void Slider::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_ticks_on_borders"), &Slider::get_ticks_on_borders);
 	ClassDB::bind_method(D_METHOD("set_ticks_on_borders", "ticks_on_border"), &Slider::set_ticks_on_borders);
 
-	ClassDB::bind_method(D_METHOD("set_adjust_step", "count"), &Slider::set_adjust_step);
-	ClassDB::bind_method(D_METHOD("is_adjusting_step"), &Slider::is_adjusting_step);
+	ClassDB::bind_method(D_METHOD("set_find_ticks", "find_ticks"), &Slider::set_find_ticks);
+	ClassDB::bind_method(D_METHOD("is_finding_ticks"), &Slider::is_finding_ticks);
 
 	ClassDB::bind_method(D_METHOD("set_editable", "editable"), &Slider::set_editable);
 	ClassDB::bind_method(D_METHOD("is_editable"), &Slider::is_editable);
@@ -370,7 +370,7 @@ void Slider::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scrollable"), "set_scrollable", "is_scrollable");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tick_count", PROPERTY_HINT_RANGE, "0,4096,1"), "set_ticks", "get_ticks");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ticks_on_borders"), "set_ticks_on_borders", "get_ticks_on_borders");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "adjust_step"), "set_adjust_step", "is_adjusting_step");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "find_ticks"), "set_find_ticks", "is_finding_ticks");
 }
 
 Slider::Slider(Orientation p_orientation) {

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -327,7 +327,7 @@ void Slider::set_adjust_step(bool p_adjust) {
 	update();
 }
 
-int Slider::is_adjusting_step() const {
+bool Slider::is_adjusting_step() const {
 	return adjust_step;
 }
 

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -320,7 +320,7 @@ void Slider::set_find_ticks(bool p_find_ticks) {
 	}
 
 	find_ticks = p_find_ticks;
-	update();
+	queue_redraw();
 }
 
 bool Slider::is_finding_ticks() const {

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -82,7 +82,7 @@ public:
 	bool get_ticks_on_borders() const;
 
 	void set_adjust_step(bool p_adjust);
-	int is_adjusting_step() const;
+	bool is_adjusting_step() const;
 
 	void set_editable(bool p_editable);
 	bool is_editable() const;

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -48,7 +48,7 @@ class Slider : public Range {
 	double custom_step = -1.0;
 	bool editable = true;
 	bool scrollable = true;
-	bool adjust_step = false;
+	bool find_ticks = false;
 
 	struct ThemeCache {
 		Ref<StyleBox> slider_style;
@@ -81,8 +81,8 @@ public:
 	void set_ticks_on_borders(bool);
 	bool get_ticks_on_borders() const;
 
-	void set_adjust_step(bool p_adjust);
-	bool is_adjusting_step() const;
+	void set_find_ticks(bool p_find_ticks);
+	bool is_finding_ticks() const;
 
 	void set_editable(bool p_editable);
 	bool is_editable() const;

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -48,6 +48,7 @@ class Slider : public Range {
 	double custom_step = -1.0;
 	bool editable = true;
 	bool scrollable = true;
+	bool adjust_step = false;
 
 	struct ThemeCache {
 		Ref<StyleBox> slider_style;
@@ -79,6 +80,9 @@ public:
 
 	void set_ticks_on_borders(bool);
 	bool get_ticks_on_borders() const;
+
+	void set_adjust_step(bool p_adjust);
+	int is_adjusting_step() const;
 
 	void set_editable(bool p_editable);
 	bool is_editable() const;


### PR DESCRIPTION
I found it odd that we must set the number of ticks on a slider by ourselves, I assume we want the grabber to be aligned with the ticks.
Since we have to find by ourselves the correct number of ticks, it becomes very tedious and difficult to align them with steps.

So, I added a bool in the slider class to make sure that if it is true, it will find the right number of ticks for the number of steps and if it is impossible to align the steps on the grabber, it will set the steps to an appropriate lower number of steps to align the ticks on the grabber.

The change is compatible with `3.x`