### PR TITLE
[Net] Rename "ssl" references to "tls" in methods and members.

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -138,7 +138,7 @@ PackedStringArray HTTPClient::_get_response_headers() {
 }
 
 void HTTPClient::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("connect_to_host", "host", "port", "use_ssl", "verify_host"), &HTTPClient::connect_to_host, DEFVAL(-1), DEFVAL(false), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("connect_to_host", "host", "port", "use_tls", "verify_host"), &HTTPClient::connect_to_host, DEFVAL(-1), DEFVAL(false), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("set_connection", "connection"), &HTTPClient::set_connection);
 	ClassDB::bind_method(D_METHOD("get_connection"), &HTTPClient::get_connection);
 	ClassDB::bind_method(D_METHOD("request_raw", "method", "url", "headers", "body"), &HTTPClient::_request_raw);
@@ -190,7 +190,7 @@ void HTTPClient::_bind_methods() {
 	BIND_ENUM_CONSTANT(STATUS_REQUESTING); // Request in progress
 	BIND_ENUM_CONSTANT(STATUS_BODY); // Request resulted in body which must be read
 	BIND_ENUM_CONSTANT(STATUS_CONNECTION_ERROR);
-	BIND_ENUM_CONSTANT(STATUS_SSL_HANDSHAKE_ERROR);
+	BIND_ENUM_CONSTANT(STATUS_TLS_HANDSHAKE_ERROR);
 
 	BIND_ENUM_CONSTANT(RESPONSE_CONTINUE);
 	BIND_ENUM_CONSTANT(RESPONSE_SWITCHING_PROTOCOLS);

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -138,7 +138,7 @@ public:
 		STATUS_REQUESTING, // Request in progress
 		STATUS_BODY, // Request resulted in body, which must be read
 		STATUS_CONNECTION_ERROR,
-		STATUS_SSL_HANDSHAKE_ERROR,
+		STATUS_TLS_HANDSHAKE_ERROR,
 
 	};
 
@@ -168,7 +168,7 @@ public:
 	Error verify_headers(const Vector<String> &p_headers);
 
 	virtual Error request(Method p_method, const String &p_url, const Vector<String> &p_headers, const uint8_t *p_body, int p_body_size) = 0;
-	virtual Error connect_to_host(const String &p_host, int p_port = -1, bool p_ssl = false, bool p_verify_host = true) = 0;
+	virtual Error connect_to_host(const String &p_host, int p_port = -1, bool p_tls = false, bool p_verify_host = true) = 0;
 
 	virtual void set_connection(const Ref<StreamPeer> &p_connection) = 0;
 	virtual Ref<StreamPeer> get_connection() const = 0;

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -46,8 +46,8 @@ private:
 	String http_proxy_host;
 	int https_proxy_port = -1; // Proxy server for https requests.
 	String https_proxy_host;
-	bool ssl = false;
-	bool ssl_verify_host = false;
+	bool tls = false;
+	bool tls_verify_host = false;
 	bool blocking = false;
 	bool handshaking = false;
 	bool head_request = false;
@@ -79,7 +79,7 @@ public:
 
 	Error request(Method p_method, const String &p_url, const Vector<String> &p_headers, const uint8_t *p_body, int p_body_size) override;
 
