### PR TITLE
Rework AnimatedTexture's `fps` into `speed_scale`

### DIFF
--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -5,18 +5,18 @@
 	</brief_description>
 	<description>
 		[AnimatedTexture] is a resource format for frame-based animations, where multiple textures can be chained automatically with a predefined delay for each frame. Unlike [AnimationPlayer] or [AnimatedSprite2D], it isn't a [Node], but has the advantage of being usable anywhere a [Texture2D] resource can be used, e.g. in a [TileSet].
-		The playback of the animation is controlled by the [member fps] property as well as each frame's optional delay (see [method set_frame_delay]). The animation loops, i.e. it will restart at frame 0 automatically after playing the last frame.
+		The playback of the animation is controlled by the [member speed_scale] property, as well as each frame's duration (see [method set_frame_duration]). The animation loops, i.e. it will restart at frame 0 automatically after playing the last frame.
 		[AnimatedTexture] currently requires all frame textures to have the same size, otherwise the bigger ones will be cropped to match the smallest one.
 		[b]Note:[/b] AnimatedTexture doesn't support using [AtlasTexture]s. Each frame needs to be a separate [Texture2D].
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_frame_delay" qualifiers="const">
+		<method name="get_frame_duration" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="frame" type="int" />
 			<description>
-				Returns the given frame's delay value.
+				Returns the given [param frame]'s duration, in seconds.
 			</description>
 		</method>
 		<method name="get_frame_texture" qualifiers="const">
@@ -26,19 +26,12 @@
 				Returns the given frame's [Texture2D].
 			</description>
 		</method>
-		<method name="set_frame_delay">
+		<method name="set_frame_duration">
 			<return type="void" />
 			<param index="0" name="frame" type="int" />
-			<param index="1" name="delay" type="float" />
+			<param index="1" name="duration" type="float" />
 			<description>
-				Sets an additional delay (in seconds) between this frame and the next one, that will be added to the time interval defined by [member fps]. By default, frames have no delay defined. If a delay value is defined, the final time interval between this frame and the next will be [code]1.0 / fps + delay[/code].
-				For example, for an animation with 3 frames, 2 FPS and a frame delay on the second frame of 1.2, the resulting playback will be:
-				[codeblock]
-				Frame 0: 0.5 s (1 / fps)
-				Frame 1: 1.7 s (1 / fps + 1.2)
-				Frame 2: 0.5 s (1 / fps)
-				Total duration: 2.7 s
-				[/codeblock]
+				Sets the duration of any given [param frame]. The final duration is affected by the [member speed_scale]. If set to [code]0[/code], the frame is skipped during playback.
 			</description>
 		</method>
 		<method name="set_frame_texture">
@@ -55,10 +48,6 @@
 		<member name="current_frame" type="int" setter="set_current_frame" getter="get_current_frame">
 			Sets the currently visible frame of the texture.
 		</member>
-		<member name="fps" type="float" setter="set_fps" getter="get_fps" default="4.0">
-			Animation speed in frames per second. This value defines the default time interval between two frames of the animation, and thus the overall duration of the animation loop based on the [member frames] property. A value of 0 means no predefined number of frames per second, the animation will play according to each frame's frame delay (see [method set_frame_delay]).
-			For example, an animation with 8 frames, no frame delay and a [code]fps[/code] value of 2 will run for 4 seconds, with each frame lasting 0.5 seconds.
-		</member>
 		<member name="frames" type="int" setter="set_frames" getter="get_frames" default="1">
 			Number of frames to use in the animation. While you can create the frames independently with [method set_frame_texture], you need to set this value for the animation to take new frames into account. The maximum number of frames is [constant MAX_FRAMES].
 		</member>
@@ -67,6 +56,9 @@
 		</member>
 		<member name="pause" type="bool" setter="set_pause" getter="get_pause" default="false">
 			If [code]true[/code], the animation will pause where it currently is (i.e. at [member current_frame]). The animation will continue from where it was paused when changing this property to [code]false[/code].
+		</member>
+		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
+			The animation speed is multiplied by this value. If set to a negative value, the animation is played in reverse.
 		</member>
 	</members>
 	<constants>

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -922,7 +922,7 @@ private:
 
 	struct Frame {
 		Ref<Texture2D> texture;
-		float delay_sec = 0.0;
+		float duration = 1.0;
 	};
 
 	Frame frames[MAX_FRAMES];
@@ -930,7 +930,7 @@ private:
 	int current_frame = 0;
 	bool pause = false;
 	bool one_shot = false;
-	float fps = 4.0;
+	float speed_scale = 1.0;
 
 	float time = 0.0;
 
@@ -958,11 +958,11 @@ public:
 	void set_frame_texture(int p_frame, const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_frame_texture(int p_frame) const;
 
-	void set_frame_delay(int p_frame, float p_delay_sec);
-	float get_frame_delay(int p_frame) const;
+	void set_frame_duration(int p_frame, float p_duration);
+	float get_frame_duration(int p_frame) const;
 
-	void set_fps(float p_fps);
-	float get_fps() const;
+	void set_speed_scale(float p_scale);
+	float get_speed_scale() const;
 
 	virtual int get_width() const override;
 	virtual int get_height() const override;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5311.
Alternative to https://github.com/godotengine/godot/pull/65182.

As lightly mentioned in https://github.com/godotengine/godot/pull/64657 while updating the description, the `fps` property in **AnimatedTexture** has somewhat confusing behaviour. Mainly, it *is* expressed in frames per seconds, yet each individual frame's delay is expressed in seconds, making it a confusing soup to work with, and explain in the documentation, despite being such a simple concept.
This PR attempts to address that, but as a more major overhaul.

`fps` has been turned into `speed_scale`. It now affects the speed scale of the entire animation, exactly like **AnimatedSprite2D**, and AnimationPlayer's `playback_speed`.
As a bonus, very akin to https://github.com/godotengine/godot/pull/65148 If `speed_scale` is a negative value, the animation **is played in reverse**!

| Showcase | Showcase (reverse) |
| --- | --- |
| ![Showcase 1](https://user-images.githubusercontent.com/66727710/187890340-ff97d3c2-b3d3-4135-86c7-ae8613821e65.gif) | ![Showcase 2](https://user-images.githubusercontent.com/66727710/187890742-d35f7162-4561-4e16-818e-0a9d075ea91a.gif) |

Each individual frame's `delay_sec` has been renamed to `duration` _(prefixes and documentation exist, making the previous name redundant)_. Furthermore, it's defaulted to 1.

Setters and getters, documentation updated, too.

_Bugsquad edit:_
Closes https://github.com/godotengine/godot-proposals/issues/4742
Closes https://github.com/godotengine/godot/pull/64657
Closes https://github.com/godotengine/godot/pull/65182