### PR TITLE
Make NavigationAgent `target_location` a property

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		2D Agent that is used in navigation to reach a location while avoiding static and dynamic obstacles. The dynamic obstacles are avoided using RVO collision avoidance. The agent needs navigation data to work correctly. [NavigationAgent2D] is physics safe.
-		[b]Note:[/b] After [method set_target_location] is used it is required to use the [method get_next_location] function once every physics frame to update the internal path logic of the NavigationAgent. The returned vector position from this function should be used as the next movement position for the agent's parent Node.
+		[b]Note:[/b] After setting [member target_location] it is required to use the [method get_next_location] function once every physics frame to update the internal path logic of the NavigationAgent. The returned vector position from this function should be used as the next movement position for the agent's parent Node.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,7 +13,7 @@
 		<method name="distance_to_target" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the distance to the target location, using the agent's global position. The user must set the target location with [method set_target_location] in order for this to be accurate.
+				Returns the distance to the target location, using the agent's global position. The user must set [member target_location] in order for this to be accurate.
 			</description>
 		</method>
 		<method name="get_final_location">
@@ -59,12 +59,6 @@
 				Returns the [RID] of this agent on the [NavigationServer2D].
 			</description>
 		</method>
-		<method name="get_target_location" qualifiers="const">
-			<return type="Vector2" />
-			<description>
-				Returns the user defined [Vector2] after setting the target location.
-			</description>
-		</method>
 		<method name="is_navigation_finished">
 			<return type="bool" />
 			<description>
@@ -74,13 +68,13 @@
 		<method name="is_target_reachable">
 			<return type="bool" />
 			<description>
-				Returns true if the target location is reachable. The target location is set using [method set_target_location].
+				Returns true if [member target_location] is reachable.
 			</description>
 		</method>
 		<method name="is_target_reached" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns true if the target location is reached. The target location is set using [method set_target_location]. It may not always be possible to reach the target location. It should always be possible to reach the final location though. See [method get_final_location].
+				Returns true if [member target_location] is reached. It may not always be possible to reach the target location. It should always be possible to reach the final location though. See [method get_final_location].
 			</description>
 		</method>
 		<method name="set_navigation_layer_value">
@@ -96,13 +90,6 @@
 			<param index="0" name="navigation_map" type="RID" />
 			<description>
 				Sets the [RID] of the navigation map this NavigationAgent node should use and also updates the [code]agent[/code] on the NavigationServer.
-			</description>
-		</method>
-		<method name="set_target_location">
-			<return type="void" />
-			<param index="0" name="location" type="Vector2" />
-			<description>
-				Sets the user desired final location. This will clear the current navigation path.
 			</description>
 		</method>
 		<method name="set_velocity">
@@ -142,6 +129,9 @@
 		<member name="target_desired_distance" type="float" setter="set_target_desired_distance" getter="get_target_desired_distance" default="1.0">
 			The distance threshold before the final target point is considered to be reached. This will allow an agent to not have to hit the point of the final target exactly, but only the area. If this value is set to low the NavigationAgent will be stuck in a repath loop cause it will constantly overshoot or undershoot the distance to the final target point on each physics frame update.
 		</member>
+		<member name="target_location" type="Vector2" setter="set_target_location" getter="get_target_location" default="Vector2(0, 0)">
+			The user-defined target location. Setting this property will clear the current navigation path.
+		</member>
 		<member name="time_horizon" type="float" setter="set_time_horizon" getter="get_time_horizon" default="20.0">
 			The minimal amount of time for which this agent's velocities, that are computed with the collision avoidance algorithm, are safe with respect to other agents. The larger the number, the sooner the agent will respond to other agents, but less freedom in choosing its velocities. Must be positive.
 		</member>
@@ -159,7 +149,7 @@
 		</signal>
 		<signal name="target_reached">
 			<description>
-				Notifies when the player defined target, set with [method set_target_location], is reached.
+				Notifies when the player-defined [member target_location] is reached.
 			</description>
 		</signal>
 		<signal name="velocity_computed">

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		3D Agent that is used in navigation to reach a location while avoiding static and dynamic obstacles. The dynamic obstacles are avoided using RVO collision avoidance. The agent needs navigation data to work correctly. [NavigationAgent3D] is physics safe.
-		[b]Note:[/b] After [method set_target_location] is used it is required to use the [method get_next_location] function once every physics frame to update the internal path logic of the NavigationAgent. The returned vector position from this function should be used as the next movement position for the agent's parent Node.
+		[b]Note:[/b] After setting [member target_location] it is required to use the [method get_next_location] function once every physics frame to update the internal path logic of the NavigationAgent. The returned vector position from this function should be used as the next movement position for the agent's parent Node.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -13,7 +13,7 @@
 		<method name="distance_to_target" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the distance to the target location, using the agent's global position. The user must set the target location with [method set_target_location] in order for this to be accurate.
+				Returns the distance to the target location, using the agent's global position. The user must set [member target_location] in order for this to be accurate.
 			</description>
 		</method>
 		<method name="get_final_location">
@@ -59,12 +59,6 @@
 				Returns the [RID] of this agent on the [NavigationServer3D].
 			</description>
 		</method>
