### PR TITLE
Allow negative indices in `move_child()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -514,7 +514,7 @@
 			<param index="0" name="child_node" type="Node" />
 			<param index="1" name="to_position" type="int" />
 			<description>
-				Moves a child node to a different position (order) among the other children. Since calls, signals, etc are performed by tree order, changing the order of children nodes may be useful.
+				Moves a child node to a different position (order) among the other children. Since calls, signals, etc are performed by tree order, changing the order of children nodes may be useful. If [param to_position] is negative, the index will be counted from the end.
 				[b]Note:[/b] Internal children can only be moved within their expected "internal range" (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -373,7 +373,7 @@ void CanvasItem::move_to_front() {
 	if (!get_parent()) {
 		return;
 	}
-	get_parent()->move_child(this, get_parent()->get_child_count() - 1);
+	get_parent()->move_child(this, -1);
 }
 
 void CanvasItem::set_modulate(const Color &p_modulate) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -328,12 +328,21 @@ void Node::move_child(Node *p_child, int p_pos) {
 
 	// We need to check whether node is internal and move it only in the relevant node range.
 	if (p_child->_is_internal_front()) {
+		if (p_pos < 0) {
+			p_pos += data.internal_children_front;
+		}
 		ERR_FAIL_INDEX_MSG(p_pos, data.internal_children_front, vformat("Invalid new child position: %d. Child is internal.", p_pos));
 		_move_child(p_child, p_pos);
 	} else if (p_child->_is_internal_back()) {
+		if (p_pos < 0) {
+			p_pos += data.internal_children_back;
+		}
 		ERR_FAIL_INDEX_MSG(p_pos, data.internal_children_back, vformat("Invalid new child position: %d. Child is internal.", p_pos));
 		_move_child(p_child, data.children.size() - data.internal_children_back + p_pos);
 	} else {
+		if (p_pos < 0) {
+			p_pos += get_child_count(false);
+		}
 		ERR_FAIL_INDEX_MSG(p_pos, data.children.size() + 1 - data.internal_children_front - data.internal_children_back, vformat("Invalid new child position: %d.", p_pos));
 		_move_child(p_child, p_pos + data.internal_children_front);
 	}


### PR DESCRIPTION
Now `move_child()` will support negative indices, properly taking internal children into account.

Fixes #65575