### PR TITLE
FindBar fix uninitialized results_count

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1695,6 +1695,8 @@ EditorHelpBit::EditorHelpBit() {
 }
 
 FindBar::FindBar() {
+	results_count = 0;
+
 	search_text = memnew(LineEdit);
 	add_child(search_text);
 	search_text->set_custom_minimum_size(Size2(100 * EDSCALE, 0));


### PR DESCRIPTION
Found by Valgrind.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
