### PR TITLE
Rename JavaScript singleton to JavaScriptBridge

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1275,8 +1275,8 @@
 			The [JavaClassWrapper] singleton.
 			[b]Note:[/b] Only implemented on Android.
 		</member>
-		<member name="JavaScript" type="JavaScript" setter="" getter="">
-			The [JavaScript] singleton.
+		<member name="JavaScriptBridge" type="JavaScriptBridge" setter="" getter="">
+			The [JavaScriptBridge] singleton.
 			[b]Note:[/b] Only implemented on the Web platform.
 		</member>
 		<member name="Marshalls" type="Marshalls" setter="" getter="">

--- a/doc/classes/JavaScriptBridge.xml
+++ b/doc/classes/JavaScriptBridge.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="JavaScript" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="JavaScriptBridge" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Singleton that connects the engine with the browser's JavaScript context in Web export.
 	</brief_description>
 	<description>
-		The JavaScript singleton is implemented only in the Web export. It's used to access the browser's JavaScript context. This allows interaction with embedding pages or calling third-party JavaScript APIs.
-		[b]Note:[/b] This singleton can be disabled at build-time to improve security. By default, the JavaScript singleton is enabled. Official export templates also have the JavaScript singleton enabled. See [url=$DOCS_URL/development/compiling/compiling_for_web.html]Compiling for the Web[/url] in the documentation for more information.
+		The JavaScriptBridge singleton is implemented only in the Web export. It's used to access the browser's JavaScript context. This allows interaction with embedding pages or calling third-party JavaScript APIs.
+		[b]Note:[/b] This singleton can be disabled at build-time to improve security. By default, the JavaScriptBridge singleton is enabled. Official export templates also have the JavaScriptBridge singleton enabled. See [url=$DOCS_URL/development/compiling/compiling_for_web.html]Compiling for the Web[/url] in the documentation for more information.
 	</description>
 	<tutorials>
 		<link title="Exporting for the Web: Calling JavaScript from script">$DOCS_URL/tutorials/export/exporting_for_web.html#calling-javascript-from-script</link>

--- a/doc/classes/JavaScriptObject.xml
+++ b/doc/classes/JavaScriptObject.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="JavaScriptObject" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A wrapper class for native JavaScript objects.
+		A wrapper class for web native JavaScript objects.
 	</brief_description>
 	<description>
-		JavaScriptObject is used to interact with JavaScript objects retrieved or created via [method JavaScript.get_interface], [method JavaScript.create_object], or [method JavaScript.create_callback].
+		JavaScriptObject is used to interact with JavaScript objects retrieved or created via [method JavaScriptBridge.get_interface], [method JavaScriptBridge.create_object], or [method JavaScriptBridge.create_callback].
 		Example:
 		[codeblock]
 		extends Node
 
-		var _my_js_callback = JavaScript.create_callback(self, "myCallback") # This reference must be kept
-		var console = JavaScript.get_interface("console")
+		var _my_js_callback = JavaScriptBridge.create_callback(self, "myCallback") # This reference must be kept
+		var console = JavaScriptBridge.get_interface("console")
 
 		func _init():
-		    var buf = JavaScript.create_object("ArrayBuffer", 10) # new ArrayBuffer(10)
+		    var buf = JavaScriptBridge.create_object("ArrayBuffer", 10) # new ArrayBuffer(10)
 		    print(buf) # prints [JavaScriptObject:OBJECT_ID]
-		    var uint8arr = JavaScript.create_object("Uint8Array", buf) # new Uint8Array(buf)
+		    var uint8arr = JavaScriptBridge.create_object("Uint8Array", buf) # new Uint8Array(buf)
 		    uint8arr[1] = 255
 		    prints(uint8arr[1], uint8arr.byteLength) # prints 255 10
 		    console.log(uint8arr) # prints in browser console "Uint8Array(10) [ 0, 255, 0, 0, 0, 0, 0, 0, 0, 0 ]"
 
