### PR TITLE
Rename TreeItem's `set_tooltip` to `set_tooltip_text`

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -16,9 +16,9 @@
 			<param index="1" name="button" type="Texture2D" />
 			<param index="2" name="id" type="int" default="-1" />
 			<param index="3" name="disabled" type="bool" default="false" />
-			<param index="4" name="tooltip" type="String" default="&quot;&quot;" />
+			<param index="4" name="tooltip_text" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a button with [Texture2D] [param button] at column [param column]. The [param id] is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately before this method. Optionally, the button can be [param disabled] and have a [param tooltip].
+				Adds a button with [Texture2D] [param button] at column [param column]. The [param id] is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately before this method. Optionally, the button can be [param disabled] and have a [param tooltip_text].
 			</description>
 		</method>
 		<method name="call_recursive" qualifiers="vararg">
@@ -96,12 +96,12 @@
 				Returns the id for the button at index [param button_idx] in column [param column].
 			</description>
 		</method>
-		<method name="get_button_tooltip" qualifiers="const">
+		<method name="get_button_tooltip_text" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="column" type="int" />
 			<param index="1" name="button_idx" type="int" />
 			<description>
-				Returns the tooltip string for the button at index [param button_idx] in column [param column].
+				Returns the tooltip text for the button at index [param button_idx] in column [param column].
 			</description>
 		</method>
 		<method name="get_cell_mode" qualifiers="const">
@@ -308,11 +308,11 @@
 				Returns item's text base writing direction.
 			</description>
 		</method>
-		<method name="get_tooltip" qualifiers="const">
+		<method name="get_tooltip_text" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="column" type="int" />
 			<description>
-				Returns the given column's tooltip.
+				Returns the given column's tooltip text.
 			</description>
 		</method>
 		<method name="get_tree" qualifiers="const">
@@ -639,7 +639,7 @@
 				Sets item's text base writing direction.
 			</description>
 		</method>
-		<method name="set_tooltip">
+		<method name="set_tooltip_text">
 			<return type="void" />
 			<param index="0" name="column" type="int" />
 			<param index="1" name="tooltip" type="String" />

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1070,7 +1070,7 @@ void ConnectionsDock::update_tree() {
 				}
 
 				// "::" separators used in make_custom_tooltip for formatting.
-				signal_item->set_tooltip(0, String(signal_name) + "::" + signaldesc + "::" + descr);
+				signal_item->set_tooltip_text(0, String(signal_name) + "::" + signaldesc + "::" + descr);
 			}
 
 			// List existing connections.

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -313,7 +313,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 	}
 
 	const String &description = DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description);
