### PR TITLE
Move debanding into internal sky shader

### DIFF
--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -104,6 +104,15 @@ uniform uint directional_light_count;
 
 layout(location = 0) out vec4 frag_color;
 
+#ifdef USE_DEBANDING
+// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
+vec3 interleaved_gradient_noise(vec2 pos) {
+	const vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);
+	float res = fract(magic.z * fract(dot(pos, magic.xy))) * 2.0 - 1.0;
+	return vec3(res, -res, res) / 255.0;
+}
+#endif
+
 void main() {
 	vec3 cube_normal;
 	cube_normal.z = -1.0;
@@ -168,4 +177,8 @@ void main() {
 
 	frag_color.rgb = color;
 	frag_color.a = alpha;
+
+#ifdef USE_DEBANDING
+	frag_color.rgb += interleaved_gradient_noise(gl_FragCoord.xy);
+#endif
 }

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1715,6 +1715,7 @@ ShaderCompiler::DefaultIdentifierActions actions;
 		actions.usage_defines["HALF_RES_COLOR"] = "\n#define USES_HALF_RES_COLOR\n";
 		actions.usage_defines["QUARTER_RES_COLOR"] = "\n#define USES_QUARTER_RES_COLOR\n";
 		actions.render_mode_defines["disable_fog"] = "#define DISABLE_FOG\n";
+		actions.render_mode_defines["use_debanding"] = "#define USE_DEBANDING\n";
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -55,7 +55,7 @@ private:
 	bool use_debanding = true;
 
 	static Mutex shader_mutex;
-	static RID shader;
+	static RID shader_cache[2];
 	static void _update_shader();
 	mutable bool shader_set = false;
 
@@ -160,7 +160,7 @@ class PhysicalSkyMaterial : public Material {
 
 private:
 	static Mutex shader_mutex;
-	static RID shader;
+	static RID shader_cache[2];
 
 	float rayleigh = 0.0f;
 	Color rayleigh_color;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -907,6 +907,7 @@ void SkyRD::init() {
 		actions.usage_defines["HALF_RES_COLOR"] = "\n#define USES_HALF_RES_COLOR\n";
 		actions.usage_defines["QUARTER_RES_COLOR"] = "\n#define USES_QUARTER_RES_COLOR\n";
 		actions.render_mode_defines["disable_fog"] = "#define DISABLE_FOG\n";
+		actions.render_mode_defines["use_debanding"] = "#define USE_DEBANDING\n";
 
 		actions.sampler_array_name = "material_samplers";
 		actions.base_texture_binding_index = 1;

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -153,6 +153,15 @@ layout(set = 3, binding = 0) uniform texture3D volumetric_fog_texture;
 
 layout(location = 0) out vec4 frag_color;
 
+#ifdef USE_DEBANDING
+// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
+vec3 interleaved_gradient_noise(vec2 pos) {
+	const vec3 magic = vec3(0.06711056f, 0.00583715f, 52.9829189f);
+	float res = fract(magic.z * fract(dot(pos, magic.xy))) * 2.0 - 1.0;
+	return vec3(res, -res, res) / 255.0;
+}
+#endif
+
 vec4 volumetric_fog_process(vec2 screen_uv) {
 	vec3 fog_pos = vec3(screen_uv, 1.0);
 
@@ -252,4 +261,8 @@ void main() {
 	// For mobile renderer we're multiplying by 0.5 as we're using a UNORM buffer.
 	// For both mobile and clustered, we also bake in the exposure value for the environment and camera.
 	frag_color.rgb = frag_color.rgb * params.luminance_multiplier;
+
+#ifdef USE_DEBANDING
+	frag_color.rgb += interleaved_gradient_noise(gl_FragCoord.xy);
+#endif
 }

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -444,6 +444,7 @@ ShaderTypes::ShaderTypes() {
 		shader_modes[RS::SHADER_SKY].modes.push_back({ PNAME("use_half_res_pass") });
 		shader_modes[RS::SHADER_SKY].modes.push_back({ PNAME("use_quarter_res_pass") });
 		shader_modes[RS::SHADER_SKY].modes.push_back({ PNAME("disable_fog") });
+		shader_modes[RS::SHADER_SKY].modes.push_back({ PNAME("use_debanding") });
 	}
 
 	/************ FOG **************************/


### PR DESCRIPTION
Fixes a bug reported on RocketChat by @Qbieshay and that I noticed recently as well.

The problem here was that the exposure coming from ``background_intensity``, ``background_energy_multiplier`` or CameraAttributes settings was being applied after debanding. In situations where the CameraAttributes settings do not cancel out the exposure, the dither effect gets scaled. E.g. if the overall exposure (after pre-multiplying by CameraAttributes exposure normalization) is greater than 1, the dither ends up becoming stronger. 

The solution is to add the dithering at the very end of the sky shader, right before values are written out to the framebuffer.

_Exaggerated settings to highlight issue_
![Screenshot from 2022-09-13 10-36-41](https://user-images.githubusercontent.com/16521339/189973385-ce0230f6-6edb-4168-b57a-79b6c7adad67.png)

_Same settings after this PR_
![Screenshot from 2022-09-13 10-36-47](https://user-images.githubusercontent.com/16521339/189973383-f45ec852-2cf8-459e-bf3d-6a3cb5d503b0.png)

