### PR TITLE
Fix AudioStreamPlayer not resuming after returning to SceneTree

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -43,11 +43,16 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
 			}
+			set_stream_paused(false);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			stop();
+			set_stream_paused(true);
 			AudioServer::get_singleton()->remove_listener_changed_callback(_listener_changed_cb, this);
+		} break;
+
+		case NOTIFICATION_PREDELETE: {
+			stop();
 		} break;
 
 		case NOTIFICATION_PAUSED: {

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -247,11 +247,16 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
 			}
+			set_stream_paused(false);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			stop();
+			set_stream_paused(true);
 			AudioServer::get_singleton()->remove_listener_changed_callback(_listener_changed_cb, this);
+		} break;
+
+		case NOTIFICATION_PREDELETE: {
+			stop();
 		} break;
 
 		case NOTIFICATION_PAUSED: {

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -40,6 +40,7 @@ void AudioStreamPlayer::_notification(int p_what) {
 			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
 			}
+			set_stream_paused(false);
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
@@ -64,6 +65,10 @@ void AudioStreamPlayer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			set_stream_paused(true);
+		} break;
+
+		case NOTIFICATION_PREDELETE: {
 			for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 				AudioServer::get_singleton()->stop_playback_stream(playback);
 			}


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/63556.

All audio playbacks were cleared when exiting the tree. Now they're all just paused.

It's worth noting that while this fixes the regression, it will **always** resume the audio playback upon returning to the tree, if possible. This, from the user's perspective, makes setting the `stream_paused `property manually a bit more unreliable than it already was before. Maybe something about it can be done another time?