### PR TITLE
C#: Fix Vector4 in godot_variant and missing marshaling

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -130,14 +130,14 @@ namespace Godot.NativeInterop
             [FieldOffset(0)] public AABB* _aabb;
             [FieldOffset(0)] public Basis* _basis;
             [FieldOffset(0)] public Transform3D* _transform3D;
-            [FieldOffset(0)] public Vector4* _vector4;
-            [FieldOffset(0)] public Vector4i* _vector4i;
             [FieldOffset(0)] public Projection* _projection;
             [FieldOffset(0)] private godot_variant_data_mem _mem;
 
             // The following fields are not in the C++ union, but this is how they're stored in _mem.
             [FieldOffset(0)] public godot_string_name _m_string_name;
             [FieldOffset(0)] public godot_string _m_string;
+            [FieldOffset(0)] public Vector4 _m_vector4;
+            [FieldOffset(0)] public Vector4i _m_vector4i;
             [FieldOffset(0)] public Vector3 _m_vector3;
             [FieldOffset(0)] public Vector3i _m_vector3i;
             [FieldOffset(0)] public Vector2 _m_vector2;
@@ -232,18 +232,6 @@ namespace Godot.NativeInterop
             get => _data._transform3D;
         }
 
-        public readonly unsafe Vector4* Vector4
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data._vector4;
-        }
-
-        public readonly unsafe Vector4i* Vector4i
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data._vector4i;
-        }
-
         public readonly unsafe Projection* Projection
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -264,6 +252,22 @@ namespace Godot.NativeInterop
             readonly get => _data._m_string;
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set => _data._m_string = value;
+        }
+
+        public Vector4 Vector4
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            readonly get => _data._m_vector4;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => _data._m_vector4 = value;
+        }
+
+        public Vector4i Vector4i
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            readonly get => _data._m_vector4i;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => _data._m_vector4i = value;
         }
 
         public Vector3 Vector3
@@ -406,6 +410,8 @@ namespace Godot.NativeInterop
                 case Variant.Type.Rect2i:
                 case Variant.Type.Vector3:
                 case Variant.Type.Vector3i:
+                case Variant.Type.Vector4:
+                case Variant.Type.Vector4i:
                 case Variant.Type.Plane:
                 case Variant.Type.Quaternion:
                 case Variant.Type.Color:

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -613,9 +613,9 @@ namespace Godot.NativeInterop
                 case Variant.Type.Transform2d:
                     return *p_var.Transform2D;
                 case Variant.Type.Vector4:
-                    return *p_var.Vector4;
+                    return p_var.Vector4;
                 case Variant.Type.Vector4i:
-                    return *p_var.Vector4i;
+                    return p_var.Vector4i;
                 case Variant.Type.Plane:
                     return p_var.Plane;
                 case Variant.Type.Quaternion:

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -176,10 +176,6 @@ namespace Godot.NativeInterop
 
         public static partial void godotsharp_variant_new_transform2d(out godot_variant r_dest, in Transform2D p_t2d);
 
-        public static partial void godotsharp_variant_new_vector4(out godot_variant r_dest, in Vector4 p_vec4);
-
-        public static partial void godotsharp_variant_new_vector4i(out godot_variant r_dest, in Vector4i p_vec4i);
-
         public static partial void godotsharp_variant_new_basis(out godot_variant r_dest, in Basis p_basis);
 
         public static partial void godotsharp_variant_new_transform3d(out godot_variant r_dest, in Transform3D p_trans);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
@@ -28,6 +28,10 @@ namespace Godot.NativeInterop
                     return new godot_variant() { Vector3 = src.Vector3, Type = Variant.Type.Vector3 };
                 case Variant.Type.Vector3i:
                     return new godot_variant() { Vector3i = src.Vector3i, Type = Variant.Type.Vector3i };
+                case Variant.Type.Vector4:
+                    return new godot_variant() { Vector4 = src.Vector4, Type = Variant.Type.Vector4 };
+                case Variant.Type.Vector4i:
+                    return new godot_variant() { Vector4i = src.Vector4i, Type = Variant.Type.Vector4i };
                 case Variant.Type.Plane:
                     return new godot_variant() { Plane = src.Plane, Type = Variant.Type.Plane };
                 case Variant.Type.Quaternion:

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantConversionCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantConversionCallbacks.cs
@@ -74,6 +74,12 @@ internal static unsafe class VariantConversionCallbacks
         static godot_variant FromTransform3D(in Transform3D @transform3d) =>
             VariantUtils.CreateFromTransform3D(@transform3d);
 
+        static godot_variant FromVector4(in Vector4 @vector4) =>
+            VariantUtils.CreateFromVector4(@vector4);
+
+        static godot_variant FromVector4I(in Vector4i vector4I) =>
+            VariantUtils.CreateFromVector4i(vector4I);
+
         static godot_variant FromAabb(in AABB @aabb) =>
             VariantUtils.CreateFromAABB(@aabb);
 
