### PR TITLE
[3.x] Remove "Defined in ..." from LSP hover

### DIFF
--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -1283,9 +1283,6 @@ struct DocumentSymbol {
 		if (documentation.length()) {
 			markdown.value += marked_documentation(documentation) + "\n\n";
 		}
-		if (script_path.length()) {
-			markdown.value += "Defined in [" + script_path + "](" + uri + ")";
-		}
 		return markdown;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Master branch PR: #65640