### PR TITLE
Fix AudioStreamPlayer2D and 3D's `playing` not updating right away

### DIFF
--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -29,7 +29,7 @@
 			<return type="void" />
 			<param index="0" name="from_position" type="float" default="0.0" />
 			<description>
-				Plays the audio from the given position [param from_position], in seconds.
+				Queues the audio to play on the next physics frame, from the given position [param from_position], in seconds.
 			</description>
 		</method>
 		<method name="seek">
@@ -73,7 +73,7 @@
 			The pitch and the tempo of the audio, as a multiplier of the audio sample's sample rate.
 		</member>
 		<member name="playing" type="bool" setter="_set_playing" getter="is_playing" default="false">
-			If [code]true[/code], audio is playing.
+			If [code]true[/code], audio is playing or is queued to be played (see [method play]).
 		</member>
 		<member name="stream" type="AudioStream" setter="set_stream" getter="get_stream">
 			The [AudioStream] object to be played.

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -29,7 +29,7 @@
 			<return type="void" />
 			<param index="0" name="from_position" type="float" default="0.0" />
 			<description>
-				Plays the audio from the given position [param from_position], in seconds.
+				Queues the audio to play on the next physics frame, from the given position [param from_position], in seconds.
 			</description>
 		</method>
 		<method name="seek">
@@ -94,7 +94,7 @@
 			The pitch and the tempo of the audio, as a multiplier of the audio sample's sample rate.
 		</member>
 		<member name="playing" type="bool" setter="_set_playing" getter="is_playing" default="false">
-			If [code]true[/code], audio is playing.
+			If [code]true[/code], audio is playing or is queued to be played (see [method play]).
 		</member>
 		<member name="stream" type="AudioStream" setter="set_stream" getter="get_stream">
 			The [AudioStream] resource to be played.

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -284,6 +284,9 @@ bool AudioStreamPlayer2D::is_playing() const {
 			return true;
 		}
 	}
+	if (setplay.get() >= 0) {
+		return true; // play() has been called this frame, but no playback exists just yet.
+	}
 	return false;
 }
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -606,6 +606,9 @@ bool AudioStreamPlayer3D::is_playing() const {
 			return true;
 		}
 	}
+	if (setplay.get() >= 0) {
+		return true; // play() has been called this frame, but no playback exists just yet.
+	}
 	return false;
 }
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/58560

**AudioStreamPlayer2D** and **AudioStreamPlayer3D** do not append a new **AudioStreamPlayback** right away. Rather, they wait for the next internal frame to do so. The `is_playing()` was ported from **AudioStreamPlayer** without accounting for this difference. The method now also checks if **AudioStreamPlayer2D**/**3D** has been "queued" to play.