### PR TITLE
Fix Label & RichTextLabel's visible_ratio not working

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -789,10 +789,10 @@ int Label::get_visible_characters() const {
 
 void Label::set_visible_ratio(float p_ratio) {
 	if (visible_ratio != p_ratio) {
-		if (visible_ratio >= 1.0) {
+		if (p_ratio >= 1.0) {
 			visible_chars = -1;
 			visible_ratio = 1.0;
-		} else if (visible_ratio < 0.0) {
+		} else if (p_ratio < 0.0) {
 			visible_chars = 0;
 			visible_ratio = 0.0;
 		} else {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4945,10 +4945,10 @@ void RichTextLabel::set_visible_ratio(float p_ratio) {
 	if (visible_ratio != p_ratio) {
 		_stop_thread();
 
-		if (visible_ratio >= 1.0) {
+		if (p_ratio >= 1.0) {
 			visible_characters = -1;
 			visible_ratio = 1.0;
-		} else if (visible_ratio < 0.0) {
+		} else if (p_ratio < 0.0) {
 			visible_characters = 0;
 			visible_ratio = 0.0;
 		} else {


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/65195.

After a merge, it was comparing the wrong value.