### PR TITLE
fix: graceful exit on macOS with missing Vulkan SDK

### DIFF
--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -54,11 +54,13 @@ def get_mvk_sdk_path():
         return [int_or_zero(i) for i in a.split(".")]
 
     dirname = os.path.expanduser("~/VulkanSDK")
-    files = os.listdir(dirname)
+    if not os.path.exists(dirname):
+        return ""
 
     ver_file = "0.0.0.0"
     ver_num = ver_parse(ver_file)
 
+    files = os.listdir(dirname)
     for file in files:
         if os.path.isdir(os.path.join(dirname, file)):
             ver_comp = ver_parse(file)
@@ -145,7 +147,7 @@ def configure(env):
         env.Append(LINKFLAGS=["-isysroot", "$MACOS_SDK_PATH"])
 
     else:  # osxcross build
-        root = os.environ.get("OSXCROSS_ROOT", 0)
+        root = os.environ.get("OSXCROSS_ROOT", "")
         if env["arch"] == "arm64":
             basecmd = root + "/target/bin/arm64-apple-" + env["osxcross_sdk"] + "-"
         else:
@@ -248,7 +250,7 @@ def configure(env):
                     env.Append(LINKFLAGS=["-L" + mvk_path])
             if not mvk_found:
                 mvk_path = get_mvk_sdk_path()
-                if os.path.isfile(os.path.join(mvk_path, "libMoltenVK.a")):
+                if mvk_path and os.path.isfile(os.path.join(mvk_path, "libMoltenVK.a")):
                     mvk_found = True
                     env.Append(LINKFLAGS=["-L" + mvk_path])
             if not mvk_found:


### PR DESCRIPTION
When you try to compile on MacOS without Vulkan installed, it ends up with error reported in #62914

The code however looks like can / should display more graceful error message instead: https://github.com/godotengine/godot/blob/c7eb423eeb5455419bb96fc1ed8e8e121c2a619a/platform/macos/detect.py#L254-L258

Adding a simple check for presence of Vulkan directory will end up showing this info, which could be more helpful than uncaught exception.