### PR TITLE
misc: add type annotation to platform.configure

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -3,6 +3,11 @@ import sys
 import platform
 import subprocess
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -17,8 +22,6 @@ def can_build():
 
 
 def get_opts():
-    from SCons.Variables import BoolVariable, EnumVariable
-
     return [
         ("ANDROID_SDK_ROOT", "Path to the Android SDK", get_env_android_sdk_root()),
         ("ndk_platform", 'Target platform (android-<api>, e.g. "android-24")', "android-24"),
@@ -74,7 +77,7 @@ def install_ndk_if_needed(env):
     env["ANDROID_NDK_ROOT"] = get_android_ndk_root(env)
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     if env["arch"] not in supported_arches:

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -2,6 +2,11 @@ import os
 import sys
 from methods import detect_darwin_sdk_path
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -42,7 +47,7 @@ def get_flags():
     ]
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -4,6 +4,11 @@ import sys
 from methods import get_compiler_version, using_gcc
 from platform_methods import detect_arch
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -58,7 +63,7 @@ def get_flags():
     ]
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
     if env["arch"] not in supported_arches:

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -3,6 +3,11 @@ import sys
 from methods import detect_darwin_sdk_path
 from platform_methods import detect_arch
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -72,7 +77,7 @@ def get_mvk_sdk_path():
     return os.path.join(os.path.join(dirname, ver_file), "MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/")
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     if env["arch"] not in supported_arches:
@@ -145,7 +150,7 @@ def configure(env):
         env.Append(LINKFLAGS=["-isysroot", "$MACOS_SDK_PATH"])
 
     else:  # osxcross build
-        root = os.environ.get("OSXCROSS_ROOT", 0)
+        root = os.environ.get("OSXCROSS_ROOT", "")
         if env["arch"] == "arm64":
             basecmd = root + "/target/bin/arm64-apple-" + env["osxcross_sdk"] + "-"
         else:

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -3,6 +3,11 @@ import os
 import sys
 from platform_methods import detect_arch
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 
 def is_active():
     return True
@@ -39,7 +44,7 @@ def get_flags():
     ]
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32"]
     if env["arch"] not in supported_arches:
@@ -83,7 +88,7 @@ def configure(env):
     env.AppendUnique(CCFLAGS=["/utf-8"])
 
     # ANGLE
-    angle_root = os.getenv("ANGLE_SRC_PATH")
+    angle_root = os.environ["ANGLE_SRC_PATH"]
     env.Prepend(CPPPATH=[angle_root + "/include"])
     jobs = str(env.GetOption("num_jobs"))
     angle_build_cmd = (
@@ -94,7 +99,7 @@ def configure(env):
         + " /p:Configuration=Release /p:Platform="
     )
 
-    if os.path.isfile(str(os.getenv("ANGLE_SRC_PATH")) + "/winrt/10/src/angle.sln"):
+    if os.path.isfile(f"{angle_root}/winrt/10/src/angle.sln"):
         env["build_angle"] = True
 
     ## Architecture

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -11,6 +11,10 @@ from emscripten_helpers import (
 )
 from methods import get_compiler_version
 from SCons.Util import WhereIs
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
 
 
 def is_active():
@@ -61,7 +65,7 @@ def get_flags():
     ]
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["wasm32"]
     if env["arch"] not in supported_arches:

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -4,6 +4,11 @@ import subprocess
 import sys
 from platform_methods import detect_arch
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from SCons import Environment
+
 # To match other platforms
 STACK_SIZE = 8388608
 
@@ -628,7 +633,7 @@ def configure_mingw(env):
     env.Append(BUILDERS={"RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")})
 
 
-def configure(env):
+def configure(env: "Environment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     if env["arch"] not in supported_arches:


### PR DESCRIPTION
In #65024 I added a type annotation to `configure()` in `platform/macos/` as a check for the changes made there, but the sentiment was that it should be a consistent thing across all platforms rather than a complementary change in the affected file.

I reverted the annotations in #65024, just to keep there only the changes relevant for the fix itself, and separated the type annotations for all `platform` directories into this PR, with all changes required to make mypy pass without errors.

However without #64784 merged this is just a fix for current moment, and wont prevent any potential breaking without the automatic check running in CI. 