### PR TITLE
C#: Ignore property indexers and report if exported

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -168,6 +168,32 @@ namespace Godot.SourceGenerators
                 location?.SourceTree?.FilePath));
         }
 
+        public static void ReportExportedMemberIsIndexer(
+            GeneratorExecutionContext context,
+            ISymbol exportedMemberSymbol
+        )
+        {
+            var locations = exportedMemberSymbol.Locations;
+            var location = locations.FirstOrDefault(l => l.SourceTree != null) ?? locations.FirstOrDefault();
+
+            string message = $"Attempted to export indexer property: " +
+                             $"'{exportedMemberSymbol.ToDisplayString()}'";
+
+            string description = $"{message}. Indexer properties can't be exported." +
+                                 " Remove the '[Export]' attribute.";
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(id: "GD0105",
+                    title: message,
+                    messageFormat: message,
+                    category: "Usage",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true,
+                    description),
+                location,
+                location?.SourceTree?.FilePath));
+        }
+
         public static void ReportSignalDelegateMissingSuffix(
             GeneratorExecutionContext context,
             INamedTypeSymbol delegateSymbol)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -112,7 +112,8 @@ namespace Godot.SourceGenerators
 
             var propertySymbols = members
                 .Where(s => !s.IsStatic && s.Kind == SymbolKind.Property)
-                .Cast<IPropertySymbol>();
+                .Cast<IPropertySymbol>()
+                .Where(s => !s.IsIndexer);
 
             var fieldSymbols = members
                 .Where(s => !s.IsStatic && s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -134,6 +134,12 @@ namespace Godot.SourceGenerators
                     continue;
                 }
 
+                if (property.IsIndexer)
+                {
+                    Common.ReportExportedMemberIsIndexer(context, property);
+                    continue;
+                }
+
                 // TODO: We should still restore read-only properties after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
                 // Ignore properties without a getter or without a setter. Godot properties must be both readable and writable.
                 if (property.IsWriteOnly)
@@ -147,7 +153,6 @@ namespace Godot.SourceGenerators
                     Common.ReportExportedMemberIsReadOnly(context, property);
                     continue;
                 }
-
 
                 var propertyType = property.Type;
                 var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(propertyType, typeCache);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
@@ -112,7 +112,8 @@ namespace Godot.SourceGenerators
 
             var propertySymbols = members
                 .Where(s => !s.IsStatic && s.Kind == SymbolKind.Property)
-                .Cast<IPropertySymbol>();
+                .Cast<IPropertySymbol>()
+                .Where(s => !s.IsIndexer);
 
             var fieldSymbols = members
                 .Where(s => !s.IsStatic && s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)


### PR DESCRIPTION
 - Ignore property indexers since they are unsupported and report a diagnostic if an user tries to export it (Fixes #64991).

Alternatively we could support them with a different name but I feel like this is an uncommon use-case and it could be confusing.
