### PR TITLE
SCons: Refactor handling of `production` flag and per-platform LTO defaults

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -47,9 +47,6 @@ def get_flags():
     return [
         ("arch", "arm64"),  # Default for convenience.
         ("tools", False),
-        # Benefits of LTO for Android (size, performance) haven't been clearly established yet.
-        # So for now we override the default value which may be set when using `production=yes`.
-        ("lto", "none"),
     ]
 
 
@@ -136,6 +133,10 @@ def configure(env):
         env.Append(CPPFLAGS=["-UNDEBUG"])
 
     # LTO
+
+    if env["lto"] == "auto":  # LTO benefits for Android (size, performance) haven't been clearly established yet.
+        env["lto"] = "none"
+
     if env["lto"] != "none":
         if env["lto"] == "thin":
             env.Append(CCFLAGS=["-flto=thin"])

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -39,9 +39,6 @@ def get_flags():
         ("arch", "arm64"),  # Default for convenience.
         ("tools", False),
         ("use_volk", False),
-        # Disable by default even if production is set, as it makes linking in Xcode
-        # on exports very slow and that's not what most users expect.
-        ("lto", "none"),
     ]
 
 
@@ -73,7 +70,11 @@ def configure(env):
         env.Append(CCFLAGS=["-gdwarf-2", "-O0"])
         env.Append(CPPDEFINES=["_DEBUG", ("DEBUG", 1)])
 
-    # LTO
+    ## LTO
+
+    if env["lto"] == "auto":  # Disable by default as it makes linking in Xcode very slow.
+        env["lto"] = "none"
+
     if env["lto"] != "none":
         if env["lto"] == "thin":
             env.Append(CCFLAGS=["-flto=thin"])

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -171,6 +171,10 @@ def configure(env):
             env.Append(LINKFLAGS=["-fsanitize=memory"])
 
     # LTO
+
+    if env["lto"] == "auto":  # Full LTO for production.
+        env["lto"] = "full"
+
     if env["lto"] != "none":
         if env["lto"] == "thin":
             if not env["use_llvm"]:

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -40,9 +40,6 @@ def get_flags():
     return [
         ("arch", detect_arch()),
         ("use_volk", False),
-        # Benefits of LTO for macOS (size, performance) haven't been clearly established yet.
-        # So for now we override the default value which may be set when using `production=yes`.
-        ("lto", "none"),
     ]
 
 
@@ -170,6 +167,10 @@ def configure(env):
         env["AS"] = basecmd + "as"
 
     # LTO
+
+    if env["lto"] == "auto":  # LTO benefits for macOS (size, performance) haven't been clearly established yet.
+        env["lto"] = "none"
+
     if env["lto"] != "none":
         if env["lto"] == "thin":
             env.Append(CCFLAGS=["-flto=thin"])
@@ -177,6 +178,8 @@ def configure(env):
         else:
             env.Append(CCFLAGS=["-flto"])
             env.Append(LINKFLAGS=["-flto"])
+
+    # Sanitizers
 
     if env["use_ubsan"] or env["use_asan"] or env["use_tsan"]:
         env.extra_suffix += ".san"

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -109,6 +109,10 @@ def configure(env):
     env["ENV"] = os.environ
 
     # LTO
+
+    if env["lto"] == "auto":  # Full LTO for production.
+        env["lto"] = "full"
+
     if env["lto"] != "none":
         if env["lto"] == "thin":
             env.Append(CCFLAGS=["-flto=thin"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -448,6 +448,9 @@ def configure_msvc(env, vcvars_msvc_config):
 
     ## LTO
 
+    if env["lto"] == "auto":  # No LTO by default for MSVC, doesn't help.
+        env["lto"] = "none"
+
     if env["lto"] != "none":
         if env["lto"] == "thin":
             print("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
@@ -563,6 +566,11 @@ def configure_mingw(env):
             env["AR"] = mingw_bin_prefix + "gcc-ar"
         if try_cmd("gcc-ranlib --version", env["mingw_prefix"], env["arch"]):
             env["RANLIB"] = mingw_bin_prefix + "gcc-ranlib"
+
+    ## LTO
+
+    if env["lto"] == "auto":  # Full LTO for production with MinGW.
+        env["lto"] = "full"
 
     if env["lto"] != "none":
         if env["lto"] == "thin":


### PR DESCRIPTION
Fixup to #63288.
Supersedes #65583, see that PR for the bug report.

Co-authored-by: @Cyberrebell 