### PR TITLE
[OS] Expose get_stdin_string to Scripting.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -253,6 +253,10 @@ Error OS::shell_open(String p_uri) {
 	return ::OS::get_singleton()->shell_open(p_uri);
 }
 
+String OS::read_string_from_stdin(bool p_block) {
+	return ::OS::get_singleton()->get_stdin_string(true);
+}
+
 int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr, bool p_open_console) {
 	List<String> args;
 	for (int i = 0; i < p_arguments.size(); i++) {
@@ -522,6 +526,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_system_fonts"), &OS::get_system_fonts);
 	ClassDB::bind_method(D_METHOD("get_system_font_path", "font_name", "bold", "italic"), &OS::get_system_font_path, DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_executable_path"), &OS::get_executable_path);
+	ClassDB::bind_method(D_METHOD("read_string_from_stdin", "block"), &OS::read_string_from_stdin, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "output", "read_stderr", "open_console"), &OS::execute, DEFVAL(Array()), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("create_process", "path", "arguments", "open_console"), &OS::create_process, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("create_instance", "arguments"), &OS::create_instance);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -175,6 +175,7 @@ public:
 	Vector<String> get_system_fonts() const;
 	String get_system_font_path(const String &p_font_name, bool p_bold = false, bool p_italic = false) const;
 	String get_executable_path() const;
+	String read_string_from_stdin(bool p_block = true);
 	int execute(const String &p_path, const Vector<String> &p_arguments, Array r_output = Array(), bool p_read_stderr = false, bool p_open_console = false);
 	int create_process(const String &p_path, const Vector<String> &p_arguments, bool p_open_console = false);
 	int create_instance(const Vector<String> &p_arguments);

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -517,6 +517,14 @@
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
+		<method name="read_string_from_stdin">
+			<return type="String" />
+			<param index="0" name="block" type="bool" default="true" />
+			<description>
+				Reads a user input string from the standard input (usually the terminal).
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows. Non-blocking reads are not currently supported on any platform.
+			</description>
+		</method>
 		<method name="request_permission">
 			<return type="bool" />
 			<param index="0" name="name" type="String" />


### PR DESCRIPTION
*Bugsquad edit: `master` version of https://github.com/godotengine/godot/pull/70378.*

Exposed as `read_string_from_stdin` so it's clear it's not retrieving a property.
The method is kept with the block parameter, but a note is added to the docs specifying that is not implemented on any platform (should we just remove it?).

Example:
```gdscript
# script.gd
extends SceneTree

func _initialize():
	var text = ""
	while text != "quit":
		printraw("Insert some text: ")
		text = OS.read_string_from_stdin().strip_edges()
		print("You inserted: %s" % text)
	print("Quitting")
	quit.call_deferred()
```

Run with: `godot -s --headless script.gd`

Closes https://github.com/godotengine/godot-proposals/issues/2322