### PR TITLE
Add `dotnet format` to CI to check C# style

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -63,3 +63,7 @@ jobs:
       - name: Style checks via clang-format (clang_format.sh)
         run: |
           bash ./misc/scripts/clang_format.sh
+
+      - name: Style checks via dotnet format (dotnet_format.sh)
+        run: |
+          bash ./misc/scripts/dotnet_format.sh

--- a/misc/scripts/dotnet_format.sh
+++ b/misc/scripts/dotnet_format.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script runs dotnet format on all relevant files in the repo.
+# This is the primary script responsible for fixing style violations in C# files.
+
+set -uo pipefail
+
+# Loops through all C# projects tracked by Git.
+git ls-files -- '*.csproj' \
+                ':!:.git/*' ':!:thirdparty/*' ':!:platform/android/java/lib/src/com/google/*' ':!:*-so_wrap.*' |
+while read -r f; do
+    # Run dotnet format.
+    dotnet format "$f"
+done
+
+diff=$(git diff --color)
+
+# If no diff has been generated all is OK, clean up, and exit.
+if [ -z "$diff" ] ; then
+    printf "Files in this commit comply with the dotnet format style rules.\n"
+    exit 0
+fi
+
+# A diff has been created, notify the user, clean up, and exit.
+printf "\n*** The following changes have been made to comply with the formatting rules:\n\n"
+echo "$diff"
+printf "\n*** Please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+exit 1

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedFields.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedFields.cs
@@ -94,16 +94,20 @@ namespace Godot.SourceGenerators.Sample
         [Export] private NodePath field_NodePath = new NodePath("foo");
         [Export] private RID field_RID;
 
-        [Export] private Godot.Collections.Dictionary field_GodotDictionary =
+        [Export]
+        private Godot.Collections.Dictionary field_GodotDictionary =
             new() { { "foo", 10 }, { Vector2.Up, Colors.Chocolate } };
 
-        [Export] private Godot.Collections.Array field_GodotArray =
+        [Export]
+        private Godot.Collections.Array field_GodotArray =
             new() { "foo", 10, Vector2.Up, Colors.Chocolate };
 
-        [Export] private Godot.Collections.Dictionary<string, bool> field_GodotGenericDictionary =
+        [Export]
+        private Godot.Collections.Dictionary<string, bool> field_GodotGenericDictionary =
             new() { { "foo", true }, { "bar", false } };
 
-        [Export] private Godot.Collections.Array<int> field_GodotGenericArray =
+        [Export]
+        private Godot.Collections.Array<int> field_GodotGenericArray =
             new() { 0, 1, 2, 3, 4, 5, 6 };
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedProperties.cs
@@ -94,16 +94,20 @@ namespace Godot.SourceGenerators.Sample
         [Export] private NodePath property_NodePath { get; set; } = new NodePath("foo");
         [Export] private RID property_RID { get; set; }
 
-        [Export] private Godot.Collections.Dictionary property_GodotDictionary { get; set; } =
+        [Export]
+        private Godot.Collections.Dictionary property_GodotDictionary { get; set; } =
             new() { { "foo", 10 }, { Vector2.Up, Colors.Chocolate } };
 
-        [Export] private Godot.Collections.Array property_GodotArray { get; set; } =
+        [Export]
+        private Godot.Collections.Array property_GodotArray { get; set; } =
             new() { "foo", 10, Vector2.Up, Colors.Chocolate };
 
-        [Export] private Godot.Collections.Dictionary<string, bool> property_GodotGenericDictionary { get; set; } =
+        [Export]
+        private Godot.Collections.Dictionary<string, bool> property_GodotGenericDictionary { get; set; } =
             new() { { "foo", true }, { "bar", false } };
 
-        [Export] private Godot.Collections.Array<int> property_GodotGenericArray { get; set; } =
+        [Export]
+        private Godot.Collections.Array<int> property_GodotGenericArray { get; set; } =
             new() { 0, 1, 2, 3, 4, 5, 6 };
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
@@ -34,7 +34,7 @@ namespace GodotTools.Core
             path = path.Replace('\\', '/');
             path = path[path.Length - 1] == '/' ? path.Substring(0, path.Length - 1) : path;
 
