### PR TITLE
PhysicsServer2DExtension and PhysicsServer3DExtension: bind all methods (really)

### DIFF
--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -142,6 +142,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_area_set_pickable" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="area" type="RID" />
+			<param index="1" name="pickable" type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="_area_set_shape" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
@@ -282,6 +289,19 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_collide_shape" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="body_shape" type="int" />
+			<param index="2" name="shape" type="RID" />
+			<param index="3" name="shape_xform" type="Transform2D" />
+			<param index="4" name="motion" type="Vector2" />
+			<param index="5" name="results" type="void*" />
+			<param index="6" name="result_max" type="int" />
+			<param index="7" name="result_count" type="int32_t*" />
+			<description>
+			</description>
+		</method>
 		<method name="_body_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>
@@ -289,6 +309,12 @@
 		</method>
 		<method name="_body_get_canvas_instance_id" qualifiers="virtual const">
 			<return type="int" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_collision_exceptions" qualifiers="virtual const">
+			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
@@ -318,6 +344,12 @@
 			</description>
 		</method>
 		<method name="_body_get_constant_torque" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
@@ -461,6 +493,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="threshold" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="_body_set_continuous_collision_detection_mode" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -502,6 +541,13 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
 			<param index="2" name="value" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_pickable" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="pickable" type="bool" />
 			<description>
 			</description>
 		</method>
@@ -550,6 +596,13 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
 			<param index="2" name="value" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_state_sync_callback" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="callback" type="PhysicsServer2DExtensionStateCallback*" />
 			<description>
 			</description>
 		</method>
@@ -648,6 +701,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_joint_disable_collisions_between_bodies" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="disable" type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
@@ -657,6 +717,12 @@
 		</method>
 		<method name="_joint_get_type" qualifiers="virtual const">
 			<return type="int" enum="PhysicsServer2D.JointType" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_is_disabled_collisions_between_bodies" qualifiers="virtual const">
+			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 			</description>
@@ -735,6 +801,26 @@
 			<description>
 			</description>
 		</method>
+		<method name="_shape_collide" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="shape_A" type="RID" />
+			<param index="1" name="xform_A" type="Transform2D" />
+			<param index="2" name="motion_A" type="Vector2" />
+			<param index="3" name="shape_B" type="RID" />
+			<param index="4" name="xform_B" type="Transform2D" />
+			<param index="5" name="motion_B" type="Vector2" />
+			<param index="6" name="results" type="void*" />
+			<param index="7" name="result_max" type="int" />
+			<param index="8" name="result_count" type="int32_t*" />
+			<description>
+			</description>
+		</method>
+		<method name="_shape_get_custom_solver_bias" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="shape" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_shape_get_data" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
@@ -747,6 +833,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_shape_set_custom_solver_bias" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="shape" type="RID" />
+			<param index="1" name="bias" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="_shape_set_data" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
@@ -756,6 +849,18 @@
 		</method>
 		<method name="_space_create" qualifiers="virtual">
 			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_get_contact_count" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_get_contacts" qualifiers="virtual const">
+			<return type="PackedVector2Array" />
+			<param index="0" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
@@ -782,6 +887,13 @@
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="active" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_set_debug_contacts" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="max_contacts" type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -274,6 +274,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_get_collision_exceptions" qualifiers="virtual const">
+			<return type="RID[]" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_body_get_collision_layer" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
@@ -300,6 +306,12 @@
 		</method>
 		<method name="_body_get_constant_torque" qualifiers="virtual const">
 			<return type="Vector3" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual const">
+			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
@@ -365,6 +377,12 @@
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_user_flags" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
@@ -457,6 +475,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="threshold" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="_body_set_enable_continuous_collision_detection" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -544,6 +569,20 @@
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
 			<param index="2" name="value" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_state_sync_callback" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="callback" type="PhysicsServer3DExtensionStateCallback*" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_user_flags" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="flags" type="int" />
 			<description>
 			</description>
 		</method>
