### PR TITLE
Portals - Show RayCast debug helper

### DIFF
--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -411,6 +411,12 @@ void RayCast::_create_debug_shape() {
 	Ref<ArrayMesh> mesh = memnew(ArrayMesh);
 
 	MeshInstance *mi = memnew(MeshInstance);
+#ifdef TOOLS_ENABLED
+	// This enables the debug helper to show up in editor runs.
+	// However it should not show up during export, because global mode
+	// can slow the portal system, and this should only be used for debugging.
+	mi->set_portal_mode(CullInstance::PORTAL_MODE_GLOBAL);
+#endif
 	mi->set_mesh(mesh);
 	add_child(mi);
 


### PR DESCRIPTION
Switches the raycast helper to global portal_mode, allowing it to show when portals are active.

Fixes #65673

## Notes
* `TOOLS_ENABLED` only because there is too much potential imo for users to mistakenly use these debug helpers in an exported game, and they are not fully supported because there is no way to specify their portal mode.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
