### PR TITLE
Improve documentation for `get_animation()`

### DIFF
--- a/doc/classes/AnimationLibrary.xml
+++ b/doc/classes/AnimationLibrary.xml
@@ -22,7 +22,7 @@
 			<return type="Animation" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the [Animation] with the key [param name], or [code]null[/code] if none is found.
+				Returns the [Animation] with the key [param name]. If the animation does not exist, [code]null[/code] is returned and an error is logged.
 			</description>
 		</method>
 		<method name="get_animation_list" qualifiers="const">

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -75,7 +75,7 @@
 			<return type="Animation" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the [Animation] with key [param name] or [code]null[/code] if not found.
+				Returns the [Animation] with the key [param name]. If the animation does not exist, [code]null[/code] is returned and an error is logged.
 			</description>
 		</method>
 		<method name="get_animation_library" qualifiers="const">

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1501,7 +1501,7 @@ bool AnimationPlayer::has_animation(const StringName &p_name) const {
 }
 
 Ref<Animation> AnimationPlayer::get_animation(const StringName &p_name) const {
-	ERR_FAIL_COND_V_MSG(!animation_set.has(p_name), Ref<Animation>(), vformat("Animation not found: %s.", p_name));
+	ERR_FAIL_COND_V_MSG(!animation_set.has(p_name), Ref<Animation>(), vformat("Animation not found: \"%s\".", p_name));
 
 	const AnimationData &data = animation_set[p_name];
 

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -85,7 +85,7 @@ bool AnimationLibrary::has_animation(const StringName &p_name) const {
 }
 
 Ref<Animation> AnimationLibrary::get_animation(const StringName &p_name) const {
-	ERR_FAIL_COND_V(!animations.has(p_name), Ref<Animation>());
+	ERR_FAIL_COND_V_MSG(!animations.has(p_name), Ref<Animation>(), vformat("Animation not found: \"%s\".", p_name));
 
 	return animations[p_name];
 }


### PR DESCRIPTION
Resolves #65005

* Updated doc for `AnimationLibrary.get_animation()` and `AnimationPlayer.get_animation()`.
* Made `AnimationLibrary.get_animation()` error message the same as `AnimationPlayer`'s, with the requested animation name in the message.