@@ -763,6 +802,18 @@
 			<description>
 			</description>
 		</method>
+		<method name="_joint_make_hinge_simple" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="body_A" type="RID" />
+			<param index="2" name="pivot_A" type="Vector3" />
+			<param index="3" name="axis_A" type="Vector3" />
+			<param index="4" name="body_B" type="RID" />
+			<param index="5" name="pivot_B" type="Vector3" />
+			<param index="6" name="axis_B" type="Vector3" />
+			<description>
+			</description>
+		</method>
 		<method name="_joint_make_pin" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
@@ -842,8 +893,20 @@
 			<description>
 			</description>
 		</method>
+		<method name="_shape_get_custom_solver_bias" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="shape" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_shape_get_data" qualifiers="virtual const">
 			<return type="Variant" />
+			<param index="0" name="shape" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_shape_get_margin" qualifiers="virtual const">
+			<return type="float" />
 			<param index="0" name="shape" type="RID" />
 			<description>
 			</description>
@@ -854,10 +917,24 @@
 			<description>
 			</description>
 		</method>
+		<method name="_shape_set_custom_solver_bias" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="shape" type="RID" />
+			<param index="1" name="bias" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="_shape_set_data" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="data" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_shape_set_margin" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="shape" type="RID" />
+			<param index="1" name="margin" type="float" />
 			<description>
 			</description>
 		</method>
@@ -876,14 +953,247 @@
 			<description>
 			</description>
 		</method>
+		<method name="_soft_body_add_collision_exception" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="body_b" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_soft_body_get_bounds" qualifiers="virtual const">
 			<return type="AABB" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
+		<method name="_soft_body_get_collision_exceptions" qualifiers="virtual const">
+			<return type="RID[]" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_collision_layer" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_collision_mask" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_damping_coefficient" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_drag_coefficient" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_linear_stiffness" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_point_global_position" qualifiers="virtual const">
+			<return type="Vector3" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_pressure_coefficient" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_simulation_precision" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_space" qualifiers="virtual const">
+			<return type="RID" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_state" qualifiers="virtual const">
+			<return type="Variant" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_total_mass" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_is_point_pinned" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_move_point" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<param index="2" name="global_position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_pin_point" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<param index="2" name="pin" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_remove_all_pinned_points" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_remove_collision_exception" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="body_b" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_collision_layer" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_collision_mask" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="mask" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_damping_coefficient" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="damping_coefficient" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_drag_coefficient" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="drag_coefficient" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_linear_stiffness" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="linear_stiffness" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_mesh" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="mesh" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_pressure_coefficient" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="pressure_coefficient" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_ray_pickable" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_simulation_precision" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="simulation_precision" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_space" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_state" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
+			<param index="2" name="variant" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_total_mass" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="total_mass" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_transform" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="transform" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_update_rendering_server" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="rendering_server_handler" type="PhysicsServer3DRenderingServerHandler" />
+			<description>
+			</description>
+		</method>
 		<method name="_space_create" qualifiers="virtual">
 			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_get_contact_count" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_get_contacts" qualifiers="virtual const">
+			<return type="PackedVector3Array" />
+			<param index="0" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
@@ -910,6 +1220,13 @@
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="active" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_set_debug_contacts" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="max_contacts" type="int" />
 			<description>
 			</description>
 		</method>

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -123,6 +123,8 @@ bool PhysicsServer2DExtension::body_test_motion_is_excluding_object(ObjectID p_o
 }
 
 void PhysicsServer2DExtension::_bind_methods() {
+	/* SHAPE API */
+
 	GDVIRTUAL_BIND(_world_boundary_shape_create);
 	GDVIRTUAL_BIND(_separation_ray_shape_create);
 	GDVIRTUAL_BIND(_segment_shape_create);
@@ -133,18 +135,32 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_concave_polygon_shape_create);
 
 	GDVIRTUAL_BIND(_shape_set_data, "shape", "data");
