### PR TITLE
Fix invalid literals in generated rst docs

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1480,6 +1480,8 @@ def format_text_block(
                                 )
 
                         tag_text = f"``{link_target}``"
+                        escape_pre = True
+                        escape_post = True
 
             # Formatting directives.
 


### PR DESCRIPTION
Before this change, API docs that look like this:

	…adding [param character]s to the right of the string.

would turn into rst files that look like this:

	…adding ``character``s to the right of the string.

That reStructuredText is invalid and causes warnings when the docs repo is built.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
