### PR TITLE
Freeze line when releasing mouse to create a new StateMachine transition

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -267,6 +267,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		for (int i = node_rects.size() - 1; i >= 0; i--) { //inverse to draw order
 			if (node_rects[i].node.has_point(mb->get_position())) { //select node since nothing else was selected
 				connecting = true;
+				connection_follows_cursor = true;
 				connecting_from = node_rects[i].node_name;
 				connecting_to = mb->get_position();
 				connecting_to_node = StringName();
@@ -296,6 +297,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			_open_menu(mb->get_position());
 		}
 		connecting_to_node = StringName();
+		connection_follows_cursor = false;
 		state_machine_draw->queue_redraw();
 	}
 
@@ -332,7 +334,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 	}
 
 	// Move mouse while connecting
-	if (mm.is_valid() && connecting && !read_only) {
+	if (mm.is_valid() && connecting && connection_follows_cursor && !read_only) {
 		connecting_to = mm->get_position();
 		connecting_to_node = StringName();
 		state_machine_draw->queue_redraw();

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -117,6 +117,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	StringName snap_y;
 
 	bool connecting = false;
+	bool connection_follows_cursor = false;
 	StringName connecting_from;
 	Vector2 connecting_to;
 	StringName connecting_to_node;


### PR DESCRIPTION
For the AnimationStateMachine editor: stops the transition line following the cursor when mouse button is released and the prompt to create a new state is created.
![godot windows tools x86_64_j27mvQLyv9](https://user-images.githubusercontent.com/12756047/188417813-a5a7fd3c-d28e-4838-8c0b-a245e1c00e3b.gif)
