### PR TITLE
Cast between float and ints in Tween.`tween_property()`

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -75,10 +75,17 @@ Ref<PropertyTweener> Tween::tween_property(Object *p_target, NodePath p_property
 	ERR_FAIL_COND_V_MSG(!valid, nullptr, "Tween invalid. Either finished or created outside scene tree.");
 	ERR_FAIL_COND_V_MSG(started, nullptr, "Can't append to a Tween that has started. Use stop() first.");
 
-#ifdef DEBUG_ENABLED
 	Variant::Type property_type = p_target->get_indexed(p_property.get_as_property_path().get_subnames()).get_type();
-	ERR_FAIL_COND_V_MSG(property_type != p_to.get_type(), Ref<PropertyTweener>(), "Type mismatch between property and final value: " + Variant::get_type_name(property_type) + " and " + Variant::get_type_name(p_to.get_type()));
-#endif
+	if (property_type != p_to.get_type()) {
+		// Cast p_to between floats and ints to avoid minor annoyances.
+		if (property_type == Variant::FLOAT && p_to.get_type() == Variant::INT) {
+			p_to = float(p_to);
+		} else if (property_type == Variant::INT && p_to.get_type() == Variant::FLOAT) {
+			p_to = int(p_to);
+		} else {
+			ERR_FAIL_V_MSG(Ref<PropertyTweener>(), "Type mismatch between property and final value: " + Variant::get_type_name(property_type) + " and " + Variant::get_type_name(p_to.get_type()));
+		}
+	}
 
 	Ref<PropertyTweener> tweener = memnew(PropertyTweener(p_target, p_property, p_to, p_duration));
 	append(tweener);


### PR DESCRIPTION
(Partially?) Closes https://github.com/godotengine/godot-proposals/issues/5283.
Alternative to https://github.com/godotengine/godot/pull/54317.

This PR only casts between **floats** and **integers**. These types are so closely intertwined between one another, that it seems reasonable to subtly cast only these ones.

I decided it this way mainly because, if the user is tweening between a **float** and **String** (that can be converted into a valid float), they're probably not doing something right. However, as I was developing this, I was wondering if conversion between **Vector2** and **Vector2i** & similar should be possible, too...

Also strips the `DEBUG_ENABLED` so that the behaviour is consistent in all builds.