### PR TITLE
HTML5: Fix warning with Emscripten 3.1.20

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -6,7 +6,7 @@ env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: 3.x
   SCONSFLAGS: verbose=yes warnings=all werror=yes debug_symbols=no
-  EM_VERSION: 3.1.10
+  EM_VERSION: 3.1.20
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -157,9 +157,9 @@ def configure(env):
     env["ARCOM_POSIX"] = env["ARCOM"].replace("$TARGET", "$TARGET.posix").replace("$SOURCES", "$SOURCES.posix")
     env["ARCOM"] = "${TEMPFILE(ARCOM_POSIX)}"
 
-    # All intermediate files are just LLVM bitcode.
+    # All intermediate files are just object files.
     env["OBJPREFIX"] = ""
-    env["OBJSUFFIX"] = ".bc"
+    env["OBJSUFFIX"] = ".o"
     env["PROGPREFIX"] = ""
     # Program() output consists of multiple files, so specify suffixes manually at builder.
     env["PROGSUFFIX"] = ""


### PR DESCRIPTION
Note for `3.5` cherrypick: might be best to update the Emscripten version to 3.1.14 which is what we use in official builds: https://github.com/godotengine/build-containers/blob/3.5/Dockerfile.javascript#L6

We'll aim to use latest Emscripten for 3.6.