### PR TITLE
CI: Downgrade Emscripten to 3.1.18

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -6,7 +6,7 @@ env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
-  EM_VERSION: 3.1.20
+  EM_VERSION: 3.1.18
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:


### PR DESCRIPTION
Emscripten 3.1.19 and 3.1.20 have a showstopping regression that breaks calling our main function for the editor build.