### PR TITLE
GDExtension: `create_instance_func` can be NULL to inhibit construction from GDScript

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -245,7 +245,7 @@ typedef struct {
 	GDNativeExtensionClassToString to_string_func;
 	GDNativeExtensionClassReference reference_func;
 	GDNativeExtensionClassUnreference unreference_func;
-	GDNativeExtensionClassCreateInstance create_instance_func; /* this one is mandatory */
+	GDNativeExtensionClassCreateInstance create_instance_func; /* if missing, GDScript cannot instantiate the class */
 	GDNativeExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 	GDNativeExtensionClassGetVirtual get_virtual_func;
 	GDNativeExtensionClassGetRID get_rid_func;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -325,6 +325,8 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 		ERR_FAIL_COND_V_MSG(!ti, nullptr, "Cannot get class '" + String(p_class) + "'.");
 		ERR_FAIL_COND_V_MSG(ti->disabled, nullptr, "Class '" + String(p_class) + "' is disabled.");
 		ERR_FAIL_COND_V_MSG(!ti->creation_func, nullptr, "Class '" + String(p_class) + "' or its base class cannot be instantiated.");
+		ERR_FAIL_COND_V_MSG((ti->native_extension && !ti->native_extension->create_instance), nullptr,
+				"GDExtension class '" + String(p_class) + "' has no constructor defined.");
 	}
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -169,6 +169,7 @@ private:
 	// Non-locking variants of get_parent_class and is_parent_class.
 	static StringName _get_parent_class(const StringName &p_class);
 	static bool _is_parent_class(const StringName &p_class, const StringName &p_inherits);
+	static bool _has_creation_func(const ClassInfo *p_class_info);
 
 public:
 	// DO NOT USE THIS!!!!!! NEEDS TO BE PUBLIC BUT DO NOT USE NO MATTER WHAT!!!


### PR DESCRIPTION
This is a small quality-of-life change that's useful for classes which should either not be instantiated (e.g. static methods) or only instantiated from the GDExtension binding. The GDScript constructor call `MyClass.new()` now causes an error, which has the nice side effect that forgetting to specify `create_instance_func` leads to a clear error rather than a half-constructed object.

Currently, the code already checks for the condition:
```cpp
(ti->native_extension && !ti->native_extension->create_instance)
```
so the API header comment `/* this one is mandatory */` is wrong. However, the `ClassDB` code doesn't act upon the null pointer, instead it constructs a "zombie" instance with initialized base but uninitialized extension.

---

The check at the bottom of the function,
```cpp
if (ti->native_extension && ti->native_extension->create_instance)
```
could now theoretically be simplified to:
```cpp
if (ti->native_extension)
```
however I'm not sure if that's desired, as another refactoring might quickly introduce UB (null pointer dereferencing).