### PR TITLE
Prevent duplicated hints in shader uniform completion

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -1050,6 +1050,10 @@ private:
 	};
 
 	CompletionType completion_type;
+	ShaderNode::Uniform::Hint current_uniform_hint = ShaderNode::Uniform::HINT_NONE;
+	TextureFilter current_uniform_filter = FILTER_DEFAULT;
+	TextureRepeat current_uniform_repeat = REPEAT_DEFAULT;
+	bool current_uniform_instance_index_defined = false;
 	int completion_line = 0;
 	BlockNode *completion_block = nullptr;
 	DataType completion_base;


### PR DESCRIPTION
Prevent suggestion of hint when it's already defined:

![image](https://user-images.githubusercontent.com/3036176/189526058-4b5a08b2-22d9-428b-8910-24b6fbd7b394.png)
