### PR TITLE
Use verbose prints when registering cameras in CameraServer

### DIFF
--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -105,10 +105,7 @@ void CameraServer::add_feed(const Ref<CameraFeed> &p_feed) {
 	// add our feed
 	feeds.push_back(p_feed);
 
-// record for debugging
-#ifdef DEBUG_ENABLED
-	print_line("Registered camera " + p_feed->get_name() + " with id " + itos(p_feed->get_id()) + " position " + itos(p_feed->get_position()) + " at index " + itos(feeds.size() - 1));
-#endif
+	print_verbose("CameraServer: Registered camera " + p_feed->get_name() + " with ID " + itos(p_feed->get_id()) + " and position " + itos(p_feed->get_position()) + " at index " + itos(feeds.size() - 1));
 
 	// let whomever is interested know
 	emit_signal(SNAME("camera_feed_added"), p_feed->get_id());
@@ -119,10 +116,7 @@ void CameraServer::remove_feed(const Ref<CameraFeed> &p_feed) {
 		if (feeds[i] == p_feed) {
 			int feed_id = p_feed->get_id();
 
-// record for debugging
-#ifdef DEBUG_ENABLED
-			print_line("Removed camera " + p_feed->get_name() + " with id " + itos(feed_id) + " position " + itos(p_feed->get_position()));
-#endif
+			print_verbose("CameraServer: Removed camera " + p_feed->get_name() + " with ID " + itos(feed_id) + " and position " + itos(p_feed->get_position()));
 
 			// remove it from our array, if this results in our feed being unreferenced it will be destroyed
 			feeds.remove_at(i);


### PR DESCRIPTION
This prevents lines from being printed every time the editor or project starts in the editor Output log.

See https://github.com/godotengine/godot/issues/65263 for an example of this.