### PR TITLE
Add AnimatedSprite."frame_refreshed" signal

### DIFF
--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -49,6 +49,7 @@ class AnimatedSprite2D : public Node2D {
 
 	bool is_over = false;
 	float timeout = 0.0;
+	bool pending_refresh;
 
 	bool hflip = false;
 	bool vflip = false;
@@ -57,6 +58,8 @@ class AnimatedSprite2D : public Node2D {
 
 	double _get_frame_duration();
 	void _reset_timeout();
+	void _queue_frame_refresh();
+	void _emit_frame_refreshed();
 	Rect2 _get_rect() const;
 
 protected:


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5146.
Alternative to https://github.com/godotengine/godot-proposals/issues/5137 **(read both, please)**.

"_frame_changed_" is emitted only when the `frame` property itself changes. This means there are occasions where the signal is not actually emitted, which can prove problematic. For example, when changing animations, `frame` is set to `0`, but if `frame` already was `0`, the signal is not emitted.

"_draw_" is emitted on every visual frame change, guaranteed. However, the signal does **not** emit when **AnimatedSprite2D** is outside the tree, or when it is not visible, the latter of which leading to odd inconsistencies. Furthermore, **AnimatedSprite3D has no "_draw_" signal of any kind**.

This PR adds "_frame_refreshed_". This signal is emitted on every visual frame change (flipping, changing offset, animation, SpriteFrames), not just the `frame` index, similar to `draw`. But UNLIKE `draw` It is emitted even when **AnimatedSprite** is not visible.

Overall, this signal can typically be more useful and consistent than `frame_changed`, and both 2D and 3D would benefit from it.

Draft because although this is the plan, I have yet to add it to **AnimatedSprite3D**. It also doesn't look like it has any overwhelming reception. If interest for something similar is out there, there I am.