### PR TITLE
Use embedding viewport instead of parent viewport to determine popup rect

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1153,7 +1153,7 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 	Rect2 parent_rect;
 
 	if (is_embedded()) {
-		parent_rect = get_parent_viewport()->get_visible_rect();
+		parent_rect = _get_embedder()->get_visible_rect();
 	} else {
 		DisplayServer::WindowID parent_id = get_parent_visible_window()->get_window_id();
 		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(parent_id);
@@ -1179,7 +1179,7 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	Rect2 parent_rect;
 
 	if (is_embedded()) {
-		parent_rect = get_parent_viewport()->get_visible_rect();
+		parent_rect = _get_embedder()->get_visible_rect();
 	} else {
 		DisplayServer::WindowID parent_id = get_parent_visible_window()->get_window_id();
 		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(parent_id);
@@ -1207,7 +1207,7 @@ void Window::popup_centered_ratio(float p_ratio) {
 	Rect2 parent_rect;
 
 	if (is_embedded()) {
-		parent_rect = get_parent_viewport()->get_visible_rect();
+		parent_rect = _get_embedder()->get_visible_rect();
 	} else {
 		DisplayServer::WindowID parent_id = get_parent_visible_window()->get_window_id();
 		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(parent_id);


### PR DESCRIPTION
- Fixes #50679
- Fixes #63504

This replaces `get_parent_viewport()` by `_get_embedder()` when computing the position of an embedded popup, this fixes the bug causing a popup to be small and not centered when it is opened from another popup.