### PR TITLE
Modify newlines in Editor Spin Slider tooltip

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -42,7 +42,7 @@ String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
 #else
 		Key key = Key::CTRL;
 #endif
-		return TS->format_number(rtos(get_value())) + "\n\n" + vformat(TTR("Hold %s to round to integers. Hold Shift for more precise changes."), find_keycode_name(key));
+		return TS->format_number(rtos(get_value())) + "\n\n" + vformat(TTR("Hold %s to round to integers.\nHold Shift for more precise changes."), find_keycode_name(key));
 	}
 	return TS->format_number(rtos(get_value()));
 }


### PR DESCRIPTION
Makes both key suggestions easier to read and more pleasing to the eye.

![Showcase](https://user-images.githubusercontent.com/66727710/187650612-06331eab-5852-4bf3-9195-654157f52b29.png)

Can be cherrypicked to 3.x.