### PR TITLE
Select the method the caret is inside of in "Method Filter" list

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -630,6 +630,11 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 			notify_script_changed(script);
 		}
 
+		ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
+		if (ste && !ste->is_connected("caret_changed", callable_mp(this, &ScriptEditor::_update_members_overview_selection))) {
+			ste->connect("caret_changed", callable_mp(this, &ScriptEditor::_update_members_overview_selection));
+		}
+
 		Object::cast_to<ScriptEditorBase>(c)->validate();
 	}
 	if (Object::cast_to<EditorHelp>(c)) {
@@ -777,6 +782,8 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save, bool p_history_back) {
 				notify_script_close(script);
 			}
 		}
+
+		current->disconnect("caret_changed", callable_mp(this, &ScriptEditor::_update_members_overview_selection));
 	}
 
 	// roll back to previous tab
@@ -1704,6 +1711,23 @@ void ScriptEditor::get_breakpoints(List<String> *p_breakpoints) {
 		Array breakpoints = _get_cached_breakpoints_for_script(E);
 		for (int i = 0; i < breakpoints.size(); i++) {
 			p_breakpoints->push_back(E + ":" + itos((int)breakpoints[i] + 1));
+		}
+	}
+}
+
+void ScriptEditor::_update_members_overview_selection() {
+	ScriptTextEditor *ste = Object::cast_to<ScriptTextEditor>(_get_current_editor());
+	if (!ste) {
+		return;
+	}
+
+	String method_name = ste->get_method_containing_caret();
+	if (!method_name.is_empty()) {
+		for (int i = 0; i < members_overview->get_item_count(); i++) {
+			if (method_name == members_overview->get_item_text(i)) {
+				members_overview->select(i);
+				members_overview->ensure_current_is_visible();
+			}
 		}
 	}
 }

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -397,6 +397,7 @@ class ScriptEditor : public PanelContainer {
 	void _autosave_scripts();
 	void _update_autosave_timer();
 
+	void _update_members_overview_selection();
 	void _update_members_overview_visibility();
 	void _update_members_overview();
 	void _toggle_members_overview_alpha_sort(bool p_alphabetic_sort);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -124,6 +124,28 @@ Vector<String> ScriptTextEditor::get_functions() {
 	return functions;
 }
 
+String ScriptTextEditor::get_method_containing_caret() {
+	CodeEdit *te = code_editor->get_text_editor();
+
+	int iterator = te->get_caret_line();
+	while (iterator > -1) {
+		String line = te->get_line(iterator).strip_edges(true, false);
+
+		if ((line.begins_with("func ") || line.begins_with("static ")) && line.contains(":")) {
+			// This line contains a function definition.
+			int parentesis_idx = line.find_char('(');
+			int space_idx = line.rfind(" ", parentesis_idx);
+
+			if (parentesis_idx > -1 && space_idx > -1 && te->is_in_comment(iterator, parentesis_idx) == -1) {
+				return line.substr(space_idx + 1, parentesis_idx - space_idx - 1);
+			}
+		}
+		// Move up the script.
+		iterator--;
+	}
+	return "";
+}
+
 void ScriptTextEditor::apply_code() {
 	if (script.is_null()) {
 		return;
@@ -1413,6 +1435,8 @@ void ScriptTextEditor::_bind_methods() {
 	ClassDB::bind_method("_get_drag_data_fw", &ScriptTextEditor::get_drag_data_fw);
 	ClassDB::bind_method("_can_drop_data_fw", &ScriptTextEditor::can_drop_data_fw);
 	ClassDB::bind_method("_drop_data_fw", &ScriptTextEditor::drop_data_fw);
+
+	ADD_SIGNAL(MethodInfo("caret_changed"));
 }
 
 Control *ScriptTextEditor::get_edit_menu() {
@@ -1745,6 +1769,10 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 	}
 }
 
+void ScriptTextEditor::_text_edit_caret_changed() {
+	emit_signal("caret_changed");
+}
+
 void ScriptTextEditor::_color_changed(const Color &p_color) {
 	String new_args;
 	if (p_color.a == 1.0f) {
@@ -1837,6 +1865,7 @@ void ScriptTextEditor::_enable_code_editor() {
 	code_editor->get_text_editor()->connect("gutter_removed", callable_mp(this, &ScriptTextEditor::_update_gutter_indexes));
 	code_editor->get_text_editor()->connect("gutter_clicked", callable_mp(this, &ScriptTextEditor::_gutter_clicked));
 	code_editor->get_text_editor()->connect("gui_input", callable_mp(this, &ScriptTextEditor::_text_edit_gui_input));
+	code_editor->get_text_editor()->connect("caret_changed", callable_mp(this, &ScriptTextEditor::_text_edit_caret_changed));
 	code_editor->show_toggle_scripts_button();
 	_update_gutter_indexes();
 

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -182,6 +182,7 @@ protected:
 	void _edit_option_toggle_inline_comment();
 	void _make_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, bool p_goto_definition, Vector2 p_pos);
 	void _text_edit_gui_input(const Ref<InputEvent> &ev);
+	void _text_edit_caret_changed();
 	void _color_changed(const Color &p_color);
 	void _prepare_edit_menu();
 
@@ -209,6 +210,7 @@ public:
 	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
 	virtual void enable_editor() override;
 	virtual Vector<String> get_functions() override;
+	String get_method_containing_caret();
 	virtual void reload_text() override;
 	virtual String get_name() override;
 	virtual Ref<Texture2D> get_theme_icon() override;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4073

The Method Filter list in the **Script Editor** now follows the caret, matching any method it is inside of.

![Showcase](https://i.gyazo.com/9f6bd1ce90c05dd403b96dcac1212bdc.gif)

The implementation is definitely sloppier than I'd like. It doesn't work for inner classes or other languages, but I love the way it feels.
*Somebody help me, the Script Editor code is such a mess of word salad to work with, I have a headache*