-	r_item->set_tooltip(0, description);
+	r_item->set_tooltip_text(0, description);
 
 	if (p_type_category == TypeCategory::OTHER_TYPE && !script_type) {
 		Ref<Texture2D> icon = EditorNode::get_editor_data().get_custom_types()[custom_type_parents[p_type]][custom_type_indices[p_type]].icon;

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -155,7 +155,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		const SceneDebuggerTree::RemoteNode &node = p_tree->nodes[i];
 		TreeItem *item = create_item(parent);
 		item->set_text(0, node.name);
-		item->set_tooltip(0, TTR("Type:") + " " + node.type_name);
+		item->set_tooltip_text(0, TTR("Type:") + " " + node.type_name);
 		Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(node.type_name, "");
 		if (icon.is_valid()) {
 			item->set_icon(0, icon);

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -61,7 +61,7 @@ void EditorPerformanceProfiler::Monitor::update_value(float p_value) {
 		} break;
 	}
 	item->set_text(1, label);
-	item->set_tooltip(1, tooltip);
+	item->set_tooltip_text(1, tooltip);
 
 	if (p_value > max) {
 		max = p_value;
@@ -73,7 +73,7 @@ void EditorPerformanceProfiler::Monitor::reset() {
 	max = 0.0f;
 	if (item) {
 		item->set_text(1, "");
-		item->set_tooltip(1, "");
+		item->set_tooltip_text(1, "");
 	}
 }
 

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -356,7 +356,7 @@ void EditorProfiler::_update_frame() {
 			item->set_metadata(1, it.script);
 			item->set_metadata(2, it.line);
 			item->set_text_alignment(2, HORIZONTAL_ALIGNMENT_RIGHT);
-			item->set_tooltip(0, it.name + "\n" + it.script + ":" + itos(it.line));
+			item->set_tooltip_text(0, it.name + "\n" + it.script + ":" + itos(it.line));
 
 			float time = dtime == DISPLAY_SELF_TIME ? it.self : it.total;
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -580,8 +580,8 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			stack_trace->set_text(1, frame_txt);
 		}
 
-		error->set_tooltip(0, tooltip);
-		error->set_tooltip(1, tooltip);
+		error->set_tooltip_text(0, tooltip);
+		error->set_tooltip_text(1, tooltip);
 
 		if (warning_count == 0 && error_count == 0) {
 			expand_all_button->set_disabled(false);

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -215,11 +215,11 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 			if (FileAccess::exists(res_path)) {
 				num_file_conflicts += 1;
 				ti->set_custom_color(0, tree->get_theme_color(SNAME("error_color"), SNAME("Editor")));
-				ti->set_tooltip(0, vformat(TTR("%s (already exists)"), res_path));
+				ti->set_tooltip_text(0, vformat(TTR("%s (already exists)"), res_path));
 				ti->set_checked(0, false);
 				ti->propagate_check(0);
 			} else {
-				ti->set_tooltip(0, res_path);
+				ti->set_tooltip_text(0, res_path);
 			}
 
 			ti->set_metadata(0, res_path);

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -630,7 +630,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 			property->set_selectable(0, true);
 			property->set_checked(0, !edited->is_class_property_disabled(class_name, name));
 			property->set_text(0, text);
-			property->set_tooltip(0, tooltip);
+			property->set_tooltip_text(0, tooltip);
 			property->set_metadata(0, name);
 			String icon_type = Variant::get_type_name(E.type);
 			property->set_icon(0, EditorNode::get_singleton()->get_class_icon(icon_type));

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -562,8 +562,8 @@ TreeItem *EditorHelpSearch::Runner::_create_class_item(TreeItem *p_parent, const
 	item->set_icon(0, icon);
 	item->set_text(0, p_doc->name);
 	item->set_text(1, TTR("Class"));
-	item->set_tooltip(0, tooltip);
-	item->set_tooltip(1, tooltip);
+	item->set_tooltip_text(0, tooltip);
+	item->set_tooltip_text(1, tooltip);
 	item->set_metadata(0, "class_name:" + p_doc->name);
 	if (p_gray) {
 		item->set_custom_color(0, disabled_color);
@@ -639,8 +639,8 @@ TreeItem *EditorHelpSearch::Runner::_create_member_item(TreeItem *p_parent, cons
 	item->set_icon(0, icon);
 	item->set_text(0, text);
 	item->set_text(1, TTRGET(p_type));
-	item->set_tooltip(0, p_tooltip);
-	item->set_tooltip(1, p_tooltip);
+	item->set_tooltip_text(0, p_tooltip);
+	item->set_tooltip_text(1, p_tooltip);
 	item->set_metadata(0, "class_" + p_metatype + ":" + p_class_name + ":" + p_name);
 
 	_match_item(item, p_name);

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -102,7 +102,7 @@ void EditorPluginSettings::update_plugins() {
 
 				TreeItem *item = plugin_list->create_item(root);
 				item->set_text(0, name);
-				item->set_tooltip(0, TTR("Name:") + " " + name + "\n" + TTR("Path:") + " " + path + "\n" + TTR("Main Script:") + " " + script + "\n" + TTR("Description:") + " " + description);
+				item->set_tooltip_text(0, TTR("Name:") + " " + name + "\n" + TTR("Path:") + " " + path + "\n" + TTR("Main Script:") + " " + script + "\n" + TTR("Description:") + " " + description);
 				item->set_metadata(0, path);
 				item->set_text(1, version);
 				item->set_metadata(1, script);

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -283,7 +283,7 @@ void SectionedInspector::update_category_list() {
 				const String tooltip = EditorPropertyNameProcessor::get_singleton()->process_name(sectionarr[i], tooltip_style);
 
 				ms->set_text(0, text);
-				ms->set_tooltip(0, tooltip);
+				ms->set_tooltip_text(0, tooltip);
 				ms->set_metadata(0, metasection);
 				ms->set_selectable(0, false);
 			}

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -440,7 +440,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 			const String tooltip = EditorPropertyNameProcessor::get_singleton()->process_name(section_name, tooltip_style);
 
 			section->set_text(0, item_name);
-			section->set_tooltip(0, tooltip);
+			section->set_tooltip_text(0, tooltip);
 			section->set_selectable(0, false);
 			section->set_selectable(1, false);
 			section->set_custom_bg_color(0, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -276,7 +276,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 			ti->set_text(0, text);
 			ti->set_icon(0, icon);
 			ti->set_icon_modulate(0, color);
-			ti->set_tooltip(0, fave);
+			ti->set_tooltip_text(0, fave);
 			ti->set_selectable(0, true);
 			ti->set_metadata(0, fave);
 			if (p_select_in_favorites && fave == path) {

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -89,7 +89,7 @@ void GroupDialog::_load_nodes(Node *p_current) {
 	if (keep) {
 		node->set_text(0, item_name);
 		node->set_metadata(0, path);
-		node->set_tooltip(0, path);
+		node->set_tooltip_text(0, path);
 
 		Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(p_current, "Node");
 		node->set_icon(0, icon);

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -176,7 +176,7 @@ void SceneImportSettings::_fill_material(Tree *p_tree, const Ref<Material> &p_ma
 
 	item->set_meta("type", "Material");
 	item->set_meta("import_id", import_id);
-	item->set_tooltip(0, vformat(TTR("Import ID: %s"), import_id));
+	item->set_tooltip_text(0, vformat(TTR("Import ID: %s"), import_id));
 	item->set_selectable(0, true);
 
 	if (p_tree == scene_tree) {
@@ -232,7 +232,7 @@ void SceneImportSettings::_fill_mesh(Tree *p_tree, const Ref<Mesh> &p_mesh, Tree
 
 	item->set_meta("type", "Mesh");
 	item->set_meta("import_id", import_id);
-	item->set_tooltip(0, vformat(TTR("Import ID: %s"), import_id));
+	item->set_tooltip_text(0, vformat(TTR("Import ID: %s"), import_id));
 
 	item->set_selectable(0, true);
 
@@ -331,7 +331,7 @@ void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 	item->set_meta("type", "Node");
 	item->set_meta("class", type);
 	item->set_meta("import_id", import_id);
-	item->set_tooltip(0, vformat(TTR("Type: %s\nImport ID: %s"), type, import_id));
+	item->set_tooltip_text(0, vformat(TTR("Type: %s\nImport ID: %s"), type, import_id));
 
 	item->set_selectable(0, true);
 
@@ -979,7 +979,7 @@ void SceneImportSettings::_save_path_changed(const String &p_path) {
 
 	if (FileAccess::exists(p_path)) {
 		save_path_item->set_text(2, "Warning: File exists");
-		save_path_item->set_tooltip(2, TTR("Existing file with the same name will be replaced."));
+		save_path_item->set_tooltip_text(2, TTR("Existing file with the same name will be replaced."));
 		save_path_item->set_icon(2, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 
 	} else {
@@ -1024,7 +1024,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 				if (md.has_import_id) {
 					if (md.settings.has("use_external/enabled") && bool(md.settings["use_external/enabled"])) {
 						item->set_text(2, "Already External");
-						item->set_tooltip(2, TTR("This material already references an external file, no action will be taken.\nDisable the external property for it to be extracted again."));
+						item->set_tooltip_text(2, TTR("This material already references an external file, no action will be taken.\nDisable the external property for it to be extracted again."));
 					} else {
 						item->set_metadata(0, E.key);
 						item->set_editable(0, true);
@@ -1039,7 +1039,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 						item->set_text(1, path);
 						if (FileAccess::exists(path)) {
 							item->set_text(2, "Warning: File exists");
-							item->set_tooltip(2, TTR("Existing file with the same name will be replaced."));
+							item->set_tooltip_text(2, TTR("Existing file with the same name will be replaced."));
 							item->set_icon(2, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 
 						} else {
@@ -1052,7 +1052,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 
 				} else {
 					item->set_text(2, "No import ID");
-					item->set_tooltip(2, TTR("Material has no name nor any other way to identify on re-import.\nPlease name it or ensure it is exported with an unique ID."));
+					item->set_tooltip_text(2, TTR("Material has no name nor any other way to identify on re-import.\nPlease name it or ensure it is exported with an unique ID."));
 					item->set_icon(2, get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
 				}
 
@@ -1077,7 +1077,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 				if (md.has_import_id) {
 					if (md.settings.has("save_to_file/enabled") && bool(md.settings["save_to_file/enabled"])) {
 						item->set_text(2, "Already Saving");
-						item->set_tooltip(2, TTR("This mesh already saves to an external resource, no action will be taken."));
+						item->set_tooltip_text(2, TTR("This mesh already saves to an external resource, no action will be taken."));
 					} else {
 						item->set_metadata(0, E.key);
 						item->set_editable(0, true);
@@ -1092,7 +1092,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 						item->set_text(1, path);
 						if (FileAccess::exists(path)) {
 							item->set_text(2, "Warning: File exists");
-							item->set_tooltip(2, TTR("Existing file with the same name will be replaced on import."));
+							item->set_tooltip_text(2, TTR("Existing file with the same name will be replaced on import."));
 							item->set_icon(2, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 
 						} else {
@@ -1105,7 +1105,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 
 				} else {
 					item->set_text(2, "No import ID");
-					item->set_tooltip(2, TTR("Mesh has no name nor any other way to identify on re-import.\nPlease name it or ensure it is exported with an unique ID."));
+					item->set_tooltip_text(2, TTR("Mesh has no name nor any other way to identify on re-import.\nPlease name it or ensure it is exported with an unique ID."));
 					item->set_icon(2, get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
 				}
 
@@ -1129,7 +1129,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 
 				if (ad.settings.has("save_to_file/enabled") && bool(ad.settings["save_to_file/enabled"])) {
 					item->set_text(2, "Already Saving");
-					item->set_tooltip(2, TTR("This animation already saves to an external resource, no action will be taken."));
+					item->set_tooltip_text(2, TTR("This animation already saves to an external resource, no action will be taken."));
 				} else {
 					item->set_metadata(0, E.key);
 					item->set_editable(0, true);
@@ -1144,7 +1144,7 @@ void SceneImportSettings::_save_dir_callback(const String &p_path) {
 					item->set_text(1, path);
 					if (FileAccess::exists(path)) {
 						item->set_text(2, "Warning: File exists");
-						item->set_tooltip(2, TTR("Existing file with the same name will be replaced on import."));
+						item->set_tooltip_text(2, TTR("Existing file with the same name will be replaced on import."));
 						item->set_icon(2, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 
 					} else {

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -193,7 +193,7 @@ void LocalizationEditor::_translation_res_option_popup(bool p_arrow_clicked) {
 	TreeItem *ed = translation_remap_options->get_edited();
 	ERR_FAIL_COND(!ed);
 
-	locale_select->set_locale(ed->get_tooltip(1));
+	locale_select->set_locale(ed->get_tooltip_text(1));
 	locale_select->popup_locale_dialog();
 }
 
@@ -202,7 +202,7 @@ void LocalizationEditor::_translation_res_option_selected(const String &p_locale
 	ERR_FAIL_COND(!ed);
 
 	ed->set_text(1, TranslationServer::get_singleton()->get_locale_name(p_locale));
-	ed->set_tooltip(1, p_locale);
+	ed->set_tooltip_text(1, p_locale);
 
 	LocalizationEditor::_translation_res_option_changed();
 }
@@ -226,7 +226,7 @@ void LocalizationEditor::_translation_res_option_changed() {
 	String key = k->get_metadata(0);
 	int idx = ed->get_metadata(0);
 	String path = ed->get_metadata(1);
-	String locale = ed->get_tooltip(1);
+	String locale = ed->get_tooltip_text(1);
 
 	ERR_FAIL_COND(!remaps.has(key));
 	PackedStringArray r = remaps[key];
@@ -486,7 +486,7 @@ void LocalizationEditor::update_translations() {
 			TreeItem *t = translation_list->create_item(root);
 			t->set_editable(0, false);
 			t->set_text(0, translations[i].replace_first("res://", ""));
-			t->set_tooltip(0, translations[i]);
+			t->set_tooltip_text(0, translations[i]);
 			t->set_metadata(0, i);
 			t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 		}
@@ -520,14 +520,14 @@ void LocalizationEditor::update_translations() {
 			TreeItem *t = translation_remap->create_item(root);
 			t->set_editable(0, false);
 			t->set_text(0, keys[i].replace_first("res://", ""));
-			t->set_tooltip(0, keys[i]);
+			t->set_tooltip_text(0, keys[i]);
 			t->set_metadata(0, keys[i]);
 			t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 
 			// Display that it has been removed if this is the case.
 			if (!FileAccess::exists(keys[i])) {
 				t->set_text(0, t->get_text(0) + vformat(" (%s)", TTR("Removed")));
-				t->set_tooltip(0, vformat(TTR("%s cannot be found."), t->get_tooltip(0)));
+				t->set_tooltip_text(0, vformat(TTR("%s cannot be found."), t->get_tooltip_text(0)));
 			}
 
 			if (keys[i] == remap_selected) {
@@ -544,19 +544,19 @@ void LocalizationEditor::update_translations() {
 					TreeItem *t2 = translation_remap_options->create_item(root2);
 					t2->set_editable(0, false);
 					t2->set_text(0, path.replace_first("res://", ""));
-					t2->set_tooltip(0, path);
+					t2->set_tooltip_text(0, path);
 					t2->set_metadata(0, j);
 					t2->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 					t2->set_cell_mode(1, TreeItem::CELL_MODE_CUSTOM);
 					t2->set_text(1, TranslationServer::get_singleton()->get_locale_name(locale));
 					t2->set_editable(1, true);
 					t2->set_metadata(1, path);
-					t2->set_tooltip(1, locale);
+					t2->set_tooltip_text(1, locale);
 
 					// Display that it has been removed if this is the case.
 					if (!FileAccess::exists(path)) {
 						t2->set_text(0, t2->get_text(0) + vformat(" (%s)", TTR("Removed")));
-						t2->set_tooltip(0, vformat(TTR("%s cannot be found."), t2->get_tooltip(0)));
+						t2->set_tooltip_text(0, vformat(TTR("%s cannot be found."), t2->get_tooltip_text(0)));
 					}
 				}
 			}
@@ -573,7 +573,7 @@ void LocalizationEditor::update_translations() {
 			TreeItem *t = translation_pot_list->create_item(root);
 			t->set_editable(0, false);
 			t->set_text(0, pot_translations[i].replace_first("res://", ""));
-			t->set_tooltip(0, pot_translations[i]);
+			t->set_tooltip_text(0, pot_translations[i]);
 			t->set_metadata(0, i);
 			t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
 		}

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -635,7 +635,7 @@ void AnimationLibraryEditor::update_tree() {
 		String al_path = al->get_path();
 		if (!al_path.is_resource_file()) {
 			libitem->set_text(1, TTR("[built-in]"));
-			libitem->set_tooltip(1, al_path);
+			libitem->set_tooltip_text(1, al_path);
 			int srpos = al_path.find("::");
 			if (srpos != -1) {
 				String base = al_path.substr(0, srpos);
@@ -687,7 +687,7 @@ void AnimationLibraryEditor::update_tree() {
 			String anim_path = anim->get_path();
 			if (!anim_path.is_resource_file()) {
 				anitem->set_text(1, TTR("[built-in]"));
-				anitem->set_tooltip(1, anim_path);
+				anitem->set_tooltip_text(1, anim_path);
 				int srpos = anim_path.find("::");
 				if (srpos != -1) {
 					String base = anim_path.substr(0, srpos);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -196,7 +196,7 @@ void ResourcePreloaderEditor::_update_library() {
 
 		String type = r->get_class();
 		ti->set_icon(0, EditorNode::get_singleton()->get_class_icon(type, "Object"));
-		ti->set_tooltip(0, TTR("Instance:") + " " + r->get_path() + "\n" + TTR("Type:") + " " + type);
+		ti->set_tooltip_text(0, TTR("Instance:") + " " + r->get_path() + "\n" + TTR("Type:") + " " + type);
 
 		ti->set_text(1, r->get_path());
 		ti->set_editable(1, false);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -354,7 +354,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
-		item->set_tooltip(0, tooltip);
+		item->set_tooltip_text(0, tooltip);
 	} else if (p_node != get_scene_node() && !p_node->get_scene_file_path().is_empty() && can_open_instance) {
 		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
 
@@ -363,7 +363,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
-		item->set_tooltip(0, tooltip);
+		item->set_tooltip_text(0, tooltip);
 	} else {
 		StringName type = EditorNode::get_singleton()->get_object_custom_type_name(p_node);
 		if (type == StringName()) {
@@ -375,7 +375,7 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}
 
-		item->set_tooltip(0, tooltip);
+		item->set_tooltip_text(0, tooltip);
 	}
 
 	if (can_open_instance && undo_redo.is_valid()) { //Show buttons only when necessary(SceneTreeDock) to avoid crashes

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1013,7 +1013,7 @@ Ref<Texture2D> TreeItem::get_button(int p_column, int p_idx) const {
 	return cells[p_column].buttons[p_idx].texture;
 }
 
-String TreeItem::get_button_tooltip(int p_column, int p_idx) const {
+String TreeItem::get_button_tooltip_text(int p_column, int p_idx) const {
 	ERR_FAIL_INDEX_V(p_column, cells.size(), String());
 	ERR_FAIL_INDEX_V(p_idx, cells[p_column].buttons.size(), String());
 	return cells[p_column].buttons[p_idx].tooltip;
@@ -1160,12 +1160,12 @@ int TreeItem::get_custom_font_size(int p_column) const {
 	return cells[p_column].custom_font_size;
 }
 
-void TreeItem::set_tooltip(int p_column, const String &p_tooltip) {
+void TreeItem::set_tooltip_text(int p_column, const String &p_tooltip) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 	cells.write[p_column].tooltip = p_tooltip;
 }
 
-String TreeItem::get_tooltip(int p_column) const {
+String TreeItem::get_tooltip_text(int p_column) const {
 	ERR_FAIL_INDEX_V(p_column, cells.size(), "");
 	return cells[p_column].tooltip;
 }
@@ -1441,9 +1441,9 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_as_button", "column", "enable"), &TreeItem::set_custom_as_button);
 	ClassDB::bind_method(D_METHOD("is_custom_set_as_button", "column"), &TreeItem::is_custom_set_as_button);
 
-	ClassDB::bind_method(D_METHOD("add_button", "column", "button", "id", "disabled", "tooltip"), &TreeItem::add_button, DEFVAL(-1), DEFVAL(false), DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("add_button", "column", "button", "id", "disabled", "tooltip_text"), &TreeItem::add_button, DEFVAL(-1), DEFVAL(false), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_button_count", "column"), &TreeItem::get_button_count);
-	ClassDB::bind_method(D_METHOD("get_button_tooltip", "column", "button_idx"), &TreeItem::get_button_tooltip);
+	ClassDB::bind_method(D_METHOD("get_button_tooltip_text", "column", "button_idx"), &TreeItem::get_button_tooltip_text);
 	ClassDB::bind_method(D_METHOD("get_button_id", "column", "button_idx"), &TreeItem::get_button_id);
 	ClassDB::bind_method(D_METHOD("get_button_by_id", "column", "id"), &TreeItem::get_button_by_id);
 	ClassDB::bind_method(D_METHOD("get_button", "column", "button_idx"), &TreeItem::get_button);
@@ -1452,8 +1452,8 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button_disabled", "column", "button_idx", "disabled"), &TreeItem::set_button_disabled);
 	ClassDB::bind_method(D_METHOD("is_button_disabled", "column", "button_idx"), &TreeItem::is_button_disabled);
 
-	ClassDB::bind_method(D_METHOD("set_tooltip", "column", "tooltip"), &TreeItem::set_tooltip);
-	ClassDB::bind_method(D_METHOD("get_tooltip", "column"), &TreeItem::get_tooltip);
+	ClassDB::bind_method(D_METHOD("set_tooltip_text", "column", "tooltip"), &TreeItem::set_tooltip_text);
+	ClassDB::bind_method(D_METHOD("get_tooltip_text", "column"), &TreeItem::get_tooltip_text);
 	ClassDB::bind_method(D_METHOD("set_text_alignment", "column", "text_alignment"), &TreeItem::set_text_alignment);
 	ClassDB::bind_method(D_METHOD("get_text_alignment", "column"), &TreeItem::get_text_alignment);
 
@@ -5005,10 +5005,10 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 				col_width -= size.width;
 			}
 			String ret;
-			if (it->get_tooltip(col) == "") {
+			if (it->get_tooltip_text(col) == "") {
 				ret = it->get_text(col);
 			} else {
-				ret = it->get_tooltip(col);
+				ret = it->get_tooltip_text(col);
 			}
 			return ret;
 		}

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -245,7 +245,7 @@ public:
 
 	void add_button(int p_column, const Ref<Texture2D> &p_button, int p_id = -1, bool p_disabled = false, const String &p_tooltip = "");
 	int get_button_count(int p_column) const;
-	String get_button_tooltip(int p_column, int p_idx) const;
+	String get_button_tooltip_text(int p_column, int p_idx) const;
 	Ref<Texture2D> get_button(int p_column, int p_idx) const;
 	int get_button_id(int p_column, int p_idx) const;
 	void erase_button(int p_column, int p_idx);
@@ -308,8 +308,8 @@ public:
 	void set_custom_as_button(int p_column, bool p_button);
 	bool is_custom_set_as_button(int p_column) const;
 
-	void set_tooltip(int p_column, const String &p_tooltip);
-	String get_tooltip(int p_column) const;
+	void set_tooltip_text(int p_column, const String &p_tooltip);
+	String get_tooltip_text(int p_column) const;
 
 	void set_text_alignment(int p_column, HorizontalAlignment p_alignment);
 	HorizontalAlignment get_text_alignment(int p_column) const;


### PR DESCRIPTION
After https://github.com/godotengine/godot/pull/64885#issue has been merged, an argument can be made that, for consistency, the other similar methods for **TreeItem** could have "text" specified to further avoid confusion.

For **TreeItem**:
`set_tooltip` -> `set_tooltip_text`
`get_tooltip` -> `get_tooltip_text`
`get_button_tooltip` -> `get_button_tooltip_text`
The `tooltip` parameter in `add_button` was renamed to `tooltip_text`

With this, **Control**.`get_tooltip()` remains always recognisable as the one method that returns a tooltip String **at a local position**.