### PR TITLE
Fix `RestFixer` for the model has `Skin` which non-inverse-global-rest

### DIFF
--- a/editor/import/post_import_plugin_skeleton_renamer.cpp
+++ b/editor/import/post_import_plugin_skeleton_renamer.cpp
@@ -143,7 +143,7 @@ void PostImportPluginSkeletonRenamer::internal_process(InternalImportCategory p_
 		// Make unique skeleton.
 		if (bool(p_options["retarget/bone_renamer/unique_node/make_unique"])) {
 			String unique_name = String(p_options["retarget/bone_renamer/unique_node/skeleton_name"]);
-			ERR_FAIL_COND_MSG(unique_name == String(), "Skeleton unique name cannot be empty.");
+			ERR_FAIL_COND_MSG(unique_name.is_empty(), "Skeleton unique name cannot be empty.");
 
 			TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
 			while (nodes.size()) {


### PR DESCRIPTION
Previously, RestFixer forced Skin to re-bind to non-inverse-global-rest and did not take into account the original bound Pose.

This PR takes the original bound Pose into account in the re-binding calculations.

Before (broken):
![image](https://user-images.githubusercontent.com/61938263/188260201-f0845acb-dd83-42ee-bfae-2dbbd82a3c66.png)

After:
![image](https://user-images.githubusercontent.com/61938263/188260155-bc506010-a7f3-430a-bd88-9905447e2ca7.png)

---
Test model
Siren Head Monkey Run / CC by [The Pre Alpha Man](https://sketchfab.com/theprealphaman)
https://sketchfab.com/3d-models/siren-head-monkey-run-2654e635af28463f86f71f9720b914e6