### PR TITLE
Add functions to pick a random element from an array

### DIFF
--- a/core/math/random_number_generator.cpp
+++ b/core/math/random_number_generator.cpp
@@ -42,6 +42,7 @@ void RandomNumberGenerator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("randfn", "mean", "deviation"), &RandomNumberGenerator::randfn, DEFVAL(0.0), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("randf_range", "from", "to"), &RandomNumberGenerator::randf_range);
 	ClassDB::bind_method(D_METHOD("randi_range", "from", "to"), &RandomNumberGenerator::randi_range);
+	ClassDB::bind_method(D_METHOD("rand_pick", "choices"), &RandomNumberGenerator::rand_pick);
 	ClassDB::bind_method(D_METHOD("randomize"), &RandomNumberGenerator::randomize);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "seed"), "set_seed", "get_seed");
@@ -49,4 +50,32 @@ void RandomNumberGenerator::_bind_methods() {
 	// Default values are non-deterministic, override for doc generation purposes.
 	ADD_PROPERTY_DEFAULT("seed", 0);
 	ADD_PROPERTY_DEFAULT("state", 0);
+}
+
+Variant RandomNumberGenerator::rand_pick(const Variant &p_choices) {
+#define PICK_RANDOM_CASE(m_variant_type, m_type)                                        \
+	case Variant::m_variant_type: {                                                     \
+		const m_type &arr = p_choices;                                                  \
+		ERR_FAIL_COND_V_MSG(arr.is_empty(), Variant(), "Can't pick from empty array."); \
+		return arr[randi() % arr.size()];                                               \
+	} break
+
+	switch (p_choices.get_type()) {
+		PICK_RANDOM_CASE(ARRAY, Array);
+		PICK_RANDOM_CASE(PACKED_BYTE_ARRAY, PackedByteArray);
+		PICK_RANDOM_CASE(PACKED_INT32_ARRAY, PackedInt32Array);
+		PICK_RANDOM_CASE(PACKED_INT64_ARRAY, PackedInt32Array);
+		PICK_RANDOM_CASE(PACKED_FLOAT32_ARRAY, PackedFloat32Array);
+		PICK_RANDOM_CASE(PACKED_FLOAT64_ARRAY, PackedFloat64Array);
+		PICK_RANDOM_CASE(PACKED_STRING_ARRAY, PackedStringArray);
+		PICK_RANDOM_CASE(PACKED_VECTOR2_ARRAY, PackedVector2Array);
+		PICK_RANDOM_CASE(PACKED_VECTOR3_ARRAY, PackedVector3Array);
+		PICK_RANDOM_CASE(PACKED_COLOR_ARRAY, PackedColorArray);
+
+		default: {
+			ERR_FAIL_V_MSG(Variant(), "Choices should be an array.");
+		}
+	}
+
+#undef PICK_RANDOM_CASE
 }

--- a/core/math/random_number_generator.h
+++ b/core/math/random_number_generator.h
@@ -57,6 +57,8 @@ public:
 	_FORCE_INLINE_ real_t randfn(real_t p_mean = 0.0, real_t p_deviation = 1.0) { return randbase.randfn(p_mean, p_deviation); }
 	_FORCE_INLINE_ int randi_range(int p_from, int p_to) { return randbase.random(p_from, p_to); }
 
+	Variant rand_pick(const Variant &p_choices);
+
 	RandomNumberGenerator() {}
 };
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -628,6 +628,37 @@ struct VariantUtilityFunctions {
 		return arr;
 	}
 
