### PR TITLE
[3.x] Update texture image data from a byte buffer

### DIFF
--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -50,6 +50,15 @@
 				Initializes the texture by allocating and setting the data from an [Image] with [code]flags[/code] from [enum Texture.Flags]. An sRGB to linear color space conversion can take place, according to [enum Image.Format].
 			</description>
 		</method>
+		<method name="update_from_data">
+			<return type="void" />
+			<argument index="0" name="data" type="PoolByteArray" />
+			<argument index="1" name="offset" type="int" default="0" />
+			<description>
+				Update the contents of the texture from a byte array without converting it to an Image first.  The array's contents has to match the image format of the previously created texture.
+				The offset parameter makes it possible to only use a part of the array to update the texture. This is useful if the content of multiple textures is available in a single array.
+			</description>
+		</method>
 		<method name="get_format" qualifiers="const">
 			<return type="int" enum="Image.Format" />
 			<description>

--- a/doc/classes/TextureLayered.xml
+++ b/doc/classes/TextureLayered.xml
@@ -59,6 +59,16 @@
 				Sets the data for the specified layer. Data takes the form of a 2-dimensional [Image] resource.
 			</description>
 		</method>
+		<method name="set_layer_data_raw">
+			<return type="void" />
+			<argument index="0" name="data" type="PoolByteArray" />
+			<argument index="1" name="offset" type="int" />
+			<argument index="2" name="layer" type="int" />
+			<description>
+				Sets the data for the specified layer from a byte array. The array's contents has to match the image format of the previously created texture.
+				The offset parameter makes it possible to only use a part of the array to update the layer. This is useful if the content of multiple textures is available in a single array.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;depth&quot;: 0,&quot;flags&quot;: 7,&quot;format&quot;: 37,&quot;height&quot;: 0,&quot;layers&quot;: [  ],&quot;width&quot;: 0}">

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -2887,6 +2887,18 @@
 				Sets the texture's image data. If it's a CubeMap, it sets the image data at a cube side.
 			</description>
 		</method>
+		<method name="texture_set_data_raw">
+			<return type="void" />
+			<argument index="0" name="texture" type="RID" />
+			<argument index="1" name="data" type="PoolByteArray" />
+			<argument index="2" name="offset" type="int" default="0" />
+			<argument index="3" name="layer" type="int" default="0" />
+			<description>
+				Sets the texture's image data from a byte array. If the texture has multiple layers, it sets the data for the specified layer.
+				The array's contents has to match the image format of the previously created texture.
+				The offset parameter makes it possible to only use a part of the array to update the layer. This is useful if the content of multiple textures is available in a single array.
+			</description>
+		</method>
 		<method name="texture_set_data_partial">
 			<return type="void" />
 			<argument index="0" name="texture" type="RID" />

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -168,6 +168,11 @@ public:
 		t->image = Ref<Image>(memnew(Image));
 		t->image->create(p_width, p_height, false, p_format);
 	}
+
+	void texture_set_data_raw(RID p_texture, const PoolByteArray &p_data, int p_offset = 0, int p_layer = 0) {
+		// TODO: Provide dummy implementation
+	}
+
 	void texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_level) {
 		DummyTexture *t = texture_owner.getornull(p_texture);
 		ERR_FAIL_COND(!t);

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -613,6 +613,64 @@ void RasterizerStorageGLES2::texture_allocate(RID p_texture, int p_width, int p_
 	texture->active = true;
 }
 
+void RasterizerStorageGLES2::texture_set_data_raw(RID p_texture, const PoolByteArray &p_data, int p_offset, int p_layer) {
+	Texture *texture = texture_owner.get(p_texture);
+
+	ERR_FAIL_COND(!texture);
+	ERR_FAIL_COND(!texture->active);
+
+	int w = texture->width;
+	int h = texture->height;
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(texture->target, texture->tex_id);
+
+	GLenum type;
+	GLenum format;
+
+	switch (texture->format) {
+		case Image::FORMAT_L8: {
+			format = GL_LUMINANCE;
+			type = GL_UNSIGNED_BYTE;
+		} break;
+		case Image::FORMAT_LA8: {
+			format = GL_LUMINANCE_ALPHA;
+			type = GL_UNSIGNED_BYTE;
+		} break;
+		case Image::FORMAT_R8: {
+			format = GL_ALPHA;
+			type = GL_UNSIGNED_BYTE;
+		} break;
+		case Image::FORMAT_RGB8: {
+			format = GL_RGB;
+			type = GL_UNSIGNED_BYTE;
+		} break;
+		case Image::FORMAT_RGBA8: {
+			format = GL_RGBA;
+			type = GL_UNSIGNED_BYTE;
+		} break;
+		case Image::FORMAT_RGBA4444: {
+			format = GL_RGBA;
+			type = GL_UNSIGNED_SHORT_4_4_4_4;
+		} break;
+		case Image::FORMAT_RGBA5551: {
+			format = GL_RGBA;
+			type = GL_UNSIGNED_SHORT_5_5_5_1;
+		} break;
+		default: {
+			ERR_FAIL_MSG("Invalid format");
+		}
+	}
+
+	PoolByteArray::Read read = data.read();
+
+	if (texture->type == VS::TEXTURE_TYPE_2D || texture->type == VS::TEXTURE_TYPE_CUBEMAP) {
+		glTexSubImage2D(texture->target, 0, 0, 0, w, h, format, type, read.ptr() + offset);
+	} else {
+		ERR_FAIL_MSG("Operation not supported for GLES2 backend");
+	}
+}
+
 void RasterizerStorageGLES2::texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_layer) {
 	Texture *texture = texture_owner.getornull(p_texture);
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -348,6 +348,7 @@ public:
 	virtual RID texture_create();
 	virtual void texture_allocate(RID p_texture, int p_width, int p_height, int p_depth_3d, Image::Format p_format, VS::TextureType p_type, uint32_t p_flags = VS::TEXTURE_FLAGS_DEFAULT);
 	virtual void texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_layer = 0);
