### PR TITLE
3.x: Cherry-pick "Implement Tabs minimum size"

### DIFF
--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -158,6 +158,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">
+			If [code]true[/code], tabs overflowing this node's width will be hidden, displaying two navigation buttons instead. Otherwise, this node's minimum size is updated so that all tabs are visible.
+		</member>
 		<member name="current_tab" type="int" setter="set_current_tab" getter="get_current_tab" default="0">
 			Select tab at index [code]tab_idx[/code].
 		</member>

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -47,6 +47,7 @@ Size2 Tabs::get_minimum_size() const {
 		Ref<Texture> tex = tabs[i].icon;
 		if (tex.is_valid()) {
 			ms.height = MAX(ms.height, tex->get_size().height);
+			ms.width += tex->get_size().width;
 			if (tabs[i].text != "") {
 				ms.width += get_constant("hseparation");
 			}

--- a/scene/gui/tabs.h
+++ b/scene/gui/tabs.h
@@ -76,11 +76,13 @@ private:
 	bool buttons_visible;
 	bool missing_right;
 	Vector<Tab> tabs;
-	int current;
-	int previous;
-	TabAlign tab_align;
-	int rb_hover;
-	bool rb_pressing;
+	int current = 0;
+	int previous = 0;
+	int _get_top_margin() const;
+	TabAlign tab_align = ALIGN_CENTER;
+	bool clip_tabs = true;
+	int rb_hover = -1;
+	bool rb_pressing = false;
 
 	bool select_with_rmb;
 
@@ -129,6 +131,9 @@ public:
 
 	void set_tab_align(TabAlign p_align);
 	TabAlign get_tab_align() const;
+
+	void set_clip_tabs(bool p_clip_tabs);
+	bool get_clip_tabs() const;
 
 	void move_tab(int from, int to);
 


### PR DESCRIPTION
I needed this fix for a project of mine and so cherry picked and merged the changes. After merging, I added a single line in the second commit which corrects the minimum width for tabs with icons. As far as I can tell this is all that is required for these changes to work as intended on 3.x.

The setting added in this change "clip_tabs" defaults to true, so is backward compatible with the original behavior.