### PR TITLE
Remove middle click shortcut to open scene tab

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5309,7 +5309,7 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 				_scene_tab_closed(scene_tabs->get_hovered_tab());
 			}
 		} else {
-			if ((mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) || (mb->get_button_index() == MouseButton::MIDDLE && mb->is_pressed())) {
+			if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) {
 				_menu_option_confirm(FILE_NEW_SCENE, true);
 			}
 		}


### PR DESCRIPTION
When you middle-click in the scene tab TabBar outside any scene tab, it opens a new tab. I never found this useful and actually it constantly gets in my way. Every day I create a few empty tabs due to missclicks or editor lags while trying to close a tab.

Not sure if anyone relies on this function. You can still open a new tab by double-clicking on the tab bar. Or with the + button. Or with the shortcut. Or via filesystem dock.

EDIT:
Fixes #37055