### PR TITLE
VCS plugin: SSH key dialog defaults to HOME

### DIFF
--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -1124,6 +1124,8 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_password->connect(SNAME("text_changed"), callable_mp(this, &VersionControlEditorPlugin::_update_set_up_warning));
 	set_up_password_input->add_child(set_up_password);
 
+	const String home_dir = OS::get_singleton()->has_environment("HOME") ? OS::get_singleton()->get_environment("HOME") : OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
+
 	HBoxContainer *set_up_ssh_public_key_input = memnew(HBoxContainer);
 	set_up_ssh_public_key_input->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	set_up_settings_vbc->add_child(set_up_ssh_public_key_input);
@@ -1147,10 +1149,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_ssh_public_key_file_dialog->set_access(FileDialog::ACCESS_FILESYSTEM);
 	set_up_ssh_public_key_file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
 	set_up_ssh_public_key_file_dialog->set_show_hidden_files(true);
-	// TODO: Make this start at the user's home folder
-	Ref<DirAccess> d = DirAccess::open(OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS));
-	d->change_dir("../");
-	set_up_ssh_public_key_file_dialog->set_current_dir(d->get_current_dir());
+	set_up_ssh_public_key_file_dialog->set_current_dir(home_dir);
 	set_up_ssh_public_key_file_dialog->connect(SNAME("file_selected"), callable_mp(this, &VersionControlEditorPlugin::_ssh_public_key_selected));
 	set_up_ssh_public_key_input_hbc->add_child(set_up_ssh_public_key_file_dialog);
 
@@ -1183,8 +1182,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_ssh_private_key_file_dialog->set_access(FileDialog::ACCESS_FILESYSTEM);
 	set_up_ssh_private_key_file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
 	set_up_ssh_private_key_file_dialog->set_show_hidden_files(true);
-	// TODO: Make this start at the user's home folder
-	set_up_ssh_private_key_file_dialog->set_current_dir(d->get_current_dir());
+	set_up_ssh_private_key_file_dialog->set_current_dir(home_dir);
 	set_up_ssh_private_key_file_dialog->connect("file_selected", callable_mp(this, &VersionControlEditorPlugin::_ssh_private_key_selected));
 	set_up_ssh_private_key_input_hbc->add_child(set_up_ssh_private_key_file_dialog);
 


### PR DESCRIPTION
Fixes #65691.

Couldn't test as I don't have a VCS setup, please confirm it works as expected :)

This uses the same logic as for the default project path editor settings.