### PR TITLE
Fixed crash with calling _edit_get_rect() on NavigationLink2D

### DIFF
--- a/scene/2d/navigation_link_2d.cpp
+++ b/scene/2d/navigation_link_2d.cpp
@@ -113,6 +113,10 @@ void NavigationLink2D::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 Rect2 NavigationLink2D::_edit_get_rect() const {
+	if (!is_inside_tree()) {
+		return Rect2();
+	}
+
 	real_t radius = NavigationServer2D::get_singleton()->map_get_link_connection_radius(get_world_2d()->get_navigation_map());
 
 	Rect2 rect(get_start_location(), Size2());


### PR DESCRIPTION
This PR fixes the bug from https://github.com/godotengine/godot/issues/65431.

This is my first PR, so let me know if this bug is significant enough to warrant a unit test (I severely doubt it, but I've been surprised before).

*Bugsquad edit:*
- Fixes #65431