### PR TITLE
Additional fixes to the Android `get_current_dir()` implementation.

### DIFF
--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -55,7 +55,7 @@ private:
 
 protected:
 	String _get_root_path() const;
-	String _get_root_string() const;
+	virtual String _get_root_string() const;
 
 	AccessType get_access_type() const;
 	String fix_path(String p_path) const;

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -135,6 +135,13 @@ String DirAccessJAndroid::get_drive(int p_drive) {
 	}
 }
 
+String DirAccessJAndroid::_get_root_string() const {
+	if (get_access_type() == ACCESS_FILESYSTEM) {
+		return "/";
+	}
+	return DirAccessUnix::_get_root_string();
+}
+
 String DirAccessJAndroid::get_current_dir(bool p_include_drive) const {
 	String base = _get_root_path();
 	String bd = current_dir;
@@ -142,10 +149,13 @@ String DirAccessJAndroid::get_current_dir(bool p_include_drive) const {
 		bd = current_dir.replace_first(base, "");
 	}
 
-	if (bd.begins_with("/")) {
-		return _get_root_string() + bd.substr(1, bd.length());
+	String root_string = _get_root_string();
+	if (bd.begins_with(root_string)) {
+		return bd;
+	} else if (bd.begins_with("/")) {
+		return root_string + bd.substr(1, bd.length());
 	} else {
-		return _get_root_string() + bd;
+		return root_string + bd;
 	}
 }
 

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -91,6 +91,9 @@ public:
 	DirAccessJAndroid();
 	~DirAccessJAndroid();
 
+protected:
+	String _get_root_string() const override;
+
 private:
 	int id = 0;
 


### PR DESCRIPTION
Follow up to the `get_current_dir` fix to address a couple of additional regressions caused by stripping the leading `/` for filesystem paths.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
