### PR TITLE
Fix contextual visibility of tileset and tilemap editors (again)

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -184,24 +184,32 @@ void TilesEditorPlugin::_notification(int p_what) {
 }
 
 void TilesEditorPlugin::make_visible(bool p_visible) {
-	is_visible = p_visible;
-
-	if (is_visible) {
+	if (p_visible || is_tile_map_selected()) {
 		// Disable and hide invalid editors.
 		TileMap *tile_map = Object::cast_to<TileMap>(ObjectDB::get_instance(tile_map_id));
 		tileset_editor_button->set_visible(tile_set.is_valid());
 		tilemap_editor_button->set_visible(tile_map);
-		if (tile_map && !is_editing_tile_set) {
+		if (tile_map && (!is_editing_tile_set || !p_visible)) {
 			EditorNode::get_singleton()->make_bottom_panel_item_visible(tilemap_editor);
 		} else {
 			EditorNode::get_singleton()->make_bottom_panel_item_visible(tileset_editor);
 		}
-
+		is_visible = true;
 	} else {
 		tileset_editor_button->hide();
 		tilemap_editor_button->hide();
 		EditorNode::get_singleton()->hide_bottom_panel();
+		is_visible = false;
 	}
+}
+
+bool TilesEditorPlugin::is_tile_map_selected() {
+	TypedArray<Node> selection = get_editor_interface()->get_selection()->get_selected_nodes();
+	if (selection.size() == 1 && Object::cast_to<TileMap>(selection[0])) {
+		return true;
+	}
+
+	return false;
 }
 
 void TilesEditorPlugin::queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMapPattern> p_pattern, Callable p_callback) {
@@ -361,18 +369,23 @@ void TilesEditorPlugin::edit(Object *p_object) {
 		} else if (p_object->is_class("TileSet")) {
 			tile_set = Ref<TileSet>(p_object);
 			if (tile_map) {
-				if (tile_map->get_tileset() != tile_set || !tile_map->is_inside_tree()) {
+				if (tile_map->get_tileset() != tile_set || !tile_map->is_inside_tree() || !is_tile_map_selected()) {
 					tile_map = nullptr;
 					tile_map_id = ObjectID();
 				}
 			}
 			is_editing_tile_set = true;
-			EditorNode::get_singleton()->make_bottom_panel_item_visible(tileset_editor);
 		}
 	}
 
 	// Update the editors.
 	_update_editors();
+
+	// If the tileset is being edited, the visibility function must be called
+	// here after _update_editors has been called.
+	if (is_editing_tile_set) {
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(tileset_editor);
+	}
 
 	// Add change listener.
 	if (tile_map) {

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -110,6 +110,8 @@ public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return tilemap_editor->forward_canvas_gui_input(p_event); }
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { tilemap_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
+	bool is_tile_map_selected();
+
 	// Pattern preview API.
 	void queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMapPattern> p_pattern, Callable p_callback);
 


### PR DESCRIPTION
I was sure I fixed this all before in this PR (#58361), but there must have been regressions which caused aspects of this to break. In either case, this should solve the TileSet and TileMap editor buttons disappearing if you click on it to inspect it as part of the tileset node in the inspector, and then click on it again to hide it. It also fixes a minor error which occurs when opening a tileset resource on its own.