### PR TITLE
Add get_distribution_name() and get_version() to OS

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -322,6 +322,14 @@ String OS::get_name() const {
 	return ::OS::get_singleton()->get_name();
 }
 
+String OS::get_distribution_name() const {
+	return ::OS::get_singleton()->get_distribution_name();
+}
+
+String OS::get_version() const {
+	return ::OS::get_singleton()->get_version();
+}
+
 Vector<String> OS::get_cmdline_args() {
 	List<String> cmdline = ::OS::get_singleton()->get_cmdline_args();
 	Vector<String> cmdlinev;
@@ -535,6 +543,8 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_environment", "variable"), &OS::has_environment);
 
 	ClassDB::bind_method(D_METHOD("get_name"), &OS::get_name);
+	ClassDB::bind_method(D_METHOD("get_distribution_name"), &OS::get_distribution_name);
+	ClassDB::bind_method(D_METHOD("get_version"), &OS::get_version);
 	ClassDB::bind_method(D_METHOD("get_cmdline_args"), &OS::get_cmdline_args);
 	ClassDB::bind_method(D_METHOD("get_cmdline_user_args"), &OS::get_cmdline_user_args);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -193,6 +193,8 @@ public:
 	bool set_environment(const String &p_var, const String &p_value) const;
 
 	String get_name() const;
+	String get_distribution_name() const;
+	String get_version() const;
 	Vector<String> get_cmdline_args();
 	Vector<String> get_cmdline_user_args();
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -161,6 +161,8 @@ public:
 	virtual bool set_environment(const String &p_var, const String &p_value) const = 0;
 
 	virtual String get_name() const = 0;
+	virtual String get_distribution_name() const = 0;
+	virtual String get_version() const = 0;
 	virtual List<String> get_cmdline_args() const { return _cmdline; }
 	virtual List<String> get_cmdline_user_args() const { return _user_args; }
 	virtual List<String> get_cmdline_platform_args() const { return List<String>(); }

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -216,6 +216,15 @@
 				Not to be confused with [method get_user_data_dir], which returns the [i]project-specific[/i] user data path.
 			</description>
 		</method>
+		<method name="get_distribution_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name of the distribution for Linux and BSD platforms (e.g. Ubuntu, Manjaro, OpenBSD, etc.).
+				Returns the same value as [method get_name] for stock Android ROMs, but attempts to return the custom ROM name for popular Android derivatives such as LineageOS.
+				Returns the same value as [method get_name] for other platforms.
+				[b]Note:[/b] This method is not supported on the web platform. It returns an empty string.
+			</description>
+		</method>
 		<method name="get_environment" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="variable" type="String" />
@@ -428,6 +437,18 @@
 				On the web, this is a virtual directory managed by the browser.
 				If the project name is empty, [code][project_name][/code] falls back to [code][unnamed project][/code].
 				Not to be confused with [method get_data_dir], which returns the [i]global[/i] (non-project-specific) user home directory.
+			</description>
+		</method>
+		<method name="get_version" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the exact production and build version of the operating system. This is different from the branded version used in marketing. This helps to distinguish between different releases of operating systems, including minor versions, and insider and custom builds.
+				For Windows, the major and minor version are returned, as well as the build number. For example, the returned string can look like [code]10.0.9926[/code] for a build of Windows 10, and it can look like [code]6.1.7601[/code] for a build of Windows 7 SP1.
+				For rolling distributions, such as Arch Linux, an empty string is returned.
+				For macOS and iOS, the major and minor version are returned, as well as the patch number.
+				For UWP, the device family version is returned.
+				For Android, the SDK version and the incremental build number are returned. If it's a custom ROM, it attempts to return its version instead.
+				[b]Note:[/b] This method is not supported on the web platform. It returns an empty string.
 			</description>
 		</method>
 		<method name="has_environment" qualifiers="const">

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -194,6 +194,14 @@ String OS_Unix::get_name() const {
 	return "Unix";
 }
 
+String OS_Unix::get_distribution_name() const {
+	return "";
+}
+
+String OS_Unix::get_version() const {
+	return "";
+}
+
 double OS_Unix::get_unix_time() const {
 	struct timeval tv_now;
 	gettimeofday(&tv_now, nullptr);

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -62,6 +62,8 @@ public:
 	virtual Error set_cwd(const String &p_cwd) override;
 
 	virtual String get_name() const override;
+	virtual String get_distribution_name() const override;
+	virtual String get_version() const override;
 
 	virtual DateTime get_datetime(bool p_utc) const override;
 	virtual TimeZoneInfo get_time_zone_info() const override;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -65,6 +65,8 @@ private:
 	GodotJavaWrapper *godot_java = nullptr;
 	GodotIOJavaWrapper *godot_io_java = nullptr;
 
+	String get_system_property(const char *key) const;
+
 public:
 	static const char *ANDROID_EXEC_PATH;
 
@@ -93,6 +95,8 @@ public:
 	virtual Error open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path = false, String *r_resolved_path = nullptr) override;
 
 	virtual String get_name() const override;
+	virtual String get_distribution_name() const override;
+	virtual String get_version() const override;
 	virtual MainLoop *get_main_loop() const override;
 
 	void main_loop_begin();

--- a/platform/ios/os_ios.h
+++ b/platform/ios/os_ios.h
@@ -100,6 +100,8 @@ public:
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String p_name, void *&p_symbol_handle, bool p_optional = false) override;
 
 	virtual String get_name() const override;
