### PR TITLE
Fixed MSAA initialisation in clustered forward renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -124,7 +124,7 @@ void RenderForwardClustered::RenderBufferDataForwardClustered::configure(RenderS
 	render_buffers = p_render_buffers;
 	ERR_FAIL_NULL(render_buffers);
 
-	bool msaa_3d = render_buffers->get_msaa_3d();
+	RS::ViewportMSAA msaa_3d = render_buffers->get_msaa_3d();
 
 	if (msaa_3d != RS::VIEWPORT_MSAA_DISABLED) {
 		RD::DataFormat format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -535,7 +535,9 @@ void RenderSceneBuffersRD::ensure_velocity() {
 				RD::TEXTURE_SAMPLES_8,
 			};
 
-			create_texture(RB_SCOPE_BUFFERS, RB_TEX_VELOCITY_MSAA, RD::DATA_FORMAT_R16G16_SFLOAT, msaa_usage_bits, ts[msaa_3d]);
+			RD::TextureSamples texture_samples = ts[msaa_3d];
+
+			create_texture(RB_SCOPE_BUFFERS, RB_TEX_VELOCITY_MSAA, RD::DATA_FORMAT_R16G16_SFLOAT, msaa_usage_bits, texture_samples);
 		}
 
 		create_texture(RB_SCOPE_BUFFERS, RB_TEX_VELOCITY, RD::DATA_FORMAT_R16G16_SFLOAT, usage_bits);


### PR DESCRIPTION
Fixed dumb typo that caused MSAA to not be initialised properly for 4x and 8x. 

Fixes #65479
