### PR TITLE
FlowContainer fix uninitialized data

### DIFF
--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -243,6 +243,8 @@ int FlowContainer::get_line_count() const {
 
 FlowContainer::FlowContainer(bool p_vertical) {
 	vertical = p_vertical;
+	cached_size = 0;
+	cached_line_count = 0;
 }
 
 void FlowContainer::_bind_methods() {


### PR DESCRIPTION
This uninitialized data was finding its way into the renderer.

## Notes
* Found with Valgrind
* In the batching renderer, rects were being sent with valid x size but uninitialized y size.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
