### PR TITLE
Fix NuGet fallback folder packages

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -17,7 +17,7 @@
 
   <!-- C# source generators -->
   <ItemGroup Condition=" '$(DisableImplicitGodotGeneratorReferences)' != 'true' ">
-    <PackageReference Include="Godot.SourceGenerators" Version="$(PackageFloatingVersion_Godot)" />
+    <PackageReference Include="Godot.SourceGenerators" Version="$(PackageVersion_Godot_SourceGenerators)" />
   </ItemGroup>
 
   <!-- Godot API references -->

--- a/modules/mono/editor/GodotTools/GodotTools.Shared/GenerateGodotNupkgsVersions.targets
+++ b/modules/mono/editor/GodotTools/GodotTools.Shared/GenerateGodotNupkgsVersions.targets
@@ -21,10 +21,13 @@
           Outputs="$(GeneratedGodotNupkgsVersionsFile)">
     <PropertyGroup>
       <GenerateGodotNupkgsVersionsCode><![CDATA[
-namespace $(RootNamespace) {
-    public class GeneratedGodotNupkgsVersions {
+namespace $(RootNamespace)
+{
+    public class GeneratedGodotNupkgsVersions
+    {
         public const string GodotNETSdk = "$(PackageVersion_Godot_NET_Sdk)"%3b
         public const string GodotSourceGenerators = "$(PackageVersion_Godot_SourceGenerators)"%3b
+        public const string GodotSharp = "$(PackageVersion_GodotSharp)"%3b
     }
 }
 ]]></GenerateGodotNupkgsVersionsCode>

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -123,7 +123,7 @@ namespace GodotTools
                     try
                     {
                         string fallbackFolder = NuGetUtils.GodotFallbackFolderPath;
-                        NuGetUtils.AddFallbackFolderToUserNuGetConfigs(NuGetUtils.GodotFallbackFolderName,
+                        NuGetUtils.AddFallbackFolderToGodotNuGetConfigs(NuGetUtils.GodotFallbackFolderName,
                             fallbackFolder);
                         NuGetUtils.AddBundledPackagesToFallbackFolder(fallbackFolder);
                     }
@@ -497,7 +497,7 @@ namespace GodotTools
             try
             {
                 // At startup we make sure NuGet.Config files have our Godot NuGet fallback folder included
-                NuGetUtils.AddFallbackFolderToUserNuGetConfigs(NuGetUtils.GodotFallbackFolderName,
+                NuGetUtils.AddFallbackFolderToGodotNuGetConfigs(NuGetUtils.GodotFallbackFolderName,
                     NuGetUtils.GodotFallbackFolderPath);
             }
             catch (Exception e)


### PR DESCRIPTION
- Creates a `Godot.Offline.Config` file to configurate NuGet with Godot's fallback folder. This is easier because now we can assume we can override the entire file since user config will likely be in the default `NuGet.Config` file or an additional `*.config` file.
	- See https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#additional-user-wide-configuration
- Ensure the NuGet fallback folder is created at the same time it is added to the NuGet configuration so future builds don't fail.
	- Fixes https://github.com/godotengine/godot/issues/44532
- Add `GodotSharp` and `GodotSharpEditor` packages to the fallback folder.
- Add `.nupkg.metadata` file to packages in fallback folder.
	- This file seems to be necessary, without it building projects offline was failing to resolve the packages for me with error NU1100. I could not find version 2 of the metadata file spec but I copied what `nuget add -Expand` creates.

---

:warning: I'm still unable to resolve the `Godot.SourceGenerators` package using the fallback folder and it seems to be related to using a floating version because using the exact package version works:

https://github.com/godotengine/godot/blob/5803a1ddc5024bcea6fa5482bee206ccac94d62e/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets#L20

Here's the full error I get:

```
Build FAILED.

       "/media/raulsntos/Data/GodotProjects/TestProject/TestProject.sln" (Restore target) (1) ->
       (Restore target) -> 
         /media/raulsntos/Data/GodotProjects/TestProject/TestProject.csproj : error NU1100: Unable to resolve 'Godot.SourceGenerators (>= 4.0.0-0)' for 'net6.0'. [/media/raulsntos/Data/GodotProjects/TestProject/TestProject.sln]

    0 Warning(s)
    1 Error(s)
```