### PR TITLE
Move GLTF camera and light conversion code into GLTFCamera and GLTFLight

### DIFF
--- a/modules/gltf/doc_classes/GLTFCamera.xml
+++ b/modules/gltf/doc_classes/GLTFCamera.xml
@@ -10,6 +10,34 @@
 		<link title="GLTF camera detailed specification">https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-camera</link>
 		<link title="GLTF camera spec and example file">https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_015_SimpleCameras.md</link>
 	</tutorials>
+	<methods>
+		<method name="from_dictionary" qualifiers="static">
+			<return type="GLTFCamera" />
+			<param index="0" name="dictionary" type="Dictionary" />
+			<description>
+				Creates a new GLTFCamera instance by parsing the given [Dictionary].
+			</description>
+		</method>
+		<method name="from_node" qualifiers="static">
+			<return type="GLTFCamera" />
+			<param index="0" name="camera_node" type="Camera3D" />
+			<description>
+				Create a new GLTFCamera instance from the given Godot [Camera3D] node.
+			</description>
+		</method>
+		<method name="to_dictionary" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Serializes this GLTFCamera instance into a [Dictionary].
+			</description>
+		</method>
+		<method name="to_node" qualifiers="const">
+			<return type="Camera3D" />
+			<description>
+				Converts this GLTFCamera instance into a Godot [Camera3D] node.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="depth_far" type="float" setter="set_depth_far" getter="get_depth_far" default="4000.0">
 			The distance to the far culling boundary for this camera relative to its local Z axis, in meters. This maps to GLTF's [code]zfar[/code] property.

--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -9,6 +9,34 @@
 	<tutorials>
 		<link title="KHR_lights_punctual GLTF extension spec">https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_lights_punctual</link>
 	</tutorials>
+	<methods>
+		<method name="from_dictionary" qualifiers="static">
+			<return type="GLTFLight" />
+			<param index="0" name="dictionary" type="Dictionary" />
+			<description>
+				Creates a new GLTFLight instance by parsing the given [Dictionary].
+			</description>
+		</method>
+		<method name="from_node" qualifiers="static">
+			<return type="GLTFLight" />
+			<param index="0" name="light_node" type="Light3D" />
+			<description>
+				Create a new GLTFLight instance from the given Godot [Light3D] node.
+			</description>
+		</method>
+		<method name="to_dictionary" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Serializes this GLTFLight instance into a [Dictionary].
+			</description>
+		</method>
+		<method name="to_node" qualifiers="const">
+			<return type="Light3D" />
+			<description>
+				Converts this GLTFLight instance into a Godot [Light3D] node.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
 			The [Color] of the light. Defaults to white. A black color causes the light to have no effect.

