### PR TITLE
Fix crash when executing `SubViewport.set_size_2d_override_stretch`

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -9011,7 +9011,7 @@ VkSampleCountFlagBits RenderingDeviceVulkan::_ensure_supported_sample_count(Text
 		// Find the closest lower supported sample count.
 		VkSampleCountFlagBits sample_count = rasterization_sample_count[p_requested_sample_count];
 		while (sample_count > VK_SAMPLE_COUNT_1_BIT) {
-			if (sample_count_flags & rasterization_sample_count[sample_count]) {
+			if (sample_count_flags & sample_count) {
 				return sample_count;
 			}
 			sample_count = (VkSampleCountFlagBits)(sample_count >> 1);


### PR DESCRIPTION
Fixes #65456

I did not find a way to reproduce the crash, but the cause of the crash is quite obvious according to the crash log.

* `sample_count` is a `VkSampleCountFlagBits` enum, it's equal to the actual number of bits (1, 2, 4, 8, 16, ...).
* `rasterization_sample_count` is an array to map `TextureSamples` to `VkSampleCountFlagBits`.
* `p_requested_sample_count` is a `TextureSamples` enum, it can be used to index `rasterization_sample_count`.

So using `sample_count` to index `rasterization_sample_count` will result in a crash when it's greater than `TEXTURE_SAMPLES_MAX` (7).

`sample_count` should be used directly like in the other `if` branch.