-	Error connect_to_host(const String &p_host, int p_port = -1, bool p_ssl = false, bool p_verify_host = true) override;
+	Error connect_to_host(const String &p_host, int p_port = -1, bool p_tls = false, bool p_verify_host = true) override;
 	void set_connection(const Ref<StreamPeer> &p_connection) override;
 	Ref<StreamPeer> get_connection() const override;
 	void close() override;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -284,8 +284,8 @@ void register_core_settings() {
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/tcp/connect_timeout_seconds", PropertyInfo(Variant::INT, "network/limits/tcp/connect_timeout_seconds", PROPERTY_HINT_RANGE, "1,1800,1"));
 	GLOBAL_DEF_RST("network/limits/packet_peer_stream/max_buffer_po2", (16));
 	ProjectSettings::get_singleton()->set_custom_property_info("network/limits/packet_peer_stream/max_buffer_po2", PropertyInfo(Variant::INT, "network/limits/packet_peer_stream/max_buffer_po2", PROPERTY_HINT_RANGE, "0,64,1,or_greater"));
-	GLOBAL_DEF("network/ssl/certificate_bundle_override", "");
-	ProjectSettings::get_singleton()->set_custom_property_info("network/ssl/certificate_bundle_override", PropertyInfo(Variant::STRING, "network/ssl/certificate_bundle_override", PROPERTY_HINT_FILE, "*.crt"));
+	GLOBAL_DEF("network/tls/certificate_bundle_override", "");
+	ProjectSettings::get_singleton()->set_custom_property_info("network/tls/certificate_bundle_override", PropertyInfo(Variant::STRING, "network/tls/certificate_bundle_override", PROPERTY_HINT_FILE, "*.crt"));
 
 	int worker_threads = GLOBAL_DEF("threading/worker_pool/max_threads", -1);
 	bool low_priority_use_system_threads = GLOBAL_DEF("threading/worker_pool/use_system_threads_for_low_priority_tasks", true);

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -616,8 +616,8 @@
 			The port number to use to contact the HTTP and HTTPS proxy in the editor (for the asset library and export template downloads). See also [member network/http_proxy/host].
 			[b]Note:[/b] Godot currently doesn't automatically use system proxy settings, so you have to enter them manually here if needed.
 		</member>
-		<member name="network/ssl/editor_ssl_certificates" type="String" setter="" getter="">
-			The SSL certificate bundle to use for HTTP requests made within the editor (e.g. from the AssetLib tab). If left empty, the [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]included Mozilla certificate bundle[/url] will be used.
+		<member name="network/tls/editor_tls_certificates" type="String" setter="" getter="">
+			The TLS certificate bundle to use for HTTP requests made within the editor (e.g. from the AssetLib tab). If left empty, the [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]included Mozilla certificate bundle[/url] will be used.
 		</member>
 		<member name="project_manager/sorting_order" type="int" setter="" getter="">
 			The sorting order to use in the project manager. When changing the sorting order in the project manager, this setting is set permanently in the editor settings.

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -7,17 +7,17 @@
 		Hyper-text transfer protocol client (sometimes called "User Agent"). Used to make HTTP requests to download web content, upload files and other data or to communicate with various services, among other use cases.
 		See the [HTTPRequest] node for a higher-level alternative.
 		[b]Note:[/b] This client only needs to connect to a host once (see [method connect_to_host]) to send multiple requests. Because of this, methods that take URLs usually take just the part after the host instead of the full URL, as the client is already connected to a host. See [method request] for a full example and to get started.
-		A [HTTPClient] should be reused between multiple requests or to connect to different hosts instead of creating one client per request. Supports SSL and SSL server certificate verification. HTTP status codes in the 2xx range indicate success, 3xx redirection (i.e. "try again, but over here"), 4xx something was wrong with the request, and 5xx something went wrong on the server's side.
+		A [HTTPClient] should be reused between multiple requests or to connect to different hosts instead of creating one client per request. Supports Transport Layer Security (TLS), including server certificate verification. HTTP status codes in the 2xx range indicate success, 3xx redirection (i.e. "try again, but over here"), 4xx something was wrong with the request, and 5xx something went wrong on the server's side.
 		For more information on HTTP, see https://developer.mozilla.org/en-US/docs/Web/HTTP (or read RFC 2616 to get it straight from the source: https://tools.ietf.org/html/rfc2616).
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
-		[b]Note:[/b] It's recommended to use transport encryption (SSL/TLS) and to avoid sending sensitive information (such as login credentials) in HTTP GET URL parameters. Consider using HTTP POST requests or HTTP headers for such information instead.
+		[b]Note:[/b] It's recommended to use transport encryption (TLS) and to avoid sending sensitive information (such as login credentials) in HTTP GET URL parameters. Consider using HTTP POST requests or HTTP headers for such information instead.
 		[b]Note:[/b] When performing HTTP requests from a project exported to Web, keep in mind the remote server may not allow requests from foreign origins due to [url=https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS]CORS[/url]. If you host the server in question, you should modify its backend to allow requests from foreign origins by adding the [code]Access-Control-Allow-Origin: *[/code] HTTP header.
-		[b]Note:[/b] SSL/TLS support is currently limited to TLS 1.0, TLS 1.1, and TLS 1.2. Attempting to connect to a TLS 1.3-only server will return an error.
-		[b]Warning:[/b] SSL/TLS certificate revocation and certificate pinning are currently not supported. Revoked certificates are accepted as long as they are otherwise valid. If this is a concern, you may want to use automatically managed certificates with a short validity period.
+		[b]Note:[/b] TLS support is currently limited to TLS 1.0, TLS 1.1, and TLS 1.2. Attempting to connect to a TLS 1.3-only server will return an error.
+		[b]Warning:[/b] TLS certificate revocation and certificate pinning are currently not supported. Revoked certificates are accepted as long as they are otherwise valid. If this is a concern, you may want to use automatically managed certificates with a short validity period.
 	</description>
 	<tutorials>
 		<link title="HTTP client class">$DOCS_URL/tutorials/networking/http_client_class.html</link>
-		<link title="SSL certificates">$DOCS_URL/tutorials/networking/ssl_certificates.html</link>
+		<link title="TLS certificates">$DOCS_URL/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<methods>
 		<method name="close">
@@ -30,13 +30,13 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="host" type="String" />
 			<param index="1" name="port" type="int" default="-1" />
-			<param index="2" name="use_ssl" type="bool" default="false" />
+			<param index="2" name="use_tls" type="bool" default="false" />
 			<param index="3" name="verify_host" type="bool" default="true" />
 			<description>
 				Connects to a host. This needs to be done before any requests are sent.
 				The host should not have http:// prepended but will strip the protocol identifier if provided.
-				If no [param port] is specified (or [code]-1[/code] is used), it is automatically set to 80 for HTTP and 443 for HTTPS (if [param use_ssl] is enabled).
-				[param verify_host] will check the SSL identity of the host if set to [code]true[/code].
+				If no [param port] is specified (or [code]-1[/code] is used), it is automatically set to 80 for HTTP and 443 for HTTPS (if [param use_tls] is enabled).
+				[param verify_host] will check the TLS identity of the host if set to [code]true[/code].
 			</description>
 		</method>
 		<method name="get_response_body_length" qualifiers="const">
@@ -262,8 +262,8 @@
 		<constant name="STATUS_CONNECTION_ERROR" value="8" enum="Status">
 			Status: Error in HTTP connection.
 		</constant>
-		<constant name="STATUS_SSL_HANDSHAKE_ERROR" value="9" enum="Status">
-			Status: Error in SSL handshake.
+		<constant name="STATUS_TLS_HANDSHAKE_ERROR" value="9" enum="Status">
+			Status: Error in TLS handshake.
 		</constant>
 		<constant name="RESPONSE_CONTINUE" value="100" enum="ResponseCode">
 			HTTP status code [code]100 Continue[/code]. Interim response that indicates everything so far is OK and that the client should continue with the request (or ignore this status if already finished).

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -6,7 +6,7 @@
 	<description>
 		A node with the ability to send HTTP requests. Uses [HTTPClient] internally.
 		Can be used to make HTTP requests, i.e. download or upload files or web content via HTTP.
-		[b]Warning:[/b] See the notes and warnings on [HTTPClient] for limitations, especially regarding SSL security.
+		[b]Warning:[/b] See the notes and warnings on [HTTPClient] for limitations, especially regarding TLS security.
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
 		[b]Example of contacting a REST API and printing one of its returned fields:[/b]
 		[codeblocks]
@@ -157,7 +157,7 @@
 	</description>
 	<tutorials>
 		<link title="Making HTTP requests">$DOCS_URL/tutorials/networking/http_request_class.html</link>
-		<link title="SSL certificates">$DOCS_URL/tutorials/networking/ssl_certificates.html</link>
+		<link title="TLS certificates">$DOCS_URL/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<methods>
 		<method name="cancel_request">
@@ -189,21 +189,21 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="url" type="String" />
 			<param index="1" name="custom_headers" type="PackedStringArray" default="PackedStringArray()" />
-			<param index="2" name="ssl_validate_domain" type="bool" default="true" />
+			<param index="2" name="tls_validate_domain" type="bool" default="true" />
 			<param index="3" name="method" type="int" enum="HTTPClient.Method" default="0" />
 			<param index="4" name="request_data" type="String" default="&quot;&quot;" />
 			<description>
 				Creates request on the underlying [HTTPClient]. If there is no configuration errors, it tries to connect using [method HTTPClient.connect_to_host] and passes parameters onto [method HTTPClient.request].
 				Returns [constant OK] if request is successfully created. (Does not imply that the server has responded), [constant ERR_UNCONFIGURED] if not in the tree, [constant ERR_BUSY] if still processing previous request, [constant ERR_INVALID_PARAMETER] if given string is not a valid URL format, or [constant ERR_CANT_CONNECT] if not using thread and the [HTTPClient] cannot connect to host.
 				[b]Note:[/b] When [param method] is [constant HTTPClient.METHOD_GET], the payload sent via [param request_data] might be ignored by the server or even cause the server to reject the request (check [url=https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.1]RFC 7231 section 4.3.1[/url] for more details). As a workaround, you can send data as a query string in the URL (see [method String.uri_encode] for an example).
-				[b]Note:[/b] It's recommended to use transport encryption (SSL/TLS) and to avoid sending sensitive information (such as login credentials) in HTTP GET URL parameters. Consider using HTTP POST requests or HTTP headers for such information instead.
+				[b]Note:[/b] It's recommended to use transport encryption (TLS) and to avoid sending sensitive information (such as login credentials) in HTTP GET URL parameters. Consider using HTTP POST requests or HTTP headers for such information instead.
 			</description>
 		</method>
 		<method name="request_raw">
 			<return type="int" enum="Error" />
 			<param index="0" name="url" type="String" />
 			<param index="1" name="custom_headers" type="PackedStringArray" default="PackedStringArray()" />
-			<param index="2" name="ssl_validate_domain" type="bool" default="true" />
+			<param index="2" name="tls_validate_domain" type="bool" default="true" />
 			<param index="3" name="method" type="int" enum="HTTPClient.Method" default="0" />
 			<param index="4" name="request_data_raw" type="PackedByteArray" default="PackedByteArray()" />
 			<description>
@@ -283,8 +283,8 @@
 		<constant name="RESULT_CONNECTION_ERROR" value="4" enum="Result">
 			Request failed due to connection (read/write) error.
 		</constant>
-		<constant name="RESULT_SSL_HANDSHAKE_ERROR" value="5" enum="Result">
-			Request failed on SSL handshake.
+		<constant name="RESULT_TLS_HANDSHAKE_ERROR" value="5" enum="Result">
+			Request failed on TLS handshake.
 		</constant>
 		<constant name="RESULT_NO_RESPONSE" value="6" enum="Result">
 			Request does not have a response (yet).

--- a/doc/classes/PacketPeerDTLS.xml
+++ b/doc/classes/PacketPeerDTLS.xml
@@ -6,7 +6,7 @@
 	<description>
 		This class represents a DTLS peer connection. It can be used to connect to a DTLS server, and is returned by [method DTLSServer.take_connection].
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
-		[b]Warning:[/b] SSL/TLS certificate revocation and certificate pinning are currently not supported. Revoked certificates are accepted as long as they are otherwise valid. If this is a concern, you may want to use automatically managed certificates with a short validity period.
+		[b]Warning:[/b] TLS certificate revocation and certificate pinning are currently not supported. Revoked certificates are accepted as long as they are otherwise valid. If this is a concern, you may want to use automatically managed certificates with a short validity period.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -34,7 +34,7 @@
 			<param index="1" name="port" type="int" />
 			<description>
 				Calling this method connects this UDP peer to the given [param host]/[param port] pair. UDP is in reality connectionless, so this option only means that incoming packets from different addresses are automatically discarded, and that outgoing packets are always sent to the connected address (future calls to [method set_dest_address] are not allowed). This method does not send any data to the remote peer, to do that, use [method PacketPeer.put_var] or [method PacketPeer.put_packet] as usual. See also [UDPServer].
-				[b]Note:[/b] Connecting to the remote peer does not help to protect from malicious attacks like IP spoofing, etc. Think about using an encryption technique like SSL or DTLS if you feel like your application is transferring sensitive information.
+				[b]Note:[/b] Connecting to the remote peer does not help to protect from malicious attacks like IP spoofing, etc. Think about using an encryption technique like TLS or DTLS if you feel like your application is transferring sensitive information.
 			</description>
 		</method>
 		<method name="get_local_port" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1494,8 +1494,8 @@
 		<member name="network/remote_fs/page_size" type="int" setter="" getter="" default="65536">
 			Page size used by remote filesystem (in bytes).
 		</member>
-		<member name="network/ssl/certificate_bundle_override" type="String" setter="" getter="" default="&quot;&quot;">
-			The CA certificates bundle to use for SSL connections. If this is set to a non-empty value, this will [i]override[/i] Godot's default [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]Mozilla certificate bundle[/url]. If left empty, the default certificate bundle will be used.
+		<member name="network/tls/certificate_bundle_override" type="String" setter="" getter="" default="&quot;&quot;">
+			The CA certificates bundle to use for TLS connections. If this is set to a non-empty value, this will [i]override[/i] Godot's default [url=https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt]Mozilla certificate bundle[/url]. If left empty, the default certificate bundle will be used.
 			If in doubt, leave this setting empty.
 		</member>
 		<member name="physics/2d/default_angular_damp" type="float" setter="" getter="" default="1.0">

--- a/doc/classes/StreamPeerTLS.xml
+++ b/doc/classes/StreamPeerTLS.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StreamPeerTLS" inherits="StreamPeer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		SSL stream peer.
+		TLS stream peer.
 	</brief_description>
 	<description>
-		SSL stream peer. This object can be used to connect to an SSL server or accept a single SSL client connection.
+		TLS stream peer. This object can be used to connect to an TLS server or accept a single TLS client connection.
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
 	</description>
 	<tutorials>
-		<link title="SSL certificates">$DOCS_URL/tutorials/networking/ssl_certificates.html</link>
+		<link title="TLS certificates">$DOCS_URL/tutorials/networking/ssl_certificates.html</link>
 	</tutorials>
 	<methods>
 		<method name="accept_stream">
@@ -75,7 +75,7 @@
 			A status representing a [StreamPeerTLS] in error state.
 		</constant>
 		<constant name="STATUS_ERROR_HOSTNAME_MISMATCH" value="4" enum="Status">
-			An error status that shows a mismatch in the SSL certificate domain presented by the host and the domain requested for validation.
+			An error status that shows a mismatch in the TLS certificate domain presented by the host and the domain requested for validation.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/X509Certificate.xml
+++ b/doc/classes/X509Certificate.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="X509Certificate" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		An X509 certificate (e.g. for SSL).
+		An X509 certificate (e.g. for TLS).
 	</brief_description>
 	<description>
 		The X509Certificate class represents an X509 certificate. Certificates can be loaded and saved like any other [Resource].
-		They can be used as the server certificate in [method StreamPeerTLS.accept_stream] (along with the proper [CryptoKey]), and to specify the only certificate that should be accepted when connecting to an SSL server via [method StreamPeerTLS.connect_to_stream].
+		They can be used as the server certificate in [method StreamPeerTLS.accept_stream] (along with the proper [CryptoKey]), and to specify the only certificate that should be accepted when connecting to an TLS server via [method StreamPeerTLS.connect_to_stream].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -717,7 +717,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "network/debug/remote_port", 6007, "1,65535,1")
 
 	// SSL
