### PR TITLE
Fix broken profiler in 4.0

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -104,6 +104,10 @@ void EditorProfiler::clear() {
 	updating_frame = false;
 	hover_metric = -1;
 	seeking = false;
+
+	// Ensure button text (start, stop) is correct
+	_set_button_text();
+	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
 static String _get_percent_txt(float p_value, float p_total) {
@@ -374,15 +378,23 @@ void EditorProfiler::_update_frame() {
 	updating_frame = false;
 }
 
-void EditorProfiler::_activate_pressed() {
+void EditorProfiler::_set_button_text() {
 	if (activate->is_pressed()) {
 		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Stop"));
-		_clear_pressed();
 	} else {
 		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Start"));
 	}
+}
+
+void EditorProfiler::_activate_pressed() {
+	_set_button_text();
+
+	if (activate->is_pressed()) {
+		_clear_pressed();
+	}
+
 	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
@@ -499,8 +511,12 @@ void EditorProfiler::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("break_request"));
 }
 
-void EditorProfiler::set_enabled(bool p_enable) {
+void EditorProfiler::set_enabled(bool p_enable, bool p_clear) {
+	activate->set_pressed(false);
 	activate->set_disabled(!p_enable);
+	if (p_clear) {
+		clear();
+	}
 }
 
 bool EditorProfiler::is_profiling() {

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -122,6 +122,7 @@ private:
 	Timer *frame_delay = nullptr;
 	Timer *plot_delay = nullptr;
 
+	void _set_button_text();
 	void _update_frame();
 
 	void _activate_pressed();
@@ -153,7 +154,7 @@ protected:
 
 public:
 	void add_frame_metric(const Metric &p_metric, bool p_final = false);
-	void set_enabled(bool p_enable);
+	void set_enabled(bool p_enable, bool p_clear = true);
 	bool is_profiling();
 	bool is_seeking() { return seeking; }
 	void disable_seeking();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -52,7 +52,6 @@
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "main/performance.h"
 #include "scene/3d/camera_3d.h"
-#include "scene/debugger/scene_debugger.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/label.h"
 #include "scene/gui/line_edit.h"
@@ -317,7 +316,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		if (!error.is_empty()) {
 			tabs->set_current_tab(0);
 		}
-		profiler->set_enabled(false);
+		profiler->set_enabled(false, false);
 		inspector->clear_cache(); // Take a chance to force remote objects update.
 
 	} else if (p_msg == "debug_exit") {
@@ -327,7 +326,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		_update_buttons_state();
 		_set_reason_text(TTR("Execution resumed."), MESSAGE_SUCCESS);
 		emit_signal(SNAME("breaked"), false, false, "", false);
-		profiler->set_enabled(true);
+		profiler->set_enabled(true, false);
 		profiler->disable_seeking();
 	} else if (p_msg == "set_pid") {
 		ERR_FAIL_COND(p_data.size() < 1);
@@ -916,6 +915,8 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	_clear_errors_list();
 	stop();
 
+	profiler->set_enabled(true, true);
+
 	peer = p_peer;
 	ERR_FAIL_COND(p_peer.is_null());
 
@@ -970,6 +971,8 @@ void ScriptEditorDebugger::stop() {
 	node_path_cache.clear();
 	res_path_cache.clear();
 	profiler_signature.clear();
+
+	profiler->set_enabled(true, false);
 
 	inspector->edit(nullptr);
 	_update_buttons_state();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
This is my stab at https://github.com/godotengine/godot/pull/59634. It is 99% @tavurth's solution, but I tweaked it a little in my 2nd commit to address the PR feedback from @Faless .

I wasn't exactly sure what the desired behaviours were in all cases, so let me know if I got anything wrong.
Here are the behaviours tested:

### No scene playing
| **Action** | **Result** |
| :---:|:---:|
| Editor opened (no scene playing) | Debugger is stopped, "Start" option is enabled |
| Debugger started (no scene playing) | Debugger is running*, "Stop" option is enabled |
| Debugger stopped (no scene playing) | Debugger is stopped, "Start" option is enabled|


### Scene playing
| **Action** | **Result** |
| :---:|:---:|
| Scene is played | Debugger is not running, "Start" option is enabled |
| Debugger is started | Debugger is running, "Stop" option is enabled |
| Scene is paused  | Debugger is paused, "Stop" option is disabled, graph is **not** cleared |
| Scene is unpaused  |Debugger is running, "Stop" option is enabled, graph is **not** cleared |
| Scene is stopped | Debugger is running*, "Stop" option is enabled, graph is **not** cleared|
| Scene is restarted | Debugger is stopped, "Start" option is enabled, graph **is** cleared  |

*but displays no output and doesn't advance any frames because nothing is running

## Note:
I would like to call specific attention to this row:
| **Action** | **Result** |
| :---:|:---:|
| Scene is played | Debugger is stopped, "Start" option is enabled |

This means that if you start the debugger BEFORE pressing "Play", when you play the scene the debugger will stop. I.e. you have to click "Start" on the debugger to get it running again for the current scene.

This means that if you want to profile the very first frame of your project, you will have to speedily click "Start" before the playing scene has finished loading. I don't know how important an issue this is, but its fiddly to fix and I didn't want to block this PR.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/44252