### PR TITLE
Fix inconsistent scene file name casing

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -45,9 +45,10 @@ public:
 	static const String PROJECT_DATA_DIR_NAME_SUFFIX;
 
 	enum {
-		//properties that are not for built in values begin from this value, so builtin ones are displayed first
+		// Properties that are not for built in values begin from this value, so builtin ones are displayed first.
 		NO_BUILTIN_ORDER_BASE = 1 << 16
 	};
+
 #ifdef TOOLS_ENABLED
 	const static PackedStringArray get_required_features();
 	const static PackedStringArray get_unsupported_features(const PackedStringArray &p_project_features);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2763,18 +2763,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				}
 			} else if (extensions.size()) {
 				String root_name = scene->get_name();
-				// Very similar to node naming logic.
-				switch (ProjectSettings::get_singleton()->get("editor/scene/scene_naming").operator int()) {
-					case SCENE_NAME_CASING_AUTO:
-						// Use casing of the root node.
-						break;
-					case SCENE_NAME_CASING_PASCAL_CASE: {
-						root_name = root_name.to_pascal_case();
-					} break;
-					case SCENE_NAME_CASING_SNAKE_CASE:
-						root_name = root_name.replace("-", "_").to_snake_case();
-						break;
-				}
+				root_name = EditorNode::adjust_scene_name_casing(root_name);
 				file->set_current_path(root_name + "." + extensions.front()->get().to_lower());
 			}
 			file->popup_file_dialog();
@@ -3088,6 +3077,19 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			restart_editor();
 		} break;
 	}
+}
+
+String EditorNode::adjust_scene_name_casing(const String &root_name) {
+	switch (ProjectSettings::get_singleton()->get("editor/scene/scene_naming").operator int()) {
+		case SCENE_NAME_CASING_AUTO:
+			// Use casing of the root node.
+			break;
+		case SCENE_NAME_CASING_PASCAL_CASE:
+			return root_name.to_pascal_case();
+		case SCENE_NAME_CASING_SNAKE_CASE:
+			return root_name.replace("-", "_").to_snake_case();
+	}
+	return root_name;
 }
 
 void EditorNode::_request_screenshot() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -125,6 +125,12 @@ public:
 		EDITOR_ASSETLIB
 	};
 
+	enum SceneNameCasing {
+		SCENE_NAME_CASING_AUTO,
+		SCENE_NAME_CASING_PASCAL_CASE,
+		SCENE_NAME_CASING_SNAKE_CASE
+	};
+
 	struct ExecuteThreadArgs {
 		String path;
 		List<String> args;
@@ -231,12 +237,6 @@ private:
 	enum {
 		MAX_INIT_CALLBACKS = 128,
 		MAX_BUILD_CALLBACKS = 128
-	};
-
-	enum ScriptNameCasing {
-		SCENE_NAME_CASING_AUTO,
-		SCENE_NAME_CASING_PASCAL_CASE,
-		SCENE_NAME_CASING_SNAKE_CASE
 	};
 
 	struct BottomPanelItem {
@@ -719,6 +719,8 @@ public:
 
 	static HBoxContainer *get_menu_hb() { return singleton->menu_hb; }
 	static VSplitContainer *get_top_split() { return singleton->top_split; }
+
+	static String adjust_scene_name_casing(const String &root_name);
 
 	static bool has_unsaved_changes() { return singleton->unsaved_cache; }
 	static void disambiguate_filenames(const Vector<String> p_full_paths, Vector<String> &r_filenames);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -916,6 +916,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			String existing;
 			if (extensions.size()) {
 				String root_name(tocopy->get_name());
+				root_name = EditorNode::adjust_scene_name_casing(root_name);
 				existing = root_name + "." + extensions.front()->get().to_lower();
 			}
 			new_scene_from_dialog->set_current_path(existing);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/57768.

Moved SceneNameCasing enum and function from `editor_node `to `project_settings`, to make it accessible to both `editor_node `AND `scene_tree_dock`

Also #included `ustring `header in `project_settings.h`