-            string[] parts = path.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
+            string[] parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
             path = string.Join(Path.DirectorySeparatorChar.ToString(), parts).Trim();
 
@@ -60,7 +60,7 @@ namespace GodotTools.Core
 
         public static string ToSafeDirName(this string dirName, bool allowDirSeparator = false)
         {
-            var invalidChars = new List<string> {":", "*", "?", "\"", "<", ">", "|"};
+            var invalidChars = new List<string> { ":", "*", "?", "\"", "<", ">", "|" };
 
             if (allowDirSeparator)
             {

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/Client.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/Client.cs
@@ -123,12 +123,16 @@ namespace GodotTools.IdeMessaging
 
             string projectMetadataDir = Path.Combine(godotProjectDir, ".godot", "mono", "metadata");
             // FileSystemWatcher requires an existing directory
-            if (!Directory.Exists(projectMetadataDir)) {
+            if (!Directory.Exists(projectMetadataDir))
+            {
                 // Check if the non hidden version exists
                 string nonHiddenProjectMetadataDir = Path.Combine(godotProjectDir, "godot", "mono", "metadata");
-                if (Directory.Exists(nonHiddenProjectMetadataDir)) {
+                if (Directory.Exists(nonHiddenProjectMetadataDir))
+                {
                     projectMetadataDir = nonHiddenProjectMetadataDir;
-                } else {
+                }
+                else
+                {
                     Directory.CreateDirectory(projectMetadataDir);
                 }
             }

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/Peer.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/Peer.cs
@@ -78,7 +78,7 @@ namespace GodotTools.IdeMessaging
             clientStream.WriteTimeout = ClientWriteTimeout;
 
             clientReader = new StreamReader(clientStream, Encoding.UTF8);
-            clientWriter = new StreamWriter(clientStream, Encoding.UTF8) {NewLine = "\n"};
+            clientWriter = new StreamWriter(clientStream, Encoding.UTF8) { NewLine = "\n" };
         }
 
         public async Task Process()

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/ResponseAwaiter.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/ResponseAwaiter.cs
@@ -17,7 +17,7 @@ namespace GodotTools.IdeMessaging
             if (content.Status == MessageStatus.Ok)
                 SetResult(JsonConvert.DeserializeObject<T>(content.Body));
             else
-                SetResult(new T {Status = content.Status});
+                SetResult(new T { Status = content.Status });
         }
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
@@ -249,8 +249,8 @@ namespace GodotTools.OpenVisualStudio
             // Thread call was rejected, so try again.
             int IOleMessageFilter.RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType)
             {
+                // flag = SERVERCALL_RETRYLATER
                 if (dwRejectType == 2)
-                    // flag = SERVERCALL_RETRYLATER
                 {
                     // Retry the thread call immediately if return >= 0 & < 100
                     return 99;

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -76,13 +76,20 @@ namespace GodotTools.Export
             else
             {
                 string arch = "";
-                if (features.Contains("x86_64")) {
+                if (features.Contains("x86_64"))
+                {
                     arch = "x86_64";
-                } else if (features.Contains("x86_32")) {
+                }
+                else if (features.Contains("x86_32"))
+                {
                     arch = "x86_32";
-                } else if (features.Contains("arm64")) {
+                }
+                else if (features.Contains("arm64"))
+                {
                     arch = "arm64";
-                } else if (features.Contains("arm32")) {
+                }
+                else if (features.Contains("arm32"))
+                {
                     arch = "arm32";
                 }
                 CompileAssembliesForDesktop(exporter, platform, isDebug, arch, aotOpts, aotTempDir, outputDataDir, assembliesPrepared, bclDir);

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -180,17 +180,17 @@ namespace GodotTools.Ides
 
             public void SendOpenFile(string file)
             {
-                SendRequest<OpenFileResponse>(new OpenFileRequest {File = file});
+                SendRequest<OpenFileResponse>(new OpenFileRequest { File = file });
             }
 
             public void SendOpenFile(string file, int line)
             {
-                SendRequest<OpenFileResponse>(new OpenFileRequest {File = file, Line = line});
+                SendRequest<OpenFileResponse>(new OpenFileRequest { File = file, Line = line });
             }
 
             public void SendOpenFile(string file, int line, int column)
             {
-                SendRequest<OpenFileResponse>(new OpenFileRequest {File = file, Line = line, Column = column});
+                SendRequest<OpenFileResponse>(new OpenFileRequest { File = file, Line = line, Column = column });
             }
         }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/MessagingServer.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/MessagingServer.cs
@@ -385,7 +385,7 @@ namespace GodotTools.Ides
                 // However, it doesn't fix resource loading if the rest of the path is also case insensitive.
                 string scriptFileLocalized = FsPathUtils.LocalizePathWithCaseChecked(request.ScriptFile);
 
-                var response = new CodeCompletionResponse {Kind = request.Kind, ScriptFile = request.ScriptFile};
+                var response = new CodeCompletionResponse { Kind = request.Kind, ScriptFile = request.ScriptFile };
                 response.Suggestions = await Task.Run(() =>
                     Internal.CodeCompletionRequest(response.Kind, scriptFileLocalized ?? request.ScriptFile));
                 return response;

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -206,10 +206,10 @@ namespace GodotTools.Utils
                 return searchDirs.Select(dir => Path.Combine(dir, name)).FirstOrDefault(File.Exists);
 
             return (from dir in searchDirs
-                select Path.Combine(dir, name)
+                    select Path.Combine(dir, name)
                 into path
-                from ext in windowsExts
-                select path + ext).FirstOrDefault(File.Exists);
+                    from ext in windowsExts
+                    select path + ext).FirstOrDefault(File.Exists);
         }
 
         [return: MaybeNull]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantConversionCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantConversionCallbacks.cs
@@ -6,7 +6,7 @@ namespace Godot.NativeInterop;
 internal static unsafe class VariantConversionCallbacks
 {
     [SuppressMessage("ReSharper", "RedundantNameQualifier")]
-    internal static delegate* <in T, godot_variant> GetToVariantCallback<T>()
+    internal static delegate*<in T, godot_variant> GetToVariantCallback<T>()
     {
         static godot_variant FromBool(in bool @bool) =>
             VariantUtils.CreateFromBool(@bool);
@@ -153,163 +153,163 @@ internal static unsafe class VariantConversionCallbacks
 
         if (typeOfT == typeof(bool))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in bool, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in bool, godot_variant>)
                 &FromBool;
         }
 
         if (typeOfT == typeof(char))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in char, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in char, godot_variant>)
                 &FromChar;
         }
 
         if (typeOfT == typeof(sbyte))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in sbyte, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in sbyte, godot_variant>)
                 &FromInt8;
         }
 
         if (typeOfT == typeof(short))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in short, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in short, godot_variant>)
                 &FromInt16;
         }
 
         if (typeOfT == typeof(int))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in int, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in int, godot_variant>)
                 &FromInt32;
         }
 
         if (typeOfT == typeof(long))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in long, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in long, godot_variant>)
                 &FromInt64;
         }
 
         if (typeOfT == typeof(byte))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in byte, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in byte, godot_variant>)
                 &FromUInt8;
         }
 
         if (typeOfT == typeof(ushort))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in ushort, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in ushort, godot_variant>)
                 &FromUInt16;
         }
 
         if (typeOfT == typeof(uint))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in uint, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in uint, godot_variant>)
                 &FromUInt32;
         }
 
         if (typeOfT == typeof(ulong))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in ulong, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in ulong, godot_variant>)
                 &FromUInt64;
         }
 
         if (typeOfT == typeof(float))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in float, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in float, godot_variant>)
                 &FromFloat;
         }
 
         if (typeOfT == typeof(double))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in double, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in double, godot_variant>)
                 &FromDouble;
         }
 
         if (typeOfT == typeof(Vector2))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Vector2, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Vector2, godot_variant>)
                 &FromVector2;
         }
 
         if (typeOfT == typeof(Vector2i))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Vector2i, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Vector2i, godot_variant>)
                 &FromVector2I;
         }
 
         if (typeOfT == typeof(Rect2))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Rect2, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Rect2, godot_variant>)
                 &FromRect2;
         }
 
         if (typeOfT == typeof(Rect2i))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Rect2i, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Rect2i, godot_variant>)
                 &FromRect2I;
         }
 
         if (typeOfT == typeof(Transform2D))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Transform2D, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Transform2D, godot_variant>)
                 &FromTransform2D;
         }
 
         if (typeOfT == typeof(Vector3))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Vector3, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Vector3, godot_variant>)
                 &FromVector3;
         }
 
         if (typeOfT == typeof(Vector3i))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Vector3i, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Vector3i, godot_variant>)
                 &FromVector3I;
         }
 
         if (typeOfT == typeof(Basis))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Basis, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Basis, godot_variant>)
                 &FromBasis;
         }
 
         if (typeOfT == typeof(Quaternion))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Quaternion, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Quaternion, godot_variant>)
                 &FromQuaternion;
         }
 
         if (typeOfT == typeof(Transform3D))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Transform3D, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Transform3D, godot_variant>)
                 &FromTransform3D;
         }
 
         if (typeOfT == typeof(AABB))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in AABB, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in AABB, godot_variant>)
                 &FromAabb;
         }
 
         if (typeOfT == typeof(Color))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Color, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Color, godot_variant>)
                 &FromColor;
         }
 
         if (typeOfT == typeof(Plane))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Plane, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Plane, godot_variant>)
                 &FromPlane;
         }
 
         if (typeOfT == typeof(Callable))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Callable, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Callable, godot_variant>)
                 &FromCallable;
         }
 
         if (typeOfT == typeof(SignalInfo))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in SignalInfo, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in SignalInfo, godot_variant>)
                 &FromSignalInfo;
         }
 
