### PR TITLE
Elaborate on behavior of ScrollContainer with multiple control children

### DIFF
--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -522,7 +522,7 @@ TypedArray<String> ScrollContainer::get_configuration_warnings() const {
 	}
 
 	if (found != 1) {
-		warnings.push_back(RTR("ScrollContainer is intended to work with a single child control.\nUse a container as child (VBox, HBox, etc.), or a Control and set the custom minimum size manually."));
+		warnings.push_back(RTR("ScrollContainer does not sort multiple children in rows or columns, but rather on top of one other.\nIf you don't want this, add a child container (HBox, VBox, etc.) or a control with a custom minimum size."));
 	}
 
 	return warnings;


### PR DESCRIPTION
Change in 3.x, with another patch: https://github.com/godotengine/godot/pull/65706

Resolves some confusion from https://github.com/godotengine/godot-proposals/issues/5409