### PR TITLE
Allow enter key to add properties to replication editor list

### DIFF
--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -256,6 +256,7 @@ ReplicationEditor::ReplicationEditor() {
 	np_line_edit = memnew(LineEdit);
 	np_line_edit->set_placeholder(":property");
 	np_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
+	np_line_edit->connect("text_submitted", callable_mp(this, &ReplicationEditor::_np_text_submitted));
 	hb->add_child(np_line_edit);
 	add_from_path_button = memnew(Button);
 	add_from_path_button->connect("pressed", callable_mp(this, &ReplicationEditor::_add_pressed));
@@ -292,7 +293,7 @@ ReplicationEditor::ReplicationEditor() {
 	vb->add_child(tree);
 
 	drop_label = memnew(Label);
-	drop_label->set_text(TTR("Add properties using the buttons above or\ndrag them them from the inspector and drop them here."));
+	drop_label->set_text(TTR("Add properties using the options above, or\ndrag them them from the inspector and drop them here."));
 	drop_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	drop_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	tree->add_child(drop_label);
@@ -384,6 +385,13 @@ void ReplicationEditor::_add_pressed() {
 		return;
 	}
 	String np_text = np_line_edit->get_text();
+
+	if (np_text.is_empty()) {
+		error_dialog->set_text(TTR("Property/path must not be empty."));
+		error_dialog->popup_centered();
+		return;
+	}
+
 	int idx = np_text.find(":");
 	if (idx == -1) {
 		np_text = ".:" + np_text;
@@ -393,6 +401,10 @@ void ReplicationEditor::_add_pressed() {
 	NodePath path = NodePath(np_text);
 
 	_add_sync_property(path);
+}
+
+void ReplicationEditor::_np_text_submitted(const String &p_newtext) {
+	_add_pressed();
 }
 
 void ReplicationEditor::_tree_item_edited() {

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -72,6 +72,7 @@ private:
 	Ref<Texture2D> _get_class_icon(const Node *p_node);
 
 	void _add_pressed();
+	void _np_text_submitted(const String &p_newtext);
 	void _tree_item_edited();
 	void _tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
 	void _update_checked(const NodePath &p_prop, int p_column, bool p_checked);


### PR DESCRIPTION
Simple usability improvement: allows the ability to use the Enter key while the path input box is in focus to add items to the replication list, as opposed to clicking the "Add from path" button on the right. It will also now reject adding a new item to the list if the input box is empty.

https://user-images.githubusercontent.com/18225391/189274012-ee36c106-9d84-4946-9eae-1077163ab04e.mp4

