### PR TITLE
Fix X11 BadMatch when calling XSetInputFocus.

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -1522,11 +1522,15 @@ void DisplayServerX11::window_set_transient(WindowID p_window, WindowID p_parent
 
 		XSetTransientForHint(x11_display, wd_window.x11_window, None);
 
+		XWindowAttributes xwa;
+		XSync(x11_display, False);
+		XGetWindowAttributes(x11_display, wd_parent.x11_window, &xwa);
+
 		// Set focus to parent sub window to avoid losing all focus when closing a nested sub-menu.
 		// RevertToPointerRoot is used to make sure we don't lose all focus in case
 		// a subwindow and its parent are both destroyed.
 		if (!wd_window.no_focus && !wd_window.is_popup && wd_window.focused) {
-			if (!wd_parent.no_focus && !wd_window.is_popup) {
+			if ((xwa.map_state == IsViewable) && !wd_parent.no_focus && !wd_window.is_popup) {
 				XSetInputFocus(x11_display, wd_parent.x11_window, RevertToPointerRoot, CurrentTime);
 			}
 		}
@@ -3646,10 +3650,14 @@ void DisplayServerX11::process_events() {
 
 				const WindowData &wd = windows[window_id];
 
+				XWindowAttributes xwa;
+				XSync(x11_display, False);
+				XGetWindowAttributes(x11_display, wd.x11_window, &xwa);
+
 				// Set focus when menu window is started.
 				// RevertToPointerRoot is used to make sure we don't lose all focus in case
 				// a subwindow and its parent are both destroyed.
-				if (!wd.no_focus && !wd.is_popup) {
+				if ((xwa.map_state == IsViewable) && !wd.no_focus && !wd.is_popup) {
 					XSetInputFocus(x11_display, wd.x11_window, RevertToPointerRoot, CurrentTime);
 				}
 			} break;


### PR DESCRIPTION
Should fix #62635
Should fix #60690

Certain X11 window managers (eg, i3wm) seem to unmap ancestors of windows that are on an inactive virtual workspace. This results in Godot windows having the X window attribute `IsUnviewable`. According to the Xlib docs, `XSetInputFocus` will fail if the window you are applying it to is not viewable. To solve the issue, we simply need to confirm the window is viewable prior to attempting to set input focus. If it is not viewable (because it's on an inactive workspace), there's no need to set the input focus. This was actually already being done under the `ConfigureNotify` event, but not the `MapNotify` event or the `window_set_transient` method.

This is my first pull request, so  apologies in advance if I've made any errors.