### PR TITLE
Fix several oddities in Project Converter

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1550,7 +1550,6 @@ static const char *class_renames[][2] = {
 	{ nullptr, nullptr },
 };
 
-// TODO - this colors needs to be validated(not all are valid)
 static const char *color_renames[][2] = {
 	{ "aliceblue", "ALICE_BLUE" },
 	{ "antiquewhite", "ANTIQUE_WHITE" },
@@ -1704,7 +1703,7 @@ static const char *color_renames[][2] = {
 
 class ProjectConverter3To4::RegExContainer {
 public:
-	// Custom GDScript
+	// Custom GDScript.
 	RegEx reg_is_empty = RegEx("\\bempty\\(");
 	RegEx reg_super = RegEx("([\t ])\\.([a-zA-Z_])");
 	RegEx reg_json_to = RegEx("\\bto_json\\b");
@@ -1721,7 +1720,7 @@ public:
 	RegEx reg_os_fullscreen = RegEx("OS.window_fullscreen[= ]+([^#^\n]+)");
 	RegEx reg_instantiate = RegEx("\\.instance\\(([^\\)]*)\\)");
 
-	// GDScript keywords
+	// GDScript keywords.
 	RegEx keyword_gdscript_tool = RegEx("^tool");
 	RegEx keyword_gdscript_export_single = RegEx("^export");
 	RegEx keyword_gdscript_export_mutli = RegEx("([\t]+)export\\b");
@@ -1735,7 +1734,7 @@ public:
 	RegEx keyword_gdscript_master = RegEx("^master func");
 	RegEx keyword_gdscript_mastersync = RegEx("^mastersync func");
 
-	// CSharp keywords
+	// CSharp keywords.
 	RegEx keyword_csharp_remote = RegEx("\\[Remote(Attribute)?(\\(\\))?\\]");
 	RegEx keyword_csharp_remotesync = RegEx("\\[(Remote)?Sync(Attribute)?(\\(\\))?\\]");
 	RegEx keyword_csharp_puppet = RegEx("\\[(Puppet|Slave)(Attribute)?(\\(\\))?\\]");
@@ -1743,11 +1742,11 @@ public:
 	RegEx keyword_csharp_master = RegEx("\\[Master(Attribute)?(\\(\\))?\\]");
 	RegEx keyword_csharp_mastersync = RegEx("\\[MasterSync(Attribute)?(\\(\\))?\\]");
 
-	// Colors
+	// Colors.
 	LocalVector<RegEx *> color_regexes;
 	LocalVector<String> color_renamed;
 
-	// Classes
+	// Classes.
 	LocalVector<RegEx *> class_tscn_regexes;
 	LocalVector<RegEx *> class_gd_regexes;
 	LocalVector<RegEx *> class_shader_regexes;
@@ -1762,7 +1761,7 @@ public:
 	LocalVector<String> class_temp_gd_renames;
 	LocalVector<String> class_temp_shader_renames;
 
-	// Common
+	// Common.
 	LocalVector<RegEx *> enum_regexes;
 	LocalVector<RegEx *> gdscript_function_regexes;
 	LocalVector<RegEx *> project_settings_regexes;
@@ -1775,58 +1774,58 @@ public:
 	LocalVector<RegEx *> csharp_signal_regexes;
 
 	RegExContainer() {
-		// Common
+		// Common.
 		{
-			// Enum
+			// Enum.
 			for (unsigned int current_index = 0; enum_renames[current_index][0]; current_index++) {
 				enum_regexes.push_back(memnew(RegEx(String("\\b") + enum_renames[current_index][0] + "\\b")));
 			}
-			// GDScript functions
+			// GDScript functions.
 			for (unsigned int current_index = 0; gdscript_function_renames[current_index][0]; current_index++) {
 				gdscript_function_regexes.push_back(memnew(RegEx(String("\\b") + gdscript_function_renames[current_index][0] + "\\b")));
 			}
-			// Project Settings
+			// Project Settings.
 			for (unsigned int current_index = 0; project_settings_renames[current_index][0]; current_index++) {
 				project_settings_regexes.push_back(memnew(RegEx(String("\\b") + project_settings_renames[current_index][0] + "\\b")));
 			}
-			// GDScript properties
+			// GDScript properties.
 			for (unsigned int current_index = 0; gdscript_properties_renames[current_index][0]; current_index++) {
 				gdscript_properties_regexes.push_back(memnew(RegEx(String("\\b") + gdscript_properties_renames[current_index][0] + "\\b")));
 			}
-			// GDScript Signals
+			// GDScript Signals.
 			for (unsigned int current_index = 0; gdscript_signals_renames[current_index][0]; current_index++) {
 				gdscript_signals_regexes.push_back(memnew(RegEx(String("\\b") + gdscript_signals_renames[current_index][0] + "\\b")));
 			}
-			// Shaders
+			// Shaders.
 			for (unsigned int current_index = 0; shaders_renames[current_index][0]; current_index++) {
 				shaders_regexes.push_back(memnew(RegEx(String("\\b") + shaders_renames[current_index][0] + "\\b")));
 			}
-			// Builtin types
+			// Builtin types.
 			for (unsigned int current_index = 0; builtin_types_renames[current_index][0]; current_index++) {
 				builtin_types_regexes.push_back(memnew(RegEx(String("\\b") + builtin_types_renames[current_index][0] + "\\b")));
 			}
-			// CSharp function renames
+			// CSharp function renames.
 			for (unsigned int current_index = 0; csharp_function_renames[current_index][0]; current_index++) {
 				csharp_function_regexes.push_back(memnew(RegEx(String("\\b") + csharp_function_renames[current_index][0] + "\\b")));
 			}
-			// CSharp properties renames
+			// CSharp properties renames.
 			for (unsigned int current_index = 0; csharp_properties_renames[current_index][0]; current_index++) {
 				csharp_properties_regexes.push_back(memnew(RegEx(String("\\b") + csharp_properties_renames[current_index][0] + "\\b")));
 			}
-			// CSharp signals renames
+			// CSharp signals renames.
 			for (unsigned int current_index = 0; csharp_signals_renames[current_index][0]; current_index++) {
 				csharp_signal_regexes.push_back(memnew(RegEx(String("\\b") + csharp_signals_renames[current_index][0] + "\\b")));
 			}
 		}
 
-		// Colors
+		// Colors.
 		{
 			for (unsigned int current_index = 0; color_renames[current_index][0]; current_index++) {
 				color_regexes.push_back(memnew(RegEx(String("\\bColor.") + color_renames[current_index][0] + "\\b")));
 				color_renamed.push_back(String("Color.") + color_renames[current_index][1]);
 			}
 		}
-		// Classes
+		// Classes.
 		{
 			for (unsigned int current_index = 0; class_renames[current_index][0]; current_index++) {
 				class_tscn_regexes.push_back(memnew(RegEx(String("\\b") + class_renames[current_index][0] + ".tscn\\b")));
@@ -1884,12 +1883,12 @@ public:
 	}
 };
 
-ProjectConverter3To4::ProjectConverter3To4(int maximum_file_size_kb, int maximum_line_length) {
-	this->maximum_file_size = maximum_file_size_kb * 1024;
-	this->maximum_line_length = maximum_line_length;
+ProjectConverter3To4::ProjectConverter3To4(int p_maximum_file_size_kb, int p_maximum_line_length) {
+	maximum_file_size = p_maximum_file_size_kb * 1024;
+	maximum_line_length = p_maximum_line_length;
 }
 
-// Function responsible for converting project
+// Function responsible for converting project.
 int ProjectConverter3To4::convert() {
 	print_line("Starting conversion.");
 	uint64_t conversion_start_time = Time::get_singleton()->get_ticks_msec();
@@ -1897,7 +1896,7 @@ int ProjectConverter3To4::convert() {
 	RegExContainer reg_container = RegExContainer();
 
 	int cached_maximum_line_length = maximum_line_length;
-	maximum_line_length = 10000; // Use only for tests bigger value, to not break them
+	maximum_line_length = 10000; // Use only for tests bigger value, to not break them.
 
 	ERR_FAIL_COND_V_MSG(!test_array_names(), ERROR_CODE, "Cannot start converting due to problems with data in arrays.");
 	ERR_FAIL_COND_V_MSG(!test_conversion(reg_container), ERROR_CODE, "Cannot start converting due to problems with converting arrays.");
@@ -1905,36 +1904,36 @@ int ProjectConverter3To4::convert() {
 	maximum_line_length = cached_maximum_line_length;
 
 	// Checking if folder contains valid Godot 3 project.
-	// Project should not be converted more than 1 times
+	// Project should not be converted more than once.
 	{
-		String conventer_text = "; Project was converted by built-in tool to Godot 4.0";
+		String converter_text = "; Project was converted by built-in tool to Godot 4.0";
 
-		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), ERROR_CODE, "Current directory doesn't contains any Godot 3 project");
+		ERR_FAIL_COND_V_MSG(!FileAccess::exists("project.godot"), ERROR_CODE, "Current working directory doesn't contain a \"project.godot\" file for a Godot 3 project.");
 
 		Error err = OK;
 		String project_godot_content = FileAccess::get_file_as_string("project.godot", &err);
 
-		ERR_FAIL_COND_V_MSG(err != OK, ERROR_CODE, "Failed to read content of \"project.godot\" file.");
-		ERR_FAIL_COND_V_MSG(project_godot_content.contains(conventer_text), ERROR_CODE, "Project already was converted with this tool.");
+		ERR_FAIL_COND_V_MSG(err != OK, ERROR_CODE, "Unable to read \"project.godot\".");
+		ERR_FAIL_COND_V_MSG(project_godot_content.contains(converter_text), ERROR_CODE, "Project was already converted with this tool.");
 
 		Ref<FileAccess> file = FileAccess::open("project.godot", FileAccess::WRITE);
-		ERR_FAIL_COND_V_MSG(file.is_null(), ERROR_CODE, "Failed to open project.godot file.");
+		ERR_FAIL_COND_V_MSG(file.is_null(), ERROR_CODE, "Unable to open \"project.godot\".");
 
-		file->store_string(conventer_text + "\n" + project_godot_content);
+		file->store_string(converter_text + "\n" + project_godot_content);
 	}
 
 	Vector<String> collected_files = check_for_files();
 
 	uint32_t converted_files = 0;
 
-	// Check file by file
+	// Check file by file.
 	for (int i = 0; i < collected_files.size(); i++) {
 		String file_name = collected_files[i];
 		Vector<String> lines;
 		uint32_t ignored_lines = 0;
 		{
 			Ref<FileAccess> file = FileAccess::open(file_name, FileAccess::READ);
-			ERR_CONTINUE_MSG(file.is_null(), "Failed to read content of \"" + file_name + "\".");
+			ERR_CONTINUE_MSG(file.is_null(), vformat("Unable to read content of \"%s\".", file_name));
 			while (!file->eof_reached()) {
 				String line = file->get_line();
 				lines.append(line);
@@ -1943,7 +1942,7 @@ int ProjectConverter3To4::convert() {
 		String file_content_before = collect_string_from_vector(lines);
 		uint64_t hash_before = file_content_before.hash();
 		uint64_t file_size = file_content_before.size();
-		print_line("Trying to convert\t" + itos(i + 1) + "/" + itos(collected_files.size()) + " file - \"" + file_name.trim_prefix("res://") + "\" with size - " + itos(file_size / 1024) + " KB");
+		print_line(vformat("Trying to convert\t%d/%d file - \"%s\" with size - %d KB", i + 1, collected_files.size(), file_name.trim_prefix("res://"), file_size / 1024));
 
 		Vector<String> reason;
 		bool is_ignored = false;
@@ -1955,15 +1954,15 @@ int ProjectConverter3To4::convert() {
 		}
 
 		if (file_size < uint64_t(maximum_file_size)) {
-			// TSCN must be the same work exactly same as .gd file because it may contains builtin script
+			// ".tscn" must work exactly the same as ".gd" files because they may contain built-in Scripts.
 			if (file_name.ends_with(".gd")) {
-				rename_classes(lines, reg_container); // Using only specialized function
+				rename_classes(lines, reg_container); // Using only specialized function.
 
 				rename_common(enum_renames, reg_container.enum_regexes, lines);
-				rename_colors(lines, reg_container); // Require to additional rename
+				rename_colors(lines, reg_container); // Require to additional rename.
 
 				rename_common(gdscript_function_renames, reg_container.gdscript_function_regexes, lines);
-				rename_gdscript_functions(lines, reg_container, false); // Require to additional rename
+				rename_gdscript_functions(lines, reg_container, false); // Require to additional rename.
 
 				rename_common(project_settings_renames, reg_container.project_settings_regexes, lines);
 				rename_gdscript_keywords(lines, reg_container);
@@ -1974,13 +1973,13 @@ int ProjectConverter3To4::convert() {
 
 				custom_rename(lines, "\\.shader", ".gdshader");
 			} else if (file_name.ends_with(".tscn")) {
-				rename_classes(lines, reg_container); // Using only specialized function
+				rename_classes(lines, reg_container); // Using only specialized function.
 
 				rename_common(enum_renames, reg_container.enum_regexes, lines);
-				rename_colors(lines, reg_container); // Require to additional rename
+				rename_colors(lines, reg_container); // Require to do additional renames.
 
 				rename_common(gdscript_function_renames, reg_container.gdscript_function_regexes, lines);
-				rename_gdscript_functions(lines, reg_container, true); // Require to additional rename
+				rename_gdscript_functions(lines, reg_container, true); // Require to do additional renames.
 
 				rename_common(project_settings_renames, reg_container.project_settings_regexes, lines);
 				rename_gdscript_keywords(lines, reg_container);
@@ -1990,8 +1989,8 @@ int ProjectConverter3To4::convert() {
 				rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines);
 
 				custom_rename(lines, "\\.shader", ".gdshader");
-			} else if (file_name.ends_with(".cs")) { // TODO, C# should use different methods
-				rename_classes(lines, reg_container); // Using only specialized function
+			} else if (file_name.ends_with(".cs")) { // TODO, C# should use different methods.
+				rename_classes(lines, reg_container); // Using only specialized function.
 				rename_common(csharp_function_renames, reg_container.csharp_function_regexes, lines);
 				rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines);
 				rename_common(csharp_properties_renames, reg_container.csharp_properties_regexes, lines);
@@ -2002,7 +2001,7 @@ int ProjectConverter3To4::convert() {
 			} else if (file_name.ends_with(".gdshader") || file_name.ends_with(".shader")) {
 				rename_common(shaders_renames, reg_container.shaders_regexes, lines);
 			} else if (file_name.ends_with("tres")) {
-				rename_classes(lines, reg_container); // Using only specialized function
+				rename_classes(lines, reg_container); // Using only specialized function.
 
 				rename_common(shaders_renames, reg_container.shaders_regexes, lines);
 				rename_common(builtin_types_renames, reg_container.builtin_types_regexes, lines);
@@ -2024,41 +2023,40 @@ int ProjectConverter3To4::convert() {
 				}
 			}
 		} else {
-			reason.append("    ERROR: File has exceeded the maximum size allowed - " + itos(maximum_file_size / 1024) + " KB");
+			reason.append(vformat("    ERROR: File has exceeded the maximum size allowed - %d KB", maximum_file_size / 1024));
 			is_ignored = true;
 		}
 
 		uint64_t end_time = Time::get_singleton()->get_ticks_msec();
 		if (is_ignored) {
-			String end_message = "    Checking file took " + itos(end_time - start_time) + " ms.";
+			String end_message = vformat("    Checking file took %d ms.", end_time - start_time);
 			print_line(end_message);
 		} else {
 			String file_content_after = collect_string_from_vector(lines);
 			uint64_t hash_after = file_content_after.hash64();
-			// Don't need to save file without any changes
-			// Save if this is a shader, because it was renamed
+			// Don't need to save file without any changes.
+			// Save if this is a shader, because it was renamed.
 			if (hash_before != hash_after || file_name.ends_with(".gdshader")) {
 				converted_files++;
 
 				Ref<FileAccess> file = FileAccess::open(file_name, FileAccess::WRITE);
-				ERR_CONTINUE_MSG(file.is_null(), "Failed to open \"" + file_name + "\" to save data to file.");
+				ERR_CONTINUE_MSG(file.is_null(), vformat("Unable to apply changes to \"%s\", no writing access.", file_name));
 				file->store_string(file_content_after);
-				reason.append("    File was changed, conversion took " + itos(end_time - start_time) + " ms.");
+				reason.append(vformat("    File was changed, conversion took %d ms.", end_time - start_time));
 			} else {
-				reason.append("    File was not changed, checking took " + itos(end_time - start_time) + " ms.");
+				reason.append(vformat("    File was left unchanged, checking took %d ms.", end_time - start_time));
 			}
 			if (ignored_lines != 0) {
-				reason.append("    Ignored " + itos(ignored_lines) + " lines, because their length exceeds maximum allowed characters - " + itos(maximum_line_length));
+				reason.append(vformat("    Ignored %d lines, because their length exceeds maximum allowed characters - %d.", ignored_lines, maximum_line_length));
 			}
 		}
 		for (int k = 0; k < reason.size(); k++) {
 			print_line(reason[k]);
 		}
 	}
-
-	print_line("Conversion ended - all files(" + itos(collected_files.size()) + "), converted files(" + itos(converted_files) + "), not converted files(" + itos(collected_files.size() - converted_files) + ").");
+	print_line(vformat("Conversion ended - all files(%d), converted files: (%d), not converted files: (%d).", collected_files.size(), converted_files, collected_files.size() - converted_files));
 	uint64_t conversion_end_time = Time::get_singleton()->get_ticks_msec();
-	print_line("Conversion of all files took " + itos(conversion_end_time - conversion_start_time) + " ms.");
+	print_line(vformat("Conversion of all files took %10.3f seconds.", (conversion_end_time - conversion_start_time) / 1000.0));
 	return 0;
 };
 
@@ -2070,7 +2068,7 @@ int ProjectConverter3To4::validate_conversion() {
 	RegExContainer reg_container = RegExContainer();
 
 	int cached_maximum_line_length = maximum_line_length;
-	maximum_line_length = 10000; // Use only for tests bigger value, to not break them
+	maximum_line_length = 10000; // To avoid breaking the tests, only use this for the their larger value.
 
 	ERR_FAIL_COND_V_MSG(!test_array_names(), ERROR_CODE, "Cannot start converting due to problems with data in arrays.");
 	ERR_FAIL_COND_V_MSG(!test_conversion(reg_container), ERROR_CODE, "Cannot start converting due to problems with converting arrays.");
@@ -2078,7 +2076,7 @@ int ProjectConverter3To4::validate_conversion() {
 	maximum_line_length = cached_maximum_line_length;
 
 	// Checking if folder contains valid Godot 3 project.
-	// Project should not be converted more than 1 times
+	// Project should not be converted more than once.
 	{
 		String conventer_text = "; Project was converted by built-in tool to Godot 4.0";
 
@@ -2095,7 +2093,7 @@ int ProjectConverter3To4::validate_conversion() {
 
 	uint32_t converted_files = 0;
 
-	// Check file by file
+	// Check file by file.
 	for (int i = 0; i < collected_files.size(); i++) {
 		String file_name = collected_files[i];
 		Vector<String> lines;
@@ -2103,14 +2101,14 @@ int ProjectConverter3To4::validate_conversion() {
 		uint64_t file_size = 0;
 		{
 			Ref<FileAccess> file = FileAccess::open(file_name, FileAccess::READ);
-			ERR_CONTINUE_MSG(file.is_null(), "Failed to read content of \"" + file_name + "\".");
+			ERR_CONTINUE_MSG(file.is_null(), vformat("Unable to read content of \"%s\".", file_name));
 			while (!file->eof_reached()) {
 				String line = file->get_line();
 				file_size += line.size();
 				lines.append(line);
 			}
 		}
-		print_line("Checking for conversion - " + itos(i + 1) + "/" + itos(collected_files.size()) + " file - \"" + file_name.trim_prefix("res://") + "\" with size - " + itos(file_size / 1024) + " KB");
+		print_line(vformat("Checking for conversion - %d/%d file - \"%s\" with size - %d KB"), i + 1, collected_files.size(), file_name.trim_prefix("res://"), file_size / 1024);
 
 		Vector<String> changed_elements;
 		Vector<String> reason;
@@ -2118,7 +2116,7 @@ int ProjectConverter3To4::validate_conversion() {
 		uint64_t start_time = Time::get_singleton()->get_ticks_msec();
 
 		if (file_name.ends_with(".shader")) {
-			reason.append("\tFile extension will be renamed from `shader` to `gdshader`.");
+			reason.append("\tFile extension will be renamed from \"shader\" to \"gdshader\".");
 		}
 
 		if (file_size < uint64_t(maximum_file_size)) {
@@ -2180,7 +2178,7 @@ int ProjectConverter3To4::validate_conversion() {
 			} else if (file_name.ends_with(".csproj")) {
 				// TODO
 			} else {
-				ERR_PRINT(file_name + " is not supported!");
+				ERR_PRINT(vformat("\"%s\", is not supported!", file_name));
 				continue;
 			}
 
@@ -2190,14 +2188,14 @@ int ProjectConverter3To4::validate_conversion() {
 				}
 			}
 		} else {
-			reason.append("\tERROR: File has exceeded the maximum size allowed  - " + itos(maximum_file_size / 1024) + " KB");
+			reason.append(vformat("\tERROR: File has exceeded the maximum size allowed  - %d KB.", maximum_file_size / 1024));
 			is_ignored = true;
 		}
 
 		uint64_t end_time = Time::get_singleton()->get_ticks_msec();
-		String end_message = "    Checking file took " + itos(end_time - start_time) + " ms.";
+		String end_message = vformat("    Checking file took %10.3f ms.", (end_time - start_time) / 1000.0);
 		if (ignored_lines != 0) {
-			end_message += " Ignored " + itos(ignored_lines) + " lines, because their length exceeds maximum allowed characters - " + itos(maximum_line_length);
+			end_message += vformat(" Ignored %d lines, because their length exceeds maximum allowed characters - %d.", ignored_lines, maximum_line_length);
 		}
 		print_line(end_message);
 
@@ -2214,13 +2212,13 @@ int ProjectConverter3To4::validate_conversion() {
 		}
 	}
 
-	print_line("Checking for valid conversion ended - all files(" + itos(collected_files.size()) + "), files which would be converted(" + itos(converted_files) + "), files which would not be converted(" + itos(collected_files.size() - converted_files) + ").");
+	print_line(vformat("Checking for valid conversion ended - all files(%d), files which would be converted(%d), files which would not be converted(%d).", collected_files.size(), converted_files, collected_files.size() - converted_files));
 	uint64_t conversion_end_time = Time::get_singleton()->get_ticks_msec();
-	print_line("Conversion of all files took " + itos(conversion_end_time - conversion_start_time) + " ms.");
+	print_line(vformat("Conversion of all files took %10.3f seconds.", (conversion_end_time - conversion_start_time) / 1000.0));
 	return 0;
 }
 
-// Collect files which will be checked, it will not touch txt, mp4, wav etc. files
+// Collect files which will be checked, excluding ".txt", ".mp4", ".wav" etc. files.
 Vector<String> ProjectConverter3To4::check_for_files() {
 	Vector<String> collected_files = Vector<String>();
 
@@ -2230,7 +2228,7 @@ Vector<String> ProjectConverter3To4::check_for_files() {
 	core_bind::Directory dir = core_bind::Directory();
 	while (!directories_to_check.is_empty()) {
 		String path = directories_to_check.get(directories_to_check.size() - 1); // Is there any pop_back function?
-		directories_to_check.resize(directories_to_check.size() - 1); // Remove last element
+		directories_to_check.resize(directories_to_check.size() - 1); // Remove last element.
 		if (dir.open(path) == OK) {
 			dir.set_include_hidden(true);
 			dir.list_dir_begin();
@@ -2267,10 +2265,7 @@ bool ProjectConverter3To4::test_conversion_gdscript_builtin(String name, String 
 	Vector<String> got = name.split("\n");
 	(this->*func)(got, reg_container, builtin_script);
 	String got_str = collect_string_from_vector(got);
-	if (expected != got_str) {
-		ERR_PRINT("Failed to convert " + what + " `" + name + "` to `" + expected + "`, got instead `" + got_str + "`");
-		return false;
-	}
+	ERR_FAIL_COND_V_MSG(expected != got_str, false, vformat("Failed to convert %s \"%s\" to \"%s\", got instead \"%s\"", what, name, expected, got_str));
 
 	return true;
 }
@@ -2279,10 +2274,7 @@ bool ProjectConverter3To4::test_conversion_with_regex(String name, String expect
 	Vector<String> got = name.split("\n");
 	(this->*func)(got, reg_container);
 	String got_str = collect_string_from_vector(got);
-	if (expected != got_str) {
-		ERR_PRINT("Failed to convert " + what + " `" + name + "` to `" + expected + "`, got instead `" + got_str + "`");
-		return false;
-	}
+	ERR_FAIL_COND_V_MSG(expected != got_str, false, vformat("Failed to convert %s \"%s\" to \"%s\", got instead \"%s\"", what, name, expected, got_str));
 
 	return true;
 }
@@ -2291,187 +2283,185 @@ bool ProjectConverter3To4::test_conversion_basic(String name, String expected, c
 	Vector<String> got = name.split("\n");
 	rename_common(array, regex_cache, got);
 	String got_str = collect_string_from_vector(got);
-	if (expected != got_str) {
-		ERR_PRINT("Failed to convert " + what + " `" + name + "` to `" + expected + "`, got instead `" + got_str + "`");
-		return false;
-	}
+	ERR_FAIL_COND_V_MSG(expected != got_str, false, vformat("Failed to convert %s \"%s\" to \"%s\", got instead \"%s\"", what, name, expected, got_str));
+
 	return true;
 }
 
-// Validate if conversions are proper
+// Validate if conversions are proper.
 bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 	bool valid = true;
 
-	valid = valid & test_conversion_basic("TYPE_REAL", "TYPE_FLOAT", enum_renames, reg_container.enum_regexes, "enum");
+	valid = valid && test_conversion_basic("TYPE_REAL", "TYPE_FLOAT", enum_renames, reg_container.enum_regexes, "enum");
 
-	valid = valid & test_conversion_basic("can_instance", "can_instantiate", gdscript_function_renames, reg_container.gdscript_function_regexes, "gdscript function");
+	valid = valid && test_conversion_basic("can_instance", "can_instantiate", gdscript_function_renames, reg_container.gdscript_function_regexes, "gdscript function");
 
-	valid = valid & test_conversion_basic("CanInstance", "CanInstantiate", csharp_function_renames, reg_container.csharp_function_regexes, "csharp function");
+	valid = valid && test_conversion_basic("CanInstance", "CanInstantiate", csharp_function_renames, reg_container.csharp_function_regexes, "csharp function");
 
-	valid = valid & test_conversion_basic("translation", "position", gdscript_properties_renames, reg_container.gdscript_properties_regexes, "gdscript property");
+	valid = valid && test_conversion_basic("translation", "position", gdscript_properties_renames, reg_container.gdscript_properties_regexes, "gdscript property");
 
-	valid = valid & test_conversion_basic("Translation", "Position", csharp_properties_renames, reg_container.csharp_properties_regexes, "csharp property");
+	valid = valid && test_conversion_basic("Translation", "Position", csharp_properties_renames, reg_container.csharp_properties_regexes, "csharp property");
 
-	valid = valid & test_conversion_basic("NORMALMAP", "NORMAL_MAP", shaders_renames, reg_container.shaders_regexes, "shader");
+	valid = valid && test_conversion_basic("NORMALMAP", "NORMAL_MAP", shaders_renames, reg_container.shaders_regexes, "shader");
 
-	valid = valid & test_conversion_basic("text_entered", "text_submitted", gdscript_signals_renames, reg_container.gdscript_signals_regexes, "gdscript signal");
+	valid = valid && test_conversion_basic("text_entered", "text_submitted", gdscript_signals_renames, reg_container.gdscript_signals_regexes, "gdscript signal");
 
-	valid = valid & test_conversion_basic("TextEntered", "TextSubmitted", csharp_signals_renames, reg_container.csharp_signal_regexes, "csharp signal");
+	valid = valid && test_conversion_basic("TextEntered", "TextSubmitted", csharp_signals_renames, reg_container.csharp_signal_regexes, "csharp signal");
 
-	valid = valid & test_conversion_basic("audio/channel_disable_threshold_db", "audio/buses/channel_disable_threshold_db", project_settings_renames, reg_container.project_settings_regexes, "project setting");
+	valid = valid && test_conversion_basic("audio/channel_disable_threshold_db", "audio/buses/channel_disable_threshold_db", project_settings_renames, reg_container.project_settings_regexes, "project setting");
 
-	valid = valid & test_conversion_basic("Transform", "Transform3D", builtin_types_renames, reg_container.builtin_types_regexes, "builtin type");
+	valid = valid && test_conversion_basic("Transform", "Transform3D", builtin_types_renames, reg_container.builtin_types_regexes, "builtin type");
 
-	// Custom Renames
+	// Custom Renames.
 
-	valid = valid & test_conversion_with_regex("(Connect(A,B,C,D,E,F,G) != OK):", "(Connect(A,new Callable(B,C),D,E,F,G) != OK):", &ProjectConverter3To4::rename_csharp_functions, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("(Disconnect(A,B,C) != OK):", "(Disconnect(A,new Callable(B,C)) != OK):", &ProjectConverter3To4::rename_csharp_functions, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("(IsConnected(A,B,C) != OK):", "(IsConnected(A,new Callable(B,C)) != OK):", &ProjectConverter3To4::rename_csharp_functions, "custom rename", reg_container);
+	valid = valid && test_conversion_with_regex("(Connect(A,B,C,D,E,F,G) != OK):", "(Connect(A,new Callable(B,C),D,E,F,G) != OK):", &ProjectConverter3To4::rename_csharp_functions, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("(Disconnect(A,B,C) != OK):", "(Disconnect(A,new Callable(B,C)) != OK):", &ProjectConverter3To4::rename_csharp_functions, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("(IsConnected(A,B,C) != OK):", "(IsConnected(A,new Callable(B,C)) != OK):", &ProjectConverter3To4::rename_csharp_functions, "custom rename", reg_container);
 
-	valid = valid & test_conversion_with_regex("[Remote]", "[RPC(MultiplayerAPI.RPCMode.AnyPeer)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("[RemoteSync]", "[RPC(MultiplayerAPI.RPCMode.AnyPeer, CallLocal = true)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("[Sync]", "[RPC(MultiplayerAPI.RPCMode.AnyPeer, CallLocal = true)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("[Slave]", "[RPC]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("[Puppet]", "[RPC]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("[PuppetSync]", "[RPC(CallLocal = true)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("[Master]", "The master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using Multiplayer.GetRemoteSenderId()\n[RPC]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
-	valid = valid & test_conversion_with_regex("[MasterSync]", "The master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using Multiplayer.GetRemoteSenderId()\n[RPC(CallLocal = true)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("[Remote]", "[RPC(MultiplayerAPI.RPCMode.AnyPeer)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("[RemoteSync]", "[RPC(MultiplayerAPI.RPCMode.AnyPeer, CallLocal = true)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("[Sync]", "[RPC(MultiplayerAPI.RPCMode.AnyPeer, CallLocal = true)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("[Slave]", "[RPC]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("[Puppet]", "[RPC]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("[PuppetSync]", "[RPC(CallLocal = true)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("[Master]", "The master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using Multiplayer.GetRemoteSenderId()\n[RPC]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
+	valid = valid && test_conversion_with_regex("[MasterSync]", "The master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using Multiplayer.GetRemoteSenderId()\n[RPC(CallLocal = true)]", &ProjectConverter3To4::rename_csharp_attributes, "custom rename csharp", reg_container);
 
-	valid = valid & test_conversion_gdscript_builtin("OS.window_fullscreen = Settings.fullscreen", "ProjectSettings.set(\"display/window/size/fullscreen\", Settings.fullscreen)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("OS.window_fullscreen = Settings.fullscreen", "ProjectSettings.set(\\\"display/window/size/fullscreen\\\", Settings.fullscreen)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, true);
-	valid = valid & test_conversion_gdscript_builtin("OS.get_window_safe_area()", "DisplayServer.get_display_safe_area()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("OS.window_fullscreen = Settings.fullscreen", "ProjectSettings.set(\"display/window/size/fullscreen\", Settings.fullscreen)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("OS.window_fullscreen = Settings.fullscreen", "ProjectSettings.set(\\\"display/window/size/fullscreen\\\", Settings.fullscreen)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, true);
+	valid = valid && test_conversion_gdscript_builtin("OS.get_window_safe_area()", "DisplayServer.get_display_safe_area()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("\tvar aa = roman(r.move_and_slide( a, b, c, d, e, f )) # Roman", "\tr.set_velocity(a)\n\tr.set_up_direction(b)\n\tr.set_floor_stop_on_slope_enabled(c)\n\tr.set_max_slides(d)\n\tr.set_floor_max_angle(e)\n\t# TODOConverter40 infinite_inertia were removed in Godot 4.0 - previous value `f`\n\tr.move_and_slide()\n\tvar aa = roman(r.velocity) # Roman", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("\tvar aa = roman(r.move_and_slide_with_snap( a, g, b, c, d, e, f )) # Roman", "\tr.set_velocity(a)\n\t# TODOConverter40 looks that snap in Godot 4.0 is float, not vector like in Godot 3 - previous value `g`\n\tr.set_up_direction(b)\n\tr.set_floor_stop_on_slope_enabled(c)\n\tr.set_max_slides(d)\n\tr.set_floor_max_angle(e)\n\t# TODOConverter40 infinite_inertia were removed in Godot 4.0 - previous value `f`\n\tr.move_and_slide()\n\tvar aa = roman(r.velocity) # Roman", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\tvar aa = roman(r.move_and_slide( a, b, c, d, e, f )) # Roman", "\tr.set_velocity(a)\n\tr.set_up_direction(b)\n\tr.set_floor_stop_on_slope_enabled(c)\n\tr.set_max_slides(d)\n\tr.set_floor_max_angle(e)\n\t# TODOConverter40 infinite_inertia were removed in Godot 4.0 - previous value `f`\n\tr.move_and_slide()\n\tvar aa = roman(r.velocity) # Roman", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\tvar aa = roman(r.move_and_slide_with_snap( a, g, b, c, d, e, f )) # Roman", "\tr.set_velocity(a)\n\t# TODOConverter40 looks that snap in Godot 4.0 is float, not vector like in Godot 3 - previous value `g`\n\tr.set_up_direction(b)\n\tr.set_floor_stop_on_slope_enabled(c)\n\tr.set_max_slides(d)\n\tr.set_floor_max_angle(e)\n\t# TODOConverter40 infinite_inertia were removed in Godot 4.0 - previous value `f`\n\tr.move_and_slide()\n\tvar aa = roman(r.velocity) # Roman", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("list_dir_begin( a , b )", "list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("list_dir_begin( a )", "list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("list_dir_begin( )", "list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("list_dir_begin( a , b )", "list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("list_dir_begin( a )", "list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("list_dir_begin( )", "list_dir_begin() # TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("sort_custom( a , b )", "sort_custom(Callable(a,b))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("sort_custom( a , b )", "sort_custom(Callable(a,b))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("func c(var a, var b)", "func c(a, b)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("func c(var a, var b)", "func c(a, b)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("draw_line(1, 2, 3, 4, 5)", "draw_line(1,2,3,4)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("draw_line(1, 2, 3, 4, 5)", "draw_line(1,2,3,4)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("\timage.lock()", "\tfalse # image.lock() # TODOConverter40, image no longer require locking, `false` helps to not broke one line if/else, so can be freely removed", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("\timage.unlock()", "\tfalse # image.unlock() # TODOConverter40, image no longer require locking, `false` helps to not broke one line if/else, so can be freely removed", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("\troman.image.unlock()", "\tfalse # roman.image.unlock() # TODOConverter40, image no longer require locking, `false` helps to not broke one line if/else, so can be freely removed", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("\tmtx.lock()", "\tmtx.lock()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("\tmutex.unlock()", "\tmutex.unlock()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\timage.lock()", "\tfalse # image.lock() # TODOConverter40, Image no longer requires locking, `false` helps to not break one line if/else, so it can freely be removed", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\timage.unlock()", "\tfalse # image.unlock() # TODOConverter40, Image no longer requires locking, `false` helps to not break one line if/else, so it can freely be removed", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\troman.image.unlock()", "\tfalse # roman.image.unlock() # TODOConverter40, Image no longer requires locking, `false` helps to not break one line if/else, so it can freely be removed", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\tmtx.lock()", "\tmtx.lock()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\tmutex.unlock()", "\tmutex.unlock()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_with_regex("extends CSGBox", "extends CSGBox3D", &ProjectConverter3To4::rename_classes, "classes", reg_container);
-	valid = valid & test_conversion_with_regex("CSGBox", "CSGBox3D", &ProjectConverter3To4::rename_classes, "classes", reg_container);
-	valid = valid & test_conversion_with_regex("Spatial", "Node3D", &ProjectConverter3To4::rename_classes, "classes", reg_container);
-	valid = valid & test_conversion_with_regex("Spatial.tscn", "Spatial.tscn", &ProjectConverter3To4::rename_classes, "classes", reg_container);
-	valid = valid & test_conversion_with_regex("Spatial.gd", "Spatial.gd", &ProjectConverter3To4::rename_classes, "classes", reg_container);
-	valid = valid & test_conversion_with_regex("Spatial.shader", "Spatial.shader", &ProjectConverter3To4::rename_classes, "classes", reg_container);
-	valid = valid & test_conversion_with_regex("Spatial.other", "Node3D.other", &ProjectConverter3To4::rename_classes, "classes", reg_container);
+	valid = valid && test_conversion_with_regex("extends CSGBox", "extends CSGBox3D", &ProjectConverter3To4::rename_classes, "classes", reg_container);
+	valid = valid && test_conversion_with_regex("CSGBox", "CSGBox3D", &ProjectConverter3To4::rename_classes, "classes", reg_container);
+	valid = valid && test_conversion_with_regex("Spatial", "Node3D", &ProjectConverter3To4::rename_classes, "classes", reg_container);
+	valid = valid && test_conversion_with_regex("Spatial.tscn", "Spatial.tscn", &ProjectConverter3To4::rename_classes, "classes", reg_container);
+	valid = valid && test_conversion_with_regex("Spatial.gd", "Spatial.gd", &ProjectConverter3To4::rename_classes, "classes", reg_container);
+	valid = valid && test_conversion_with_regex("Spatial.shader", "Spatial.shader", &ProjectConverter3To4::rename_classes, "classes", reg_container);
+	valid = valid && test_conversion_with_regex("Spatial.other", "Node3D.other", &ProjectConverter3To4::rename_classes, "classes", reg_container);
 
-	valid = valid & test_conversion_with_regex("\nonready", "\n@onready", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("onready", "@onready", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex(" onready", " onready", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\nexport", "\n@export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\texport", "\t@export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\texport_dialog", "\texport_dialog", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("export", "@export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex(" export", " export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("tool", "@tool", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n    tool", "\n    tool", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\ntool", "\n\n@tool", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\nremote func", "\n\n@rpc(any_peer) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\nremotesync func", "\n\n@rpc(any_peer, call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\nsync func", "\n\n@rpc(any_peer, call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\nslave func", "\n\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\npuppet func", "\n\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\npuppetsync func", "\n\n@rpc(call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\nmaster func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid & test_conversion_with_regex("\n\nmastersync func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc(call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\nonready", "\n@onready", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("onready", "@onready", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex(" onready", " onready", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\nexport", "\n@export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\texport", "\t@export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\texport_dialog", "\texport_dialog", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("export", "@export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex(" export", " export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("tool", "@tool", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n    tool", "\n    tool", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\ntool", "\n\n@tool", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nremote func", "\n\n@rpc(any_peer) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nremotesync func", "\n\n@rpc(any_peer, call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nsync func", "\n\n@rpc(any_peer, call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nslave func", "\n\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\npuppet func", "\n\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\npuppetsync func", "\n\n@rpc(call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nmaster func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nmastersync func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc(call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 
-	valid = valid & test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function , get_function", "var size : Vector2 = Vector2() :\n	get:\n		return size # TODOConverter40 Copy here content of get_function\n	set(mod_value):\n		mod_value  # TODOConverter40 Copy here content of set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function , ", "var size : Vector2 = Vector2() :\n	get:\n		return size # TODOConverter40 Non existent get function \n	set(mod_value):\n		mod_value  # TODOConverter40 Copy here content of set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function", "var size : Vector2 = Vector2() :\n	get:\n		return size # TODOConverter40 Non existent get function \n	set(mod_value):\n		mod_value  # TODOConverter40 Copy here content of set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget  , get_function", "var size : Vector2 = Vector2() :\n	get:\n		return size # TODOConverter40 Copy here content of get_function \n	set(mod_value):\n		mod_value  # TODOConverter40  Non existent set function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function , get_function", "var size : Vector2 = Vector2() :\n	get:\n		return size # TODOConverter40 Copy here content of get_function\n	set(mod_value):\n		mod_value  # TODOConverter40 Copy here content of set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function , ", "var size : Vector2 = Vector2() :\n	get:\n		return size # TODOConverter40 Non existent get function \n	set(mod_value):\n		mod_value  # TODOConverter40 Copy here content of set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget set_function", "var size : Vector2 = Vector2() :\n	get:\n		return size # TODOConverter40 Non existent get function \n	set(mod_value):\n		mod_value  # TODOConverter40 Copy here content of set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var size : Vector2 = Vector2() setget  , get_function", "var size : Vector2 = Vector2() :\n	get:\n		return size # TODOConverter40 Copy here content of get_function \n	set(mod_value):\n		mod_value  # TODOConverter40  Non existent set function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("get_node(@", "get_node(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("get_node(@", "get_node(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("yield(this, \"timeout\")", "await this.timeout", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("yield(this, \\\"timeout\\\")", "await this.timeout", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, true);
+	valid = valid && test_conversion_gdscript_builtin("yield(this, \"timeout\")", "await this.timeout", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("yield(this, \\\"timeout\\\")", "await this.timeout", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, true);
 
-	valid = valid & test_conversion_gdscript_builtin(" Transform.xform(Vector3(a,b,c)) ", " Transform * Vector3(a,b,c) ", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin(" Transform.xform_inv(Vector3(a,b,c)) ", " Vector3(a,b,c) * Transform ", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin(" Transform.xform(Vector3(a,b,c)) ", " Transform * Vector3(a,b,c) ", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin(" Transform.xform_inv(Vector3(a,b,c)) ", " Vector3(a,b,c) * Transform ", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("export(float) var lifetime = 3.0", "export var lifetime: float = 3.0", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("export(String, 'AnonymousPro', 'CourierPrime') var _font_name = 'AnonymousPro'", "export var _font_name = 'AnonymousPro' # (String, 'AnonymousPro', 'CourierPrime')", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false); // TODO, this is only a workaround
-	valid = valid & test_conversion_gdscript_builtin("export(PackedScene) var mob_scene", "export var mob_scene: PackedScene", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("export(float) var lifetime = 3.0", "export var lifetime: float = 3.0", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("export(String, 'AnonymousPro', 'CourierPrime') var _font_name = 'AnonymousPro'", "export var _font_name = 'AnonymousPro' # (String, 'AnonymousPro', 'CourierPrime')", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false); // TODO, this is only a workaround
+	valid = valid && test_conversion_gdscript_builtin("export(PackedScene) var mob_scene", "export var mob_scene: PackedScene", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("var d = parse_json(roman(sfs))", "var test_json_conv = JSON.new()\ntest_json_conv.parse(roman(sfs))\nvar d = test_json_conv.get_data()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var d = parse_json(roman(sfs))", "var test_json_conv = JSON.new()\ntest_json_conv.parse(roman(sfs))\nvar d = test_json_conv.get_data()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("to_json( AA ) szon", "JSON.new().stringify( AA ) szon", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("s to_json", "s JSON.new().stringify", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("AF to_json2", "AF to_json2", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("var rr = JSON.parse(a)", "var test_json_conv = JSON.new()\ntest_json_conv.parse(a)\nvar rr = test_json_conv.get_data()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("to_json( AA ) szon", "JSON.new().stringify( AA ) szon", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("s to_json", "s JSON.new().stringify", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("AF to_json2", "AF to_json2", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("var rr = JSON.parse(a)", "var test_json_conv = JSON.new()\ntest_json_conv.parse(a)\nvar rr = test_json_conv.get_data()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("empty()", "is_empty()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin(".empty", ".empty", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("empty()", "is_empty()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin(".empty", ".empty", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin(").roman(", ").roman(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("\t.roman(", "\tsuper.roman(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin(" .roman(", " super.roman(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin(".1", ".1", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin(" .1", " .1", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("'.'", "'.'", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("'.a'", "'.a'", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("\t._input(_event)", "\tsuper._input(_event)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin(").roman(", ").roman(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\t.roman(", "\tsuper.roman(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin(" .roman(", " super.roman(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin(".1", ".1", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin(" .1", " .1", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("'.'", "'.'", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("'.a'", "'.a'", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("\t._input(_event)", "\tsuper._input(_event)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("(connect(A,B,C) != OK):", "(connect(A,Callable(B,C)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(connect(A,B,C,D) != OK):", "(connect(A,Callable(B,C).bind(D)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(connect(A,B,C,[D]) != OK):", "(connect(A,Callable(B,C).bind(D)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(connect(A,B,C,[D,E]) != OK):", "(connect(A,Callable(B,C).bind(D,E)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(connect(A,B,C,[D,E],F) != OK):", "(connect(A,Callable(B,C).bind(D,E),F) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(connect(A,B,C,D,E) != OK):", "(connect(A,Callable(B,C).bind(D),E) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(connect(A,B,C) != OK):", "(connect(A,Callable(B,C)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(connect(A,B,C,D) != OK):", "(connect(A,Callable(B,C).bind(D)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(connect(A,B,C,[D]) != OK):", "(connect(A,Callable(B,C).bind(D)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(connect(A,B,C,[D,E]) != OK):", "(connect(A,Callable(B,C).bind(D,E)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(connect(A,B,C,[D,E],F) != OK):", "(connect(A,Callable(B,C).bind(D,E),F) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(connect(A,B,C,D,E) != OK):", "(connect(A,Callable(B,C).bind(D),E) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("(start(A,B) != OK):", "(start(Callable(A,B)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("func start(A,B):", "func start(A,B):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(start(A,B,C,D,E,F,G) != OK):", "(start(Callable(A,B).bind(C),D,E,F,G) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("disconnect(A,B,C) != OK):", "disconnect(A,Callable(B,C)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("is_connected(A,B,C) != OK):", "is_connected(A,Callable(B,C)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("is_connected(A,B,C))", "is_connected(A,Callable(B,C)))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(start(A,B) != OK):", "(start(Callable(A,B)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("func start(A,B):", "func start(A,B):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(start(A,B,C,D,E,F,G) != OK):", "(start(Callable(A,B).bind(C),D,E,F,G) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("disconnect(A,B,C) != OK):", "disconnect(A,Callable(B,C)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("is_connected(A,B,C) != OK):", "is_connected(A,Callable(B,C)) != OK):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("is_connected(A,B,C))", "is_connected(A,Callable(B,C)))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("(tween_method(A,B,C,D,E).foo())", "(tween_method(Callable(A,B),C,D,E).foo())", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(tween_method(A,B,C,D,E,[F,G]).foo())", "(tween_method(Callable(A,B).bind(F,G),C,D,E).foo())", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(tween_callback(A,B).foo())", "(tween_callback(Callable(A,B)).foo())", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("(tween_callback(A,B,[C,D]).foo())", "(tween_callback(Callable(A,B).bind(C,D)).foo())", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(tween_method(A,B,C,D,E).foo())", "(tween_method(Callable(A,B),C,D,E).foo())", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(tween_method(A,B,C,D,E,[F,G]).foo())", "(tween_method(Callable(A,B).bind(F,G),C,D,E).foo())", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(tween_callback(A,B).foo())", "(tween_callback(Callable(A,B)).foo())", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("(tween_callback(A,B,[C,D]).foo())", "(tween_callback(Callable(A,B).bind(C,D)).foo())", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("func _init(", "func _init(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("func _init(p_x:int)->void:", "func _init(p_x:int):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("q_PackedDataContainer._iter_init(variable1)", "q_PackedDataContainer._iter_init(variable1)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("func _init(", "func _init(", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("func _init(p_x:int)->void:", "func _init(p_x:int):", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("q_PackedDataContainer._iter_init(variable1)", "q_PackedDataContainer._iter_init(variable1)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("assert(speed < 20, str(randi()%10))", "assert(speed < 20) #,str(randi()%10))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("assert(speed < 2)", "assert(speed < 2)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("assert(false, \"Missing type --\" + str(argument.type) + \"--, needs to be added to project\")", "assert(false) #,\"Missing type --\" + str(argument.type) + \"--, needs to be added to project\")", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("assert(speed < 20, str(randi()%10))", "assert(speed < 20) #,str(randi()%10))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("assert(speed < 2)", "assert(speed < 2)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("assert(false, \"Missing type --\" + str(argument.type) + \"--, needs to be added to project\")", "assert(false) #,\"Missing type --\" + str(argument.type) + \"--, needs to be added to project\")", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("create_from_image(aa, bb)", "create_from_image(aa) #,bb", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("q_ImageTexture.create_from_image(variable1, variable2)", "q_ImageTexture.create_from_image(variable1) #,variable2", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("create_from_image(aa, bb)", "create_from_image(aa) #,bb", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("q_ImageTexture.create_from_image(variable1, variable2)", "q_ImageTexture.create_from_image(variable1) #,variable2", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("set_cell_item(a, b, c, d ,e) # AA", "set_cell_item( Vector3(a,b,c) ,d,e) # AA", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("set_cell_item(a, b)", "set_cell_item(a, b)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("get_cell_item_orientation(a, b,c)", "get_cell_item_orientation(Vector3i(a,b,c))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("get_cell_item(a, b,c)", "get_cell_item(Vector3i(a,b,c))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("map_to_world(a, b,c)", "map_to_local(Vector3i(a,b,c))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("set_cell_item(a, b, c, d ,e) # AA", "set_cell_item( Vector3(a,b,c) ,d,e) # AA", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("set_cell_item(a, b)", "set_cell_item(a, b)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("get_cell_item_orientation(a, b,c)", "get_cell_item_orientation(Vector3i(a,b,c))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("get_cell_item(a, b,c)", "get_cell_item(Vector3i(a,b,c))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("map_to_world(a, b,c)", "map_to_local(Vector3i(a,b,c))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("PackedStringArray(req_godot).join('.')", "'.'.join(PackedStringArray(req_godot))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("=PackedStringArray(req_godot).join('.')", "='.'.join(PackedStringArray(req_godot))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("PackedStringArray(req_godot).join('.')", "'.'.join(PackedStringArray(req_godot))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("=PackedStringArray(req_godot).join('.')", "='.'.join(PackedStringArray(req_godot))", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_gdscript_builtin("apply_force(position, impulse)", "apply_force(impulse, position)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("apply_impulse(position, impulse)", "apply_impulse(impulse, position)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("draw_rect(a,b,c,d,e).abc", "draw_rect(a,b,c,d).abc# e) TODOGODOT4 Antialiasing argument is missing", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("get_focus_owner()", "get_viewport().gui_get_focus_owner()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("button.pressed = 1", "button.button_pressed = 1", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("button.pressed=1", "button.button_pressed=1", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
-	valid = valid & test_conversion_gdscript_builtin("button.pressed SF", "button.pressed SF", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("apply_force(position, impulse)", "apply_force(impulse, position)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("apply_impulse(position, impulse)", "apply_impulse(impulse, position)", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("draw_rect(a,b,c,d,e).abc", "draw_rect(a,b,c,d).abc# e) TODOGODOT4 Antialiasing argument is missing", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("get_focus_owner()", "get_viewport().gui_get_focus_owner()", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("button.pressed = 1", "button.button_pressed = 1", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("button.pressed=1", "button.button_pressed=1", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
+	valid = valid && test_conversion_gdscript_builtin("button.pressed SF", "button.pressed SF", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 
-	valid = valid & test_conversion_with_regex("AAA Color.white AF", "AAA Color.WHITE AF", &ProjectConverter3To4::rename_colors, "custom rename", reg_container);
+	valid = valid && test_conversion_with_regex("AAA Color.white AF", "AAA Color.WHITE AF", &ProjectConverter3To4::rename_colors, "custom rename", reg_container);
 
 	// Custom rule conversion
 	{
@@ -2483,9 +2473,9 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		custom_rename(got, from, to);
 		String got_str = collect_string_from_vector(got);
 		if (got_str != expected) {
-			ERR_PRINT("Failed to convert custom rename `" + name + "` to `" + expected + "`, got instead `" + got_str + "`");
+			ERR_PRINT(vformat("Failed to convert custom rename \"%s\" to \"%s\", got \"%s\", instead.", name, expected, got_str));
 		}
-		valid = valid & (got_str == expected);
+		valid = valid && (got_str == expected);
 	}
 
 	// get_object_of_execution
@@ -2494,36 +2484,36 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 	String expected = "kieliszek.";
 	String got = get_object_of_execution(base);
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from get_object_of_execution `" + base + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 {
 	String base = "r.";
 	String expected = "r.";
 	String got = get_object_of_execution(base);
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from get_object_of_execution `" + base + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 {
 	String base = "mortadela(";
 	String expected = "";
 	String got = get_object_of_execution(base);
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from get_object_of_execution `" + base + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 {
 	String base = "var node = $world/ukraine/lviv.";
 	String expected = "$world/ukraine/lviv.";
 	String got = get_object_of_execution(base);
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from get_object_of_execution `" + base + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 }
 // get_starting_space
@@ -2532,9 +2522,9 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 	String expected = "\t\t\t";
 	String got = get_starting_space(base);
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from get_starting_space `" + base + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from get_object_of_execution. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", base, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 // Parse Arguments
 {
@@ -2546,9 +2536,9 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		got += part + "|||";
 	}
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from parse_arguments `" + line + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 {
 	String line = "(a , b , c)";
@@ -2559,9 +2549,9 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		got += part + "|||";
 	}
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from parse_arguments `" + line + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 {
 	String line = "(a , \"b,\" , c)";
@@ -2572,9 +2562,9 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		got += part + "|||";
 	}
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from parse_arguments `" + line + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 {
 	String line = "(a , \"(,),,,,\" , c)";
@@ -2585,35 +2575,35 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		got += part + "|||";
 	}
 	if (got != expected) {
-		ERR_PRINT("Failed to get proper data from parse_arguments `" + line + "` should return `" + expected + "`(" + itos(expected.size()) + "), got instead `" + got + "`(" + itos(got.size()) + ")");
+		ERR_PRINT(vformat("Failed to get proper data from parse_arguments. \"%s\" should return \"%s\"(%d), got \"%s\"(%d), instead.", line, expected, expected.size(), got, got.size()));
 	}
-	valid = valid & (got == expected);
+	valid = valid && (got == expected);
 }
 
 return valid;
 }
 
-// Validate in all arrays if names don't do cyclic renames `Node` -> `Node2D` | `Node2D` -> `2DNode`
+// Validate in all arrays if names don't do cyclic renames "Node" -> "Node2D" | "Node2D" -> "2DNode"
 bool ProjectConverter3To4::test_array_names() {
 	bool valid = true;
 	Vector<String> names = Vector<String>();
 
-	// Validate if all classes are valid
+	// Validate if all classes are valid.
 	{
 		for (unsigned int current_index = 0; class_renames[current_index][0]; current_index++) {
 			const String old_class = class_renames[current_index][0];
 			const String new_class = class_renames[current_index][1];
 
-			// Light2D, Texture, Viewport are special classes(probably virtual ones)
+			// Light2D, Texture, Viewport are special classes(probably virtual ones).
 			if (ClassDB::class_exists(StringName(old_class)) && old_class != "Light2D" && old_class != "Texture" && old_class != "Viewport") {
-				ERR_PRINT(String("Class `") + old_class + "` exists in Godot 4.0, so cannot be renamed to something else.");
-				valid = false; // This probably should be only a warning, but not 100% sure - this would need to be added to CI
+				ERR_PRINT(vformat("Class \"%s\" exists in Godot 4.0, so it cannot be renamed to something else.", old_class));
+				valid = false; // This probably should be only a warning, but not 100% sure - this would need to be added to CI.
 			}
 
-			// Callable is special class, to which normal classes may be renamed
+			// Callable is special class, to which normal classes may be renamed.
 			if (!ClassDB::class_exists(StringName(new_class)) && new_class != "Callable") {
-				ERR_PRINT(String("Class `") + new_class + "` doesn't exists in Godot 4.0, so cannot be used in conversion.");
-				valid = false; // This probably should be only a warning, but not 100% sure - this would need to be added to CI
+				ERR_PRINT(vformat("Class \"%s\" does not exist in Godot 4.0, so it cannot be used in the conversion.", old_class));
+				valid = false; // This probably should be only a warning, but not 100% sure - this would need to be added to CI.
 			}
 		}
 	}
@@ -2621,8 +2611,8 @@ bool ProjectConverter3To4::test_array_names() {
 	{
 		HashSet<String> all_functions;
 
-		// List of excluded functions from builtin types and global namespace, because currently it is not possible to get list of functions from them
-		// This will be available when https://github.com/godotengine/godot/pull/49053 or similar will be included into Godot
+		// List of excluded functions from builtin types and global namespace, because currently it is not possible to get list of functions from them.
+		// This will be available when https://github.com/godotengine/godot/pull/49053 or similar will be included into Godot.
 		static const char *builtin_types_excluded_functions[] = { "dict_to_inst", "inst_to_dict", "bytes_to_var", "bytes_to_var_with_objects", "db_to_linear", "deg_to_rad", "linear_to_db", "rad_to_deg", "randf_range", "snapped", "str_to_var", "var_to_str", "var_to_bytes", "var_to_bytes_with_objects", "move_toward", "uri_encode", "uri_decode", "remove_at", "get_rotation_quaternion", "clamp", "grow_side", "is_absolute_path", "is_valid_int", "lerp", "to_ascii_buffer", "to_utf8_buffer", "to_utf32_buffer", "snapped", "remap", nullptr };
 		for (int current_index = 0; builtin_types_excluded_functions[current_index]; current_index++) {
 			all_functions.insert(builtin_types_excluded_functions[current_index]);
@@ -2652,82 +2642,79 @@ bool ProjectConverter3To4::test_array_names() {
 
 		int current_element = 0;
 		while (gdscript_function_renames[current_element][0] != nullptr) {
+			String name_3_x = gdscript_function_renames[current_element][0];
+			String name_4_0 = gdscript_function_renames[current_element][1];
 			if (!all_functions.has(gdscript_function_renames[current_element][1])) {
-				ERR_PRINT(String("Missing gdscript function in pair (") + gdscript_function_renames[current_element][0] + " - ===> " + gdscript_function_renames[current_element][1] + " <===)");
+				ERR_PRINT(vformat("Missing GDScript function in pair (%s - ===> %s <===)", name_3_x, name_4_0));
 				valid = false;
 			}
 			current_element++;
 		}
 	}
 	if (!valid) {
-		ERR_PRINT("Found function which is used in converter, but cannot be found in Godot 4. Rename this element to new name or remove entire rule about it if is obsolete.");
+		ERR_PRINT("Found function which is used in the converter, but it cannot be found in Godot 4. Rename this element or remove its entry if it's obsolete.");
 	}
 
-	valid = valid & test_single_array(enum_renames);
-	valid = valid & test_single_array(class_renames, true);
-	valid = valid & test_single_array(gdscript_function_renames, true);
-	valid = valid & test_single_array(csharp_function_renames, true);
-	valid = valid & test_single_array(gdscript_properties_renames, true);
-	valid = valid & test_single_array(csharp_properties_renames);
-	valid = valid & test_single_array(shaders_renames, true);
-	valid = valid & test_single_array(gdscript_signals_renames);
-	valid = valid & test_single_array(project_settings_renames);
-	valid = valid & test_single_array(builtin_types_renames);
-	valid = valid & test_single_array(color_renames);
+	valid = valid && test_single_array(enum_renames);
+	valid = valid && test_single_array(class_renames, true);
+	valid = valid && test_single_array(gdscript_function_renames, true);
+	valid = valid && test_single_array(csharp_function_renames, true);
+	valid = valid && test_single_array(gdscript_properties_renames, true);
+	valid = valid && test_single_array(csharp_properties_renames);
+	valid = valid && test_single_array(shaders_renames, true);
+	valid = valid && test_single_array(gdscript_signals_renames);
+	valid = valid && test_single_array(project_settings_renames);
+	valid = valid && test_single_array(builtin_types_renames);
+	valid = valid && test_single_array(color_renames);
 
 	return valid;
 }
 
-// Validate in one array if names don't do cyclic renames `Node` -> `Node2D` | `Node2D` -> `2DNode`
-// Also checks if in name contains spaces at the end or beginning
-bool ProjectConverter3To4::test_single_array(const char *array[][2], bool ignore_second_check) {
+// Validates the array to prevent cyclic renames, such as `Node` -> `Node2D`, then `Node2D` -> `2DNode`.
+// Also checks if names contain leading or trailing spaces.
+bool ProjectConverter3To4::test_single_array(const char *p_array[][2], bool p_ignore_4_0_name) {
 	bool valid = true;
 	Vector<String> names = Vector<String>();
 
-	for (unsigned int current_index = 0; array[current_index][0]; current_index++) {
-		if (String(array[current_index][0]).begins_with(" ") || String(array[current_index][0]).ends_with(" ")) {
-			{
-				ERR_PRINT(String("Entry \"") + array[current_index][0] + "\" ends or stars with space.");
-				valid = false;
-			}
-		}
-		if (names.has(array[current_index][0])) {
-			ERR_PRINT(String("Found duplicated things, pair ( -> ") + array[current_index][0] + " , " + array[current_index][1] + ")");
+	for (unsigned int current_index = 0; p_array[current_index][0]; current_index++) {
+		String name_3_x = p_array[current_index][0];
+		String name_4_0 = p_array[current_index][1];
+		if (name_3_x != name_3_x.strip_edges()) {
+			ERR_PRINT(vformat("Invalid Entry \"%s\" contains leading or trailing spaces.", name_3_x));
 			valid = false;
 		}
-		names.append(array[current_index][0]);
+		if (names.has(name_3_x)) {
+			ERR_PRINT(vformat("Found duplicated entry, pair ( -> %s , %s)", name_3_x, name_4_0));
+			valid = false;
+		}
+		names.append(name_3_x);
 
-		if (String(array[current_index][1]).begins_with(" ") || String(array[current_index][1]).ends_with(" ")) {
-			{
-				ERR_PRINT(String("Entry \"") + array[current_index][1] + "\" ends or stars with space.");
-				valid = false;
-			}
-		}
-		if (names.has(array[current_index][1])) {
-			ERR_PRINT(String("Found duplicated things, pair (") + array[current_index][0] + " , ->" + array[current_index][1] + ")");
+		if (name_4_0 != name_4_0.strip_edges()) {
+			ERR_PRINT(vformat("Invalid Entry \"%s\" contains leading or trailing spaces.", name_3_x));
 			valid = false;
 		}
-		if (!ignore_second_check) {
-			names.append(array[current_index][1]);
+		if (names.has(name_4_0)) {
+			ERR_PRINT(vformat("Found duplicated entry, pair ( -> %s , %s)", name_3_x, name_4_0));
+			valid = false;
+		}
+		if (!p_ignore_4_0_name) {
+			names.append(name_4_0);
 		}
 	}
 	return valid;
 };
 
-// Returns arguments from given function execution, this cannot be really done as regex
+// Returns arguments from given function execution, this cannot be really done as regex.
 // `abc(d,e(f,g),h)` -> [d], [e(f,g)], [h]
 Vector<String> ProjectConverter3To4::parse_arguments(const String &line) {
 	Vector<String> parts;
 	int string_size = line.length();
-	int start_part = 0; // Index of beginning of start par
+	int start_part = 0; // Index of beginning of start part.
 	int parts_counter = 0;
 	char32_t previous_character = '\0';
-	bool is_inside_string = false; // if true, it ignore this 3 characters ( , ) inside string
+	bool is_inside_string = false; // If true, it ignores these 3 characters ( , ) inside string.
 
-	if (line.count("(") != line.count(")")) {
-		ERR_PRINT("Converter internal bug: substring should have equal number of open and close parenthess in line - `" + line + "`");
-		return parts;
-	}
+	ERR_FAIL_COND_V_MSG(line.count("(") != line.count(")"), parts, vformat("Converter internal bug: substring should have equal number of open and close parentheses in line - \"%s\".", line));
 
 	for (int current_index = 0; current_index < string_size; current_index++) {
 		char32_t character = line.get(current_index);
@@ -2788,9 +2775,9 @@ Vector<String> ProjectConverter3To4::parse_arguments(const String &line) {
 	return clean_parts;
 }
 
-// Finds latest parenthess owned by function
+// Finds latest parenthesis owned by function.
 // `function(abc(a,b),DD)):` finds this parenthess `function(abc(a,b),DD => ) <= ):`
-int ProjectConverter3To4::get_end_parenthess(const String &line) const {
+int ProjectConverter3To4::get_end_parenthesis(const String &line) const {
 	int current_state = 0;
 	for (int current_index = 0; line.length() > current_index; current_index++) {
 		char32_t character = line.get(current_index);
@@ -2807,8 +2794,8 @@ int ProjectConverter3To4::get_end_parenthess(const String &line) const {
 	return -1;
 }
 
-// Connects arguments from vector to one string
-// Needed when after processing e.g. 2 arguments, later arguments are not changed in any way
+// Merges multiple arguments into a single String.
+// Needed when after processing e.g. 2 arguments, later arguments are not changed in any way.
 String ProjectConverter3To4::connect_arguments(const Vector<String> &arguments, int from, int to) const {
 	if (to == -1) {
 		to = arguments.size();
@@ -2828,7 +2815,7 @@ String ProjectConverter3To4::connect_arguments(const Vector<String> &arguments, 
 	return value;
 }
 
-// Return spaces or tabs which starts line e.g. `\t\tmove_this` will return `\t\t`
+// Returns the indentation (spaces and tabs) at the start of the line e.g. `\t\tmove_this` returns `\t\t`.
 String ProjectConverter3To4::get_starting_space(const String &line) const {
 	String empty_space;
 	int current_character = 0;
@@ -2860,9 +2847,8 @@ String ProjectConverter3To4::get_starting_space(const String &line) const {
 	return empty_space;
 }
 
-// Return object which execute specific function
-// e.g. in `var roman = kieliszek.funkcja()` to this function is passed everything before function which we want to check
-// so it is `var roman = kieliszek.` and this function return `kieliszek.`
+// Returns the object that’s executing the function in the line.
+// e.g. Passing the line "var roman = kieliszek.funkcja()" to this function returns "kieliszek".
 String ProjectConverter3To4::get_object_of_execution(const String &line) const {
 	int end = line.size() - 1; // Last one is \0
 	int variable_start = end - 1;
@@ -2880,10 +2866,10 @@ String ProjectConverter3To4::get_object_of_execution(const String &line) const {
 			if (start == 0) {
 				break;
 			} else if (is_nodepath_sep) {
-				// Freeze variable_start, try to fetch more chars since this might be node path literal
+				// Freeze variable_start, try to fetch more chars since this might be a Node path literal.
 				is_possibly_nodepath = true;
 			} else if (is_nodepath_start) {
-				// Found $, this is a node path literal
+				// Found $, this is a Node path literal.
 				is_valid_nodepath = true;
 				break;
 			}
@@ -2893,8 +2879,8 @@ String ProjectConverter3To4::get_object_of_execution(const String &line) const {
 			start--;
 			continue;
 		} else {
-			// Abandon all hope, this is neither a variable nor a node path literal
-			variable_start++; // Found invalid character, needs to be ignored
+			// Abandon all hope, this is neither a variable nor a Node path literal.
+			variable_start++; // Found invalid character, needs to be ignored.
 			break;
 		}
 	}
@@ -2943,7 +2929,7 @@ void ProjectConverter3To4::rename_classes(Vector<String> &lines, const RegExCont
 			for (unsigned int current_index = 0; class_renames[current_index][0]; current_index++) {
 				if (line.contains(class_renames[current_index][0])) {
 					bool found_ignored_items = false;
-					// Renaming Spatial.tscn to TEMP_RENAMED_CLASS.tscn
+					// Renaming Spatial.tscn to TEMP_RENAMED_CLASS.tscn.
 					if (line.contains(String(class_renames[current_index][0]) + ".")) {
 						found_ignored_items = true;
 						line = reg_container.class_tscn_regexes[current_index]->sub(line, "TEMP_RENAMED_CLASS.tscn", true);
@@ -2951,10 +2937,10 @@ void ProjectConverter3To4::rename_classes(Vector<String> &lines, const RegExCont
 						line = reg_container.class_shader_regexes[current_index]->sub(line, "TEMP_RENAMED_CLASS.shader", true);
 					}
 
-					// Causal renaming Spatial -> Node3D
+					// Causal renaming Spatial -> Node3D.
 					line = reg_container.class_regexes[current_index]->sub(line, class_renames[current_index][1], true);
 
-					// Restore Spatial.tscn from TEMP_RENAMED_CLASS.tscn
+					// Restore Spatial.tscn from TEMP_RENAMED_CLASS.tscn.
 					if (found_ignored_items) {
 						line = reg_container.class_temp_tscn.sub(line, reg_container.class_temp_tscn_renames[current_index], true);
 						line = reg_container.class_temp_gd.sub(line, reg_container.class_temp_gd_renames[current_index], true);
@@ -2977,7 +2963,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_classes(Vector<String> &li
 				if (line.contains(class_renames[current_index][0])) {
 					String old_line = line;
 					bool found_ignored_items = false;
-					// Renaming Spatial.tscn to TEMP_RENAMED_CLASS.tscn
+					// Renaming Spatial.tscn to TEMP_RENAMED_CLASS.tscn.
 					if (line.contains(String(class_renames[current_index][0]) + ".")) {
 						found_ignored_items = true;
 						line = reg_container.class_tscn_regexes[current_index]->sub(line, "TEMP_RENAMED_CLASS.tscn", true);
@@ -2985,13 +2971,13 @@ Vector<String> ProjectConverter3To4::check_for_rename_classes(Vector<String> &li
 						line = reg_container.class_shader_regexes[current_index]->sub(line, "TEMP_RENAMED_CLASS.shader", true);
 					}
 
-					// Causal renaming Spatial -> Node3D
+					// Causal renaming Spatial -> Node3D.
 					TypedArray<RegExMatch> reg_match = reg_container.class_regexes[current_index]->search_all(line);
 					if (reg_match.size() > 0) {
 						found_renames.append(line_formatter(current_line, class_renames[current_index][0], class_renames[current_index][1], old_line));
 					}
 
-					// Restore Spatial.tscn from TEMP_RENAMED_CLASS.tscn
+					// Restore Spatial.tscn from TEMP_RENAMED_CLASS.tscn.
 					if (found_ignored_items) {
 						line = reg_container.class_temp_tscn.sub(line, reg_container.class_temp_tscn_renames[current_index], true);
 						line = reg_container.class_temp_gd.sub(line, reg_container.class_temp_gd_renames[current_index], true);
@@ -3031,13 +3017,14 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_functions(Vector<
 	return found_renames;
 }
 
-// TODO, this function should run only on all .gd files and also on lines in tscn files which
+// TODO, this function should run only on all ".gd" files and also on lines in ".tscn" files which are parts of built-in Scripts.
 void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContainer &reg_container, bool builtin) {
-	// In this and other functions, reg.sub are used only after checking line with str.contains function which is sometimes few times faster with bigger line lengths
+	// In this and other functions, reg.sub() is used only after checking lines with str.contains().
+	// With longer lines, doing so can sometimes be significantly faster.
 
 	if ((line.contains(".lock") || line.contains(".unlock")) && !line.contains("mtx") && !line.contains("mutex") && !line.contains("Mutex")) {
-		line = reg_container.reg_image_lock.sub(line, "false # $1.lock() # TODOConverter40, image no longer require locking, `false` helps to not broke one line if/else, so can be freely removed", true);
-		line = reg_container.reg_image_unlock.sub(line, "false # $1.unlock() # TODOConverter40, image no longer require locking, `false` helps to not broke one line if/else, so can be freely removed", true);
+		line = reg_container.reg_image_lock.sub(line, "false # $1.lock() # TODOConverter40, Image no longer requires locking, `false` helps to not break one line if/else, so it can freely be removed", true);
+		line = reg_container.reg_image_unlock.sub(line, "false # $1.unlock() # TODOConverter40, Image no longer requires locking, `false` helps to not break one line if/else, so it can freely be removed", true);
 	}
 
 	// PackedStringArray(req_godot).join('.') -> '.'.join(PackedStringArray(req_godot))       PoolStringArray
@@ -3116,7 +3103,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- r.move_and_slide( a, b, c, d, e )  ->  r.set_velocity(a) ... r.move_and_slide()         KinematicBody
 	if (line.contains(("move_and_slide("))) {
 		int start = line.find("move_and_slide(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			String base_obj = get_object_of_execution(line.substr(0, start));
 			String starting_space = get_starting_space(line);
@@ -3162,7 +3149,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- r.move_and_slide_with_snap( a, b, c, d, e )  ->  r.set_velocity(a) ... r.move_and_slide()         KinematicBody
 	if (line.contains("move_and_slide_with_snap(")) {
 		int start = line.find("move_and_slide_with_snap(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			String base_obj = get_object_of_execution(line.substr(0, start));
 			String starting_space = get_starting_space(line);
@@ -3213,7 +3200,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- sort_custom( a , b )  ->  sort_custom(Callable( a , b ))            Object
 	if (line.contains("sort_custom(")) {
 		int start = line.find("sort_custom(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
@@ -3225,7 +3212,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- list_dir_begin( )  ->  list_dir_begin()            Object
 	if (line.contains("list_dir_begin(")) {
 		int start = line.find("list_dir_begin(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			line = line.substr(0, start) + "list_dir_begin() " + line.substr(end + start) + "# TODOGODOT4 fill missing arguments https://github.com/godotengine/godot/pull/40547";
 		}
@@ -3234,7 +3221,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- draw_line(1,2,3,4,5) -> draw_line(1,2,3,4)            CanvasItem
 	if (line.contains("draw_line(")) {
 		int start = line.find("draw_line(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 5) {
@@ -3247,7 +3234,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	if (line.contains("func ") && line.contains("var ")) {
 		int start = line.find("func ");
 		start = line.substr(start).find("(") + start;
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 
@@ -3265,7 +3252,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- yield(this, \"timeout\") -> await this.timeout         GDScript
 	if (line.contains("yield(")) {
 		int start = line.find("yield(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
@@ -3281,7 +3268,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- parse_json( AA ) -> TODO       Object
 	if (line.contains("parse_json(")) {
 		int start = line.find("parse_json(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			line = line.substr(0, start) + "JSON.new().stringify(" + connect_arguments(parts, 0) + ")" + line.substr(end + start);
@@ -3291,7 +3278,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- .xform(Vector3(a,b,c)) -> * Vector3(a,b,c)            Transform
 	if (line.contains(".xform(")) {
 		int start = line.find(".xform(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 1) {
@@ -3303,7 +3290,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- .xform_inv(Vector3(a,b,c)) -> * Vector3(a,b,c)       Transform
 	if (line.contains(".xform_inv(")) {
 		int start = line.find(".xform_inv(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			String object_exec = get_object_of_execution(line.substr(0, start));
 			if (line.contains(object_exec + ".xform")) {
@@ -3321,7 +3308,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		int start = line.find("connect(");
 		// Protection from disconnect
 		if (start == 0 || line.get(start - 1) != 's') {
-			int end = get_end_parenthess(line.substr(start)) + 1;
+			int end = get_end_parenthesis(line.substr(start)) + 1;
 			if (end > -1) {
 				Vector<String> parts = parse_arguments(line.substr(start, end));
 				if (parts.size() == 3) {
@@ -3335,7 +3322,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- disconnect(a,b,c) -> disconnect(a,Callable(b,c))      Object
 	if (line.contains("disconnect(")) {
 		int start = line.find("disconnect(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
@@ -3346,7 +3333,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- is_connected(a,b,c) -> is_connected(a,Callable(b,c))      Object
 	if (line.contains("is_connected(")) {
 		int start = line.find("is_connected(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
@@ -3358,7 +3345,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- "(tween_method(A,B,C,D,E,[F,G]) != OK):", "(tween_method(Callable(A,B).bind(F,G),C,D,E)      Object
 	if (line.contains("tween_method(")) {
 		int start = line.find("tween_method(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 5) {
@@ -3371,7 +3358,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- "(tween_callback(A,B,[C,D]) != OK):", "(connect(Callable(A,B).bind(C,D))      Object
 	if (line.contains("tween_callback(")) {
 		int start = line.find("tween_callback(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
@@ -3385,7 +3372,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- start(a,b,c,d) -> start(Callable(a,b).bind(c),d)      Thread
 	if (line.contains("start(")) {
 		int start = line.find("start(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		// Protection from 'func start'
 		if (!line.begins_with("func ")) {
 			if (end > -1) {
@@ -3412,7 +3399,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  assert(speed < 20, str(randi()%10))  ->  assert(speed < 20) #,str(randi()%10))    GDScript - GDScript bug constant message
 	if (line.contains("assert(")) {
 		int start = line.find("assert(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
@@ -3423,7 +3410,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  create_from_image(aa, bb)  ->   create_from_image(aa) #, bb   ImageTexture
 	if (line.contains("create_from_image(")) {
 		int start = line.find("create_from_image(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
@@ -3434,7 +3421,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  set_cell_item(a, b, c, d ,e)  ->   set_cell_item(Vector3(a, b, c), d ,e)
 	if (line.contains("set_cell_item(")) {
 		int start = line.find("set_cell_item(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() > 2) {
@@ -3445,7 +3432,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  get_cell_item(a, b, c)  ->   get_cell_item(Vector3i(a, b, c))
 	if (line.contains("get_cell_item(")) {
 		int start = line.find("get_cell_item(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
@@ -3456,7 +3443,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  get_cell_item_orientation(a, b, c)  ->   get_cell_item_orientation(Vector3i(a, b, c))
 	if (line.contains("get_cell_item_orientation(")) {
 		int start = line.find("get_cell_item_orientation(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
@@ -3467,7 +3454,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  apply_impulse(A, B)  ->   apply_impulse(B, A)
 	if (line.contains("apply_impulse(")) {
 		int start = line.find("apply_impulse(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
@@ -3478,7 +3465,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  apply_force(A, B)  ->   apply_force(B, A)
 	if (line.contains("apply_force(")) {
 		int start = line.find("apply_force(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
@@ -3489,7 +3476,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  map_to_world(a, b, c)  ->   map_to_local(Vector3i(a, b, c))
 	if (line.contains("map_to_world(")) {
 		int start = line.find("map_to_world(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
@@ -3502,7 +3489,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  OS.get_window_safe_area()  ->   DisplayServer.get_display_safe_area()
 	if (line.contains("OS.get_window_safe_area(")) {
 		int start = line.find("OS.get_window_safe_area(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 0) {
@@ -3513,7 +3500,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	//  draw_rect(a,b,c,d,e)  ->   draw_rect(a,b,c,d)#e) TODOGODOT4 Antialiasing argument is missing
 	if (line.contains("draw_rect(")) {
 		int start = line.find("draw_rect(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 5) {
@@ -3566,7 +3553,7 @@ void ProjectConverter3To4::process_csharp_line(String &line, const RegExContaine
 		int start = line.find("Connect(");
 		// Protection from disconnect
 		if (start == 0 || line.get(start - 1) != 's') {
-			int end = get_end_parenthess(line.substr(start)) + 1;
+			int end = get_end_parenthesis(line.substr(start)) + 1;
 			if (end > -1) {
 				Vector<String> parts = parse_arguments(line.substr(start, end));
 				if (parts.size() >= 3) {
@@ -3578,7 +3565,7 @@ void ProjectConverter3To4::process_csharp_line(String &line, const RegExContaine
 	// -- Disconnect(a,b,c) -> Disconnect(a,Callable(b,c))      Object
 	if (line.contains("Disconnect(")) {
 		int start = line.find("Disconnect(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
@@ -3589,7 +3576,7 @@ void ProjectConverter3To4::process_csharp_line(String &line, const RegExContaine
 	// -- IsConnected(a,b,c) -> IsConnected(a,Callable(b,c))      Object
 	if (line.contains("IsConnected(")) {
 		int start = line.find("IsConnected(");
-		int end = get_end_parenthess(line.substr(start)) + 1;
+		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
@@ -3866,7 +3853,7 @@ Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lin
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			TypedArray<RegExMatch> reg_match = reg.search_all(line);
 			if (reg_match.size() > 0) {
-				found_renames.append(line_formatter(current_line, from.replace("\\.", "."), to, line)); // Without replacing it will print "\.shader" instead ".shader"
+				found_renames.append(line_formatter(current_line, from.replace("\\.", "."), to, line)); // Without replacing it will print "\.shader" instead ".shader".
 			}
 		}
 		current_line++;
@@ -3920,19 +3907,28 @@ String ProjectConverter3To4::line_formatter(int current_line, String from, Strin
 	if (line.size() > 400) {
 		line = line.substr(0, 397) + "...";
 	}
-	return String("Line (") + itos(current_line) + ") " + from.replace("\r", "").replace("\n", "") + " -> " + to.replace("\r", "").replace("\n", "") + "  -  LINE \"\"\" " + line.replace("\r", "").replace("\n", "").strip_edges() + " \"\"\"";
+
+	from = from.strip_escapes();
+	to = to.strip_escapes();
+	line = line.replace("\r", "").replace("\n", "").strip_edges();
+
+	return vformat("Line(%d), %s -> %s  -  LINE \"\"\" %s \"\"\"", current_line, from, to, line);
 }
 
 // Prints only full lines e.g.:
 // Line (1) - FULL LINES - """yield(get_tree().create_timer(3), 'timeout')"""  =====>  """ await get_tree().create_timer(3).timeout """
-String ProjectConverter3To4::simple_line_formatter(int current_line, String old_line, String line) {
+String ProjectConverter3To4::simple_line_formatter(int current_line, String old_line, String new_line) {
 	if (old_line.size() > 1000) {
 		old_line = old_line.substr(0, 997) + "...";
 	}
-	if (line.size() > 1000) {
-		line = line.substr(0, 997) + "...";
+	if (new_line.size() > 1000) {
+		new_line = new_line.substr(0, 997) + "...";
 	}
-	return String("Line (") + itos(current_line) + ") - FULL LINES - \"\"\"" + old_line.replace("\r", "").replace("\n", "").strip_edges() + "\"\"\"  =====>  \"\"\" " + line.replace("\r", "").replace("\n", "").strip_edges() + " \"\"\"";
+
+	old_line = old_line.replace("\r", "").replace("\n", "").strip_edges();
+	new_line = new_line.replace("\r", "").replace("\n", "").strip_edges();
+
+	return vformat("Line (%d) - FULL LINES - \"\"\" %s \"\"\"  =====>  \"\"\" %s \"\"\"", current_line, old_line, new_line);
 }
 
 // Collects string from vector strings
@@ -3948,14 +3944,14 @@ String ProjectConverter3To4::collect_string_from_vector(Vector<String> &vector) 
 	return string;
 }
 
-#else // No regex.
+#else // No RegEx.
 
 int ProjectConverter3To4::convert() {
-	ERR_FAIL_V_MSG(ERROR_CODE, "Can't run converter for Godot 3.x projects as RegEx module is disabled.");
+	ERR_FAIL_V_MSG(ERROR_CODE, "Can't run converter for Godot 3.x projects, because RegEx module is disabled.");
 }
 
 int ProjectConverter3To4::validate_conversion() {
-	ERR_FAIL_V_MSG(ERROR_CODE, "Can't validate conversion for Godot 3.x projects as RegEx module is disabled.");
+	ERR_FAIL_V_MSG(ERROR_CODE, "Can't validate conversion for Godot 3.x projects, because RegEx module is disabled.");
 }
 
 #endif // MODULE_REGEX_ENABLED

--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -76,7 +76,7 @@ private:
 	Vector<String> check_for_files();
 
 	Vector<String> parse_arguments(const String &line);
-	int get_end_parenthess(const String &line) const;
+	int get_end_parenthesis(const String &line) const;
 	String connect_arguments(const Vector<String> &line, int from, int to = -1) const;
 	String get_starting_space(const String &line) const;
 	String get_object_of_execution(const String &line) const;


### PR DESCRIPTION
Fix #65482

This is not a complete list. Nor are all of the changes exhaustive.
- Measure final execution time in seconds instead of milliseconds.
- Use `vformat()` instead of unreadable string concatenation whenever necessary.
- Replaces every `&` used with booleans with `&&` because Visual Studio was really complaining about it.
- Adds punctuation to some comments, in accordance to codebase guidelines.
- Fixes some typos around the file (such as "_parenthesis_" being called "_parenthess_"), as well as attempting to change some sentences to be more English-correct.
- Reworded some comments and error messages outright.