### PR TITLE
Add support for scene/resource customization in export plugins

### DIFF
--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -68,6 +68,8 @@ public:
 	Error load(const String &p_path);
 	Error parse(const String &p_data);
 
+	String encode_to_text() const; // used by exporter
+
 	void clear();
 
 	Error load_encrypted(const String &p_path, const Vector<uint8_t> &p_key);

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -98,6 +98,12 @@
 				Removes the entire contents of the config.
 			</description>
 		</method>
+		<method name="encode_to_text" qualifiers="const">
+			<return type="String" />
+			<description>
+				Obtain the text version of this config file (the same text that would be written to a file).
+			</description>
+		</method>
 		<method name="erase_section">
 			<return type="void" />
 			<param index="0" name="section" type="String" />

--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExportPlatform" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -10,6 +10,51 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_begin_customize_resources" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="platform" type="EditorExportPlatform" />
+			<param index="1" name="features" type="PackedStringArray" />
+			<description>
+				Return true if this plugin will customize resources based on the platform and features used.
+			</description>
+		</method>
+		<method name="_begin_customize_scenes" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="platform" type="EditorExportPlatform" />
+			<param index="1" name="features" type="PackedStringArray" />
+			<description>
+				Return true if this plugin will customize scenes based on the platform and features used.
+			</description>
+		</method>
+		<method name="_customize_resource" qualifiers="virtual">
+			<return type="Resource" />
+			<param index="0" name="resource" type="Resource" />
+			<param index="1" name="path" type="String" />
+			<description>
+				Customize a resource. If changes are made to it, return the same or a new resource. Otherwise, return [code]null[/code].
+				The [i]path[/i] argument is only used when customizing an actual file, otherwise this means that this resource is part of another one and it will be empty.
+			</description>
+		</method>
+		<method name="_customize_scene" qualifiers="virtual">
+			<return type="Node" />
+			<param index="0" name="scene" type="Node" />
+			<param index="1" name="path" type="String" />
+			<description>
+				Customize a scene. If changes are made to it, return the same or a new scene. Otherwise, return [code]null[/code]. If a new scene is returned, it is up to you to dispose of the old one.
+			</description>
+		</method>
+		<method name="_end_customize_resources" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				This is called when the customization process for resources ends.
+			</description>
+		</method>
+		<method name="_end_customize_scenes" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				This is called when the customization process for scenes ends.
+			</description>
+		</method>
 		<method name="_export_begin" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="features" type="PackedStringArray" />
@@ -34,6 +79,18 @@
 			<description>
 				Virtual method to be overridden by the user. Called for each exported file, providing arguments that can be used to identify the file. [param path] is the path of the file, [param type] is the [Resource] represented by the file (e.g. [PackedScene]) and [param features] is the list of features for the export.
 				Calling [method skip] inside this callback will make the file not included in the export.
+			</description>
+		</method>
+		<method name="_get_customization_configuration_hash" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+				Return a hash based on the configuration passed (for both scenes and resources). This helps keep separate caches for separate export configurations.
+			</description>
+		</method>
+		<method name="_get_name" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				Return the name identifier of this plugin (for future identification by the exporter).
 			</description>
 		</method>
 		<method name="add_file">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4107,6 +4107,7 @@ void EditorNode::register_editor_types() {
 	GDREGISTER_CLASS(EditorSyntaxHighlighter);
 	GDREGISTER_ABSTRACT_CLASS(EditorInterface);
 	GDREGISTER_CLASS(EditorExportPlugin);
+	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatform);
 	GDREGISTER_CLASS(EditorResourceConversionPlugin);
 	GDREGISTER_CLASS(EditorSceneFormatImporter);
 	GDREGISTER_CLASS(EditorScenePostImportPlugin);
