### PR TITLE
ci: wait for static check result before starting builds

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,5 +1,10 @@
 name: 🤖 Android Builds
-on: [push, pull_request]
+on:
+  workflow_run:
+      workflows:
+        - "📊 Static Checks"
+      types:
+        - completed
 
 # Global Settings
 env:
@@ -15,6 +20,7 @@ jobs:
   android-template:
     runs-on: "ubuntu-20.04"
     name: Template (target=release, tools=no)
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,5 +1,10 @@
 name: 🍏 iOS Builds
-on: [push, pull_request]
+on:
+  workflow_run:
+      workflows:
+        - "📊 Static Checks"
+      types:
+        - completed
 
 # Global Settings
 env:
@@ -15,6 +20,7 @@ jobs:
   ios-template:
     runs-on: "macos-latest"
     name: Template (target=release, tools=no)
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,5 +1,10 @@
 name: 🐧 Linux Builds
-on: [push, pull_request]
+on:
+  workflow_run:
+      workflows:
+        - "📊 Static Checks"
+      types:
+        - completed
 
 # Global Settings
 env:
@@ -17,6 +22,8 @@ jobs:
   build-linux:
     runs-on: "ubuntu-20.04"
     name: ${{ matrix.name }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,5 +1,10 @@
 name: 🍎 macOS Builds
-on: [push, pull_request]
+on:
+  workflow_run:
+      workflows:
+        - "📊 Static Checks"
+      types:
+        - completed
 
 # Global Settings
 env:
@@ -15,6 +20,8 @@ jobs:
   build-macos:
     runs-on: "macos-latest"
     name: ${{ matrix.name }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,4 +1,4 @@
-name: 📊 Static Checks
+name: "📊 Static Checks"
 on: [push, pull_request]
 
 concurrency:

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -1,5 +1,12 @@
 name: 🌐 Web Builds
-on: [push, pull_request]
+on:
+  workflow_run:
+      workflows:
+        - "📊 Static Checks"
+      types:
+        - completed
+      branches:
+        - '**'
 
 # Global Settings
 env:
@@ -17,6 +24,7 @@ jobs:
   web-template:
     runs-on: "ubuntu-20.04"
     name: Template (target=release, tools=no)
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,5 +1,10 @@
 name: 🏁 Windows Builds
-on: [push, pull_request]
+on:
+  workflow_run:
+      workflows:
+        - "📊 Static Checks"
+      types:
+        - completed
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment
@@ -18,6 +23,8 @@ jobs:
     # Windows 10 with latest image
     runs-on: "windows-latest"
     name: ${{ matrix.name }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The CI workflow "📊 Static Checks" checks code formatting etc. and even if all the build workflows in pipeline are successful, the pipeline needs to be eventually re-run in case this one fails. So it would make sense to not run the "expensive" jobs unless we know the basic one is successful. 

downside: CI will take longer, as this one jobs needs to finish first. But from what I understand the bottleneck in CI is the number of available workers which can run builds, so this feels like a good tradeoff.

Changes in this PR make the pipeline work in two steps:
-  "📊 Static Checks" runs first
- if the job result is successful, all builds will run as expected
- if the job result is unsuccessful, builds will be terminated immediately

This cant be demonstrated on PR, as CI uses the workflow files from default branch. See the results in my fork: https://github.com/yedpodtrzitko/godot/actions

![Screen Shot 2022-08-31 at 12 24 42](https://user-images.githubusercontent.com/162526/187588704-f41324a7-0d4d-48cc-821a-a5ba5bb824b9.jpg)

