### PR TITLE
Fix "Treat Warnings as Errors" Project Setting doing nothing

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -230,7 +230,7 @@ void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_
 	warning.leftmost_column = p_source->leftmost_column;
 	warning.rightmost_column = p_source->rightmost_column;
 
-	if (warn_level == GDScriptWarning::WarnLevel::ERROR) {
+	if (warn_level == GDScriptWarning::WarnLevel::ERROR || bool(GLOBAL_GET("debug/gdscript/warnings/treat_warnings_as_errors"))) {
 		push_error(warning.get_message(), p_source);
 		return;
 	}


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/58330.

![image](https://user-images.githubusercontent.com/66727710/188491832-1aa8d9dc-d5e8-4f3d-b8c2-2afb697056a9.png)

The setting wasn't being accounted for, at all. I'm not sure the current fix is performant, as I've heard fetching Project Settings is really slow, so it should be cached somewhere? Regardless, it gets the job done.