### PR TITLE
Fix UTF-8 validation in static checks

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -qq dos2unix recode clang-format-13 libxml2-utils
-          sudo update-alternatives --remove-all clang-format
+          sudo apt-get install -qq dos2unix recode clang-format-13 libxml2-utils python3-pip moreutils
+          sudo update-alternatives --remove-all clang-format || true
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
           sudo pip3 install black==22.3.0 pygments pytest
 

--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -41,7 +41,7 @@ while IFS= read -rd '' f; do
         continue
     fi
     # Ensure that files are UTF-8 formatted.
-    recode UTF-8 "$f" 2> /dev/null
+    isutf8 "$f" >> utf8-validation.txt 2>&1
     # Ensure that files have LF line endings and do not contain a BOM.
     dos2unix "$f" 2> /dev/null
     # Remove trailing space characters and ensures that files end
@@ -51,15 +51,28 @@ done
 
 diff=$(git diff --color)
 
-# If no diff has been generated all is OK, clean up, and exit.
-if [ -z "$diff" ] ; then
+# If no UTF-8 violations were collected and no diff has been
+# generated all is OK, clean up, and exit.
+if [ ! -s utf8-validation.txt ] && [ -z "$diff" ] ; then
     printf "Files in this commit comply with the formatting rules.\n"
+    rm -f utf8-violations.txt
     exit 0
 fi
 
-# A diff has been created, notify the user, clean up, and exit.
-printf "\n*** The following differences were found between the code "
-printf "and the formatting rules:\n\n"
-echo "$diff"
+# Violations detected, notify the user, clean up, and exit.
+if [ -s utf8-validation.txt ]
+then
+    printf "\n*** The following files contain invalid UTF-8 character sequences:\n\n"
+    cat utf8-validation.txt
+    rm -f utf8-validation.txt
+fi
+
+if [ ! -z "$diff" ]
+then
+    printf "\n*** The following differences were found between the code "
+    printf "and the formatting rules:\n\n"
+    echo "$diff"
+fi
+
 printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
 exit 1


### PR DESCRIPTION
Use isutf8 instead of recode to detect invalid UTF-8 sequences.

The previous use of recode depended on the default charset set to UTF-8 in the environment, which was not necessarily true if the workflow was executed on a local machine. It also did a complete copy of all source files to temporary files, even if the files were valid. The new version with isutf8 only checks the file validity in place and outputs an error message if there are any
violations. On my machine the new version finishes in ~20 seconds while the old version took ~50 seconds.

Also the PR adds the necessary dependencies to run the static checks locally
using act (https://github.com/nektos/act) with the Medium size image.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
