### PR TITLE
Shrink shader editor's oversized borders

### DIFF
--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -115,8 +115,8 @@ public:
 	ShaderTextEditor();
 };
 
-class ShaderEditor : public PanelContainer {
-	GDCLASS(ShaderEditor, PanelContainer);
+class ShaderEditor : public MarginContainer {
+	GDCLASS(ShaderEditor, MarginContainer);
 
 	enum {
 		EDIT_UNDO,


### PR DESCRIPTION
Due to it originally being a `PanelContainer` (for no reason it seems), its borders were larger compared to other places of the editor. Switching it to be a `MarginContainer` instead fixes this.