### PR TITLE
Improve normal smoothing in the `SurfaceTool`

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -236,9 +236,9 @@
 				[b]Note:[/b] This function takes an enum, not the exact number of weights.
 			</description>
 		</method>
-		<method name="set_smooth_group">
+		<method name="set_smooth_normals">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
+			<param index="0" name="smooth" type="bool" />
 			<description>
 				Specifies whether the current vertex (if using only vertex arrays) or current index (if also using index arrays) should use smooth normals for normal calculation.
 			</description>

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -227,7 +227,6 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 	String current_material_library;
 	String current_material;
 	String current_group;
-	uint32_t smooth_group = 0;
 	bool smoothing = true;
 
 	while (true) {
@@ -317,10 +316,7 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 					ERR_FAIL_INDEX_V(vtx, vertices.size(), ERR_FILE_CORRUPT);
 
 					Vector3 vertex = vertices[vtx];
-					if (!smoothing) {
-						smooth_group++;
-					}
-					surf_tool->set_smooth_group(smooth_group);
+					surf_tool->set_smooth_normals(smoothing);
 					surf_tool->add_vertex(vertex);
 				}
 
@@ -335,7 +331,6 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 				do_smooth = true;
 			}
 			if (do_smooth != smoothing) {
-				smooth_group++;
 				smoothing = do_smooth;
 			}
 		} else if (/*l.begins_with("g ") ||*/ l.begins_with("usemtl ") || (l.begins_with("o ") || f->eof_reached())) { //commit group to mesh

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -50,7 +50,7 @@ public:
 		Vector<int> bones;
 		Vector<float> weights;
 		Color custom[RS::ARRAY_CUSTOM_COUNT];
-		uint32_t smooth_group = 0;
+		bool smooth_normal = false;
 
 		bool operator==(const Vertex &p_vertex) const;
 
@@ -127,7 +127,7 @@ private:
 	Vector<int> last_bones;
 	Vector<float> last_weights;
 	Plane last_tangent;
-	uint32_t last_smooth_group = 0;
+	uint32_t last_smooth_normal = 0;
 
 	SkinWeightCount skin_weights = SKIN_4_WEIGHTS;
 
@@ -169,7 +169,7 @@ public:
 	void set_custom(int p_channel_index, const Color &p_custom);
 	void set_bones(const Vector<int> &p_bones);
 	void set_weights(const Vector<float> &p_weights);
-	void set_smooth_group(uint32_t p_group);
+	void set_smooth_normals(bool p_smooth);
 
 	void add_vertex(const Vector3 &p_vertex);
 


### PR DESCRIPTION
This fixes #65076 while keeping it possible to generate smooth normals. SurfaceTool.add_smooth_group() has been renamed to .set_smooth_normals() to better explain what it is doing. The new name also better matches the naming of .set_uv(), set_color(), set_tangent() ...