### PR TITLE
Introduce small idle delay in the Find bar

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -769,6 +769,9 @@
 		<member name="text_editor/completion/put_callhint_tooltip_below_current_line" type="bool" setter="" getter="">
 			If [code]true[/code], the code completion tooltip will appear below the current line unless there is no space on screen below the current line. If [code]false[/code], the code completion tooltip will appear above the current line.
 		</member>
+		<member name="text_editor/completion/search_idle_delay" type="float" setter="" getter="">
+			The delay in seconds after which the script editor should search for the pattern in the Find bar when the user stops typing in it.
+		</member>
 		<member name="text_editor/completion/use_single_quotes" type="bool" setter="" getter="">
 			If [code]true[/code], performs string autocompletion with single quotes. If [code]false[/code], performs string autocompletion with double quotes (which matches the [url=https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url]).
 		</member>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -94,6 +94,7 @@ void FindReplaceBar::_notification(int p_what) {
 			hide_button->set_hover_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 			hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 			hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
+			search_idle_timer->set_wait_time(EDITOR_GET("text_editor/completion/search_idle_delay"));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -572,6 +573,13 @@ void FindReplaceBar::_editor_text_changed() {
 }
 
 void FindReplaceBar::_search_text_changed(const String &p_text) {
+	search_idle_timer->start();
+}
+
+void FindReplaceBar::_search_idle_timer_timeout() {
+	if (!is_visible_in_tree()) {
+		return;
+	}
 	results_count = -1;
 	results_count_to_current = -1;
 	needs_to_count_results = true;
@@ -712,6 +720,12 @@ FindReplaceBar::FindReplaceBar() {
 	whole_words->set_text(TTR("Whole Words"));
 	whole_words->set_focus_mode(FOCUS_NONE);
 	whole_words->connect("toggled", callable_mp(this, &FindReplaceBar::_search_options_changed));
+
+	search_idle_timer = memnew(Timer);
+	add_child(search_idle_timer);
+	search_idle_timer->set_one_shot(true);
+	search_idle_timer->set_wait_time(EDITOR_GET("text_editor/completion/search_idle_delay"));
+	search_idle_timer->connect("timeout", callable_mp(this, &FindReplaceBar::_search_idle_timer_timeout));
 
 	// replace toolbar
 	replace_text = memnew(LineEdit);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -69,6 +69,7 @@ class FindReplaceBar : public HBoxContainer {
 	CheckBox *case_sensitive = nullptr;
 	CheckBox *whole_words = nullptr;
 	TextureButton *hide_button = nullptr;
+	Timer *search_idle_timer = nullptr;
 
 	LineEdit *replace_text = nullptr;
 	Button *replace = nullptr;
@@ -110,6 +111,8 @@ protected:
 	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 
 	bool _search(uint32_t p_flags, int p_from_line, int p_from_col);
+
+	void _search_idle_timer_timeout();
 
 	void _replace();
 	void _replace_all();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -566,6 +566,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Completion
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 2.0, "0.1,10,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/search_idle_delay", 0.25, "0.01,5,0.01")
 	_initial_set("text_editor/completion/auto_brace_complete", true);
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01")
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);


### PR DESCRIPTION
(I think this should be discussed, as some of the problems it solves have different, maybe more desirable solutions - I discussed one in the linked proposal. I think some users might just be annoyed by this delay and think it's a bug or a performance regression.)

Makes it so FindReplaceBar only starts searching for the pattern if the user stops typing for 0.25sec.

Adds a new editor setting, "Search Idle Delay", to customize this duration.

*Production edit: Closes https://github.com/godotengine/godot-proposals/issues/5361*

Alternative solution: #67592