### PR TITLE
Fix "grab_focus: Condition "!is_inside_tree()" is true" when AcceptDialog was visible from the editor.

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -60,9 +60,16 @@ void AcceptDialog::_update_theme_item_cache() {
 
 void AcceptDialog::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_VISIBILITY_CHANGED: {
+		case NOTIFICATION_POST_ENTER_TREE: {
 			if (is_visible()) {
 				get_ok_button()->grab_focus();
+			}
+		} break;
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible()) {
+				if (get_ok_button()->is_inside_tree()) {
+					get_ok_button()->grab_focus();
+				}
 				_update_child_rects();
 				parent_visible = get_parent_visible_window();
 				if (parent_visible) {


### PR DESCRIPTION
Fix  #65363

The error happened when the AcceptDialog's visibility was turned on from the editor. When trying to grab the focus the node was not in the tree yet.
I moved the grab focus that happened in `NOTIFICATION_VISIBILITY_CHANGED` to:

`NOTIFICATION_READY`: To check if it was visible and be able to grab the focus. (When ready the node is already in the tree so it has no problems). This only turns grabs the focus on ready.

I also added a check in the `NOTIFICATION_VISIBILITY_CHANGED`. It checks if the ok button is in the tree. If its is, `grab_focus` is called. This allows the focus happen when turning visibility on and off during the game.

It is not compatible with the 3.x branch because the Dialog is different. They can't be showed from the editor and need the `popup()` method to be visible. Anyways, this error doesn't happen in 3.x versions.

![image](https://user-images.githubusercontent.com/109873547/188501548-b4e4e260-b52b-4eba-939e-6f68d8bcef9b.png)
