### PR TITLE
Fix RayCast2DEditor uninitialized value

### DIFF
--- a/editor/plugins/ray_cast_2d_editor_plugin.h
+++ b/editor/plugins/ray_cast_2d_editor_plugin.h
@@ -41,7 +41,7 @@ class RayCast2DEditor : public Control {
 
 	UndoRedo *undo_redo = nullptr;
 	CanvasItemEditor *canvas_item_editor = nullptr;
-	RayCast2D *node;
+	RayCast2D *node = nullptr;
 
 	bool pressed = false;
 	Point2 original_cast_to;


### PR DESCRIPTION
node was previously read before being set. Found by Valgrind.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
