### PR TITLE
Register varargs variant methods.

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1006,11 +1006,7 @@ static void register_builtin_method(const Vector<String> &p_argnames, const Vect
 
 	imi.call = T::call;
 	imi.validated_call = T::validated_call;
-	if (T::is_vararg()) {
-		imi.ptrcall = nullptr;
-	} else {
-		imi.ptrcall = T::ptrcall;
-	}
+	imi.ptrcall = T::ptrcall;
 
 	imi.default_arguments = p_def_args;
 	imi.argument_names = p_argnames;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Hi, 

Was there a reason for this guard on ptrcall initialization for varargs variant methods?

I am working on https://github.com/godotengine/godot-cpp/pull/837, trying to make those varargs methods work from extensions. The PR on godot-cpp is **not ready at all**, because [I don't know what I am doing](https://i.kym-cdn.com/entries/icons/original/000/008/342/ihave.jpg) with this argument encoding thing.
  But with the fix from this PR, the call seems to work - apart from the arguments being nonsense.