### PR TITLE
[3.x] Added material blit

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -1785,6 +1785,18 @@
 				Returns a mesh of a sphere with the given amount of horizontal and vertical subdivisions.
 			</description>
 		</method>
+		<method name="material_blit">
+			<return type="void" />
+			<argument index="0" name="material" type="RID" />
+			<argument index="1" name="source_texture" type="RID" />
+			<argument index="2" name="output_texture" type="RID" />
+			<argument index="3" name="source_rect" type="Rect2" default="Rect2( 0, 0, 0, 0 )" />
+			<argument index="4" name="output_rect" type="Rect2" default="Rect2( 0, 0, 0, 0 )" />
+			<description>
+				Performs a blit operation from a source texture to a output texture, using a material to render the output texture.
+				It's possible to provide a custom source rectangle to customize the area that the source texture is read and the output rectangle to customize the area that the output texture is written.
+			</description>
+		</method>
 		<method name="material_create">
 			<return type="RID" />
 			<description>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -285,6 +285,8 @@ public:
 
 	void material_set_next_pass(RID p_material, RID p_next_material) {}
 
+	void material_blit(RID p_material, RID p_source_tex, RID p_output_tex, const Rect2 &p_source_rect = Rect2(), const Rect2 &p_output_rect = Rect2()) {}
+
 	bool material_is_animated(RID p_material) { return false; }
 	bool material_casts_shadows(RID p_material) { return false; }
 

--- a/drivers/gles2/rasterizer_canvas_base_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_base_gles2.cpp
@@ -181,6 +181,161 @@ void RasterizerCanvasBaseGLES2::_set_texture_rect_mode(bool p_texture_rect, bool
 	}
 }
 
