### PR TITLE
Simplify network GDExtension bindings using EXBIND macros.

### DIFF
--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -152,40 +152,22 @@ void PacketPeer::_bind_methods() {
 
 /***************/
 
-int PacketPeerExtension::get_available_packet_count() const {
-	int count;
-	if (GDVIRTUAL_CALL(_get_available_packet_count, count)) {
-		return count;
-	}
-	WARN_PRINT_ONCE("PacketPeerExtension::_get_available_packet_count is unimplemented!");
-	return -1;
-}
-
 Error PacketPeerExtension::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
-	int err;
+	Error err;
 	if (GDVIRTUAL_CALL(_get_packet, r_buffer, &r_buffer_size, err)) {
-		return (Error)err;
+		return err;
 	}
 	WARN_PRINT_ONCE("PacketPeerExtension::_get_packet_native is unimplemented!");
 	return FAILED;
 }
 
 Error PacketPeerExtension::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
-	int err;
+	Error err;
 	if (GDVIRTUAL_CALL(_put_packet, p_buffer, p_buffer_size, err)) {
-		return (Error)err;
+		return err;
 	}
 	WARN_PRINT_ONCE("PacketPeerExtension::_put_packet_native is unimplemented!");
 	return FAILED;
-}
-
-int PacketPeerExtension::get_max_packet_size() const {
-	int size;
-	if (GDVIRTUAL_CALL(_get_max_packet_size, size)) {
-		return size;
-	}
-	WARN_PRINT_ONCE("PacketPeerExtension::_get_max_packet_size is unimplemented!");
-	return 0;
 }
 
 void PacketPeerExtension::_bind_methods() {

--- a/core/io/packet_peer.h
+++ b/core/io/packet_peer.h
@@ -35,6 +35,7 @@
 #include "core/object/class_db.h"
 #include "core/templates/ring_buffer.h"
 
+#include "core/extension/ext_wrappers.gen.inc"
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/script_language.h"
 #include "core/variant/native_ptr.h"
@@ -84,16 +85,14 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual int get_available_packet_count() const override;
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
-	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	virtual int get_max_packet_size() const override;
+	GDVIRTUAL2R(Error, _get_packet, GDNativeConstPtr<const uint8_t *>, GDNativePtr<int>);
 
-	/* GDExtension */
-	GDVIRTUAL0RC(int, _get_available_packet_count);
-	GDVIRTUAL2R(int, _get_packet, GDNativeConstPtr<const uint8_t *>, GDNativePtr<int>);
-	GDVIRTUAL2R(int, _put_packet, GDNativeConstPtr<const uint8_t>, int);
-	GDVIRTUAL0RC(int, _get_max_packet_size);
+	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
+	GDVIRTUAL2R(Error, _put_packet, GDNativeConstPtr<const uint8_t>, int);
+
+	EXBIND0RC(int, get_available_packet_count);
+	EXBIND0RC(int, get_max_packet_size);
 };
 
 class PacketPeerStream : public PacketPeer {

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -410,48 +410,39 @@ void StreamPeer::_bind_methods() {
 
 ////////////////////////////////
 
-int StreamPeerExtension::get_available_bytes() const {
-	int count;
-	if (GDVIRTUAL_CALL(_get_available_bytes, count)) {
-		return count;
-	}
-	WARN_PRINT_ONCE("StreamPeerExtension::_get_available_bytes is unimplemented!");
-	return -1;
-}
-
 Error StreamPeerExtension::get_data(uint8_t *r_buffer, int p_bytes) {
-	int err;
+	Error err;
 	int received = 0;
 	if (GDVIRTUAL_CALL(_get_data, r_buffer, p_bytes, &received, err)) {
-		return (Error)err;
+		return err;
 	}
 	WARN_PRINT_ONCE("StreamPeerExtension::_get_data is unimplemented!");
 	return FAILED;
 }
 
 Error StreamPeerExtension::get_partial_data(uint8_t *r_buffer, int p_bytes, int &r_received) {
-	int err;
+	Error err;
 	if (GDVIRTUAL_CALL(_get_partial_data, r_buffer, p_bytes, &r_received, err)) {
-		return (Error)err;
+		return err;
 	}
 	WARN_PRINT_ONCE("StreamPeerExtension::_get_partial_data is unimplemented!");
 	return FAILED;
 }
 
 Error StreamPeerExtension::put_data(const uint8_t *p_data, int p_bytes) {
-	int err;
+	Error err;
 	int sent = 0;
 	if (GDVIRTUAL_CALL(_put_data, p_data, p_bytes, &sent, err)) {
-		return (Error)err;
+		return err;
 	}
 	WARN_PRINT_ONCE("StreamPeerExtension::_put_data is unimplemented!");
 	return FAILED;
 }
 
 Error StreamPeerExtension::put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) {
-	int err;
+	Error err;
 	if (GDVIRTUAL_CALL(_put_data, p_data, p_bytes, &r_sent, err)) {
-		return (Error)err;
+		return err;
 	}
 	WARN_PRINT_ONCE("StreamPeerExtension::_put_partial_data is unimplemented!");
 	return FAILED;

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -33,6 +33,7 @@
 
 #include "core/object/ref_counted.h"
 
+#include "core/extension/ext_wrappers.gen.inc"
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/script_language.h"
 #include "core/variant/native_ptr.h"
@@ -104,16 +105,18 @@ protected:
 
 public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes) override;
-	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;
-	virtual Error get_data(uint8_t *p_buffer, int p_bytes) override;
-	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
-	virtual int get_available_bytes() const override;
+	GDVIRTUAL3R(Error, _put_data, GDNativeConstPtr<const uint8_t>, int, GDNativePtr<int>);
 
-	GDVIRTUAL3R(int, _put_data, GDNativeConstPtr<const uint8_t>, int, GDNativePtr<int>);
-	GDVIRTUAL3R(int, _put_partial_data, GDNativeConstPtr<const uint8_t>, int, GDNativePtr<int>);
-	GDVIRTUAL3R(int, _get_data, GDNativePtr<uint8_t>, int, GDNativePtr<int>);
-	GDVIRTUAL3R(int, _get_partial_data, GDNativePtr<uint8_t>, int, GDNativePtr<int>);
-	GDVIRTUAL0RC(int, _get_available_bytes);
+	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;
+	GDVIRTUAL3R(Error, _put_partial_data, GDNativeConstPtr<const uint8_t>, int, GDNativePtr<int>);
+
+	virtual Error get_data(uint8_t *p_buffer, int p_bytes) override;
+	GDVIRTUAL3R(Error, _get_data, GDNativePtr<uint8_t>, int, GDNativePtr<int>);
+
+	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
+	GDVIRTUAL3R(Error, _get_partial_data, GDNativePtr<uint8_t>, int, GDNativePtr<int>);
+
+	EXBIND0RC(int, get_available_bytes);
 };
 
 class StreamPeerBuffer : public StreamPeer {

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -16,7 +16,7 @@
 			</description>
 		</method>
 		<method name="_get_connection_status" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="MultiplayerPeer.ConnectionStatus" />
 			<description>
 				Called when the connection status is requested on the [MultiplayerPeer] (see [method MultiplayerPeer.get_connection_status]).
 			</description>
@@ -28,7 +28,7 @@
 			</description>
 		</method>
 		<method name="_get_packet" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="const uint8_t **" />
 			<param index="1" name="r_buffer_size" type="int32_t*" />
 			<description>
@@ -54,7 +54,7 @@
 			</description>
 		</method>
 		<method name="_get_transfer_mode" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="MultiplayerPeer.TransferMode" />
 			<description>
 				Called when the transfer mode to use is read on this [MultiplayerPeer] (see [member MultiplayerPeer.transfer_mode]).
 			</description>
@@ -78,13 +78,13 @@
 			</description>
 		</method>
 		<method name="_poll" qualifiers="virtual">
-			<return type="int" />
+			<return type="void" />
 			<description>
 				Called when the [MultiplayerAPI] is polled. See [method MultiplayerAPI.poll].
 			</description>
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_buffer" type="const uint8_t*" />
 			<param index="1" name="p_buffer_size" type="int" />
 			<description>
@@ -92,7 +92,7 @@
 			</description>
 		</method>
 		<method name="_put_packet_script" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_buffer" type="PackedByteArray" />
 			<description>
 				Called when a packet needs to be sent by the [MultiplayerAPI], if [method _put_packet] isn't implemented. Use this when extending this class via GDScript.
@@ -121,7 +121,7 @@
 		</method>
 		<method name="_set_transfer_mode" qualifiers="virtual">
 			<return type="void" />
-			<param index="0" name="p_mode" type="int" />
+			<param index="0" name="p_mode" type="int" enum="MultiplayerPeer.TransferMode" />
 			<description>
 				Called when the transfer mode is set on this [MultiplayerPeer] (see [member MultiplayerPeer.transfer_mode]).
 			</description>

--- a/doc/classes/PacketPeerExtension.xml
+++ b/doc/classes/PacketPeerExtension.xml
@@ -18,14 +18,14 @@
 			</description>
 		</method>
 		<method name="_get_packet" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="const uint8_t **" />
 			<param index="1" name="r_buffer_size" type="int32_t*" />
 			<description>
 			</description>
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_buffer" type="const uint8_t*" />
 			<param index="1" name="p_buffer_size" type="int" />
 			<description>

--- a/doc/classes/StreamPeerExtension.xml
+++ b/doc/classes/StreamPeerExtension.xml
@@ -13,7 +13,7 @@
 			</description>
 		</method>
 		<method name="_get_data" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="uint8_t*" />
 			<param index="1" name="r_bytes" type="int" />
 			<param index="2" name="r_received" type="int32_t*" />
@@ -21,7 +21,7 @@
 			</description>
 		</method>
 		<method name="_get_partial_data" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="uint8_t*" />
 			<param index="1" name="r_bytes" type="int" />
 			<param index="2" name="r_received" type="int32_t*" />
@@ -29,7 +29,7 @@
 			</description>
 		</method>
 		<method name="_put_data" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_data" type="const uint8_t*" />
 			<param index="1" name="p_bytes" type="int" />
 			<param index="2" name="r_sent" type="int32_t*" />
@@ -37,7 +37,7 @@
 			</description>
 		</method>
 		<method name="_put_partial_data" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_data" type="const uint8_t*" />
 			<param index="1" name="p_bytes" type="int" />
 			<param index="2" name="r_sent" type="int32_t*" />

--- a/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
@@ -48,7 +48,7 @@
 			</description>
 		</method>
 		<method name="_get_packet" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="r_buffer" type="const uint8_t **" />
 			<param index="1" name="r_buffer_size" type="int32_t*" />
 			<description>
@@ -60,12 +60,12 @@
 			</description>
 		</method>
 		<method name="_get_ready_state" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="WebRTCDataChannel.ChannelState" />
 			<description>
 			</description>
 		</method>
 		<method name="_get_write_mode" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="WebRTCDataChannel.WriteMode" />
 			<description>
 			</description>
 		</method>
@@ -80,12 +80,12 @@
 			</description>
 		</method>
 		<method name="_poll" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<description>
 			</description>
 		</method>
 		<method name="_put_packet" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_buffer" type="const uint8_t*" />
 			<param index="1" name="p_buffer_size" type="int" />
 			<description>
@@ -93,7 +93,7 @@
 		</method>
 		<method name="_set_write_mode" qualifiers="virtual">
 			<return type="void" />
-			<param index="0" name="p_write_mode" type="int" />
+			<param index="0" name="p_write_mode" type="int" enum="WebRTCDataChannel.WriteMode" />
 			<description>
 			</description>
 		</method>

--- a/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
@@ -8,7 +8,7 @@
 	</tutorials>
 	<methods>
 		<method name="_add_ice_candidate" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_sdp_mid_name" type="String" />
 			<param index="1" name="p_sdp_mline_index" type="int" />
 			<param index="2" name="p_sdp_name" type="String" />
@@ -28,35 +28,35 @@
 			</description>
 		</method>
 		<method name="_create_offer" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<description>
 			</description>
 		</method>
 		<method name="_get_connection_state" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="WebRTCPeerConnection.ConnectionState" />
 			<description>
 			</description>
 		</method>
 		<method name="_initialize" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_config" type="Dictionary" />
 			<description>
 			</description>
 		</method>
 		<method name="_poll" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<description>
 			</description>
 		</method>
 		<method name="_set_local_description" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_type" type="String" />
 			<param index="1" name="p_sdp" type="String" />
 			<description>
 			</description>
 		</method>
 		<method name="_set_remote_description" qualifiers="virtual">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="p_type" type="String" />
 			<param index="1" name="p_sdp" type="String" />
 			<description>

--- a/modules/webrtc/webrtc_data_channel_extension.cpp
+++ b/modules/webrtc/webrtc_data_channel_extension.cpp
@@ -56,160 +56,20 @@ void WebRTCDataChannelExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_buffered_amount);
 }
 
