### PR TITLE
Rename AnimatedTexture's `oneshot` to `one_shot`

### DIFF
--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -62,7 +62,7 @@
 		<member name="frames" type="int" setter="set_frames" getter="get_frames" default="1">
 			Number of frames to use in the animation. While you can create the frames independently with [method set_frame_texture], you need to set this value for the animation to take new frames into account. The maximum number of frames is [constant MAX_FRAMES].
 		</member>
-		<member name="oneshot" type="bool" setter="set_oneshot" getter="get_oneshot" default="false">
+		<member name="one_shot" type="bool" setter="set_one_shot" getter="get_one_shot" default="false">
 			If [code]true[/code], the animation will only play once and will not loop back to the first frame after reaching the end. Note that reaching the end will not set [member pause] to [code]true[/code].
 		</member>
 		<member name="pause" type="bool" setter="set_pause" getter="get_pause" default="false">

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -289,8 +289,8 @@ bool ConnectDialog::get_deferred() const {
 	return deferred->is_pressed();
 }
 
-bool ConnectDialog::get_oneshot() const {
-	return oneshot->is_pressed();
+bool ConnectDialog::get_one_shot() const {
+	return one_shot->is_pressed();
 }
 
 /*
@@ -325,7 +325,7 @@ void ConnectDialog::init(ConnectionData p_cd, bool p_edit) {
 	bool b_oneshot = (p_cd.flags & CONNECT_ONESHOT) == CONNECT_ONESHOT;
 
 	deferred->set_pressed(b_deferred);
-	oneshot->set_pressed(b_oneshot);
+	one_shot->set_pressed(b_oneshot);
 
 	MethodInfo r_signal;
 	Ref<Script> source_script = source->get_script();
@@ -484,11 +484,11 @@ ConnectDialog::ConnectDialog() {
 	deferred->set_tooltip_text(TTR("Defers the signal, storing it in a queue and only firing it at idle time."));
 	vbc_right->add_child(deferred);
 
-	oneshot = memnew(CheckBox);
-	oneshot->set_h_size_flags(0);
-	oneshot->set_text(TTR("Oneshot"));
-	oneshot->set_tooltip_text(TTR("Disconnects the signal after its first emission."));
-	vbc_right->add_child(oneshot);
+	one_shot = memnew(CheckBox);
+	one_shot->set_h_size_flags(0);
+	one_shot->set_text(TTR("Oneshot"));
+	one_shot->set_tooltip_text(TTR("Disconnects the signal after its first emission."));
+	vbc_right->add_child(one_shot);
 
 	cdbinds = memnew(ConnectDialogBinds);
 
@@ -564,7 +564,7 @@ void ConnectionsDock::_make_or_edit_connection() {
 		cd.binds = connect_dialog->get_binds();
 	}
 	bool b_deferred = connect_dialog->get_deferred();
-	bool b_oneshot = connect_dialog->get_oneshot();
+	bool b_oneshot = connect_dialog->get_one_shot();
 	cd.flags = CONNECT_PERSIST | (b_deferred ? CONNECT_DEFERRED : 0) | (b_oneshot ? CONNECT_ONESHOT : 0);
 
 	// Conditions to add function: must have a script and must not have the method already

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -121,7 +121,7 @@ private:
 	EditorInspector *bind_editor = nullptr;
 	OptionButton *type_list = nullptr;
 	CheckBox *deferred = nullptr;
-	CheckBox *oneshot = nullptr;
+	CheckBox *one_shot = nullptr;
 	CheckButton *advanced = nullptr;
 	Vector<Control *> bind_controls;
 
@@ -153,7 +153,7 @@ public:
 	Vector<Variant> get_binds() const;
 
 	bool get_deferred() const;
-	bool get_oneshot() const;
+	bool get_one_shot() const;
 	bool is_editing() const;
 
 	void init(ConnectionData p_cd, bool p_edit = false);

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -331,6 +331,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "get_network_peer", "get_multiplayer_peer" }, // Multiplayer API
 	{ "get_network_unique_id", "get_unique_id" }, // Multiplayer API
 	{ "get_ok", "get_ok_button" }, // AcceptDialog
+	{ "get_oneshot", "get_one_shot" }, // AnimatedTexture
 	{ "get_option_visibility", "_get_option_visibility" }, // EditorImportPlugin
 	{ "get_parameter_default_value", "_get_parameter_default_value" }, // AnimationNode
 	{ "get_parameter_list", "_get_parameter_list" }, // AnimationNode
@@ -506,6 +507,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "set_mid_height", "set_height" }, // CapsuleMesh
 	{ "set_network_master", "set_multiplayer_authority" }, // Node
 	{ "set_network_peer", "set_multiplayer_peer" }, // Multiplayer API
+	{ "set_oneshot", "set_one_shot" }, // AnimatedTexture
 	{ "set_pause_mode", "set_process_mode" }, // Node
 	{ "set_physical_scancode", "set_physical_keycode" }, // InputEventKey
 	{ "set_refuse_new_network_connections", "set_refuse_new_connections" }, // Multiplayer API
@@ -747,6 +749,7 @@ static const char *csharp_function_renames[][2] = {
 	{ "GetNetworkMaster", "GetMultiplayerAuthority" }, // Node
 	{ "GetNetworkPeer", "GetMultiplayerPeer" }, // Multiplayer API
 	{ "GetNetworkUniqueId", "GetUniqueId" }, // Multiplayer API
+	{ "GetOneshot", "GetOneShot" }, // AnimatedTexture
 	{ "GetOk", "GetOkButton" }, // AcceptDialog
 	{ "GetOptionVisibility", "_GetOptionVisibility" }, // EditorImportPlugin
 	{ "GetParameterDefaultValue", "_GetParameterDefaultValue" }, // AnimationNode
@@ -913,6 +916,7 @@ static const char *csharp_function_renames[][2] = {
 	{ "SetMidHeight", "SetHeight" }, // CapsuleMesh
 	{ "SetNetworkMaster", "SetMultiplayerAuthority" }, // Node
 	{ "SetNetworkPeer", "SetMultiplayerPeer" }, // Multiplayer API
+	{ "SetOneshot", "SetOneShot" }, // AnimatedTexture
 	{ "SetPhysicalScancode", "SetPhysicalKeycode" }, // InputEventKey
 	{ "SetRefuseNewNetworkConnections", "SetRefuseNewConnections" }, // Multiplayer API
 	{ "SetRegion", "SetRegionEnabled" }, // Sprite2D, Sprite broke AtlasTexture
@@ -1051,6 +1055,7 @@ static const char *gdscript_properties_renames[][2] = {
 	{ "offset_h", "drag_horizontal_offset" }, // Camera2D
 	{ "offset_v", "drag_vertical_offset" }, // Camera2D
 	{ "ofs", "offset" }, // Theme
+	{ "oneshot", "one_shot" }, // AnimatedTexture
 	{ "out_of_range_mode", "max_polyphony" }, // AudioStreamPlayer3D
 	{ "pause_mode", "process_mode" }, // Node
 	{ "physical_scancode", "physical_keycode" }, // InputEventKey
@@ -1144,6 +1149,7 @@ static const char *csharp_properties_renames[][2] = {
 	{ "OffsetH", "DragHorizontalOffset" }, // Camera2D
 	{ "OffsetV", "DragVerticalOffset" }, // Camera2D
 	{ "Ofs", "Offset" }, // Theme
+	{ "Oneshot", "OneShot" }, // AnimatedTexture
 	{ "OutOfRangeMode", "MaxPolyphony" }, // AudioStreamPlayer3D
 	{ "PauseMode", "ProcessMode" }, // Node
 	{ "PhysicalScancode", "PhysicalKeycode" }, // InputEventKey

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2632,7 +2632,7 @@ void AnimatedTexture::_update_proxy() {
 		if (time > frame_limit) {
 			current_frame++;
 			if (current_frame >= frame_count) {
-				if (oneshot) {
+				if (one_shot) {
 					current_frame = frame_count - 1;
 				} else {
 					current_frame = 0;
@@ -2684,13 +2684,13 @@ bool AnimatedTexture::get_pause() const {
 	return pause;
 }
 
-void AnimatedTexture::set_oneshot(bool p_oneshot) {
+void AnimatedTexture::set_one_shot(bool p_one_shot) {
 	RWLockWrite r(rw_lock);
-	oneshot = p_oneshot;
+	one_shot = p_one_shot;
 }
 
-bool AnimatedTexture::get_oneshot() const {
-	return oneshot;
+bool AnimatedTexture::get_one_shot() const {
+	return one_shot;
 }
 
 void AnimatedTexture::set_frame_texture(int p_frame, const Ref<Texture2D> &p_texture) {
@@ -2809,8 +2809,8 @@ void AnimatedTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pause", "pause"), &AnimatedTexture::set_pause);
 	ClassDB::bind_method(D_METHOD("get_pause"), &AnimatedTexture::get_pause);
 
-	ClassDB::bind_method(D_METHOD("set_oneshot", "oneshot"), &AnimatedTexture::set_oneshot);
-	ClassDB::bind_method(D_METHOD("get_oneshot"), &AnimatedTexture::get_oneshot);
+	ClassDB::bind_method(D_METHOD("set_one_shot", "one_shot"), &AnimatedTexture::set_one_shot);
+	ClassDB::bind_method(D_METHOD("get_one_shot"), &AnimatedTexture::get_one_shot);
 
 	ClassDB::bind_method(D_METHOD("set_fps", "fps"), &AnimatedTexture::set_fps);
 	ClassDB::bind_method(D_METHOD("get_fps"), &AnimatedTexture::get_fps);
@@ -2824,7 +2824,7 @@ void AnimatedTexture::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "frames", PROPERTY_HINT_RANGE, "1," + itos(MAX_FRAMES), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_frames", "get_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_frame", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_current_frame", "get_current_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pause"), "set_pause", "get_pause");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "oneshot"), "set_oneshot", "get_oneshot");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_shot"), "set_one_shot", "get_one_shot");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fps", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_fps", "get_fps");
 
 	for (int i = 0; i < MAX_FRAMES; i++) {

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -929,7 +929,7 @@ private:
 	int frame_count = 1.0;
 	int current_frame = 0;
 	bool pause = false;
-	bool oneshot = false;
+	bool one_shot = false;
 	float fps = 4.0;
 
 	float time = 0.0;
@@ -952,8 +952,8 @@ public:
 	void set_pause(bool p_pause);
 	bool get_pause() const;
 
-	void set_oneshot(bool p_oneshot);
-	bool get_oneshot() const;
+	void set_one_shot(bool p_one_shot);
+	bool get_one_shot() const;
 
 	void set_frame_texture(int p_frame, const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_frame_texture(int p_frame) const;


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/65197.

Every other exposed `one_shot` is spaced out like this:

![image](https://user-images.githubusercontent.com/66727710/187924952-20d08c50-b4ec-413f-a0fa-21e952cb18ef.png)

So, for consistency:

**AnimatedTexture**.`oneshot` -> `one_shot`