### PR TITLE
Fix possible crash if opening `CodeEdit` by clicking on the script list

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -36,6 +36,7 @@
 
 void CodeEdit::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			style_normal = get_theme_stylebox(SNAME("normal"));
 


### PR DESCRIPTION
I've detected a strange crash which happens only on my internal project:

![crash](https://user-images.githubusercontent.com/3036176/187071922-47190e39-cd63-48c3-aff9-f2c61d30d300.gif)

Crash log is:

```
================================================================
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.0.alpha.custom_build (487a57b1742230d60c97bd4376fb0150dec7a8f1)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[0] CodeEdit::_fold_gutter_draw_callback (C:\Git\godot\scene\gui\code_edit.cpp:1404)
[1] CodeEdit::_fold_gutter_draw_callback (C:\Git\godot\scene\gui\code_edit.cpp:1404)
[2] call_with_variant_args_helper<CodeEdit,int,int,Rect2,0,1,2> (C:\Git\godot\core\variant\binder_common.h:267)
[3] call_with_variant_args<CodeEdit,int,int,Rect2> (C:\Git\godot\core\variant\binder_common.h:377)
[4] CallableCustomMethodPointer<CodeEdit,int,int,Rect2>::call (C:\Git\godot\core\object\callable_method_pointer.h:105)
[5] Callable::callp (C:\Git\godot\core\variant\callable.cpp:51)
[6] TextEdit::_notification (C:\Git\godot\scene\gui\text_edit.cpp:1060)
[7] TextEdit::_notificationv (C:\Git\godot\scene\gui\text_edit.h:42)
[8] CodeEdit::_notificationv (C:\Git\godot\scene\gui\code_edit.h:37)
[9] Object::notification (C:\Git\godot\core\object\object.cpp:792)
[10] CanvasItem::_update_callback (C:\Git\godot\scene\main\canvas_item.cpp:136)
[11] call_with_variant_args_helper<CanvasItem> (C:\Git\godot\core\variant\binder_common.h:267)
[12] call_with_variant_args_dv<CanvasItem> (C:\Git\godot\core\variant\binder_common.h:410)
[13] MethodBindT<CanvasItem>::call (C:\Git\godot\core\object\method_bind.h:322)
[14] Object::callp (C:\Git\godot\core\object\object.cpp:733)
[15] Callable::callp (C:\Git\godot\core\variant\callable.cpp:62)
[16] MessageQueue::_call_function (C:\Git\godot\core\object\message_queue.cpp:230)
[17] MessageQueue::flush (C:\Git\godot\core\object\message_queue.cpp:277)
[18] SceneTree::physics_process (C:\Git\godot\scene\main\scene_tree.cpp:422)
[19] Main::iteration (C:\Git\godot\main\main.cpp:2928)
[20] OS_Windows::run (C:\Git\godot\platform\windows\os_windows.cpp:907)
[21] widechar_main (C:\Git\godot\platform\windows\godot_windows.cpp:179)
[22] _main (C:\Git\godot\platform\windows\godot_windows.cpp:201)
[23] main (C:\Git\godot\platform\windows\godot_windows.cpp:215)
[24] WinMain (C:\Git\godot\platform\windows\godot_windows.cpp:229)
[25] __scrt_common_main_seh (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[26] BaseThreadInitThunk
-- END OF BACKTRACE --
================================================================
```

Seems like `CodeEdit` does not properly initialize its theme before this happened. I've fixed it by simply call the _notification method immediately after the `add_child` call.