### PR TITLE
Clean-up/change some Skeleton3D API

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -71,7 +71,7 @@
 				Force updates the bone transform for the bone at [param bone_idx] and all of its children.
 			</description>
 		</method>
-		<method name="get_bone_children">
+		<method name="get_bone_children" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="bone_idx" type="int" />
 			<description>
@@ -172,7 +172,7 @@
 				Returns the modification stack attached to this skeleton, if one exists.
 			</description>
 		</method>
-		<method name="get_parentless_bones">
+		<method name="get_parentless_bones" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<description>
 				Returns an array with all of the bones that are parentless. Another way to look at this is that it returns the indexes of all the bones that are not dependent or modified by other bones in the Skeleton.

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -315,9 +315,7 @@ void Skeleton3D::_notification(int p_what) {
 					rs->skeleton_bone_set_transform(skeleton, i, bonesptr[bone_index].pose_global * skin->get_bind_pose(i));
 				}
 			}
-#ifdef TOOLS_ENABLED
 			emit_signal(SceneStringNames::get_singleton()->pose_updated);
-#endif // TOOLS_ENABLED
 		} break;
 
 #ifndef _3D_DISABLED
@@ -603,18 +601,25 @@ void Skeleton3D::unparent_bone_and_rest(int p_bone) {
 int Skeleton3D::get_bone_parent(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, -1);
-
+	if (process_order_dirty) {
+		const_cast<Skeleton3D *>(this)->_update_process_order();
+	}
 	return bones[p_bone].parent;
 }
 
-Vector<int> Skeleton3D::get_bone_children(int p_bone) {
+Vector<int> Skeleton3D::get_bone_children(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Vector<int>());
+	if (process_order_dirty) {
+		const_cast<Skeleton3D *>(this)->_update_process_order();
+	}
 	return bones[p_bone].child_bones;
 }
 
-Vector<int> Skeleton3D::get_parentless_bones() {
-	_update_process_order();
+Vector<int> Skeleton3D::get_parentless_bones() const {
+	if (process_order_dirty) {
+		const_cast<Skeleton3D *>(this)->_update_process_order();
+	}
 	return parentless_bones;
 }
 

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -191,11 +191,8 @@ public:
 
 	void unparent_bone_and_rest(int p_bone);
 
-	Vector<int> get_bone_children(int p_bone);
-	void set_bone_children(int p_bone, Vector<int> p_children);
-	void add_bone_child(int p_bone, int p_child);
-	void remove_bone_child(int p_bone, int p_child);
-	Vector<int> get_parentless_bones();
+	Vector<int> get_bone_children(int p_bone) const;
+	Vector<int> get_parentless_bones() const;
 
 	int get_bone_count() const;
 


### PR DESCRIPTION
- Follow up #64802
  - Function declarations must be removed from the header as well
- `pose_updated` signal is now available to the public
  - It was done ADD_SIGNAL in public to begin with, but the signal firing only done in TOOLS_ENABLED. If made public, there are enough use cases that it would not make sense to keep this as TOOLS_ENABLED only
- Made `get_bone_children()` and `get_parentless_bones()` qualifiers to const
  - Same as other getters