-	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "network/ssl/editor_ssl_certificates", _SYSTEM_CERTS_PATH, "*.crt,*.pem", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "network/tls/editor_tls_certificates", _SYSTEM_CERTS_PATH, "*.crt,*.pem", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
 	// Profiler
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "debugger/profiler_frame_history_size", 3600, "60,10000,1")

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -172,7 +172,7 @@ void ExportTemplateManager::_download_template_completed(int p_status, int p_cod
 		case HTTPRequest::RESULT_BODY_SIZE_LIMIT_EXCEEDED:
 		case HTTPRequest::RESULT_CONNECTION_ERROR:
 		case HTTPRequest::RESULT_CHUNKED_BODY_SIZE_MISMATCH:
-		case HTTPRequest::RESULT_SSL_HANDSHAKE_ERROR:
+		case HTTPRequest::RESULT_TLS_HANDSHAKE_ERROR:
 		case HTTPRequest::RESULT_CANT_CONNECT: {
 			_set_current_progress_status(TTR("Can't connect to the mirror."), true);
 		} break;
@@ -345,8 +345,8 @@ bool ExportTemplateManager::_humanize_http_status(HTTPRequest *p_request, String
 			*r_status = TTR("Connection Error");
 			success = false;
 			break;
-		case HTTPClient::STATUS_SSL_HANDSHAKE_ERROR:
-			*r_status = TTR("SSL Handshake Error");
+		case HTTPClient::STATUS_TLS_HANDSHAKE_ERROR:
+			*r_status = TTR("TLS Handshake Error");
 			success = false;
 			break;
 	}

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -324,7 +324,7 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 			status->set_text(TTR("Can't connect."));
 		} break;
 		case HTTPRequest::RESULT_CANT_CONNECT:
