### PR TITLE
[3.x] Implement adaptive multibuffer 2D rendering option

### DIFF
--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -48,12 +48,14 @@ static const GLenum gl_primitive[] = {
 };
 
 void RasterizerCanvasGLES2::_batch_upload_buffers() {
+	batch_gl_data.next();
+
 	// noop?
 	if (!bdata.vertices.size()) {
 		return;
 	}
 
-	glBindBuffer(GL_ARRAY_BUFFER, bdata.gl_vertex_buffer);
+	glBindBuffer(GL_ARRAY_BUFFER, batch_gl_data.current_vertex_buffer());
 
 	// usage flag is a project setting
 	GLenum buffer_usage_flag = GL_DYNAMIC_DRAW;
@@ -112,8 +114,8 @@ void RasterizerCanvasGLES2::_batch_render_lines(const Batch &p_batch, Rasterizer
 	int sizeof_vert = sizeof(BatchVertex);
 
 	// bind the index and vertex buffer
-	glBindBuffer(GL_ARRAY_BUFFER, bdata.gl_vertex_buffer);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bdata.gl_index_buffer);
+	glBindBuffer(GL_ARRAY_BUFFER, batch_gl_data.current_vertex_buffer());
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batch_gl_data.current_index_buffer());
 
 	uint64_t pointer = 0;
 	glVertexAttribPointer(VS::ARRAY_VERTEX, 2, GL_FLOAT, GL_FALSE, sizeof_vert, (const void *)pointer);
@@ -193,8 +195,8 @@ void RasterizerCanvasGLES2::_batch_render_generic(const Batch &p_batch, Rasteriz
 	_bind_canvas_texture(tex.RID_texture, tex.RID_normal);
 
 	// bind the index and vertex buffer
-	glBindBuffer(GL_ARRAY_BUFFER, bdata.gl_vertex_buffer);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bdata.gl_index_buffer);
+	glBindBuffer(GL_ARRAY_BUFFER, batch_gl_data.current_vertex_buffer());
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, batch_gl_data.current_index_buffer());
 
 	uint64_t pointer = 0;
 	glVertexAttribPointer(VS::ARRAY_VERTEX, 2, GL_FLOAT, GL_FALSE, sizeof_vert, (const void *)pointer);
