### PR TITLE
[3.x] Add deferred notifications

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -426,9 +426,19 @@ void Node::move_child(Node *p_child, int p_pos) {
 	}
 	// notification second
 	move_child_notify(p_child);
-	for (int i = motion_from; i <= motion_to; i++) {
-		data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+
+	if (is_inside_tree()) {
+		SceneTree *tree = get_tree();
+
+		for (int i = motion_from; i <= motion_to; i++) {
+			tree->send_deferred_notification(data.children[i], SceneTree::DEFERRED_NOTIFICATION_MOVED_IN_PARENT);
+		}
+	} else {
+		for (int i = motion_from; i <= motion_to; i++) {
+			data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+		}
 	}
+
 	p_child->_propagate_groups_dirty();
 
 	data.blocked--;
@@ -1352,9 +1362,19 @@ void Node::remove_child(Node *p_child) {
 	child_count = data.children.size();
 	children = data.children.ptrw();
 
-	for (int i = idx; i < child_count; i++) {
-		children[i]->data.pos = i;
-		children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+	if (is_inside_tree()) {
+		SceneTree *tree = get_tree();
+
+		for (int i = idx; i < child_count; i++) {
+			children[i]->data.pos = i;
+			tree->send_deferred_notification(children[i], SceneTree::DEFERRED_NOTIFICATION_MOVED_IN_PARENT);
+		}
+	} else {
+		// send notifications directly, less efficient
+		for (int i = idx; i < child_count; i++) {
+			children[i]->data.pos = i;
+			children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
+		}
 	}
 
 	p_child->data.parent = nullptr;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -134,6 +134,10 @@ private:
 
 		int process_priority;
 
+		// Will probably end up using 32 bits anyway (we don't need 32 flags here), but just in case...
+		// Can possibly be combined with one of the other wasteful data types above.
+		uint8_t deferred_notification_pending_flags = 0;
+
 		// Keep bitpacked values together to get better packing
 		PauseMode pause_mode : 2;
 		PhysicsInterpolationMode physics_interpolation_mode : 2;
@@ -512,6 +516,16 @@ public:
 	void set_custom_multiplayer(Ref<MultiplayerAPI> p_multiplayer);
 	const Map<StringName, MultiplayerAPI::RPCMode>::Element *get_node_rpc_mode(const StringName &p_method);
 	const Map<StringName, MultiplayerAPI::RPCMode>::Element *get_node_rset_mode(const StringName &p_property);
+
+	bool check_and_set_notification_pending(uint8_t p_notification_flag) {
+		static_assert(SceneTree::DEFERRED_NOTIFICATION_MAX < 8, "To support more than 8 flags, increase the storage type.");
+		if (data.deferred_notification_pending_flags & p_notification_flag) {
+			return false; // already set
+		}
+		data.deferred_notification_pending_flags |= p_notification_flag;
+		return true;
+	}
+	void clear_notification_pending(uint8_t p_notification_flag) { data.deferred_notification_pending_flags &= ~p_notification_flag; }
 
 	Node();
 	~Node();

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -97,6 +97,11 @@ public:
 		STRETCH_ASPECT_EXPAND,
 	};
 
+	enum DeferredNotificationType {
+		DEFERRED_NOTIFICATION_MOVED_IN_PARENT = 0,
+		DEFERRED_NOTIFICATION_MAX = 1,
+	};
+
 private:
 	struct Group {
 		Vector<Node *> nodes;
@@ -109,6 +114,8 @@ private:
 		SelfList<Spatial>::List _spatials_list;
 		void physics_process();
 	} _client_physics_interpolation;
+
+	LocalVector<ObjectID> _deferred_notification_lists[DEFERRED_NOTIFICATION_MAX];
 
 	Viewport *root;
 
@@ -302,8 +309,10 @@ public:
 	void call_group(const StringName &p_group, const StringName &p_function, VARIANT_ARG_LIST);
 	void notify_group(const StringName &p_group, int p_notification);
 	void set_group(const StringName &p_group, const String &p_name, const Variant &p_value);
+	void send_deferred_notification(Node *p_node, DeferredNotificationType p_deferred_notification);
 
 	void flush_transform_notifications();
+	void flush_deferred_notifications();
 
 	virtual void input_text(const String &p_text);
 	virtual void input_event(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
Adds the ability to defer sending notifications to the next flush, instead of sending notifications immediately. This system allows the prevention of duplicate notifications on the same frame / tick, which can result in large numbers of notifications and slowdown.

Helps address #61929
Alternative to #74672

## Notes
* Although #62444 helps with notifications specifically during deletion, this PR deals with detaching and moving nodes, which also suffers from slowdowns.
* Duplicate notifications can become especially problematic with large numbers of child nodes, especially `NOTIFICATION_MOVED_IN_PARENT`
* This adds a framework whereby deferred notifications are sent via the `SceneTree` rather than sent directly to the Node. The  `SceneTree` keeps lists for each deferred notification type, which can be flushed on frames and physics ticks.
* In order to prevent duplicates, dirty flags are stored on each node for each deferred type.
* Also relevant to 4.x, I can do version for 4.x if this is approved.

## Statistics
Using the MRP from #61929, trying with Nodes, blank and filled MeshInstances:

### 30000 nodes queue_deleted:
Before 20.6 seconds
After 7.06 seconds

### Notifications sent:
Before 450 million
After 30000

## Discussion and additional methods
This PR essentially replaces the heavyweight notification with a cheaper call, but these cheap calls are still made a lot of times.
 
An additional technique might be to maintain a list of interested children for each notification type (like observer pattern), but the added complexity and memory use is likely not warranted at this stage. Another problem is that for `NOTIFICATION_MOVED_IN_PARENT`, we are only sending to the children _after_ a certain point in the child list, and this could become expensive unless the subscriber list was also sorted by child index.

Another idea is for nodes to register their interest in a notification type (via a set of bitflags), and check this prior to sending the more heavyweight notification.

However although both of these techniques are theoretically possible in core, there is a problem - users must also be able to respond to notifications (either through script or deriving from classes in modules etc), and users would have to register interest / or lack of interest somehow, and thus this might not be doable in a backward compatible way.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
