### PR TITLE
Rename `PopupMenu`'s `set/get_current_index()` to `set/get_focused_item()`

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -182,7 +182,7 @@
 				Removes all items from the [PopupMenu].
 			</description>
 		</method>
-		<method name="get_current_index" qualifiers="const">
+		<method name="get_focused_item" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the index of the currently focused item. Returns [code]-1[/code] if no item is focused.
@@ -332,7 +332,7 @@
 				Moves the scroll view to make the item at the given [param index] visible.
 			</description>
 		</method>
-		<method name="set_current_index">
+		<method name="set_focused_item">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<description>

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -137,7 +137,7 @@ void MenuBar::_open_popup(int p_index, bool p_focus_item) {
 	if (p_focus_item) {
 		for (int i = 0; i < pm->get_item_count(); i++) {
 			if (!pm->is_item_disabled(i)) {
-				pm->set_current_index(i);
+				pm->set_focused_item(i);
 				break;
 			}
 		}

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -107,7 +107,7 @@ void MenuButton::pressed() {
 	if (!_was_pressed_by_mouse()) {
 		for (int i = 0; i < popup->get_item_count(); i++) {
 			if (!popup->is_item_disabled(i)) {
-				popup->set_current_index(i);
+				popup->set_focused_item(i);
 				break;
 			}
 		}
@@ -169,7 +169,7 @@ void MenuButton::_notification(int p_what) {
 
 				menu_btn_other->pressed();
 				// As the popup wasn't triggered by a mouse click, the item focus needs to be removed manually.
-				menu_btn_other->get_popup()->set_current_index(-1);
+				menu_btn_other->get_popup()->set_focused_item(-1);
 			}
 		} break;
 	}

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -238,7 +238,7 @@ void OptionButton::pressed() {
 	// If not triggered by the mouse, start the popup with the checked item (or the first enabled one) focused.
 	if (current != NONE_SELECTED && !popup->is_item_disabled(current)) {
 		if (!_was_pressed_by_mouse()) {
-			popup->set_current_index(current);
+			popup->set_focused_item(current);
 		} else {
 			popup->scroll_to_item(current);
 		}
@@ -246,7 +246,7 @@ void OptionButton::pressed() {
 		for (int i = 0; i < popup->get_item_count(); i++) {
 			if (!popup->is_item_disabled(i)) {
 				if (!_was_pressed_by_mouse()) {
-					popup->set_current_index(i);
+					popup->set_focused_item(i);
 				} else {
 					popup->scroll_to_item(i);
 				}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -209,7 +209,7 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	if (p_by_keyboard) {
 		for (int i = 0; i < submenu_pum->get_item_count(); i++) {
 			if (!submenu_pum->is_item_disabled(i)) {
-				submenu_pum->set_current_index(i);
+				submenu_pum->set_focused_item(i);
 				break;
 			}
 		}
@@ -1547,7 +1547,7 @@ bool PopupMenu::is_item_shortcut_disabled(int p_idx) const {
 	return items[p_idx].shortcut_is_disabled;
 }
 
-void PopupMenu::set_current_index(int p_idx) {
+void PopupMenu::set_focused_item(int p_idx) {
 	if (p_idx != -1) {
 		ERR_FAIL_INDEX(p_idx, items.size());
 	}
@@ -1564,7 +1564,7 @@ void PopupMenu::set_current_index(int p_idx) {
 	control->queue_redraw();
 }
 
-int PopupMenu::get_current_index() const {
+int PopupMenu::get_focused_item() const {
 	return mouse_over;
 }
 
@@ -2057,8 +2057,8 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_shortcut", "index"), &PopupMenu::get_item_shortcut);
 	ClassDB::bind_method(D_METHOD("get_item_indent", "index"), &PopupMenu::get_item_indent);
 
-	ClassDB::bind_method(D_METHOD("set_current_index", "index"), &PopupMenu::set_current_index);
-	ClassDB::bind_method(D_METHOD("get_current_index"), &PopupMenu::get_current_index);
+	ClassDB::bind_method(D_METHOD("set_focused_item", "index"), &PopupMenu::set_focused_item);
+	ClassDB::bind_method(D_METHOD("get_focused_item"), &PopupMenu::get_focused_item);
 	ClassDB::bind_method(D_METHOD("set_item_count", "count"), &PopupMenu::set_item_count);
 	ClassDB::bind_method(D_METHOD("get_item_count"), &PopupMenu::get_item_count);
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -261,8 +261,8 @@ public:
 	int get_item_max_states(int p_idx) const;
 	int get_item_state(int p_idx) const;
 
-	void set_current_index(int p_idx);
-	int get_current_index() const;
+	void set_focused_item(int p_idx);
+	int get_focused_item() const;
 
 	void set_item_count(int p_count);
 	int get_item_count() const;


### PR DESCRIPTION
A clearer name for what this method does. Hope I'm not too late for the bikeshedding. 😜