### PR TITLE
Default object to scene for usability and to match defaults.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6223,10 +6223,6 @@ EditorNode::EditorNode() {
 		import_wav.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_wav);
 
-		Ref<ResourceImporterOBJ> import_obj;
-		import_obj.instantiate();
-		ResourceFormatImporter::get_singleton()->add_importer(import_obj);
-
 		Ref<ResourceImporterShaderFile> import_shader_file;
 		import_shader_file.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_shader_file);
@@ -6252,6 +6248,10 @@ EditorNode::EditorNode() {
 			import_escn.instantiate();
 			ResourceImporterScene::add_importer(import_escn);
 		}
+
+		Ref<ResourceImporterOBJ> import_obj;
+		import_obj.instantiate();
+		ResourceFormatImporter::get_singleton()->add_importer(import_obj);
 
 		Ref<ResourceImporterBitMap> import_bitmap;
 		import_bitmap.instantiate();


### PR DESCRIPTION
Resolves `.obj` not creating lods reported by `snek#8225` on discord.

Fixes: https://github.com/godotengine/godot/issues/65294

Changes behaviour of `.obj` importer to import as scene. The old import as `.mesh` is not default but still exists.

User developers can manually switch to import as mesh.