### PR TITLE
Fix uniform buffer being created every frame when halfsize mismatches

### DIFF
--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -443,6 +443,11 @@ void SSEffects::downsample_depth(RID p_depth_buffer, const Vector<RID> &p_depth_
 
 	RD::get_singleton()->draw_command_begin_label("Downsample Depth");
 	if (p_invalidate_uniform_set || use_full_mips != ss_effects.used_full_mips_last_frame || use_half_size != ss_effects.used_half_size_last_frame || use_mips != ss_effects.used_mips_last_frame) {
+		if (ss_effects.downsample_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(ss_effects.downsample_uniform_set)) {
+			RD::get_singleton()->free(ss_effects.downsample_uniform_set);
+			ss_effects.downsample_uniform_set = RID();
+		}
+
 		Vector<RD::Uniform> uniforms;
 		{
 			RD::Uniform u;
@@ -516,6 +521,7 @@ void SSEffects::downsample_depth(RID p_depth_buffer, const Vector<RID> &p_depth_
 
 	ss_effects.used_full_mips_last_frame = use_full_mips;
 	ss_effects.used_half_size_last_frame = use_half_size;
+	ss_effects.used_mips_last_frame = use_mips;
 }
 
 /* SSIL */

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -128,6 +128,11 @@ void RenderSceneBuffersRD::cleanup() {
 		ss_effects.linear_depth_slices.clear();
 	}
 
+	if (ss_effects.downsample_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(ss_effects.downsample_uniform_set)) {
+		RD::get_singleton()->free(ss_effects.downsample_uniform_set);
+		ss_effects.downsample_uniform_set = RID();
+	}
+
 	sse->ssao_free(ss_effects.ssao);
 	sse->ssil_free(ss_effects.ssil);
 	sse->ssr_free(ssr);


### PR DESCRIPTION
When SSAO and SSIL aren't both set to full size or half size we were creating a new uniform buffer every frame.

The bug is fixed by the line `ss_effects.used_mips_last_frame = use_mips;` but we were also missing proper de-allocation of this uniform buffer. In most cases the uniform buffer is destroyed when it should due to dependencies but in theory it would be possible a new buffer is created when settings change while the old buffer remained. 

Fixes #63202
