### PR TITLE
Add support for querying paths from NavigationServer

### DIFF
--- a/doc/classes/NavigationPathQueryParameters2D.xml
+++ b/doc/classes/NavigationPathQueryParameters2D.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationPathQueryParameters2D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Parameters for querying a path between a start location and a target location.
+	</brief_description>
+	<description>
+		This class contains information required to find a path between a start and end location when calling [method NavigationServer2D.query_path].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create" qualifiers="static">
+			<return type="NavigationPathQueryParameters2D" />
+			<param index="0" name="map" type="RID" />
+			<param index="1" name="origin" type="Vector2" />
+			<param index="2" name="destination" type="Vector2" />
+			<param index="3" name="layers" type="int" default="1" />
+			<description>
+				Convenience factory for creating a valid [NavigationPathQueryParameters2D].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="destination" type="Vector2" setter="set_destination" getter="get_destination" default="Vector2(0, 0)">
+			The location to find a path to in global coordinates.
+		</member>
+		<member name="map" type="RID" setter="set_map" getter="get_map">
+			The map to search for a path within.
+		</member>
+		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
+			The navigation layers the query will use (as a bitmask). Only regions and links that share a layer will be consulted.
+		</member>
+		<member name="optimize_path" type="bool" setter="set_optimize_path" getter="get_optimize_path" default="true">
+			If [code]true[/code], the path receives post-processing with a funnel algorithm to smooth the path. If [code]false[/code] all path positions will be placed at the center of each passed navigation mesh polygon edge.
+		</member>
+		<member name="origin" type="Vector2" setter="set_origin" getter="get_origin" default="Vector2(0, 0)">
+			The location to find a path from in global coordinates.
+		</member>
+	</members>
+</class>

--- a/doc/classes/NavigationPathQueryParameters3D.xml
+++ b/doc/classes/NavigationPathQueryParameters3D.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationPathQueryParameters3D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Parameters for querying a path between a start location and a target location.
+	</brief_description>
+	<description>
+		This class contains information required to find a path between a start and end location when calling [method NavigationServer3D.query_path].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create" qualifiers="static">
+			<return type="NavigationPathQueryParameters3D" />
+			<param index="0" name="map" type="RID" />
+			<param index="1" name="origin" type="Vector3" />
+			<param index="2" name="destination" type="Vector3" />
+			<param index="3" name="layers" type="int" default="1" />
+			<description>
+				Convenience factory for creating a valid [NavigationPathQueryParameters3D].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="destination" type="Vector3" setter="set_destination" getter="get_destination" default="Vector3(0, 0, 0)">
+			The location to find a path to in global coordinates.
+		</member>
+		<member name="map" type="RID" setter="set_map" getter="get_map">
+			The map to search for a path within.
+		</member>
+		<member name="navigation_layers" type="int" setter="set_navigation_layers" getter="get_navigation_layers" default="1">
+			The navigation layers the query will use (as a bitmask). Only regions and links that share a layer will be consulted.
+		</member>
+		<member name="optimize_path" type="bool" setter="set_optimize_path" getter="get_optimize_path" default="true">
+			If [code]true[/code], the path receives post-processing with a funnel algorithm to smooth the path. If [code]false[/code] all path positions will be placed at the center of each passed navigation mesh polygon edge.
+		</member>
+		<member name="origin" type="Vector3" setter="set_origin" getter="get_origin" default="Vector3(0, 0, 0)">
+			The location to find a path from in global coordinates.
+		</member>
+	</members>
+</class>

--- a/doc/classes/NavigationPathQueryResult2D.xml
+++ b/doc/classes/NavigationPathQueryResult2D.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationPathQueryResult2D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Result from a [NavigationServer2D] navigation path query.
+	</brief_description>
+	<description>
+		This class contains result of a navigation path query from [method NavigationServer2D.query_path].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="path" type="PackedVector2Array" setter="set_path" getter="get_path" default="PackedVector2Array()">
+			A series of waypoints to follow in order to reach the destination passed in [NavigationPathQueryParameters2D]. All points are in global coordinates.
+		</member>
+		<member name="path_length" type="float" setter="set_path_length" getter="get_path_length" default="0.0">
+			Total length of the path in world units.
+		</member>
+	</members>
+</class>

