### PR TITLE
C#: Fix module builds for Windows 32-bit with mingw-w64

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2035,6 +2035,52 @@ void CSharpScript::_update_exports_values(HashMap<StringName, Variant> &values, 
 }
 #endif
 
+void GD_CLR_STDCALL CSharpScript::_add_property_info_list_callback(CSharpScript *p_script, const String *p_current_class_name, void *p_props, int32_t p_count) {
+	GDMonoCache::godotsharp_property_info *props = (GDMonoCache::godotsharp_property_info *)p_props;
+
+#ifdef TOOLS_ENABLED
+	p_script->exported_members_cache.push_back(PropertyInfo(
+			Variant::NIL, *p_current_class_name, PROPERTY_HINT_NONE,
+			p_script->get_path(), PROPERTY_USAGE_CATEGORY));
+#endif
+
+	for (int i = 0; i < p_count; i++) {
+		const GDMonoCache::godotsharp_property_info &prop = props[i];
+
+		StringName name = *reinterpret_cast<const StringName *>(&prop.name);
+		String hint_string = *reinterpret_cast<const String *>(&prop.hint_string);
+
+		PropertyInfo pinfo(prop.type, name, prop.hint, hint_string, prop.usage);
+
+		p_script->member_info[name] = pinfo;
+
+		if (prop.exported) {
+#ifdef TOOLS_ENABLED
+			p_script->exported_members_cache.push_back(pinfo);
+#endif
+
+#if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
+			p_script->exported_members_names.insert(name);
+#endif
+		}
+	}
+}
+
+#ifdef TOOLS_ENABLED
+void GD_CLR_STDCALL CSharpScript::_add_property_default_values_callback(CSharpScript *p_script, void *p_def_vals, int32_t p_count) {
+	GDMonoCache::godotsharp_property_def_val_pair *def_vals = (GDMonoCache::godotsharp_property_def_val_pair *)p_def_vals;
+
+	for (int i = 0; i < p_count; i++) {
+		const GDMonoCache::godotsharp_property_def_val_pair &def_val_pair = def_vals[i];
+
+		StringName name = *reinterpret_cast<const StringName *>(&def_val_pair.name);
+		Variant value = *reinterpret_cast<const Variant *>(&def_val_pair.value);
+
+		p_script->exported_members_defval_cache[name] = value;
+	}
+}
+#endif
+
 bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_update) {
 #ifdef TOOLS_ENABLED
 	bool is_editor = Engine::get_singleton()->is_editor_hint();
@@ -2066,49 +2112,10 @@ bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_upda
 #endif
 
 		if (GDMonoCache::godot_api_cache_updated) {
-			GDMonoCache::managed_callbacks.ScriptManagerBridge_GetPropertyInfoList(this,
-					[](CSharpScript *p_script, const String *p_current_class_name, GDMonoCache::godotsharp_property_info *p_props, int32_t p_count) {
-#ifdef TOOLS_ENABLED
-						p_script->exported_members_cache.push_back(PropertyInfo(
-								Variant::NIL, *p_current_class_name, PROPERTY_HINT_NONE,
-								p_script->get_path(), PROPERTY_USAGE_CATEGORY));
-#endif
-
-						for (int i = 0; i < p_count; i++) {
-							const GDMonoCache::godotsharp_property_info &prop = p_props[i];
-
-							StringName name = *reinterpret_cast<const StringName *>(&prop.name);
-							String hint_string = *reinterpret_cast<const String *>(&prop.hint_string);
-
-							PropertyInfo pinfo(prop.type, name, prop.hint, hint_string, prop.usage);
-
-							p_script->member_info[name] = pinfo;
-
-							if (prop.exported) {
+			GDMonoCache::managed_callbacks.ScriptManagerBridge_GetPropertyInfoList(this, &_add_property_info_list_callback);
 
 #ifdef TOOLS_ENABLED
-								p_script->exported_members_cache.push_back(pinfo);
-#endif
-
-#if defined(TOOLS_ENABLED) || defined(DEBUG_ENABLED)
-								p_script->exported_members_names.insert(name);
-#endif
-							}
-						}
-					});
-
-#ifdef TOOLS_ENABLED
-			GDMonoCache::managed_callbacks.ScriptManagerBridge_GetPropertyDefaultValues(this,
-					[](CSharpScript *p_script, GDMonoCache::godotsharp_property_def_val_pair *p_def_vals, int32_t p_count) {
-						for (int i = 0; i < p_count; i++) {
-							const GDMonoCache::godotsharp_property_def_val_pair &def_val_pair = p_def_vals[i];
-
-							StringName name = *reinterpret_cast<const StringName *>(&def_val_pair.name);
-							Variant value = *reinterpret_cast<const Variant *>(&def_val_pair.value);
-
-							p_script->exported_members_defval_cache[name] = value;
-						}
-					});
+			GDMonoCache::managed_callbacks.ScriptManagerBridge_GetPropertyDefaultValues(this, &_add_property_default_values_callback);
 #endif
 		}
 	}

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -133,6 +133,10 @@ class CSharpScript : public Script {
 
 	void _clear();
 
+	static void GD_CLR_STDCALL _add_property_info_list_callback(CSharpScript *p_script, const String *p_current_class_name, void *p_props, int32_t p_count);
+#ifdef TOOLS_ENABLED
+	static void GD_CLR_STDCALL _add_property_default_values_callback(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
+#endif
 	bool _update_exports(PlaceHolderScriptInstance *p_instance_to_update = nullptr);
 
 	CSharpInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_is_ref_counted, Callable::CallError &r_error);

--- a/modules/mono/mono_gd/gd_mono.h
+++ b/modules/mono/mono_gd/gd_mono.h
@@ -35,10 +35,12 @@
 
 #include "../godotsharp_defs.h"
 
+#ifndef GD_CLR_STDCALL
 #ifdef WIN32
 #define GD_CLR_STDCALL __stdcall
 #else
 #define GD_CLR_STDCALL
+#endif
 #endif
 
 namespace gdmono {
@@ -55,8 +57,6 @@ struct PluginCallbacks {
 #endif
 
 } // namespace gdmono
-
-#undef GD_CLR_STDCALL
 
 class GDMono {
 	bool runtime_initialized;

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -47,10 +47,12 @@ class CSharpScript;
 
 namespace GDMonoCache {
 
+#ifndef GD_CLR_STDCALL
 #ifdef WIN32
 #define GD_CLR_STDCALL __stdcall
 #else
 #define GD_CLR_STDCALL
+#endif
 #endif
 
 struct godotsharp_property_info {
@@ -68,8 +70,8 @@ struct godotsharp_property_def_val_pair {
 };
 
 struct ManagedCallbacks {
-	using Callback_ScriptManagerBridge_GetPropertyInfoList_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const String *, godotsharp_property_info *p_props, int32_t p_count);
-	using Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, godotsharp_property_def_val_pair *p_def_vals, int32_t p_count);
+	using Callback_ScriptManagerBridge_GetPropertyInfoList_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, const String *, void *p_props, int32_t p_count);
+	using Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add = void(GD_CLR_STDCALL *)(CSharpScript *p_script, void *p_def_vals, int32_t p_count);
 
 	using FuncSignalAwaiter_SignalCallback = void(GD_CLR_STDCALL *)(GCHandleIntPtr, const Variant **, int32_t, bool *);
 	using FuncDelegateUtils_InvokeWithVariantArgs = void(GD_CLR_STDCALL *)(GCHandleIntPtr, const Variant **, uint32_t, const Variant *);
@@ -144,7 +146,5 @@ extern bool godot_api_cache_updated;
 void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks);
 
 } // namespace GDMonoCache
-
-#undef GD_CLR_STDCALL
 
 #endif // GD_MONO_CACHE_H


### PR DESCRIPTION
The lambda was giving issues, so I re-wrote it as a static function.

Fixes #65522

This way of adding properties is old, and it will change in the future. It should be done in `update_script_class_info` like methods and signals. But for now, this fix will do.
