### PR TITLE
C#: Assume 64-bit types when type has no meta

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ScriptBoilerplate.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ScriptBoilerplate.cs
@@ -7,7 +7,7 @@ namespace Godot.SourceGenerators.Sample
         private NodePath _nodePath;
         private int _velocity;
 
-        public override void _Process(float delta)
+        public override void _Process(double delta)
         {
             _ = delta;
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
@@ -117,13 +117,13 @@ namespace GodotTools.Build
             }
         }
 
-        private void IssueActivated(int idx)
+        private void IssueActivated(long idx)
         {
             if (idx < 0 || idx >= _issuesList.ItemCount)
                 throw new ArgumentOutOfRangeException(nameof(idx), "Item list index out of range.");
 
             // Get correct issue idx from issue list
-            int issueIndex = (int)_issuesList.GetItemMetadata(idx);
+            int issueIndex = (int)_issuesList.GetItemMetadata((int)idx);
 
             if (issueIndex < 0 || issueIndex >= _issues.Count)
                 throw new InvalidOperationException("Issue index out of range.");
@@ -311,7 +311,7 @@ namespace GodotTools.Build
             Copy
         }
 
-        private void IssuesListContextOptionPressed(int id)
+        private void IssuesListContextOptionPressed(long id)
         {
             switch ((IssuesContextMenuOption)id)
             {
@@ -336,9 +336,9 @@ namespace GodotTools.Build
             }
         }
 
-        private void IssuesListClicked(int index, Vector2 atPosition, int mouseButtonIndex)
+        private void IssuesListClicked(long index, Vector2 atPosition, long mouseButtonIndex)
         {
-            if (mouseButtonIndex != (int)MouseButton.Right)
+            if (mouseButtonIndex != (long)MouseButton.Right)
             {
                 return;
             }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -93,7 +93,7 @@ namespace GodotTools.Build
 
         private void ViewLogToggled(bool pressed) => BuildOutputView.LogVisible = pressed;
 
-        private void BuildMenuOptionPressed(int id)
+        private void BuildMenuOptionPressed(long id)
         {
             switch ((BuildMenuOptions)id)
             {
@@ -175,7 +175,7 @@ namespace GodotTools.Build
             AddChild(BuildOutputView);
         }
 
-        public override void _Notification(int what)
+        public override void _Notification(long what)
         {
             base._Notification(what);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -67,7 +67,7 @@ namespace GodotTools.Export
             }
         }
 
-        public override void _ExportBegin(string[] features, bool isDebug, string path, int flags)
+        public override void _ExportBegin(string[] features, bool isDebug, string path, long flags)
         {
             base._ExportBegin(features, isDebug, path, flags);
 
@@ -90,7 +90,7 @@ namespace GodotTools.Export
             }
         }
 
-        private void _ExportBeginImpl(string[] features, bool isDebug, string path, int flags)
+        private void _ExportBeginImpl(string[] features, bool isDebug, string path, long flags)
         {
             _ = flags; // Unused
 

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -111,7 +111,7 @@ namespace GodotTools
             _toolBarBuildButton.Show();
         }
 
