### PR TITLE
Improve style and add contextual highlight to the editor launch pad

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -335,15 +335,17 @@ private:
 	PopupMenu *export_as_menu = nullptr;
 	Button *export_button = nullptr;
 	Button *prev_scene = nullptr;
+	Button *search_button = nullptr;
+	TextureProgressBar *audio_vu = nullptr;
+
+	PanelContainer *launch_pad = nullptr;
 	Button *play_button = nullptr;
 	Button *pause_button = nullptr;
 	Button *stop_button = nullptr;
-	Button *run_settings_button = nullptr;
 	Button *play_scene_button = nullptr;
 	Button *play_custom_scene_button = nullptr;
-	Button *search_button = nullptr;
+	PanelContainer *write_movie_panel = nullptr;
 	Button *write_movie_button = nullptr;
-	TextureProgressBar *audio_vu = nullptr;
 
 	Timer *screenshot_timer = nullptr;
 
@@ -580,6 +582,8 @@ private:
 	void _quick_opened();
 	void _quick_run();
 	void _open_command_palette();
+
+	void _write_movie_toggled(bool p_enabled);
 
 	void _run(bool p_current = false, const String &p_custom = "");
 	void _run_native(const Ref<EditorExportPreset> &p_preset);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -740,8 +740,26 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("ScriptEditorPanel", "EditorStyles", make_empty_stylebox(default_margin_size, 0, default_margin_size, default_margin_size));
 	theme->set_stylebox("ScriptEditor", "EditorStyles", make_empty_stylebox(0, 0, 0, 0));
 
-	// Play button group
-	theme->set_stylebox("PlayButtonPanel", "EditorStyles", style_empty);
+	// Launch Pad and Play buttons
+	Ref<StyleBoxFlat> style_launch_pad = make_flat_stylebox(dark_color_1, 2 * EDSCALE, 0, 2 * EDSCALE, 0, corner_width);
+	style_launch_pad->set_corner_radius_all(corner_radius * EDSCALE);
+	theme->set_stylebox("LaunchPadNormal", "EditorStyles", style_launch_pad);
+	Ref<StyleBoxFlat> style_launch_pad_movie = style_launch_pad->duplicate();
+	style_launch_pad_movie->set_bg_color(accent_color * Color(1, 1, 1, 0.1));
+	style_launch_pad_movie->set_border_color(accent_color);
+	style_launch_pad_movie->set_border_width_all(Math::round(2 * EDSCALE));
+	theme->set_stylebox("LaunchPadMovieMode", "EditorStyles", style_launch_pad_movie);
+
+	theme->set_stylebox("MovieWriterButtonNormal", "EditorStyles", make_empty_stylebox(0, 0, 0, 0));
+	Ref<StyleBoxFlat> style_write_movie_button = style_widget_pressed->duplicate();
+	style_write_movie_button->set_bg_color(accent_color);
+	style_write_movie_button->set_corner_radius_all(corner_radius * EDSCALE);
+	style_write_movie_button->set_default_margin(SIDE_TOP, 0);
+	style_write_movie_button->set_default_margin(SIDE_BOTTOM, 0);
+	style_write_movie_button->set_default_margin(SIDE_LEFT, 0);
+	style_write_movie_button->set_default_margin(SIDE_RIGHT, 0);
+	style_write_movie_button->set_expand_margin_size(SIDE_RIGHT, 2 * EDSCALE);
+	theme->set_stylebox("MovieWriterButtonPressed", "EditorStyles", style_write_movie_button);
 
 	theme->set_stylebox("normal", "MenuButton", style_menu);
 	theme->set_stylebox("hover", "MenuButton", style_widget_hover);


### PR DESCRIPTION
A companion to https://github.com/godotengine/godot/pull/65042, also inspired by https://twitter.com/LucyLavend/status/1564213890510163969 and my own pet peeve with the current way the movie writer button is displayed.

I want it to be clear that it affects other buttons, instead of being an independent button. Here's what I've ended up with:


https://user-images.githubusercontent.com/11782833/187474263-e12c63df-b47c-400a-8d14-247ea9b98fb2.mp4