-		case HTTPRequest::RESULT_SSL_HANDSHAKE_ERROR: {
+		case HTTPRequest::RESULT_TLS_HANDSHAKE_ERROR: {
 			error_text = TTR("Can't connect to host:") + " " + host;
 			status->set_text(TTR("Can't connect."));
 		} break;
@@ -1102,7 +1102,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 		case HTTPRequest::RESULT_CHUNKED_BODY_SIZE_MISMATCH: {
 			error_label->set_text(TTR("Connection error, please try again."));
 		} break;
-		case HTTPRequest::RESULT_SSL_HANDSHAKE_ERROR:
+		case HTTPRequest::RESULT_TLS_HANDSHAKE_ERROR:
 		case HTTPRequest::RESULT_CANT_CONNECT: {
 			error_label->set_text(TTR("Can't connect to host:") + " " + host);
 		} break;

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1263,7 +1263,7 @@ static const char *project_settings_renames[][2] = {
 	{ "network/limits/debugger_stdout/max_errors_per_second", "network/limits/debugger/max_errors_per_second" },
 	{ "network/limits/debugger_stdout/max_messages_per_frame", "network/limits/debugger/max_queued_messages" },
 	{ "network/limits/debugger_stdout/max_warnings_per_second", "network/limits/debugger/max_warnings_per_second" },
-	{ "network/ssl/certificates", "network/ssl/certificate_bundle_override" },
+	{ "network/ssl/certificates", "network/tls/certificate_bundle_override" },
 	{ "physics/2d/thread_model", "physics/2d/run_on_thread" }, // TODO not sure
 	{ "rendering/environment/default_clear_color", "rendering/environment/defaults/default_clear_color" },
 	{ "rendering/environment/default_environment", "rendering/environment/defaults/default_environment" },

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2786,7 +2786,7 @@ bool Main::start() {
 			Engine::get_singleton()->startup_benchmark_begin_measure("game_load");
 
 			// Load SSL Certificates from Project Settings (or builtin).
-			Crypto::load_default_certificates(GLOBAL_DEF("network/ssl/certificate_bundle_override", ""));
+			Crypto::load_default_certificates(GLOBAL_DEF("network/tls/certificate_bundle_override", ""));
 
 			if (!game_path.is_empty()) {
 				Node *scene = nullptr;
@@ -2843,7 +2843,7 @@ bool Main::start() {
 		if (project_manager || editor) {
 			// Load SSL Certificates from Editor Settings (or builtin)
 			Crypto::load_default_certificates(
-					EditorSettings::get_singleton()->get_setting("network/ssl/editor_ssl_certificates").operator String());
+					EditorSettings::get_singleton()->get_setting("network/tls/editor_tls_certificates").operator String());
 		}
 #endif
 	}

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -39,7 +39,7 @@
 #include <mbedtls/ssl.h>
 
 class CryptoMbedTLS;
-class SSLContextMbedTLS;
+class TLSContextMbedTLS;
 class CryptoKeyMbedTLS : public CryptoKey {
 private:
 	mbedtls_pk_context pkey;
@@ -69,7 +69,7 @@ public:
 	_FORCE_INLINE_ void unlock() { locks--; }
 
 	friend class CryptoMbedTLS;
-	friend class SSLContextMbedTLS;
+	friend class TLSContextMbedTLS;
 };
 
 class X509CertificateMbedTLS : public X509Certificate {
@@ -98,7 +98,7 @@ public:
 	_FORCE_INLINE_ void unlock() { locks--; }
 
 	friend class CryptoMbedTLS;
-	friend class SSLContextMbedTLS;
+	friend class TLSContextMbedTLS;
 };
 
 class HMACContextMbedTLS : public HMACContext {

--- a/modules/mbedtls/dtls_server_mbedtls.h
+++ b/modules/mbedtls/dtls_server_mbedtls.h
@@ -32,7 +32,7 @@
 #define DTLS_SERVER_MBEDTLS_H
 
 #include "core/io/dtls_server.h"
-#include "ssl_context_mbedtls.h"
+#include "tls_context_mbedtls.h"
 
 class DTLSServerMbedTLS : public DTLSServer {
 private:

--- a/modules/mbedtls/packet_peer_mbed_dtls.cpp
+++ b/modules/mbedtls/packet_peer_mbed_dtls.cpp
@@ -79,7 +79,7 @@ int PacketPeerMbedDTLS::bio_recv(void *ctx, unsigned char *buf, size_t len) {
 }
 
 void PacketPeerMbedDTLS::_cleanup() {
-	ssl_ctx->clear();
+	tls_ctx->clear();
 	base = Ref<PacketPeer>();
 	status = STATUS_DISCONNECTED;
 }
@@ -91,16 +91,16 @@ int PacketPeerMbedDTLS::_set_cookie() {
 	uint16_t port = base->get_packet_port();
 	memcpy(client_id, addr.get_ipv6(), 16);
 	memcpy(&client_id[16], (uint8_t *)&port, 2);
-	return mbedtls_ssl_set_client_transport_id(ssl_ctx->get_context(), client_id, 18);
+	return mbedtls_ssl_set_client_transport_id(tls_ctx->get_context(), client_id, 18);
 }
 
 Error PacketPeerMbedDTLS::_do_handshake() {
 	int ret = 0;
-	while ((ret = mbedtls_ssl_handshake(ssl_ctx->get_context())) != 0) {
+	while ((ret = mbedtls_ssl_handshake(tls_ctx->get_context())) != 0) {
 		if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
 			if (ret != MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED) {
 				ERR_PRINT("TLS handshake error: " + itos(ret));
-				SSLContextMbedTLS::print_mbedtls_error(ret);
+				TLSContextMbedTLS::print_mbedtls_error(ret);
 			}
 			_cleanup();
 			status = STATUS_ERROR;
@@ -121,12 +121,12 @@ Error PacketPeerMbedDTLS::connect_to_peer(Ref<PacketPeerUDP> p_base, bool p_vali
 	int ret = 0;
 	int authmode = p_validate_certs ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_NONE;
 
-	Error err = ssl_ctx->init_client(MBEDTLS_SSL_TRANSPORT_DATAGRAM, authmode, p_ca_certs);
+	Error err = tls_ctx->init_client(MBEDTLS_SSL_TRANSPORT_DATAGRAM, authmode, p_ca_certs);
 	ERR_FAIL_COND_V(err != OK, err);
 
-	mbedtls_ssl_set_hostname(ssl_ctx->get_context(), p_for_hostname.utf8().get_data());
-	mbedtls_ssl_set_bio(ssl_ctx->get_context(), this, bio_send, bio_recv, nullptr);
-	mbedtls_ssl_set_timer_cb(ssl_ctx->get_context(), &timer, mbedtls_timing_set_delay, mbedtls_timing_get_delay);
+	mbedtls_ssl_set_hostname(tls_ctx->get_context(), p_for_hostname.utf8().get_data());
+	mbedtls_ssl_set_bio(tls_ctx->get_context(), this, bio_send, bio_recv, nullptr);
+	mbedtls_ssl_set_timer_cb(tls_ctx->get_context(), &timer, mbedtls_timing_set_delay, mbedtls_timing_get_delay);
 
 	status = STATUS_HANDSHAKING;
 
@@ -139,13 +139,13 @@ Error PacketPeerMbedDTLS::connect_to_peer(Ref<PacketPeerUDP> p_base, bool p_vali
 }
 
 Error PacketPeerMbedDTLS::accept_peer(Ref<PacketPeerUDP> p_base, Ref<CryptoKey> p_key, Ref<X509Certificate> p_cert, Ref<X509Certificate> p_ca_chain, Ref<CookieContextMbedTLS> p_cookies) {
-	Error err = ssl_ctx->init_server(MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_VERIFY_NONE, p_key, p_cert, p_cookies);
+	Error err = tls_ctx->init_server(MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_VERIFY_NONE, p_key, p_cert, p_cookies);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	base = p_base;
 	base->set_blocking_mode(false);
 
-	mbedtls_ssl_session_reset(ssl_ctx->get_context());
+	mbedtls_ssl_session_reset(tls_ctx->get_context());
 
 	int ret = _set_cookie();
 	if (ret != 0) {
@@ -153,8 +153,8 @@ Error PacketPeerMbedDTLS::accept_peer(Ref<PacketPeerUDP> p_base, Ref<CryptoKey> 
 		ERR_FAIL_V_MSG(FAILED, "Error setting DTLS client cookie");
 	}
 
-	mbedtls_ssl_set_bio(ssl_ctx->get_context(), this, bio_send, bio_recv, nullptr);
-	mbedtls_ssl_set_timer_cb(ssl_ctx->get_context(), &timer, mbedtls_timing_set_delay, mbedtls_timing_get_delay);
+	mbedtls_ssl_set_bio(tls_ctx->get_context(), this, bio_send, bio_recv, nullptr);
+	mbedtls_ssl_set_timer_cb(tls_ctx->get_context(), &timer, mbedtls_timing_set_delay, mbedtls_timing_get_delay);
 
 	status = STATUS_HANDSHAKING;
 
@@ -173,11 +173,11 @@ Error PacketPeerMbedDTLS::put_packet(const uint8_t *p_buffer, int p_bytes) {
 		return OK;
 	}
 
-	int ret = mbedtls_ssl_write(ssl_ctx->get_context(), p_buffer, p_bytes);
+	int ret = mbedtls_ssl_write(tls_ctx->get_context(), p_buffer, p_bytes);
 	if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 		ret = 0; // non blocking io
 	} else if (ret <= 0) {
-		SSLContextMbedTLS::print_mbedtls_error(ret);
+		TLSContextMbedTLS::print_mbedtls_error(ret);
 		_cleanup();
 		return ERR_CONNECTION_ERROR;
 	}
@@ -190,7 +190,7 @@ Error PacketPeerMbedDTLS::get_packet(const uint8_t **r_buffer, int &r_bytes) {
 
 	r_bytes = 0;
 
-	int ret = mbedtls_ssl_read(ssl_ctx->get_context(), packet_buffer, PACKET_BUFFER_SIZE);
+	int ret = mbedtls_ssl_read(tls_ctx->get_context(), packet_buffer, PACKET_BUFFER_SIZE);
 	if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 		ret = 0; // non blocking io
 	} else if (ret <= 0) {
@@ -200,7 +200,7 @@ Error PacketPeerMbedDTLS::get_packet(const uint8_t **r_buffer, int &r_bytes) {
 		} else {
 			_cleanup();
 			status = STATUS_ERROR;
-			SSLContextMbedTLS::print_mbedtls_error(ret);
+			TLSContextMbedTLS::print_mbedtls_error(ret);
 		}
 		return ERR_CONNECTION_ERROR;
 	}
@@ -220,7 +220,7 @@ void PacketPeerMbedDTLS::poll() {
 
 	ERR_FAIL_COND(!base.is_valid());
 
-	int ret = mbedtls_ssl_read(ssl_ctx->get_context(), nullptr, 0);
+	int ret = mbedtls_ssl_read(tls_ctx->get_context(), nullptr, 0);
 
 	if (ret < 0 && ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
 		if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
@@ -229,7 +229,7 @@ void PacketPeerMbedDTLS::poll() {
 		} else {
 			_cleanup();
 			status = STATUS_ERROR;
-			SSLContextMbedTLS::print_mbedtls_error(ret);
+			TLSContextMbedTLS::print_mbedtls_error(ret);
 		}
 	}
 }
@@ -237,7 +237,7 @@ void PacketPeerMbedDTLS::poll() {
 int PacketPeerMbedDTLS::get_available_packet_count() const {
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, 0);
 
-	return mbedtls_ssl_get_bytes_avail(&(ssl_ctx->ssl)) > 0 ? 1 : 0;
+	return mbedtls_ssl_get_bytes_avail(&(tls_ctx->tls)) > 0 ? 1 : 0;
 }
 
 int PacketPeerMbedDTLS::get_max_packet_size() const {
@@ -245,7 +245,7 @@ int PacketPeerMbedDTLS::get_max_packet_size() const {
 }
 
 PacketPeerMbedDTLS::PacketPeerMbedDTLS() {
-	ssl_ctx.instantiate();
+	tls_ctx.instantiate();
 }
 
 PacketPeerMbedDTLS::~PacketPeerMbedDTLS() {
@@ -261,7 +261,7 @@ void PacketPeerMbedDTLS::disconnect_from_peer() {
 		int ret = 0;
 		// Send SSL close notification, blocking, but ignore other errors.
 		do {
-			ret = mbedtls_ssl_close_notify(ssl_ctx->get_context());
+			ret = mbedtls_ssl_close_notify(tls_ctx->get_context());
 		} while (ret == MBEDTLS_ERR_SSL_WANT_WRITE);
 	}
 

--- a/modules/mbedtls/packet_peer_mbed_dtls.h
+++ b/modules/mbedtls/packet_peer_mbed_dtls.h
@@ -32,7 +32,7 @@
 #define PACKET_PEER_MBED_DTLS_H
 
 #include "core/io/packet_peer_dtls.h"
-#include "ssl_context_mbedtls.h"
+#include "tls_context_mbedtls.h"
 
 #include <mbedtls/timing.h>
 
@@ -56,7 +56,7 @@ private:
 	void _cleanup();
 
 protected:
-	Ref<SSLContextMbedTLS> ssl_ctx;
+	Ref<TLSContextMbedTLS> tls_ctx;
 	mbedtls_timing_delay_context timer;
 
 	Error _do_handshake();

--- a/modules/mbedtls/register_types.cpp
+++ b/modules/mbedtls/register_types.cpp
@@ -45,7 +45,7 @@ void initialize_mbedtls_module(ModuleInitializationLevel p_level) {
 	}
 
 	CryptoMbedTLS::initialize_crypto();
-	StreamPeerMbedTLS::initialize_ssl();
+	StreamPeerMbedTLS::initialize_tls();
 	PacketPeerMbedDTLS::initialize_dtls();
 	DTLSServerMbedTLS::initialize();
 }
@@ -57,6 +57,6 @@ void uninitialize_mbedtls_module(ModuleInitializationLevel p_level) {
 
 	DTLSServerMbedTLS::finalize();
 	PacketPeerMbedDTLS::finalize_dtls();
-	StreamPeerMbedTLS::finalize_ssl();
+	StreamPeerMbedTLS::finalize_tls();
 	CryptoMbedTLS::finalize_crypto();
 }

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -74,18 +74,18 @@ int StreamPeerMbedTLS::bio_recv(void *ctx, unsigned char *buf, size_t len) {
 }
 
 void StreamPeerMbedTLS::_cleanup() {
-	ssl_ctx->clear();
+	tls_ctx->clear();
 	base = Ref<StreamPeer>();
 	status = STATUS_DISCONNECTED;
 }
 
 Error StreamPeerMbedTLS::_do_handshake() {
 	int ret = 0;
-	while ((ret = mbedtls_ssl_handshake(ssl_ctx->get_context())) != 0) {
+	while ((ret = mbedtls_ssl_handshake(tls_ctx->get_context())) != 0) {
 		if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
 			// An error occurred.
 			ERR_PRINT("TLS handshake error: " + itos(ret));
-			SSLContextMbedTLS::print_mbedtls_error(ret);
+			TLSContextMbedTLS::print_mbedtls_error(ret);
 			disconnect_from_stream();
 			status = STATUS_ERROR;
 			return FAILED;
@@ -108,11 +108,11 @@ Error StreamPeerMbedTLS::connect_to_stream(Ref<StreamPeer> p_base, bool p_valida
 	base = p_base;
 	int authmode = p_validate_certs ? MBEDTLS_SSL_VERIFY_REQUIRED : MBEDTLS_SSL_VERIFY_NONE;
 
-	Error err = ssl_ctx->init_client(MBEDTLS_SSL_TRANSPORT_STREAM, authmode, p_ca_certs);
+	Error err = tls_ctx->init_client(MBEDTLS_SSL_TRANSPORT_STREAM, authmode, p_ca_certs);
 	ERR_FAIL_COND_V(err != OK, err);
 
-	mbedtls_ssl_set_hostname(ssl_ctx->get_context(), p_for_hostname.utf8().get_data());
-	mbedtls_ssl_set_bio(ssl_ctx->get_context(), this, bio_send, bio_recv, nullptr);
+	mbedtls_ssl_set_hostname(tls_ctx->get_context(), p_for_hostname.utf8().get_data());
+	mbedtls_ssl_set_bio(tls_ctx->get_context(), this, bio_send, bio_recv, nullptr);
 
 	status = STATUS_HANDSHAKING;
 
@@ -127,12 +127,12 @@ Error StreamPeerMbedTLS::connect_to_stream(Ref<StreamPeer> p_base, bool p_valida
 Error StreamPeerMbedTLS::accept_stream(Ref<StreamPeer> p_base, Ref<CryptoKey> p_key, Ref<X509Certificate> p_cert, Ref<X509Certificate> p_ca_chain) {
 	ERR_FAIL_COND_V(p_base.is_null(), ERR_INVALID_PARAMETER);
 
-	Error err = ssl_ctx->init_server(MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_VERIFY_NONE, p_key, p_cert);
+	Error err = tls_ctx->init_server(MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_VERIFY_NONE, p_key, p_cert);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	base = p_base;
 
-	mbedtls_ssl_set_bio(ssl_ctx->get_context(), this, bio_send, bio_recv, nullptr);
+	mbedtls_ssl_set_bio(tls_ctx->get_context(), this, bio_send, bio_recv, nullptr);
 
 	status = STATUS_HANDSHAKING;
 
@@ -173,7 +173,7 @@ Error StreamPeerMbedTLS::put_partial_data(const uint8_t *p_data, int p_bytes, in
 		return OK;
 	}
 
-	int ret = mbedtls_ssl_write(ssl_ctx->get_context(), p_data, p_bytes);
+	int ret = mbedtls_ssl_write(tls_ctx->get_context(), p_data, p_bytes);
 	if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 		// Non blocking IO
 		ret = 0;
@@ -182,7 +182,7 @@ Error StreamPeerMbedTLS::put_partial_data(const uint8_t *p_data, int p_bytes, in
 		disconnect_from_stream();
 		return ERR_FILE_EOF;
 	} else if (ret <= 0) {
-		SSLContextMbedTLS::print_mbedtls_error(ret);
+		TLSContextMbedTLS::print_mbedtls_error(ret);
 		disconnect_from_stream();
 		return ERR_CONNECTION_ERROR;
 	}
@@ -216,7 +216,7 @@ Error StreamPeerMbedTLS::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r
 
 	r_received = 0;
 
-	int ret = mbedtls_ssl_read(ssl_ctx->get_context(), p_buffer, p_bytes);
+	int ret = mbedtls_ssl_read(tls_ctx->get_context(), p_buffer, p_bytes);
 	if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 		ret = 0; // non blocking io
 	} else if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
@@ -224,7 +224,7 @@ Error StreamPeerMbedTLS::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r
 		disconnect_from_stream();
 		return ERR_FILE_EOF;
 	} else if (ret <= 0) {
-		SSLContextMbedTLS::print_mbedtls_error(ret);
+		TLSContextMbedTLS::print_mbedtls_error(ret);
 		disconnect_from_stream();
 		return ERR_CONNECTION_ERROR;
 	}
@@ -245,7 +245,7 @@ void StreamPeerMbedTLS::poll() {
 	// We could pass nullptr as second parameter, but some behaviour sanitizers don't seem to like that.
 	// Passing a 1 byte buffer to workaround it.
 	uint8_t byte;
-	int ret = mbedtls_ssl_read(ssl_ctx->get_context(), &byte, 0);
+	int ret = mbedtls_ssl_read(tls_ctx->get_context(), &byte, 0);
 
 	if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
 		// Nothing to read/write (non blocking IO)
@@ -254,7 +254,7 @@ void StreamPeerMbedTLS::poll() {
 		disconnect_from_stream();
 		return;
 	} else if (ret < 0) {
-		SSLContextMbedTLS::print_mbedtls_error(ret);
+		TLSContextMbedTLS::print_mbedtls_error(ret);
 		disconnect_from_stream();
 		return;
 	}
@@ -269,11 +269,11 @@ void StreamPeerMbedTLS::poll() {
 int StreamPeerMbedTLS::get_available_bytes() const {
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, 0);
 
-	return mbedtls_ssl_get_bytes_avail(&(ssl_ctx->ssl));
+	return mbedtls_ssl_get_bytes_avail(&(tls_ctx->tls));
 }
 
 StreamPeerMbedTLS::StreamPeerMbedTLS() {
-	ssl_ctx.instantiate();
+	tls_ctx.instantiate();
 }
 
 StreamPeerMbedTLS::~StreamPeerMbedTLS() {
@@ -288,7 +288,7 @@ void StreamPeerMbedTLS::disconnect_from_stream() {
 	Ref<StreamPeerTCP> tcp = base;
 	if (tcp.is_valid() && tcp->get_status() == StreamPeerTCP::STATUS_CONNECTED) {
 		// We are still connected on the socket, try to send close notify.
-		mbedtls_ssl_close_notify(ssl_ctx->get_context());
+		mbedtls_ssl_close_notify(tls_ctx->get_context());
 	}
 
 	_cleanup();
@@ -306,12 +306,12 @@ StreamPeerTLS *StreamPeerMbedTLS::_create_func() {
 	return memnew(StreamPeerMbedTLS);
 }
 
-void StreamPeerMbedTLS::initialize_ssl() {
+void StreamPeerMbedTLS::initialize_tls() {
 	_create = _create_func;
 	available = true;
 }
 
-void StreamPeerMbedTLS::finalize_ssl() {
+void StreamPeerMbedTLS::finalize_tls() {
 	available = false;
 	_create = nullptr;
 }

--- a/modules/mbedtls/stream_peer_mbedtls.h
+++ b/modules/mbedtls/stream_peer_mbedtls.h
@@ -32,7 +32,7 @@
 #define STREAM_PEER_MBEDTLS_H
 
 #include "core/io/stream_peer_tls.h"
-#include "ssl_context_mbedtls.h"
+#include "tls_context_mbedtls.h"
 
 class StreamPeerMbedTLS : public StreamPeerTLS {
 private:
@@ -48,7 +48,7 @@ private:
 	void _cleanup();
 
 protected:
-	Ref<SSLContextMbedTLS> ssl_ctx;
+	Ref<TLSContextMbedTLS> tls_ctx;
 
 	Error _do_handshake();
 
@@ -69,8 +69,8 @@ public:
 
 	virtual int get_available_bytes() const;
 
-	static void initialize_ssl();
-	static void finalize_ssl();
+	static void initialize_tls();
+	static void finalize_tls();
 
 	StreamPeerMbedTLS();
 	~StreamPeerMbedTLS();

--- a/modules/mbedtls/tls_context_mbedtls.cpp
+++ b/modules/mbedtls/tls_context_mbedtls.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  ssl_context_mbedtls.cpp                                              */
+/*  tls_context_mbedtls.cpp                                              */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "ssl_context_mbedtls.h"
+#include "tls_context_mbedtls.h"
 
 static void my_debug(void *ctx, int level,
 		const char *file, int line,
@@ -37,7 +37,7 @@ static void my_debug(void *ctx, int level,
 	fflush(stdout);
 }
 
-void SSLContextMbedTLS::print_mbedtls_error(int p_ret) {
+void TLSContextMbedTLS::print_mbedtls_error(int p_ret) {
 	printf("mbedtls error: returned -0x%x\n\n", -p_ret);
 	fflush(stdout);
 }
@@ -82,12 +82,12 @@ CookieContextMbedTLS::~CookieContextMbedTLS() {
 	clear();
 }
 
-/// SSLContextMbedTLS
+/// TLSContextMbedTLS
 
-Error SSLContextMbedTLS::_setup(int p_endpoint, int p_transport, int p_authmode) {
+Error TLSContextMbedTLS::_setup(int p_endpoint, int p_transport, int p_authmode) {
 	ERR_FAIL_COND_V_MSG(inited, ERR_ALREADY_IN_USE, "This SSL context is already active");
 
-	mbedtls_ssl_init(&ssl);
+	mbedtls_ssl_init(&tls);
 	mbedtls_ssl_config_init(&conf);
 	mbedtls_ctr_drbg_init(&ctr_drbg);
 	mbedtls_entropy_init(&entropy);
@@ -110,7 +110,7 @@ Error SSLContextMbedTLS::_setup(int p_endpoint, int p_transport, int p_authmode)
 	return OK;
 }
 
-Error SSLContextMbedTLS::init_server(int p_transport, int p_authmode, Ref<CryptoKeyMbedTLS> p_pkey, Ref<X509CertificateMbedTLS> p_cert, Ref<CookieContextMbedTLS> p_cookies) {
+Error TLSContextMbedTLS::init_server(int p_transport, int p_authmode, Ref<CryptoKeyMbedTLS> p_pkey, Ref<X509CertificateMbedTLS> p_cert, Ref<CookieContextMbedTLS> p_cookies) {
 	ERR_FAIL_COND_V(!p_pkey.is_valid(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(!p_cert.is_valid(), ERR_INVALID_PARAMETER);
 
@@ -146,11 +146,11 @@ Error SSLContextMbedTLS::init_server(int p_transport, int p_authmode, Ref<Crypto
 		cookies = p_cookies;
 		mbedtls_ssl_conf_dtls_cookies(&conf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check, &(cookies->cookie_ctx));
 	}
-	mbedtls_ssl_setup(&ssl, &conf);
+	mbedtls_ssl_setup(&tls, &conf);
 	return OK;
 }
 
-Error SSLContextMbedTLS::init_client(int p_transport, int p_authmode, Ref<X509CertificateMbedTLS> p_valid_cas) {
+Error TLSContextMbedTLS::init_client(int p_transport, int p_authmode, Ref<X509CertificateMbedTLS> p_valid_cas) {
 	Error err = _setup(MBEDTLS_SSL_IS_CLIENT, p_transport, p_authmode);
 	ERR_FAIL_COND_V(err != OK, err);
 
@@ -172,15 +172,15 @@ Error SSLContextMbedTLS::init_client(int p_transport, int p_authmode, Ref<X509Ce
 
 	// Set valid CAs
 	mbedtls_ssl_conf_ca_chain(&conf, &(cas->cert), nullptr);
-	mbedtls_ssl_setup(&ssl, &conf);
+	mbedtls_ssl_setup(&tls, &conf);
 	return OK;
 }
 
-void SSLContextMbedTLS::clear() {
+void TLSContextMbedTLS::clear() {
 	if (!inited) {
 		return;
 	}
-	mbedtls_ssl_free(&ssl);
+	mbedtls_ssl_free(&tls);
 	mbedtls_ssl_config_free(&conf);
 	mbedtls_ctr_drbg_free(&ctr_drbg);
 	mbedtls_entropy_free(&entropy);
@@ -198,14 +198,14 @@ void SSLContextMbedTLS::clear() {
 	inited = false;
 }
 
-mbedtls_ssl_context *SSLContextMbedTLS::get_context() {
+mbedtls_ssl_context *TLSContextMbedTLS::get_context() {
 	ERR_FAIL_COND_V(!inited, nullptr);
-	return &ssl;
+	return &tls;
 }
 
-SSLContextMbedTLS::SSLContextMbedTLS() {
+TLSContextMbedTLS::TLSContextMbedTLS() {
 }
 
-SSLContextMbedTLS::~SSLContextMbedTLS() {
+TLSContextMbedTLS::~TLSContextMbedTLS() {
 	clear();
 }

--- a/modules/mbedtls/tls_context_mbedtls.h
+++ b/modules/mbedtls/tls_context_mbedtls.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  ssl_context_mbedtls.h                                                */
+/*  tls_context_mbedtls.h                                                */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SSL_CONTEXT_MBEDTLS_H
-#define SSL_CONTEXT_MBEDTLS_H
+#ifndef TLS_CONTEXT_MBEDTLS_H
+#define TLS_CONTEXT_MBEDTLS_H
 
 #include "crypto_mbedtls.h"
 
@@ -44,10 +44,10 @@
 #include <mbedtls/ssl.h>
 #include <mbedtls/ssl_cookie.h>
 
-class SSLContextMbedTLS;
+class TLSContextMbedTLS;
 
 class CookieContextMbedTLS : public RefCounted {
-	friend class SSLContextMbedTLS;
+	friend class TLSContextMbedTLS;
 
 protected:
 	bool inited = false;
@@ -63,7 +63,7 @@ public:
 	~CookieContextMbedTLS();
 };
 
-class SSLContextMbedTLS : public RefCounted {
+class TLSContextMbedTLS : public RefCounted {
 protected:
 	bool inited = false;
 
@@ -73,7 +73,7 @@ public:
 	Ref<X509CertificateMbedTLS> certs;
 	mbedtls_entropy_context entropy;
 	mbedtls_ctr_drbg_context ctr_drbg;
-	mbedtls_ssl_context ssl;
+	mbedtls_ssl_context tls;
 	mbedtls_ssl_config conf;
 
 	Ref<CookieContextMbedTLS> cookies;
@@ -86,8 +86,8 @@ public:
 
 	mbedtls_ssl_context *get_context();
 
-	SSLContextMbedTLS();
-	~SSLContextMbedTLS();
+	TLSContextMbedTLS();
+	~TLSContextMbedTLS();
 };
 
-#endif // SSL_CONTEXT_MBEDTLS_H
+#endif // TLS_CONTEXT_MBEDTLS_H

--- a/modules/websocket/doc_classes/WebSocketClient.xml
+++ b/modules/websocket/doc_classes/WebSocketClient.xml
@@ -24,8 +24,8 @@
 				If [code]true[/code] is passed as [code]gd_mp_api[/code], the client will behave like a multiplayer peer for the [MultiplayerAPI], connections to non-Godot servers will not work, and [signal data_received] will not be emitted.
 				If [code]false[/code] is passed instead (default), you must call [PacketPeer] functions ([code]put_packet[/code], [code]get_packet[/code], etc.) on the [WebSocketPeer] returned via [code]get_peer(1)[/code] and not on this object directly (e.g. [code]get_peer(1).put_packet(data)[/code]).
 				You can optionally pass a list of [code]custom_headers[/code] to be added to the handshake HTTP request.
-				[b]Note:[/b] To avoid mixed content warnings or errors in Web, you may have to use a [code]url[/code] that starts with [code]wss://[/code] (secure) instead of [code]ws://[/code]. When doing so, make sure to use the fully qualified domain name that matches the one defined in the server's SSL certificate. Do not connect directly via the IP address for [code]wss://[/code] connections, as it won't match with the SSL certificate.
-				[b]Note:[/b] Specifying [code]custom_headers[/code] is not supported in Web exports due to browsers restrictions.
+				[b]Note:[/b] To avoid mixed content warnings or errors in Web, you may have to use a [code]url[/code] that starts with [code]wss://[/code] (secure) instead of [code]ws://[/code]. When doing so, make sure to use the fully qualified domain name that matches the one defined in the server's TLS certificate. Do not connect directly via the IP address for [code]wss://[/code] connections, as it won't match with the TLS certificate.
+				[b]Note:[/b] Specifying [code]custom_headers[/code] is not supported in Web exports due to browsers' restrictions.
 			</description>
 		</method>
 		<method name="disconnect_from_host">
@@ -50,12 +50,12 @@
 		</method>
 	</methods>
 	<members>
-		<member name="trusted_ssl_certificate" type="X509Certificate" setter="set_trusted_ssl_certificate" getter="get_trusted_ssl_certificate">
-			If specified, this [X509Certificate] will be the only one accepted when connecting to an SSL host. Any other certificate provided by the server will be regarded as invalid.
-			[b]Note:[/b] Specifying a custom [code]trusted_ssl_certificate[/code] is not supported in Web exports due to browsers restrictions.
+		<member name="trusted_tls_certificate" type="X509Certificate" setter="set_trusted_tls_certificate" getter="get_trusted_tls_certificate">
+			If specified, this [X509Certificate] will be the only one accepted when connecting to an TLS host. Any other certificate provided by the server will be regarded as invalid.
+			[b]Note:[/b] Specifying a custom [code]trusted_tls_certificate[/code] is not supported in Web exports due to browsers' restrictions.
 		</member>
-		<member name="verify_ssl" type="bool" setter="set_verify_ssl_enabled" getter="is_verify_ssl_enabled">
-			If [code]true[/code], SSL certificate verification is enabled.
+		<member name="verify_tls" type="bool" setter="set_verify_tls_enabled" getter="is_verify_tls_enabled">
+			If [code]true[/code], TLS certificate verification is enabled.
 			[b]Note:[/b] You must specify the certificates to be used in the Project Settings for it to work when exported.
 		</member>
 	</members>

--- a/modules/websocket/doc_classes/WebSocketServer.xml
+++ b/modules/websocket/doc_classes/WebSocketServer.xml
@@ -79,16 +79,16 @@
 			When not set to [code]*[/code] will restrict incoming connections to the specified IP address. Setting [code]bind_ip[/code] to [code]127.0.0.1[/code] will cause the server to listen only to the local host.
 		</member>
 		<member name="ca_chain" type="X509Certificate" setter="set_ca_chain" getter="get_ca_chain">
-			When using SSL (see [member private_key] and [member ssl_certificate]), you can set this to a valid [X509Certificate] to be provided as additional CA chain information during the SSL handshake.
+			When using TLS (see [member private_key] and [member tls_certificate]), you can set this to a valid [X509Certificate] to be provided as additional CA chain information during the TLS handshake.
 		</member>
 		<member name="handshake_timeout" type="float" setter="set_handshake_timeout" getter="get_handshake_timeout" default="3.0">
 			The time in seconds before a pending client (i.e. a client that has not yet finished the HTTP handshake) is considered stale and forcefully disconnected.
 		</member>
 		<member name="private_key" type="CryptoKey" setter="set_private_key" getter="get_private_key">
-			When set to a valid [CryptoKey] (along with [member ssl_certificate]) will cause the server to require SSL instead of regular TCP (i.e. the [code]wss://[/code] protocol).
+			When set to a valid [CryptoKey] (along with [member tls_certificate]) will cause the server to require TLS instead of regular TCP (i.e. the [code]wss://[/code] protocol).
 		</member>
-		<member name="ssl_certificate" type="X509Certificate" setter="set_ssl_certificate" getter="get_ssl_certificate">
-			When set to a valid [X509Certificate] (along with [member private_key]) will cause the server to require SSL instead of regular TCP (i.e. the [code]wss://[/code] protocol).
+		<member name="tls_certificate" type="X509Certificate" setter="set_tls_certificate" getter="get_tls_certificate">
+			When set to a valid [X509Certificate] (along with [member private_key]) will cause the server to require TLS instead of regular TCP (i.e. the [code]wss://[/code] protocol).
 		</member>
 	</members>
 	<signals>

--- a/modules/websocket/emws_client.cpp
+++ b/modules/websocket/emws_client.cpp
@@ -65,7 +65,7 @@ void EMWSClient::_esws_on_close(void *obj, int code, const char *reason, int was
 	client->_on_disconnect(was_clean != 0);
 }
 
-Error EMWSClient::connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, const Vector<String> p_protocols, const Vector<String> p_custom_headers) {
+Error EMWSClient::connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_tls, const Vector<String> p_protocols, const Vector<String> p_custom_headers) {
 	if (_js_id) {
 		godot_js_websocket_destroy(_js_id);
 		_js_id = 0;
@@ -84,9 +84,9 @@ Error EMWSClient::connect_to_host(String p_host, String p_path, uint16_t p_port,
 	if (p_custom_headers.size()) {
 		WARN_PRINT_ONCE("Custom headers are not supported in Web platform.");
 	}
-	if (p_ssl) {
+	if (p_tls) {
 		str = "wss://";
-		if (ssl_cert.is_valid()) {
+		if (tls_cert.is_valid()) {
 			WARN_PRINT_ONCE("Custom SSL certificate is not supported in Web platform.");
 		}
 	}

--- a/modules/websocket/emws_client.h
+++ b/modules/websocket/emws_client.h
@@ -54,7 +54,7 @@ private:
 
 public:
 	Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) override;
-	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, const Vector<String> p_protocol = Vector<String>(), const Vector<String> p_custom_headers = Vector<String>()) override;
+	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_tls, const Vector<String> p_protocol = Vector<String>(), const Vector<String> p_custom_headers = Vector<String>()) override;
 	Ref<WebSocketPeer> get_peer(int p_peer_id) const override;
 	void disconnect_from_host(int p_code = 1000, String p_reason = "") override;
 	IPAddress get_connected_host() const override;

--- a/modules/websocket/websocket_client.cpp
+++ b/modules/websocket/websocket_client.cpp
@@ -48,34 +48,34 @@ Error WebSocketClient::connect_to_url(String p_url, const Vector<String> p_proto
 	Error err = p_url.parse_url(scheme, host, port, path);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Invalid URL: " + p_url);
 
-	bool ssl = false;
+	bool tls = false;
 	if (scheme == "wss://") {
-		ssl = true;
+		tls = true;
 	}
 	if (port == 0) {
-		port = ssl ? 443 : 80;
+		port = tls ? 443 : 80;
 	}
 	if (path.is_empty()) {
 		path = "/";
 	}
-	return connect_to_host(host, path, port, ssl, p_protocols, p_custom_headers);
+	return connect_to_host(host, path, port, tls, p_protocols, p_custom_headers);
 }
 
-void WebSocketClient::set_verify_ssl_enabled(bool p_verify_ssl) {
-	verify_ssl = p_verify_ssl;
+void WebSocketClient::set_verify_tls_enabled(bool p_verify_tls) {
+	verify_tls = p_verify_tls;
 }
 
-bool WebSocketClient::is_verify_ssl_enabled() const {
-	return verify_ssl;
+bool WebSocketClient::is_verify_tls_enabled() const {
+	return verify_tls;
 }
 
-Ref<X509Certificate> WebSocketClient::get_trusted_ssl_certificate() const {
-	return ssl_cert;
+Ref<X509Certificate> WebSocketClient::get_trusted_tls_certificate() const {
+	return tls_cert;
 }
 
-void WebSocketClient::set_trusted_ssl_certificate(Ref<X509Certificate> p_cert) {
+void WebSocketClient::set_trusted_tls_certificate(Ref<X509Certificate> p_cert) {
 	ERR_FAIL_COND(get_connection_status() != CONNECTION_DISCONNECTED);
-	ssl_cert = p_cert;
+	tls_cert = p_cert;
 }
 
 bool WebSocketClient::is_server() const {
@@ -123,15 +123,15 @@ void WebSocketClient::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("disconnect_from_host", "code", "reason"), &WebSocketClient::disconnect_from_host, DEFVAL(1000), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_connected_host"), &WebSocketClient::get_connected_host);
 	ClassDB::bind_method(D_METHOD("get_connected_port"), &WebSocketClient::get_connected_port);
-	ClassDB::bind_method(D_METHOD("set_verify_ssl_enabled", "enabled"), &WebSocketClient::set_verify_ssl_enabled);
-	ClassDB::bind_method(D_METHOD("is_verify_ssl_enabled"), &WebSocketClient::is_verify_ssl_enabled);
+	ClassDB::bind_method(D_METHOD("set_verify_tls_enabled", "enabled"), &WebSocketClient::set_verify_tls_enabled);
+	ClassDB::bind_method(D_METHOD("is_verify_tls_enabled"), &WebSocketClient::is_verify_tls_enabled);
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "verify_ssl", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_verify_ssl_enabled", "is_verify_ssl_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "verify_tls", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_verify_tls_enabled", "is_verify_tls_enabled");
 
-	ClassDB::bind_method(D_METHOD("get_trusted_ssl_certificate"), &WebSocketClient::get_trusted_ssl_certificate);
-	ClassDB::bind_method(D_METHOD("set_trusted_ssl_certificate", "cert"), &WebSocketClient::set_trusted_ssl_certificate);
+	ClassDB::bind_method(D_METHOD("get_trusted_tls_certificate"), &WebSocketClient::get_trusted_tls_certificate);
+	ClassDB::bind_method(D_METHOD("set_trusted_tls_certificate", "cert"), &WebSocketClient::set_trusted_tls_certificate);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "trusted_ssl_certificate", PROPERTY_HINT_RESOURCE_TYPE, "X509Certificate", PROPERTY_USAGE_NONE), "set_trusted_ssl_certificate", "get_trusted_ssl_certificate");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "trusted_tls_certificate", PROPERTY_HINT_RESOURCE_TYPE, "X509Certificate", PROPERTY_USAGE_NONE), "set_trusted_tls_certificate", "get_trusted_tls_certificate");
 
 	ADD_SIGNAL(MethodInfo("data_received"));
 	ADD_SIGNAL(MethodInfo("connection_established", PropertyInfo(Variant::STRING, "protocol")));

--- a/modules/websocket/websocket_client.h
+++ b/modules/websocket/websocket_client.h
@@ -42,20 +42,20 @@ class WebSocketClient : public WebSocketMultiplayerPeer {
 
 protected:
 	Ref<WebSocketPeer> _peer;
-	bool verify_ssl = true;
-	Ref<X509Certificate> ssl_cert;
+	bool verify_tls = true;
+	Ref<X509Certificate> tls_cert;
 
 	static void _bind_methods();
 
 public:
 	Error connect_to_url(String p_url, const Vector<String> p_protocols = Vector<String>(), bool gd_mp_api = false, const Vector<String> p_custom_headers = Vector<String>());
 
-	void set_verify_ssl_enabled(bool p_verify_ssl);
-	bool is_verify_ssl_enabled() const;
-	Ref<X509Certificate> get_trusted_ssl_certificate() const;
-	void set_trusted_ssl_certificate(Ref<X509Certificate> p_cert);
+	void set_verify_tls_enabled(bool p_verify_tls);
+	bool is_verify_tls_enabled() const;
+	Ref<X509Certificate> get_trusted_tls_certificate() const;
+	void set_trusted_tls_certificate(Ref<X509Certificate> p_cert);
 
-	virtual Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, const Vector<String> p_protocol = Vector<String>(), const Vector<String> p_custom_headers = Vector<String>()) = 0;
+	virtual Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_tls, const Vector<String> p_protocol = Vector<String>(), const Vector<String> p_custom_headers = Vector<String>()) = 0;
 	virtual void disconnect_from_host(int p_code = 1000, String p_reason = "") = 0;
 	virtual IPAddress get_connected_host() const = 0;
 	virtual uint16_t get_connected_port() const = 0;

--- a/modules/websocket/websocket_server.cpp
+++ b/modules/websocket/websocket_server.cpp
@@ -58,9 +58,9 @@ void WebSocketServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_private_key", "key"), &WebSocketServer::set_private_key);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "private_key", PROPERTY_HINT_RESOURCE_TYPE, "CryptoKey", PROPERTY_USAGE_NONE), "set_private_key", "get_private_key");
 
-	ClassDB::bind_method(D_METHOD("get_ssl_certificate"), &WebSocketServer::get_ssl_certificate);
-	ClassDB::bind_method(D_METHOD("set_ssl_certificate", "cert"), &WebSocketServer::set_ssl_certificate);
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "ssl_certificate", PROPERTY_HINT_RESOURCE_TYPE, "X509Certificate", PROPERTY_USAGE_NONE), "set_ssl_certificate", "get_ssl_certificate");
+	ClassDB::bind_method(D_METHOD("get_tls_certificate"), &WebSocketServer::get_tls_certificate);
+	ClassDB::bind_method(D_METHOD("set_tls_certificate", "cert"), &WebSocketServer::set_tls_certificate);
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tls_certificate", PROPERTY_HINT_RESOURCE_TYPE, "X509Certificate", PROPERTY_USAGE_NONE), "set_tls_certificate", "get_tls_certificate");
 
 	ClassDB::bind_method(D_METHOD("get_ca_chain"), &WebSocketServer::get_ca_chain);
 	ClassDB::bind_method(D_METHOD("set_ca_chain", "ca_chain"), &WebSocketServer::set_ca_chain);
@@ -95,13 +95,13 @@ void WebSocketServer::set_private_key(Ref<CryptoKey> p_key) {
 	private_key = p_key;
 }
 
-Ref<X509Certificate> WebSocketServer::get_ssl_certificate() const {
-	return ssl_cert;
+Ref<X509Certificate> WebSocketServer::get_tls_certificate() const {
+	return tls_cert;
 }
 
-void WebSocketServer::set_ssl_certificate(Ref<X509Certificate> p_cert) {
+void WebSocketServer::set_tls_certificate(Ref<X509Certificate> p_cert) {
 	ERR_FAIL_COND(is_listening());
-	ssl_cert = p_cert;
+	tls_cert = p_cert;
 }
 
 Ref<X509Certificate> WebSocketServer::get_ca_chain() const {

--- a/modules/websocket/websocket_server.h
+++ b/modules/websocket/websocket_server.h
@@ -46,7 +46,7 @@ protected:
 	static void _bind_methods();
 
 	Ref<CryptoKey> private_key;
-	Ref<X509Certificate> ssl_cert;
+	Ref<X509Certificate> tls_cert;
 	Ref<X509Certificate> ca_chain;
 	uint32_t handshake_timeout = 3000;
 
@@ -74,8 +74,8 @@ public:
 	Ref<CryptoKey> get_private_key() const;
 	void set_private_key(Ref<CryptoKey> p_key);
 
-	Ref<X509Certificate> get_ssl_certificate() const;
-	void set_ssl_certificate(Ref<X509Certificate> p_cert);
+	Ref<X509Certificate> get_tls_certificate() const;
+	void set_tls_certificate(Ref<X509Certificate> p_cert);
 
 	Ref<X509Certificate> get_ca_chain() const;
 	void set_ca_chain(Ref<X509Certificate> p_ca_chain);

--- a/modules/websocket/wsl_client.h
+++ b/modules/websocket/wsl_client.h
@@ -65,7 +65,7 @@ private:
 	uint16_t _port = 0;
 	Array _ip_candidates;
 	Vector<String> _protocols;
-	bool _use_ssl = false;
+	bool _use_tls = false;
 	IP::ResolverID _resolver_id = IP::RESOLVER_INVALID_ID;
 
 	void _do_handshake();
@@ -73,7 +73,7 @@ private:
 
 public:
 	Error set_buffers(int p_in_buffer, int p_in_packets, int p_out_buffer, int p_out_packets) override;
-	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_ssl, const Vector<String> p_protocol = Vector<String>(), const Vector<String> p_custom_headers = Vector<String>()) override;
+	Error connect_to_host(String p_host, String p_path, uint16_t p_port, bool p_tls, const Vector<String> p_protocol = Vector<String>(), const Vector<String> p_custom_headers = Vector<String>()) override;
 	int get_max_packet_size() const override;
 	Ref<WebSocketPeer> get_peer(int p_peer_id) const override;
 	void disconnect_from_host(int p_code = 1000, String p_reason = "") override;

--- a/modules/websocket/wsl_server.cpp
+++ b/modules/websocket/wsl_server.cpp
@@ -102,16 +102,16 @@ Error WSLServer::PendingPeer::do_handshake(const Vector<String> p_protocols, uin
 		return ERR_TIMEOUT;
 	}
 
-	if (use_ssl) {
-		Ref<StreamPeerTLS> ssl = static_cast<Ref<StreamPeerTLS>>(connection);
-		if (ssl.is_null()) {
+	if (use_tls) {
+		Ref<StreamPeerTLS> tls = static_cast<Ref<StreamPeerTLS>>(connection);
+		if (tls.is_null()) {
 			ERR_FAIL_V_MSG(ERR_BUG, "Couldn't get StreamPeerTLS for WebSocket handshake.");
 		}
-		ssl->poll();
-		if (ssl->get_status() == StreamPeerTLS::STATUS_HANDSHAKING) {
+		tls->poll();
+		if (tls->get_status() == StreamPeerTLS::STATUS_HANDSHAKING) {
 			return ERR_BUSY;
-		} else if (ssl->get_status() != StreamPeerTLS::STATUS_CONNECTED) {
-			print_verbose(vformat("WebSocket SSL connection error during handshake (StreamPeerTLS status code %d).", ssl->get_status()));
+		} else if (tls->get_status() != StreamPeerTLS::STATUS_CONNECTED) {
+			print_verbose(vformat("WebSocket SSL connection error during handshake (StreamPeerTLS status code %d).", tls->get_status()));
 			return FAILED;
 		}
 	}
@@ -247,12 +247,12 @@ void WSLServer::poll() {
 		}
 
 		Ref<PendingPeer> peer = memnew(PendingPeer);
-		if (private_key.is_valid() && ssl_cert.is_valid()) {
-			Ref<StreamPeerTLS> ssl = Ref<StreamPeerTLS>(StreamPeerTLS::create());
-			ssl->set_blocking_handshake_enabled(false);
-			ssl->accept_stream(conn, private_key, ssl_cert, ca_chain);
-			peer->connection = ssl;
-			peer->use_ssl = true;
+		if (private_key.is_valid() && tls_cert.is_valid()) {
+			Ref<StreamPeerTLS> tls = Ref<StreamPeerTLS>(StreamPeerTLS::create());
+			tls->set_blocking_handshake_enabled(false);
+			tls->accept_stream(conn, private_key, tls_cert, ca_chain);
+			peer->connection = tls;
+			peer->use_tls = true;
 		} else {
 			peer->connection = conn;
 		}

--- a/modules/websocket/wsl_server.h
+++ b/modules/websocket/wsl_server.h
@@ -51,7 +51,7 @@ private:
 	public:
 		Ref<StreamPeerTCP> tcp;
 		Ref<StreamPeer> connection;
-		bool use_ssl = false;
+		bool use_tls = false;
 
 		uint64_t time = 0;
 		uint8_t req_buf[WSL_MAX_HEADER_SIZE] = {};

--- a/platform/web/export/editor_http_server.h
+++ b/platform/web/export/editor_http_server.h
@@ -42,18 +42,18 @@ private:
 	Ref<TCPServer> server;
 	HashMap<String, String> mimes;
 	Ref<StreamPeerTCP> tcp;
-	Ref<StreamPeerTLS> ssl;
+	Ref<StreamPeerTLS> tls;
 	Ref<StreamPeer> peer;
 	Ref<CryptoKey> key;
 	Ref<X509Certificate> cert;
-	bool use_ssl = false;
+	bool use_tls = false;
 	uint64_t time = 0;
 	uint8_t req_buf[4096];
 	int req_pos = 0;
 
 	void _clear_client() {
 		peer = Ref<StreamPeer>();
-		ssl = Ref<StreamPeerTLS>();
+		tls = Ref<StreamPeerTLS>();
 		tcp = Ref<StreamPeerTCP>();
 		memset(req_buf, 0, sizeof(req_buf));
 		time = 0;
@@ -98,19 +98,19 @@ public:
 		_clear_client();
 	}
 
-	Error listen(int p_port, IPAddress p_address, bool p_use_ssl, String p_ssl_key, String p_ssl_cert) {
-		use_ssl = p_use_ssl;
-		if (use_ssl) {
+	Error listen(int p_port, IPAddress p_address, bool p_use_tls, String p_tls_key, String p_tls_cert) {
+		use_tls = p_use_tls;
+		if (use_tls) {
 			Ref<Crypto> crypto = Crypto::create();
 			if (crypto.is_null()) {
 				return ERR_UNAVAILABLE;
 			}
-			if (!p_ssl_key.is_empty() && !p_ssl_cert.is_empty()) {
+			if (!p_tls_key.is_empty() && !p_tls_cert.is_empty()) {
 				key = Ref<CryptoKey>(CryptoKey::create());
-				Error err = key->load(p_ssl_key);
+				Error err = key->load(p_tls_key);
 				ERR_FAIL_COND_V(err != OK, err);
 				cert = Ref<X509Certificate>(X509Certificate::create());
-				err = cert->load(p_ssl_cert);
+				err = cert->load(p_tls_cert);
 				ERR_FAIL_COND_V(err != OK, err);
 			} else {
 				_set_internal_certs(crypto);
@@ -201,22 +201,22 @@ public:
 			return;
 		}
 
-		if (use_ssl) {
-			if (ssl.is_null()) {
-				ssl = Ref<StreamPeerTLS>(StreamPeerTLS::create());
-				peer = ssl;
-				ssl->set_blocking_handshake_enabled(false);
-				if (ssl->accept_stream(tcp, key, cert) != OK) {
+		if (use_tls) {
+			if (tls.is_null()) {
+				tls = Ref<StreamPeerTLS>(StreamPeerTLS::create());
+				peer = tls;
+				tls->set_blocking_handshake_enabled(false);
+				if (tls->accept_stream(tcp, key, cert) != OK) {
 					_clear_client();
 					return;
 				}
 			}
-			ssl->poll();
-			if (ssl->get_status() == StreamPeerTLS::STATUS_HANDSHAKING) {
+			tls->poll();
+			if (tls->get_status() == StreamPeerTLS::STATUS_HANDSHAKING) {
 				// Still handshaking, keep waiting.
 				return;
 			}
-			if (ssl->get_status() != StreamPeerTLS::STATUS_CONNECTED) {
+			if (tls->get_status() != StreamPeerTLS::STATUS_CONNECTED) {
 				_clear_client();
 				return;
 			}

--- a/platform/web/export/export.cpp
+++ b/platform/web/export/export.cpp
@@ -36,12 +36,12 @@
 void register_web_exporter() {
 	EDITOR_DEF("export/web/http_host", "localhost");
 	EDITOR_DEF("export/web/http_port", 8060);
-	EDITOR_DEF("export/web/use_ssl", false);
-	EDITOR_DEF("export/web/ssl_key", "");
-	EDITOR_DEF("export/web/ssl_certificate", "");
+	EDITOR_DEF("export/web/use_tls", false);
+	EDITOR_DEF("export/web/tls_key", "");
+	EDITOR_DEF("export/web/tls_certificate", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "export/web/http_port", PROPERTY_HINT_RANGE, "1,65535,1"));
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/web/ssl_key", PROPERTY_HINT_GLOBAL_FILE, "*.key"));
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/web/ssl_certificate", PROPERTY_HINT_GLOBAL_FILE, "*.crt,*.pem"));
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/web/tls_key", PROPERTY_HINT_GLOBAL_FILE, "*.key"));
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/web/tls_certificate", PROPERTY_HINT_GLOBAL_FILE, "*.crt,*.pem"));
 
 	Ref<EditorExportPlatformWeb> platform;
 	platform.instantiate();

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -633,23 +633,23 @@ Error EditorExportPlatformWeb::run(const Ref<EditorExportPreset> &p_preset, int 
 	}
 	ERR_FAIL_COND_V_MSG(!bind_ip.is_valid(), ERR_INVALID_PARAMETER, "Invalid editor setting 'export/web/http_host': '" + bind_host + "'. Try using '127.0.0.1'.");
 
-	const bool use_ssl = EDITOR_GET("export/web/use_ssl");
-	const String ssl_key = EDITOR_GET("export/web/ssl_key");
-	const String ssl_cert = EDITOR_GET("export/web/ssl_certificate");
+	const bool use_tls = EDITOR_GET("export/web/use_tls");
+	const String tls_key = EDITOR_GET("export/web/tls_key");
+	const String tls_cert = EDITOR_GET("export/web/tls_certificate");
 
 	// Restart server.
 	{
 		MutexLock lock(server_lock);
 
 		server->stop();
-		err = server->listen(bind_port, bind_ip, use_ssl, ssl_key, ssl_cert);
+		err = server->listen(bind_port, bind_ip, use_tls, tls_key, tls_cert);
 	}
 	if (err != OK) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Run"), vformat(TTR("Error starting HTTP server: %d."), err));
 		return err;
 	}
 
-	OS::get_singleton()->shell_open(String((use_ssl ? "https://" : "http://") + bind_host + ":" + itos(bind_port) + "/tmp_js_export.html"));
+	OS::get_singleton()->shell_open(String((use_tls ? "https://" : "http://") + bind_host + ":" + itos(bind_port) + "/tmp_js_export.html"));
 	// FIXME: Find out how to clean up export files after running the successfully
 	// exported game. Might not be trivial.
 	return OK;

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -37,14 +37,14 @@ void HTTPClientWeb::_parse_headers(int p_len, const char **p_headers, void *p_re
 	}
 }
 
-Error HTTPClientWeb::connect_to_host(const String &p_host, int p_port, bool p_ssl, bool p_verify_host) {
+Error HTTPClientWeb::connect_to_host(const String &p_host, int p_port, bool p_tls, bool p_verify_host) {
 	close();
-	if (p_ssl && !p_verify_host) {
+	if (p_tls && !p_verify_host) {
 		WARN_PRINT("Disabling HTTPClientWeb's host verification is not supported for the Web platform, host will be verified");
 	}
 
 	port = p_port;
-	use_tls = p_ssl;
+	use_tls = p_tls;
 
 	host = p_host;
 

--- a/platform/web/http_client_web.h
+++ b/platform/web/http_client_web.h
@@ -86,7 +86,7 @@ public:
 
 	Error request(Method p_method, const String &p_url, const Vector<String> &p_headers, const uint8_t *p_body, int p_body_size) override;
 
-	Error connect_to_host(const String &p_host, int p_port = -1, bool p_ssl = false, bool p_verify_host = true) override;
+	Error connect_to_host(const String &p_host, int p_port = -1, bool p_tls = false, bool p_verify_host = true) override;
 	void set_connection(const Ref<StreamPeer> &p_connection) override;
 	Ref<StreamPeer> get_connection() const override;
 	void close() override;

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -48,7 +48,7 @@ public:
 		RESULT_CANT_CONNECT,
 		RESULT_CANT_RESOLVE,
 		RESULT_CONNECTION_ERROR,
-		RESULT_SSL_HANDSHAKE_ERROR,
+		RESULT_TLS_HANDSHAKE_ERROR,
 		RESULT_NO_RESPONSE,
 		RESULT_BODY_SIZE_LIMIT_EXCEEDED,
 		RESULT_BODY_DECOMPRESS_FAILED,
@@ -67,8 +67,8 @@ private:
 	String url;
 	int port = 80;
 	Vector<String> headers;
-	bool validate_ssl = false;
-	bool use_ssl = false;
+	bool validate_tls = false;
+	bool use_tls = false;
 	HTTPClient::Method method;
 	Vector<uint8_t> request_data;
 
@@ -121,8 +121,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	Error request(const String &p_url, const Vector<String> &p_custom_headers = Vector<String>(), bool p_ssl_validate_domain = true, HTTPClient::Method p_method = HTTPClient::METHOD_GET, const String &p_request_data = ""); //connects to a full url and perform request
-	Error request_raw(const String &p_url, const Vector<String> &p_custom_headers = Vector<String>(), bool p_ssl_validate_domain = true, HTTPClient::Method p_method = HTTPClient::METHOD_GET, const Vector<uint8_t> &p_request_data_raw = Vector<uint8_t>()); //connects to a full url and perform request
+	Error request(const String &p_url, const Vector<String> &p_custom_headers = Vector<String>(), bool p_tls_validate_domain = true, HTTPClient::Method p_method = HTTPClient::METHOD_GET, const String &p_request_data = ""); //connects to a full url and perform request
+	Error request_raw(const String &p_url, const Vector<String> &p_custom_headers = Vector<String>(), bool p_tls_validate_domain = true, HTTPClient::Method p_method = HTTPClient::METHOD_GET, const Vector<uint8_t> &p_request_data_raw = Vector<uint8_t>()); //connects to a full url and perform request
 	void cancel_request();
 	HTTPClient::Status get_http_client_status() const;
 


### PR DESCRIPTION
Follow-up on #65447 .
Also convert most references from SSL to TLS in docs.

CC @godotengine/documentation :

The tutorial URL also needs renaming in godot-docs.

We probably want to review if/where to use `SSL/TLS` over just `TLS` in the docs.

I feel like it make them clearer, but we might want to only use the combo in class descriptions? Or maybe just the HTTP* classes and methods (the web is the only place where "SSL" is still often wrongly used as a synonym to "TLS").