### PR TITLE
Rearrange `editor/naming/*` project settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1285,6 +1285,10 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("editor/script/templates_search_path", "res://script_templates");
 	custom_prop_info["editor/script/templates_search_path"] = PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR);
 
+	// For correct doc generation.
+	GLOBAL_DEF("editor/naming/default_signal_callback_name", "_on_{node_name}_{signal_name}");
+	GLOBAL_DEF("editor/naming/default_signal_callback_to_self_name", "_on_{signal_name}");
+
 	_add_builtin_input_map();
 
 	// Keep the enum values in sync with the `DisplayServer::ScreenOrientation` enum.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -659,10 +659,16 @@
 		<member name="editor/movie_writer/speaker_mode" type="int" setter="" getter="" default="0">
 			The speaker mode to use in the recorded audio when writing a movie. See [enum AudioServer.SpeakerMode] for possible values.
 		</member>
-		<member name="editor/node_naming/name_casing" type="int" setter="" getter="" default="0">
+		<member name="editor/naming/default_signal_callback_name" type="String" setter="" getter="" default="&quot;_on_{node_name}_{signal_name}&quot;">
+			The format of the default signal callback name (in the Signal Connection Dialog). The following substitutions are available: [code]{NodeName}[/code], [code]{nodeName}[/code], [code]{node_name}[/code], [code]{SignalName}[/code], [code]{signalName}[/code], and [code]{signal_name}[/code].
+		</member>
+		<member name="editor/naming/default_signal_callback_to_self_name" type="String" setter="" getter="" default="&quot;_on_{signal_name}&quot;">
+			The format of the default signal callback name when a signal connects to the same node that emits it (in the Signal Connection Dialog). The following substitutions are available: [code]{NodeName}[/code], [code]{nodeName}[/code], [code]{node_name}[/code], [code]{SignalName}[/code], [code]{signalName}[/code], and [code]{signal_name}[/code].
+		</member>
+		<member name="editor/naming/node_name_casing" type="int" setter="" getter="" default="0">
 			When creating node names automatically, set the type of casing in this project. This is mostly an editor setting.
 		</member>
-		<member name="editor/node_naming/name_num_separator" type="int" setter="" getter="" default="0">
+		<member name="editor/naming/node_name_num_separator" type="int" setter="" getter="" default="0">
 			What to use to separate node name from number. This is mostly an editor setting.
 		</member>
 		<member name="editor/run/main_run_args" type="String" setter="" getter="" default="&quot;&quot;">

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -30,6 +30,7 @@
 
 #include "connections_dialog.h"
 
+#include "core/config/project_settings.h"
 #include "editor/doc_tools.h"
 #include "editor/editor_help.h"
 #include "editor/editor_node.h"
