### PR TITLE
Fix code generation for `VisualShaderNodeTextureParameterTriplanar`

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -6119,6 +6119,13 @@ String VisualShaderNodeTextureParameterTriplanar::generate_global_per_func(Shade
 	return code;
 }
 
+String VisualShaderNodeTextureParameterTriplanar::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
+	String code = _get_qual_str() + "uniform sampler2D " + get_parameter_name();
+	code += get_sampler_hint(texture_type, color_default, texture_filter, texture_repeat);
+	code += ";\n";
+	return code;
+}
+
 String VisualShaderNodeTextureParameterTriplanar::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String id = get_parameter_name();
 

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -2279,6 +2279,7 @@ public:
 
 	virtual String generate_global_per_node(Shader::Mode p_mode, int p_id) const override;
 	virtual String generate_global_per_func(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
+	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
 	VisualShaderNodeTextureParameterTriplanar();


### PR DESCRIPTION
Seems like I broke it accidentally when renaming uniform to parameter.