-int WebRTCDataChannelExtension::get_available_packet_count() const {
-	int count;
-	if (GDVIRTUAL_CALL(_get_available_packet_count, count)) {
-		return count;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_available_packet_count is unimplemented!");
-	return -1;
-}
-
 Error WebRTCDataChannelExtension::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
-	int err;
+	Error err;
 	if (GDVIRTUAL_CALL(_get_packet, r_buffer, &r_buffer_size, err)) {
-		return (Error)err;
+		return err;
 	}
 	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_packet_native is unimplemented!");
 	return FAILED;
 }
 
 Error WebRTCDataChannelExtension::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
-	int err;
+	Error err;
 	if (GDVIRTUAL_CALL(_put_packet, p_buffer, p_buffer_size, err)) {
-		return (Error)err;
+		return err;
 	}
 	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_put_packet_native is unimplemented!");
 	return FAILED;
-}
-
-int WebRTCDataChannelExtension::get_max_packet_size() const {
-	int size;
-	if (GDVIRTUAL_CALL(_get_max_packet_size, size)) {
-		return size;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_max_packet_size is unimplemented!");
-	return 0;
-}
-
-Error WebRTCDataChannelExtension::poll() {
-	int err;
-	if (GDVIRTUAL_CALL(_poll, err)) {
-		return (Error)err;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_poll is unimplemented!");
-	return ERR_UNCONFIGURED;
-}
-
-void WebRTCDataChannelExtension::close() {
-	if (GDVIRTUAL_CALL(_close)) {
-		return;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_close is unimplemented!");
-}
-
-void WebRTCDataChannelExtension::set_write_mode(WriteMode p_mode) {
-	if (GDVIRTUAL_CALL(_set_write_mode, p_mode)) {
-		return;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_set_write_mode is unimplemented!");
-}
-
-WebRTCDataChannel::WriteMode WebRTCDataChannelExtension::get_write_mode() const {
-	int mode;
-	if (GDVIRTUAL_CALL(_get_write_mode, mode)) {
-		return (WriteMode)mode;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_write_mode is unimplemented!");
-	return WRITE_MODE_BINARY;
-}
-
-bool WebRTCDataChannelExtension::was_string_packet() const {
-	bool was_string;
-	if (GDVIRTUAL_CALL(_was_string_packet, was_string)) {
-		return was_string;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_was_string_packet is unimplemented!");
-	return false;
-}
-
-WebRTCDataChannel::ChannelState WebRTCDataChannelExtension::get_ready_state() const {
-	int state;
-	if (GDVIRTUAL_CALL(_get_ready_state, state)) {
-		return (ChannelState)state;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_ready_state is unimplemented!");
-	return STATE_CLOSED;
-}
-
-String WebRTCDataChannelExtension::get_label() const {
-	String label;
-	if (GDVIRTUAL_CALL(_get_label, label)) {
-		return label;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_label is unimplemented!");
-	return label;
-}
-
-bool WebRTCDataChannelExtension::is_ordered() const {
-	bool ordered;
-	if (GDVIRTUAL_CALL(_is_ordered, ordered)) {
-		return ordered;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_is_ordered is unimplemented!");
-	return false;
-}
-
-int WebRTCDataChannelExtension::get_id() const {
-	int id;
-	if (GDVIRTUAL_CALL(_get_id, id)) {
-		return id;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_id is unimplemented!");
-	return -1;
-}
-
-int WebRTCDataChannelExtension::get_max_packet_life_time() const {
-	int lifetime;
-	if (GDVIRTUAL_CALL(_get_max_packet_life_time, lifetime)) {
-		return lifetime;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_max_packet_life_time is unimplemented!");
-	return -1;
-}
-
-int WebRTCDataChannelExtension::get_max_retransmits() const {
-	int retransmits;
-	if (GDVIRTUAL_CALL(_get_max_retransmits, retransmits)) {
-		return retransmits;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_max_retransmits is unimplemented!");
-	return -1;
-}
-
-String WebRTCDataChannelExtension::get_protocol() const {
-	String protocol;
-	if (GDVIRTUAL_CALL(_get_protocol, protocol)) {
-		return protocol;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_protocol is unimplemented!");
-	return protocol;
-}
-
-bool WebRTCDataChannelExtension::is_negotiated() const {
-	bool negotiated;
-	if (GDVIRTUAL_CALL(_is_negotiated, negotiated)) {
-		return negotiated;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_is_negotiated is unimplemented!");
-	return false;
-}
-
-int WebRTCDataChannelExtension::get_buffered_amount() const {
-	int amount;
-	if (GDVIRTUAL_CALL(_get_buffered_amount, amount)) {
-		return amount;
-	}
-	WARN_PRINT_ONCE("WebRTCDataChannelExtension::_get_buffered_amount is unimplemented!");
-	return -1;
 }

--- a/modules/webrtc/webrtc_data_channel_extension.h
+++ b/modules/webrtc/webrtc_data_channel_extension.h
@@ -33,6 +33,7 @@
 
 #include "webrtc_data_channel.h"
 
+#include "core/extension/ext_wrappers.gen.inc"
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/script_language.h"
 #include "core/variant/native_ptr.h"
@@ -44,53 +45,33 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void set_write_mode(WriteMode mode) override;
-	virtual WriteMode get_write_mode() const override;
-	virtual bool was_string_packet() const override;
+	EXBIND0R(Error, poll);
+	EXBIND0(close);
 
-	virtual ChannelState get_ready_state() const override;
-	virtual String get_label() const override;
-	virtual bool is_ordered() const override;
-	virtual int get_id() const override;
-	virtual int get_max_packet_life_time() const override;
-	virtual int get_max_retransmits() const override;
-	virtual String get_protocol() const override;
-	virtual bool is_negotiated() const override;
-	virtual int get_buffered_amount() const override;
+	EXBIND1(set_write_mode, WriteMode);
+	EXBIND0RC(WriteMode, get_write_mode);
 
-	virtual Error poll() override;
-	virtual void close() override;
+	EXBIND0RC(bool, was_string_packet);
+
+	EXBIND0RC(ChannelState, get_ready_state);
+	EXBIND0RC(String, get_label);
+	EXBIND0RC(bool, is_ordered);
+	EXBIND0RC(int, get_id);
+	EXBIND0RC(int, get_max_packet_life_time);
+	EXBIND0RC(int, get_max_retransmits);
+	EXBIND0RC(String, get_protocol);
+	EXBIND0RC(bool, is_negotiated);
+	EXBIND0RC(int, get_buffered_amount);
 
 	/** Inherited from PacketPeer: **/
-	virtual int get_available_packet_count() const override;
+	EXBIND0RC(int, get_available_packet_count);
+	EXBIND0RC(int, get_max_packet_size);
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
 
-	virtual int get_max_packet_size() const override;
-
 	/** GDExtension **/
-	GDVIRTUAL0RC(int, _get_available_packet_count);
-	GDVIRTUAL2R(int, _get_packet, GDNativeConstPtr<const uint8_t *>, GDNativePtr<int>);
-	GDVIRTUAL2R(int, _put_packet, GDNativeConstPtr<const uint8_t>, int);
-	GDVIRTUAL0RC(int, _get_max_packet_size);
-
-	GDVIRTUAL0R(int, _poll);
-	GDVIRTUAL0(_close);
-
-	GDVIRTUAL1(_set_write_mode, int);
-	GDVIRTUAL0RC(int, _get_write_mode);
-
-	GDVIRTUAL0RC(bool, _was_string_packet);
-
-	GDVIRTUAL0RC(int, _get_ready_state);
-	GDVIRTUAL0RC(String, _get_label);
-	GDVIRTUAL0RC(bool, _is_ordered);
-	GDVIRTUAL0RC(int, _get_id);
-	GDVIRTUAL0RC(int, _get_max_packet_life_time);
-	GDVIRTUAL0RC(int, _get_max_retransmits);
-	GDVIRTUAL0RC(String, _get_protocol);
-	GDVIRTUAL0RC(bool, _is_negotiated);
-	GDVIRTUAL0RC(int, _get_buffered_amount);
+	GDVIRTUAL2R(Error, _get_packet, GDNativeConstPtr<const uint8_t *>, GDNativePtr<int>);
+	GDVIRTUAL2R(Error, _put_packet, GDNativeConstPtr<const uint8_t>, int);
 
 	WebRTCDataChannelExtension() {}
 };

--- a/modules/webrtc/webrtc_peer_connection_extension.cpp
+++ b/modules/webrtc/webrtc_peer_connection_extension.cpp
@@ -42,24 +42,6 @@ void WebRTCPeerConnectionExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_close);
 }
 
-WebRTCPeerConnection::ConnectionState WebRTCPeerConnectionExtension::get_connection_state() const {
-	int state;
-	if (GDVIRTUAL_CALL(_get_connection_state, state)) {
-		return (ConnectionState)state;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_get_connection_state is unimplemented!");
-	return STATE_DISCONNECTED;
-}
-
-Error WebRTCPeerConnectionExtension::initialize(Dictionary p_config) {
-	int err;
-	if (GDVIRTUAL_CALL(_initialize, p_config, err)) {
-		return (Error)err;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_initialize is unimplemented!");
-	return ERR_UNCONFIGURED;
-}
-
 Ref<WebRTCDataChannel> WebRTCPeerConnectionExtension::create_data_channel(String p_label, Dictionary p_options) {
 	Object *ret = nullptr;
 	if (GDVIRTUAL_CALL(_create_data_channel, p_label, p_options, ret)) {
@@ -69,56 +51,4 @@ Ref<WebRTCDataChannel> WebRTCPeerConnectionExtension::create_data_channel(String
 	}
 	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_create_data_channel is unimplemented!");
 	return nullptr;
-}
-
-Error WebRTCPeerConnectionExtension::create_offer() {
-	int err;
-	if (GDVIRTUAL_CALL(_create_offer, err)) {
-		return (Error)err;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_create_offer is unimplemented!");
-	return ERR_UNCONFIGURED;
-}
-
-Error WebRTCPeerConnectionExtension::set_local_description(String p_type, String p_sdp) {
-	int err;
-	if (GDVIRTUAL_CALL(_set_local_description, p_type, p_sdp, err)) {
-		return (Error)err;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_set_local_description is unimplemented!");
-	return ERR_UNCONFIGURED;
-}
-
-Error WebRTCPeerConnectionExtension::set_remote_description(String p_type, String p_sdp) {
-	int err;
-	if (GDVIRTUAL_CALL(_set_remote_description, p_type, p_sdp, err)) {
-		return (Error)err;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_set_remote_description is unimplemented!");
-	return ERR_UNCONFIGURED;
-}
-
-Error WebRTCPeerConnectionExtension::add_ice_candidate(String p_sdp_mid_name, int p_sdp_mline_index, String p_sdp_name) {
-	int err;
-	if (GDVIRTUAL_CALL(_add_ice_candidate, p_sdp_mid_name, p_sdp_mline_index, p_sdp_name, err)) {
-		return (Error)err;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_add_ice_candidate is unimplemented!");
-	return ERR_UNCONFIGURED;
-}
-
-Error WebRTCPeerConnectionExtension::poll() {
-	int err;
-	if (GDVIRTUAL_CALL(_poll, err)) {
-		return (Error)err;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_poll is unimplemented!");
-	return ERR_UNCONFIGURED;
-}
-
-void WebRTCPeerConnectionExtension::close() {
-	if (GDVIRTUAL_CALL(_close)) {
-		return;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_close is unimplemented!");
 }

--- a/modules/webrtc/webrtc_peer_connection_extension.h
+++ b/modules/webrtc/webrtc_peer_connection_extension.h
@@ -33,6 +33,7 @@
 
 #include "webrtc_peer_connection.h"
 
+#include "core/extension/ext_wrappers.gen.inc"
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/script_language.h"
 #include "core/variant/native_ptr.h"
@@ -44,27 +45,21 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual ConnectionState get_connection_state() const override;
-
-	virtual Error initialize(Dictionary p_config = Dictionary()) override;
+	// FIXME Can't be directly exposed due to issues in exchanging Ref(s) between godot and extensions.
+	// See godot-cpp GH-652 .
 	virtual Ref<WebRTCDataChannel> create_data_channel(String p_label, Dictionary p_options = Dictionary()) override;
-	virtual Error create_offer() override;
-	virtual Error set_remote_description(String type, String sdp) override;
-	virtual Error set_local_description(String type, String sdp) override;
-	virtual Error add_ice_candidate(String p_sdp_mid_name, int p_sdp_mline_index, String p_sdp_name) override;
-	virtual Error poll() override;
-	virtual void close() override;
+	GDVIRTUAL2R(Object *, _create_data_channel, String, Dictionary);
+	// EXBIND2R(Ref<WebRTCDataChannel>, create_data_channel, String, Dictionary);
 
 	/** GDExtension **/
-	GDVIRTUAL0RC(int, _get_connection_state);
-	GDVIRTUAL1R(int, _initialize, Dictionary);
-	GDVIRTUAL2R(Object *, _create_data_channel, String, Dictionary);
-	GDVIRTUAL0R(int, _create_offer);
-	GDVIRTUAL2R(int, _set_remote_description, String, String);
-	GDVIRTUAL2R(int, _set_local_description, String, String);
-	GDVIRTUAL3R(int, _add_ice_candidate, String, int, String);
-	GDVIRTUAL0R(int, _poll);
-	GDVIRTUAL0(_close);
+	EXBIND0RC(ConnectionState, get_connection_state);
+	EXBIND1R(Error, initialize, Dictionary);
+	EXBIND0R(Error, create_offer);
+	EXBIND2R(Error, set_remote_description, String, String);
+	EXBIND2R(Error, set_local_description, String, String);
+	EXBIND3R(Error, add_ice_candidate, String, int, String);
+	EXBIND0R(Error, poll);
+	EXBIND0(close);
 
 	WebRTCPeerConnectionExtension() {}
 };

--- a/scene/main/multiplayer_peer.cpp
+++ b/scene/main/multiplayer_peer.cpp
@@ -120,19 +120,10 @@ void MultiplayerPeer::_bind_methods() {
 
 /*************/
 
-int MultiplayerPeerExtension::get_available_packet_count() const {
-	int count;
-	if (GDVIRTUAL_CALL(_get_available_packet_count, count)) {
-		return count;
-	}
-	WARN_PRINT_ONCE("MultiplayerPeerExtension::_get_available_packet_count is unimplemented!");
-	return -1;
-}
-
 Error MultiplayerPeerExtension::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
-	int err;
+	Error err;
 	if (GDVIRTUAL_CALL(_get_packet, r_buffer, &r_buffer_size, err)) {
-		return (Error)err;
+		return err;
 	}
 	if (GDVIRTUAL_IS_OVERRIDDEN(_get_packet_script)) {
 		if (!GDVIRTUAL_CALL(_get_packet_script, script_buffer)) {
@@ -153,9 +144,9 @@ Error MultiplayerPeerExtension::get_packet(const uint8_t **r_buffer, int &r_buff
 }
 
 Error MultiplayerPeerExtension::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
-	int err;
+	Error err;
 	if (GDVIRTUAL_CALL(_put_packet, p_buffer, p_buffer_size, err)) {
-		return (Error)err;
+		return err;
 	}
 	if (GDVIRTUAL_IS_OVERRIDDEN(_put_packet_script)) {
 		PackedByteArray a;
@@ -171,87 +162,6 @@ Error MultiplayerPeerExtension::put_packet(const uint8_t *p_buffer, int p_buffer
 	return FAILED;
 }
 
-int MultiplayerPeerExtension::get_max_packet_size() const {
-	int size;
-	if (GDVIRTUAL_CALL(_get_max_packet_size, size)) {
-		return size;
-	}
-	WARN_PRINT_ONCE("MultiplayerPeerExtension::_get_max_packet_size is unimplemented!");
-	return 0;
-}
-
-void MultiplayerPeerExtension::set_transfer_channel(int p_channel) {
-	if (GDVIRTUAL_CALL(_set_transfer_channel, p_channel)) {
-		return;
-	}
-	MultiplayerPeer::set_transfer_channel(p_channel);
-}
-
-int MultiplayerPeerExtension::get_transfer_channel() const {
-	int channel;
-	if (GDVIRTUAL_CALL(_get_transfer_channel, channel)) {
-		return channel;
-	}
-	return MultiplayerPeer::get_transfer_channel();
-}
-
-void MultiplayerPeerExtension::set_transfer_mode(TransferMode p_mode) {
-	if (GDVIRTUAL_CALL(_set_transfer_mode, p_mode)) {
-		return;
-	}
-	MultiplayerPeer::set_transfer_mode(p_mode);
-}
-
-MultiplayerPeer::TransferMode MultiplayerPeerExtension::get_transfer_mode() const {
-	int mode;
-	if (GDVIRTUAL_CALL(_get_transfer_mode, mode)) {
-		return (MultiplayerPeer::TransferMode)mode;
-	}
-	return MultiplayerPeer::get_transfer_mode();
-}
-
-void MultiplayerPeerExtension::set_target_peer(int p_peer_id) {
-	if (GDVIRTUAL_CALL(_set_target_peer, p_peer_id)) {
-		return;
-	}
-	WARN_PRINT_ONCE("MultiplayerPeerExtension::_set_target_peer is unimplemented!");
-}
-
-int MultiplayerPeerExtension::get_packet_peer() const {
-	int peer;
-	if (GDVIRTUAL_CALL(_get_packet_peer, peer)) {
-		return peer;
-	}
-	WARN_PRINT_ONCE("MultiplayerPeerExtension::_get_packet_peer is unimplemented!");
-	return 0;
-}
-
-bool MultiplayerPeerExtension::is_server() const {
-	bool server;
-	if (GDVIRTUAL_CALL(_is_server, server)) {
-		return server;
-	}
-	WARN_PRINT_ONCE("MultiplayerPeerExtension::_is_server is unimplemented!");
-	return false;
-}
-
-void MultiplayerPeerExtension::poll() {
-	int err;
-	if (GDVIRTUAL_CALL(_poll, err)) {
-		return;
-	}
-	WARN_PRINT_ONCE("MultiplayerPeerExtension::_poll is unimplemented!");
-}
-
-int MultiplayerPeerExtension::get_unique_id() const {
-	int id;
-	if (GDVIRTUAL_CALL(_get_unique_id, id)) {
-		return id;
-	}
-	WARN_PRINT_ONCE("MultiplayerPeerExtension::_get_unique_id is unimplemented!");
-	return 0;
-}
-
 void MultiplayerPeerExtension::set_refuse_new_connections(bool p_enable) {
 	if (GDVIRTUAL_CALL(_set_refuse_new_connections, p_enable)) {
 		return;
@@ -265,15 +175,6 @@ bool MultiplayerPeerExtension::is_refusing_new_connections() const {
 		return refusing;
 	}
 	return MultiplayerPeer::is_refusing_new_connections();
-}
-
-MultiplayerPeer::ConnectionStatus MultiplayerPeerExtension::get_connection_status() const {
-	int status;
-	if (GDVIRTUAL_CALL(_get_connection_status, status)) {
-		return (ConnectionStatus)status;
-	}
-	WARN_PRINT_ONCE("MultiplayerPeerExtension::_get_connection_status is unimplemented!");
-	return CONNECTION_DISCONNECTED;
 }
 
 void MultiplayerPeerExtension::_bind_methods() {
@@ -300,4 +201,7 @@ void MultiplayerPeerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_set_refuse_new_connections, "p_enable");
 	GDVIRTUAL_BIND(_is_refusing_new_connections);
 	GDVIRTUAL_BIND(_get_connection_status);
+
+	ADD_PROPERTY_DEFAULT("transfer_mode", TRANSFER_MODE_RELIABLE);
+	ADD_PROPERTY_DEFAULT("transfer_channel", 0);
 }

--- a/scene/main/multiplayer_peer.h
+++ b/scene/main/multiplayer_peer.h
@@ -33,6 +33,7 @@
 
 #include "core/io/packet_peer.h"
 
+#include "core/extension/ext_wrappers.gen.inc"
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/script_language.h"
 #include "core/variant/native_ptr.h"
@@ -103,55 +104,35 @@ protected:
 	PackedByteArray script_buffer;
 
 public:
-	/* PacketPeer */
-	virtual int get_available_packet_count() const override;
+	/* PacketPeer extension */
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override; ///< buffer is GONE after next get_packet
+	GDVIRTUAL2R(Error, _get_packet, GDNativeConstPtr<const uint8_t *>, GDNativePtr<int>);
+	GDVIRTUAL0R(PackedByteArray, _get_packet_script); // For GDScript.
+
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	virtual int get_max_packet_size() const override;
+	GDVIRTUAL2R(Error, _put_packet, GDNativeConstPtr<const uint8_t>, int);
+	GDVIRTUAL1R(Error, _put_packet_script, PackedByteArray); // For GDScript.
 
-	/* MultiplayerPeer */
-	virtual void set_transfer_channel(int p_channel) override;
-	virtual int get_transfer_channel() const override;
-	virtual void set_transfer_mode(TransferMode p_mode) override;
-	virtual TransferMode get_transfer_mode() const override;
-	virtual void set_target_peer(int p_peer_id) override;
+	EXBIND0RC(int, get_available_packet_count);
+	EXBIND0RC(int, get_max_packet_size);
 
-	virtual int get_packet_peer() const override;
-
-	virtual bool is_server() const override;
-
-	virtual void poll() override;
-
-	virtual int get_unique_id() const override;
-
+	/* MultiplayerPeer extension */
 	virtual void set_refuse_new_connections(bool p_enable) override;
+	GDVIRTUAL1(_set_refuse_new_connections, bool); // Optional.
+
 	virtual bool is_refusing_new_connections() const override;
+	GDVIRTUAL0RC(bool, _is_refusing_new_connections); // Optional.
 
-	virtual ConnectionStatus get_connection_status() const override;
-
-	/* PacketPeer GDExtension */
-	GDVIRTUAL0RC(int, _get_available_packet_count);
-	GDVIRTUAL2R(int, _get_packet, GDNativeConstPtr<const uint8_t *>, GDNativePtr<int>);
-	GDVIRTUAL2R(int, _put_packet, GDNativeConstPtr<const uint8_t>, int);
-	GDVIRTUAL0RC(int, _get_max_packet_size);
-
-	/* PacketPeer GDScript */
-	GDVIRTUAL0R(PackedByteArray, _get_packet_script);
-	GDVIRTUAL1R(int, _put_packet_script, PackedByteArray);
-
-	/* MultiplayerPeer GDExtension */
-	GDVIRTUAL1(_set_transfer_channel, int);
-	GDVIRTUAL0RC(int, _get_transfer_channel);
-	GDVIRTUAL1(_set_transfer_mode, int);
-	GDVIRTUAL0RC(int, _get_transfer_mode);
-	GDVIRTUAL1(_set_target_peer, int);
-	GDVIRTUAL0RC(int, _get_packet_peer);
-	GDVIRTUAL0RC(bool, _is_server);
-	GDVIRTUAL0R(int, _poll);
-	GDVIRTUAL0RC(int, _get_unique_id);
-	GDVIRTUAL1(_set_refuse_new_connections, bool);
-	GDVIRTUAL0RC(bool, _is_refusing_new_connections);
-	GDVIRTUAL0RC(int, _get_connection_status);
+	EXBIND1(set_transfer_channel, int);
+	EXBIND0RC(int, get_transfer_channel);
+	EXBIND1(set_transfer_mode, TransferMode);
+	EXBIND0RC(TransferMode, get_transfer_mode);
+	EXBIND1(set_target_peer, int);
+	EXBIND0RC(int, get_packet_peer);
+	EXBIND0RC(bool, is_server);
+	EXBIND0(poll);
+	EXBIND0RC(int, get_unique_id);
+	EXBIND0RC(ConnectionStatus, get_connection_status);
 };
 
 #endif // MULTIPLAYER_PEER_H


### PR DESCRIPTION
Simplify StreamPeer, PacketPeer, MultiplayerPeer extension.

Simplify and update `WebRTC*Extension` with newly supported types.

Note: `create_data_channel` still uses `Object *` due to godotengine/godot-cpp#652 (and all the proposed fix seem to leak memory for this case, unlike using `Object *`).