### PR TITLE
[3.x] Fix UTF-8 validation in static checks

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -qq dos2unix recode clang-format-13 libxml2-utils
-          sudo update-alternatives --remove-all clang-format
+          sudo apt-get install -qq dos2unix clang-format-13 libxml2-utils python3-pip moreutils
+          sudo update-alternatives --remove-all clang-format || true
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
           sudo pip3 install black==22.3.0 pygments
 


### PR DESCRIPTION
Port for 3.x of PR: https://github.com/godotengine/godot/pull/65358

Use isutf8 instead of recode to detect invalid UTF-8 sequences.

Also add the necessary dependencies to run the static checks locally using act (https://github.com/nektos/act) with the Medium size image.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
