### PR TITLE
Remove unused category in ClassDoc

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -154,7 +154,6 @@ public:
 	struct ClassDoc {
 		String name;
 		String inherits;
-		String category; // FIXME: Wrongly used by VisualScriptPropertySelector, should be removed.
 		String brief_description;
 		String description;
 		Vector<TutorialDoc> tutorials;


### PR DESCRIPTION
According to the comment, this String was used by **VisualScriptPropertySelector** on accident. But since Visual Scripting has been _completely_ stripped away, this is now safe to remove.