### PR TITLE
Add read-only mode to tileset editor

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -113,6 +113,8 @@ public:
 	};
 
 private:
+	bool read_only = false;
+
 	Ref<TileSet> tile_set;
 	TileSetAtlasSource *tile_set_atlas_source = nullptr;
 	int tile_set_atlas_source_id = TileSet::INVALID_SOURCE;
@@ -209,7 +211,7 @@ private:
 	HBoxContainer *tool_settings = nullptr;
 	HBoxContainer *tool_settings_tile_data_toolbar_container = nullptr;
 	Button *tools_settings_erase_button = nullptr;
-	MenuButton *tool_advanced_menu_buttom = nullptr;
+	MenuButton *tool_advanced_menu_button = nullptr;
 
 	// Selection.
 	RBSet<TileSelection> selection;

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -45,6 +45,8 @@ class TileSetEditor : public VBoxContainer {
 	static TileSetEditor *singleton;
 
 private:
+	bool read_only = false;
+
 	Ref<TileSet> tile_set;
 	bool tile_set_changed_needs_update = false;
 	HSplitContainer *split_container = nullptr;

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
@@ -91,6 +91,8 @@ private:
 	};
 
 private:
+	bool read_only = false;
+
 	Ref<TileSet> tile_set;
 	TileSetScenesCollectionSource *tile_set_scenes_collection_source = nullptr;
 	int tile_set_source_id = -1;


### PR DESCRIPTION
Makes it so that the TileSet editor is opened in read-only mode when its respective tileset is embedded inside of a foreign resource. Introduces behaviour consistent with previous PRs covering similar things: #63249 #63245