-		<method name="get_target_location" qualifiers="const">
-			<return type="Vector3" />
-			<description>
-				Returns the user defined [Vector3] after setting the target location.
-			</description>
-		</method>
 		<method name="is_navigation_finished">
 			<return type="bool" />
 			<description>
@@ -74,13 +68,13 @@
 		<method name="is_target_reachable">
 			<return type="bool" />
 			<description>
-				Returns true if the target location is reachable. The target location is set using [method set_target_location].
+				Returns true if [member target_location] is reachable.
 			</description>
 		</method>
 		<method name="is_target_reached" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns true if the target location is reached. The target location is set using [method set_target_location]. It may not always be possible to reach the target location. It should always be possible to reach the final location though. See [method get_final_location].
+				Returns true if [member target_location] is reached. It may not always be possible to reach the target location. It should always be possible to reach the final location though. See [method get_final_location].
 			</description>
 		</method>
 		<method name="set_navigation_layer_value">
@@ -96,13 +90,6 @@
 			<param index="0" name="navigation_map" type="RID" />
 			<description>
 				Sets the [RID] of the navigation map this NavigationAgent node should use and also updates the [code]agent[/code] on the NavigationServer.
-			</description>
-		</method>
-		<method name="set_target_location">
-			<return type="void" />
-			<param index="0" name="location" type="Vector3" />
-			<description>
-				Sets the user desired final location. This will clear the current navigation path.
 			</description>
 		</method>
 		<method name="set_velocity">
@@ -148,6 +135,9 @@
 		<member name="target_desired_distance" type="float" setter="set_target_desired_distance" getter="get_target_desired_distance" default="1.0">
 			The distance threshold before the final target point is considered to be reached. This will allow an agent to not have to hit the point of the final target exactly, but only the area. If this value is set to low the NavigationAgent will be stuck in a repath loop cause it will constantly overshoot or undershoot the distance to the final target point on each physics frame update.
 		</member>
+		<member name="target_location" type="Vector3" setter="set_target_location" getter="get_target_location" default="Vector3(0, 0, 0)">
+			The user-defined target location. Setting this property will clear the current navigation path.
+		</member>
 		<member name="time_horizon" type="float" setter="set_time_horizon" getter="get_time_horizon" default="5.0">
 			The minimal amount of time for which this agent's velocities, that are computed with the collision avoidance algorithm, are safe with respect to other agents. The larger the number, the sooner the agent will respond to other agents, but less freedom in choosing its velocities. Must be positive.
 		</member>
@@ -165,7 +155,7 @@
 		</signal>
 		<signal name="target_reached">
 			<description>
-				Notifies when the player defined target, set with [method set_target_location], is reached.
+				Notifies when the player-defined [member target_location] is reached.
 			</description>
 		</signal>
 		<signal name="velocity_computed">

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -75,6 +75,7 @@ void NavigationAgent2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_target_location", "location"), &NavigationAgent2D::set_target_location);
 	ClassDB::bind_method(D_METHOD("get_target_location"), &NavigationAgent2D::get_target_location);
+
 	ClassDB::bind_method(D_METHOD("get_next_location"), &NavigationAgent2D::get_next_location);
 	ClassDB::bind_method(D_METHOD("distance_to_target"), &NavigationAgent2D::distance_to_target);
 	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &NavigationAgent2D::set_velocity);
@@ -88,6 +89,7 @@ void NavigationAgent2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_avoidance_done", "new_velocity"), &NavigationAgent2D::_avoidance_done);
 
 	ADD_GROUP("Pathfinding", "");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "target_location", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_target_location", "get_target_location");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_desired_distance", PROPERTY_HINT_RANGE, "0.1,100,0.01,suffix:px"), "set_path_desired_distance", "get_path_desired_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "target_desired_distance", PROPERTY_HINT_RANGE, "0.1,100,0.01,suffix:px"), "set_target_desired_distance", "get_target_desired_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_max_distance", PROPERTY_HINT_RANGE, "10,100,1,suffix:px"), "set_path_max_distance", "get_path_max_distance");

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -79,6 +79,7 @@ void NavigationAgent3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_target_location", "location"), &NavigationAgent3D::set_target_location);
 	ClassDB::bind_method(D_METHOD("get_target_location"), &NavigationAgent3D::get_target_location);
+
 	ClassDB::bind_method(D_METHOD("get_next_location"), &NavigationAgent3D::get_next_location);
 	ClassDB::bind_method(D_METHOD("distance_to_target"), &NavigationAgent3D::distance_to_target);
 	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &NavigationAgent3D::set_velocity);
@@ -92,6 +93,7 @@ void NavigationAgent3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_avoidance_done", "new_velocity"), &NavigationAgent3D::_avoidance_done);
 
 	ADD_GROUP("Pathfinding", "");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_location", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_target_location", "get_target_location");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_desired_distance", PROPERTY_HINT_RANGE, "0.1,100,0.01,suffix:m"), "set_path_desired_distance", "get_path_desired_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "target_desired_distance", PROPERTY_HINT_RANGE, "0.1,100,0.01,suffix:m"), "set_target_desired_distance", "get_target_desired_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent_height_offset", PROPERTY_HINT_RANGE, "-100.0,100,0.01,suffix:m"), "set_agent_height_offset", "get_agent_height_offset");


### PR DESCRIPTION
This PR turns the existing `set_target_location()` and `get_target_location()` into a property.