### PR TITLE
Improve naming of theme properties throughout GUI code

### DIFF
--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -35,7 +35,7 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckBox] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="check_v_adjust" data_type="constant" type="int" default="0">
+		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -35,7 +35,7 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckButton] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="check_v_adjust" data_type="constant" type="int" default="0">
+		<theme_item name="check_v_offset" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="4">
@@ -50,29 +50,29 @@
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [CheckButton]'s text.
 		</theme_item>
-		<theme_item name="off" data_type="icon" type="Texture2D">
-			The icon to display when the [CheckButton] is unchecked (for left-to-right layouts).
-		</theme_item>
-		<theme_item name="off_disabled" data_type="icon" type="Texture2D">
-			The icon to display when the [CheckButton] is unchecked and disabled (for left-to-right layouts).
-		</theme_item>
-		<theme_item name="off_disabled_mirrored" data_type="icon" type="Texture2D">
-			The icon to display when the [CheckButton] is unchecked and disabled (for right-to-left layouts).
-		</theme_item>
-		<theme_item name="off_mirrored" data_type="icon" type="Texture2D">
-			The icon to display when the [CheckButton] is unchecked (for right-to-left layouts).
-		</theme_item>
-		<theme_item name="on" data_type="icon" type="Texture2D">
+		<theme_item name="checked" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="on_disabled" data_type="icon" type="Texture2D">
+		<theme_item name="checked_disabled" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked and disabled (for left-to-right layouts).
 		</theme_item>
