### PR TITLE
Fix dropped XEvents early in main window lifetime.

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -4991,15 +4991,22 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	}
 	cursor_set_shape(CURSOR_BUSY);
 
-	XEvent xevent;
+	Vector<XEvent> save_events;
 	while (XPending(x11_display) > 0) {
+		XEvent xevent{ 0 };
 		XNextEvent(x11_display, &xevent);
 		if (xevent.type == ConfigureNotify) {
 			_window_changed(&xevent);
-		} else if (xevent.type == MapNotify) {
-			// Have we failed to set fullscreen while the window was unmapped?
-			_validate_mode_on_map(main_window);
+		} else {
+			// Don't discard this event, we must resend it...
+			save_events.push_back(xevent);
 		}
+	}
+
+	// Resend events that would have been dropped by the early event queue
+	// processing we just performed.
+	for (XEvent &ev : save_events) {
+		XSendEvent(x11_display, ev.xany.window, False, 0, &ev);
 	}
 
 	events_thread.start(_poll_events_thread, this);


### PR DESCRIPTION
`DisplayServerX11` processes all pending events near the end of its constructor, prior to starting the dedicated event thread. It does this apparently so that it can process specific events (`ConfigureNotify`) at a very early stage:

```
 XEvent xevent; 
 while (XPending(x11_display) > 0) { 
 	XNextEvent(x11_display, &xevent); 
 	if (xevent.type == ConfigureNotify) { 
 		_window_changed(&xevent); 
 	} 
 } 

events_thread.start(_poll_events_thread, this);
```
Looking through the git history, it seems to have been added to solve a bug with the splash screen, though I'm not sure if it's still actually doing anything or if its a holdover from before the DisplayServer was introduced. Either way, it's prone to issues because its popping _every_ event from the event queue, and silently dropping all the events that it doesn't care to process. This causes all the events that occur between window creation, and this loop, to never be processed by the application. To give an illustration:

```
show_window: 71303170 (0)
Dropped event of type: 28
Dropped event of type: 28
Dropped event of type: 28
Dropped event of type: 28
Dropped event of type: 28
Dropped event of type: 28
Dropped event of type: 21
Dropped event of type: 28
Dropped event of type: 19
Dropped event of type: 15
Dropped event of type: 12
Dropped event of type: 9
Dropped event of type: 11
Dropped event of type: 28
Dropped event of type: 28

// Received no debug messages from the event thread...
```

All of these events are being dropped at this loop, and never reaching the event thread. Instead, in this PR we can store every event that isn't being processed early, and then simply resend them back to the window with `XSendEvent` so that they can later be processed by the event thread:

```
show_window: 71303170 (0)
Resend event of type: 28
Resend event of type: 28
Resend event of type: 28
Resend event of type: 28
Resend event of type: 28
Resend event of type: 28
Resend event of type: 21
Resend event of type: 28
Resend event of type: 19
Resend event of type: 15
Resend event of type: 12
Resend event of type: 9
Resend event of type: 11
Resend event of type: 28
Resend event of type: 28

// Events have reached the event thread
[1] MapNotify window=71303170 (0)
[1] VisibilityNotify window=71303170 (0), state=0
[1] Expose window=71303170 (0), count='0'
[1] FocusIn window=71303170 (0), mode='0'
```
