### PR TITLE
fixed order in SConstruct

### DIFF
--- a/platform_methods.py
+++ b/platform_methods.py
@@ -111,3 +111,7 @@ def detect_arch():
         print("Unsupported CPU architecture: " + host_machine)
         print("Falling back to x86_64.")
         return "x86_64"
+
+
+def is_lto_recommended(detect, env):
+    return not (("lto", "none") in detect.get_flags() or env.msvc)


### PR DESCRIPTION
In https://github.com/godotengine/godot/pull/63288 the LTO handling was improved but the default value for LTO wouldn't effect the build.

Without my changes if you add `production=yes` but no lto argument the platform specific configure() function is called with lto=none and will add no lto compiler flags. After configure() lto will be defaulted to full and print "Using LTO: full" but in fact the compiler will run without LTO as the compiler flags were set before.