### PR TITLE
Don't print error in `get_cell_tile_data()`

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -104,7 +104,8 @@
 			<param index="1" name="coords" type="Vector2i" />
 			<param index="2" name="use_proxies" type="bool" default="false" />
 			<description>
-				Returns the tile source ID of the cell on layer [param layer] at coordinates [param coords]. If [param use_proxies] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
+				Returns the tile source ID of the cell on layer [param layer] at coordinates [param coords]. Returns [code]-1[/code] if the cell does not exist.
+				If [param use_proxies] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
 			</description>
 		</method>
 		<method name="get_cell_tile_data" qualifiers="const">
@@ -113,8 +114,17 @@
 			<param index="1" name="coords" type="Vector2i" />
 			<param index="2" name="use_proxies" type="bool" default="false" />
 			<description>
-				Returns the [TileData] object associated with the given cell, or [code]null[/code] if the cell is not a [TileSetAtlasSource].
+				Returns the [TileData] object associated with the given cell, or [code]null[/code] if the cell does not exist or is not a [TileSetAtlasSource].
 				If [param use_proxies] is [code]false[/code], ignores the [TileSet]'s tile proxies, returning the raw alternative identifier. See [method TileSet.map_tile_proxy].
+				[codeblock]
+				func get_clicked_tile_power():
+				    var clicked_cell = tile_map.local_to_map(tile_map.get_local_mouse_position())
+				    var data = tile_map.get_cell_tile_data(0, clicked_cell)
+				    if data:
+				        return data.get_custom_data("power")
+				    else:
+				        return 0
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_coords_for_body_rid">

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -2026,7 +2026,7 @@ void TileMap::erase_cell(int p_layer, const Vector2i &p_coords) {
 int TileMap::get_cell_source_id(int p_layer, const Vector2i &p_coords, bool p_use_proxies) const {
 	ERR_FAIL_INDEX_V(p_layer, (int)layers.size(), TileSet::INVALID_SOURCE);
 
-	// Get a cell source id from position
+	// Get a cell source id from position.
 	const HashMap<Vector2i, TileMapCell> &tile_map = layers[p_layer].tile_map;
 	HashMap<Vector2i, TileMapCell>::ConstIterator E = tile_map.find(p_coords);
 
@@ -2082,7 +2082,9 @@ int TileMap::get_cell_alternative_tile(int p_layer, const Vector2i &p_coords, bo
 
 TileData *TileMap::get_cell_tile_data(int p_layer, const Vector2i &p_coords, bool p_use_proxies) const {
 	int source_id = get_cell_source_id(p_layer, p_coords, p_use_proxies);
-	ERR_FAIL_COND_V_MSG(source_id == TileSet::INVALID_SOURCE, nullptr, vformat("Invalid TileSetSource at cell %s. Make sure a tile exists at this cell.", p_coords));
+	if (source_id == TileSet::INVALID_SOURCE) {
+		return nullptr;
+	}
 
 	Ref<TileSetAtlasSource> source = tile_set->get_source(source_id);
 	if (source.is_valid()) {


### PR DESCRIPTION
Recently my game started spamming cryptic `Invalid TileSetSource at cell` error. As it turned out, it started when I replaced my old workaround method with the new `get_cell_source_id()`, which fails when the cell does not exist. I think checking an empty cell is a valid use-case (in my case I am using it on a collided floor tile, and the collision is sometimes reporting position outside TileMap for whatever reason), so I silenced the error.

Also includes some doc improvements.