### PR TITLE
AnimationNodeBlendTreeEditor - Ignore node rename if already exited blend tree

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -907,6 +907,10 @@ void AnimationNodeBlendTreeEditor::_bind_methods() {
 AnimationNodeBlendTreeEditor *AnimationNodeBlendTreeEditor::singleton = nullptr;
 
 void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<AnimationNode> p_node) {
+	if (blend_tree.is_null()) {
+		return;
+	}
+
 	String prev_name = blend_tree->get_node_name(p_node);
 	ERR_FAIL_COND(prev_name.is_empty());
 	GraphNode *gn = Object::cast_to<GraphNode>(graph->get_node(prev_name));


### PR DESCRIPTION
Fixes #65597

This PR discards the pending rename because the rename handler runs after the path is modified and blend_tree is invalidated.
