### PR TITLE
Change Array arguments to TypedArray

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -60,8 +60,8 @@
 		<method name="add_surface_from_arrays">
 			<return type="void" />
 			<param index="0" name="primitive" type="int" enum="Mesh.PrimitiveType" />
-			<param index="1" name="arrays" type="Array" />
-			<param index="2" name="blend_shapes" type="Array" default="[]" />
+			<param index="1" name="arrays" type="Array[]" />
+			<param index="2" name="blend_shapes" type="Array[]" default="[]" />
 			<param index="3" name="lods" type="Dictionary" default="{}" />
 			<param index="4" name="compress_flags" type="int" default="0" />
 			<description>

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -214,8 +214,8 @@
 			<param index="0" name="source_file" type="String" />
 			<param index="1" name="save_path" type="String" />
 			<param index="2" name="options" type="Dictionary" />
-			<param index="3" name="platform_variants" type="Array" />
-			<param index="4" name="gen_files" type="Array" />
+			<param index="3" name="platform_variants" type="String[]" />
+			<param index="4" name="gen_files" type="String[]" />
 			<description>
 				Imports [param source_file] into [param save_path] with the import [param options] specified. The [param platform_variants] and [param gen_files] arrays will be modified by this function.
 				This method must be overridden to do the actual importing work. See this class' description for an example of overriding this method.

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -167,7 +167,7 @@
 		</method>
 		<method name="make_mesh_previews">
 			<return type="Texture2D[]" />
-			<param index="0" name="meshes" type="Array" />
+			<param index="0" name="meshes" type="Mesh[]" />
 			<param index="1" name="preview_size" type="int" />
 			<description>
 				Returns mesh previews rendered at the given size as an [Array] of [Texture2D]s.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -135,7 +135,7 @@
 		<method name="set_builtin_action_override">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
-			<param index="1" name="actions_list" type="Array" />
+			<param index="1" name="actions_list" type="InputEvent[]" />
 			<description>
 				Overrides the built-in editor action [param name] with the input actions defined in [param actions_list].
 			</description>

--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -112,8 +112,8 @@
 		<method name="_parse_file" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
-			<param index="1" name="msgids" type="Array" />
-			<param index="2" name="msgids_context_plural" type="Array" />
+			<param index="1" name="msgids" type="String[]" />
+			<param index="2" name="msgids_context_plural" type="Array[]" />
 			<description>
 				Override this method to define a custom parsing logic to extract the translatable strings.
 			</description>

--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -53,7 +53,7 @@
 			</description>
 		</method>
 		<method name="_get_branch_list" qualifiers="virtual">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<description>
 				Gets an instance of an [Array] of [String]s containing available branch names in the VCS.
 			</description>
@@ -73,7 +73,7 @@
 			</description>
 		</method>
 		<method name="_get_line_diff" qualifiers="virtual">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<param index="0" name="file_path" type="String" />
 			<param index="1" name="text" type="String" />
 			<description>
@@ -81,20 +81,20 @@
 			</description>
 		</method>
 		<method name="_get_modified_files_data" qualifiers="virtual">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<description>
 				Returns an [Array] of [Dictionary] items (see [method create_status_file]), each containing the status data of every modified file in the project folder.
 			</description>
 		</method>
 		<method name="_get_previous_commits" qualifiers="virtual">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<param index="0" name="max_commits" type="int" />
 			<description>
 				Returns an [Array] of [Dictionary] items (see [method create_commit]), each containing the data for a past commit.
 			</description>
 		</method>
 		<method name="_get_remotes" qualifiers="virtual">
-			<return type="Array" />
+			<return type="Dictionary[]" />
 			<description>
 				Returns an [Array] of [String]s, each containing the name of a remote configured in the VCS.
 			</description>
@@ -175,7 +175,7 @@
 		<method name="add_diff_hunks_into_diff_file">
 			<return type="Dictionary" />
 			<param index="0" name="diff_file" type="Dictionary" />
-			<param index="1" name="diff_hunks" type="Array" />
+			<param index="1" name="diff_hunks" type="Dictionary[]" />
 			<description>
 				Helper function to add an array of [code]diff_hunks[/code] into a [code]diff_file[/code].
 			</description>
@@ -183,7 +183,7 @@
 		<method name="add_line_diffs_into_diff_hunk">
 			<return type="Dictionary" />
 			<param index="0" name="diff_hunk" type="Dictionary" />
-			<param index="1" name="line_diffs" type="Array" />
+			<param index="1" name="line_diffs" type="Dictionary[]" />
 			<description>
 				Helper function to add an array of [code]line_diffs[/code] into a [code]diff_hunk[/code].
 			</description>

--- a/doc/classes/ImageTextureLayered.xml
+++ b/doc/classes/ImageTextureLayered.xml
@@ -9,7 +9,7 @@
 	<methods>
 		<method name="create_from_images">
 			<return type="int" enum="Error" />
-			<param index="0" name="images" type="Array" />
+			<param index="0" name="images" type="Image[]" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -22,7 +22,7 @@
 			<return type="void" />
 			<param index="0" name="primitive" type="int" enum="Mesh.PrimitiveType" />
 			<param index="1" name="arrays" type="Array" />
-			<param index="2" name="blend_shapes" type="Array" default="[]" />
+			<param index="2" name="blend_shapes" type="Array[]" default="[]" />
 			<param index="3" name="lods" type="Dictionary" default="{}" />
 			<param index="4" name="material" type="Material" default="null" />
 			<param index="5" name="name" type="String" default="&quot;&quot;" />

--- a/doc/classes/PhysicsPointQueryParameters2D.xml
+++ b/doc/classes/PhysicsPointQueryParameters2D.xml
@@ -21,7 +21,7 @@
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="4294967295">
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
-		<member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[]">
+		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
 			The list of objects or object [RID]s that will be excluded from collisions.
 		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">

--- a/doc/classes/PhysicsRayQueryParameters2D.xml
+++ b/doc/classes/PhysicsRayQueryParameters2D.xml
@@ -14,7 +14,7 @@
 			<param index="0" name="from" type="Vector2" />
 			<param index="1" name="to" type="Vector2" />
 			<param index="2" name="collision_mask" type="int" default="4294967295" />
-			<param index="3" name="exclude" type="Array" default="[]" />
+			<param index="3" name="exclude" type="RID[]" default="[]" />
 			<description>
 				Returns a new, pre-configured [PhysicsRayQueryParameters2D] object. Use it to quickly create query parameters using the most common options.
 				[codeblock]
@@ -34,7 +34,7 @@
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="4294967295">
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
-		<member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[]">
+		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
 			The list of objects or object [RID]s that will be excluded from collisions.
 		</member>
 		<member name="from" type="Vector2" setter="set_from" getter="get_from" default="Vector2(0, 0)">

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -18,7 +18,7 @@
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="4294967295">
 			The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
-		<member name="exclude" type="Array" setter="set_exclude" getter="get_exclude" default="[]">
+		<member name="exclude" type="RID[]" setter="set_exclude" getter="get_exclude" default="[]">
 			The list of objects or object [RID]s that will be excluded from collisions.
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.0">

--- a/doc/classes/PhysicsTestMotionParameters2D.xml
+++ b/doc/classes/PhysicsTestMotionParameters2D.xml
@@ -13,7 +13,7 @@
 			If set to [code]true[/code], shapes of type [constant PhysicsServer2D.SHAPE_SEPARATION_RAY] are used to detect collisions and can stop the motion. Can be useful when snapping to the ground.
 			If set to [code]false[/code], shapes of type [constant PhysicsServer2D.SHAPE_SEPARATION_RAY] are only used for separation when overlapping with other bodies. That's the main use for separation ray shapes.
 		</member>
