### PR TITLE
Prevent stripping the edges of strings when using Find in Files

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -422,8 +422,7 @@ void FindInFilesDialog::set_find_in_files_mode(FindInFilesMode p_mode) {
 }
 
 String FindInFilesDialog::get_search_text() const {
-	String text = _search_text_line_edit->get_text();
-	return text.strip_edges();
+	return _search_text_line_edit->get_text();
 }
 
 String FindInFilesDialog::get_replace_text() const {


### PR DESCRIPTION
*Edit: Fixes https://github.com/godotengine/godot/issues/48464*

Why would Find in Files remove trailing whitespaces from the string? Users want to search for exactly what they typed.

Didn't add special case for trimming when Whole Words is checked. Still, the new behavior is consistent with that of the Find & Replace bar. In fact, we should probably unify their functionality somehow to avoid such inconsistencies in the future?

![image](https://user-images.githubusercontent.com/85438892/188743686-b2809c0c-ded5-415b-9b94-7c9838695e86.png)