### PR TITLE
Add await for WorkerThreadPool tasks by managing them in the SceneTree

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -54,6 +54,24 @@
 				[b]Note:[/b] The scene change is deferred, which means that the new scene node is added on the next idle frame. You won't be able to access it immediately after the [method change_scene_to] call.
 			</description>
 		</method>
+		<method name="create_group_task">
+			<return type="SceneTreeGroupTask" />
+			<param index="0" name="action" type="Callable" />
+			<param index="1" name="elements" type="int" />
+			<param index="2" name="tasks_needed" type="int" default="-1" />
+			<param index="3" name="high_priority" type="bool" default="false" />
+			<param index="4" name="description" type="String" default="&quot;&quot;" />
+			<description>
+			</description>
+		</method>
+		<method name="create_task">
+			<return type="SceneTreeTask" />
+			<param index="0" name="action" type="Callable" />
+			<param index="1" name="high_priority" type="bool" default="false" />
+			<param index="2" name="description" type="String" default="&quot;&quot;" />
+			<description>
+			</description>
+		</method>
 		<method name="create_timer">
 			<return type="SceneTreeTimer" />
 			<param index="0" name="time_sec" type="float" />

--- a/doc/classes/SceneTreeGroupTask.xml
+++ b/doc/classes/SceneTreeGroupTask.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SceneTreeGroupTask" inherits="SceneTreeTask" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		[WorkerThreadPool] group task.
+	</brief_description>
+	<description>
+		A [WorkerThreadPool] task managed by the scene tree, which emits [signal completed] on completion. See also [method SceneTree.create_group_task].
+		[codeblocks]
+		[gdscript]
+		await get_tree().create_task(job).completed
+		[/gdscript]
+		[/codeblocks]
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/SceneTreeTask.xml
+++ b/doc/classes/SceneTreeTask.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SceneTreeTask" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		[WorkerThreadPool] task.
+	</brief_description>
+	<description>
+		A [WorkerThreadPool] task managed by the scene tree, which emits [signal completed] on completion. See also [method SceneTree.create_task].
+		[codeblocks]
+		[gdscript]
+		await get_tree().create_group_task(job).completed
+		[/gdscript]
+		[/codeblocks]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_processed_element_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Get the number of processed elements. Either 0 or 1 if completed.
+			</description>
+		</method>
+		<method name="is_completed" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Checks if the task is completed.
+			</description>
+		</method>
+		<method name="wait_for_completion" qualifiers="const">
+			<return type="void" />
+			<description>
+				Blocks and waits for the task to complete.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="completed">
+			<description>
+				Emitted when the task is completed.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -930,6 +930,8 @@ void register_scene_types() {
 
 	GDREGISTER_CLASS(SceneTree);
 	GDREGISTER_ABSTRACT_CLASS(SceneTreeTimer); // sorry, you can't create it
+	GDREGISTER_ABSTRACT_CLASS(SceneTreeTask);
+	GDREGISTER_ABSTRACT_CLASS(SceneTreeGroupTask);
 
 #ifndef DISABLE_DEPRECATED
 	// Dropped in 4.0, near approximation.


### PR DESCRIPTION
This allows `await` on `WorkerThreadPool` tasks instead of only `wait()` which will block. The `SceneTree` manages high-level task objects which it checks every iteration their state and emits a `completed` signal when they are completed.

Code goes from blocking:
```gdscript
var id := WorkerThreadPool.add_task(job)
WorkerThreadPool.wait_for_task_completion(id) # Blocks the thread
```
To async:
```gdscript
var task := get_tree().create_task(job)
await task.completed # Async waiting
```

See: https://github.com/godotengine/godot-proposals/issues/5118