### PR TITLE
Fix missing `import sys` in `methods.py`

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import glob
 import subprocess
 from collections import OrderedDict


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/65161. This PR is not needed in `master`.

Thanks @feiyunw for the report :slightly_smiling_face: