### PR TITLE
Fix code folding icon color not matching defined color (3.x)

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -233,6 +233,14 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 		exceptions.insert("StatusSuccess");
 		exceptions.insert("StatusWarning");
 		exceptions.insert("OverbrightIndicator");
+
+		// Prevents Code Editor icons from changing
+		exceptions.insert("GuiTab");
+		exceptions.insert("GuiSpace");
+		exceptions.insert("GuiEllipsis");
+		exceptions.insert("TextEditFold");
+		exceptions.insert("TextEditFolded");
+		exceptions.insert("TextEditorPlay");
 	}
 
 	// These ones should be converted even if we are using a dark theme.
@@ -986,8 +994,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("side_margin", "TabContainer", 0);
 	theme->set_icon("tab", "TextEdit", theme->get_icon("GuiTab", "EditorIcons"));
 	theme->set_icon("space", "TextEdit", theme->get_icon("GuiSpace", "EditorIcons"));
-	theme->set_icon("folded", "TextEdit", theme->get_icon("GuiTreeArrowRight", "EditorIcons"));
-	theme->set_icon("fold", "TextEdit", theme->get_icon("GuiTreeArrowDown", "EditorIcons"));
+	theme->set_icon("folded", "TextEdit", theme->get_icon("TextEditFolded", "EditorIcons"));
+	theme->set_icon("fold", "TextEdit", theme->get_icon("TextEditFold", "EditorIcons"));
 	theme->set_color("font_color", "TextEdit", font_color);
 	theme->set_color("font_color_readonly", "TextEdit", font_color_readonly);
 	theme->set_color("caret_color", "TextEdit", font_color);
@@ -1322,7 +1330,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const float mono_value = mono_color.r;
 	const Color alpha1 = Color(mono_value, mono_value, mono_value, 0.07);
 	const Color alpha2 = Color(mono_value, mono_value, mono_value, 0.14);
-	const Color alpha3 = Color(mono_value, mono_value, mono_value, 0.7);
+	const Color alpha3 = Color(mono_value, mono_value, mono_value, 0.27);
 
 	// editor main color
 	const Color main_color = dark_theme ? Color(0.34, 0.7, 1.0) : Color(0.02, 0.5, 1.0);

--- a/editor/icons/icon_text_edit_fold.svg
+++ b/editor/icons/icon_text_edit_fold.svg
@@ -1,0 +1,1 @@
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="m3 5 3 3 3-3" fill="none" stroke="#fff" stroke-width="2"/></svg>

--- a/editor/icons/icon_text_edit_folded.svg
+++ b/editor/icons/icon_text_edit_folded.svg
@@ -1,0 +1,1 @@
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="m4 9 3-3-3-3" fill="none" stroke="#fff" stroke-width="2"/></svg>

--- a/editor/icons/icon_text_editor_play.svg
+++ b/editor/icons/icon_text_editor_play.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m4 1048.4v-8l7 4z" fill="#e0e0e0" fill-rule="evenodd" stroke="#e0e0e0" stroke-linejoin="round" stroke-width="2" transform="translate(0 -1036.4)"/></svg>

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5444,7 +5444,7 @@ void TextEdit::_update_caches() {
 	cache.folded_icon = get_icon("folded");
 	cache.can_fold_icon = get_icon("fold");
 	cache.folded_eol_icon = get_icon("GuiEllipsis", "EditorIcons");
-	cache.executing_icon = get_icon("MainPlay", "EditorIcons");
+	cache.executing_icon = get_icon("TextEditorPlay", "EditorIcons");
 	text.set_font(cache.font);
 
 	if (syntax_highlighter) {


### PR DESCRIPTION
Fix #58379 for `3.x`

Cherrypick of #58457 from `master`

Caused by reusing icons from the main editor in the code editor. These
icons were converted based on the main editor theme and not the code
editor theme.

 - Create new icons for use specifically in the code editor
 - Add these icons to the exceptions when converting dark theme icons
   to light theme automatically
 - Change the default value of the code folding color to match previous
   color
 - Code folding icon is now pure white by default to correctly match
   the color defined in settings

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
