### PR TITLE
Add guards to enable Godot builds with disabled Navigation module

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_node.h"
 
+#include "modules/modules_enabled.gen.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/io/config_file.h"
@@ -65,8 +66,10 @@
 #include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display_server.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_2d.h"
 #include "servers/navigation_server_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "servers/physics_server_2d.h"
 #include "servers/rendering/rendering_device.h"
 
@@ -170,8 +173,10 @@
 #include "editor/plugins/mesh_instance_3d_editor_plugin.h"
 #include "editor/plugins/mesh_library_editor_plugin.h"
 #include "editor/plugins/multimesh_editor_plugin.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "editor/plugins/navigation_link_2d_editor_plugin.h"
 #include "editor/plugins/navigation_polygon_editor_plugin.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/plugins/occluder_instance_3d_editor_plugin.h"
 #include "editor/plugins/packed_scene_translation_parser_plugin.h"
@@ -568,6 +573,7 @@ void EditorNode::_update_from_settings() {
 	tree->set_debug_collision_contact_color(GLOBAL_GET("debug/shapes/collision/contact_color"));
 
 #ifdef DEBUG_ENABLED
+#ifdef MODULE_NAVIGATION_ENABLED
 	NavigationServer3D::get_singleton_mut()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/edge_connection_color"));
 	NavigationServer3D::get_singleton_mut()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/geometry_edge_color"));
 	NavigationServer3D::get_singleton_mut()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/geometry_face_color"));
@@ -578,6 +584,7 @@ void EditorNode::_update_from_settings() {
 	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/enable_edge_lines"));
 	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/enable_edge_lines_xray"));
 	NavigationServer3D::get_singleton_mut()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/enable_geometry_face_random_color"));
+#endif // MODULE_NAVIGATION_ENABLED
 #endif // DEBUG_ENABLED
 }
 
@@ -6087,12 +6094,14 @@ EditorNode::EditorNode() {
 
 	AudioServer::get_singleton()->set_enable_tagging_used_audio_streams(true);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// No navigation server by default if in editor.
 	if (NavigationServer3D::get_singleton()->get_debug_enabled()) {
 		NavigationServer3D::get_singleton()->set_active(true);
 	} else {
 		NavigationServer3D::get_singleton()->set_active(false);
 	}
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// No physics by default if in editor.
 	PhysicsServer3D::get_singleton()->set_active(false);
@@ -7354,8 +7363,10 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(GPUParticles2DEditorPlugin));
 	add_editor_plugin(memnew(LightOccluder2DEditorPlugin));
 	add_editor_plugin(memnew(Line2DEditorPlugin));
+#ifdef MODULE_NAVIGATION_ENABLED
 	add_editor_plugin(memnew(NavigationLink2DEditorPlugin));
 	add_editor_plugin(memnew(NavigationPolygonEditorPlugin));
+#endif // MODULE_NAVIGATION_ENABLED
 	add_editor_plugin(memnew(Path2DEditorPlugin));
 	add_editor_plugin(memnew(Polygon2DEditorPlugin));
 	add_editor_plugin(memnew(Cast2DEditorPlugin));

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -30,6 +30,8 @@
 
 #include "resource_importer_scene.h"
 
+#include "modules/modules_enabled.gen.h"
+
 #include "core/error/error_macros.h"
 #include "core/io/resource_saver.h"
 #include "editor/editor_node.h"
@@ -38,7 +40,9 @@
 #include "scene/3d/collision_shape_3d.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/3d/navigation_region_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "scene/3d/occluder_instance_3d.h"
 #include "scene/3d/physics_body_3d.h"
 #include "scene/3d/vehicle_body_3d.h"
@@ -795,6 +799,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 			}
 		}
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	} else if (_teststr(name, "navmesh") && Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		if (isroot) {
 			return p_node;
@@ -813,6 +818,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		p_node->replace_by(nmi);
 		memdelete(p_node);
 		p_node = nmi;
+#endif // MODULE_NAVIGATION_ENABLED
 	} else if (_teststr(name, "occ") || _teststr(name, "occonly")) {
 		if (isroot) {
 			return p_node;
@@ -1285,6 +1291,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 		}
 	}
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	//navmesh (node may have changed type above)
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
@@ -1314,6 +1321,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 			}
 		}
 	}
+#endif // MODULE_NAVIGATION_ENABLED
 
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_settings.h"
 #include "editor/fileserver/editor_file_server.h"
 #include "editor/plugins/script_editor_plugin.h"
+#include "modules/modules_enabled.gen.h"
 #include "scene/gui/menu_button.h"
 
 DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
@@ -75,9 +76,11 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 	debug_menu->add_check_shortcut(ED_SHORTCUT("editor/visible_paths", TTR("Visible Paths")), RUN_DEBUG_PATHS);
 	debug_menu->set_item_tooltip(-1,
 			TTR("When this option is enabled, curve resources used by path nodes will be visible in the running project."));
+#ifdef MODULE_NAVIGATION_ENABLED
 	debug_menu->add_check_shortcut(ED_SHORTCUT("editor/visible_navigation", TTR("Visible Navigation")), RUN_DEBUG_NAVIGATION);
 	debug_menu->set_item_tooltip(-1,
 			TTR("When this option is enabled, navigation meshes and polygons will be visible in the running project."));
+#endif // MODULE_NAVIGATION_ENABLED
 	debug_menu->add_separator();
 	debug_menu->add_check_shortcut(ED_SHORTCUT("editor/sync_scene_changes", TTR("Synchronize Scene Changes")), RUN_LIVE_DEBUG);
 	debug_menu->set_item_tooltip(-1,
@@ -161,11 +164,13 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS), !ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_paths", !ischecked);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 		} break;
 		case RUN_DEBUG_NAVIGATION: {
 			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_NAVIGATION));
 			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_NAVIGATION), !ischecked);
 			EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_navigation", !ischecked);