+void RasterizerCanvasBaseGLES2::material_blit(RasterizerStorageGLES2::Material *p_material, RasterizerStorageGLES2::Texture *p_source_tex, RasterizerStorageGLES2::Texture *p_output_tex, const Rect2i &p_source_rect, const Rect2i &p_output_rect) {
+	RasterizerStorageGLES2::Shader *shader = p_material->shader;
+
+	int src_width, src_height;
+	GLint src_filter;
+	if (p_source_tex) {
+		src_width = p_source_tex->alloc_width;
+		src_height = p_source_tex->alloc_height;
+		src_filter = (p_source_tex->flags & VS::TEXTURE_FLAG_FILTER) ? GL_LINEAR : GL_NEAREST;
+	} else {
+		src_width = p_output_tex->alloc_width;
+		src_height = p_output_tex->alloc_height;
+		src_filter = GL_NEAREST;
+	}
+
+	// Create output framebuffer
+	GLuint fbo_output;
+	glGenFramebuffers(1, &fbo_output);
+
+	// Configure output texture
+	glBindFramebuffer(GL_FRAMEBUFFER, fbo_output);
+	glBindTexture(GL_TEXTURE_2D, p_output_tex->tex_id);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, src_filter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, src_filter);
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_output_tex->tex_id, 0);
+
+	glDepthMask(GL_FALSE);
+	glEnable(GL_SCISSOR_TEST);
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_BLEND);
+	glDepthFunc(GL_LEQUAL);
+	glColorMask(1, 1, 1, 1);
+	glActiveTexture(GL_TEXTURE0 + storage->config.max_texture_image_units - 1);
+	if (p_source_tex) {
+		glBindTexture(GL_TEXTURE_2D, p_source_tex->tex_id);
+	} else {
+		glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
+	}
+
+	glViewport(p_output_rect.position.x, p_output_rect.position.y, p_output_rect.size.x, p_output_rect.size.y);
+	glScissor(p_output_rect.position.x, p_output_rect.position.y, p_output_rect.size.x, p_output_rect.size.y);
+
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_TEXTURE_RECT, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_LIGHTING, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_SHADOWS, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::SHADOW_FILTER_NEAREST, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::SHADOW_FILTER_PCF3, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::SHADOW_FILTER_PCF5, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::SHADOW_FILTER_PCF7, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::SHADOW_FILTER_PCF9, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::SHADOW_FILTER_PCF13, false);
+	// state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_DISTANCE_FIELD, false);
+	// state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_NINEPATCH, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_ATTRIB_LIGHT_ANGLE, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_ATTRIB_MODULATE, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_ATTRIB_LARGE_VERTEX, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_SKELETON, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::LINEAR_TO_SRGB, false);
+
+	state.canvas_shader.set_custom_shader(shader->custom_code_id);
+	state.canvas_shader.bind();
+	ERR_FAIL_COND(!ShaderGLES2::get_active());
+
+	int tc = p_material->textures.size();
+	Pair<StringName, RID> *textures = p_material->textures.ptrw();
+
+	ShaderLanguage::ShaderNode::Uniform::Hint *texture_hints = shader->texture_hints.ptrw();
+
+	for (int i = 0; i < tc; i++) {
+		glActiveTexture(GL_TEXTURE0 + i);
+
+		RasterizerStorageGLES2::Texture *t = storage->texture_owner.getornull(textures[i].second);
+
+		if (!t) {
+			switch (texture_hints[i]) {
+				case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO:
+				case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.black_tex);
+				} break;
+				case ShaderLanguage::ShaderNode::Uniform::HINT_TRANSPARENT: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.transparent_tex);
+				} break;
+				case ShaderLanguage::ShaderNode::Uniform::HINT_ANISO: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.aniso_tex);
+				} break;
+				case ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.normal_tex);
+				} break;
+				default: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
+				} break;
+			}
+
+			continue;
+		}
+
+		if (t->redraw_if_visible) {
+			VisualServerRaster::redraw_request(false);
+		}
+
+		t = t->get_ptr();
+
+#ifdef TOOLS_ENABLED
+		if (t->detect_normal && texture_hints[i] == ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL) {
+			t->detect_normal(t->detect_normal_ud);
+		}
+#endif
+		if (t->render_target) {
+			t->render_target->used_in_frame = true;
+		}
+
+		glBindTexture(t->target, t->tex_id);
+	}
+
+	Vector2 proj_off(p_source_rect.position);
+	Vector2 proj_scl(p_source_rect.size);
+	proj_off.x = proj_off.x / (float)src_width;
+	proj_off.y = proj_off.y / (float)src_height;
+	proj_scl.x = proj_scl.x / (float)src_width;
+	proj_scl.y = proj_scl.y / (float)src_height;
+	Vector2 proj_inv_scl(1.0 / proj_scl.x, 1.0 / proj_scl.y);
+
+	Transform proj_tr(
+			proj_inv_scl.x, 0.0, 0.0,
+			0.0, proj_inv_scl.y, 0.0,
+			0.0, 0.0, 1.0,
+			-proj_off.x * proj_inv_scl.x * 2.0 + proj_inv_scl.x - 1.0,
+			-proj_off.y * proj_inv_scl.y * 2.0 + proj_inv_scl.y - 1.0,
+			0.0);
+	Transform idt_tr;
+
+	state.canvas_shader.set_uniform(CanvasShaderGLES2::PROJECTION_MATRIX, proj_tr);
+	state.canvas_shader.set_uniform(CanvasShaderGLES2::MODELVIEW_MATRIX, idt_tr);
+	state.canvas_shader.set_uniform(CanvasShaderGLES2::EXTRA_MATRIX, idt_tr);
+	state.canvas_shader.set_uniform(CanvasShaderGLES2::FINAL_MODULATE, Color(1, 1, 1, 1));
+
+	state.canvas_shader.use_material(p_material);
+
+	// Clear the output texture
+	glClearColor(1.0, 0.0, 0.0, 1.0);
+	glClear(GL_COLOR_BUFFER_BIT);
+
+	// Draw the scene
+	storage->bind_quad_array();
+	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+	// Unbind and delete
+	glDisable(GL_SCISSOR_TEST);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glDeleteFramebuffers(1, &fbo_output);
+}
+
 RasterizerStorageGLES2::Texture *RasterizerCanvasBaseGLES2::_bind_canvas_texture(const RID &p_texture, const RID &p_normal_map) {
 	RasterizerStorageGLES2::Texture *tex_return = nullptr;
 

--- a/drivers/gles2/rasterizer_canvas_base_gles2.h
+++ b/drivers/gles2/rasterizer_canvas_base_gles2.h
@@ -139,6 +139,8 @@ public:
 	RasterizerStorageGLES2::Texture *_bind_canvas_texture(const RID &p_texture, const RID &p_normal_map);
 	void _set_texture_rect_mode(bool p_texture_rect, bool p_light_angle = false, bool p_modulate = false, bool p_large_vertex = false);
 
+	void material_blit(RasterizerStorageGLES2::Material *p_material, RasterizerStorageGLES2::Texture *p_source_tex, RasterizerStorageGLES2::Texture *p_output_tex, const Rect2i &p_source_rect, const Rect2i &p_output_rect);
+
 	void initialize();
 	void finalize();
 

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -920,6 +920,98 @@ VS::EnvironmentBG RasterizerSceneGLES2::environment_get_background(RID p_env) {
 	return env->bg_mode;
 }
 
+void RasterizerSceneGLES2::material_blit(RasterizerStorageGLES2::Material *p_material, RasterizerStorageGLES2::Texture *p_source_tex, RasterizerStorageGLES2::Texture *p_output_tex, const Rect2i &p_source_rect, const Rect2i &p_output_rect) {
+	int src_width, src_height;
+	if (p_source_tex) {
+		src_width = p_source_tex->alloc_width;
+		src_height = p_source_tex->alloc_height;
+	} else {
+		src_width = p_output_tex->alloc_width;
+		src_height = p_output_tex->alloc_height;
+	}
+
+	// Create output framebuffer
+	GLuint fbo_output;
+	glGenFramebuffers(1, &fbo_output);
+
+	// Configure output texture
+	glBindFramebuffer(GL_FRAMEBUFFER, fbo_output);
+	glBindTexture(GL_TEXTURE_2D, p_output_tex->tex_id);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_output_tex->tex_id, 0);
+
+	glDepthMask(GL_FALSE);
+	glEnable(GL_SCISSOR_TEST);
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_BLEND);
+	glDepthFunc(GL_LEQUAL);
+	glColorMask(1, 1, 1, 1);
+
+	glViewport(p_output_rect.position.x, p_output_rect.position.y, p_output_rect.size.x, p_output_rect.size.y);
+	glScissor(p_output_rect.position.x, p_output_rect.position.y, p_output_rect.size.x, p_output_rect.size.y);
+
+	state.scene_shader.set_conditional(SceneShaderGLES2::SHADELESS, true);
+	// state.scene_shader.set_conditional(SceneShaderGLES3::USE_FORWARD_LIGHTING, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::USE_VERTEX_LIGHTING, false);
+	// state.scene_shader.set_conditional(SceneShaderGLES2::USE_LIGHT_DIRECTIONAL, false);
+	// state.scene_shader.set_conditional(SceneShaderGLES2::LIGHT_DIRECTIONAL_SHADOW, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::LIGHT_USE_PSSM4, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::LIGHT_USE_PSSM2, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::LIGHT_USE_PSSM_BLEND, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::LIGHT_USE_PSSM_BLEND, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_5, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::SHADOW_MODE_PCF_13, false);
+	// state.scene_shader.set_conditional(SceneShaderGLES2::USE_GI_PROBES, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::USE_LIGHTMAP_CAPTURE, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::USE_LIGHTMAP, false);
+	// state.scene_shader.set_conditional(SceneShaderGLES2::USE_LIGHTMAP_LAYERED, false);
+	state.scene_shader.set_conditional(SceneShaderGLES2::USE_RADIANCE_MAP, false);
+	// state.scene_shader.set_conditional(SceneShaderGLES2::USE_CONTACT_SHADOWS, false);
+
+	Vector2 proj_off(p_source_rect.position);
+	Vector2 proj_scl(p_source_rect.size);
+	proj_off.x = proj_off.x / (float)src_width;
+	proj_off.y = proj_off.y / (float)src_height;
+	proj_scl.x = proj_scl.x / (float)src_width;
+	proj_scl.y = proj_scl.y / (float)src_height;
+	Vector2 proj_inv_scl(1.0 / proj_scl.x, 1.0 / proj_scl.y);
+
+	Transform proj_tr(
+			proj_inv_scl.x, 0.0, 0.0,
+			0.0, proj_inv_scl.y, 0.0,
+			0.0, 0.0, 1.0,
+			-proj_off.x * proj_inv_scl.x * 2.0 + proj_inv_scl.x - 1.0,
+			-proj_off.y * proj_inv_scl.y * 2.0 + proj_inv_scl.y - 1.0,
+			0.0);
+	Transform idt_tr;
+
+	_setup_material(p_material, 0, Size2i());
+	ERR_FAIL_COND(!ShaderGLES2::get_active());
+
+	state.scene_shader.set_uniform(SceneShaderGLES2::PROJECTION_MATRIX, proj_tr);
+	state.scene_shader.set_uniform(SceneShaderGLES2::PROJECTION_INVERSE_MATRIX, proj_tr.affine_inverse());
+	state.scene_shader.set_uniform(SceneShaderGLES2::CAMERA_MATRIX, idt_tr);
+	state.scene_shader.set_uniform(SceneShaderGLES2::CAMERA_INVERSE_MATRIX, idt_tr);
+	state.scene_shader.set_uniform(SceneShaderGLES2::WORLD_TRANSFORM, idt_tr);
+
+	// Clear the output texture
+	glClearColor(1.0, 0.0, 0.0, 1.0);
+	glClear(GL_COLOR_BUFFER_BIT);
+
+	// Draw the scene
+	storage->bind_quad_array();
+	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+	// Unbind and delete
+	glDisable(GL_SCISSOR_TEST);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glDeleteFramebuffers(1, &fbo_output);
+}
+
 int RasterizerSceneGLES2::environment_get_canvas_max_layer(RID p_env) {
 	const Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND_V(!env, -1);

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -502,6 +502,8 @@ public:
 	virtual VS::EnvironmentBG environment_get_background(RID p_env);
 	virtual int environment_get_canvas_max_layer(RID p_env);
 
+	void material_blit(RasterizerStorageGLES2::Material *p_material, RasterizerStorageGLES2::Texture *p_source_tex, RasterizerStorageGLES2::Texture *p_output_tex, const Rect2i &p_source_rect, const Rect2i &p_output_rect);
+
 	/* LIGHT INSTANCE */
 
 	struct LightInstance : public RID_Data {

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1837,6 +1837,73 @@ void RasterizerStorageGLES2::material_set_next_pass(RID p_material, RID p_next_m
 	material->next_pass = p_next_material;
 }
 
+void RasterizerStorageGLES2::material_blit(RID p_material, RID p_source_tex, RID p_output_tex, const Rect2 &p_source_rect, const Rect2 &p_output_rect) {
+	Material *material = material_owner.getornull(p_material);
+	ERR_FAIL_COND(!material);
+
+	Shader *shader_res = material->shader;
+	ERR_FAIL_COND(!shader_res);
+
+	Texture *source_tex = nullptr;
+	if (p_source_tex.is_valid()) {
+		source_tex = texture_owner.getornull(p_source_tex);
+		ERR_FAIL_COND(!source_tex);
+	}
+
+	Texture *output_tex = texture_owner.getornull(p_output_tex);
+	ERR_FAIL_COND(!output_tex);
+
+	if (material->dirty_list.in_list()) {
+		_update_material(material);
+	}
+
+	Size2i src_tex_size;
+
+	if (source_tex) {
+		src_tex_size.x = source_tex->alloc_width;
+		src_tex_size.y = source_tex->alloc_height;
+	} else {
+		src_tex_size.x = output_tex->alloc_width;
+		src_tex_size.y = output_tex->alloc_height;
+	}
+
+	Point2i src_pos(p_source_rect.position);
+	Size2i src_size(p_source_rect.size);
+	Point2i out_pos(p_output_rect.position);
+	Size2i out_size(p_output_rect.size);
+
+	if (src_size.x == 0)
+		src_size.x = src_tex_size.x;
+	if (src_size.y == 0)
+		src_size.y = src_tex_size.y;
+
+	if (out_size.x == 0)
+		out_size.x = output_tex->alloc_width;
+	if (out_size.y == 0)
+		out_size.y = output_tex->alloc_height;
+
+	ERR_FAIL_COND_MSG(src_pos.x < 0 || src_pos.x + src_size.x > src_tex_size.x, "Source rect is out of bounds");
+	ERR_FAIL_COND_MSG(src_pos.y < 0 || src_pos.y + src_size.y > src_tex_size.y, "Source rect is out of bounds");
+	ERR_FAIL_COND_MSG(out_pos.x < 0 || out_pos.x + out_size.x > output_tex->alloc_width, "Output rect is out of bounds");
+	ERR_FAIL_COND_MSG(out_pos.y < 0 || out_pos.y + out_size.y > output_tex->alloc_height, "Output rect is out of bounds");
+
+	Rect2i src_rect(src_pos, src_size);
+	Rect2i out_rect(out_pos, out_size);
+
+	switch (shader_res->mode) {
+		case VS::SHADER_CANVAS_ITEM: {
+			canvas->material_blit(material, source_tex, output_tex, src_rect, out_rect);
+		} break;
+		case VS::SHADER_SPATIAL: {
+			scene->material_blit(material, source_tex, output_tex, src_rect, out_rect);
+		} break;
+		case VS::SHADER_PARTICLES:
+			break;
+		case VS::SHADER_MAX:
+			break;
+	}
+}
+
 bool RasterizerStorageGLES2::material_is_animated(RID p_material) {
 	Material *material = material_owner.get(p_material);
 	ERR_FAIL_COND_V(!material, false);

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -607,6 +607,8 @@ public:
 	virtual void material_set_line_width(RID p_material, float p_width);
 	virtual void material_set_next_pass(RID p_material, RID p_next_material);
 
+	virtual void material_blit(RID p_material, RID p_source_tex, RID p_output_tex, const Rect2 &p_source_rect = Rect2(), const Rect2 &p_output_rect = Rect2());
+
 	virtual bool material_is_animated(RID p_material);
 	virtual bool material_casts_shadows(RID p_material);
 	virtual bool material_uses_tangents(RID p_material);

--- a/drivers/gles3/rasterizer_canvas_base_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_base_gles3.cpp
@@ -715,6 +715,168 @@ void RasterizerCanvasBaseGLES3::render_rect_nvidia_workaround(const Item::Comman
 	}
 }
 
+void RasterizerCanvasBaseGLES3::material_blit(RasterizerStorageGLES3::Material *p_material, RasterizerStorageGLES3::Texture *p_source_tex, RasterizerStorageGLES3::Texture *p_output_tex, const Rect2i &p_source_rect, const Rect2i &p_output_rect) {
+	RasterizerStorageGLES3::Shader *shader = p_material->shader;
+
+	int src_width, src_height;
+	GLint src_filter;
+	if (p_source_tex) {
+		src_width = p_source_tex->alloc_width;
+		src_height = p_source_tex->alloc_height;
+		src_filter = (p_source_tex->flags & VS::TEXTURE_FLAG_FILTER) ? GL_LINEAR : GL_NEAREST;
+	} else {
+		src_width = p_output_tex->alloc_width;
+		src_height = p_output_tex->alloc_height;
+		src_filter = GL_NEAREST;
+	}
+
+	// Create output framebuffer
+	GLuint fbo_output;
+	glGenFramebuffers(1, &fbo_output);
+
+	// Configure output texture
+	glBindFramebuffer(GL_FRAMEBUFFER, fbo_output);
+	glBindTexture(GL_TEXTURE_2D, p_output_tex->tex_id);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, src_filter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, src_filter);
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_output_tex->tex_id, 0);
+
+	glDepthMask(GL_FALSE);
+	glEnable(GL_SCISSOR_TEST);
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_BLEND);
+	glDepthFunc(GL_LEQUAL);
+	glColorMask(1, 1, 1, 1);
+	glActiveTexture(GL_TEXTURE0);
+	if (p_source_tex) {
+		glBindTexture(GL_TEXTURE_2D, p_source_tex->tex_id);
+	} else {
+		glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
+	}
+
+	glViewport(p_output_rect.position.x, p_output_rect.position.y, p_output_rect.size.x, p_output_rect.size.y);
+	glScissor(p_output_rect.position.x, p_output_rect.position.y, p_output_rect.size.x, p_output_rect.size.y);
+
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_TEXTURE_RECT, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_LIGHTING, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_SHADOWS, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::SHADOW_FILTER_NEAREST, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::SHADOW_FILTER_PCF3, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::SHADOW_FILTER_PCF5, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::SHADOW_FILTER_PCF7, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::SHADOW_FILTER_PCF9, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::SHADOW_FILTER_PCF13, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_DISTANCE_FIELD, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_NINEPATCH, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_ATTRIB_LIGHT_ANGLE, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_ATTRIB_MODULATE, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_ATTRIB_LARGE_VERTEX, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::USE_SKELETON, false);
+	state.canvas_shader.set_conditional(CanvasShaderGLES3::LINEAR_TO_SRGB, false);
+
+	Vector2 proj_off(p_source_rect.position);
+	Vector2 proj_scl(p_source_rect.size);
+	proj_off.x = proj_off.x / (float)src_width;
+	proj_off.y = proj_off.y / (float)src_height;
+	proj_scl.x = proj_scl.x / (float)src_width;
+	proj_scl.y = proj_scl.y / (float)src_height;
+	Vector2 proj_inv_scl(1.0 / proj_scl.x, 1.0 / proj_scl.y);
+
+	Transform proj_tr(
+			proj_inv_scl.x, 0.0, 0.0,
+			0.0, proj_inv_scl.y, 0.0,
+			0.0, 0.0, 1.0,
+			-proj_off.x * proj_inv_scl.x * 2.0 + proj_inv_scl.x - 1.0,
+			-proj_off.y * proj_inv_scl.y * 2.0 + proj_inv_scl.y - 1.0,
+			0.0);
+	Transform idt_tr;
+
+	store_transform(proj_tr, state.canvas_item_ubo_data.projection_matrix);
+
+	glBindBuffer(GL_UNIFORM_BUFFER, state.canvas_item_ubo);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(CanvasItemUBO), &state.canvas_item_ubo_data, GL_DYNAMIC_DRAW);
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+	glBindBufferBase(GL_UNIFORM_BUFFER, 0, state.canvas_item_ubo);
+
+	if (p_material->ubo_id) {
+		glBindBufferBase(GL_UNIFORM_BUFFER, 2, p_material->ubo_id);
+	}
+
+	state.canvas_shader.set_custom_shader(shader->custom_code_id);
+	state.canvas_shader.bind();
+	ERR_FAIL_COND(!ShaderGLES3::get_active());
+
+	int tc = p_material->textures.size();
+	RID *textures = p_material->textures.ptrw();
+	ShaderLanguage::ShaderNode::Uniform::Hint *texture_hints = shader->texture_hints.ptrw();
+
+	for (int i = 0; i < tc; i++) {
+		glActiveTexture(GL_TEXTURE2 + i);
+
+		RasterizerStorageGLES3::Texture *t = storage->texture_owner.getornull(textures[i]);
+		if (!t) {
+			switch (texture_hints[i]) {
+				case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO:
+				case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.black_tex);
+				} break;
+				case ShaderLanguage::ShaderNode::Uniform::HINT_TRANSPARENT: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.transparent_tex);
+				} break;
+				case ShaderLanguage::ShaderNode::Uniform::HINT_ANISO: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.aniso_tex);
+				} break;
+				case ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.normal_tex);
+				} break;
+				default: {
+					glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
+				} break;
+			}
+
+			//check hints
+
+			continue;
+		}
+
+		if (t->redraw_if_visible) { //check before proxy, because this is usually used with proxies
+			VisualServerRaster::redraw_request(false);
+		}
+
+		t = t->get_ptr();
+
+		if (storage->config.srgb_decode_supported && t->using_srgb) {
+			//no srgb in 2D
+			glTexParameteri(t->target, _TEXTURE_SRGB_DECODE_EXT, _SKIP_DECODE_EXT);
+			t->using_srgb = false;
+		}
+
+		glBindTexture(t->target, t->tex_id);
+	}
+
+	state.canvas_shader.set_uniform(CanvasShaderGLES3::FINAL_MODULATE, Color(1, 1, 1, 1));
+	state.canvas_shader.set_uniform(CanvasShaderGLES3::MODELVIEW_MATRIX, idt_tr);
+	state.canvas_shader.set_uniform(CanvasShaderGLES3::EXTRA_MATRIX, idt_tr);
+
+	// Clear the output texture
+	glClearColor(1.0, 0.0, 0.0, 1.0);
+	glClear(GL_COLOR_BUFFER_BIT);
+
+	// Draw the scene
+	glBindVertexArray(storage->resources.quadie_array);
+	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+	glBindVertexArray(0);
+
+	// Unbind and delete
+	glDisable(GL_SCISSOR_TEST);
+	glBindBufferBase(GL_UNIFORM_BUFFER, 0, 0);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glDeleteFramebuffers(1, &fbo_output);
+}
+
 void RasterizerCanvasBaseGLES3::_copy_texscreen(const Rect2 &p_rect) {
 	ERR_FAIL_COND_MSG(storage->frame.current_rt->effects.mip_maps[0].sizes.size() == 0, "Can't use screen texture copying in a render target configured without copy buffers. To resolve this, change the viewport's Usage property to \"2D\" or \"3D\" instead of \"2D Without Sampling\" or \"3D Without Effects\" respectively.");
 

--- a/drivers/gles3/rasterizer_canvas_base_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_base_gles3.h
@@ -151,6 +151,8 @@ public:
 	void draw_lens_distortion_rect(const Rect2 &p_rect, float p_k1, float p_k2, const Vector2 &p_eye_center, float p_oversample);
 	void render_rect_nvidia_workaround(const Item::CommandRect *p_rect, const RasterizerStorageGLES3::Texture *p_texture);
 
+	void material_blit(RasterizerStorageGLES3::Material *p_material, RasterizerStorageGLES3::Texture *p_source_tex, RasterizerStorageGLES3::Texture *p_output_tex, const Rect2i &p_source_rect, const Rect2i &p_output_rect);
+
 	void initialize();
 	void finalize();
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3120,6 +3120,105 @@ void RasterizerSceneGLES3::_copy_texture_to_front_buffer(GLuint p_texture) {
 	storage->shaders.copy.set_conditional(CopyShaderGLES3::DISABLE_ALPHA, false);
 }
 
+void RasterizerSceneGLES3::material_blit(RasterizerStorageGLES3::Material *p_material, RasterizerStorageGLES3::Texture *p_source_tex, RasterizerStorageGLES3::Texture *p_output_tex, const Rect2i &p_source_rect, const Rect2i &p_output_rect) {
+	int src_width, src_height;
+	if (p_source_tex) {
+		src_width = p_source_tex->alloc_width;
+		src_height = p_source_tex->alloc_height;
+	} else {
+		src_width = p_output_tex->alloc_width;
+		src_height = p_output_tex->alloc_height;
+	}
+
+	// Create output framebuffer
+	GLuint fbo_output;
+	glGenFramebuffers(1, &fbo_output);
+
+	// Configure output texture
+	glBindFramebuffer(GL_FRAMEBUFFER, fbo_output);
+	glBindTexture(GL_TEXTURE_2D, p_output_tex->tex_id);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_output_tex->tex_id, 0);
+
+	glDepthMask(GL_FALSE);
+	glEnable(GL_SCISSOR_TEST);
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_BLEND);
+	glDepthFunc(GL_LEQUAL);
+	glColorMask(1, 1, 1, 1);
+
+	glViewport(p_output_rect.position.x, p_output_rect.position.y, p_output_rect.size.x, p_output_rect.size.y);
+	glScissor(p_output_rect.position.x, p_output_rect.position.y, p_output_rect.size.x, p_output_rect.size.y);
+
+	state.scene_shader.set_conditional(SceneShaderGLES3::SHADELESS, true);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_FORWARD_LIGHTING, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_VERTEX_LIGHTING, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHT_DIRECTIONAL, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::LIGHT_DIRECTIONAL_SHADOW, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::LIGHT_USE_PSSM4, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::LIGHT_USE_PSSM2, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::LIGHT_USE_PSSM_BLEND, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::LIGHT_USE_PSSM_BLEND, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_MODE_PCF_5, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::SHADOW_MODE_PCF_13, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_GI_PROBES, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP_CAPTURE, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_LIGHTMAP_LAYERED, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_RADIANCE_MAP, false);
+	state.scene_shader.set_conditional(SceneShaderGLES3::USE_CONTACT_SHADOWS, false);
+
+	Vector2 proj_off(p_source_rect.position);
+	Vector2 proj_scl(p_source_rect.size);
+	proj_off.x = proj_off.x / (float)src_width;
+	proj_off.y = proj_off.y / (float)src_height;
+	proj_scl.x = proj_scl.x / (float)src_width;
+	proj_scl.y = proj_scl.y / (float)src_height;
+	Vector2 proj_inv_scl(1.0 / proj_scl.x, 1.0 / proj_scl.y);
+
+	Transform proj_tr(
+			proj_inv_scl.x, 0.0, 0.0,
+			0.0, proj_inv_scl.y, 0.0,
+			0.0, 0.0, 1.0,
+			-proj_off.x * proj_inv_scl.x * 2.0 + proj_inv_scl.x - 1.0,
+			-proj_off.y * proj_inv_scl.y * 2.0 + proj_inv_scl.y - 1.0,
+			0.0);
+	Transform idt_tr;
+
+	store_transform(proj_tr, state.ubo_data.projection_matrix);
+	store_transform(proj_tr.affine_inverse(), state.ubo_data.inv_projection_matrix);
+	store_transform(idt_tr, state.ubo_data.camera_matrix);
+	store_transform(idt_tr, state.ubo_data.camera_inverse_matrix);
+
+	glBindBuffer(GL_UNIFORM_BUFFER, state.scene_ubo);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(State::SceneDataUBO), &state.ubo_data, GL_DYNAMIC_DRAW);
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+	glBindBufferBase(GL_UNIFORM_BUFFER, 0, state.scene_ubo);
+	_setup_material(p_material, 0, 0);
+	ERR_FAIL_COND(!ShaderGLES3::get_active());
+
+	state.scene_shader.set_uniform(SceneShaderGLES3::WORLD_TRANSFORM, idt_tr);
+
+	// Clear the output texture
+	glClearColor(1.0, 0.0, 0.0, 1.0);
+	glClear(GL_COLOR_BUFFER_BIT);
+
+	// Draw the scene
+	glDisable(GL_SCISSOR_TEST);
+	glBindVertexArray(storage->resources.quadie_array);
+	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+	glBindVertexArray(0);
+
+	// Unbind and delete
+	glBindBufferBase(GL_UNIFORM_BUFFER, 0, 0);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glDeleteFramebuffers(1, &fbo_output);
+}
+
 void RasterizerSceneGLES3::_fill_render_list(InstanceBase **p_cull_result, int p_cull_count, bool p_depth_pass, bool p_shadow_pass) {
 	current_geometry_index = 0;
 	current_material_index = 0;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -568,6 +568,8 @@ public:
 	virtual VS::EnvironmentBG environment_get_background(RID p_env);
 	virtual int environment_get_canvas_max_layer(RID p_env);
 
+	void material_blit(RasterizerStorageGLES3::Material *p_material, RasterizerStorageGLES3::Texture *p_source_tex, RasterizerStorageGLES3::Texture *p_output_tex, const Rect2i &p_source_rect, const Rect2i &p_output_rect);
+
 	/* LIGHT INSTANCE */
 
 	struct LightDataUBO {

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2620,6 +2620,73 @@ void RasterizerStorageGLES3::material_set_next_pass(RID p_material, RID p_next_m
 	material->next_pass = p_next_material;
 }
 
+void RasterizerStorageGLES3::material_blit(RID p_material, RID p_source_tex, RID p_output_tex, const Rect2 &p_source_rect, const Rect2 &p_output_rect) {
+	Material *material = material_owner.getornull(p_material);
+	ERR_FAIL_COND(!material);
+
+	Shader *shader_res = material->shader;
+	ERR_FAIL_COND(!shader_res);
+
+	Texture *source_tex = nullptr;
+	if (p_source_tex.is_valid()) {
+		source_tex = texture_owner.getornull(p_source_tex);
+		ERR_FAIL_COND(!source_tex);
+	}
+
+	Texture *output_tex = texture_owner.getornull(p_output_tex);
+	ERR_FAIL_COND(!output_tex);
+
+	if (material->dirty_list.in_list()) {
+		_update_material(material);
+	}
+
+	Size2i src_tex_size;
+
+	if (source_tex) {
+		src_tex_size.x = source_tex->alloc_width;
+		src_tex_size.y = source_tex->alloc_height;
+	} else {
+		src_tex_size.x = output_tex->alloc_width;
+		src_tex_size.y = output_tex->alloc_height;
+	}
+
+	Point2i src_pos(p_source_rect.position);
+	Size2i src_size(p_source_rect.size);
+	Point2i out_pos(p_output_rect.position);
+	Size2i out_size(p_output_rect.size);
+
+	if (src_size.x == 0)
+		src_size.x = src_tex_size.x;
+	if (src_size.y == 0)
+		src_size.y = src_tex_size.y;
+
+	if (out_size.x == 0)
+		out_size.x = output_tex->alloc_width;
+	if (out_size.y == 0)
+		out_size.y = output_tex->alloc_height;
+
+	ERR_FAIL_COND_MSG(src_pos.x < 0 || src_pos.x + src_size.x > src_tex_size.x, "Source rect is out of bounds");
+	ERR_FAIL_COND_MSG(src_pos.y < 0 || src_pos.y + src_size.y > src_tex_size.y, "Source rect is out of bounds");
+	ERR_FAIL_COND_MSG(out_pos.x < 0 || out_pos.x + out_size.x > output_tex->alloc_width, "Output rect is out of bounds");
+	ERR_FAIL_COND_MSG(out_pos.y < 0 || out_pos.y + out_size.y > output_tex->alloc_height, "Output rect is out of bounds");
+
+	Rect2i src_rect(src_pos, src_size);
+	Rect2i out_rect(out_pos, out_size);
+
+	switch (shader_res->mode) {
+		case VS::SHADER_CANVAS_ITEM: {
+			canvas->material_blit(material, source_tex, output_tex, src_rect, out_rect);
+		} break;
+		case VS::SHADER_SPATIAL: {
+			scene->material_blit(material, source_tex, output_tex, src_rect, out_rect);
+		} break;
+		case VS::SHADER_PARTICLES:
+			break;
+		case VS::SHADER_MAX:
+			break;
+	}
+}
+
 bool RasterizerStorageGLES3::material_is_animated(RID p_material) {
 	Material *material = material_owner.get(p_material);
 	ERR_FAIL_COND_V(!material, false);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -624,6 +624,8 @@ public:
 	virtual void material_set_line_width(RID p_material, float p_width);
 	virtual void material_set_next_pass(RID p_material, RID p_next_material);
 
+	virtual void material_blit(RID p_material, RID p_source_tex, RID p_output_tex, const Rect2 &p_source_rect = Rect2(), const Rect2 &p_output_rect = Rect2());
+
 	virtual bool material_is_animated(RID p_material);
 	virtual bool material_casts_shadows(RID p_material);
 	virtual bool material_uses_tangents(RID p_material);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -293,6 +293,8 @@ public:
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) = 0;
 
+	virtual void material_blit(RID p_material, RID p_source_tex, RID p_output_tex, const Rect2 &p_source_rect = Rect2(), const Rect2 &p_output_rect = Rect2()) = 0;
+
 	virtual bool material_is_animated(RID p_material) = 0;
 	virtual bool material_casts_shadows(RID p_material) = 0;
 	virtual bool material_uses_tangents(RID p_material);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -205,6 +205,7 @@ public:
 	BIND2(shader_add_custom_define, RID, const String &)
 	BIND2C(shader_get_custom_defines, RID, Vector<String> *)
 	BIND2(shader_remove_custom_define, RID, const String &)
+	BIND5(material_blit, RID, RID, RID, const Rect2 &, const Rect2 &)
 
 	BIND1(set_shader_async_hidden_forbidden, bool)
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -146,6 +146,8 @@ public:
 	FUNC2(material_set_line_width, RID, float)
 	FUNC2(material_set_next_pass, RID, RID)
 
+	FUNC5(material_blit, RID, RID, RID, const Rect2 &, const Rect2 &)
+
 	/* MESH API */
 
 	FUNCRID(mesh)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1887,6 +1887,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("material_set_render_priority", "material", "priority"), &VisualServer::material_set_render_priority);
 	ClassDB::bind_method(D_METHOD("material_set_line_width", "material", "width"), &VisualServer::material_set_line_width);
 	ClassDB::bind_method(D_METHOD("material_set_next_pass", "material", "next_material"), &VisualServer::material_set_next_pass);
+	ClassDB::bind_method(D_METHOD("material_blit", "material", "source_texture", "output_texture", "source_rect", "output_rect"), &VisualServer::material_blit, DEFVAL(Rect2()), DEFVAL(Rect2()));
 
 	ClassDB::bind_method(D_METHOD("mesh_create"), &VisualServer::mesh_create);
 	ClassDB::bind_method(D_METHOD("mesh_surface_get_format_offset", "format", "vertex_len", "index_len", "array_index"), &VisualServer::mesh_surface_get_format_offset);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -230,6 +230,8 @@ public:
 	virtual void material_set_line_width(RID p_material, float p_width) = 0;
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) = 0;
 
