### PR TITLE
Exposed collision depth for PhysicsDirectBodyState2D and 3d

### DIFF
--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -149,6 +149,13 @@
 				[b]Note:[/b] By default, this returns 0 unless bodies are configured to monitor contacts. See [member RigidBody2D.contact_monitor].
 			</description>
 		</method>
+		<method name="get_contact_depth" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="contact_idx" type="int" />
+			<description>
+				Returns the penetration depth of the collsion.
+			</description>
+		</method>
 		<method name="get_contact_local_normal" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />

--- a/doc/classes/PhysicsDirectBodyState2DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState2DExtension.xml
@@ -130,6 +130,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_contact_depth" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_contact_local_normal" qualifiers="virtual const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -149,6 +149,13 @@
 				[b]Note:[/b] By default, this returns 0 unless bodies are configured to monitor contacts. See [member RigidBody3D.contact_monitor].
 			</description>
 		</method>
+		<method name="get_contact_depth" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="contact_idx" type="int" />
+			<description>
+				Returns the penetration depth of the collsion.
+			</description>
+		</method>
 		<method name="get_contact_impulse" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="contact_idx" type="int" />

--- a/doc/classes/PhysicsDirectBodyState3DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState3DExtension.xml
@@ -130,6 +130,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_contact_depth" qualifiers="virtual const">
+			<return type="float" />
+			<param index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_contact_impulse" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="contact_idx" type="int" />

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -94,6 +94,7 @@ void PhysicsDirectBodyState2DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_contact_local_position, "contact_idx");
 	GDVIRTUAL_BIND(_get_contact_local_normal, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_depth, "contact_idx");
 	GDVIRTUAL_BIND(_get_contact_local_shape, "contact_idx");
 	GDVIRTUAL_BIND(_get_contact_collider, "contact_idx");
 	GDVIRTUAL_BIND(_get_contact_collider_position, "contact_idx");

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -93,6 +93,7 @@ public:
 
 	EXBIND1RC(Vector2, get_contact_local_position, int)
 	EXBIND1RC(Vector2, get_contact_local_normal, int)
+	EXBIND1RC(real_t, get_contact_depth, int)
 	EXBIND1RC(int, get_contact_local_shape, int)
 
 	EXBIND1RC(RID, get_contact_collider, int)

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -97,6 +97,7 @@ void PhysicsDirectBodyState3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_contact_local_position, "contact_idx");
 	GDVIRTUAL_BIND(_get_contact_local_normal, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_depth, "contact_idx");
 	GDVIRTUAL_BIND(_get_contact_impulse, "contact_idx");
 	GDVIRTUAL_BIND(_get_contact_local_shape, "contact_idx");
 	GDVIRTUAL_BIND(_get_contact_collider, "contact_idx");

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -95,6 +95,7 @@ public:
 	EXBIND1RC(Vector3, get_contact_local_position, int)
 	EXBIND1RC(Vector3, get_contact_local_normal, int)
 	EXBIND1RC(real_t, get_contact_impulse, int)
+	EXBIND1RC(real_t, get_contact_depth, int)
 	EXBIND1RC(int, get_contact_local_shape, int)
 	EXBIND1RC(RID, get_contact_collider, int)
 	EXBIND1RC(Vector3, get_contact_collider_position, int)

--- a/servers/physics_2d/godot_body_direct_state_2d.cpp
+++ b/servers/physics_2d/godot_body_direct_state_2d.cpp
@@ -186,6 +186,11 @@ int GodotPhysicsDirectBodyState2D::get_contact_local_shape(int p_contact_idx) co
 	return body->contacts[p_contact_idx].local_shape;
 }
 
+real_t GodotPhysicsDirectBodyState2D::get_contact_depth(int p_contact_idx) const {
+	ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, -1);
+	return body->contacts[p_contact_idx].depth;
+}
+
 RID GodotPhysicsDirectBodyState2D::get_contact_collider(int p_contact_idx) const {
 	ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, RID());
 	return body->contacts[p_contact_idx].collider;

--- a/servers/physics_2d/godot_body_direct_state_2d.h
+++ b/servers/physics_2d/godot_body_direct_state_2d.h
@@ -87,6 +87,7 @@ public:
 	virtual Vector2 get_contact_local_position(int p_contact_idx) const override;
 	virtual Vector2 get_contact_local_normal(int p_contact_idx) const override;
 	virtual int get_contact_local_shape(int p_contact_idx) const override;
+	virtual real_t get_contact_depth(int p_contact_idx) const override;
 
 	virtual RID get_contact_collider(int p_contact_idx) const override;
 	virtual Vector2 get_contact_collider_position(int p_contact_idx) const override;

