### PR TITLE
Disable HDR warning for Viewport on GLES2 projects

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3031,7 +3031,7 @@ String Viewport::get_configuration_warning() const {
 		warning += TTR("The Viewport size must be greater than or equal to 2 pixels on both dimensions to render anything.");
 	}
 
-	if (hdr && (usage == USAGE_2D || usage == USAGE_2D_NO_SAMPLING)) {
+	if (!VisualServer::get_singleton()->is_low_end() && hdr && (usage == USAGE_2D || usage == USAGE_2D_NO_SAMPLING)) {
 		if (warning != String()) {
 			warning += "\n\n";
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fixes #65033