@@ -321,42 +321,42 @@ internal static unsafe class VariantConversionCallbacks
             {
                 case TypeCode.SByte:
                 {
-                    return (delegate* <in T, godot_variant>)(delegate* <in sbyte, godot_variant>)
+                    return (delegate*<in T, godot_variant>)(delegate*<in sbyte, godot_variant>)
                         &FromInt8;
                 }
                 case TypeCode.Int16:
                 {
-                    return (delegate* <in T, godot_variant>)(delegate* <in short, godot_variant>)
+                    return (delegate*<in T, godot_variant>)(delegate*<in short, godot_variant>)
                         &FromInt16;
                 }
                 case TypeCode.Int32:
                 {
-                    return (delegate* <in T, godot_variant>)(delegate* <in int, godot_variant>)
+                    return (delegate*<in T, godot_variant>)(delegate*<in int, godot_variant>)
                         &FromInt32;
                 }
                 case TypeCode.Int64:
                 {
-                    return (delegate* <in T, godot_variant>)(delegate* <in long, godot_variant>)
+                    return (delegate*<in T, godot_variant>)(delegate*<in long, godot_variant>)
                         &FromInt64;
                 }
                 case TypeCode.Byte:
                 {
-                    return (delegate* <in T, godot_variant>)(delegate* <in byte, godot_variant>)
+                    return (delegate*<in T, godot_variant>)(delegate*<in byte, godot_variant>)
                         &FromUInt8;
                 }
                 case TypeCode.UInt16:
                 {
-                    return (delegate* <in T, godot_variant>)(delegate* <in ushort, godot_variant>)
+                    return (delegate*<in T, godot_variant>)(delegate*<in ushort, godot_variant>)
                         &FromUInt16;
                 }
                 case TypeCode.UInt32:
                 {
-                    return (delegate* <in T, godot_variant>)(delegate* <in uint, godot_variant>)
+                    return (delegate*<in T, godot_variant>)(delegate*<in uint, godot_variant>)
                         &FromUInt32;
                 }
                 case TypeCode.UInt64:
                 {
-                    return (delegate* <in T, godot_variant>)(delegate* <in ulong, godot_variant>)
+                    return (delegate*<in T, godot_variant>)(delegate*<in ulong, godot_variant>)
                         &FromUInt64;
                 }
                 default:
@@ -366,121 +366,121 @@ internal static unsafe class VariantConversionCallbacks
 
         if (typeOfT == typeof(string))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in string, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in string, godot_variant>)
                 &FromString;
         }
 
         if (typeOfT == typeof(byte[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in byte[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in byte[], godot_variant>)
                 &FromByteArray;
         }
 
         if (typeOfT == typeof(int[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in int[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in int[], godot_variant>)
                 &FromInt32Array;
         }
 
         if (typeOfT == typeof(long[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in long[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in long[], godot_variant>)
                 &FromInt64Array;
         }
 
         if (typeOfT == typeof(float[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in float[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in float[], godot_variant>)
                 &FromFloatArray;
         }
 
         if (typeOfT == typeof(double[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in double[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in double[], godot_variant>)
                 &FromDoubleArray;
         }
 
         if (typeOfT == typeof(string[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in string[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in string[], godot_variant>)
                 &FromStringArray;
         }
 
         if (typeOfT == typeof(Vector2[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Vector2[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Vector2[], godot_variant>)
                 &FromVector2Array;
         }
 
         if (typeOfT == typeof(Vector3[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Vector3[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Vector3[], godot_variant>)
                 &FromVector3Array;
         }
 
         if (typeOfT == typeof(Color[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Color[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Color[], godot_variant>)
                 &FromColorArray;
         }
 
         if (typeOfT == typeof(StringName[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in StringName[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in StringName[], godot_variant>)
                 &FromStringNameArray;
         }
 
         if (typeOfT == typeof(NodePath[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in NodePath[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in NodePath[], godot_variant>)
                 &FromNodePathArray;
         }
 
         if (typeOfT == typeof(RID[]))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in RID[], godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in RID[], godot_variant>)
                 &FromRidArray;
         }
 
         if (typeof(Godot.Object).IsAssignableFrom(typeOfT))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Godot.Object, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Godot.Object, godot_variant>)
                 &FromGodotObject;
         }
 
         if (typeOfT == typeof(StringName))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in StringName, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in StringName, godot_variant>)
                 &FromStringName;
         }
 
         if (typeOfT == typeof(NodePath))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in NodePath, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in NodePath, godot_variant>)
                 &FromNodePath;
         }
 
         if (typeOfT == typeof(RID))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in RID, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in RID, godot_variant>)
                 &FromRid;
         }
 
         if (typeOfT == typeof(Godot.Collections.Dictionary))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Godot.Collections.Dictionary, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Godot.Collections.Dictionary, godot_variant>)
                 &FromGodotDictionary;
         }
 
         if (typeOfT == typeof(Godot.Collections.Array))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Godot.Collections.Array, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Godot.Collections.Array, godot_variant>)
                 &FromGodotArray;
         }
 
         if (typeOfT == typeof(Variant))
         {
-            return (delegate* <in T, godot_variant>)(delegate* <in Variant, godot_variant>)
+            return (delegate*<in T, godot_variant>)(delegate*<in Variant, godot_variant>)
                 &FromVariant;
         }
 
@@ -488,7 +488,7 @@ internal static unsafe class VariantConversionCallbacks
     }
 
     [SuppressMessage("ReSharper", "RedundantNameQualifier")]
-    internal static delegate* <in godot_variant, T> GetToManagedCallback<T>()
+    internal static delegate*<in godot_variant, T> GetToManagedCallback<T>()
     {
         static bool ToBool(in godot_variant variant) =>
             VariantUtils.ConvertToBool(variant);
@@ -638,163 +638,163 @@ internal static unsafe class VariantConversionCallbacks
 
         if (typeOfT == typeof(bool))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, bool>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, bool>)
                 &ToBool;
         }
 
         if (typeOfT == typeof(char))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, char>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, char>)
                 &ToChar;
         }
 
         if (typeOfT == typeof(sbyte))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, sbyte>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, sbyte>)
                 &ToInt8;
         }
 
         if (typeOfT == typeof(short))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, short>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, short>)
                 &ToInt16;
         }
 
         if (typeOfT == typeof(int))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, int>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, int>)
                 &ToInt32;
         }
 
         if (typeOfT == typeof(long))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, long>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, long>)
                 &ToInt64;
         }
 
         if (typeOfT == typeof(byte))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, byte>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, byte>)
                 &ToUInt8;
         }
 
         if (typeOfT == typeof(ushort))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, ushort>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, ushort>)
                 &ToUInt16;
         }
 
         if (typeOfT == typeof(uint))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, uint>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, uint>)
                 &ToUInt32;
         }
 
         if (typeOfT == typeof(ulong))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, ulong>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, ulong>)
                 &ToUInt64;
         }
 
         if (typeOfT == typeof(float))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, float>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, float>)
                 &ToFloat;
         }
 
         if (typeOfT == typeof(double))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, double>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, double>)
                 &ToDouble;
         }
 
         if (typeOfT == typeof(Vector2))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Vector2>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Vector2>)
                 &ToVector2;
         }
 
         if (typeOfT == typeof(Vector2i))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Vector2i>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Vector2i>)
                 &ToVector2I;
         }
 
         if (typeOfT == typeof(Rect2))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Rect2>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Rect2>)
                 &ToRect2;
         }
 
         if (typeOfT == typeof(Rect2i))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Rect2i>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Rect2i>)
                 &ToRect2I;
         }
 
         if (typeOfT == typeof(Transform2D))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Transform2D>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Transform2D>)
                 &ToTransform2D;
         }
 
         if (typeOfT == typeof(Vector3))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Vector3>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Vector3>)
                 &ToVector3;
         }
 
         if (typeOfT == typeof(Vector3i))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Vector3i>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Vector3i>)
                 &ToVector3I;
         }
 
         if (typeOfT == typeof(Basis))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Basis>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Basis>)
                 &ToBasis;
         }
 
         if (typeOfT == typeof(Quaternion))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Quaternion>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Quaternion>)
                 &ToQuaternion;
         }
 
         if (typeOfT == typeof(Transform3D))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Transform3D>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Transform3D>)
                 &ToTransform3D;
         }
 
         if (typeOfT == typeof(AABB))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, AABB>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, AABB>)
                 &ToAabb;
         }
 
         if (typeOfT == typeof(Color))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Color>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Color>)
                 &ToColor;
         }
 
         if (typeOfT == typeof(Plane))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Plane>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Plane>)
                 &ToPlane;
         }
 
         if (typeOfT == typeof(Callable))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Callable>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Callable>)
                 &ToCallable;
         }
 
         if (typeOfT == typeof(SignalInfo))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, SignalInfo>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, SignalInfo>)
                 &ToSignalInfo;
         }
 
