### PR TITLE
Update AudioStreamGeneratorPlayback.xml

### DIFF
--- a/doc/classes/AudioStreamGeneratorPlayback.xml
+++ b/doc/classes/AudioStreamGeneratorPlayback.xml
@@ -27,7 +27,7 @@
 		<method name="get_frames_available" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of audio data frames left to play. If this returned number reaches [code]0[/code], the audio will stop playing until frames are added again. Therefore, make sure your script can always generate and push new audio frames fast enough to avoid audio cracking.
+				Returns the number of frames that can be pushed to the audio sample data buffer without overflowing it. If the result is [code]0[/code], the buffer is full.
 			</description>
 		</method>
 		<method name="get_skips" qualifiers="const">


### PR DESCRIPTION
Fixed incorrect method description for `get_frames_available`. According to [The AudioStreamGenerator source on the master branch](https://github.com/godotengine/godot/blob/master/servers/audio/effects/audio_stream_generator.cpp#L132), the `get_frames_available` method returns the space remaining in the sample buffer.

This change is compatible with 3.5, as [the source for AudioStreamGenerator on the 3.5 branch](https://github.com/godotengine/godot/blob/3.5/servers/audio/effects/audio_stream_generator.cpp#L125) is the same.




