### PR TITLE
Various fixes to C# warnings

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -997,6 +997,12 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 
 	p_output.append("namespace " BINDINGS_NAMESPACE ";\n\n");
 
+	p_output.append("\n"
+					"#if !EXTRA_WARNINGS\n"
+					"#pragma warning disable CA1716 // Disable warning: "
+					"'Identifiers should not match keywords'\n"
+					"#endif\n");
+
 	p_output.append("public static partial class " BINDINGS_GLOBAL_SCOPE_CLASS "\n{");
 
 	for (const ConstantInterface &iconstant : global_constants) {
@@ -1094,6 +1100,11 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 			p_output.append(CLOSE_BLOCK);
 		}
 	}
+
+	p_output.append("\n"
+					"#if !EXTRA_WARNINGS\n"
+					"#pragma warning restore CA1716\n"
+					"#endif\n");
 }
 
 Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
@@ -1409,6 +1420,14 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 	output.append("using System.ComponentModel;\n"); // EditorBrowsable
 	output.append("using System.Diagnostics;\n"); // DebuggerBrowsable
 	output.append("using Godot.NativeInterop;\n");
+
+	output.append("\n"
+				  "#if !EXTRA_WARNINGS\n"
+				  "#pragma warning disable CS0108 // Disable warning: "
+				  "'Member hides inherited member. Use the new keyword if hiding was intended.'\n"
+				  "#pragma warning disable CA1716 // Disable warning: "
+				  "'Identifiers should not match keywords'\n"
+				  "#endif\n");
 
 	output.append("\n#nullable disable\n");
 
@@ -1911,6 +1930,12 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 	output << INDENT1 "}\n";
 
 	output.append(CLOSE_BLOCK /* class */);
+
+	output.append("\n"
+				  "#if !EXTRA_WARNINGS\n"
+				  "#pragma warning restore CS0108\n"
+				  "#pragma warning restore CA1716\n"
+				  "#endif\n");
 
 	return _save_file(p_output_file, output);
 }

--- a/modules/mono/glue/GodotSharp/.editorconfig
+++ b/modules/mono/glue/GodotSharp/.editorconfig
@@ -6,9 +6,6 @@ dotnet_diagnostic.CA1062.severity = error
 dotnet_diagnostic.CA1069.severity = none
 # CA1708: Identifiers should differ by more than case
 dotnet_diagnostic.CA1708.severity = none
-# CA1716: Identifiers should not match keywords
-# This is suppressed, because it will report `@event` as well as `event`
-dotnet_diagnostic.CA1716.severity = none
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.CS1591.severity = none
 # CS1573: Parameter has no matching param tag in the XML comment

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -510,8 +510,11 @@ namespace Godot
                 parameterTypes[i] = parameterType;
             }
 
+            // TODO: Suppressing invalid warning, remove when issue is fixed (https://github.com/DotNetAnalyzers/ReflectionAnalyzers/issues/209)
+#pragma warning disable REFL045 // These flags are insufficient to match any members
             methodInfo = declaringType.GetMethod(methodName, (BindingFlags)flags, null, parameterTypes, null);
             return methodInfo != null && methodInfo.ReturnType == returnType;
+#pragma warning restore REFL045
         }
 
         private static Type? DeserializeType(BinaryReader reader)


### PR DESCRIPTION
- Suppress CS0108 caused by shadowing members in derived classes.
	- Fixes https://github.com/godotengine/godot/issues/15763
- Suppress CA1716 caused by parameter names matching C# keywords.
	- Follow up to https://github.com/godotengine/godot/pull/87518.

<details>
<summary><h3>Extracted to different PRs</h3></summary>

- Suppress REFL045 in a false positive scenario.
	- Extracted to https://github.com/godotengine/godot/pull/88570.
- Suppress CA1710 caused by Array not having the Collection suffix.
	- Extracted to https://github.com/godotengine/godot/pull/87518.
- Suppress CA1716 caused by parameter names matching C# keywords.
	- Extracted to https://github.com/godotengine/godot/pull/87518.
- Use SymbolEqualityComparer in ScriptPathAttributeGenerator to fix RS1024.
	- Extracted to https://github.com/godotengine/godot/pull/87342.
- Suppress dependencies of SourceGenerators package to fix NU5128.
	- Extracted to https://github.com/godotengine/godot/pull/79501.
- Suppress nullability warnings in source generators because we already have a Debug.Assert (but it's missing the nullability annotations in netstandard2.0).
	- Extracted to https://github.com/godotengine/godot/pull/87518.
- Implement disposable pattern in `GodotSynchronizationContext` (and make it sealed).
	- Extracted to https://github.com/godotengine/godot/pull/72053.
- Fix reference to `NotificationSceneInstantiated` in the documentation.
	- Follow up to https://github.com/godotengine/godot/pull/64410.
	- Extracted to https://github.com/godotengine/godot/pull/72462.
- Fix RS2008: Enable analyzer release tracking.
	- Implemented by https://github.com/godotengine/godot/pull/80343.

</details>

### TODO
- [ ] Fix CA1001: Type owns disposable field but is not disposable.
	- [ ] `Array` and `Dictionary`: This was already discussed a bit in https://github.com/godotengine/godot/pull/64089#discussion_r940589373 but I think it's not as straightforward as the rest of the fixes and it should probably be handled in a separate PR.
	- [ ] `Variant`: It already implements `IDisposable` so I don't know why it complains.
		- Seems like it's a bug in the analyzer: https://github.com/dotnet/roslyn-analyzers/issues/6151.