@@ -242,9 +243,9 @@ StringName ConnectDialog::generate_method_callback_name(Node *p_source, String p
 
 	String dst_method;
 	if (p_source == p_target) {
-		dst_method = String(EDITOR_GET("interface/editors/default_signal_callback_to_self_name")).format(subst);
+		dst_method = String(GLOBAL_GET("editor/naming/default_signal_callback_to_self_name")).format(subst);
 	} else {
-		dst_method = String(EDITOR_GET("interface/editors/default_signal_callback_name")).format(subst);
+		dst_method = String(GLOBAL_GET("editor/naming/default_signal_callback_name")).format(subst);
 	}
 
 	return dst_method;
@@ -1237,9 +1238,6 @@ ConnectionsDock::ConnectionsDock() {
 	tree->connect("item_mouse_selected", callable_mp(this, &ConnectionsDock::_rmb_pressed));
 
 	add_theme_constant_override("separation", 3 * EDSCALE);
-
-	EDITOR_DEF("interface/editors/default_signal_callback_name", "_on_{node_name}_{signal_name}");
-	EDITOR_DEF("interface/editors/default_signal_callback_to_self_name", "_on_{signal_name}");
 }
 
 ConnectionsDock::~ConnectionsDock() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3046,7 +3046,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 }
 
 String EditorNode::adjust_scene_name_casing(const String &root_name) {
-	switch (GLOBAL_GET("editor/scene/scene_naming").operator int()) {
+	switch (GLOBAL_GET("editor/naming/scene_name_casing").operator int()) {
 		case SCENE_NAME_CASING_AUTO:
 			// Use casing of the root node.
 			break;
@@ -5900,7 +5900,7 @@ void EditorNode::_feature_profile_changed() {
 }
 
 void EditorNode::_bind_methods() {
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/scene/scene_naming", PROPERTY_HINT_ENUM, "Auto,PascalCase,snake_case"), SCENE_NAME_CASING_SNAKE_CASE);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/naming/scene_name_casing", PROPERTY_HINT_ENUM, "Auto,PascalCase,snake_case"), SCENE_NAME_CASING_SNAKE_CASE);
 	ClassDB::bind_method("edit_current", &EditorNode::edit_current);
 	ClassDB::bind_method("edit_node", &EditorNode::edit_node);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2188,7 +2188,7 @@ void SceneTreeDock::_do_create(Node *p_parent) {
 	ERR_FAIL_COND(!child);
 
 	String new_name = p_parent->validate_child_name(child);
-	if (GLOBAL_GET("editor/node_naming/name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
+	if (GLOBAL_GET("editor/naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
 		new_name = adjust_name_casing(new_name);
 	}
 	child->set_name(new_name);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -971,7 +971,7 @@ void SceneTreeEditor::_renamed() {
 	String raw_new_name = which->get_text(0);
 	if (raw_new_name.strip_edges().is_empty()) {
 		// If name is empty, fallback to class name.
-		if (GLOBAL_GET("editor/node_naming/name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
+		if (GLOBAL_GET("editor/naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
 			raw_new_name = Node::adjust_name_casing(n->get_class());
 		} else {
 			raw_new_name = n->get_class();

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -944,7 +944,7 @@ String Node::validate_child_name(Node *p_child) {
 #endif
 
 String Node::adjust_name_casing(const String &p_name) {
-	switch (GLOBAL_GET("editor/node_naming/name_casing").operator int()) {
+	switch (GLOBAL_GET("editor/naming/node_name_casing").operator int()) {
 		case NAME_CASING_PASCAL_CASE:
 			return p_name.to_pascal_case();
 		case NAME_CASING_CAMEL_CASE:
@@ -2795,8 +2795,8 @@ void Node::unhandled_key_input(const Ref<InputEvent> &p_key_event) {
 }
 
 void Node::_bind_methods() {
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/node_naming/name_num_separator", PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"), 0);
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/node_naming/name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case"), NAME_CASING_PASCAL_CASE);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/naming/node_name_num_separator", PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"), 0);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/naming/node_name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case"), NAME_CASING_PASCAL_CASE);
 
 	ClassDB::bind_static_method("Node", D_METHOD("print_orphan_nodes"), &Node::print_orphan_nodes);
 	ClassDB::bind_method(D_METHOD("add_sibling", "sibling", "force_readable_name"), &Node::add_sibling, DEFVAL(false));
@@ -3017,7 +3017,7 @@ void Node::_bind_methods() {
 }
 
 String Node::_get_name_num_separator() {
-	switch (GLOBAL_GET("editor/node_naming/name_num_separator").operator int()) {
+	switch (GLOBAL_GET("editor/naming/node_name_num_separator").operator int()) {
 		case 0:
 			return "";
 		case 1:


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/47700418/200494761-b23550bd-b5d9-4310-a715-952262c626a1.png)

1\. Renamed the following project settings:

Before                               |After
-------------------------------------|-------------------------------------
editor/scene/scene_naming            |editor/naming/scene_name_casing
editor/node_naming/name_num_separator|editor/naming/node_name_num_separator
editor/node_naming/name_casing       |editor/naming/node_name_casing

2\. The following editor settings replaced with project settings:

Before                                                |After
------------------------------------------------------|--------------------------------------------------
interface/editors/default_signal_callback_name        |editor/naming/default_signal_callback_name
interface/editors/default_signal_callback_to_self_name|editor/naming/default_signal_callback_to_self_name

**Notes:**

1\. The project settings from the `editor` section should be moved to Editor Settings, but with the ability to override them for the project.

2\. The setting `editor/naming/scene_name_casing` may need to be changed to `editor/naming/file_name_casing` (not only scene files should use this setting, but other resource types as well). See #57768.

3\. I found that doc generation does not work for all project settings. It depends on the file where the setting is defined with `GLOBAL_DEF`:

* core/config/project_settings.cpp - ok
* editor/editor_file_system.cpp - error
* editor/editor_node.cpp - error
* editor/export/editor_export_plugin.cpp - error
* editor/plugins/version_control_editor_plugin.cpp - error
* scene/main/node.cpp - ok
* servers/movie_writer/movie_writer.cpp - ok

<details>
<summary>Details</summary>

```
GLOBAL_DEF("editor/

core/config/project_settings.cpp: 4
1223:  2: 	GLOBAL_DEF("editor/run/main_run_args", "");
1225:  2: 	GLOBAL_DEF("editor/script/search_in_file_extensions", extensions);
1228:  2: 	GLOBAL_DEF("editor/script/templates_search_path", "res://script_templates");
1232:  2: 	GLOBAL_DEF("editor/naming/default_signal_callback_name", "_on_{node_name}_{signal_name}");
editor/editor_file_system.cpp: 2
2416: 39: 	reimport_on_missing_imported_files = GLOBAL_DEF("editor/import/reimport_missing_imported_files", true);
2417:  2: 	GLOBAL_DEF("editor/import/use_multiple_threads", true);
editor/editor_node.cpp: 1
5947:  2: 	GLOBAL_DEF("editor/naming/scene_name_casing", SCENE_NAME_CASING_SNAKE_CASE);
editor/export/editor_export_plugin.cpp: 1
200:  2: 	GLOBAL_DEF("editor/export/convert_text_resources_to_binary", false);
editor/plugins/version_control_editor_plugin.cpp: 3
 95: 29: 		String installed_plugin = GLOBAL_DEF("editor/version_control/plugin_name", "");
 96: 25: 		String project_path = GLOBAL_DEF("editor/version_control/project_path", OS::get_singleton()->get_resource_dir());
 98: 30: 		bool has_autoload_enable = GLOBAL_DEF("editor/version_control/autoload_on_startup", false);
scene/main/node.cpp: 2
2785:  2: 	GLOBAL_DEF("editor/naming/node_name_num_separator", 0);
2787:  2: 	GLOBAL_DEF("editor/naming/node_name_casing", NAME_CASING_PASCAL_CASE);
servers/movie_writer/movie_writer.cpp: 3
134:  2: 	GLOBAL_DEF("editor/movie_writer/mix_rate", 48000);
136:  2: 	GLOBAL_DEF("editor/movie_writer/speaker_mode", 0);
138:  2: 	GLOBAL_DEF("editor/movie_writer/mjpeg_quality", 0.75);
```

</details>