### PR TITLE
fixed and optimized Area2/3D get_overlaping_bodies/areas

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -426,36 +426,36 @@ bool Area2D::is_monitorable() const {
 }
 
 TypedArray<Node2D> Area2D::get_overlapping_bodies() const {
-	ERR_FAIL_COND_V_MSG(!monitoring, Array(), "Can't find overlapping bodies when monitoring is off.");
 	TypedArray<Node2D> ret;
+	ERR_FAIL_COND_V_MSG(!monitoring, ret, "Can't find overlapping bodies when monitoring is off.");
 	ret.resize(body_map.size());
 	int idx = 0;
 	for (const KeyValue<ObjectID, BodyState> &E : body_map) {
 		Object *obj = ObjectDB::get_instance(E.key);
-		if (!obj) {
-			ret.resize(ret.size() - 1); //ops
-		} else {
-			ret[idx++] = obj;
+		if (obj) {
+			ret[idx] = obj;
+			idx++;
 		}
 	}
 
+	ret.resize(idx);
 	return ret;
 }
 
 TypedArray<Area2D> Area2D::get_overlapping_areas() const {
-	ERR_FAIL_COND_V_MSG(!monitoring, Array(), "Can't find overlapping bodies when monitoring is off.");
 	TypedArray<Area2D> ret;
+	ERR_FAIL_COND_V_MSG(!monitoring, ret, "Can't find overlapping areas when monitoring is off.");
 	ret.resize(area_map.size());
 	int idx = 0;
 	for (const KeyValue<ObjectID, AreaState> &E : area_map) {
 		Object *obj = ObjectDB::get_instance(E.key);
-		if (!obj) {
-			ret.resize(ret.size() - 1); //ops
-		} else {
-			ret[idx++] = obj;
+		if (obj) {
+			ret[idx] = obj;
+			idx++;
 		}
 	}
 
+	ret.resize(idx);
 	return ret;
 }
 

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -473,19 +473,19 @@ bool Area3D::is_monitoring() const {
 }
 
 TypedArray<Node3D> Area3D::get_overlapping_bodies() const {
-	ERR_FAIL_COND_V(!monitoring, Array());
-	Array ret;
+	TypedArray<Node3D> ret;
+	ERR_FAIL_COND_V_MSG(!monitoring, ret, "Can't find overlapping bodies when monitoring is off.");
 	ret.resize(body_map.size());
 	int idx = 0;
 	for (const KeyValue<ObjectID, BodyState> &E : body_map) {
 		Object *obj = ObjectDB::get_instance(E.key);
-		if (!obj) {
-			ret.resize(ret.size() - 1); //ops
-		} else {
-			ret[idx++] = obj;
+		if (obj) {
+			ret[idx] = obj;
+			idx++;
 		}
 	}
 
+	ret.resize(idx);
 	return ret;
 }
 
@@ -506,19 +506,18 @@ bool Area3D::is_monitorable() const {
 }
 
 TypedArray<Area3D> Area3D::get_overlapping_areas() const {
-	ERR_FAIL_COND_V(!monitoring, Array());
-	Array ret;
+	TypedArray<Area3D> ret;
+	ERR_FAIL_COND_V_MSG(!monitoring, ret, "Can't find overlapping areas when monitoring is off.");
 	ret.resize(area_map.size());
 	int idx = 0;
 	for (const KeyValue<ObjectID, AreaState> &E : area_map) {
 		Object *obj = ObjectDB::get_instance(E.key);
-		if (!obj) {
-			ret.resize(ret.size() - 1); //ops
-		} else {
-			ret[idx++] = obj;
+		if (obj) {
+			ret[idx] = obj;
+			idx++;
 		}
 	}
-
+	ret.resize(idx);
 	return ret;
 }
 


### PR DESCRIPTION
-fixed a typo in Area2D::get_overlapping_areas and added ERR_FAIL_COND_V_MSG in Area3D::get_overlapping_bodies
-made it so area3d get_overlaping_x is similar to its counterpart func in area2d so that it uses TypedArray instead of Array and Err_FAIL_COND_V_MSG instead of no message
-minimized array resize calls is Area2/3D::get_overlapping_areas/bodies
