### PR TITLE
CI: Wait for static check results before starting builds

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -1,5 +1,6 @@
 name: 🤖 Android Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -1,5 +1,6 @@
 name: 🍏 iOS Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -1,5 +1,6 @@
 name: 🐧 Linux Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -1,5 +1,6 @@
 name: 🍎 macOS Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,0 +1,41 @@
+name: 🔗 GHA
+on: [push, pull_request]
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-runner
+  cancel-in-progress: true
+
+jobs:
+  static-checks:
+    name: 📊 Static
+    uses: ./.github/workflows/static_checks.yml
+
+  android-build:
+    name: 🤖 Android
+    needs: static-checks
+    uses: ./.github/workflows/android_builds.yml
+
+  ios-build:
+    name: 🍏 iOS
+    needs: static-checks
+    uses: ./.github/workflows/ios_builds.yml
+
+  linux-build:
+    name: 🐧 Linux
+    needs: static-checks
+    uses: ./.github/workflows/linux_builds.yml
+
+  macos-build:
+    name: 🍎 macOS
+    needs: static-checks
+    uses: ./.github/workflows/macos_builds.yml
+
+  windows-build:
+    name: 🏁 Windows
+    needs: static-checks
+    uses: ./.github/workflows/windows_builds.yml
+
+  web-build:
+    name: 🌐 Web
+    needs: static-checks
+    uses: ./.github/workflows/web_builds.yml

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,5 +1,6 @@
 name: 📊 Static Checks
-on: [push, pull_request]
+on:
+  workflow_call:
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -1,5 +1,6 @@
 name: 🌐 Web Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 env:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,5 +1,6 @@
 name: 🏁 Windows Builds
-on: [push, pull_request]
+on:
+  workflow_call:
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment


### PR DESCRIPTION
// Another attempt for what did not work in #65123

The CI workflow "📊 Static Checks" checks code formatting etc. and even if all the build workflows in pipeline are successful, the pipeline needs to be eventually re-run in case this one fails. From what I understand the bottleneck for the CI pipeline is the number of available workers which can run builds, so it would make sense to not run the "expensive" jobs unless the basic one is successful. 

Unfortunately it's impossible to make various workflow files depend on each other, so the approach here utilizes [Reusable Workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows):
- change the trigger event for all builders to [workflow_call](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_call), which means they need to be invoked manually
- create new workflow file `runner.yml` as an entrypoint for the pipeline
- in there, invoke "📊 Static Checks" first
- run other builds if 📊 Static Checks job was successful

This means builders wont be shown separately in the [Actions Tab](https://github.com/godotengine/godot/actions), since they are now treated as a part of the Runner workflow. That makes it easier to cancel the whole build with a single click (a minuscule case, but still a nice thing to have) and it declutters the content there to a single row only per each git push. But that also means you cant see or filter the build types (ios, android...) there directly.