### PR TITLE
[3.x] Disable logic that triggers automatic focus gain as the Godot Editor is loaded

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -584,10 +584,12 @@ void EditorAssetLibrary::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
+#ifndef ANDROID_ENABLED
 				// Focus the search box automatically when switching to the Templates tab (in the Project Manager)
 				// or switching to the AssetLib tab (in the editor).
 				// The Project Manager's project filter box is automatically focused in the project manager code.
 				filter->grab_focus();
+#endif
 
 				if (initial_loading) {
 					_repository_changed(0); // Update when shown for the first time.

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -469,7 +469,9 @@ void ScriptTextEditor::set_edit_state(const Variant &p_state) {
 	}
 
 	if (editor_enabled) {
+#ifndef ANDROID_ENABLED
 		ensure_focus();
+#endif
 	}
 }
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1791,11 +1791,13 @@ void ProjectManager::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_READY: {
+#ifndef ANDROID_ENABLED
 			if (_project_list->get_project_count() >= 1) {
 				// Focus on the search box immediately to allow the user
 				// to search without having to reach for their mouse
 				project_filter->search_box->grab_focus();
 			}
+#endif
 
 			if (asset_library) {
 				// Suggest browsing asset library to get templates/demos.
@@ -2332,6 +2334,7 @@ void ProjectManager::_on_filter_option_changed() {
 }
 
 void ProjectManager::_on_tab_changed(int p_tab) {
+#ifndef ANDROID_ENABLED
 	if (p_tab == 0) { // Projects
 		// Automatically grab focus when the user moves from the Templates tab
 		// back to the Projects tab.
@@ -2343,6 +2346,7 @@ void ProjectManager::_on_tab_changed(int p_tab) {
 
 	// The Templates tab's search field is focused on display in the asset
 	// library editor plugin code.
+#endif
 }
 
 void ProjectManager::_bind_methods() {


### PR DESCRIPTION
For the Godot Android Editor, this is an inconvenience as it causes the soft keyboard to show and block half of the view

Addresses part of https://github.com/godotengine/godot-proposals/issues/3931

[master version](#65402)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
