### PR TITLE
Use proper color type for transparent render targets in GLES3

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1199,7 +1199,7 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 
 	rt->color_internal_format = rt->is_transparent ? GL_RGBA8 : GL_RGB10_A2;
 	rt->color_format = GL_RGBA;
-	rt->color_type = rt->is_transparent ? GL_BYTE : GL_UNSIGNED_INT_2_10_10_10_REV;
+	rt->color_type = rt->is_transparent ? GL_UNSIGNED_BYTE : GL_UNSIGNED_INT_2_10_10_10_REV;
 	rt->image_format = Image::FORMAT_RGBA8;
 
 	glDisable(GL_SCISSOR_TEST);


### PR DESCRIPTION
Fixes one of the errors in https://github.com/godotengine/godot/issues/65702

This fixes the render target error in https://github.com/godotengine/godot/issues/65702. The problem was that ``GL_RGBA8`` textures [need their type set to ``GL_UNSIGNED_BYTE``](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glTexImage2D.xhtml) 

Even with this change, the editor still does not fully render in the web