+	virtual void material_blit(RID p_material, RID p_source_tex, RID p_output_tex, const Rect2 &p_source_rect = Rect2(), const Rect2 &p_output_rect = Rect2()) = 0;
+
 	/* MESH API */
 
 	enum ArrayType {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
This is a WIP pull request, the goal of this feature is to make it easier to use shaders to perform instant compute operations in the GPU, without the need to support compute shaders, that can be used on lower-end devices ("instant" means that the shader runs in sync with the caller thread, so it can freeze the thread for some time if the shader performs expensive calculations). The idea is to blit a source texture into a output texture, using any user-defined shader, being Spatial or Canvas Item shader. 

The feature is available as a single VisualServer method call:
`VisualServer.material_blit(RID material, RID source_texture, RID output_texture)`
The `source_texture` can be read in a CanvasItem shader as `TEXTURE` input.

I had some issues to write the code, as I don't understand much of rendering back-end, so the code is a bit messy and I may need some help to complete this feature if relevant. I'm targetting 3.x as it is OpenGL only for now, and I don't have Vulkan support in my machine to write a 4.x version.

Here is a demo run of a simple paint program using this feature:

https://user-images.githubusercontent.com/43936806/187516955-bf0b40be-02f4-4401-a71d-96cd3ef424f1.mp4

<sub>Don't mind my drawing skills 😅 </sub>

Here is the paint demo project:
[Paint.zip](https://github.com/godotengine/godot/files/9455689/Paint.zip)

*Bugsquad edit: This partially addresses https://github.com/godotengine/godot-proposals/issues/1010.*