### PR TITLE
C# Modify the MemberName generated for the user script

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptMethodsGenerator.cs
@@ -133,7 +133,9 @@ namespace Godot.SourceGenerators
                 .Distinct(new MethodOverloadEqualityComparer())
                 .ToArray();
 
-            source.Append("    private partial class GodotInternal {\n");
+            source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
+
+            source.Append($"    public new class MethodName : {symbol.BaseType.FullQualifiedName()}.MethodName {{\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
@@ -144,7 +146,7 @@ namespace Godot.SourceGenerators
 
             foreach (string methodName in distinctMethodNames)
             {
-                source.Append("        public static readonly StringName MethodName_");
+                source.Append("        public new static readonly StringName ");
                 source.Append(methodName);
                 source.Append(" = \"");
                 source.Append(methodName);
@@ -157,8 +159,6 @@ namespace Godot.SourceGenerators
 
             if (godotClassMethods.Length > 0)
             {
-                source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
-
                 const string listType = "System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>";
 
                 source.Append("    internal new static ")
@@ -179,9 +179,9 @@ namespace Godot.SourceGenerators
 
                 source.Append("        return methods;\n");
                 source.Append("    }\n");
-
-                source.Append("#pragma warning restore CS0109\n");
             }
+
+            source.Append("#pragma warning restore CS0109\n");
 
             // Generate InvokeGodotClassMethod
 
@@ -242,7 +242,7 @@ namespace Godot.SourceGenerators
 
         private static void AppendMethodInfo(StringBuilder source, MethodInfo methodInfo)
         {
-            source.Append("        methods.Add(new(name: GodotInternal.MethodName_")
+            source.Append("        methods.Add(new(name: MethodName.")
                 .Append(methodInfo.Name)
                 .Append(", returnVal: ");
 
@@ -350,7 +350,7 @@ namespace Godot.SourceGenerators
             source.Append("        ");
             if (!isFirstEntry)
                 source.Append("else ");
-            source.Append("if (method == GodotInternal.MethodName_");
+            source.Append("if (method == MethodName.");
             source.Append(methodName);
             source.Append(") {\n           return true;\n        }\n");
         }
@@ -362,7 +362,7 @@ namespace Godot.SourceGenerators
         {
             string methodName = method.Method.Name;
 
-            source.Append("        if (method == GodotInternal.MethodName_");
+            source.Append("        if (method == MethodName.");
             source.Append(methodName);
             source.Append(" && argCount == ");
             source.Append(method.ParamTypes.Length);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -122,14 +122,16 @@ namespace Godot.SourceGenerators
             var godotClassProperties = propertySymbols.WhereIsGodotCompatibleType(typeCache).ToArray();
             var godotClassFields = fieldSymbols.WhereIsGodotCompatibleType(typeCache).ToArray();
 
-            source.Append("    private partial class GodotInternal {\n");
+            source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
+
+            source.Append($"    public new class PropertyName : {symbol.BaseType.FullQualifiedName()}.PropertyName {{\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
             foreach (var property in godotClassProperties)
             {
                 string propertyName = property.PropertySymbol.Name;
-                source.Append("        public static readonly StringName PropName_");
+                source.Append("        public new static readonly StringName ");
                 source.Append(propertyName);
                 source.Append(" = \"");
                 source.Append(propertyName);
@@ -139,7 +141,7 @@ namespace Godot.SourceGenerators
             foreach (var field in godotClassFields)
             {
                 string fieldName = field.FieldSymbol.Name;
-                source.Append("        public static readonly StringName PropName_");
+                source.Append("        public new static readonly StringName ");
                 source.Append(fieldName);
                 source.Append(" = \"");
                 source.Append(fieldName);
@@ -214,8 +216,6 @@ namespace Godot.SourceGenerators
 
                 // Generate GetGodotPropertyList
 
-                source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
-
                 string dictionaryType = "System.Collections.Generic.List<global::Godot.Bridge.PropertyInfo>";
 
                 source.Append("    internal new static ")
@@ -289,7 +289,7 @@ namespace Godot.SourceGenerators
             if (!isFirstEntry)
                 source.Append("else ");
 
-            source.Append("if (name == GodotInternal.PropName_")
+            source.Append("if (name == PropertyName.")
                 .Append(propertyMemberName)
                 .Append(") {\n")
                 .Append("            ")
@@ -313,7 +313,7 @@ namespace Godot.SourceGenerators
             if (!isFirstEntry)
                 source.Append("else ");
 
-            source.Append("if (name == GodotInternal.PropName_")
+            source.Append("if (name == PropertyName.")
                 .Append(propertyMemberName)
                 .Append(") {\n")
                 .Append("            value = ")
@@ -342,7 +342,7 @@ namespace Godot.SourceGenerators
         {
             source.Append("        properties.Add(new(type: (Godot.Variant.Type)")
                 .Append((int)propertyInfo.Type)
-                .Append(", name: GodotInternal.PropName_")
+                .Append(", name: PropertyName.")
                 .Append(propertyInfo.Name)
                 .Append(", hint: (Godot.PropertyHint)")
                 .Append((int)propertyInfo.Hint)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -243,7 +243,7 @@ namespace Godot.SourceGenerators
                     source.Append(" = ");
                     source.Append(exportedMember.Value ?? "default");
                     source.Append(";\n");
-                    source.Append("        values.Add(GodotInternal.PropName_");
+                    source.Append("        values.Add(PropertyName.");
                     source.Append(exportedMember.Name);
                     source.Append(", ");
                     source.Append(defaultValueLocalName);

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
@@ -159,7 +159,7 @@ namespace Godot.SourceGenerators
             {
                 string propertyName = property.PropertySymbol.Name;
 
-                source.Append("        info.AddProperty(GodotInternal.PropName_")
+                source.Append("        info.AddProperty(PropertyName.")
                     .Append(propertyName)
                     .Append(", ")
                     .AppendManagedToVariantExpr(string.Concat("this.", propertyName), property.Type)
@@ -172,7 +172,7 @@ namespace Godot.SourceGenerators
             {
                 string fieldName = field.FieldSymbol.Name;
 
-                source.Append("        info.AddProperty(GodotInternal.PropName_")
+                source.Append("        info.AddProperty(PropertyName.")
                     .Append(fieldName)
                     .Append(", ")
                     .AppendManagedToVariantExpr(string.Concat("this.", fieldName), field.Type)
@@ -185,7 +185,7 @@ namespace Godot.SourceGenerators
             {
                 string signalName = signalDelegate.Name;
 
-                source.Append("        info.AddSignalEventDelegate(GodotInternal.SignalName_")
+                source.Append("        info.AddSignalEventDelegate(SignalName.")
                     .Append(signalName)
                     .Append(", this.backing_")
                     .Append(signalName)
@@ -204,7 +204,7 @@ namespace Godot.SourceGenerators
             {
                 string propertyName = property.PropertySymbol.Name;
 
-                source.Append("        if (info.TryGetProperty(GodotInternal.PropName_")
+                source.Append("        if (info.TryGetProperty(PropertyName.")
                     .Append(propertyName)
                     .Append(", out var _value_")
                     .Append(propertyName)
@@ -223,7 +223,7 @@ namespace Godot.SourceGenerators
             {
                 string fieldName = field.FieldSymbol.Name;
 
-                source.Append("        if (info.TryGetProperty(GodotInternal.PropName_")
+                source.Append("        if (info.TryGetProperty(PropertyName.")
                     .Append(fieldName)
                     .Append(", out var _value_")
                     .Append(fieldName)
@@ -245,7 +245,7 @@ namespace Godot.SourceGenerators
 
                 source.Append("        if (info.TryGetSignalEventDelegate<")
                     .Append(signalDelegateQualifiedName)
-                    .Append(">(GodotInternal.SignalName_")
+                    .Append(">(SignalName.")
                     .Append(signalName)
                     .Append(", out var _value_")
                     .Append(signalName)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -173,14 +173,16 @@ namespace Godot.SourceGenerators
                 godotSignalDelegates.Add(new(signalName, signalDelegateSymbol, invokeMethodData.Value));
             }
 
-            source.Append("    private partial class GodotInternal {\n");
+            source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
+
+            source.Append($"    public new class SignalName : {symbol.BaseType.FullQualifiedName()}.SignalName {{\n");
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
             foreach (var signalDelegate in godotSignalDelegates)
             {
                 string signalName = signalDelegate.Name;
-                source.Append("        public static readonly StringName SignalName_");
+                source.Append("        public new static readonly StringName ");
                 source.Append(signalName);
                 source.Append(" = \"");
                 source.Append(signalName);
@@ -193,8 +195,6 @@ namespace Godot.SourceGenerators
 
             if (godotSignalDelegates.Count > 0)
             {
-                source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
-
                 const string listType = "System.Collections.Generic.List<global::Godot.Bridge.MethodInfo>";
 
                 source.Append("    internal new static ")
@@ -215,9 +215,9 @@ namespace Godot.SourceGenerators
 
                 source.Append("        return signals;\n");
                 source.Append("    }\n");
-
-                source.Append("#pragma warning restore CS0109\n");
             }
+
+            source.Append("#pragma warning restore CS0109\n");
 
             // Generate signal event
 
@@ -291,7 +291,7 @@ namespace Godot.SourceGenerators
 
         private static void AppendMethodInfo(StringBuilder source, MethodInfo methodInfo)
         {
-            source.Append("        signals.Add(new(name: GodotInternal.SignalName_")
+            source.Append("        signals.Add(new(name: SignalName.")
                 .Append(methodInfo.Name)
                 .Append(", returnVal: ");
 
@@ -400,7 +400,7 @@ namespace Godot.SourceGenerators
             string signalName = signal.Name;
             var invokeMethodData = signal.InvokeMethodData;
 
-            source.Append("        if (signal == GodotInternal.SignalName_");
+            source.Append("        if (signal == SignalName.");
             source.Append(signalName);
             source.Append(" && argCount == ");
             source.Append(invokeMethodData.ParamTypes.Length);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Modify the MemberName generated for the user script.
This will be consistent with that PR(#52815).
The user's own script can do the same.

`PropertyName.XXX`
`MethodName.XXX`
`SignalName.XXX`

修改为用户脚本生成的成员名称.
这样可以和该PR(#52815)一致.
用户自己的脚本也可以这样.