### PR TITLE
Prevent crash at loading some scenes

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -288,9 +288,11 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 									// then tell this node to reference that resource.
 									if (n.instance >= 0) {
 										Ref<Resource> node_res = node->get(snames[nprops[j].name]);
-										node_res->copy_from(res);
-										node_res->configure_for_local_scene(node, resources_local_to_scene);
-										value = node_res;
+										if (node_res.is_valid()) {
+											node_res->copy_from(res);
+											node_res->configure_for_local_scene(node, resources_local_to_scene);
+											value = node_res;
+										}
 									} else {
 										HashMap<Ref<Resource>, Ref<Resource>>::Iterator E = resources_local_to_scene.find(res);
 										Node *base = i == 0 ? node : ret_nodes[0];


### PR DESCRIPTION
I've detected the crash when loading some complex scenes (with multiple PackedScenes) - seems like the regression from https://github.com/godotengine/godot/pull/64526 / https://github.com/godotengine/godot/pull/64526#issuecomment-1229526955

```
================================================================
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.0.alpha.custom_build (006915b4824a91c0e0fc95ac6aa2f70908a0a027)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[0] SceneState::instantiate (C:\GIT\godot\scene\resources\packed_scene.cpp:291)
[1] SceneState::instantiate (C:\GIT\godot\scene\resources\packed_scene.cpp:291)
[2] PackedScene::instantiate (C:\GIT\godot\scene\resources\packed_scene.cpp:1743)
[3] SceneState::instantiate (C:\GIT\godot\scene\resources\packed_scene.cpp:168)
[4] PackedScene::instantiate (C:\GIT\godot\scene\resources\packed_scene.cpp:1743)
[5] EditorNode::load_scene (C:\GIT\godot\editor\editor_node.cpp:3823)
[6] EditorNode::_load_open_scenes_from_config (C:\GIT\godot\editor\editor_node.cpp:5023)
[7] EditorNode::_load_docks (C:\GIT\godot\editor\editor_node.cpp:4813)
[8] EditorNode::_sources_changed (C:\GIT\godot\editor\editor_node.cpp:1060)
[9] CallableCustomMethodPointer<EditorNode,bool>::call (C:\GIT\godot\core\object\callable_method_pointer.h:105)
[10] Callable::callp (C:\GIT\godot\core\variant\callable.cpp:51)
[11] Object::emit_signalp (C:\GIT\godot\core\object\object.cpp:1046)
[12] Object::emit_signal<bool> (C:\GIT\godot\core\object\object.h:873)
[13] EditorFileSystem::_notification (C:\GIT\godot\editor\editor_file_system.cpp:1250)
[14] EditorFileSystem::_notificationv (C:\GIT\godot\editor\editor_file_system.h:143)
[15] Object::notification (C:\GIT\godot\core\object\object.cpp:792)
[16] SceneTree::_notify_group_pause (C:\GIT\godot\scene\main\scene_tree.cpp:891)
[17] SceneTree::process (C:\GIT\godot\scene\main\scene_tree.cpp:456)
[18] Main::iteration (C:\GIT\godot\main\main.cpp:2958)
[19] OS_Windows::run (C:\GIT\godot\platform\windows\os_windows.cpp:907)
[20] widechar_main (C:\GIT\godot\platform\windows\godot_windows.cpp:179)
[21] _main (C:\GIT\godot\platform\windows\godot_windows.cpp:203)
[22] main (C:\GIT\godot\platform\windows\godot_windows.cpp:215)
[23] __scrt_common_main_seh (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[24] BaseThreadInitThunk
-- END OF BACKTRACE --
================================================================
```