+	GDVIRTUAL_BIND(_shape_set_custom_solver_bias, "shape", "bias");
 
 	GDVIRTUAL_BIND(_shape_get_type, "shape");
 	GDVIRTUAL_BIND(_shape_get_data, "shape");
+	GDVIRTUAL_BIND(_shape_get_custom_solver_bias, "shape");
+	GDVIRTUAL_BIND(_shape_collide, "shape_A", "xform_A", "motion_A", "shape_B", "xform_B", "motion_B", "results", "result_max", "result_count");
+
+	/* SPACE API */
 
 	GDVIRTUAL_BIND(_space_create);
 	GDVIRTUAL_BIND(_space_set_active, "space", "active");
 	GDVIRTUAL_BIND(_space_is_active, "space");
+
 	GDVIRTUAL_BIND(_space_set_param, "space", "param", "value");
 	GDVIRTUAL_BIND(_space_get_param, "space", "param");
+
 	GDVIRTUAL_BIND(_space_get_direct_state, "space");
 
+	GDVIRTUAL_BIND(_space_set_debug_contacts, "space", "max_contacts");
+	GDVIRTUAL_BIND(_space_get_contacts, "space");
+	GDVIRTUAL_BIND(_space_get_contact_count, "space");
+
+	/* AREA API */
+
 	GDVIRTUAL_BIND(_area_create);
+
 	GDVIRTUAL_BIND(_area_set_space, "area", "space");
 	GDVIRTUAL_BIND(_area_get_space, "area");
 
@@ -160,8 +176,11 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_area_remove_shape, "area", "shape_idx");
 	GDVIRTUAL_BIND(_area_clear_shapes, "area");
 
-	GDVIRTUAL_BIND(_area_set_collision_layer, "area", "layer");
-	GDVIRTUAL_BIND(_area_set_collision_mask, "area", "mask");
+	GDVIRTUAL_BIND(_area_attach_object_instance_id, "area", "id");
+	GDVIRTUAL_BIND(_area_get_object_instance_id, "area");
+
+	GDVIRTUAL_BIND(_area_attach_canvas_instance_id, "area", "id");
+	GDVIRTUAL_BIND(_area_get_canvas_instance_id, "area");
 
 	GDVIRTUAL_BIND(_area_set_param, "area", "param", "value");
 	GDVIRTUAL_BIND(_area_set_transform, "area", "transform");
@@ -169,15 +188,16 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_area_get_param, "area", "param");
 	GDVIRTUAL_BIND(_area_get_transform, "area");
 
-	GDVIRTUAL_BIND(_area_attach_object_instance_id, "area", "id");
-	GDVIRTUAL_BIND(_area_get_object_instance_id, "area");
+	GDVIRTUAL_BIND(_area_set_collision_layer, "area", "layer");
+	GDVIRTUAL_BIND(_area_set_collision_mask, "area", "mask");
 
-	GDVIRTUAL_BIND(_area_attach_canvas_instance_id, "area", "id");
-	GDVIRTUAL_BIND(_area_get_canvas_instance_id, "area");
+	GDVIRTUAL_BIND(_area_set_monitorable, "area", "monitorable");
+	GDVIRTUAL_BIND(_area_set_pickable, "area", "pickable");
 
 	GDVIRTUAL_BIND(_area_set_monitor_callback, "area", "callback");
 	GDVIRTUAL_BIND(_area_set_area_monitor_callback, "area", "callback");
-	GDVIRTUAL_BIND(_area_set_monitorable, "area", "monitorable");
+
+	/* BODY API */
 
 	GDVIRTUAL_BIND(_body_create);
 
@@ -195,11 +215,11 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_body_get_shape, "body", "shape_idx");
 	GDVIRTUAL_BIND(_body_get_shape_transform, "body", "shape_idx");
 