--- a/servers/physics_3d/godot_body_direct_state_3d.cpp
+++ b/servers/physics_3d/godot_body_direct_state_3d.cpp
@@ -188,6 +188,11 @@ Vector3 GodotPhysicsDirectBodyState3D::get_contact_local_normal(int p_contact_id
 	return body->contacts[p_contact_idx].local_normal;
 }
 
+real_t GodotPhysicsDirectBodyState3D::get_contact_depth(int p_contact_idx) const {
+	ERR_FAIL_INDEX_V(p_contact_idx, body->contact_count, -1);
+	return body->contacts[p_contact_idx].depth;
+}
+
 real_t GodotPhysicsDirectBodyState3D::get_contact_impulse(int p_contact_idx) const {
 	return 0.0f; // Only implemented for bullet
 }

--- a/servers/physics_3d/godot_body_direct_state_3d.h
+++ b/servers/physics_3d/godot_body_direct_state_3d.h
@@ -91,6 +91,7 @@ public:
 	virtual Vector3 get_contact_local_normal(int p_contact_idx) const override;
 	virtual real_t get_contact_impulse(int p_contact_idx) const override;
 	virtual int get_contact_local_shape(int p_contact_idx) const override;
+	virtual real_t get_contact_depth(int p_contact_idx) const override;
 
 	virtual RID get_contact_collider(int p_contact_idx) const override;
 	virtual Vector3 get_contact_collider_position(int p_contact_idx) const override;

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -120,6 +120,7 @@ void PhysicsDirectBodyState2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_contact_local_position", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_local_position);
 	ClassDB::bind_method(D_METHOD("get_contact_local_normal", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_local_normal);
 	ClassDB::bind_method(D_METHOD("get_contact_local_shape", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_local_shape);
+	ClassDB::bind_method(D_METHOD("get_contact_depth", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_depth);
 	ClassDB::bind_method(D_METHOD("get_contact_collider", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_position", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider_position);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_id", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_collider_id);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -92,6 +92,7 @@ public:
 	virtual Vector2 get_contact_local_position(int p_contact_idx) const = 0;
 	virtual Vector2 get_contact_local_normal(int p_contact_idx) const = 0;
 	virtual int get_contact_local_shape(int p_contact_idx) const = 0;
+	virtual real_t get_contact_depth(int p_contact_idx) const = 0;
 
 	virtual RID get_contact_collider(int p_contact_idx) const = 0;
 	virtual Vector2 get_contact_collider_position(int p_contact_idx) const = 0;

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -138,6 +138,7 @@ void PhysicsDirectBodyState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_contact_local_normal", "contact_idx"), &PhysicsDirectBodyState3D::get_contact_local_normal);
 	ClassDB::bind_method(D_METHOD("get_contact_impulse", "contact_idx"), &PhysicsDirectBodyState3D::get_contact_impulse);
 	ClassDB::bind_method(D_METHOD("get_contact_local_shape", "contact_idx"), &PhysicsDirectBodyState3D::get_contact_local_shape);
+	ClassDB::bind_method(D_METHOD("get_contact_depth", "contact_idx"), &PhysicsDirectBodyState3D::get_contact_depth);
 	ClassDB::bind_method(D_METHOD("get_contact_collider", "contact_idx"), &PhysicsDirectBodyState3D::get_contact_collider);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_position", "contact_idx"), &PhysicsDirectBodyState3D::get_contact_collider_position);
 	ClassDB::bind_method(D_METHOD("get_contact_collider_id", "contact_idx"), &PhysicsDirectBodyState3D::get_contact_collider_id);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -97,6 +97,7 @@ public:
 	virtual Vector3 get_contact_local_normal(int p_contact_idx) const = 0;
 	virtual real_t get_contact_impulse(int p_contact_idx) const = 0;
 	virtual int get_contact_local_shape(int p_contact_idx) const = 0;
+	virtual real_t get_contact_depth(int p_contact_idx) const = 0;
 
 	virtual RID get_contact_collider(int p_contact_idx) const = 0;
 	virtual Vector3 get_contact_collider_position(int p_contact_idx) const = 0;


### PR DESCRIPTION
Exposed collision depth for PhysicsDirectBodyState2D and 3d. It is already calculated and stored by the engine with other contact data, but was not exposed to GDScript.

I am working on a project that requires penetration depth of collision to separate overlapping bodies without applying any force.  There is already an open [proposal](https://github.com/godotengine/godot-proposals/issues/1370).