### PR TITLE
Rework AnimatedTexture's `fps` into `base_delay`

### DIFF
--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[AnimatedTexture] is a resource format for frame-based animations, where multiple textures can be chained automatically with a predefined delay for each frame. Unlike [AnimationPlayer] or [AnimatedSprite2D], it isn't a [Node], but has the advantage of being usable anywhere a [Texture2D] resource can be used, e.g. in a [TileSet].
-		The playback of the animation is controlled by the [member fps] property as well as each frame's optional delay (see [method set_frame_delay]). The animation loops, i.e. it will restart at frame 0 automatically after playing the last frame.
+		The playback of the animation is controlled by the [member base_delay] property as well as each frame's optional delay (see [method set_frame_delay]). The animation loops, i.e. it will restart at frame 0 automatically after playing the last frame.
 		[AnimatedTexture] currently requires all frame textures to have the same size, otherwise the bigger ones will be cropped to match the smallest one.
 		[b]Note:[/b] AnimatedTexture doesn't support using [AtlasTexture]s. Each frame needs to be a separate [Texture2D].
 	</description>
@@ -31,14 +31,7 @@
 			<param index="0" name="frame" type="int" />
 			<param index="1" name="delay" type="float" />
 			<description>
-				Sets an additional delay (in seconds) between this frame and the next one, that will be added to the time interval defined by [member fps]. By default, frames have no delay defined. If a delay value is defined, the final time interval between this frame and the next will be [code]1.0 / fps + delay[/code].
-				For example, for an animation with 3 frames, 2 FPS and a frame delay on the second frame of 1.2, the resulting playback will be:
-				[codeblock]
-				Frame 0: 0.5 s (1 / fps)
-				Frame 1: 1.7 s (1 / fps + 1.2)
-				Frame 2: 0.5 s (1 / fps)
-				Total duration: 2.7 s
-				[/codeblock]
+				Sets an additional delay (in seconds) between this frame and the next one, that will be added to the time interval defined by [member base_delay]. By default, frames have no delay defined. If a delay value is defined, the final time interval between this frame and the next will be [code]base_delay + delay[/code].
 			</description>
 		</method>
 		<method name="set_frame_texture">
@@ -52,12 +45,11 @@
 		</method>
 	</methods>
 	<members>
+		<member name="base_delay" type="float" setter="set_base_delay" getter="get_base_delay" default="0.0">
+			The time all frames take to switch to the next frame, in seconds. This property does not include the additional delay that may have been set for each frame (see [method set_frame_delay]).
+		</member>
 		<member name="current_frame" type="int" setter="set_current_frame" getter="get_current_frame">
 			Sets the currently visible frame of the texture.
