### PR TITLE
Prevent subwindow_focused from pointing to a window that is not a subwindow

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -461,6 +461,7 @@ private:
 	void _sub_window_update(Window *p_window);
 	void _sub_window_grab_focus(Window *p_window);
 	void _sub_window_remove(Window *p_window);
+	int _sub_window_find(Window *p_window);
 	bool _sub_windows_forward_input(const Ref<InputEvent> &p_event);
 	SubWindowResize _sub_window_get_resize_margin(Window *p_subwindow, const Point2 &p_point);
 


### PR DESCRIPTION
Fixes #53861 (this PR fixes the output error part, the rendering part was fixed by #63091)

This prevents the `subwindow_focused` variable from being set to a window that is not a subwindow of this viewport, thus preventing the `scene\main\viewport.cpp:221 - Condition "index == -1" is true` error from showing when a subwindow is shown.

I also added a `_sub_window_find` method, to avoid duplication.