### PR TITLE
Allow multiple words in Docs Help Search filter

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -320,6 +320,11 @@ bool EditorHelpSearch::Runner::_phase_match_classes_init() {
 	matched_item = nullptr;
 	match_highest_score = 0;
 
+	terms = term.split_spaces();
+	if (terms.is_empty()) {
+		terms.append(term);
+	}
+
 	return true;
 }
 
@@ -344,62 +349,38 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 		// Make an exception for annotations, since there are not that many of them.
 		if (term.length() > 1 || term == "@") {
 			if (search_flags & SEARCH_CONSTRUCTORS) {
-				for (int i = 0; i < class_doc.constructors.size(); i++) {
-					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.constructors[i].name : class_doc.constructors[i].name.to_lower();
-					if (method_name.find(term) > -1 ||
-							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
-							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
-							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
-						match.constructors.push_back(const_cast<DocData::MethodDoc *>(&class_doc.constructors[i]));
-					}
-				}
+				_match_method_name_and_push_back(class_doc.constructors, &match.constructors);
 			}
 			if (search_flags & SEARCH_METHODS) {
-				for (int i = 0; i < class_doc.methods.size(); i++) {
-					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.methods[i].name : class_doc.methods[i].name.to_lower();
-					if (method_name.find(term) > -1 ||
-							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
-							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
-							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
-						match.methods.push_back(const_cast<DocData::MethodDoc *>(&class_doc.methods[i]));
-					}
-				}
+				_match_method_name_and_push_back(class_doc.methods, &match.methods);
 			}
 			if (search_flags & SEARCH_OPERATORS) {
-				for (int i = 0; i < class_doc.operators.size(); i++) {
-					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.operators[i].name : class_doc.operators[i].name.to_lower();
-					if (method_name.find(term) > -1 ||
-							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
-							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
-							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
-						match.operators.push_back(const_cast<DocData::MethodDoc *>(&class_doc.operators[i]));
-					}
-				}
+				_match_method_name_and_push_back(class_doc.operators, &match.operators);
 			}
 			if (search_flags & SEARCH_SIGNALS) {
 				for (int i = 0; i < class_doc.signals.size(); i++) {
-					if (_match_string(term, class_doc.signals[i].name)) {
+					if (_all_terms_in_name(class_doc.signals[i].name)) {
 						match.signals.push_back(const_cast<DocData::MethodDoc *>(&class_doc.signals[i]));
 					}
 				}
 			}
 			if (search_flags & SEARCH_CONSTANTS) {
 				for (int i = 0; i < class_doc.constants.size(); i++) {
-					if (_match_string(term, class_doc.constants[i].name)) {
+					if (_all_terms_in_name(class_doc.constants[i].name)) {
 						match.constants.push_back(const_cast<DocData::ConstantDoc *>(&class_doc.constants[i]));
 					}
 				}
 			}
 			if (search_flags & SEARCH_PROPERTIES) {
 				for (int i = 0; i < class_doc.properties.size(); i++) {
-					if (_match_string(term, class_doc.properties[i].name) || _match_string(term, class_doc.properties[i].getter) || _match_string(term, class_doc.properties[i].setter)) {
+					if (_all_terms_in_name(class_doc.properties[i].name)) {
 						match.properties.push_back(const_cast<DocData::PropertyDoc *>(&class_doc.properties[i]));
 					}
 				}
 			}
 			if (search_flags & SEARCH_THEME_ITEMS) {
 				for (int i = 0; i < class_doc.theme_properties.size(); i++) {
-					if (_match_string(term, class_doc.theme_properties[i].name)) {
+					if (_all_terms_in_name(class_doc.theme_properties[i].name)) {
 						match.theme_properties.push_back(const_cast<DocData::ThemeItemDoc *>(&class_doc.theme_properties[i]));
 					}
 				}
@@ -411,7 +392,6 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 					}
 				}
 			}
-			matches[class_doc.name] = match;
 		}
 		matches[class_doc.name] = match;
 	}
@@ -506,6 +486,28 @@ bool EditorHelpSearch::Runner::_phase_member_items() {
 bool EditorHelpSearch::Runner::_phase_select_match() {
 	if (matched_item) {
 		matched_item->select(0);
+	}
+	return true;
+}
+
+void EditorHelpSearch::Runner::_match_method_name_and_push_back(Vector<DocData::MethodDoc> &p_methods, Vector<DocData::MethodDoc *> *r_match_methods) {
+	// Constructors, Methods, Operators...
+	for (int i = 0; i < p_methods.size(); i++) {
+		String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? p_methods[i].name : p_methods[i].name.to_lower();
+		if (_all_terms_in_name(method_name) ||
+				(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
+				(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
+				(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
+			r_match_methods->push_back(const_cast<DocData::MethodDoc *>(&p_methods[i]));
+		}
+	}
+}
+
+bool EditorHelpSearch::Runner::_all_terms_in_name(String name) {
+	for (int i = 0; i < terms.size(); i++) {
+		if (!_match_string(terms[i], name)) {
+			return false;
+		}
 	}
 	return true;
 }

--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -119,6 +119,7 @@ class EditorHelpSearch::Runner : public RefCounted {
 	Control *ui_service = nullptr;
 	Tree *results_tree = nullptr;
 	String term;
+	Vector<String> terms;
 	int search_flags;
 
 	Ref<Texture2D> empty_icon;
@@ -145,6 +146,8 @@ class EditorHelpSearch::Runner : public RefCounted {
 
 	String _build_method_tooltip(const DocData::ClassDoc *p_class_doc, const DocData::MethodDoc *p_doc) const;
 
+	void _match_method_name_and_push_back(Vector<DocData::MethodDoc> &p_methods, Vector<DocData::MethodDoc *> *r_match_methods);
+	bool _all_terms_in_name(String name);
 	bool _match_string(const String &p_term, const String &p_string) const;
 	void _match_item(TreeItem *p_item, const String &p_text);
 	TreeItem *_create_class_hierarchy(const ClassMatch &p_match);


### PR DESCRIPTION
Have you ever tried looking up a term in the **Help Search** window, but you didn't exactly remember how it was called, or you just assume "The space does not matter" _like how most search filters behave_, only to be met with emptiness?
This PR addresses that! Happy times.
|  |  |
| --- | --- |
 | ![image](https://user-images.githubusercontent.com/66727710/188304488-10c3fede-e36f-46f8-8051-10f568c79e27.png) |![image](https://user-images.githubusercontent.com/66727710/188304598-fdc4391d-fa3b-45ed-93bd-70651a1f5c33.png) |


This is how most search filters behave.
Also refactors the search's `match_classes` phase to reduce code duplication.

If this PR is welcome, I will apply the same logic to several other filters present in the Engine. Perhaps unifying the logic, somehow?