-	GDVIRTUAL_BIND(_body_remove_shape, "body", "shape_idx");
-	GDVIRTUAL_BIND(_body_clear_shapes, "body");
-
 	GDVIRTUAL_BIND(_body_set_shape_disabled, "body", "shape_idx", "disabled");
 	GDVIRTUAL_BIND(_body_set_shape_as_one_way_collision, "body", "shape_idx", "enable", "margin");
+
+	GDVIRTUAL_BIND(_body_remove_shape, "body", "shape_idx");
+	GDVIRTUAL_BIND(_body_clear_shapes, "body");
 
 	GDVIRTUAL_BIND(_body_attach_object_instance_id, "body", "id");
 	GDVIRTUAL_BIND(_body_get_object_instance_id, "body");
@@ -249,24 +269,38 @@ void PhysicsServer2DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_add_collision_exception, "body", "excepted_body");
 	GDVIRTUAL_BIND(_body_remove_collision_exception, "body", "excepted_body");
+	GDVIRTUAL_BIND(_body_get_collision_exceptions, "body");
 
 	GDVIRTUAL_BIND(_body_set_max_contacts_reported, "body", "amount");
 	GDVIRTUAL_BIND(_body_get_max_contacts_reported, "body");
 
+	GDVIRTUAL_BIND(_body_set_contacts_reported_depth_threshold, "body", "threshold");
+	GDVIRTUAL_BIND(_body_get_contacts_reported_depth_threshold, "body");
+
 	GDVIRTUAL_BIND(_body_set_omit_force_integration, "body", "enable");
 	GDVIRTUAL_BIND(_body_is_omitting_force_integration, "body");
 
+	GDVIRTUAL_BIND(_body_set_state_sync_callback, "body", "callback");
 	GDVIRTUAL_BIND(_body_set_force_integration_callback, "body", "callable", "userdata");
+
+	GDVIRTUAL_BIND(_body_collide_shape, "body", "body_shape", "shape", "shape_xform", "motion", "results", "result_max", "result_count");
+
+	GDVIRTUAL_BIND(_body_set_pickable, "body", "pickable");
+
+	GDVIRTUAL_BIND(_body_get_direct_state, "body");
 
 	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "collide_separation_ray", "recovery_as_collision", "result");
 
-	GDVIRTUAL_BIND(_body_get_direct_state, "body");
+	/* JOINT API */
 
 	GDVIRTUAL_BIND(_joint_create);
 	GDVIRTUAL_BIND(_joint_clear, "joint");
 
 	GDVIRTUAL_BIND(_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_joint_get_param, "joint", "param");
+
+	GDVIRTUAL_BIND(_joint_disable_collisions_between_bodies, "joint", "disable");
+	GDVIRTUAL_BIND(_joint_is_disabled_collisions_between_bodies, "joint");
 
 	GDVIRTUAL_BIND(_joint_make_pin, "joint", "anchor", "body_a", "body_b");
 	GDVIRTUAL_BIND(_joint_make_groove, "joint", "a_groove1", "a_groove2", "b_anchor", "body_a", "body_b");
@@ -279,6 +313,8 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_damped_spring_joint_get_param, "joint", "param");
 
 	GDVIRTUAL_BIND(_joint_get_type, "joint");
+
+	/* MISC */
 
 	GDVIRTUAL_BIND(_free_rid, "rid");
 

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -204,6 +204,8 @@ protected:
 public:
 	// The warning is valid, but unavoidable. If the function is not overridden it will error anyway.
 
+	/* SHAPE API */
+
 	EXBIND0R(RID, world_boundary_shape_create)
 	EXBIND0R(RID, separation_ray_shape_create)
 	EXBIND0R(RID, segment_shape_create)
@@ -252,6 +254,7 @@ public:
 	EXBIND4(area_add_shape, RID, RID, const Transform2D &, bool)
 	EXBIND3(area_set_shape, RID, int, RID)
 	EXBIND3(area_set_shape_transform, RID, int, const Transform2D &)
