### PR TITLE
Add a lifecycle method for manual theme item caching to `Control`

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -44,7 +44,6 @@ void BoxContainer::_resort() {
 
 	Size2i new_size = get_size();
 
-	int sep = get_theme_constant(SNAME("separation")); //,vertical?"VBoxContainer":"HBoxContainer");
 	bool rtl = is_layout_rtl();
 
 	bool first = true;
@@ -90,7 +89,7 @@ void BoxContainer::_resort() {
 		return;
 	}
 
-	int stretch_max = (vertical ? new_size.height : new_size.width) - (children_count - 1) * sep;
+	int stretch_max = (vertical ? new_size.height : new_size.width) - (children_count - 1) * theme_cache.separation;
 	int stretch_diff = stretch_max - stretch_min;
 	if (stretch_diff < 0) {
 		//avoid negative stretch space
@@ -214,7 +213,7 @@ void BoxContainer::_resort() {
 		if (first) {
 			first = false;
 		} else {
-			ofs += sep;
+			ofs += theme_cache.separation;
 		}
 
 		int from = ofs;
@@ -248,7 +247,6 @@ Size2 BoxContainer::get_minimum_size() const {
 	/* Calculate MINIMUM SIZE */
 
 	Size2i minimum;
-	int sep = get_theme_constant(SNAME("separation")); //,vertical?"VBoxContainer":"HBoxContainer");
 
 	bool first = true;
 
@@ -273,7 +271,7 @@ Size2 BoxContainer::get_minimum_size() const {
 				minimum.width = size.width;
 			}
 
-			minimum.height += size.height + (first ? 0 : sep);
+			minimum.height += size.height + (first ? 0 : theme_cache.separation);
 
 		} else { /* HORIZONTAL */
 
@@ -281,13 +279,19 @@ Size2 BoxContainer::get_minimum_size() const {
 				minimum.height = size.height;
 			}
 
-			minimum.width += size.width + (first ? 0 : sep);
+			minimum.width += size.width + (first ? 0 : theme_cache.separation);
 		}
 
 		first = false;
 	}
 
 	return minimum;
+}
+
+void BoxContainer::_update_theme_item_cache() {
+	Container::_update_theme_item_cache();
+
+	theme_cache.separation = get_theme_constant(SNAME("separation")); //,vertical?"VBoxContainer":"HBoxContainer");
 }
 
 void BoxContainer::_notification(int p_what) {

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -47,11 +47,16 @@ private:
 	bool vertical = false;
 	AlignmentMode alignment = ALIGNMENT_BEGIN;
 
+	struct ThemeCache {
+		int separation = 0;
+	} theme_cache;
+
 	void _resort();
 
 protected:
-	void _notification(int p_what);
+	virtual void _update_theme_item_cache() override;
 
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -36,7 +36,7 @@
 Size2 Button::get_minimum_size() const {
 	Ref<Texture2D> _icon = icon;
 	if (_icon.is_null() && has_theme_icon(SNAME("icon"))) {
-		_icon = Control::get_theme_icon(SNAME("icon"));
+		_icon = theme_cache.icon;
 	}
 
 	return get_minimum_size_for_text_and_icon("", _icon);
@@ -44,6 +44,45 @@ Size2 Button::get_minimum_size() const {
 
 void Button::_set_internal_margin(Side p_side, float p_value) {
 	_internal_margin[p_side] = p_value;
+}
+
+void Button::_update_theme_item_cache() {
+	BaseButton::_update_theme_item_cache();
+
+	theme_cache.normal = get_theme_stylebox(SNAME("normal"));
+	theme_cache.normal_mirrored = get_theme_stylebox(SNAME("normal_mirrored"));
+	theme_cache.pressed = get_theme_stylebox(SNAME("pressed"));
+	theme_cache.pressed_mirrored = get_theme_stylebox(SNAME("pressed_mirrored"));
+	theme_cache.hover = get_theme_stylebox(SNAME("hover"));
+	theme_cache.hover_mirrored = get_theme_stylebox(SNAME("hover_mirrored"));
+	theme_cache.hover_pressed = get_theme_stylebox(SNAME("hover_pressed"));
+	theme_cache.hover_pressed_mirrored = get_theme_stylebox(SNAME("hover_pressed_mirrored"));
+	theme_cache.disabled = get_theme_stylebox(SNAME("disabled"));
+	theme_cache.disabled_mirrored = get_theme_stylebox(SNAME("disabled_mirrored"));
+	theme_cache.focus = get_theme_stylebox(SNAME("focus"));
+
+	theme_cache.font_color = get_theme_color(SNAME("font_color"));
+	theme_cache.font_focus_color = get_theme_color(SNAME("font_focus_color"));
+	theme_cache.font_pressed_color = get_theme_color(SNAME("font_pressed_color"));
+	theme_cache.font_hover_color = get_theme_color(SNAME("font_hover_color"));
+	theme_cache.font_hover_pressed_color = get_theme_color(SNAME("font_hover_pressed_color"));
+	theme_cache.font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
+
+	theme_cache.font = get_theme_font(SNAME("font"));
+	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
+	theme_cache.outline_size = get_theme_constant(SNAME("outline_size"));
+	theme_cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
+
+	theme_cache.icon_normal_color = get_theme_color(SNAME("icon_normal_color"));
+	theme_cache.icon_focus_color = get_theme_color(SNAME("icon_focus_color"));
+	theme_cache.icon_pressed_color = get_theme_color(SNAME("icon_pressed_color"));
+	theme_cache.icon_hover_color = get_theme_color(SNAME("icon_hover_color"));
+	theme_cache.icon_hover_pressed_color = get_theme_color(SNAME("icon_hover_pressed_color"));
+	theme_cache.icon_disabled_color = get_theme_color(SNAME("icon_disabled_color"));
+
+	theme_cache.icon = get_theme_icon(SNAME("icon"));
+
+	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
 }
 
 void Button::_notification(int p_what) {
@@ -73,15 +112,15 @@ void Button::_notification(int p_what) {
 			Color color;
 			Color color_icon(1, 1, 1, 1);
 
-			Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
+			Ref<StyleBox> style = theme_cache.normal;
 			bool rtl = is_layout_rtl();
 
 			switch (get_draw_mode()) {
 				case DRAW_NORMAL: {
 					if (rtl && has_theme_stylebox(SNAME("normal_mirrored"))) {
-						style = get_theme_stylebox(SNAME("normal_mirrored"));
+						style = theme_cache.normal_mirrored;
 					} else {
-						style = get_theme_stylebox(SNAME("normal"));
+						style = theme_cache.normal;
 					}
 
 					if (!flat) {
@@ -90,14 +129,14 @@ void Button::_notification(int p_what) {
 
 					// Focus colors only take precedence over normal state.
 					if (has_focus()) {
-						color = get_theme_color(SNAME("font_focus_color"));
+						color = theme_cache.font_focus_color;
 						if (has_theme_color(SNAME("icon_focus_color"))) {
-							color_icon = get_theme_color(SNAME("icon_focus_color"));
+							color_icon = theme_cache.icon_focus_color;
 						}
 					} else {
-						color = get_theme_color(SNAME("font_color"));
+						color = theme_cache.font_color;
 						if (has_theme_color(SNAME("icon_normal_color"))) {
-							color_icon = get_theme_color(SNAME("icon_normal_color"));
+							color_icon = theme_cache.icon_normal_color;
 						}
 					}
 				} break;
@@ -105,19 +144,19 @@ void Button::_notification(int p_what) {
 					// Edge case for CheckButton and CheckBox.
 					if (has_theme_stylebox("hover_pressed")) {
 						if (rtl && has_theme_stylebox(SNAME("hover_pressed_mirrored"))) {
-							style = get_theme_stylebox(SNAME("hover_pressed_mirrored"));
+							style = theme_cache.hover_pressed_mirrored;
 						} else {
-							style = get_theme_stylebox(SNAME("hover_pressed"));
+							style = theme_cache.hover_pressed;
 						}
 
 						if (!flat) {
 							style->draw(ci, Rect2(Point2(0, 0), size));
 						}
 						if (has_theme_color(SNAME("font_hover_pressed_color"))) {
-							color = get_theme_color(SNAME("font_hover_pressed_color"));
+							color = theme_cache.font_hover_pressed_color;
 						}
 						if (has_theme_color(SNAME("icon_hover_pressed_color"))) {
-							color_icon = get_theme_color(SNAME("icon_hover_pressed_color"));
+							color_icon = theme_cache.icon_hover_pressed_color;
 						}
 
 						break;
@@ -126,53 +165,53 @@ void Button::_notification(int p_what) {
 				}
 				case DRAW_PRESSED: {
 					if (rtl && has_theme_stylebox(SNAME("pressed_mirrored"))) {
-						style = get_theme_stylebox(SNAME("pressed_mirrored"));
+						style = theme_cache.pressed_mirrored;
 					} else {
-						style = get_theme_stylebox(SNAME("pressed"));
+						style = theme_cache.pressed;
 					}
 
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
 					if (has_theme_color(SNAME("font_pressed_color"))) {
-						color = get_theme_color(SNAME("font_pressed_color"));
+						color = theme_cache.font_pressed_color;
 					} else {
-						color = get_theme_color(SNAME("font_color"));
+						color = theme_cache.font_color;
 					}
 					if (has_theme_color(SNAME("icon_pressed_color"))) {
-						color_icon = get_theme_color(SNAME("icon_pressed_color"));
+						color_icon = theme_cache.icon_pressed_color;
 					}
 
 				} break;
 				case DRAW_HOVER: {
 					if (rtl && has_theme_stylebox(SNAME("hover_mirrored"))) {
-						style = get_theme_stylebox(SNAME("hover_mirrored"));
+						style = theme_cache.hover_mirrored;
 					} else {
-						style = get_theme_stylebox(SNAME("hover"));
+						style = theme_cache.hover;
 					}
 
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					color = get_theme_color(SNAME("font_hover_color"));
+					color = theme_cache.font_hover_color;
 					if (has_theme_color(SNAME("icon_hover_color"))) {
-						color_icon = get_theme_color(SNAME("icon_hover_color"));
+						color_icon = theme_cache.icon_hover_color;
 					}
 
 				} break;
 				case DRAW_DISABLED: {
 					if (rtl && has_theme_stylebox(SNAME("disabled_mirrored"))) {
-						style = get_theme_stylebox(SNAME("disabled_mirrored"));
+						style = theme_cache.disabled_mirrored;
 					} else {
-						style = get_theme_stylebox(SNAME("disabled"));
+						style = theme_cache.disabled;
 					}
 
 					if (!flat) {
 						style->draw(ci, Rect2(Point2(0, 0), size));
 					}
-					color = get_theme_color(SNAME("font_disabled_color"));
+					color = theme_cache.font_disabled_color;
 					if (has_theme_color(SNAME("icon_disabled_color"))) {
-						color_icon = get_theme_color(SNAME("icon_disabled_color"));
+						color_icon = theme_cache.icon_disabled_color;
 					} else {
 						color_icon.a = 0.4;
 					}
@@ -181,13 +220,13 @@ void Button::_notification(int p_what) {
 			}
 
 			if (has_focus()) {
-				Ref<StyleBox> style2 = get_theme_stylebox(SNAME("focus"));
+				Ref<StyleBox> style2 = theme_cache.focus;
 				style2->draw(ci, Rect2(Point2(), size));
 			}
 
 			Ref<Texture2D> _icon;
 			if (icon.is_null() && has_theme_icon(SNAME("icon"))) {
-				_icon = Control::get_theme_icon(SNAME("icon"));
+				_icon = theme_cache.icon;
 			} else {
 				_icon = icon;
 			}
@@ -217,21 +256,21 @@ void Button::_notification(int p_what) {
 				if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_LEFT) {
 					style_offset.x = style->get_margin(SIDE_LEFT);
 					if (_internal_margin[SIDE_LEFT] > 0) {
-						icon_ofs_region = _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("h_separation"));
+						icon_ofs_region = _internal_margin[SIDE_LEFT] + theme_cache.h_separation;
 					}
 				} else if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER) {
 					style_offset.x = 0.0;
 				} else if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_RIGHT) {
 					style_offset.x = -style->get_margin(SIDE_RIGHT);
 					if (_internal_margin[SIDE_RIGHT] > 0) {
-						icon_ofs_region = -_internal_margin[SIDE_RIGHT] - get_theme_constant(SNAME("h_separation"));
+						icon_ofs_region = -_internal_margin[SIDE_RIGHT] - theme_cache.h_separation;
 					}
 				}
 				style_offset.y = style->get_margin(SIDE_TOP);
 
 				if (expand_icon) {
 					Size2 _size = get_size() - style->get_offset() * 2;
-					int icon_text_separation = text.is_empty() ? 0 : get_theme_constant(SNAME("h_separation"));
+					int icon_text_separation = text.is_empty() ? 0 : theme_cache.h_separation;
 					_size.width -= icon_text_separation + icon_ofs_region;
 					if (!clip_text && icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER) {
 						_size.width -= text_buf->get_size().width;
@@ -261,7 +300,7 @@ void Button::_notification(int p_what) {
 				}
 			}
 
-			Point2 icon_ofs = !_icon.is_null() ? Point2(icon_region.size.width + get_theme_constant(SNAME("h_separation")), 0) : Point2();
+			Point2 icon_ofs = !_icon.is_null() ? Point2(icon_region.size.width + theme_cache.h_separation, 0) : Point2();
 			if (align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER && icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER) {
 				icon_ofs.x = 0.0;
 			}
@@ -271,10 +310,10 @@ void Button::_notification(int p_what) {
 			int text_width = MAX(1, (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x);
 
 			if (_internal_margin[SIDE_LEFT] > 0) {
-				text_clip -= _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("h_separation"));
+				text_clip -= _internal_margin[SIDE_LEFT] + theme_cache.h_separation;
 			}
 			if (_internal_margin[SIDE_RIGHT] > 0) {
-				text_clip -= _internal_margin[SIDE_RIGHT] + get_theme_constant(SNAME("h_separation"));
+				text_clip -= _internal_margin[SIDE_RIGHT] + theme_cache.h_separation;
 			}
 
 			Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - text_buf->get_size() - Point2(_internal_margin[SIDE_RIGHT] - _internal_margin[SIDE_LEFT], 0)) / 2.0;
@@ -288,7 +327,7 @@ void Button::_notification(int p_what) {
 						icon_ofs.x = 0.0;
 					}
 					if (_internal_margin[SIDE_LEFT] > 0) {
-						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x + _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("h_separation"));
+						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x + _internal_margin[SIDE_LEFT] + theme_cache.h_separation;
 					} else {
 						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x;
 					}
@@ -305,7 +344,7 @@ void Button::_notification(int p_what) {
 				} break;
 				case HORIZONTAL_ALIGNMENT_RIGHT: {
 					if (_internal_margin[SIDE_RIGHT] > 0) {
-						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width - _internal_margin[SIDE_RIGHT] - get_theme_constant(SNAME("h_separation"));
+						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width - _internal_margin[SIDE_RIGHT] - theme_cache.h_separation;
 					} else {
 						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width;
 					}
@@ -316,8 +355,8 @@ void Button::_notification(int p_what) {
 				} break;
 			}
 
-			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
-			int outline_size = get_theme_constant(SNAME("outline_size"));
+			Color font_outline_color = theme_cache.font_outline_color;
+			int outline_size = theme_cache.outline_size;
 			if (outline_size > 0 && font_outline_color.a > 0) {
 				text_buf->draw_outline(ci, text_ofs, outline_size, font_outline_color);
 			}
@@ -346,7 +385,7 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		if (icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
 			minsize.width += p_icon->get_width();
 			if (!xl_text.is_empty() || !p_text.is_empty()) {
-				minsize.width += MAX(0, get_theme_constant(SNAME("h_separation")));
+				minsize.width += MAX(0, theme_cache.h_separation);
 			}
 		} else {
 			minsize.width = MAX(minsize.width, p_icon->get_width());
@@ -354,12 +393,12 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 	}
 
 	if (!xl_text.is_empty() || !p_text.is_empty()) {
-		Ref<Font> font = get_theme_font(SNAME("font"));
-		float font_height = font->get_height(get_theme_font_size(SNAME("font_size")));
+		Ref<Font> font = theme_cache.font;
+		float font_height = font->get_height(theme_cache.font_size);
 		minsize.height = MAX(font_height, minsize.height);
 	}
 
-	return get_theme_stylebox(SNAME("normal"))->get_minimum_size() + minsize;
+	return theme_cache.normal->get_minimum_size() + minsize;
 }
 
 void Button::_shape(Ref<TextParagraph> p_paragraph, String p_text) {
@@ -371,10 +410,15 @@ void Button::_shape(Ref<TextParagraph> p_paragraph, String p_text) {
 		p_text = xl_text;
 	}
 
-	Ref<Font> font = get_theme_font(SNAME("font"));
-	int font_size = get_theme_font_size(SNAME("font_size"));
-
 	p_paragraph->clear();
+
+	Ref<Font> font = theme_cache.font;
+	int font_size = theme_cache.font_size;
+	if (font.is_null() || font_size == 0) {
+		// Can't shape without a valid font and a non-zero size.
+		return;
+	}
+
 	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {
 		p_paragraph->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
 	} else {

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -54,10 +54,48 @@ private:
 	HorizontalAlignment icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
 	float _internal_margin[4] = {};
 
+	struct ThemeCache {
+		Ref<StyleBox> normal;
+		Ref<StyleBox> normal_mirrored;
+		Ref<StyleBox> pressed;
+		Ref<StyleBox> pressed_mirrored;
+		Ref<StyleBox> hover;
+		Ref<StyleBox> hover_mirrored;
+		Ref<StyleBox> hover_pressed;
+		Ref<StyleBox> hover_pressed_mirrored;
+		Ref<StyleBox> disabled;
+		Ref<StyleBox> disabled_mirrored;
+		Ref<StyleBox> focus;
+
+		Color font_color;
+		Color font_focus_color;
+		Color font_pressed_color;
+		Color font_hover_color;
+		Color font_hover_pressed_color;
+		Color font_disabled_color;
+
+		Ref<Font> font;
+		int font_size = 0;
+		int outline_size = 0;
+		Color font_outline_color;
+
+		Color icon_normal_color;
+		Color icon_focus_color;
+		Color icon_pressed_color;
+		Color icon_hover_color;
+		Color icon_hover_pressed_color;
+		Color icon_disabled_color;
+
+		Ref<Texture2D> icon;
+
+		int h_separation = 0;
+	} theme_cache;
+
 	void _shape(Ref<TextParagraph> p_paragraph = Ref<TextParagraph>(), String p_text = "");
 
 protected:
 	void _set_internal_margin(Side p_side, float p_value);
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -33,39 +33,30 @@
 #include "servers/rendering_server.h"
 
 Size2 CheckBox::get_icon_size() const {
-	Ref<Texture2D> checked = Control::get_theme_icon(SNAME("checked"));
-	Ref<Texture2D> unchecked = Control::get_theme_icon(SNAME("unchecked"));
-	Ref<Texture2D> radio_checked = Control::get_theme_icon(SNAME("radio_checked"));
-	Ref<Texture2D> radio_unchecked = Control::get_theme_icon(SNAME("radio_unchecked"));
-	Ref<Texture2D> checked_disabled = Control::get_theme_icon(SNAME("checked_disabled"));
-	Ref<Texture2D> unchecked_disabled = Control::get_theme_icon(SNAME("unchecked_disabled"));
-	Ref<Texture2D> radio_checked_disabled = Control::get_theme_icon(SNAME("radio_checked_disabled"));
-	Ref<Texture2D> radio_unchecked_disabled = Control::get_theme_icon(SNAME("radio_unchecked_disabled"));
-
 	Size2 tex_size = Size2(0, 0);
-	if (!checked.is_null()) {
-		tex_size = Size2(checked->get_width(), checked->get_height());
+	if (!theme_cache.checked.is_null()) {
+		tex_size = Size2(theme_cache.checked->get_width(), theme_cache.checked->get_height());
 	}
-	if (!unchecked.is_null()) {
-		tex_size = Size2(MAX(tex_size.width, unchecked->get_width()), MAX(tex_size.height, unchecked->get_height()));
+	if (!theme_cache.unchecked.is_null()) {
+		tex_size = Size2(MAX(tex_size.width, theme_cache.unchecked->get_width()), MAX(tex_size.height, theme_cache.unchecked->get_height()));
 	}
-	if (!radio_checked.is_null()) {
-		tex_size = Size2(MAX(tex_size.width, radio_checked->get_width()), MAX(tex_size.height, radio_checked->get_height()));
+	if (!theme_cache.radio_checked.is_null()) {
+		tex_size = Size2(MAX(tex_size.width, theme_cache.radio_checked->get_width()), MAX(tex_size.height, theme_cache.radio_checked->get_height()));
 	}
-	if (!radio_unchecked.is_null()) {
-		tex_size = Size2(MAX(tex_size.width, radio_unchecked->get_width()), MAX(tex_size.height, radio_unchecked->get_height()));
+	if (!theme_cache.radio_unchecked.is_null()) {
+		tex_size = Size2(MAX(tex_size.width, theme_cache.radio_unchecked->get_width()), MAX(tex_size.height, theme_cache.radio_unchecked->get_height()));
 	}
-	if (!checked_disabled.is_null()) {
-		tex_size = Size2(MAX(tex_size.width, checked_disabled->get_width()), MAX(tex_size.height, checked_disabled->get_height()));
+	if (!theme_cache.checked_disabled.is_null()) {
+		tex_size = Size2(MAX(tex_size.width, theme_cache.checked_disabled->get_width()), MAX(tex_size.height, theme_cache.checked_disabled->get_height()));
 	}
-	if (!unchecked_disabled.is_null()) {
-		tex_size = Size2(MAX(tex_size.width, unchecked_disabled->get_width()), MAX(tex_size.height, unchecked_disabled->get_height()));
+	if (!theme_cache.unchecked_disabled.is_null()) {
+		tex_size = Size2(MAX(tex_size.width, theme_cache.unchecked_disabled->get_width()), MAX(tex_size.height, theme_cache.unchecked_disabled->get_height()));
 	}
-	if (!radio_checked_disabled.is_null()) {
-		tex_size = Size2(MAX(tex_size.width, radio_checked_disabled->get_width()), MAX(tex_size.height, radio_checked_disabled->get_height()));
+	if (!theme_cache.radio_checked_disabled.is_null()) {
+		tex_size = Size2(MAX(tex_size.width, theme_cache.radio_checked_disabled->get_width()), MAX(tex_size.height, theme_cache.radio_checked_disabled->get_height()));
 	}
-	if (!radio_unchecked_disabled.is_null()) {
-		tex_size = Size2(MAX(tex_size.width, radio_unchecked_disabled->get_width()), MAX(tex_size.height, radio_unchecked_disabled->get_height()));
+	if (!theme_cache.radio_unchecked_disabled.is_null()) {
+		tex_size = Size2(MAX(tex_size.width, theme_cache.radio_unchecked_disabled->get_width()), MAX(tex_size.height, theme_cache.radio_unchecked_disabled->get_height()));
 	}
 	return tex_size;
 }
@@ -75,12 +66,28 @@ Size2 CheckBox::get_minimum_size() const {
 	Size2 tex_size = get_icon_size();
 	minsize.width += tex_size.width;
 	if (get_text().length() > 0) {
-		minsize.width += MAX(0, get_theme_constant(SNAME("h_separation")));
+		minsize.width += MAX(0, theme_cache.h_separation);
 	}
-	Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
-	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(SIDE_TOP) + sb->get_margin(SIDE_BOTTOM));
+	minsize.height = MAX(minsize.height, tex_size.height + theme_cache.normal_style->get_margin(SIDE_TOP) + theme_cache.normal_style->get_margin(SIDE_BOTTOM));
 
 	return minsize;
+}
+
+void CheckBox::_update_theme_item_cache() {
+	Button::_update_theme_item_cache();
+
+	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
+	theme_cache.check_v_adjust = get_theme_constant(SNAME("check_v_adjust"));
+	theme_cache.normal_style = get_theme_stylebox(SNAME("normal"));
+
+	theme_cache.checked = get_theme_icon(SNAME("checked"));
+	theme_cache.unchecked = get_theme_icon(SNAME("unchecked"));
+	theme_cache.radio_checked = get_theme_icon(SNAME("radio_checked"));
+	theme_cache.radio_unchecked = get_theme_icon(SNAME("radio_unchecked"));
+	theme_cache.checked_disabled = get_theme_icon(SNAME("checked_disabled"));
+	theme_cache.unchecked_disabled = get_theme_icon(SNAME("unchecked_disabled"));
+	theme_cache.radio_checked_disabled = get_theme_icon(SNAME("radio_checked_disabled"));
+	theme_cache.radio_unchecked_disabled = get_theme_icon(SNAME("radio_unchecked_disabled"));
 }
 
 void CheckBox::_notification(int p_what) {
@@ -100,22 +107,39 @@ void CheckBox::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
 
-			Ref<Texture2D> on = Control::get_theme_icon(vformat("%s%s", is_radio() ? "radio_checked" : "checked", is_disabled() ? "_disabled" : ""));
-			Ref<Texture2D> off = Control::get_theme_icon(vformat("%s%s", is_radio() ? "radio_unchecked" : "unchecked", is_disabled() ? "_disabled" : ""));
-			Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
+			Ref<Texture2D> on_tex;
+			Ref<Texture2D> off_tex;
+
+			if (is_radio()) {
+				if (is_disabled()) {
+					on_tex = theme_cache.radio_checked_disabled;
+					off_tex = theme_cache.radio_unchecked_disabled;
+				} else {
+					on_tex = theme_cache.radio_checked;
+					off_tex = theme_cache.radio_unchecked;
+				}
+			} else {
+				if (is_disabled()) {
+					on_tex = theme_cache.checked_disabled;
+					off_tex = theme_cache.unchecked_disabled;
+				} else {
+					on_tex = theme_cache.checked;
+					off_tex = theme_cache.unchecked;
+				}
+			}
 
 			Vector2 ofs;
 			if (is_layout_rtl()) {
-				ofs.x = get_size().x - sb->get_margin(SIDE_RIGHT) - get_icon_size().width;
+				ofs.x = get_size().x - theme_cache.normal_style->get_margin(SIDE_RIGHT) - get_icon_size().width;
 			} else {
-				ofs.x = sb->get_margin(SIDE_LEFT);
+				ofs.x = theme_cache.normal_style->get_margin(SIDE_LEFT);
 			}
-			ofs.y = int((get_size().height - get_icon_size().height) / 2) + get_theme_constant(SNAME("check_v_adjust"));
+			ofs.y = int((get_size().height - get_icon_size().height) / 2) + theme_cache.check_v_adjust;
 
 			if (is_pressed()) {
-				on->draw(ci, ofs);
+				on_tex->draw(ci, ofs);
 			} else {
-				off->draw(ci, ofs);
+				off_tex->draw(ci, ofs);
 			}
 		} break;
 	}

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -36,9 +36,26 @@
 class CheckBox : public Button {
 	GDCLASS(CheckBox, Button);
 
+	struct ThemeCache {
+		int h_separation = 0;
+		int check_v_adjust = 0;
+		Ref<StyleBox> normal_style;
+
+		Ref<Texture2D> checked;
+		Ref<Texture2D> unchecked;
+		Ref<Texture2D> radio_checked;
+		Ref<Texture2D> radio_unchecked;
+		Ref<Texture2D> checked_disabled;
+		Ref<Texture2D> unchecked_disabled;
+		Ref<Texture2D> radio_checked_disabled;
+		Ref<Texture2D> radio_unchecked_disabled;
+	} theme_cache;
+
 protected:
 	Size2 get_icon_size() const;
 	Size2 get_minimum_size() const override;
+
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 
 	bool is_radio();

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -36,9 +36,26 @@
 class CheckButton : public Button {
 	GDCLASS(CheckButton, Button);
 
+	struct ThemeCache {
+		int h_separation = 0;
+		int check_v_adjust = 0;
+		Ref<StyleBox> normal_style;
+
+		Ref<Texture2D> checked;
+		Ref<Texture2D> unchecked;
+		Ref<Texture2D> checked_disabled;
+		Ref<Texture2D> unchecked_disabled;
+		Ref<Texture2D> checked_mirrored;
+		Ref<Texture2D> unchecked_mirrored;
+		Ref<Texture2D> checked_disabled_mirrored;
+		Ref<Texture2D> unchecked_disabled_mirrored;
+	} theme_cache;
+
 protected:
 	Size2 get_icon_size() const;
 	virtual Size2 get_minimum_size() const override;
+
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 
 public:

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2330,6 +2330,9 @@ void Control::_invalidate_theme_cache() {
 	data.theme_constant_cache.clear();
 }
 
+void Control::_update_theme_item_cache() {
+}
+
 void Control::set_theme(const Ref<Theme> &p_theme) {
 	if (data.theme == p_theme) {
 		return;
@@ -3103,6 +3106,11 @@ void Control::remove_child_notify(Node *p_child) {
 
 void Control::_notification(int p_notification) {
 	switch (p_notification) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			_invalidate_theme_cache();
+			_update_theme_item_cache();
+		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			// Need to defer here, because theme owner information might be set in
 			// add_child_notify, which doesn't get called until right after this.
@@ -3236,6 +3244,7 @@ void Control::_notification(int p_notification) {
 		case NOTIFICATION_THEME_CHANGED: {
 			emit_signal(SceneStringNames::get_singleton()->theme_changed);
 			_invalidate_theme_cache();
+			_update_theme_item_cache();
 			update_minimum_size();
 			queue_redraw();
 		} break;
@@ -3257,6 +3266,7 @@ void Control::_notification(int p_notification) {
 			if (is_inside_tree()) {
 				data.is_rtl_dirty = true;
 				_invalidate_theme_cache();
+				_update_theme_item_cache();
 				_size_changed();
 			}
 		} break;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -325,6 +325,10 @@ protected:
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 
+	// Theming.
+
+	virtual void _update_theme_item_cache();
+
 	// Internationalization.
 
 	virtual TypedArray<Vector2i> structured_text_parser(TextServer::StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -44,9 +44,6 @@ void FlowContainer::_resort() {
 		return;
 	}
 
-	int separation_horizontal = get_theme_constant(SNAME("h_separation"));
-	int separation_vertical = get_theme_constant(SNAME("v_separation"));
-
 	bool rtl = is_layout_rtl();
 
 	HashMap<Control *, Size2i> children_minsize_cache;
@@ -74,14 +71,14 @@ void FlowContainer::_resort() {
 
 		if (vertical) { /* VERTICAL */
 			if (children_in_current_line > 0) {
-				ofs.y += separation_vertical;
+				ofs.y += theme_cache.v_separation;
 			}
 			if (ofs.y + child_msc.y > current_container_size) {
-				line_length = ofs.y - separation_vertical;
+				line_length = ofs.y - theme_cache.v_separation;
 				lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total });
 
 				// Move in new column (vertical line).
-				ofs.x += line_height + separation_horizontal;
+				ofs.x += line_height + theme_cache.h_separation;
 				ofs.y = 0;
 				line_height = 0;
 				line_stretch_ratio_total = 0;
@@ -96,14 +93,14 @@ void FlowContainer::_resort() {
 
 		} else { /* HORIZONTAL */
 			if (children_in_current_line > 0) {
-				ofs.x += separation_horizontal;
+				ofs.x += theme_cache.h_separation;
 			}
 			if (ofs.x + child_msc.x > current_container_size) {
-				line_length = ofs.x - separation_horizontal;
+				line_length = ofs.x - theme_cache.h_separation;
 				lines_data.push_back(_LineData{ children_in_current_line, line_height, line_length, current_container_size - line_length, line_stretch_ratio_total });
 
 				// Move in new line.
-				ofs.y += line_height + separation_vertical;
+				ofs.y += line_height + theme_cache.v_separation;
 				ofs.x = 0;
 				line_height = 0;
 				line_stretch_ratio_total = 0;
@@ -146,11 +143,11 @@ void FlowContainer::_resort() {
 			current_line_idx++;
 			child_idx_in_line = 0;
 			if (vertical) {
-				ofs.x += line_data.min_line_height + separation_horizontal;
+				ofs.x += line_data.min_line_height + theme_cache.h_separation;
 				ofs.y = 0;
 			} else {
 				ofs.x = 0;
-				ofs.y += line_data.min_line_height + separation_vertical;
+				ofs.y += line_data.min_line_height + theme_cache.v_separation;
 			}
 			line_data = lines_data[current_line_idx];
 		}
@@ -184,9 +181,9 @@ void FlowContainer::_resort() {
 		fit_child_in_rect(child, child_rect);
 
 		if (vertical) { /* VERTICAL */
-			ofs.y += child_size.height + separation_vertical;
+			ofs.y += child_size.height + theme_cache.v_separation;
 		} else { /* HORIZONTAL */
-			ofs.x += child_size.width + separation_horizontal;
+			ofs.x += child_size.width + theme_cache.h_separation;
 		}
 
 		child_idx_in_line++;
@@ -248,6 +245,13 @@ Vector<int> FlowContainer::get_allowed_size_flags_vertical() const {
 	flags.append(SIZE_SHRINK_CENTER);
 	flags.append(SIZE_SHRINK_END);
 	return flags;
+}
+
+void FlowContainer::_update_theme_item_cache() {
+	Container::_update_theme_item_cache();
+
+	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
+	theme_cache.v_separation = get_theme_constant(SNAME("v_separation"));
 }
 
 void FlowContainer::_notification(int p_what) {

--- a/scene/gui/flow_container.h
+++ b/scene/gui/flow_container.h
@@ -42,11 +42,17 @@ private:
 
 	bool vertical = false;
 
+	struct ThemeCache {
+		int h_separation = 0;
+		int v_separation = 0;
+	} theme_cache;
+
 	void _resort();
 
 protected:
-	void _notification(int p_what);
+	virtual void _update_theme_item_cache() override;
 
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -31,6 +31,13 @@
 #include "grid_container.h"
 #include "core/templates/rb_set.h"
 
+void GridContainer::_update_theme_item_cache() {
+	Container::_update_theme_item_cache();
+
+	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
+	theme_cache.v_separation = get_theme_constant(SNAME("v_separation"));
+}
+
 void GridContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
@@ -38,9 +45,6 @@ void GridContainer::_notification(int p_what) {
 			RBMap<int, int> row_minh; // Max of min_height of all controls in each row (indexed by row).
 			RBSet<int> col_expanded; // Columns which have the SIZE_EXPAND flag set.
 			RBSet<int> row_expanded; // Rows which have the SIZE_EXPAND flag set.
-
-			int hsep = get_theme_constant(SNAME("h_separation"));
-			int vsep = get_theme_constant(SNAME("v_separation"));
 
 			// Compute the per-column/per-row data.
 			int valid_controls_index = 0;
@@ -98,8 +102,8 @@ void GridContainer::_notification(int p_what) {
 					remaining_space.height -= E.value;
 				}
 			}
-			remaining_space.height -= vsep * MAX(max_row - 1, 0);
-			remaining_space.width -= hsep * MAX(max_col - 1, 0);
+			remaining_space.height -= theme_cache.v_separation * MAX(max_row - 1, 0);
+			remaining_space.width -= theme_cache.h_separation * MAX(max_col - 1, 0);
 
 			bool can_fit = false;
 			while (!can_fit && col_expanded.size() > 0) {
@@ -202,7 +206,7 @@ void GridContainer::_notification(int p_what) {
 						col_ofs = 0;
 					}
 					if (row > 0) {
-						row_ofs += (row_expanded.has(row - 1) ? row_expand : row_minh[row - 1]) + vsep;
+						row_ofs += (row_expanded.has(row - 1) ? row_expand : row_minh[row - 1]) + theme_cache.v_separation;
 
 						if (row_expanded.has(row - 1) && row - 1 < row_remaining_pixel_index) {
 							// Apply the remaining pixel of the previous row.
@@ -224,11 +228,11 @@ void GridContainer::_notification(int p_what) {
 				if (rtl) {
 					Point2 p(col_ofs - s.width, row_ofs);
 					fit_child_in_rect(c, Rect2(p, s));
-					col_ofs -= s.width + hsep;
+					col_ofs -= s.width + theme_cache.h_separation;
 				} else {
 					Point2 p(col_ofs, row_ofs);
 					fit_child_in_rect(c, Rect2(p, s));
-					col_ofs += s.width + hsep;
+					col_ofs += s.width + theme_cache.h_separation;
 				}
 			}
 		} break;
@@ -271,9 +275,6 @@ Size2 GridContainer::get_minimum_size() const {
 	RBMap<int, int> col_minw;
 	RBMap<int, int> row_minh;
 
-	int hsep = get_theme_constant(SNAME("h_separation"));
-	int vsep = get_theme_constant(SNAME("v_separation"));
-
 	int max_row = 0;
 	int max_col = 0;
 
@@ -313,8 +314,8 @@ Size2 GridContainer::get_minimum_size() const {
 		ms.height += E.value;
 	}
 
-	ms.height += vsep * max_row;
-	ms.width += hsep * max_col;
+	ms.height += theme_cache.v_separation * max_row;
+	ms.width += theme_cache.h_separation * max_col;
 
 	return ms;
 }

--- a/scene/gui/grid_container.h
+++ b/scene/gui/grid_container.h
@@ -38,7 +38,14 @@ class GridContainer : public Container {
 
 	int columns = 1;
 
+	struct ThemeCache {
+		int h_separation = 0;
+		int v_separation = 0;
+	} theme_cache;
+
 protected:
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -109,23 +109,45 @@ private:
 	int max_columns = 1;
 
 	Size2 fixed_icon_size;
-
 	Size2 max_item_size_cache;
 
 	int defer_select_single = -1;
-
 	bool allow_rmb_select = false;
-
 	bool allow_reselect = false;
 
 	real_t icon_scale = 1.0;
 
 	bool do_autoscroll_to_bottom = false;
 
+	struct ThemeCache {
+		int h_separation = 0;
+		int v_separation = 0;
+
+		Ref<StyleBox> bg_style;
+		Ref<StyleBox> bg_focus_style;
+
+		Ref<Font> font;
+		int font_size = 0;
+		Color font_color;
+		Color font_selected_color;
+		int font_outline_size = 0;
+		Color font_outline_color;
+
+		int line_separation = 0;
+		int icon_margin = 0;
+		Ref<StyleBox> selected_style;
+		Ref<StyleBox> selected_focus_style;
+		Ref<StyleBox> cursor_style;
+		Ref<StyleBox> cursor_focus_style;
+		Color guide_color;
+	} theme_cache;
+
 	void _scroll_changed(double);
 	void _shape(int p_idx);
 
 protected:
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -71,7 +71,7 @@ bool Label::is_uppercase() const {
 }
 
 int Label::get_line_height(int p_line) const {
-	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : get_theme_font(SNAME("font"));
+	Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
 	if (p_line >= 0 && p_line < lines_rid.size()) {
 		return TS->shaped_text_get_size(lines_rid[p_line]).y;
 	} else if (lines_rid.size() > 0) {
@@ -81,13 +81,13 @@ int Label::get_line_height(int p_line) const {
 		}
 		return h;
 	} else {
-		int font_size = settings.is_valid() ? settings->get_font_size() : get_theme_font_size(SNAME("font_size"));
+		int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
 		return font->get_height(font_size);
 	}
 }
 
 void Label::_shape() {
-	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"), SNAME("Label"));
+	Ref<StyleBox> style = theme_cache.normal_style;
 	int width = (get_size().width - style->get_minimum_size().width);
 
 	if (dirty || font_dirty) {
@@ -99,8 +99,8 @@ void Label::_shape() {
 		} else {
 			TS->shaped_text_set_direction(text_rid, (TextServer::Direction)text_direction);
 		}
-		const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : get_theme_font(SNAME("font"));
-		int font_size = settings.is_valid() ? settings->get_font_size() : get_theme_font_size(SNAME("font_size"));
+		const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
+		int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
 		ERR_FAIL_COND(font.is_null());
 		String text = (uppercase) ? TS->string_to_upper(xl_text, language) : xl_text;
 		if (visible_chars >= 0 && visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
@@ -232,8 +232,8 @@ void Label::_shape() {
 }
 
 void Label::_update_visible() {
-	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : get_theme_constant(SNAME("line_spacing"), SNAME("Label"));
-	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"), SNAME("Label"));
+	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
+	Ref<StyleBox> style = theme_cache.normal_style;
 	int lines_visible = lines_rid.size();
 
 	if (max_lines_visible >= 0 && lines_visible > max_lines_visible) {
@@ -272,6 +272,22 @@ inline void draw_glyph_outline(const Glyph &p_gl, const RID &p_canvas, const Col
 	}
 }
 
+void Label::_update_theme_item_cache() {
+	Control::_update_theme_item_cache();
+
+	theme_cache.normal_style = get_theme_stylebox(SNAME("normal"));
+	theme_cache.font = get_theme_font(SNAME("font"));
+
+	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
+	theme_cache.line_spacing = get_theme_constant(SNAME("line_spacing"));
+	theme_cache.font_color = get_theme_color(SNAME("font_color"));
+	theme_cache.font_shadow_color = get_theme_color(SNAME("font_shadow_color"));
+	theme_cache.font_shadow_offset = Point2(get_theme_constant(SNAME("shadow_offset_x")), get_theme_constant(SNAME("shadow_offset_y")));
+	theme_cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
+	theme_cache.font_outline_size = get_theme_constant(SNAME("outline_size"));
+	theme_cache.font_shadow_outline_size = get_theme_constant(SNAME("shadow_outline_size"));
+}
+
 void Label::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -307,15 +323,15 @@ void Label::_notification(int p_what) {
 
 			Size2 string_size;
 			Size2 size = get_size();
-			Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
-			Ref<Font> font = (has_settings && settings->get_font().is_valid()) ? settings->get_font() : get_theme_font(SNAME("font"));
-			Color font_color = has_settings ? settings->get_font_color() : get_theme_color(SNAME("font_color"));
-			Color font_shadow_color = has_settings ? settings->get_shadow_color() : get_theme_color(SNAME("font_shadow_color"));
-			Point2 shadow_ofs = has_settings ? settings->get_shadow_offset() : Point2(get_theme_constant(SNAME("shadow_offset_x")), get_theme_constant(SNAME("shadow_offset_y")));
-			int line_spacing = has_settings ? settings->get_line_spacing() : get_theme_constant(SNAME("line_spacing"));
-			Color font_outline_color = has_settings ? settings->get_outline_color() : get_theme_color(SNAME("font_outline_color"));
-			int outline_size = has_settings ? settings->get_outline_size() : get_theme_constant(SNAME("outline_size"));
-			int shadow_outline_size = has_settings ? settings->get_shadow_size() : get_theme_constant(SNAME("shadow_outline_size"));
+			Ref<StyleBox> style = theme_cache.normal_style;
+			Ref<Font> font = (has_settings && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
+			Color font_color = has_settings ? settings->get_font_color() : theme_cache.font_color;
+			Color font_shadow_color = has_settings ? settings->get_shadow_color() : theme_cache.font_shadow_color;
+			Point2 shadow_ofs = has_settings ? settings->get_shadow_offset() : theme_cache.font_shadow_offset;
+			int line_spacing = has_settings ? settings->get_line_spacing() : theme_cache.line_spacing;
+			Color font_outline_color = has_settings ? settings->get_outline_color() : theme_cache.font_outline_color;
+			int outline_size = has_settings ? settings->get_outline_size() : theme_cache.font_outline_size;
+			int shadow_outline_size = has_settings ? settings->get_shadow_size() : theme_cache.font_shadow_outline_size;
 			bool rtl = (TS->shaped_text_get_inferred_direction(text_rid) == TextServer::DIRECTION_RTL);
 			bool rtl_layout = is_layout_rtl();
 
@@ -562,12 +578,12 @@ Size2 Label::get_minimum_size() const {
 
 	Size2 min_size = minsize;
 
-	const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : get_theme_font(SNAME("font"));
-	int font_size = settings.is_valid() ? settings->get_font_size() : get_theme_font_size(SNAME("font_size"));
+	const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
+	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
 
 	min_size.height = MAX(min_size.height, font->get_height(font_size) + font->get_spacing(TextServer::SPACING_TOP) + font->get_spacing(TextServer::SPACING_BOTTOM));
 
-	Size2 min_style = get_theme_stylebox(SNAME("normal"))->get_minimum_size();
+	Size2 min_style = theme_cache.normal_style->get_minimum_size();
 	if (autowrap_mode != TextServer::AUTOWRAP_OFF) {
 		return Size2(1, (clip || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? 1 : min_size.height) + min_style;
 	} else {
@@ -590,8 +606,8 @@ int Label::get_line_count() const {
 }
 
 int Label::get_visible_line_count() const {
-	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
-	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : get_theme_constant(SNAME("line_spacing"));
+	Ref<StyleBox> style = theme_cache.normal_style;
+	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
 	int lines_visible = 0;
 	float total_h = 0.0;
 	for (int64_t i = lines_skipped; i < lines_rid.size(); i++) {

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -67,13 +67,28 @@ private:
 
 	Ref<LabelSettings> settings;
 
+	struct ThemeCache {
+		Ref<StyleBox> normal_style;
+		Ref<Font> font;
+
+		int font_size = 0;
+		int line_spacing = 0;
+		Color font_color;
+		Color font_shadow_color;
+		Point2 font_shadow_offset;
+		Color font_outline_color;
+		int font_outline_size;
+		int font_shadow_outline_size;
+	} theme_cache;
+
 	void _update_visible();
 	void _shape();
 	void _invalidate();
 
 protected:
-	void _notification(int p_what);
+	virtual void _update_theme_item_cache() override;
 
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -174,6 +174,31 @@ private:
 	double caret_blink_timer = 0.0;
 	bool caret_blinking = false;
 
+	struct ThemeCache {
+		Ref<StyleBox> normal;
+		Ref<StyleBox> read_only;
+		Ref<StyleBox> focus;
+
+		Ref<Font> font;
+		int font_size = 0;
+		Color font_color;
+		Color font_uneditable_color;
+		Color font_selected_color;
+		int font_outline_size;
+		Color font_outline_color;
+		Color font_placeholder_color;
+		int caret_width = 0;
+		Color caret_color;
+		int minimum_character_width = 0;
+		Color selection_color;
+
+		Ref<Texture2D> clear_icon;
+		Color clear_button_color;
+		Color clear_button_color_pressed;
+
+		int base_scale = 0;
+	} theme_cache;
+
 	bool _is_over_clear_button(const Point2 &p_pos) const;
 
 	void _clear_undo_stack();
@@ -215,6 +240,7 @@ private:
 	void _ensure_menu();
 
 protected:
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	static void _bind_methods();
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -33,8 +33,8 @@
 #include "core/string/translation.h"
 
 void LinkButton::_shape() {
-	Ref<Font> font = get_theme_font(SNAME("font"));
-	int font_size = get_theme_font_size(SNAME("font_size"));
+	Ref<Font> font = theme_cache.font;
+	int font_size = theme_cache.font_size;
 
 	text_buf->clear();
 	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {
@@ -125,6 +125,26 @@ Size2 LinkButton::get_minimum_size() const {
 	return text_buf->get_size();
 }
 
+void LinkButton::_update_theme_item_cache() {
+	BaseButton::_update_theme_item_cache();
+
+	theme_cache.focus = get_theme_stylebox(SNAME("focus"));
+
+	theme_cache.font_color = get_theme_color(SNAME("font_color"));
+	theme_cache.font_focus_color = get_theme_color(SNAME("font_focus_color"));
+	theme_cache.font_pressed_color = get_theme_color(SNAME("font_pressed_color"));
+	theme_cache.font_hover_color = get_theme_color(SNAME("font_hover_color"));
+	theme_cache.font_hover_pressed_color = get_theme_color(SNAME("font_hover_pressed_color"));
+	theme_cache.font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
+
+	theme_cache.font = get_theme_font(SNAME("font"));
+	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
+	theme_cache.outline_size = get_theme_constant(SNAME("outline_size"));
+	theme_cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
+
+	theme_cache.underline_spacing = get_theme_constant(SNAME("underline_spacing"));
+}
+
 void LinkButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -153,9 +173,9 @@ void LinkButton::_notification(int p_what) {
 			switch (get_draw_mode()) {
 				case DRAW_NORMAL: {
 					if (has_focus()) {
-						color = get_theme_color(SNAME("font_focus_color"));
+						color = theme_cache.font_focus_color;
 					} else {
-						color = get_theme_color(SNAME("font_color"));
+						color = theme_cache.font_color;
 					}
 
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
@@ -163,35 +183,35 @@ void LinkButton::_notification(int p_what) {
 				case DRAW_HOVER_PRESSED:
 				case DRAW_PRESSED: {
 					if (has_theme_color(SNAME("font_pressed_color"))) {
-						color = get_theme_color(SNAME("font_pressed_color"));
+						color = theme_cache.font_pressed_color;
 					} else {
-						color = get_theme_color(SNAME("font_color"));
+						color = theme_cache.font_color;
 					}
 
 					do_underline = underline_mode != UNDERLINE_MODE_NEVER;
 
 				} break;
 				case DRAW_HOVER: {
-					color = get_theme_color(SNAME("font_hover_color"));
+					color = theme_cache.font_hover_color;
 					do_underline = underline_mode != UNDERLINE_MODE_NEVER;
 
 				} break;
 				case DRAW_DISABLED: {
-					color = get_theme_color(SNAME("font_disabled_color"));
+					color = theme_cache.font_disabled_color;
 					do_underline = underline_mode == UNDERLINE_MODE_ALWAYS;
 
 				} break;
 			}
 
 			if (has_focus()) {
-				Ref<StyleBox> style = get_theme_stylebox(SNAME("focus"));
+				Ref<StyleBox> style = theme_cache.focus;
 				style->draw(ci, Rect2(Point2(), size));
 			}
 
 			int width = text_buf->get_line_width();
 
-			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
-			int outline_size = get_theme_constant(SNAME("outline_size"));
+			Color font_outline_color = theme_cache.font_outline_color;
+			int outline_size = theme_cache.outline_size;
 			if (is_layout_rtl()) {
 				if (outline_size > 0 && font_outline_color.a > 0) {
 					text_buf->draw_outline(get_canvas_item(), Vector2(size.width - width, 0), outline_size, font_outline_color);
@@ -205,7 +225,7 @@ void LinkButton::_notification(int p_what) {
 			}
 
 			if (do_underline) {
-				int underline_spacing = get_theme_constant(SNAME("underline_spacing")) + text_buf->get_line_underline_position();
+				int underline_spacing = theme_cache.underline_spacing + text_buf->get_line_underline_position();
 				int y = text_buf->get_line_ascent() + underline_spacing;
 
 				if (is_layout_rtl()) {

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -55,10 +55,29 @@ private:
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 	Array st_args;
 
+	struct ThemeCache {
+		Ref<StyleBox> focus;
+
+		Color font_color;
+		Color font_focus_color;
+		Color font_pressed_color;
+		Color font_hover_color;
+		Color font_hover_pressed_color;
+		Color font_disabled_color;
+
+		Ref<Font> font;
+		int font_size = 0;
+		int outline_size = 0;
+		Color font_outline_color;
+
+		int underline_spacing = 0;
+	} theme_cache;
+
 	void _shape();
 
 protected:
 	virtual Size2 get_minimum_size() const override;
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -30,12 +30,16 @@
 
 #include "margin_container.h"
 
-Size2 MarginContainer::get_minimum_size() const {
-	int margin_left = get_theme_constant(SNAME("margin_left"));
-	int margin_top = get_theme_constant(SNAME("margin_top"));
-	int margin_right = get_theme_constant(SNAME("margin_right"));
-	int margin_bottom = get_theme_constant(SNAME("margin_bottom"));
+void MarginContainer::_update_theme_item_cache() {
+	Container::_update_theme_item_cache();
 
+	theme_cache.margin_left = get_theme_constant(SNAME("margin_left"));
+	theme_cache.margin_top = get_theme_constant(SNAME("margin_top"));
+	theme_cache.margin_right = get_theme_constant(SNAME("margin_right"));
+	theme_cache.margin_bottom = get_theme_constant(SNAME("margin_bottom"));
+}
+
+Size2 MarginContainer::get_minimum_size() const {
 	Size2 max;
 
 	for (int i = 0; i < get_child_count(); i++) {
@@ -59,8 +63,8 @@ Size2 MarginContainer::get_minimum_size() const {
 		}
 	}
 
-	max.width += (margin_left + margin_right);
-	max.height += (margin_top + margin_bottom);
+	max.width += (theme_cache.margin_left + theme_cache.margin_right);
+	max.height += (theme_cache.margin_top + theme_cache.margin_bottom);
 
 	return max;
 }
@@ -86,11 +90,6 @@ Vector<int> MarginContainer::get_allowed_size_flags_vertical() const {
 void MarginContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
-			int margin_left = get_theme_constant(SNAME("margin_left"));
-			int margin_top = get_theme_constant(SNAME("margin_top"));
-			int margin_right = get_theme_constant(SNAME("margin_right"));
-			int margin_bottom = get_theme_constant(SNAME("margin_bottom"));
-
 			Size2 s = get_size();
 
 			for (int i = 0; i < get_child_count(); i++) {
@@ -102,9 +101,9 @@ void MarginContainer::_notification(int p_what) {
 					continue;
 				}
 
-				int w = s.width - margin_left - margin_right;
-				int h = s.height - margin_top - margin_bottom;
-				fit_child_in_rect(c, Rect2(margin_left, margin_top, w, h));
+				int w = s.width - theme_cache.margin_left - theme_cache.margin_right;
+				int h = s.height - theme_cache.margin_top - theme_cache.margin_bottom;
+				fit_child_in_rect(c, Rect2(theme_cache.margin_left, theme_cache.margin_top, w, h));
 			}
 		} break;
 

--- a/scene/gui/margin_container.h
+++ b/scene/gui/margin_container.h
@@ -36,7 +36,16 @@
 class MarginContainer : public Container {
 	GDCLASS(MarginContainer, Container);
 
+	struct ThemeCache {
+		int margin_left = 0;
+		int margin_top = 0;
+		int margin_right = 0;
+		int margin_bottom = 0;
+	} theme_cache;
+
 protected:
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 
 public:

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -340,6 +340,35 @@ void MenuBar::_update_menu() {
 	queue_redraw();
 }
 
+void MenuBar::_update_theme_item_cache() {
+	Control::_update_theme_item_cache();
+
+	theme_cache.normal = get_theme_stylebox(SNAME("normal"));
+	theme_cache.normal_mirrored = get_theme_stylebox(SNAME("normal_mirrored"));
+	theme_cache.disabled = get_theme_stylebox(SNAME("disabled"));
+	theme_cache.disabled_mirrored = get_theme_stylebox(SNAME("disabled_mirrored"));
+	theme_cache.pressed = get_theme_stylebox(SNAME("pressed"));
+	theme_cache.pressed_mirrored = get_theme_stylebox(SNAME("pressed_mirrored"));
+	theme_cache.hover = get_theme_stylebox(SNAME("hover"));
+	theme_cache.hover_mirrored = get_theme_stylebox(SNAME("hover_mirrored"));
+	theme_cache.hover_pressed = get_theme_stylebox(SNAME("hover_pressed"));
+	theme_cache.hover_pressed_mirrored = get_theme_stylebox(SNAME("hover_pressed_mirrored"));
+
+	theme_cache.font = get_theme_font(SNAME("font"));
+	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
+	theme_cache.outline_size = get_theme_constant(SNAME("outline_size"));
+	theme_cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
+
+	theme_cache.font_color = get_theme_color(SNAME("font_color"));
+	theme_cache.font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
+	theme_cache.font_pressed_color = get_theme_color(SNAME("font_pressed_color"));
+	theme_cache.font_hover_color = get_theme_color(SNAME("font_hover_color"));
+	theme_cache.font_hover_pressed_color = get_theme_color(SNAME("font_hover_pressed_color"));
+	theme_cache.font_focus_color = get_theme_color(SNAME("font_focus_color"));
+
+	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
+}
+
 void MenuBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -394,8 +423,7 @@ void MenuBar::_notification(int p_what) {
 }
 
 int MenuBar::_get_index_at_point(const Point2 &p_point) const {
-	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
-	int hsep = get_theme_constant(SNAME("h_separation"));
+	Ref<StyleBox> style = theme_cache.normal;
 	int offset = 0;
 	for (int i = 0; i < menu_cache.size(); i++) {
 		if (menu_cache[i].hidden) {
@@ -407,7 +435,7 @@ int MenuBar::_get_index_at_point(const Point2 &p_point) const {
 				return i;
 			}
 		}
-		offset += size.x + hsep;
+		offset += size.x + theme_cache.h_separation;
 	}
 	return -1;
 }
@@ -415,8 +443,7 @@ int MenuBar::_get_index_at_point(const Point2 &p_point) const {
 Rect2 MenuBar::_get_menu_item_rect(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, menu_cache.size(), Rect2());
 
-	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
-	int hsep = get_theme_constant(SNAME("h_separation"));
+	Ref<StyleBox> style = theme_cache.normal;
 
 	int offset = 0;
 	for (int i = 0; i < p_index; i++) {
@@ -424,7 +451,7 @@ Rect2 MenuBar::_get_menu_item_rect(int p_index) const {
 			continue;
 		}
 		Size2 size = menu_cache[i].text_buf->get_size() + style->get_minimum_size();
-		offset += size.x + hsep;
+		offset += size.x + theme_cache.h_separation;
 	}
 
 	return Rect2(Point2(offset, 0), menu_cache[p_index].text_buf->get_size() + style->get_minimum_size());
@@ -443,76 +470,76 @@ void MenuBar::_draw_menu_item(int p_index) {
 	}
 
 	Color color;
-	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
+	Ref<StyleBox> style = theme_cache.normal;
 	Rect2 item_rect = _get_menu_item_rect(p_index);
 
 	if (menu_cache[p_index].disabled) {
 		if (rtl && has_theme_stylebox(SNAME("disabled_mirrored"))) {
-			style = get_theme_stylebox(SNAME("disabled_mirrored"));
+			style = theme_cache.disabled_mirrored;
 		} else {
-			style = get_theme_stylebox(SNAME("disabled"));
+			style = theme_cache.disabled;
 		}
 		if (!flat) {
 			style->draw(ci, item_rect);
 		}
-		color = get_theme_color(SNAME("font_disabled_color"));
+		color = theme_cache.font_disabled_color;
 	} else if (hovered && pressed && has_theme_stylebox("hover_pressed")) {
 		if (rtl && has_theme_stylebox(SNAME("hover_pressed_mirrored"))) {
-			style = get_theme_stylebox(SNAME("hover_pressed_mirrored"));
+			style = theme_cache.hover_pressed_mirrored;
 		} else {
-			style = get_theme_stylebox(SNAME("hover_pressed"));
+			style = theme_cache.hover_pressed;
 		}
 		if (!flat) {
 			style->draw(ci, item_rect);
 		}
 		if (has_theme_color(SNAME("font_hover_pressed_color"))) {
-			color = get_theme_color(SNAME("font_hover_pressed_color"));
+			color = theme_cache.font_hover_pressed_color;
 		}
 	} else if (pressed) {
 		if (rtl && has_theme_stylebox(SNAME("pressed_mirrored"))) {
-			style = get_theme_stylebox(SNAME("pressed_mirrored"));
+			style = theme_cache.pressed_mirrored;
 		} else {
-			style = get_theme_stylebox(SNAME("pressed"));
+			style = theme_cache.pressed;
 		}
 		if (!flat) {
 			style->draw(ci, item_rect);
 		}
 		if (has_theme_color(SNAME("font_pressed_color"))) {
-			color = get_theme_color(SNAME("font_pressed_color"));
+			color = theme_cache.font_pressed_color;
 		} else {
-			color = get_theme_color(SNAME("font_color"));
+			color = theme_cache.font_color;
 		}
 	} else if (hovered) {
 		if (rtl && has_theme_stylebox(SNAME("hover_mirrored"))) {
-			style = get_theme_stylebox(SNAME("hover_mirrored"));
+			style = theme_cache.hover_mirrored;
 		} else {
-			style = get_theme_stylebox(SNAME("hover"));
+			style = theme_cache.hover;
 		}
 		if (!flat) {
 			style->draw(ci, item_rect);
 		}
-		color = get_theme_color(SNAME("font_hover_color"));
+		color = theme_cache.font_hover_color;
 	} else {
 		if (rtl && has_theme_stylebox(SNAME("normal_mirrored"))) {
-			style = get_theme_stylebox(SNAME("normal_mirrored"));
+			style = theme_cache.normal_mirrored;
 		} else {
-			style = get_theme_stylebox(SNAME("normal"));
+			style = theme_cache.normal;
 		}
 		if (!flat) {
 			style->draw(ci, item_rect);
 		}
 		// Focus colors only take precedence over normal state.
 		if (has_focus()) {
-			color = get_theme_color(SNAME("font_focus_color"));
+			color = theme_cache.font_focus_color;
 		} else {
-			color = get_theme_color(SNAME("font_color"));
+			color = theme_cache.font_color;
 		}
 	}
 
 	Point2 text_ofs = item_rect.position + Point2(style->get_margin(SIDE_LEFT), style->get_margin(SIDE_TOP));
 
-	Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
-	int outline_size = get_theme_constant(SNAME("outline_size"));
+	Color font_outline_color = theme_cache.font_outline_color;
+	int outline_size = theme_cache.outline_size;
 	if (outline_size > 0 && font_outline_color.a > 0) {
 		menu_cache[p_index].text_buf->draw_outline(ci, text_ofs, outline_size, font_outline_color);
 	}
@@ -520,16 +547,13 @@ void MenuBar::_draw_menu_item(int p_index) {
 }
 
 void MenuBar::shape(Menu &p_menu) {
-	Ref<Font> font = get_theme_font(SNAME("font"));
-	int font_size = get_theme_font_size(SNAME("font_size"));
-
 	p_menu.text_buf->clear();
 	if (text_direction == Control::TEXT_DIRECTION_INHERITED) {
 		p_menu.text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
 	} else {
 		p_menu.text_buf->set_direction((TextServer::Direction)text_direction);
 	}
-	p_menu.text_buf->add_string(p_menu.name, font, font_size, language);
+	p_menu.text_buf->add_string(p_menu.name, theme_cache.font, theme_cache.font_size, language);
 }
 
 void MenuBar::_refresh_menu_names() {
@@ -759,7 +783,7 @@ Size2 MenuBar::get_minimum_size() const {
 		return Size2();
 	}
 
-	Ref<StyleBox> style = get_theme_stylebox(SNAME("normal"));
+	Ref<StyleBox> style = theme_cache.normal;
 
 	Vector2 size;
 	for (int i = 0; i < menu_cache.size(); i++) {
@@ -771,7 +795,7 @@ Size2 MenuBar::get_minimum_size() const {
 		size.x += sz.x;
 	}
 	if (menu_cache.size() > 1) {
-		size.x += get_theme_constant(SNAME("h_separation")) * (menu_cache.size() - 1);
+		size.x += theme_cache.h_separation * (menu_cache.size() - 1);
 	}
 	return size;
 }

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -76,6 +76,33 @@ class MenuBar : public Control {
 	Vector2i old_mouse_pos;
 	ObjectID shortcut_context;
 
+	struct ThemeCache {
+		Ref<StyleBox> normal;
+		Ref<StyleBox> normal_mirrored;
+		Ref<StyleBox> disabled;
+		Ref<StyleBox> disabled_mirrored;
+		Ref<StyleBox> pressed;
+		Ref<StyleBox> pressed_mirrored;
+		Ref<StyleBox> hover;
+		Ref<StyleBox> hover_mirrored;
+		Ref<StyleBox> hover_pressed;
+		Ref<StyleBox> hover_pressed_mirrored;
+
+		Ref<Font> font;
+		int font_size = 0;
+		int outline_size = 0;
+		Color font_outline_color;
+
+		Color font_color;
+		Color font_disabled_color;
+		Color font_pressed_color;
+		Color font_hover_color;
+		Color font_hover_pressed_color;
+		Color font_focus_color;
+
+		int h_separation = 0;
+	} theme_cache;
+
 	int _get_index_at_point(const Point2 &p_point) const;
 	Rect2 _get_menu_item_rect(int p_index) const;
 	void _draw_menu_item(int p_index);
@@ -96,6 +123,7 @@ class MenuBar : public Control {
 protected:
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void move_child_notify(Node *p_child) override;

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -43,6 +43,23 @@ class OptionButton : public Button {
 	Vector2 _cached_size;
 	bool cache_refresh_pending = false;
 
+	struct ThemeCache {
+		Ref<StyleBox> normal;
+
+		Color font_color;
+		Color font_focus_color;
+		Color font_pressed_color;
+		Color font_hover_color;
+		Color font_hover_pressed_color;
+		Color font_disabled_color;
+
+		int h_separation = 0;
+
+		Ref<Texture2D> arrow_icon;
+		int arrow_margin = 0;
+		int modulate_arrow = 0;
+	} theme_cache;
+
 	void _focused(int p_which);
 	void _selected(int p_which);
 	void _select(int p_which, bool p_emit = false);
@@ -54,6 +71,7 @@ class OptionButton : public Button {
 
 protected:
 	Size2 get_minimum_size() const override;
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -30,12 +30,17 @@
 
 #include "panel.h"
 
+void Panel::_update_theme_item_cache() {
+	Control::_update_theme_item_cache();
+
+	theme_cache.panel_style = get_theme_stylebox(SNAME("panel"));
+}
+
 void Panel::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
-			Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
-			style->draw(ci, Rect2(Point2(), get_size()));
+			theme_cache.panel_style->draw(ci, Rect2(Point2(), get_size()));
 		} break;
 	}
 }

--- a/scene/gui/panel.h
+++ b/scene/gui/panel.h
@@ -36,7 +36,13 @@
 class Panel : public Control {
 	GDCLASS(Panel, Control);
 
+	struct ThemeCache {
+		Ref<StyleBox> panel_style;
+	} theme_cache;
+
 protected:
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 
 public:

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -31,14 +31,6 @@
 #include "panel_container.h"
 
 Size2 PanelContainer::get_minimum_size() const {
-	Ref<StyleBox> style;
-
-	if (has_theme_stylebox(SNAME("panel"))) {
-		style = get_theme_stylebox(SNAME("panel"));
-	} else {
-		style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
-	}
-
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = Object::cast_to<Control>(get_child(i));
@@ -54,8 +46,8 @@ Size2 PanelContainer::get_minimum_size() const {
 		ms.height = MAX(ms.height, minsize.height);
 	}
 
-	if (style.is_valid()) {
-		ms += style->get_minimum_size();
+	if (theme_cache.panel_style.is_valid()) {
+		ms += theme_cache.panel_style->get_minimum_size();
 	}
 	return ms;
 }
@@ -78,35 +70,25 @@ Vector<int> PanelContainer::get_allowed_size_flags_vertical() const {
 	return flags;
 }
 
+void PanelContainer::_update_theme_item_cache() {
+	Container::_update_theme_item_cache();
+
+	theme_cache.panel_style = get_theme_stylebox(SNAME("panel"));
+}
+
 void PanelContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
-			Ref<StyleBox> style;
-
-			if (has_theme_stylebox(SNAME("panel"))) {
-				style = get_theme_stylebox(SNAME("panel"));
-			} else {
-				style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
-			}
-
-			style->draw(ci, Rect2(Point2(), get_size()));
+			theme_cache.panel_style->draw(ci, Rect2(Point2(), get_size()));
 		} break;
 
 		case NOTIFICATION_SORT_CHILDREN: {
-			Ref<StyleBox> style;
-
-			if (has_theme_stylebox(SNAME("panel"))) {
-				style = get_theme_stylebox(SNAME("panel"));
-			} else {
-				style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
-			}
-
 			Size2 size = get_size();
 			Point2 ofs;
-			if (style.is_valid()) {
-				size -= style->get_minimum_size();
-				ofs += style->get_offset();
+			if (theme_cache.panel_style.is_valid()) {
+				size -= theme_cache.panel_style->get_minimum_size();
+				ofs += theme_cache.panel_style->get_offset();
 			}
 
 			for (int i = 0; i < get_child_count(); i++) {

--- a/scene/gui/panel_container.h
+++ b/scene/gui/panel_container.h
@@ -36,7 +36,12 @@
 class PanelContainer : public Container {
 	GDCLASS(PanelContainer, Container);
 
+	struct ThemeCache {
+		Ref<StyleBox> panel_style;
+	} theme_cache;
+
 protected:
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 
 public:

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -38,7 +38,20 @@ class ProgressBar : public Range {
 
 	bool percent_visible = true;
 
+	struct ThemeCache {
+		Ref<StyleBox> bg_style;
+		Ref<StyleBox> fg_style;
+
+		Ref<Font> font;
+		int font_size = 0;
+		Color font_color;
+		int font_outline_size = 0;
+		Color font_outline_color;
+	} theme_cache;
+
 protected:
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -70,8 +70,8 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (b->is_pressed()) {
 			double ofs = orientation == VERTICAL ? b->get_position().y : b->get_position().x;
-			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-			Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+			Ref<Texture2D> incr = theme_cache.increment_icon;
 
 			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
 			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
@@ -146,7 +146,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (drag.active) {
 			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
-			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
 
 			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
 			ofs -= decr_size;
@@ -156,8 +156,8 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 			set_as_ratio(drag.value_at_click + diff);
 		} else {
 			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
-			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-			Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+			Ref<Texture2D> incr = theme_cache.increment_icon;
 
 			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
 			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
@@ -217,6 +217,24 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void ScrollBar::_update_theme_item_cache() {
+	Range::_update_theme_item_cache();
+
+	theme_cache.scroll_style = get_theme_stylebox(SNAME("scroll"));
+	theme_cache.scroll_focus_style = get_theme_stylebox(SNAME("scroll_focus"));
+	theme_cache.scroll_offset_style = get_theme_stylebox(SNAME("hscroll"));
+	theme_cache.grabber_style = get_theme_stylebox(SNAME("grabber"));
+	theme_cache.grabber_hl_style = get_theme_stylebox(SNAME("grabber_highlight"));
+	theme_cache.grabber_pressed_style = get_theme_stylebox(SNAME("grabber_pressed"));
+
+	theme_cache.increment_icon = get_theme_icon(SNAME("increment"));
+	theme_cache.increment_hl_icon = get_theme_icon(SNAME("increment_highlight"));
+	theme_cache.increment_pressed_icon = get_theme_icon(SNAME("increment_pressed"));
+	theme_cache.decrement_icon = get_theme_icon(SNAME("decrement"));
+	theme_cache.decrement_hl_icon = get_theme_icon(SNAME("decrement_highlight"));
+	theme_cache.decrement_pressed_icon = get_theme_icon(SNAME("decrement_pressed"));
+}
+
 void ScrollBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
@@ -225,30 +243,30 @@ void ScrollBar::_notification(int p_what) {
 			Ref<Texture2D> decr, incr;
 
 			if (decr_active) {
-				decr = get_theme_icon(SNAME("decrement_pressed"));
+				decr = theme_cache.decrement_pressed_icon;
 			} else if (highlight == HIGHLIGHT_DECR) {
-				decr = get_theme_icon(SNAME("decrement_highlight"));
+				decr = theme_cache.decrement_hl_icon;
 			} else {
-				decr = get_theme_icon(SNAME("decrement"));
+				decr = theme_cache.decrement_icon;
 			}
 
 			if (incr_active) {
-				incr = get_theme_icon(SNAME("increment_pressed"));
+				incr = theme_cache.increment_pressed_icon;
 			} else if (highlight == HIGHLIGHT_INCR) {
-				incr = get_theme_icon(SNAME("increment_highlight"));
+				incr = theme_cache.increment_hl_icon;
 			} else {
-				incr = get_theme_icon(SNAME("increment"));
+				incr = theme_cache.increment_icon;
 			}
 
-			Ref<StyleBox> bg = has_focus() ? get_theme_stylebox(SNAME("scroll_focus")) : get_theme_stylebox(SNAME("scroll"));
+			Ref<StyleBox> bg = has_focus() ? theme_cache.scroll_focus_style : theme_cache.scroll_style;
 
 			Ref<StyleBox> grabber;
 			if (drag.active) {
-				grabber = get_theme_stylebox(SNAME("grabber_pressed"));
+				grabber = theme_cache.grabber_pressed_style;
 			} else if (highlight == HIGHLIGHT_RANGE) {
-				grabber = get_theme_stylebox(SNAME("grabber_highlight"));
+				grabber = theme_cache.grabber_hl_style;
 			} else {
-				grabber = get_theme_stylebox(SNAME("grabber"));
+				grabber = theme_cache.grabber_style;
 			}
 
 			Point2 ofs;
@@ -414,7 +432,7 @@ void ScrollBar::_notification(int p_what) {
 }
 
 double ScrollBar::get_grabber_min_size() const {
-	Ref<StyleBox> grabber = get_theme_stylebox(SNAME("grabber"));
+	Ref<StyleBox> grabber = theme_cache.grabber_style;
 	Size2 gminsize = grabber->get_minimum_size() + grabber->get_center_size();
 	return (orientation == VERTICAL) ? gminsize.height : gminsize.width;
 }
@@ -435,17 +453,17 @@ double ScrollBar::get_area_size() const {
 	switch (orientation) {
 		case VERTICAL: {
 			double area = get_size().height;
-			area -= get_theme_stylebox(SNAME("scroll"))->get_minimum_size().height;
-			area -= get_theme_icon(SNAME("increment"))->get_height();
-			area -= get_theme_icon(SNAME("decrement"))->get_height();
+			area -= theme_cache.scroll_style->get_minimum_size().height;
+			area -= theme_cache.increment_icon->get_height();
+			area -= theme_cache.decrement_icon->get_height();
 			area -= get_grabber_min_size();
 			return area;
 		} break;
 		case HORIZONTAL: {
 			double area = get_size().width;
-			area -= get_theme_stylebox(SNAME("scroll"))->get_minimum_size().width;
-			area -= get_theme_icon(SNAME("increment"))->get_width();
-			area -= get_theme_icon(SNAME("decrement"))->get_width();
+			area -= theme_cache.scroll_style->get_minimum_size().width;
+			area -= theme_cache.increment_icon->get_width();
+			area -= theme_cache.decrement_icon->get_width();
 			area -= get_grabber_min_size();
 			return area;
 		} break;
@@ -459,13 +477,13 @@ double ScrollBar::get_area_offset() const {
 	double ofs = 0.0;
 
 	if (orientation == VERTICAL) {
-		ofs += get_theme_stylebox(SNAME("hscroll"))->get_margin(SIDE_TOP);
-		ofs += get_theme_icon(SNAME("decrement"))->get_height();
+		ofs += theme_cache.scroll_offset_style->get_margin(SIDE_TOP);
+		ofs += theme_cache.decrement_icon->get_height();
 	}
 
 	if (orientation == HORIZONTAL) {
-		ofs += get_theme_stylebox(SNAME("hscroll"))->get_margin(SIDE_LEFT);
-		ofs += get_theme_icon(SNAME("decrement"))->get_width();
+		ofs += theme_cache.scroll_offset_style->get_margin(SIDE_LEFT);
+		ofs += theme_cache.decrement_icon->get_width();
 	}
 
 	return ofs;
@@ -476,9 +494,9 @@ double ScrollBar::get_grabber_offset() const {
 }
 
 Size2 ScrollBar::get_minimum_size() const {
-	Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
-	Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-	Ref<StyleBox> bg = get_theme_stylebox(SNAME("scroll"));
+	Ref<Texture2D> incr = theme_cache.increment_icon;
+	Ref<Texture2D> decr = theme_cache.decrement_icon;
+	Ref<StyleBox> bg = theme_cache.scroll_style;
 	Size2 minsize;
 
 	if (orientation == VERTICAL) {

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -86,14 +86,31 @@ class ScrollBar : public Range {
 	double target_scroll = 0.0;
 	bool smooth_scroll_enabled = false;
 
+	struct ThemeCache {
+		Ref<StyleBox> scroll_style;
+		Ref<StyleBox> scroll_focus_style;
+		Ref<StyleBox> scroll_offset_style;
+		Ref<StyleBox> grabber_style;
+		Ref<StyleBox> grabber_hl_style;
+		Ref<StyleBox> grabber_pressed_style;
+
+		Ref<Texture2D> increment_icon;
+		Ref<Texture2D> increment_hl_icon;
+		Ref<Texture2D> increment_pressed_icon;
+		Ref<Texture2D> decrement_icon;
+		Ref<Texture2D> decrement_hl_icon;
+		Ref<Texture2D> decrement_pressed_icon;
+	} theme_cache;
+
 	void _drag_node_exit();
 	void _drag_node_input(const Ref<InputEvent> &p_input);
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 protected:
-	void _notification(int p_what);
+	virtual void _update_theme_item_cache() override;
 
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -35,7 +35,6 @@
 #include "scene/main/window.h"
 
 Size2 ScrollContainer::get_minimum_size() const {
-	Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
 	Size2 min_size;
 
 	// Calculated in this function, as it needs to traverse all child controls once to calculate;
@@ -77,8 +76,14 @@ Size2 ScrollContainer::get_minimum_size() const {
 		min_size.x += v_scroll->get_minimum_size().x;
 	}
 
-	min_size += sb->get_minimum_size();
+	min_size += theme_cache.bg_style->get_minimum_size();
 	return min_size;
+}
+
+void ScrollContainer::_update_theme_item_cache() {
+	Container::_update_theme_item_cache();
+
+	theme_cache.bg_style = get_theme_stylebox(SNAME("bg"));
 }
 
 void ScrollContainer::_cancel_drag() {
@@ -271,9 +276,8 @@ void ScrollContainer::_reposition_children() {
 	Size2 size = get_size();
 	Point2 ofs;
 
-	Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
-	size -= sb->get_minimum_size();
-	ofs += sb->get_offset();
+	size -= theme_cache.bg_style->get_minimum_size();
+	ofs += theme_cache.bg_style->get_offset();
 	bool rtl = is_layout_rtl();
 
 	if (h_scroll->is_visible_in_tree() && h_scroll->get_parent() == this) { //scrolls may have been moved out for reasons
@@ -337,8 +341,7 @@ void ScrollContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
-			draw_style_box(sb, Rect2(Vector2(), get_size()));
+			draw_style_box(theme_cache.bg_style, Rect2(Vector2(), get_size()));
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
@@ -413,8 +416,7 @@ void ScrollContainer::_notification(int p_what) {
 
 void ScrollContainer::update_scrollbars() {
 	Size2 size = get_size();
-	Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
-	size -= sb->get_minimum_size();
+	size -= theme_cache.bg_style->get_minimum_size();
 
 	Size2 hmin = h_scroll->get_combined_minimum_size();
 	Size2 vmin = v_scroll->get_combined_minimum_size();

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -69,9 +69,14 @@ private:
 	int deadzone = 0;
 	bool follow_focus = false;
 
+	struct ThemeCache {
+		Ref<StyleBox> bg_style;
+	} theme_cache;
+
 	void _cancel_drag();
 
 protected:
+	virtual void _update_theme_item_cache() override;
 	Size2 get_minimum_size() const override;
 
 	void _gui_focus_changed(Control *p_control);

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -33,24 +33,30 @@
 Size2 Separator::get_minimum_size() const {
 	Size2 ms(3, 3);
 	if (orientation == VERTICAL) {
-		ms.x = get_theme_constant(SNAME("separation"));
+		ms.x = theme_cache.separation;
 	} else { // HORIZONTAL
-		ms.y = get_theme_constant(SNAME("separation"));
+		ms.y = theme_cache.separation;
 	}
 	return ms;
+}
+
+void Separator::_update_theme_item_cache() {
+	Control::_update_theme_item_cache();
+
+	theme_cache.separation = get_theme_constant(SNAME("separation"));
+	theme_cache.separator_style = get_theme_stylebox(SNAME("separator"));
 }
 
 void Separator::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
 			Size2i size = get_size();
-			Ref<StyleBox> style = get_theme_stylebox(SNAME("separator"));
-			Size2i ssize = style->get_minimum_size() + style->get_center_size();
+			Size2i ssize = theme_cache.separator_style->get_minimum_size() + theme_cache.separator_style->get_center_size();
 
 			if (orientation == VERTICAL) {
-				style->draw(get_canvas_item(), Rect2((size.x - ssize.x) / 2, 0, ssize.x, size.y));
+				theme_cache.separator_style->draw(get_canvas_item(), Rect2((size.x - ssize.x) / 2, 0, ssize.x, size.y));
 			} else {
-				style->draw(get_canvas_item(), Rect2(0, (size.y - ssize.y) / 2, size.x, ssize.y));
+				theme_cache.separator_style->draw(get_canvas_item(), Rect2(0, (size.y - ssize.y) / 2, size.x, ssize.y));
 			}
 		} break;
 	}

--- a/scene/gui/separator.h
+++ b/scene/gui/separator.h
@@ -35,8 +35,16 @@
 class Separator : public Control {
 	GDCLASS(Separator, Control);
 
+	struct ThemeCache {
+		int separation = 0;
+		Ref<StyleBox> separator_style;
+	} theme_cache;
+
 protected:
 	Orientation orientation = Orientation::HORIZONTAL;
+
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 
 public:

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -49,11 +49,24 @@ class Slider : public Range {
 	bool editable = true;
 	bool scrollable = true;
 
+	struct ThemeCache {
+		Ref<StyleBox> slider_style;
+		Ref<StyleBox> grabber_area_style;
+		Ref<StyleBox> grabber_area_hl_style;
+
+		Ref<Texture2D> grabber_icon;
+		Ref<Texture2D> grabber_hl_icon;
+		Ref<Texture2D> grabber_disabled_icon;
+		Ref<Texture2D> tick_icon;
+	} theme_cache;
+
 protected:
+	bool ticks_on_borders = false;
+
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	static void _bind_methods();
-	bool ticks_on_borders = false;
 
 public:
 	virtual Size2 get_minimum_size() const override;

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -210,25 +210,29 @@ inline void SpinBox::_adjust_width_for_icon(const Ref<Texture2D> &icon) {
 	}
 }
 
+void SpinBox::_update_theme_item_cache() {
+	Range::_update_theme_item_cache();
+
+	theme_cache.updown_icon = get_theme_icon(SNAME("updown"));
+}
+
 void SpinBox::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			Ref<Texture2D> updown = get_theme_icon(SNAME("updown"));
-
-			_adjust_width_for_icon(updown);
+			_adjust_width_for_icon(theme_cache.updown_icon);
 
 			RID ci = get_canvas_item();
 			Size2i size = get_size();
 
 			if (is_layout_rtl()) {
-				updown->draw(ci, Point2i(0, (size.height - updown->get_height()) / 2));
+				theme_cache.updown_icon->draw(ci, Point2i(0, (size.height - theme_cache.updown_icon->get_height()) / 2));
 			} else {
-				updown->draw(ci, Point2i(size.width - updown->get_width(), (size.height - updown->get_height()) / 2));
+				theme_cache.updown_icon->draw(ci, Point2i(size.width - theme_cache.updown_icon->get_width(), (size.height - theme_cache.updown_icon->get_height()) / 2));
 			}
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			_adjust_width_for_icon(get_theme_icon(SNAME("updown")));
+			_adjust_width_for_icon(theme_cache.updown_icon);
 			_value_changed(0);
 		} break;
 

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -69,9 +69,14 @@ class SpinBox : public Range {
 
 	inline void _adjust_width_for_icon(const Ref<Texture2D> &icon);
 
+	struct ThemeCache {
+		Ref<Texture2D> updown_icon;
+	} theme_cache;
+
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
+	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 
 	static void _bind_methods();

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -76,9 +76,7 @@ void SplitContainer::_resort() {
 	bool second_expanded = (vertical ? second->get_v_size_flags() : second->get_h_size_flags()) & SIZE_EXPAND;
 
 	// Determine the separation between items
-	Ref<Texture2D> g = get_theme_icon(SNAME("grabber"));
-	int sep = get_theme_constant(SNAME("separation"));
-	sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(sep, vertical ? g->get_height() : g->get_width()) : 0;
+	int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(theme_cache.separation, vertical ? theme_cache.grabber_icon->get_height() : theme_cache.grabber_icon->get_width()) : 0;
 
 	// Compute the minimum size
 	Size2 ms_first = first->get_combined_minimum_size();
@@ -131,9 +129,7 @@ Size2 SplitContainer::get_minimum_size() const {
 	/* Calculate MINIMUM SIZE */
 
 	Size2i minimum;
-	Ref<Texture2D> g = get_theme_icon(SNAME("grabber"));
-	int sep = get_theme_constant(SNAME("separation"));
-	sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(sep, vertical ? g->get_height() : g->get_width()) : 0;
+	int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(theme_cache.separation, vertical ? theme_cache.grabber_icon->get_height() : theme_cache.grabber_icon->get_width()) : 0;
 
 	for (int i = 0; i < 2; i++) {
 		if (!_getch(i)) {
@@ -162,6 +158,14 @@ Size2 SplitContainer::get_minimum_size() const {
 	return minimum;
 }
 
+void SplitContainer::_update_theme_item_cache() {
+	Container::_update_theme_item_cache();
+
+	theme_cache.separation = get_theme_constant(SNAME("separation"));
+	theme_cache.autohide = get_theme_constant(SNAME("autohide"));
+	theme_cache.grabber_icon = get_theme_icon(SNAME("grabber"));
+}
+
 void SplitContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED:
@@ -175,7 +179,7 @@ void SplitContainer::_notification(int p_what) {
 
 		case NOTIFICATION_MOUSE_EXIT: {
 			mouse_inside = false;
-			if (get_theme_constant(SNAME("autohide"))) {
+			if (theme_cache.autohide) {
 				queue_redraw();
 			}
 		} break;
@@ -185,7 +189,7 @@ void SplitContainer::_notification(int p_what) {
 				return;
 			}
 
-			if (collapsed || (!dragging && !mouse_inside && get_theme_constant(SNAME("autohide")))) {
+			if (collapsed || (!dragging && !mouse_inside && theme_cache.autohide)) {
 				return;
 			}
 
@@ -193,8 +197,8 @@ void SplitContainer::_notification(int p_what) {
 				return;
 			}
 
-			int sep = dragger_visibility != DRAGGER_HIDDEN_COLLAPSED ? get_theme_constant(SNAME("separation")) : 0;
-			Ref<Texture2D> tex = get_theme_icon(SNAME("grabber"));
+			int sep = dragger_visibility != DRAGGER_HIDDEN_COLLAPSED ? theme_cache.separation : 0;
+			Ref<Texture2D> tex = theme_cache.grabber_icon;
 			Size2 size = get_size();
 
 			if (vertical) {
@@ -222,16 +226,14 @@ void SplitContainer::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid()) {
 		if (mb->get_button_index() == MouseButton::LEFT) {
 			if (mb->is_pressed()) {
-				int sep = get_theme_constant(SNAME("separation"));
-
 				if (vertical) {
-					if (mb->get_position().y > middle_sep && mb->get_position().y < middle_sep + sep) {
+					if (mb->get_position().y > middle_sep && mb->get_position().y < middle_sep + theme_cache.separation) {
 						dragging = true;
 						drag_from = mb->get_position().y;
 						drag_ofs = split_offset;
 					}
 				} else {
-					if (mb->get_position().x > middle_sep && mb->get_position().x < middle_sep + sep) {
+					if (mb->get_position().x > middle_sep && mb->get_position().x < middle_sep + theme_cache.separation) {
 						dragging = true;
 						drag_from = mb->get_position().x;
 						drag_ofs = split_offset;
@@ -248,14 +250,14 @@ void SplitContainer::gui_input(const Ref<InputEvent> &p_event) {
 	if (mm.is_valid()) {
 		bool mouse_inside_state = false;
 		if (vertical) {
-			mouse_inside_state = mm->get_position().y > middle_sep && mm->get_position().y < middle_sep + get_theme_constant(SNAME("separation"));
+			mouse_inside_state = mm->get_position().y > middle_sep && mm->get_position().y < middle_sep + theme_cache.separation;
 		} else {
-			mouse_inside_state = mm->get_position().x > middle_sep && mm->get_position().x < middle_sep + get_theme_constant(SNAME("separation"));
+			mouse_inside_state = mm->get_position().x > middle_sep && mm->get_position().x < middle_sep + theme_cache.separation;
 		}
 
 		if (mouse_inside != mouse_inside_state) {
 			mouse_inside = mouse_inside_state;
-			if (get_theme_constant(SNAME("autohide"))) {
+			if (theme_cache.autohide) {
 				queue_redraw();
 			}
 		}
@@ -281,14 +283,12 @@ Control::CursorShape SplitContainer::get_cursor_shape(const Point2 &p_pos) const
 	}
 
 	if (!collapsed && _getch(0) && _getch(1) && dragger_visibility == DRAGGER_VISIBLE) {
-		int sep = get_theme_constant(SNAME("separation"));
-
 		if (vertical) {
-			if (p_pos.y > middle_sep && p_pos.y < middle_sep + sep) {
+			if (p_pos.y > middle_sep && p_pos.y < middle_sep + theme_cache.separation) {
 				return CURSOR_VSPLIT;
 			}
 		} else {
-			if (p_pos.x > middle_sep && p_pos.x < middle_sep + sep) {
+			if (p_pos.x > middle_sep && p_pos.x < middle_sep + theme_cache.separation) {
 				return CURSOR_HSPLIT;
 			}
 		}

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -55,12 +55,20 @@ private:
 	DraggerVisibility dragger_visibility = DRAGGER_VISIBLE;
 	bool mouse_inside = false;
 
+	struct ThemeCache {
+		int separation = 0;
+		int autohide = 0;
+		Ref<Texture2D> grabber_icon;
+	} theme_cache;
+
 	Control *_getch(int p_idx) const;
 
 	void _resort();
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -44,14 +44,7 @@ Size2 TabBar::get_minimum_size() const {
 		return ms;
 	}
 
-	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
-	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
-	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
-	Ref<StyleBox> button_highlight = get_theme_stylebox(SNAME("button_highlight"));
-	Ref<Texture2D> close = get_theme_icon(SNAME("close"));
-	int hseparation = get_theme_constant(SNAME("h_separation"));
-
-	int y_margin = MAX(MAX(tab_unselected->get_minimum_size().height, tab_selected->get_minimum_size().height), tab_disabled->get_minimum_size().height);
+	int y_margin = MAX(MAX(theme_cache.tab_unselected_style->get_minimum_size().height, theme_cache.tab_selected_style->get_minimum_size().height), theme_cache.tab_disabled_style->get_minimum_size().height);
 
 	for (int i = 0; i < tabs.size(); i++) {
 		if (tabs[i].hidden) {
@@ -62,22 +55,22 @@ Size2 TabBar::get_minimum_size() const {
 
 		Ref<StyleBox> style;
 		if (tabs[i].disabled) {
-			style = tab_disabled;
+			style = theme_cache.tab_disabled_style;
 		} else if (current == i) {
-			style = tab_selected;
+			style = theme_cache.tab_selected_style;
 		} else {
-			style = tab_unselected;
+			style = theme_cache.tab_unselected_style;
 		}
 		ms.width += style->get_minimum_size().width;
 
 		Ref<Texture2D> tex = tabs[i].icon;
 		if (tex.is_valid()) {
 			ms.height = MAX(ms.height, tex->get_size().height + y_margin);
-			ms.width += tex->get_size().width + hseparation;
+			ms.width += tex->get_size().width + theme_cache.h_separation;
 		}
 
 		if (!tabs[i].text.is_empty()) {
-			ms.width += tabs[i].size_text + hseparation;
+			ms.width += tabs[i].size_text + theme_cache.h_separation;
 		}
 		ms.height = MAX(ms.height, tabs[i].text_buf->get_size().y + y_margin);
 
@@ -87,22 +80,22 @@ Size2 TabBar::get_minimum_size() const {
 			Ref<Texture2D> rb = tabs[i].right_button;
 
 			if (close_visible) {
-				ms.width += button_highlight->get_minimum_size().width + rb->get_width();
+				ms.width += theme_cache.button_hl_style->get_minimum_size().width + rb->get_width();
 			} else {
-				ms.width += button_highlight->get_margin(SIDE_LEFT) + rb->get_width() + hseparation;
+				ms.width += theme_cache.button_hl_style->get_margin(SIDE_LEFT) + rb->get_width() + theme_cache.h_separation;
 			}
 
 			ms.height = MAX(ms.height, rb->get_height() + y_margin);
 		}
 
 		if (close_visible) {
-			ms.width += button_highlight->get_margin(SIDE_LEFT) + close->get_width() + hseparation;
+			ms.width += theme_cache.button_hl_style->get_margin(SIDE_LEFT) + theme_cache.close_icon->get_width() + theme_cache.h_separation;
 
-			ms.height = MAX(ms.height, close->get_height() + y_margin);
+			ms.height = MAX(ms.height, theme_cache.close_icon->get_height() + y_margin);
 		}
 
 		if (ms.width - ofs > style->get_minimum_size().width) {
-			ms.width -= hseparation;
+			ms.width -= theme_cache.h_separation;
 		}
 	}
 
@@ -122,16 +115,13 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 		Point2 pos = mm->get_position();
 
 		if (buttons_visible) {
-			Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
-			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-
 			if (is_layout_rtl()) {
-				if (pos.x < decr->get_width()) {
+				if (pos.x < theme_cache.decrement_icon->get_width()) {
 					if (highlight_arrow != 1) {
 						highlight_arrow = 1;
 						queue_redraw();
 					}
-				} else if (pos.x < incr->get_width() + decr->get_width()) {
+				} else if (pos.x < theme_cache.increment_icon->get_width() + theme_cache.decrement_icon->get_width()) {
 					if (highlight_arrow != 0) {
 						highlight_arrow = 0;
 						queue_redraw();
@@ -141,8 +131,8 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 					queue_redraw();
 				}
 			} else {
-				int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
-				if (pos.x > limit_minus_buttons + decr->get_width()) {
+				int limit_minus_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+				if (pos.x > limit_minus_buttons + theme_cache.decrement_icon->get_width()) {
 					if (highlight_arrow != 1) {
 						highlight_arrow = 1;
 						queue_redraw();
@@ -214,18 +204,15 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 			Point2 pos = mb->get_position();
 
 			if (buttons_visible) {
-				Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
-				Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-
 				if (is_layout_rtl()) {
-					if (pos.x < decr->get_width()) {
+					if (pos.x < theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
 							_update_cache();
 							queue_redraw();
 						}
 						return;
-					} else if (pos.x < incr->get_width() + decr->get_width()) {
+					} else if (pos.x < theme_cache.increment_icon->get_width() + theme_cache.decrement_icon->get_width()) {
 						if (offset > 0) {
 							offset--;
 							_update_cache();
@@ -234,8 +221,8 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 						return;
 					}
 				} else {
-					int limit = get_size().width - incr->get_width() - decr->get_width();
-					if (pos.x > limit + decr->get_width()) {
+					int limit = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
+					if (pos.x > limit + theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
 							offset++;
 							_update_cache();
@@ -299,9 +286,6 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void TabBar::_shape(int p_tab) {
-	Ref<Font> font = get_theme_font(SNAME("font"));
-	int font_size = get_theme_font_size(SNAME("font_size"));
-
 	tabs.write[p_tab].xl_text = atr(tabs[p_tab].text);
 	tabs.write[p_tab].text_buf->clear();
 	tabs.write[p_tab].text_buf->set_width(-1);
@@ -311,7 +295,37 @@ void TabBar::_shape(int p_tab) {
 		tabs.write[p_tab].text_buf->set_direction((TextServer::Direction)tabs[p_tab].text_direction);
 	}
 
-	tabs.write[p_tab].text_buf->add_string(tabs[p_tab].xl_text, font, font_size, tabs[p_tab].language);
+	tabs.write[p_tab].text_buf->add_string(tabs[p_tab].xl_text, theme_cache.font, theme_cache.font_size, tabs[p_tab].language);
+}
+
+void TabBar::_update_theme_item_cache() {
+	Control::_update_theme_item_cache();
+
+	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
+
+	theme_cache.tab_unselected_style = get_theme_stylebox(SNAME("tab_unselected"));
+	theme_cache.tab_selected_style = get_theme_stylebox(SNAME("tab_selected"));
+	theme_cache.tab_disabled_style = get_theme_stylebox(SNAME("tab_disabled"));
+
+	theme_cache.increment_icon = get_theme_icon(SNAME("increment"));
+	theme_cache.increment_hl_icon = get_theme_icon(SNAME("increment_highlight"));
+	theme_cache.decrement_icon = get_theme_icon(SNAME("decrement"));
+	theme_cache.decrement_hl_icon = get_theme_icon(SNAME("decrement_highlight"));
+	theme_cache.drop_mark_icon = get_theme_icon(SNAME("drop_mark"));
+	theme_cache.drop_mark_color = get_theme_color(SNAME("drop_mark_color"));
+
+	theme_cache.font = get_theme_font(SNAME("font"));
+	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
+	theme_cache.outline_size = get_theme_constant(SNAME("outline_size"));
+
+	theme_cache.font_selected_color = get_theme_color(SNAME("font_selected_color"));
+	theme_cache.font_unselected_color = get_theme_color(SNAME("font_unselected_color"));
+	theme_cache.font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
+	theme_cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
+
+	theme_cache.close_icon = get_theme_icon(SNAME("close"));
+	theme_cache.button_pressed_style = get_theme_stylebox(SNAME("button_pressed"));
+	theme_cache.button_hl_style = get_theme_stylebox(SNAME("button_highlight"));
 }
 
 void TabBar::_notification(int p_what) {
@@ -352,18 +366,9 @@ void TabBar::_notification(int p_what) {
 				return;
 			}
 
-			Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
-			Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
-			Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
-			Color font_selected_color = get_theme_color(SNAME("font_selected_color"));
-			Color font_unselected_color = get_theme_color(SNAME("font_unselected_color"));
-			Color font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
-			Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
-			Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-
 			bool rtl = is_layout_rtl();
 			Vector2 size = get_size();
-			int limit_minus_buttons = size.width - incr->get_width() - decr->get_width();
+			int limit_minus_buttons = size.width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
 
 			int ofs = tabs[offset].ofs_cache;
 
@@ -378,14 +383,14 @@ void TabBar::_notification(int p_what) {
 					Color col;
 
 					if (tabs[i].disabled) {
-						sb = tab_disabled;
-						col = font_disabled_color;
+						sb = theme_cache.tab_disabled_style;
+						col = theme_cache.font_disabled_color;
 					} else if (i == current) {
-						sb = tab_selected;
-						col = font_selected_color;
+						sb = theme_cache.tab_selected_style;
+						col = theme_cache.font_selected_color;
 					} else {
-						sb = tab_unselected;
-						col = font_unselected_color;
+						sb = theme_cache.tab_unselected_style;
+						col = theme_cache.font_unselected_color;
 					}
 
 					_draw_tab(sb, col, i, rtl ? size.width - ofs - tabs[i].size_cache : ofs);
@@ -396,41 +401,38 @@ void TabBar::_notification(int p_what) {
 
 			// Draw selected tab in the front, but only if it's visible.
 			if (current >= offset && current <= max_drawn_tab && !tabs[current].hidden) {
-				Ref<StyleBox> sb = tabs[current].disabled ? tab_disabled : tab_selected;
+				Ref<StyleBox> sb = tabs[current].disabled ? theme_cache.tab_disabled_style : theme_cache.tab_selected_style;
 				float x = rtl ? size.width - tabs[current].ofs_cache - tabs[current].size_cache : tabs[current].ofs_cache;
 
-				_draw_tab(sb, font_selected_color, current, x);
+				_draw_tab(sb, theme_cache.font_selected_color, current, x);
 			}
 
 			if (buttons_visible) {
-				Ref<Texture2D> incr_hl = get_theme_icon(SNAME("increment_highlight"));
-				Ref<Texture2D> decr_hl = get_theme_icon(SNAME("decrement_highlight"));
-
-				int vofs = (size.height - incr->get_size().height) / 2;
+				int vofs = (size.height - theme_cache.increment_icon->get_size().height) / 2;
 
 				if (rtl) {
 					if (missing_right) {
-						draw_texture(highlight_arrow == 1 ? decr_hl : decr, Point2(0, vofs));
+						draw_texture(highlight_arrow == 1 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon, Point2(0, vofs));
 					} else {
-						draw_texture(decr, Point2(0, vofs), Color(1, 1, 1, 0.5));
+						draw_texture(theme_cache.decrement_icon, Point2(0, vofs), Color(1, 1, 1, 0.5));
 					}
 
 					if (offset > 0) {
-						draw_texture(highlight_arrow == 0 ? incr_hl : incr, Point2(incr->get_size().width, vofs));
+						draw_texture(highlight_arrow == 0 ? theme_cache.increment_hl_icon : theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs));
 					} else {
-						draw_texture(incr, Point2(incr->get_size().width, vofs), Color(1, 1, 1, 0.5));
+						draw_texture(theme_cache.increment_icon, Point2(theme_cache.increment_icon->get_size().width, vofs), Color(1, 1, 1, 0.5));
 					}
 				} else {
 					if (offset > 0) {
-						draw_texture(highlight_arrow == 0 ? decr_hl : decr, Point2(limit_minus_buttons, vofs));
+						draw_texture(highlight_arrow == 0 ? theme_cache.decrement_hl_icon : theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs));
 					} else {
-						draw_texture(decr, Point2(limit_minus_buttons, vofs), Color(1, 1, 1, 0.5));
+						draw_texture(theme_cache.decrement_icon, Point2(limit_minus_buttons, vofs), Color(1, 1, 1, 0.5));
 					}
 
 					if (missing_right) {
-						draw_texture(highlight_arrow == 1 ? incr_hl : incr, Point2(limit_minus_buttons + decr->get_size().width, vofs));
+						draw_texture(highlight_arrow == 1 ? theme_cache.increment_hl_icon : theme_cache.increment_icon, Point2(limit_minus_buttons + theme_cache.decrement_icon->get_size().width, vofs));
 					} else {
-						draw_texture(incr, Point2(limit_minus_buttons + decr->get_size().width, vofs), Color(1, 1, 1, 0.5));
+						draw_texture(theme_cache.increment_icon, Point2(limit_minus_buttons + theme_cache.decrement_icon->get_size().width, vofs), Color(1, 1, 1, 0.5));
 					}
 				}
 			}
@@ -462,10 +464,7 @@ void TabBar::_notification(int p_what) {
 					}
 				}
 
-				Ref<Texture2D> drop_mark = get_theme_icon(SNAME("drop_mark"));
-				Color drop_mark_color = get_theme_color(SNAME("drop_mark_color"));
-
-				drop_mark->draw(get_canvas_item(), Point2(x - drop_mark->get_width() / 2, (size.height - drop_mark->get_height()) / 2), drop_mark_color);
+				theme_cache.drop_mark_icon->draw(get_canvas_item(), Point2(x - theme_cache.drop_mark_icon->get_width() / 2, (size.height - theme_cache.drop_mark_icon->get_height()) / 2), theme_cache.drop_mark_color);
 			}
 		} break;
 	}
@@ -474,10 +473,6 @@ void TabBar::_notification(int p_what) {
 void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_index, float p_x) {
 	RID ci = get_canvas_item();
 	bool rtl = is_layout_rtl();
-
-	Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
-	int outline_size = get_theme_constant(SNAME("outline_size"));
-	int hseparation = get_theme_constant(SNAME("h_separation"));
 
 	Rect2 sb_rect = Rect2(p_x, 0, tabs[p_index].size_cache, get_size().height);
 	p_tab_style->draw(ci, sb_rect);
@@ -491,7 +486,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 	if (icon.is_valid()) {
 		icon->draw(ci, Point2i(rtl ? p_x - icon->get_width() : p_x, p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - icon->get_height()) / 2));
 
-		p_x = rtl ? p_x - icon->get_width() - hseparation : p_x + icon->get_width() + hseparation;
+		p_x = rtl ? p_x - icon->get_width() - theme_cache.h_separation : p_x + icon->get_width() + theme_cache.h_separation;
 	}
 
 	// Draw the text.
@@ -499,17 +494,17 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 		Point2i text_pos = Point2i(rtl ? p_x - tabs[p_index].size_text : p_x,
 				p_tab_style->get_margin(SIDE_TOP) + ((sb_rect.size.y - sb_ms.y) - tabs[p_index].text_buf->get_size().y) / 2);
 
-		if (outline_size > 0 && font_outline_color.a > 0) {
-			tabs[p_index].text_buf->draw_outline(ci, text_pos, outline_size, font_outline_color);
+		if (theme_cache.outline_size > 0 && theme_cache.font_outline_color.a > 0) {
+			tabs[p_index].text_buf->draw_outline(ci, text_pos, theme_cache.outline_size, theme_cache.font_outline_color);
 		}
 		tabs[p_index].text_buf->draw(ci, text_pos, p_font_color);
 
-		p_x = rtl ? p_x - tabs[p_index].size_text - hseparation : p_x + tabs[p_index].size_text + hseparation;
+		p_x = rtl ? p_x - tabs[p_index].size_text - theme_cache.h_separation : p_x + tabs[p_index].size_text + theme_cache.h_separation;
 	}
 
 	// Draw and calculate rect of the right button.
 	if (tabs[p_index].right_button.is_valid()) {
-		Ref<StyleBox> style = get_theme_stylebox(SNAME("button_highlight"));
+		Ref<StyleBox> style = theme_cache.button_hl_style;
 		Ref<Texture2D> rb = tabs[p_index].right_button;
 
 		Rect2 rb_rect;
@@ -521,7 +516,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 
 		if (rb_hover == p_index) {
 			if (rb_pressing) {
-				get_theme_stylebox(SNAME("button_pressed"))->draw(ci, rb_rect);
+				theme_cache.button_pressed_style->draw(ci, rb_rect);
 			} else {
 				style->draw(ci, rb_rect);
 			}
@@ -534,8 +529,8 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 
 	// Draw and calculate rect of the close button.
 	if (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && p_index == current)) {
-		Ref<StyleBox> style = get_theme_stylebox(SNAME("button_highlight"));
-		Ref<Texture2D> cb = get_theme_icon(SNAME("close"));
+		Ref<StyleBox> style = theme_cache.button_hl_style;
+		Ref<Texture2D> cb = theme_cache.close_icon;
 
 		Rect2 cb_rect;
 		cb_rect.size = style->get_minimum_size() + cb->get_size();
@@ -546,7 +541,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 
 		if (!tabs[p_index].disabled && cb_hover == p_index) {
 			if (cb_pressing) {
-				get_theme_stylebox(SNAME("button_pressed"))->draw(ci, cb_rect);
+				theme_cache.button_pressed_style->draw(ci, cb_rect);
 			} else {
 				style->draw(ci, cb_rect);
 			}
@@ -849,14 +844,8 @@ void TabBar::_update_cache() {
 		return;
 	}
 
-	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
-	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
-	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
-	Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
-	Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-
 	int limit = get_size().width;
-	int limit_minus_buttons = limit - incr->get_width() - decr->get_width();
+	int limit_minus_buttons = limit - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
 
 	int w = 0;
 
@@ -1258,52 +1247,47 @@ void TabBar::move_tab(int p_from, int p_to) {
 int TabBar::get_tab_width(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, tabs.size(), 0);
 
-	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
-	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
-	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
-	int hseparation = get_theme_constant(SNAME("h_separation"));
-
 	Ref<StyleBox> style;
 
 	if (tabs[p_idx].disabled) {
-		style = tab_disabled;
+		style = theme_cache.tab_disabled_style;
 	} else if (current == p_idx) {
-		style = tab_selected;
+		style = theme_cache.tab_selected_style;
 	} else {
-		style = tab_unselected;
+		style = theme_cache.tab_unselected_style;
 	}
 	int x = style->get_minimum_size().width;
 
 	Ref<Texture2D> tex = tabs[p_idx].icon;
 	if (tex.is_valid()) {
-		x += tex->get_width() + hseparation;
+		x += tex->get_width() + theme_cache.h_separation;
 	}
 
 	if (!tabs[p_idx].text.is_empty()) {
-		x += tabs[p_idx].size_text + hseparation;
+		x += tabs[p_idx].size_text + theme_cache.h_separation;
 	}
 
 	bool close_visible = cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && p_idx == current);
 
 	if (tabs[p_idx].right_button.is_valid()) {
-		Ref<StyleBox> btn_style = get_theme_stylebox(SNAME("button_highlight"));
+		Ref<StyleBox> btn_style = theme_cache.button_hl_style;
 		Ref<Texture2D> rb = tabs[p_idx].right_button;
 
 		if (close_visible) {
 			x += btn_style->get_minimum_size().width + rb->get_width();
 		} else {
-			x += btn_style->get_margin(SIDE_LEFT) + rb->get_width() + hseparation;
+			x += btn_style->get_margin(SIDE_LEFT) + rb->get_width() + theme_cache.h_separation;
 		}
 	}
 
 	if (close_visible) {
-		Ref<StyleBox> btn_style = get_theme_stylebox(SNAME("button_highlight"));
-		Ref<Texture2D> cb = get_theme_icon(SNAME("close"));
-		x += btn_style->get_margin(SIDE_LEFT) + cb->get_width() + hseparation;
+		Ref<StyleBox> btn_style = theme_cache.button_hl_style;
+		Ref<Texture2D> cb = theme_cache.close_icon;
+		x += btn_style->get_margin(SIDE_LEFT) + cb->get_width() + theme_cache.h_separation;
 	}
 
 	if (x > style->get_minimum_size().width) {
-		x -= hseparation;
+		x -= theme_cache.h_separation;
 	}
 
 	return x;
@@ -1314,9 +1298,7 @@ void TabBar::_ensure_no_over_offset() {
 		return;
 	}
 
-	Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
-	Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-	int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
+	int limit_minus_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
 
 	int prev_offset = offset;
 
@@ -1359,9 +1341,7 @@ void TabBar::ensure_tab_visible(int p_idx) {
 		return;
 	}
 
-	Ref<Texture2D> incr = get_theme_icon(SNAME("increment"));
-	Ref<Texture2D> decr = get_theme_icon(SNAME("decrement"));
-	int limit_minus_buttons = get_size().width - incr->get_width() - decr->get_width();
+	int limit_minus_buttons = get_size().width - theme_cache.increment_icon->get_width() - theme_cache.decrement_icon->get_width();
 
 	int total_w = tabs[max_drawn_tab].ofs_cache - tabs[offset].ofs_cache;
 	for (int i = max_drawn_tab; i <= p_idx; i++) {

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -104,6 +104,34 @@ private:
 	bool scroll_to_selected = true;
 	int tabs_rearrange_group = -1;
 
+	struct ThemeCache {
+		int h_separation = 0;
+
+		Ref<StyleBox> tab_unselected_style;
+		Ref<StyleBox> tab_selected_style;
+		Ref<StyleBox> tab_disabled_style;
+
+		Ref<Texture2D> increment_icon;
+		Ref<Texture2D> increment_hl_icon;
+		Ref<Texture2D> decrement_icon;
+		Ref<Texture2D> decrement_hl_icon;
+		Ref<Texture2D> drop_mark_icon;
+		Color drop_mark_color;
+
+		Ref<Font> font;
+		int font_size;
+		int outline_size = 0;
+
+		Color font_selected_color;
+		Color font_unselected_color;
+		Color font_disabled_color;
+		Color font_outline_color;
+
+		Ref<Texture2D> close_icon;
+		Ref<StyleBox> button_pressed_style;
+		Ref<StyleBox> button_hl_style;
+	} theme_cache;
+
 	int get_tab_width(int p_idx) const;
 	void _ensure_no_over_offset();
 
@@ -117,6 +145,7 @@ private:
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void _update_theme_item_cache() override;
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -60,26 +60,24 @@ void TabContainer::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		// Handle menu button.
-		Ref<Texture2D> menu = get_theme_icon(SNAME("menu"));
-
 		if (is_layout_rtl()) {
-			if (popup && pos.x < menu->get_width()) {
+			if (popup && pos.x < theme_cache.menu_icon->get_width()) {
 				emit_signal(SNAME("pre_popup_pressed"));
 
 				Vector2 popup_pos = get_screen_position();
-				popup_pos.y += menu->get_height();
+				popup_pos.y += theme_cache.menu_icon->get_height();
 
 				popup->set_position(popup_pos);
 				popup->popup();
 				return;
 			}
 		} else {
-			if (popup && pos.x > size.width - menu->get_width()) {
+			if (popup && pos.x > size.width - theme_cache.menu_icon->get_width()) {
 				emit_signal(SNAME("pre_popup_pressed"));
 
 				Vector2 popup_pos = get_screen_position();
 				popup_pos.x += size.width - popup->get_size().width;
-				popup_pos.y += menu->get_height();
+				popup_pos.y += theme_cache.menu_icon->get_height();
 
 				popup->set_position(popup_pos);
 				popup->popup();
@@ -103,10 +101,9 @@ void TabContainer::gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
-		Ref<Texture2D> menu = get_theme_icon(SNAME("menu"));
 		if (popup) {
 			if (is_layout_rtl()) {
-				if (pos.x <= menu->get_width()) {
+				if (pos.x <= theme_cache.menu_icon->get_width()) {
 					if (!menu_hovered) {
 						menu_hovered = true;
 						queue_redraw();
@@ -117,7 +114,7 @@ void TabContainer::gui_input(const Ref<InputEvent> &p_event) {
 					queue_redraw();
 				}
 			} else {
-				if (pos.x >= size.width - menu->get_width()) {
+				if (pos.x >= size.width - theme_cache.menu_icon->get_width()) {
 					if (!menu_hovered) {
 						menu_hovered = true;
 						queue_redraw();
@@ -134,6 +131,41 @@ void TabContainer::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 	}
+}
+
+void TabContainer::_update_theme_item_cache() {
+	Container::_update_theme_item_cache();
+
+	theme_cache.side_margin = get_theme_constant(SNAME("side_margin"));
+
+	theme_cache.panel_style = get_theme_stylebox(SNAME("panel"));
+	theme_cache.tabbar_style = get_theme_stylebox(SNAME("tabbar_background"));
+
+	theme_cache.menu_icon = get_theme_icon(SNAME("menu"));
+	theme_cache.menu_hl_icon = get_theme_icon(SNAME("menu_highlight"));
+
+	// TabBar overrides.
+	theme_cache.icon_separation = get_theme_constant(SNAME("icon_separation"));
+	theme_cache.outline_size = get_theme_constant(SNAME("outline_size"));
+
+	theme_cache.tab_unselected_style = get_theme_stylebox(SNAME("tab_unselected"));
+	theme_cache.tab_selected_style = get_theme_stylebox(SNAME("tab_selected"));
+	theme_cache.tab_disabled_style = get_theme_stylebox(SNAME("tab_disabled"));
+
+	theme_cache.increment_icon = get_theme_icon(SNAME("increment"));
+	theme_cache.increment_hl_icon = get_theme_icon(SNAME("increment_highlight"));
+	theme_cache.decrement_icon = get_theme_icon(SNAME("decrement"));
+	theme_cache.decrement_hl_icon = get_theme_icon(SNAME("decrement_highlight"));
+	theme_cache.drop_mark_icon = get_theme_icon(SNAME("drop_mark"));
+	theme_cache.drop_mark_color = get_theme_color(SNAME("drop_mark_color"));
+
+	theme_cache.font_selected_color = get_theme_color(SNAME("font_selected_color"));
+	theme_cache.font_unselected_color = get_theme_color(SNAME("font_unselected_color"));
+	theme_cache.font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
+	theme_cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
+
+	theme_cache.tab_font = get_theme_font(SNAME("font"));
+	theme_cache.tab_font_size = get_theme_font_size(SNAME("font_size"));
 }
 
 void TabContainer::_notification(int p_what) {
@@ -155,31 +187,26 @@ void TabContainer::_notification(int p_what) {
 			Size2 size = get_size();
 
 			// Draw only the tab area if the header is hidden.
-			Ref<StyleBox> panel = get_theme_stylebox(SNAME("panel"));
 			if (!tabs_visible) {
-				panel->draw(canvas, Rect2(0, 0, size.width, size.height));
+				theme_cache.panel_style->draw(canvas, Rect2(0, 0, size.width, size.height));
 				return;
 			}
 
 			int header_height = _get_top_margin();
 
 			// Draw background for the tabbar.
-			Ref<StyleBox> tabbar_background = get_theme_stylebox(SNAME("tabbar_background"));
-			tabbar_background->draw(canvas, Rect2(0, 0, size.width, header_height));
+			theme_cache.tabbar_style->draw(canvas, Rect2(0, 0, size.width, header_height));
 			// Draw the background for the tab's content.
-			panel->draw(canvas, Rect2(0, header_height, size.width, size.height - header_height));
+			theme_cache.panel_style->draw(canvas, Rect2(0, header_height, size.width, size.height - header_height));
 
 			// Draw the popup menu.
 			if (get_popup()) {
-				Ref<Texture2D> menu = get_theme_icon(SNAME("menu"));
-				Ref<Texture2D> menu_hl = get_theme_icon(SNAME("menu_highlight"));
-
-				int x = is_layout_rtl() ? 0 : get_size().width - menu->get_width();
+				int x = is_layout_rtl() ? 0 : get_size().width - theme_cache.menu_icon->get_width();
 
 				if (menu_hovered) {
-					menu_hl->draw(get_canvas_item(), Point2(x, (header_height - menu_hl->get_height()) / 2));
+					theme_cache.menu_hl_icon->draw(get_canvas_item(), Point2(x, (header_height - theme_cache.menu_hl_icon->get_height()) / 2));
 				} else {
-					menu->draw(get_canvas_item(), Point2(x, (header_height - menu->get_height()) / 2));
+					theme_cache.menu_icon->draw(get_canvas_item(), Point2(x, (header_height - theme_cache.menu_icon->get_height()) / 2));
 				}
 			}
 		} break;
@@ -198,23 +225,27 @@ void TabContainer::_on_theme_changed() {
 		return;
 	}
 
-	tab_bar->add_theme_style_override(SNAME("tab_unselected"), get_theme_stylebox(SNAME("tab_unselected")));
-	tab_bar->add_theme_style_override(SNAME("tab_selected"), get_theme_stylebox(SNAME("tab_selected")));
-	tab_bar->add_theme_style_override(SNAME("tab_disabled"), get_theme_stylebox(SNAME("tab_disabled")));
-	tab_bar->add_theme_icon_override(SNAME("increment"), get_theme_icon(SNAME("increment")));
-	tab_bar->add_theme_icon_override(SNAME("increment_highlight"), get_theme_icon(SNAME("increment_highlight")));
-	tab_bar->add_theme_icon_override(SNAME("decrement"), get_theme_icon(SNAME("decrement")));
-	tab_bar->add_theme_icon_override(SNAME("decrement_highlight"), get_theme_icon(SNAME("decrement_highlight")));
-	tab_bar->add_theme_icon_override(SNAME("drop_mark"), get_theme_icon(SNAME("drop_mark")));
-	tab_bar->add_theme_color_override(SNAME("drop_mark_color"), get_theme_color(SNAME("drop_mark_color")));
-	tab_bar->add_theme_color_override(SNAME("font_selected_color"), get_theme_color(SNAME("font_selected_color")));
-	tab_bar->add_theme_color_override(SNAME("font_unselected_color"), get_theme_color(SNAME("font_unselected_color")));
-	tab_bar->add_theme_color_override(SNAME("font_disabled_color"), get_theme_color(SNAME("font_disabled_color")));
-	tab_bar->add_theme_color_override(SNAME("font_outline_color"), get_theme_color(SNAME("font_outline_color")));
-	tab_bar->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("font")));
-	tab_bar->add_theme_font_size_override(SNAME("font_size"), get_theme_font_size(SNAME("font_size")));
-	tab_bar->add_theme_constant_override(SNAME("h_separation"), get_theme_constant(SNAME("icon_separation")));
-	tab_bar->add_theme_constant_override(SNAME("outline_size"), get_theme_constant(SNAME("outline_size")));
+	tab_bar->add_theme_style_override(SNAME("tab_unselected"), theme_cache.tab_unselected_style);
+	tab_bar->add_theme_style_override(SNAME("tab_selected"), theme_cache.tab_selected_style);
+	tab_bar->add_theme_style_override(SNAME("tab_disabled"), theme_cache.tab_disabled_style);
+
+	tab_bar->add_theme_icon_override(SNAME("increment"), theme_cache.increment_icon);
+	tab_bar->add_theme_icon_override(SNAME("increment_highlight"), theme_cache.increment_hl_icon);
+	tab_bar->add_theme_icon_override(SNAME("decrement"), theme_cache.decrement_icon);
+	tab_bar->add_theme_icon_override(SNAME("decrement_highlight"), theme_cache.decrement_hl_icon);
+	tab_bar->add_theme_icon_override(SNAME("drop_mark"), theme_cache.drop_mark_icon);
+	tab_bar->add_theme_color_override(SNAME("drop_mark_color"), theme_cache.drop_mark_color);
+
+	tab_bar->add_theme_color_override(SNAME("font_selected_color"), theme_cache.font_selected_color);
+	tab_bar->add_theme_color_override(SNAME("font_unselected_color"), theme_cache.font_unselected_color);
+	tab_bar->add_theme_color_override(SNAME("font_disabled_color"), theme_cache.font_disabled_color);
+	tab_bar->add_theme_color_override(SNAME("font_outline_color"), theme_cache.font_outline_color);
+
+	tab_bar->add_theme_font_override(SNAME("font"), theme_cache.tab_font);
+	tab_bar->add_theme_font_size_override(SNAME("font_size"), theme_cache.tab_font_size);
+
+	tab_bar->add_theme_constant_override(SNAME("h_separation"), theme_cache.icon_separation);
+	tab_bar->add_theme_constant_override(SNAME("outline_size"), theme_cache.outline_size);
 
 	_update_margins();
 	if (get_tab_count() > 0) {
@@ -228,7 +259,6 @@ void TabContainer::_on_theme_changed() {
 }
 
 void TabContainer::_repaint() {
-	Ref<StyleBox> sb = get_theme_stylebox(SNAME("panel"));
 	Vector<Control *> controls = _get_tab_controls();
 	int current = get_current_tab();
 
@@ -243,10 +273,10 @@ void TabContainer::_repaint() {
 				c->set_offset(SIDE_TOP, _get_top_margin());
 			}
 
-			c->set_offset(SIDE_TOP, c->get_offset(SIDE_TOP) + sb->get_margin(SIDE_TOP));
-			c->set_offset(SIDE_LEFT, c->get_offset(SIDE_LEFT) + sb->get_margin(SIDE_LEFT));
-			c->set_offset(SIDE_RIGHT, c->get_offset(SIDE_RIGHT) - sb->get_margin(SIDE_RIGHT));
-			c->set_offset(SIDE_BOTTOM, c->get_offset(SIDE_BOTTOM) - sb->get_margin(SIDE_BOTTOM));
+			c->set_offset(SIDE_TOP, c->get_offset(SIDE_TOP) + theme_cache.panel_style->get_margin(SIDE_TOP));
+			c->set_offset(SIDE_LEFT, c->get_offset(SIDE_LEFT) + theme_cache.panel_style->get_margin(SIDE_LEFT));
+			c->set_offset(SIDE_RIGHT, c->get_offset(SIDE_RIGHT) - theme_cache.panel_style->get_margin(SIDE_RIGHT));
+			c->set_offset(SIDE_BOTTOM, c->get_offset(SIDE_BOTTOM) - theme_cache.panel_style->get_margin(SIDE_BOTTOM));
 		} else {
 			c->hide();
 		}
@@ -256,8 +286,7 @@ void TabContainer::_repaint() {
 }
 
 void TabContainer::_update_margins() {
-	int menu_width = get_theme_icon(SNAME("menu"))->get_width();
-	int side_margin = get_theme_constant(SNAME("side_margin"));
+	int menu_width = theme_cache.menu_icon->get_width();
 
 	// Directly check for validity, to avoid errors when quitting.
 	bool has_popup = popup_obj_id.is_valid();
@@ -271,7 +300,7 @@ void TabContainer::_update_margins() {
 
 	switch (get_tab_alignment()) {
 		case TabBar::ALIGNMENT_LEFT: {
-			tab_bar->set_offset(SIDE_LEFT, side_margin);
+			tab_bar->set_offset(SIDE_LEFT, theme_cache.side_margin);
 			tab_bar->set_offset(SIDE_RIGHT, has_popup ? -menu_width : 0);
 		} break;
 
@@ -293,10 +322,10 @@ void TabContainer::_update_margins() {
 			int total_tabs_width = last_tab_rect.position.x - first_tab_pos + last_tab_rect.size.width;
 
 			// Calculate if all the tabs would still fit if the margin was present.
-			if (get_clip_tabs() && (tab_bar->get_offset_buttons_visible() || (get_tab_count() > 1 && (total_tabs_width + side_margin) > get_size().width))) {
+			if (get_clip_tabs() && (tab_bar->get_offset_buttons_visible() || (get_tab_count() > 1 && (total_tabs_width + theme_cache.side_margin) > get_size().width))) {
 				tab_bar->set_offset(SIDE_RIGHT, has_popup ? -menu_width : 0);
 			} else {
-				tab_bar->set_offset(SIDE_RIGHT, -side_margin);
+				tab_bar->set_offset(SIDE_RIGHT, -theme_cache.side_margin);
 			}
 		} break;
 
@@ -798,13 +827,12 @@ Size2 TabContainer::get_minimum_size() const {
 
 		if (!get_clip_tabs()) {
 			if (get_popup()) {
-				ms.x += get_theme_icon(SNAME("menu"))->get_width();
+				ms.x += theme_cache.menu_icon->get_width();
 			}
 
-			int side_margin = get_theme_constant(SNAME("side_margin"));
-			if (side_margin > 0 && get_tab_alignment() != TabBar::ALIGNMENT_CENTER &&
+			if (theme_cache.side_margin > 0 && get_tab_alignment() != TabBar::ALIGNMENT_CENTER &&
 					(get_tab_alignment() != TabBar::ALIGNMENT_RIGHT || !get_popup())) {
-				ms.x += side_margin;
+				ms.x += theme_cache.side_margin;
 			}
 		}
 	}
@@ -824,7 +852,7 @@ Size2 TabContainer::get_minimum_size() const {
 	}
 	ms.y += max_control_height;
 
-	Size2 panel_ms = get_theme_stylebox(SNAME("panel"))->get_minimum_size();
+	Size2 panel_ms = theme_cache.panel_style->get_minimum_size();
 	ms.x = MAX(ms.x, panel_ms.x);
 	ms.y += panel_ms.y;
 

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -48,6 +48,39 @@ class TabContainer : public Container {
 	bool theme_changing = false;
 	Node *child_removing = nullptr;
 
+	struct ThemeCache {
+		int side_margin = 0;
+
+		Ref<StyleBox> panel_style;
+		Ref<StyleBox> tabbar_style;
+
+		Ref<Texture2D> menu_icon;
+		Ref<Texture2D> menu_hl_icon;
+
+		// TabBar overrides.
+		int icon_separation = 0;
+		int outline_size = 0;
+
+		Ref<StyleBox> tab_unselected_style;
+		Ref<StyleBox> tab_selected_style;
+		Ref<StyleBox> tab_disabled_style;
+
+		Ref<Texture2D> increment_icon;
+		Ref<Texture2D> increment_hl_icon;
+		Ref<Texture2D> decrement_icon;
+		Ref<Texture2D> decrement_hl_icon;
+		Ref<Texture2D> drop_mark_icon;
+		Color drop_mark_color;
+
+		Color font_selected_color;
+		Color font_unselected_color;
+		Color font_disabled_color;
+		Color font_outline_color;
+
+		Ref<Font> tab_font;
+		int tab_font_size;
+	} theme_cache;
+
 	int _get_top_margin() const;
 	Vector<Control *> _get_tab_controls() const;
 	void _on_theme_changed();
@@ -65,6 +98,8 @@ class TabContainer : public Container {
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void _update_theme_item_cache() override;
+
 	void _notification(int p_what);
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void move_child_notify(Node *p_child) override;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1286,14 +1286,14 @@ Size2 TreeItem::get_minimum_size(int p_column) {
 
 		// Icon.
 		if (cell.mode == CELL_MODE_CHECK) {
-			size.width += tree->cache.checked->get_width() + tree->cache.hseparation;
+			size.width += tree->theme_cache.checked->get_width() + tree->theme_cache.hseparation;
 		}
 		if (cell.icon.is_valid()) {
 			Size2i icon_size = cell.get_icon_size();
 			if (cell.icon_max_w > 0 && icon_size.width > cell.icon_max_w) {
 				icon_size.width = cell.icon_max_w;
 			}
-			size.width += icon_size.width + tree->cache.hseparation;
+			size.width += icon_size.width + tree->theme_cache.hseparation;
 			size.height = MAX(size.height, icon_size.height);
 		}
 
@@ -1301,13 +1301,13 @@ Size2 TreeItem::get_minimum_size(int p_column) {
 		for (int i = 0; i < cell.buttons.size(); i++) {
 			Ref<Texture2D> texture = cell.buttons[i].texture;
 			if (texture.is_valid()) {
-				Size2 button_size = texture->get_size() + tree->cache.button_pressed->get_minimum_size();
+				Size2 button_size = texture->get_size() + tree->theme_cache.button_pressed->get_minimum_size();
 				size.width += button_size.width;
 				size.height = MAX(size.height, button_size.height);
 			}
 		}
 		if (cell.buttons.size() >= 2) {
-			size.width += (cell.buttons.size() - 1) * tree->cache.button_margin;
+			size.width += (cell.buttons.size() - 1) * tree->theme_cache.button_margin;
 		}
 
 		cells.write[p_column].cached_minimum_size = size;
@@ -1535,68 +1535,66 @@ TreeItem::~TreeItem() {
 /**********************************************/
 /**********************************************/
 
-void Tree::update_cache() {
-	cache.font = get_theme_font(SNAME("font"));
-	cache.font_size = get_theme_font_size(SNAME("font_size"));
-	cache.tb_font = get_theme_font(SNAME("title_button_font"));
-	cache.tb_font_size = get_theme_font_size(SNAME("title_button_font_size"));
-	cache.bg = get_theme_stylebox(SNAME("bg"));
-	cache.selected = get_theme_stylebox(SNAME("selected"));
-	cache.selected_focus = get_theme_stylebox(SNAME("selected_focus"));
-	cache.cursor = get_theme_stylebox(SNAME("cursor"));
-	cache.cursor_unfocus = get_theme_stylebox(SNAME("cursor_unfocused"));
-	cache.button_pressed = get_theme_stylebox(SNAME("button_pressed"));
+void Tree::_update_theme_item_cache() {
+	Control::_update_theme_item_cache();
 
-	cache.checked = get_theme_icon(SNAME("checked"));
-	cache.unchecked = get_theme_icon(SNAME("unchecked"));
-	cache.indeterminate = get_theme_icon(SNAME("indeterminate"));
-	if (is_layout_rtl()) {
-		cache.arrow_collapsed = get_theme_icon(SNAME("arrow_collapsed_mirrored"));
-	} else {
-		cache.arrow_collapsed = get_theme_icon(SNAME("arrow_collapsed"));
-	}
-	cache.arrow = get_theme_icon(SNAME("arrow"));
-	cache.select_arrow = get_theme_icon(SNAME("select_arrow"));
-	cache.updown = get_theme_icon(SNAME("updown"));
+	theme_cache.font = get_theme_font(SNAME("font"));
+	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
+	theme_cache.tb_font = get_theme_font(SNAME("title_button_font"));
+	theme_cache.tb_font_size = get_theme_font_size(SNAME("title_button_font_size"));
+	theme_cache.bg = get_theme_stylebox(SNAME("bg"));
+	theme_cache.bg_focus = get_theme_stylebox(SNAME("bg_focus"));
+	theme_cache.selected = get_theme_stylebox(SNAME("selected"));
+	theme_cache.selected_focus = get_theme_stylebox(SNAME("selected_focus"));
+	theme_cache.cursor = get_theme_stylebox(SNAME("cursor"));
+	theme_cache.cursor_unfocus = get_theme_stylebox(SNAME("cursor_unfocused"));
+	theme_cache.button_pressed = get_theme_stylebox(SNAME("button_pressed"));
 
-	cache.custom_button = get_theme_stylebox(SNAME("custom_button"));
-	cache.custom_button_hover = get_theme_stylebox(SNAME("custom_button_hover"));
-	cache.custom_button_pressed = get_theme_stylebox(SNAME("custom_button_pressed"));
-	cache.custom_button_font_highlight = get_theme_color(SNAME("custom_button_font_highlight"));
+	theme_cache.checked = get_theme_icon(SNAME("checked"));
+	theme_cache.unchecked = get_theme_icon(SNAME("unchecked"));
+	theme_cache.indeterminate = get_theme_icon(SNAME("indeterminate"));
+	theme_cache.arrow = get_theme_icon(SNAME("arrow"));
+	theme_cache.arrow_collapsed = get_theme_icon(SNAME("arrow_collapsed"));
+	theme_cache.arrow_collapsed_mirrored = get_theme_icon(SNAME("arrow_collapsed_mirrored"));
+	theme_cache.select_arrow = get_theme_icon(SNAME("select_arrow"));
+	theme_cache.updown = get_theme_icon(SNAME("updown"));
 
-	cache.font_color = get_theme_color(SNAME("font_color"));
-	cache.font_selected_color = get_theme_color(SNAME("font_selected_color"));
-	cache.drop_position_color = get_theme_color(SNAME("drop_position_color"));
-	cache.hseparation = get_theme_constant(SNAME("h_separation"));
-	cache.vseparation = get_theme_constant(SNAME("v_separation"));
-	cache.item_margin = get_theme_constant(SNAME("item_margin"));
-	cache.button_margin = get_theme_constant(SNAME("button_margin"));
+	theme_cache.custom_button = get_theme_stylebox(SNAME("custom_button"));
+	theme_cache.custom_button_hover = get_theme_stylebox(SNAME("custom_button_hover"));
+	theme_cache.custom_button_pressed = get_theme_stylebox(SNAME("custom_button_pressed"));
+	theme_cache.custom_button_font_highlight = get_theme_color(SNAME("custom_button_font_highlight"));
 
-	cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
-	cache.font_outline_size = get_theme_constant(SNAME("outline_size"));
+	theme_cache.font_color = get_theme_color(SNAME("font_color"));
+	theme_cache.font_selected_color = get_theme_color(SNAME("font_selected_color"));
+	theme_cache.drop_position_color = get_theme_color(SNAME("drop_position_color"));
+	theme_cache.hseparation = get_theme_constant(SNAME("h_separation"));
+	theme_cache.vseparation = get_theme_constant(SNAME("v_separation"));
+	theme_cache.item_margin = get_theme_constant(SNAME("item_margin"));
+	theme_cache.button_margin = get_theme_constant(SNAME("button_margin"));
 
-	cache.draw_guides = get_theme_constant(SNAME("draw_guides"));
-	cache.guide_color = get_theme_color(SNAME("guide_color"));
-	cache.draw_relationship_lines = get_theme_constant(SNAME("draw_relationship_lines"));
-	cache.relationship_line_width = get_theme_constant(SNAME("relationship_line_width"));
-	cache.parent_hl_line_width = get_theme_constant(SNAME("parent_hl_line_width"));
-	cache.children_hl_line_width = get_theme_constant(SNAME("children_hl_line_width"));
-	cache.parent_hl_line_margin = get_theme_constant(SNAME("parent_hl_line_margin"));
-	cache.relationship_line_color = get_theme_color(SNAME("relationship_line_color"));
-	cache.parent_hl_line_color = get_theme_color(SNAME("parent_hl_line_color"));
-	cache.children_hl_line_color = get_theme_color(SNAME("children_hl_line_color"));
+	theme_cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
+	theme_cache.font_outline_size = get_theme_constant(SNAME("outline_size"));
 
-	cache.scroll_border = get_theme_constant(SNAME("scroll_border"));
-	cache.scroll_speed = get_theme_constant(SNAME("scroll_speed"));
+	theme_cache.draw_guides = get_theme_constant(SNAME("draw_guides"));
+	theme_cache.guide_color = get_theme_color(SNAME("guide_color"));
+	theme_cache.draw_relationship_lines = get_theme_constant(SNAME("draw_relationship_lines"));
+	theme_cache.relationship_line_width = get_theme_constant(SNAME("relationship_line_width"));
+	theme_cache.parent_hl_line_width = get_theme_constant(SNAME("parent_hl_line_width"));
+	theme_cache.children_hl_line_width = get_theme_constant(SNAME("children_hl_line_width"));
+	theme_cache.parent_hl_line_margin = get_theme_constant(SNAME("parent_hl_line_margin"));
+	theme_cache.relationship_line_color = get_theme_color(SNAME("relationship_line_color"));
+	theme_cache.parent_hl_line_color = get_theme_color(SNAME("parent_hl_line_color"));
+	theme_cache.children_hl_line_color = get_theme_color(SNAME("children_hl_line_color"));
 
-	cache.title_button = get_theme_stylebox(SNAME("title_button_normal"));
-	cache.title_button_pressed = get_theme_stylebox(SNAME("title_button_pressed"));
-	cache.title_button_hover = get_theme_stylebox(SNAME("title_button_hover"));
-	cache.title_button_color = get_theme_color(SNAME("title_button_color"));
+	theme_cache.scroll_border = get_theme_constant(SNAME("scroll_border"));
+	theme_cache.scroll_speed = get_theme_constant(SNAME("scroll_speed"));
 
-	cache.base_scale = get_theme_default_base_scale();
+	theme_cache.title_button = get_theme_stylebox(SNAME("title_button_normal"));
+	theme_cache.title_button_pressed = get_theme_stylebox(SNAME("title_button_pressed"));
+	theme_cache.title_button_hover = get_theme_stylebox(SNAME("title_button_hover"));
+	theme_cache.title_button_color = get_theme_color(SNAME("title_button_color"));
 
-	v_scroll->set_custom_step(cache.font->get_height(cache.font_size));
+	theme_cache.base_scale = get_theme_default_base_scale();
 }
 
 int Tree::compute_item_height(TreeItem *p_item) const {
@@ -1604,7 +1602,7 @@ int Tree::compute_item_height(TreeItem *p_item) const {
 		return 0;
 	}
 
-	ERR_FAIL_COND_V(cache.font.is_null(), 0);
+	ERR_FAIL_COND_V(theme_cache.font.is_null(), 0);
 	int height = 0;
 
 	for (int i = 0; i < columns.size(); i++) {
@@ -1622,7 +1620,7 @@ int Tree::compute_item_height(TreeItem *p_item) const {
 
 		switch (p_item->cells[i].mode) {
 			case TreeItem::CELL_MODE_CHECK: {
-				int check_icon_h = cache.checked->get_height();
+				int check_icon_h = theme_cache.checked->get_height();
 				if (height < check_icon_h) {
 					height = check_icon_h;
 				}
@@ -1642,7 +1640,7 @@ int Tree::compute_item_height(TreeItem *p_item) const {
 					}
 				}
 				if (p_item->cells[i].mode == TreeItem::CELL_MODE_CUSTOM && p_item->cells[i].custom_button) {
-					height += cache.custom_button->get_minimum_size().height;
+					height += theme_cache.custom_button->get_minimum_size().height;
 				}
 
 			} break;
@@ -1655,7 +1653,7 @@ int Tree::compute_item_height(TreeItem *p_item) const {
 		height = item_min_height;
 	}
 
-	height += cache.vseparation;
+	height += theme_cache.vseparation;
 
 	return height;
 }
@@ -1665,7 +1663,7 @@ int Tree::get_item_height(TreeItem *p_item) const {
 		return 0;
 	}
 	int height = compute_item_height(p_item);
-	height += cache.vseparation;
+	height += theme_cache.vseparation;
 
 	if (!p_item->collapsed) { /* if not collapsed, check the children */
 
@@ -1682,7 +1680,7 @@ int Tree::get_item_height(TreeItem *p_item) const {
 }
 
 void Tree::draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Color &p_color, const Color &p_icon_color, int p_ol_size, const Color &p_ol_color) {
-	ERR_FAIL_COND(cache.font.is_null());
+	ERR_FAIL_COND(theme_cache.font.is_null());
 
 	Rect2i rect = p_rect;
 	Size2 ts = p_cell.text_buf->get_size();
@@ -1694,7 +1692,7 @@ void Tree::draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Co
 		if (p_cell.icon_max_w > 0 && bmsize.width > p_cell.icon_max_w) {
 			bmsize.width = p_cell.icon_max_w;
 		}
-		w += bmsize.width + cache.hseparation;
+		w += bmsize.width + theme_cache.hseparation;
 		if (rect.size.width > 0 && (w + ts.width) > rect.size.width) {
 			ts.width = rect.size.width - w;
 		}
@@ -1728,8 +1726,8 @@ void Tree::draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Co
 			p_cell.text_buf->draw_outline(ci, draw_pos, p_ol_size, p_ol_color);
 		}
 		p_cell.text_buf->draw(ci, draw_pos, p_color);
-		rect.position.x += ts.width + cache.hseparation;
-		rect.size.x -= ts.width + cache.hseparation;
+		rect.position.x += ts.width + theme_cache.hseparation;
+		rect.size.x -= ts.width + theme_cache.hseparation;
 	}
 
 	if (!p_cell.icon.is_null()) {
@@ -1741,8 +1739,8 @@ void Tree::draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Co
 		}
 
 		p_cell.draw_icon(ci, rect.position + Size2i(0, Math::floor((real_t)(rect.size.y - bmsize.y) / 2)), bmsize, p_icon_color);
-		rect.position.x += bmsize.x + cache.hseparation;
-		rect.size.x -= bmsize.x + cache.hseparation;
+		rect.position.x += bmsize.x + theme_cache.hseparation;
+		rect.size.x -= bmsize.x + theme_cache.hseparation;
 	}
 
 	if (!rtl) {
@@ -1764,7 +1762,7 @@ void Tree::update_column(int p_col) {
 		columns.write[p_col].text_buf->set_direction((TextServer::Direction)columns[p_col].text_direction);
 	}
 
-	columns.write[p_col].text_buf->add_string(columns[p_col].title, cache.font, cache.font_size, columns[p_col].language);
+	columns.write[p_col].text_buf->add_string(columns[p_col].title, theme_cache.font, theme_cache.font_size, columns[p_col].language);
 }
 
 void Tree::update_item_cell(TreeItem *p_item, int p_col) {
@@ -1813,14 +1811,14 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 	if (p_item->cells[p_col].custom_font.is_valid()) {
 		font = p_item->cells[p_col].custom_font;
 	} else {
-		font = cache.font;
+		font = theme_cache.font;
 	}
 
 	int font_size;
 	if (p_item->cells[p_col].custom_font_size > 0) {
 		font_size = p_item->cells[p_col].custom_font_size;
 	} else {
-		font_size = cache.font_size;
+		font_size = theme_cache.font_size;
 	}
 	p_item->cells.write[p_col].text_buf->add_string(valtext, font, font_size, p_item->cells[p_col].language);
 	TS->shaped_text_set_bidi_override(p_item->cells[p_col].text_buf->get_rid(), structured_text_parser(p_item->cells[p_col].st_parser, p_item->cells[p_col].st_args, valtext));
@@ -1840,7 +1838,7 @@ void Tree::update_item_cache(TreeItem *p_item) {
 }
 
 int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item) {
-	if (p_pos.y - cache.offset.y > (p_draw_size.height)) {
+	if (p_pos.y - theme_cache.offset.y > (p_draw_size.height)) {
 		return -1; //draw no more!
 	}
 
@@ -1856,18 +1854,18 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 	bool rtl = cache.rtl;
 
 	/* Calculate height of the label part */
-	label_h += cache.vseparation;
+	label_h += theme_cache.vseparation;
 
 	/* Draw label, if height fits */
 
 	bool skip = (p_item == root && hide_root);
 
-	if (!skip && (p_pos.y + label_h - cache.offset.y) > 0) {
+	if (!skip && (p_pos.y + label_h - theme_cache.offset.y) > 0) {
 		// Draw separation.
 
-		ERR_FAIL_COND_V(cache.font.is_null(), -1);
+		ERR_FAIL_COND_V(theme_cache.font.is_null(), -1);
 
-		int ofs = p_pos.x + ((p_item->disable_folding || hide_folding) ? cache.hseparation : cache.item_margin);
+		int ofs = p_pos.x + ((p_item->disable_folding || hide_folding) ? theme_cache.hseparation : theme_cache.item_margin);
 		int skip2 = 0;
 		for (int i = 0; i < columns.size(); i++) {
 			if (skip2) {
@@ -1885,8 +1883,8 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					continue;
 				}
 			} else {
-				ofs += cache.hseparation;
-				w -= cache.hseparation;
+				ofs += theme_cache.hseparation;
+				w -= theme_cache.hseparation;
 			}
 
 			if (p_item->cells[i].expand_right) {
@@ -1902,10 +1900,10 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				int button_w = 0;
 				for (int j = p_item->cells[i].buttons.size() - 1; j >= 0; j--) {
 					Ref<Texture2D> b = p_item->cells[i].buttons[j].texture;
-					button_w += b->get_size().width + cache.button_pressed->get_minimum_size().width + cache.button_margin;
+					button_w += b->get_size().width + theme_cache.button_pressed->get_minimum_size().width + theme_cache.button_margin;
 				}
 
-				int total_ofs = ofs - cache.offset.x;
+				int total_ofs = ofs - theme_cache.offset.x;
 
 				if (total_ofs + w > p_draw_size.width) {
 					w = MAX(button_w, p_draw_size.width - total_ofs);
@@ -1915,9 +1913,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			int bw = 0;
 			for (int j = p_item->cells[i].buttons.size() - 1; j >= 0; j--) {
 				Ref<Texture2D> b = p_item->cells[i].buttons[j].texture;
-				Size2 s = b->get_size() + cache.button_pressed->get_minimum_size();
+				Size2 s = b->get_size() + theme_cache.button_pressed->get_minimum_size();
 
-				Point2i o = Point2i(ofs + w - s.width, p_pos.y) - cache.offset + p_draw_ofs;
+				Point2i o = Point2i(ofs + w - s.width, p_pos.y) - theme_cache.offset + p_draw_ofs;
 
 				if (cache.click_type == Cache::CLICK_BUTTON && cache.click_item == p_item && cache.click_column == i && cache.click_index == j && !p_item->cells[i].buttons[j].disabled) {
 					// Being pressed.
@@ -1925,48 +1923,48 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					if (rtl) {
 						od.x = get_size().width - od.x - s.x;
 					}
-					cache.button_pressed->draw(get_canvas_item(), Rect2(od.x, od.y, s.width, MAX(s.height, label_h)));
+					theme_cache.button_pressed->draw(get_canvas_item(), Rect2(od.x, od.y, s.width, MAX(s.height, label_h)));
 				}
 
 				o.y += (label_h - s.height) / 2;
-				o += cache.button_pressed->get_offset();
+				o += theme_cache.button_pressed->get_offset();
 
 				if (rtl) {
 					o.x = get_size().width - o.x - b->get_width();
 				}
 
 				b->draw(ci, o, p_item->cells[i].buttons[j].disabled ? Color(1, 1, 1, 0.5) : p_item->cells[i].buttons[j].color);
-				w -= s.width + cache.button_margin;
-				bw += s.width + cache.button_margin;
+				w -= s.width + theme_cache.button_margin;
+				bw += s.width + theme_cache.button_margin;
 			}
 
-			Rect2i item_rect = Rect2i(Point2i(ofs, p_pos.y) - cache.offset + p_draw_ofs, Size2i(w, label_h));
+			Rect2i item_rect = Rect2i(Point2i(ofs, p_pos.y) - theme_cache.offset + p_draw_ofs, Size2i(w, label_h));
 			Rect2i cell_rect = item_rect;
 			if (i != 0) {
-				cell_rect.position.x -= cache.hseparation;
-				cell_rect.size.x += cache.hseparation;
+				cell_rect.position.x -= theme_cache.hseparation;
+				cell_rect.size.x += theme_cache.hseparation;
 			}
 
-			if (cache.draw_guides) {
+			if (theme_cache.draw_guides) {
 				Rect2 r = cell_rect;
 				if (rtl) {
 					r.position.x = get_size().width - r.position.x - r.size.x;
 				}
-				RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(r.position.x, r.position.y + r.size.height), r.position + r.size, cache.guide_color, 1);
+				RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(r.position.x, r.position.y + r.size.height), r.position + r.size, theme_cache.guide_color, 1);
 			}
 
 			if (i == 0) {
 				if (p_item->cells[0].selected && select_mode == SELECT_ROW) {
-					Rect2i row_rect = Rect2i(Point2i(cache.bg->get_margin(SIDE_LEFT), item_rect.position.y), Size2i(get_size().width - cache.bg->get_minimum_size().width, item_rect.size.y));
+					Rect2i row_rect = Rect2i(Point2i(theme_cache.bg->get_margin(SIDE_LEFT), item_rect.position.y), Size2i(get_size().width - theme_cache.bg->get_minimum_size().width, item_rect.size.y));
 					//Rect2 r = Rect2i(row_rect.pos,row_rect.size);
 					//r.grow(cache.selected->get_margin(SIDE_LEFT));
 					if (rtl) {
 						row_rect.position.x = get_size().width - row_rect.position.x - row_rect.size.x;
 					}
 					if (has_focus()) {
-						cache.selected_focus->draw(ci, row_rect);
+						theme_cache.selected_focus->draw(ci, row_rect);
 					} else {
-						cache.selected->draw(ci, row_rect);
+						theme_cache.selected->draw(ci, row_rect);
 					}
 				}
 			}
@@ -1982,9 +1980,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					}
 					if (p_item->cells[i].selected) {
 						if (has_focus()) {
-							cache.selected_focus->draw(ci, r);
+							theme_cache.selected_focus->draw(ci, r);
 						} else {
-							cache.selected->draw(ci, r);
+							theme_cache.selected->draw(ci, r);
 						}
 					}
 				}
@@ -1996,8 +1994,8 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					r.position.x = p_draw_ofs.x;
 					r.size.x = w + ofs;
 				} else {
-					r.position.x -= cache.hseparation;
-					r.size.x += cache.hseparation;
+					r.position.x -= theme_cache.hseparation;
+					r.size.x += theme_cache.hseparation;
 				}
 				if (rtl) {
 					r.position.x = get_size().width - r.position.x - r.size.x;
@@ -2020,28 +2018,34 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				if (drop_mode_over == p_item) {
 					if (drop_mode_section == 0 || drop_mode_section == -1) {
 						// Line above.
-						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), cache.drop_position_color);
+						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), theme_cache.drop_position_color);
 					}
 					if (drop_mode_section == 0) {
 						// Side lines.
-						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, 1, r.size.y), cache.drop_position_color);
-						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x + r.size.x - 1, r.position.y, 1, r.size.y), cache.drop_position_color);
+						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, 1, r.size.y), theme_cache.drop_position_color);
+						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x + r.size.x - 1, r.position.y, 1, r.size.y), theme_cache.drop_position_color);
 					}
 					if (drop_mode_section == 0 || (drop_mode_section == 1 && (!p_item->get_first_child() || p_item->is_collapsed()))) {
 						// Line below.
-						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y + r.size.y, r.size.x, 1), cache.drop_position_color);
+						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y + r.size.y, r.size.x, 1), theme_cache.drop_position_color);
 					}
 				} else if (drop_mode_over == p_item->get_parent()) {
 					if (drop_mode_section == 1 && !p_item->get_prev() /* && !drop_mode_over->is_collapsed() */) { // The drop_mode_over shouldn't ever be collapsed in here, otherwise we would be drawing a child of a collapsed item.
 						// Line above.
-						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), cache.drop_position_color);
+						RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), theme_cache.drop_position_color);
 					}
 				}
 			}
 
-			Color col = p_item->cells[i].custom_color ? p_item->cells[i].color : get_theme_color(p_item->cells[i].selected ? "font_selected_color" : "font_color");
-			Color font_outline_color = cache.font_outline_color;
-			int outline_size = cache.font_outline_size;
+			Color col;
+			if (p_item->cells[i].custom_color) {
+				col = p_item->cells[i].color;
+			} else {
+				col = p_item->cells[i].selected ? theme_cache.font_selected_color : theme_cache.font_color;
+			}
+
+			Color font_outline_color = theme_cache.font_outline_color;
+			int outline_size = theme_cache.font_outline_size;
 			Color icon_col = p_item->cells[i].icon_color;
 
 			if (p_item->cells[i].dirty) {
@@ -2061,9 +2065,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					draw_item_rect(p_item->cells.write[i], item_rect, col, icon_col, outline_size, font_outline_color);
 				} break;
 				case TreeItem::CELL_MODE_CHECK: {
-					Ref<Texture2D> checked = cache.checked;
-					Ref<Texture2D> unchecked = cache.unchecked;
-					Ref<Texture2D> indeterminate = cache.indeterminate;
+					Ref<Texture2D> checked = theme_cache.checked;
+					Ref<Texture2D> unchecked = theme_cache.unchecked;
+					Ref<Texture2D> indeterminate = theme_cache.indeterminate;
 					Point2i check_ofs = item_rect.position;
 					check_ofs.y += Math::floor((real_t)(item_rect.size.y - checked->get_height()) / 2);
 
@@ -2075,7 +2079,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 						unchecked->draw(ci, check_ofs);
 					}
 
-					int check_w = checked->get_width() + cache.hseparation;
+					int check_w = checked->get_width() + theme_cache.hseparation;
 
 					text_pos.x += check_w;
 
@@ -2091,7 +2095,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 							break;
 						}
 
-						Ref<Texture2D> downarrow = cache.select_arrow;
+						Ref<Texture2D> downarrow = theme_cache.select_arrow;
 						int cell_width = item_rect.size.x - downarrow->get_width();
 
 						p_item->cells.write[i].text_buf->set_width(cell_width);
@@ -2113,7 +2117,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 						downarrow->draw(ci, arrow_pos);
 					} else {
-						Ref<Texture2D> updown = cache.updown;
+						Ref<Texture2D> updown = theme_cache.updown;
 
 						int cell_width = item_rect.size.x - updown->get_width();
 
@@ -2170,7 +2174,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 						break;
 					}
 
-					Ref<Texture2D> downarrow = cache.select_arrow;
+					Ref<Texture2D> downarrow = theme_cache.select_arrow;
 
 					Rect2i ir = item_rect;
 
@@ -2182,16 +2186,16 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					if (p_item->cells[i].custom_button) {
 						if (cache.hover_item == p_item && cache.hover_cell == i) {
 							if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
-								draw_style_box(cache.custom_button_pressed, ir);
+								draw_style_box(theme_cache.custom_button_pressed, ir);
 							} else {
-								draw_style_box(cache.custom_button_hover, ir);
-								col = cache.custom_button_font_highlight;
+								draw_style_box(theme_cache.custom_button_hover, ir);
+								col = theme_cache.custom_button_font_highlight;
 							}
 						} else {
-							draw_style_box(cache.custom_button, ir);
+							draw_style_box(theme_cache.custom_button, ir);
 						}
-						ir.size -= cache.custom_button->get_minimum_size();
-						ir.position += cache.custom_button->get_offset();
+						ir.size -= theme_cache.custom_button->get_minimum_size();
+						ir.position += theme_cache.custom_button->get_offset();
 					}
 
 					draw_item_rect(p_item->cells.write[i], ir, col, icon_col, outline_size, font_outline_color);
@@ -2212,9 +2216,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					cell_rect.position.x = get_size().width - cell_rect.position.x - cell_rect.size.x;
 				}
 				if (has_focus()) {
-					cache.cursor->draw(ci, cell_rect);
+					theme_cache.cursor->draw(ci, cell_rect);
 				} else {
-					cache.cursor_unfocus->draw(ci, cell_rect);
+					theme_cache.cursor_unfocus->draw(ci, cell_rect);
 				}
 			}
 		}
@@ -2224,13 +2228,17 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			Ref<Texture2D> arrow;
 
 			if (p_item->collapsed) {
-				arrow = cache.arrow_collapsed;
+				if (is_layout_rtl()) {
+					arrow = theme_cache.arrow_collapsed_mirrored;
+				} else {
+					arrow = theme_cache.arrow_collapsed;
+				}
 			} else {
-				arrow = cache.arrow;
+				arrow = theme_cache.arrow;
 			}
 
-			Point2 apos = p_pos + Point2i(0, (label_h - arrow->get_height()) / 2) - cache.offset + p_draw_ofs;
-			apos.x += cache.item_margin - arrow->get_width();
+			Point2 apos = p_pos + Point2i(0, (label_h - arrow->get_height()) / 2) - theme_cache.offset + p_draw_ofs;
+			apos.x += theme_cache.item_margin - arrow->get_width();
 
 			if (rtl) {
 				apos.x = get_size().width - apos.x - arrow->get_width();
@@ -2243,7 +2251,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 	Point2 children_pos = p_pos;
 
 	if (!skip) {
-		children_pos.x += cache.item_margin;
+		children_pos.x += theme_cache.item_margin;
 		htotal += label_h;
 		children_pos.y += htotal;
 	}
@@ -2251,7 +2259,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 	if (!p_item->collapsed) { /* if not collapsed, check the children */
 		TreeItem *c = p_item->first_child;
 
-		int base_ofs = children_pos.y - cache.offset.y + p_draw_ofs.y;
+		int base_ofs = children_pos.y - theme_cache.offset.y + p_draw_ofs.y;
 		int prev_ofs = base_ofs;
 		int prev_hl_ofs = base_ofs;
 
@@ -2262,20 +2270,20 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			// Draw relationship lines.
-			if (cache.draw_relationship_lines > 0 && (!hide_root || c->parent != root) && c->is_visible()) {
-				int root_ofs = children_pos.x + ((p_item->disable_folding || hide_folding) ? cache.hseparation : cache.item_margin);
-				int parent_ofs = p_pos.x + cache.item_margin;
-				Point2i root_pos = Point2i(root_ofs, children_pos.y + label_h / 2) - cache.offset + p_draw_ofs;
+			if (theme_cache.draw_relationship_lines > 0 && (!hide_root || c->parent != root) && c->is_visible()) {
+				int root_ofs = children_pos.x + ((p_item->disable_folding || hide_folding) ? theme_cache.hseparation : theme_cache.item_margin);
+				int parent_ofs = p_pos.x + theme_cache.item_margin;
+				Point2i root_pos = Point2i(root_ofs, children_pos.y + label_h / 2) - theme_cache.offset + p_draw_ofs;
 
 				if (c->get_visible_child_count() > 0) {
-					root_pos -= Point2i(cache.arrow->get_width(), 0);
+					root_pos -= Point2i(theme_cache.arrow->get_width(), 0);
 				}
 
-				float line_width = cache.relationship_line_width * Math::round(cache.base_scale);
-				float parent_line_width = cache.parent_hl_line_width * Math::round(cache.base_scale);
-				float children_line_width = cache.children_hl_line_width * Math::round(cache.base_scale);
+				float line_width = theme_cache.relationship_line_width * Math::round(theme_cache.base_scale);
+				float parent_line_width = theme_cache.parent_hl_line_width * Math::round(theme_cache.base_scale);
+				float children_line_width = theme_cache.children_hl_line_width * Math::round(theme_cache.base_scale);
 
-				Point2i parent_pos = Point2i(parent_ofs - cache.arrow->get_width() / 2, p_pos.y + label_h / 2 + cache.arrow->get_height() / 2) - cache.offset + p_draw_ofs;
+				Point2i parent_pos = Point2i(parent_ofs - theme_cache.arrow->get_width() / 2, p_pos.y + label_h / 2 + theme_cache.arrow->get_height() / 2) - theme_cache.offset + p_draw_ofs;
 
 				int more_prev_ofs = 0;
 
@@ -2289,43 +2297,43 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					if (_is_branch_selected(c)) {
 						// If this item or one of its children is selected, we draw the line using parent highlight style.
 						if (htotal >= 0) {
-							RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + Math::floor(parent_line_width / 2), root_pos.y), cache.parent_hl_line_color, parent_line_width);
+							RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + Math::floor(parent_line_width / 2), root_pos.y), theme_cache.parent_hl_line_color, parent_line_width);
 						}
-						RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(parent_line_width / 2)), Point2i(parent_pos.x, prev_hl_ofs), cache.parent_hl_line_color, parent_line_width);
+						RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(parent_line_width / 2)), Point2i(parent_pos.x, prev_hl_ofs), theme_cache.parent_hl_line_color, parent_line_width);
 
-						more_prev_ofs = cache.parent_hl_line_margin;
+						more_prev_ofs = theme_cache.parent_hl_line_margin;
 						prev_hl_ofs = root_pos.y + Math::floor(parent_line_width / 2);
 					} else if (p_item->is_selected(0)) {
 						// If parent item is selected (but this item is not), we draw the line using children highlight style.
 						// Siblings of the selected branch can be drawn with a slight offset and their vertical line must appear as highlighted.
 						if (_is_sibling_branch_selected(c)) {
 							if (htotal >= 0) {
-								RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + Math::floor(parent_line_width / 2), root_pos.y), cache.children_hl_line_color, children_line_width);
+								RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + Math::floor(parent_line_width / 2), root_pos.y), theme_cache.children_hl_line_color, children_line_width);
 							}
-							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(parent_line_width / 2)), Point2i(parent_pos.x, prev_hl_ofs), cache.parent_hl_line_color, parent_line_width);
+							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(parent_line_width / 2)), Point2i(parent_pos.x, prev_hl_ofs), theme_cache.parent_hl_line_color, parent_line_width);
 
 							prev_hl_ofs = root_pos.y + Math::floor(parent_line_width / 2);
 						} else {
 							if (htotal >= 0) {
-								RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + Math::floor(children_line_width / 2), root_pos.y), cache.children_hl_line_color, children_line_width);
+								RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + Math::floor(children_line_width / 2), root_pos.y), theme_cache.children_hl_line_color, children_line_width);
 							}
-							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(children_line_width / 2)), Point2i(parent_pos.x, prev_ofs + Math::floor(children_line_width / 2)), cache.children_hl_line_color, children_line_width);
+							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(children_line_width / 2)), Point2i(parent_pos.x, prev_ofs + Math::floor(children_line_width / 2)), theme_cache.children_hl_line_color, children_line_width);
 						}
 					} else {
 						// If nothing of the above is true, we draw the line using normal style.
 						// Siblings of the selected branch can be drawn with a slight offset and their vertical line must appear as highlighted.
 						if (_is_sibling_branch_selected(c)) {
 							if (htotal >= 0) {
-								RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + cache.parent_hl_line_margin, root_pos.y), cache.relationship_line_color, line_width);
+								RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + theme_cache.parent_hl_line_margin, root_pos.y), theme_cache.relationship_line_color, line_width);
 							}
-							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(parent_line_width / 2)), Point2i(parent_pos.x, prev_hl_ofs), cache.parent_hl_line_color, parent_line_width);
+							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(parent_line_width / 2)), Point2i(parent_pos.x, prev_hl_ofs), theme_cache.parent_hl_line_color, parent_line_width);
 
 							prev_hl_ofs = root_pos.y + Math::floor(parent_line_width / 2);
 						} else {
 							if (htotal >= 0) {
-								RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + Math::floor(line_width / 2), root_pos.y), cache.relationship_line_color, line_width);
+								RenderingServer::get_singleton()->canvas_item_add_line(ci, root_pos, Point2i(parent_pos.x + Math::floor(line_width / 2), root_pos.y), theme_cache.relationship_line_color, line_width);
 							}
-							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(line_width / 2)), Point2i(parent_pos.x, prev_ofs + Math::floor(line_width / 2)), cache.relationship_line_color, line_width);
+							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(parent_pos.x, root_pos.y + Math::floor(line_width / 2)), Point2i(parent_pos.x, prev_ofs + Math::floor(line_width / 2)), theme_cache.relationship_line_color, line_width);
 						}
 					}
 				}
@@ -2338,12 +2346,12 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					break; // Last loop done, stop.
 				}
 
-				if (cache.draw_relationship_lines == 0) {
+				if (theme_cache.draw_relationship_lines == 0) {
 					return -1; // No need to draw anymore, full stop.
 				}
 
 				htotal = -1;
-				children_pos.y = cache.offset.y + p_draw_size.height;
+				children_pos.y = theme_cache.offset.y + p_draw_size.height;
 			} else {
 				htotal += child_h;
 				children_pos.y += child_h;
@@ -2494,7 +2502,7 @@ Rect2 Tree::search_item_rect(TreeItem *p_from, TreeItem *p_item) {
 
 void Tree::_range_click_timeout() {
 	if (range_item_last && !range_drag_enabled && Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
-		Point2 pos = get_local_mouse_position() - cache.bg->get_offset();
+		Point2 pos = get_local_mouse_position() - theme_cache.bg->get_offset();
 		if (show_column_titles) {
 			pos.y -= _get_title_button_height();
 
@@ -2512,7 +2520,7 @@ void Tree::_range_click_timeout() {
 		Ref<InputEventMouseButton> mb;
 		mb.instantiate();
 
-		int x_limit = get_size().width - cache.bg->get_minimum_size().width;
+		int x_limit = get_size().width - theme_cache.bg->get_minimum_size().width;
 		if (h_scroll->is_visible()) {
 			x_limit -= h_scroll->get_minimum_size().width;
 		}
@@ -2521,7 +2529,7 @@ void Tree::_range_click_timeout() {
 
 		propagate_mouse_activated = false; // done from outside, so signal handler can't clear the tree in the middle of emit (which is a common case)
 		blocked++;
-		propagate_mouse_event(pos + cache.offset, 0, 0, x_limit + cache.offset.width, false, root, MouseButton::LEFT, mb);
+		propagate_mouse_event(pos + theme_cache.offset, 0, 0, x_limit + theme_cache.offset.width, false, root, MouseButton::LEFT, mb);
 		blocked--;
 
 		if (range_click_timer->is_one_shot()) {
@@ -2550,7 +2558,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 		return 0;
 	}
 
-	int item_h = compute_item_height(p_item) + cache.vseparation;
+	int item_h = compute_item_height(p_item) + theme_cache.vseparation;
 
 	bool skip = (p_item == root && hide_root);
 
@@ -2561,7 +2569,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			return -1;
 		}
 
-		if (!p_item->disable_folding && !hide_folding && p_item->first_child && (p_pos.x >= x_ofs && p_pos.x < (x_ofs + cache.item_margin))) {
+		if (!p_item->disable_folding && !hide_folding && p_item->first_child && (p_pos.x >= x_ofs && p_pos.x < (x_ofs + theme_cache.item_margin))) {
 			p_item->set_collapsed(!p_item->is_collapsed());
 			return -1;
 		}
@@ -2580,7 +2588,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			if (p_item->cells[i].expand_right) {
 				int plus = 1;
 				while (i + plus < columns.size() && !p_item->cells[i + plus].editable && p_item->cells[i + plus].mode == TreeItem::CELL_MODE_STRING && p_item->cells[i + plus].text.is_empty() && p_item->cells[i + plus].icon.is_null()) {
-					col_width += cache.hseparation;
+					col_width += theme_cache.hseparation;
 					col_width += get_column_width(i + plus);
 					plus++;
 				}
@@ -2600,16 +2608,16 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 		if (col == -1) {
 			return -1;
 		} else if (col == 0) {
-			int margin = x_ofs + cache.item_margin; //-cache.hseparation;
-			//int lm = cache.bg->get_margin(SIDE_LEFT);
+			int margin = x_ofs + theme_cache.item_margin; //-theme_cache.hseparation;
+			//int lm = theme_cache.bg->get_margin(SIDE_LEFT);
 			col_width -= margin;
 			limit_w -= margin;
 			col_ofs += margin;
 			x -= margin;
 		} else {
-			col_width -= cache.hseparation;
-			limit_w -= cache.hseparation;
-			x -= cache.hseparation;
+			col_width -= theme_cache.hseparation;
+			limit_w -= theme_cache.hseparation;
+			x -= theme_cache.hseparation;
 		}
 
 		if (!p_item->disable_folding && !hide_folding && !p_item->cells[col].editable && !p_item->cells[col].selectable && p_item->get_first_child()) {
@@ -2626,7 +2634,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			int button_w = 0;
 			for (int j = p_item->cells[col].buttons.size() - 1; j >= 0; j--) {
 				Ref<Texture2D> b = p_item->cells[col].buttons[j].texture;
-				button_w += b->get_size().width + cache.button_pressed->get_minimum_size().width + cache.button_margin;
+				button_w += b->get_size().width + theme_cache.button_pressed->get_minimum_size().width + theme_cache.button_margin;
 			}
 
 			col_width = MAX(button_w, MIN(limit_w, col_width));
@@ -2634,7 +2642,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 		for (int j = c.buttons.size() - 1; j >= 0; j--) {
 			Ref<Texture2D> b = c.buttons[j].texture;
-			int w = b->get_size().width + cache.button_pressed->get_minimum_size().width;
+			int w = b->get_size().width + theme_cache.button_pressed->get_minimum_size().width;
 
 			if (x > col_width - w) {
 				if (c.buttons[j].disabled) {
@@ -2662,7 +2670,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 				return -1;
 			}
 
-			col_width -= w + cache.button_margin;
+			col_width -= w + theme_cache.button_margin;
 		}
 
 		if (p_button == MouseButton::LEFT || (p_button == MouseButton::RIGHT && allow_rmb_select)) {
@@ -2742,7 +2750,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			case TreeItem::CELL_MODE_CHECK: {
 				bring_up_editor = false; //checkboxes are not edited with editor
 				if (force_edit_checkbox_only_on_checkbox) {
-					if (x < cache.checked->get_width()) {
+					if (x < theme_cache.checked->get_width()) {
 						p_item->set_checked(col, !c.checked);
 						item_edited(col, p_item, p_button);
 					}
@@ -2764,7 +2772,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 					}
 
 					popup_menu->set_size(Size2(col_width, 0));
-					popup_menu->set_position(get_screen_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h) - cache.offset);
+					popup_menu->set_position(get_screen_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h) - theme_cache.offset);
 					popup_menu->popup();
 					popup_edited_item = p_item;
 					popup_edited_item_col = col;
@@ -2822,9 +2830,9 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			case TreeItem::CELL_MODE_CUSTOM: {
 				edited_item = p_item;
 				edited_col = col;
-				bool on_arrow = x > col_width - cache.select_arrow->get_width();
+				bool on_arrow = x > col_width - theme_cache.select_arrow->get_width();
 
-				custom_popup_rect = Rect2i(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h - cache.offset.y), Size2(get_column_width(col), item_h));
+				custom_popup_rect = Rect2i(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs + item_h - theme_cache.offset.y), Size2(get_column_width(col), item_h));
 
 				if (on_arrow || !p_item->cells[col].custom_button) {
 					emit_signal(SNAME("custom_popup_edited"), ((bool)(x >= (col_width - item_h / 2))));
@@ -2846,7 +2854,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 		popup_pressing_edited_item = p_item;
 		popup_pressing_edited_item_column = col;
 
-		pressing_item_rect = Rect2(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs) - cache.offset, Size2(col_width, item_h));
+		pressing_item_rect = Rect2(get_global_position() + Point2i(col_ofs, _get_title_button_height() + y_ofs) - theme_cache.offset, Size2(col_width, item_h));
 		pressing_for_editor_text = editor_text;
 		pressing_for_editor = true;
 
@@ -2855,8 +2863,8 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 		Point2i new_pos = p_pos;
 
 		if (!skip) {
-			x_ofs += cache.item_margin;
-			//new_pos.x-=cache.item_margin;
+			x_ofs += theme_cache.item_margin;
+			//new_pos.x-=theme_cache.item_margin;
 			y_ofs += item_h;
 			new_pos.y -= item_h;
 		}
@@ -3300,18 +3308,14 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
-		if (cache.font.is_null()) { // avoid a strange case that may corrupt stuff
-			update_cache();
-		}
-
-		Ref<StyleBox> bg = cache.bg;
+		Ref<StyleBox> bg = theme_cache.bg;
 		bool rtl = is_layout_rtl();
 
 		Point2 pos = mm->get_position();
 		if (rtl) {
 			pos.x = get_size().width - pos.x;
 		}
-		pos -= cache.bg->get_offset();
+		pos -= theme_cache.bg->get_offset();
 
 		Cache::ClickType old_hover = cache.hover_type;
 		int old_index = cache.hover_index;
@@ -3321,7 +3325,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		if (show_column_titles) {
 			pos.y -= _get_title_button_height();
 			if (pos.y < 0) {
-				pos.x += cache.offset.x;
+				pos.x += theme_cache.offset.x;
 				int len = 0;
 				for (int i = 0; i < columns.size(); i++) {
 					len += get_column_width(i);
@@ -3339,7 +3343,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			if (rtl) {
 				mpos.x = get_size().width - mpos.x;
 			}
-			mpos -= cache.bg->get_offset();
+			mpos -= theme_cache.bg->get_offset();
 			mpos.y -= _get_title_button_height();
 			if (mpos.y >= 0) {
 				if (h_scroll->is_visible_in_tree()) {
@@ -3430,10 +3434,6 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
-		if (cache.font.is_null()) { // avoid a strange case that may corrupt stuff
-			update_cache();
-		}
-
 		bool rtl = is_layout_rtl();
 
 		if (!mb->is_pressed()) {
@@ -3443,12 +3443,12 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				if (rtl) {
 					pos.x = get_size().width - pos.x;
 				}
-				pos -= cache.bg->get_offset();
+				pos -= theme_cache.bg->get_offset();
 				if (show_column_titles) {
 					pos.y -= _get_title_button_height();
 
 					if (pos.y < 0) {
-						pos.x += cache.offset.x;
+						pos.x += theme_cache.offset.x;
 						int len = 0;
 						for (int i = 0; i < columns.size(); i++) {
 							len += get_column_width(i);
@@ -3537,7 +3537,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		switch (mb->get_button_index()) {
 			case MouseButton::RIGHT:
 			case MouseButton::LEFT: {
-				Ref<StyleBox> bg = cache.bg;
+				Ref<StyleBox> bg = theme_cache.bg;
 
 				Point2 pos = mb->get_position();
 				if (rtl) {
@@ -3549,7 +3549,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 					pos.y -= _get_title_button_height();
 
 					if (pos.y < 0) {
-						pos.x += cache.offset.x;
+						pos.x += theme_cache.offset.x;
 						int len = 0;
 						for (int i = 0; i < columns.size(); i++) {
 							len += get_column_width(i);
@@ -3572,14 +3572,14 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				pressing_for_editor = false;
 				propagate_mouse_activated = false;
 
-				int x_limit = get_size().width - cache.bg->get_minimum_size().width;
+				int x_limit = get_size().width - theme_cache.bg->get_minimum_size().width;
 				if (h_scroll->is_visible()) {
 					x_limit -= h_scroll->get_minimum_size().width;
 				}
 
 				cache.rtl = is_layout_rtl();
 				blocked++;
-				propagate_mouse_event(pos + cache.offset, 0, 0, x_limit + cache.offset.width, mb->is_double_click(), root, mb->get_button_index(), mb);
+				propagate_mouse_event(pos + theme_cache.offset, 0, 0, x_limit + theme_cache.offset.width, mb->is_double_click(), root, mb->get_button_index(), mb);
 				blocked--;
 
 				if (pressing_for_editor) {
@@ -3766,7 +3766,7 @@ bool Tree::is_editing() {
 }
 
 Size2 Tree::get_internal_min_size() const {
-	Size2i size = cache.bg->get_offset();
+	Size2i size = theme_cache.bg->get_offset();
 	if (root) {
 		size.height += get_item_height(root);
 	}
@@ -3789,23 +3789,23 @@ void Tree::update_scrollbars() {
 	Size2 hmin = h_scroll->get_combined_minimum_size();
 	Size2 vmin = v_scroll->get_combined_minimum_size();
 
-	v_scroll->set_begin(Point2(size.width - vmin.width, cache.bg->get_margin(SIDE_TOP)));
-	v_scroll->set_end(Point2(size.width, size.height - cache.bg->get_margin(SIDE_TOP) - cache.bg->get_margin(SIDE_BOTTOM)));
+	v_scroll->set_begin(Point2(size.width - vmin.width, theme_cache.bg->get_margin(SIDE_TOP)));
+	v_scroll->set_end(Point2(size.width, size.height - theme_cache.bg->get_margin(SIDE_TOP) - theme_cache.bg->get_margin(SIDE_BOTTOM)));
 
 	h_scroll->set_begin(Point2(0, size.height - hmin.height));
 	h_scroll->set_end(Point2(size.width - vmin.width, size.height));
 
 	Size2 internal_min_size = get_internal_min_size();
 
-	bool display_vscroll = internal_min_size.height + cache.bg->get_margin(SIDE_TOP) > size.height;
-	bool display_hscroll = internal_min_size.width + cache.bg->get_margin(SIDE_LEFT) > size.width;
+	bool display_vscroll = internal_min_size.height + theme_cache.bg->get_margin(SIDE_TOP) > size.height;
+	bool display_hscroll = internal_min_size.width + theme_cache.bg->get_margin(SIDE_LEFT) > size.width;
 	for (int i = 0; i < 2; i++) {
 		// Check twice, as both values are dependent on each other.
 		if (display_hscroll) {
-			display_vscroll = internal_min_size.height + cache.bg->get_margin(SIDE_TOP) + hmin.height > size.height;
+			display_vscroll = internal_min_size.height + theme_cache.bg->get_margin(SIDE_TOP) + hmin.height > size.height;
 		}
 		if (display_vscroll) {
-			display_hscroll = internal_min_size.width + cache.bg->get_margin(SIDE_LEFT) + vmin.width > size.width;
+			display_hscroll = internal_min_size.width + theme_cache.bg->get_margin(SIDE_LEFT) + vmin.width > size.width;
 		}
 	}
 
@@ -3813,29 +3813,29 @@ void Tree::update_scrollbars() {
 		v_scroll->show();
 		v_scroll->set_max(internal_min_size.height);
 		v_scroll->set_page(size.height - hmin.height - tbh);
-		cache.offset.y = v_scroll->get_value();
+		theme_cache.offset.y = v_scroll->get_value();
 	} else {
 		v_scroll->hide();
-		cache.offset.y = 0;
+		theme_cache.offset.y = 0;
 	}
 
 	if (display_hscroll) {
 		h_scroll->show();
 		h_scroll->set_max(internal_min_size.width);
 		h_scroll->set_page(size.width - vmin.width);
-		cache.offset.x = h_scroll->get_value();
+		theme_cache.offset.x = h_scroll->get_value();
 	} else {
 		h_scroll->hide();
-		cache.offset.x = 0;
+		theme_cache.offset.x = 0;
 	}
 }
 
 int Tree::_get_title_button_height() const {
-	ERR_FAIL_COND_V(cache.font.is_null() || cache.title_button.is_null(), 0);
+	ERR_FAIL_COND_V(theme_cache.font.is_null() || theme_cache.title_button.is_null(), 0);
 	int h = 0;
 	if (show_column_titles) {
 		for (int i = 0; i < columns.size(); i++) {
-			h = MAX(h, columns[i].text_buf->get_size().y + cache.title_button->get_minimum_size().height);
+			h = MAX(h, columns[i].text_buf->get_size().y + theme_cache.title_button->get_minimum_size().height);
 		}
 	}
 	return h;
@@ -3860,10 +3860,6 @@ void Tree::_notification(int p_what) {
 			drag_touching = false;
 		} break;
 
-		case NOTIFICATION_ENTER_TREE: {
-			update_cache();
-		} break;
-
 		case NOTIFICATION_DRAG_END: {
 			drop_mode_flags = 0;
 			scrolling = false;
@@ -3873,7 +3869,7 @@ void Tree::_notification(int p_what) {
 
 		case NOTIFICATION_DRAG_BEGIN: {
 			single_select_defer = nullptr;
-			if (cache.scroll_speed > 0) {
+			if (theme_cache.scroll_speed > 0) {
 				scrolling = true;
 				set_physics_process_internal(true);
 			}
@@ -3917,22 +3913,22 @@ void Tree::_notification(int p_what) {
 			}
 
 			Point2 mouse_position = get_viewport()->get_mouse_position() - get_global_position();
-			if (scrolling && get_rect().grow(cache.scroll_border).has_point(mouse_position)) {
+			if (scrolling && get_rect().grow(theme_cache.scroll_border).has_point(mouse_position)) {
 				Point2 point;
 
-				if ((ABS(mouse_position.x) < ABS(mouse_position.x - get_size().width)) && (ABS(mouse_position.x) < cache.scroll_border)) {
-					point.x = mouse_position.x - cache.scroll_border;
-				} else if (ABS(mouse_position.x - get_size().width) < cache.scroll_border) {
-					point.x = mouse_position.x - (get_size().width - cache.scroll_border);
+				if ((ABS(mouse_position.x) < ABS(mouse_position.x - get_size().width)) && (ABS(mouse_position.x) < theme_cache.scroll_border)) {
+					point.x = mouse_position.x - theme_cache.scroll_border;
+				} else if (ABS(mouse_position.x - get_size().width) < theme_cache.scroll_border) {
+					point.x = mouse_position.x - (get_size().width - theme_cache.scroll_border);
 				}
 
-				if ((ABS(mouse_position.y) < ABS(mouse_position.y - get_size().height)) && (ABS(mouse_position.y) < cache.scroll_border)) {
-					point.y = mouse_position.y - cache.scroll_border;
-				} else if (ABS(mouse_position.y - get_size().height) < cache.scroll_border) {
-					point.y = mouse_position.y - (get_size().height - cache.scroll_border);
+				if ((ABS(mouse_position.y) < ABS(mouse_position.y - get_size().height)) && (ABS(mouse_position.y) < theme_cache.scroll_border)) {
+					point.y = mouse_position.y - theme_cache.scroll_border;
+				} else if (ABS(mouse_position.y - get_size().height) < theme_cache.scroll_border) {
+					point.y = mouse_position.y - (get_size().height - theme_cache.scroll_border);
 				}
 
-				point *= cache.scroll_speed * get_physics_process_delta_time();
+				point *= theme_cache.scroll_speed * get_physics_process_delta_time();
 				point += get_scroll();
 				h_scroll->set_value(point.x);
 				v_scroll->set_value(point.y);
@@ -3940,13 +3936,12 @@ void Tree::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			update_cache();
+			v_scroll->set_custom_step(theme_cache.font->get_height(theme_cache.font_size));
+
 			update_scrollbars();
 			RID ci = get_canvas_item();
 
-			Ref<StyleBox> bg = cache.bg;
-			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
-			int outline_size = get_theme_constant(SNAME("outline_size"));
+			Ref<StyleBox> bg = theme_cache.bg;
 
 			Point2 draw_ofs;
 			draw_ofs += bg->get_offset();
@@ -3970,11 +3965,11 @@ void Tree::_notification(int p_what) {
 
 			if (show_column_titles) {
 				//title buttons
-				int ofs2 = cache.bg->get_margin(SIDE_LEFT);
+				int ofs2 = theme_cache.bg->get_margin(SIDE_LEFT);
 				for (int i = 0; i < columns.size(); i++) {
-					Ref<StyleBox> sb = (cache.click_type == Cache::CLICK_TITLE && cache.click_index == i) ? cache.title_button_pressed : ((cache.hover_type == Cache::CLICK_TITLE && cache.hover_index == i) ? cache.title_button_hover : cache.title_button);
-					Ref<Font> f = cache.tb_font;
-					Rect2 tbrect = Rect2(ofs2 - cache.offset.x, bg->get_margin(SIDE_TOP), get_column_width(i), tbh);
+					Ref<StyleBox> sb = (cache.click_type == Cache::CLICK_TITLE && cache.click_index == i) ? theme_cache.title_button_pressed : ((cache.hover_type == Cache::CLICK_TITLE && cache.hover_index == i) ? theme_cache.title_button_hover : theme_cache.title_button);
+					Ref<Font> f = theme_cache.tb_font;
+					Rect2 tbrect = Rect2(ofs2 - theme_cache.offset.x, bg->get_margin(SIDE_TOP), get_column_width(i), tbh);
 					if (cache.rtl) {
 						tbrect.position.x = get_size().width - tbrect.size.x - tbrect.position.x;
 					}
@@ -3985,10 +3980,10 @@ void Tree::_notification(int p_what) {
 					columns.write[i].text_buf->set_width(clip_w);
 
 					Vector2 text_pos = tbrect.position + Point2i(sb->get_offset().x + (tbrect.size.width - columns[i].text_buf->get_size().x) / 2, (tbrect.size.height - columns[i].text_buf->get_size().y) / 2);
-					if (outline_size > 0 && font_outline_color.a > 0) {
-						columns[i].text_buf->draw_outline(ci, text_pos, outline_size, font_outline_color);
+					if (theme_cache.font_outline_size > 0 && theme_cache.font_outline_color.a > 0) {
+						columns[i].text_buf->draw_outline(ci, text_pos, theme_cache.font_outline_size, theme_cache.font_outline_color);
 					}
-					columns[i].text_buf->draw(ci, text_pos, cache.title_button_color);
+					columns[i].text_buf->draw(ci, text_pos, theme_cache.title_button_color);
 				}
 			}
 
@@ -3996,8 +3991,7 @@ void Tree::_notification(int p_what) {
 			// Otherwise, section heading backgrounds can appear to be in front of the focus outline when scrolling.
 			if (has_focus()) {
 				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, true);
-				const Ref<StyleBox> bg_focus = get_theme_stylebox(SNAME("bg_focus"));
-				bg_focus->draw(ci, Rect2(Point2(), get_size()));
+				theme_cache.bg_focus->draw(ci, Rect2(Point2(), get_size()));
 				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, false);
 			}
 		} break;
@@ -4005,7 +3999,6 @@ void Tree::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			update_cache();
 			_update_all();
 		} break;
 
@@ -4040,7 +4033,7 @@ Size2 Tree::get_minimum_size() const {
 		return Size2();
 	} else {
 		Vector2 min_size = get_internal_min_size();
-		Ref<StyleBox> bg = cache.bg;
+		Ref<StyleBox> bg = theme_cache.bg;
 		if (bg.is_valid()) {
 			min_size.x += bg->get_margin(SIDE_LEFT) + bg->get_margin(SIDE_RIGHT);
 			min_size.y += bg->get_margin(SIDE_TOP) + bg->get_margin(SIDE_BOTTOM);
@@ -4336,7 +4329,7 @@ int Tree::get_column_minimum_width(int p_column) const {
 
 	// Check if the visible title of the column is wider.
 	if (show_column_titles) {
-		min_width = MAX(cache.font->get_string_size(columns[p_column].title, HORIZONTAL_ALIGNMENT_LEFT, -1, cache.font_size).width + cache.bg->get_margin(SIDE_LEFT) + cache.bg->get_margin(SIDE_RIGHT), min_width);
+		min_width = MAX(theme_cache.font->get_string_size(columns[p_column].title, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).width + theme_cache.bg->get_margin(SIDE_LEFT) + theme_cache.bg->get_margin(SIDE_RIGHT), min_width);
 	}
 
 	if (!columns[p_column].clip_content) {
@@ -4360,9 +4353,9 @@ int Tree::get_column_minimum_width(int p_column) const {
 			// Get the item minimum size.
 			Size2 item_size = item->get_minimum_size(p_column);
 			if (p_column == 0) {
-				item_size.width += cache.item_margin * depth;
+				item_size.width += theme_cache.item_margin * depth;
 			} else {
-				item_size.width += cache.hseparation;
+				item_size.width += theme_cache.hseparation;
 			}
 
 			// Check if the item is wider.
@@ -4381,7 +4374,7 @@ int Tree::get_column_width(int p_column) const {
 	if (columns[p_column].expand) {
 		int expand_area = get_size().width;
 
-		Ref<StyleBox> bg = cache.bg;
+		Ref<StyleBox> bg = theme_cache.bg;
 
 		if (bg.is_valid()) {
 			expand_area -= bg->get_margin(SIDE_LEFT) + bg->get_margin(SIDE_RIGHT);
@@ -4458,7 +4451,7 @@ int Tree::get_item_offset(TreeItem *p_item) const {
 
 		ofs += compute_item_height(it);
 		if (it != root || !hide_root) {
-			ofs += cache.vseparation;
+			ofs += theme_cache.vseparation;
 		}
 
 		if (it->first_child && !it->collapsed) {
@@ -4489,14 +4482,14 @@ void Tree::ensure_cursor_is_visible() {
 		return; // Nothing under cursor.
 	}
 
-	const Size2 area_size = get_size() - cache.bg->get_minimum_size();
+	const Size2 area_size = get_size() - theme_cache.bg->get_minimum_size();
 
 	int y_offset = get_item_offset(selected_item);
 	if (y_offset != -1) {
 		const int tbh = _get_title_button_height();
 		y_offset -= tbh;
 
-		const int cell_h = compute_item_height(selected_item) + cache.vseparation;
+		const int cell_h = compute_item_height(selected_item) + theme_cache.vseparation;
 		const int screen_h = area_size.height - h_scroll->get_combined_minimum_size().height - tbh;
 
 		if (cell_h > screen_h) { // Screen size is too small, maybe it was not resized yet.
@@ -4563,7 +4556,7 @@ Rect2 Tree::get_item_rect(TreeItem *p_item, int p_column, int p_button) const {
 			Vector2 ofst = Vector2(r.position.x + r.size.x, r.position.y);
 			for (int j = c.buttons.size() - 1; j >= 0; j--) {
 				Ref<Texture2D> b = c.buttons[j].texture;
-				Size2 size = b->get_size() + cache.button_pressed->get_minimum_size();
+				Size2 size = b->get_size() + theme_cache.button_pressed->get_minimum_size();
 				ofst.x -= size.x;
 
 				if (j == p_button) {
@@ -4596,9 +4589,6 @@ void Tree::set_column_title(int p_column, const String &p_title) {
 		return;
 	}
 
-	if (cache.font.is_null()) { // avoid a strange case that may corrupt stuff
-		update_cache();
-	}
 	columns.write[p_column].title = p_title;
 	update_column(p_column);
 	queue_redraw();
@@ -4660,7 +4650,7 @@ void Tree::scroll_to_item(TreeItem *p_item, bool p_center_on_item) {
 	const real_t tree_height = get_size().y;
 	const Rect2 item_rect = get_item_rect(p_item);
 	const real_t item_y = item_rect.position.y;
-	const real_t item_height = item_rect.size.y + cache.vseparation;
+	const real_t item_height = item_rect.size.y + theme_cache.vseparation;
 
 	if (p_center_on_item) {
 		v_scroll->set_value(item_y - (tree_height - item_height) / 2.0f);
@@ -4784,7 +4774,7 @@ TreeItem *Tree::_find_item_at_pos(TreeItem *p_item, const Point2 &p_pos, int &r_
 	Point2 pos = p_pos;
 
 	if ((root != p_item || !hide_root) && p_item->is_visible()) {
-		h = compute_item_height(p_item) + cache.vseparation;
+		h = compute_item_height(p_item) + theme_cache.vseparation;
 		if (pos.y < h) {
 			if (drop_mode_flags == DROP_MODE_ON_ITEM) {
 				section = 0;
@@ -4841,7 +4831,7 @@ int Tree::get_column_at_position(const Point2 &p_pos) const {
 		if (is_layout_rtl()) {
 			pos.x = get_size().width - pos.x;
 		}
-		pos -= cache.bg->get_offset();
+		pos -= theme_cache.bg->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return -1;
@@ -4871,7 +4861,7 @@ int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 		if (is_layout_rtl()) {
 			pos.x = get_size().width - pos.x;
 		}
-		pos -= cache.bg->get_offset();
+		pos -= theme_cache.bg->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return -100;
@@ -4901,7 +4891,7 @@ TreeItem *Tree::get_item_at_position(const Point2 &p_pos) const {
 		if (is_layout_rtl()) {
 			pos.x = get_size().width - pos.x;
 		}
-		pos -= cache.bg->get_offset();
+		pos -= theme_cache.bg->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return nullptr;
@@ -4928,7 +4918,7 @@ TreeItem *Tree::get_item_at_position(const Point2 &p_pos) const {
 int Tree::get_button_id_at_position(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;
-		pos -= cache.bg->get_offset();
+		pos -= theme_cache.bg->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return -1;
@@ -4954,7 +4944,7 @@ int Tree::get_button_id_at_position(const Point2 &p_pos) const {
 
 			for (int j = c.buttons.size() - 1; j >= 0; j--) {
 				Ref<Texture2D> b = c.buttons[j].texture;
-				Size2 size = b->get_size() + cache.button_pressed->get_minimum_size();
+				Size2 size = b->get_size() + theme_cache.button_pressed->get_minimum_size();
 				if (pos.x > col_width - size.width) {
 					return c.buttons[j].id;
 				}
@@ -4969,7 +4959,7 @@ int Tree::get_button_id_at_position(const Point2 &p_pos) const {
 String Tree::get_tooltip(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;
-		pos -= cache.bg->get_offset();
+		pos -= theme_cache.bg->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return Control::get_tooltip(p_pos);
@@ -4995,7 +4985,7 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 
 			for (int j = c.buttons.size() - 1; j >= 0; j--) {
 				Ref<Texture2D> b = c.buttons[j].texture;
-				Size2 size = b->get_size() + cache.button_pressed->get_minimum_size();
+				Size2 size = b->get_size() + theme_cache.button_pressed->get_minimum_size();
 				if (pos.x > col_width - size.width) {
 					String tooltip = c.buttons[j].tooltip;
 					if (!tooltip.is_empty()) {
@@ -5231,8 +5221,6 @@ Tree::Tree() {
 	set_mouse_filter(MOUSE_FILTER_STOP);
 
 	set_clip_contents(true);
-
-	update_cache();
 }
 
 Tree::~Tree() {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -482,12 +482,13 @@ private:
 
 	void propagate_set_columns(TreeItem *p_item);
 
-	struct Cache {
+	struct ThemeCache {
 		Ref<Font> font;
 		Ref<Font> tb_font;
 		int font_size = 0;
 		int tb_font_size = 0;
 		Ref<StyleBox> bg;
+		Ref<StyleBox> bg_focus;
 		Ref<StyleBox> selected;
 		Ref<StyleBox> selected_focus;
 		Ref<StyleBox> cursor;
@@ -505,8 +506,9 @@ private:
 		Ref<Texture2D> checked;
 		Ref<Texture2D> unchecked;
 		Ref<Texture2D> indeterminate;
-		Ref<Texture2D> arrow_collapsed;
 		Ref<Texture2D> arrow;
+		Ref<Texture2D> arrow_collapsed;
+		Ref<Texture2D> arrow_collapsed_mirrored;
 		Ref<Texture2D> select_arrow;
 		Ref<Texture2D> updown;
 
@@ -536,7 +538,9 @@ private:
 		int scroll_border = 0;
 		int scroll_speed = 0;
 		int font_outline_size = 0;
+	} theme_cache;
 
+	struct Cache {
 		enum ClickType {
 			CLICK_NONE,
 			CLICK_TITLE,
@@ -559,7 +563,6 @@ private:
 		Point2i text_editor_position;
 
 		bool rtl = false;
-
 	} cache;
 
 	int _get_title_button_height() const;
@@ -572,7 +575,6 @@ private:
 	bool v_scroll_enabled = true;
 
 	Size2 get_internal_min_size() const;
-	void update_cache();
 	void update_scrollbars();
 
 	Rect2 search_item_rect(TreeItem *p_from, TreeItem *p_item);
@@ -620,6 +622,8 @@ private:
 	bool _scroll(bool p_horizontal, float p_pages);
 
 protected:
+	virtual void _update_theme_item_cache() override;
+
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Join me on a journey towards more organized utilization of theme items! In Part 1 we're adding the framework for controls and cover most controls with updated and, hopefully, improved code to utilize said framework.

-----

As we're trying to improve the theme propagation logic and theme utilization in built-in controls and the editor, @AaronRecord made https://github.com/godotengine/godot/pull/62845, which unearthed some issues with how some UI elements are currently written. Namely, a significant amount of editor UI elements don't react correctly to theme changes which results in broken visuals. Before https://github.com/godotengine/godot/pull/62845 it was hard to spot those issues, as they would only fail to update on theme changes (so when a user messes with editor settings, which is fairly rare). After that PR, the issues became apparent as we no longer have theme immediately upon `NOTIFICATION_ENTER_TREE`, which allowed those controls to behave seemingly correct.

On top of that, we have a longstanding code quality issue. The code accessing theme items is disconnected and all over the place. As mentioned above, sometimes controls don't implement handlers for the necessary system events (like `NOTIFICATION_THEME_CHANGED`). Sometimes code is excessively run during each draw call, or at other times where no update to theme happened and thus the complicated execution path is unnecessary. I've partially addressed it with the dumb theme item cache in https://github.com/godotengine/godot/pull/64314, so performance-wise we're probably in a good spot.

Still, theme items excessively rely on strings, which results in hard-to-maintain error-prone code. I am slowly moving towards solving this completely with `ThemeDB` (https://github.com/godotengine/godot-proposals/issues/4486), but that work is still very much in progress. In the meantime my plan to improve code quality, is as follows:

- Add to `Control` and `Window` a virtual method that would be called automatically at necessary points in time to generate the "not-so-dumb" cache. The cache structure remains a responsibility of each individual control or window class, but for consistency I'm proposing to create `ThemeCache` struct named `theme_cache`.
- Make each control and window class utilize it, move all `get_theme_*` calls to that method and use class properties instead throughout the rest of the methods.
- Implement the same logic for editor controls/widgets. At least the ones directly extending control types.
- Patch the remaining editor widgets with some other ad-hoc caching.

This removes the need for contributors to think about when is it correct to update theme items, as there is now a method for it. This also reduces the amount of theme related strings in the codebase, keeping them only in the specific place of each class.
For editor widgets this hopefully makes it harder to write code that would not implement theme support properly, removing the issues uncovered by https://github.com/godotengine/godot/pull/62845.

-----

This PR is only the first one of several.
- It adds `Control::_update_theme_item_cache()` and adds calls to it in the appropriate places to ensure items are valid and up to date.
- It implements the method for most of control nodes.
- Cleans up some bad theme item accesses.

I've omitted `CodeEdit` and `TextEdit` for now, because they already have some sort of cache and I wanted to push this as soon as possible. `Tree` is in a similar position, but I've already committed to it today, so it was converted to the new system.

I've also omitted `RichTextLabel`, as it's big and I don't want to break it right now. The system is optional, so it doesn't really matter if everything is implemented at the same time.

And I've also omitted `GraphEdit`/`GraphNode` and `ColorPicker`/`ColorPickerButton`/`ColorPresetButton`, as those have refactoring PRs in works, and I don't want to introduce major conflicts for now (https://github.com/godotengine/godot/pull/61414 and https://github.com/godotengine/godot/pull/62910).

-----

I will continue tomorrow with Window-based nodes and the reported editor widgets. There are around 3k calls to `get_theme_*` in our codebase, so help is appreciated (if we decide to merge this, of course). Poke me on RC if you want to take a part of this work upon yourself.