### PR TITLE
Fix Range doesn't take into account the min value when setting the value.

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -81,7 +81,7 @@ void Range::Shared::emit_changed(const char *p_what) {
 
 void Range::set_value(double p_val) {
 	if (shared->step > 0) {
-		p_val = Math::round(p_val / shared->step) * shared->step;
+		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
 	}
 
 	if (_rounded_values) {


### PR DESCRIPTION
Co-Authored-By: @Astral-Sheep
The change is compatible with `3.x`

### Version of Godot
4.0 and older

### Information about the system
Windows, should be on other platforms too.

### Description of the problem
I was developing a feature for Godot (https://github.com/godotengine/godot/pull/64934) and found a bug which does not come from my feature since I reproduced it on master.

The bug is that when the min value of a slider is different than 0, the value is calculated without considering the min value.

My feature allows me to automatically set the ticks of a slider from the step, as such I tested unusual range values.
The bug is not very visible since a slider is often used between 0 and 100.

### Steps to follow to reproduce the problem
1. Create a slider
2. Set: min value to 50 ; max value to 1000 ; step to 475 ; ticks to 3
3. Move the grabber to the center, you will see that it is slightly off center.

The tick in the centre is placed at the value 525 since this is the distance between min and max divided by 2. 
When moved the grabber (range value) is at 475, as if it doesn't consider the min value.
If we start at 50 and add it 475, we should have 525. The range does not correctly take into account the min value.

With my feature, I was able to test many unusual ranges and they all have the same bug, which is fixed with my changes.

Without changes:
<img width="720" alt="bug" src="https://user-images.githubusercontent.com/76911907/187510424-03434fe2-5392-47cf-80a0-a77508713b43.png">

With changes:
<img width="720" alt="fix" src="https://user-images.githubusercontent.com/76911907/187510446-c157ae20-b639-476e-abb1-518a33e0b58e.png">