### PR TITLE
Change project manager language dropdown to not fit to longest item.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2724,9 +2724,10 @@ ProjectManager::ProjectManager() {
 		settings_hb->add_child(h_spacer);
 
 		language_btn = memnew(OptionButton);
-		language_btn->set_flat(true);
 		language_btn->set_icon(get_theme_icon(SNAME("Environment"), SNAME("EditorIcons")));
 		language_btn->set_focus_mode(Control::FOCUS_NONE);
+		language_btn->set_fit_to_longest_item(false);
+		language_btn->set_flat(true);
 		language_btn->connect("item_selected", callable_mp(this, &ProjectManager::_language_selected));
 #ifdef ANDROID_ENABLED
 		// The language selection dropdown doesn't work on Android (as the setting isn't saved), see GH-60353.


### PR DESCRIPTION
I hereby present to you the most simple pull request:

Before:
![image](https://user-images.githubusercontent.com/14253836/189784972-a1c32971-d760-40d0-8718-d88002788261.png)
After:
![image](https://user-images.githubusercontent.com/14253836/189784985-cbf72885-153a-4c88-b8e9-9f67af1a095b.png)
