### PR TITLE
Fix crash when encoding freed object in `ConfigFile`

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1680,7 +1680,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		} break;
 
 		case Variant::OBJECT: {
-			Object *obj = p_variant;
+			Object *obj = p_variant.get_validated_object();
 
 			if (!obj) {
 				p_store_string_func(p_store_string_ud, "null");


### PR DESCRIPTION
Fixes #65316

No validation will be done when casting a `Variant` to `Object *`, so a wild pointer won't be detected. Using the pointer crashes the engine.