### PR TITLE
Minor fixes to Vector4 in core

### DIFF
--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -115,7 +115,7 @@ struct _NO_DISCARD_ Vector2i {
 
 	real_t aspect() const { return width / (real_t)height; }
 	Vector2i sign() const { return Vector2i(SIGN(x), SIGN(y)); }
-	Vector2i abs() const { return Vector2i(ABS(x), ABS(y)); }
+	Vector2i abs() const { return Vector2i(Math::abs(x), Math::abs(y)); }
 	Vector2i clamp(const Vector2i &p_min, const Vector2i &p_max) const;
 
 	operator String() const;

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -128,7 +128,7 @@ double Vector3i::length() const {
 }
 
 Vector3i Vector3i::abs() const {
-	return Vector3i(ABS(x), ABS(y), ABS(z));
+	return Vector3i(Math::abs(x), Math::abs(y), Math::abs(z));
 }
 
 Vector3i Vector3i::sign() const {

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -80,15 +80,26 @@ real_t Vector4::length() const {
 }
 
 void Vector4::normalize() {
-	*this /= length();
+	real_t lengthsq = length_squared();
+	if (lengthsq == 0) {
+		x = y = z = w = 0;
+	} else {
+		real_t length = Math::sqrt(lengthsq);
+		x /= length;
+		y /= length;
+		z /= length;
+		w /= length;
+	}
 }
 
 Vector4 Vector4::normalized() const {
-	return *this / length();
+	Vector4 v = *this;
+	v.normalize();
+	return v;
 }
 
 bool Vector4::is_normalized() const {
-	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON); // Use less epsilon.
+	return Math::is_equal_approx(length_squared(), (real_t)1, (real_t)UNIT_EPSILON);
 }
 
 real_t Vector4::distance_to(const Vector4 &p_to) const {
@@ -187,3 +198,5 @@ Vector4 Vector4::clamp(const Vector4 &p_min, const Vector4 &p_max) const {
 Vector4::operator String() const {
 	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ", " + String::num_real(z, false) + ", " + String::num_real(w, false) + ")";
 }
+
+static_assert(sizeof(Vector4) == 4 * sizeof(real_t));

--- a/core/math/vector4i.cpp
+++ b/core/math/vector4i.cpp
@@ -84,8 +84,10 @@ Vector4i::operator Vector4() const {
 }
 
 Vector4i::Vector4i(const Vector4 &p_vec4) {
-	x = p_vec4.x;
-	y = p_vec4.y;
-	z = p_vec4.z;
-	w = p_vec4.w;
+	x = (int32_t)p_vec4.x;
+	y = (int32_t)p_vec4.y;
+	z = (int32_t)p_vec4.z;
+	w = (int32_t)p_vec4.w;
 }
+
+static_assert(sizeof(Vector4i) == 4 * sizeof(int32_t));

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -132,7 +132,7 @@ double Vector4i::length() const {
 }
 
 Vector4i Vector4i::abs() const {
-	return Vector4i(ABS(x), ABS(y), ABS(z), ABS(w));
+	return Vector4i(Math::abs(x), Math::abs(y), Math::abs(z), Math::abs(w));
 }
 
 Vector4i Vector4i::sign() const {


### PR DESCRIPTION
* Update Vector4's `normalize` implementation to be the same as Vector3's implementation. This fixes a bug where `print(Vector4.ZERO.normalized())` would give `(nan, nan, nan, nan)`.
* Change the implicit casts in the Vector4 -> Vector4i constructor to explicit ones.
* Change `ABS` to `Math::abs`. I'm not totally sure if there is a difference in practice, but the comment above `ABS` says to prefer the one in Math. This change also affects Vector2i and Vector3i.
* Add static asserts to Vector4 and Vector4i that they have the correct size. I'm not sure if this is desired, but I had this code so I figured I'd throw it in this PR. If it's not desired, it's easy to remove.

These bugs were found by copying an old Vector4 implementation I had lying around on top of Godot's Vector4.