### PR TITLE
Expose registration of physics servers to GDExtension

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1302,8 +1302,14 @@
 		<member name="PhysicsServer2D" type="PhysicsServer2D" setter="" getter="">
 			The [PhysicsServer2D] singleton.
 		</member>
+		<member name="PhysicsServer2DManager" type="PhysicsServer2DManager" setter="" getter="">
+			The [PhysicsServer2DManager] singleton.
+		</member>
 		<member name="PhysicsServer3D" type="PhysicsServer3D" setter="" getter="">
 			The [PhysicsServer3D] singleton.
+		</member>
+		<member name="PhysicsServer3DManager" type="PhysicsServer3DManager" setter="" getter="">
+			The [PhysicsServer3DManager] singleton.
 		</member>
 		<member name="ProjectSettings" type="ProjectSettings" setter="" getter="">
 			The [ProjectSettings] singleton.

--- a/doc/classes/PhysicsServer2DManager.xml
+++ b/doc/classes/PhysicsServer2DManager.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsServer2DManager" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Manager for 2D physics server implementations.
+	</brief_description>
+	<description>
+		[PhysicsServer2DManager] is the API for registering [PhysicsServer2D] implementations, and for setting the default implementation.
+		[b]Note:[/b] It is not possible to switch physics servers at runtime. This class is only used on startup at the server initialization level, by Godot itself and possibly by GDExtensions.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="register_server">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="create_callback" type="Callable" />
+			<description>
+				Register a [PhysicsServer2D] implementation by passing a [param name] and a [Callable] that returns a [PhysicsServer2D] object.
+			</description>
+		</method>
+		<method name="set_default_server">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="priority" type="int" />
+			<description>
+				Set the default [PhysicsServer2D] implementation to the one identified by [param name], if [param priority] is greater than the priority of the current default implementation.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/PhysicsServer3DManager.xml
+++ b/doc/classes/PhysicsServer3DManager.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsServer3DManager" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Manager for 3D physics server implementations.
+	</brief_description>
+	<description>
+		[PhysicsServer3DManager] is the API for registering [PhysicsServer3D] implementations, and for setting the default implementation.
+		[b]Note:[/b] It is not possible to switch physics servers at runtime. This class is only used on startup at the server initialization level, by Godot itself and possibly by GDExtensions.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="register_server">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="create_callback" type="Callable" />
+			<description>
+				Register a [PhysicsServer3D] implementation by passing a [param name] and a [Callable] that returns a [PhysicsServer2D] object.
+			</description>
+		</method>
+		<method name="set_default_server">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="priority" type="int" />
+			<description>
+				Set the default [PhysicsServer3D] implementation to the one identified by [param name], if [param priority] is greater than the priority of the current default implementation.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -126,7 +126,9 @@ static RenderingServer *rendering_server = nullptr;
 static CameraServer *camera_server = nullptr;
 static XRServer *xr_server = nullptr;
 static TextServerManager *tsman = nullptr;
+static PhysicsServer3DManager *physics_server_3d_manager = nullptr;
 static PhysicsServer3D *physics_server_3d = nullptr;
+static PhysicsServer2DManager *physics_server_2d_manager = nullptr;
 static PhysicsServer2D *physics_server_2d = nullptr;
 static NavigationServer3D *navigation_server_3d = nullptr;
 static NavigationServer2D *navigation_server_2d = nullptr;
@@ -223,25 +225,24 @@ static String get_full_version_string() {
 	return String(VERSION_FULL_BUILD) + hash;
 }
 
