### PR TITLE
Correct output file names for Visual Studio project generation

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -705,7 +705,7 @@ def generate_vs_project(env, num_jobs):
             # required for Visual Studio to understand that it needs to generate an NMAKE
             # project. Do not modify without knowing what you are doing.
             PLATFORMS = ["Win32", "x64"]
-            PLATFORM_IDS = ["32", "64"]
+            PLATFORM_IDS = ["x86_32", "x86_64"]
             CONFIGURATIONS = ["debug", "release", "release_debug"]
             CONFIGURATION_IDS = ["tools", "opt", "opt.tools"]
 


### PR DESCRIPTION
Changes the output path of generated Visual Studio projects from ["32" and "64"] to ["x86_32" and "x86_64"] respectively, matching the new executable naming convention of the build system and allowing the correct files to be debugged in Visual Studio.