### PR TITLE
Fix various uninitialized member pointers

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -597,7 +597,7 @@ protected:
 public:
 	static RasterizerSceneGLES3 *get_singleton() { return singleton; }
 
-	RasterizerCanvasGLES3 *canvas;
+	RasterizerCanvasGLES3 *canvas = nullptr;
 
 	RenderGeometryInstance *geometry_instance_create(RID p_base) override;
 	void geometry_instance_free(RenderGeometryInstance *p_geometry_instance) override;

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -151,7 +151,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	Button *edit = nullptr;
 	MarginContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
-	EditorSpinSlider *size_sliderv;
+	EditorSpinSlider *size_sliderv = nullptr;
 	Button *button_add_item = nullptr;
 	EditorPaginator *paginator = nullptr;
 

--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -192,7 +192,7 @@ class SceneImportSettings : public ConfirmationDialog {
 
 	bool editing_animation = false;
 
-	Timer *update_view_timer;
+	Timer *update_view_timer = nullptr;
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -100,8 +100,8 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	Vector2 add_node_pos;
 
-	ConfirmationDialog *delete_window;
-	Tree *delete_tree;
+	ConfirmationDialog *delete_window = nullptr;
+	Tree *delete_tree = nullptr;
 
 	bool box_selecting = false;
 	Point2 box_selecting_from;

--- a/editor/plugins/bone_map_editor_plugin.h
+++ b/editor/plugins/bone_map_editor_plugin.h
@@ -62,7 +62,7 @@ private:
 	bool selected = false;
 	bool require = false;
 
-	TextureRect *circle;
+	TextureRect *circle = nullptr;
 
 	void fetch_textures();
 
@@ -87,8 +87,8 @@ class BoneMapperItem : public VBoxContainer {
 
 	Ref<BoneMap> bone_map;
 
-	EditorPropertyText *skeleton_bone_selector;
-	Button *picker_button;
+	EditorPropertyText *skeleton_bone_selector = nullptr;
+	Button *picker_button = nullptr;
 
 	void _update_property();
 	void _open_picker();
@@ -135,24 +135,24 @@ public:
 class BoneMapper : public VBoxContainer {
 	GDCLASS(BoneMapper, VBoxContainer);
 
-	Skeleton3D *skeleton;
+	Skeleton3D *skeleton = nullptr;
 	Ref<BoneMap> bone_map;
 
-	EditorPropertyResource *profile_selector;
+	EditorPropertyResource *profile_selector = nullptr;
 
 	Vector<BoneMapperItem *> bone_mapper_items;
 
-	Button *clear_mapping_button;
+	Button *clear_mapping_button = nullptr;
 
-	VBoxContainer *mapper_item_vbox;
+	VBoxContainer *mapper_item_vbox = nullptr;
 
 	int current_group_idx = 0;
 	int current_bone_idx = -1;
 
-	AspectRatioContainer *bone_mapper_field;
-	EditorPropertyEnum *profile_group_selector;
-	ColorRect *profile_bg;
-	TextureRect *profile_texture;
+	AspectRatioContainer *bone_mapper_field = nullptr;
+	EditorPropertyEnum *profile_group_selector = nullptr;
+	ColorRect *profile_bg = nullptr;
+	TextureRect *profile_texture = nullptr;
 	Vector<BoneMapperButton *> bone_mapper_buttons;
 
 	void create_editor();
@@ -201,9 +201,9 @@ public:
 class BoneMapEditor : public VBoxContainer {
 	GDCLASS(BoneMapEditor, VBoxContainer);
 
-	Skeleton3D *skeleton;
+	Skeleton3D *skeleton = nullptr;
 	Ref<BoneMap> bone_map;
-	BoneMapper *bone_mapper;
+	BoneMapper *bone_mapper = nullptr;
 
 	void fetch_objects();
 	void clear_editors();
@@ -219,7 +219,7 @@ public:
 
 class EditorInspectorPluginBoneMap : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorPluginBoneMap, EditorInspectorPlugin);
-	BoneMapEditor *editor;
+	BoneMapEditor *editor = nullptr;
 
 public:
 	virtual bool can_handle(Object *p_object) override;

--- a/editor/plugins/cast_2d_editor_plugin.h
+++ b/editor/plugins/cast_2d_editor_plugin.h
@@ -42,7 +42,7 @@ class Cast2DEditor : public Control {
 
 	Ref<EditorUndoRedoManager> undo_redo;
 	CanvasItemEditor *canvas_item_editor = nullptr;
-	Node2D *node;
+	Node2D *node = nullptr;
 
 	bool pressed = false;
 	Point2 original_target_position;

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -186,7 +186,7 @@ public:
 class SizeFlagPresetPicker : public ControlEditorPresetPicker {
 	GDCLASS(SizeFlagPresetPicker, ControlEditorPresetPicker);
 
-	CheckBox *expand_button;
+	CheckBox *expand_button = nullptr;
 
 	bool vertical = false;
 

--- a/editor/plugins/navigation_link_2d_editor_plugin.h
+++ b/editor/plugins/navigation_link_2d_editor_plugin.h
@@ -42,7 +42,7 @@ class NavigationLink2DEditor : public Control {
 
 	Ref<EditorUndoRedoManager> undo_redo;
 	CanvasItemEditor *canvas_item_editor = nullptr;
-	NavigationLink2D *node;
+	NavigationLink2D *node = nullptr;
 
 	bool start_grabbed = false;
 	Vector2 original_start_location;


### PR DESCRIPTION
Using this command:
```
find -name "thirdparty" -prune -o -name "*.h" -exec sed -i {} -e '/return /! s/\t\([A-Za-z0-9_]* \*[A-Za-z0-9_]*\)\;/\t\1 = nullptr;/g' \;
```

And then reviewing the changes manually to discard the ones that don't
seem correct/safe/good (notably changes to `core` unions).

Follow-up to #59867, cleaning up newly added code.