### PR TITLE
Allow images to be imported "for editor use" and respect editor settings

### DIFF
--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -52,6 +52,7 @@ public:
 	enum LoaderFlags {
 		FLAG_NONE = 0,
 		FLAG_FORCE_LINEAR = 1,
+		FLAG_CONVERT_COLORS = 2,
 	};
 
 	virtual ~ImageFormatLoader() {}

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -108,6 +108,15 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 		}
 	}
 
+#ifdef TOOLS_ENABLED
+	if (r_path_and_type.metadata && !r_path_and_type.path.is_empty()) {
+		Dictionary metadata = r_path_and_type.metadata;
+		if (metadata.has("has_editor_variant")) {
+			r_path_and_type.path = r_path_and_type.path.get_basename() + ".editor." + r_path_and_type.path.get_extension();
+		}
+	}
+#endif
+
 	if (r_path_and_type.path.is_empty() || r_path_and_type.type.is_empty()) {
 		return ERR_FILE_CORRUPT;
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3364,6 +3364,8 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 		Ref<Texture2D> icon = p_editor->get_icon();
 		if (icon.is_valid()) {
 			tb->set_icon(icon);
+			// Make sure the control is updated if the icon is reimported.
+			icon->connect("changed", callable_mp((Control *)tb, &Control::update_minimum_size));
 		} else if (singleton->gui_base->has_theme_icon(p_editor->get_name(), SNAME("EditorIcons"))) {
 			tb->set_icon(singleton->gui_base->get_theme_icon(p_editor->get_name(), SNAME("EditorIcons")));
 		}

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -447,6 +447,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Colors
 	bool dark_theme = EditorSettings::get_singleton()->is_dark_theme();
 
+#ifdef MODULE_SVG_ENABLED
+	if (dark_theme) {
+		ImageLoaderSVG::set_forced_color_map(HashMap<Color, Color>());
+	} else {
+		ImageLoaderSVG::set_forced_color_map(EditorColorMap::get());
+	}
+#endif
+
 	// Ensure base colors are in the 0..1 luminance range to avoid 8-bit integer overflow or text rendering issues.
 	// Some places in the editor use 8-bit integer colors.
 	const Color dark_color_1 = base_color.lerp(Color(0, 0, 0, 1), contrast).clamp();

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -35,6 +35,12 @@
 
 #include <thorvg.h>
 
+HashMap<Color, Color> ImageLoaderSVG::forced_color_map = HashMap<Color, Color>();
+
+void ImageLoaderSVG::set_forced_color_map(const HashMap<Color, Color> &p_color_map) {
+	forced_color_map = p_color_map;
+}
+
 void ImageLoaderSVG::_replace_color_property(const HashMap<Color, Color> &p_color_map, const String &p_prefix, String &r_string) {
 	// Replace colors in the SVG based on what is passed in `p_color_map`.
 	// Used to change the colors of editor icons based on the used theme.
@@ -138,7 +144,13 @@ void ImageLoaderSVG::get_recognized_extensions(List<String> *p_extensions) const
 
 Error ImageLoaderSVG::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, uint32_t p_flags, float p_scale) {
 	String svg = p_fileaccess->get_as_utf8_string();
-	create_image_from_string(p_image, svg, p_scale, false, HashMap<Color, Color>());
+
+	if (p_flags & FLAG_CONVERT_COLORS) {
+		create_image_from_string(p_image, svg, p_scale, false, forced_color_map);
+	} else {
+		create_image_from_string(p_image, svg, p_scale, false, HashMap<Color, Color>());
+	}
+
 	ERR_FAIL_COND_V(p_image->is_empty(), FAILED);
 	if (p_flags & FLAG_FORCE_LINEAR) {
 		p_image->srgb_to_linear();

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -34,9 +34,13 @@
 #include "core/io/image_loader.h"
 
 class ImageLoaderSVG : public ImageFormatLoader {
+	static HashMap<Color, Color> forced_color_map;
+
 	void _replace_color_property(const HashMap<Color, Color> &p_color_map, const String &p_prefix, String &r_string);
 
 public:
+	static void set_forced_color_map(const HashMap<Color, Color> &p_color_map);
+
 	void create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, const HashMap<Color, Color> &p_color_map);
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, uint32_t p_flags, float p_scale) override;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5034.

This is implemented pretty much as I've described in the proposal. There are now two new import options that let the SVG icons to be imported for editor use and either scale, or convert colors, or both. We still need to document somehow which colors do we use, and there are some other limitations to the color conversion logic as it is currently implemented. But scaling is straightforward.

One limitation which I don't know how to fix without dirty hacks in core is that if you change the polarity of the editor theme you need to restart the editor or manually reimport the image for it to update. Changing scale already requires a restart, so it's not a big deal. There is already a hacky thing in core resource importer, but it shouldn't be too bad because we sometimes allow `TOOLS_ENABLED` in core and I think in this case this is a valid need.

Anyway, **DEMO TIME**!

https://user-images.githubusercontent.com/11782833/186957259-941b849b-8639-4fa2-98ac-ab547a4e73be.mp4


_This work is kindly sponsored by the **[Dialogic](https://github.com/coppolaemilio/dialogic)** project._