### PR TITLE
Fix last_modified_time on scripts

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1077,10 +1077,12 @@ Error GDScript::load_source_code(const String &p_path) {
 	}
 
 	source = s;
+	path = p_path;
 #ifdef TOOLS_ENABLED
 	source_changed_cache = true;
-#endif
-	path = p_path;
+	set_edited(false);
+	set_last_modified_time(FileAccess::get_modified_time(path));
+#endif // TOOLS_ENABLED
 	return OK;
 }
 


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/60997, supersedes https://github.com/godotengine/godot/pull/61870. Based on https://github.com/godotengine/godot/pull/61870#issuecomment-1156464611:

> We discussed this in a meeting and the consensus is that the `load_source_code()` function should set this when called, since it's already dealing with the file.


