### PR TITLE
Unite `GradientEdit` and `GradientEditor` as editor-only widget

### DIFF
--- a/editor/plugins/gradient_editor.h
+++ b/editor/plugins/gradient_editor.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gradient_edit.h                                                      */
+/*  gradient_editor.h                                                    */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,15 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GRADIENT_EDIT_H
-#define GRADIENT_EDIT_H
+#ifndef GRADIENT_EDITOR_H
+#define GRADIENT_EDITOR_H
 
 #include "scene/gui/color_picker.h"
 #include "scene/gui/popup.h"
 #include "scene/resources/gradient.h"
 
-class GradientEdit : public Control {
-	GDCLASS(GradientEdit, Control);
+class GradientEditor : public Control {
+	GDCLASS(GradientEditor, Control);
 
 	PopupPanel *popup = nullptr;
 	ColorPicker *picker = nullptr;
@@ -46,6 +46,8 @@ class GradientEdit : public Control {
 	Vector<Gradient::Point> points;
 	Gradient::InterpolationMode interpolation_mode = Gradient::GRADIENT_INTERPOLATE_LINEAR;
 
+	bool editing = false;
+	Ref<Gradient> gradient;
 	Ref<Gradient> gradient_cache;
 	Ref<GradientTexture1D> preview_texture;
 
@@ -56,8 +58,10 @@ class GradientEdit : public Control {
 	int draw_spacing = BASE_SPACING;
 	int draw_point_width = BASE_POINT_WIDTH;
 
-	void _draw_checker(int x, int y, int w, int h);
+	void _gradient_changed();
+	void _ramp_changed();
 	void _color_changed(const Color &p_color);
+
 	int _get_point_from_pos(int x);
 	void _show_color_picker();
 
@@ -67,20 +71,26 @@ protected:
 	static void _bind_methods();
 
 public:
+	void set_gradient(const Ref<Gradient> &p_gradient);
+	void reverse_gradient();
+
 	void set_ramp(const Vector<float> &p_offsets, const Vector<Color> &p_colors);
+
 	Vector<float> get_offsets() const;
 	Vector<Color> get_colors() const;
 	void set_points(Vector<Gradient::Point> &p_points);
 	Vector<Gradient::Point> &get_points();
+
 	void set_interpolation_mode(Gradient::InterpolationMode p_interp_mode);
 	Gradient::InterpolationMode get_interpolation_mode();
+
 	ColorPicker *get_picker();
 	PopupPanel *get_popup();
 
 	virtual Size2 get_minimum_size() const override;
 
-	GradientEdit();
-	virtual ~GradientEdit();
+	GradientEditor();
+	virtual ~GradientEditor();
 };
 
-#endif // GRADIENT_EDIT_H
+#endif // GRADIENT_EDITOR_H

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -37,62 +37,6 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "node_3d_editor_plugin.h"
 
-Size2 GradientEditor::get_minimum_size() const {
-	return Size2(0, 60) * EDSCALE;
-}
-
-void GradientEditor::_gradient_changed() {
-	if (editing) {
-		return;
-	}
-
-	editing = true;
-	Vector<Gradient::Point> points = gradient->get_points();
-	set_points(points);
-	set_interpolation_mode(gradient->get_interpolation_mode());
-	queue_redraw();
-	editing = false;
-}
-
-void GradientEditor::_ramp_changed() {
-	editing = true;
-	Ref<EditorUndoRedoManager> undo_redo = EditorNode::get_undo_redo();
-	undo_redo->create_action(TTR("Gradient Edited"), UndoRedo::MERGE_ENDS);
-	undo_redo->add_do_method(gradient.ptr(), "set_offsets", get_offsets());
-	undo_redo->add_do_method(gradient.ptr(), "set_colors", get_colors());
-	undo_redo->add_do_method(gradient.ptr(), "set_interpolation_mode", get_interpolation_mode());
-	undo_redo->add_undo_method(gradient.ptr(), "set_offsets", gradient->get_offsets());
-	undo_redo->add_undo_method(gradient.ptr(), "set_colors", gradient->get_colors());
-	undo_redo->add_undo_method(gradient.ptr(), "set_interpolation_mode", gradient->get_interpolation_mode());
-	undo_redo->commit_action();
-	editing = false;
-}
-
-void GradientEditor::_bind_methods() {
-}
-
-void GradientEditor::set_gradient(const Ref<Gradient> &p_gradient) {
-	gradient = p_gradient;
-	connect("ramp_changed", callable_mp(this, &GradientEditor::_ramp_changed));
-	gradient->connect("changed", callable_mp(this, &GradientEditor::_gradient_changed));
-	set_points(gradient->get_points());
-	set_interpolation_mode(gradient->get_interpolation_mode());
-}
-
-void GradientEditor::reverse_gradient() {
-	gradient->reverse();
-	set_points(gradient->get_points());
-	emit_signal(SNAME("ramp_changed"));
-	queue_redraw();
-}
-
-GradientEditor::GradientEditor() {
-	GradientEdit::get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(GradientEdit::get_picker()));
-	editing = false;
-}
-
-///////////////////////
-
 void GradientReverseButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {

--- a/editor/plugins/gradient_editor_plugin.h
+++ b/editor/plugins/gradient_editor_plugin.h
@@ -32,26 +32,7 @@
 #define GRADIENT_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
-#include "scene/gui/gradient_edit.h"
-
-class GradientEditor : public GradientEdit {
-	GDCLASS(GradientEditor, GradientEdit);
-
-	bool editing;
-	Ref<Gradient> gradient;
-
-	void _gradient_changed();
-	void _ramp_changed();
-
-protected:
-	static void _bind_methods();
-
-public:
-	virtual Size2 get_minimum_size() const override;
-	void set_gradient(const Ref<Gradient> &p_gradient);
-	void reverse_gradient();
-	GradientEditor();
-};
+#include "gradient_editor.h"
 
 class GradientReverseButton : public BaseButton {
 	GDCLASS(GradientReverseButton, BaseButton);


### PR DESCRIPTION
I noticed that `GradientEdit` was a part of `/scene/gui` despite not being used outside of the editor, and not being exposed. Seems this is how it was added [back in 2015](https://github.com/godotengine/godot/commit/df9d48d9b552c30b9b42940a964ccc4271e6905b#diff-e4c9d70a3ecc449ede1e49b7ea01ed9128d2931c21e284d7a50d3f63cd7a13e2) when it was still ColorRamp and not Gradient.

Initially I wanted to simply move files to the appropriate folder, `/editor/plugins`, next to its only user, `GradientEditorPlugin`. But upon further investigation I found out that in the editor part the `GradientEdit` is extended into `GradientEditor`. I saw no point keeping two classes, so I merged them under the `GradientEditor` name.

I briefly considered if maybe we want to keep the base `GradientEdit` in scene types and expose it, but to do this properly it needs to be evaluated for its public APIs. As at this point we don't have the need to expose it, this is a better solution. We can always extract a base type later, if we decide on it and see a good API to expose.

This technically breaks compat with modules, hence the label.