### PR TITLE
Fix arm32 detection in Engine.

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -194,7 +194,7 @@ String Engine::get_architecture_name() const {
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 	return "arm64";
 
-#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7S__) || defined(_M_ARM)
+#elif defined(__arm__) || defined(_M_ARM)
 	return "arm32";
 
 #elif defined(__riscv)


### PR DESCRIPTION
The `__ARM_ARCH_7A__` and `__ARM_ARCH_7S__` are not enough, since they do not cover e.g. `__ARM_ARCH_8A__` in 32 bit mode, so instead of trying to cover any possible ARM version that can work in 32 bit mode, we can replace it with the `__arm__` macro which is defined for arm32 only (arm64 uses `__aarch64__`).