### PR TITLE
Fix rendering when using WebGL2

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1023,8 +1023,8 @@ void RasterizerCanvasGLES3::_bind_instance_data_buffer(uint32_t p_max_index) {
 
 	glBindBufferBase(GL_UNIFORM_BUFFER, INSTANCE_UNIFORM_LOCATION, state.canvas_instance_data_buffers[state.current_buffer]);
 #ifdef WEB_ENABLED
-	//WebGL 2.0 does not support mapping buffers, so use slow glBufferData instead
-	glBufferData(GL_UNIFORM_BUFFER, sizeof(InstanceData) * p_max_index, state.instance_data_array, GL_DYNAMIC_DRAW);
+	//WebGL 2.0 does not support mapping buffers, so use slow glBufferSubData instead
+	glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(InstanceData) * p_max_index, state.instance_data_array);
 #else
 	void *ubo = glMapBufferRange(GL_UNIFORM_BUFFER, 0, sizeof(InstanceData) * p_max_index, GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
 	memcpy(ubo, state.instance_data_array, sizeof(InstanceData) * p_max_index);

--- a/drivers/gles3/shaders/canvas_uniforms_inc.glsl
+++ b/drivers/gles3/shaders/canvas_uniforms_inc.glsl
@@ -94,27 +94,6 @@ layout(std140) uniform CanvasData { //ubo:0
 #define LIGHT_FLAGS_SHADOW_PCF5 uint(1 << 22)
 #define LIGHT_FLAGS_SHADOW_PCF13 uint(2 << 22)
 
-struct Light {
-	mat2x4 texture_matrix; //light to texture coordinate matrix (transposed)
-	mat2x4 shadow_matrix; //light to shadow coordinate matrix (transposed)
-	vec4 color;
-
-	uint shadow_color; // packed
-	uint flags; //index to light texture
-	float shadow_pixel_size;
-	float height;
-
-	vec2 position;
-	float shadow_zfar_inv;
-	float shadow_y_ofs;
-
-	vec4 atlas_rect;
-};
-
-layout(std140) uniform LightData { //ubo:2
-	Light light_data[MAX_LIGHTS];
-};
-
 layout(std140) uniform DrawDataInstances { //ubo:3
 
 	DrawData draw_data[MAX_DRAW_DATA_INSTANCES];

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -68,7 +68,7 @@ void RenderSceneBuffersGLES3::configure(RID p_render_target, const Size2i p_inte
 	glGenTextures(1, &depth_texture);
 	glBindTexture(GL_TEXTURE_2D, depth_texture);
 
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, rt->size.x, rt->size.y, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, rt->size.x, rt->size.y, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/65304
Fixes: https://github.com/godotengine/godot/issues/64453

Fixes 3D rendering in WebGL2 and 2D rendering. I can now run the web-based project manager

![Screenshot from 2022-09-06 14-44-30](https://user-images.githubusercontent.com/16521339/188746477-709d3b08-fa33-4814-b70f-1c44e5231bb1.png)

There isn't an option to create a project using OpenGL3 yet, so I haven't tested running a project yet.

Fixes include:
1. Using proper depth buffer format in 3D (this had previously been fixed already in https://github.com/godotengine/godot/pull/63794 but the changes were lost in a rebase of https://github.com/godotengine/godot/pull/63901),
2. Remove unused lighting and shadowing code in 2D, and
3. Update 2D UBOs using glBufferSubData so that they remain the appropriate size.

cc @dsnopek 

