### PR TITLE
Add a few buttons in Remote Scene Tree

### DIFF
--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -129,6 +129,7 @@ protected:
 	void _debugger_wants_stop(int p_id);
 	void _debugger_changed(int p_tab);
 	void _remote_tree_updated(int p_debugger);
+	void _remote_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _remote_object_updated(ObjectID p_id, int p_debugger);
 	void _remote_object_property_updated(ObjectID p_id, const String &p_property, int p_debugger);
 	void _remote_object_requested(ObjectID p_id, int p_debugger);

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -65,6 +65,7 @@ void EditorDebuggerTree::_notification(int p_what) {
 void EditorDebuggerTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("object_selected", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::INT, "debugger")));
 	ADD_SIGNAL(MethodInfo("save_node", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "filename"), PropertyInfo(Variant::INT, "debugger")));
+	ADD_SIGNAL(MethodInfo("open"));
 }
 
 void EditorDebuggerTree::_scene_tree_selected() {
@@ -162,7 +163,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		}
 		item->set_metadata(0, node.id);
 
-		// Set current item as collapsed if necessary (root is never collapsed)
+		// Set current item as collapsed if necessary (root is never collapsed).
 		if (parent) {
 			if (!unfold_cache.has(node.id)) {
 				item->set_collapsed(true);
@@ -178,12 +179,39 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 			}
 		} else { // Must use path
 			if (last_path == _get_path(item)) {
-				updating_scene_tree = false; // Force emission of new selection
+				updating_scene_tree = false; // Force emission of new selection.
 				item->select(0);
 				if (filter_changed) {
 					scroll_item = item;
 				}
 				updating_scene_tree = true;
+			}
+		}
+
+		// Add buttons.
+		const Color remote_button_color = Color(1, 1, 1, 0.8);
+		if (!node.scene_file_path.is_empty()) {
+			String node_scene_file_path = node.scene_file_path;
+			Ref<Texture2D> button_icon = get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons"));
+			String tooltip = vformat(TTR("This node has been instantiated from a PackedScene file:\n%s\nClick to open the original file in the Editor."), node_scene_file_path);
+
+			item->set_meta("scene_file_path", node_scene_file_path);
+			item->add_button(0, button_icon, BUTTON_SUBSCENE, false, tooltip);
+			item->set_button_color(0, item->get_button_count(0) - 1, remote_button_color);
+		}
+
+		if (node.view_flags & SceneDebuggerTree::RemoteNode::VIEW_HAS_VISIBLE_METHOD) {
+			bool node_visible = node.view_flags & SceneDebuggerTree::RemoteNode::VIEW_VISIBLE;
+			bool node_visible_in_tree = node.view_flags & SceneDebuggerTree::RemoteNode::VIEW_VISIBLE_IN_TREE;
+			Ref<Texture2D> button_icon = get_theme_icon(node_visible ? SNAME("GuiVisibilityVisible") : SNAME("GuiVisibilityHidden"), SNAME("EditorIcons"));
+			String tooltip = TTR("Toggle Visibility");
+
+			item->set_meta("visible", node_visible);
+			item->add_button(0, button_icon, BUTTON_VISIBILITY, false, tooltip);
+			if (ClassDB::is_parent_class(node.type_name, "CanvasItem") || ClassDB::is_parent_class(node.type_name, "Node3D")) {
+				item->set_button_color(0, item->get_button_count(0) - 1, node_visible_in_tree ? remote_button_color : Color(1, 1, 1, 0.6));
+			} else {
+				item->set_button_color(0, item->get_button_count(0) - 1, remote_button_color);
 			}
 		}
 

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -65,6 +65,11 @@ protected:
 	void _notification(int p_what);
 
 public:
+	enum Button {
+		BUTTON_SUBSCENE = 0,
+		BUTTON_VISIBILITY = 1,
+	};
+
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 
 	String get_selected_path();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1401,6 +1401,7 @@ void SceneTreeDock::_node_replace_owner(Node *p_base, Node *p_node, Node *p_root
 
 void SceneTreeDock::_load_request(const String &p_path) {
 	EditorNode::get_singleton()->open_request(p_path);
+	_local_tree_selected();
 }
 
 void SceneTreeDock::_script_open_request(const Ref<Script> &p_script) {
@@ -3218,6 +3219,7 @@ void SceneTreeDock::add_remote_tree_editor(Control *p_remote) {
 	add_child(p_remote);
 	remote_tree = p_remote;
 	remote_tree->hide();
+	remote_tree->connect("open", callable_mp(this, &SceneTreeDock::_load_request));
 }
 
 void SceneTreeDock::show_remote_tree() {

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -110,12 +110,23 @@ public:
 		String name;
 		String type_name;
 		ObjectID id;
+		String scene_file_path;
+		uint8_t view_flags = 0;
 
-		RemoteNode(int p_child, const String &p_name, const String &p_type, ObjectID p_id) {
+		enum ViewFlags {
+			VIEW_HAS_VISIBLE_METHOD = 1 << 1,
+			VIEW_VISIBLE = 1 << 2,
+			VIEW_VISIBLE_IN_TREE = 1 << 3,
+		};
+
+		RemoteNode(int p_child, const String &p_name, const String &p_type, ObjectID p_id, const String p_scene_file_path, int p_view_flags) {
 			child_count = p_child;
 			name = p_name;
 			type_name = p_type;
 			id = p_id;
+
+			scene_file_path = p_scene_file_path;
+			view_flags = p_view_flags;
 		}
 
 		RemoteNode() {}


### PR DESCRIPTION
Implements... closes https://github.com/godotengine/godot-proposals/issues/5267.

This PR adds two buttons to the remote **SceneTree** displayed in the Editor:

![Showcase](https://i.gyazo.com/5844a404468e027702c654dd83f89d9d.gif)

A **Scene** button to any scene root **Node** instantiated from file. When clicked, it opens the original **PackedScene** it comes from and switches off the remote **Tree** display.

![image](https://user-images.githubusercontent.com/66727710/187561254-efca5257-b6a0-49c1-983e-91693c653e8b.png)

A **Visibility Toggle** button. Enough said. Clicking on it toggles the remote Node's visibility.

I would like to ask a few questions regarding this PR's implementation:
- I feel like this should be an editor setting. It can potentially be quite annoying to see. 
   - Especially the "_eyes_". The "_eyes_" are particularly distracting. I only included it because it's part of the proposal. Should they be just outright removed? Or should it all be an editor setting with a few modes to choose from?
- Regarding technical implementation (and possible jank):
    - A new signal `open` _(akin to **SceneTreeEditor**)_ has been added to the  **EditorDebuggerTree** , emitted when the Scene button is pressed. However, the all of the "pressed" answering logic is present in **EditorDebuggerNode**. Because of this, the enum storing the button ids is public, and **EditorDebuggerNode** emits the signal for the remote tree. This all feels odd to me, but I only did it because other "remote tree manipulating" methods were there. I wouldn't want these classes to be more cryptic than they are already, should the logic be moved to to **EditorDebuggerTree**?