### PR TITLE
Fix some corner cases in the `Menu/OptionButton` item auto-highlight

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -337,6 +337,7 @@
 			<param index="0" name="index" type="int" />
 			<description>
 				Sets the currently focused item as the given [param index].
+				Passing [code]-1[/code] as the index makes so that no item is focused.
 			</description>
 		</method>
 		<method name="set_item_accelerator">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -65,8 +65,9 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 	bool button_masked = mouse_button.is_valid() && (mouse_button_to_mask(mouse_button->get_button_index()) & button_mask) != MouseButton::NONE;
 	if (button_masked || ui_accept) {
 		was_mouse_pressed = button_masked;
-
 		on_action_event(p_event);
+		was_mouse_pressed = false;
+
 		return;
 	}
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -103,9 +103,14 @@ void MenuButton::pressed() {
 	popup->set_position(gp);
 	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), size));
 
-	// If not triggered by the mouse, start the popup with its first item selected.
-	if (popup->get_item_count() > 0 && !_was_pressed_by_mouse()) {
-		popup->set_current_index(0);
+	// If not triggered by the mouse, start the popup with its first enabled item focused.
+	if (!_was_pressed_by_mouse()) {
+		for (int i = 0; i < popup->get_item_count(); i++) {
+			if (!popup->is_item_disabled(i)) {
+				popup->set_current_index(i);
+				break;
+			}
+		}
 	}
 
 	popup->popup();
@@ -161,7 +166,10 @@ void MenuButton::_notification(int p_what) {
 			if (menu_btn_other && menu_btn_other != this && menu_btn_other->is_switch_on_hover() && !menu_btn_other->is_disabled() &&
 					(get_parent()->is_ancestor_of(menu_btn_other) || menu_btn_other->get_parent()->is_ancestor_of(popup))) {
 				popup->hide();
+
 				menu_btn_other->pressed();
+				// As the popup wasn't triggered by a mouse click, the item focus needs to be removed manually.
+				menu_btn_other->get_popup()->set_current_index(-1);
 			}
 		} break;
 	}

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -207,12 +207,24 @@ void OptionButton::pressed() {
 	popup->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));
 
-	// If not triggered by the mouse, start the popup with the checked item selected.
-	if (popup->get_item_count() > 0) {
+	// If not triggered by the mouse, start the popup with the checked item (or the first enabled one) focused.
+	if (current != NONE_SELECTED && !popup->is_item_disabled(current)) {
 		if (!_was_pressed_by_mouse()) {
-			popup->set_current_index(current > -1 ? current : 0);
+			popup->set_current_index(current);
 		} else {
-			popup->scroll_to_item(current > -1 ? current : 0);
+			popup->scroll_to_item(current);
+		}
+	} else {
+		for (int i = 0; i < popup->get_item_count(); i++) {
+			if (!popup->is_item_disabled(i)) {
+				if (!_was_pressed_by_mouse()) {
+					popup->set_current_index(i);
+				} else {
+					popup->scroll_to_item(i);
+				}
+
+				break;
+			}
 		}
 	}
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -216,9 +216,14 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 
 	submenu_pum->activated_by_keyboard = p_by_keyboard;
 
-	// If not triggered by the mouse, start the popup with its first item selected.
-	if (submenu_pum->get_item_count() > 0 && p_by_keyboard) {
-		submenu_pum->set_current_index(0);
+	// If not triggered by the mouse, start the popup with its first enabled item focused.
+	if (p_by_keyboard) {
+		for (int i = 0; i < submenu_pum->get_item_count(); i++) {
+			if (!submenu_pum->is_item_disabled(i)) {
+				submenu_pum->set_current_index(i);
+				break;
+			}
+		}
 	}
 
 	submenu_pum->popup();
@@ -1532,14 +1537,19 @@ bool PopupMenu::is_item_shortcut_disabled(int p_idx) const {
 }
 
 void PopupMenu::set_current_index(int p_idx) {
-	ERR_FAIL_INDEX(p_idx, items.size());
+	if (p_idx != -1) {
+		ERR_FAIL_INDEX(p_idx, items.size());
+	}
 
 	if (mouse_over == p_idx) {
 		return;
 	}
 
 	mouse_over = p_idx;
-	scroll_to_item(mouse_over);
+	if (mouse_over != -1) {
+		scroll_to_item(mouse_over);
+	}
+
 	control->update();
 }
 


### PR DESCRIPTION
- Fix auto-highlight triggering when switching between `MenuButton`s on hover.
  - This was done by making `PopupMenu`'s `set_current_index()` allow `-1` as a value.
- Make auto-highlight ignore disabled items.