@@ -281,6 +287,18 @@ internal static unsafe class VariantConversionCallbacks
         {
             return (delegate*<in T, godot_variant>)(delegate*<in Transform3D, godot_variant>)
                 &FromTransform3D;
+        }
+
+        if (typeOfT == typeof(Vector4))
+        {
+            return (delegate*<in T, godot_variant>)(delegate*<in Vector4, godot_variant>)
+                &FromVector4;
+        }
+
+        if (typeOfT == typeof(Vector4i))
+        {
+            return (delegate*<in T, godot_variant>)(delegate*<in Vector4i, godot_variant>)
+                &FromVector4I;
         }
 
         if (typeOfT == typeof(AABB))
@@ -556,6 +574,12 @@ internal static unsafe class VariantConversionCallbacks
         static Transform3D ToTransform3D(in godot_variant variant) =>
             VariantUtils.ConvertToTransform3D(variant);
 
+        static Vector4 ToVector4(in godot_variant variant) =>
+            VariantUtils.ConvertToVector4(variant);
+
+        static Vector4i ToVector4I(in godot_variant variant) =>
+            VariantUtils.ConvertToVector4i(variant);
+
         static AABB ToAabb(in godot_variant variant) =>
             VariantUtils.ConvertToAABB(variant);
 
@@ -766,6 +790,18 @@ internal static unsafe class VariantConversionCallbacks
         {
             return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Transform3D>)
                 &ToTransform3D;
+        }
+
+        if (typeOfT == typeof(Vector4))
+        {
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Vector4>)
+                &ToVector4;
+        }
+
+        if (typeOfT == typeof(Vector4i))
+        {
+            return (delegate*<in godot_variant, T>)(delegate*<in godot_variant, Vector4i>)
+                &ToVector4I;
         }
 
         if (typeOfT == typeof(AABB))

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -37,6 +37,12 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromVector3i(Vector3i from)
             => new() { Type = Variant.Type.Vector3i, Vector3i = from };
 
+        public static godot_variant CreateFromVector4(Vector4 from)
+            => new() { Type = Variant.Type.Vector4, Vector4 = from };
+
+        public static godot_variant CreateFromVector4i(Vector4i from)
+            => new() { Type = Variant.Type.Vector4i, Vector4i = from };
+
         public static godot_variant CreateFromRect2(Rect2 from)
             => new() { Type = Variant.Type.Rect2, Rect2 = from };
 
@@ -55,18 +61,6 @@ namespace Godot.NativeInterop
         public static godot_variant CreateFromTransform2D(Transform2D from)
         {
             NativeFuncs.godotsharp_variant_new_transform2d(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromVector4(Vector4 from)
-        {
-            NativeFuncs.godotsharp_variant_new_vector4(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromVector4i(Vector4i from)
-        {
-            NativeFuncs.godotsharp_variant_new_vector4i(out godot_variant ret, from);
             return ret;
         }
 
@@ -386,12 +380,12 @@ namespace Godot.NativeInterop
 
         public static unsafe Vector4 ConvertToVector4(in godot_variant p_var)
             => p_var.Type == Variant.Type.Vector4 ?
-                *p_var.Vector4 :
+                p_var.Vector4 :
                 NativeFuncs.godotsharp_variant_as_vector4(p_var);
 
         public static unsafe Vector4i ConvertToVector4i(in godot_variant p_var)
             => p_var.Type == Variant.Type.Vector4i ?
-                *p_var.Vector4i :
+                p_var.Vector4i :
                 NativeFuncs.godotsharp_variant_as_vector4i(p_var);
 
         public static unsafe Basis ConvertToBasis(in godot_variant p_var)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Variant.cs
@@ -65,6 +65,8 @@ public partial struct Variant : IDisposable
             case Type.Rect2i:
             case Type.Vector3:
             case Type.Vector3i:
+            case Type.Vector4:
+            case Type.Vector4i:
             case Type.Plane:
             case Type.Quaternion:
             case Type.Color:

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -548,14 +548,6 @@ void godotsharp_variant_new_transform2d(godot_variant *r_dest, const Transform2D
 	memnew_placement(r_dest, Variant(*p_t2d));
 }
 
-void godotsharp_variant_new_vector4(godot_variant *r_dest, const Vector4 *p_vec4) {
-	memnew_placement(r_dest, Variant(*p_vec4));
-}
-
-void godotsharp_variant_new_vector4i(godot_variant *r_dest, const Vector4i *p_vec4i) {
-	memnew_placement(r_dest, Variant(*p_vec4i));
-}
-
 void godotsharp_variant_new_basis(godot_variant *r_dest, const Basis *p_basis) {
 	memnew_placement(r_dest, Variant(*p_basis));
 }
@@ -1377,8 +1369,6 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_variant_new_node_path,
 	(void *)godotsharp_variant_new_object,
 	(void *)godotsharp_variant_new_transform2d,
-	(void *)godotsharp_variant_new_vector4,
-	(void *)godotsharp_variant_new_vector4i,
 	(void *)godotsharp_variant_new_basis,
 	(void *)godotsharp_variant_new_transform3d,
 	(void *)godotsharp_variant_new_projection,


### PR DESCRIPTION
`Vector4` and `Vector4i` were implemented incorrectly in `godot_variant`. They were also missing their respective Variant conversion callbacks (used for generic collections).

Took the chance to remove unnecessary native calls for creating Variant from Vector4, as now it can be done from C# (which is faster).
