### PR TITLE
Fix MacOS compiler flags in .NET module

### DIFF
--- a/modules/mono/editor/hostfxr_resolver.cpp
+++ b/modules/mono/editor/hostfxr_resolver.cpp
@@ -82,7 +82,7 @@ namespace {
 String get_hostfxr_file_name() {
 #if defined(WINDOWS_ENABLED) || defined(UWP_ENABLED)
 	return "hostfxr.dll";
-#elif defined(OSX_ENABLED) || defined(IOS_ENABLED)
+#elif defined(MACOS_ENABLED) || defined(IOS_ENABLED)
 	return "libhostfxr.dylib";
 #else
 	return "libhostfxr.so";
@@ -197,7 +197,7 @@ bool get_default_installation_dir(String &r_dotnet_root) {
 
 	r_dotnet_root = path::join(program_files_dir, "dotnet");
 	return true;
-#elif defined(TARGET_OSX)
+#elif defined(MACOS_ENABLED)
 	r_dotnet_root = "/usr/local/share/dotnet";
 
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)


### PR DESCRIPTION
I don't have a MacOS device to test this but I believe these compiler flags were renamed and this is the correct name now.