### PR TITLE
Never duplicate `script` with Resource.`duplicate()`

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -260,6 +260,11 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 		}
 		Variant p = get(E.name);
 
+		if (E.name == "script") {
+			r->set(E.name, p); // Do not ever duplicate Script property.
+			continue;
+		}
+
 		if ((p.get_type() == Variant::DICTIONARY || p.get_type() == Variant::ARRAY)) {
 			r->set(E.name, p.duplicate(p_subresources));
 		} else if (p.get_type() == Variant::OBJECT && (p_subresources || (E.usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE))) {

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -24,7 +24,7 @@
 			<param index="0" name="subresources" type="bool" default="false" />
 			<description>
 				Duplicates this resource, returning a new resource with its [code]export[/code]ed or [constant PROPERTY_USAGE_STORAGE] properties copied from the original.
-				If [param subresources] is [code]false[/code], a shallow copy is returned. Nested resources within subresources are not duplicated and are shared from the original resource. This behavior can be overriden by the [constant PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE] flag.
+				If [param subresources] is [code]false[/code], a shallow copy is returned. Nested resources within subresources are not duplicated and are shared from the original resource. This behavior can be overriden by the [constant PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE] flag. The resource's [code]script[/code] is [b]always[/b] shared.
 				[b]Note:[/b] For custom resources, this method will fail if [method Object._init] has been defined with required parameters.
 			</description>
 		</method>


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/58031.

Excludes the `script` property of a Resource from being ever duplicated. This doesn't mean that a **Script** resource cannot ever be duplicated, however.