### PR TITLE
[3.x] Additional fixes to the Android `get_current_dir()` implementation.

### DIFF
--- a/core/os/dir_access.h
+++ b/core/os/dir_access.h
@@ -54,7 +54,7 @@ private:
 
 protected:
 	String _get_root_path() const;
-	String _get_root_string() const;
+	virtual String _get_root_string() const;
 
 	AccessType get_access_type() const;
 	String fix_path(String p_path) const;

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -134,6 +134,13 @@ String DirAccessJAndroid::get_drive(int p_drive) {
 	}
 }
 
+String DirAccessJAndroid::_get_root_string() const {
+	if (get_access_type() == ACCESS_FILESYSTEM) {
+		return "/";
+	}
+	return DirAccessUnix::_get_root_string();
+}
+
 String DirAccessJAndroid::get_current_dir() {
 	String base = _get_root_path();
 	String bd = current_dir;
@@ -141,10 +148,13 @@ String DirAccessJAndroid::get_current_dir() {
 		bd = current_dir.replace_first(base, "");
 	}
 
-	if (bd.begins_with("/")) {
-		return _get_root_string() + bd.substr(1, bd.length());
+	String root_string = _get_root_string();
+	if (bd.begins_with(root_string)) {
+		return bd;
+	} else if (bd.begins_with("/")) {
+		return root_string + bd.substr(1, bd.length());
 	} else {
-		return _get_root_string() + bd;
+		return root_string + bd;
 	}
 }
 

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -91,6 +91,9 @@ public:
 	DirAccessJAndroid();
 	~DirAccessJAndroid();
 
+protected:
+	String _get_root_string() const override;
+
 private:
 	int id = 0;
 


### PR DESCRIPTION
Follow up to the `get_current_dir` fix to address a couple of additional regressions caused by stripping the leading `/` for filesystem paths.

*Bugsquad edit:* `master` PR: #65095.