### PR TITLE
Include both name and prefixed name in `owned_unique_nodes` HashMap

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -204,7 +204,7 @@
 				If [code]recursive[/code] is [code]true[/code], all child nodes are included, even if deeply nested. Nodes are checked in tree order, so this node's first direct child is checked first, then its own direct children, etc., before moving to the second direct child, and so on. If [code]recursive[/code] is [code]false[/code], only this node's direct children are matched.
 				If [code]owned[/code] is [code]true[/code], this method only finds nodes who have an assigned [member Node.owner]. This is especially important for scenes instantiated through a script, because those scenes don't have an owner.
 				Returns [code]null[/code] if no matching [Node] is found.
-				[b]Note:[/b] As this method walks through all the descendants of the node, it is the slowest way to get a reference to another node. Whenever possible, consider using [method get_node] with unique names instead (see [member unique_name_in_owner]), or caching the node references into variable.
+				[b]Note:[/b] As this method walks through all the descendants of the node, it is the slowest way to get a reference to another node. Whenever possible, consider using [method get_node] with unique names instead (see [member unique_name_in_owner]), [method get_unique_node], or caching the node references into variable.
 				[b]Note:[/b] To find all descendant nodes matching a pattern or a class type, see [method find_children].
 			</description>
 		</method>
@@ -393,6 +393,32 @@
 			<return type="SceneTree" />
 			<description>
 				Returns the [SceneTree] that contains this node.
+			</description>
+		</method>
+		<method name="get_unique_node" qualifiers="const">
+			<return type="Node" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns the unique node whose [member name] matches the specified [code]name[/code], within the current [member owner]. If the unique node does not exist, [code]null[/code] is returned. Attempts to access methods on this return value will result in an "Attempt to call &lt;method&gt; on a null instance." error. See [member unique_name_in_owner].
+				This method is the equivalent of [method get_node], when using the unique name accessor [code]%[/code] to fetch a single node.
+				[b]Example:[/b] Assume Hero has been set with an unique name in the following scene:
+				[codeblock]
+				/Town
+				/Town/Tree
+				/Town/House
+				/Town/House/Hero
+				[/codeblock]
+				The following methods will safely return Hero, so long as its owner is the scene root:
+				[codeblocks]
+				[gdscript]
+				get_node("%Hero")
+				get_unique_node("Hero")
+				[/gdscript]
+				[csharp]
+				getNode("%Hero");
+				getUniqueNode("Hero");
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_viewport" qualifiers="const">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1364,6 +1364,34 @@ bool Node::has_node(const NodePath &p_path) const {
 	return get_node_or_null(p_path) != nullptr;
 }
 
+Node *Node::get_unique_node(const StringName &p_name) const {
+	if (!p_name) {
+		ERR_FAIL_V_MSG(nullptr, "'name' parameter cannot be empty");
+	}
+
+	const StringName key = StringName(UNIQUE_NODE_PREFIX + p_name);
+
+	if (data.owned_unique_nodes.size()) {
+		// Has unique nodes in ownership.
+		Node *const *unique = data.owned_unique_nodes.getptr(key);
+		if (!unique) {
+			// Could not find 'p_name' among the Unique Nodes this node owns.
+			return nullptr;
+		}
+		return *unique;
+	} else if (data.owner) {
+		Node **unique = data.owner->data.owned_unique_nodes.getptr(key);
+		if (!unique) {
+			// Could not find 'p_name' among the Unique Nodes this node's owner contains.
+			return nullptr;
+		}
+		return *unique;
+	} else {
+		// No Unique Nodes could be found across the owner.
+		return nullptr;
+	}
+}
+
 // Finds the first child node (in tree order) whose name matches the given pattern.
 // Can be recursive or not, and limited to owned nodes.
 Node *Node::find_child(const String &p_pattern, bool p_recursive, bool p_owned) const {
@@ -2672,6 +2700,22 @@ void Node::get_argument_options(const StringName &p_function, int p_idx, List<St
 	if ((pf == "has_node" || pf == "get_node") && p_idx == 0) {
 		_add_nodes_to_options(this, this, r_options);
 	}
+	if ((pf == "get_unique_node") && p_idx == 0) {
+		HashMap<StringName, Node *>::ConstIterator elem = data.owned_unique_nodes.begin();
+		while (elem) {
+			String name = elem->value->data.name;
+			r_options->push_back(name.quote());
+			++elem;
+		}
+		if (data.owner) {
+			elem = data.owner->data.owned_unique_nodes.begin();
+			while (elem) {
+				String name = elem->value->data.name;
+				r_options->push_back(name.quote());
+				++elem;
+			}
+		}
+	}
 	Object::get_argument_options(p_function, p_idx, r_options);
 }
 
@@ -2798,6 +2842,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_node", "path"), &Node::has_node);
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);
 	ClassDB::bind_method(D_METHOD("get_node_or_null", "path"), &Node::get_node_or_null);
+	ClassDB::bind_method(D_METHOD("get_unique_node", "name"), &Node::get_unique_node);
 	ClassDB::bind_method(D_METHOD("get_parent"), &Node::get_parent);
 	ClassDB::bind_method(D_METHOD("find_child", "pattern", "recursive", "owned"), &Node::find_child, DEFVAL(true), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("find_children", "pattern", "type", "recursive", "owned"), &Node::find_children, DEFVAL(""), DEFVAL(true), DEFVAL(true));

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -312,6 +312,7 @@ public:
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;
+	Node *get_unique_node(const StringName &p_name) const;
 	Node *find_child(const String &p_pattern, bool p_recursive = true, bool p_owned = true) const;
 	TypedArray<Node> find_children(const String &p_pattern, const String &p_type = "", bool p_recursive = true, bool p_owned = true) const;
 	bool has_node_and_resource(const NodePath &p_path) const;


### PR DESCRIPTION
Requires https://github.com/godotengine/godot/pull/64023 to be merged first.
Alternative to https://github.com/godotengine/godot/pull/64274. Read these two for further information.
As brought up by https://github.com/godotengine/godot/pull/64274#issuecomment-1228415024.

To quote myself:
> As brought up in that PR, whenever names are added to the `owned_unique_nodes` **HashMap**, their prefix ("%") is included too. It's technically incorrect, but this is not actually too much of a problem. [I speculated](https://github.com/godotengine/godot/pull/64023#issuecomment-1208076439) that this was done to speed up access in `get_node()`, as there would be no need to strip the prefix before using the name as a key.

This doesn't affect `get_node("%Node")` 's speed, but makes `get_unique_node("Node")` considerably faster than in the original PR (faster than `get_node("%Node")`), at the cost of increased memory usage (basically doubles the `owned_unique_nodes` HashMap size).

_It's worth arguing if this is necessary in the first place. As I have expressed plenty of times before, I personally see highly unlikely that users are making use of extremely complex **NodePaths** with unique name prefixes in them, such as `"%Path/To/%Scene/%UniqueNode"`. It leads to very "nasty" and convuluted code, especially because it's not guaranteed that the unique node is a direct child of its owner._