### PR TITLE
Open the directory where the project was exported to in the default file manager

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -473,6 +473,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/autoscan_project_path", "", "")
 	const String fs_dir_default_project_path = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/default_project_path", fs_dir_default_project_path, "")
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_GLOBAL_DIR, "filesystem/directories/export_path/open_export_directory", true, "");
 
 	// On save
 	_initial_set("filesystem/on_save/compress_binary_resources", true);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -391,6 +391,18 @@ void ProjectExportDialog::_update_parameters(const String &p_edited_property) {
 	_update_current_preset();
 }
 
+void ProjectExportDialog::open_export_dir(const String &p_path, int err) {
+	bool open_export_dir = EditorSettings::get_singleton()->get_setting("filesystem/directories/export_path/open_export_directory");
+
+	if (DisplayServer::get_singleton()->get_name() == "headless") {
+		return;
+	}
+
+	if (open_export_dir && err == OK) {
+		OS::get_singleton()->shell_open(p_path.get_base_dir());
+	}
+}
+
 void ProjectExportDialog::_runnable_pressed() {
 	if (updating) {
 		return;
@@ -839,11 +851,14 @@ void ProjectExportDialog::_export_pck_zip_selected(const String &p_path) {
 	Ref<EditorExportPlatform> platform = current->get_platform();
 	ERR_FAIL_COND(platform.is_null());
 
+	Error err;
 	if (p_path.ends_with(".zip")) {
-		platform->export_zip(current, export_pck_zip_debug->is_pressed(), p_path);
+		err = platform->export_zip(current, export_pck_zip_debug->is_pressed(), p_path);
 	} else if (p_path.ends_with(".pck")) {
-		platform->export_pack(current, export_pck_zip_debug->is_pressed(), p_path);
+		err = platform->export_pack(current, export_pck_zip_debug->is_pressed(), p_path);
 	}
+
+	open_export_dir(p_path, err);
 }
 
 void ProjectExportDialog::_open_export_template_manager() {
@@ -929,6 +944,7 @@ void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 			result_dialog->popup_centered_ratio(0.5);
 		}
 	}
+	open_export_dir(p_path, err);
 }
 
 void ProjectExportDialog::_export_all_dialog() {

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -96,6 +96,8 @@ private:
 
 	String default_filename;
 
+	void open_export_dir(const String &p_path, int err);
+
 	void _runnable_pressed();
 	void _update_parameters(const String &p_edited_property);
 	void _name_changed(const String &p_string);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2535,6 +2535,18 @@ String EditorExportPlatformAndroid::join_list(List<String> parts, const String &
 	return ret;
 }
 
+void EditorExportPlatformAndroid::open_export_dir(const String &p_path, int err) {
+	bool open_export_dir = EditorSettings::get_singleton()->get_setting("filesystem/directories/export_path/open_export_directory");
+
+	if (DisplayServer::get_singleton()->get_name() == "headless") {
+		return;
+	}
+
+	if (open_export_dir && err == OK) {
+		OS::get_singleton()->shell_open(p_path.get_base_dir());
+	}
+}
+
 Error EditorExportPlatformAndroid::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
 	int export_format = int(p_preset->get("custom_build/export_format"));
 	bool should_sign = p_preset->get("package/signed");
@@ -3119,6 +3131,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		}
 	}
 
+	open_export_dir(p_path, err);
 	CLEANUP_AND_RETURN(OK);
 }
 

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -230,6 +230,8 @@ public:
 
 	String join_list(List<String> parts, const String &separator) const;
 
+	void open_export_dir(const String& p_path, int err);
+
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
 
 	Error export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int export_format, bool should_sign, int p_flags);

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1832,8 +1832,20 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 #else
 	print_line(".ipa can only be built on macOS. Leaving Xcode project without building the package.");
 #endif
-
+	open_export_dir(p_path, err);
 	return OK;
+}
+
+void EditorExportPlatformIOS::open_export_dir(const String &p_path, int err) {
+	bool open_export_dir = EditorSettings::get_singleton()->get_setting("filesystem/directories/export_path/open_export_directory");
+
+	if (DisplayServer::get_singleton()->get_name() == "headless") {
+		return;
+	}
+
+	if (open_export_dir && err == OK) {
+		OS::get_singleton()->shell_open(p_path.get_base_dir());
+	}
 }
 
 bool EditorExportPlatformIOS::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -201,7 +201,7 @@ public:
 		return list;
 	}
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
-
+	void open_export_dir(const String& p_path, int err);
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
 

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -253,6 +253,19 @@ bool EditorExportPlatformUWP::has_valid_project_configuration(const Ref<EditorEx
 	return valid;
 }
 
+
+void EditorExportPlatformUWP::open_export_dir(const String &p_path, int err) {
+	bool open_export_dir = EditorSettings::get_singleton()->get_setting("filesystem/directories/export_path/open_export_directory");
+
+	if (DisplayServer::get_singleton()->get_name() == "headless") {
+		return;
+	}
+
+	if (open_export_dir && err == OK) {
+		OS::get_singleton()->shell_open(p_path.get_base_dir());
+	}
+}
+
 Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
@@ -491,7 +504,7 @@ Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_p
 
 	OS::get_singleton()->execute(signtool_path, args);
 #endif // WINDOWS_ENABLED
-
+	open_export_dir(p_path, err);
 	return OK;
 }
 

--- a/platform/uwp/export/export_plugin.h
+++ b/platform/uwp/export/export_plugin.h
@@ -431,6 +431,7 @@ public:
 
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const override;
+	void open_export_dir(const String &p_path, int err);
 
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

redid pr #58511

Feature now works for Android&Web, ios&uwp should be working too
also `--headless` arg is now respected and file manager wont be opened when exporting from the terminal

*This closes https://github.com/godotengine/godot-proposals/issues/4114.*