### PR TITLE
[3.x] Fix finding AnimationPlayer in scene import

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -32,6 +32,7 @@
 #define RESOURCE_IMPORTER_SCENE_H
 
 #include "core/io/resource_importer.h"
+#include "scene/animation/animation_player.h"
 #include "scene/resources/animation.h"
 #include "scene/resources/mesh.h"
 #include "scene/resources/shape.h"
@@ -144,6 +145,7 @@ public:
 	virtual int get_import_order() const { return ResourceImporter::IMPORT_ORDER_SCENE; }
 
 	void _find_meshes(Node *p_node, Map<Ref<ArrayMesh>, Transform> &meshes);
+	AnimationPlayer *_find_animation_player(Node *p_node);
 
 	void _make_external_resources(Node *p_node, const String &p_base_path, bool p_make_animations, bool p_animations_as_text, bool p_keep_animations, bool p_make_materials, bool p_materials_as_text, bool p_keep_materials, bool p_make_meshes, bool p_meshes_as_text, Map<Ref<Animation>, Ref<Animation>> &p_animations, Map<Ref<Material>, Ref<Material>> &p_materials, Map<Ref<ArrayMesh>, Ref<ArrayMesh>> &p_meshes);
 


### PR DESCRIPTION
The scene importer always assumed that the AnimationPlayer is called "AnimationPlayer".

This is not always true: for example the GLTF importer just creates an AnimationPlayer with the default name, which may be "animation_player", depending on the project settings.

This fix instead chooses the first node that is an AnimationPlayer, and warns if there is more than one.

_(Does not seem to apply to master. I couldn't find a hard coded name there.)_


Maybe related issue: https://github.com/godotengine/godot/issues/45418