### PR TITLE
Allow depth-writing shaders to work with shadow maps

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1667,6 +1667,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
+		actions.usage_defines["DEPTH"] = "#define DEPTH_USED\n";
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
 		actions.usage_defines["BINORMAL"] = "@TANGENT";

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -648,6 +648,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
+		actions.usage_defines["DEPTH"] = "#define DEPTH_USED\n";
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
 		actions.usage_defines["BINORMAL"] = "@TANGENT";

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -538,6 +538,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
 		actions.renames["SPECULAR_LIGHT"] = "specular_light";
 
+		actions.usage_defines["DEPTH"] = "#define DEPTH_USED\n";
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
 		actions.usage_defines["BINORMAL"] = "@TANGENT";


### PR DESCRIPTION
Solution to [Proposal-1942](https://github.com/godotengine/godot-proposals/issues/1942)

- Allowed objects with a DEPTH setting fragment shader to receive shadows and cast shadow on themselves.
- The change allows fragment shaders to modify the VERTEX variable, so they can be update it consistently to DEPTH change.
- There is still a FIXME comment in the code change. I need a hint there how to add a shader compilation time condition.

Tested only on Windows with the Vulkan renderer. Please see the test results in my comment on the proposal above.