### PR TITLE
Fix file list in FileDialog not updating on first run

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -145,6 +145,8 @@ void EditorFileDialog::_notification(int p_what) {
 			if (!is_visible()) {
 				set_process_shortcut_input(false);
 			}
+
+			invalidate(); // For consistency with the standard FileDialog.
 		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
@@ -304,10 +306,6 @@ void EditorFileDialog::_post_popup() {
 	}
 	set_current_dir(current);
 
-	if (invalidated) {
-		update_file_list();
-		invalidated = false;
-	}
 	if (mode == FILE_MODE_SAVE_FILE) {
 		file->grab_focus();
 	} else {
@@ -320,19 +318,13 @@ void EditorFileDialog::_post_popup() {
 		file_box->set_visible(true);
 	}
 
-	if (is_visible() && !get_current_file().is_empty()) {
+	if (!get_current_file().is_empty()) {
 		_request_single_thumbnail(get_current_dir().path_join(get_current_file()));
 	}
 
-	if (is_visible()) {
-		_update_recent();
-
-		local_history.clear();
-		local_history_pos = -1;
-		_push_history();
-
-		_update_favorites();
-	}
+	local_history.clear();
+	local_history_pos = -1;
+	_push_history();
 
 	set_process_shortcut_input(true);
 }

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -87,6 +87,8 @@ void FileDialog::_notification(int p_what) {
 			if (!is_visible()) {
 				set_process_shortcut_input(false);
 			}
+
+			invalidate(); // Put it here to preview in the editor.
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -223,10 +225,6 @@ void FileDialog::_save_confirm_pressed() {
 
 void FileDialog::_post_popup() {
 	ConfirmationDialog::_post_popup();
-	if (invalidated) {
-		update_file_list();
-		invalidated = false;
-	}
 	if (mode == FILE_MODE_SAVE_FILE) {
 		file->grab_focus();
 	} else {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fix another issue in #33533.

~~Fix `Ctrl+H` not working when using `show` instead of `popup*`.~~


