### PR TITLE
Add read-only mode to inspector array and dictionary viewer.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1651,6 +1651,10 @@ void EditorInspectorArray::_panel_draw(int p_index) {
 void EditorInspectorArray::_panel_gui_input(Ref<InputEvent> p_event, int p_index) {
 	ERR_FAIL_INDEX(p_index, (int)array_elements.size());
 
+	if (read_only) {
+		return;
+	}
+
 	Ref<InputEventKey> key_ref = p_event;
 	if (key_ref.is_valid()) {
 		const InputEventKey &key = **key_ref;
@@ -2151,7 +2155,7 @@ void EditorInspectorArray::drop_data_fw(const Point2 &p_point, const Variant &p_
 }
 
 bool EditorInspectorArray::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	if (!movable) {
+	if (!movable || read_only) {
 		return false;
 	}
 	// First, update drawing.
@@ -2271,7 +2275,9 @@ VBoxContainer *EditorInspectorArray::get_vbox(int p_index) {
 	}
 }
 
-EditorInspectorArray::EditorInspectorArray() {
+EditorInspectorArray::EditorInspectorArray(bool p_read_only) {
+	read_only = p_read_only;
+
 	set_mouse_filter(Control::MOUSE_FILTER_STOP);
 
 	odd_style.instantiate();
@@ -2297,6 +2303,7 @@ EditorInspectorArray::EditorInspectorArray() {
 
 	add_button = EditorInspector::create_inspector_action_button(TTR("Add Element"));
 	add_button->connect("pressed", callable_mp(this, &EditorInspectorArray::_add_button_pressed));
+	add_button->set_disabled(read_only);
 	vbox->add_child(add_button);
 
 	control_dropping = memnew(Control);
@@ -2317,6 +2324,7 @@ EditorInspectorArray::EditorInspectorArray() {
 	new_size_spin_box->set_max(16384);
 	new_size_spin_box->connect("value_changed", callable_mp(this, &EditorInspectorArray::_new_size_spin_box_value_changed));
 	new_size_spin_box->get_line_edit()->connect("text_submitted", callable_mp(this, &EditorInspectorArray::_new_size_spin_box_text_submitted));
+	new_size_spin_box->set_editable(!read_only);
 	resize_dialog_vbox->add_margin_child(TTRC("New Size:"), new_size_spin_box);
 
 	vbox->connect("visibility_changed", callable_mp(this, &EditorInspectorArray::_vbox_visibility_changed));
@@ -3035,7 +3043,7 @@ void EditorInspector::update_tree() {
 			if (p.type == Variant::NIL) {
 				// Setup the array to use a method to create/move/delete elements.
 				array_element_prefix = class_name_components[0];
-				editor_inspector_array = memnew(EditorInspectorArray);
+				editor_inspector_array = memnew(EditorInspectorArray(all_read_only));
 
 				String array_label = path.contains("/") ? path.substr(path.rfind("/") + 1) : path;
 				array_label = EditorPropertyNameProcessor::get_singleton()->process_name(property_label_string, property_name_style);
@@ -3047,7 +3055,7 @@ void EditorInspector::update_tree() {
 				// Setup the array to use the count property and built-in functions to create/move/delete elements.
 				if (class_name_components.size() >= 2) {
 					array_element_prefix = class_name_components[1];
-					editor_inspector_array = memnew(EditorInspectorArray);
+					editor_inspector_array = memnew(EditorInspectorArray(all_read_only));
 					int page = per_array_page.has(array_element_prefix) ? per_array_page[array_element_prefix] : 0;
 
 					editor_inspector_array->setup_with_count_property(object, class_name_components[0], p.name, array_element_prefix, page, c, foldable, movable, numbered, page_size, add_button_text, swap_method);

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -333,6 +333,7 @@ class EditorInspectorArray : public EditorInspectorSection {
 	int begin_array_index = 0;
 	int end_array_index = 0;
 
+	bool read_only = false;
 	bool movable = true;
 	bool numbered = false;
 
@@ -404,7 +405,7 @@ public:
 	void setup_with_count_property(Object *p_object, String p_label, const StringName &p_count_property, const StringName &p_array_element_prefix, int p_page, const Color &p_bg_color, bool p_foldable, bool p_movable = true, bool p_numbered = false, int p_page_length = 5, const String &p_add_item_text = "", const String &p_swap_method = "");
 	VBoxContainer *get_vbox(int p_index);
 
-	EditorInspectorArray();
+	EditorInspectorArray(bool p_read_only);
 };
 
 class EditorPaginator : public HBoxContainer {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -268,6 +268,7 @@ void EditorPropertyArray::update_property() {
 			size_slider->set_step(1);
 			size_slider->set_max(1000000);
 			size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
+			size_slider->set_read_only(is_read_only());
 			size_slider->connect("value_changed", callable_mp(this, &EditorPropertyArray::_length_changed));
 			hbox->add_child(size_slider);
 
@@ -278,6 +279,7 @@ void EditorPropertyArray::update_property() {
 			button_add_item = EditorInspector::create_inspector_action_button(TTR("Add Element"));
 			button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			button_add_item->connect(SNAME("pressed"), callable_mp(this, &EditorPropertyArray::_add_element));
+			button_add_item->set_disabled(is_read_only());
 			vbox->add_child(button_add_item);
 
 			paginator = memnew(EditorPaginator);
@@ -328,6 +330,7 @@ void EditorPropertyArray::update_property() {
 			Button *reorder_button = memnew(Button);
 			reorder_button->set_icon(get_theme_icon(SNAME("TripleBar"), SNAME("EditorIcons")));
 			reorder_button->set_default_cursor_shape(Control::CURSOR_MOVE);
+			reorder_button->set_disabled(is_read_only());
 			reorder_button->connect("gui_input", callable_mp(this, &EditorPropertyArray::_reorder_button_gui_input));
 			reorder_button->connect("button_down", callable_mp(this, &EditorPropertyArray::_reorder_button_down).bind(i + offset));
 			reorder_button->connect("button_up", callable_mp(this, &EditorPropertyArray::_reorder_button_up));
@@ -358,6 +361,7 @@ void EditorPropertyArray::update_property() {
 			prop->connect("property_changed", callable_mp(this, &EditorPropertyArray::_property_changed));
 			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyArray::_object_id_selected));
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
+			prop->set_read_only(is_read_only());
 			hbox->add_child(prop);
 
 			bool is_untyped_array = array.get_type() == Variant::ARRAY && subtype == Variant::NIL;
@@ -366,10 +370,12 @@ void EditorPropertyArray::update_property() {
 				Button *edit = memnew(Button);
 				edit->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 				hbox->add_child(edit);
+				edit->set_disabled(is_read_only());
 				edit->connect("pressed", callable_mp(this, &EditorPropertyArray::_change_type).bind(edit, i + offset));
 			} else {
 				Button *remove = memnew(Button);
 				remove->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+				remove->set_disabled(is_read_only());
 				remove->connect("pressed", callable_mp(this, &EditorPropertyArray::_remove_pressed).bind(i + offset));
 				hbox->add_child(remove);
 			}
@@ -409,6 +415,10 @@ void EditorPropertyArray::_button_draw() {
 }
 
 bool EditorPropertyArray::_is_drop_valid(const Dictionary &p_drag_data) const {
+	if (is_read_only()) {
+		return false;
+	}
+
 	String allowed_type = Variant::get_type_name(subtype);
 
 	// When the subtype is of type Object, an additional subtype may be specified in the hint string
@@ -609,7 +619,7 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 }
 
 void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_event) {
-	if (reorder_from_index < 0) {
+	if (reorder_from_index < 0 || is_read_only()) {
 		return;
 	}
 
@@ -646,6 +656,10 @@ void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_eve
 }
 
 void EditorPropertyArray::_reorder_button_down(int p_index) {
+	if (is_read_only()) {
+		return;
+	}
+
 	reorder_from_index = p_index;
 	reorder_to_index = p_index;
 	reorder_selected_element_hbox = Object::cast_to<HBoxContainer>(property_vbox->get_child(p_index % page_length));
@@ -656,6 +670,10 @@ void EditorPropertyArray::_reorder_button_down(int p_index) {
 }
 
 void EditorPropertyArray::_reorder_button_up() {
+	if (is_read_only()) {
+		return;
+	}
+
 	if (reorder_from_index != reorder_to_index) {
 		// Move the element.
 		Variant array = object->get_array();
@@ -1097,6 +1115,10 @@ void EditorPropertyDictionary::update_property() {
 				}
 			}
 
+			ERR_FAIL_COND(!prop);
+
+			prop->set_read_only(is_read_only());
+
 			if (i == amount) {
 				PanelContainer *pc = memnew(PanelContainer);
 				property_vbox->add_child(pc);
@@ -1135,6 +1157,7 @@ void EditorPropertyDictionary::update_property() {
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
 			Button *edit = memnew(Button);
 			edit->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+			edit->set_disabled(is_read_only());
 			hbox->add_child(edit);
 			edit->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_change_type).bind(edit, change_index));
 
@@ -1143,6 +1166,7 @@ void EditorPropertyDictionary::update_property() {
 			if (i == amount + 1) {
 				button_add_item = EditorInspector::create_inspector_action_button(TTR("Add Key/Value Pair"));
 				button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+				button_add_item->set_disabled(is_read_only());
 				button_add_item->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_add_key_value));
 				add_vbox->add_child(button_add_item);
 			}


### PR DESCRIPTION
Ensures the inspector viewer for arrays and dictionaries respect the 'read-only' state of their respective properties.