### PR TITLE
Improve Scene Tree Dock's Node filter (Allow multiple terms & more)

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -602,7 +602,7 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 	updating_tree = false;
 	tree_dirty = false;
 
-	if (!filter.is_empty()) {
+	if (!filter.strip_edges().is_empty()) {
 		_update_filter(nullptr, p_scroll_to_selected);
 	}
 }
@@ -617,18 +617,28 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 		return false;
 	}
 
-	bool keep = false;
+	bool keep_for_children = false;
 	for (TreeItem *child = p_parent->get_first_child(); child; child = child->get_next()) {
-		keep = _update_filter(child, p_scroll_to_selected) || keep;
+		// Always keep if at least one of the children are kept.
+		keep_for_children = _update_filter(child, p_scroll_to_selected) || keep_for_children;
 	}
 
-	if (!keep) {
-		StringName node_type = get_node(p_parent->get_metadata(0))->get_class();
-		bool is_kept_by_type = (filter.begins_with("type:") && filter.trim_prefix("type:").is_subsequence_ofn(node_type)) || (filter.begins_with("t:") && filter.trim_prefix("t:").is_subsequence_ofn(node_type));
-		keep = (filter.is_subsequence_ofn(p_parent->get_text(0)) || is_kept_by_type);
+	// Now find other reasons to keep this Node, too.
+	PackedStringArray terms = filter.to_lower().split_spaces();
+	bool keep = _item_matches_all_terms(p_parent, terms);
+
+	p_parent->set_visible(keep_for_children || keep);
+	if (keep_for_children) {
+		if (keep) {
+			p_parent->clear_custom_color(0);
+			p_parent->set_selectable(0, true);
+		} else {
+			p_parent->set_custom_color(0, get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
+			p_parent->set_selectable(0, false);
+			p_parent->deselect(0);
+		}
 	}
 
-	p_parent->set_visible(keep);
 	if (editor_selection) {
 		Node *n = get_node(p_parent->get_metadata(0));
 		if (keep) {
@@ -643,7 +653,68 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 		}
 	}
 
-	return keep;
+	return keep || keep_for_children;
+}
+
+bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, PackedStringArray p_terms) {
+	if (p_terms.is_empty()) {
+		return true;
+	}
+
+	for (int i = 0; i < p_terms.size(); i++) {
+		String term = p_terms[i];
+
+		// Recognise special filter.
+		if (term.contains(":") && !term.get_slicec(':', 0).is_empty()) {
+			String parameter = term.get_slicec(':', 0);
+			String argument = term.get_slicec(':', 1);
+
+			if (parameter == "type" || parameter == "t") {
+				// Filter by Type.
+				String node_type = get_node(p_item->get_metadata(0))->get_class().to_lower();
+
+				if (!node_type.contains(argument)) {
+					return false;
+				}
+			} else if (parameter == "group" || parameter == "g") {
+				// Filter by Group.
+				Node *node = get_node(p_item->get_metadata(0));
+
+				List<Node::GroupInfo> group_info_list;
+				node->get_groups(&group_info_list);
+				if (group_info_list.is_empty()) {
+					return false;
+				}
+				// When argument is empty, match all Nodes belonging to any group.
+				if (!argument.is_empty()) {
+					bool term_in_groups = false;
+					for (int j = 0; j < group_info_list.size(); j++) {
+						// Ignore private groups.
+						if (String(group_info_list[j].name).begins_with("__")) {
+							continue;
+						}
+						if (String(group_info_list[j].name).to_lower().contains(argument)) {
+							term_in_groups = true;
+							break;
+						}
+					}
+					if (!term_in_groups) {
+						return false;
+					}
+				}
+			} else {
+				WARN_PRINT(vformat(TTR("Special Node filter \"%s\" is not recognised. Available filters include \"type\" and \"group\"."), parameter));
+				continue;
+			}
+		} else {
+			// Default.
+			if (!p_item->get_text(0).to_lower().contains(term)) {
+				return false;
+			}
+		}
+	}
+
+	return true;
 }
 
 void SceneTreeEditor::_compute_hash(Node *p_node, uint64_t &hash) {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -78,6 +78,7 @@ class SceneTreeEditor : public Control {
 	void _test_update_tree();
 	void _update_tree(bool p_scroll_to_selected = false);
 	bool _update_filter(TreeItem *p_parent = nullptr, bool p_scroll_to_selected = false);
+	bool _item_matches_all_terms(TreeItem *p_item, PackedStringArray p_terms);
 	void _tree_changed();
 	void _tree_process_mode_changed();
 	void _node_removed(Node *p_node);


### PR DESCRIPTION
This PR is a continuation of https://github.com/godotengine/godot/pull/65315, and a bit of a misnomer, because it actually does a whooping **3** things at once:

- Allows more than one term to be passed in the "**Filter Node**" search box, each term separated by spaces.💙
- Grays out any parent Node not matching the search, but still having to be there because a child does. This essentially (partially) supersedes https://github.com/godotengine/godot/pull/58481.
- To test the waters of this new implementation, and potentially expand upon the concept in the future (https://github.com/godotengine/godot-proposals/issues/4986):

   - Along with the already existing `type:` (https://github.com/godotengine/godot/pull/58377), adds a new `group:` filter. It matches any Node belonging to the passed group. If no argument is passed, it matches all Nodes belonging to any group. It also ignores groups used internally, and its alias is `g`.

Suppose we have this sample Scene: 
![image](https://user-images.githubusercontent.com/66727710/188404390-54ce0be6-1fed-4cb2-84bd-6d9b2914e7ee.png)

| "    fl    light     " | "type:audio ju p" | "pe type:col"|
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/66727710/188402766-6f7c698e-aaa4-40a8-b8a6-776f46a5029d.png) |![image](https://user-images.githubusercontent.com/66727710/188400528-07288e63-8180-43c8-81ab-ed2eb91b1ad3.png) | ![image](https://user-images.githubusercontent.com/66727710/188405133-28d6f777-fe03-4203-9cb4-eaffd3c8497d.png)

Note that, and this is going to be in the test, **ScaryObstacle1** and **ScaryObstacle2** belong to the "_enemy_" group. **ScarierObstacle** belongs to the "_enemy_" and "_horrifying_" group.

| "group:" | "group:horr"| "g:hor g:en" | 
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/66727710/188401780-43214e56-ca86-4f13-ac92-17d7ecf1c1c4.png) | ![image](https://user-images.githubusercontent.com/66727710/188401608-4097826c-f102-4f39-948d-7bfca02d4c89.png) | ![image](https://user-images.githubusercontent.com/66727710/188402401-fcc09c45-6ca5-46fd-a7e3-fcfc3c4edeb6.png)

Lastly, this implementation uses `String.contains()` over `String.is_subsequence_of()`. While the subsequence lead to "quicker typing", it also showed very inconsistent and unexpected results.