-		    # Equivalent of JavaScript: Array.from(uint8arr).forEach(myCallback)
-		    JavaScript.get_interface("Array").from(uint8arr).forEach(_my_js_callback)
+		    # Equivalent of JavaScriptBridge: Array.from(uint8arr).forEach(myCallback)
+		    JavaScriptBridge.get_interface("Array").from(uint8arr).forEach(_my_js_callback)
 
 		func myCallback(args):
 		    # Will be called with the parameters passed to the "forEach" callback

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -6,7 +6,7 @@ web_files = [
     "audio_driver_web.cpp",
     "display_server_web.cpp",
     "http_client_web.cpp",
-    "javascript_singleton.cpp",
+    "javascript_bridge_singleton.cpp",
     "web_main.cpp",
     "os_web.cpp",
     "api/web_tools_editor_plugin.cpp",

--- a/platform/web/api/api.cpp
+++ b/platform/web/api/api.cpp
@@ -30,66 +30,66 @@
 
 #include "api.h"
 #include "core/config/engine.h"
-#include "javascript_singleton.h"
+#include "javascript_bridge_singleton.h"
 #include "web_tools_editor_plugin.h"
 
-static JavaScript *javascript_singleton;
+static JavaScriptBridge *javascript_bridge_singleton;
 
 void register_web_api() {
 	WebToolsEditorPlugin::initialize();
 	GDREGISTER_ABSTRACT_CLASS(JavaScriptObject);
-	GDREGISTER_ABSTRACT_CLASS(JavaScript);
-	javascript_singleton = memnew(JavaScript);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaScript", javascript_singleton));
+	GDREGISTER_ABSTRACT_CLASS(JavaScriptBridge);
+	javascript_bridge_singleton = memnew(JavaScriptBridge);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaScriptBridge", javascript_bridge_singleton));
 }
 
 void unregister_web_api() {
-	memdelete(javascript_singleton);
+	memdelete(javascript_bridge_singleton);
 }
 
-JavaScript *JavaScript::singleton = nullptr;
+JavaScriptBridge *JavaScriptBridge::singleton = nullptr;
 
-JavaScript *JavaScript::get_singleton() {
+JavaScriptBridge *JavaScriptBridge::get_singleton() {
 	return singleton;
 }
 
-JavaScript::JavaScript() {
-	ERR_FAIL_COND_MSG(singleton != nullptr, "JavaScript singleton already exist.");
+JavaScriptBridge::JavaScriptBridge() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "JavaScriptBridge singleton already exist.");
 	singleton = this;
 }
 
-JavaScript::~JavaScript() {}
+JavaScriptBridge::~JavaScriptBridge() {}
 
-void JavaScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("eval", "code", "use_global_execution_context"), &JavaScript::eval, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("get_interface", "interface"), &JavaScript::get_interface);
-	ClassDB::bind_method(D_METHOD("create_callback", "callable"), &JavaScript::create_callback);
+void JavaScriptBridge::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("eval", "code", "use_global_execution_context"), &JavaScriptBridge::eval, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_interface", "interface"), &JavaScriptBridge::get_interface);
+	ClassDB::bind_method(D_METHOD("create_callback", "callable"), &JavaScriptBridge::create_callback);
 	{
 		MethodInfo mi;
 		mi.name = "create_object";
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "object"));
-		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "create_object", &JavaScript::_create_object_bind, mi);
+		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "create_object", &JavaScriptBridge::_create_object_bind, mi);
 	}
-	ClassDB::bind_method(D_METHOD("download_buffer", "buffer", "name", "mime"), &JavaScript::download_buffer, DEFVAL("application/octet-stream"));
-	ClassDB::bind_method(D_METHOD("pwa_needs_update"), &JavaScript::pwa_needs_update);
-	ClassDB::bind_method(D_METHOD("pwa_update"), &JavaScript::pwa_update);
+	ClassDB::bind_method(D_METHOD("download_buffer", "buffer", "name", "mime"), &JavaScriptBridge::download_buffer, DEFVAL("application/octet-stream"));
+	ClassDB::bind_method(D_METHOD("pwa_needs_update"), &JavaScriptBridge::pwa_needs_update);
+	ClassDB::bind_method(D_METHOD("pwa_update"), &JavaScriptBridge::pwa_update);
 	ADD_SIGNAL(MethodInfo("pwa_update_available"));
 }
 
 #if !defined(WEB_ENABLED) || !defined(JAVASCRIPT_EVAL_ENABLED)
-Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
+Variant JavaScriptBridge::eval(const String &p_code, bool p_use_global_exec_context) {
 	return Variant();
 }
 
-Ref<JavaScriptObject> JavaScript::get_interface(const String &p_interface) {
+Ref<JavaScriptObject> JavaScriptBridge::get_interface(const String &p_interface) {
 	return Ref<JavaScriptObject>();
 }
 
-Ref<JavaScriptObject> JavaScript::create_callback(const Callable &p_callable) {
+Ref<JavaScriptObject> JavaScriptBridge::create_callback(const Callable &p_callable) {
 	return Ref<JavaScriptObject>();
 }
 
-Variant JavaScript::_create_object_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+Variant JavaScriptBridge::_create_object_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	if (p_argcount < 1) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		r_error.argument = 0;
@@ -105,12 +105,12 @@ Variant JavaScript::_create_object_bind(const Variant **p_args, int p_argcount, 
 }
 #endif
 #if !defined(WEB_ENABLED)
-bool JavaScript::pwa_needs_update() const {
+bool JavaScriptBridge::pwa_needs_update() const {
 	return false;
 }
-Error JavaScript::pwa_update() {
+Error JavaScriptBridge::pwa_update() {
 	return ERR_UNAVAILABLE;
 }
-void JavaScript::download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime) {
+void JavaScriptBridge::download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime) {
 }
 #endif

--- a/platform/web/api/javascript_bridge_singleton.h
+++ b/platform/web/api/javascript_bridge_singleton.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  javascript_singleton.h                                               */
+/*  javascript_bridge_singleton.h                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef JAVASCRIPT_SINGLETON_H
-#define JAVASCRIPT_SINGLETON_H
+#ifndef JAVASCRIPT_BRIDGE_SINGLETON_H
+#define JAVASCRIPT_BRIDGE_SINGLETON_H
 
 #include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
@@ -44,11 +44,11 @@ protected:
 	virtual void _get_property_list(List<PropertyInfo> *p_list) const {}
 };
 
-class JavaScript : public Object {
+class JavaScriptBridge : public Object {
 private:
-	GDCLASS(JavaScript, Object);
+	GDCLASS(JavaScriptBridge, Object);
 
-	static JavaScript *singleton;
+	static JavaScriptBridge *singleton;
 
 protected:
 	static void _bind_methods();
@@ -62,9 +62,9 @@ public:
 	bool pwa_needs_update() const;
 	Error pwa_update();
 
-	static JavaScript *get_singleton();
-	JavaScript();
-	~JavaScript();
+	static JavaScriptBridge *get_singleton();
+	JavaScriptBridge();
+	~JavaScriptBridge();
 };
 
-#endif // JAVASCRIPT_SINGLETON_H
+#endif // JAVASCRIPT_BRIDGE_SINGLETON_H

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -45,7 +45,7 @@
 #include <emscripten.h>
 #include <stdlib.h>
 
-#include "api/javascript_singleton.h"
+#include "api/javascript_bridge_singleton.h"
 #include "godot_js.h"
 
 void OS_Web::alert(const String &p_alert, const String &p_title) {
@@ -199,8 +199,8 @@ void OS_Web::update_pwa_state_callback() {
 	if (OS_Web::get_singleton()) {
 		OS_Web::get_singleton()->pwa_is_waiting = true;
 	}
-	if (JavaScript::get_singleton()) {
-		JavaScript::get_singleton()->emit_signal("pwa_update_available");
+	if (JavaScriptBridge::get_singleton()) {
+		JavaScriptBridge::get_singleton()->emit_signal("pwa_update_available");
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

- Rename singleton `JavaScript` to `JavaScriptBridge`
- ~~Rename class `JavaScriptObject` to `WebObject`~~

Close https://github.com/godotengine/godot-proposals/issues/5205
