### PR TITLE
Resize Viewport for XR in the Viewport node

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3347,6 +3347,7 @@
 			<param index="0" name="viewport" type="RID" />
 			<param index="1" name="width" type="int" />
 			<param index="2" name="height" type="int" />
+			<param index="3" name="view_count" type="int" default="1" />
 			<description>
 				Sets the viewport's width and height.
 			</description>

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1402,13 +1402,14 @@ void TextureStorage::render_target_set_size(RID p_render_target, int p_width, in
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND(!rt);
 
-	if (p_width == rt->size.x && p_height == rt->size.y) {
+	if (p_width == rt->size.x && p_height == rt->size.y && p_view_count == rt->view_count) {
 		return;
 	}
 
 	_clear_render_target(rt);
 
 	rt->size = Size2i(p_width, p_height);
+	rt->view_count = p_view_count;
 
 	_update_render_target(rt);
 }

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -339,6 +339,7 @@ struct RenderTarget {
 
 	Point2i position = Point2i(0, 0);
 	Size2i size = Size2i(0, 0);
+	uint32_t view_count = 1;
 	int mipmap_count = 1;
 	RID self;
 	GLuint fbo = 0;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -230,6 +230,7 @@ private:
 	Size2i size = Size2i(512, 512);
 	Size2i size_2d_override;
 	bool size_allocated = false;
+	uint32_t view_count = 1;
 
 	RID contact_2d_debug;
 	RID contact_3d_debug_multimesh;
@@ -469,7 +470,7 @@ private:
 	uint64_t event_count = 0;
 
 protected:
-	void _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, const Transform2D &p_stretch_transform, bool p_allocated);
+	void _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, const Transform2D &p_stretch_transform, bool p_allocated, uint32_t p_view_count = 1);
 
 	Size2i _get_size() const;
 	Size2i _get_size_2d_override() const;
@@ -710,7 +711,7 @@ public:
 	void _propagate_enter_world_3d(Node *p_node);
 	void _propagate_exit_world_3d(Node *p_node);
 
-	void set_use_xr(bool p_use_xr);
+	virtual void set_use_xr(bool p_use_xr);
 	bool is_using_xr();
 #endif // _3D_DISABLED
 
@@ -765,6 +766,10 @@ public:
 	ClearMode get_clear_mode() const;
 
 	virtual Transform2D get_screen_transform() const override;
+
+#ifndef _3D_DISABLED
+	virtual void set_use_xr(bool p_use_xr) override;
+#endif // _3D_DISABLED
 
 	SubViewport();
 	~SubViewport();

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -316,6 +316,10 @@ public:
 	Rect2i get_parent_rect() const;
 	virtual DisplayServer::WindowID get_window_id() const override;
 
+#ifndef _3D_DISABLED
+	virtual void set_use_xr(bool p_use_xr) override;
+#endif // _3D_DISABLED
+
 	Window();
 	~Window();
 };

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -54,6 +54,7 @@ public:
 
 		Size2i internal_size;
 		Size2i size;
+		uint32_t view_count;
 		RID camera;
 		RID scenario;
 
@@ -150,6 +151,7 @@ public:
 		RendererScene::RenderInfo render_info;
 
 		Viewport() {
+			view_count = 1;
 			update_mode = RS::VIEWPORT_UPDATE_WHEN_VISIBLE;
 			clear_mode = RS::VIEWPORT_CLEAR_ALWAYS;
 			transparent_bg = false;
@@ -176,8 +178,6 @@ public:
 			time_gpu_begin = 0;
 			time_gpu_end = 0;
 		}
-
-		uint32_t get_view_count();
 	};
 
 	HashMap<String, RID> timestamp_vp_map;
@@ -210,7 +210,7 @@ public:
 
 	void viewport_set_use_xr(RID p_viewport, bool p_use_xr);
 
-	void viewport_set_size(RID p_viewport, int p_width, int p_height);
+	void viewport_set_size(RID p_viewport, int p_width, int p_height, uint32_t view_count);
 
 	void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
 	void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -580,7 +580,7 @@ public:
 	FUNCRIDSPLIT(viewport)
 
 	FUNC2(viewport_set_use_xr, RID, bool)
-	FUNC3(viewport_set_size, RID, int, int)
+	FUNC4(viewport_set_size, RID, int, int, uint32_t)
 
 	FUNC2(viewport_set_active, RID, bool)
 	FUNC2(viewport_set_parent_viewport, RID, RID)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2170,7 +2170,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("viewport_create"), &RenderingServer::viewport_create);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_xr", "viewport", "use_xr"), &RenderingServer::viewport_set_use_xr);
-	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::viewport_set_size);
+	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height", "view_count"), &RenderingServer::viewport_set_size, DEFVAL(1));
 	ClassDB::bind_method(D_METHOD("viewport_set_active", "viewport", "active"), &RenderingServer::viewport_set_active);
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &RenderingServer::viewport_set_parent_viewport);
 	ClassDB::bind_method(D_METHOD("viewport_attach_to_screen", "viewport", "rect", "screen"), &RenderingServer::viewport_attach_to_screen, DEFVAL(Rect2()), DEFVAL(DisplayServer::MAIN_WINDOW_ID));

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -798,7 +798,7 @@ public:
 	};
 
 	virtual void viewport_set_use_xr(RID p_viewport, bool p_use_xr) = 0;
-	virtual void viewport_set_size(RID p_viewport, int p_width, int p_height) = 0;
+	virtual void viewport_set_size(RID p_viewport, int p_width, int p_height, uint32_t p_view_count = 1) = 0;
 	virtual void viewport_set_active(RID p_viewport, bool p_active) = 0;
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;
 


### PR DESCRIPTION
This is an alternative approach to fixing the same bug as PR #64513 based on a suggestion from @BastiaanOlij 

It doesn't totally work: weird things happen when you resize the window. I tried modifying the Window node to act differently when `use_xr` is true, but that got pretty messy and I couldn't get it working right (things just got weirder ;-)) so it's not included in this PR.

In any case, if this seems to @BastiaanOlij and @clayjohn like the better way to go from an architectural perspective, I can continue trying working on it and hopefully iron out those problems!

(However, to me PR #64513 seems like the simpler fix to the bug. I could make an even simpler PR using the same approach as that one, that just adds 1 line to fix the bug, but it'd be less efficient for reasons explained in the description there.)