### PR TITLE
Add support for system dark mode and accent color detection.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -104,6 +104,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_accent_color" qualifiers="const">
+			<return type="Color" />
+			<description>
+				Returns OS theme accent color. Returns [code]Color(0, 0, 0, 0)[/code], if accent color is unknown.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
+			</description>
+		</method>
 		<method name="get_display_cutouts" qualifiers="const">
 			<return type="Rect2[]" />
 			<description>
@@ -642,6 +649,20 @@
 		<method name="ime_get_text" qualifiers="const">
 			<return type="String" />
 			<description>
+			</description>
+		</method>
+		<method name="is_dark_mode" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if OS is using dark mode.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
+			</description>
+		</method>
+		<method name="is_dark_mode_supported" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if OS supports dark mode.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
 		<method name="keyboard_get_current_layout" qualifiers="const">

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -284,6 +284,10 @@ public:
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;
 
+	virtual bool is_dark_mode_supported() const override;
+	virtual bool is_dark_mode() const override;
+	virtual Color get_accent_color() const override;
+
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override;
 	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override;
 

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1682,6 +1682,41 @@ void DisplayServerMacOS::tts_stop() {
 	[tts stopSpeaking];
 }
 
+bool DisplayServerMacOS::is_dark_mode_supported() const {
+	if (@available(macOS 10.14, *)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+bool DisplayServerMacOS::is_dark_mode() const {
+	if (@available(macOS 10.14, *)) {
+		if (![[NSUserDefaults standardUserDefaults] objectForKey:@"AppleInterfaceStyle"]) {
+			return false;
+		} else {
+			return ([[[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"] isEqual:@"Dark"]);
+		}
+	} else {
+		return false;
+	}
+}
+
+Color DisplayServerMacOS::get_accent_color() const {
+	if (@available(macOS 10.14, *)) {
+		NSColor *color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+		if (color) {
+			CGFloat components[4];
+			[color getRed:&components[0] green:&components[1] blue:&components[2] alpha:&components[3]];
+			return Color(components[0], components[1], components[2], components[3]);
+		} else {
+			return Color(0, 0, 0, 0);
+		}
+	} else {
+		return Color(0, 0, 0, 0);
+	}
+}
+
 Error DisplayServerMacOS::dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -152,6 +152,12 @@ typedef UINT(WINAPI *WTInfoPtr)(UINT p_category, UINT p_index, LPVOID p_output);
 typedef BOOL(WINAPI *WTPacketPtr)(HANDLE p_ctx, UINT p_param, LPVOID p_packets);
 typedef BOOL(WINAPI *WTEnablePtr)(HANDLE p_ctx, BOOL p_enable);
 
+typedef bool(WINAPI *IsDarkModeAllowedForAppPtr)();
+typedef bool(WINAPI *ShouldAppsUseDarkModePtr)();
+typedef DWORD(WINAPI *GetImmersiveColorFromColorSetExPtr)(UINT dwImmersiveColorSet, UINT dwImmersiveColorType, bool bIgnoreHighContrast, UINT dwHighContrastCacheMode);
+typedef int(WINAPI *GetImmersiveColorTypeFromNamePtr)(const WCHAR *name);
+typedef int(WINAPI *GetImmersiveUserColorSetPreferencePtr)(bool bForceCheckRegistry, bool bSkipCheckOnFail);
+
 // Windows Ink API
 #ifndef POINTER_STRUCTURES
 
@@ -277,6 +283,14 @@ class DisplayServerWindows : public DisplayServer {
 	//GDCLASS(DisplayServerWindows, DisplayServer)
 
 	_THREAD_SAFE_CLASS_
+
+	// UXTheme API
+	static bool ux_theme_available;
+	static IsDarkModeAllowedForAppPtr IsDarkModeAllowedForApp;
+	static ShouldAppsUseDarkModePtr ShouldAppsUseDarkMode;
+	static GetImmersiveColorFromColorSetExPtr GetImmersiveColorFromColorSetEx;
+	static GetImmersiveColorTypeFromNamePtr GetImmersiveColorTypeFromName;
+	static GetImmersiveUserColorSetPreferencePtr GetImmersiveUserColorSetPreference;
 
 	// WinTab API
 	static bool wintab_available;
@@ -484,6 +498,10 @@ public:
 	virtual void tts_pause() override;
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;
+
+	virtual bool is_dark_mode_supported() const override;
+	virtual bool is_dark_mode() const override;
+	virtual Color get_accent_color() const override;
 
 	virtual void mouse_set_mode(MouseMode p_mode) override;
 	virtual MouseMode mouse_get_mode() const override;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -586,6 +586,10 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tts_set_utterance_callback", "event", "callable"), &DisplayServer::tts_set_utterance_callback);
 	ClassDB::bind_method(D_METHOD("_tts_post_utterance_event", "event", "id", "char_pos"), &DisplayServer::tts_post_utterance_event);
 
+	ClassDB::bind_method(D_METHOD("is_dark_mode_supported"), &DisplayServer::is_dark_mode_supported);
+	ClassDB::bind_method(D_METHOD("is_dark_mode"), &DisplayServer::is_dark_mode);
+	ClassDB::bind_method(D_METHOD("get_accent_color"), &DisplayServer::get_accent_color);
+
 	ClassDB::bind_method(D_METHOD("mouse_set_mode", "mouse_mode"), &DisplayServer::mouse_set_mode);
 	ClassDB::bind_method(D_METHOD("mouse_get_mode"), &DisplayServer::mouse_get_mode);
 

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -210,6 +210,10 @@ public:
 	virtual void tts_set_utterance_callback(TTSUtteranceEvent p_event, const Callable &p_callable);
 	virtual void tts_post_utterance_event(TTSUtteranceEvent p_event, int p_id, int p_pos = 0);
 
+	virtual bool is_dark_mode_supported() const { return false; };
+	virtual bool is_dark_mode() const { return false; };
+	virtual Color get_accent_color() const { return Color(0, 0, 0, 0); };
+
 	enum MouseMode {
 		MOUSE_MODE_VISIBLE,
 		MOUSE_MODE_HIDDEN,


### PR DESCRIPTION
- Adds support for system dark mode (`DS.is_dark_mode` and `DS.is_dark_mode_supported`) and accent color (`DS.get_accent_color`) detection on macOS and Windows.
- Adds support for dark mode title bar on Windows.

Demo project:
[sys_theme_test.zip](https://github.com/godotengine/godot/files/9443510/sys_theme_test.zip)

<details>
  <summary>macOS screen recording</summary>

https://user-images.githubusercontent.com/7645683/187171622-bd0f1e2f-5a4a-47e6-9c60-70ba3d447f76.mov

</details>
<details>
  <summary>Windows screen recording</summary>

https://user-images.githubusercontent.com/7645683/187171814-510a4959-57c8-4848-838e-b1de877ceae9.mp4

</details>

Implements https://github.com/godotengine/godot-proposals/issues/1868
Might be used as a base to implement https://github.com/godotengine/godot-proposals/discussions/4924

<details>
  <summary>Auto theme sample (probably should be done as a separate PR, and support live reloading)</summary>

```diff
diff --git a/editor/editor_settings.cpp b/editor/editor_settings.cpp
index f5d3b4842d..c28600f670 100644
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -449,7 +449,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/show_low_level_opentype_features", false, "")
 
 	// Theme
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Default", "Default,Breeze Dark,Godot 2,Gray,Light,Solarized (Dark),Solarized (Light),Custom")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Auto", "Auto,Default,Breeze Dark,Godot 2,Gray,Light,Solarized (Dark),Solarized (Light),Custom")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/theme/icon_and_font_color", 0, "Auto,Dark,Light")
 	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/base_color", Color(0.2, 0.23, 0.31), "")
 	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/accent_color", Color(0.41, 0.61, 0.91), "")
diff --git a/editor/editor_themes.cpp b/editor/editor_themes.cpp
index d20caef51c..e9e19a6381 100644
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -406,7 +406,20 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Please use alphabetical order if you're adding a new theme here
 	// (after "Custom")
 
-	if (preset == "Custom") {
+	if (preset == "Auto") {
+		if (DisplayServer::get_singleton()->is_dark_mode_supported()) {
+			preset_accent_color = DisplayServer::get_singleton()->get_accent_color();
+			if (DisplayServer::get_singleton()->is_dark_mode()) {
+				preset_base_color = Color(0.21, 0.24, 0.29);
+			} else {
+				preset_base_color = Color(0.9, 0.9, 0.9);
+			}
+		} else {
+			preset_accent_color = Color(0.44, 0.73, 0.98);
+			preset_base_color = Color(0.21, 0.24, 0.29);
+		}
+		preset_contrast = default_contrast;
+	} else if (preset == "Custom") {
 		accent_color = EDITOR_GET("interface/theme/accent_color");
 		base_color = EDITOR_GET("interface/theme/base_color");
 		contrast = EDITOR_GET("interface/theme/contrast");
```

</details>