### PR TITLE
doc/Makefile fails if path contains spaces - Fixes #65623

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-BASEDIR = $(CURDIR)
+BASEDIR = .
 CLASSES = $(BASEDIR)/classes/ $(BASEDIR)/../modules/
 OUTPUTDIR = $(BASEDIR)/_build
 TOOLSDIR = $(BASEDIR)/tools


### PR DESCRIPTION
This pull request fixes #65623

The python script failed to find the path as the space made the makefile think that it was another argument.

With this pull request there can be spaces included in the path of where the godot repo is saved.