@@ -7417,11 +7418,6 @@ EditorNode::EditorNode() {
 	editor_plugins_over = memnew(EditorPluginList);
 	editor_plugins_force_over = memnew(EditorPluginList);
 	editor_plugins_force_input_forwarding = memnew(EditorPluginList);
-
-	Ref<EditorExportTextSceneToBinaryPlugin> export_text_to_binary_plugin;
-	export_text_to_binary_plugin.instantiate();
-
-	EditorExport::get_singleton()->add_export_plugin(export_text_to_binary_plugin);
 
 	Ref<GDExtensionExportPlugin> gdextension_export_plugin;
 	gdextension_export_plugin.instantiate();

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -351,6 +351,8 @@ EditorExport::EditorExport() {
 
 	singleton = this;
 	set_process(true);
+
+	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", true);
 }
 
 EditorExport::~EditorExport() {

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -40,6 +40,8 @@ struct EditorProgress;
 #include "scene/gui/rich_text_label.h"
 #include "scene/main/node.h"
 
+class EditorExportPlugin;
+
 class EditorExportPlatform : public RefCounted {
 	GDCLASS(EditorExportPlatform, RefCounted);
 
@@ -98,6 +100,20 @@ private:
 	void _edit_filter_list(HashSet<String> &r_list, const String &p_filter, bool exclude);
 
 	static Error _add_shared_object(void *p_userdata, const SharedObject &p_so);
+
+	struct FileExportCache {
+		uint64_t source_modified_time = 0;
+		String source_md5;
+		String saved_path;
+		bool used = false;
+	};
+
+	bool _export_customize_dictionary(Dictionary &dict, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins);
+	bool _export_customize_array(Array &array, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins);
+	bool _export_customize_object(Object *p_object, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins);
+	bool _export_customize_scene_resources(Node *p_root, Node *p_node, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins);
+
+	String _export_customize(const String &p_path, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins, LocalVector<Ref<EditorExportPlugin>> &customize_scenes_plugins, HashMap<String, FileExportCache> &export_cache, const String &export_base_path, bool p_force_save);
 
 protected:
 	struct ExportNotifier {

--- a/editor/export/editor_export_plugin.cpp
+++ b/editor/export/editor_export_plugin.cpp
@@ -138,6 +138,64 @@ void EditorExportPlugin::_export_end_script() {
 	GDVIRTUAL_CALL(_export_end);
 }
 
+// Customization
+
+bool EditorExportPlugin::_begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const {
+	bool ret = false;
+	if (GDVIRTUAL_CALL(_begin_customize_resources, p_platform, p_features, ret)) {
+		return ret;
+	}
+	return false;
+}
+
+Ref<Resource> EditorExportPlugin::_customize_resource(const Ref<Resource> &p_resource, const String &p_path) {
+	Ref<Resource> ret;
+	if (GDVIRTUAL_REQUIRED_CALL(_customize_resource, p_resource, p_path, ret)) {
+		return ret;
+	}
+	return Ref<Resource>();
+}
+
+bool EditorExportPlugin::_begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const {
+	bool ret = false;
+	if (GDVIRTUAL_CALL(_begin_customize_scenes, p_platform, p_features, ret)) {
+		return ret;
+	}
+	return false;
+}
+
+Node *EditorExportPlugin::_customize_scene(Node *p_root, const String &p_path) {
+	Node *ret = nullptr;
+	if (GDVIRTUAL_REQUIRED_CALL(_customize_scene, p_root, p_path, ret)) {
+		return ret;
+	}
+	return nullptr;
+}
+
+uint64_t EditorExportPlugin::_get_customization_configuration_hash() const {
+	uint64_t ret = 0;
+	if (GDVIRTUAL_REQUIRED_CALL(_get_customization_configuration_hash, ret)) {
+		return ret;
+	}
+	return 0;
+}
+
+void EditorExportPlugin::_end_customize_scenes() {
+	GDVIRTUAL_CALL(_end_customize_scenes);
+}
+
+void EditorExportPlugin::_end_customize_resources() {
+	GDVIRTUAL_CALL(_end_customize_resources);
+}
+
+String EditorExportPlugin::_get_name() const {
+	String ret;
+	if (GDVIRTUAL_REQUIRED_CALL(_get_name, ret)) {
+		return ret;
+	}
+	return "";
+}
+
 void EditorExportPlugin::_export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) {
 }
 
@@ -164,38 +222,20 @@ void EditorExportPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_export_file, "path", "type", "features");
 	GDVIRTUAL_BIND(_export_begin, "features", "is_debug", "path", "flags");
 	GDVIRTUAL_BIND(_export_end);
+
+	GDVIRTUAL_BIND(_begin_customize_resources, "platform", "features");
+	GDVIRTUAL_BIND(_customize_resource, "resource", "path");
+
+	GDVIRTUAL_BIND(_begin_customize_scenes, "platform", "features");
+	GDVIRTUAL_BIND(_customize_scene, "scene", "path");
+
+	GDVIRTUAL_BIND(_get_customization_configuration_hash);
+
+	GDVIRTUAL_BIND(_end_customize_scenes);
+	GDVIRTUAL_BIND(_end_customize_resources);
+
+	GDVIRTUAL_BIND(_get_name);
 }
 
 EditorExportPlugin::EditorExportPlugin() {
-}
-
-///////////////////////
-
-void EditorExportTextSceneToBinaryPlugin::_export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) {
-	String extension = p_path.get_extension().to_lower();
-	if (extension != "tres" && extension != "tscn") {
-		return;
-	}
-
-	bool convert = GLOBAL_GET("editor/export/convert_text_resources_to_binary");
-	if (!convert) {
-		return;
-	}
-	String tmp_path = EditorPaths::get_singleton()->get_cache_dir().path_join("tmpfile.res");
-	Error err = ResourceFormatLoaderText::convert_file_to_binary(p_path, tmp_path);
-	if (err != OK) {
-		DirAccess::remove_file_or_error(tmp_path);
-		ERR_FAIL();
-	}
-	Vector<uint8_t> data = FileAccess::get_file_as_array(tmp_path);
-	if (data.size() == 0) {
-		DirAccess::remove_file_or_error(tmp_path);
-		ERR_FAIL();
-	}
-	DirAccess::remove_file_or_error(tmp_path);
-	add_file(p_path + ".converted.res", data, true);
-}
-
-EditorExportTextSceneToBinaryPlugin::EditorExportTextSceneToBinaryPlugin() {
-	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", false);
 }