+#endif // MODULE_NAVIGATION_ENABLED
 
 		} break;
 		case RUN_RELOAD_SCRIPTS: {
@@ -192,7 +197,9 @@ void DebuggerEditorPlugin::_update_debug_options() {
 	bool check_file_server = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
 	bool check_debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisons", false);
 	bool check_debug_paths = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_paths", false);
+#ifdef MODULE_NAVIGATION_ENABLED
 	bool check_debug_navigation = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_navigation", false);
+#endif // MODULE_NAVIGATION_ENABLED
 	bool check_live_debug = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_live_debug", true);
 	bool check_reload_scripts = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_reload_scripts", true);
 	int instances = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_instances", 1);
@@ -209,9 +216,11 @@ void DebuggerEditorPlugin::_update_debug_options() {
 	if (check_debug_paths) {
 		_menu_option(RUN_DEBUG_PATHS);
 	}
+#ifdef MODULE_NAVIGATION_ENABLED
 	if (check_debug_navigation) {
 		_menu_option(RUN_DEBUG_NAVIGATION);
 	}
+#endif // MODULE_NAVIGATION_ENABLED
 	if (check_live_debug) {
 		_menu_option(RUN_LIVE_DEBUG);
 	}

--- a/editor/plugins/debugger_editor_plugin.h
+++ b/editor/plugins/debugger_editor_plugin.h
@@ -32,6 +32,7 @@
 #define DEBUGGER_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
+#include "modules/modules_enabled.gen.h"
 
 class EditorFileServer;
 class MenuButton;
@@ -50,7 +51,9 @@ private:
 		RUN_LIVE_DEBUG,
 		RUN_DEBUG_COLLISONS,
 		RUN_DEBUG_PATHS,
+#ifdef MODULE_NAVIGATION_ENABLED
 		RUN_DEBUG_NAVIGATION,
+#endif // MODULE_NAVIGATION_ENABLED
 		RUN_DEPLOY_REMOTE_DEBUG,
 		RUN_RELOAD_SCRIPTS,
 	};

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -35,7 +35,10 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "node_3d_editor_plugin.h"
 #include "scene/3d/collision_shape_3d.h"
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/3d/navigation_region_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "scene/3d/physics_body_3d.h"
 #include "scene/gui/box_container.h"
 
@@ -242,6 +245,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 		} break;
 
+#ifdef MODULE_NAVIGATION_ENABLED
 		case MENU_OPTION_CREATE_NAVMESH: {
 			Ref<NavigationMesh> nmesh = memnew(NavigationMesh);
 
@@ -266,6 +270,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 			ur->add_undo_method(node, "remove_child", nmi);
 			ur->commit_action();
 		} break;
+#endif // MODULE_NAVIGATION_ENABLED
 
 		case MENU_OPTION_CREATE_OUTLINE_MESH: {
 			outline_dialog->popup_centered(Vector2(200, 90));
@@ -506,8 +511,10 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	options->get_popup()->set_item_tooltip(-1, TTR("Creates a simplified convex collision shape.\nThis is similar to single collision shape, but can result in a simpler geometry in some cases, at the cost of accuracy."));
 	options->get_popup()->add_item(TTR("Create Multiple Convex Collision Siblings"), MENU_OPTION_CREATE_MULTIPLE_CONVEX_COLLISION_SHAPES);
 	options->get_popup()->set_item_tooltip(-1, TTR("Creates a polygon-based collision shape.\nThis is a performance middle-ground between a single convex collision and a polygon-based collision."));
+#ifdef MODULE_NAVIGATION_ENABLED
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Create Navigation Mesh"), MENU_OPTION_CREATE_NAVMESH);
+#endif // MODULE_NAVIGATION_ENABLED
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Create Outline Mesh..."), MENU_OPTION_CREATE_OUTLINE_MESH);
 	options->get_popup()->set_item_tooltip(options->get_popup()->get_item_count() - 1, TTR("Creates a static outline mesh. The outline mesh will have its normals flipped automatically.\nThis can be used instead of the StandardMaterial Grow property when using that property isn't possible."));

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -34,9 +34,12 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "main/main.h"
+#include "modules/modules_enabled.gen.h"
 #include "node_3d_editor_plugin.h"
 #include "scene/3d/mesh_instance_3d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/3d/navigation_region_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "scene/3d/physics_body_3d.h"
 #include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
@@ -158,6 +161,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 
 		p_library->set_item_shapes(id, collisions);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 		Ref<NavigationMesh> navmesh;
 		Transform3D navmesh_transform;
 		for (int j = 0; j < mi->get_child_count(); j++) {
@@ -176,6 +180,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 			p_library->set_item_navmesh(id, navmesh);
 			p_library->set_item_navmesh_transform(id, navmesh_transform);
 		}
+#endif // MODULE_NAVIGATION_ENABLED
 	}
 
 	//generate previews!

--- a/editor/plugins/navigation_link_2d_editor_plugin.cpp
+++ b/editor/plugins/navigation_link_2d_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_link_2d_editor_plugin.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "canvas_item_editor_plugin.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
@@ -189,3 +190,4 @@ NavigationLink2DEditorPlugin::NavigationLink2DEditorPlugin() {
 	editor = memnew(NavigationLink2DEditor);
 	EditorNode::get_singleton()->get_gui_base()->add_child(editor);
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/editor/plugins/navigation_link_2d_editor_plugin.h
+++ b/editor/plugins/navigation_link_2d_editor_plugin.h
@@ -31,6 +31,9 @@
 #ifndef NAVIGATION_LINK_2D_EDITOR_PLUGIN_H
 #define NAVIGATION_LINK_2D_EDITOR_PLUGIN_H
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "editor/editor_plugin.h"
 #include "scene/2d/navigation_link_2d.h"
 
@@ -79,5 +82,6 @@ public:
 
 	NavigationLink2DEditorPlugin();
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_LINK_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_polygon_editor_plugin.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 Ref<NavigationPolygon> NavigationPolygonEditor::_ensure_navpoly() const {
 	Ref<NavigationPolygon> navpoly = node->get_navigation_polygon();
 	if (!navpoly.is_valid()) {
@@ -117,3 +118,4 @@ NavigationPolygonEditor::NavigationPolygonEditor() {}
 NavigationPolygonEditorPlugin::NavigationPolygonEditorPlugin() :
 		AbstractPolygon2DEditorPlugin(memnew(NavigationPolygonEditor), "NavigationRegion2D") {
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/editor/plugins/navigation_polygon_editor_plugin.h
+++ b/editor/plugins/navigation_polygon_editor_plugin.h
@@ -31,6 +31,8 @@
 #ifndef NAVIGATION_POLYGON_EDITOR_PLUGIN_H
 #define NAVIGATION_POLYGON_EDITOR_PLUGIN_H
 
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "editor/plugins/abstract_polygon_2d_editor.h"
 #include "scene/2d/navigation_region_2d.h"
 
@@ -66,5 +68,6 @@ class NavigationPolygonEditorPlugin : public AbstractPolygon2DEditorPlugin {
 public:
 	NavigationPolygonEditorPlugin();
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_POLYGON_EDITOR_PLUGIN_H

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -54,8 +54,10 @@
 #include "scene/3d/lightmap_probe.h"
 #include "scene/3d/marker_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/3d/navigation_link_3d.h"
 #include "scene/3d/navigation_region_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "scene/3d/occluder_instance_3d.h"
 #include "scene/3d/ray_cast_3d.h"
 #include "scene/3d/reflection_probe.h"
@@ -4841,25 +4843,34 @@ void CollisionPolygon3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 ////
 
+#ifdef MODULE_NAVIGATION_ENABLED
 NavigationRegion3DGizmoPlugin::NavigationRegion3DGizmoPlugin() {
 	create_material("face_material", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color(), false, false, true);
 	create_material("face_material_disabled", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_color(), false, false, true);
 	create_material("edge_material", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_color());
 	create_material("edge_material_disabled", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_color());
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 bool NavigationRegion3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
 	return Object::cast_to<NavigationRegion3D>(p_spatial) != nullptr;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 String NavigationRegion3DGizmoPlugin::get_gizmo_name() const {
 	return "NavigationRegion3D";
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 int NavigationRegion3DGizmoPlugin::get_priority() const {
 	return -1;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	NavigationRegion3D *navigationregion = Object::cast_to<NavigationRegion3D>(p_gizmo->get_spatial_node());
 
@@ -5168,6 +5179,7 @@ void NavigationLink3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo
 
 	ur->commit_action();
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 //////
 

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -33,6 +33,7 @@
 
 #include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
+#include "modules/modules_enabled.gen.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/3d/skeleton_3d.h"
@@ -606,6 +607,7 @@ public:
 	CollisionPolygon3DGizmoPlugin();
 };
 
+#ifdef MODULE_NAVIGATION_ENABLED
 class NavigationRegion3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(NavigationRegion3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
@@ -630,6 +632,7 @@ public:
 
 	NavigationRegion3DGizmoPlugin();
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 class NavigationLink3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(NavigationLink3DGizmoPlugin, EditorNode3DGizmoPlugin);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -44,6 +44,7 @@
 #include "editor/plugins/node_3d_editor_gizmos.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/scene_tree_dock.h"
+#include "modules/modules_enabled.gen.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/collision_shape_3d.h"
 #include "scene/3d/decal.h"
@@ -7523,8 +7524,10 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<CollisionObject3DGizmoPlugin>(memnew(CollisionObject3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionShape3DGizmoPlugin>(memnew(CollisionShape3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionPolygon3DGizmoPlugin>(memnew(CollisionPolygon3DGizmoPlugin)));
+#ifdef MODULE_NAVIGATION_ENABLED
 	add_gizmo_plugin(Ref<NavigationLink3DGizmoPlugin>(memnew(NavigationLink3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<NavigationRegion3DGizmoPlugin>(memnew(NavigationRegion3DGizmoPlugin)));
+#endif // MODULE_NAVIGATION_ENABLED
 	add_gizmo_plugin(Ref<Joint3DGizmoPlugin>(memnew(Joint3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<PhysicalBone3DGizmoPlugin>(memnew(PhysicalBone3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<FogVolumeGizmoPlugin>(memnew(FogVolumeGizmoPlugin)));

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -43,6 +43,7 @@
 #ifdef DEBUG_ENABLED
 #include "servers/navigation_server_3d.h"
 #endif // DEBUG_ENABLED
+#include "modules/modules_enabled.gen.h"
 
 void TileDataEditor::_tile_set_changed_plan_update() {
 	_tile_set_changed_update_needed = true;
@@ -2621,6 +2622,7 @@ TileDataTerrainsEditor::~TileDataTerrainsEditor() {
 	memdelete(dummy_object);
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 Variant TileDataNavigationEditor::_get_painted_value() {
 	Ref<NavigationPolygon> navigation_polygon;
 	navigation_polygon.instantiate();
@@ -2633,7 +2635,9 @@ Variant TileDataNavigationEditor::_get_painted_value() {
 	navigation_polygon->make_polygons_from_outlines();
 	return navigation_polygon;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileDataNavigationEditor::_set_painted_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile) {
 	TileData *tile_data = p_tile_set_atlas_source->get_tile_data(p_coords, p_alternative_tile);
 	ERR_FAIL_COND(!tile_data);
@@ -2647,7 +2651,9 @@ void TileDataNavigationEditor::_set_painted_value(TileSetAtlasSource *p_tile_set
 	}
 	polygon_editor->set_background(p_tile_set_atlas_source->get_texture(), p_tile_set_atlas_source->get_tile_texture_region(p_coords), p_tile_set_atlas_source->get_tile_effective_texture_offset(p_coords, p_alternative_tile), tile_data->get_flip_h(), tile_data->get_flip_v(), tile_data->get_transpose(), tile_data->get_modulate());
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileDataNavigationEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile, Variant p_value) {
 	TileData *tile_data = p_tile_set_atlas_source->get_tile_data(p_coords, p_alternative_tile);
 	ERR_FAIL_COND(!tile_data);
@@ -2656,13 +2662,17 @@ void TileDataNavigationEditor::_set_value(TileSetAtlasSource *p_tile_set_atlas_s
 
 	polygon_editor->set_background(p_tile_set_atlas_source->get_texture(), p_tile_set_atlas_source->get_tile_texture_region(p_coords), p_tile_set_atlas_source->get_tile_effective_texture_offset(p_coords, p_alternative_tile), tile_data->get_flip_h(), tile_data->get_flip_v(), tile_data->get_transpose(), tile_data->get_modulate());
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 Variant TileDataNavigationEditor::_get_value(TileSetAtlasSource *p_tile_set_atlas_source, Vector2 p_coords, int p_alternative_tile) {
 	TileData *tile_data = p_tile_set_atlas_source->get_tile_data(p_coords, p_alternative_tile);
 	ERR_FAIL_COND_V(!tile_data, Variant());
 	return tile_data->get_navigation_polygon(navigation_layer);
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileDataNavigationEditor::_setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, HashMap<TileMapCell, Variant, TileMapCell> p_previous_values, Variant p_new_value) {
 	for (const KeyValue<TileMapCell, Variant> &E : p_previous_values) {
 		Vector2i coords = E.key.get_atlas_coords();
@@ -2670,11 +2680,15 @@ void TileDataNavigationEditor::_setup_undo_redo_action(TileSetAtlasSource *p_til
 		undo_redo->add_do_property(p_tile_set_atlas_source, vformat("%d:%d/%d/navigation_layer_%d/polygon", coords.x, coords.y, E.key.alternative_tile, navigation_layer), p_new_value);
 	}
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileDataNavigationEditor::_tile_set_changed() {
 	polygon_editor->set_tile_set(tile_set);
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileDataNavigationEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -2684,7 +2698,9 @@ void TileDataNavigationEditor::_notification(int p_what) {
 		} break;
 	}
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 TileDataNavigationEditor::TileDataNavigationEditor() {
 	undo_redo = EditorNode::get_undo_redo();
 
@@ -2692,7 +2708,9 @@ TileDataNavigationEditor::TileDataNavigationEditor() {
 	polygon_editor->set_multiple_polygon_mode(true);
 	add_child(polygon_editor);
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileDataNavigationEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected) {
 	TileData *tile_data = _get_tile_data(p_cell);
 	ERR_FAIL_COND(!tile_data);
@@ -2742,3 +2760,4 @@ void TileDataNavigationEditor::draw_over_tile(CanvasItem *p_canvas_item, Transfo
 
 	RenderingServer::get_singleton()->canvas_item_add_set_transform(p_canvas_item->get_canvas_item(), Transform2D());
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -37,6 +37,7 @@
 #include "editor/progress_dialog.h"
 
 #include "editor/editor_node.h"
+#include "modules/modules_enabled.gen.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/control.h"
@@ -714,6 +715,7 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		tile_data_editors.erase(vformat("physics_layer_%d", i));
 	}
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// --- Navigation ---
 	ADD_TILE_DATA_EDITOR_GROUP("Navigation");
 	for (int i = 0; i < tile_set->get_navigation_layers_count(); i++) {
@@ -731,6 +733,7 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		tile_data_editors[vformat("navigation_layer_%d", i)]->queue_delete();
 		tile_data_editors.erase(vformat("navigation_layer_%d", i));
 	}
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// --- Custom Data ---
 	ADD_TILE_DATA_EDITOR_GROUP("Custom Data");
@@ -2590,6 +2593,7 @@ void EditorPropertyTilePolygon::_polygons_changed() {
 				occluder->set_polygon(generic_tile_polygon_editor->get_polygon(0));
 			}
 			emit_changed(get_edited_property(), occluder);
+#ifdef MODULE_NAVIGATION_ENABLED
 		} else if (base_type == "NavigationPolygon") {
 			Ref<NavigationPolygon> navigation_polygon;
 			if (generic_tile_polygon_editor->get_polygon_count() >= 1) {
@@ -2601,6 +2605,7 @@ void EditorPropertyTilePolygon::_polygons_changed() {
 				navigation_polygon->make_polygons_from_outlines();
 			}
 			emit_changed(get_edited_property(), navigation_polygon);
+#endif // MODULE_NAVIGATION_ENABLED
 		}
 	} else {
 		if (base_type.is_empty()) {
@@ -2644,6 +2649,7 @@ void EditorPropertyTilePolygon::update_property() {
 			if (occluder.is_valid()) {
 				generic_tile_polygon_editor->add_polygon(occluder->get_polygon());
 			}
+#ifdef MODULE_NAVIGATION_ENABLED
 		} else if (base_type == "NavigationPolygon") {
 			// Single OccluderPolygon2D.
 			Ref<NavigationPolygon> navigation_polygon = get_edited_object()->get(get_edited_property());
@@ -2653,6 +2659,7 @@ void EditorPropertyTilePolygon::update_property() {
 					generic_tile_polygon_editor->add_polygon(navigation_polygon->get_outline(i));
 				}
 			}
+#endif // MODULE_NAVIGATION_ENABLED
 		}
 	} else {
 		int count = get_edited_object()->get(count_property);
@@ -2734,6 +2741,7 @@ bool EditorInspectorPluginTileData::parse_property(Object *p_object, const Varia
 				return true;
 			}
 		}
+#ifdef MODULE_NAVIGATION_ENABLED
 	} else if (components.size() == 2 && components[0].begins_with("navigation_layer_") && components[0].trim_prefix("navigation_layer_").is_valid_int()) {
 		// Navigation layers.
 		int layer_index = components[0].trim_prefix("navigation_layer_").to_int();
@@ -2744,6 +2752,7 @@ bool EditorInspectorPluginTileData::parse_property(Object *p_object, const Varia
 			add_property_editor(p_path, ep);
 			return true;
 		}
+#endif // MODULE_NAVIGATION_ENABLED
 	}
 	return false;
 }

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -38,6 +38,8 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_undo_redo_manager.h"
 
+#include "modules/modules_enabled.gen.h"
+
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
 #include "scene/gui/tab_container.h"
@@ -428,8 +430,10 @@ void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_
 	} else if (components.size() >= 2 && components[0].begins_with("terrain_set_") && components[0].trim_prefix("terrain_set_").is_valid_int() && components[1] == "terrain_") {
 		int terrain_set = components[0].trim_prefix("terrain_set_").to_int();
 		end = tile_set->get_terrains_count(terrain_set);
+#ifdef MODULE_NAVIGATION_ENABLED
 	} else if (p_array_prefix == "navigation_layer_") {
 		end = tile_set->get_navigation_layers_count();
+#endif // MODULE_NAVIGATION_ENABLED
 	} else if (p_array_prefix == "custom_data_layer_") {
 		end = tile_set->get_custom_data_layers_count();
 	} else {
@@ -518,10 +522,12 @@ void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_
 								ADD_UNDO(tile_data, "terrains_peering_bit/" + String(TileSet::CELL_NEIGHBOR_ENUM_TO_TEXT[terrain_index]));
 							}
 						}
+#ifdef MODULE_NAVIGATION_ENABLED
 					} else if (p_array_prefix == "navigation_layer_") {
 						for (int layer_index = begin; layer_index < end; layer_index++) {
 							ADD_UNDO(tile_data, vformat("navigation_layer_%d/polygon", layer_index));
 						}
+#endif // MODULE_NAVIGATION_ENABLED
 					} else if (p_array_prefix == "custom_data_layer_") {
 						for (int layer_index = begin; layer_index < end; layer_index++) {
 							ADD_UNDO(tile_data, vformat("custom_data_%d", layer_index));
@@ -567,6 +573,7 @@ void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_
 		} else {
 			undo_redo->add_do_method(tile_set, "move_terrain", terrain_set, p_from_index, p_to_pos);
 		}
+#ifdef MODULE_NAVIGATION_ENABLED
 	} else if (p_array_prefix == "navigation_layer_") {
 		if (p_from_index < 0) {
 			undo_redo->add_do_method(tile_set, "add_navigation_layer", p_to_pos);
@@ -575,6 +582,7 @@ void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_
 		} else {
 			undo_redo->add_do_method(tile_set, "move_navigation_layer", p_from_index, p_to_pos);
 		}
+#endif // MODULE_NAVIGATION_ENABLED
 	} else if (p_array_prefix == "custom_data_layer_") {
 		if (p_from_index < 0) {
 			undo_redo->add_do_method(tile_set, "add_custom_data_layer", p_to_pos);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -58,6 +58,7 @@
 #include "servers/display_server.h"
 #include "servers/navigation_server_3d.h"
 #include "servers/physics_server_2d.h"
+#include "modules/modules_enabled.gen.h"
 
 class ProjectDialog : public ConfirmationDialog {
 	GDCLASS(ProjectDialog, ConfirmationDialog);
@@ -2491,7 +2492,9 @@ ProjectManager::ProjectManager() {
 	}
 
 	// Turn off some servers we aren't going to be using in the Project Manager.
+#ifdef MODULE_NAVIGATION_ENABLED
 	NavigationServer3D::get_singleton()->set_active(false);
+#endif // MODULE_NAVIGATION_ENABLED
 	PhysicsServer3D::get_singleton()->set_active(false);
 	PhysicsServer2D::get_singleton()->set_active(false);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -69,8 +69,10 @@
 #include "servers/display_server.h"
 #include "servers/movie_writer/movie_writer.h"
 #include "servers/movie_writer/movie_writer_mjpeg.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_2d.h"
 #include "servers/navigation_server_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "servers/physics_server_2d.h"
 #include "servers/physics_server_3d.h"
 #include "servers/register_server_types.h"
@@ -130,8 +132,10 @@ static PhysicsServer3DManager *physics_server_3d_manager = nullptr;
 static PhysicsServer3D *physics_server_3d = nullptr;
 static PhysicsServer2DManager *physics_server_2d_manager = nullptr;
 static PhysicsServer2D *physics_server_2d = nullptr;
+#ifdef MODULE_NAVIGATION_ENABLED
 static NavigationServer3D *navigation_server_3d = nullptr;
 static NavigationServer2D *navigation_server_2d = nullptr;
+#endif // MODULE_NAVIGATION_ENABLED
 static ThemeDB *theme_db = nullptr;
 // We error out if setup2() doesn't turn this true
 static bool _start_success = false;
@@ -263,13 +267,16 @@ void finalize_display() {
 	memdelete(display_server);
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void initialize_navigation_server() {
 	ERR_FAIL_COND(navigation_server_3d != nullptr);
 
 	navigation_server_3d = NavigationServer3DManager::new_default_server();
 	navigation_server_2d = memnew(NavigationServer2D);
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void finalize_navigation_server() {
 	memdelete(navigation_server_3d);
 	navigation_server_3d = nullptr;
@@ -277,6 +284,7 @@ void finalize_navigation_server() {
 	memdelete(navigation_server_2d);
 	navigation_server_2d = nullptr;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 void initialize_theme_db() {
 	theme_db = memnew(ThemeDB);
@@ -2197,7 +2205,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	MAIN_PRINT("Main: Load Physics");
 
 	initialize_physics();
+#ifdef MODULE_NAVIGATION_ENABLED
 	initialize_navigation_server();
+#endif // MODULE_NAVIGATION_ENABLED
 	register_server_singletons();
 
 	// This loads global classes, so it must happen before custom loaders and savers are registered
@@ -2536,11 +2546,13 @@ bool Main::start() {
 		if (debug_paths) {
 			sml->set_debug_paths_hint(true);
 		}
+#ifdef MODULE_NAVIGATION_ENABLED
 		if (debug_navigation) {
 			sml->set_debug_navigation_hint(true);
 			NavigationServer3D::get_singleton()->set_active(true);
 			NavigationServer3D::get_singleton_mut()->set_debug_enabled(true);
 		}
+#endif // MODULE_NAVIGATION_ENABLED
 #endif
 
 		bool embed_subwindows = GLOBAL_DEF("display/window/subwindows/embed_subwindows", true);
@@ -2977,7 +2989,9 @@ bool Main::iteration() {
 			break;
 		}
 
+#ifdef MODULE_NAVIGATION_ENABLED
 		NavigationServer3D::get_singleton_mut()->process(physics_step * time_scale);
+#endif // MODULE_NAVIGATION_ENABLED
 
 		message_queue->flush();
 
@@ -3193,7 +3207,9 @@ void Main::cleanup(bool p_force) {
 
 	OS::get_singleton()->finalize();
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	finalize_navigation_server();
+#endif // MODULE_NAVIGATION_ENABLED
 	finalize_display();
 
 	if (input) {

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -34,6 +34,7 @@
 #include "scene/3d/node_3d.h"
 #include "scene/resources/mesh_library.h"
 #include "scene/resources/multimesh.h"
+#include "modules/modules_enabled.gen.h"
 
 //heh heh, godotsphir!! this shares no code and the design is completely different with previous projects i've done..
 //should scale better with hardware that supports instancing
@@ -95,11 +96,13 @@ class GridMap : public Node3D {
 	 * A GridMap can have multiple Octants.
 	 */
 	struct Octant {
+#ifdef MODULE_NAVIGATION_ENABLED
 		struct NavMesh {
 			RID region;
 			Transform3D xform;
 			RID navmesh_debug_instance;
 		};
+#endif // MODULE_NAVIGATION_ENABLED
 
 		struct MultimeshInstance {
 			RID instance;
@@ -118,13 +121,17 @@ class GridMap : public Node3D {
 		RID collision_debug;
 		RID collision_debug_instance;
 #ifdef DEBUG_ENABLED
+#ifdef MODULE_NAVIGATION_ENABLED
 		RID navigation_debug_edge_connections_instance;
 		Ref<ArrayMesh> navigation_debug_edge_connections_mesh;
+#endif // MODULE_NAVIGATION_ENABLED
 #endif // DEBUG_ENABLED
 
 		bool dirty = false;
 		RID static_body;
+#ifdef MODULE_NAVIGATION_ENABLED
 		HashMap<IndexKey, NavMesh> navmesh_ids;
+#endif // MODULE_NAVIGATION_ENABLED
 	};
 
 	union OctantKey {
@@ -151,9 +158,11 @@ class GridMap : public Node3D {
 	uint32_t collision_layer = 1;
 	uint32_t collision_mask = 1;
 	Ref<PhysicsMaterial> physics_material;
+#ifdef MODULE_NAVIGATION_ENABLED
 	bool bake_navigation = false;
 	RID map_override;
 	uint32_t navigation_layers = 1;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	Transform3D last_transform;
 
@@ -192,9 +201,11 @@ class GridMap : public Node3D {
 	void _octant_clean_up(const OctantKey &p_key);
 	void _octant_transform(const OctantKey &p_key);
 #ifdef DEBUG_ENABLED
+#ifdef MODULE_NAVIGATION_ENABLED
 	void _update_octant_navigation_debug_edge_connections_mesh(const OctantKey &p_key);
 	void _navigation_map_changed(RID p_map);
 	void _update_navigation_debug_edge_connections();
+#endif // MODULE_NAVIGATION_ENABLED
 #endif // DEBUG_ENABLED
 	bool awaiting_update = false;
 
@@ -245,6 +256,7 @@ public:
 
 	Array get_collision_shapes() const;
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	void set_bake_navigation(bool p_bake_navigation);
 	bool is_baking_navigation();
 
@@ -256,6 +268,7 @@ public:
 
 	void set_navigation_layer_value(int p_layer_number, bool p_value);
 	bool get_navigation_layer_value(int p_layer_number) const;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	void set_mesh_library(const Ref<MeshLibrary> &p_mesh_library);
 	Ref<MeshLibrary> get_mesh_library() const;

--- a/modules/navigation/register_types.cpp
+++ b/modules/navigation/register_types.cpp
@@ -30,6 +30,10 @@
 
 #include "register_types.h"
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
+
 #include "core/config/engine.h"
 #include "servers/navigation_server_3d.h"
 
@@ -80,3 +84,4 @@ void uninitialize_navigation_module(ModuleInitializationLevel p_level) {
 	}
 #endif
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/math/geometry_2d.h"
 #include "scene/resources/world_2d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_2d.h"
 
 void NavigationAgent2D::_bind_methods() {
@@ -459,3 +460,4 @@ void NavigationAgent2D::_check_distance_to_target() {
 		}
 	}
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -32,7 +32,9 @@
 #define NAVIGATION_AGENT_2D_H
 
 #include "scene/main/node.h"
+#include "modules/modules_enabled.gen.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 class Node2D;
 
 class NavigationAgent2D : public Node {
@@ -162,5 +164,6 @@ private:
 	void _request_repath();
 	void _check_distance_to_target();
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_AGENT_2D_H

--- a/scene/2d/navigation_link_2d.cpp
+++ b/scene/2d/navigation_link_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_link_2d.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "core/math/geometry_2d.h"
 #include "scene/resources/world_2d.h"
 #include "servers/navigation_server_2d.h"
@@ -286,3 +287,4 @@ NavigationLink2D::~NavigationLink2D() {
 	NavigationServer2D::get_singleton()->free(link);
 	link = RID();
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/2d/navigation_link_2d.h
+++ b/scene/2d/navigation_link_2d.h
@@ -32,7 +32,9 @@
 #define NAVIGATION_LINK_2D_H
 
 #include "scene/2d/node_2d.h"
+#include "modules/modules_enabled.gen.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 class NavigationLink2D : public Node2D {
 	GDCLASS(NavigationLink2D, Node2D);
 
@@ -84,5 +86,6 @@ public:
 	NavigationLink2D();
 	~NavigationLink2D();
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_LINK_2D_H

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -33,6 +33,7 @@
 #include "scene/2d/collision_shape_2d.h"
 #include "scene/2d/physics_body_2d.h"
 #include "scene/resources/world_2d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_2d.h"
 
 void NavigationObstacle2D::_bind_methods() {
@@ -193,3 +194,4 @@ void NavigationObstacle2D::set_radius(real_t p_radius) {
 	radius = p_radius;
 	reevaluate_agent_radius();
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -33,6 +33,9 @@
 
 #include "scene/2d/node_2d.h"
 #include "scene/main/node.h"
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 
 class NavigationObstacle2D : public Node {
 	GDCLASS(NavigationObstacle2D, Node);
@@ -73,5 +76,6 @@ private:
 	void reevaluate_agent_radius();
 	real_t estimate_agent_radius() const;
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_OBSTACLE_2D_H

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -34,6 +34,7 @@
 #include "core/math/geometry_2d.h"
 #include "core/os/mutex.h"
 #include "scene/resources/world_2d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_2d.h"
 #include "servers/navigation_server_3d.h"
 
@@ -628,3 +629,4 @@ NavigationRegion2D::~NavigationRegion2D() {
 	NavigationServer3D::get_singleton_mut()->disconnect("navigation_debug_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 #endif // DEBUG_ENABLED
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -32,6 +32,9 @@
 #define NAVIGATION_REGION_2D_H
 
 #include "scene/2d/node_2d.h"
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/resources/navigation_mesh.h"
 
 class NavigationPolygon : public Resource {
@@ -139,5 +142,6 @@ public:
 	NavigationRegion2D();
 	~NavigationRegion2D();
 };
+#endif //MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_REGION_2D_H

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -31,8 +31,11 @@
 #include "tile_map.h"
 
 #include "core/io/marshalls.h"
+#include "modules/modules_enabled.gen.h"
 #include "scene/resources/world_2d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_2d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 
 #ifdef DEBUG_ENABLED
 #include "servers/navigation_server_3d.h"
@@ -505,7 +508,9 @@ void TileMap::_notification(int p_what) {
 	if (tile_set.is_valid()) {
 		_rendering_notification(p_what);
 		_physics_notification(p_what);
+#ifdef MODULE_NAVIGATION_ENABLED
 		_navigation_notification(p_what);
+#endif // MODULE_NAVIGATION_ENABLED
 	}
 }
 
@@ -739,16 +744,20 @@ TileMap::VisibilityMode TileMap::get_collision_visibility_mode() {
 	return collision_visibility_mode;
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileMap::set_navigation_visibility_mode(TileMap::VisibilityMode p_show_navigation) {
 	navigation_visibility_mode = p_show_navigation;
 	_clear_internals();
 	_recreate_internals();
 	emit_signal(SNAME("changed"));
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 TileMap::VisibilityMode TileMap::get_navigation_visibility_mode() {
 	return navigation_visibility_mode;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 void TileMap::set_y_sort_enabled(bool p_enable) {
 	Node2D::set_y_sort_enabled(p_enable);
@@ -848,7 +857,9 @@ void TileMap::_update_dirty_quadrants() {
 		// Call the update_dirty_quadrant method on plugins.
 		_rendering_update_dirty_quadrants(dirty_quadrant_list);
 		_physics_update_dirty_quadrants(dirty_quadrant_list);
+#ifdef MODULE_NAVIGATION_ENABLED
 		_navigation_update_dirty_quadrants(dirty_quadrant_list);
+#endif // MODULE_NAVIGATION_ENABLED
 		_scenes_update_dirty_quadrants(dirty_quadrant_list);
 
 		// Redraw the debug canvas_items.
@@ -861,7 +872,9 @@ void TileMap::_update_dirty_quadrants() {
 
 			_rendering_draw_quadrant_debug(q->self());
 			_physics_draw_quadrant_debug(q->self());
+#ifdef MODULE_NAVIGATION_ENABLED
 			_navigation_draw_quadrant_debug(q->self());
+#endif // MODULE_NAVIGATION_ENABLED
 			_scenes_draw_quadrant_debug(q->self());
 		}
 
@@ -928,7 +941,9 @@ void TileMap::_erase_quadrant(HashMap<Vector2i, TileMapQuadrant>::Iterator Q) {
 	if (tile_set.is_valid()) {
 		_rendering_cleanup_quadrant(q);
 		_physics_cleanup_quadrant(q);
+#ifdef MODULE_NAVIGATION_ENABLED
 		_navigation_cleanup_quadrant(q);
+#endif // MODULE_NAVIGATION_ENABLED
 		_scenes_cleanup_quadrant(q);
 	}
 
@@ -1628,6 +1643,7 @@ void TileMap::_physics_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 	}
 };
 
+#ifdef MODULE_NAVIGATION_ENABLED
 /////////////////////////////// Navigation //////////////////////////////////////
 
 void TileMap::_navigation_notification(int p_what) {
@@ -1824,6 +1840,7 @@ void TileMap::_navigation_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 		}
 	}
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 /////////////////////////////// Scenes //////////////////////////////////////
 
@@ -3870,8 +3887,10 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_visibility_mode", "collision_visibility_mode"), &TileMap::set_collision_visibility_mode);
 	ClassDB::bind_method(D_METHOD("get_collision_visibility_mode"), &TileMap::get_collision_visibility_mode);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("set_navigation_visibility_mode", "navigation_visibility_mode"), &TileMap::set_navigation_visibility_mode);
 	ClassDB::bind_method(D_METHOD("get_navigation_visibility_mode"), &TileMap::get_navigation_visibility_mode);
+#endif // MODULE_NAVIGATION_ENABLED
 
 	ClassDB::bind_method(D_METHOD("set_cell", "layer", "coords", "source_id", "atlas_coords", "alternative_tile"), &TileMap::set_cell, DEFVAL(TileSet::INVALID_SOURCE), DEFVAL(TileSetSource::INVALID_ATLAS_COORDS), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("erase_cell", "layer", "coords"), &TileMap::erase_cell);
@@ -3916,7 +3935,9 @@ void TileMap::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_quadrant_size", PROPERTY_HINT_RANGE, "1,128,1"), "set_quadrant_size", "get_quadrant_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collision_animatable"), "set_collision_animatable", "is_collision_animatable");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_visibility_mode", PROPERTY_HINT_ENUM, "Default,Force Show,Force Hide"), "set_collision_visibility_mode", "get_collision_visibility_mode");
+#ifdef MODULE_NAVIGATION_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_visibility_mode", PROPERTY_HINT_ENUM, "Default,Force Show,Force Hide"), "set_navigation_visibility_mode", "get_navigation_visibility_mode");
+#endif // MODULE_NAVIGATION_ENABLED
 
 	ADD_ARRAY("layers", "layer_");
 

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -31,6 +31,7 @@
 #ifndef TILE_MAP_H
 #define TILE_MAP_H
 
+#include "modules/modules_enabled.gen.h"
 #include "scene/2d/node_2d.h"
 #include "scene/gui/control.h"
 #include "scene/resources/tile_set.h"
@@ -73,8 +74,10 @@ struct TileMapQuadrant {
 	// Physics.
 	List<RID> bodies;
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation.
 	HashMap<Vector2i, Vector<RID>> navigation_regions;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// Scenes.
 	HashMap<Vector2i, String> scenes;
@@ -89,7 +92,9 @@ struct TileMapQuadrant {
 		canvas_items = q.canvas_items;
 		occluders = q.occluders;
 		bodies = q.bodies;
+#ifdef MODULE_NAVIGATION_ENABLED
 		navigation_regions = q.navigation_regions;
+#endif // MODULE_NAVIGATION_ENABLED
 	}
 
 	TileMapQuadrant(const TileMapQuadrant &q) :
@@ -100,7 +105,9 @@ struct TileMapQuadrant {
 		canvas_items = q.canvas_items;
 		occluders = q.occluders;
 		bodies = q.bodies;
+#ifdef MODULE_NAVIGATION_ENABLED
 		navigation_regions = q.navigation_regions;
+#endif // MODULE_NAVIGATION_ENABLED
 	}
 
 	TileMapQuadrant() :
@@ -256,10 +263,12 @@ private:
 	void _physics_cleanup_quadrant(TileMapQuadrant *p_quadrant);
 	void _physics_draw_quadrant_debug(TileMapQuadrant *p_quadrant);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	void _navigation_notification(int p_what);
 	void _navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List &r_dirty_quadrant_list);
 	void _navigation_cleanup_quadrant(TileMapQuadrant *p_quadrant);
 	void _navigation_draw_quadrant_debug(TileMapQuadrant *p_quadrant);
+#endif // MODULE_NAVIGATION_ENABLED
 
 	void _scenes_update_dirty_quadrants(SelfList<TileMapQuadrant>::List &r_dirty_quadrant_list);
 	void _scenes_cleanup_quadrant(TileMapQuadrant *p_quadrant);

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_agent_3d.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_3d.h"
 
 void NavigationAgent3D::_bind_methods() {
@@ -476,3 +477,4 @@ void NavigationAgent3D::_check_distance_to_target() {
 		}
 	}
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -32,7 +32,9 @@
 #define NAVIGATION_AGENT_3D_H
 
 #include "scene/main/node.h"
+#include "modules/modules_enabled.gen.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 class Node3D;
 
 class NavigationAgent3D : public Node {
@@ -174,5 +176,6 @@ private:
 	void _request_repath();
 	void _check_distance_to_target();
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_AGENT_3D_H

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -31,6 +31,8 @@
 #include "navigation_link_3d.h"
 
 #include "mesh_instance_3d.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_3d.h"
 
 #ifdef DEBUG_ENABLED
@@ -387,3 +389,4 @@ TypedArray<String> NavigationLink3D::get_configuration_warnings() const {
 
 	return warnings;
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/3d/navigation_link_3d.h
+++ b/scene/3d/navigation_link_3d.h
@@ -32,7 +32,9 @@
 #define NAVIGATION_LINK_3D_H
 
 #include "scene/3d/node_3d.h"
+#include "modules/modules_enabled.gen.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 class NavigationLink3D : public Node3D {
 	GDCLASS(NavigationLink3D, Node3D);
 
@@ -86,5 +88,6 @@ public:
 
 	TypedArray<String> get_configuration_warnings() const override;
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_LINK_3D_H

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -32,6 +32,7 @@
 
 #include "scene/3d/collision_shape_3d.h"
 #include "scene/3d/physics_body_3d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_3d.h"
 
 void NavigationObstacle3D::_bind_methods() {
@@ -200,3 +201,4 @@ void NavigationObstacle3D::set_radius(real_t p_radius) {
 	radius = p_radius;
 	reevaluate_agent_radius();
 }
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -32,6 +32,9 @@
 #define NAVIGATION_OBSTACLE_3D_H
 
 #include "scene/3d/node_3d.h"
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 
 class NavigationObstacle3D : public Node {
 	GDCLASS(NavigationObstacle3D, Node);
@@ -72,5 +75,6 @@ private:
 	void reevaluate_agent_radius();
 	real_t estimate_agent_radius() const;
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_OBSTACLE_3D_H

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -31,6 +31,8 @@
 #include "navigation_region_3d.h"
 
 #include "mesh_instance_3d.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_3d.h"
 
 void NavigationRegion3D::set_enabled(bool p_enabled) {
@@ -593,3 +595,4 @@ void NavigationRegion3D::_update_debug_edge_connections_mesh() {
 	}
 }
 #endif // DEBUG_ENABLED
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -32,6 +32,9 @@
 #define NAVIGATION_REGION_3D_H
 
 #include "scene/3d/node_3d.h"
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/resources/navigation_mesh.h"
 
 class NavigationRegion3D : public Node3D {
@@ -95,5 +98,6 @@ public:
 	NavigationRegion3D();
 	~NavigationRegion3D();
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_REGION_3D_H

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -55,7 +55,9 @@
 #include "scene/resources/world_3d.h"
 #include "scene/scene_string_names.h"
 #include "servers/display_server.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "servers/physics_server_2d.h"
 #include "servers/physics_server_3d.h"
 #include "window.h"
@@ -681,6 +683,7 @@ bool SceneTree::is_debugging_paths_hint() const {
 	return debug_paths_hint;
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void SceneTree::set_debug_navigation_hint(bool p_enabled) {
 	debug_navigation_hint = p_enabled;
 }
@@ -688,6 +691,7 @@ void SceneTree::set_debug_navigation_hint(bool p_enabled) {
 bool SceneTree::is_debugging_navigation_hint() const {
 	return debug_navigation_hint;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 #endif
 
 void SceneTree::set_debug_collisions_color(const Color &p_color) {
@@ -818,7 +822,9 @@ void SceneTree::set_pause(bool p_enabled) {
 		return;
 	}
 	paused = p_enabled;
+#ifdef MODULE_NAVIGATION_ENABLED
 	NavigationServer3D::get_singleton()->set_active(!p_enabled);
+#endif // MODULE_NAVIGATION_ENABLED
 	PhysicsServer3D::get_singleton()->set_active(!p_enabled);
 	PhysicsServer2D::get_singleton()->set_active(!p_enabled);
 	if (get_root()) {
@@ -1214,8 +1220,10 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_debugging_collisions_hint"), &SceneTree::is_debugging_collisions_hint);
 	ClassDB::bind_method(D_METHOD("set_debug_paths_hint", "enable"), &SceneTree::set_debug_paths_hint);
 	ClassDB::bind_method(D_METHOD("is_debugging_paths_hint"), &SceneTree::is_debugging_paths_hint);
+#ifdef MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("set_debug_navigation_hint", "enable"), &SceneTree::set_debug_navigation_hint);
 	ClassDB::bind_method(D_METHOD("is_debugging_navigation_hint"), &SceneTree::is_debugging_navigation_hint);
+#endif // MODULE_NAVIGATION_ENABLED
 
 	ClassDB::bind_method(D_METHOD("set_edited_scene_root", "scene"), &SceneTree::set_edited_scene_root);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &SceneTree::get_edited_scene_root);
@@ -1276,7 +1284,9 @@ void SceneTree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "quit_on_go_back"), "set_quit_on_go_back", "is_quit_on_go_back");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_collisions_hint"), "set_debug_collisions_hint", "is_debugging_collisions_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_paths_hint"), "set_debug_paths_hint", "is_debugging_paths_hint");
+#ifdef MODULE_NAVIGATION_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_navigation_hint"), "set_debug_navigation_hint", "is_debugging_navigation_hint");
+#endif // MODULE_NAVIGATION_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused"), "set_pause", "is_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "edited_scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_edited_scene_root", "get_edited_scene_root");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "current_scene", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_current_scene", "get_current_scene");

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -35,6 +35,7 @@
 #include "core/os/thread_safe.h"
 #include "core/templates/self_list.h"
 #include "scene/resources/mesh.h"
+#include "modules/modules_enabled.gen.h"
 
 #undef Window
 
@@ -153,12 +154,16 @@ private:
 	Color debug_collision_contact_color;
 	Color debug_paths_color;
 	float debug_paths_width = 1.0f;
+#ifdef MODULE_NAVIGATION_ENABLED
 	Color debug_navigation_color;
 	Color debug_navigation_disabled_color;
+#endif // MODULE_NAVIGATION_ENABLED
 	Ref<ArrayMesh> debug_contact_mesh;
 	Ref<Material> debug_paths_material;
+#ifdef MODULE_NAVIGATION_ENABLED
 	Ref<Material> navigation_material;
 	Ref<Material> navigation_disabled_material;
+#endif // MODULE_NAVIGATION_ENABLED
 	Ref<Material> collision_material;
 	int collision_debug_contacts;
 
@@ -309,8 +314,10 @@ public:
 	void set_debug_paths_hint(bool p_enabled);
 	bool is_debugging_paths_hint() const;
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	void set_debug_navigation_hint(bool p_enabled);
 	bool is_debugging_navigation_hint() const;
+#endif // MODULE_NAVIGATION_ENABLED
 #else
 	void set_debug_collisions_hint(bool p_enabled) {}
 	bool is_debugging_collisions_hint() const { return false; }
@@ -318,8 +325,10 @@ public:
 	void set_debug_paths_hint(bool p_enabled) {}
 	bool is_debugging_paths_hint() const { return false; }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	void set_debug_navigation_hint(bool p_enabled) {}
 	bool is_debugging_navigation_hint() const { return false; }
+#endif // MODULE_NAVIGATION_ENABLED
 #endif
 
 	void set_debug_collisions_color(const Color &p_color);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -34,6 +34,7 @@
 #include "core/extension/native_extension_manager.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
+#include "modules/modules_enabled.gen.h"
 #include "scene/2d/animated_sprite_2d.h"
 #include "scene/2d/area_2d.h"
 #include "scene/2d/audio_listener_2d.h"
@@ -53,9 +54,11 @@
 #include "scene/2d/marker_2d.h"
 #include "scene/2d/mesh_instance_2d.h"
 #include "scene/2d/multimesh_instance_2d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/2d/navigation_agent_2d.h"
 #include "scene/2d/navigation_link_2d.h"
 #include "scene/2d/navigation_obstacle_2d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "scene/2d/parallax_background.h"
 #include "scene/2d/parallax_layer.h"
 #include "scene/2d/path_2d.h"
@@ -240,10 +243,12 @@
 #include "scene/3d/marker_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/multimesh_instance_3d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/3d/navigation_agent_3d.h"
 #include "scene/3d/navigation_link_3d.h"
 #include "scene/3d/navigation_obstacle_3d.h"
 #include "scene/3d/navigation_region_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "scene/3d/node_3d.h"
 #include "scene/3d/occluder_instance_3d.h"
 #include "scene/3d/path_3d.h"
@@ -576,10 +581,12 @@ void register_scene_types() {
 	GDREGISTER_CLASS(ConeTwistJoint3D);
 	GDREGISTER_CLASS(Generic6DOFJoint3D);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	GDREGISTER_CLASS(NavigationRegion3D);
 	GDREGISTER_CLASS(NavigationAgent3D);
 	GDREGISTER_CLASS(NavigationObstacle3D);
 	GDREGISTER_CLASS(NavigationLink3D);
+#endif // MODULE_NAVIGATION_ENABLED
 
 	OS::get_singleton()->yield(); // may take time to init
 #endif // _3D_DISABLED
@@ -933,12 +940,14 @@ void register_scene_types() {
 	GDREGISTER_CLASS(Path2D);
 	GDREGISTER_CLASS(PathFollow2D);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	GDREGISTER_CLASS(NavigationMesh);
 	GDREGISTER_CLASS(NavigationPolygon);
 	GDREGISTER_CLASS(NavigationRegion2D);
 	GDREGISTER_CLASS(NavigationAgent2D);
 	GDREGISTER_CLASS(NavigationObstacle2D);
 	GDREGISTER_CLASS(NavigationLink2D);
+#endif // MODULE_NAVIGATION_ENABLED
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -1025,6 +1034,7 @@ void register_scene_types() {
 	ClassDB::add_compatibility_class("Listener", "AudioListener3D");
 	ClassDB::add_compatibility_class("MeshInstance", "MeshInstance3D");
 	ClassDB::add_compatibility_class("MultiMeshInstance", "MultiMeshInstance3D");
+#ifdef MODULE_NAVIGATION_ENABLED
 	ClassDB::add_compatibility_class("NavigationAgent", "NavigationAgent3D");
 	ClassDB::add_compatibility_class("NavigationMeshInstance", "NavigationRegion3D");
 	ClassDB::add_compatibility_class("NavigationObstacle", "NavigationObstacle3D");
@@ -1032,6 +1042,7 @@ void register_scene_types() {
 	ClassDB::add_compatibility_class("NavigationRegion", "NavigationRegion3D");
 	ClassDB::add_compatibility_class("Navigation2DServer", "NavigationServer2D");
 	ClassDB::add_compatibility_class("NavigationServer", "NavigationServer3D");
+#endif // MODULE_NAVIGATION_ENABLED
 	ClassDB::add_compatibility_class("OmniLight", "OmniLight3D");
 	ClassDB::add_compatibility_class("PanoramaSky", "Sky");
 	ClassDB::add_compatibility_class("Particles", "GPUParticles3D");
@@ -1142,10 +1153,15 @@ void register_scene_types() {
 
 	for (int i = 0; i < 32; i++) {
 		GLOBAL_DEF_BASIC(vformat("%s/layer_%d", PNAME("layer_names/2d_physics"), i + 1), "");
-		GLOBAL_DEF_BASIC(vformat("%s/layer_%d", PNAME("layer_names/2d_navigation"), i + 1), "");
 		GLOBAL_DEF_BASIC(vformat("%s/layer_%d", PNAME("layer_names/3d_physics"), i + 1), "");
+	}
+
+#ifdef MODULE_NAVIGATION_ENABLED
+	for (int i = 0; i < 32; i++) {
+		GLOBAL_DEF_BASIC(vformat("%s/layer_%d", PNAME("layer_names/2d_navigation"), i + 1), "");
 		GLOBAL_DEF_BASIC(vformat("%s/layer_%d", PNAME("layer_names/3d_navigation"), i + 1), "");
 	}
+#endif // MODULE_NAVIGATION_ENABLED
 
 	if (RenderingServer::get_singleton()) {
 		ColorPicker::init_shaders(); // RenderingServer needs to exist for this to succeed.

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -955,6 +955,7 @@ Ref<Shape3D> ImporterMesh::create_trimesh_shape() const {
 	return shape;
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 Ref<NavigationMesh> ImporterMesh::create_navigation_mesh() {
 	Vector<Face3> faces = get_faces();
 	if (faces.size() == 0) {
@@ -999,6 +1000,7 @@ Ref<NavigationMesh> ImporterMesh::create_navigation_mesh() {
 
 	return nm;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 extern bool (*array_mesh_lightmap_unwrap_callback)(float p_texel_size, const float *p_vertices, const float *p_normals, int p_vertex_count, const int *p_indices, int p_index_count, const uint8_t *p_cache_data, bool *r_use_cache, uint8_t **r_mesh_cache, int *r_mesh_cache_size, float **r_uv, int **r_vertex, int *r_vertex_count, int **r_index, int *r_index_count, int *r_size_hint_x, int *r_size_hint_y);
 

--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -33,6 +33,7 @@
 
 #include "core/io/resource.h"
 #include "core/templates/local_vector.h"
+#include "modules/modules_enabled.gen.h"
 #include "scene/resources/concave_polygon_shape_3d.h"
 #include "scene/resources/convex_polygon_shape_3d.h"
 #include "scene/resources/mesh.h"
@@ -120,7 +121,9 @@ public:
 	Vector<Face3> get_faces() const;
 	Vector<Ref<Shape3D>> convex_decompose(const Mesh::ConvexDecompositionSettings &p_settings) const;
 	Ref<Shape3D> create_trimesh_shape() const;
+#ifdef MODULE_NAVIGATION_ENABLED
 	Ref<NavigationMesh> create_navigation_mesh();
+#endif // MODULE_NAVIGATION_ENABLED
 	Error lightmap_unwrap_cached(const Transform3D &p_base_transform, float p_texel_size, const Vector<uint8_t> &p_src_cache, Vector<uint8_t> &r_dst_cache);
 
 	void set_lightmap_size_hint(const Size2i &p_size);

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -57,10 +57,12 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 			_set_item_shapes(idx, p_value);
 		} else if (what == "preview") {
 			set_item_preview(idx, p_value);
+#ifdef MODULE_NAVIGATION_ENABLED
 		} else if (what == "navmesh") {
 			set_item_navmesh(idx, p_value);
 		} else if (what == "navmesh_transform") {
 			set_item_navmesh_transform(idx, p_value);
+#endif // MODULE_NAVIGATION_ENABLED
 		} else {
 			return false;
 		}
@@ -85,10 +87,12 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = get_item_mesh_transform(idx);
 	} else if (what == "shapes") {
 		r_ret = _get_item_shapes(idx);
+#ifdef MODULE_NAVIGATION_ENABLED
 	} else if (what == "navmesh") {
 		r_ret = get_item_navmesh(idx);
 	} else if (what == "navmesh_transform") {
 		r_ret = get_item_navmesh_transform(idx);
+#endif // MODULE_NAVIGATION_ENABLED
 	} else if (what == "preview") {
 		r_ret = get_item_preview(idx);
 	} else {
@@ -105,8 +109,10 @@ void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::OBJECT, name + PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, "Mesh"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, name + PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, name + PNAME("shapes")));
+#ifdef MODULE_NAVIGATION_ENABLED
 		p_list->push_back(PropertyInfo(Variant::OBJECT, name + PNAME("navmesh"), PROPERTY_HINT_RESOURCE_TYPE, "NavigationMesh"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, name + PNAME("navmesh_transform"), PROPERTY_HINT_NONE, "suffix:m"));
+#endif // MODULE_NAVIGATION_ENABLED
 		p_list->push_back(PropertyInfo(Variant::OBJECT, name + PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT));
 	}
 }
@@ -150,6 +156,7 @@ void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes)
 	notify_property_list_changed();
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void MeshLibrary::set_item_navmesh(int p_item, const Ref<NavigationMesh> &p_navmesh) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].navmesh = p_navmesh;
@@ -158,7 +165,9 @@ void MeshLibrary::set_item_navmesh(int p_item, const Ref<NavigationMesh> &p_navm
 	emit_changed();
 	notify_property_list_changed();
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void MeshLibrary::set_item_navmesh_transform(int p_item, const Transform3D &p_transform) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].navmesh_transform = p_transform;
@@ -166,6 +175,7 @@ void MeshLibrary::set_item_navmesh_transform(int p_item, const Transform3D &p_tr
 	emit_changed();
 	notify_property_list_changed();
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
@@ -194,15 +204,19 @@ Vector<MeshLibrary::ShapeData> MeshLibrary::get_item_shapes(int p_item) const {
 	return item_map[p_item].shapes;
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 Ref<NavigationMesh> MeshLibrary::get_item_navmesh(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<NavigationMesh>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].navmesh;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 Transform3D MeshLibrary::get_item_navmesh_transform(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Transform3D(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].navmesh_transform;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Texture2D>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
@@ -314,15 +328,19 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_name", "id", "name"), &MeshLibrary::set_item_name);
 	ClassDB::bind_method(D_METHOD("set_item_mesh", "id", "mesh"), &MeshLibrary::set_item_mesh);
 	ClassDB::bind_method(D_METHOD("set_item_mesh_transform", "id", "mesh_transform"), &MeshLibrary::set_item_mesh_transform);
+#ifdef MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("set_item_navmesh", "id", "navmesh"), &MeshLibrary::set_item_navmesh);
 	ClassDB::bind_method(D_METHOD("set_item_navmesh_transform", "id", "navmesh"), &MeshLibrary::set_item_navmesh_transform);
+#endif // MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
 	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
 	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_mesh_transform", "id"), &MeshLibrary::get_item_mesh_transform);
+#ifdef MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("get_item_navmesh", "id"), &MeshLibrary::get_item_navmesh);
 	ClassDB::bind_method(D_METHOD("get_item_navmesh_transform", "id"), &MeshLibrary::get_item_navmesh_transform);
+#endif // MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
 	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
 	ClassDB::bind_method(D_METHOD("remove_item", "id"), &MeshLibrary::remove_item);

--- a/scene/resources/mesh_library.h
+++ b/scene/resources/mesh_library.h
@@ -33,7 +33,10 @@
 
 #include "core/io/resource.h"
 #include "core/templates/rb_map.h"
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/3d/navigation_region_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "scene/resources/mesh.h"
 #include "shape_3d.h"
 
@@ -51,9 +54,11 @@ public:
 		Ref<Mesh> mesh;
 		Vector<ShapeData> shapes;
 		Ref<Texture2D> preview;
-		Transform3D navmesh_transform;
 		Transform3D mesh_transform;
+#ifdef MODULE_NAVIGATION_ENABLED
+		Transform3D navmesh_transform;
 		Ref<NavigationMesh> navmesh;
+#endif // MODULE_NAVIGATION_ENABLED
 	};
 
 	RBMap<int, Item> item_map;
@@ -74,15 +79,19 @@ public:
 	void set_item_name(int p_item, const String &p_name);
 	void set_item_mesh(int p_item, const Ref<Mesh> &p_mesh);
 	void set_item_mesh_transform(int p_item, const Transform3D &p_transform);
+#ifdef MODULE_NAVIGATION_ENABLED
 	void set_item_navmesh(int p_item, const Ref<NavigationMesh> &p_navmesh);
 	void set_item_navmesh_transform(int p_item, const Transform3D &p_transform);
+#endif // MODULE_NAVIGATION_ENABLED
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
 	String get_item_name(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Transform3D get_item_mesh_transform(int p_item) const;
+#ifdef MODULE_NAVIGATION_ENABLED
 	Ref<NavigationMesh> get_item_navmesh(int p_item) const;
 	Transform3D get_item_navmesh_transform(int p_item) const;
+#endif // MODULE_NAVIGATION_ENABLED
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 	Ref<Texture2D> get_item_preview(int p_item) const;
 

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -30,6 +30,7 @@
 
 #include "navigation_mesh.h"
 
+#ifdef MODULE_NAVIGATION_ENABLED
 #ifdef DEBUG_ENABLED
 #include "servers/navigation_server_3d.h"
 #endif // DEBUG_ENABLED
@@ -626,3 +627,4 @@ bool NavigationMesh::_get(const StringName &p_name, Variant &r_ret) const {
 #endif // DISABLE_DEPRECATED
 
 NavigationMesh::NavigationMesh() {}
+#endif // MODULE_NAVIGATION_ENABLED

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -31,6 +31,9 @@
 #ifndef NAVIGATION_MESH_H
 #define NAVIGATION_MESH_H
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/resources/mesh.h"
 
 class NavigationMesh : public Resource {
@@ -212,5 +215,6 @@ public:
 VARIANT_ENUM_CAST(NavigationMesh::SamplePartitionType);
 VARIANT_ENUM_CAST(NavigationMesh::ParsedGeometryType);
 VARIANT_ENUM_CAST(NavigationMesh::SourceGeometryMode);
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_MESH_H

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -35,10 +35,14 @@
 #include "core/math/geometry_2d.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_set.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/2d/navigation_region_2d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "scene/gui/control.h"
 #include "scene/resources/convex_polygon_shape_2d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_2d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 
 /////////////////////////////// TileMapPattern //////////////////////////////////////
 
@@ -938,6 +942,7 @@ bool TileSet::is_valid_terrain_peering_bit(int p_terrain_set, TileSet::CellNeigh
 	return is_valid_terrain_peering_bit_for_mode(terrain_mode, p_peering_bit);
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 // Navigation
 int TileSet::get_navigation_layers_count() const {
 	return navigation_layers.size();
@@ -990,6 +995,7 @@ uint32_t TileSet::get_navigation_layer_layers(int p_layer_index) const {
 	ERR_FAIL_INDEX_V(p_layer_index, navigation_layers.size(), 0);
 	return navigation_layers[p_layer_index].layers;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 // Custom data.
 int TileSet::get_custom_data_layers_count() const {
@@ -2483,8 +2489,10 @@ void TileSet::reset_state() {
 	per_terrain_pattern_tiles.clear();
 	terrains_cache_dirty = true;
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation
 	navigation_layers.clear();
+#endif // MODULE_NAVIGATION_ENABLED
 
 	custom_data_layers.clear();
 	custom_data_layers_by_name.clear();
@@ -2570,12 +2578,15 @@ void TileSet::_compatibility_conversion() {
 						}
 						tile_data->set_occluder(0, ctd->occluder);
 					}
+
+#ifdef MODULE_NAVIGATION_ENABLED
 					if (ctd->navigation.is_valid()) {
 						if (get_navigation_layers_count() < 1) {
 							add_navigation_layer();
 						}
 						tile_data->set_navigation_polygon(0, ctd->autotile_navpoly_map[coords]);
 					}
+#endif // MODULE_NAVIGATION_ENABLED
 
 					tile_data->set_z_index(ctd->z_index);
 
@@ -2661,12 +2672,14 @@ void TileSet::_compatibility_conversion() {
 								}
 								tile_data->set_occluder(0, ctd->autotile_occluder_map[coords]);
 							}
+#ifdef MODULE_NAVIGATION_ENABLED
 							if (ctd->autotile_navpoly_map.has(coords)) {
 								if (get_navigation_layers_count() < 1) {
 									add_navigation_layer();
 								}
 								tile_data->set_navigation_polygon(0, ctd->autotile_navpoly_map[coords]);
 							}
+#endif // MODULE_NAVIGATION_ENABLED
 							if (ctd->autotile_priority_map.has(coords)) {
 								tile_data->set_probability(ctd->autotile_priority_map[coords]);
 							}
@@ -2702,8 +2715,10 @@ void TileSet::_compatibility_conversion() {
 							// Those are offset for the whole atlas, they are likely useless for the atlases, but might make sense for single tiles.
 							// texture offset
 							// occluder_offset
+#ifdef MODULE_NAVIGATION_ENABLED
 							// navigation_offset
 
+#endif // MODULE_NAVIGATION_ENABLED
 							// For terrains, ignored for now?
 							// bitmask_mode
 							// bitmask_flags
@@ -2843,6 +2858,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 					}
 					p.pop_front();
 				}
+#ifdef MODULE_NAVIGATION_ENABLED
 			} else if (what == "navpoly_map") {
 				Array p = p_value;
 				Vector2 last_coord;
@@ -2854,6 +2870,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 					}
 					p.pop_front();
 				}
+#endif // MODULE_NAVIGATION_ENABLED
 			} else if (what == "priority_map") {
 				Array p = p_value;
 				Vector3 val;
@@ -2919,7 +2936,9 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 		// IGNORED FOR NOW, maybe useless ?
 		else if (what == "occluder_offset") {
 			// Not
+#ifdef MODULE_NAVIGATION_ENABLED
 		} else if (what == "navigation_offset") {
+#endif // MODULE_NAVIGATION_ENABLED
 		}
 		*/
 
@@ -3015,6 +3034,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 					return true;
 				}
 			}
+#ifdef MODULE_NAVIGATION_ENABLED
 		} else if (components.size() == 2 && components[0].begins_with("navigation_layer_") && components[0].trim_prefix("navigation_layer_").is_valid_int()) {
 			// Navigation layers.
 			int index = components[0].trim_prefix("navigation_layer_").to_int();
@@ -3027,6 +3047,7 @@ bool TileSet::_set(const StringName &p_name, const Variant &p_value) {
 				set_navigation_layer_layers(index, p_value);
 				return true;
 			}
+#endif // MODULE_NAVIGATION_ENABLED
 		} else if (components.size() == 2 && components[0].begins_with("custom_data_layer_") && components[0].trim_prefix("custom_data_layer_").is_valid_int()) {
 			// Custom data layers.
 			int index = components[0].trim_prefix("custom_data_layer_").to_int();
@@ -3148,6 +3169,7 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 				return true;
 			}
 		}
+#ifdef MODULE_NAVIGATION_ENABLED
 	} else if (components.size() == 2 && components[0].begins_with("navigation_layer_") && components[0].trim_prefix("navigation_layer_").is_valid_int()) {
 		// navigation layers.
 		int index = components[0].trim_prefix("navigation_layer_").to_int();
@@ -3158,6 +3180,7 @@ bool TileSet::_get(const StringName &p_name, Variant &r_ret) const {
 			r_ret = get_navigation_layer_layers(index);
 			return true;
 		}
+#endif // MODULE_NAVIGATION_ENABLED
 	} else if (components.size() == 2 && components[0].begins_with("custom_data_layer_") && components[0].trim_prefix("custom_data_layer_").is_valid_int()) {
 		// Custom data layers.
 		int index = components[0].trim_prefix("custom_data_layer_").to_int();
@@ -3266,11 +3289,13 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 		}
 	}
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation.
 	p_list->push_back(PropertyInfo(Variant::NIL, "Navigation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
 	for (int i = 0; i < navigation_layers.size(); i++) {
 		p_list->push_back(PropertyInfo(Variant::INT, vformat("navigation_layer_%d/layers", i), PROPERTY_HINT_LAYERS_2D_NAVIGATION));
 	}
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// Custom data.
 	String argt = "Any";
@@ -3378,6 +3403,7 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_terrain_color", "terrain_set", "terrain_index", "color"), &TileSet::set_terrain_color);
 	ClassDB::bind_method(D_METHOD("get_terrain_color", "terrain_set", "terrain_index"), &TileSet::get_terrain_color);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation
 	ClassDB::bind_method(D_METHOD("get_navigation_layers_count"), &TileSet::get_navigation_layers_count);
 	ClassDB::bind_method(D_METHOD("add_navigation_layer", "to_position"), &TileSet::add_navigation_layer, DEFVAL(-1));
@@ -3385,6 +3411,7 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_navigation_layer", "layer_index"), &TileSet::remove_navigation_layer);
 	ClassDB::bind_method(D_METHOD("set_navigation_layer_layers", "layer_index", "layers"), &TileSet::set_navigation_layer_layers);
 	ClassDB::bind_method(D_METHOD("get_navigation_layer_layers", "layer_index"), &TileSet::get_navigation_layer_layers);
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// Custom data
 	ClassDB::bind_method(D_METHOD("get_custom_data_layers_count"), &TileSet::get_custom_data_layers_count);
@@ -3431,7 +3458,9 @@ void TileSet::_bind_methods() {
 	ADD_GROUP("", "");
 	ADD_ARRAY("physics_layers", "physics_layer_");
 	ADD_ARRAY("terrain_sets", "terrain_set_");
+#ifdef MODULE_NAVIGATION_ENABLED
 	ADD_ARRAY("navigation_layers", "navigation_layer_");
+#endif // MODULE_NAVIGATION_ENABLED
 	ADD_ARRAY("custom_data_layers", "custom_data_layer_");
 
 	// -- Enum binding --
@@ -3633,6 +3662,7 @@ void TileSetAtlasSource::remove_terrain(int p_terrain_set, int p_index) {
 	}
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileSetAtlasSource::add_navigation_layer(int p_to_pos) {
 	for (KeyValue<Vector2i, TileAlternativesData> E_tile : tiles) {
 		for (KeyValue<int, TileData *> E_alternative : E_tile.value.alternatives) {
@@ -3640,7 +3670,9 @@ void TileSetAtlasSource::add_navigation_layer(int p_to_pos) {
 		}
 	}
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileSetAtlasSource::move_navigation_layer(int p_from_index, int p_to_pos) {
 	for (KeyValue<Vector2i, TileAlternativesData> E_tile : tiles) {
 		for (KeyValue<int, TileData *> E_alternative : E_tile.value.alternatives) {
@@ -3648,7 +3680,9 @@ void TileSetAtlasSource::move_navigation_layer(int p_from_index, int p_to_pos) {
 		}
 	}
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileSetAtlasSource::remove_navigation_layer(int p_index) {
 	for (KeyValue<Vector2i, TileAlternativesData> E_tile : tiles) {
 		for (KeyValue<int, TileData *> E_alternative : E_tile.value.alternatives) {
@@ -3656,6 +3690,7 @@ void TileSetAtlasSource::remove_navigation_layer(int p_index) {
 		}
 	}
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 void TileSetAtlasSource::add_custom_data_layer(int p_to_pos) {
 	for (KeyValue<Vector2i, TileAlternativesData> E_tile : tiles) {
@@ -4852,7 +4887,10 @@ void TileData::notify_tile_data_properties_should_change() {
 			terrain_peering_bits[bit_index] = -1;
 		}
 	}
+
+#ifdef MODULE_NAVIGATION_ENABLED
 	navigation.resize(tile_set->get_navigation_layers_count());
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// Convert custom data to the new type.
 	custom_data.resize(tile_set->get_custom_data_layers_count());
@@ -4987,6 +5025,7 @@ void TileData::remove_terrain(int p_terrain_set, int p_index) {
 	}
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileData::add_navigation_layer(int p_to_pos) {
 	if (p_to_pos < 0) {
 		p_to_pos = navigation.size();
@@ -4994,18 +5033,23 @@ void TileData::add_navigation_layer(int p_to_pos) {
 	ERR_FAIL_INDEX(p_to_pos, navigation.size() + 1);
 	navigation.insert(p_to_pos, Ref<NavigationPolygon>());
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileData::move_navigation_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, navigation.size());
 	ERR_FAIL_INDEX(p_to_pos, navigation.size() + 1);
 	navigation.insert(p_to_pos, navigation[p_from_index]);
 	navigation.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 void TileData::remove_navigation_layer(int p_index) {
 	ERR_FAIL_INDEX(p_index, navigation.size());
 	navigation.remove_at(p_index);
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 void TileData::add_custom_data_layer(int p_to_pos) {
 	if (p_to_pos < 0) {
@@ -5018,7 +5062,9 @@ void TileData::add_custom_data_layer(int p_to_pos) {
 void TileData::move_custom_data_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, custom_data.size());
 	ERR_FAIL_INDEX(p_to_pos, custom_data.size() + 1);
+#ifdef MODULE_NAVIGATION_ENABLED
 	custom_data.insert(p_to_pos, navigation[p_from_index]);
+#endif // MODULE_NAVIGATION_ENABLED
 	custom_data.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
 }
 
@@ -5056,8 +5102,10 @@ TileData *TileData::duplicate() {
 	// Terrain
 	output->terrain_set = -1;
 	memcpy(output->terrain_peering_bits, terrain_peering_bits, 16 * sizeof(int));
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation
 	output->navigation = navigation;
+#endif // MODULE_NAVIGATION_ENABLED
 	// Misc
 	output->probability = probability;
 	// Custom data
@@ -5339,6 +5387,7 @@ TileSet::TerrainsPattern TileData::get_terrains_pattern() const {
 	return output;
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 // Navigation
 void TileData::set_navigation_polygon(int p_layer_id, Ref<NavigationPolygon> p_navigation_polygon) {
 	ERR_FAIL_INDEX(p_layer_id, navigation.size());
@@ -5350,6 +5399,7 @@ Ref<NavigationPolygon> TileData::get_navigation_polygon(int p_layer_id) const {
 	ERR_FAIL_INDEX_V(p_layer_id, navigation.size(), Ref<NavigationPolygon>());
 	return navigation[p_layer_id];
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 // Misc
 void TileData::set_probability(float p_probability) {
@@ -5461,6 +5511,7 @@ bool TileData::_set(const StringName &p_name, const Variant &p_value) {
 				return true;
 			}
 		}
+#ifdef MODULE_NAVIGATION_ENABLED
 	} else if (components.size() == 2 && components[0].begins_with("navigation_layer_") && components[0].trim_prefix("navigation_layer_").is_valid_int()) {
 		// Navigation layers.
 		int layer_index = components[0].trim_prefix("navigation_layer_").to_int();
@@ -5478,6 +5529,7 @@ bool TileData::_set(const StringName &p_name, const Variant &p_value) {
 			set_navigation_polygon(layer_index, polygon);
 			return true;
 		}
+#endif // MODULE_NAVIGATION_ENABLED
 	} else if (components.size() == 2 && components[0] == "terrains_peering_bit") {
 		// Terrains.
 		for (int i = 0; i < TileSet::CELL_NEIGHBOR_MAX; i++) {
@@ -5568,6 +5620,7 @@ bool TileData::_get(const StringName &p_name, Variant &r_ret) const {
 				}
 			}
 			return false;
+#ifdef MODULE_NAVIGATION_ENABLED
 		} else if (components.size() == 2 && components[0].begins_with("navigation_layer_") && components[0].trim_prefix("navigation_layer_").is_valid_int()) {
 			// Occlusion layers.
 			int layer_index = components[0].trim_prefix("navigation_layer_").to_int();
@@ -5579,6 +5632,7 @@ bool TileData::_get(const StringName &p_name, Variant &r_ret) const {
 				r_ret = get_navigation_polygon(layer_index);
 				return true;
 			}
+#endif // MODULE_NAVIGATION_ENABLED
 		} else if (components.size() == 1 && components[0].begins_with("custom_data_") && components[0].trim_prefix("custom_data_").is_valid_int()) {
 			// Custom data layers.
 			int layer_index = components[0].trim_prefix("custom_data_").to_int();
@@ -5655,6 +5709,7 @@ void TileData::_get_property_list(List<PropertyInfo> *p_list) const {
 			}
 		}
 
+#ifdef MODULE_NAVIGATION_ENABLED
 		// Navigation layers.
 		p_list->push_back(PropertyInfo(Variant::NIL, "Navigation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
 		for (int i = 0; i < navigation.size(); i++) {
@@ -5664,6 +5719,7 @@ void TileData::_get_property_list(List<PropertyInfo> *p_list) const {
 			}
 			p_list->push_back(property_info);
 		}
+#endif // MODULE_NAVIGATION_ENABLED
 
 		// Custom data layers.
 		p_list->push_back(PropertyInfo(Variant::NIL, "Custom data", PROPERTY_HINT_NONE, "custom_data_", PROPERTY_USAGE_GROUP));
@@ -5726,9 +5782,11 @@ void TileData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_terrain_peering_bit", "peering_bit", "terrain"), &TileData::set_terrain_peering_bit);
 	ClassDB::bind_method(D_METHOD("get_terrain_peering_bit", "peering_bit"), &TileData::get_terrain_peering_bit);
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation
 	ClassDB::bind_method(D_METHOD("set_navigation_polygon", "layer_id", "navigation_polygon"), &TileData::set_navigation_polygon);
 	ClassDB::bind_method(D_METHOD("get_navigation_polygon", "layer_id"), &TileData::get_navigation_polygon);
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// Misc.
 	ClassDB::bind_method(D_METHOD("set_probability", "probability"), &TileData::set_probability);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -48,6 +48,7 @@
 #include "scene/resources/shader.h"
 #include "scene/resources/texture.h"
 #endif
+#include "modules/modules_enabled.gen.h"
 
 class TileMap;
 struct TileMapQuadrant;
@@ -177,15 +178,19 @@ private:
 		int autotile_spacing = 0;
 		HashMap<Vector2i, int> autotile_bitmask_flags;
 		HashMap<Vector2i, Ref<OccluderPolygon2D>> autotile_occluder_map;
+#ifdef MODULE_NAVIGATION_ENABLED
 		HashMap<Vector2i, Ref<NavigationPolygon>> autotile_navpoly_map;
+#endif // MODULE_NAVIGATION_ENABLED
 		HashMap<Vector2i, int> autotile_priority_map;
 		HashMap<Vector2i, int> autotile_z_index_map;
 
 		Vector<CompatibilityShapeData> shapes;
 		Ref<OccluderPolygon2D> occluder;
 		Vector2 occluder_offset;
+#ifdef MODULE_NAVIGATION_ENABLED
 		Ref<NavigationPolygon> navigation;
 		Vector2 navigation_offset;
+#endif // MODULE_NAVIGATION_ENABLED
 		int z_index = 0;
 	};
 
@@ -345,11 +350,13 @@ private:
 	bool terrains_cache_dirty = true;
 	void _update_terrains_cache();
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation
 	struct NavigationLayer {
 		uint32_t layers = 1;
 	};
 	Vector<NavigationLayer> navigation_layers;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// CustomData
 	struct CustomDataLayer {
@@ -465,6 +472,7 @@ public:
 	bool is_valid_terrain_peering_bit_for_mode(TileSet::TerrainMode p_terrain_mode, TileSet::CellNeighbor p_peering_bit) const;
 	bool is_valid_terrain_peering_bit(int p_terrain_set, TileSet::CellNeighbor p_peering_bit) const;
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation
 	int get_navigation_layers_count() const;
 	void add_navigation_layer(int p_index = -1);
@@ -472,6 +480,7 @@ public:
 	void remove_navigation_layer(int p_index);
 	void set_navigation_layer_layers(int p_layer_index, uint32_t p_layers);
 	uint32_t get_navigation_layer_layers(int p_layer_index) const;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// Custom data
 	int get_custom_data_layers_count() const;
@@ -563,9 +572,11 @@ public:
 	virtual void add_terrain(int p_terrain_set, int p_index){};
 	virtual void move_terrain(int p_terrain_set, int p_from_index, int p_to_pos){};
 	virtual void remove_terrain(int p_terrain_set, int p_index){};
+#ifdef MODULE_NAVIGATION_ENABLED
 	virtual void add_navigation_layer(int p_index){};
 	virtual void move_navigation_layer(int p_from_index, int p_to_pos){};
 	virtual void remove_navigation_layer(int p_index){};
+#endif // MODULE_NAVIGATION_ENABLED
 	virtual void add_custom_data_layer(int p_index){};
 	virtual void move_custom_data_layer(int p_from_index, int p_to_pos){};
 	virtual void remove_custom_data_layer(int p_index){};
@@ -651,9 +662,11 @@ public:
 	virtual void add_terrain(int p_terrain_set, int p_index) override;
 	virtual void move_terrain(int p_terrain_set, int p_from_index, int p_to_pos) override;
 	virtual void remove_terrain(int p_terrain_set, int p_index) override;
+#ifdef MODULE_NAVIGATION_ENABLED
 	virtual void add_navigation_layer(int p_index) override;
 	virtual void move_navigation_layer(int p_from_index, int p_to_pos) override;
 	virtual void remove_navigation_layer(int p_index) override;
+#endif // MODULE_NAVIGATION_ENABLED
 	virtual void add_custom_data_layer(int p_index) override;
 	virtual void move_custom_data_layer(int p_from_index, int p_to_pos) override;
 	virtual void remove_custom_data_layer(int p_index) override;
@@ -810,8 +823,10 @@ private:
 	int terrain = -1;
 	int terrain_peering_bits[16] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation
 	Vector<Ref<NavigationPolygon>> navigation;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// Misc
 	double probability = 1.0;
@@ -841,9 +856,11 @@ public:
 	void add_terrain(int p_terrain_set, int p_index);
 	void move_terrain(int p_terrain_set, int p_from_index, int p_to_pos);
 	void remove_terrain(int p_terrain_set, int p_index);
+#ifdef MODULE_NAVIGATION_ENABLED
 	void add_navigation_layer(int p_index);
 	void move_navigation_layer(int p_from_index, int p_to_pos);
 	void remove_navigation_layer(int p_index);
+#endif // MODULE_NAVIGATION_ENABLED
 	void add_custom_data_layer(int p_index);
 	void move_custom_data_layer(int p_from_index, int p_to_pos);
 	void remove_custom_data_layer(int p_index);
@@ -904,9 +921,11 @@ public:
 
 	TileSet::TerrainsPattern get_terrains_pattern() const; // Not exposed.
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Navigation
 	void set_navigation_polygon(int p_layer_id, Ref<NavigationPolygon> p_navigation_polygon);
 	Ref<NavigationPolygon> get_navigation_polygon(int p_layer_id) const;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	// Misc
 	void set_probability(float p_probability);

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -34,7 +34,9 @@
 #include "scene/2d/camera_2d.h"
 #include "scene/2d/visible_on_screen_notifier_2d.h"
 #include "scene/main/window.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_2d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "servers/physics_server_2d.h"
 #include "servers/rendering_server.h"
 
@@ -46,20 +48,26 @@ RID World2D::get_space() const {
 	return space;
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 RID World2D::get_navigation_map() const {
 	return navigation_map;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 void World2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_canvas"), &World2D::get_canvas);
 	ClassDB::bind_method(D_METHOD("get_space"), &World2D::get_space);
+#ifdef MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &World2D::get_navigation_map);
+#endif // MODULE_NAVIGATION_ENABLED
 
 	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World2D::get_direct_space_state);
 
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "canvas", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_canvas");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
+#ifdef MODULE_NAVIGATION_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
+#endif // MODULE_NAVIGATION_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsDirectSpaceState2D", PROPERTY_USAGE_NONE), "", "get_direct_space_state");
 }
 
@@ -80,16 +88,20 @@ World2D::World2D() {
 	PhysicsServer2D::get_singleton()->area_set_param(space, PhysicsServer2D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_DEF("physics/2d/default_angular_damp", 1.0));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/default_angular_damp", PropertyInfo(Variant::FLOAT, "physics/2d/default_angular_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	// Create and configure the navigation_map to be more friendly with pixels than meters.
 	navigation_map = NavigationServer2D::get_singleton()->map_create();
 	NavigationServer2D::get_singleton()->map_set_active(navigation_map, true);
 	NavigationServer2D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/2d/default_cell_size", 1));
 	NavigationServer2D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/2d/default_edge_connection_margin", 1));
 	NavigationServer2D::get_singleton()->map_set_link_connection_radius(navigation_map, GLOBAL_DEF("navigation/2d/default_link_connection_radius", 4));
+#endif // MODULE_NAVIGATION_ENABLED
 }
 
 World2D::~World2D() {
 	RenderingServer::get_singleton()->free(canvas);
 	PhysicsServer2D::get_singleton()->free(space);
+#ifdef MODULE_NAVIGATION_ENABLED
 	NavigationServer2D::get_singleton()->free(navigation_map);
+#endif // MODULE_NAVIGATION_ENABLED
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -31,6 +31,8 @@
 #ifndef WORLD_2D_H
 #define WORLD_2D_H
 
+#include "modules/modules_enabled.gen.h"
+
 #include "core/io/resource.h"
 #include "scene/resources/world_2d.h"
 #include "servers/physics_server_2d.h"
@@ -44,7 +46,9 @@ class World2D : public Resource {
 
 	RID canvas;
 	RID space;
+#ifdef MODULE_NAVIGATION_ENABLED
 	RID navigation_map;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	HashSet<Viewport *> viewports;
 
@@ -58,7 +62,9 @@ protected:
 public:
 	RID get_canvas() const;
 	RID get_space() const;
+#ifdef MODULE_NAVIGATION_ENABLED
 	RID get_navigation_map() const;
+#endif // MODULE_NAVIGATION_ENABLED
 
 	PhysicsDirectSpaceState2D *get_direct_space_state();
 

--- a/scene/resources/world_3d.cpp
+++ b/scene/resources/world_3d.cpp
@@ -36,7 +36,9 @@
 #include "scene/resources/camera_attributes.h"
 #include "scene/resources/environment.h"
 #include "scene/scene_string_names.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 
 void World3D::_register_camera(Camera3D *p_camera) {
 #ifndef _3D_DISABLED
@@ -54,9 +56,11 @@ RID World3D::get_space() const {
 	return space;
 }
 
+#ifdef MODULE_NAVIGATION_ENABLED
 RID World3D::get_navigation_map() const {
 	return navigation_map;
 }
+#endif // MODULE_NAVIGATION_ENABLED
 
 RID World3D::get_scenario() const {
 	return scenario;
@@ -119,7 +123,9 @@ PhysicsDirectSpaceState3D *World3D::get_direct_space_state() {
 
 void World3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_space"), &World3D::get_space);
+#ifdef MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("get_navigation_map"), &World3D::get_navigation_map);
+#endif // MODULE_NAVIGATION_ENABLED
 	ClassDB::bind_method(D_METHOD("get_scenario"), &World3D::get_scenario);
 	ClassDB::bind_method(D_METHOD("set_environment", "env"), &World3D::set_environment);
 	ClassDB::bind_method(D_METHOD("get_environment"), &World3D::get_environment);
@@ -132,7 +138,9 @@ void World3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_environment", PROPERTY_HINT_RESOURCE_TYPE, "Environment"), "set_fallback_environment", "get_fallback_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_attributes", PROPERTY_HINT_RESOURCE_TYPE, "CameraAttributesPractical,CameraAttributesPhysical"), "set_camera_attributes", "get_camera_attributes");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
+#ifdef MODULE_NAVIGATION_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
+#endif // MODULE_NAVIGATION_ENABLED
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "scenario", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_scenario");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsDirectSpaceState3D", PROPERTY_USAGE_NONE), "", "get_direct_space_state");
 }
@@ -149,15 +157,19 @@ World3D::World3D() {
 	PhysicsServer3D::get_singleton()->area_set_param(space, PhysicsServer3D::AREA_PARAM_ANGULAR_DAMP, GLOBAL_DEF("physics/3d/default_angular_damp", 0.1));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/default_angular_damp", PropertyInfo(Variant::FLOAT, "physics/3d/default_angular_damp", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"));
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	navigation_map = NavigationServer3D::get_singleton()->map_create();
 	NavigationServer3D::get_singleton()->map_set_active(navigation_map, true);
 	NavigationServer3D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/3d/default_cell_size", 0.25));
 	NavigationServer3D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.25));
 	NavigationServer3D::get_singleton()->map_set_link_connection_radius(navigation_map, GLOBAL_DEF("navigation/3d/default_link_connection_radius", 1.0));
+#endif // MODULE_NAVIGATION_ENABLED
 }
 
 World3D::~World3D() {
 	PhysicsServer3D::get_singleton()->free(space);
 	RenderingServer::get_singleton()->free(scenario);
+#ifdef MODULE_NAVIGATION_ENABLED
 	NavigationServer3D::get_singleton()->free(navigation_map);
+#endif // MODULE_NAVIGATION_ENABLED
 }

--- a/scene/resources/world_3d.h
+++ b/scene/resources/world_3d.h
@@ -31,6 +31,8 @@
 #ifndef WORLD_3D_H
 #define WORLD_3D_H
 
+#include "modules/modules_enabled.gen.h"
+
 #include "core/io/resource.h"
 #include "scene/resources/environment.h"
 #include "servers/physics_server_3d.h"
@@ -46,7 +48,9 @@ class World3D : public Resource {
 
 private:
 	RID space;
+#ifdef MODULE_NAVIGATION_ENABLED
 	RID navigation_map;
+#endif // MODULE_NAVIGATION_ENABLED
 	RID scenario;
 
 	Ref<Environment> environment;
@@ -65,7 +69,9 @@ protected:
 
 public:
 	RID get_space() const;
+#ifdef MODULE_NAVIGATION_ENABLED
 	RID get_navigation_map() const;
+#endif // MODULE_NAVIGATION_ENABLED
 	RID get_scenario() const;
 
 	void set_environment(const Ref<Environment> &p_environment);

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/math/transform_2d.h"
 #include "core/math/transform_3d.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "servers/navigation_server_3d.h"
 
 NavigationServer2D *NavigationServer2D::singleton = nullptr;
@@ -409,3 +410,4 @@ bool FORWARD_1_C(agent_is_map_changed, RID, p_agent, rid_to_rid);
 void FORWARD_4_C(agent_set_callback, RID, p_agent, Object *, p_receiver, StringName, p_method, Variant, p_udata, rid_to_rid, obj_to_obj, sn_to_sn, var_to_var);
 
 void FORWARD_1_C(free, RID, p_object, rid_to_rid);
+#endif // MODULE_NAVIGATION_ENABLED

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -33,6 +33,9 @@
 
 #include "core/object/class_db.h"
 #include "core/templates/rid.h"
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/2d/navigation_region_2d.h"
 
 // This server exposes the `NavigationServer3D` features in the 2D world.
@@ -246,5 +249,6 @@ public:
 	bool get_debug_navigation_enable_edge_connections() const;
 #endif // DEBUG_ENABLED
 };
+#endif //MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_SERVER_2D_H

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -34,6 +34,7 @@
 #include "core/config/project_settings.h"
 #endif // DEBUG_ENABLED
 
+#ifdef MODULE_NAVIGATION_ENABLED
 NavigationServer3D *NavigationServer3D::singleton = nullptr;
 
 void NavigationServer3D::_bind_methods() {
@@ -485,3 +486,4 @@ bool NavigationServer3D::get_debug_enabled() const {
 	return debug_enabled;
 }
 #endif // DEBUG_ENABLED
+#endif // MODULE_NAVIGATION_ENABLED

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -33,6 +33,9 @@
 
 #include "core/object/class_db.h"
 #include "core/templates/rid.h"
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "scene/3d/navigation_region_3d.h"
 
 /// This server uses the concept of internal mutability.
@@ -342,5 +345,6 @@ public:
 	static void set_default_server(NavigationServer3DCallback p_callback);
 	static NavigationServer3D *new_default_server();
 };
+#endif // MODULE_NAVIGATION_ENABLED
 
 #endif // NAVIGATION_SERVER_3D_H

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -60,8 +60,11 @@
 #include "movie_writer/movie_writer.h"
 #include "movie_writer/movie_writer_mjpeg.h"
 #include "movie_writer/movie_writer_pngwav.h"
+#include "modules/modules_enabled.gen.h"
+#ifdef MODULE_NAVIGATION_ENABLED
 #include "navigation_server_2d.h"
 #include "navigation_server_3d.h"
+#endif // MODULE_NAVIGATION_ENABLED
 #include "physics_2d/godot_physics_server_2d.h"
 #include "physics_3d/godot_physics_server_3d.h"
 #include "physics_server_2d.h"
@@ -163,8 +166,11 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionResult, "Vector3 travel;Vector3 remainder;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionStateCallback, "void *instance;void (*callback)(void *p_instance, PhysicsDirectBodyState3D *p_state)");
 
+#ifdef MODULE_NAVIGATION_ENABLED
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
+#endif // MODULE_NAVIGATION_ENABLED
+
 	GDREGISTER_CLASS(XRServer);
 	GDREGISTER_CLASS(CameraServer);
 
@@ -300,8 +306,10 @@ void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("AudioServer", AudioServer::get_singleton(), "AudioServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer2D", PhysicsServer2D::get_singleton(), "PhysicsServer2D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3D", PhysicsServer3D::get_singleton(), "PhysicsServer3D"));
+#ifdef MODULE_NAVIGATION_ENABLED
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer2D", NavigationServer2D::get_singleton_mut(), "NavigationServer2D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationServer3D", NavigationServer3D::get_singleton_mut(), "NavigationServer3D"));
+#endif // MODULE_NAVIGATION_ENABLED
 	Engine::get_singleton()->add_singleton(Engine::Singleton("XRServer", XRServer::get_singleton(), "XRServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
 }


### PR DESCRIPTION
Fixes: #36091

Adds `MODULE_NAVIGATION_ENABLED` guards to the codebase so Godot can be build with the Navigation module disabled.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
