### PR TITLE
Fix GDScript preload fails in standalone build unless files are present in directory

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3189,7 +3189,7 @@ void GDScriptAnalyzer::reduce_preload(GDScriptParser::PreloadNode *p_preload) {
 			p_preload->resolved_path = parser->script_path.get_base_dir().path_join(p_preload->resolved_path);
 		}
 		p_preload->resolved_path = p_preload->resolved_path.simplify_path();
-		if (!FileAccess::exists(p_preload->resolved_path)) {
+		if (!ResourceLoader::exists(p_preload->resolved_path)) {
 			push_error(vformat(R"(Preload file "%s" does not exist.)", p_preload->resolved_path), p_preload->path);
 		} else {
 			// TODO: Don't load if validating: use completion cache.


### PR DESCRIPTION
**Intro:**
When exporting files into a pck format
files that are imported (those that have .import file) are replaced by whatever path is in the .import file + the .import file itself [[ref]](https://github.com/godotengine/godot/blob/736632ee7ed00a3474448cfd227f696f82905ac7/editor/export/editor_export_platform.cpp#L635-L707).

Example:
adding `audio.ogg` will add instead `audio.ogg.import` and `.godot/imported/audio.ogg-{hash}.oggvorbisstr`

With the exception of files that are meant to be kept (see previous ref) + the icon and the splash files [[ref]](https://github.com/godotengine/godot/blob/736632ee7ed00a3474448cfd227f696f82905ac7/editor/export/editor_export_platform.cpp#L802-L811)

**Problem:**
The problem is when checking for file existence, namely for `preload` where the gdscript analyser call `FileAccess::exists(p_preload->resolved_path)` it fails for every imported file (except the exceptions listed above), since `audio.ogg` does not exist (as per the example).

**Solution:**
Since for every imported file, the .import file is also added [[ref]](https://github.com/godotengine/godot/blob/736632ee7ed00a3474448cfd227f696f82905ac7/editor/export/editor_export_platform.cpp#L699-L705), we can make a second check to check for that .import file instead.

Fixes #56343