### PR TITLE
Fix crash when executing `CSGMesh3D.set_mesh` with headless Godot

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -81,6 +81,7 @@ public:
 		s->vertex_count = p_surface.vertex_count;
 		s->index_data = p_surface.index_data;
 		s->index_count = p_surface.index_count;
+		s->skin_data = p_surface.skin_data;
 	}
 
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const override { return 0; }


### PR DESCRIPTION
Fixes #65318

Set `SurfaceData.skin_data` like in #65016.