### PR TITLE
CSharp parameterless constructor for non-zero Structs like GDScript

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -204,7 +204,7 @@
 		</constant>
 		<constant name="IDENTITY" value="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">
 			The identity basis, with no rotation or scaling applied.
-			This is identical to calling [code]Basis()[/code] without any parameters. This constant can be used to make your code clearer, and for consistency with C#.
+			This is identical to calling [code]Basis()[/code] without any parameters. This constant can be used to make your code clearer.
 		</constant>
 		<constant name="FLIP_X" value="Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1)">
 			The basis that will flip something along the X axis when used in a transformation.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -664,8 +664,6 @@ namespace Godot
 
         /// <summary>
         /// The identity basis, with no rotation or scaling applied.
-        /// This is used as a replacement for <c>Basis()</c> in GDScript.
-        /// Do not use <c>new Basis()</c> with no arguments in C#, because it sets all values to zero.
         /// </summary>
         /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Up, Vector3.Back)</c>.</value>
         public static Basis Identity { get { return _identity; } }
@@ -684,6 +682,14 @@ namespace Godot
         /// </summary>
         /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Up, Vector3.Forward)</c>.</value>
         public static Basis FlipZ { get { return _flipZ; } }
+
+        /// <summary>
+        /// Constructs an identity basis with no rotation or scaling applied.
+        /// </summary>
+        public Basis()
+        {
+            this = _identity;
+        }
 
         /// <summary>
         /// Constructs a pure rotation basis matrix from the given quaternion.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -59,6 +59,14 @@ namespace Godot
         public Vector4 w;
 
         /// <summary>
+        /// Constructs an identity projection with no distortion applied.
+        /// </summary>
+        public Projection()
+        {
+            this = _identity;
+        }
+
+        /// <summary>
         /// Constructs a projection from 4 vectors (matrix columns).
         /// </summary>
         /// <param name="x">The X column, or column index 0.</param>
@@ -762,8 +770,6 @@ namespace Godot
 
         /// <summary>
         /// The identity projection, with no distortion applied.
-        /// This is used as a replacement for <c>Projection()</c> in GDScript.
-        /// Do not use <c>new Projection()</c> with no arguments in C#, because it sets all values to zero.
         /// </summary>
         /// <value>Equivalent to <c>new Projection(new Vector4(1, 0, 0, 0), new Vector4(0, 1, 0, 0), new Vector4(0, 0, 1, 0), new Vector4(0, 0, 0, 1))</c>.</value>
         public static Projection Identity { get { return _identity; } }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -483,6 +483,14 @@ namespace Godot
         public static Quaternion Identity { get { return _identity; } }
 
         /// <summary>
+        /// Constructs an identity quaternion representing no rotation.
+        /// </summary>
+        public Quaternion()
+        {
+            this = _identity;
+        }
+
+        /// <summary>
         /// Constructs a <see cref="Quaternion"/> defined by the given values.
         /// </summary>
         /// <param name="x">X component of the quaternion (imaginary <c>i</c> axis part).</param>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -394,8 +394,6 @@ namespace Godot
 
         /// <summary>
         /// The identity transform, with no translation, rotation, or scaling applied.
-        /// This is used as a replacement for <c>Transform2D()</c> in GDScript.
-        /// Do not use <c>new Transform2D()</c> with no arguments in C#, because it sets all values to zero.
         /// </summary>
         /// <value>Equivalent to <c>new Transform2D(Vector2.Right, Vector2.Down, Vector2.Zero)</c>.</value>
         public static Transform2D Identity { get { return _identity; } }
@@ -409,6 +407,14 @@ namespace Godot
         /// </summary>
         /// <value>Equivalent to <c>new Transform2D(Vector2.Right, Vector2.Up, Vector2.Zero)</c>.</value>
         public static Transform2D FlipY { get { return _flipY; } }
+
+        /// <summary>
+        /// Constructs an identity transform with no translation, rotation, or scaling applied.
+        /// </summary>
+        public Transform2D()
+        {
+            this = _identity;
+        }
 
         /// <summary>
         /// Constructs a transformation matrix from 3 vectors (matrix columns).

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -311,8 +311,6 @@ namespace Godot
 
         /// <summary>
         /// The identity transform, with no translation, rotation, or scaling applied.
-        /// This is used as a replacement for <c>Transform()</c> in GDScript.
-        /// Do not use <c>new Transform()</c> with no arguments in C#, because it sets all values to zero.
         /// </summary>
         /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Up, Vector3.Back, Vector3.Zero)</c>.</value>
         public static Transform3D Identity { get { return _identity; } }
@@ -331,6 +329,14 @@ namespace Godot
         /// </summary>
         /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Up, Vector3.Forward, Vector3.Zero)</c>.</value>
         public static Transform3D FlipZ { get { return _flipZ; } }
+
+        /// <summary>
+        /// Constructs an identity transform with no translation, rotation, or scaling applied.
+        /// </summary>
+        public Transform3D()
+        {
+            this = _identity;
+        }
 
         /// <summary>
         /// Constructs a transformation matrix from 4 vectors (matrix columns).


### PR DESCRIPTION
### Change CSharp to use parameterless constructors to match GDScript.

If the old behavior is prefered please close this pull request.
If this should be merged the docs `C# API differences to GDScript` must be updated.