### PR TITLE
Fix "Save Branch as Scene" storing root Node's `unique_name_in_owner`

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2474,9 +2474,12 @@ void SceneTreeDock::_new_scene_from(String p_file) {
 	Node *copy = base->duplicate_from_editor(duplimap);
 
 	if (copy) {
+		// Handle Unique Nodes.
 		for (int i = 0; i < copy->get_child_count(false); i++) {
 			_set_node_owner_recursive(copy->get_child(i, false), copy);
 		}
+		// Root node cannot ever be unique name in its own Scene!
+		copy->set_unique_name_in_owner(false);
 
 		Ref<PackedScene> sdata = memnew(PackedScene);
 		Error err = sdata->pack(copy);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -297,9 +297,31 @@ void SceneDebugger::_save_node(ObjectID id, const String &p_path) {
 	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(id));
 	ERR_FAIL_COND(!node);
 
+	HashMap<const Node *, Node *> duplimap;
+	Node *copy = node->duplicate_from_editor(duplimap);
+
+	// Handle Unique Nodes.
+	for (int i = 0; i < copy->get_child_count(false); i++) {
+		_set_node_owner_recursive(copy->get_child(i, false), copy);
+	}
+	// Root node cannot ever be unique name in its own Scene!
+	copy->set_unique_name_in_owner(false);
+
 	Ref<PackedScene> ps = memnew(PackedScene);
-	ps->pack(node);
+	ps->pack(copy);
 	ResourceSaver::save(ps, p_path);
+
+	memdelete(copy);
+}
+
+void SceneDebugger::_set_node_owner_recursive(Node *p_node, Node *p_owner) {
+	if (!p_node->get_owner()) {
+		p_node->set_owner(p_owner);
+	}
+
+	for (int i = 0; i < p_node->get_child_count(false); i++) {
+		_set_node_owner_recursive(p_node->get_child(i, false), p_owner);
+	}
 }
 
 void SceneDebugger::_send_object_id(ObjectID p_id, int p_max_size) {

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -75,6 +75,7 @@ public:
 #ifdef DEBUG_ENABLED
 private:
 	static void _save_node(ObjectID id, const String &p_path);
+	static void _set_node_owner_recursive(Node *p_node, Node *p_owner);
 	static void _set_object_property(ObjectID p_id, const String &p_property, const Variant &p_value);
 	static void _send_object_id(ObjectID p_id, int p_max_size = 1 << 20);
 


### PR DESCRIPTION
Fix #64425

~This PR originally acted on **PackedScene**'s `pack()`~
~Hacky, but it does what it does.~

Doesn't fix the other issue(s) brought up in https://github.com/godotengine/godot/issues/64425#issuecomment-1234636015