### PR TITLE
[Web] Require threads, rtti, allow optimize=speed.

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -6,7 +6,7 @@ env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
-  EM_VERSION: 3.1.10
+  EM_VERSION: 3.1.20
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -140,14 +140,8 @@ if env["builtin_harfbuzz"]:
             env_harfbuzz.Prepend(CPPPATH=["#thirdparty/graphite/include"])
             env_harfbuzz.Append(CCFLAGS=["-DGRAPHITE2_STATIC"])
 
-    if env["platform"] == "android" or env["platform"] == "linuxbsd":
+    if env["platform"] in ["android", "linuxbsd", "web"]:
         env_harfbuzz.Append(CCFLAGS=["-DHAVE_PTHREAD"])
-
-    if env["platform"] == "web":
-        if env["threads_enabled"]:
-            env_harfbuzz.Append(CCFLAGS=["-DHAVE_PTHREAD"])
-        else:
-            env_harfbuzz.Append(CCFLAGS=["-DHB_NO_MT"])
 
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
 

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -35,18 +35,17 @@ for ext in env["JS_EXTERNS"]:
     sys_env["ENV"]["EMCC_CLOSURE_ARGS"] += " --externs " + ext.abspath
 
 build = []
-if env["gdnative_enabled"]:
-    build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
-    if env["threads_enabled"]:
-        build_targets.append("#bin/godot${PROGSUFFIX}.worker.js")
+build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm", "#bin/godot${PROGSUFFIX}.worker.js"]
+if env["dlink_enabled"]:
     # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
     sys_env["LIBS"] = []
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
     sys_env.Append(LIBS=["idbfs.js"])
     # Configure it as a main module (dynamic linking support).
+    sys_env["CCFLAGS"].remove("SIDE_MODULE=2")
+    sys_env["LINKFLAGS"].remove("SIDE_MODULE=2")
     sys_env.Append(CCFLAGS=["-s", "MAIN_MODULE=1"])
     sys_env.Append(LINKFLAGS=["-s", "MAIN_MODULE=1"])
-    sys_env.Append(CCFLAGS=["-s", "EXPORT_ALL=1"])
     sys_env.Append(LINKFLAGS=["-s", "EXPORT_ALL=1"])
     sys_env.Append(LINKFLAGS=["-s", "WARN_ON_UNDEFINED_SYMBOLS=0"])
     # Force exporting the standard library (printf, malloc, etc.)
@@ -55,16 +54,9 @@ if env["gdnative_enabled"]:
     sys = sys_env.Program(build_targets, ["web_runtime.cpp"])
 
     # The side library, containing all Godot code.
-    wasm_env = env.Clone()
-    wasm_env.Append(CPPDEFINES=["WASM_GDNATIVE"])  # So that OS knows it can run GDNative libraries.
-    wasm_env.Append(CCFLAGS=["-s", "SIDE_MODULE=2"])
-    wasm_env.Append(LINKFLAGS=["-s", "SIDE_MODULE=2"])
-    wasm = wasm_env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
+    wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
     build = sys + [wasm[0]]
 else:
-    build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
-    if env["threads_enabled"]:
-        build_targets.append("#bin/godot${PROGSUFFIX}.worker.js")
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.
     sys_env.Append(LIBS=["idbfs.js"])
     build = sys_env.Program(build_targets, web_files + ["web_runtime.cpp"])
@@ -88,6 +80,8 @@ wrap_list = [
 ]
 js_wrapped = env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFILESUFFIX="${PROGSUFFIX}.wrapped.js")
 
-# Extra will be the thread worker, or the GDNative side, or None
-extra = build[2:] if len(build) > 2 else None
-env.CreateTemplateZip(js_wrapped, build[1], extra)
+# 0 - unwrapped js file (use wrapped one instead)
+# 1 - wasm file
+# 2 - worker file
+# 3 - wasm side (when dlink is enabled).
+env.CreateTemplateZip(js_wrapped, build[1], build[2], build[3] if len(build) > 3 else None)

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -37,26 +37,25 @@ def create_engine_file(env, target, source, externs):
     return env.Textfile(target, [env.File(s) for s in source])
 
 
-def create_template_zip(env, js, wasm, extra):
+def create_template_zip(env, js, wasm, worker, side):
     binary_name = "godot.tools" if env["tools"] else "godot"
     zip_dir = env.Dir("#bin/.web_zip")
     in_files = [
         js,
         wasm,
+        worker,
         "#platform/web/js/libs/audio.worklet.js",
     ]
     out_files = [
         zip_dir.File(binary_name + ".js"),
         zip_dir.File(binary_name + ".wasm"),
+        zip_dir.File(binary_name + ".worker.js"),
         zip_dir.File(binary_name + ".audio.worklet.js"),
     ]
-    # GDNative/Threads specific
-    if env["gdnative_enabled"]:
-        in_files.append(extra.pop())  # Runtime
+    # Dynamic linking (extensions) specific.
+    if env["dlink_enabled"]:
+        in_files.append(side)  # Side wasm (contains the actual Godot code).
         out_files.append(zip_dir.File(binary_name + ".side.wasm"))
-    if env["threads_enabled"]:
-        in_files.append(extra.pop())  # Worker
-        out_files.append(zip_dir.File(binary_name + ".worker.js"))
 
     service_worker = "#misc/dist/html/service-worker.js"
     if env["tools"]:

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -57,20 +57,10 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 	Mutex server_lock;
 	Thread server_thread;
 
-	enum ExportMode {
-		EXPORT_MODE_NORMAL = 0,
-		EXPORT_MODE_THREADS = 1,
-		EXPORT_MODE_GDNATIVE = 2,
-		EXPORT_MODE_THREADS_GDNATIVE = 3,
-	};
-
-	String _get_template_name(ExportMode p_mode, bool p_debug) const {
-		String name = "webassembly";
-		if (p_mode & EXPORT_MODE_GDNATIVE) {
-			name += "_gdnative";
-		}
-		if (p_mode & EXPORT_MODE_THREADS) {
-			name += "_threads";
+	String _get_template_name(bool p_extension, bool p_debug) const {
+		String name = "web";
+		if (p_extension) {
+			name += "_dlink";
 		}
 		if (p_debug) {
 			name += "_debug.zip";

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -140,26 +140,9 @@ int OS_Web::get_processor_count() const {
 }
 
 bool OS_Web::_check_internal_feature_support(const String &p_feature) {
-	if (p_feature == "html5" || p_feature == "web") {
-		return true;
-	}
-
-#ifdef JAVASCRIPT_EVAL_ENABLED
 	if (p_feature == "web") {
 		return true;
 	}
-#endif
-#ifndef NO_THREADS
-	if (p_feature == "threads") {
-		return true;
-	}
-#endif
-#if WASM_GDNATIVE
-	if (p_feature == "wasm32") {
-		return true;
-	}
-#endif
-
 	return false;
 }
 


### PR DESCRIPTION
Update export names (`web[_dlink]_[release|debug].zip`).

The Build with dynamic linking is broken due to high number of imports
in output wasm (likely emscripten issue https://github.com/emscripten-core/emscripten/issues/15487).

godotengine/godot-build-scripts#62 will need update.
Closes #65070