### PR TITLE
SCons: Fix compilation database generation with MSVC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -438,19 +438,6 @@ if selected_platform in platform_list:
             )
             env.SetOption("num_jobs", safer_cpu_count)
 
-    if env["compiledb"]:
-        # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
-        from SCons import __version__ as scons_raw_version
-
-        scons_ver = env._get_major_minor_revision(scons_raw_version)
-
-        if scons_ver < (4, 0, 0):
-            print("The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version)
-            Exit(255)
-
-        env.Tool("compilation_db")
-        env.Alias("compiledb", env.CompilationDatabase())
-
     # 'dev' and 'production' are aliases to set default options if they haven't been set
     # manually by the user.
     if env["dev"]:
@@ -839,6 +826,19 @@ if selected_platform in platform_list:
     if env["vsproj"]:
         env.vs_incs = []
         env.vs_srcs = []
+
+    if env["compiledb"]:
+        # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
+        from SCons import __version__ as scons_raw_version
+
+        scons_ver = env._get_major_minor_revision(scons_raw_version)
+
+        if scons_ver < (4, 0, 0):
+            print("The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version)
+            Exit(255)
+
+        env.Tool("compilation_db")
+        env.Alias("compiledb", env.CompilationDatabase())
 
     Export("env")
 


### PR DESCRIPTION
Fixes #54434.

Co-authored-by: @dmoody256

Didn't get to test it myself, would be great if a few MSVC users could confirm it works (to enable compilation database generation, you should pass `compiledb=yes` to SCons).