### PR TITLE
[3.x] Optimize `String.repeat()`

### DIFF
--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -3081,17 +3081,19 @@ String String::replacen(const String &p_key, const String &p_with) const {
 String String::repeat(int p_count) const {
 	ERR_FAIL_COND_V_MSG(p_count < 0, "", "Parameter count should be a positive number.");
 
-	String new_string;
-	const CharType *src = this->c_str();
+	int len = length();
+	String new_string = *this;
+	new_string.resize(p_count * len + 1);
 
-	new_string.resize(length() * p_count + 1);
-	new_string[length() * p_count] = 0;
-
-	for (int i = 0; i < p_count; i++) {
-		for (int j = 0; j < length(); j++) {
-			new_string[i * length() + j] = src[j];
-		}
+	CharType *dst = new_string.ptrw();
+	int offset = 1;
+	int stride = 1;
+	while (offset < p_count) {
+		memcpy(dst + offset * len, dst, stride * len * sizeof(CharType));
+		offset += stride;
+		stride = MIN(stride * 2, p_count - offset);
 	}
+	dst[p_count * len] = _null;
 
 	return new_string;
 }


### PR DESCRIPTION
This backports the [optimization done in `master`](https://github.com/godotengine/godot/pull/64489).

**Testing project:** [test_string_repeat_3.x.zip](https://github.com/godotengine/godot/files/9440068/test_string_repeat_3.x.zip)
*Requires readding and exposing a `repeat_slow()` method with the old code to work.*

## Benchmark

**OS:** Fedora 36
**CPU:** Intel Core i7-6700K @ 4.4 GHz
**Compiler:** Clang 14.0.5

*Performed on an editor debug build, but a release build should also benefit significantly.*

Type | Before | After
-|-|-
len1 x4  |  5.967ms | 5.267ms
len1 x40 |  17.193ms | 5.445ms
len1 x400 |  126.042ms | 5.735ms
len1 x4000 | 1213.496ms | 7.698ms
len5 x4  |  10.426ms | 5.284ms
len5 x40 |  61.751ms | 5.6ms
len5 x400 | 569.243ms | 6.278ms
len45 x4 |  50.869ms | 5.38ms
len45 x40 | 462.394ms | 6.103ms
len250 x4 | 266.615ms | 5.668ms