### PR TITLE
Fix some errors affecting the Web editor

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -640,9 +640,21 @@
 			If [code]true[/code], Blender 3D scene files with the [code].blend[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to a Blender executable in the editor settings at [code]filesystem/import/blender/blender3_path[/code]. Blender 3.0 or later is required.
 		</member>
+		<member name="filesystem/import/blender/enabled.android" type="bool" setter="" getter="" default="false">
+			Override for [member filesystem/import/blender/enabled] on Android where Blender can't easily be accessed from Godot.
+		</member>
+		<member name="filesystem/import/blender/enabled.web" type="bool" setter="" getter="" default="false">
+			Override for [member filesystem/import/blender/enabled] on the Web where Blender can't easily be accessed from Godot.
+		</member>
 		<member name="filesystem/import/fbx/enabled" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], Autodesk FBX 3D scene files with the [code].fbx[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to a FBX2glTF executable in the editor settings at [code]filesystem/import/fbx/fbx2gltf_path[/code].
+		</member>
+		<member name="filesystem/import/fbx/enabled.android" type="bool" setter="" getter="" default="false">
+			Override for [member filesystem/import/fbx/enabled] on Android where FBX2glTF can't easily be accessed from Godot.
+		</member>
+		<member name="filesystem/import/fbx/enabled.web" type="bool" setter="" getter="" default="false">
+			Override for [member filesystem/import/fbx/enabled] on the Web where FBX2glTF can't easily be accessed from Godot.
 		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -191,25 +191,6 @@ static Ref<StyleBoxLine> make_line_stylebox(Color p_color, int p_thickness = 1, 
 	return style;
 }
 
-static Ref<Texture2D> flip_icon(Ref<Texture2D> p_texture, bool p_flip_y = false, bool p_flip_x = false) {
-	if (!p_flip_y && !p_flip_x) {
-		return p_texture;
-	}
-
-	Ref<Image> img = p_texture->get_image();
-	ERR_FAIL_NULL_V(img, Ref<Texture2D>());
-	img = img->duplicate();
-
-	if (p_flip_y) {
-		img->flip_y();
-	}
-	if (p_flip_x) {
-		img->flip_x();
-	}
-
-	return ImageTexture::create_from_image(img);
-}
-
 #ifdef MODULE_SVG_ENABLED
 // See also `generate_icon()` in `scene/resources/default_theme.cpp`.
 static Ref<ImageTexture> editor_generate_icon(int p_index, float p_scale, float p_saturation, const HashMap<Color, Color> &p_convert_colors = HashMap<Color, Color>()) {
@@ -1567,14 +1548,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("camera", "GraphEditMinimap", style_minimap_camera);
 	theme->set_stylebox("node", "GraphEditMinimap", style_minimap_node);
 
-	Ref<Texture2D> minimap_resizer_icon = theme->get_icon(SNAME("GuiResizer"), SNAME("EditorIcons"));
 	Color minimap_resizer_color;
 	if (dark_theme) {
 		minimap_resizer_color = Color(1, 1, 1, 0.65);
 	} else {
 		minimap_resizer_color = Color(0, 0, 0, 0.65);
 	}
-	theme->set_icon("resizer", "GraphEditMinimap", flip_icon(minimap_resizer_icon, true, true));
+	theme->set_icon("resizer", "GraphEditMinimap", theme->get_icon(SNAME("GuiResizerTopLeft"), SNAME("EditorIcons")));
 	theme->set_color("resizer_color", "GraphEditMinimap", minimap_resizer_color);
 
 	// GraphNode

--- a/editor/icons/GuiResizerTopLeft.svg
+++ b/editor/icons/GuiResizerTopLeft.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m4 12c.55228 0 1-.44772 1-1v-6h6c.55228 0 1-.44772 1-1s-.44772-1-1-1h-7c-.55226.000055-.99994.44774-1 1v7c0 .55228.44772 1 1 1z" fill="#fff" fill-opacity=".58824"/></svg>

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -142,6 +142,11 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		GLOBAL_DEF_RST("filesystem/import/fbx/enabled", true);
 		GDREGISTER_CLASS(EditorSceneFormatImporterBlend);
 		GDREGISTER_CLASS(EditorSceneFormatImporterFBX);
+		// Can't (a priori) run external app on these platforms.
+		GLOBAL_DEF_RST("filesystem/import/blender/enabled.android", false);
+		GLOBAL_DEF_RST("filesystem/import/blender/enabled.web", false);
+		GLOBAL_DEF_RST("filesystem/import/fbx/enabled.android", false);
+		GLOBAL_DEF_RST("filesystem/import/fbx/enabled.web", false);
 
 		ClassDB::set_current_api(prev_api);
 		EditorNode::add_init_callback(_editor_init);

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -997,7 +997,7 @@ void DisplayServerWeb::window_set_mode(WindowMode p_mode, WindowID p_window) {
 		} break;
 		case WINDOW_MODE_MAXIMIZED:
 		case WINDOW_MODE_MINIMIZED:
-			WARN_PRINT("WindowMode MAXIMIZED and MINIMIZED are not supported in Web platform.");
+			// WindowMode MAXIMIZED and MINIMIZED are not supported in Web platform.
 			break;
 		default:
 			break;


### PR DESCRIPTION
- Don't warn about minimized/maximized modes not being available.
- Blender and FBX export both depend on running thirdparty applications, which can't be done (easily at least) for Web and Android editors.
- Editor theme complained about not being able to retrieve texture data for an icon. It was only used once so instead of flipping at runtime, let's just add a flipped icon.

Part of #65702.