### PR TITLE
Add patches load with project settings.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -674,6 +674,21 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bool p_upwards, bool p_ignore_override) {
 	Error err = _setup(p_path, p_main_pack, p_upwards, p_ignore_override);
 	if (err == OK && !p_ignore_override) {
+		String patches_config = GLOBAL_GET("application/config/patches_config");
+		if (!patches_config.is_empty()) {
+			Ref<ConfigFile> config;
+			config.instantiate();
+			if (config->load(patches_config) == OK && config->has_section("patches")) {
+				String path = String(config->get_value("patches", "path", patches_config.get_base_dir()));
+				PackedStringArray files = PackedStringArray(config->get_value("patches", "files"));
+				if (!files.is_empty()) {
+					for (const String &file : files) {
+						_load_resource_pack(path.path_join(file));
+					}
+					_load_settings_text_or_binary("res://project.godot", "res://project.binary");
+				}
+			}
+		}
 		String custom_settings = GLOBAL_GET("application/config/project_settings_override");
 		if (!custom_settings.is_empty()) {
 			_load_settings_text(custom_settings);
@@ -1443,6 +1458,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/config/use_custom_user_dir", false);
 	GLOBAL_DEF("application/config/custom_user_dir_name", "");
 	GLOBAL_DEF("application/config/project_settings_override", "");
+	GLOBAL_DEF("application/config/patches_config", "");
 
 	GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
 	GLOBAL_DEF("application/config/auto_accept_quit", true);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -287,6 +287,9 @@
 		<member name="application/config/name_localized" type="Dictionary" setter="" getter="" default="{}">
 			Translations of the project's name. This setting is used by OS tools to translate application name on Android, iOS and macOS.
 		</member>
+		<member name="application/config/patches_config" type="String" setter="" getter="" default="&quot;&quot;">
+			Specifies a configuration file for load patches. For example: [code]user://patches.cfg[/code]. This file must contain a "patches" section with a "files" key. Optional "path" key can be used if the patches are not in the same folder as the configuration file.
+		</member>
 		<member name="application/config/project_settings_override" type="String" setter="" getter="" default="&quot;&quot;">
 			Specifies a file to override project settings. For example: [code]user://custom_settings.cfg[/code]. See "Overriding" in the [ProjectSettings] class description at the top for more information.
 			[b]Note:[/b] Regardless of this setting's value, [code]res://override.cfg[/code] will still be read to override the project settings.


### PR DESCRIPTION
Adds `application/config/patches_config` setting. 
On start loads patches and reload project settings for apply patched `Autoloads`, `class_name` etc.

Fixes https://github.com/godotengine/godot-proposals/issues/146#issuecomment-674542744

Related to: https://github.com/godotengine/godot/pull/64712
