### PR TITLE
Fix inferred enums not showing up in inspector

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2726,6 +2726,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 				result.builtin_type = Variant::INT;
 				result.native_type = base.native_type;
 				result.enum_type = base.enum_type;
+				result.enum_values = base.enum_values;
 				p_identifier->set_datatype(result);
 				return;
 			} else {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fixes #65010

`enum_values` originally wasn't being forwarded to the new type inside `reduce_identifier_from_base`, which caused hint strings derived from the new type to be blank, which ultimately caused an empty enum dropdown menu.