+	virtual String get_distribution_name() const override;
+	virtual String get_version() const override;
 	virtual String get_model_name() const override;
 
 	virtual Error shell_open(String p_uri) override;

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -240,6 +240,15 @@ String OS_IOS::get_name() const {
 	return "iOS";
 }
 
+String OS_IOS::get_distribution_name() const {
+	return get_name();
+}
+
+String OS_IOS::get_version() const {
+	NSOperatingSystemVersion ver = [NSProcessInfo processInfo].operatingSystemVersion;
+	return vformat("%d.%d.%d", (int64_t)ver.majorVersion, (int64_t)ver.minorVersion, (int64_t)ver.patchVersion);
+}
+
 String OS_IOS::get_model_name() const {
 	String model = ios->get_model();
 	if (model != "") {

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -67,6 +67,8 @@ class OS_LinuxBSD : public OS_Unix {
 
 	MainLoop *main_loop = nullptr;
 
+	String get_systemd_os_release_info_value(const String &key) const;
+
 protected:
 	virtual void initialize() override;
 	virtual void finalize() override;
@@ -77,6 +79,8 @@ protected:
 
 public:
 	virtual String get_name() const override;
+	virtual String get_distribution_name() const override;
+	virtual String get_version() const override;
 
 	virtual MainLoop *get_main_loop() const override;
 

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -75,6 +75,8 @@ public:
 	virtual List<String> get_cmdline_platform_args() const override;
 
 	virtual String get_name() const override;
+	virtual String get_distribution_name() const override;
+	virtual String get_version() const override;
 
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -134,6 +134,15 @@ String OS_MacOS::get_name() const {
 	return "macOS";
 }
 
+String OS_MacOS::get_distribution_name() const {
+	return get_name();
+}
+
+String OS_MacOS::get_version() const {
+	NSOperatingSystemVersion ver = [NSProcessInfo processInfo].operatingSystemVersion;
+	return vformat("%d.%d.%d", (int64_t)ver.majorVersion, (int64_t)ver.minorVersion, (int64_t)ver.patchVersion);
+}
+
 void OS_MacOS::alert(const String &p_alert, const String &p_title) {
 	NSAlert *window = [[NSAlert alloc] init];
 	NSString *ns_title = [NSString stringWithUTF8String:p_title.utf8().get_data()];

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -444,6 +444,16 @@ String OS_UWP::get_name() const {
 	return "UWP";
 }
 
+String OS_UWP::get_distribution_name() const {
+	return get_name();
+}
+
+String OS_UWP::get_version() const {
+	winrt::hstring df_version = VersionInfo().DeviceFamilyVersion();
+	static String version = String(winrt::to_string(df_version).c_str());
+	return version;
+}
+
 OS::DateTime OS_UWP::get_datetime(bool p_utc) const {
 	SYSTEMTIME systemtime;
 	if (p_utc) {

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -183,6 +183,8 @@ public:
 	virtual MainLoop *get_main_loop() const;
 
 	virtual String get_name() const;
+	virtual String get_distribution_name() const;
+	virtual String get_version() const;
 
 	virtual DateTime get_datetime(bool p_utc) const;
 	virtual TimeZoneInfo get_time_zone_info() const;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -290,6 +290,24 @@ String OS_Windows::get_name() const {
 	return "Windows";
 }
 
+String OS_Windows::get_distribution_name() const {
+	return get_name();
+}
+
+String OS_Windows::get_version() const {
+	typedef LONG NTSTATUS, *PNTSTATUS;
+	typedef NTSTATUS(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+	RtlGetVersionPtr version_ptr = (RtlGetVersionPtr)GetProcAddress(GetModuleHandle("ntdll.dll"), "RtlGetVersion");
+	if (version_ptr != nullptr) {
+		RTL_OSVERSIONINFOW fow = { 0 };
+		fow.dwOSVersionInfoSize = sizeof(fow);
+		if (version_ptr(&fow) == 0x00000000) {
+			return vformat("%d.%d.%d", (int64_t)fow.dwMajorVersion, (int64_t)fow.dwMinorVersion, (int64_t)fow.dwBuildNumber);
+		}
+	}
+	return "";
+}
+
 OS::DateTime OS_Windows::get_datetime(bool p_utc) const {
 	SYSTEMTIME systemtime;
 	if (p_utc) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -143,6 +143,8 @@ public:
 	virtual MainLoop *get_main_loop() const override;
 
 	virtual String get_name() const override;
+	virtual String get_distribution_name() const override;
+	virtual String get_version() const override;
 
 	virtual void initialize_joypads() override {}
 


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/5022


### LinuxBSD

uses (in this order)
* /etc/os-release returns (systemd) [info](https://man.archlinux.org/man/os-release.5.en)
  * for systemd-users, this returns values such as `20.04.5 LTS (Focal Fossa)` (on Ubuntu)
  * though for e.g. Fedora, this returns `32 (Workstation Edition)`. Here, the `VERSION_ID` would return just `32` ([source](https://man.archlinux.org/man/os-release.5.en#EXAMPLES)). But for Ubuntu, this field contains just `20.04`. If the +`.5` on Ubuntu is not important, then we can read from `Version_ID` instead.
* `uname`
  * as a fallback: for *BSD family, it works quite well (https://www.freebsd.org/cgi/man.cgi?query=uname)
  * if `/etc/os-release` is removed, then for systemd-users like Ubuntu, this would return a more technical name `#49~20.04.1-Ubuntu SMP Thu Aug 4 19:15:44 UTC 2022`. But this is probably too much?

The only alternatives to /etc/os-release and uname I know of
* hostnamectl (but is also systemd, as far as I know)
* lsb_release (Debian-only -> Debian already has systemd)


### macOS / iOS

using NSOperatingSystemVersion
* https://developer.apple.com/documentation/foundation/nsoperatingsystemversion
  * supported versions: iOS 8.0+ iPadOS 8.0+ macOS 10.10+ Mac Catalyst 13.0+ tvOS 9.0+ watchOS 2.0+ 
    * i.e. roughly up to 8-year-old software

if anything goes wrong with above, use uname as fallback (if so, call `version`, `release` returns kernel version)
* https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/uname.3.html


### Windows

uses: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion


### UWP

https://docs.microsoft.com/en-us/uwp/api/windows.system.profile.analyticsinfo.versioninfo?view=winrt-22621
* returns DeviceFamilyVersion for version()

### Android

https://developer.android.com/reference/android/os/Build.VERSION

**Distribution Name**  
* check if custom ROM -> if it is, try to return its name by going through a list of handpicked Android ROMs
* otherwise, return `OS.get_name()`

**Version**  
* check if custom ROM -> if it is, try to read its version (some ROMs write into `ro.modversion`)
* for ROMs that DON'T write into `ro.modversion`, check a select few
* otherwise return `sdk_int` and `incremental` of standard Android


### Web

**not supported**

As Godot uses emscripten, you can probably get Browser Name and Version via [this](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-call-javascript-from-native), but I won't get into that… ~~But I'll include it in this PR, if someone wants to look it up and gives feedback in a comment~~ I took a look at the library I linked in my comment [here](https://github.com/godotengine/godot/pull/65525#issuecomment-1241227410), and the checks for different browsers alone are almost 700 line of code (we could reduce it to 100 lines or so, I reckon. Even less, if we support only a small subset). And it has various utility methods, so it's unknown how many more lines would be required without reading more code. But it would most likely at least double the lines of code in this PR (and it would be a fork of that lib). Therefore, this should be done in a separate PR, if there's interest.  
It can even be considered to include the library as a whole into Godot and also use it to detect OS on Web. And add a Web-specific method `get_browser_engine()`.