### PR TITLE
Decrease StyleBoxFlat corner detail in editor theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -182,7 +182,7 @@ static Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left =
 	Ref<StyleBoxFlat> style(memnew(StyleBoxFlat));
 	style->set_bg_color(p_color);
 	// Adjust level of detail based on the corners' effective sizes.
-	style->set_corner_detail(Math::ceil(1.5 * p_corner_width * EDSCALE));
+	style->set_corner_detail(Math::ceil(0.8 * p_corner_width * EDSCALE));
 	style->set_corner_radius_all(p_corner_width * EDSCALE);
 	style->set_default_margin(SIDE_LEFT, p_margin_left * EDSCALE);
 	style->set_default_margin(SIDE_RIGHT, p_margin_right * EDSCALE);
@@ -593,7 +593,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_default = make_flat_stylebox(base_color, default_margin_size, default_margin_size, default_margin_size, default_margin_size, corner_width);
 	style_default->set_border_width_all(border_width);
 	style_default->set_border_color(base_color);
-	style_default->set_draw_center(true);
 
 	// Button and widgets
 	const float extra_spacing = EDITOR_GET("interface/theme/additional_spacing");
@@ -661,10 +660,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tab_base->set_border_width_all(0);
 	// Don't round the top corners to avoid creating a small blank space between the tabs and the main panel.
 	// This also makes the top highlight look better.
-	style_tab_base->set_corner_detail(corner_width);
-	style_tab_base->set_corner_radius_all(0);
-	style_tab_base->set_corner_radius(CORNER_TOP_LEFT, corner_radius * EDSCALE);
-	style_tab_base->set_corner_radius(CORNER_TOP_RIGHT, corner_radius * EDSCALE);
+	style_tab_base->set_corner_radius(CORNER_BOTTOM_LEFT, 0);
+	style_tab_base->set_corner_radius(CORNER_BOTTOM_RIGHT, 0);
 
 	// Prevent visible artifacts and cover the top-left rounded corner of the panel below the tab if selected
 	// We can't prevent them with both rounded corners and non-zero border width, though
@@ -1650,6 +1647,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	graphsbselected->set_border_width(SIDE_TOP, 24 * EDSCALE);
 	graphsbcomment->set_border_width(SIDE_TOP, 24 * EDSCALE);
 	graphsbcommentselected->set_border_width(SIDE_TOP, 24 * EDSCALE);
+
+	graphsb->set_corner_detail(corner_radius * EDSCALE);
+	graphsbselected->set_corner_detail(corner_radius * EDSCALE);
+	graphsbcomment->set_corner_detail(corner_radius * EDSCALE);
+	graphsbcommentselected->set_corner_detail(corner_radius * EDSCALE);
 
 	theme->set_stylebox("frame", "GraphNode", graphsb);
 	theme->set_stylebox("selected_frame", "GraphNode", graphsbselected);


### PR DESCRIPTION
Decreases the corner detail of editor theme StyleBoxFlats from `Math::ceil(1.5 * p_corner_width * EDSCALE)` to `Math::ceil(0.8 * p_corner_width * EDSCALE)`. This improves the performance of the editor because the hundreds of StyleBoxes require generating and rendering far fewer points while having the same appearance.

The corner detail of the GraphNode panel StyleBoxes is set to `corner_radius` so that they still look good when the GraphEdit is zoomed in.

**Corner Detail Comparison:**
| Corner Radius | Before | After |
---|---|---
| 3 (default) | 5 | 3 |
| 4 | 6 | 4 |
| 6 | 9 | 5 |