--- a/modules/gltf/extensions/gltf_light.cpp
+++ b/modules/gltf/extensions/gltf_light.cpp
@@ -31,6 +31,12 @@
 #include "gltf_light.h"
 
 void GLTFLight::_bind_methods() {
+	ClassDB::bind_static_method("GLTFLight", D_METHOD("from_node", "light_node"), &GLTFLight::from_node);
+	ClassDB::bind_method(D_METHOD("to_node"), &GLTFLight::to_node);
+
+	ClassDB::bind_static_method("GLTFLight", D_METHOD("from_dictionary", "dictionary"), &GLTFLight::from_dictionary);
+	ClassDB::bind_method(D_METHOD("to_dictionary"), &GLTFLight::to_dictionary);
+
 	ClassDB::bind_method(D_METHOD("get_color"), &GLTFLight::get_color);
 	ClassDB::bind_method(D_METHOD("set_color", "color"), &GLTFLight::set_color);
 	ClassDB::bind_method(D_METHOD("get_intensity"), &GLTFLight::get_intensity);
@@ -98,4 +104,117 @@ float GLTFLight::get_outer_cone_angle() {
 
 void GLTFLight::set_outer_cone_angle(float p_outer_cone_angle) {
 	outer_cone_angle = p_outer_cone_angle;
+}
+
+Ref<GLTFLight> GLTFLight::from_node(const Light3D *p_light) {
+	Ref<GLTFLight> l;
+	l.instantiate();
+	l->color = p_light->get_color();
+	if (cast_to<DirectionalLight3D>(p_light)) {
+		l->light_type = "directional";
+		const DirectionalLight3D *light = cast_to<const DirectionalLight3D>(p_light);
+		l->intensity = light->get_param(DirectionalLight3D::PARAM_ENERGY);
+		l->range = FLT_MAX; // Range for directional lights is infinite in Godot.
+	} else if (cast_to<const OmniLight3D>(p_light)) {
+		l->light_type = "point";
+		const OmniLight3D *light = cast_to<const OmniLight3D>(p_light);
+		l->range = light->get_param(OmniLight3D::PARAM_RANGE);
+		l->intensity = light->get_param(OmniLight3D::PARAM_ENERGY);
+	} else if (cast_to<const SpotLight3D>(p_light)) {
+		l->light_type = "spot";
+		const SpotLight3D *light = cast_to<const SpotLight3D>(p_light);
+		l->range = light->get_param(SpotLight3D::PARAM_RANGE);
+		l->intensity = light->get_param(SpotLight3D::PARAM_ENERGY);
+		l->outer_cone_angle = Math::deg_to_rad(light->get_param(SpotLight3D::PARAM_SPOT_ANGLE));
+		// This equation is the inverse of the import equation (which has a desmos link).
+		float angle_ratio = 1 - (0.2 / (0.1 + light->get_param(SpotLight3D::PARAM_SPOT_ATTENUATION)));
+		angle_ratio = MAX(0, angle_ratio);
+		l->inner_cone_angle = l->outer_cone_angle * angle_ratio;
+	}
+	return l;
+}
+
+Light3D *GLTFLight::to_node() const {
+	if (light_type == "directional") {
+		DirectionalLight3D *light = memnew(DirectionalLight3D);
+		light->set_param(Light3D::PARAM_ENERGY, intensity);
+		light->set_color(color);
+		return light;
+	}
+	const float range = CLAMP(this->range, 0, 4096);
+	if (light_type == "point") {
+		OmniLight3D *light = memnew(OmniLight3D);
+		light->set_param(OmniLight3D::PARAM_ENERGY, intensity);
+		light->set_param(OmniLight3D::PARAM_RANGE, range);
+		light->set_color(color);
+		return light;
+	}
+	if (light_type == "spot") {
+		SpotLight3D *light = memnew(SpotLight3D);
+		light->set_param(SpotLight3D::PARAM_ENERGY, intensity);
+		light->set_param(SpotLight3D::PARAM_RANGE, range);
+		light->set_param(SpotLight3D::PARAM_SPOT_ANGLE, Math::rad_to_deg(outer_cone_angle));
+		light->set_color(color);
+		// Line of best fit derived from guessing, see https://www.desmos.com/calculator/biiflubp8b
+		// The points in desmos are not exact, except for (1, infinity).
+		float angle_ratio = inner_cone_angle / outer_cone_angle;
+		float angle_attenuation = 0.2 / (1 - angle_ratio) - 0.1;
+		light->set_param(SpotLight3D::PARAM_SPOT_ATTENUATION, angle_attenuation);
+		return light;
+	}
+	return memnew(Light3D);
+}
+
+Ref<GLTFLight> GLTFLight::from_dictionary(const Dictionary p_dictionary) {
+	ERR_FAIL_COND_V_MSG(!p_dictionary.has("type"), Ref<GLTFLight>(), "Failed to parse GLTF light, missing required field 'type'.");
+	Ref<GLTFLight> light;
+	light.instantiate();
+	const String &type = p_dictionary["type"];
+	light->light_type = type;
+
+	if (p_dictionary.has("color")) {
+		const Array &arr = p_dictionary["color"];
+		if (arr.size() == 3) {
+			light->color = Color(arr[0], arr[1], arr[2]).linear_to_srgb();
+		} else {
+			ERR_PRINT("Error parsing GLTF light: The color must have exactly 3 numbers.");
+		}
+	}
+	if (p_dictionary.has("intensity")) {
+		light->intensity = p_dictionary["intensity"];
+	}
+	if (p_dictionary.has("range")) {
+		light->range = p_dictionary["range"];
+	}
+	if (type == "spot") {
+		const Dictionary &spot = p_dictionary["spot"];
+		light->inner_cone_angle = spot["innerConeAngle"];
+		light->outer_cone_angle = spot["outerConeAngle"];
+		if (light->inner_cone_angle >= light->outer_cone_angle) {
+			ERR_PRINT("Error parsing GLTF light: The inner angle must be smaller than the outer angle.");
+		}
+	} else if (type != "point" && type != "directional") {
+		ERR_PRINT("Error parsing GLTF light: Light type '" + type + "' is unknown.");
+	}
+	return light;
+}
+
+Dictionary GLTFLight::to_dictionary() const {
+	Dictionary d;
+	Array color_array;
+	color_array.resize(3);
+	color_array[0] = color.r;
+	color_array[1] = color.g;
+	color_array[2] = color.b;
+	d["color"] = color_array;
+	d["type"] = light_type;
+	if (light_type == "spot") {
+		Dictionary spot_dict;
+		spot_dict["innerConeAngle"] = inner_cone_angle;
+		spot_dict["outerConeAngle"] = outer_cone_angle;
+		d["spot"] = spot_dict;
+	}
+	d["intensity"] = intensity;
+	d["range"] = range;
+	return d;
 }

--- a/modules/gltf/extensions/gltf_light.h
+++ b/modules/gltf/extensions/gltf_light.h
@@ -70,6 +70,12 @@ public:
 
 	float get_outer_cone_angle();
 	void set_outer_cone_angle(float p_outer_cone_angle);
+
+	static Ref<GLTFLight> from_node(const Light3D *p_light);
+	Light3D *to_node() const;
+
+	static Ref<GLTFLight> from_dictionary(const Dictionary p_dictionary);
+	Dictionary to_dictionary() const;
 };
 
 #endif // GLTF_LIGHT_H

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4534,28 +4534,7 @@ Error GLTFDocument::_serialize_lights(Ref<GLTFState> state) {
 	}
 	Array lights;
 	for (GLTFLightIndex i = 0; i < state->lights.size(); i++) {
-		Dictionary d;
-		Ref<GLTFLight> light = state->lights[i];
-		Array color;
-		color.resize(3);
-		color[0] = light->color.r;
-		color[1] = light->color.g;
-		color[2] = light->color.b;
-		d["color"] = color;
-		d["type"] = light->light_type;
-		if (light->light_type == "spot") {
-			Dictionary s;
-			float inner_cone_angle = light->inner_cone_angle;
-			s["innerConeAngle"] = inner_cone_angle;
-			float outer_cone_angle = light->outer_cone_angle;
-			s["outerConeAngle"] = outer_cone_angle;
-			d["spot"] = s;
-		}
-		float intensity = light->intensity;
-		d["intensity"] = intensity;
-		float range = light->range;
-		d["range"] = range;
-		lights.push_back(d);
+		lights.push_back(state->lights[i]->to_dictionary());
 	}
 
 	Dictionary extensions;
@@ -4627,35 +4606,10 @@ Error GLTFDocument::_parse_lights(Ref<GLTFState> state) {
 	const Array &lights = lights_punctual["lights"];
 
 	for (GLTFLightIndex light_i = 0; light_i < lights.size(); light_i++) {
-		const Dictionary &d = lights[light_i];
-
-		Ref<GLTFLight> light;
-		light.instantiate();
-		ERR_FAIL_COND_V(!d.has("type"), ERR_PARSE_ERROR);
-		const String &type = d["type"];
-		light->light_type = type;
-
-		if (d.has("color")) {
-			const Array &arr = d["color"];
-			ERR_FAIL_COND_V(arr.size() != 3, ERR_PARSE_ERROR);
-			const Color c = Color(arr[0], arr[1], arr[2]).linear_to_srgb();
-			light->color = c;
+		Ref<GLTFLight> light = GLTFLight::from_dictionary(lights[light_i]);
+		if (light.is_null()) {
+			return Error::ERR_PARSE_ERROR;
 		}
-		if (d.has("intensity")) {
-			light->intensity = d["intensity"];
-		}
-		if (d.has("range")) {
-			light->range = d["range"];
-		}
-		if (type == "spot") {
-			const Dictionary &spot = d["spot"];
-			light->inner_cone_angle = spot["innerConeAngle"];
-			light->outer_cone_angle = spot["outerConeAngle"];
-			ERR_CONTINUE_MSG(light->inner_cone_angle >= light->outer_cone_angle, "The inner angle must be smaller than the outer angle.");
-		} else if (type != "point" && type != "directional") {
-			ERR_CONTINUE_MSG(true, "Light type is unknown.");
-		}
-
 		state->lights.push_back(light);
 	}
 
@@ -5148,45 +5102,7 @@ Node3D *GLTFDocument::_generate_light(Ref<GLTFState> state, const GLTFNodeIndex 
 	print_verbose("glTF: Creating light for: " + gltf_node->get_name());
 
 	Ref<GLTFLight> l = state->lights[gltf_node->light];
-
-	float intensity = l->intensity;
-	if (intensity > 10) {
-		// GLTF spec has the default around 1, but Blender defaults lights to 100.
-		// The only sane way to handle this is to check where it came from and
-		// handle it accordingly. If it's over 10, it probably came from Blender.
-		intensity /= 100;
-	}
-
-	if (l->light_type == "directional") {
-		DirectionalLight3D *light = memnew(DirectionalLight3D);
-		light->set_param(Light3D::PARAM_ENERGY, intensity);
-		light->set_color(l->color);
-		return light;
-	}
-
-	const float range = CLAMP(l->range, 0, 4096);
-	if (l->light_type == "point") {
-		OmniLight3D *light = memnew(OmniLight3D);
-		light->set_param(OmniLight3D::PARAM_ENERGY, intensity);
-		light->set_param(OmniLight3D::PARAM_RANGE, range);
-		light->set_color(l->color);
-		return light;
-	}
-	if (l->light_type == "spot") {
-		SpotLight3D *light = memnew(SpotLight3D);
-		light->set_param(SpotLight3D::PARAM_ENERGY, intensity);
-		light->set_param(SpotLight3D::PARAM_RANGE, range);
-		light->set_param(SpotLight3D::PARAM_SPOT_ANGLE, Math::rad_to_deg(l->outer_cone_angle));
-		light->set_color(l->color);
-
-		// Line of best fit derived from guessing, see https://www.desmos.com/calculator/biiflubp8b
-		// The points in desmos are not exact, except for (1, infinity).
-		float angle_ratio = l->inner_cone_angle / l->outer_cone_angle;
-		float angle_attenuation = 0.2 / (1 - angle_ratio) - 0.1;
-		light->set_param(SpotLight3D::PARAM_SPOT_ATTENUATION, angle_attenuation);
-		return light;
-	}
-	return memnew(Node3D);
+	return l->to_node();
 }
 
 Camera3D *GLTFDocument::_generate_camera(Ref<GLTFState> state, const GLTFNodeIndex node_index) {
@@ -5228,31 +5144,7 @@ GLTFCameraIndex GLTFDocument::_convert_camera(Ref<GLTFState> state, Camera3D *p_
 GLTFLightIndex GLTFDocument::_convert_light(Ref<GLTFState> state, Light3D *p_light) {
 	print_verbose("glTF: Converting light: " + p_light->get_name());
 
-	Ref<GLTFLight> l;
-	l.instantiate();
-	l->color = p_light->get_color();
-	if (cast_to<DirectionalLight3D>(p_light)) {
-		l->light_type = "directional";
-		DirectionalLight3D *light = cast_to<DirectionalLight3D>(p_light);
-		l->intensity = light->get_param(DirectionalLight3D::PARAM_ENERGY);
-		l->range = FLT_MAX; // Range for directional lights is infinite in Godot.
-	} else if (cast_to<OmniLight3D>(p_light)) {
-		l->light_type = "point";
-		OmniLight3D *light = cast_to<OmniLight3D>(p_light);
-		l->range = light->get_param(OmniLight3D::PARAM_RANGE);
-		l->intensity = light->get_param(OmniLight3D::PARAM_ENERGY);
-	} else if (cast_to<SpotLight3D>(p_light)) {
-		l->light_type = "spot";
-		SpotLight3D *light = cast_to<SpotLight3D>(p_light);
-		l->range = light->get_param(SpotLight3D::PARAM_RANGE);
-		l->intensity = light->get_param(SpotLight3D::PARAM_ENERGY);
-		l->outer_cone_angle = Math::deg_to_rad(light->get_param(SpotLight3D::PARAM_SPOT_ANGLE));
-
-		// This equation is the inverse of the import equation (which has a desmos link).
-		float angle_ratio = 1 - (0.2 / (0.1 + light->get_param(SpotLight3D::PARAM_SPOT_ATTENUATION)));
-		angle_ratio = MAX(0, angle_ratio);
-		l->inner_cone_angle = l->outer_cone_angle * angle_ratio;
-	}
+	Ref<GLTFLight> l = GLTFLight::from_node(p_light);
 
 	GLTFLightIndex light_index = state->lights.size();
 	state->lights.push_back(l);

--- a/modules/gltf/structures/gltf_camera.h
+++ b/modules/gltf/structures/gltf_camera.h
@@ -63,6 +63,12 @@ public:
 	void set_depth_far(real_t p_val) { depth_far = p_val; }
 	real_t get_depth_near() const { return depth_near; }
 	void set_depth_near(real_t p_val) { depth_near = p_val; }
+
+	static Ref<GLTFCamera> from_node(const Camera3D *p_light);
+	Camera3D *to_node() const;
+
+	static Ref<GLTFCamera> from_dictionary(const Dictionary p_dictionary);
+	Dictionary to_dictionary() const;
 };
 
 #endif // GLTF_CAMERA_H


### PR DESCRIPTION
This PR moves GLTF camera conversion code into GLTFCamera, and moves GLTF light conversion code into GLTFLight. This is to reduce the size of GLTFDocument, including both the amount of lines of code and how many responsibilities it has. I started with cameras and lights because these classes are relatively simple compared to the others.

The design of the GLTF module is that GLTFState holds collections of structures and extensions (like GLTFCamera and GLTFLight), and GLTFDocument operates on GLTFState and its elements. With this PR, more of the heavy lifting code is moved to the smaller classes. GLTFDocument still does a lot of the work of calling the methods on the smaller classes, storing data inside of GLTFState, and retrieving data from GLTFState.