### PR TITLE
Low priority redraw request for AnimatedSprite

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -367,6 +367,9 @@ void AnimatedSprite::_notification(int p_what) {
 			if (frame < 0) {
 				return;
 			}
+			if (!OS::get_singleton()->is_update_pending()) {
+				return;
+			}
 
 			float remaining = get_process_delta_time();
 


### PR DESCRIPTION
Prevents animated sprite from creating continuous redraws in vital_redraws_only mode.

## Notes
* This has no effect except when `vital_redraws_only` mode is on.
* Just noticed this case that I have not seen previously, in a user MRP.
* See #53463 for the original PR introducing vital redraws and #61965 adding more cases.
* Ideally it would be nice to switch off internal process, but this simple technique gets most of the benefit with no risk.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
