### PR TITLE
Rename Object.get_indexed() to Object.get_by_path()

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -388,7 +388,7 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 	}
 }
 
-void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid) {
+void Object::set_by_path(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid) {
 	if (p_names.is_empty()) {
 		if (r_valid) {
 			*r_valid = false;
@@ -447,7 +447,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	ERR_FAIL_COND(!value_stack.is_empty());
 }
 
-Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) const {
+Variant Object::get_by_path(const Vector<StringName> &p_names, bool *r_valid) const {
 	if (p_names.is_empty()) {
 		if (r_valid) {
 			*r_valid = false;
@@ -1355,12 +1355,12 @@ Variant Object::_get_bind(const StringName &p_name) const {
 	return get(p_name);
 }
 
-void Object::_set_indexed_bind(const NodePath &p_name, const Variant &p_value) {
-	set_indexed(p_name.get_as_property_path().get_subnames(), p_value);
+void Object::_set_by_path_bind(const NodePath &p_name, const Variant &p_value) {
+	set_by_path(p_name.get_as_property_path().get_subnames(), p_value);
 }
 
-Variant Object::_get_indexed_bind(const NodePath &p_name) const {
-	return get_indexed(p_name.get_as_property_path().get_subnames());
+Variant Object::_get_by_path_bind(const NodePath &p_name) const {
+	return get_by_path(p_name.get_as_property_path().get_subnames());
 }
 
 void Object::initialize_class() {
@@ -1468,8 +1468,8 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_class", "class"), &Object::is_class);
 	ClassDB::bind_method(D_METHOD("set", "property", "value"), &Object::_set_bind);
 	ClassDB::bind_method(D_METHOD("get", "property"), &Object::_get_bind);
-	ClassDB::bind_method(D_METHOD("set_indexed", "property", "value"), &Object::_set_indexed_bind);
-	ClassDB::bind_method(D_METHOD("get_indexed", "property"), &Object::_get_indexed_bind);
+	ClassDB::bind_method(D_METHOD("set_by_path", "property", "value"), &Object::_set_by_path_bind);
+	ClassDB::bind_method(D_METHOD("get_by_path", "property"), &Object::_get_by_path_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);
 	ClassDB::bind_method(D_METHOD("get_method_list"), &Object::_get_method_list_bind);
 	ClassDB::bind_method(D_METHOD("notification", "what", "reversed"), &Object::notification, DEFVAL(false));

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -607,8 +607,8 @@ private:
 	TypedArray<Dictionary> _get_incoming_connections() const;
 	void _set_bind(const StringName &p_set, const Variant &p_value);
 	Variant _get_bind(const StringName &p_name) const;
-	void _set_indexed_bind(const NodePath &p_name, const Variant &p_value);
-	Variant _get_indexed_bind(const NodePath &p_name) const;
+	void _set_by_path_bind(const NodePath &p_name, const Variant &p_value);
+	Variant _get_by_path_bind(const NodePath &p_name) const;
 
 	_FORCE_INLINE_ void _construct_object(bool p_reference);
 
@@ -805,8 +805,8 @@ public:
 
 	void set(const StringName &p_name, const Variant &p_value, bool *r_valid = nullptr);
 	Variant get(const StringName &p_name, bool *r_valid = nullptr) const;
-	void set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid = nullptr);
-	Variant get_indexed(const Vector<StringName> &p_names, bool *r_valid = nullptr) const;
+	void set_by_path(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid = nullptr);
+	Variant get_by_path(const Vector<StringName> &p_names, bool *r_valid = nullptr) const;
 
 	void get_property_list(List<PropertyInfo> *p_list, bool p_reversed = false) const;
 	void validate_property(PropertyInfo &p_property) const;

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -345,6 +345,12 @@
 				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
 			</description>
 		</method>
+		<method name="get_by_path" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="property" type="NodePath" />
+			<description>
+			</description>
+		</method>
 		<method name="get_class" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -360,14 +366,6 @@
 				- [code]source[/code] is a reference to the signal emitter.
 				- [code]signal_name[/code] is the name of the connected signal.
 				- [code]method_name[/code] is the name of the method to which the signal is connected.
-			</description>
-		</method>
-		<method name="get_indexed" qualifiers="const">
-			<return type="Variant" />
-			<param index="0" name="property" type="NodePath" />
-			<description>
-				Gets the object's property indexed by the given [NodePath]. The node path should be relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Examples: [code]"position:x"[/code] or [code]"material:next_pass:blend_mode"[/code].
-				[b]Note:[/b] Even though the method takes [NodePath] argument, it doesn't support actual paths to [Node]s in the scene tree, only colon-separated sub-property paths. For the purpose of nodes, use [method Node.get_node_and_resource] instead.
 			</description>
 		</method>
 		<method name="get_instance_id" qualifiers="const">
@@ -521,6 +519,13 @@
 				If set to [code]true[/code], signal emission is blocked.
 			</description>
 		</method>
+		<method name="set_by_path">
+			<return type="void" />
+			<param index="0" name="property" type="NodePath" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+			</description>
+		</method>
 		<method name="set_deferred">
 			<return type="void" />
 			<param index="0" name="property" type="StringName" />
@@ -528,28 +533,6 @@
 			<description>
 				Assigns a new value to the given property, after the current frame's physics step. This is equivalent to calling [method set] via [method call_deferred], i.e. [code]call_deferred("set", property, value)[/code].
 				[b]Note:[/b] In C#, the property name must be specified as snake_case if it is defined by a built-in Godot node. This doesn't apply to user-defined properties where you should use the same convention as in the C# source (typically PascalCase).
-			</description>
-		</method>
-		<method name="set_indexed">
-			<return type="void" />
-			<param index="0" name="property" type="NodePath" />
-			<param index="1" name="value" type="Variant" />
-			<description>
-				Assigns a new value to the property identified by the [NodePath]. The node path should be relative to the current object and can use the colon character ([code]:[/code]) to access nested properties. Example:
-				[codeblocks]
-				[gdscript]
-				var node = Node2D.new()
-				node.set_indexed("position", Vector2(42, 0))
-				node.set_indexed("position:y", -10)
-				print(node.position) # (42, -10)
-				[/gdscript]
-				[csharp]
-				var node = new Node2D();
-				node.SetIndexed("position", new Vector2(42, 0));
-				node.SetIndexed("position:y", -10);
-				GD.Print(node.Position); // (42, -10)
-				[/csharp]
-				[/codeblocks]
 			</description>
 		</method>
 		<method name="set_message_translation">

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4220,12 +4220,12 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 	if (res.is_valid()) {
 		property_info_base = res;
 		if (r_current_val) {
-			*r_current_val = res->get_indexed(leftover_path);
+			*r_current_val = res->get_by_path(leftover_path);
 		}
 	} else if (node) {
 		property_info_base = node;
 		if (r_current_val) {
-			*r_current_val = node->get_indexed(leftover_path);
+			*r_current_val = node->get_by_path(leftover_path);
 		}
 	}
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -59,7 +59,7 @@ void AnimatedValuesBackup::restore() const {
 	for (int i = 0; i < entries.size(); i++) {
 		const AnimatedValuesBackup::Entry *entry = &entries[i];
 		if (entry->bone_idx == -1) {
-			entry->object->set_indexed(entry->subpath, entry->value);
+			entry->object->set_by_path(entry->subpath, entry->value);
 		} else {
 			Array arr = entry->value;
 			if (arr.size() == 3) {
@@ -624,7 +624,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 
 				if (update_mode == Animation::UPDATE_CAPTURE) {
 					if (p_started || pa->capture == Variant()) {
-						pa->capture = pa->object->get_indexed(pa->subpath);
+						pa->capture = pa->object->get_by_path(pa->subpath);
 					}
 
 					int key_count = a->track_get_key_count(i);
@@ -692,7 +692,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 						switch (pa->special) {
 							case SP_NONE: {
 								bool valid;
-								pa->object->set_indexed(pa->subpath, value, &valid); //you are not speshul
+								pa->object->set_by_path(pa->subpath, value, &valid); //you are not speshul
 #ifdef DEBUG_ENABLED
 								if (!valid) {
 									ERR_PRINT("Failed setting track value '" + String(pa->owner->path) + "'. Check if the property exists or the type of key is valid. Animation '" + a->get_name() + "' at node '" + get_path() + "'.");
@@ -1112,7 +1112,7 @@ void AnimationPlayer::_animation_update_transforms() {
 		switch (pa->special) {
 			case SP_NONE: {
 				bool valid;
-				pa->object->set_indexed(pa->subpath, pa->value_accum, &valid); //you are not speshul
+				pa->object->set_by_path(pa->subpath, pa->value_accum, &valid); //you are not speshul
 #ifdef DEBUG_ENABLED
 
 				if (!valid) {
@@ -1171,7 +1171,7 @@ void AnimationPlayer::_animation_update_transforms() {
 		TrackNodeCache::BezierAnim *ba = cache_update_bezier[i];
 
 		ERR_CONTINUE(ba->accum_pass != accum_pass);
-		ba->object->set_indexed(ba->bezier_property, ba->bezier_accum);
+		ba->object->set_by_path(ba->bezier_property, ba->bezier_accum);
 	}
 
 	cache_update_bezier_size = 0;
@@ -2006,7 +2006,7 @@ Ref<AnimatedValuesBackup> AnimationPlayer::backup_animated_values(Node *p_root_o
 					entry.object = E.value.object;
 					entry.subpath = E.value.subpath;
 					bool valid;
-					entry.value = E.value.object->get_indexed(E.value.subpath, &valid);
+					entry.value = E.value.object->get_by_path(E.value.subpath, &valid);
 					entry.bone_idx = -1;
 					if (valid) {
 						backup->entries.push_back(entry);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1393,14 +1393,14 @@ void AnimationTree::_process_graph(double p_delta) {
 								}
 								Variant value = a->track_get_key_value(i, idx);
 								value = _post_process_key_value(a, i, value, t->object);
-								t->object->set_indexed(t->subpath, value);
+								t->object->set_by_path(t->subpath, value);
 							} else {
 								List<int> indices;
 								a->value_track_get_key_indices(i, time, delta, &indices, pingponged);
 								for (int &F : indices) {
 									Variant value = a->track_get_key_value(i, F);
 									value = _post_process_key_value(a, i, value, t->object);
-									t->object->set_indexed(t->subpath, value);
+									t->object->set_by_path(t->subpath, value);
 								}
 							}
 						}
@@ -1698,13 +1698,13 @@ void AnimationTree::_process_graph(double p_delta) {
 				case Animation::TYPE_VALUE: {
 					TrackCacheValue *t = static_cast<TrackCacheValue *>(track);
 
-					t->object->set_indexed(t->subpath, t->value);
+					t->object->set_by_path(t->subpath, t->value);
 
 				} break;
 				case Animation::TYPE_BEZIER: {
 					TrackCacheBezier *t = static_cast<TrackCacheBezier *>(track);
 
-					t->object->set_indexed(t->subpath, t->value);
+					t->object->set_by_path(t->subpath, t->value);
 
 				} break;
 				default: {

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -75,7 +75,7 @@ Ref<PropertyTweener> Tween::tween_property(Object *p_target, NodePath p_property
 	ERR_FAIL_COND_V_MSG(!valid, nullptr, "Tween invalid. Either finished or created outside scene tree.");
 	ERR_FAIL_COND_V_MSG(started, nullptr, "Can't append to a Tween that has started. Use stop() first.");
 
-	Variant::Type property_type = p_target->get_indexed(p_property.get_as_property_path().get_subnames()).get_type();
+	Variant::Type property_type = p_target->get_by_path(p_property.get_as_property_path().get_subnames()).get_type();
 	if (property_type != p_to.get_type()) {
 		// Cast p_to between floats and ints to avoid minor annoyances.
 		if (property_type == Variant::FLOAT && p_to.get_type() == Variant::INT) {
@@ -744,7 +744,7 @@ void PropertyTweener::start() {
 	}
 
 	if (do_continue) {
-		initial_val = target_instance->get_indexed(property);
+		initial_val = target_instance->get_by_path(property);
 	}
 
 	if (relative) {
@@ -773,11 +773,11 @@ bool PropertyTweener::step(float &r_delta) {
 
 	float time = MIN(elapsed_time - delay, duration);
 	if (time < duration) {
-		target_instance->set_indexed(property, tween->interpolate_variant(initial_val, delta_val, time, duration, trans_type, ease_type));
+		target_instance->set_by_path(property, tween->interpolate_variant(initial_val, delta_val, time, duration, trans_type, ease_type));
 		r_delta = 0;
 		return true;
 	} else {
-		target_instance->set_indexed(property, final_val);
+		target_instance->set_by_path(property, final_val);
 		finished = true;
 		r_delta = elapsed_time - delay - duration;
 		emit_signal(SNAME("finished"));
@@ -807,7 +807,7 @@ void PropertyTweener::_bind_methods() {
 PropertyTweener::PropertyTweener(Object *p_target, NodePath p_property, Variant p_to, float p_duration) {
 	target = p_target->get_instance_id();
 	property = p_property.get_as_property_path().get_subnames();
-	initial_val = p_target->get_indexed(property);
+	initial_val = p_target->get_by_path(property);
 	base_final_val = p_to;
 	final_val = base_final_val;
 	duration = p_duration;


### PR DESCRIPTION
and Object.set_indexed() also renamed to Object.set_by_path()

resolve https://github.com/godotengine/godot-proposals/issues/4727.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
