### PR TITLE
Mark Script button if it's tool in Scene Tree Editor

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -386,9 +386,17 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 
 		Ref<Script> script = p_node->get_script();
 		if (!script.is_null()) {
-			item->add_button(0, get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + script->get_path());
+			String additional_notes;
+			// Can't set tooltip after adding button, need to do it before.
+			if (script->is_tool()) {
+				additional_notes += "\n" + TTR("This script is currently running in the editor.");
+			}
+			item->add_button(0, get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + script->get_path() + additional_notes);
 			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == script) {
 				item->set_button_color(0, item->get_button_count(0) - 1, Color(1, 1, 1, 0.5));
+			}
+			if (script->is_tool()) {
+				item->set_button_color(0, item->get_button_count(0) - 1, get_theme_color(SNAME("accent_color"), SNAME("Editor")));
 			}
 		}
 


### PR DESCRIPTION
I recall there was a proposal mentioning this, but I don't remember what it was.
This PR... uh... Images speak louder than words...

![image](https://user-images.githubusercontent.com/66727710/187468214-5959ccad-22d3-4b12-825d-7accba8a9ec6.png)

Also adds a note on the tooltip if the Script is tool.

The color is the same one used on the **Script Editor's script list**: a very saturated accent color.