### PR TITLE
Disable dark mode title bar on Windows 10.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2398,14 +2398,14 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		} break;
 		case WM_SETTINGCHANGE: {
 			if (lParam && CompareStringOrdinal(reinterpret_cast<LPCWCH>(lParam), -1, L"ImmersiveColorSet", -1, true) == CSTR_EQUAL) {
-				if (is_dark_mode_supported()) {
+				if (is_dark_mode_supported() && dark_title_available) {
 					BOOL value = is_dark_mode();
 					::DwmSetWindowAttribute(windows[window_id].hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
 				}
 			}
 		} break;
 		case WM_THEMECHANGED: {
-			if (is_dark_mode_supported()) {
+			if (is_dark_mode_supported() && dark_title_available) {
 				BOOL value = is_dark_mode();
 				::DwmSetWindowAttribute(windows[window_id].hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
 			}
@@ -3520,7 +3520,7 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			wd.pre_fs_valid = true;
 		}
 
-		if (is_dark_mode_supported()) {
+		if (is_dark_mode_supported() && dark_title_available) {
 			BOOL value = is_dark_mode();
 			::DwmSetWindowAttribute(wd.hWnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
 		}
@@ -3612,6 +3612,7 @@ WTPacketPtr DisplayServerWindows::wintab_WTPacket = nullptr;
 WTEnablePtr DisplayServerWindows::wintab_WTEnable = nullptr;
 
 // UXTheme API.
+bool DisplayServerWindows::dark_title_available = false;
 bool DisplayServerWindows::ux_theme_available = false;
 IsDarkModeAllowedForAppPtr DisplayServerWindows::IsDarkModeAllowedForApp = nullptr;
 ShouldAppsUseDarkModePtr DisplayServerWindows::ShouldAppsUseDarkMode = nullptr;
@@ -3704,7 +3705,21 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	// Enforce default keep screen on value.
 	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 
-	// Load UXTheme
+	// Load Windows version info.
+	OSVERSIONINFOW os_ver;
+	ZeroMemory(&os_ver, sizeof(OSVERSIONINFOW));
+	os_ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFOW);
+
+	HMODULE nt_lib = LoadLibraryW(L"ntdll.dll");
+	if (nt_lib) {
+		RtlGetVersionPtr RtlGetVersion = (RtlGetVersionPtr)GetProcAddress(nt_lib, "RtlGetVersion");
+		if (RtlGetVersion) {
+			RtlGetVersion(&os_ver);
+		}
+		FreeLibrary(nt_lib);
+	}
+
+	// Load UXTheme.
 	HMODULE ux_theme_lib = LoadLibraryW(L"uxtheme.dll");
 	if (ux_theme_lib) {
 		IsDarkModeAllowedForApp = (IsDarkModeAllowedForAppPtr)GetProcAddress(ux_theme_lib, MAKEINTRESOURCEA(136));
@@ -3714,6 +3729,9 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 		GetImmersiveUserColorSetPreference = (GetImmersiveUserColorSetPreferencePtr)GetProcAddress(ux_theme_lib, MAKEINTRESOURCEA(98));
 
 		ux_theme_available = IsDarkModeAllowedForApp && ShouldAppsUseDarkMode && GetImmersiveColorFromColorSetEx && GetImmersiveColorTypeFromName && GetImmersiveUserColorSetPreference;
+		if (os_ver.dwBuildNumber >= 22000) {
+			dark_title_available = true;
+		}
 	}
 
 	// Note: Wacom WinTab driver API for pen input, for devices incompatible with Windows Ink.

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -157,6 +157,7 @@ typedef bool(WINAPI *ShouldAppsUseDarkModePtr)();
 typedef DWORD(WINAPI *GetImmersiveColorFromColorSetExPtr)(UINT dwImmersiveColorSet, UINT dwImmersiveColorType, bool bIgnoreHighContrast, UINT dwHighContrastCacheMode);
 typedef int(WINAPI *GetImmersiveColorTypeFromNamePtr)(const WCHAR *name);
 typedef int(WINAPI *GetImmersiveUserColorSetPreferencePtr)(bool bForceCheckRegistry, bool bSkipCheckOnFail);
+typedef HRESULT(WINAPI *RtlGetVersionPtr)(OSVERSIONINFOW *lpVersionInformation);
 
 // Windows Ink API
 #ifndef POINTER_STRUCTURES
@@ -285,6 +286,7 @@ class DisplayServerWindows : public DisplayServer {
 	_THREAD_SAFE_CLASS_
 
 	// UXTheme API
+	static bool dark_title_available;
 	static bool ux_theme_available;
 	static IsDarkModeAllowedForAppPtr IsDarkModeAllowedForApp;
 	static ShouldAppsUseDarkModePtr ShouldAppsUseDarkMode;


### PR DESCRIPTION
- Adds Windows 10 build version checks.
- Disables dark mode title bar on Windows 10 (it's officially supported only on Windows 11, and is buggy on Windows 10).

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/65492.*