+	EXBIND3(area_set_shape_disabled, RID, int, bool)
 
 	EXBIND1RC(int, area_get_shape_count, RID)
 	EXBIND2RC(RID, area_get_shape, RID, int)
@@ -259,8 +262,6 @@ public:
 
 	EXBIND2(area_remove_shape, RID, int)
 	EXBIND1(area_clear_shapes, RID)
-
-	EXBIND3(area_set_shape_disabled, RID, int, bool)
 
 	EXBIND2(area_attach_object_instance_id, RID, ObjectID)
 	EXBIND1RC(ObjectID, area_get_object_instance_id, RID)
@@ -415,7 +416,6 @@ public:
 	/* JOINT API */
 
 	EXBIND0R(RID, joint_create)
-
 	EXBIND1(joint_clear, RID)
 
 	EXBIND3(joint_set_param, RID, JointParam, real_t)

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -125,6 +125,8 @@ bool PhysicsServer3DExtension::body_test_motion_is_excluding_object(ObjectID p_o
 }
 
 void PhysicsServer3DExtension::_bind_methods() {
+	/* SHAPE API */
+
 	GDVIRTUAL_BIND(_world_boundary_shape_create);
 	GDVIRTUAL_BIND(_separation_ray_shape_create);
 	GDVIRTUAL_BIND(_sphere_shape_create);
@@ -137,18 +139,34 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_custom_shape_create);
 
 	GDVIRTUAL_BIND(_shape_set_data, "shape", "data");
+	GDVIRTUAL_BIND(_shape_set_custom_solver_bias, "shape", "bias");
+
+	GDVIRTUAL_BIND(_shape_set_margin, "shape", "margin");
+	GDVIRTUAL_BIND(_shape_get_margin, "shape");
 
 	GDVIRTUAL_BIND(_shape_get_type, "shape");
 	GDVIRTUAL_BIND(_shape_get_data, "shape");
+	GDVIRTUAL_BIND(_shape_get_custom_solver_bias, "shape");
+
+	/* SPACE API */
 
 	GDVIRTUAL_BIND(_space_create);
 	GDVIRTUAL_BIND(_space_set_active, "space", "active");
 	GDVIRTUAL_BIND(_space_is_active, "space");
+
 	GDVIRTUAL_BIND(_space_set_param, "space", "param", "value");
 	GDVIRTUAL_BIND(_space_get_param, "space", "param");
+
 	GDVIRTUAL_BIND(_space_get_direct_state, "space");
 
+	GDVIRTUAL_BIND(_space_set_debug_contacts, "space", "max_contacts");
+	GDVIRTUAL_BIND(_space_get_contacts, "space");
+	GDVIRTUAL_BIND(_space_get_contact_count, "space");
+
+	/* AREA API */
+
 	GDVIRTUAL_BIND(_area_create);
+
 	GDVIRTUAL_BIND(_area_set_space, "area", "space");
 	GDVIRTUAL_BIND(_area_get_space, "area");
 
@@ -164,8 +182,8 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_area_remove_shape, "area", "shape_idx");
 	GDVIRTUAL_BIND(_area_clear_shapes, "area");
 
-	GDVIRTUAL_BIND(_area_set_collision_layer, "area", "layer");
-	GDVIRTUAL_BIND(_area_set_collision_mask, "area", "mask");
+	GDVIRTUAL_BIND(_area_attach_object_instance_id, "area", "id");
+	GDVIRTUAL_BIND(_area_get_object_instance_id, "area");
 
 	GDVIRTUAL_BIND(_area_set_param, "area", "param", "value");
 	GDVIRTUAL_BIND(_area_set_transform, "area", "transform");
@@ -173,14 +191,16 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_area_get_param, "area", "param");
 	GDVIRTUAL_BIND(_area_get_transform, "area");
 
