### PR TITLE
Fix a case in global function highlighting

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -318,8 +318,18 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			Color col = Color();
 			if (global_functions.has(word)) {
 				// "assert" and "preload" are reserved, so highlight even if not followed by a bracket.
-				if (word == "assert" || word == "preload" || str[to] == '(') {
+				if (word == "assert" || word == "preload") {
 					col = global_function_color;
+				} else {
+					// For other global functions, check if followed by bracket.
+					int k = to;
+					while (k < line_length && is_whitespace(str[k])) {
+						k++;
+					}
+
+					if (str[k] == '(') {
+						col = global_function_color;
+					}
 				}
 			} else if (keywords.has(word)) {
 				col = keywords[word];
@@ -668,14 +678,14 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 
 	if (godot_2_theme || EditorSettings::get_singleton()->is_dark_theme()) {
 		function_definition_color = Color(0.4, 0.9, 1.0);
-		global_function_color = Color(0.6, 0.6, 0.9);
+		global_function_color = Color(0.64, 0.64, 0.96);
 		node_path_color = Color(0.72, 0.77, 0.49);
 		node_ref_color = Color(0.39, 0.76, 0.35);
 		annotation_color = Color(1.0, 0.7, 0.45);
 		string_name_color = Color(1.0, 0.76, 0.65);
 	} else {
 		function_definition_color = Color(0, 0.6, 0.6);
-		global_function_color = Color(0.4, 0.2, 0.8);
+		global_function_color = Color(0.36, 0.18, 0.72);
 		node_path_color = Color(0.18, 0.55, 0);
 		node_ref_color = Color(0.0, 0.5, 0);
 		annotation_color = Color(0.8, 0.37, 0);


### PR DESCRIPTION
Ah yeah, the highlighter's need to address unusual syntax you don't normally think about. I missed yet another such detail in #64651 

With this PR, global functions are now highlighted as such even if the bracket is a few whitespaces away:

![image](https://user-images.githubusercontent.com/85438892/187784855-388414c8-7b0a-4e87-b7bd-1246d09416d1.png)

Also tweaked the default color a tiny bit as some users complained it was too dark and hard to read on some themes.