### PR TITLE
[3.x] Center the Tree's text editor vertically

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2712,7 +2712,7 @@ bool Tree::edit_selected() {
 		return true;
 
 	} else if (c.mode == TreeItem::CELL_MODE_STRING || c.mode == TreeItem::CELL_MODE_RANGE) {
-		Vector2 ofs(0, (text_editor->get_size().height - rect.size.height) / 2);
+		Vector2 ofs(0, (text_editor->get_size().height - rect.size.height) / 2 - 1); // "-1" centers vertically.
 		Point2i textedpos = get_global_position() + rect.position - ofs;
 		cache.text_editor_position = textedpos;
 		text_editor->set_position(textedpos);


### PR DESCRIPTION
Part of #64536 ported to 3.x with a simpler "-1".

There's no need account for the icon because that's how it works already _(in a way, before #64536 there was a minor regression from 3.x)_