### PR TITLE
Fixed GodotSharp build failing when real_t is double

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -333,14 +333,14 @@ namespace Godot
         /// <param name="to">The destination color for interpolation.</param>
         /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
         /// <returns>The resulting color of the interpolation.</returns>
-        public Color Lerp(Color to, float weight)
+        public Color Lerp(Color to, real_t weight)
         {
             return new Color
             (
-                Mathf.Lerp(r, to.r, weight),
-                Mathf.Lerp(g, to.g, weight),
-                Mathf.Lerp(b, to.b, weight),
-                Mathf.Lerp(a, to.a, weight)
+                (float)Mathf.Lerp(r, to.r, weight),
+                (float)Mathf.Lerp(g, to.g, weight),
+                (float)Mathf.Lerp(b, to.b, weight),
+                (float)Mathf.Lerp(a, to.a, weight)
             );
         }
 
@@ -355,10 +355,10 @@ namespace Godot
         {
             return new Color
             (
-                Mathf.Lerp(r, to.r, weight.r),
-                Mathf.Lerp(g, to.g, weight.g),
-                Mathf.Lerp(b, to.b, weight.b),
-                Mathf.Lerp(a, to.a, weight.a)
+                (float)Mathf.Lerp(r, to.r, weight.r),
+                (float)Mathf.Lerp(g, to.g, weight.g),
+                (float)Mathf.Lerp(b, to.b, weight.b),
+                (float)Mathf.Lerp(a, to.a, weight.a)
             );
         }
 


### PR DESCRIPTION
Master's GodotSharp package is currently failing to build when the engine is built with REAL_T_IS_DOUBLE (scons float=64).

Because Mathf.Lerp returns real_t and Color still uses floats something needs to change, so I added some casts to float.
It looks like other functions in Color.cs have also done this (Color.Clamp for example) so this change puts Color.Lerp in line with the other functions.

I also changed Lerp's weight parameter from float to real_t, all the Lerp functions elsewhere use real_t so I think it's more consistent that way(?)

build_assemblies.py succeeds at building with the changes applied.
`./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin --push-nupkgs-local ~/MyLocalNugetSource`