### PR TITLE
Un-defer the initial theme changed notification in `Window`

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -865,9 +865,7 @@ void Window::_notification(int p_what) {
 				RS::get_singleton()->viewport_set_active(get_viewport_rid(), true);
 			}
 
-			// Need to defer here, because theme owner information might be set in
-			// add_child_notify, which doesn't get called until right after this.
-			call_deferred(SNAME("notification"), NOTIFICATION_THEME_CHANGED);
+			notification(NOTIFICATION_THEME_CHANGED);
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {


### PR DESCRIPTION
Missed the `Window` needing the same change in https://github.com/godotengine/godot/pull/65250. Noticed in https://github.com/godotengine/godot/pull/65279#issuecomment-1236103906.