--- a/doc/classes/NavigationPathQueryResult3D.xml
+++ b/doc/classes/NavigationPathQueryResult3D.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationPathQueryResult3D" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Result from a [NavigationServer3D] navigation path query.
+	</brief_description>
+	<description>
+		This class contains result of a navigation path query from [method NavigationServer3D.query_path].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="path" type="PackedVector3Array" setter="set_path" getter="get_path" default="PackedVector3Array()">
+			A series of waypoints to follow in order to reach the destination passed in [NavigationPathQueryParameters3D]. All points are in global coordinates.
+		</member>
+		<member name="path_length" type="float" setter="set_path_length" getter="get_path_length" default="0.0">
+			Total length of the path in world units.
+		</member>
+	</members>
+</class>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -368,6 +368,13 @@
 				Set the map's link connection radius used to connect links to navigation polygons.
 			</description>
 		</method>
+		<method name="query_path" qualifiers="const">
+			<return type="NavigationPathQueryResult2D" />
+			<param index="0" name="parameters" type="NavigationPathQueryParameters2D" />
+			<description>
+				Returns the navigation path to reach the destination from the origin. See [NavigationPathQueryParameters2D] for details.
+			</description>
+		</method>
 		<method name="region_create" qualifiers="const">
 			<return type="RID" />
 			<description>

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -410,6 +410,13 @@
 				[b]Note:[/b] This function is not thread safe.
 			</description>
 		</method>
+		<method name="query_path" qualifiers="const">
+			<return type="NavigationPathQueryResult3D" />
+			<param index="0" name="parameters" type="NavigationPathQueryParameters3D" />
+			<description>
+				Returns the navigation path to reach the destination from the origin. See [NavigationPathQueryParameters3D] for details.
+			</description>
+		</method>
 		<method name="region_bake_navmesh" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="mesh" type="NavigationMesh" />

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -228,7 +228,38 @@ Vector<Vector3> GodotNavigationServer::map_get_path(RID p_map, Vector3 p_origin,
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_COND_V(map == nullptr, Vector<Vector3>());
 
-	return map->get_path(p_origin, p_destination, p_optimize, p_navigation_layers);
+	const gd::PathQueryParameters params{
+		p_origin,
+		p_destination,
+		p_optimize,
+		p_navigation_layers
+	};
+	const gd::PathQueryResult result = map->query_path(params);
+
+	return result.path;
+}
+
+Ref<NavigationPathQueryResult3D> GodotNavigationServer::query_path(const Ref<NavigationPathQueryParameters3D> &p_parameters) const {
+	ERR_FAIL_COND_V(!p_parameters.is_valid(), Ref<NavigationPathQueryResult3D>());
+
+	const NavMap *map = map_owner.get_or_null(p_parameters->get_map());
+	ERR_FAIL_COND_V(map == nullptr, Ref<NavigationPathQueryResult3D>());
+
+	// Map parameters and run query
+	const gd::PathQueryParameters params{
+		p_parameters->get_origin(),
+		p_parameters->get_destination(),
+		p_parameters->get_optimize_path(),
+		p_parameters->get_navigation_layers()
+	};
+	const gd::PathQueryResult result = map->query_path(params);
+
+	// Map result to common object and return
+	Ref<NavigationPathQueryResult3D> query_result;
+	query_result.instantiate();
+	query_result->set_path(result.path);
+	query_result->set_path_length(result.path_length);
+	return query_result;
 }
 
 Vector3 GodotNavigationServer::map_get_closest_point_to_segment(RID p_map, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision) const {

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -106,6 +106,7 @@ public:
 	virtual real_t map_get_link_connection_radius(RID p_map) const override;
 
 	virtual Vector<Vector3> map_get_path(RID p_map, Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) const override;
+	virtual Ref<NavigationPathQueryResult3D> query_path(const Ref<NavigationPathQueryParameters3D> &p_parameters) const override;
 
 	virtual Vector3 map_get_closest_point_to_segment(RID p_map, const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision = false) const override;
 	virtual Vector3 map_get_closest_point(RID p_map, const Vector3 &p_point) const override;

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -115,7 +115,7 @@ public:
 
 	gd::PointKey get_point_key(const Vector3 &p_pos) const;
 
-	Vector<Vector3> get_path(Vector3 p_origin, Vector3 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) const;
+	gd::PathQueryResult query_path(const gd::PathQueryParameters &p_parameters) const;
 	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, const bool p_use_collision) const;
 	Vector3 get_closest_point(const Vector3 &p_point) const;
 	Vector3 get_closest_point_normal(const Vector3 &p_point) const;

