### PR TITLE
Stop ShapeCast3D drawing when debug collisions off

### DIFF
--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -205,7 +205,7 @@ bool ShapeCast3D::is_enabled() const {
 
 void ShapeCast3D::set_target_position(const Vector3 &p_point) {
 	target_position = p_point;
-	if (is_inside_tree()) {
+	if (is_inside_tree() && get_tree()->is_debugging_collisions_hint()) {
 		_update_debug_shape();
 	}
 	update_gizmos();
@@ -306,7 +306,7 @@ real_t ShapeCast3D::get_closest_collision_unsafe_fraction() const {
 }
 
 void ShapeCast3D::resource_changed(Ref<Resource> p_res) {
-	if (is_inside_tree()) {
+	if (is_inside_tree() && get_tree()->is_debugging_collisions_hint()) {
 		_update_debug_shape();
 	}
 	update_gizmos();
@@ -327,7 +327,7 @@ void ShapeCast3D::set_shape(const Ref<Shape3D> &p_shape) {
 		shape_rid = shape->get_rid();
 	}
 
-	if (is_inside_tree()) {
+	if (is_inside_tree() && get_tree()->is_debugging_collisions_hint()) {
 		_update_debug_shape();
 	}
 


### PR DESCRIPTION
ShapeCast3D is debug drawing when it shouldn't be (when Visible Collision Shapes/is_debugging_collisions_hint() is off).
It turns itself on when the Shape or Target Position is set, this PR fixes that.