### PR TITLE
Fix LinearDepth calculation in the Visual Shader node for GLES3

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -7247,7 +7247,11 @@ String VisualShaderNodeProximityFade::generate_code(Shader::Mode p_mode, VisualS
 
 	String proximity_fade_distance = vformat("%s", p_input_vars[0]);
 	code += "	float __depth_tex = textureLod(DEPTH_TEXTURE, SCREEN_UV, 0.0).r;\n";
-	code += "	vec4 __depth_world_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, __depth_tex, 1.0);\n";
+	if (!RenderingServer::get_singleton()->is_low_end()) {
+		code += "	vec4 __depth_world_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, __depth_tex, 1.0);\n";
+	} else {
+		code += "	vec4 __depth_world_pos = INV_PROJECTION_MATRIX * vec4(vec3(SCREEN_UV, __depth_tex) * 2.0 - 1.0, 1.0);\n";
+	}
 	code += "	__depth_world_pos.xyz /= __depth_world_pos.z;\n";
 	code += vformat("	%s = clamp(1.0 - smoothstep(__depth_world_pos.z + %s, __depth_world_pos.z, VERTEX.z), 0.0, 1.0);\n", p_output_vars[0], p_input_vars[0]);
 


### PR DESCRIPTION
This change will calculate the depth ndc differently for GLES3 and Vulkan as described in here:
stable:
https://docs.godotengine.org/en/stable/tutorials/shaders/advanced_postprocessing.html
godot 4 with vulkan:
https://docs.godotengine.org/en/latest/tutorials/shaders/advanced_postprocessing.html

Original PR: https://github.com/godotengine/godot/pull/64248