### PR TITLE
Document MultiMesh members

### DIFF
--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="MultiMesh" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Provides high-performance mesh instancing.
+		Provides high-performance drawing of a mesh multiple times using GPU instancing.
 	</brief_description>
 	<description>
 		MultiMesh provides low-level mesh instancing. Drawing thousands of [MeshInstance3D] nodes can be slow, since each object is submitted to the GPU then drawn individually.
 		MultiMesh is much faster as it can draw thousands of instances with a single draw call, resulting in less API overhead.
 		As a drawback, if the instances are too far away from each other, performance may be reduced as every single instance will always render (they are spatially indexed as one, for the whole object).
 		Since instances may have any behavior, the AABB used for visibility must be provided by the user.
+		[b]Note:[/b] A MultiMesh is a single object, therefore the same maximum lights per object restriction applies. This means, that once the maximum lights are consumed by one or more instances, the rest of the MultiMesh instances will [b]not[/b] receive any lighting.
+		[b]Note:[/b] Blend Shapes will be ignored if used in a MultiMesh.
 	</description>
 	<tutorials>
 		<link title="Animating thousands of fish with MultiMeshInstance">$DOCS_URL/tutorials/performance/vertex_animation/animating_thousands_of_fish.html</link>
@@ -24,7 +26,7 @@
 			<return type="Color" />
 			<param index="0" name="instance" type="int" />
 			<description>
-				Gets a specific instance's color.
+				Gets a specific instance's color multiplier.
 			</description>
 		</method>
 		<method name="get_instance_custom_data" qualifiers="const">
@@ -53,8 +55,8 @@
 			<param index="0" name="instance" type="int" />
 			<param index="1" name="color" type="Color" />
 			<description>
-				Sets the color of a specific instance by [i]multiplying[/i] the mesh's existing vertex colors.
-				For the color to take effect, ensure that [member use_colors] is [code]true[/code] on the [MultiMesh] and [member BaseMaterial3D.vertex_color_use_as_albedo] is [code]true[/code] on the material. If the color doesn't look as expected, make sure the material's albedo color is set to pure white ([code]Color(1, 1, 1)[/code]).
+				Sets the color of a specific instance by [i]multiplying[/i] the mesh's existing vertex colors. This allows for different color tinting per instance.
+				For the color to take effect, ensure that [member use_colors] is [code]true[/code] on the [MultiMesh] and [member BaseMaterial3D.vertex_color_use_as_albedo] is [code]true[/code] on the material. If you intend to set an absolute color instead of tinting, make sure the material's albedo color is set to pure white ([code]Color(1, 1, 1)[/code]).
 			</description>
 		</method>
 		<method name="set_instance_custom_data">
@@ -64,6 +66,7 @@
 			<description>
 				Sets custom data for a specific instance. Although [Color] is used, it is just a container for 4 floating point numbers.
 				For the custom data to be used, ensure that [member use_custom_data] is [code]true[/code].
+				This custom instance data has to be manually accessed in your custom shader using [code]INSTANCE_CUSTOM[/code].
 			</description>
 		</method>
 		<method name="set_instance_transform">
@@ -87,28 +90,33 @@
 		<member name="buffer" type="PackedFloat32Array" setter="set_buffer" getter="get_buffer" default="PackedFloat32Array()">
 		</member>
 		<member name="color_array" type="PackedColorArray" setter="_set_color_array" getter="_get_color_array">
+			See [method set_instance_color].
 		</member>
 		<member name="custom_data_array" type="PackedColorArray" setter="_set_custom_data_array" getter="_get_custom_data_array">
+			See [method set_instance_custom_data].
 		</member>
 		<member name="instance_count" type="int" setter="set_instance_count" getter="get_instance_count" default="0">
 			Number of instances that will get drawn. This clears and (re)sizes the buffers. Setting data format or flags afterwards will have no effect.
 			By default, all instances are drawn but you can limit this with [member visible_instance_count].
 		</member>
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
-			Mesh to be drawn.
+			[Mesh] resource to be instanced.
+			The looks of the individual instances can be modified using [method set_instance_color] and [method set_instance_custom_data].
 		</member>
 		<member name="transform_2d_array" type="PackedVector2Array" setter="_set_transform_2d_array" getter="_get_transform_2d_array">
+			See [method set_instance_transform_2d].
 		</member>
 		<member name="transform_array" type="PackedVector3Array" setter="_set_transform_array" getter="_get_transform_array">
+			See [method set_instance_transform].
 		</member>
 		<member name="transform_format" type="int" setter="set_transform_format" getter="get_transform_format" enum="MultiMesh.TransformFormat" default="0">
 			Format of transform used to transform mesh, either 2D or 3D.
 		</member>
 		<member name="use_colors" type="bool" setter="set_use_colors" getter="is_using_colors" default="false">
-			If [code]true[/code], the [MultiMesh] will use color data (see [member color_array]).
+			If [code]true[/code], the [MultiMesh] will use color data (see [method set_instance_color]). Can only be set when [member instance_count] is [code]0[/code] or less. This means that you need to call this method before setting the instance count, or temporarily reset it to [code]0[/code].
 		</member>
 		<member name="use_custom_data" type="bool" setter="set_use_custom_data" getter="is_using_custom_data" default="false">
-			If [code]true[/code], the [MultiMesh] will use custom data (see [member custom_data_array]).
+			If [code]true[/code], the [MultiMesh] will use custom data (see [method set_instance_custom_data]). Can only be set when [member instance_count] is [code]0[/code] or less. This means that you need to call this method before setting the instance count, or temporarily reset it to [code]0[/code].
 		</member>
 		<member name="visible_instance_count" type="int" setter="set_visible_instance_count" getter="get_visible_instance_count" default="-1">
 			Limits the number of instances drawn, -1 draws all instances. Changing this does not change the sizes of the buffers.


### PR DESCRIPTION
now all members are described, except for `buffer`, because there are 2 `MeshStorage::multimesh_set_buffer` (one for gles3 and the other Vulkan, I reckon). Former respects e.g. custom color and data, while the latter is only concerned with data cache and aabb… Not sure how to describe this in any useful and concise way

Note: blend shape info comes from https://github.com/godotengine/godot/issues/15778#issuecomment-944393517

Fixes #44912, if it's only left open for documentation purposes (handled in 2nd commit in this PR)