### PR TITLE
Fix 'Make Unique' on AnimationLibrary not applying to embedded animations.

### DIFF
--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -198,11 +198,17 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 		} break;
 		case FILE_MENU_MAKE_LIBRARY_UNIQUE: {
 			StringName lib_name = file_dialog_library;
+			List<StringName> animation_list;
 
-			Ref<AnimationLibrary> ald = al->duplicate();
-
-			// TODO: should probably make all foreign animations assigned to this library
-			// unique too.
+			Ref<AnimationLibrary> ald = memnew(AnimationLibrary);
+			al->get_animation_list(&animation_list);
+			for (const StringName &animation_name : animation_list) {
+				Ref<Animation> animation = al->get_animation(animation_name);
+				if (EditorNode::get_singleton()->is_resource_read_only(animation)) {
+					animation = animation->duplicate();
+				}
+				ald->add_animation(animation_name, animation);
+			}
 
 			Ref<EditorUndoRedoManager> undo_redo = EditorNode::get_singleton()->get_undo_redo();
 			undo_redo->create_action(vformat(TTR("Make Animation Library Unique: %s"), lib_name));

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -283,26 +283,7 @@ void AnimationPlayerEditor::_animation_selected(int p_which) {
 
 		Ref<Animation> anim = player->get_animation(current);
 		{
-			bool animation_library_is_foreign = false;
-			if (!anim->get_path().is_resource_file()) {
-				int srpos = anim->get_path().find("::");
-				if (srpos != -1) {
-					String base = anim->get_path().substr(0, srpos);
-					if (ResourceLoader::get_resource_type(base) == "PackedScene") {
-						if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
-							animation_library_is_foreign = true;
-						}
-					} else {
-						if (FileAccess::exists(base + ".import")) {
-							animation_library_is_foreign = true;
-						}
-					}
-				}
-			} else {
-				if (FileAccess::exists(anim->get_path() + ".import")) {
-					animation_library_is_foreign = true;
-				}
-			}
+			bool animation_library_is_foreign = EditorNode::get_singleton()->is_resource_read_only(anim);
 
 			track_editor->set_animation(anim, animation_library_is_foreign);
 			Node *root = player->get_node(player->get_root());
@@ -773,26 +754,7 @@ void AnimationPlayerEditor::_animation_edit() {
 	if (current != String()) {
 		Ref<Animation> anim = player->get_animation(current);
 
-		bool animation_library_is_foreign = false;
-		if (!anim->get_path().is_resource_file()) {
-			int srpos = anim->get_path().find("::");
-			if (srpos != -1) {
-				String base = anim->get_path().substr(0, srpos);
-				if (ResourceLoader::get_resource_type(base) == "PackedScene") {
-					if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
-						animation_library_is_foreign = true;
-					}
-				} else {
-					if (FileAccess::exists(base + ".import")) {
-						animation_library_is_foreign = true;
-					}
-				}
-			}
-		} else {
-			if (FileAccess::exists(anim->get_path() + ".import")) {
-				animation_library_is_foreign = true;
-			}
-		}
+		bool animation_library_is_foreign = EditorNode::get_singleton()->is_resource_read_only(anim);
 
 		track_editor->set_animation(anim, animation_library_is_foreign);
 
@@ -866,25 +828,7 @@ void AnimationPlayerEditor::_update_player() {
 		// Check if the global library is foreign since we want to disable options for adding/remove/renaming animations if it is.
 		Ref<AnimationLibrary> library = player->get_animation_library(K);
 		if (K == "") {
-			if (!library->get_path().is_resource_file()) {
-				int srpos = library->get_path().find("::");
-				if (srpos != -1) {
-					String base = library->get_path().substr(0, srpos);
-					if (ResourceLoader::get_resource_type(base) == "PackedScene") {
-						if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
-							foreign_global_anim_lib = true;
-						}
-					} else {
-						if (FileAccess::exists(base + ".import")) {
-							foreign_global_anim_lib = true;
-						}
-					}
-				}
-			} else {
-				if (FileAccess::exists(library->get_path() + ".import")) {
-					foreign_global_anim_lib = true;
-				}
-			}
+			foreign_global_anim_lib = EditorNode::get_singleton()->is_resource_read_only(library);
 		}
 
 		List<StringName> animlist;
@@ -950,26 +894,7 @@ void AnimationPlayerEditor::_update_player() {
 		String current = animation->get_item_text(animation->get_selected());
 		Ref<Animation> anim = player->get_animation(current);
 
-		bool animation_library_is_foreign = false;
-		if (!anim->get_path().is_resource_file()) {
-			int srpos = anim->get_path().find("::");
-			if (srpos != -1) {
-				String base = anim->get_path().substr(0, srpos);
-				if (ResourceLoader::get_resource_type(base) == "PackedScene") {
-					if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
-						animation_library_is_foreign = true;
-					}
-				} else {
-					if (FileAccess::exists(base + ".import")) {
-						animation_library_is_foreign = true;
-					}
-				}
-			}
-		} else {
-			if (FileAccess::exists(anim->get_path() + ".import")) {
-				animation_library_is_foreign = true;
-			}
-		}
+		bool animation_library_is_foreign = EditorNode::get_singleton()->is_resource_read_only(anim);
 
 		track_editor->set_animation(anim, animation_library_is_foreign);
 		Node *root = player->get_node(player->get_root());


### PR DESCRIPTION
Fixes the AnimationEditor's AnimationLibrary so that using the 'make unique' function will also duplicate any resources embedded inside the animation library. It also refactors AnimationEditor's plugin to use the internal read-only functions which reduces code duplication.