### PR TITLE
Fix GLES directional shadow uninitialized data

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -288,13 +288,13 @@ public:
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version);
 
 	struct DirectionalShadow {
-		GLuint fbo;
-		GLuint depth;
-		GLuint color;
+		GLuint fbo = 0;
+		GLuint depth = 0;
+		GLuint color = 0;
 
-		int light_count;
-		int size;
-		int current_light;
+		int light_count = 0;
+		int size = 0;
+		int current_light = 0;
 	} directional_shadow;
 
 	virtual int get_directional_light_shadow_size(RID p_light_intance);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -278,11 +278,11 @@ public:
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version);
 
 	struct DirectionalShadow {
-		GLuint fbo;
-		GLuint depth;
-		int light_count;
-		int size;
-		int current_light;
+		GLuint fbo = 0;
+		GLuint depth = 0;
+		int light_count = 0;
+		int size = 0;
+		int current_light = 0;
 	} directional_shadow;
 
 	virtual int get_directional_light_shadow_size(RID p_light_intance);


### PR DESCRIPTION
Valgrind shows `directional_shadow.fbo` accessed when uninitialized in `directional_shadow_create`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
