### PR TITLE
Add a button to create a trail mesh skeleton

### DIFF
--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -49,6 +49,7 @@ class MeshInstance3DEditor : public Control {
 		MENU_OPTION_CREATE_UV2,
 		MENU_OPTION_DEBUG_UV1,
 		MENU_OPTION_DEBUG_UV2,
+		MENU_OPTION_CREATE_TRAIL_SKELETON
 	};
 
 	MeshInstance3D *node = nullptr;


### PR DESCRIPTION
This adds a button to the mesh dropdown that allows the user to create a skeleton from a trail mesh to be able to control it manually (without a particle system).

![image](https://user-images.githubusercontent.com/3101690/189555230-0d71ef2f-43a3-4336-94fe-307ecb7f0109.png)