-        private void _MenuOptionPressed(int id)
+        private void _MenuOptionPressed(long id)
         {
             switch ((MenuOptions)id)
             {

--- a/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/HotReloadAssemblyWatcher.cs
@@ -9,7 +9,7 @@ namespace GodotTools
     {
         private Timer _watchTimer;
 
-        public override void _Notification(int what)
+        public override void _Notification(long what)
         {
             if (what == Node.NotificationWmWindowFocusIn)
             {

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2585,6 +2585,16 @@ const String BindingsGenerator::_get_generic_type_parameters(const TypeInterface
 	return params;
 }
 
+StringName BindingsGenerator::_get_type_name_from_meta(Variant::Type p_type, GodotTypeInfo::Metadata p_meta) {
+	if (p_type == Variant::INT) {
+		return _get_int_type_name_from_meta(p_meta);
+	} else if (p_type == Variant::FLOAT) {
+		return _get_float_type_name_from_meta(p_meta);
+	} else {
+		return Variant::get_type_name(p_type);
+	}
+}
+
 StringName BindingsGenerator::_get_int_type_name_from_meta(GodotTypeInfo::Metadata p_meta) {
 	switch (p_meta) {
 		case GodotTypeInfo::METADATA_INT_IS_INT8:
@@ -2612,8 +2622,8 @@ StringName BindingsGenerator::_get_int_type_name_from_meta(GodotTypeInfo::Metada
 			return "ulong";
 			break;
 		default:
-			// Assume INT32
-			return "int";
+			// Assume INT64
+			return "long";
 	}
 }
 
@@ -2626,12 +2636,8 @@ StringName BindingsGenerator::_get_float_type_name_from_meta(GodotTypeInfo::Meta
 			return "double";
 			break;
 		default:
-			// Assume real_t (float or double depending of REAL_T_IS_DOUBLE)
-#ifdef REAL_T_IS_DOUBLE
+			// Assume FLOAT64
 			return "double";
-#else
-			return "float";
-#endif
 	}
 }
 
@@ -2922,13 +2928,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			} else if (return_info.type == Variant::NIL) {
 				imethod.return_type.cname = name_cache.type_void;
 			} else {
-				if (return_info.type == Variant::INT) {
-					imethod.return_type.cname = _get_int_type_name_from_meta(m ? m->get_argument_meta(-1) : GodotTypeInfo::METADATA_NONE);
-				} else if (return_info.type == Variant::FLOAT) {
-					imethod.return_type.cname = _get_float_type_name_from_meta(m ? m->get_argument_meta(-1) : GodotTypeInfo::METADATA_NONE);
-				} else {
-					imethod.return_type.cname = Variant::get_type_name(return_info.type);
-				}
+				imethod.return_type.cname = _get_type_name_from_meta(return_info.type, m ? m->get_argument_meta(-1) : GodotTypeInfo::METADATA_NONE);
 			}
 
 			for (int i = 0; i < argc; i++) {
@@ -2952,13 +2952,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				} else if (arginfo.type == Variant::NIL) {
 					iarg.type.cname = name_cache.type_Variant;
 				} else {
-					if (arginfo.type == Variant::INT) {
-						iarg.type.cname = _get_int_type_name_from_meta(m ? m->get_argument_meta(i) : GodotTypeInfo::METADATA_NONE);
-					} else if (arginfo.type == Variant::FLOAT) {
-						iarg.type.cname = _get_float_type_name_from_meta(m ? m->get_argument_meta(i) : GodotTypeInfo::METADATA_NONE);
-					} else {
-						iarg.type.cname = Variant::get_type_name(arginfo.type);
-					}
+					iarg.type.cname = _get_type_name_from_meta(arginfo.type, m ? m->get_argument_meta(i) : GodotTypeInfo::METADATA_NONE);
 				}
 
 				iarg.name = escape_csharp_keyword(snake_to_camel_case(iarg.name));
@@ -3060,13 +3054,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				} else if (arginfo.type == Variant::NIL) {
 					iarg.type.cname = name_cache.type_Variant;
 				} else {
-					if (arginfo.type == Variant::INT) {
-						iarg.type.cname = _get_int_type_name_from_meta(GodotTypeInfo::METADATA_NONE);
-					} else if (arginfo.type == Variant::FLOAT) {
-						iarg.type.cname = _get_float_type_name_from_meta(GodotTypeInfo::METADATA_NONE);
-					} else {
-						iarg.type.cname = Variant::get_type_name(arginfo.type);
-					}
+					iarg.type.cname = _get_type_name_from_meta(arginfo.type, GodotTypeInfo::METADATA_NONE);
 				}
 
 				iarg.name = escape_csharp_keyword(snake_to_camel_case(iarg.name));

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -703,6 +703,7 @@ class BindingsGenerator {
 
 	const String _get_generic_type_parameters(const TypeInterface &p_itype, const List<TypeReference> &p_generic_type_parameters);
 
+	StringName _get_type_name_from_meta(Variant::Type p_type, GodotTypeInfo::Metadata p_meta);
 	StringName _get_int_type_name_from_meta(GodotTypeInfo::Metadata p_meta);
 	StringName _get_float_type_name_from_meta(GodotTypeInfo::Metadata p_meta);
 

--- a/modules/mono/editor/script_templates/CharacterBody2D/basic_movement.cs
+++ b/modules/mono/editor/script_templates/CharacterBody2D/basic_movement.cs
@@ -11,13 +11,13 @@ public partial class _CLASS_ : _BASE_
     // Get the gravity from the project settings to be synced with RigidBody nodes.
     public float gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle();
 
-    public override void _PhysicsProcess(float delta)
+    public override void _PhysicsProcess(double delta)
     {
         Vector2 velocity = Velocity;
 
         // Add the gravity.
         if (!IsOnFloor())
-            velocity.y += gravity * delta;
+            velocity.y += gravity * (float)delta;
 
         // Handle Jump.
         if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())

--- a/modules/mono/editor/script_templates/CharacterBody3D/basic_movement.cs
+++ b/modules/mono/editor/script_templates/CharacterBody3D/basic_movement.cs
@@ -11,17 +11,17 @@ public partial class _CLASS_ : _BASE_
     // Get the gravity from the project settings to be synced with RigidBody nodes.
     public float gravity = ProjectSettings.GetSetting("physics/3d/default_gravity").AsSingle();
 
-    public override void _PhysicsProcess(float delta)
+    public override void _PhysicsProcess(double delta)
     {
         Vector3 velocity = Velocity;
 
         // Add the gravity.
         if (!IsOnFloor())
-            velocity.y -= gravity * delta;
+            velocity.y -= gravity * (float)delta;
 
         // Handle Jump.
         if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())
-             velocity.y = JumpVelocity;
+            velocity.y = JumpVelocity;
 
         // Get the input direction and handle the movement/deceleration.
         // As good practice, you should replace UI actions with custom gameplay actions.

--- a/modules/mono/editor/script_templates/Node/default.cs
+++ b/modules/mono/editor/script_templates/Node/default.cs
@@ -11,7 +11,7 @@ public partial class _CLASS_ : _BASE_
     }
 
     // Called every frame. 'delta' is the elapsed time since the previous frame.
-    public override void _Process(float delta)
+    public override void _Process(double delta)
     {
     }
 }

--- a/modules/mono/editor/script_templates/VisualShaderNodeCustom/basic.cs
+++ b/modules/mono/editor/script_templates/VisualShaderNodeCustom/basic.cs
@@ -20,37 +20,37 @@ public partial class VisualShaderNode_CLASS_ : _BASE_
         return "";
     }
 
-    public override int _GetReturnIconType()
+    public override long _GetReturnIconType()
     {
         return 0;
     }
 
-    public override int _GetInputPortCount()
+    public override long _GetInputPortCount()
     {
         return 0;
     }
 
-    public override string _GetInputPortName(int port)
+    public override string _GetInputPortName(long port)
     {
         return "";
     }
 
-    public override int _GetInputPortType(int port)
+    public override long _GetInputPortType(long port)
     {
         return 0;
     }
 
-    public override int _GetOutputPortCount()
+    public override long _GetOutputPortCount()
     {
         return 1;
     }
 
-    public override string _GetOutputPortName(int port)
+    public override string _GetOutputPortName(long port)
     {
         return "result";
     }
 
-    public override int _GetOutputPortType(int port)
+    public override long _GetOutputPortType(long port)
     {
         return 0;
     }


### PR DESCRIPTION
The C# bindings generator was assuming 32-bit types when no meta was specified. 
@reduz explained in Rocket Chat that this was wrong:

> @raulsntos you have to always assume double unless otherwise specified btw
> same for int, assume int64_t unless otherwise specified. This for scalars

Now, when the C# bindings generator finds a type without meta assume the type refers to the 64-bit version of the type:
- `float` is converted to `double`
- `int` is converted to `long`

Fixes #65139
