### PR TITLE
Fix broken patterns on TileMap layer change

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -3677,6 +3677,7 @@ void TileMapEditor::_update_layers_selection() {
 		tile_map_layer = -1;
 	}
 	tile_map->set_selected_layer(toggle_highlight_selected_layer_button->is_pressed() ? tile_map_layer : -1);
+	tileset_changed_needs_update = false; // Update is not needed here and actually causes problems.
 
 	layers_selection_button->clear();
 	if (tile_map->get_layers_count() > 0) {


### PR DESCRIPTION
Fixes #53901
The problem was `_update_selection_pattern_from_tileset_tiles_selection()` being called as a result of TileMap `changed` signal. Seems like the update is not required when layer is changed, so canceling it should be safe. Maybe.