+	static inline Variant rand_pick(const Variant &p_choices, Callable::CallError &r_error) {
+		r_error.error = Callable::CallError::CALL_OK;
+
+#define PICK_RANDOM_CASE(m_variant_type, m_type)                                        \
+	case Variant::m_variant_type: {                                                     \
+		const m_type &arr = VariantInternalAccessor<m_type>::get(&p_choices);           \
+		ERR_FAIL_COND_V_MSG(arr.is_empty(), Variant(), "Can't pick from empty array."); \
+		return arr[Math::rand() % arr.size()];                                          \
+	} break
+
+		switch (p_choices.get_type()) {
+			PICK_RANDOM_CASE(ARRAY, Array);
+			PICK_RANDOM_CASE(PACKED_BYTE_ARRAY, PackedByteArray);
+			PICK_RANDOM_CASE(PACKED_INT32_ARRAY, PackedInt32Array);
+			PICK_RANDOM_CASE(PACKED_INT64_ARRAY, PackedInt32Array);
+			PICK_RANDOM_CASE(PACKED_FLOAT32_ARRAY, PackedFloat32Array);
+			PICK_RANDOM_CASE(PACKED_FLOAT64_ARRAY, PackedFloat64Array);
+			PICK_RANDOM_CASE(PACKED_STRING_ARRAY, PackedStringArray);
+			PICK_RANDOM_CASE(PACKED_VECTOR2_ARRAY, PackedVector2Array);
+			PICK_RANDOM_CASE(PACKED_VECTOR3_ARRAY, PackedVector3Array);
+			PICK_RANDOM_CASE(PACKED_COLOR_ARRAY, PackedColorArray);
+
+			default: {
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				return Variant();
+			}
+		}
+
+#undef PICK_RANDOM_CASE
+	}
+
 	// Utility
 
 	static inline Variant weakref(const Variant &obj, Callable::CallError &r_error) {
@@ -1473,6 +1504,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(randfn, sarray("mean", "deviation"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBIND(seed, sarray("base"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 	FUNCBINDR(rand_from_seed, sarray("seed"), Variant::UTILITY_FUNC_TYPE_RANDOM);
+	FUNCBINDVR(rand_pick, sarray("choices"), Variant::UTILITY_FUNC_TYPE_RANDOM);
 
 	// Utility
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -830,6 +830,13 @@
 				Random from seed: pass a [param seed], and an array with both number and new seed is returned. "Seed" here refers to the internal state of the pseudo random number generator. The internal state of the current implementation is 64 bits.
 			</description>
 		</method>
+		<method name="rand_pick">
+			<return type="Variant" />
+			<param index="0" name="choices" type="Variant" />
+			<description>
+				Returns a pseudo-random element from the [param choices] array. If [param choices] is not an array, or if the array is empty, [code]null[/code] is returned and an error is logged.
+			</description>
+		</method>
 		<method name="randf">
 			<return type="float" />
 			<description>

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -19,6 +19,13 @@
 		<link title="Random number generation">$DOCS_URL/tutorials/math/random_number_generation.html</link>
 	</tutorials>
 	<methods>
+		<method name="rand_pick">
+			<return type="Variant" />
+			<param index="0" name="choices" type="Variant" />
+			<description>
+				Returns a pseudo-random element from the [param choices] array. If [param choices] is not an array, or if the array is empty, [code]null[/code] is returned and an error is logged.
+			</description>
+		</method>
 		<method name="randf">
 			<return type="float" />
 			<description>


### PR DESCRIPTION
Revival of #57007
Closes https://github.com/godotengine/godot-proposals/issues/3454

In addition to the original functionality, I decided to also support

* Picking from packed arrays
    * To keep things simple, I made it a free function that takes any array type (`Array`, `PackedStringArray`, etc...) instead of a method on each array type. This also makes it easier to extend later if we want to support picking from more types.
    * To be consistent with functions like `randi()` and `randi_range()`, I named the function `rand_pick()`.
* Using a random number generator
    * A similar `rand_pick()` method is added to `RandomNumberGenerator`.

```gdscript
# Regular array
var arr := [1, 2, 3, 4, 5]
print(rand_pick(arr))
print(rand_pick(arr))

# Packed array
print(rand_pick("Mon Tue Wed Thu Fri Sat Sun".split(" ")))

# With RandomNumberGenerator (useful for procedural generation)
var rng := RandomNumberGenerator.new()
rng.state = 2022
print(rng.rand_pick(arr))  # Prints 1
print(rng.rand_pick(arr))  # Prints 2
rng.state = 2022
print(rng.rand_pick(arr))  # Prints 1
print(rng.rand_pick(arr))  # Prints 2
```
