### PR TITLE
Fix crash when executing `VisualShaderNodeParticleMeshEmitter.set_mesh` with headless Godot

### DIFF
--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -99,6 +99,7 @@ public:
 	virtual RS::SurfaceData mesh_get_surface(RID p_mesh, int p_surface) const override {
 		DummyMesh *m = mesh_owner.get_or_null(p_mesh);
 		ERR_FAIL_COND_V(!m, RS::SurfaceData());
+		ERR_FAIL_INDEX_V(p_surface, m->surfaces.size(), RS::SurfaceData());
 		RS::SurfaceData s = m->surfaces[p_surface];
 		return s;
 	}


### PR DESCRIPTION
Fixes #65458

Regular mesh storages all have such bound checks:

https://github.com/godotengine/godot/blob/019253512d75eb5e012772921ace6c092d8f5380/drivers/gles3/storage/mesh_storage.cpp#L338-L341
https://github.com/godotengine/godot/blob/019253512d75eb5e012772921ace6c092d8f5380/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp#L530-L533

Not using the unsigned version because the surface count of `DummyMesh` is `int` (vector size).