### PR TITLE
Rename ProgressBar.`percent_visible` to `show_percentage`

### DIFF
--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -12,7 +12,7 @@
 		<member name="fill_mode" type="int" setter="set_fill_mode" getter="get_fill_mode" default="0">
 			The fill direction. See [enum FillMode] for possible values.
 		</member>
-		<member name="percent_visible" type="bool" setter="set_percent_visible" getter="is_percent_visible" default="true">
+		<member name="show_percentage" type="bool" setter="set_show_percentage" getter="is_percentage_shown" default="true">
 			If [code]true[/code], the fill percentage is displayed on the bar.
 		</member>
 	</members>
@@ -44,10 +44,10 @@
 			The size of the text outline.
 		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">
-			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
+			Font used to draw the fill percentage if [member show_percentage] is [code]true[/code].
 		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size used to draw the fill percentage if [member percent_visible] is [code]true[/code].
+			Font size used to draw the fill percentage if [member show_percentage] is [code]true[/code].
 		</theme_item>
 		<theme_item name="background" data_type="style" type="StyleBox">
 			The style of the background.

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -242,7 +242,7 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 				}
 			}
 
-			pb->set_percent_visible(false);
+			pb->set_show_percentage(false);
 			pb->set_custom_minimum_size(Vector2(0, 14) * EDSCALE);
 			animations[E] = pb;
 			node->add_child(pb);

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1128,6 +1128,7 @@ static const char *csharp_properties_renames[][2] = {
 	//	{ "CastTo", "TargetPosition" }, // RayCast2D, RayCast3D
 	//	{ "Doubleclick", "DoubleClick" }, // InputEventMouseButton
 	//	{ "Group", "ButtonGroup" }, // BaseButton
+	//  { "PercentVisible, "ShowPercentage}, // ProgressBar, conflicts with Label and RichTextLabel, but may be a worth it.
 	//	{ "ProcessMode", "ProcessCallback" }, // AnimationTree, Camera2D
 	//	{ "Scancode", "Keycode" }, // InputEventKey
 	//	{ "Toplevel", "TopLevel" }, // Node

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -36,7 +36,7 @@ Size2 ProgressBar::get_minimum_size() const {
 	Size2 minimum_size = theme_cache.background_style->get_minimum_size();
 	minimum_size.height = MAX(minimum_size.height, theme_cache.fill_style->get_minimum_size().height);
 	minimum_size.width = MAX(minimum_size.width, theme_cache.fill_style->get_minimum_size().width);
-	if (percent_visible) {
+	if (show_percentage) {
 		String txt = "100%";
 		TextLine tl = TextLine(txt, theme_cache.font, theme_cache.font_size);
 		minimum_size.height = MAX(minimum_size.height, theme_cache.background_style->get_minimum_size().height + tl.get_size().y);
@@ -102,7 +102,7 @@ void ProgressBar::_notification(int p_what) {
 					break;
 			}
 
-			if (percent_visible) {
+			if (show_percentage) {
 				String txt = TS->format_number(itos(int(get_as_ratio() * 100))) + TS->percent_sign();
 				TextLine tl = TextLine(txt, theme_cache.font, theme_cache.font_size);
 				Vector2 text_pos = (Point2(get_size().width - tl.get_size().x, get_size().height - tl.get_size().y) / 2).round();
@@ -127,27 +127,27 @@ int ProgressBar::get_fill_mode() {
 	return mode;
 }
 
-void ProgressBar::set_percent_visible(bool p_visible) {
-	if (percent_visible == p_visible) {
+void ProgressBar::set_show_percentage(bool p_visible) {
+	if (show_percentage == p_visible) {
 		return;
 	}
-	percent_visible = p_visible;
+	show_percentage = p_visible;
 	update_minimum_size();
 	queue_redraw();
 }
 
-bool ProgressBar::is_percent_visible() const {
-	return percent_visible;
+bool ProgressBar::is_percentage_shown() const {
+	return show_percentage;
 }
 
 void ProgressBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fill_mode", "mode"), &ProgressBar::set_fill_mode);
 	ClassDB::bind_method(D_METHOD("get_fill_mode"), &ProgressBar::get_fill_mode);
-	ClassDB::bind_method(D_METHOD("set_percent_visible", "visible"), &ProgressBar::set_percent_visible);
-	ClassDB::bind_method(D_METHOD("is_percent_visible"), &ProgressBar::is_percent_visible);
+	ClassDB::bind_method(D_METHOD("set_show_percentage", "visible"), &ProgressBar::set_show_percentage);
+	ClassDB::bind_method(D_METHOD("is_percentage_shown"), &ProgressBar::is_percentage_shown);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill_mode", PROPERTY_HINT_ENUM, "Begin to End,End to Begin,Top to Bottom,Bottom to Top"), "set_fill_mode", "get_fill_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "percent_visible"), "set_percent_visible", "is_percent_visible");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_percentage"), "set_show_percentage", "is_percentage_shown");
 
 	BIND_ENUM_CONSTANT(FILL_BEGIN_TO_END);
 	BIND_ENUM_CONSTANT(FILL_END_TO_BEGIN);

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -36,7 +36,7 @@
 class ProgressBar : public Range {
 	GDCLASS(ProgressBar, Range);
 
-	bool percent_visible = true;
+	bool show_percentage = true;
 
 	struct ThemeCache {
 		Ref<StyleBox> background_style;
@@ -67,8 +67,8 @@ public:
 	void set_fill_mode(int p_fill);
 	int get_fill_mode();
 
-	void set_percent_visible(bool p_visible);
-	bool is_percent_visible() const;
+	void set_show_percentage(bool p_visible);
+	bool is_percentage_shown() const;
 
 	Size2 get_minimum_size() const override;
 	ProgressBar();


### PR DESCRIPTION
Judging by this comment's confusion, https://github.com/godotengine/godot/pull/64665#issuecomment-1228345052, a rename may be needed, even if it may not be this one https://github.com/godotengine/godot/pull/64665#issuecomment-1229426587.

For **ProgressBar**:
`percent_visible` -> `show_percentage`
`set_percent_visible` -> `set_show_percentage`
`is_percent_visible` -> `is_percentage_shown`

Note that this is no longer truly "required", because **Label** and **RichTextLabel**'s `percent_visible`, an entirely different and unrelated property, had its name changed already in the aforementioned PR.