### PR TITLE
Add check before redrawing graph node slot stylebox

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -367,7 +367,7 @@ void GraphNode::_notification(int p_what) {
 			}
 
 			for (const KeyValue<int, Slot> &E : slot_info) {
-				if (E.key < 0 || E.key >= cache_y.size()) {
+				if (E.key < 0 || E.key >= cache_y.size() || get_child_count() == 0) {
 					continue;
 				}
 				if (!slot_info.has(E.key)) {


### PR DESCRIPTION
Fixes #65557 

Ensure Graph Nodes have more than 0 children before redrawing slot styleboxes. There is already a check in place to ensure the slot's key is not greater than `cache_y.size()`, but it seems the cache isn't updated before redrawing occurs. Possibly a better fix would be to make sure the cache is updated before redrawing? Not sure, pretty new to the engine still.