--- a/editor/export/editor_export_plugin.h
+++ b/editor/export/editor_export_plugin.h
@@ -34,6 +34,7 @@
 #include "core/extension/native_extension.h"
 #include "editor_export_preset.h"
 #include "editor_export_shared_object.h"
+#include "scene/main/node.h"
 
 class EditorExportPlugin : public RefCounted {
 	GDCLASS(EditorExportPlugin, RefCounted);
@@ -77,6 +78,7 @@ class EditorExportPlugin : public RefCounted {
 		macos_plugin_files.clear();
 	}
 
+	// Export
 	void _export_file_script(const String &p_path, const String &p_type, const Vector<String> &p_features);
 	void _export_begin_script(const Vector<String> &p_features, bool p_debug, const String &p_path, int p_flags);
 	void _export_end_script();
@@ -108,6 +110,31 @@ protected:
 	GDVIRTUAL4(_export_begin, Vector<String>, bool, String, uint32_t)
 	GDVIRTUAL0(_export_end)
 
+	GDVIRTUAL2RC(bool, _begin_customize_resources, const Ref<EditorExportPlatform> &, const Vector<String> &)
+	GDVIRTUAL2R(Ref<Resource>, _customize_resource, const Ref<Resource> &, String)
+
+	GDVIRTUAL2RC(bool, _begin_customize_scenes, const Ref<EditorExportPlatform> &, const Vector<String> &)
+	GDVIRTUAL2R(Node *, _customize_scene, Node *, String)
+	GDVIRTUAL0RC(uint64_t, _get_customization_configuration_hash)
+
+	GDVIRTUAL0(_end_customize_scenes)
+	GDVIRTUAL0(_end_customize_resources)
+
+	GDVIRTUAL0RC(String, _get_name)
+
+	bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const; // Return true if this plugin does property export customization
+	Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path); // If nothing is returned, it means do not touch (nothing changed). If something is returned (either the same or a different resource) it means changes are made.
+
+	bool _begin_customize_scenes(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) const; // Return true if this plugin does property export customization
+	Node *_customize_scene(Node *p_root, const String &p_path); // Return true if a change was made
+
+	uint64_t _get_customization_configuration_hash() const; // Hash used for caching customized resources and scenes.
+
+	void _end_customize_scenes();
+	void _end_customize_resources();
+
+	virtual String _get_name() const;
+
 public:
 	Vector<String> get_ios_frameworks() const;
 	Vector<String> get_ios_embedded_frameworks() const;
@@ -119,14 +146,6 @@ public:
 	const Vector<String> &get_macos_plugin_files() const;
 
 	EditorExportPlugin();
-};
-
-class EditorExportTextSceneToBinaryPlugin : public EditorExportPlugin {
-	GDCLASS(EditorExportTextSceneToBinaryPlugin, EditorExportPlugin);
-
-public:
-	virtual void _export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) override;
-	EditorExportTextSceneToBinaryPlugin();
 };
 
 #endif // EDITOR_EXPORT_PLUGIN_H

--- a/editor/plugins/gdextension_export_plugin.h
+++ b/editor/plugins/gdextension_export_plugin.h
@@ -36,6 +36,7 @@
 class GDExtensionExportPlugin : public EditorExportPlugin {
 protected:
 	virtual void _export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features);
+	virtual String _get_name() const { return "GDExtension"; }
 };
 
 void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) {

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -88,6 +88,8 @@ public:
 		// TODO: Re-add compiled GDScript on export.
 		return;
 	}
+
+	virtual String _get_name() const override { return "GDScript"; }
 };
 
 static void _editor_init() {


### PR DESCRIPTION
EditorExportPlugin adds a set of callbacks to allow customizing scenes, resources or subresources in all files exported:
* Can take scene files, resource files and subresources in all of them.
* Allows any degree of customization to any file during export.
* Uses a cache for the converted files if nothing changes, so this work only happens if a file is modified.
* Uses hashing to differentiate export configuration caches.
* Removed the previous conversion code to binary, as this one uses existing stuff.

This API is useful in several scenarios:
* Needed by the "server" export platform to get rid of textures, meshes, audio, etc.
* Needed by text to binary converters.
* Needed by eventual optimizations such as shader precompiling on export, mesh merging and optimization, etc.

Obligatory screenshot of API:
![image](https://user-images.githubusercontent.com/6265307/187654277-20458306-3b06-46e4-9af0-46d9b8893b4a.png)

~~This is a draft, feedback is very welcome.~~. Should be ready for review now.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