+	virtual void texture_set_data_raw(RID p_texture, const PoolByteArray &p_data, int p_offset = 0, int p_layer = 0);
 	virtual void texture_set_data_partial(RID p_texture, const Ref<Image> &p_image, int src_x, int src_y, int src_w, int src_h, int dst_x, int dst_y, int p_dst_mip, int p_layer = 0);
 	virtual Ref<Image> texture_get_data(RID p_texture, int p_layer = 0) const;
 	virtual void texture_set_flags(RID p_texture, uint32_t p_flags);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -700,6 +700,116 @@ void RasterizerStorageGLES3::texture_allocate(RID p_texture, int p_width, int p_
 	texture->active = true;
 }
 
+void RasterizerStorageGLES3::texture_set_data_raw(RID p_texture, const PoolByteArray &p_data, int p_offset, int p_layer) {
+	Texture *texture = texture_owner.get(p_texture);
+
+	ERR_FAIL_COND(!texture);
+	ERR_FAIL_COND(!texture->active);
+
+	int w = texture->width;
+	int h = texture->height;
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(texture->target, texture->tex_id);
+
+	GLenum type;
+	GLenum format;
+
+	switch (texture->format) {
+		case Image::FORMAT_L8: {
+#ifdef GLES_OVER_GL
+			format = GL_RED;
+			type = GL_UNSIGNED_BYTE;
+#else
+			format = GL_LUMINANCE;
+			type = GL_UNSIGNED_BYTE;
+#endif
+		} break;
+		case Image::FORMAT_LA8: {
+#ifdef GLES_OVER_GL
+			format = GL_RG;
+			type = GL_UNSIGNED_BYTE;
+#else
+			format = GL_LUMINANCE_ALPHA;
+			type = GL_UNSIGNED_BYTE;
+#endif
+		} break;
+		case Image::FORMAT_R8: {
+			format = GL_RED;
+			type = GL_UNSIGNED_BYTE;
+
+		} break;
+		case Image::FORMAT_RG8: {
+			format = GL_RG;
+			type = GL_UNSIGNED_BYTE;
+
+		} break;
+		case Image::FORMAT_RGB8: {
+			format = GL_RGB;
+			type = GL_UNSIGNED_BYTE;
+		} break;
+		case Image::FORMAT_RGBA8: {
+			format = GL_RGBA;
+			type = GL_UNSIGNED_BYTE;
+		} break;
+		case Image::FORMAT_RGBA4444: {
+			format = GL_RGBA;
+			type = GL_UNSIGNED_SHORT_4_4_4_4;
+		} break;
+		case Image::FORMAT_RGBA5551: {
+			format = GL_RGBA;
+			type = GL_UNSIGNED_SHORT_5_5_5_1;
+		} break;
+		case Image::FORMAT_RF: {
+			format = GL_RED;
+			type = GL_FLOAT;
+		} break;
+		case Image::FORMAT_RGF: {
+			format = GL_RG;
+			type = GL_FLOAT;
+		} break;
+		case Image::FORMAT_RGBF: {
+			format = GL_RGB;
+			type = GL_FLOAT;
+		} break;
+		case Image::FORMAT_RGBAF: {
+			format = GL_RGBA;
+			type = GL_FLOAT;
+		} break;
+		case Image::FORMAT_RH: {
+			format = GL_RED;
+			type = GL_HALF_FLOAT;
+		} break;
+		case Image::FORMAT_RGH: {
+			format = GL_RG;
+			type = GL_HALF_FLOAT;
+		} break;
+		case Image::FORMAT_RGBH: {
+			format = GL_RGB;
+			type = GL_HALF_FLOAT;
+		} break;
+		case Image::FORMAT_RGBAH: {
+			format = GL_RGBA;
+			type = GL_HALF_FLOAT;
+		} break;
+		case Image::FORMAT_RGBE9995: {
+			format = GL_RGB;
+			type = GL_UNSIGNED_INT_5_9_9_9_REV;
+		} break;
+		default: {
+			ERR_FAIL_MSG("Invalid format");
+		}
+	}
+
+	PoolByteArray::Read read = data.read();
+
+	if (texture->type == VS::TEXTURE_TYPE_2D || texture->type == VS::TEXTURE_TYPE_CUBEMAP) {
+		glTexSubImage2D(texture->target, 0, 0, 0, w, h, format, type, read.ptr() + offset);
+	} else {
+		glTexSubImage3D(texture->target, 0, 0, 0, p_layer, w, h, 1, format, type, read.ptr() + offset);
+	}
+}
+
 void RasterizerStorageGLES3::texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_layer) {
 	Texture *texture = texture_owner.get(p_texture);
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -360,6 +360,7 @@ public:
 	virtual RID texture_create();
 	virtual void texture_allocate(RID p_texture, int p_width, int p_height, int p_depth_3d, Image::Format p_format, VS::TextureType p_type, uint32_t p_flags = VS::TEXTURE_FLAGS_DEFAULT);
 	virtual void texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_layer = 0);
