### PR TITLE
C#: Fix byteCount in `NativeMemory.Alloc`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -831,7 +831,7 @@ namespace Godot.Bridge
                 }
                 else
                 {
-                    interopProperties = ((godotsharp_property_info*)NativeMemory.Alloc((nuint)length))!;
+                    interopProperties = ((godotsharp_property_info*)NativeMemory.Alloc((nuint)length, (nuint)sizeof(godotsharp_property_info)))!;
                 }
 
                 try
@@ -951,7 +951,7 @@ namespace Godot.Bridge
                 }
                 else
                 {
-                    interopDefaultValues = ((godotsharp_property_def_val_pair*)NativeMemory.Alloc((nuint)length))!;
+                    interopDefaultValues = ((godotsharp_property_def_val_pair*)NativeMemory.Alloc((nuint)length, (nuint)sizeof(godotsharp_property_def_val_pair)))!;
                 }
 
                 try


### PR DESCRIPTION
`NativeMemory.Alloc` takes the byte count as parameter, this is calculated by multiplying the element size in bytes by the length of the array.

Fixes #64953