--- a/modules/navigation/nav_utils.h
+++ b/modules/navigation/nav_utils.h
@@ -150,6 +150,18 @@ struct ClosestPointQueryResult {
 	RID owner;
 };
 
+struct PathQueryParameters {
+	Vector3 origin;
+	Vector3 destination;
+	bool optimize = true;
+	uint32_t navigation_layers = 1;
+};
+
+struct PathQueryResult {
+	Vector<Vector3> path;
+	real_t path_length = 0.0;
+};
+
 } // namespace gd
 
 #endif // NAV_UTILS_H

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -34,6 +34,7 @@
 #include "scene/main/node.h"
 
 class Node2D;
+class NavigationPathQueryResult2D;
 
 class NavigationAgent2D : public Node {
 	GDCLASS(NavigationAgent2D, Node);
@@ -58,7 +59,7 @@ class NavigationAgent2D : public Node {
 	real_t path_max_distance = 3.0;
 
 	Vector2 target_location;
-	Vector<Vector2> navigation_path;
+	Ref<NavigationPathQueryResult2D> navigation_result;
 	int nav_path_index = 0;
 	bool velocity_submitted = false;
 	Vector2 prev_safe_velocity;
@@ -138,9 +139,7 @@ public:
 
 	Vector2 get_next_location();
 
-	Vector<Vector2> get_nav_path() const {
-		return navigation_path;
-	}
+	Vector<Vector2> get_nav_path() const;
 
 	int get_nav_path_index() const {
 		return nav_path_index;

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -34,6 +34,7 @@
 #include "scene/main/node.h"
 
 class Node3D;
+class NavigationPathQueryResult3D;
 
 class NavigationAgent3D : public Node {
 	GDCLASS(NavigationAgent3D, Node);
@@ -60,7 +61,7 @@ class NavigationAgent3D : public Node {
 	real_t path_max_distance = 3.0;
 
 	Vector3 target_location;
-	Vector<Vector3> navigation_path;
+	Ref<NavigationPathQueryResult3D> navigation_result;
 	int nav_path_index = 0;
 	bool velocity_submitted = false;
 	Vector3 prev_safe_velocity;
@@ -150,9 +151,7 @@ public:
 
 	Vector3 get_next_location();
 
-	Vector<Vector3> get_nav_path() const {
-		return navigation_path;
-	}
+	Vector<Vector3> get_nav_path() const;
 
 	int get_nav_path_index() const {
 		return nav_path_index;

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -35,6 +35,9 @@
 #include "core/templates/rid.h"
 #include "scene/2d/navigation_region_2d.h"
 
+class NavigationPathQueryParameters2D;
+class NavigationPathQueryResult2D;
+
 // This server exposes the `NavigationServer3D` features in the 2D world.
 class NavigationServer2D : public Object {
 	GDCLASS(NavigationServer2D, Object);
@@ -84,6 +87,9 @@ public:
 
 	/// Returns the navigation path to reach the destination from the origin.
 	virtual Vector<Vector2> map_get_path(RID p_map, Vector2 p_origin, Vector2 p_destination, bool p_optimize, uint32_t p_navigation_layers = 1) const;
+
+	/// Returns a path to reach a destination along with additional information about the path.
+	virtual Ref<NavigationPathQueryResult2D> query_path(const Ref<NavigationPathQueryParameters2D> &p_parameters) const;
 
 	virtual Vector2 map_get_closest_point(RID p_map, const Vector2 &p_point) const;
 	virtual RID map_get_closest_point_owner(RID p_map, const Vector2 &p_point) const;
@@ -245,6 +251,69 @@ public:
 	void set_debug_navigation_enable_edge_connections(const bool p_value);
 	bool get_debug_navigation_enable_edge_connections() const;
 #endif // DEBUG_ENABLED
+};
+
+/// Parameters for querying a path between two points on a navigation map.
+class NavigationPathQueryParameters2D : public RefCounted {
+	GDCLASS(NavigationPathQueryParameters2D, RefCounted);
+
+	RID map;
+	bool optimize_path = true;
+	Vector2 origin;
+	Vector2 destination;
+	uint32_t navigation_layers = 1;
+
+protected:
+	static void _bind_methods();
+
+public:
+	/// Convenience factory for path queries.
+	/// @param p_origin Location to start from.
+	/// @param p_destination Location to move to.
+	/// @param p_navigation_layers Layers to limit the path search to.
+	/// @return A valid query parameters object.
+	static Ref<NavigationPathQueryParameters2D> create(const RID &p_map, const Vector2 &p_origin, const Vector2 &p_destination, const uint32_t p_navigation_layers = 1) {
+		Ref<NavigationPathQueryParameters2D> query;
+		query.instantiate();
+		query->set_map(p_map);
+		query->set_origin(p_origin);
+		query->set_destination(p_destination);
+		query->set_navigation_layers(p_navigation_layers);
+		return query;
+	}
+
+	void set_map(const RID &p_map) { map = p_map; }
+	RID get_map() const { return map; }
+
+	void set_optimize_path(const bool p_optimize_path) { optimize_path = p_optimize_path; }
+	bool get_optimize_path() const { return optimize_path; }
+
+	void set_origin(const Vector2 &p_origin) { origin = p_origin; }
+	Vector2 get_origin() const { return origin; }
+
+	void set_destination(const Vector2 &p_destination) { destination = p_destination; }
+	Vector2 get_destination() const { return destination; }
+
+	void set_navigation_layers(const uint32_t p_navigation_layers) { navigation_layers = p_navigation_layers; }
+	uint32_t get_navigation_layers() const { return navigation_layers; }
+};
+
+/// Result of a query for path between two points on a navigation map.
+class NavigationPathQueryResult2D : public RefCounted {
+	GDCLASS(NavigationPathQueryResult2D, RefCounted);
+
+	Vector<Vector2> path;
+	real_t path_length = 0.0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_path(const Vector<Vector2> &p_path) { path = p_path; }
+	Vector<Vector2> get_path() const { return path; }
+
+	void set_path_length(const real_t p_path_length) { path_length = p_path_length; }
+	real_t get_path_length() const { return path_length; }
 };
 
 #endif // NAVIGATION_SERVER_2D_H

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -51,6 +51,7 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_set_link_connection_radius", "map", "radius"), &NavigationServer3D::map_set_link_connection_radius);
 	ClassDB::bind_method(D_METHOD("map_get_link_connection_radius", "map"), &NavigationServer3D::map_get_link_connection_radius);
 	ClassDB::bind_method(D_METHOD("map_get_path", "map", "origin", "destination", "optimize", "navigation_layers"), &NavigationServer3D::map_get_path, DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("query_path", "parameters"), &NavigationServer3D::query_path);
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_to_segment", "map", "start", "end", "use_collision"), &NavigationServer3D::map_get_closest_point_to_segment, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("map_get_closest_point", "map", "to_point"), &NavigationServer3D::map_get_closest_point);
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_normal", "map", "to_point"), &NavigationServer3D::map_get_closest_point_normal);
@@ -115,7 +116,6 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("process", "delta_time"), &NavigationServer3D::process);
 
 	ADD_SIGNAL(MethodInfo("map_changed", PropertyInfo(Variant::RID, "map")));
-
 	ADD_SIGNAL(MethodInfo("navigation_debug_changed"));
 }
 
@@ -485,3 +485,43 @@ bool NavigationServer3D::get_debug_enabled() const {
 	return debug_enabled;
 }
 #endif // DEBUG_ENABLED
+
+/////////////////////////////
+
+void NavigationPathQueryParameters3D::_bind_methods() {
+	ClassDB::bind_static_method("NavigationPathQueryParameters3D", D_METHOD("create", "map", "origin", "destination", "layers"), &NavigationPathQueryParameters3D::create, DEFVAL(1));
+
+	ClassDB::bind_method(D_METHOD("set_map", "map"), &NavigationPathQueryParameters3D::set_map);
+	ClassDB::bind_method(D_METHOD("get_map"), &NavigationPathQueryParameters3D::get_map);
+
+	ClassDB::bind_method(D_METHOD("set_optimize_path", "optimize"), &NavigationPathQueryParameters3D::set_optimize_path);
+	ClassDB::bind_method(D_METHOD("get_optimize_path"), &NavigationPathQueryParameters3D::get_optimize_path);
+
+	ClassDB::bind_method(D_METHOD("set_origin", "origin"), &NavigationPathQueryParameters3D::set_origin);
+	ClassDB::bind_method(D_METHOD("get_origin"), &NavigationPathQueryParameters3D::get_origin);
+
+	ClassDB::bind_method(D_METHOD("set_destination", "destination"), &NavigationPathQueryParameters3D::set_destination);
+	ClassDB::bind_method(D_METHOD("get_destination"), &NavigationPathQueryParameters3D::get_destination);
+
+	ClassDB::bind_method(D_METHOD("set_navigation_layers", "layers"), &NavigationPathQueryParameters3D::set_navigation_layers);
+	ClassDB::bind_method(D_METHOD("get_navigation_layers"), &NavigationPathQueryParameters3D::get_navigation_layers);
+
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "map"), "set_map", "get_map");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "optimize_path"), "set_optimize_path", "get_optimize_path");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "origin"), "set_origin", "get_origin");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "destination"), "set_destination", "get_destination");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_navigation_layers", "get_navigation_layers");
+}
+
+/////////////////////////////
+
+void NavigationPathQueryResult3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_path", "path"), &NavigationPathQueryResult3D::set_path);
+	ClassDB::bind_method(D_METHOD("get_path"), &NavigationPathQueryResult3D::get_path);
+
+	ClassDB::bind_method(D_METHOD("set_path_length", "length"), &NavigationPathQueryResult3D::set_path_length);
+	ClassDB::bind_method(D_METHOD("get_path_length"), &NavigationPathQueryResult3D::get_path_length);
+
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "path"), "set_path", "get_path");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_length"), "set_path_length", "get_path_length");
+}

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -164,7 +164,12 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionStateCallback, "void *instance;void (*callback)(void *p_instance, PhysicsDirectBodyState3D *p_state)");
 
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
+	GDREGISTER_CLASS(NavigationPathQueryParameters2D);
+	GDREGISTER_CLASS(NavigationPathQueryResult2D);
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
+	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
+	GDREGISTER_CLASS(NavigationPathQueryResult3D);
+
 	GDREGISTER_CLASS(XRServer);
 	GDREGISTER_CLASS(CameraServer);
 


