### PR TITLE
Fix switching `MenuBar`'s menus with the keys while mouse hovering

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -377,6 +377,11 @@ void MenuBar::_notification(int p_what) {
 			MutexLock lock(mutex);
 
 			Vector2 pos = DisplayServer::get_singleton()->mouse_get_position() - mouse_pos_adjusted - get_global_position();
+			if (pos == old_mouse_pos) {
+				return;
+			}
+			old_mouse_pos = pos;
+
 			int index = _get_index_at_point(pos);
 			if (index >= 0 && index != active_menu) {
 				selected_menu = index;

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -73,6 +73,7 @@ class MenuBar : public Control {
 	int active_menu = -1;
 
 	Vector2i mouse_pos_adjusted;
+	Vector2i old_mouse_pos;
 	ObjectID shortcut_context;
 
 	int _get_index_at_point(const Point2 &p_point) const;


### PR DESCRIPTION
Currently, trying to switch between menus in the `MenuBar` using the left/right keys will not work properly if the mouse is hovering it.