### PR TITLE
Fixes engine runs into an infinite loop when searching using FindBar

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4622,7 +4622,10 @@ bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p
 			queue_redraw();
 			return true;
 		}
-		p_search_previous ? current_line-- : current_line++;
+
+		if (current_line != ending_line) {
+			p_search_previous ? current_line-- : current_line++;
+		}
 	}
 
 	if (p_from_selection && selection.active) {


### PR DESCRIPTION
The exact commit that cause the bug is: 8ab13f8acefef73a0d68560c6866639d9ca0dc80 
In file `rich_text_label.cpp`
method `bool RichTextLabel::search(const String &p_string, bool p_from_selection, bool p_search_previous) {`

The loop inside that function:
```
	// Search remainder of the file
	while (current_line != ending_line) {
		// Wrap around
		if (current_line < 0) {
			current_line = main->lines.size() - 1;
		} else if (current_line >= main->lines.size()) {
			current_line = 0;
		}

		if (_search_line(main, current_line, p_string, char_idx, p_search_previous)) {
			scroll_to_line(current_line);
			update();
			return true;
		}
		p_search_previous ? current_line-- : current_line++;
	}
```
The special case is `ending_line = 0`
When the statement `else if (current_line >= main->lines.size()) {` is true: the `current_line` is set to 0
but the line `p_search_previous ? current_line-- : current_line++;` continue to execute and program ran into `infinite loop`

_Production edit: Fixes #64962_