-	GDVIRTUAL_BIND(_area_attach_object_instance_id, "area", "id");
-	GDVIRTUAL_BIND(_area_get_object_instance_id, "area");
+	GDVIRTUAL_BIND(_area_set_collision_layer, "area", "layer");
+	GDVIRTUAL_BIND(_area_set_collision_mask, "area", "mask");
+
+	GDVIRTUAL_BIND(_area_set_monitorable, "area", "monitorable");
+	GDVIRTUAL_BIND(_area_set_ray_pickable, "area", "enable");
 
 	GDVIRTUAL_BIND(_area_set_monitor_callback, "area", "callback");
 	GDVIRTUAL_BIND(_area_set_area_monitor_callback, "area", "callback");
-	GDVIRTUAL_BIND(_area_set_monitorable, "area", "monitorable");
 
-	GDVIRTUAL_BIND(_area_set_ray_pickable, "area", "enable");
+	/* BODY API */
 
 	GDVIRTUAL_BIND(_body_create);
 
@@ -189,15 +209,6 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_set_mode, "body", "mode");
 	GDVIRTUAL_BIND(_body_get_mode, "body");
-
-	GDVIRTUAL_BIND(_body_set_collision_layer, "body", "layer");
-	GDVIRTUAL_BIND(_body_get_collision_layer, "body");
-
-	GDVIRTUAL_BIND(_body_set_collision_mask, "body", "mask");
-	GDVIRTUAL_BIND(_body_get_collision_mask, "body");
-
-	GDVIRTUAL_BIND(_body_set_collision_priority, "body", "priority");
-	GDVIRTUAL_BIND(_body_get_collision_priority, "body");
 
 	GDVIRTUAL_BIND(_body_add_shape, "body", "shape", "transform", "disabled");
 	GDVIRTUAL_BIND(_body_set_shape, "body", "shape_idx", "shape");
@@ -216,6 +227,18 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_set_enable_continuous_collision_detection, "body", "enable");
 	GDVIRTUAL_BIND(_body_is_continuous_collision_detection_enabled, "body");
+
+	GDVIRTUAL_BIND(_body_set_collision_layer, "body", "layer");
+	GDVIRTUAL_BIND(_body_get_collision_layer, "body");
+
+	GDVIRTUAL_BIND(_body_set_collision_mask, "body", "mask");
+	GDVIRTUAL_BIND(_body_get_collision_mask, "body");
+
+	GDVIRTUAL_BIND(_body_set_collision_priority, "body", "priority");
+	GDVIRTUAL_BIND(_body_get_collision_priority, "body");
+
+	GDVIRTUAL_BIND(_body_set_user_flags, "body", "flags");
+	GDVIRTUAL_BIND(_body_get_user_flags, "body");
 
 	GDVIRTUAL_BIND(_body_set_param, "body", "param", "value");
 	GDVIRTUAL_BIND(_body_get_param, "body", "param");
@@ -250,13 +273,18 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_add_collision_exception, "body", "excepted_body");
 	GDVIRTUAL_BIND(_body_remove_collision_exception, "body", "excepted_body");
+	GDVIRTUAL_BIND(_body_get_collision_exceptions, "body");
 
 	GDVIRTUAL_BIND(_body_set_max_contacts_reported, "body", "amount");
 	GDVIRTUAL_BIND(_body_get_max_contacts_reported, "body");
 
+	GDVIRTUAL_BIND(_body_set_contacts_reported_depth_threshold, "body", "threshold");
+	GDVIRTUAL_BIND(_body_get_contacts_reported_depth_threshold, "body");
+
 	GDVIRTUAL_BIND(_body_set_omit_force_integration, "body", "enable");
 	GDVIRTUAL_BIND(_body_is_omitting_force_integration, "body");
 
+	GDVIRTUAL_BIND(_body_set_state_sync_callback, "body", "callback");
 	GDVIRTUAL_BIND(_body_set_force_integration_callback, "body", "callable", "userdata");
 
 	GDVIRTUAL_BIND(_body_set_ray_pickable, "body", "enable");