-// FIXME: Could maybe be moved to PhysicsServer3DManager and PhysicsServer2DManager directly
-// to have less code in main.cpp.
+// FIXME: Could maybe be moved to have less code in main.cpp.
 void initialize_physics() {
 	/// 3D Physics Server
-	physics_server_3d = PhysicsServer3DManager::new_server(
+	physics_server_3d = PhysicsServer3DManager::get_singleton()->new_server(
 			ProjectSettings::get_singleton()->get(PhysicsServer3DManager::setting_property_name));
 	if (!physics_server_3d) {
 		// Physics server not found, Use the default physics
-		physics_server_3d = PhysicsServer3DManager::new_default_server();
+		physics_server_3d = PhysicsServer3DManager::get_singleton()->new_default_server();
 	}
 	ERR_FAIL_COND(!physics_server_3d);
 	physics_server_3d->init();
 
-	/// 2D Physics server
-	physics_server_2d = PhysicsServer2DManager::new_server(
-			ProjectSettings::get_singleton()->get(PhysicsServer2DManager::setting_property_name));
+	// 2D Physics server
+	physics_server_2d = PhysicsServer2DManager::get_singleton()->new_server(
+			ProjectSettings::get_singleton()->get(PhysicsServer2DManager::get_singleton()->setting_property_name));
 	if (!physics_server_2d) {
 		// Physics server not found, Use the default physics
-		physics_server_2d = PhysicsServer2DManager::new_default_server();
+		physics_server_2d = PhysicsServer2DManager::get_singleton()->new_default_server();
 	}
 	ERR_FAIL_COND(!physics_server_2d);
 	physics_server_2d->init();
@@ -450,6 +451,9 @@ Error Main::test_setup() {
 		tsman->add_interface(ts);
 	}
 
+	physics_server_3d_manager = memnew(PhysicsServer3DManager);
+	physics_server_2d_manager = memnew(PhysicsServer2DManager);
+
 	// From `Main::setup2()`.
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	register_core_extensions();
@@ -554,6 +558,12 @@ void Main::test_cleanup() {
 	}
 	if (tsman) {
 		memdelete(tsman);
+	}
+	if (physics_server_3d_manager) {
+		memdelete(physics_server_3d_manager);
+	}
+	if (physics_server_2d_manager) {
+		memdelete(physics_server_2d_manager);
 	}
 	if (globals) {
 		memdelete(globals);
@@ -1782,6 +1792,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		ts.instantiate();
 		tsman->add_interface(ts);
 	}
+
+	physics_server_3d_manager = memnew(PhysicsServer3DManager);
+	physics_server_2d_manager = memnew(PhysicsServer2DManager);
 
 	register_server_types();
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
@@ -3156,6 +3169,9 @@ void Main::cleanup(bool p_force) {
 
 	finalize_theme_db();
 
+	// Before deinitializing server extensions, finalize servers which may be loaded as extensions.
+	finalize_physics();
+
 	NativeExtensionManager::get_singleton()->deinitialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	unregister_server_types();
@@ -3177,7 +3193,6 @@ void Main::cleanup(bool p_force) {
 
 	OS::get_singleton()->finalize();
 
-	finalize_physics();
 	finalize_navigation_server();
 	finalize_display();
 
@@ -3205,6 +3220,12 @@ void Main::cleanup(bool p_force) {
 	}
 	if (tsman) {
 		memdelete(tsman);
+	}
+	if (physics_server_3d_manager) {
+		memdelete(physics_server_3d_manager);
+	}
+	if (physics_server_2d_manager) {
+		memdelete(physics_server_2d_manager);
 	}
 	if (globals) {
 		memdelete(globals);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -766,16 +766,18 @@ public:
 	real_t get_collision_unsafe_fraction() const;
 };
 
-typedef PhysicsServer2D *(*CreatePhysicsServer2DCallback)();
+class PhysicsServer2DManager : public Object {
+	GDCLASS(PhysicsServer2DManager, Object);
 
-class PhysicsServer2DManager {
+	static PhysicsServer2DManager *singleton;
+
 	struct ClassInfo {
 		String name;
-		CreatePhysicsServer2DCallback create_callback = nullptr;
+		Callable create_callback;
 
 		ClassInfo() {}
 
-		ClassInfo(String p_name, CreatePhysicsServer2DCallback p_create_callback) :
+		ClassInfo(String p_name, Callable p_create_callback) :
 				name(p_name),
 				create_callback(p_create_callback) {}
 
@@ -789,24 +791,30 @@ class PhysicsServer2DManager {
 		}
 	};
 
-	static Vector<ClassInfo> physics_2d_servers;
-	static int default_server_id;
-	static int default_server_priority;
+	Vector<ClassInfo> physics_2d_servers;
+	int default_server_id = -1;
+	int default_server_priority = -1;
+
+	void on_servers_changed();
+
+protected:
+	static void _bind_methods();
 
 public:
 	static const String setting_property_name;
 
-private:
-	static void on_servers_changed();
+	static PhysicsServer2DManager *get_singleton();
 
-public:
-	static void register_server(const String &p_name, CreatePhysicsServer2DCallback p_creat_callback);
-	static void set_default_server(const String &p_name, int p_priority = 0);
-	static int find_server_id(const String &p_name);
-	static int get_servers_count();
-	static String get_server_name(int p_id);
-	static PhysicsServer2D *new_default_server();
-	static PhysicsServer2D *new_server(const String &p_name);
+	void register_server(const String &p_name, const Callable &p_create_callback);
+	void set_default_server(const String &p_name, int p_priority = 0);
+	int find_server_id(const String &p_name);
+	int get_servers_count();
+	String get_server_name(int p_id);
+	PhysicsServer2D *new_default_server();
+	PhysicsServer2D *new_server(const String &p_name);
+
+	PhysicsServer2DManager();
+	~PhysicsServer2DManager();
 };
 
 VARIANT_ENUM_CAST(PhysicsServer2D::ShapeType);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -983,16 +983,18 @@ public:
 	real_t get_collision_depth(int p_collision_index = 0) const;
 };
 
-typedef PhysicsServer3D *(*CreatePhysicsServer3DCallback)();
+class PhysicsServer3DManager : public Object {
+	GDCLASS(PhysicsServer3DManager, Object);
 
-class PhysicsServer3DManager {
+	static PhysicsServer3DManager *singleton;
+
 	struct ClassInfo {
 		String name;
-		CreatePhysicsServer3DCallback create_callback = nullptr;
+		Callable create_callback;
 
 		ClassInfo() {}
 
-		ClassInfo(String p_name, CreatePhysicsServer3DCallback p_create_callback) :
+		ClassInfo(String p_name, Callable p_create_callback) :
 				name(p_name),
 				create_callback(p_create_callback) {}
 
@@ -1006,24 +1008,30 @@ class PhysicsServer3DManager {
 		}
 	};
 
-	static Vector<ClassInfo> physics_servers;
-	static int default_server_id;
-	static int default_server_priority;
+	Vector<ClassInfo> physics_servers;
+	int default_server_id = -1;
+	int default_server_priority = -1;
+
+	void on_servers_changed();
+
+protected:
+	static void _bind_methods();
 
 public:
 	static const String setting_property_name;
 
-private:
-	static void on_servers_changed();
+	static PhysicsServer3DManager *get_singleton();
 
-public:
-	static void register_server(const String &p_name, CreatePhysicsServer3DCallback p_creat_callback);
-	static void set_default_server(const String &p_name, int p_priority = 0);
-	static int find_server_id(const String &p_name);
-	static int get_servers_count();
-	static String get_server_name(int p_id);
-	static PhysicsServer3D *new_default_server();
-	static PhysicsServer3D *new_server(const String &p_name);
+	void register_server(const String &p_name, const Callable &p_create_callback);
+	void set_default_server(const String &p_name, int p_priority = 0);
+	int find_server_id(const String &p_name);
+	int get_servers_count();
+	String get_server_name(int p_id);
+	PhysicsServer3D *new_default_server();
+	PhysicsServer3D *new_server(const String &p_name);
+
+	PhysicsServer3DManager();
+	~PhysicsServer3DManager();
 };
 
 VARIANT_ENUM_CAST(PhysicsServer3D::ShapeType);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -85,7 +85,7 @@
 
 ShaderTypes *shader_types = nullptr;
 
-PhysicsServer3D *_createGodotPhysics3DCallback() {
+static PhysicsServer3D *_createGodotPhysics3DCallback() {
 	bool using_threads = GLOBAL_GET("physics/3d/run_on_separate_thread");
 
 	PhysicsServer3D *physics_server_3d = memnew(GodotPhysicsServer3D(using_threads));
@@ -93,7 +93,7 @@ PhysicsServer3D *_createGodotPhysics3DCallback() {
 	return memnew(PhysicsServer3DWrapMT(physics_server_3d, using_threads));
 }
 
-PhysicsServer2D *_createGodotPhysics2DCallback() {
+static PhysicsServer2D *_createGodotPhysics2DCallback() {
 	bool using_threads = GLOBAL_GET("physics/2d/run_on_separate_thread");
 
 	PhysicsServer2D *physics_server_2d = memnew(GodotPhysicsServer2D(using_threads));
@@ -133,6 +133,9 @@ void register_server_types() {
 	GDREGISTER_ABSTRACT_CLASS(RenderingServer);
 	GDREGISTER_CLASS(AudioServer);
 
+	GDREGISTER_CLASS(PhysicsServer2DManager);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer2DManager", PhysicsServer2DManager::get_singleton(), "PhysicsServer2DManager"));
+
 	GDREGISTER_ABSTRACT_CLASS(PhysicsServer2D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer2DExtension);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectBodyState2DExtension);
@@ -143,6 +146,9 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionShapeRestInfo, "Vector2 point;Vector2 normal;RID rid;ObjectID collider_id;int shape;Vector2 linear_velocity");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionMotionResult, "Vector2 travel;Vector2 remainder;Vector2 collision_point;Vector2 collision_normal;Vector2 collider_velocity;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;int collision_local_shape;ObjectID collider_id;RID collider;int collider_shape");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionStateCallback, "void *instance;void (*callback)(void *p_instance, PhysicsDirectBodyState2D *p_state)");
+
+	GDREGISTER_CLASS(PhysicsServer3DManager);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3DManager", PhysicsServer3DManager::get_singleton(), "PhysicsServer3DManager"));
 
 	GDREGISTER_ABSTRACT_CLASS(PhysicsServer3D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer3DExtension);
@@ -264,15 +270,15 @@ void register_server_types() {
 	GLOBAL_DEF(PhysicsServer2DManager::setting_property_name, "DEFAULT");
 	ProjectSettings::get_singleton()->set_custom_property_info(PhysicsServer2DManager::setting_property_name, PropertyInfo(Variant::STRING, PhysicsServer2DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"));
 
-	PhysicsServer2DManager::register_server("GodotPhysics2D", &_createGodotPhysics2DCallback);
-	PhysicsServer2DManager::set_default_server("GodotPhysics2D");
+	PhysicsServer2DManager::get_singleton()->register_server("GodotPhysics2D", callable_mp_static(_createGodotPhysics2DCallback));
+	PhysicsServer2DManager::get_singleton()->set_default_server("GodotPhysics2D");
 
 	// Physics 3D
 	GLOBAL_DEF(PhysicsServer3DManager::setting_property_name, "DEFAULT");
 	ProjectSettings::get_singleton()->set_custom_property_info(PhysicsServer3DManager::setting_property_name, PropertyInfo(Variant::STRING, PhysicsServer3DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"));
 
-	PhysicsServer3DManager::register_server("GodotPhysics3D", &_createGodotPhysics3DCallback);
-	PhysicsServer3DManager::set_default_server("GodotPhysics3D");
+	PhysicsServer3DManager::get_singleton()->register_server("GodotPhysics3D", callable_mp_static(_createGodotPhysics3DCallback));
+	PhysicsServer3DManager::get_singleton()->set_default_server("GodotPhysics3D");
 
 	writer_mjpeg = memnew(MovieWriterMJPEG);
 	MovieWriter::add_writer(writer_mjpeg);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -207,10 +207,10 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			RenderingServerDefault::get_singleton()->init();
 			RenderingServerDefault::get_singleton()->set_render_loop_enabled(false);
 
-			physics_server_3d = PhysicsServer3DManager::new_default_server();
+			physics_server_3d = PhysicsServer3DManager::get_singleton()->new_default_server();
 			physics_server_3d->init();
 
-			physics_server_2d = PhysicsServer2DManager::new_default_server();
+			physics_server_2d = PhysicsServer2DManager::get_singleton()->new_default_server();
 			physics_server_2d->init();
 
 			navigation_server_3d = NavigationServer3DManager::new_default_server();


### PR DESCRIPTION
This exposes `PhysicsServer2DManager` and `PhysicsServer3DManager` with a minimalist API that can be used by GDExtensions:

![physicsserver2dmanager](https://user-images.githubusercontent.com/229837/188661800-2fb84276-407b-4d54-93d3-2d52cd20db11.png)

Note that the `Callable` can be conveniently created in engine/module code by using `callable_mp_static` (as can be seen in this PR). This convenience unfortunately does not seem to extend to GDExtension (so far). On the GDExtension side a `Callable` must currently apparently be created from a bound method.

Small test project: [PhysicsServer2DExtension_test.zip](https://github.com/godotengine/godot/files/9501358/PhysicsServer2DExtension_test.zip)
