### PR TITLE
Scene tree dock improvements (paste into multiple selections, Esc key to clear selection)

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2758,8 +2758,6 @@ void FileSystemDock::_reselect_items_selected_on_drag_begin(bool reset) {
 }
 
 void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
-	Ref<InputEventKey> key = p_event;
-
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
 		TreeItem *item = tree->get_item_at_position(mm->get_position());
@@ -2788,6 +2786,7 @@ void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
 		}
 	}
 
+	Ref<InputEventKey> key = p_event;
 	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
 		if (ED_IS_SHORTCUT("filesystem_dock/duplicate", p_event)) {
 			_tree_rmb_option(FILE_DUPLICATE);
@@ -2801,6 +2800,8 @@ void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
 			_tree_rmb_option(FILE_RENAME);
 		} else if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			focus_on_filter();
+		} else if (key->get_keycode() == Key::ESCAPE) {
+			tree->deselect_all();
 		} else {
 			return;
 		}
@@ -2859,6 +2860,8 @@ void FileSystemDock::_file_list_gui_input(Ref<InputEvent> p_event) {
 			_file_list_rmb_option(FILE_RENAME);
 		} else if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			focus_on_filter();
+		} else if (key->get_keycode() == Key::ESCAPE) {
+			files->deselect_all();
 		} else {
 			return;
 		}

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -84,6 +84,14 @@ void SceneTreeDock::input(const Ref<InputEvent> &p_event) {
 			pending_click_select = nullptr;
 		}
 	}
+
+	Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid() && k->is_pressed()) {
+		if (k->get_keycode() == Key::ESCAPE) {
+			editor_selection->clear();
+		}
+	}
 }
 
 void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
@@ -2774,7 +2782,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	if (profile_allow_editing) {
 		menu->add_icon_shortcut(get_theme_icon(SNAME("ActionCut"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/cut_node"), TOOL_CUT);
 		menu->add_icon_shortcut(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/copy_node"), TOOL_COPY);
-		if (selection.size() == 1 && !node_clipboard.is_empty()) {
+		if (!node_clipboard.is_empty()) {
 			menu->add_icon_shortcut(get_theme_icon(SNAME("ActionPaste"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/paste_node"), TOOL_PASTE);
 		}
 		menu->add_separator();
@@ -3098,19 +3106,7 @@ List<Node *> SceneTreeDock::paste_nodes() {
 		return pasted_nodes;
 	}
 
-	Node *paste_parent = edited_scene;
 	List<Node *> selection = editor_selection->get_selected_node_list();
-	if (selection.size() > 0) {
-		paste_parent = selection.back()->get();
-	}
-
-	Node *owner = nullptr;
-	if (paste_parent) {
-		owner = paste_parent->get_owner();
-	}
-	if (!owner) {
-		owner = paste_parent;
-	}
 
 	Ref<EditorUndoRedoManager> &ur = editor_data->get_undo_redo();
 	ur->create_action(TTR("Paste Node(s)"), UndoRedo::MERGE_DISABLE, EditorNode::get_singleton()->get_edited_scene());
@@ -3133,42 +3129,49 @@ List<Node *> SceneTreeDock::paste_nodes() {
 	}
 
 	for (Node *node : node_clipboard) {
-		HashMap<const Node *, Node *> duplimap;
-
-		Node *dup = node->duplicate_from_editor(duplimap, resource_remap);
-		ERR_CONTINUE(!dup);
-
-		pasted_nodes.push_back(dup);
-
-		if (!paste_parent) {
-			paste_parent = dup;
-			owner = dup;
-			ur->add_do_method(EditorNode::get_singleton(), "set_edited_scene", dup);
-		} else {
-			ur->add_do_method(paste_parent, "add_child", dup, true);
-		}
-
-		for (KeyValue<const Node *, Node *> &E2 : duplimap) {
-			Node *d = E2.value;
-			if (d != dup) {
-				ur->add_do_method(d, "set_owner", owner);
+		for (Node *target_node : selection) {
+			Node *owner = target_node->get_owner();
+			if (!owner) {
+				owner = target_node;
 			}
-		}
 
-		if (dup != owner) {
-			ur->add_do_method(dup, "set_owner", owner);
-		}
-		ur->add_do_method(editor_selection, "add_node", dup);
+			HashMap<const Node *, Node *> duplimap;
 
-		if (dup == paste_parent) {
-			ur->add_undo_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
-		} else {
-			ur->add_undo_method(paste_parent, "remove_child", dup);
-		}
-		ur->add_do_reference(dup);
+			Node *dup = node->duplicate_from_editor(duplimap, resource_remap);
+			ERR_CONTINUE(!dup);
 
-		if (node_clipboard.size() == 1) {
-			ur->add_do_method(EditorNode::get_singleton(), "push_item", dup);
+			pasted_nodes.push_back(dup);
+
+			if (!target_node) {
+				target_node = dup;
+				owner = dup;
+				ur->add_do_method(EditorNode::get_singleton(), "set_edited_scene", dup);
+			} else {
+				ur->add_do_method(target_node, "add_child", dup, true);
+			}
+
+			for (KeyValue<const Node *, Node *> &E2 : duplimap) {
+				Node *d = E2.value;
+				if (d != dup) {
+					ur->add_do_method(d, "set_owner", owner);
+				}
+			}
+
+			if (dup != owner) {
+				ur->add_do_method(dup, "set_owner", owner);
+			}
+			ur->add_do_method(editor_selection, "add_node", dup);
+
+			if (dup == target_node) {
+				ur->add_undo_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
+			} else {
+				ur->add_undo_method(target_node, "remove_child", dup);
+			}
+			ur->add_do_reference(dup);
+
+			if (node_clipboard.size() == 1) {
+				ur->add_do_method(EditorNode::get_singleton(), "push_item", dup);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds the ability to press the Esc key while the scene tree dock is in focus and clear the active selection (just as is the case with the 2D/3D viewport). It also adds the ability to paste into multiple selected nodes at once, which was a major QOL issue for me in having to paste a helper node I made into different areas of the scene tree individually.

https://user-images.githubusercontent.com/18225391/187647627-560f29d6-9d16-49ac-9311-9afb89e9f59a.mp4

I noticed an undo-redo issue while testing this, which has been mentioned in #65138, but that's unrelated and also seems to happen prior to alpha 15.