@@ -265,12 +293,68 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_get_direct_state, "body");
 
+	/* SOFT BODY API */
+
+	GDVIRTUAL_BIND(_soft_body_create);
+
+	GDVIRTUAL_BIND(_soft_body_update_rendering_server, "body", "rendering_server_handler");
+
+	GDVIRTUAL_BIND(_soft_body_set_space, "body", "space");
+	GDVIRTUAL_BIND(_soft_body_get_space, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_ray_pickable, "body", "enable");
+
+	GDVIRTUAL_BIND(_soft_body_set_collision_layer, "body", "layer");
+	GDVIRTUAL_BIND(_soft_body_get_collision_layer, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_collision_mask, "body", "mask");
+	GDVIRTUAL_BIND(_soft_body_get_collision_mask, "body");
+
+	GDVIRTUAL_BIND(_soft_body_add_collision_exception, "body", "body_b");
+	GDVIRTUAL_BIND(_soft_body_remove_collision_exception, "body", "body_b");
+	GDVIRTUAL_BIND(_soft_body_get_collision_exceptions, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_state, "body", "state", "variant");
+	GDVIRTUAL_BIND(_soft_body_get_state, "body", "state");
+
+	GDVIRTUAL_BIND(_soft_body_set_transform, "body", "transform");
+
+	GDVIRTUAL_BIND(_soft_body_set_simulation_precision, "body", "simulation_precision");
+	GDVIRTUAL_BIND(_soft_body_get_simulation_precision, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_total_mass, "body", "total_mass");
+	GDVIRTUAL_BIND(_soft_body_get_total_mass, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_linear_stiffness, "body", "linear_stiffness");
+	GDVIRTUAL_BIND(_soft_body_get_linear_stiffness, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_pressure_coefficient, "body", "pressure_coefficient");
+	GDVIRTUAL_BIND(_soft_body_get_pressure_coefficient, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_damping_coefficient, "body", "damping_coefficient");
+	GDVIRTUAL_BIND(_soft_body_get_damping_coefficient, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_drag_coefficient, "body", "drag_coefficient");
+	GDVIRTUAL_BIND(_soft_body_get_drag_coefficient, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_mesh, "body", "mesh");
+
 	GDVIRTUAL_BIND(_soft_body_get_bounds, "body");
+
+	GDVIRTUAL_BIND(_soft_body_move_point, "body", "point_index", "global_position");
+	GDVIRTUAL_BIND(_soft_body_get_point_global_position, "body", "point_index");
+
+	GDVIRTUAL_BIND(_soft_body_remove_all_pinned_points, "body");
+	GDVIRTUAL_BIND(_soft_body_pin_point, "body", "point_index", "pin");
+	GDVIRTUAL_BIND(_soft_body_is_point_pinned, "body", "point_index");
+
+	/* JOINT API */
 
 	GDVIRTUAL_BIND(_joint_create);
 	GDVIRTUAL_BIND(_joint_clear, "joint");
 
 	GDVIRTUAL_BIND(_joint_make_pin, "joint", "body_A", "local_A", "body_B", "local_B");
+
 	GDVIRTUAL_BIND(_pin_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_pin_joint_get_param, "joint", "param");
 
@@ -281,6 +365,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_pin_joint_get_local_b, "joint");
 
 	GDVIRTUAL_BIND(_joint_make_hinge, "joint", "body_A", "hinge_A", "body_B", "hinge_B");
+	GDVIRTUAL_BIND(_joint_make_hinge_simple, "joint", "body_A", "pivot_A", "axis_A", "body_B", "pivot_B", "axis_B");
 
 	GDVIRTUAL_BIND(_hinge_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_hinge_joint_get_param, "joint", "param");
@@ -298,11 +383,6 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_cone_twist_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_cone_twist_joint_get_param, "joint", "param");
 
