### PR TITLE
Replace Vector2 and Vector2i with Size2 and Size2i

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -416,8 +416,8 @@ int Image::get_height() const {
 	return height;
 }
 
-Vector2i Image::get_size() const {
-	return Vector2i(width, height);
+Size2i Image::get_size() const {
+	return Size2i(width, height);
 }
 
 bool Image::has_mipmaps() const {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -209,7 +209,7 @@ private:
 public:
 	int get_width() const; ///< Get image width
 	int get_height() const; ///< Get image height
-	Vector2i get_size() const;
+	Size2i get_size() const;
 	bool has_mipmaps() const;
 	int get_mipmap_count() const;
 

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -57,7 +57,7 @@ static real_t heuristic_chebyshev(const Vector2i &p_from, const Vector2i &p_to) 
 
 static real_t (*heuristics[AStarGrid2D::HEURISTIC_MAX])(const Vector2i &, const Vector2i &) = { heuristic_manhattan, heuristic_euclidian, heuristic_octile, heuristic_chebyshev };
 
-void AStarGrid2D::set_size(const Vector2i &p_size) {
+void AStarGrid2D::set_size(const Size2i &p_size) {
 	ERR_FAIL_COND(p_size.x < 0 || p_size.y < 0);
 	if (p_size != size) {
 		size = p_size;
@@ -65,7 +65,7 @@ void AStarGrid2D::set_size(const Vector2i &p_size) {
 	}
 }
 
-Vector2i AStarGrid2D::get_size() const {
+Size2i AStarGrid2D::get_size() const {
 	return size;
 }
 
@@ -80,14 +80,14 @@ Vector2 AStarGrid2D::get_offset() const {
 	return offset;
 }
 
-void AStarGrid2D::set_cell_size(const Vector2 &p_cell_size) {
+void AStarGrid2D::set_cell_size(const Size2 &p_cell_size) {
 	if (!cell_size.is_equal_approx(p_cell_size)) {
 		cell_size = p_cell_size;
 		dirty = true;
 	}
 }
 
-Vector2 AStarGrid2D::get_cell_size() const {
+Size2 AStarGrid2D::get_cell_size() const {
 	return cell_size;
 }
 

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -58,9 +58,9 @@ public:
 	};
 
 private:
-	Vector2i size;
+	Size2i size;
 	Vector2 offset;
-	Vector2 cell_size = Vector2(1, 1);
+	Size2 cell_size = Size2(1, 1);
 	bool dirty = false;
 
 	bool jumping_enabled = false;
@@ -136,14 +136,14 @@ protected:
 	GDVIRTUAL2RC(real_t, _compute_cost, Vector2i, Vector2i)
 
 public:
-	void set_size(const Vector2i &p_size);
-	Vector2i get_size() const;
+	void set_size(const Size2i &p_size);
+	Size2i get_size() const;
 
 	void set_offset(const Vector2 &p_offset);
 	Vector2 get_offset() const;
 
-	void set_cell_size(const Vector2 &p_cell_size);
-	Vector2 get_cell_size() const;
+	void set_cell_size(const Size2 &p_cell_size);
+	Size2 get_cell_size() const;
 
 	void update();
 

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -186,21 +186,21 @@ ArrayOccluder3D::~ArrayOccluder3D() {
 
 /////////////////////////////////////////////////
 
-void QuadOccluder3D::set_size(const Vector2 &p_size) {
+void QuadOccluder3D::set_size(const Size2 &p_size) {
 	if (size == p_size) {
 		return;
 	}
 
-	size = p_size.max(Vector2());
+	size = p_size.max(Size2());
 	_update();
 }
 
-Vector2 QuadOccluder3D::get_size() const {
+Size2 QuadOccluder3D::get_size() const {
 	return size;
 }
 
 void QuadOccluder3D::_update_arrays(PackedVector3Array &r_vertices, PackedInt32Array &r_indices) {
-	Vector2 _size = Vector2(size.x / 2.0f, size.y / 2.0f);
+	Size2 _size = Size2(size.x / 2.0f, size.y / 2.0f);
 
 	r_vertices = {
 		Vector3(-_size.x, -_size.y, 0),

--- a/scene/3d/occluder_instance_3d.h
+++ b/scene/3d/occluder_instance_3d.h
@@ -88,15 +88,15 @@ class QuadOccluder3D : public Occluder3D {
 	GDCLASS(QuadOccluder3D, Occluder3D);
 
 private:
-	Vector2 size = Vector2(1.0f, 1.0f);
+	Size2 size = Vector2(1.0f, 1.0f);
 
 protected:
 	virtual void _update_arrays(PackedVector3Array &r_vertices, PackedInt32Array &r_indices) override;
 	static void _bind_methods();
 
 public:
-	Vector2 get_size() const;
-	void set_size(const Vector2 &p_size);
+	Size2 get_size() const;
+	void set_size(const Size2 &p_size);
 
 	QuadOccluder3D();
 	~QuadOccluder3D();

--- a/scene/resources/rectangle_shape_2d.cpp
+++ b/scene/resources/rectangle_shape_2d.cpp
@@ -41,7 +41,7 @@ void RectangleShape2D::_update_shape() {
 bool RectangleShape2D::_set(const StringName &p_name, const Variant &p_value) {
 	if (p_name == "extents") { // Compatibility with Godot 3.x.
 		// Convert to `size`, twice as big.
-		set_size((Vector2)p_value * 2);
+		set_size((Size2)p_value * 2);
 		return true;
 	}
 	return false;
@@ -57,13 +57,13 @@ bool RectangleShape2D::_get(const StringName &p_name, Variant &r_property) const
 }
 #endif // DISABLE_DEPRECATED
 
-void RectangleShape2D::set_size(const Vector2 &p_size) {
+void RectangleShape2D::set_size(const Size2 &p_size) {
 	ERR_FAIL_COND_MSG(p_size.x < 0 || p_size.y < 0, "RectangleShape2D size cannot be negative.");
 	size = p_size;
 	_update_shape();
 }
 
-Vector2 RectangleShape2D::get_size() const {
+Size2 RectangleShape2D::get_size() const {
 	return size;
 }
 
@@ -106,6 +106,6 @@ void RectangleShape2D::_bind_methods() {
 
 RectangleShape2D::RectangleShape2D() :
 		Shape2D(PhysicsServer2D::get_singleton()->rectangle_shape_create()) {
-	size = Vector2(20, 20);
+	size = Size2(20, 20);
 	_update_shape();
 }

--- a/scene/resources/rectangle_shape_2d.h
+++ b/scene/resources/rectangle_shape_2d.h
@@ -36,7 +36,7 @@
 class RectangleShape2D : public Shape2D {
 	GDCLASS(RectangleShape2D, Shape2D);
 
-	Vector2 size;
+	Size2 size;
 	void _update_shape();
 
 protected:
@@ -47,8 +47,8 @@ protected:
 #endif // DISABLE_DEPRECATED
 
 public:
-	void set_size(const Vector2 &p_size);
-	Vector2 get_size() const;
+	void set_size(const Size2 &p_size);
+	Size2 get_size() const;
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) override;
 	virtual Rect2 get_rect() const override;

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -118,7 +118,7 @@ void TileMapPattern::remove_cell(const Vector2i &p_coords, bool p_update_size) {
 
 	pattern.erase(p_coords);
 	if (p_update_size) {
-		size = Vector2i();
+		size = Size2i();
 		for (const KeyValue<Vector2i, TileMapCell> &E : pattern) {
 			size = size.max(E.key + Vector2i(1, 1));
 		}
@@ -157,11 +157,11 @@ TypedArray<Vector2i> TileMapPattern::get_used_cells() const {
 	return a;
 }
 
-Vector2i TileMapPattern::get_size() const {
+Size2i TileMapPattern::get_size() const {
 	return size;
 }
 
-void TileMapPattern::set_size(const Vector2i &p_size) {
+void TileMapPattern::set_size(const Size2i &p_size) {
 	for (const KeyValue<Vector2i, TileMapCell> &E : pattern) {
 		Vector2i coords = E.key;
 		if (p_size.x <= coords.x || p_size.y <= coords.y) {
@@ -178,7 +178,7 @@ bool TileMapPattern::is_empty() const {
 };
 
 void TileMapPattern::clear() {
-	size = Vector2i();
+	size = Size2i();
 	pattern.clear();
 	emit_changed();
 };

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -117,7 +117,7 @@ union TileMapCell {
 class TileMapPattern : public Resource {
 	GDCLASS(TileMapPattern, Resource);
 
-	Vector2i size;
+	Size2i size;
 	HashMap<Vector2i, TileMapCell> pattern;
 
 	void _set_tile_data(const Vector<int> &p_data);
@@ -140,8 +140,8 @@ public:
 
 	TypedArray<Vector2i> get_used_cells() const;
 
-	Vector2i get_size() const;
-	void set_size(const Vector2i &p_size);
+	Size2i get_size() const;
+	void set_size(const Size2i &p_size);
 	bool is_empty() const;
 
 	void clear();

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3855,11 +3855,11 @@ VisualShaderNodeUniform::VisualShaderNodeUniform() {
 
 ////////////// ResizeableBase
 
-void VisualShaderNodeResizableBase::set_size(const Vector2 &p_size) {
+void VisualShaderNodeResizableBase::set_size(const Size2 &p_size) {
 	size = p_size;
 }
 
-Vector2 VisualShaderNodeResizableBase::get_size() const {
+Size2 VisualShaderNodeResizableBase::get_size() const {
 	return size;
 }
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -612,15 +612,15 @@ class VisualShaderNodeResizableBase : public VisualShaderNode {
 	GDCLASS(VisualShaderNodeResizableBase, VisualShaderNode);
 
 protected:
-	Vector2 size = Size2(0, 0);
+	Size2 size = Size2(0, 0);
 	bool allow_v_resize = true;
 
 protected:
 	static void _bind_methods();
 
 public:
-	void set_size(const Vector2 &p_size);
-	Vector2 get_size() const;
+	void set_size(const Size2 &p_size);
+	Size2 get_size() const;
 
 	bool is_allow_v_resize() const;
 	void set_allow_v_resize(bool p_enabled);


### PR DESCRIPTION
Changed get_size and set_size to use the Size2 typedefs

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
