### PR TITLE
Increase ItemList item height in editor theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1212,7 +1212,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_color", "ItemList", font_color);
 	theme->set_color("font_selected_color", "ItemList", mono_color);
 	theme->set_color("guide_color", "ItemList", guide_color);
-	theme->set_constant("v_separation", "ItemList", widget_default_margin.y - EDSCALE);
+	theme->set_constant("v_separation", "ItemList", force_even_vsep * 0.5 * EDSCALE);
 	theme->set_constant("h_separation", "ItemList", 6 * EDSCALE);
 	theme->set_constant("icon_margin", "ItemList", 6 * EDSCALE);
 	theme->set_constant("line_separation", "ItemList", 3 * EDSCALE);


### PR DESCRIPTION
Makes ItemList use the same item height as PopupMenu. This makes it easier to select items.

With the default theme, items are only 2 pixels taller, so there is not a huge difference but it still goes a long way in making it easier to select ItemList items and making the UI look less squished together.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/188068789-0dffb415-fd5f-4184-893f-c27105102326.png) | ![image](https://user-images.githubusercontent.com/67974470/188068347-efc07634-c8c0-4ad1-81b9-08b1611b3a6f.png) |