### PR TITLE
Toggle control expand flag directly via top bar

### DIFF
--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -36,6 +36,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/check_button.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/separator.h"
 
@@ -660,6 +661,10 @@ void SizeFlagPresetPicker::_preset_button_pressed(const int p_preset) {
 	emit_signal("size_flags_selected", flags);
 }
 
+void SizeFlagPresetPicker::_expand_button_pressed() {
+	emit_signal("expand_flag_toggled", expand_button->is_pressed());
+}
+
 void SizeFlagPresetPicker::set_allowed_flags(Vector<SizeFlags> &p_flags) {
 	preset_buttons[SIZE_SHRINK_BEGIN]->set_disabled(!p_flags.has(SIZE_SHRINK_BEGIN));
 	preset_buttons[SIZE_SHRINK_CENTER]->set_disabled(!p_flags.has(SIZE_SHRINK_CENTER));
@@ -673,6 +678,10 @@ void SizeFlagPresetPicker::set_allowed_flags(Vector<SizeFlags> &p_flags) {
 		expand_button->set_pressed(false);
 		expand_button->set_tooltip_text(TTR("Some parents of the selected nodes do not support the Expand flag."));
 	}
+}
+
+void SizeFlagPresetPicker::set_expand_flag(bool p_expand) {
+	expand_button->set_pressed(p_expand);
 }
 
 void SizeFlagPresetPicker::_notification(int p_notification) {
@@ -698,6 +707,7 @@ void SizeFlagPresetPicker::_notification(int p_notification) {
 
 void SizeFlagPresetPicker::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("size_flags_selected", PropertyInfo(Variant::INT, "size_flags")));
+	ADD_SIGNAL(MethodInfo("expand_flag_toggled", PropertyInfo(Variant::BOOL, "expand_flag")));
 }
 
 SizeFlagPresetPicker::SizeFlagPresetPicker(bool p_vertical) {
@@ -717,10 +727,11 @@ SizeFlagPresetPicker::SizeFlagPresetPicker(bool p_vertical) {
 	_add_separator(main_row, memnew(VSeparator));
 	_add_row_button(main_row, SIZE_FILL, TTR("Fill"));
 
-	expand_button = memnew(CheckBox);
+	expand_button = memnew(CheckButton);
 	expand_button->set_flat(true);
-	expand_button->set_text(TTR("Align with Expand"));
+	expand_button->set_text(TTR("Expand"));
 	expand_button->set_tooltip_text(TTR("Enable to also set the Expand flag.\nDisable to only set Shrink/Fill flags."));
+	expand_button->connect("pressed", callable_mp(this, &SizeFlagPresetPicker::_expand_button_pressed));
 	main_vb->add_child(expand_button);
 }
 
@@ -812,12 +823,49 @@ void ControlEditorToolbar::_container_flags_selected(int p_flags, bool p_vertica
 	for (Node *E : selection) {
 		Control *control = Object::cast_to<Control>(E);
 		if (control) {
+			int old_flags = p_vertical ? control->get_v_size_flags() : control->get_h_size_flags();
 			if (p_vertical) {
 				undo_redo->add_do_method(control, "set_v_size_flags", p_flags);
+				undo_redo->add_undo_method(control, "set_v_size_flags", old_flags);
 			} else {
 				undo_redo->add_do_method(control, "set_h_size_flags", p_flags);
+				undo_redo->add_undo_method(control, "set_h_size_flags", old_flags);
 			}
-			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
+		}
+	}
+
+	undo_redo->commit_action();
+}
+
+void ControlEditorToolbar::_expand_flag_toggled(bool p_expand, bool p_vertical) {
+	List<Node *> selection = editor_selection->get_selected_node_list();
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	if (p_vertical) {
+		undo_redo->create_action(TTR("Change Vertical Expand Flag"));
+	} else {
+		undo_redo->create_action(TTR("Change Horizontal Expand Flag"));
+	}
+
+	for (Node *E : selection) {
+		Control *control = Object::cast_to<Control>(E);
+		if (control) {
+			int old_flags = p_vertical ? control->get_v_size_flags() : control->get_h_size_flags();
+			int new_flags = old_flags;
+
+			if (p_expand) {
+				new_flags |= Control::SIZE_EXPAND;
+			} else {
+				new_flags &= ~Control::SIZE_EXPAND;
+			}
+
+			if (p_vertical) {
+				undo_redo->add_do_method(control, "set_v_size_flags", new_flags);
+				undo_redo->add_undo_method(control, "set_v_size_flags", old_flags);
+			} else {
+				undo_redo->add_do_method(control, "set_h_size_flags", new_flags);
+				undo_redo->add_undo_method(control, "set_h_size_flags", old_flags);
+			}
 		}
 	}
 
@@ -968,6 +1016,30 @@ void ControlEditorToolbar::_selection_changed() {
 			container_h_picker->set_allowed_flags(allowed_all_flags);
 			container_v_picker->set_allowed_flags(allowed_all_flags);
 		}
+
+		// Update expand toggles.
+		int nb_valid_controls = 0;
+		int nb_h_expand = 0;
+		int nb_v_expand = 0;
+
+		List<Node *> selection = editor_selection->get_selected_node_list();
+		for (Node *E : selection) {
+			Control *control = Object::cast_to<Control>(E);
+			if (!control) {
+				continue;
+			}
+
+			nb_valid_controls++;
+			if (control->get_h_size_flags() & Control::SIZE_EXPAND) {
+				nb_h_expand++;
+			}
+			if (control->get_v_size_flags() & Control::SIZE_EXPAND) {
+				nb_v_expand++;
+			}
+		}
+
+		container_h_picker->set_expand_flag(nb_valid_controls == nb_h_expand);
+		container_v_picker->set_expand_flag(nb_valid_controls == nb_v_expand);
 	} else {
 		containers_button->set_visible(false);
 	}
@@ -1025,6 +1097,7 @@ ControlEditorToolbar::ControlEditorToolbar() {
 	container_h_picker = memnew(SizeFlagPresetPicker(false));
 	containers_button->get_popup_hbox()->add_child(container_h_picker);
 	container_h_picker->connect("size_flags_selected", callable_mp(this, &ControlEditorToolbar::_container_flags_selected).bind(false));
+	container_h_picker->connect("expand_flag_toggled", callable_mp(this, &ControlEditorToolbar::_expand_flag_toggled).bind(false));
 
 	containers_button->get_popup_hbox()->add_child(memnew(HSeparator));
 
@@ -1034,6 +1107,7 @@ ControlEditorToolbar::ControlEditorToolbar() {
 	container_v_picker = memnew(SizeFlagPresetPicker(true));
 	containers_button->get_popup_hbox()->add_child(container_v_picker);
 	container_v_picker->connect("size_flags_selected", callable_mp(this, &ControlEditorToolbar::_container_flags_selected).bind(true));
+	container_v_picker->connect("expand_flag_toggled", callable_mp(this, &ControlEditorToolbar::_expand_flag_toggled).bind(true));
 
 	// Editor connections.
 	editor_selection = EditorNode::get_singleton()->get_editor_selection();

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -45,6 +45,7 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
 
+class CheckButton;
 class EditorSelection;
 class GridContainer;
 
@@ -191,11 +192,12 @@ public:
 class SizeFlagPresetPicker : public ControlEditorPresetPicker {
 	GDCLASS(SizeFlagPresetPicker, ControlEditorPresetPicker);
 
-	CheckBox *expand_button = nullptr;
+	CheckButton *expand_button = nullptr;
 
 	bool vertical = false;
 
 	virtual void _preset_button_pressed(const int p_preset) override;
+	void _expand_button_pressed();
 
 protected:
 	void _notification(int p_notification);
@@ -203,6 +205,7 @@ protected:
 
 public:
 	void set_allowed_flags(Vector<SizeFlags> &p_flags);
+	void set_expand_flag(bool p_expand);
 
 	SizeFlagPresetPicker(bool p_vertical);
 };
@@ -225,6 +228,7 @@ class ControlEditorToolbar : public HBoxContainer {
 	void _anchors_to_current_ratio();
 	void _anchor_mode_toggled(bool p_status);
 	void _container_flags_selected(int p_flags, bool p_vertical);
+	void _expand_flag_toggled(bool p_expand, bool p_vertical);
 
 	Vector2 _position_to_anchor(const Control *p_control, Vector2 position);
 	bool _is_node_locked(const Node *p_node);


### PR DESCRIPTION
Fixes #81726

- Change the label from "Align with Expand" to just "Expand".
- Turns "Expand" checkbox to a check buton, to make UX clearer.
- Opening the container sizing popup loads the current value for the "Expand" check button, based on user's selection.
- Clicking on the check button immediately toggles the flag for the selected controls.
- Fix (unreported) bug that redo does nothing when changing shrink flags.

![24-05-09_14-28-15_godot windows editor x86_64_Aldabratortoise](https://github.com/godotengine/godot/assets/5117197/e5efa5f5-c27b-4b67-a635-2aeb78f28729)
