### PR TITLE
Make auto-advance flag a requirement for conditional/expression evaluation

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -22,14 +22,11 @@
 		<member name="advance_expression" type="String" setter="set_advance_expression" getter="get_advance_expression" default="&quot;&quot;">
 			Use an expression as a condition for state machine transitions. It is possible to create complex animation advance conditions for switching between states and gives much greater flexibility for creating complex state machines by directly interfacing with the script code.
 		</member>
-		<member name="auto_advance" type="bool" setter="set_auto_advance" getter="has_auto_advance" default="false">
-			Turn on the transition automatically when this state is reached. This works best with [constant SWITCH_MODE_AT_END].
-		</member>
-		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
-			Don't use this transition during [method AnimationNodeStateMachinePlayback.travel] or [member auto_advance].
+		<member name="advance_mode" type="int" setter="set_advance_mode" getter="get_advance_mode" enum="AnimationNodeStateMachineTransition.AdvanceMode" default="1">
+			Determines whether the transition should disabled, enabled when using [method AnimationNodeStateMachinePlayback.travel], or traversed automatically if the [member advance_condition] and [member advance_expression] checks are true (if assigned).
 		</member>
 		<member name="priority" type="int" setter="set_priority" getter="get_priority" default="1">
-			Lower priority transitions are preferred when travelling through the tree via [method AnimationNodeStateMachinePlayback.travel] or [member auto_advance].
+			Lower priority transitions are preferred when travelling through the tree via [method AnimationNodeStateMachinePlayback.travel] or [member advance_mode] is set to [constant ADVANCE_MODE_AUTO].
 		</member>
 		<member name="switch_mode" type="int" setter="set_switch_mode" getter="get_switch_mode" enum="AnimationNodeStateMachineTransition.SwitchMode" default="0">
 			The transition type.
@@ -57,6 +54,15 @@
 		</constant>
 		<constant name="SWITCH_MODE_AT_END" value="2" enum="SwitchMode">
 			Wait for the current state playback to end, then switch to the beginning of the next state animation.
+		</constant>
+		<constant name="ADVANCE_MODE_DISABLED" value="0" enum="AdvanceMode">
+			Don't use this transition.
+		</constant>
+		<constant name="ADVANCE_MODE_ENABLED" value="1" enum="AdvanceMode">
+			Only use this transition during [method AnimationNodeStateMachinePlayback.travel].
+		</constant>
+		<constant name="ADVANCE_MODE_AUTO" value="2" enum="AdvanceMode">
+			Automatically use this transition if the [member advance_condition] and [member advance_expression] checks are true (if assigned).
 		</constant>
 	</constants>
 </class>

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -52,15 +52,18 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	Button *tool_select = nullptr;
 	Button *tool_create = nullptr;
 	Button *tool_connect = nullptr;
-	Button *tool_group = nullptr;
-	Button *tool_ungroup = nullptr;
 	Popup *name_edit_popup = nullptr;
 	LineEdit *name_edit = nullptr;
 
-	HBoxContainer *tool_erase_hb = nullptr;
+	HBoxContainer *selection_tools_hb = nullptr;
+	Button *tool_group = nullptr;
+	Button *tool_ungroup = nullptr;
 	Button *tool_erase = nullptr;
 
-	OptionButton *transition_mode = nullptr;
+	HBoxContainer *transition_tools_hb = nullptr;
+	OptionButton *switch_mode = nullptr;
+	Button *auto_advance = nullptr;
+
 	OptionButton *play_mode = nullptr;
 
 	PanelContainer *panel = nullptr;

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -44,14 +44,19 @@ public:
 		SWITCH_MODE_AT_END,
 	};
 
+	enum AdvanceMode {
+		ADVANCE_MODE_DISABLED,
+		ADVANCE_MODE_ENABLED,
+		ADVANCE_MODE_AUTO,
+	};
+
 private:
 	SwitchMode switch_mode = SWITCH_MODE_IMMEDIATE;
-	bool auto_advance = false;
+	AdvanceMode advance_mode = ADVANCE_MODE_ENABLED;
 	StringName advance_condition;
 	StringName advance_condition_name;
 	float xfade_time = 0.0;
 	Ref<Curve> xfade_curve;
-	bool disabled = false;
 	int priority = 1;
 	String advance_expression;
 
@@ -65,8 +70,8 @@ public:
 	void set_switch_mode(SwitchMode p_mode);
 	SwitchMode get_switch_mode() const;
 
-	void set_auto_advance(bool p_enable);
-	bool has_auto_advance() const;
+	void set_advance_mode(AdvanceMode p_mode);
+	AdvanceMode get_advance_mode() const;
 
 	void set_advance_condition(const StringName &p_condition);
 	StringName get_advance_condition() const;
@@ -82,9 +87,6 @@ public:
 	void set_xfade_curve(const Ref<Curve> &p_curve);
 	Ref<Curve> get_xfade_curve() const;
 
-	void set_disabled(bool p_disabled);
-	bool is_disabled() const;
-
 	void set_priority(int p_priority);
 	int get_priority() const;
 
@@ -92,6 +94,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(AnimationNodeStateMachineTransition::SwitchMode)
+VARIANT_ENUM_CAST(AnimationNodeStateMachineTransition::AdvanceMode)
 
 class AnimationNodeStateMachine;
 


### PR DESCRIPTION
This is a PR to address a potential major design discontinuity with Godot's StateMachine system. This has been bothering me for a while, and I believe I understand why certain aspects of AnimationStateMachine's feel so counter-inuitive. I feel it is a consequence of two distinct ways of traversing them: via travel or via auto-advance/conditions. With travel, conditions are actually ignored, and it is a regular A* traversal to simply get to a desired node, whereas auto-advance can use conditional branch to have a state machine essentially drive itself.

The problem I feel with the current implementation is that you have mainly three types of transitions:
- No auto-advance and no condition: does nothing on its own
- No auto-advance but has conditions: advances but if conditions are met
- Auto-advance: ignores all conditions and advances regardless

My problem is that auto-advance more or less overwrites the behaviour conditions, and this feels very strange from a usability standpoint. It essentially makes the it an either/or scenario, and the relationship between these two elements is not obvious. My proposal therefore is to make it so that for any automatic traversal, auto-advance must always be on, and conditional evaluation is only done if auto-advance is set. While this PR only changes the actual behaviour and documentation to provide better explanation, I think more could be done on the editor side to make the relationship between the two more obvious. I could also supplement this with features such as allowing you to set the default state of auto-advance on new transitions in the same way you can for switch mode.

I feel strongly on the whole that short of removing auto-advance entirely (which doesn't feel fair given not having auto-advance active can make it useful for the 'travel' method), this is the best way to address a pretty glaring design issue, and it feels relevant to address this given the potential that a lot of game logic can be implemented purely via state machines.