### PR TITLE
Bind all methods in PhysicsServer2DExtension, PhysicsServer3DExtension

### DIFF
--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -600,6 +600,21 @@
 			<description>
 			</description>
 		</method>
+		<method name="_end_sync" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_finish" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_flush_queries" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 		<method name="_free_rid" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
@@ -609,6 +624,16 @@
 		<method name="_get_process_info" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer2D.ProcessInfo" />
+			<description>
+			</description>
+		</method>
+		<method name="_init" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_is_flushing_queries" qualifiers="virtual const">
+			<return type="bool" />
 			<description>
 			</description>
 		</method>
@@ -765,6 +790,17 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
 			<param index="2" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_step" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="step" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_sync" qualifiers="virtual">
+			<return type="void" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -604,6 +604,21 @@
 			<description>
 			</description>
 		</method>
+		<method name="_end_sync" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_finish" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_flush_queries" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 		<method name="_free_rid" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
@@ -682,6 +697,16 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
 			<param index="2" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_init" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_is_flushing_queries" qualifiers="virtual const">
+			<return type="bool" />
 			<description>
 			</description>
 		</method>
@@ -898,6 +923,17 @@
 		</method>
 		<method name="_sphere_shape_create" qualifiers="virtual">
 			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_step" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="step" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_sync" qualifiers="virtual">
+			<return type="void" />
 			<description>
 			</description>
 		</method>

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -284,6 +284,14 @@ void PhysicsServer2DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_set_active, "active");
 
+	GDVIRTUAL_BIND(_init);
+	GDVIRTUAL_BIND(_step, "step");
+	GDVIRTUAL_BIND(_sync);
+	GDVIRTUAL_BIND(_flush_queries);
+	GDVIRTUAL_BIND(_end_sync);
+	GDVIRTUAL_BIND(_finish);
+
+	GDVIRTUAL_BIND(_is_flushing_queries);
 	GDVIRTUAL_BIND(_get_process_info, "process_info");
 }
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -315,6 +315,14 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_set_active, "active");
 
+	GDVIRTUAL_BIND(_init);
+	GDVIRTUAL_BIND(_step, "step");
+	GDVIRTUAL_BIND(_sync);
+	GDVIRTUAL_BIND(_flush_queries);
+	GDVIRTUAL_BIND(_end_sync);
+	GDVIRTUAL_BIND(_finish);
+
+	GDVIRTUAL_BIND(_is_flushing_queries);
 	GDVIRTUAL_BIND(_get_process_info, "process_info");
 }
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -537,8 +537,8 @@ public:
 	EXBIND0(init)
 	EXBIND1(step, real_t)
 	EXBIND0(sync)
-	EXBIND0(end_sync)
 	EXBIND0(flush_queries)
+	EXBIND0(end_sync)
 	EXBIND0(finish)
 
 	EXBIND0RC(bool, is_flushing_queries)


### PR DESCRIPTION
This is needed in order for `--dump-extension-api` to dump these methods as part of the API, which will allow `godot-cpp` to generate the respective virtual methods, which can then be overridden by a GDExtension.