### PR TITLE
Fix .NET exporting in Linux

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -176,8 +176,9 @@ namespace GodotTools.Build
                 arguments.Add("--no-restore");
 
             // Incremental or rebuild
-            if (buildInfo.Rebuild)
-                arguments.Add("--no-incremental");
+            // TODO: Not supported in `dotnet publish` (https://github.com/dotnet/sdk/issues/11099)
+            // if (buildInfo.Rebuild)
+            //     arguments.Add("--no-incremental");
 
             // Configuration
             arguments.Add("-c");

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -112,7 +112,7 @@ namespace GodotTools.Export
             string buildConfig = isDebug ? "ExportDebug" : "ExportRelease";
 
             // TODO: This works for now, as we only implemented support for x86 family desktop so far, but it needs to be fixed
-            string arch = features.Contains("64") ? "x86_64" : "x86";
+            string arch = features.Contains("x86_64") ? "x86_64" : "x86";
 
             string ridOS = DetermineRuntimeIdentifierOS(platform);
             string ridArch = DetermineRuntimeIdentifierArch(arch);

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -70,9 +70,7 @@ namespace GodotTools.Utils
         {
             ["Windows"] = Platforms.Windows,
             ["macOS"] = Platforms.MacOS,
-            ["LinuxBSD"] = Platforms.LinuxBSD,
-            // "X11" for compatibility, temporarily, while we are on an outdated branch
-            ["X11"] = Platforms.LinuxBSD,
+            ["Linux"] = Platforms.LinuxBSD,
             ["UWP"] = Platforms.UWP,
             ["Haiku"] = Platforms.Haiku,
             ["Android"] = Platforms.Android,

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -103,12 +103,12 @@ const char_t *get_data(const HostFxrCharString &p_char_str) {
 }
 
 #ifdef TOOLS_ENABLED
-String find_hostfxr(size_t p_known_buffet_size, get_hostfxr_parameters *p_get_hostfxr_params) {
+String find_hostfxr(size_t p_known_buffer_size, get_hostfxr_parameters *p_get_hostfxr_params) {
 	// Pre-allocate a large buffer for the path to hostfxr
 	Vector<char_t> buffer;
-	buffer.resize(p_known_buffet_size);
+	buffer.resize(p_known_buffer_size);
 
-	int rc = get_hostfxr_path(buffer.ptrw(), &p_known_buffet_size, p_get_hostfxr_params);
+	int rc = get_hostfxr_path(buffer.ptrw(), &p_known_buffer_size, p_get_hostfxr_params);
 
 	ERR_FAIL_COND_V_MSG(rc != 0, String(), "get_hostfxr_path failed with code: " + itos(rc));
 


### PR DESCRIPTION
- Fix platform detection after Linux OS name was renamed from `LinuxBSD` to `Linux`
	- Follow up to #61352
	- Fixes https://github.com/godotengine/godot/issues/56450
- Fix arch detection after renaming `64` to `x86_64`
	- Follow up to #55778
	- Partially fixes #64983
- Fix typo in `find_hostfxr`
