### PR TITLE
Add Preprocessor Check for `DISABLE_DEPRECATED` in Grid Map's `_octant_update()`

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -647,7 +647,11 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 				SceneTree *st = SceneTree::get_singleton();
 				if (st && st->is_debugging_navigation_hint()) {
 					if (!nm.navmesh_debug_instance.is_valid()) {
+#ifndef DISABLE_DEPRECATED
 						RID navmesh_debug_rid = navmesh->get_debug_mesh()->get_rid();
+#else
+						RID navmesh_debug_rid = navmesh->_get_debug_mesh()->get_rid();
+#endif
 						nm.navmesh_debug_instance = RS::get_singleton()->instance_create();
 						RS::get_singleton()->instance_set_base(nm.navmesh_debug_instance, navmesh_debug_rid);
 						RS::get_singleton()->mesh_surface_set_material(navmesh_debug_rid, 0, st->get_debug_navigation_material()->get_rid());


### PR DESCRIPTION
### Notes

I ran into this error today when building, and I believe the solution is fairly simple. This should resolve #65300 

### Statement of Problem

In `navigation_mesh.cpp` when deprecated features are enabled, a method, `Ref<Mesh> NavigationMesh::get_debug_mesh()`, is defined (starting on line `#344` in `master` on `2022/09/04`).

```c++
#ifndef DISABLE_DEPRECATED
Ref<Mesh> NavigationMesh::get_debug_mesh() {
```

Further down, another method, `Ref<ArrayMesh> NavigationMesh::_get_debug_mesh()`, is defined  (starting on line `#430` in `master` on `2022/09/04`).

```c++
#ifdef DEBUG_ENABLED
Ref<ArrayMesh> NavigationMesh::_get_debug_mesh() {
```

In the Grid Map module, when debugging is enabled, `_octant_update()` attempts to get the `RID` of the `navmesh`'s `debug_mesh` by calling `get_debug_mesh()` on a `NavigationMesh` instance (starting on line `#646` in `master` on `2022/09/04`). However, if deprecated features are disabled, `get_debug_mesh()` does not exist as a method on `NavigationMesh`, resulting in a compile-time error.

```c++
// add navigation debugmesh visual instances if debug is enabled
SceneTree *st = SceneTree::get_singleton();
if (st && st->is_debugging_navigation_hint()) {
    if (!nm.navmesh_debug_instance.is_valid()) {
        RID navmesh_debug_rid = navmesh->get_debug_mesh()->get_rid();
        nm.navmesh_debug_instance = RS::get_singleton()->instance_create();
        RS::get_singleton()->instance_set_base(nm.navmesh_debug_instance, navmesh_debug_rid);
        RS::get_singleton()->mesh_surface_set_material(navmesh_debug_rid, 0, st->get_debug_navigation_material()->get_rid());
    }
```

### Proposed Solution

Since the function `Ref<ArrayMesh> NavigationMesh::_get_debug_mesh()` does exist in the context of disabled deprecated features, and one of the consequences of disabling deprecated features is that the debug mesh uses an `ArrayMesh` instead of a `Mesh`, I propose the simple solution of adding a preprocessor check for the `DISABLE_DEPRECATED` flag and calling `get_debug_mesh()` when the deprecated features are enabled (because this check is the necessary and sufficient condition for the function to exist), otherwise calling `_get_debug_mesh()` which will always exist when the section of `_octant_update()` under consideration is run because it is only run when `is_debugging_navigation_hint()` returns a truthy (existent) value (and the `SceneTree` singleton exists) which is only the case when debugging is enabled.


```c++
    if (!nm.navmesh_debug_instance.is_valid()) {
#ifndef DISABLE_DEPRECATED
        RID navmesh_debug_rid = navmesh->get_debug_mesh()->get_rid();
#else
        RID navmesh_debug_rid = navmesh->_get_debug_mesh()->get_rid();
#endif
        nm.navmesh_debug_instance = RS::get_singleton()->instance_create();
```