-		<theme_item name="on_disabled_mirrored" data_type="icon" type="Texture2D">
+		<theme_item name="checked_disabled_mirrored" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked and disabled (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="on_mirrored" data_type="icon" type="Texture2D">
+		<theme_item name="checked_mirrored" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked (for right-to-left layouts).
+		</theme_item>
+		<theme_item name="unchecked" data_type="icon" type="Texture2D">
+			The icon to display when the [CheckButton] is unchecked (for left-to-right layouts).
+		</theme_item>
+		<theme_item name="unchecked_disabled" data_type="icon" type="Texture2D">
+			The icon to display when the [CheckButton] is unchecked and disabled (for left-to-right layouts).
+		</theme_item>
+		<theme_item name="unchecked_disabled_mirrored" data_type="icon" type="Texture2D">
+			The icon to display when the [CheckButton] is unchecked and disabled (for right-to-left layouts).
+		</theme_item>
+		<theme_item name="unchecked_mirrored" data_type="icon" type="Texture2D">
+			The icon to display when the [CheckButton] is unchecked (for right-to-left layouts).
 		</theme_item>
 		<theme_item name="disabled" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is disabled.

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -131,13 +131,13 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="file_icon_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
-			The color modulation applied to the file icon.
-		</theme_item>
-		<theme_item name="files_disabled" data_type="color" type="Color" default="Color(1, 1, 1, 0.25)">
+		<theme_item name="file_disabled_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.25)">
 			The color tint for disabled files (when the [FileDialog] is used in open folder mode).
 		</theme_item>
-		<theme_item name="folder_icon_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="file_icon_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color modulation applied to the file icon.
+		</theme_item>
+		<theme_item name="folder_icon_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the folder icon.
 		</theme_item>
 		<theme_item name="back_folder" data_type="icon" type="Texture2D">

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -469,17 +469,17 @@
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the item's text.
 		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			Default [StyleBox] for the [ItemList], i.e. used when the control is not being focused.
-		</theme_item>
-		<theme_item name="bg_focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ItemList] is being focused.
-		</theme_item>
 		<theme_item name="cursor" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [ItemList] is being focused.
 		</theme_item>
 		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
 			[StyleBox] used for the cursor, when the [ItemList] is not being focused.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			The focused style for the [ItemList], drawn on top of the background, but below everything else.
+		</theme_item>
+		<theme_item name="panel" data_type="style" type="StyleBox">
+			The background style for the [ItemList].
 		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is not being focused.

--- a/doc/classes/Panel.xml
+++ b/doc/classes/Panel.xml
@@ -15,7 +15,5 @@
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style of this [Panel].
 		</theme_item>
-		<theme_item name="panel_fg" data_type="style" type="StyleBox">
-		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -49,10 +49,10 @@
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size used to draw the fill percentage if [member percent_visible] is [code]true[/code].
 		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
+		<theme_item name="background" data_type="style" type="StyleBox">
 			The style of the background.
 		</theme_item>
-		<theme_item name="fg" data_type="style" type="StyleBox">
+		<theme_item name="fill" data_type="style" type="StyleBox">
 			The style of the progress (i.e. the part that fills the bar).
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -87,7 +87,7 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" data_type="style" type="StyleBox">
+		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background [StyleBox] of the [ScrollContainer].
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -558,12 +558,6 @@
 		<theme_item name="updown" data_type="icon" type="Texture2D">
 			The updown arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
 		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			Default [StyleBox] for the [Tree], i.e. used when the control is not being focused.
-		</theme_item>
-		<theme_item name="bg_focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Tree] is being focused.
-		</theme_item>
 		<theme_item name="button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when a button in the tree is pressed.
 		</theme_item>
@@ -581,6 +575,12 @@
 		</theme_item>
 		<theme_item name="custom_button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's pressed.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			The focused style for the [Tree], drawn on top of everything.
+		</theme_item>
+		<theme_item name="panel" data_type="style" type="StyleBox">
+			The background style for the [Tree].
 		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is not being focused.

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2411,7 +2411,7 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 	draw_texture(
 			icon_to_draw,
 			ofs,
-			p_index == hovering_key_idx ? get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog")) : Color(1, 1, 1));
+			p_index == hovering_key_idx ? get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")) : Color(1, 1, 1));
 }
 
 // Helper.
@@ -4766,7 +4766,7 @@ void AnimationTrackEditor::_notification(int p_what) {
 			view_group->set_icon(get_theme_icon(view_group->is_pressed() ? SNAME("AnimationTrackList") : SNAME("AnimationTrackGroup"), SNAME("EditorIcons")));
 			selected_filter->set_icon(get_theme_icon(SNAME("AnimationFilter"), SNAME("EditorIcons")));
 			imported_anim_warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
-			main_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			main_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 			edit->get_popup()->set_item_icon(edit->get_popup()->get_item_index(EDIT_APPLY_RESET), get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 		} break;
 

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1027,7 +1027,7 @@ void EditorAudioBuses::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			bus_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			bus_scroll->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -44,7 +44,7 @@ void EditorDirDialog::_update_dir(TreeItem *p_item, EditorFileSystemDirectory *p
 
 	p_item->set_metadata(0, p_dir->get_path());
 	p_item->set_icon(0, tree->get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
-	p_item->set_icon_modulate(0, tree->get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog")));
+	p_item->set_icon_modulate(0, tree->get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")));
 
 	if (!p_item->get_parent()) {
 		p_item->set_text(0, "res://");

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -84,7 +84,7 @@ void EditorFileDialog::_update_theme_item_cache() {
 	theme_cache.favorites_down = get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons"));
 
 	theme_cache.folder = get_theme_icon(SNAME("Folder"), SNAME("EditorIcons"));
-	theme_cache.folder_icon_modulate = get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
+	theme_cache.folder_icon_color = get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog"));
 
 	theme_cache.action_copy = get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons"));
 	theme_cache.action_delete = get_theme_icon(SNAME("Remove"), SNAME("EditorIcons"));
@@ -839,7 +839,7 @@ void EditorFileDialog::update_file_list() {
 		d["dir"] = true;
 
 		item_list->set_item_metadata(-1, d);
-		item_list->set_item_icon_modulate(-1, theme_cache.folder_icon_modulate);
+		item_list->set_item_icon_modulate(-1, theme_cache.folder_icon_color);
 
 		dirs.pop_front();
 	}
@@ -1385,7 +1385,7 @@ void EditorFileDialog::_update_favorites() {
 	for (int i = 0; i < favorited_paths.size(); i++) {
 		favorites->add_item(favorited_names[i], theme_cache.folder);
 		favorites->set_item_metadata(-1, favorited_paths[i]);
-		favorites->set_item_icon_modulate(-1, theme_cache.folder_icon_modulate);
+		favorites->set_item_icon_modulate(-1, theme_cache.folder_icon_color);
 
 		if (i == current_favorite) {
 			favorite->set_pressed(true);
@@ -1468,7 +1468,7 @@ void EditorFileDialog::_update_recent() {
 	for (int i = 0; i < recentd_paths.size(); i++) {
 		recent->add_item(recentd_names[i], theme_cache.folder);
 		recent->set_item_metadata(-1, recentd_paths[i]);
-		recent->set_item_icon_modulate(-1, theme_cache.folder_icon_modulate);
+		recent->set_item_icon_modulate(-1, theme_cache.folder_icon_color);
 	}
 	EditorSettings::get_singleton()->set_recent_dirs(recentd);
 }

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -161,7 +161,7 @@ private:
 		Ref<Texture2D> favorites_down;
 
 		Ref<Texture2D> folder;
-		Color folder_icon_modulate;
+		Color folder_icon_color;
 
 		Ref<Texture2D> action_copy;
 		Ref<Texture2D> action_delete;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3487,9 +3487,9 @@ void EditorInspector::_update_inspector_bg() {
 			n = n->get_parent();
 		}
 		count_subinspectors = MIN(15, count_subinspectors);
-		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_bg" + itos(count_subinspectors), SNAME("Editor")));
+		add_theme_style_override("panel", get_theme_stylebox("sub_inspector_bg" + itos(count_subinspectors), SNAME("Editor")));
 	} else {
-		add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 	}
 }
 void EditorInspector::set_sub_inspector(bool p_enable) {

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -769,7 +769,7 @@ void EditorResourcePicker::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			draw_style_box(get_theme_stylebox(SNAME("bg"), SNAME("Tree")), Rect2(Point2(), get_size()));
+			draw_style_box(get_theme_stylebox(SNAME("panel"), SNAME("Tree")), Rect2(Point2(), get_size()));
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -193,7 +193,7 @@ void EditorSettingsDialog::_update_icons() {
 	shortcut_search_box->set_clear_button_enabled(true);
 
 	restart_close_button->set_icon(shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-	restart_container->add_theme_style_override("panel", shortcuts->get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	restart_container->add_theme_style_override("panel", shortcuts->get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 	restart_icon->set_texture(shortcuts->get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 	restart_label->add_theme_color_override("font_color", shortcuts->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 }

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -894,15 +894,15 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("hover", "CheckButton", style_menu);
 	theme->set_stylebox("hover_pressed", "CheckButton", style_menu);
 
-	theme->set_icon("on", "CheckButton", theme->get_icon(SNAME("GuiToggleOn"), SNAME("EditorIcons")));
-	theme->set_icon("on_disabled", "CheckButton", theme->get_icon(SNAME("GuiToggleOnDisabled"), SNAME("EditorIcons")));
-	theme->set_icon("off", "CheckButton", theme->get_icon(SNAME("GuiToggleOff"), SNAME("EditorIcons")));
-	theme->set_icon("off_disabled", "CheckButton", theme->get_icon(SNAME("GuiToggleOffDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("checked", "CheckButton", theme->get_icon(SNAME("GuiToggleOn"), SNAME("EditorIcons")));
+	theme->set_icon("checked_disabled", "CheckButton", theme->get_icon(SNAME("GuiToggleOnDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked", "CheckButton", theme->get_icon(SNAME("GuiToggleOff"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked_disabled", "CheckButton", theme->get_icon(SNAME("GuiToggleOffDisabled"), SNAME("EditorIcons")));
 
-	theme->set_icon("on_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOnMirrored"), SNAME("EditorIcons")));
-	theme->set_icon("on_disabled_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOnDisabledMirrored"), SNAME("EditorIcons")));
-	theme->set_icon("off_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOffMirrored"), SNAME("EditorIcons")));
-	theme->set_icon("off_disabled_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOffDisabledMirrored"), SNAME("EditorIcons")));
+	theme->set_icon("checked_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOnMirrored"), SNAME("EditorIcons")));
+	theme->set_icon("checked_disabled_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOnDisabledMirrored"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOffMirrored"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked_disabled_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOffDisabledMirrored"), SNAME("EditorIcons")));
 
 	theme->set_color("font_color", "CheckButton", font_color);
 	theme->set_color("font_hover_color", "CheckButton", font_hover_color);
@@ -918,7 +918,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_disabled_color", "CheckButton", icon_disabled_color);
 
 	theme->set_constant("h_separation", "CheckButton", 8 * EDSCALE);
-	theme->set_constant("check_v_adjust", "CheckButton", 0 * EDSCALE);
+	theme->set_constant("check_v_offset", "CheckButton", 0 * EDSCALE);
 
 	// Checkbox
 	Ref<StyleBoxFlat> sb_checkbox = style_menu->duplicate();
@@ -955,7 +955,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_disabled_color", "CheckBox", icon_disabled_color);
 
 	theme->set_constant("h_separation", "CheckBox", 8 * EDSCALE);
-	theme->set_constant("check_v_adjust", "CheckBox", 0 * EDSCALE);
+	theme->set_constant("check_v_offset", "CheckBox", 0 * EDSCALE);
 
 	// PopupDialog
 	theme->set_stylebox("panel", "PopupDialog", style_popup);
@@ -1095,7 +1095,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Make Trees easier to distinguish from other controls by using a darker background color.
 	style_tree_bg->set_bg_color(dark_color_1.lerp(dark_color_2, 0.5));
 	style_tree_bg->set_border_color(dark_color_3);
-	theme->set_stylebox("bg", "Tree", style_tree_bg);
+	theme->set_stylebox("panel", "Tree", style_tree_bg);
 
 	// Tree
 	theme->set_icon("checked", "Tree", theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));
@@ -1106,7 +1106,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("arrow_collapsed_mirrored", "Tree", theme->get_icon(SNAME("GuiTreeArrowLeft"), SNAME("EditorIcons")));
 	theme->set_icon("updown", "Tree", theme->get_icon(SNAME("GuiTreeUpdown"), SNAME("EditorIcons")));
 	theme->set_icon("select_arrow", "Tree", theme->get_icon(SNAME("GuiDropdown"), SNAME("EditorIcons")));
-	theme->set_stylebox("bg_focus", "Tree", style_widget_focus);
+	theme->set_stylebox("focus", "Tree", style_widget_focus);
 	theme->set_stylebox("custom_button", "Tree", make_empty_stylebox());
 	theme->set_stylebox("custom_button_pressed", "Tree", make_empty_stylebox());
 	theme->set_stylebox("custom_button_hover", "Tree", style_widget);
@@ -1197,12 +1197,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_itemlist_cursor->set_draw_center(false);
 	style_itemlist_cursor->set_border_width_all(border_width);
 	style_itemlist_cursor->set_border_color(highlight_color);
+	theme->set_stylebox("panel", "ItemList", style_itemlist_bg);
+	theme->set_stylebox("focus", "ItemList", style_widget_focus);
 	theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
 	theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
 	theme->set_stylebox("selected_focus", "ItemList", style_tree_focus);
 	theme->set_stylebox("selected", "ItemList", style_tree_selected);
-	theme->set_stylebox("bg_focus", "ItemList", style_widget_focus);
-	theme->set_stylebox("bg", "ItemList", style_itemlist_bg);
 	theme->set_color("font_color", "ItemList", font_color);
 	theme->set_color("font_selected_color", "ItemList", mono_color);
 	theme->set_color("guide_color", "ItemList", guide_color);
@@ -1547,8 +1547,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("updown_disabled", "SpinBox", theme->get_icon(SNAME("GuiSpinboxUpdownDisabled"), SNAME("EditorIcons")));
 
 	// ProgressBar
-	theme->set_stylebox("bg", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressBar"), SNAME("EditorIcons")), 4, 4, 4, 4, 0, 0, 0, 0));
-	theme->set_stylebox("fg", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressFill"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 1, 2, 1));
+	theme->set_stylebox("background", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressBar"), SNAME("EditorIcons")), 4, 4, 4, 4, 0, 0, 0, 0));
+	theme->set_stylebox("fill", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressFill"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 1, 2, 1));
 	theme->set_color("font_color", "ProgressBar", font_color);
 
 	// GraphEdit
@@ -1694,7 +1694,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("toggle_hidden", "FileDialog", theme->get_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
 	// Use a different color for folder icons to make them easier to distinguish from files.
 	// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
-	theme->set_color("folder_icon_modulate", "FileDialog", (dark_theme ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(accent_color, 0.7));
+	theme->set_color("folder_icon_color", "FileDialog", (dark_theme ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(accent_color, 0.7));
 	theme->set_color("files_disabled", "FileDialog", font_disabled_color);
 
 	// ColorPicker

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -76,7 +76,7 @@ bool FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 	subdirectory_item->set_text(0, dname);
 	subdirectory_item->set_structured_text_bidi_override(0, TextServer::STRUCTURED_TEXT_FILE);
 	subdirectory_item->set_icon(0, get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
-	subdirectory_item->set_icon_modulate(0, get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog")));
+	subdirectory_item->set_icon_modulate(0, get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")));
 	subdirectory_item->set_selectable(0, true);
 	String lpath = p_dir->get_path();
 	subdirectory_item->set_metadata(0, lpath);
@@ -246,7 +246,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 		}
 
 		Ref<Texture2D> folder_icon = get_theme_icon(SNAME("Folder"), SNAME("EditorIcons"));
-		const Color folder_color = get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
+		const Color folder_color = get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog"));
 
 		String text;
 		Ref<Texture2D> icon;
@@ -778,7 +778,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	}
 
 	Ref<Texture2D> folder_icon = (use_thumbnails) ? folder_thumbnail : get_theme_icon(SNAME("folder"), SNAME("FileDialog"));
-	const Color folder_color = get_theme_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"));
+	const Color folder_color = get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog"));
 
 	// Build the FileInfo list.
 	List<FileInfo> file_list;

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1343,8 +1343,8 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	for (int i = 0; i < 16; i++) {
 		glyph_table->set_column_title(i + 1, String::num_int64(i, 16));
 	}
-	glyph_table->add_theme_style_override("selected", glyph_table->get_theme_stylebox(SNAME("bg")));
-	glyph_table->add_theme_style_override("selected_focus", glyph_table->get_theme_stylebox(SNAME("bg")));
+	glyph_table->add_theme_style_override("selected", glyph_table->get_theme_stylebox(SNAME("panel")));
+	glyph_table->add_theme_style_override("selected_focus", glyph_table->get_theme_stylebox(SNAME("panel")));
 	glyph_table->add_theme_constant_override("h_separation", 0);
 	glyph_table->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	glyph_table->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -552,9 +552,9 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 			error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 			tool_blend->set_icon(get_theme_icon(SNAME("EditPivot"), SNAME("EditorIcons")));
 			tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
 			tool_create->set_icon(get_theme_icon(SNAME("EditKey"), SNAME("EditorIcons")));

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -774,9 +774,9 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 			error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 			tool_blend->set_icon(get_theme_icon(SNAME("EditPivot"), SNAME("EditorIcons")));
 			tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
 			tool_create->set_icon(get_theme_icon(SNAME("EditKey"), SNAME("EditorIcons")));

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -800,7 +800,7 @@ void AnimationNodeBlendTreeEditor::_update_editor_settings() {
 }
 
 void AnimationNodeBlendTreeEditor::_update_theme() {
-	error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 	error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 }
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1551,9 +1551,9 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 			error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 
 			tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
 			tool_create->set_icon(get_theme_icon(SNAME("ToolAddNode"), SNAME("EditorIcons")));

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -584,8 +584,8 @@ void EditorAssetLibrary::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_tr->set_texture(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 			filter->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
-			library_scroll_bg->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-			downloads_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			library_scroll_bg->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
+			downloads_scroll->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 			error_label->add_theme_color_override("color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		} break;
 

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -640,7 +640,7 @@ void CurveEditor::_draw() {
 	// Background
 
 	Vector2 view_size = get_rect().size;
-	draw_style_box(get_theme_stylebox(SNAME("bg"), SNAME("Tree")), Rect2(Point2(), view_size));
+	draw_style_box(get_theme_stylebox(SNAME("panel"), SNAME("Tree")), Rect2(Point2(), view_size));
 
 	// Grid
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -94,8 +94,8 @@ void Polygon2DEditor::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
-			uv_edit_draw->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-			bone_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			uv_edit_draw->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
+			bone_scroll->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -428,7 +428,7 @@ void SpriteFramesEditor::_notification(int p_what) {
 			split_sheet_zoom_out->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
 			split_sheet_zoom_reset->set_icon(get_theme_icon(SNAME("ZoomReset"), SNAME("EditorIcons")));
 			split_sheet_zoom_in->set_icon(get_theme_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
-			split_sheet_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			split_sheet_scroll->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -823,7 +823,7 @@ void TextureRegionEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			edit_draw->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			edit_draw->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_READY: {
 			zoom_out->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1031,9 +1031,11 @@ static const char *gdscript_properties_renames[][2] = {
 	//	{ "filename", "scene_file_path" }, // Node
 	{ "as_normalmap", "as_normal_map" }, // NoiseTexture
 	{ "bbcode_text", "text" }, // RichTextLabel
+	{ "bg", "panel" }, // Theme
+	{ "bg_focus", "focus" }, // Theme
 	{ "caret_moving_by_right_click", "caret_move_on_right_click" }, // TextEdit
 	{ "caret_position", "caret_column" }, // LineEdit
-	{ "check_vadjust", "check_v_adjust" }, // Theme
+	{ "check_vadjust", "check_v_offset" }, // Theme
 	{ "close_h_ofs", "close_h_offset" }, // Theme
 	{ "close_v_ofs", "close_v_offset" }, // Theme
 	{ "commentfocus", "comment_focus" }, // Theme
@@ -1051,6 +1053,9 @@ static const char *gdscript_properties_renames[][2] = {
 	{ "focus_neighbour_left", "focus_neighbor_left" }, // Control
 	{ "focus_neighbour_right", "focus_neighbor_right" }, // Control
 	{ "focus_neighbour_top", "focus_neighbor_top" }, // Control
+	{ "file_icon_modulate", "file_icon_color" }, // Theme
+	{ "files_disabled", "file_disabled_color" }, // Theme
+	{ "folder_icon_modulate", "folder_icon_color" }, // Theme
 	{ "global_rate_scale", "playback_speed_scale" }, // AudioServer
 	{ "gravity_distance_scale", "gravity_point_distance_scale" }, // Area2D
 	{ "gravity_vec", "gravity_direction" }, // Area2D
@@ -1065,7 +1070,11 @@ static const char *gdscript_properties_renames[][2] = {
 	{ "mid_height", "height" }, // CapsuleMesh
 	{ "offset_h", "drag_horizontal_offset" }, // Camera2D
 	{ "offset_v", "drag_vertical_offset" }, // Camera2D
+	{ "off", "unchecked" }, // Theme
+	{ "off_disabled", "unchecked_disabled" }, // Theme
 	{ "ofs", "offset" }, // Theme
+	{ "on", "checked" }, // Theme
+	{ "on_disabled", "checked_disabled" }, // Theme
 	{ "oneshot", "one_shot" }, // AnimatedTexture
 	{ "out_of_range_mode", "max_polyphony" }, // AudioStreamPlayer3D
 	{ "pause_mode", "process_mode" }, // Node

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2606,7 +2606,7 @@ ProjectManager::ProjectManager() {
 		}
 
 		PanelContainer *pc = memnew(PanelContainer);
-		pc->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		pc->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		pc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		search_tree_vb->add_child(pc);
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -521,7 +521,7 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 void ProjectSettingsEditor::_update_theme() {
 	search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	restart_close_button->set_icon(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-	restart_container->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	restart_container->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 	restart_icon->set_texture(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 	restart_label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -53,7 +53,7 @@ void SceneCreateDialog::_notification(int p_what) {
 			node_type_3d->set_icon(get_theme_icon(SNAME("Node3D"), SNAME("EditorIcons")));
 			node_type_gui->set_icon(get_theme_icon(SNAME("Control"), SNAME("EditorIcons")));
 			node_type_other->add_theme_icon_override(SNAME("icon"), get_theme_icon(SNAME("Node"), SNAME("EditorIcons")));
-			status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 	}
 }

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -134,7 +134,7 @@ void ScriptCreateDialog::_notification(int p_what) {
 			path_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 			parent_browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 			parent_search_button->set_icon(get_theme_icon(SNAME("ClassList"), SNAME("EditorIcons")));
-			status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 	}
 }

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -89,7 +89,7 @@ void ShaderCreateDialog::_update_theme() {
 	}
 
 	path_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
-	status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 }
 
 void ShaderCreateDialog::_update_language_info() {

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -57,7 +57,7 @@ void OpenXRActionMapEditor::_notification(int p_what) {
 			for (int i = 0; i < tabs->get_child_count(); i++) {
 				Control *tab = static_cast<Control *>(tabs->get_child(i));
 				if (tab) {
-					tab->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+					tab->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 				}
 			}
 		} break;
@@ -113,7 +113,7 @@ OpenXRInteractionProfileEditorBase *OpenXRActionMapEditor::_add_interaction_prof
 	// now add it in..
 	ERR_FAIL_NULL_V(new_profile_editor, nullptr);
 	tabs->add_child(new_profile_editor);
-	new_profile_editor->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	new_profile_editor->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 	tabs->set_tab_button_icon(tabs->get_tab_count() - 1, get_theme_icon(SNAME("close"), SNAME("TabBar")));
 
 	interaction_profiles.push_back(new_profile_editor);

--- a/modules/openxr/editor/openxr_select_action_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_action_dialog.cpp
@@ -39,7 +39,7 @@ void OpenXRSelectActionDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			scroll->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 	}
 }

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -38,7 +38,7 @@ void OpenXRSelectInteractionProfileDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			scroll->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 	}
 }

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -77,7 +77,7 @@ void CheckBox::_update_theme_item_cache() {
 	Button::_update_theme_item_cache();
 
 	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
-	theme_cache.check_v_adjust = get_theme_constant(SNAME("check_v_adjust"));
+	theme_cache.check_v_offset = get_theme_constant(SNAME("check_v_offset"));
 	theme_cache.normal_style = get_theme_stylebox(SNAME("normal"));
 
 	theme_cache.checked = get_theme_icon(SNAME("checked"));
@@ -134,7 +134,7 @@ void CheckBox::_notification(int p_what) {
 			} else {
 				ofs.x = theme_cache.normal_style->get_margin(SIDE_LEFT);
 			}
-			ofs.y = int((get_size().height - get_icon_size().height) / 2) + theme_cache.check_v_adjust;
+			ofs.y = int((get_size().height - get_icon_size().height) / 2) + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
 				on_tex->draw(ci, ofs);

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -38,7 +38,7 @@ class CheckBox : public Button {
 
 	struct ThemeCache {
 		int h_separation = 0;
-		int check_v_adjust = 0;
+		int check_v_offset = 0;
 		Ref<StyleBox> normal_style;
 
 		Ref<Texture2D> checked;

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -82,17 +82,17 @@ void CheckButton::_update_theme_item_cache() {
 	Button::_update_theme_item_cache();
 
 	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
-	theme_cache.check_v_adjust = get_theme_constant(SNAME("check_v_adjust"));
+	theme_cache.check_v_offset = get_theme_constant(SNAME("check_v_offset"));
 	theme_cache.normal_style = get_theme_stylebox(SNAME("normal"));
 
-	theme_cache.checked = get_theme_icon(SNAME("on"));
-	theme_cache.unchecked = get_theme_icon(SNAME("off"));
-	theme_cache.checked_disabled = get_theme_icon(SNAME("on_disabled"));
-	theme_cache.unchecked_disabled = get_theme_icon(SNAME("off_disabled"));
-	theme_cache.checked_mirrored = get_theme_icon(SNAME("on_mirrored"));
-	theme_cache.unchecked_mirrored = get_theme_icon(SNAME("off_mirrored"));
-	theme_cache.checked_disabled_mirrored = get_theme_icon(SNAME("on_disabled_mirrored"));
-	theme_cache.unchecked_disabled_mirrored = get_theme_icon(SNAME("off_disabled_mirrored"));
+	theme_cache.checked = get_theme_icon(SNAME("checked"));
+	theme_cache.unchecked = get_theme_icon(SNAME("unchecked"));
+	theme_cache.checked_disabled = get_theme_icon(SNAME("checked_disabled"));
+	theme_cache.unchecked_disabled = get_theme_icon(SNAME("unchecked_disabled"));
+	theme_cache.checked_mirrored = get_theme_icon(SNAME("checked_mirrored"));
+	theme_cache.unchecked_mirrored = get_theme_icon(SNAME("unchecked_mirrored"));
+	theme_cache.checked_disabled_mirrored = get_theme_icon(SNAME("checked_disabled_mirrored"));
+	theme_cache.unchecked_disabled_mirrored = get_theme_icon(SNAME("unchecked_disabled_mirrored"));
 }
 
 void CheckButton::_notification(int p_what) {
@@ -142,7 +142,7 @@ void CheckButton::_notification(int p_what) {
 			} else {
 				ofs.x = get_size().width - (tex_size.width + theme_cache.normal_style->get_margin(SIDE_RIGHT));
 			}
-			ofs.y = (get_size().height - tex_size.height) / 2 + theme_cache.check_v_adjust;
+			ofs.y = (get_size().height - tex_size.height) / 2 + theme_cache.check_v_offset;
 
 			if (is_pressed()) {
 				on_tex->draw(ci, ofs);

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -38,7 +38,7 @@ class CheckButton : public Button {
 
 	struct ThemeCache {
 		int h_separation = 0;
-		int check_v_adjust = 0;
+		int check_v_offset = 0;
 		Ref<StyleBox> normal_style;
 
 		Ref<Texture2D> checked;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -70,9 +70,9 @@ void FileDialog::_update_theme_item_cache() {
 	theme_cache.folder = get_theme_icon(SNAME("folder"));
 	theme_cache.file = get_theme_icon(SNAME("file"));
 
-	theme_cache.folder_icon_modulate = get_theme_color(SNAME("folder_icon_modulate"));
-	theme_cache.file_icon_modulate = get_theme_color(SNAME("file_icon_modulate"));
-	theme_cache.files_disabled = get_theme_color(SNAME("files_disabled"));
+	theme_cache.folder_icon_color = get_theme_color(SNAME("folder_icon_color"));
+	theme_cache.file_icon_color = get_theme_color(SNAME("file_icon_color"));
+	theme_cache.file_disabled_color = get_theme_color(SNAME("file_disabled_color"));
 
 	// TODO: Define own colors?
 	theme_cache.icon_normal_color = get_theme_color(SNAME("font_color"), SNAME("Button"));
@@ -552,7 +552,7 @@ void FileDialog::update_file_list() {
 		TreeItem *ti = tree->create_item(root);
 		ti->set_text(0, dir_name);
 		ti->set_icon(0, theme_cache.folder);
-		ti->set_icon_modulate(0, theme_cache.folder_icon_modulate);
+		ti->set_icon_modulate(0, theme_cache.folder_icon_color);
 
 		Dictionary d;
 		d["name"] = dir_name;
@@ -613,10 +613,10 @@ void FileDialog::update_file_list() {
 			} else {
 				ti->set_icon(0, theme_cache.file);
 			}
-			ti->set_icon_modulate(0, theme_cache.file_icon_modulate);
+			ti->set_icon_modulate(0, theme_cache.file_icon_color);
 
 			if (mode == FILE_MODE_OPEN_DIR) {
-				ti->set_custom_color(0, theme_cache.files_disabled);
+				ti->set_custom_color(0, theme_cache.file_disabled_color);
 				ti->set_selectable(0, false);
 			}
 			Dictionary d;

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -118,9 +118,9 @@ private:
 		Ref<Texture2D> folder;
 		Ref<Texture2D> file;
 
-		Color folder_icon_modulate;
-		Color file_icon_modulate;
-		Color files_disabled;
+		Color folder_icon_color;
+		Color file_icon_color;
+		Color file_disabled_color;
 
 		Color icon_normal_color;
 		Color icon_hover_color;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -655,7 +655,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && mb->is_pressed()) {
 		search_string = ""; //any mousepress cancels
 		Vector2 pos = mb->get_position();
-		pos -= theme_cache.bg_style->get_offset();
+		pos -= theme_cache.panel_style->get_offset();
 		pos.y += scroll_bar->get_value();
 
 		if (is_layout_rtl()) {
@@ -985,8 +985,8 @@ void ItemList::_update_theme_item_cache() {
 	theme_cache.h_separation = get_theme_constant(SNAME("h_separation"));
 	theme_cache.v_separation = get_theme_constant(SNAME("v_separation"));
 
-	theme_cache.bg_style = get_theme_stylebox(SNAME("bg"));
-	theme_cache.bg_focus_style = get_theme_stylebox(SNAME("bg_focus"));
+	theme_cache.panel_style = get_theme_stylebox(SNAME("panel"));
+	theme_cache.focus_style = get_theme_stylebox(SNAME("focus"));
 
 	theme_cache.font = get_theme_font(SNAME("font"));
 	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
@@ -1025,13 +1025,13 @@ void ItemList::_notification(int p_what) {
 			int mw = scroll_bar->get_minimum_size().x;
 			scroll_bar->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -mw);
 			scroll_bar->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
-			scroll_bar->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, theme_cache.bg_style->get_margin(SIDE_TOP));
-			scroll_bar->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -theme_cache.bg_style->get_margin(SIDE_BOTTOM));
+			scroll_bar->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, theme_cache.panel_style->get_margin(SIDE_TOP));
+			scroll_bar->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -theme_cache.panel_style->get_margin(SIDE_BOTTOM));
 
 			Size2 size = get_size();
-			int width = size.width - theme_cache.bg_style->get_minimum_size().width;
+			int width = size.width - theme_cache.panel_style->get_minimum_size().width;
 
-			draw_style_box(theme_cache.bg_style, Rect2(Point2(), size));
+			draw_style_box(theme_cache.panel_style, Rect2(Point2(), size));
 
 			Ref<StyleBox> sbsel;
 			Ref<StyleBox> cursor;
@@ -1047,7 +1047,7 @@ void ItemList::_notification(int p_what) {
 
 			if (has_focus()) {
 				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
-				draw_style_box(theme_cache.bg_focus_style, Rect2(Point2(), size));
+				draw_style_box(theme_cache.focus_style, Rect2(Point2(), size));
 				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
 			}
 
@@ -1109,7 +1109,7 @@ void ItemList::_notification(int p_what) {
 					items.write[i].min_rect_cache.size = minsize;
 				}
 
-				int fit_size = size.x - theme_cache.bg_style->get_minimum_size().width - mw;
+				int fit_size = size.x - theme_cache.panel_style->get_minimum_size().width - mw;
 
 				//2-attempt best fit
 				current_columns = 0x7FFFFFFF;
@@ -1160,10 +1160,10 @@ void ItemList::_notification(int p_what) {
 					}
 
 					if (all_fit) {
-						float page = MAX(0, size.height - theme_cache.bg_style->get_minimum_size().height);
+						float page = MAX(0, size.height - theme_cache.panel_style->get_minimum_size().height);
 						float max = MAX(page, ofs.y + max_h);
 						if (auto_height) {
-							auto_height_value = ofs.y + max_h + theme_cache.bg_style->get_minimum_size().height;
+							auto_height_value = ofs.y + max_h + theme_cache.panel_style->get_minimum_size().height;
 						}
 						scroll_bar->set_max(max);
 						scroll_bar->set_page(page);
@@ -1204,7 +1204,7 @@ void ItemList::_notification(int p_what) {
 
 			ensure_selected_visible = false;
 
-			Vector2 base_ofs = theme_cache.bg_style->get_offset();
+			Vector2 base_ofs = theme_cache.panel_style->get_offset();
 			base_ofs.y -= int(scroll_bar->get_value());
 
 			const Rect2 clip(-base_ofs, size); // visible frame, don't need to draw outside of there
@@ -1442,7 +1442,7 @@ void ItemList::_notification(int p_what) {
 				}
 
 				const int y = base_ofs.y + separators[i];
-				draw_line(Vector2(theme_cache.bg_style->get_margin(SIDE_LEFT), y), Vector2(width, y), theme_cache.guide_color);
+				draw_line(Vector2(theme_cache.panel_style->get_margin(SIDE_LEFT), y), Vector2(width, y), theme_cache.guide_color);
 			}
 		} break;
 	}
@@ -1454,7 +1454,7 @@ void ItemList::_scroll_changed(double) {
 
 int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 	Vector2 pos = p_pos;
-	pos -= theme_cache.bg_style->get_offset();
+	pos -= theme_cache.panel_style->get_offset();
 	pos.y += scroll_bar->get_value();
 
 	if (is_layout_rtl()) {
@@ -1491,7 +1491,7 @@ bool ItemList::is_pos_at_end_of_items(const Point2 &p_pos) const {
 	}
 
 	Vector2 pos = p_pos;
-	pos -= theme_cache.bg_style->get_offset();
+	pos -= theme_cache.panel_style->get_offset();
 	pos.y += scroll_bar->get_value();
 
 	if (is_layout_rtl()) {

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -123,8 +123,8 @@ private:
 		int h_separation = 0;
 		int v_separation = 0;
 
-		Ref<StyleBox> bg_style;
-		Ref<StyleBox> bg_focus_style;
+		Ref<StyleBox> panel_style;
+		Ref<StyleBox> focus_style;
 
 		Ref<Font> font;
 		int font_size = 0;

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -33,13 +33,13 @@
 #include "scene/resources/text_line.h"
 
 Size2 ProgressBar::get_minimum_size() const {
-	Size2 minimum_size = theme_cache.bg_style->get_minimum_size();
-	minimum_size.height = MAX(minimum_size.height, theme_cache.fg_style->get_minimum_size().height);
-	minimum_size.width = MAX(minimum_size.width, theme_cache.fg_style->get_minimum_size().width);
+	Size2 minimum_size = theme_cache.background_style->get_minimum_size();
+	minimum_size.height = MAX(minimum_size.height, theme_cache.fill_style->get_minimum_size().height);
+	minimum_size.width = MAX(minimum_size.width, theme_cache.fill_style->get_minimum_size().width);
 	if (percent_visible) {
 		String txt = "100%";
 		TextLine tl = TextLine(txt, theme_cache.font, theme_cache.font_size);
-		minimum_size.height = MAX(minimum_size.height, theme_cache.bg_style->get_minimum_size().height + tl.get_size().y);
+		minimum_size.height = MAX(minimum_size.height, theme_cache.background_style->get_minimum_size().height + tl.get_size().y);
 	} else { // this is needed, else the progressbar will collapse
 		minimum_size.width = MAX(minimum_size.width, 1);
 		minimum_size.height = MAX(minimum_size.height, 1);
@@ -50,8 +50,8 @@ Size2 ProgressBar::get_minimum_size() const {
 void ProgressBar::_update_theme_item_cache() {
 	Range::_update_theme_item_cache();
 
-	theme_cache.bg_style = get_theme_stylebox(SNAME("bg"));
-	theme_cache.fg_style = get_theme_stylebox(SNAME("fg"));
+	theme_cache.background_style = get_theme_stylebox(SNAME("background"));
+	theme_cache.fill_style = get_theme_stylebox(SNAME("fill"));
 
 	theme_cache.font = get_theme_font(SNAME("font"));
 	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
@@ -63,14 +63,14 @@ void ProgressBar::_update_theme_item_cache() {
 void ProgressBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			draw_style_box(theme_cache.bg_style, Rect2(Point2(), get_size()));
+			draw_style_box(theme_cache.background_style, Rect2(Point2(), get_size()));
 
 			float r = get_as_ratio();
 
 			switch (mode) {
 				case FILL_BEGIN_TO_END:
 				case FILL_END_TO_BEGIN: {
-					int mp = theme_cache.fg_style->get_minimum_size().width;
+					int mp = theme_cache.fill_style->get_minimum_size().width;
 					int p = round(r * (get_size().width - mp));
 					// We want FILL_BEGIN_TO_END to map to right to left when UI layout is RTL,
 					// and left to right otherwise. And likewise for FILL_END_TO_BEGIN.
@@ -78,23 +78,23 @@ void ProgressBar::_notification(int p_what) {
 					if (p > 0) {
 						if (right_to_left) {
 							int p_remaining = round((1.0 - r) * (get_size().width - mp));
-							draw_style_box(theme_cache.fg_style, Rect2(Point2(p_remaining, 0), Size2(p + theme_cache.fg_style->get_minimum_size().width, get_size().height)));
+							draw_style_box(theme_cache.fill_style, Rect2(Point2(p_remaining, 0), Size2(p + theme_cache.fill_style->get_minimum_size().width, get_size().height)));
 						} else {
-							draw_style_box(theme_cache.fg_style, Rect2(Point2(0, 0), Size2(p + theme_cache.fg_style->get_minimum_size().width, get_size().height)));
+							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, 0), Size2(p + theme_cache.fill_style->get_minimum_size().width, get_size().height)));
 						}
 					}
 				} break;
 				case FILL_TOP_TO_BOTTOM:
 				case FILL_BOTTOM_TO_TOP: {
-					int mp = theme_cache.fg_style->get_minimum_size().height;
+					int mp = theme_cache.fill_style->get_minimum_size().height;
 					int p = round(r * (get_size().height - mp));
 
 					if (p > 0) {
 						if (mode == FILL_TOP_TO_BOTTOM) {
-							draw_style_box(theme_cache.fg_style, Rect2(Point2(0, 0), Size2(get_size().width, p + theme_cache.fg_style->get_minimum_size().height)));
+							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, 0), Size2(get_size().width, p + theme_cache.fill_style->get_minimum_size().height)));
 						} else {
 							int p_remaining = round((1.0 - r) * (get_size().height - mp));
-							draw_style_box(theme_cache.fg_style, Rect2(Point2(0, p_remaining), Size2(get_size().width, p + theme_cache.fg_style->get_minimum_size().height)));
+							draw_style_box(theme_cache.fill_style, Rect2(Point2(0, p_remaining), Size2(get_size().width, p + theme_cache.fill_style->get_minimum_size().height)));
 						}
 					}
 				} break;

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -39,8 +39,8 @@ class ProgressBar : public Range {
 	bool percent_visible = true;
 
 	struct ThemeCache {
-		Ref<StyleBox> bg_style;
-		Ref<StyleBox> fg_style;
+		Ref<StyleBox> background_style;
+		Ref<StyleBox> fill_style;
 
 		Ref<Font> font;
 		int font_size = 0;

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1676,8 +1676,8 @@ void RichTextLabel::_update_theme_item_cache() {
 
 	theme_cache.normal_style = get_theme_stylebox(SNAME("normal"));
 	theme_cache.focus_style = get_theme_stylebox(SNAME("focus"));
-	theme_cache.progress_bg_style = get_theme_stylebox(SNAME("bg"), SNAME("ProgressBar"));
-	theme_cache.progress_fg_style = get_theme_stylebox(SNAME("fg"), SNAME("ProgressBar"));
+	theme_cache.progress_bg_style = get_theme_stylebox(SNAME("background"), SNAME("ProgressBar"));
+	theme_cache.progress_fg_style = get_theme_stylebox(SNAME("fill"), SNAME("ProgressBar"));
 
 	theme_cache.line_separation = get_theme_constant(SNAME("line_separation"));
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1693,7 +1693,6 @@ void RichTextLabel::_update_theme_item_cache() {
 	theme_cache.shadow_offset_x = get_theme_constant(SNAME("shadow_offset_x"));
 	theme_cache.shadow_offset_y = get_theme_constant(SNAME("shadow_offset_y"));
 	theme_cache.outline_size = get_theme_constant(SNAME("outline_size"));
-	theme_cache.outline_color = get_theme_color(SNAME("outline_color"));
 
 	theme_cache.bold_font = get_theme_font(SNAME("bold_font"));
 	theme_cache.bold_font_size = get_theme_font_size(SNAME("bold_font_size"));
@@ -3941,7 +3940,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			int fs = theme_cache.normal_font_size * 3;
 			Ref<Font> f = theme_cache.normal_font;
 			Color color = theme_cache.default_color;
-			Color outline_color = theme_cache.outline_color;
+			Color outline_color = theme_cache.font_outline_color;
 			int outline_size = theme_cache.outline_size;
 			Rect2 dropcap_margins = Rect2();
 

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -76,14 +76,14 @@ Size2 ScrollContainer::get_minimum_size() const {
 		min_size.x += v_scroll->get_minimum_size().x;
 	}
 
-	min_size += theme_cache.bg_style->get_minimum_size();
+	min_size += theme_cache.panel_style->get_minimum_size();
 	return min_size;
 }
 
 void ScrollContainer::_update_theme_item_cache() {
 	Container::_update_theme_item_cache();
 
-	theme_cache.bg_style = get_theme_stylebox(SNAME("bg"));
+	theme_cache.panel_style = get_theme_stylebox(SNAME("panel"));
 }
 
 void ScrollContainer::_cancel_drag() {
@@ -276,8 +276,8 @@ void ScrollContainer::_reposition_children() {
 	Size2 size = get_size();
 	Point2 ofs;
 
-	size -= theme_cache.bg_style->get_minimum_size();
-	ofs += theme_cache.bg_style->get_offset();
+	size -= theme_cache.panel_style->get_minimum_size();
+	ofs += theme_cache.panel_style->get_offset();
 	bool rtl = is_layout_rtl();
 
 	if (h_scroll->is_visible_in_tree() && h_scroll->get_parent() == this) { //scrolls may have been moved out for reasons
@@ -341,7 +341,7 @@ void ScrollContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			draw_style_box(theme_cache.bg_style, Rect2(Vector2(), get_size()));
+			draw_style_box(theme_cache.panel_style, Rect2(Vector2(), get_size()));
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
@@ -416,7 +416,7 @@ void ScrollContainer::_notification(int p_what) {
 
 void ScrollContainer::update_scrollbars() {
 	Size2 size = get_size();
-	size -= theme_cache.bg_style->get_minimum_size();
+	size -= theme_cache.panel_style->get_minimum_size();
 
 	Size2 hmin = h_scroll->get_combined_minimum_size();
 	Size2 vmin = v_scroll->get_combined_minimum_size();

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -70,7 +70,7 @@ private:
 	bool follow_focus = false;
 
 	struct ThemeCache {
-		Ref<StyleBox> bg_style;
+		Ref<StyleBox> panel_style;
 	} theme_cache;
 
 	void _cancel_drag();

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -82,9 +82,8 @@ void SplitContainer::_compute_middle_sep(bool p_clamp) {
 	int ms_second = second->get_combined_minimum_size()[axis];
 
 	// Determine the separation between items.
-	Ref<Texture2D> g = get_theme_icon(SNAME("grabber"));
-	int sep = get_theme_constant(SNAME("separation"));
-	sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(sep, vertical ? g->get_height() : g->get_width()) : 0;
+	Ref<Texture2D> g = _get_grabber_icon();
+	int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(theme_cache.separation, vertical ? g->get_height() : g->get_width()) : 0;
 
 	// Compute the wished separation_point.
 	int wished_middle_sep = 0;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1538,12 +1538,14 @@ TreeItem::~TreeItem() {
 void Tree::_update_theme_item_cache() {
 	Control::_update_theme_item_cache();
 
+	theme_cache.panel_style = get_theme_stylebox(SNAME("panel"));
+	theme_cache.focus_style = get_theme_stylebox(SNAME("focus"));
+
 	theme_cache.font = get_theme_font(SNAME("font"));
 	theme_cache.font_size = get_theme_font_size(SNAME("font_size"));
 	theme_cache.tb_font = get_theme_font(SNAME("title_button_font"));
 	theme_cache.tb_font_size = get_theme_font_size(SNAME("title_button_font_size"));
-	theme_cache.bg = get_theme_stylebox(SNAME("bg"));
-	theme_cache.bg_focus = get_theme_stylebox(SNAME("bg_focus"));
+
 	theme_cache.selected = get_theme_stylebox(SNAME("selected"));
 	theme_cache.selected_focus = get_theme_stylebox(SNAME("selected_focus"));
 	theme_cache.cursor = get_theme_stylebox(SNAME("cursor"));
@@ -1955,7 +1957,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 			if (i == 0) {
 				if (p_item->cells[0].selected && select_mode == SELECT_ROW) {
-					Rect2i row_rect = Rect2i(Point2i(theme_cache.bg->get_margin(SIDE_LEFT), item_rect.position.y), Size2i(get_size().width - theme_cache.bg->get_minimum_size().width, item_rect.size.y));
+					Rect2i row_rect = Rect2i(Point2i(theme_cache.panel_style->get_margin(SIDE_LEFT), item_rect.position.y), Size2i(get_size().width - theme_cache.panel_style->get_minimum_size().width, item_rect.size.y));
 					//Rect2 r = Rect2i(row_rect.pos,row_rect.size);
 					//r.grow(cache.selected->get_margin(SIDE_LEFT));
 					if (rtl) {
@@ -2502,7 +2504,7 @@ Rect2 Tree::search_item_rect(TreeItem *p_from, TreeItem *p_item) {
 
 void Tree::_range_click_timeout() {
 	if (range_item_last && !range_drag_enabled && Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
-		Point2 pos = get_local_mouse_position() - theme_cache.bg->get_offset();
+		Point2 pos = get_local_mouse_position() - theme_cache.panel_style->get_offset();
 		if (show_column_titles) {
 			pos.y -= _get_title_button_height();
 
@@ -2520,7 +2522,7 @@ void Tree::_range_click_timeout() {
 		Ref<InputEventMouseButton> mb;
 		mb.instantiate();
 
-		int x_limit = get_size().width - theme_cache.bg->get_minimum_size().width;
+		int x_limit = get_size().width - theme_cache.panel_style->get_minimum_size().width;
 		if (h_scroll->is_visible()) {
 			x_limit -= h_scroll->get_minimum_size().width;
 		}
@@ -2609,7 +2611,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			return -1;
 		} else if (col == 0) {
 			int margin = x_ofs + theme_cache.item_margin; //-theme_cache.hseparation;
-			//int lm = theme_cache.bg->get_margin(SIDE_LEFT);
+			//int lm = theme_cache.panel_style->get_margin(SIDE_LEFT);
 			col_width -= margin;
 			limit_w -= margin;
 			col_ofs += margin;
@@ -3308,14 +3310,14 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
-		Ref<StyleBox> bg = theme_cache.bg;
+		Ref<StyleBox> bg = theme_cache.panel_style;
 		bool rtl = is_layout_rtl();
 
 		Point2 pos = mm->get_position();
 		if (rtl) {
 			pos.x = get_size().width - pos.x;
 		}
-		pos -= theme_cache.bg->get_offset();
+		pos -= theme_cache.panel_style->get_offset();
 
 		Cache::ClickType old_hover = cache.hover_type;
 		int old_index = cache.hover_index;
@@ -3343,7 +3345,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			if (rtl) {
 				mpos.x = get_size().width - mpos.x;
 			}
-			mpos -= theme_cache.bg->get_offset();
+			mpos -= theme_cache.panel_style->get_offset();
 			mpos.y -= _get_title_button_height();
 			if (mpos.y >= 0) {
 				if (h_scroll->is_visible_in_tree()) {
@@ -3443,7 +3445,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				if (rtl) {
 					pos.x = get_size().width - pos.x;
 				}
-				pos -= theme_cache.bg->get_offset();
+				pos -= theme_cache.panel_style->get_offset();
 				if (show_column_titles) {
 					pos.y -= _get_title_button_height();
 
@@ -3537,7 +3539,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		switch (mb->get_button_index()) {
 			case MouseButton::RIGHT:
 			case MouseButton::LEFT: {
-				Ref<StyleBox> bg = theme_cache.bg;
+				Ref<StyleBox> bg = theme_cache.panel_style;
 
 				Point2 pos = mb->get_position();
 				if (rtl) {
@@ -3572,7 +3574,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				pressing_for_editor = false;
 				propagate_mouse_activated = false;
 
-				int x_limit = get_size().width - theme_cache.bg->get_minimum_size().width;
+				int x_limit = get_size().width - theme_cache.panel_style->get_minimum_size().width;
 				if (h_scroll->is_visible()) {
 					x_limit -= h_scroll->get_minimum_size().width;
 				}
@@ -3766,7 +3768,7 @@ bool Tree::is_editing() {
 }
 
 Size2 Tree::get_internal_min_size() const {
-	Size2i size = theme_cache.bg->get_offset();
+	Size2i size = theme_cache.panel_style->get_offset();
 	if (root) {
 		size.height += get_item_height(root);
 	}
@@ -3789,23 +3791,23 @@ void Tree::update_scrollbars() {
 	Size2 hmin = h_scroll->get_combined_minimum_size();
 	Size2 vmin = v_scroll->get_combined_minimum_size();
 
-	v_scroll->set_begin(Point2(size.width - vmin.width, theme_cache.bg->get_margin(SIDE_TOP)));
-	v_scroll->set_end(Point2(size.width, size.height - theme_cache.bg->get_margin(SIDE_TOP) - theme_cache.bg->get_margin(SIDE_BOTTOM)));
+	v_scroll->set_begin(Point2(size.width - vmin.width, theme_cache.panel_style->get_margin(SIDE_TOP)));
+	v_scroll->set_end(Point2(size.width, size.height - theme_cache.panel_style->get_margin(SIDE_TOP) - theme_cache.panel_style->get_margin(SIDE_BOTTOM)));
 
 	h_scroll->set_begin(Point2(0, size.height - hmin.height));
 	h_scroll->set_end(Point2(size.width - vmin.width, size.height));
 
 	Size2 internal_min_size = get_internal_min_size();
 
-	bool display_vscroll = internal_min_size.height + theme_cache.bg->get_margin(SIDE_TOP) > size.height;
-	bool display_hscroll = internal_min_size.width + theme_cache.bg->get_margin(SIDE_LEFT) > size.width;
+	bool display_vscroll = internal_min_size.height + theme_cache.panel_style->get_margin(SIDE_TOP) > size.height;
+	bool display_hscroll = internal_min_size.width + theme_cache.panel_style->get_margin(SIDE_LEFT) > size.width;
 	for (int i = 0; i < 2; i++) {
 		// Check twice, as both values are dependent on each other.
 		if (display_hscroll) {
-			display_vscroll = internal_min_size.height + theme_cache.bg->get_margin(SIDE_TOP) + hmin.height > size.height;
+			display_vscroll = internal_min_size.height + theme_cache.panel_style->get_margin(SIDE_TOP) + hmin.height > size.height;
 		}
 		if (display_vscroll) {
-			display_hscroll = internal_min_size.width + theme_cache.bg->get_margin(SIDE_LEFT) + vmin.width > size.width;
+			display_hscroll = internal_min_size.width + theme_cache.panel_style->get_margin(SIDE_LEFT) + vmin.width > size.width;
 		}
 	}
 
@@ -3941,7 +3943,7 @@ void Tree::_notification(int p_what) {
 			update_scrollbars();
 			RID ci = get_canvas_item();
 
-			Ref<StyleBox> bg = theme_cache.bg;
+			Ref<StyleBox> bg = theme_cache.panel_style;
 
 			Point2 draw_ofs;
 			draw_ofs += bg->get_offset();
@@ -3965,7 +3967,7 @@ void Tree::_notification(int p_what) {
 
 			if (show_column_titles) {
 				//title buttons
-				int ofs2 = theme_cache.bg->get_margin(SIDE_LEFT);
+				int ofs2 = theme_cache.panel_style->get_margin(SIDE_LEFT);
 				for (int i = 0; i < columns.size(); i++) {
 					Ref<StyleBox> sb = (cache.click_type == Cache::CLICK_TITLE && cache.click_index == i) ? theme_cache.title_button_pressed : ((cache.hover_type == Cache::CLICK_TITLE && cache.hover_index == i) ? theme_cache.title_button_hover : theme_cache.title_button);
 					Ref<Font> f = theme_cache.tb_font;
@@ -3987,11 +3989,11 @@ void Tree::_notification(int p_what) {
 				}
 			}
 
-			// Draw the background focus outline last, so that it is drawn in front of the section headings.
+			// Draw the focus outline last, so that it is drawn in front of the section headings.
 			// Otherwise, section heading backgrounds can appear to be in front of the focus outline when scrolling.
 			if (has_focus()) {
 				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, true);
-				theme_cache.bg_focus->draw(ci, Rect2(Point2(), get_size()));
+				theme_cache.focus_style->draw(ci, Rect2(Point2(), get_size()));
 				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, false);
 			}
 		} break;
@@ -4033,7 +4035,7 @@ Size2 Tree::get_minimum_size() const {
 		return Size2();
 	} else {
 		Vector2 min_size = get_internal_min_size();
-		Ref<StyleBox> bg = theme_cache.bg;
+		Ref<StyleBox> bg = theme_cache.panel_style;
 		if (bg.is_valid()) {
 			min_size.x += bg->get_margin(SIDE_LEFT) + bg->get_margin(SIDE_RIGHT);
 			min_size.y += bg->get_margin(SIDE_TOP) + bg->get_margin(SIDE_BOTTOM);
@@ -4329,7 +4331,7 @@ int Tree::get_column_minimum_width(int p_column) const {
 
 	// Check if the visible title of the column is wider.
 	if (show_column_titles) {
-		min_width = MAX(theme_cache.font->get_string_size(columns[p_column].title, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).width + theme_cache.bg->get_margin(SIDE_LEFT) + theme_cache.bg->get_margin(SIDE_RIGHT), min_width);
+		min_width = MAX(theme_cache.font->get_string_size(columns[p_column].title, HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).width + theme_cache.panel_style->get_margin(SIDE_LEFT) + theme_cache.panel_style->get_margin(SIDE_RIGHT), min_width);
 	}
 
 	if (!columns[p_column].clip_content) {
@@ -4374,7 +4376,7 @@ int Tree::get_column_width(int p_column) const {
 	if (columns[p_column].expand) {
 		int expand_area = get_size().width;
 
-		Ref<StyleBox> bg = theme_cache.bg;
+		Ref<StyleBox> bg = theme_cache.panel_style;
 
 		if (bg.is_valid()) {
 			expand_area -= bg->get_margin(SIDE_LEFT) + bg->get_margin(SIDE_RIGHT);
@@ -4482,7 +4484,7 @@ void Tree::ensure_cursor_is_visible() {
 		return; // Nothing under cursor.
 	}
 
-	const Size2 area_size = get_size() - theme_cache.bg->get_minimum_size();
+	const Size2 area_size = get_size() - theme_cache.panel_style->get_minimum_size();
 
 	int y_offset = get_item_offset(selected_item);
 	if (y_offset != -1) {
@@ -4831,7 +4833,7 @@ int Tree::get_column_at_position(const Point2 &p_pos) const {
 		if (is_layout_rtl()) {
 			pos.x = get_size().width - pos.x;
 		}
-		pos -= theme_cache.bg->get_offset();
+		pos -= theme_cache.panel_style->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return -1;
@@ -4861,7 +4863,7 @@ int Tree::get_drop_section_at_position(const Point2 &p_pos) const {
 		if (is_layout_rtl()) {
 			pos.x = get_size().width - pos.x;
 		}
-		pos -= theme_cache.bg->get_offset();
+		pos -= theme_cache.panel_style->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return -100;
@@ -4891,7 +4893,7 @@ TreeItem *Tree::get_item_at_position(const Point2 &p_pos) const {
 		if (is_layout_rtl()) {
 			pos.x = get_size().width - pos.x;
 		}
-		pos -= theme_cache.bg->get_offset();
+		pos -= theme_cache.panel_style->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return nullptr;
@@ -4918,7 +4920,7 @@ TreeItem *Tree::get_item_at_position(const Point2 &p_pos) const {
 int Tree::get_button_id_at_position(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;
-		pos -= theme_cache.bg->get_offset();
+		pos -= theme_cache.panel_style->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return -1;
@@ -4959,7 +4961,7 @@ int Tree::get_button_id_at_position(const Point2 &p_pos) const {
 String Tree::get_tooltip(const Point2 &p_pos) const {
 	if (root) {
 		Point2 pos = p_pos;
-		pos -= theme_cache.bg->get_offset();
+		pos -= theme_cache.panel_style->get_offset();
 		pos.y -= _get_title_button_height();
 		if (pos.y < 0) {
 			return Control::get_tooltip(p_pos);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -483,12 +483,14 @@ private:
 	void propagate_set_columns(TreeItem *p_item);
 
 	struct ThemeCache {
+		Ref<StyleBox> panel_style;
+		Ref<StyleBox> focus_style;
+
 		Ref<Font> font;
 		Ref<Font> tb_font;
 		int font_size = 0;
 		int tb_font_size = 0;
-		Ref<StyleBox> bg;
-		Ref<StyleBox> bg_focus;
+
 		Ref<StyleBox> selected;
 		Ref<StyleBox> selected_focus;
 		Ref<StyleBox> cursor;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -318,7 +318,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_outline_color", "CheckBox", Color(1, 1, 1));
 
 	theme->set_constant("h_separation", "CheckBox", 4 * scale);
-	theme->set_constant("check_v_adjust", "CheckBox", 0 * scale);
+	theme->set_constant("check_v_offset", "CheckBox", 0 * scale);
 	theme->set_constant("outline_size", "CheckBox", 0);
 
 	// CheckButton
@@ -336,15 +336,15 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("hover_pressed", "CheckButton", cb_empty);
 	theme->set_stylebox("focus", "CheckButton", focus);
 
-	theme->set_icon("on", "CheckButton", icons["toggle_on"]);
-	theme->set_icon("on_disabled", "CheckButton", icons["toggle_on_disabled"]);
-	theme->set_icon("off", "CheckButton", icons["toggle_off"]);
-	theme->set_icon("off_disabled", "CheckButton", icons["toggle_off_disabled"]);
+	theme->set_icon("checked", "CheckButton", icons["toggle_on"]);
+	theme->set_icon("checked_disabled", "CheckButton", icons["toggle_on_disabled"]);
+	theme->set_icon("unchecked", "CheckButton", icons["toggle_off"]);
+	theme->set_icon("unchecked_disabled", "CheckButton", icons["toggle_off_disabled"]);
 
-	theme->set_icon("on_mirrored", "CheckButton", icons["toggle_on_mirrored"]);
-	theme->set_icon("on_disabled_mirrored", "CheckButton", icons["toggle_on_disabled_mirrored"]);
-	theme->set_icon("off_mirrored", "CheckButton", icons["toggle_off_mirrored"]);
-	theme->set_icon("off_disabled_mirrored", "CheckButton", icons["toggle_off_disabled_mirrored"]);
+	theme->set_icon("checked_mirrored", "CheckButton", icons["toggle_on_mirrored"]);
+	theme->set_icon("checked_disabled_mirrored", "CheckButton", icons["toggle_on_disabled_mirrored"]);
+	theme->set_icon("unchecked_mirrored", "CheckButton", icons["toggle_off_mirrored"]);
+	theme->set_icon("unchecked_disabled_mirrored", "CheckButton", icons["toggle_off_disabled_mirrored"]);
 
 	theme->set_font("font", "CheckButton", Ref<Font>());
 	theme->set_font_size("font_size", "CheckButton", -1);
@@ -358,7 +358,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_outline_color", "CheckButton", Color(1, 1, 1));
 
 	theme->set_constant("h_separation", "CheckButton", 4 * scale);
-	theme->set_constant("check_v_adjust", "CheckButton", 0 * scale);
+	theme->set_constant("check_v_offset", "CheckButton", 0 * scale);
 	theme->set_constant("outline_size", "CheckButton", 0);
 
 	// Label
@@ -423,8 +423,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// ProgressBar
 
-	theme->set_stylebox("bg", "ProgressBar", make_flat_stylebox(style_disabled_color, 2, 2, 2, 2, 6));
-	theme->set_stylebox("fg", "ProgressBar", make_flat_stylebox(style_progress_color, 2, 2, 2, 2, 6));
+	theme->set_stylebox("background", "ProgressBar", make_flat_stylebox(style_disabled_color, 2, 2, 2, 2, 6));
+	theme->set_stylebox("fill", "ProgressBar", make_flat_stylebox(style_progress_color, 2, 2, 2, 2, 6));
 
 	theme->set_font("font", "ProgressBar", Ref<Font>());
 	theme->set_font_size("font_size", "ProgressBar", -1);
@@ -588,7 +588,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	Ref<StyleBoxEmpty> empty;
 	empty.instantiate();
-	theme->set_stylebox("bg", "ScrollContainer", empty);
+	theme->set_stylebox("panel", "ScrollContainer", empty);
 
 	// Window
 
@@ -623,9 +623,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("toggle_hidden", "FileDialog", icons["visibility_visible"]);
 	theme->set_icon("folder", "FileDialog", icons["folder"]);
 	theme->set_icon("file", "FileDialog", icons["file"]);
-	theme->set_color("folder_icon_modulate", "FileDialog", Color(1, 1, 1));
-	theme->set_color("file_icon_modulate", "FileDialog", Color(1, 1, 1));
-	theme->set_color("files_disabled", "FileDialog", Color(1, 1, 1, 0.25));
+	theme->set_color("folder_icon_color", "FileDialog", Color(1, 1, 1));
+	theme->set_color("file_icon_color", "FileDialog", Color(1, 1, 1));
+	theme->set_color("file_disabled_color", "FileDialog", Color(1, 1, 1, 0.25));
 
 	// Popup
 
@@ -737,8 +737,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// Tree
 
-	theme->set_stylebox("bg", "Tree", make_flat_stylebox(style_normal_color, 4, 4, 4, 5));
-	theme->set_stylebox("bg_focus", "Tree", focus);
+	theme->set_stylebox("panel", "Tree", make_flat_stylebox(style_normal_color, 4, 4, 4, 5));
+	theme->set_stylebox("focus", "Tree", focus);
 	theme->set_stylebox("selected", "Tree", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("selected_focus", "Tree", make_flat_stylebox(style_selected_color));
 	theme->set_stylebox("cursor", "Tree", focus);
@@ -791,8 +791,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// ItemList
 
-	theme->set_stylebox("bg", "ItemList", make_flat_stylebox(style_normal_color));
-	theme->set_stylebox("bg_focus", "ItemList", focus);
+	theme->set_stylebox("panel", "ItemList", make_flat_stylebox(style_normal_color));
+	theme->set_stylebox("focus", "ItemList", focus);
 	theme->set_constant("h_separation", "ItemList", 4);
 	theme->set_constant("v_separation", "ItemList", 2);
 	theme->set_constant("icon_margin", "ItemList", 4);

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -139,7 +139,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// Panel
 	theme->set_stylebox("panel", "Panel", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
-	theme->set_stylebox("panel_fg", "Panel", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
 
 	// Button
 


### PR DESCRIPTION
I really wanted to introduce some sensible naming scheme for theme items by Godot 4, but ran out of time. So in this, and a couple follow-up PRs I'll try to clean up some names that are the most problematic for one reason or another. This PR also includes a second commit that fixes some random theming issues I've noticed while working on this. Put it in a dedicated commit so that it's clear which changes are not related to renames directly.

The list of changes:

* `ItemList`:
  * `bg` -> `panel`
  * `bg_focus` -> `focus`

The name "bg" is used across several different controls, but is not consistent with other controls which call the main stylebox "panel". Calling it "bg" is a misnomer, as it's not just providing a background, but also adds offsets. Also we frown upon shortened names, and rename those occurrences for 4.0.
As for "bg_focus", here it is technically not too wrong, since it is drawn below the items (unlike `Tree`, where it is drawn above). However, the name doesn't fit the rest of the controls that have a dedicated focus style, and I feel like the order of drawing is an implementation detail that should not be reflected in the name. We may even want to introduce a theme constant to control whether it should be drawn above all or below, since there have been a few issues with that. So anyway, for consistency, this is now called "focus".

* `Tree`:
  * `bg` -> `panel`
  * `bg_focus` -> `focus`

Same as `ItemList`, but also here focus is indeed drawn on top of everything, making it a completely wrong name.

* `ProgressBar`:
  * `bg` -> `background`
  * `fg` -> `fill`

This should make the semantic meaning clearer, instead of referring to their draw order.

* `ScrollContainer`:
  * `bg` -> `panel`

Same as previous entries, this is more consistent, not a shortened name, etc.

* `FileDialog`:
  * `*_icon_modulate` -> `*_icon_color`
  * `files_disabled` -> `file_disabled_color`

Technically, colors assigned to icons are used for modulation, but we don't call them that in most theme properties, hence the rename. "files_disabled" is just weird and I think is an obvious one.

* `CheckButton`:
  * `on*`/`off*` -> `checked*`/`unchecked*`

This makes the names consistent with `CheckBox`, and in general less awkward.

* `check_v_adjust` -> `check_v_offset`

A couple of classes have this. We typically call adjustments like that offsets, hence the rename.

-----

As for fixes, `Panel` had an unused style, `RichTextLabel` had an extra definition for the text outline which was never actually set, and `SplitContainer` had a regression in theme caching from a recent fix-up PR.

-----

I've added the necessary conversion rules to the tool, but it will probably misbehave on some "bg" properties which were used elsewhere as well. The ones I've renamed are probably the most relevant cases, so it's better to include a rename, I think.

I also don't know if theme renames should be added to the C# list, as I don't see under what circumstances they would be found in C# code as regular camelCase properties. They should only be found in strings or in scene files, so the already include rules seem wrong to me, and I didn't add the new ones there.