### PR TITLE
Sibling SubViewports must be rendered from top to bottom

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -73,33 +73,36 @@ static Transform2D _canvas_get_transform(RendererViewport::Viewport *p_viewport,
 }
 
 Vector<RendererViewport::Viewport *> RendererViewport::_sort_active_viewports() {
-	// We need to sort the viewports in a "topological order",
-	// children first and parents last, we use the Kahn's algorithm to achieve that.
+	// We need to sort the viewports in a "topological order", children first and
+	// parents last. We also need to keep sibling viewports in the original order
+	// from top to bottom.
 
 	Vector<Viewport *> result;
 	List<Viewport *> nodes;
 
-	for (Viewport *viewport : active_viewports) {
+	for (int i = active_viewports.size() - 1; i >= 0; --i) {
+		Viewport *viewport = active_viewports[i];
 		if (viewport->parent.is_valid()) {
 			continue;
 		}
 
 		nodes.push_back(viewport);
+		result.insert(0, viewport);
 	}
 
 	while (!nodes.is_empty()) {
-		Viewport *node = nodes[0];
+		const Viewport *node = nodes[0];
 		nodes.pop_front();
 
-		result.insert(0, node);
-
-		for (Viewport *child : active_viewports) {
+		for (int i = active_viewports.size() - 1; i >= 0; --i) {
+			Viewport *child = active_viewports[i];
 			if (child->parent != node->self) {
 				continue;
 			}
 
 			if (!nodes.find(child)) {
 				nodes.push_back(child);
+				result.insert(0, child);
 			}
 		}
 	}


### PR DESCRIPTION
Sibling SubViewports must be rendered in the same order as in the Scene Tree, from top to bottom. _sort_active_viewports() reversed their order. 

Fixes #65545

This is not the "Kahn algorithm" anymore, that's why I removed the comment. It resembles an "Iterative Depth First Postorder Tree Traversal" with the added benefit of keeping the Siblings in the correct order.
