### PR TITLE
Fix Import dock being too wide

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -628,6 +628,9 @@ ImportDock::ImportDock() {
 	content->add_margin_child(TTR("Import As:"), hb);
 	import_as = memnew(OptionButton);
 	import_as->set_disabled(true);
+	import_as->set_fit_to_longest_item(false);
+	import_as->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
+	import_as->set_h_size_flags(SIZE_EXPAND_FILL);
 	import_as->connect("item_selected", callable_mp(this, &ImportDock::_importer_selected));
 	hb->add_child(import_as);
 	import_as->set_h_size_flags(SIZE_EXPAND_FILL);


### PR DESCRIPTION
This enables trimming in the "Import As" OptionButton:
![godot windows tools x86_64_oF4gKOXqi6](https://user-images.githubusercontent.com/2223172/187201073-c8205892-f6cb-44bf-8b69-1dbaba24e05e.gif)

Together with #65028 it fixes #64273

Technically part of #63970