-	GDVIRTUAL_BIND(_joint_get_type, "joint");
-
-	GDVIRTUAL_BIND(_joint_set_solver_priority, "joint", "priority");
-	GDVIRTUAL_BIND(_joint_get_solver_priority, "joint");
-
 	GDVIRTUAL_BIND(_joint_make_generic_6dof, "joint", "body_A", "local_ref_A", "body_B", "local_ref_B");
 
 	GDVIRTUAL_BIND(_generic_6dof_joint_set_param, "joint", "axis", "param", "value");
@@ -310,6 +390,11 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_generic_6dof_joint_set_flag, "joint", "axis", "flag", "enable");
 	GDVIRTUAL_BIND(_generic_6dof_joint_get_flag, "joint", "axis", "flag");
+
+	GDVIRTUAL_BIND(_joint_get_type, "joint");
+
+	GDVIRTUAL_BIND(_joint_set_solver_priority, "joint", "priority");
+	GDVIRTUAL_BIND(_joint_get_solver_priority, "joint");
 
 	GDVIRTUAL_BIND(_free_rid, "rid");
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -210,6 +210,8 @@ protected:
 public:
 	// The warning is valid, but unavoidable. If the function is not overridden it will error anyway.
 
+	/* SHAPE API */
+
 	EXBIND0R(RID, world_boundary_shape_create)
 	EXBIND0R(RID, separation_ray_shape_create)
 	EXBIND0R(RID, sphere_shape_create)
@@ -262,6 +264,7 @@ public:
 	EXBIND1RC(int, area_get_shape_count, RID)
 	EXBIND2RC(RID, area_get_shape, RID, int)
 	EXBIND2RC(Transform3D, area_get_shape_transform, RID, int)
+
 	EXBIND2(area_remove_shape, RID, int)
 	EXBIND1(area_clear_shapes, RID)
 
@@ -297,12 +300,11 @@ public:
 	EXBIND4(body_add_shape, RID, RID, const Transform3D &, bool)
 	EXBIND3(body_set_shape, RID, int, RID)
 	EXBIND3(body_set_shape_transform, RID, int, const Transform3D &)
+	EXBIND3(body_set_shape_disabled, RID, int, bool)
 
 	EXBIND1RC(int, body_get_shape_count, RID)
-	EXBIND2RC(Transform3D, body_get_shape_transform, RID, int)
 	EXBIND2RC(RID, body_get_shape, RID, int)
-
-	EXBIND3(body_set_shape_disabled, RID, int, bool)
+	EXBIND2RC(Transform3D, body_get_shape_transform, RID, int)
 
 	EXBIND2(body_remove_shape, RID, int)
 	EXBIND1(body_clear_shapes, RID)
@@ -333,9 +335,9 @@ public:
 	EXBIND3(body_set_state, RID, BodyState, const Variant &)
 	EXBIND2RC(Variant, body_get_state, RID, BodyState)
 
-	EXBIND2(body_apply_torque_impulse, RID, const Vector3 &)
 	EXBIND2(body_apply_central_impulse, RID, const Vector3 &)
 	EXBIND3(body_apply_impulse, RID, const Vector3 &, const Vector3 &)
+	EXBIND2(body_apply_torque_impulse, RID, const Vector3 &)
 
 	EXBIND2(body_apply_central_force, RID, const Vector3 &)
 	EXBIND3(body_apply_force, RID, const Vector3 &, const Vector3 &)
@@ -476,7 +478,6 @@ public:
 	/* JOINT API */
 
 	EXBIND0R(RID, joint_create)
-
 	EXBIND1(joint_clear, RID)
 
 	EXBIND5(joint_make_pin, RID, RID, const Vector3 &, RID, const Vector3 &)


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/65465: there were just a few more...

Now you can line up the header file and `_bind_methods` and see that all is bound.

I prefer to bind everything, so that we do not artificially hinder potential GDExtension developers.

I ran into one of the missing methods when trying to implement a custom physics server.