### PR TITLE
Fix right-click edit/inspect menu display context

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3920,7 +3920,7 @@ void EditorNode::edit_foreign_resource(Ref<Resource> p_resource) {
 	InspectorDock::get_singleton()->call_deferred("edit_resource", p_resource);
 }
 
-bool EditorNode::is_resource_read_only(Ref<Resource> p_resource) {
+bool EditorNode::is_resource_read_only(Ref<Resource> p_resource, bool p_foreign_resources_are_writable) {
 	ERR_FAIL_COND_V(p_resource.is_null(), false);
 
 	String path = p_resource->get_path();
@@ -3932,7 +3932,11 @@ bool EditorNode::is_resource_read_only(Ref<Resource> p_resource) {
 			// If the base resource is a packed scene, we treat it as read-only if it is not the currently edited scene.
 			if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 				if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
-					return true;
+					// If we have not flagged foreign resources as writable or the base scene the resource is
+					// part was imported, it can be considered read-only.
+					if (!p_foreign_resources_are_writable || FileAccess::exists(base + ".import")) {
+						return true;
+					}
 				}
 			} else {
 				// If a corresponding .import file exists for the base file, we assume it to be imported and should therefore treated as read-only.

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -784,7 +784,7 @@ public:
 	void open_request(const String &p_path);
 	void edit_foreign_resource(Ref<Resource> p_resource);
 
-	bool is_resource_read_only(Ref<Resource> p_resource);
+	bool is_resource_read_only(Ref<Resource> p_resource, bool p_foreign_resources_are_writable = false);
 
 	bool is_changing_scene() const;
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -186,7 +186,7 @@ void EditorResourcePicker::_update_menu_items() {
 	// Add options for changing existing value of the resource.
 	if (edited_resource.is_valid()) {
 		// Determine if the edited resource is part of another scene (foreign) which was imported
-		bool is_edited_resource_foreign_import = EditorNode::get_singleton()->is_resource_read_only(edited_resource);
+		bool is_edited_resource_foreign_import = EditorNode::get_singleton()->is_resource_read_only(edited_resource, true);
 
 		// If the resource is determined to be foreign and imported, change the menu entry's description to 'inspect' rather than 'edit'
 		// since will only be able to view its properties in read-only mode.


### PR DESCRIPTION
Fixes the right-click menu showing the 'inspect' button on resource embedded in editable scenes when it should show 'edit' since the option will open the respective scene and resource for editing. 'Inspect' should be reserved for non-editable resource such as those directly from the import system.
![q6JEWaQYM2](https://user-images.githubusercontent.com/12756047/188960159-0df959aa-7ffe-4887-8301-072206037cc5.png)
