### PR TITLE
Discontinued `spherical_interpolate_with()` in `Transform3D`

### DIFF
--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -94,9 +94,7 @@ void Transform3D::set_look_at(const Vector3 &p_eye, const Vector3 &p_target, con
 	origin = p_eye;
 }
 
-Transform3D Transform3D::spherical_interpolate_with(const Transform3D &p_transform, real_t p_c) const {
-	/* not sure if very "efficient" but good enough? */
-
+Transform3D Transform3D::interpolate_with(const Transform3D &p_transform, real_t p_c) const {
 	Transform3D interp;
 
 	Vector3 src_scale = basis.get_scale();
@@ -109,15 +107,6 @@ Transform3D Transform3D::spherical_interpolate_with(const Transform3D &p_transfo
 
 	interp.basis.set_quaternion_scale(src_rot.slerp(dst_rot, p_c).normalized(), src_scale.lerp(dst_scale, p_c));
 	interp.origin = src_loc.lerp(dst_loc, p_c);
-
-	return interp;
-}
-
-Transform3D Transform3D::interpolate_with(const Transform3D &p_transform, real_t p_c) const {
-	Transform3D interp;
-
-	interp.basis = basis.lerp(p_transform.basis, p_c);
-	interp.origin = origin.lerp(p_transform.origin, p_c);
 
 	return interp;
 }

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -103,7 +103,6 @@ struct _NO_DISCARD_ Transform3D {
 	void operator*=(const real_t p_val);
 	Transform3D operator*(const real_t p_val) const;
 
-	Transform3D spherical_interpolate_with(const Transform3D &p_transform, real_t p_c) const;
 	Transform3D interpolate_with(const Transform3D &p_transform, real_t p_c) const;
 
 	_FORCE_INLINE_ Transform3D inverse_xform(const Transform3D &t) const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1969,7 +1969,6 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform3D, translated, sarray("offset"), varray());
 	bind_method(Transform3D, translated_local, sarray("offset"), varray());
 	bind_method(Transform3D, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
-	bind_method(Transform3D, spherical_interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, is_equal_approx, sarray("xform"), varray());
 

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -141,14 +141,6 @@
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>
-		<method name="spherical_interpolate_with" qualifiers="const">
-			<return type="Transform3D" />
-			<param index="0" name="xform" type="Transform3D" />
-			<param index="1" name="weight" type="float" />
-			<description>
-				Returns a transform spherically interpolated between this transform and another by a given [param weight] (on the range of 0.0 to 1.0).
-			</description>
-		</method>
 		<method name="translated" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="offset" type="Vector3" />


### PR DESCRIPTION
When I implemented `Basis::lerp()` for `Node3D::rotation_edit_mode`, I added `Transform3D::spherical_interpolate_with()` separately from `Transform3D::interpolate_with()`, but I think it will never be used in practice.

Also, `interpolate_with()` existed in `Transform2D`, which uses `slerp()` as its default and was not consistent. So I think that rather than implementing `spherical_interpolate_with()` in Transform2D, it is a right way to implement `spherical_interpolate_with()` in Transform3D and do `slerp()` in `Transform3D::interpolate_with()`.