### PR TITLE
Make Git hooks work on worktrees on Windows

### DIFF
--- a/misc/hooks/pre-commit-black
+++ b/misc/hooks/pre-commit-black
@@ -70,7 +70,7 @@ if [ ! -x "$BLACK" ] ; then
             $XMSG -center -title "Error" "Error: black executable not found."
             exit 1
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
-            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            winmessage="$(canonicalize_filename "$(dirname -- "$0")/winmessage.ps1")"
             $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -center -title "Error" --text "Error: black executable not found."
             exit 1
         fi
@@ -160,7 +160,7 @@ while true; do
                 yn="N"
             fi
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
-            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            winmessage="$(canonicalize_filename "$(dirname -- "$0")/winmessage.ps1")"
             $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
             choice=$?
             if [ "$choice" = "100" ] ; then

--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -90,7 +90,7 @@ if [ ! -x "$CLANG_FORMAT" ] ; then
             $XMSG -center -title "Error" "$message"
             exit 1
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
-            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            winmessage="$(canonicalize_filename "$(dirname -- "$0")/winmessage.ps1")"
             $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -center -title "Error" --text "$message"
             exit 1
         fi
@@ -200,7 +200,7 @@ while true; do
                 yn="N"
             fi
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
-            winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
+            winmessage="$(canonicalize_filename "$(dirname -- "$0")/winmessage.ps1")"
             $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
             choice=$?
             if [ "$choice" = "100" ] ; then


### PR DESCRIPTION
This PR replaces the hardcoded path to the Windows utility script to prompt the user by the actual location of the hooks.

Without this patch, the aforementioned script wouldn't be found in case the Godot repo is being worked on via a worktree.