### PR TITLE
Add `filled`, `border_width`, `editor_only` properties to ColorRect

### DIFF
--- a/doc/classes/ColorRect.xml
+++ b/doc/classes/ColorRect.xml
@@ -5,13 +5,19 @@
 	</brief_description>
 	<description>
 		Displays a rectangle filled with a solid [member color]. If you need to display the border alone, consider using [ReferenceRect] instead.
+		Displays a rectangle filled with a solid [member color] by default, but can be used as a reference box which displays only a border around its rectangle.
+		If you need more advanced functionality, [ColorRect] uses [method CanvasItem.draw_rect] for drawing rectangles, so you can extend [ColorRect] or create a new class via script.
 	</description>
 	<tutorials>
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>
 	</tutorials>
 	<members>
+		<member name="border_width" type="float" setter="set_border_width" getter="get_border_width" default="1.0">
+			Sets the border width of the [ColorRect]. The border grows both inwards and outwards with respect to the rectangle box.
+			[b]Note:[/b] This property has no effect when [member filled] is [code]true[/code].
+		</member>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)">
-			The fill color.
+			Sets the rectangle's fill and border color.
 			[codeblocks]
 			[gdscript]
 			$ColorRect.color = Color(1, 0, 0, 1) # Set ColorRect's color to red.
@@ -20,6 +26,12 @@
 			GetNode&lt;ColorRect&gt;("ColorRect").Color = new Color(1, 0, 0, 1); // Set ColorRect's color to red.
 			[/csharp]
 			[/codeblocks]
+		</member>
+		<member name="editor_only" type="bool" setter="set_editor_only" getter="is_editor_only" default="false">
+			If [code]true[/code], the [ColorRect] will only be visible while in the editor.
+		</member>
+		<member name="filled" type="bool" setter="set_filled" getter="is_filled" default="true">
+			If [code]true[/code], the [ColorRect]'s area is filled with a solid [member color], otherwise only the rectangle's border is displayed.
 		</member>
 	</members>
 </class>

--- a/scene/gui/color_rect.cpp
+++ b/scene/gui/color_rect.cpp
@@ -42,11 +42,49 @@ Color ColorRect::get_color() const {
 	return color;
 }
 
+void ColorRect::set_filled(bool p_filled) {
+	filled = p_filled;
+	queue_redraw();
+	notify_property_list_changed();
+}
+
+bool ColorRect::is_filled() const {
+	return filled;
+}
+
+void ColorRect::set_border_width(float p_width) {
+	border_width = p_width;
+	queue_redraw();
+}
+
+float ColorRect::get_border_width() const {
+	return border_width;
+}
+
+void ColorRect::set_editor_only(bool p_enabled) {
+	editor_only = p_enabled;
+	queue_redraw();
+}
+
+bool ColorRect::is_editor_only() const {
+	return editor_only;
+}
+
 void ColorRect::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			draw_rect(Rect2(Point2(), get_size()), color);
+			if (Engine::get_singleton()->is_editor_hint() || !editor_only) {
+				draw_rect(Rect2(Point2(), get_size()), color, filled, filled ? 1.0 : border_width);
+			}
 		} break;
+	}
+}
+
+void ColorRect::_validate_property(PropertyInfo &property) const {
+	if (property.name == "border_width") {
+		if (filled) {
+			property.usage = PROPERTY_USAGE_NO_EDITOR;
+		}
 	}
 }
 
@@ -54,5 +92,17 @@ void ColorRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_color", "color"), &ColorRect::set_color);
 	ClassDB::bind_method(D_METHOD("get_color"), &ColorRect::get_color);
 
+	ClassDB::bind_method(D_METHOD("set_filled", "filled"), &ColorRect::set_filled);
+	ClassDB::bind_method(D_METHOD("is_filled"), &ColorRect::is_filled);
+
+	ClassDB::bind_method(D_METHOD("set_border_width", "width"), &ColorRect::set_border_width);
+	ClassDB::bind_method(D_METHOD("get_border_width"), &ColorRect::get_border_width);
+
+	ClassDB::bind_method(D_METHOD("is_editor_only"), &ColorRect::is_editor_only);
+	ClassDB::bind_method(D_METHOD("set_editor_only", "enabled"), &ColorRect::set_editor_only);
+
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filled"), "set_filled", "is_filled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "border_width", PROPERTY_HINT_RANGE, "0.0,5.0,0.1,or_greater"), "set_border_width", "get_border_width"); // Should be after `filled`.
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_only"), "set_editor_only", "is_editor_only");
 }

--- a/scene/gui/color_rect.h
+++ b/scene/gui/color_rect.h
@@ -37,14 +37,27 @@ class ColorRect : public Control {
 	GDCLASS(ColorRect, Control);
 
 	Color color = Color(1, 1, 1);
+	bool filled = true;
+	float border_width = 1.0; // Has no effect when `filled` is `true`.
+	bool editor_only = false;
 
 protected:
 	void _notification(int p_what);
+	void _validate_property(PropertyInfo &property) const;
 	static void _bind_methods();
 
 public:
 	void set_color(const Color &p_color);
 	Color get_color() const;
+
+	void set_filled(bool p_filled);
+	bool is_filled() const;
+
+	void set_border_width(float p_width);
+	float get_border_width() const;
+
+	void set_editor_only(bool p_enabled);
+	bool is_editor_only() const;
 };
 
 #endif // COLOR_RECT_H


### PR DESCRIPTION
Salvages https://github.com/godotengine/godot/pull/42931.
Closes https://github.com/godotengine/godot-proposals/issues/1687.

Ports over the properties of **ReferenceRect** to **ColorRect** itself.

![Showcase](https://i.gyazo.com/36f4301541e9b3dd437f864173c3d683.gif)

This also renders **ReferenceRect** impressively redundant, but... It'd be very last minute to... ✂️ ✂️ ✂️ https://github.com/godotengine/godot/pull/65559