-		<member name="exclude_bodies" type="Array" setter="set_exclude_bodies" getter="get_exclude_bodies" default="[]">
+		<member name="exclude_bodies" type="RID[]" setter="set_exclude_bodies" getter="get_exclude_bodies" default="[]">
 			Optional array of body [RID] to exclude from collision.
 		</member>
 		<member name="exclude_objects" type="Array" setter="set_exclude_objects" getter="get_exclude_objects" default="[]">

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -631,7 +631,7 @@
 		</method>
 		<method name="uniform_set_create">
 			<return type="RID" />
-			<param index="0" name="uniforms" type="Array" />
+			<param index="0" name="uniforms" type="RDUniform[]" />
 			<param index="1" name="shader" type="RID" />
 			<param index="2" name="shader_set" type="int" />
 			<description>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -21,7 +21,7 @@
 		<method name="bake_render_uv2">
 			<return type="Image[]" />
 			<param index="0" name="base" type="RID" />
-			<param index="1" name="material_overrides" type="Array" />
+			<param index="1" name="material_overrides" type="RID[]" />
 			<param index="2" name="image_size" type="Vector2i" />
 			<description>
 			</description>
@@ -1601,7 +1601,7 @@
 		</method>
 		<method name="instances_cull_convex" qualifiers="const">
 			<return type="PackedInt64Array" />
-			<param index="0" name="convex" type="Array" />
+			<param index="0" name="convex" type="Plane[]" />
 			<param index="1" name="scenario" type="RID" />
 			<description>
 				Returns an array of object IDs intersecting with the provided convex shape. Only visual 3D nodes are considered, such as [MeshInstance3D] or [DirectionalLight3D]. Use [method @GlobalScope.instance_from_id] to obtain the actual nodes. A scenario RID must be provided, which is available in the [World3D] you want to query. This forces an update for all resources queued to update.

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1035,7 +1035,7 @@
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
-			<param index="2" name="fonts" type="Array" />
+			<param index="2" name="fonts" type="RID[]" />
 			<param index="3" name="size" type="int" />
 			<param index="4" name="opentype_features" type="Dictionary" default="{}" />
 			<description>
@@ -1057,7 +1057,7 @@
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="text" type="String" />
-			<param index="2" name="fonts" type="Array" />
+			<param index="2" name="fonts" type="RID[]" />
 			<param index="3" name="size" type="int" />
 			<param index="4" name="opentype_features" type="Dictionary" default="{}" />
 			<param index="5" name="language" type="String" default="&quot;&quot;" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1020,7 +1020,7 @@
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
-			<param index="2" name="fonts" type="Array" />
+			<param index="2" name="fonts" type="RID[]" />
 			<param index="3" name="size" type="int" />
 			<param index="4" name="opentype_features" type="Dictionary" />
 			<description>
@@ -1042,7 +1042,7 @@
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="text" type="String" />
-			<param index="2" name="fonts" type="Array" />
+			<param index="2" name="fonts" type="RID[]" />
 			<param index="3" name="size" type="int" />
 			<param index="4" name="opentype_features" type="Dictionary" />
 			<param index="5" name="language" type="String" />

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2384,7 +2384,7 @@ void RasterizerSceneGLES3::sub_surface_scattering_set_quality(RS::SubSurfaceScat
 void RasterizerSceneGLES3::sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) {
 }
 
-TypedArray<Image> RasterizerSceneGLES3::bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) {
+TypedArray<Image> RasterizerSceneGLES3::bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) {
 	return TypedArray<Image>();
 }
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -771,7 +771,7 @@ public:
 	void sub_surface_scattering_set_quality(RS::SubSurfaceScatteringQuality p_quality) override;
 	void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) override;
 
-	TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) override;
+	TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) override;
 
 	bool free(RID p_rid) override;
 	void update() override;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -48,7 +48,7 @@
 #include "scene/gui/popup_menu.h"
 #include "servers/rendering_server.h"
 
