### PR TITLE
Rework how current Camera2D is determined

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -55,6 +55,18 @@
 				[b]Note:[/b] The returned value is not the same as [member Node2D.global_position], as it is affected by the drag properties. It is also not the same as the current position if [member position_smoothing_enabled] is [code]true[/code] (see [method get_screen_center_position]).
 			</description>
 		</method>
+		<method name="is_current" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this [Camera2D] is the active camera (see [method Viewport.get_camera_2d]).
+			</description>
+		</method>
+		<method name="make_current">
+			<return type="void" />
+			<description>
+				Forces this [Camera2D] to become the current active one. [member enabled] must be [code]true[/code].
+			</description>
+		</method>
 		<method name="reset_smoothing">
 			<return type="void" />
 			<description>
@@ -82,9 +94,6 @@
 	<members>
 		<member name="anchor_mode" type="int" setter="set_anchor_mode" getter="get_anchor_mode" enum="Camera2D.AnchorMode" default="1">
 			The Camera2D's anchor point. See [enum AnchorMode] constants.
-		</member>
-		<member name="current" type="bool" setter="set_current" getter="is_current" default="false">
-			If [code]true[/code], the camera acts as the active camera for its [Viewport] ancestor. Only one camera can be current in a given viewport, so setting a different camera in the same viewport [code]current[/code] will disable whatever camera was already active in that viewport.
 		</member>
 		<member name="custom_viewport" type="Node" setter="set_custom_viewport" getter="get_custom_viewport">
 			The custom [Viewport] node attached to the [Camera2D]. If [code]null[/code] or not a [Viewport], uses the default viewport instead.
@@ -123,6 +132,10 @@
 		</member>
 		<member name="editor_draw_screen" type="bool" setter="set_screen_drawing_enabled" getter="is_screen_drawing_enabled" default="true">
 			If [code]true[/code], draws the camera's screen rectangle in the editor.
+		</member>
+		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
+			Controls whether the camera can be active or not. If [code]true[/code], the [Camera2D] will become the main camera when it enters the scene tree and there is no active camera currently (see [method Viewport.get_camera_2d]).
+			When the camera is currently active and [member enabled] is set to [code]false[/code], the next enabled [Camera2D] in the scene tree will become active.
 		</member>
 		<member name="ignore_rotation" type="bool" setter="set_ignore_rotation" getter="is_ignoring_rotation" default="true">
 			If [code]true[/code], the camera's rendered view is not affected by its [member Node2D.rotation] and [member Node2D.global_rotation].

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -64,7 +64,7 @@ protected:
 	Vector2 zoom_scale = Vector2(1, 1);
 	AnchorMode anchor_mode = ANCHOR_MODE_DRAG_CENTER;
 	bool ignore_rotation = true;
-	bool current = false;
+	bool enabled = true;
 	real_t position_smoothing_speed = 5.0;
 	bool follow_smoothing_enabled = false;
 
@@ -88,7 +88,6 @@ protected:
 	void _update_scroll();
 
 	void _make_current(Object *p_which);
-	void set_current(bool p_current);
 
 	void _set_old_smoothing(real_t p_enable);
 
@@ -154,6 +153,9 @@ public:
 
 	void set_process_callback(Camera2DProcessCallback p_mode);
 	Camera2DProcessCallback get_process_callback() const;
+
+	void set_enabled(bool p_enabled);
+	bool is_enabled() const;
 
 	void make_current();
 	void clear_current();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1048,6 +1048,25 @@ Transform2D Viewport::get_final_transform() const {
 	return stretch_transform * global_canvas_transform;
 }
 
+void Viewport::assign_next_enabled_camera_2d(const StringName &p_camera_group) {
+	List<Node *> camera_list;
+	get_tree()->get_nodes_in_group(p_camera_group, &camera_list);
+
+	Camera2D *new_camera = nullptr;
+	for (const Node *E : camera_list) {
+		const Camera2D *cam = Object::cast_to<Camera2D>(E);
+		if (cam->is_enabled()) {
+			new_camera = const_cast<Camera2D *>(cam);
+			break;
+		}
+	}
+
+	_camera_2d_set(new_camera);
+	if (!camera_2d) {
+		set_canvas_transform(Transform2D());
+	}
+}
+
 void Viewport::_update_canvas_items(Node *p_node) {
 	if (p_node != this) {
 		Window *w = Object::cast_to<Window>(p_node);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -512,6 +512,7 @@ public:
 	Transform2D get_global_canvas_transform() const;
 
 	Transform2D get_final_transform() const;
+	void assign_next_enabled_camera_2d(const StringName &p_camera_group);
 
 	void gui_set_root_order_dirty();
 


### PR DESCRIPTION
Recently I started a new project and this reminded me about my old proposal about Camera2D (guess why).

This PR reworks how Camera2D's "current" works. First, "current" is no longer a state of the camera. `is_current()` will now simply return whether `viewport->get_camera_2d()` points to this camera. `current` property is removed. `make_current()` still exists, but only as a method.

I added a new property - `enabled`. When an enabled Camera2D enters tree and there is no other active Camera2D, it will call `make_current()`. When `enabled` is disabled or camera exits tree, it will do `clear_current()`. `clear_current()` now does extra thing - it looks for the next `enabled` Camera2D in the viewport and makes it current, or resets the view if there is no enabled camera. You can force current camera with `make_current()` (the camera needs to be enabled).

I think this simplifies the system, because the old `current` property was weird. You could have multiple cameras set as "current" and the last one that entered tree would just take over the view. And when current camera exited tree, there was no longer a current camera. With the new system, only one Camera2D can be "current" at a time and the new property only tells whether the camera can be made current or not and currently active camera is assigned automatically based on that.

And the most important thing that helps to avoid the most common mistake in 2D projects - `enabled` is true by default.

Closes https://github.com/godotengine/godot-proposals/issues/3253

(note that the compatibility breakage here doesn't have much impact, because most projects either use no cameras or use 1 enabled camera).