### PR TITLE
[3.x] Update the versioning logic for the Godot Android Editor

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -127,16 +127,36 @@ ext.generateGodotLibraryVersion = { List<String> requiredKeys ->
         if (requiredKeys.empty) {
             libraryVersionName = map.values().join(".")
             try {
+                if (map.containsKey("status")) {
+                    int statusCode = 0
+                    String statusValue = map["status"]
+                    if (statusValue == null) {
+                        statusCode = 0
+                    } else if (statusValue.startsWith("alpha")) {
+                        statusCode = 1
+                    } else if (statusValue.startsWith("beta")) {
+                        statusCode = 2
+                    } else if (statusValue.startsWith("rc")) {
+                        statusCode = 3
+                    } else if (statusValue.startsWith("stable")) {
+                        statusCode = 4
+                    } else {
+                        statusCode = 0
+                    }
+
+                    libraryVersionCode = statusCode
+                }
+
                 if (map.containsKey("patch")) {
-                    libraryVersionCode = Integer.parseInt(map["patch"])
+                    libraryVersionCode += Integer.parseInt(map["patch"]) * 10
                 }
 
                 if (map.containsKey("minor")) {
-                    libraryVersionCode += (Integer.parseInt(map["minor"]) * 100)
+                    libraryVersionCode += (Integer.parseInt(map["minor"]) * 1000)
                 }
 
                 if (map.containsKey("major")) {
-                    libraryVersionCode += (Integer.parseInt(map["major"]) * 10000)
+                    libraryVersionCode += (Integer.parseInt(map["major"]) * 100000)
                 }
             } catch (NumberFormatException ignore) {
                 libraryVersionCode = 1

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -12,6 +12,25 @@ dependencies {
     implementation "androidx.window:window:1.0.0"
 }
 
+ext {
+    // Build number added as a suffix to the version code, and incremented for each build/upload to
+    // the Google Play store.
+    // This should be reset on each stable release of Godot.
+    editorBuildNumber = 0
+    // Value by which the Godot version code should be offset by to make room for the build number
+    editorBuildNumberOffset = 100
+}
+
+def generateVersionCode() {
+    int libraryVersionCode = getGodotLibraryVersionCode()
+    return (libraryVersionCode * editorBuildNumberOffset) + editorBuildNumber
+}
+
+def generateVersionName() {
+    String libraryVersionName = getGodotLibraryVersionName()
+    return libraryVersionName + ".$editorBuildNumber"
+}
+
 android {
     compileSdkVersion versions.compileSdk
     buildToolsVersion versions.buildTools
@@ -20,8 +39,8 @@ android {
     defaultConfig {
         // The 'applicationId' suffix allows to install Godot 3.x(v3) and 4.x(v4) on the same device
         applicationId "org.godotengine.editor.v3"
-        versionCode getGodotLibraryVersionCode()
-        versionName getGodotLibraryVersionName()
+        versionCode generateVersionCode()
+        versionName generateVersionName()
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
 

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <supports-screens
         android:largeScreens="true"
         android:normalScreens="true"
-        android:smallScreens="true"
+        android:smallScreens="false"
         android:xlargeScreens="true" />
 
     <uses-feature


### PR DESCRIPTION
This is necessary to separate subsequent uploads to the Google Play store as each upload needs to increment the version code.

Also updates the set of supported screen size to exclude small devices (e.g: watches). Affects less than **0.5%** of supported devices.

<img width="1023" alt="Screen Shot 2022-09-12 at 7 29 55 AM" src="https://user-images.githubusercontent.com/914968/189680908-8527c8a2-0d2f-4386-8c50-c1c37384da23.png">


[master version](https://github.com/godotengine/godot/pull/65682)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
