### PR TITLE
Batching - fix uninitialized color read

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -1335,7 +1335,7 @@ PREAMBLE(bool)::_prefill_line(RasterizerCanvas::Item::CommandLine *p_line, FillS
 
 	// if the color has changed we need a new batch
 	// (only single color line batches supported so far)
-	if (r_fill_state.curr_batch->color != bcol) {
+	if (!change_batch && r_fill_state.curr_batch->color != bcol) {
 		change_batch = true;
 	}
 


### PR DESCRIPTION
Valgrind was showing a read from uninitialized memory. `r_fill_state.curr_batch->color` is unset (for performance reasons), so can contain random data.

This actually doesn't matter in practice, since logically this uninitialized state can only occur when `change_batch` is set, and the only side effect is that `change_batch` is set. Hence why no bugs occur in practice.

This PR prevents this read from uninitialized data. It is likely free in terms of performance after optimization, and keeps the Valgrind logs clearer, so why not.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
