### PR TITLE
Basis constructor: row vectors -> column vectors 

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -238,10 +238,8 @@ struct _NO_DISCARD_ Basis {
 	Basis(const Vector3 &p_axis, real_t p_angle, const Vector3 &p_scale) { set_axis_angle_scale(p_axis, p_angle, p_scale); }
 	static Basis from_scale(const Vector3 &p_scale);
 
-	_FORCE_INLINE_ Basis(const Vector3 &row0, const Vector3 &row1, const Vector3 &row2) {
-		rows[0] = row0;
-		rows[1] = row1;
-		rows[2] = row2;
+	_FORCE_INLINE_ Basis(const Vector3 &p_x_axis, const Vector3 &p_y_axis, const Vector3 &p_z_axis) {
+		set_columns(p_x_axis, p_y_axis, p_z_axis);
 	}
 
 	_FORCE_INLINE_ Basis() {}

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -134,11 +134,11 @@ Vector3 Vector3::octahedron_tangent_decode(const Vector2 &p_oct, float *sign) {
 }
 
 Basis Vector3::outer(const Vector3 &p_with) const {
-	Vector3 row0(x * p_with.x, x * p_with.y, x * p_with.z);
-	Vector3 row1(y * p_with.x, y * p_with.y, y * p_with.z);
-	Vector3 row2(z * p_with.x, z * p_with.y, z * p_with.z);
-
-	return Basis(row0, row1, row2);
+	Basis basis;
+	basis.rows[0] = Vector3(x * p_with.x, x * p_with.y, x * p_with.z);
+	basis.rows[1] = Vector3(y * p_with.x, y * p_with.y, y * p_with.z);
+	basis.rows[2] = Vector3(z * p_with.x, z * p_with.y, z * p_with.z);
+	return basis;
 }
 
 bool Vector3::is_equal_approx(const Vector3 &p_v) const {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -426,7 +426,9 @@ PhysicalBone3D *Skeleton3DEditor::create_physical_bone(int bone_id, int bone_chi
 	bone_shape->set_name("CollisionShape3D");
 
 	Transform3D capsule_transform;
-	capsule_transform.basis = Basis(Vector3(1, 0, 0), Vector3(0, 0, 1), Vector3(0, -1, 0));
+	capsule_transform.basis.rows[0] = Vector3(1, 0, 0);
+	capsule_transform.basis.rows[1] = Vector3(0, 0, 1);
+	capsule_transform.basis.rows[2] = Vector3(0, -1, 0);
 	bone_shape->set_transform(capsule_transform);
 
 	/// Get an up vector not collinear with child rest origin


### PR DESCRIPTION
The Basis constructor takes row vectors but the doc says column.
```cpp
_FORCE_INLINE_ Basis(const Vector3 &row0, const Vector3 &row1, const Vector3 &row2) {
    rows[0] = row0;
    rows[1] = row1;
    rows[2] = row2;
}
```

> Constructs a basis matrix from 3 axis vectors (matrix columns).

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/5295
- Fixes #59806