@@ -1195,6 +1197,10 @@ void RasterizerCanvasGLES2::render_batches(Item *p_current_clip, bool &r_reclip,
 void RasterizerCanvasGLES2::canvas_end() {
 	batch_canvas_end();
 	RasterizerCanvasBaseGLES2::canvas_end();
+}
+
+void RasterizerCanvasGLES2::canvas_adapt() {
+	batch_gl_data.adapt();
 }
 
 void RasterizerCanvasGLES2::canvas_begin() {
@@ -2326,23 +2332,15 @@ void RasterizerCanvasGLES2::gl_disable_scissor() const {
 	glDisable(GL_SCISSOR_TEST);
 }
 
-void RasterizerCanvasGLES2::initialize() {
-	RasterizerGLES2::gl_check_errors();
-	RasterizerCanvasBaseGLES2::initialize();
-
-	batch_initialize();
-
+void RasterizerCanvasGLES2::initialize_buffer(GLuint vertex_buffer, GLuint index_buffer) {
 	// just reserve some space (may not be needed as we are orphaning, but hey ho)
-	glGenBuffers(1, &bdata.gl_vertex_buffer);
-
 	if (bdata.vertex_buffer_size_bytes) {
-		glBindBuffer(GL_ARRAY_BUFFER, bdata.gl_vertex_buffer);
+		glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer);
 		glBufferData(GL_ARRAY_BUFFER, bdata.vertex_buffer_size_bytes, nullptr, GL_DYNAMIC_DRAW);
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 		// pre fill index buffer, the indices never need to change so can be static
-		glGenBuffers(1, &bdata.gl_index_buffer);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bdata.gl_index_buffer);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer);
 
 		Vector<uint16_t> indices;
 		indices.resize(bdata.index_buffer_size_units);
@@ -2367,9 +2365,20 @@ void RasterizerCanvasGLES2::initialize() {
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
 	} // only if there is a vertex buffer (batching is on)
+}
+
+void RasterizerCanvasGLES2::initialize() {
+	RasterizerGLES2::gl_check_errors();
+	RasterizerCanvasBaseGLES2::initialize();
+
+	batch_initialize();
+
+	batch_gl_data.resize(1);
+
 	RasterizerGLES2::gl_check_errors();
 }
 
-RasterizerCanvasGLES2::RasterizerCanvasGLES2() {
+RasterizerCanvasGLES2::RasterizerCanvasGLES2() :
+		batch_gl_data(*this) {
 	batch_constructor();
 }

--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -462,6 +462,11 @@ void RasterizerGLES2::end_frame(bool p_swap_buffers) {
 	} else {
 		glFinish();
 	}
+
+	bool multiple_buffer_batching = GLOBAL_GET("rendering/batching/options/multiple_buffer_batching");
+	if (multiple_buffer_batching) {
+		canvas->canvas_adapt();
+	}
 }
 
 void RasterizerGLES2::finalize() {

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -54,6 +54,10 @@ void RasterizerCanvasGLES3::canvas_begin() {
 	RasterizerCanvasBaseGLES3::canvas_begin();
 }
 
+void RasterizerCanvasGLES3::canvas_adapt() {
+	batch_gl_data.adapt();
+}
+
 void RasterizerCanvasGLES3::canvas_render_items_begin(const Color &p_modulate, Light *p_light, const Transform2D &p_base_transform) {
 	batch_canvas_render_items_begin(p_modulate, p_light, p_base_transform);
 }
@@ -1930,12 +1934,16 @@ void RasterizerCanvasGLES3::canvas_render_items_implementation(Item *p_item_list
 }
 
 void RasterizerCanvasGLES3::_batch_upload_buffers() {
+	batch_gl_data.next();
+
 	// noop?
 	if (!bdata.vertices.size()) {
 		return;
 	}
 
-	glBindBuffer(GL_ARRAY_BUFFER, bdata.gl_vertex_buffer);
+	const GLuint gl_vertex_buffer = batch_gl_data.current_vertex_buffer();
+
+	glBindBuffer(GL_ARRAY_BUFFER, gl_vertex_buffer);
 
 	// usage flag is a project setting
 	GLenum buffer_usage_flag = GL_DYNAMIC_DRAW;
@@ -1977,7 +1985,7 @@ void RasterizerCanvasGLES3::_batch_render_lines(const Batch &p_batch, Rasterizer
 
 	_bind_canvas_texture(RID(), RID());
 
-	glBindVertexArray(batch_gl_data.batch_vertex_array[0]);
+	glBindVertexArray(batch_gl_data.current_vertex_array()[0]);
 
 	glDisableVertexAttribArray(VS::ARRAY_COLOR);
 	glVertexAttrib4fv(VS::ARRAY_COLOR, (float *)&p_batch.color);
@@ -2021,19 +2029,19 @@ void RasterizerCanvasGLES3::_batch_render_prepare() {
 			return;
 			break;
 		case RasterizerStorageCommon::FVF_REGULAR: // no change
-			glBindVertexArray(batch_gl_data.batch_vertex_array[0]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[0]);
 			break;
 		case RasterizerStorageCommon::FVF_COLOR:
-			glBindVertexArray(batch_gl_data.batch_vertex_array[1]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[1]);
 			break;
 		case RasterizerStorageCommon::FVF_LIGHT_ANGLE:
-			glBindVertexArray(batch_gl_data.batch_vertex_array[2]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[2]);
 			break;
 		case RasterizerStorageCommon::FVF_MODULATED:
-			glBindVertexArray(batch_gl_data.batch_vertex_array[3]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[3]);
 			break;
 		case RasterizerStorageCommon::FVF_LARGE:
-			glBindVertexArray(batch_gl_data.batch_vertex_array[4]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[4]);
 			break;
 	}
 }
@@ -2056,19 +2064,19 @@ void RasterizerCanvasGLES3::_batch_render_generic(const Batch &p_batch, Rasteriz
 			return;
 			break;
 		case RasterizerStorageCommon::FVF_REGULAR: // no change
-			glBindVertexArray(batch_gl_data.batch_vertex_array[0]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[0]);
 			break;
 		case RasterizerStorageCommon::FVF_COLOR:
-			glBindVertexArray(batch_gl_data.batch_vertex_array[1]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[1]);
 			break;
 		case RasterizerStorageCommon::FVF_LIGHT_ANGLE:
-			glBindVertexArray(batch_gl_data.batch_vertex_array[2]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[2]);
 			break;
 		case RasterizerStorageCommon::FVF_MODULATED:
-			glBindVertexArray(batch_gl_data.batch_vertex_array[3]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[3]);
 			break;
 		case RasterizerStorageCommon::FVF_LARGE:
-			glBindVertexArray(batch_gl_data.batch_vertex_array[4]);
+			glBindVertexArray(batch_gl_data.current_vertex_array()[4]);
 			break;
 	}
 
@@ -2148,23 +2156,15 @@ void RasterizerCanvasGLES3::_batch_render_generic(const Batch &p_batch, Rasteriz
 	*/
 }
 
-void RasterizerCanvasGLES3::initialize() {
-	RasterizerGLES3::gl_check_errors();
-	RasterizerCanvasBaseGLES3::initialize();
-
-	batch_initialize();
-
+void RasterizerCanvasGLES3::initialize_buffer(GLuint vertex_buffer, GLuint index_buffer, GLuint vertex_array[5]) {
 	// just reserve some space (may not be needed as we are orphaning, but hey ho)
-	glGenBuffers(1, &bdata.gl_vertex_buffer);
-
 	if (bdata.vertex_buffer_size_bytes) {
-		glBindBuffer(GL_ARRAY_BUFFER, bdata.gl_vertex_buffer);
+		glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer);
 		glBufferData(GL_ARRAY_BUFFER, bdata.vertex_buffer_size_bytes, nullptr, GL_DYNAMIC_DRAW);
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 		// pre fill index buffer, the indices never need to change so can be static
-		glGenBuffers(1, &bdata.gl_index_buffer);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bdata.gl_index_buffer);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer);
 
 		Vector<uint16_t> indices;
 		indices.resize(bdata.index_buffer_size_units);
@@ -2211,10 +2211,9 @@ void RasterizerCanvasGLES3::initialize() {
 				break;
 		}
 
-		glGenVertexArrays(1, &batch_gl_data.batch_vertex_array[vao]);
-		glBindVertexArray(batch_gl_data.batch_vertex_array[vao]);
-		glBindBuffer(GL_ARRAY_BUFFER, bdata.gl_vertex_buffer);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bdata.gl_index_buffer);
+		glBindVertexArray(vertex_array[vao]);
+		glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer);
 
 		uint64_t pointer = 0;
 		glEnableVertexAttribArray(VS::ARRAY_VERTEX);
@@ -2274,6 +2273,15 @@ void RasterizerCanvasGLES3::initialize() {
 
 		glBindVertexArray(0);
 	} // for vao
+}
+
+void RasterizerCanvasGLES3::initialize() {
+	RasterizerGLES3::gl_check_errors();
+	RasterizerCanvasBaseGLES3::initialize();
+
+	batch_initialize();
+
+	batch_gl_data.resize(1);
 
 	// deal with ninepatch mode option
 	if (bdata.settings_ninepatch_mode == 1) {
@@ -2283,6 +2291,7 @@ void RasterizerCanvasGLES3::initialize() {
 	RasterizerGLES3::gl_check_errors();
 }
 
-RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
+RasterizerCanvasGLES3::RasterizerCanvasGLES3() :
+		batch_gl_data(*this) {
 	batch_constructor();
 }

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -420,6 +420,11 @@ void RasterizerGLES3::end_frame(bool p_swap_buffers) {
 	} else {
 		glFinish();
 	}
+
+	bool multiple_buffer_batching = GLOBAL_GET("rendering/batching/options/multiple_buffer_batching");
+	if (multiple_buffer_batching) {
+		canvas->canvas_adapt();
+	}
 }
 
 void RasterizerGLES3::finalize() {

--- a/drivers/gles_common/rasterizer_array.h
+++ b/drivers/gles_common/rasterizer_array.h
@@ -153,6 +153,15 @@ public:
 		return p;
 	}
 
+	T *request_with_grow(int p_num_items) {
+		T *p = request(p_num_items);
+		if (!p) {
+			grow();
+			return request_with_grow(p_num_items);
+		}
+		return p;
+	}
+
 	// none of that inefficient pass by value stuff here, thanks
 	T *request() {
 		if (_size < _max_size) {

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -283,8 +283,6 @@ public:
 			reset_flush();
 			reset_joined_item();
 
-			gl_vertex_buffer = 0;
-			gl_index_buffer = 0;
 			max_quads = 0;
 			vertex_buffer_size_units = 0;
 			vertex_buffer_size_bytes = 0;
@@ -350,9 +348,6 @@ public:
 			use_large_verts = false;
 			fvf = RasterizerStorageCommon::FVF_REGULAR;
 		}
-
-		unsigned int gl_vertex_buffer;
-		unsigned int gl_index_buffer;
 
 		uint32_t max_quads;
 		uint32_t vertex_buffer_size_units;

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2703,6 +2703,7 @@ VisualServer::VisualServer() {
 
 	GLOBAL_DEF("rendering/batching/options/use_batching", true);
 	GLOBAL_DEF_RST("rendering/batching/options/use_batching_in_editor", true);
+	GLOBAL_DEF_RST("rendering/batching/options/multiple_buffer_batching", false);
 	GLOBAL_DEF("rendering/batching/options/single_rect_fallback", false);
 	GLOBAL_DEF("rendering/batching/parameters/max_join_item_commands", 16);
 	GLOBAL_DEF("rendering/batching/parameters/colored_vertex_format_threshold", 0.25f);


### PR DESCRIPTION
The current 2D rendering algorithm assumes that the OpenGL driver
supports buffer orphaning. However, this is not always the case, e.g.
the Oculus Quest 2 does not.

This change adds an option to switch to adaptive multibuffer rendering
where a separate buffer is used for each rendering batch to avoid
implicit synchronization. The number of buffers is set adaptively based
on the number of batches required for rendering the previous frame.

Companion proposal: https://github.com/godotengine/godot-proposals/issues/5348

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
