### PR TITLE
Make MessageQueue growable

### DIFF
--- a/core/object/message_queue.cpp
+++ b/core/object/message_queue.cpp
@@ -49,26 +49,31 @@ Error MessageQueue::push_set(ObjectID p_id, const StringName &p_prop, const Vari
 	_THREAD_SAFE_METHOD_
 
 	uint8_t room_needed = sizeof(Message) + sizeof(Variant);
+	Buffer &buffer = buffers[write_buffer];
 
-	if ((buffer_end + room_needed) >= buffer_size) {
-		String type;
-		if (ObjectDB::get_instance(p_id)) {
-			type = ObjectDB::get_instance(p_id)->get_class();
+	if ((buffer.end + room_needed) > buffer.data.size()) {
+		if ((buffer.end + room_needed) > max_allowed_buffer_size) {
+			String type;
+			if (ObjectDB::get_instance(p_id)) {
+				type = ObjectDB::get_instance(p_id)->get_class();
+			}
+			print_line("Failed set: " + type + ":" + p_prop + " target ID: " + itos(p_id));
+			statistics();
+			ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_mb' in project settings.");
+		} else {
+			buffer.data.resize(buffer.end + room_needed);
 		}
-		print_line("Failed set: " + type + ":" + p_prop + " target ID: " + itos(p_id));
-		statistics();
-		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
 	}
 
-	Message *msg = memnew_placement(&buffer[buffer_end], Message);
+	Message *msg = memnew_placement(&buffer.data[buffer.end], Message);
 	msg->args = 1;
 	msg->callable = Callable(p_id, p_prop);
 	msg->type = TYPE_SET;
 
-	buffer_end += sizeof(Message);
+	buffer.end += sizeof(Message);
 
-	Variant *v = memnew_placement(&buffer[buffer_end], Variant);
-	buffer_end += sizeof(Variant);
+	Variant *v = memnew_placement(&buffer.data[buffer.end], Variant);
+	buffer.end += sizeof(Variant);
 	*v = p_value;
 
 	return OK;
@@ -80,21 +85,30 @@ Error MessageQueue::push_notification(ObjectID p_id, int p_notification) {
 	ERR_FAIL_COND_V(p_notification < 0, ERR_INVALID_PARAMETER);
 
 	uint8_t room_needed = sizeof(Message);
+	Buffer &buffer = buffers[write_buffer];
 
-	if ((buffer_end + room_needed) >= buffer_size) {
-		print_line("Failed notification: " + itos(p_notification) + " target ID: " + itos(p_id));
-		statistics();
-		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
+	if ((buffer.end + room_needed) > buffer.data.size()) {
+		if ((buffer.end + room_needed) > max_allowed_buffer_size) {
+			String type;
+			if (ObjectDB::get_instance(p_id)) {
+				type = ObjectDB::get_instance(p_id)->get_class();
+			}
+			print_line("Failed notification: " + itos(p_notification) + " target ID: " + itos(p_id));
+			statistics();
+			ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_mb' in project settings.");
+		} else {
+			buffer.data.resize(buffer.end + room_needed);
+		}
 	}
 
-	Message *msg = memnew_placement(&buffer[buffer_end], Message);
+	Message *msg = memnew_placement(&buffer.data[buffer.end], Message);
 
 	msg->type = TYPE_NOTIFICATION;
 	msg->callable = Callable(p_id, CoreStringNames::get_singleton()->notification); //name is meaningless but callable needs it
 	//msg->target;
 	msg->notification = p_notification;
 
-	buffer_end += sizeof(Message);
+	buffer.end += sizeof(Message);
 
 	return OK;
 }
@@ -115,14 +129,23 @@ Error MessageQueue::push_callablep(const Callable &p_callable, const Variant **p
 	_THREAD_SAFE_METHOD_
 
 	int room_needed = sizeof(Message) + sizeof(Variant) * p_argcount;
+	Buffer &buffer = buffers[write_buffer];
 
-	if ((buffer_end + room_needed) >= buffer_size) {
-		print_line("Failed method: " + p_callable);
-		statistics();
-		ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_kb' in project settings.");
+	if ((buffer.end + room_needed) > buffer.data.size()) {
+		if ((buffer.end + room_needed) > max_allowed_buffer_size) {
+			String type;
+			if (ObjectDB::get_instance(p_callable.get_object_id())) {
+				type = ObjectDB::get_instance(p_callable.get_object_id())->get_class();
+			}
+			print_line("Failed method: " + p_callable);
+			statistics();
+			ERR_FAIL_V_MSG(ERR_OUT_OF_MEMORY, "Message queue out of memory. Try increasing 'memory/limits/message_queue/max_size_mb' in project settings.");
+		} else {
+			buffer.data.resize(buffer.end + room_needed);
+		}
 	}
 
-	Message *msg = memnew_placement(&buffer[buffer_end], Message);
+	Message *msg = memnew_placement(&buffer.data[buffer.end], Message);
 	msg->args = p_argcount;
 	msg->callable = p_callable;
 	msg->type = TYPE_CALL;
@@ -130,11 +153,11 @@ Error MessageQueue::push_callablep(const Callable &p_callable, const Variant **p
 		msg->type |= FLAG_SHOW_ERROR;
 	}
 
-	buffer_end += sizeof(Message);
+	buffer.end += sizeof(Message);
 
 	for (int i = 0; i < p_argcount; i++) {
-		Variant *v = memnew_placement(&buffer[buffer_end], Variant);
-		buffer_end += sizeof(Variant);
+		Variant *v = memnew_placement(&buffer.data[buffer.end], Variant);
+		buffer.end += sizeof(Variant);
 		*v = *p_args[i];
 	}
 
@@ -147,9 +170,11 @@ void MessageQueue::statistics() {
 	HashMap<Callable, int> call_count;
 	int null_count = 0;
 
+	Buffer &buffer = buffers[write_buffer];
+
 	uint32_t read_pos = 0;
-	while (read_pos < buffer_end) {
-		Message *message = (Message *)&buffer[read_pos];
+	while (read_pos < buffer.end) {
+		Message *message = (Message *)&buffer.data[read_pos];
 
 		Object *target = message->callable.get_object();
 
@@ -195,7 +220,7 @@ void MessageQueue::statistics() {
 		}
 	}
 
-	print_line("TOTAL BYTES: " + itos(buffer_end));
+	print_line("TOTAL BYTES: " + itos(buffer.end));
 	print_line("NULL count: " + itos(null_count));
 
 	for (const KeyValue<StringName, int> &E : set_count) {
@@ -212,7 +237,8 @@ void MessageQueue::statistics() {
 }
 
 int MessageQueue::get_max_buffer_usage() const {
-	return buffer_max_used;
+	// Note this may be better read_buffer, or a combination, depending when this is read.
+	return buffers[write_buffer].data.size();
 }
 
 void MessageQueue::_call_function(const Callable &p_callable, const Variant *p_args, int p_argcount, bool p_show_error) {
@@ -232,76 +258,134 @@ void MessageQueue::_call_function(const Callable &p_callable, const Variant *p_a
 	}
 }
 
-void MessageQueue::flush() {
-	if (buffer_end > buffer_max_used) {
-		buffer_max_used = buffer_end;
+void MessageQueue::_update_buffer_monitor() {
+	// The number of flushes is an approximate delay before
+	// considering shrinking. This is somewhat of a magic number,
+	// but only acts to prevent excessive oscillations.
+	if (++_buffer_size_monitor.flush_count == 8192) {
+		uint32_t max_size = _buffer_size_monitor.max_size;
+
+		// Uncomment this define to log message queue sizes and
+		// auto-shrinking behaviour.
+		// #define GODOT_DEBUG_MESSAGE_QUEUE_SIZES
+#ifdef GODOT_DEBUG_MESSAGE_QUEUE_SIZES
+		print_line("MessageQueue buffer max size " + itos(max_size) + " bytes.");
+#endif
+
+		// reset for next time
+		_buffer_size_monitor.flush_count = 0;
+		_buffer_size_monitor.max_size = 0;
+
+		for (uint32_t n = 0; n < 2; n++) {
+			uint32_t cap = buffers[n].data.get_capacity();
+
+			// Only worry about reducing memory if the capacity is high
+			// (due to e.g. loading a level or something).
+			// The shrinking will only take place below 256K, to prevent
+			// excessive reallocating.
+			if (cap > (256 * 1024)) {
+				// Only shrink if we are routinely using a lot less than the capacity.
+				if ((max_size * 4) < cap) {
+					buffers[n].data.reserve(cap / 2, true);
+#ifdef GODOT_DEBUG_MESSAGE_QUEUE_SIZES
+					print_line("MessageQueue reducing buffer[" + itos(n) + "] capacity from " + itos(cap) + " bytes to " + itos(cap / 2) + " bytes.");
+#endif
+				}
+			}
+		}
 	}
+}
 
-	uint32_t read_pos = 0;
-
-	//using reverse locking strategy
+void MessageQueue::flush() {
 	_THREAD_SAFE_LOCK_
 
 	if (flushing) {
 		_THREAD_SAFE_UNLOCK_
-		ERR_FAIL_COND(flushing); //already flushing, you did something odd
+		ERR_FAIL_MSG("Already flushing"); //already flushing, you did something odd
 	}
+
+	// first flip buffers, in preparation
+	SWAP(read_buffer, write_buffer);
 	flushing = true;
 
-	while (read_pos < buffer_end) {
-		//lock on each iteration, so a call can re-add itself to the message queue
+	_update_buffer_monitor();
 
-		Message *message = (Message *)&buffer[read_pos];
+	_THREAD_SAFE_UNLOCK_
 
-		uint32_t advance = sizeof(Message);
-		if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
-			advance += sizeof(Variant) * message->args;
-		}
+	// This loop works by having a read buffer and write buffer.
+	// While we are reading from one buffer we can be filling another.
+	// This enables them to be independent, and not require locks per message.
+	// It also avoids pushing and resizing the write buffer corrupting the read buffer.
+	// The trade off is that it requires more memory.
+	// However the peak size of each can be lower, because they do not ADD
+	// to each other during transit.
+	while (buffers[read_buffer].data.size()) {
+		uint32_t read_pos = 0;
+		Buffer &buffer = buffers[read_buffer];
 
-		//pre-advance so this function is reentrant
-		read_pos += advance;
+		while (read_pos < buffer.end) {
+			Message *message = (Message *)&buffer.data[read_pos];
 
-		_THREAD_SAFE_UNLOCK_
-
-		Object *target = message->callable.get_object();
-
-		if (target != nullptr) {
-			switch (message->type & FLAG_MASK) {
-				case TYPE_CALL: {
-					Variant *args = (Variant *)(message + 1);
-
-					// messages don't expect a return value
-
-					_call_function(message->callable, args, message->args, message->type & FLAG_SHOW_ERROR);
-
-				} break;
-				case TYPE_NOTIFICATION: {
-					// messages don't expect a return value
-					target->notification(message->notification);
-
-				} break;
-				case TYPE_SET: {
-					Variant *arg = (Variant *)(message + 1);
-					// messages don't expect a return value
-					target->set(message->callable.get_method(), *arg);
-
-				} break;
+			uint32_t advance = sizeof(Message);
+			if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
+				advance += sizeof(Variant) * message->args;
 			}
-		}
 
-		if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
-			Variant *args = (Variant *)(message + 1);
-			for (int i = 0; i < message->args; i++) {
-				args[i].~Variant();
+			read_pos += advance;
+
+			Object *target = message->callable.get_object();
+
+			if (target != nullptr) {
+				switch (message->type & FLAG_MASK) {
+					case TYPE_CALL: {
+						Variant *args = (Variant *)(message + 1);
+
+						// messages don't expect a return value
+
+						_call_function(message->callable, args, message->args, message->type & FLAG_SHOW_ERROR);
+
+					} break;
+					case TYPE_NOTIFICATION: {
+						// messages don't expect a return value
+						target->notification(message->notification);
+
+					} break;
+					case TYPE_SET: {
+						Variant *arg = (Variant *)(message + 1);
+						// messages don't expect a return value
+						target->set(message->callable.get_method(), *arg);
+
+					} break;
+				}
 			}
-		}
 
-		message->~Message();
+			if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
+				Variant *args = (Variant *)(message + 1);
+				for (int i = 0; i < message->args; i++) {
+					args[i].~Variant();
+				}
+			}
+
+			message->~Message();
+
+		} // while going through buffer
+
+		buffer.end = 0; // reset buffer
+
+		uint32_t buffer_data_size = buffer.data.size();
+		buffer.data.clear();
 
 		_THREAD_SAFE_LOCK_
-	}
+		// keep track of the maximum used size, so we can downsize buffers when appropriate
+		_buffer_size_monitor.max_size = MAX(buffer_data_size, _buffer_size_monitor.max_size);
 
-	buffer_end = 0; // reset buffer
+		// flip buffers, this is the only part that requires a lock
+		SWAP(read_buffer, write_buffer);
+		_THREAD_SAFE_UNLOCK_
+
+	} // while read buffer not empty
+
+	_THREAD_SAFE_LOCK_
 	flushing = false;
 	_THREAD_SAFE_UNLOCK_
 }
@@ -314,31 +398,33 @@ MessageQueue::MessageQueue() {
 	ERR_FAIL_COND_MSG(singleton != nullptr, "A MessageQueue singleton already exists.");
 	singleton = this;
 
-	buffer_size = GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "memory/limits/message_queue/max_size_kb", PROPERTY_HINT_RANGE, "1024,4096,1,or_greater"), DEFAULT_QUEUE_SIZE_KB);
-	buffer_size *= 1024;
-	buffer = memnew_arr(uint8_t, buffer_size);
+	max_allowed_buffer_size = GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "memory/limits/message_queue/max_size_mb", PROPERTY_HINT_RANGE, "4,512,1,or_greater"), 32);
+	max_allowed_buffer_size *= 1024 * 1024;
 }
 
 MessageQueue::~MessageQueue() {
-	uint32_t read_pos = 0;
+	for (int which = 0; which < 2; which++) {
+		Buffer &buffer = buffers[which];
+		uint32_t read_pos = 0;
 
-	while (read_pos < buffer_end) {
-		Message *message = (Message *)&buffer[read_pos];
-		Variant *args = (Variant *)(message + 1);
-		int argc = message->args;
-		if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
-			for (int i = 0; i < argc; i++) {
-				args[i].~Variant();
+		while (read_pos < buffer.end) {
+			Message *message = (Message *)&buffer.data[read_pos];
+			Variant *args = (Variant *)(message + 1);
+			int argc = message->args;
+			if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
+				for (int i = 0; i < argc; i++) {
+					args[i].~Variant();
+				}
+			}
+			message->~Message();
+
+			read_pos += sizeof(Message);
+			if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
+				read_pos += sizeof(Variant) * message->args;
 			}
 		}
-		message->~Message();
 
-		read_pos += sizeof(Message);
-		if ((message->type & FLAG_MASK) != TYPE_NOTIFICATION) {
-			read_pos += sizeof(Variant) * message->args;
-		}
-	}
+	} // for which
 
 	singleton = nullptr;
-	memdelete_arr(buffer);
 }

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -123,9 +123,10 @@ public:
 	}
 	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
 	_FORCE_INLINE_ U get_capacity() const { return capacity; }
-	_FORCE_INLINE_ void reserve(U p_size) {
+
+	_FORCE_INLINE_ void reserve(U p_size, bool p_allow_shrink = false) {
 		p_size = tight ? p_size : nearest_power_of_2_templated(p_size);
-		if (p_size > capacity) {
+		if (!p_allow_shrink ? p_size > capacity : ((p_size >= count) && (p_size != capacity))) {
 			capacity = p_size;
 			data = (T *)memrealloc(data, capacity * sizeof(T));
 			CRASH_COND_MSG(!data, "Out of memory");

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1710,7 +1710,7 @@
 		<member name="layer_names/3d_render/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D render layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
-		<member name="memory/limits/message_queue/max_size_kb" type="int" setter="" getter="" default="4096">
+		<member name="memory/limits/message_queue/max_size_mb" type="int" setter="" getter="" default="32">
 			Godot uses a message queue to defer some function calls. If you run out of space on it (you will see an error), you can increase the size here.
 		</member>
 		<member name="memory/limits/multithreaded_server/rid_pool_prealloc" type="int" setter="" getter="" default="60">


### PR DESCRIPTION
* Uses simple vector resizing (po2)
* Uses pair of read and write buffers
* Monitors queue sizes and periodically shrinks the queue if the reserved capacity is excessive

Co-authored-by: reduz <reduzio@gmail.com>

Fixes #35653
Supersedes #35658
Supersedes #62303

Based on @reduz PR #62303, instead of using a single `LocalVector` buffer, this uses a mirrored pair. This prevents the problems caused by writing to the same `LocalVector` buffer at the same time as reading, which was causing problems.

* This has the advantage of not requiring locks between each Message, making the message queue much more efficient. (I haven't benchmarked just how much faster, but anyone interested could try.)
* The disadvantage is that it potentially can use more memory because of the use of double buffering.
* The memory use is ameliorated because, as reading and writing doesn't happen to the same queue, the peak usage of either queue is lower. So in fact the memory use is likely to be considerably lower than twice.

## Auto-sizing
Although growing with power of 2 resizing is simple, this has the potential to overuse memory because large queue sizes are typically only needed for events such as loading a scene. For this reason, the PR now features a memory monitor that measures the largest used queue size over a period of time, and if the currently used size is significantly below the capacity, the queues are shrunk.

This is done with a large delay to avoid oscillations, and will not shrink the queue below a minimum size of 256Kb (where memory use is less of a concern).

## Notes
* I have tidied up a viable version of the PR because it was on the list of urgent bugs for the beta, and it hadn't been worked on for a while now - reduz may have more pressing areas to work on.
* There are a number of alternative approaches, including using `PagedAllocator` and making local copies of the messages (as I described in https://github.com/godotengine/godot/pull/62303#issuecomment-1186266537 ) . This PR though is probably the most efficient.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