### PR DESCRIPTION
Alternative to: #62429

Adds `NavigationPathQueryParameters*` and `NavigationPathQueryResult*` objects for 3D and 2D navigation.  These objects allow for returning additional information about the path computed by the navigation server.  The design is similar to queries in `PhysicsServer*`.

However, this PR tries to solve the problem in a simpler manner, leaving off support for asynchronous queries and different algorithms for the future.  Support for `NavigationLink*` is also not included in this PR.  If the API is accepted, I plan to submit a future PR to add the information required to understand when a link is being traveled.

As noted in the other PR, support for returning additional information is useful for resolving: godotengine/godot-proposals#2527, godotengine/godot-proposals#3812, #19011, #60277, and #62115. 

Usage:
``` gdscript

var nav_map_rid := get_world_2d().navigation_map;
var query := NavigationPathQueryParameters2D.create(nav_map_rid, start_location, target_location);

var result := NavigationServer2D.query_path(query);
```

Discussion Questions:
~~1. I decided to break compatibility for 4.x by replacing `map_get_path` with `map_query_path`.  I believe this is the right thing to do, as with `NavigationLink*`, getting a flat list of points doesn't give enough information to navigate correctly.  Should I add `map_get_path` back for compatibility?~~ [EDIT]: Decided to leave the old API alone, this PR no longer breaks compat.
2. For asynchronous queries, I plan to add an API similar to `void query_path_async(parameters: NavigationPathQueryParameters, Callback callback)`, where the callback would return the result.  Thoughts?