### PR TITLE
doc: Clarifying NavigationAgent and NavigationAgent2D velocity_computed requires avoidance_enabled to be true to emit

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -165,7 +165,7 @@
 		<signal name="velocity_computed">
 			<param index="0" name="safe_velocity" type="Vector3" />
 			<description>
-				Notifies when the collision avoidance velocity is calculated. Emitted by [method set_velocity].
+				Notifies when the collision avoidance velocity is calculated. Emitted by [method set_velocity]. Only emitted when [member avoidance_enabled] is true.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -171,7 +171,7 @@
 		<signal name="velocity_computed">
 			<param index="0" name="safe_velocity" type="Vector3" />
 			<description>
-				Notifies when the collision avoidance velocity is calculated. Emitted by [method set_velocity].
+				Notifies when the collision avoidance velocity is calculated. Emitted by [method set_velocity]. Only emitted when [member avoidance_enabled] is true.
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
velocity_computed is only emitted when avoidance_enabled is true, which its false by default. Clarifying in the class reference that it won't be emitted if avoidance enabled is false.