-TypedArray<Texture2D> EditorInterface::_make_mesh_previews(const Array &p_meshes, int p_preview_size) {
+TypedArray<Texture2D> EditorInterface::_make_mesh_previews(const TypedArray<Mesh> &p_meshes, int p_preview_size) {
 	Vector<Ref<Mesh>> meshes;
 
 	for (int i = 0; i < p_meshes.size(); i++) {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -67,7 +67,7 @@ protected:
 	static void _bind_methods();
 	static EditorInterface *singleton;
 
-	TypedArray<Texture2D> _make_mesh_previews(const Array &p_meshes, int p_preview_size);
+	TypedArray<Texture2D> _make_mesh_previews(const TypedArray<Mesh> &p_meshes, int p_preview_size);
 
 public:
 	static EditorInterface *get_singleton() { return singleton; }

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1536,7 +1536,7 @@ Ref<Shortcut> ED_SHORTCUT_ARRAY(const String &p_path, const String &p_name, cons
 	return sc;
 }
 
-void EditorSettings::set_builtin_action_override(const String &p_name, const Array &p_events) {
+void EditorSettings::set_builtin_action_override(const String &p_name, const TypedArray<InputEvent> &p_events) {
 	List<Ref<InputEvent>> event_list;
 
 	// Override the whole list, since events may have their order changed or be added, removed or edited.

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -175,7 +175,7 @@ public:
 	Ref<Shortcut> get_shortcut(const String &p_name) const;
 	void get_shortcut_list(List<String> *r_shortcuts);
 
-	void set_builtin_action_override(const String &p_name, const Array &p_events);
+	void set_builtin_action_override(const String &p_name, const TypedArray<InputEvent> &p_events);
 	const Array get_builtin_action_overrides(const String &p_name) const;
 
 	void notify_changes();

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -38,8 +38,8 @@
 EditorTranslationParser *EditorTranslationParser::singleton = nullptr;
 
 Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) {
-	Array ids;
-	Array ids_ctx_plural;
+	TypedArray<String> ids;
+	TypedArray<Array> ids_ctx_plural;
 
 	if (GDVIRTUAL_CALL(_parse_file, p_path, ids, ids_ctx_plural)) {
 		// Add user's extracted translatable messages.

--- a/editor/editor_translation_parser.h
+++ b/editor/editor_translation_parser.h
@@ -35,6 +35,7 @@
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
+#include "core/variant/typed_array.h"
 
 class EditorTranslationParserPlugin : public RefCounted {
 	GDCLASS(EditorTranslationParserPlugin, RefCounted);
@@ -42,7 +43,7 @@ class EditorTranslationParserPlugin : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL3(_parse_file, String, Array, Array)
+	GDVIRTUAL3(_parse_file, String, TypedArray<String>, TypedArray<Array>)
 	GDVIRTUAL0RC(Vector<String>, _get_recognized_extensions)
 
 public:

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -57,7 +57,7 @@ void EditorVCSInterface::set_credentials(String p_username, String p_password, S
 }
 
 List<String> EditorVCSInterface::get_remotes() {
-	Array result;
+	TypedArray<Dictionary> result;
 	if (!GDVIRTUAL_CALL(_get_remotes, result)) {
 		UNIMPLEMENTED();
 		return {};
@@ -71,7 +71,7 @@ List<String> EditorVCSInterface::get_remotes() {
 }
 
 List<EditorVCSInterface::StatusFile> EditorVCSInterface::get_modified_files_data() {
-	Array result;
+	TypedArray<Dictionary> result;
 	if (!GDVIRTUAL_CALL(_get_modified_files_data, result)) {
 		UNIMPLEMENTED();
 		return {};
@@ -123,7 +123,7 @@ List<EditorVCSInterface::DiffFile> EditorVCSInterface::get_diff(String p_identif
 }
 
 List<EditorVCSInterface::Commit> EditorVCSInterface::get_previous_commits(int p_max_commits) {
-	Array result;
+	TypedArray<Dictionary> result;
 	if (!GDVIRTUAL_CALL(_get_previous_commits, p_max_commits, result)) {
 		UNIMPLEMENTED();
 		return {};
@@ -137,7 +137,7 @@ List<EditorVCSInterface::Commit> EditorVCSInterface::get_previous_commits(int p_
 }
 
 List<String> EditorVCSInterface::get_branch_list() {
-	Array result;
+	TypedArray<Dictionary> result;
 	if (!GDVIRTUAL_CALL(_get_branch_list, result)) {
 		UNIMPLEMENTED();
 		return {};
@@ -210,7 +210,7 @@ void EditorVCSInterface::fetch(String p_remote) {
 }
 
 List<EditorVCSInterface::DiffHunk> EditorVCSInterface::get_line_diff(String p_file_path, String p_text) {
-	Array result;
+	TypedArray<Dictionary> result;
 	if (!GDVIRTUAL_CALL(_get_line_diff, p_file_path, p_text, result)) {
 		UNIMPLEMENTED();
 		return {};
@@ -257,11 +257,11 @@ Dictionary EditorVCSInterface::create_diff_hunk(int p_old_start, int p_new_start
 	diff_hunk["old_lines"] = p_old_lines;
 	diff_hunk["new_start"] = p_new_start;
 	diff_hunk["old_start"] = p_old_start;
-	diff_hunk["diff_lines"] = Array();
+	diff_hunk["diff_lines"] = TypedArray<Dictionary>();
 	return diff_hunk;
 }
 
-Dictionary EditorVCSInterface::add_line_diffs_into_diff_hunk(Dictionary p_diff_hunk, Array p_line_diffs) {
+Dictionary EditorVCSInterface::add_line_diffs_into_diff_hunk(Dictionary p_diff_hunk, TypedArray<Dictionary> p_line_diffs) {
 	p_diff_hunk["diff_lines"] = p_line_diffs;
 	return p_diff_hunk;
 }
@@ -270,7 +270,7 @@ Dictionary EditorVCSInterface::create_diff_file(String p_new_file, String p_old_
 	Dictionary file_diff;
 	file_diff["new_file"] = p_new_file;
 	file_diff["old_file"] = p_old_file;
-	file_diff["diff_hunks"] = Array();
+	file_diff["diff_hunks"] = TypedArray<Dictionary>();
 	return file_diff;
 }
 
@@ -284,7 +284,7 @@ Dictionary EditorVCSInterface::create_commit(String p_msg, String p_author, Stri
 	return commit_info;
 }
 
-Dictionary EditorVCSInterface::add_diff_hunks_into_diff_file(Dictionary p_diff_file, Array p_diff_hunks) {
+Dictionary EditorVCSInterface::add_diff_hunks_into_diff_file(Dictionary p_diff_file, TypedArray<Dictionary> p_diff_hunks) {
 	p_diff_file["diff_hunks"] = p_diff_hunks;
 	return p_diff_file;
 }
@@ -312,7 +312,7 @@ EditorVCSInterface::DiffHunk EditorVCSInterface::_convert_diff_hunk(Dictionary p
 	dh.old_lines = p_diff_hunk["old_lines"];
 	dh.new_start = p_diff_hunk["new_start"];
 	dh.old_start = p_diff_hunk["old_start"];
-	Array diff_lines = p_diff_hunk["diff_lines"];
+	TypedArray<Dictionary> diff_lines = p_diff_hunk["diff_lines"];
 	for (int i = 0; i < diff_lines.size(); i++) {
 		DiffLine dl = _convert_diff_line(diff_lines[i]);
 		dh.diff_lines.push_back(dl);
@@ -324,7 +324,7 @@ EditorVCSInterface::DiffFile EditorVCSInterface::_convert_diff_file(Dictionary p
 	DiffFile df;
 	df.new_file = p_diff_file["new_file"];
 	df.old_file = p_diff_file["old_file"];
-	Array diff_hunks = p_diff_file["diff_hunks"];
+	TypedArray<Dictionary> diff_hunks = p_diff_file["diff_hunks"];
 	for (int i = 0; i < diff_hunks.size(); i++) {
 		DiffHunk dh = _convert_diff_hunk(diff_hunks[i]);
 		df.diff_hunks.push_back(dh);

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -108,7 +108,7 @@ protected:
 	// Proxy endpoints for extensions to implement
 	GDVIRTUAL1R(bool, _initialize, String);
 	GDVIRTUAL5(_set_credentials, String, String, String, String, String);
-	GDVIRTUAL0R(Array, _get_modified_files_data);
+	GDVIRTUAL0R(TypedArray<Dictionary>, _get_modified_files_data);
 	GDVIRTUAL1(_stage_file, String);
 	GDVIRTUAL1(_unstage_file, String);
 	GDVIRTUAL1(_discard_file, String);
@@ -116,9 +116,9 @@ protected:
 	GDVIRTUAL2R(TypedArray<Dictionary>, _get_diff, String, int);
 	GDVIRTUAL0R(bool, _shut_down);
 	GDVIRTUAL0R(String, _get_vcs_name);
-	GDVIRTUAL1R(Array, _get_previous_commits, int);
-	GDVIRTUAL0R(Array, _get_branch_list);
-	GDVIRTUAL0R(Array, _get_remotes);
+	GDVIRTUAL1R(TypedArray<Dictionary>, _get_previous_commits, int);
+	GDVIRTUAL0R(TypedArray<Dictionary>, _get_branch_list);
+	GDVIRTUAL0R(TypedArray<Dictionary>, _get_remotes);
 	GDVIRTUAL1(_create_branch, String);
 	GDVIRTUAL1(_remove_branch, String);
 	GDVIRTUAL2(_create_remote, String, String);
@@ -128,7 +128,7 @@ protected:
 	GDVIRTUAL1(_pull, String);
 	GDVIRTUAL2(_push, String, bool);
 	GDVIRTUAL1(_fetch, String);
-	GDVIRTUAL2R(Array, _get_line_diff, String, String);
+	GDVIRTUAL2R(TypedArray<Dictionary>, _get_line_diff, String, String);
 
 public:
 	static EditorVCSInterface *get_singleton();
@@ -171,8 +171,8 @@ public:
 	Dictionary create_diff_file(String p_new_file, String p_old_file);
 	Dictionary create_commit(String p_msg, String p_author, String p_id, int64_t p_unix_timestamp, int64_t p_offset_minutes);
 	Dictionary create_status_file(String p_file_path, ChangeType p_change, TreeArea p_area);
-	Dictionary add_line_diffs_into_diff_hunk(Dictionary p_diff_hunk, Array p_line_diffs);
-	Dictionary add_diff_hunks_into_diff_file(Dictionary p_diff_file, Array p_diff_hunks);
+	Dictionary add_line_diffs_into_diff_hunk(Dictionary p_diff_hunk, TypedArray<Dictionary> p_line_diffs);
+	Dictionary add_diff_hunks_into_diff_file(Dictionary p_diff_file, TypedArray<Dictionary> p_diff_hunks);
 
 	void popup_error(String p_msg);
 };

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -164,7 +164,7 @@ bool EditorImportPlugin::get_option_visibility(const String &p_path, const Strin
 
 Error EditorImportPlugin::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	Dictionary options;
-	Array platform_variants, gen_files;
+	TypedArray<String> platform_variants, gen_files;
 
 	HashMap<StringName, Variant>::ConstIterator E = p_options.begin();
 	while (E) {

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -51,7 +51,7 @@ protected:
 	GDVIRTUAL0RC(float, _get_priority)
 	GDVIRTUAL0RC(int, _get_import_order)
 	GDVIRTUAL3RC(bool, _get_option_visibility, String, StringName, Dictionary)
-	GDVIRTUAL5RC(int, _import, String, String, Dictionary, Array, Array)
+	GDVIRTUAL5RC(int, _import, String, String, Dictionary, TypedArray<String>, TypedArray<String>)
 
 public:
 	EditorImportPlugin();

--- a/modules/gltf/doc_classes/GLTFMesh.xml
+++ b/modules/gltf/doc_classes/GLTFMesh.xml
@@ -9,7 +9,7 @@
 	<members>
 		<member name="blend_weights" type="PackedFloat32Array" setter="set_blend_weights" getter="get_blend_weights" default="PackedFloat32Array()">
 		</member>
-		<member name="instance_materials" type="Array" setter="set_instance_materials" getter="get_instance_materials" default="[]">
+		<member name="instance_materials" type="Material[]" setter="set_instance_materials" getter="get_instance_materials" default="[]">
 		</member>
 		<member name="mesh" type="ImporterMesh" setter="set_mesh" getter="get_mesh">
 		</member>

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5007,7 +5007,7 @@ GLTFMeshIndex GLTFDocument::_convert_mesh_to_gltf(Ref<GLTFState> state, MeshInst
 
 	Ref<GLTFMesh> gltf_mesh;
 	gltf_mesh.instantiate();
-	Array instance_materials;
+	TypedArray<Material> instance_materials;
 	for (int32_t surface_i = 0; surface_i < current_mesh->get_surface_count(); surface_i++) {
 		Ref<Material> mat = current_mesh->get_surface_material(surface_i);
 		if (p_mesh_instance->get_surface_override_material(surface_i).is_valid()) {

--- a/modules/gltf/structures/gltf_mesh.cpp
+++ b/modules/gltf/structures/gltf_mesh.cpp
@@ -53,11 +53,11 @@ void GLTFMesh::set_mesh(Ref<ImporterMesh> p_mesh) {
 	mesh = p_mesh;
 }
 
-Array GLTFMesh::get_instance_materials() {
+TypedArray<Material> GLTFMesh::get_instance_materials() {
 	return instance_materials;
 }
 
-void GLTFMesh::set_instance_materials(Array p_instance_materials) {
+void GLTFMesh::set_instance_materials(TypedArray<Material> p_instance_materials) {
 	instance_materials = p_instance_materials;
 }
 

--- a/modules/gltf/structures/gltf_mesh.h
+++ b/modules/gltf/structures/gltf_mesh.h
@@ -42,7 +42,7 @@ class GLTFMesh : public Resource {
 private:
 	Ref<ImporterMesh> mesh;
 	Vector<float> blend_weights;
-	Array instance_materials;
+	TypedArray<Material> instance_materials;
 
 protected:
 	static void _bind_methods();
@@ -52,8 +52,8 @@ public:
 	void set_mesh(Ref<ImporterMesh> p_mesh);
 	Vector<float> get_blend_weights();
 	void set_blend_weights(Vector<float> p_blend_weights);
-	Array get_instance_materials();
-	void set_instance_materials(Array p_instance_materials);
+	TypedArray<Material> get_instance_materials();
+	void set_instance_materials(TypedArray<Material> p_instance_materials);
 };
 
 #endif // GLTF_MESH_H

--- a/modules/ogg/doc_classes/OggPacketSequence.xml
+++ b/modules/ogg/doc_classes/OggPacketSequence.xml
@@ -17,10 +17,10 @@
 		</method>
 	</methods>
 	<members>
-		<member name="granule_positions" type="Array" setter="set_packet_granule_positions" getter="get_packet_granule_positions" default="[]">
+		<member name="granule_positions" type="PackedInt64Array" setter="set_packet_granule_positions" getter="get_packet_granule_positions" default="PackedInt64Array()">
 			Contains the granule positions for each page in this packet sequence.
 		</member>
-		<member name="packet_data" type="Array" setter="set_packet_data" getter="get_packet_data" default="[]">
+		<member name="packet_data" type="Array[]" setter="set_packet_data" getter="get_packet_data" default="[]">
 			Contains the raw packets that make up this OggPacketSequence.
 		</member>
 		<member name="sampling_rate" type="float" setter="set_sampling_rate" getter="get_sampling_rate" default="0.0">

--- a/modules/ogg/ogg_packet_sequence.cpp
+++ b/modules/ogg/ogg_packet_sequence.cpp
@@ -41,7 +41,7 @@ void OggPacketSequence::push_page(int64_t p_granule_pos, const Vector<PackedByte
 	data_version++;
 }
 
-void OggPacketSequence::set_packet_data(const Array &p_data) {
+void OggPacketSequence::set_packet_data(const TypedArray<Array> &p_data) {
 	data_version++; // Update the data version so old playbacks know that they can't rely on us anymore.
 	page_data.clear();
 	for (int page_idx = 0; page_idx < p_data.size(); page_idx++) {
@@ -54,8 +54,8 @@ void OggPacketSequence::set_packet_data(const Array &p_data) {
 	}
 }
 
-Array OggPacketSequence::get_packet_data() const {
-	Array ret;
+TypedArray<Array> OggPacketSequence::get_packet_data() const {
+	TypedArray<Array> ret;
 	for (const Vector<PackedByteArray> &page : page_data) {
 		Array page_variant;
 		for (const PackedByteArray &packet : page) {
@@ -66,7 +66,7 @@ Array OggPacketSequence::get_packet_data() const {
 	return ret;
 }
 
-void OggPacketSequence::set_packet_granule_positions(const Array &p_granule_positions) {
+void OggPacketSequence::set_packet_granule_positions(const PackedInt64Array &p_granule_positions) {
 	data_version++; // Update the data version so old playbacks know that they can't rely on us anymore.
 	page_granule_positions.clear();
 	for (int page_idx = 0; page_idx < p_granule_positions.size(); page_idx++) {
@@ -75,8 +75,8 @@ void OggPacketSequence::set_packet_granule_positions(const Array &p_granule_posi
 	}
 }
 
-Array OggPacketSequence::get_packet_granule_positions() const {
-	Array ret;
+PackedInt64Array OggPacketSequence::get_packet_granule_positions() const {
+	PackedInt64Array ret;
 	for (int64_t granule_pos : page_granule_positions) {
 		ret.push_back(granule_pos);
 	}
@@ -127,8 +127,8 @@ void OggPacketSequence::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_length"), &OggPacketSequence::get_length);
 
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "packet_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_packet_data", "get_packet_data");
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "granule_positions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_packet_granule_positions", "get_packet_granule_positions");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "packet_data", PROPERTY_HINT_ARRAY_TYPE, "PackedByteArray", PROPERTY_USAGE_NO_EDITOR), "set_packet_data", "get_packet_data");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT64_ARRAY, "granule_positions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_packet_granule_positions", "get_packet_granule_positions");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sampling_rate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_sampling_rate", "get_sampling_rate");
 }
 

--- a/modules/ogg/ogg_packet_sequence.h
+++ b/modules/ogg/ogg_packet_sequence.h
@@ -67,11 +67,11 @@ public:
 	// This should be called for each page, even for pages that no packets ended on.
 	void push_page(int64_t p_granule_pos, const Vector<PackedByteArray> &p_data);
 
-	void set_packet_data(const Array &p_data);
-	Array get_packet_data() const;
+	void set_packet_data(const TypedArray<Array> &p_data);
+	TypedArray<Array> get_packet_data() const;
 
-	void set_packet_granule_positions(const Array &p_granule_positions);
-	Array get_packet_granule_positions() const;
+	void set_packet_granule_positions(const PackedInt64Array &p_granule_positions);
+	PackedInt64Array get_packet_granule_positions() const;
 
 	// Sets a sampling rate associated with this object. OggPacketSequence doesn't understand codecs,
 	// so this value is naively stored as a convenience.

--- a/modules/regex/doc_classes/RegExMatch.xml
+++ b/modules/regex/doc_classes/RegExMatch.xml
@@ -44,7 +44,7 @@
 		<member name="names" type="Dictionary" setter="" getter="get_names" default="{}">
 			A dictionary of named groups and its corresponding group number. Only groups that were matched are included. If multiple groups have the same name, that name would refer to the first matching one.
 		</member>
-		<member name="strings" type="Array" setter="" getter="get_strings" default="[]">
+		<member name="strings" type="PackedStringArray" setter="" getter="get_strings" default="PackedStringArray()">
 			An [Array] of the match and its capturing groups.
 		</member>
 		<member name="subject" type="String" setter="" getter="get_subject" default="&quot;&quot;">

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -82,8 +82,8 @@ Dictionary RegExMatch::get_names() const {
 	return result;
 }
 
-Array RegExMatch::get_strings() const {
-	Array result;
+PackedStringArray RegExMatch::get_strings() const {
+	PackedStringArray result;
 
 	int size = data.size();
 

--- a/modules/regex/regex.h
+++ b/modules/regex/regex.h
@@ -63,7 +63,7 @@ public:
 	int get_group_count() const;
 	Dictionary get_names() const;
 
-	Array get_strings() const;
+	PackedStringArray get_strings() const;
 	String get_string(const Variant &p_name) const;
 	int get_start(const Variant &p_name) const;
 	int get_end(const Variant &p_name) const;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -3823,7 +3823,7 @@ Variant TextServerAdvanced::shaped_get_span_meta(const RID &p_shaped, int64_t p_
 	return sd->spans[p_index].meta;
 }
 
-void TextServerAdvanced::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
+void TextServerAdvanced::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
 	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_COND(!sd);
 	ERR_FAIL_INDEX(p_index, sd->spans.size());
@@ -3844,7 +3844,7 @@ void TextServerAdvanced::shaped_set_span_update_font(const RID &p_shaped, int64_
 	}
 }
 
-bool TextServerAdvanced::shaped_text_add_string(const RID &p_shaped, const String &p_text, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
+bool TextServerAdvanced::shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
 	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_COND_V(!sd, false);
 	ERR_FAIL_COND_V(p_size <= 0, false);
@@ -5048,7 +5048,7 @@ _FORCE_INLINE_ void TextServerAdvanced::_add_featuers(const Dictionary &p_source
 	}
 }
 
-void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, Array p_fonts, int64_t p_span, int64_t p_fb_index) {
+void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index) {
 	int fs = p_sd->spans[p_span].font_size;
 	if (p_fb_index >= p_fonts.size()) {
 		// Add fallback glyphs.

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -407,7 +407,7 @@ class TextServerAdvanced : public TextServerExtension {
 	int64_t _convert_pos(const ShapedTextDataAdvanced *p_sd, int64_t p_pos) const;
 	int64_t _convert_pos_inv(const ShapedTextDataAdvanced *p_sd, int64_t p_pos) const;
 	bool _shape_substr(ShapedTextDataAdvanced *p_new_sd, const ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_length) const;
-	void _shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, Array p_fonts, int64_t p_span, int64_t p_fb_index);
+	void _shape_run(ShapedTextDataAdvanced *p_sd, int64_t p_start, int64_t p_end, hb_script_t p_script, hb_direction_t p_direction, TypedArray<RID> p_fonts, int64_t p_span, int64_t p_fb_index);
 	Glyph _shape_single_glyph(ShapedTextDataAdvanced *p_sd, char32_t p_char, hb_script_t p_script, hb_direction_t p_direction, const RID &p_font, int64_t p_font_size);
 
 	_FORCE_INLINE_ void _add_featuers(const Dictionary &p_source, Vector<hb_feature_t> &r_ftrs);
@@ -656,13 +656,13 @@ public:
 	virtual void shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) override;
 	virtual int64_t shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const override;
 
-	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) override;
+	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) override;
 	virtual bool shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int64_t p_length = 1) override;
 	virtual bool shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER) override;
 
 	virtual int64_t shaped_get_span_count(const RID &p_shaped) const override;
 	virtual Variant shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const override;
-	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) override;
+	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) override;
 
 	virtual RID shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const override;
 	virtual RID shaped_text_get_parent(const RID &p_shaped) const override;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -2792,7 +2792,7 @@ Variant TextServerFallback::shaped_get_span_meta(const RID &p_shaped, int64_t p_
 	return sd->spans[p_index].meta;
 }
 
-void TextServerFallback::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
+void TextServerFallback::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
 	ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_COND(!sd);
 	ERR_FAIL_INDEX(p_index, sd->spans.size());
@@ -2816,7 +2816,7 @@ void TextServerFallback::shaped_set_span_update_font(const RID &p_shaped, int64_
 	sd->valid = false;
 }
 
-bool TextServerFallback::shaped_text_add_string(const RID &p_shaped, const String &p_text, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
+bool TextServerFallback::shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
 	ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_COND_V(!sd, false);
 

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -535,13 +535,13 @@ public:
 	virtual void shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) override;
 	virtual int64_t shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const override;
 
-	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) override;
+	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) override;
 	virtual bool shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int64_t p_length = 1) override;
 	virtual bool shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER) override;
 
 	virtual int64_t shaped_get_span_count(const RID &p_shaped) const override;
 	virtual Variant shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const override;
-	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) override;
+	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) override;
 
 	virtual RID shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const override;
 	virtual RID shaped_text_get_parent(const RID &p_shaped) const override;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -753,11 +753,11 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 			MeshesFound &mf = meshes_found.write[m_i];
 
 			Size2i lightmap_size = mf.mesh->get_lightmap_size_hint() * mf.lightmap_scale;
-			Vector<RID> overrides;
+			TypedArray<RID> overrides;
 			overrides.resize(mf.overrides.size());
 			for (int i = 0; i < mf.overrides.size(); i++) {
 				if (mf.overrides[i].is_valid()) {
-					overrides.write[i] = mf.overrides[i]->get_rid();
+					overrides[i] = mf.overrides[i]->get_rid();
 				}
 			}
 			TypedArray<Image> images = RS::get_singleton()->bake_render_uv2(mf.mesh->get_rid(), overrides, lightmap_size);

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -154,7 +154,7 @@ Mesh::BlendShapeMode ImporterMesh::get_blend_shape_mode() const {
 	return blend_shape_mode;
 }
 
-void ImporterMesh::add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes, const Dictionary &p_lods, const Ref<Material> &p_material, const String &p_name, const uint32_t p_flags) {
+void ImporterMesh::add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes, const Dictionary &p_lods, const Ref<Material> &p_material, const String &p_name, const uint32_t p_flags) {
 	ERR_FAIL_COND(p_blend_shapes.size() != blend_shapes.size());
 	ERR_FAIL_COND(p_arrays.size() != Mesh::ARRAY_MAX);
 	Surface s;
@@ -1230,7 +1230,7 @@ void ImporterMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_blend_shape_mode", "mode"), &ImporterMesh::set_blend_shape_mode);
 	ClassDB::bind_method(D_METHOD("get_blend_shape_mode"), &ImporterMesh::get_blend_shape_mode);
 
-	ClassDB::bind_method(D_METHOD("add_surface", "primitive", "arrays", "blend_shapes", "lods", "material", "name", "flags"), &ImporterMesh::add_surface, DEFVAL(Array()), DEFVAL(Dictionary()), DEFVAL(Ref<Material>()), DEFVAL(String()), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("add_surface", "primitive", "arrays", "blend_shapes", "lods", "material", "name", "flags"), &ImporterMesh::add_surface, DEFVAL(TypedArray<Array>()), DEFVAL(Dictionary()), DEFVAL(Ref<Material>()), DEFVAL(String()), DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("get_surface_count"), &ImporterMesh::get_surface_count);
 	ClassDB::bind_method(D_METHOD("get_surface_primitive_type", "surface_idx"), &ImporterMesh::get_surface_primitive_type);

--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -93,7 +93,7 @@ public:
 	int get_blend_shape_count() const;
 	String get_blend_shape_name(int p_blend_shape) const;
 
-	void add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), const Ref<Material> &p_material = Ref<Material>(), const String &p_name = String(), const uint32_t p_flags = 0);
+	void add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), const Ref<Material> &p_material = Ref<Material>(), const String &p_name = String(), const uint32_t p_flags = 0);
 	int get_surface_count() const;
 
 	void set_blend_shape_mode(Mesh::BlendShapeMode p_blend_shape_mode);

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1614,7 +1614,7 @@ void ArrayMesh::add_surface(uint32_t p_format, PrimitiveType p_primitive, const 
 	emit_changed();
 }
 
-void ArrayMesh::add_surface_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes, const Dictionary &p_lods, uint32_t p_flags) {
+void ArrayMesh::add_surface_from_arrays(PrimitiveType p_primitive, const TypedArray<Array> &p_arrays, const TypedArray<Array> &p_blend_shapes, const Dictionary &p_lods, uint32_t p_flags) {
 	ERR_FAIL_COND(p_arrays.size() != ARRAY_MAX);
 
 	RS::SurfaceData surface;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -265,7 +265,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_surface_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const Array &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), uint32_t p_flags = 0);
+	void add_surface_from_arrays(PrimitiveType p_primitive, const TypedArray<Array> &p_arrays, const TypedArray<Array> &p_blend_shapes = TypedArray<Array>(), const Dictionary &p_lods = Dictionary(), uint32_t p_flags = 0);
 
 	void add_surface(uint32_t p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data = Vector<uint8_t>(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<RS::SurfaceData::LOD> &p_lods = Vector<RS::SurfaceData::LOD>());
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2955,7 +2955,7 @@ ImageTextureLayered::LayeredType ImageTextureLayered::get_layered_type() const {
 	return layered_type;
 }
 
-Error ImageTextureLayered::_create_from_images(const Array &p_images) {
+Error ImageTextureLayered::_create_from_images(const TypedArray<Image> &p_images) {
 	Vector<Ref<Image>> images;
 	for (int i = 0; i < p_images.size(); i++) {
 		Ref<Image> img = p_images[i];
@@ -2966,8 +2966,8 @@ Error ImageTextureLayered::_create_from_images(const Array &p_images) {
 	return create_from_images(images);
 }
 
-Array ImageTextureLayered::_get_images() const {
-	Array images;
+TypedArray<Image> ImageTextureLayered::_get_images() const {
+	TypedArray<Image> images;
 	for (int i = 0; i < layers; i++) {
 		images.push_back(get_layer_data(i));
 	}
@@ -3054,7 +3054,7 @@ void ImageTextureLayered::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_get_images"), &ImageTextureLayered::_get_images);
 
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_images", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_INTERNAL), "create_from_images", "_get_images");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_images", PROPERTY_HINT_ARRAY_TYPE, "Image", PROPERTY_USAGE_INTERNAL), "create_from_images", "_get_images");
 }
 
 ImageTextureLayered::ImageTextureLayered(LayeredType p_layered_type) {

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -422,9 +422,9 @@ class ImageTextureLayered : public TextureLayered {
 	int layers = 0;
 	bool mipmaps = false;
 
-	Error _create_from_images(const Array &p_images);
+	Error _create_from_images(const TypedArray<Image> &p_images);
 
-	Array _get_images() const;
+	TypedArray<Image> _get_images() const;
 
 protected:
 	static void _bind_methods();

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -148,7 +148,7 @@ PhysicsDirectBodyState2D::PhysicsDirectBodyState2D() {}
 
 ///////////////////////////////////////////////////////
 
-Ref<PhysicsRayQueryParameters2D> PhysicsRayQueryParameters2D::create(Vector2 p_from, Vector2 p_to, uint32_t p_mask, const Vector<RID> &p_exclude) {
+Ref<PhysicsRayQueryParameters2D> PhysicsRayQueryParameters2D::create(Vector2 p_from, Vector2 p_to, uint32_t p_mask, const TypedArray<RID> &p_exclude) {
 	Ref<PhysicsRayQueryParameters2D> params;
 	params.instantiate();
 	params->set_from(p_from);
@@ -158,25 +158,25 @@ Ref<PhysicsRayQueryParameters2D> PhysicsRayQueryParameters2D::create(Vector2 p_f
 	return params;
 }
 
-void PhysicsRayQueryParameters2D::set_exclude(const Vector<RID> &p_exclude) {
+void PhysicsRayQueryParameters2D::set_exclude(const TypedArray<RID> &p_exclude) {
 	parameters.exclude.clear();
 	for (int i = 0; i < p_exclude.size(); i++) {
 		parameters.exclude.insert(p_exclude[i]);
 	}
 }
 
-Vector<RID> PhysicsRayQueryParameters2D::get_exclude() const {
-	Vector<RID> ret;
+TypedArray<RID> PhysicsRayQueryParameters2D::get_exclude() const {
+	TypedArray<RID> ret;
 	ret.resize(parameters.exclude.size());
 	int idx = 0;
 	for (const RID &E : parameters.exclude) {
-		ret.write[idx++] = E;
+		ret[idx++] = E;
 	}
 	return ret;
 }
 
 void PhysicsRayQueryParameters2D::_bind_methods() {
-	ClassDB::bind_static_method("PhysicsRayQueryParameters2D", D_METHOD("create", "from", "to", "collision_mask", "exclude"), &PhysicsRayQueryParameters2D::create, DEFVAL(UINT32_MAX), DEFVAL(Vector<RID>()));
+	ClassDB::bind_static_method("PhysicsRayQueryParameters2D", D_METHOD("create", "from", "to", "collision_mask", "exclude"), &PhysicsRayQueryParameters2D::create, DEFVAL(UINT32_MAX), DEFVAL(TypedArray<RID>()));
 
 	ClassDB::bind_method(D_METHOD("set_from", "from"), &PhysicsRayQueryParameters2D::set_from);
 	ClassDB::bind_method(D_METHOD("get_from"), &PhysicsRayQueryParameters2D::get_from);
@@ -210,19 +210,19 @@ void PhysicsRayQueryParameters2D::_bind_methods() {
 
 ///////////////////////////////////////////////////////
 
-void PhysicsPointQueryParameters2D::set_exclude(const Vector<RID> &p_exclude) {
+void PhysicsPointQueryParameters2D::set_exclude(const TypedArray<RID> &p_exclude) {
 	parameters.exclude.clear();
 	for (int i = 0; i < p_exclude.size(); i++) {
 		parameters.exclude.insert(p_exclude[i]);
 	}
 }
 
-Vector<RID> PhysicsPointQueryParameters2D::get_exclude() const {
-	Vector<RID> ret;
+TypedArray<RID> PhysicsPointQueryParameters2D::get_exclude() const {
+	TypedArray<RID> ret;
 	ret.resize(parameters.exclude.size());
 	int idx = 0;
 	for (const RID &E : parameters.exclude) {
-		ret.write[idx++] = E;
+		ret[idx++] = E;
 	}
 	return ret;
 }
@@ -269,19 +269,19 @@ void PhysicsShapeQueryParameters2D::set_shape_rid(const RID &p_shape) {
 	}
 }
 
-void PhysicsShapeQueryParameters2D::set_exclude(const Vector<RID> &p_exclude) {
+void PhysicsShapeQueryParameters2D::set_exclude(const TypedArray<RID> &p_exclude) {
 	parameters.exclude.clear();
 	for (int i = 0; i < p_exclude.size(); i++) {
 		parameters.exclude.insert(p_exclude[i]);
 	}
 }
 
-Vector<RID> PhysicsShapeQueryParameters2D::get_exclude() const {
-	Vector<RID> ret;
+TypedArray<RID> PhysicsShapeQueryParameters2D::get_exclude() const {
+	TypedArray<RID> ret;
 	ret.resize(parameters.exclude.size());
 	int idx = 0;
 	for (const RID &E : parameters.exclude) {
-		ret.write[idx++] = E;
+		ret[idx++] = E;
 	}
 	return ret;
 }
@@ -461,21 +461,21 @@ void PhysicsDirectSpaceState2D::_bind_methods() {
 
 ///////////////////////////////
 
-Vector<RID> PhysicsTestMotionParameters2D::get_exclude_bodies() const {
-	Vector<RID> exclude;
+TypedArray<RID> PhysicsTestMotionParameters2D::get_exclude_bodies() const {
+	TypedArray<RID> exclude;
 	exclude.resize(parameters.exclude_bodies.size());
 
 	int body_index = 0;
 	for (RID body : parameters.exclude_bodies) {
-		exclude.write[body_index++] = body;
+		exclude[body_index++] = body;
 	}
 
 	return exclude;
 }
 
-void PhysicsTestMotionParameters2D::set_exclude_bodies(const Vector<RID> &p_exclude) {
-	for (RID body : p_exclude) {
-		parameters.exclude_bodies.insert(body);
+void PhysicsTestMotionParameters2D::set_exclude_bodies(const TypedArray<RID> &p_exclude) {
+	for (int i = 0; i < p_exclude.size(); i++) {
+		parameters.exclude_bodies.insert(p_exclude[i]);
 	}
 }
 

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -610,7 +610,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	static Ref<PhysicsRayQueryParameters2D> create(Vector2 p_from, Vector2 p_to, uint32_t p_mask, const Vector<RID> &p_exclude);
+	static Ref<PhysicsRayQueryParameters2D> create(Vector2 p_from, Vector2 p_to, uint32_t p_mask, const TypedArray<RID> &p_exclude);
 	const PhysicsDirectSpaceState2D::RayParameters &get_parameters() const { return parameters; }
 
 	void set_from(const Vector2 &p_from) { parameters.from = p_from; }
@@ -631,8 +631,8 @@ public:
 	void set_hit_from_inside(bool p_enable) { parameters.hit_from_inside = p_enable; }
 	bool is_hit_from_inside_enabled() const { return parameters.hit_from_inside; }
 
-	void set_exclude(const Vector<RID> &p_exclude);
-	Vector<RID> get_exclude() const;
+	void set_exclude(const TypedArray<RID> &p_exclude);
+	TypedArray<RID> get_exclude() const;
 };
 
 class PhysicsPointQueryParameters2D : public RefCounted {
@@ -661,8 +661,8 @@ public:
 	void set_collide_with_areas(bool p_enable) { parameters.collide_with_areas = p_enable; }
 	bool is_collide_with_areas_enabled() const { return parameters.collide_with_areas; }
 
-	void set_exclude(const Vector<RID> &p_exclude);
-	Vector<RID> get_exclude() const;
+	void set_exclude(const TypedArray<RID> &p_exclude);
+	TypedArray<RID> get_exclude() const;
 };
 
 class PhysicsShapeQueryParameters2D : public RefCounted {
@@ -702,8 +702,8 @@ public:
 	void set_collide_with_areas(bool p_enable) { parameters.collide_with_areas = p_enable; }
 	bool is_collide_with_areas_enabled() const { return parameters.collide_with_areas; }
 
-	void set_exclude(const Vector<RID> &p_exclude);
-	Vector<RID> get_exclude() const;
+	void set_exclude(const TypedArray<RID> &p_exclude);
+	TypedArray<RID> get_exclude() const;
 };
 
 class PhysicsTestMotionParameters2D : public RefCounted {
@@ -729,8 +729,8 @@ public:
 	bool is_collide_separation_ray_enabled() const { return parameters.collide_separation_ray; }
 	void set_collide_separation_ray_enabled(bool p_enabled) { parameters.collide_separation_ray = p_enabled; }
 
-	Vector<RID> get_exclude_bodies() const;
-	void set_exclude_bodies(const Vector<RID> &p_exclude);
+	TypedArray<RID> get_exclude_bodies() const;
+	void set_exclude_bodies(const TypedArray<RID> &p_exclude);
 
 	Array get_exclude_objects() const;
 	void set_exclude_objects(const Array &p_exclude);

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -206,7 +206,7 @@ public:
 	void sub_surface_scattering_set_quality(RS::SubSurfaceScatteringQuality p_quality) override {}
 	void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) override {}
 
-	TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) override { return TypedArray<Image>(); }
+	TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) override { return TypedArray<Image>(); }
 
 	bool free(RID p_rid) override {
 		if (is_environment(p_rid)) {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -4178,7 +4178,7 @@ float RendererSceneRenderRD::screen_space_roughness_limiter_get_limit() const {
 	return screen_space_roughness_limiter_limit;
 }
 
-TypedArray<Image> RendererSceneRenderRD::bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) {
+TypedArray<Image> RendererSceneRenderRD::bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) {
 	RD::TextureFormat tf;
 	tf.format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
 	tf.width = p_image_size.width; // Always 64x64

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -1216,7 +1216,7 @@ public:
 	int get_roughness_layers() const;
 	bool is_using_radiance_cubemap_array() const;
 
-	virtual TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) override;
+	virtual TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) override;
 
 	virtual bool free(RID p_rid) override;
 

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -312,7 +312,7 @@ public:
 
 	virtual void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) = 0;
 
-	virtual TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) = 0;
+	virtual TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) = 0;
 	virtual void voxel_gi_set_quality(RS::VoxelGIQuality) = 0;
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) = 0;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3999,7 +3999,7 @@ bool RendererSceneCull::free(RID p_rid) {
 	return true;
 }
 
-TypedArray<Image> RendererSceneCull::bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) {
+TypedArray<Image> RendererSceneCull::bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) {
 	return scene_render->bake_render_uv2(p_base, p_material_overrides, p_image_size);
 }
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1063,7 +1063,7 @@ public:
 	void render_particle_colliders();
 	virtual void render_probes();
 
-	TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size);
+	TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size);
 
 	//pass to scene render
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -350,7 +350,7 @@ public:
 	virtual void sub_surface_scattering_set_quality(RS::SubSurfaceScatteringQuality p_quality) = 0;
 	virtual void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) = 0;
 
-	virtual TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) = 0;
+	virtual TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) = 0;
 
 	virtual bool free(RID p_rid) = 0;
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -235,7 +235,7 @@ RID RenderingDevice::_shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv
 	return shader_create_from_spirv(stage_data);
 }
 
-RID RenderingDevice::_uniform_set_create(const Array &p_uniforms, RID p_shader, uint32_t p_shader_set) {
+RID RenderingDevice::_uniform_set_create(const TypedArray<RDUniform> &p_uniforms, RID p_shader, uint32_t p_shader_set) {
 	Vector<Uniform> uniforms;
 	uniforms.resize(p_uniforms.size());
 	for (int i = 0; i < p_uniforms.size(); i++) {

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -42,7 +42,7 @@ class RDSamplerState;
 class RDVertexAttribute;
 class RDShaderSource;
 class RDShaderSPIRV;
-class RDUniforms;
+class RDUniform;
 class RDPipelineRasterizationState;
 class RDPipelineMultisampleState;
 class RDPipelineDepthStencilState;
@@ -1288,7 +1288,7 @@ protected:
 	Vector<uint8_t> _shader_compile_binary_from_spirv(const Ref<RDShaderSPIRV> &p_bytecode, const String &p_shader_name = "");
 	RID _shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv, const String &p_shader_name = "");
 
-	RID _uniform_set_create(const Array &p_uniforms, RID p_shader, uint32_t p_shader_set);
+	RID _uniform_set_create(const TypedArray<RDUniform> &p_uniforms, RID p_shader, uint32_t p_shader_set);
 
 	Error _buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p_size, const Vector<uint8_t> &p_data, uint32_t p_post_barrier = BARRIER_MASK_ALL);
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -779,7 +779,7 @@ public:
 	FUNC2RC(Variant, instance_geometry_get_shader_uniform_default_value, RID, const StringName &)
 	FUNC2C(instance_geometry_get_shader_uniform_list, RID, List<PropertyInfo> *)
 
-	FUNC3R(TypedArray<Image>, bake_render_uv2, RID, const Vector<RID> &, const Size2i &)
+	FUNC3R(TypedArray<Image>, bake_render_uv2, RID, const TypedArray<RID> &, const Size2i &)
 
 	FUNC1(gi_set_use_half_resolution, bool)
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -95,7 +95,7 @@ PackedInt64Array RenderingServer::_instances_cull_ray_bind(const Vector3 &p_from
 	return to_int_array(ids);
 }
 
-PackedInt64Array RenderingServer::_instances_cull_convex_bind(const Array &p_convex, RID p_scenario) const {
+PackedInt64Array RenderingServer::_instances_cull_convex_bind(const TypedArray<Plane> &p_convex, RID p_scenario) const {
 	if (RSG::threaded) {
 		WARN_PRINT_ONCE("Using this function with a threaded renderer hurts performance, as it causes a server stall.");
 	}
@@ -1633,7 +1633,7 @@ TypedArray<Dictionary> RenderingServer::_instance_geometry_get_shader_uniform_li
 }
 
 TypedArray<Image> RenderingServer::_bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) {
-	Vector<RID> mat_overrides;
+	TypedArray<RID> mat_overrides;
 	for (int i = 0; i < p_material_overrides.size(); i++) {
 		mat_overrides.push_back(p_material_overrides[i]);
 	}

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1219,7 +1219,7 @@ public:
 
 	PackedInt64Array _instances_cull_aabb_bind(const AABB &p_aabb, RID p_scenario = RID()) const;
 	PackedInt64Array _instances_cull_ray_bind(const Vector3 &p_from, const Vector3 &p_to, RID p_scenario = RID()) const;
-	PackedInt64Array _instances_cull_convex_bind(const Array &p_convex, RID p_scenario = RID()) const;
+	PackedInt64Array _instances_cull_convex_bind(const TypedArray<Plane> &p_convex, RID p_scenario = RID()) const;
 
 	enum InstanceFlags {
 		INSTANCE_FLAG_USE_BAKED_LIGHT,
@@ -1265,7 +1265,7 @@ public:
 		BAKE_CHANNEL_EMISSION
 	};
 
-	virtual TypedArray<Image> bake_render_uv2(RID p_base, const Vector<RID> &p_material_overrides, const Size2i &p_image_size) = 0;
+	virtual TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) = 0;
 
 	/* CANVAS (2D) */
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -1136,7 +1136,7 @@ int64_t TextServerExtension::shaped_text_get_spacing(const RID &p_shaped, TextSe
 	return 0;
 }
 
-bool TextServerExtension::shaped_text_add_string(const RID &p_shaped, const String &p_text, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
+bool TextServerExtension::shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features, const String &p_language, const Variant &p_meta) {
 	bool ret;
 	if (GDVIRTUAL_CALL(shaped_text_add_string, p_shaped, p_text, p_fonts, p_size, p_opentype_features, p_language, p_meta, ret)) {
 		return ret;
@@ -1176,7 +1176,7 @@ Variant TextServerExtension::shaped_get_span_meta(const RID &p_shaped, int64_t p
 	return false;
 }
 
-void TextServerExtension::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
+void TextServerExtension::shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features) {
 	GDVIRTUAL_CALL(shaped_set_span_update_font, p_shaped, p_index, p_fonts, p_size, p_opentype_features);
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -378,19 +378,19 @@ public:
 	GDVIRTUAL3(shaped_text_set_spacing, RID, SpacingType, int64_t);
 	GDVIRTUAL2RC(int64_t, shaped_text_get_spacing, RID, SpacingType);
 
-	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) override;
+	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) override;
 	virtual bool shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int64_t p_length = 1) override;
 	virtual bool shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER) override;
-	GDVIRTUAL7R(bool, shaped_text_add_string, RID, const String &, const Array &, int64_t, const Dictionary &, const String &, const Variant &);
+	GDVIRTUAL7R(bool, shaped_text_add_string, RID, const String &, const TypedArray<RID> &, int64_t, const Dictionary &, const String &, const Variant &);
 	GDVIRTUAL5R(bool, shaped_text_add_object, RID, const Variant &, const Size2 &, InlineAlignment, int64_t);
 	GDVIRTUAL4R(bool, shaped_text_resize_object, RID, const Variant &, const Size2 &, InlineAlignment);
 
 	virtual int64_t shaped_get_span_count(const RID &p_shaped) const override;
 	virtual Variant shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const override;
-	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) override;
+	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) override;
 	GDVIRTUAL1RC(int64_t, shaped_get_span_count, RID);
 	GDVIRTUAL2RC(Variant, shaped_get_span_meta, RID, int64_t);
-	GDVIRTUAL5(shaped_set_span_update_font, RID, int64_t, const Array &, int64_t, const Dictionary &);
+	GDVIRTUAL5(shaped_set_span_update_font, RID, int64_t, const TypedArray<RID> &, int64_t, const Dictionary &);
 
 	virtual RID shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const override;
 	virtual RID shaped_text_get_parent(const RID &p_shaped) const override;

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -408,13 +408,13 @@ public:
 	virtual void shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) = 0;
 	virtual int64_t shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const = 0;
 
-	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) = 0;
+	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) = 0;
 	virtual bool shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int64_t p_length = 1) = 0;
 	virtual bool shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER) = 0;
 
 	virtual int64_t shaped_get_span_count(const RID &p_shaped) const = 0;
 	virtual Variant shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const = 0;
-	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const Array &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) = 0;
+	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) = 0;
 
 	virtual RID shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const = 0; // Copy shaped substring (e.g. line break) without reshaping, but correctly reordered, preservers range.
 	virtual RID shaped_text_get_parent(const RID &p_shaped) const = 0;


### PR DESCRIPTION
Follow-up to the #63959 series.

This PR changes method argumens from Array to TypedArray where applicable.

Also I changed a few return types; not sure if I missed them in the previous PRs or they were added afterwards. It would be nice to keep an eye on newly added methods and enforce TypedArray where possible.