-		</member>
-		<member name="fps" type="float" setter="set_fps" getter="get_fps" default="4.0">
-			Animation speed in frames per second. This value defines the default time interval between two frames of the animation, and thus the overall duration of the animation loop based on the [member frames] property. A value of 0 means no predefined number of frames per second, the animation will play according to each frame's frame delay (see [method set_frame_delay]).
-			For example, an animation with 8 frames, no frame delay and a [code]fps[/code] value of 2 will run for 4 seconds, with each frame lasting 0.5 seconds.
 		</member>
 		<member name="frames" type="int" setter="set_frames" getter="get_frames" default="1">
 			Number of frames to use in the animation. While you can create the frames independently with [method set_frame_texture], you need to set this value for the animation to take new frames into account. The maximum number of frames is [constant MAX_FRAMES].

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2617,17 +2617,9 @@ void AnimatedTexture::_update_proxy() {
 
 	time += delta;
 
-	float limit;
-
-	if (fps == 0) {
-		limit = 0;
-	} else {
-		limit = 1.0 / fps;
-	}
-
 	int iter_max = frame_count;
 	while (iter_max && !pause) {
-		float frame_limit = limit + frames[current_frame].delay_sec;
+		float frame_limit = base_delay + frames[current_frame].delay;
 
 		if (time > frame_limit) {
 			current_frame++;
@@ -2715,7 +2707,7 @@ void AnimatedTexture::set_frame_delay(int p_frame, float p_delay_sec) {
 
 	RWLockRead r(rw_lock);
 
-	frames[p_frame].delay_sec = p_delay_sec;
+	frames[p_frame].delay = p_delay_sec;
 }
 
 float AnimatedTexture::get_frame_delay(int p_frame) const {
@@ -2723,17 +2715,17 @@ float AnimatedTexture::get_frame_delay(int p_frame) const {
 
 	RWLockRead r(rw_lock);
 
-	return frames[p_frame].delay_sec;
+	return frames[p_frame].delay;
 }
 
-void AnimatedTexture::set_fps(float p_fps) {
-	ERR_FAIL_COND(p_fps < 0 || p_fps >= 1000);
+void AnimatedTexture::set_base_delay(float p_base_delay) {
+	ERR_FAIL_COND(p_base_delay < 0 || p_base_delay >= 1000);
 
-	fps = p_fps;
+	base_delay = p_base_delay;
 }
 
-float AnimatedTexture::get_fps() const {
-	return fps;
+float AnimatedTexture::get_base_delay() const {
+	return base_delay;
 }
 
 int AnimatedTexture::get_width() const {
@@ -2812,8 +2804,8 @@ void AnimatedTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_oneshot", "oneshot"), &AnimatedTexture::set_oneshot);
 	ClassDB::bind_method(D_METHOD("get_oneshot"), &AnimatedTexture::get_oneshot);
 
-	ClassDB::bind_method(D_METHOD("set_fps", "fps"), &AnimatedTexture::set_fps);
-	ClassDB::bind_method(D_METHOD("get_fps"), &AnimatedTexture::get_fps);
+	ClassDB::bind_method(D_METHOD("set_base_delay", "base_delay"), &AnimatedTexture::set_base_delay);
+	ClassDB::bind_method(D_METHOD("get_base_delay"), &AnimatedTexture::get_base_delay);
 
 	ClassDB::bind_method(D_METHOD("set_frame_texture", "frame", "texture"), &AnimatedTexture::set_frame_texture);
 	ClassDB::bind_method(D_METHOD("get_frame_texture", "frame"), &AnimatedTexture::get_frame_texture);
@@ -2825,11 +2817,11 @@ void AnimatedTexture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_frame", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_current_frame", "get_current_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pause"), "set_pause", "get_pause");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "oneshot"), "set_oneshot", "get_oneshot");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fps", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_fps", "get_fps");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "base_delay", PROPERTY_HINT_RANGE, "0,16,0.01,or_greater,suffix:s"), "set_base_delay", "get_base_delay");
 
 	for (int i = 0; i < MAX_FRAMES; i++) {
 		ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "frame_" + itos(i) + "/texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_frame_texture", "get_frame_texture", i);
-		ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "frame_" + itos(i) + "/delay_sec", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,suffix:s", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_frame_delay", "get_frame_delay", i);
+		ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "frame_" + itos(i) + "/delay", PROPERTY_HINT_RANGE, "0.0,16.0,0.01,or_greater,suffix:s", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "set_frame_delay", "get_frame_delay", i);
 	}
 
 	BIND_CONSTANT(MAX_FRAMES);

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -922,7 +922,7 @@ private:
 
 	struct Frame {
 		Ref<Texture2D> texture;
-		float delay_sec = 0.0;
+		float delay = 1.0;
 	};
 
 	Frame frames[MAX_FRAMES];
@@ -930,7 +930,7 @@ private:
 	int current_frame = 0;
 	bool pause = false;
 	bool oneshot = false;
-	float fps = 4.0;
+	float base_delay = 0.0;
 
 	float time = 0.0;
 
@@ -961,8 +961,8 @@ public:
 	void set_frame_delay(int p_frame, float p_delay_sec);
 	float get_frame_delay(int p_frame) const;
 
-	void set_fps(float p_fps);
-	float get_fps() const;
+	void set_base_delay(float p_fps);
+	float get_base_delay() const;
 
 	virtual int get_width() const override;
 	virtual int get_height() const override;


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/65188.

As lightly mentioned in https://github.com/godotengine/godot/pull/64657 while updating the description, the `fps` property in **AnimatedTexture** has somewhat confusing behaviour. Mainly, it *is* expressed in frames per seconds, yet each individual frame's delay is expressed in seconds, making it a confusing soup to work with, and explain in the documentation, despite being such a simple concept.
This PR attempts to address that.

`fps` has been turned into `base_delay`.
`frame_n/delay_sec` has been renamed to `frame_n/delay` _(prefixes exist, making the previous name redundant)_.

![image](https://user-images.githubusercontent.com/66727710/187851852-cc330a49-01c7-4cc1-9e95-a4f119ad1dea.png)

This is more so an experiment, a test, for the other PR. See https://github.com/godotengine/godot/pull/65188.