### PR TITLE
Make local-to-scene resources behavior consistent in child scenes

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -297,7 +297,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 										if (E) {
 											value = E->value;
 										} else {
-											if (p_edit_state == GEN_EDIT_STATE_MAIN || p_edit_state == GEN_EDIT_STATE_MAIN_INHERITED) {
+											if (p_edit_state == GEN_EDIT_STATE_MAIN) {
 												//for the main scene, use the resource as is
 												res->configure_for_local_scene(base, resources_local_to_scene);
 												resources_local_to_scene[res] = res;


### PR DESCRIPTION
See #64526 for background. ~Also this supersedes it.~ **UPDATE:** This PR complements it.

~Like the other PR, this very likely fixes- #62014.~