### PR TITLE
C#: Fix exported game crash because of uninitialized callbacks

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
@@ -27,7 +27,8 @@ namespace GodotPlugins.Game
     internal static partial class Main
     {
         [UnmanagedCallersOnly(EntryPoint = ""godotsharp_game_main_init"")]
-        private static godot_bool InitializeFromGameProject(IntPtr godotDllHandle, IntPtr outManagedCallbacks)
+        private static godot_bool InitializeFromGameProject(IntPtr godotDllHandle, IntPtr outManagedCallbacks,
+            IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
         {
             try
             {
@@ -36,6 +37,8 @@ namespace GodotPlugins.Game
                 var coreApiAssembly = typeof(Godot.Object).Assembly;
 
                 NativeLibrary.SetDllImportResolver(coreApiAssembly, dllImportResolver);
+
+                NativeFuncs.Initialize(unmanagedCallbacks, unmanagedCallbacksSize);
 
                 ManagedCallbacks.Create(outManagedCallbacks);
 


### PR DESCRIPTION
This was a regression from 2c180f62d985194060f1a8d2070c130081177c90, where I forgot to update the source generator.