+	virtual void texture_set_data_raw(RID p_texture, const PoolByteArray &p_data, int p_offset = 0, int p_layer = 0);
 	virtual void texture_set_data_partial(RID p_texture, const Ref<Image> &p_image, int src_x, int src_y, int src_w, int src_h, int dst_x, int dst_y, int p_dst_mip, int p_layer = 0);
 	virtual Ref<Image> texture_get_data(RID p_texture, int p_layer = 0) const;
 	virtual void texture_set_flags(RID p_texture, uint32_t p_flags);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -203,6 +203,11 @@ void ImageTexture::create_from_image(const Ref<Image> &p_image, uint32_t p_flags
 	image_stored = true;
 }
 
+void ImageTexture::update_from_data(const PoolByteArray &p_data, int p_offset) {
+	ERR_FAIL_COND(!texture.is_valid());
+	VisualServer::get_singleton()->texture_set_data_raw(texture, p_data, p_offset);
+}
+
 void ImageTexture::set_flags(uint32_t p_flags) {
 	if (flags == p_flags) {
 		return;
@@ -384,6 +389,7 @@ void ImageTexture::_set_data(Dictionary p_data) {
 void ImageTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create", "width", "height", "format", "flags"), &ImageTexture::create, DEFVAL(FLAGS_DEFAULT));
 	ClassDB::bind_method(D_METHOD("create_from_image", "image", "flags"), &ImageTexture::create_from_image, DEFVAL(FLAGS_DEFAULT));
+	ClassDB::bind_method(D_METHOD("update_from_data", "data", "offset"), &ImageTexture::update_from_data, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_format"), &ImageTexture::get_format);
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("load", "path"), &ImageTexture::load);
@@ -2662,6 +2668,11 @@ void TextureLayered::set_layer_data(const Ref<Image> &p_image, int p_layer) {
 	VS::get_singleton()->texture_set_data(texture, p_image, p_layer);
 }
 
+void TextureLayered::set_layer_data_raw(const PoolByteArray &p_data, int p_offset, int p_layer) {
+	ERR_FAIL_COND(!texture.is_valid());
+	VisualServer::get_singleton()->texture_set_data_raw(texture, p_data, p_offset, p_layer);
+}
+
 Ref<Image> TextureLayered::get_layer_data(int p_layer) const {
 	ERR_FAIL_COND_V(!texture.is_valid(), Ref<Image>());
 	return VS::get_singleton()->texture_get_data(texture, p_layer);
@@ -2696,6 +2707,7 @@ void TextureLayered::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_depth"), &TextureLayered::get_depth);
 
 	ClassDB::bind_method(D_METHOD("set_layer_data", "image", "layer"), &TextureLayered::set_layer_data);
+	ClassDB::bind_method(D_METHOD("set_layer_data_raw", "data", "offset", "layer"), &TextureLayered::set_layer_data_raw);
 	ClassDB::bind_method(D_METHOD("get_layer_data", "layer"), &TextureLayered::get_layer_data);
 	ClassDB::bind_method(D_METHOD("set_data_partial", "image", "x_offset", "y_offset", "layer", "mipmap"), &TextureLayered::set_data_partial, DEFVAL(0));
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -125,6 +125,7 @@ protected:
 public:
 	void create(int p_width, int p_height, Image::Format p_format, uint32_t p_flags = FLAGS_DEFAULT);
 	void create_from_image(const Ref<Image> &p_image, uint32_t p_flags = FLAGS_DEFAULT);
+	void update_from_data(const PoolByteArray &p_data, int p_offset = 0);
 
 	void set_flags(uint32_t p_flags);
 	uint32_t get_flags() const;
@@ -507,6 +508,7 @@ public:
 
 	void create(uint32_t p_width, uint32_t p_height, uint32_t p_depth, Image::Format p_format, uint32_t p_flags = FLAGS_DEFAULT_TEXTURE_ARRAY);
 	void set_layer_data(const Ref<Image> &p_image, int p_layer);
+	void set_layer_data_raw(const PoolByteArray &p_data, int p_offset, int p_layer);
 	Ref<Image> get_layer_data(int p_layer) const;
 	void set_data_partial(const Ref<Image> &p_image, int p_x_ofs, int p_y_ofs, int p_z, int p_mipmap = 0);
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -214,7 +214,7 @@ public:
 			uint32_t p_flags = VS::TEXTURE_FLAGS_DEFAULT) = 0;
 
 	virtual void texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_level = 0) = 0;
-
+	virtual void texture_set_data_raw(RID p_texture, const PoolByteArray &p_data, int p_offset = 0, int p_layer = 0) = 0;
 	virtual void texture_set_data_partial(RID p_texture,
 			const Ref<Image> &p_image,
 			int src_x, int src_y,

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -157,6 +157,7 @@ public:
 	BIND0R(RID, texture_create)
 	BIND7(texture_allocate, RID, int, int, int, Image::Format, TextureType, uint32_t)
 	BIND3(texture_set_data, RID, const Ref<Image> &, int)
+	BIND4(texture_set_data_raw, RID, const PoolByteArray &, int, int);
 	BIND10(texture_set_data_partial, RID, const Ref<Image> &, int, int, int, int, int, int, int, int)
 	BIND2RC(Ref<Image>, texture_get_data, RID, int)
 	BIND2(texture_set_flags, RID, uint32_t)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -79,6 +79,7 @@ public:
 	/* EVENT QUEUING */
 	FUNCRID(texture)
 	FUNC7(texture_allocate, RID, int, int, int, Image::Format, TextureType, uint32_t)
+	FUNC4(texture_set_data_raw, RID, const PoolByteArray &, int, int);
 	FUNC3(texture_set_data, RID, const Ref<Image> &, int)
 	FUNC10(texture_set_data_partial, RID, const Ref<Image> &, int, int, int, int, int, int, int, int)
 	FUNC2RC(Ref<Image>, texture_get_data, RID, int)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1847,6 +1847,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_create_from_image", "image", "flags"), &VisualServer::texture_create_from_image, DEFVAL(TEXTURE_FLAGS_DEFAULT));
 	ClassDB::bind_method(D_METHOD("texture_allocate", "texture", "width", "height", "depth_3d", "format", "type", "flags"), &VisualServer::texture_allocate, DEFVAL(TEXTURE_FLAGS_DEFAULT));
 	ClassDB::bind_method(D_METHOD("texture_set_data", "texture", "image", "layer"), &VisualServer::texture_set_data, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("texture_set_data_raw", "texture", "data", "offset", "layer"), &VisualServer::texture_set_data_raw, DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("texture_set_data_partial", "texture", "image", "src_x", "src_y", "src_w", "src_h", "dst_x", "dst_y", "dst_mip", "layer"), &VisualServer::texture_set_data_partial, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("texture_get_data", "texture", "cube_side"), &VisualServer::texture_get_data, DEFVAL(CUBEMAP_LEFT));
 	ClassDB::bind_method(D_METHOD("texture_set_flags", "texture", "flags"), &VisualServer::texture_set_flags);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -129,6 +129,8 @@ public:
 			uint32_t p_flags = TEXTURE_FLAGS_DEFAULT) = 0;
 
 	virtual void texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
+	virtual void texture_set_data_raw(RID p_texture, const PoolByteArray &p_data, int p_offset = 0, int p_layer = 0) = 0;
+
 	virtual void texture_set_data_partial(RID p_texture,
 			const Ref<Image> &p_image,
 			int src_x, int src_y,


### PR DESCRIPTION
When a texture needs to be updated frequently (e.g. every frame)
converting the texture data first to an image causes too many delays.
The new APIs allow the applications to update the image data of a
texture directly from a byte array. An offset parameter makes it
possible to only use a part of the byte array for the update.

Companion proposal: https://github.com/godotengine/godot-proposals/issues/5342

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
