### PR TITLE
Fix highlighting after value keywords

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -39,10 +39,10 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 	Type next_type = NONE;
 	Type current_type = NONE;
-	Type previous_type = NONE;
+	Type prev_type = NONE;
 
-	String previous_text = "";
-	int previous_column = 0;
+	String prev_text = "";
+	int prev_column = 0;
 
 	bool prev_is_char = false;
 	bool prev_is_digit = false;
@@ -224,9 +224,9 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 						}
 					}
 
-					previous_type = REGION;
-					previous_text = "";
-					previous_column = j;
+					prev_type = REGION;
+					prev_text = "";
+					prev_column = j;
 					j = from + (end_key_length - 1);
 					if (region_end_index == -1) {
 						color_region_cache[p_line] = in_region;
@@ -243,17 +243,15 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 		// A bit of a hack, but couldn't come up with anything better.
 		if (j > 0 && (str[j] == '&' || str[j] == '^' || str[j] == '%' || str[j] == '+' || str[j] == '-' || str[j] == '~' || str[j] == '.')) {
-			if (!keywords.has(previous_text)) {
-				if (previous_text == "PI" || previous_text == "TAU" || previous_text == "INF" || previous_text == "NAN") {
+			if (prev_text == "true" || prev_text == "false" || prev_text == "self" || prev_text == "null" || prev_text == "PI" || prev_text == "TAU" || prev_text == "INF" || prev_text == "NAN") {
+				is_binary_op = true;
+			} else if (!keywords.has(prev_text)) {
+				int k = j - 1;
+				while (k > 0 && is_whitespace(str[k])) {
+					k--;
+				}
+				if (!is_symbol(str[k]) || str[k] == '"' || str[k] == '\'' || str[k] == ')' || str[k] == ']' || str[k] == '}') {
 					is_binary_op = true;
-				} else {
-					int k = j - 1;
-					while (k > 0 && is_whitespace(str[k])) {
-						k--;
-					}
-					if (!is_symbol(str[k]) || str[k] == '"' || str[k] == '\'' || str[k] == ')' || str[k] == ']' || str[k] == '}') {
-						is_binary_op = true;
-					}
 				}
 			}
 		}
@@ -345,7 +343,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 		}
 
 		if (!in_function_name && in_word && !in_keyword) {
-			if (previous_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::SIGNAL)) {
+			if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::SIGNAL)) {
 				in_signal_declaration = true;
 			} else {
 				int k = j;
@@ -360,12 +358,12 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 				if (str[k] == '(') {
 					in_function_name = true;
-				} else if (previous_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::VAR)) {
+				} else if (prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::VAR)) {
 					in_variable_declaration = true;
 				}
 
 				// Check for lambda.
-				if (in_function_name && previous_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC)) {
+				if (in_function_name && prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC)) {
 					k = j - 1;
 					while (k > 0 && is_whitespace(str[k])) {
 						k--;
@@ -481,7 +479,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 		} else if (in_function_name) {
 			next_type = FUNCTION;
 
-			if (!in_lambda && previous_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC)) {
+			if (!in_lambda && prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC)) {
 				color = function_definition_color;
 			} else {
 				color = function_color;
@@ -503,20 +501,20 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			if (current_type == NONE) {
 				current_type = next_type;
 			} else {
-				previous_type = current_type;
+				prev_type = current_type;
 				current_type = next_type;
 
 				// no need to store regions...
-				if (previous_type == REGION) {
-					previous_text = "";
-					previous_column = j;
+				if (prev_type == REGION) {
+					prev_text = "";
+					prev_column = j;
 				} else {
-					String text = str.substr(previous_column, j - previous_column).strip_edges();
-					previous_column = j;
+					String text = str.substr(prev_column, j - prev_column).strip_edges();
+					prev_column = j;
 
 					// ignore if just whitespace
 					if (!text.is_empty()) {
-						previous_text = text;
+						prev_text = text;
 					}
 				}
 			}


### PR DESCRIPTION
Related to #65008

Finishes an incomplete fix from #65003... Keywords that represent a value should be exceptions to considering operators as unary in the highlighter. I coded it completely wrongly.

Also renamed `previous_[...]` variables to `prev_[...]` throughout the highlighter so the exceptions LoC doesn't get super long, also for consistency. Hope that's OK.

Closes #66350