### PR TITLE
Fix getting an error message when moving a node among a window and other types of nodes

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -338,6 +338,7 @@ void CanvasItem::_notification(int p_what) {
 			}
 			if (window) {
 				window->disconnect(SceneStringNames::get_singleton()->visibility_changed, callable_mp(this, &CanvasItem::_window_visibility_changed));
+				window = nullptr;
 			}
 			global_invalid = true;
 			parent_visible_in_tree = false;


### PR DESCRIPTION
Fix #65224.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
