### PR TITLE
Fix AABB errors on meshes with bones on multiple surfaces

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -334,7 +334,14 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
 			const AABB &bone = p_surface.bone_aabbs[i];
 			if (bone.has_volume()) {
-				mesh->bone_aabbs.write[i].merge_with(bone);
+				AABB &mesh_bone = mesh->bone_aabbs.write[i];
+				if (mesh_bone != AABB()) {
+					// Already initialized, merge AABBs.
+					mesh_bone.merge_with(bone);
+				} else {
+					// Not yet initialized, copy the bone AABB.
+					mesh_bone = bone;
+				}
 			}
 		}
 		mesh->aabb.merge_with(p_surface.aabb);

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -445,7 +445,14 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
 			const AABB &bone = p_surface.bone_aabbs[i];
 			if (bone.has_volume()) {
-				mesh->bone_aabbs.write[i].merge_with(bone);
+				AABB &mesh_bone = mesh->bone_aabbs.write[i];
+				if (mesh_bone != AABB()) {
+					// Already initialized, merge AABBs.
+					mesh_bone.merge_with(bone);
+				} else {
+					// Not yet initialized, copy the bone AABB.
+					mesh_bone = bone;
+				}
 			}
 		}
 		mesh->aabb.merge_with(p_surface.aabb);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/64416 and https://github.com/godotengine/godot/pull/64581
Fixes an edge case for https://github.com/godotengine/godot/issues/56458

I can no longer reproduce the errors in both [this project (comment)](https://github.com/godotengine/godot/pull/64416#issuecomment-1219783299) and my own project.

Bug explanation:
```diff
@@ -415,6 +415,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
        }
 
        if (mesh->surface_count == 0) {
+               // Some of these bones may be unused, so they have (-1, -1, -1) size.
                mesh->bone_aabbs = p_surface.bone_aabbs;
                mesh->aabb = p_surface.aabb;
        } else {
@@ -426,6 +427,7 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
                for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
                        const AABB &bone = p_surface.bone_aabbs[i];
                        if (!bone.has_no_volume()) {
+                               // Now we merge the mesh AABB, which could have (-1, -1, -1) size. This is a problem!
                                mesh->bone_aabbs.write[i].merge_with(bone);
                        }
                }
```