### PR TITLE
Fix fullscreen on X11.

### DIFF
--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -268,6 +268,7 @@ class DisplayServerX11 : public DisplayServer {
 	void _update_real_mouse_position(const WindowData &wd);
 	bool _window_maximize_check(WindowID p_window, const char *p_atom_name) const;
 	bool _window_fullscreen_check(WindowID p_window) const;
+	void _validate_fullscreen_on_map(WindowID p_window);
 	void _update_size_hints(WindowID p_window);
 	void _set_wm_fullscreen(WindowID p_window, bool p_enabled);
 	void _set_wm_maximized(WindowID p_window, bool p_enabled);


### PR DESCRIPTION
Should fix #54065

It appears to be the case that if an attempt is made to use the `_NET_WM_STATE_FULLSCREEN` EWMH hint on a window that is not mapped, applying the hint will silently fail. Whether this is a EWMH specification requirement, or it's left up to the window manager's discretion, I am not sure. Regardless, `DisplayServerX11::_create_window` attempts to do just this, and this leaves Godot in an internal state where it believes the window is in fullscreen, but in reality it is not. What this pull request does is whenever a window receives a `MapNotify` request, we test to see if Godot believes the window is fullscreen, and also test to see if `_NET_WM_STATE_FULLSCREEN` genuinely was set. If there is a discrepancy, we re-attempt setting the window to fullscreen now that we know for sure that the window has been mapped. 

This PR was tested on i3wm, as its the only window manager i have installed. It's probably a good idea to test it on other window managers.