@@ -806,42 +806,42 @@ internal static unsafe class VariantConversionCallbacks
             {
                 case TypeCode.SByte:
                 {
-                    return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, sbyte>)
+                    return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, sbyte>)
                         &ToInt8;
                 }
                 case TypeCode.Int16:
                 {
-                    return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, short>)
+                    return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, short>)
                         &ToInt16;
                 }
                 case TypeCode.Int32:
                 {
-                    return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, int>)
+                    return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, int>)
                         &ToInt32;
                 }
                 case TypeCode.Int64:
                 {
-                    return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, long>)
+                    return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, long>)
                         &ToInt64;
                 }
                 case TypeCode.Byte:
                 {
-                    return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, byte>)
+                    return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, byte>)
                         &ToUInt8;
                 }
                 case TypeCode.UInt16:
                 {
-                    return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, ushort>)
+                    return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, ushort>)
                         &ToUInt16;
                 }
                 case TypeCode.UInt32:
                 {
-                    return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, uint>)
+                    return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, uint>)
                         &ToUInt32;
                 }
                 case TypeCode.UInt64:
                 {
-                    return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, ulong>)
+                    return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, ulong>)
                         &ToUInt64;
                 }
                 default:
@@ -851,121 +851,121 @@ internal static unsafe class VariantConversionCallbacks
 
         if (typeOfT == typeof(string))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, string>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, string>)
                 &ToString;
         }
 
         if (typeOfT == typeof(byte[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, byte[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, byte[]>)
                 &ToByteArray;
         }
 
         if (typeOfT == typeof(int[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, int[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, int[]>)
                 &ToInt32Array;
         }
 
         if (typeOfT == typeof(long[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, long[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, long[]>)
                 &ToInt64Array;
         }
 
         if (typeOfT == typeof(float[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, float[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, float[]>)
                 &ToFloatArray;
         }
 
         if (typeOfT == typeof(double[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, double[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, double[]>)
                 &ToDoubleArray;
         }
 
         if (typeOfT == typeof(string[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, string[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, string[]>)
                 &ToStringArray;
         }
 
         if (typeOfT == typeof(Vector2[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Vector2[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Vector2[]>)
                 &ToVector2Array;
         }
 
         if (typeOfT == typeof(Vector3[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Vector3[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Vector3[]>)
                 &ToVector3Array;
         }
 
         if (typeOfT == typeof(Color[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Color[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Color[]>)
                 &ToColorArray;
         }
 
         if (typeOfT == typeof(StringName[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, StringName[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, StringName[]>)
                 &ToStringNameArray;
         }
 
         if (typeOfT == typeof(NodePath[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, NodePath[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, NodePath[]>)
                 &ToNodePathArray;
         }
 
         if (typeOfT == typeof(RID[]))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, RID[]>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, RID[]>)
                 &ToRidArray;
         }
 
         if (typeof(Godot.Object).IsAssignableFrom(typeOfT))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Godot.Object>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Godot.Object>)
                 &ToGodotObject;
         }
 
         if (typeOfT == typeof(StringName))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, StringName>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, StringName>)
                 &ToStringName;
         }
 
         if (typeOfT == typeof(NodePath))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, NodePath>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, NodePath>)
                 &ToNodePath;
         }
 
         if (typeOfT == typeof(RID))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, RID>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, RID>)
                 &ToRid;
         }
 
         if (typeOfT == typeof(Godot.Collections.Dictionary))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Godot.Collections.Dictionary>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Godot.Collections.Dictionary>)
                 &ToGodotDictionary;
         }
 
         if (typeOfT == typeof(Godot.Collections.Array))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Godot.Collections.Array>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Godot.Collections.Array>)
                 &ToGodotArray;
         }
 
         if (typeOfT == typeof(Variant))
         {
-            return (delegate* <in godot_variant, T>)(delegate* <in godot_variant, Variant>)
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Variant>)
                 &ToVariant;
         }
 


### PR DESCRIPTION
Use [`dotnet format`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-format) to format the C# projects like we do with `clang-format` for C++ and output the diff in the static checks CI.

`dotnet format` uses the `.editorconfig` configuration so right now it's pretty relaxed since we don't have many rules enforced, by default it applies code fixes for rules with the `warning` severity (we can set the rule severity in `.editorconfig` for the rules we want applied and/or modify the severity used by `dotnet format` to one of `warning`|`info`|`error`).

This PR does not modify `.editorconfig` but we should consider adding some rules such as [IDE0005](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005) (remove unnecessary using directives). See https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/.

Formatting can also be suppressed if we need to in specific situations (or you can also suppress the specific rule by diagnostic ID):

```csharp
#pragma warning disable format

...

#pragma warning restore format
```

This PR also applies the changes made by `dotnet format` to pass CI (currently a separate commit for convenience but they will be squashed before merging).