### PR TITLE
Add Code Block Guidelines to Script Editor & CodeEdit

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -451,6 +451,9 @@
 		<member name="code_completion_prefixes" type="String[]" setter="set_code_completion_prefixes" getter="get_code_comletion_prefixes" default="[]">
 			Sets prefixes that will trigger code completion.
 		</member>
+		<member name="codeblock_guidelines_style" type="int" setter="set_codeblock_guidelines_style" getter="get_codeblock_guidelines_style" enum="CodeEdit.CodeblockGuidelinesStyle" default="0">
+			Sets the style to display code block guidelines. See [enum CodeblockGuidelinesStyle].
+		</member>
 		<member name="delimiter_comments" type="String[]" setter="set_comment_delimiters" getter="get_comment_delimiters" default="[]">
 			Sets the comment delimiters. All existing comment delimiters will be removed.
 		</member>
@@ -527,6 +530,15 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="CODEBLOCK_GUIDE_STYLE_NONE" value="0" enum="CodeblockGuidelinesStyle">
+			Codeblock guides are not drawn.
+		</constant>
+		<constant name="CODEBLOCK_GUIDE_STYLE_LINE" value="1" enum="CodeblockGuidelinesStyle">
+			Draws guidelines denoting the blocks of code.
+		</constant>
+		<constant name="CODEBLOCK_GUIDE_STYLE_LINE_CLOSE" value="2" enum="CodeblockGuidelinesStyle">
+			Draws guidelines denoting the blocks of code. Additionally, horizontal lines connect from the end of the block to the last letter when applicable.
+		</constant>
 		<constant name="KIND_CLASS" value="0" enum="CodeCompletionKind">
 			Marks the option as a class.
 		</constant>
@@ -579,6 +591,12 @@
 		</theme_item>
 		<theme_item name="code_folding_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 0.8)">
 			[Color] for all icons related to line folding.
+		</theme_item>
+		<theme_item name="codeblock_guideline_active_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 0.25)">
+			[Color] for the code block guideline, if enabled, when the caret is inside of it.
+		</theme_item>
+		<theme_item name="codeblock_guideline_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 0.1)">
+			[Color] for the code block guideline, if enabled.
 		</theme_item>
 		<theme_item name="completion_background_color" data_type="color" type="Color" default="Color(0.17, 0.16, 0.2, 1)">
 			Sets the background [Color] for the code completion popup.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -661,6 +661,9 @@
 		<member name="text_editor/appearance/caret/type" type="int" setter="" getter="">
 			The shape of the caret to use in the script editor. [b]Line[/b] displays a vertical line to the left of the current character, whereas [b]Block[/b] displays a outline over the current character.
 		</member>
+		<member name="text_editor/appearance/guidelines/codeblock_guidelines_style" type="int" setter="" getter="">
+			The style to use for the line marking the beginning and end of a block of code (see [enum CodeEdit.CodeblockGuidelinesStyle]). To customise the color of the line, see [member text_editor/theme/highlighting/codeblock_guideline_color] and [member text_editor/theme/highlighting/codeblock_guideline_active_color].
+		</member>
 		<member name="text_editor/appearance/guidelines/line_length_guideline_hard_column" type="int" setter="" getter="">
 			The column at which to display a subtle line as a line length guideline for scripts. This should generally be greater than [member text_editor/appearance/guidelines/line_length_guideline_soft_column].
 		</member>
@@ -823,6 +826,12 @@
 		</member>
 		<member name="text_editor/theme/highlighting/code_folding_color" type="Color" setter="" getter="">
 			The script editor's color for the code folding icon (displayed in the gutter).
+		</member>
+		<member name="text_editor/theme/highlighting/codeblock_guideline_active_color" type="Color" setter="" getter="">
+			The script editor's color for the code block guideline, when the caret is inside the code block. See also [member text_editor/appearance/guidelines/codeblock_guidelines_style].
+		</member>
+		<member name="text_editor/theme/highlighting/codeblock_guideline_color" type="Color" setter="" getter="">
+			The script editor's color for the code block guideline. See also [member text_editor/appearance/guidelines/codeblock_guidelines_style].
 		</member>
 		<member name="text_editor/theme/highlighting/comment_color" type="Color" setter="" getter="">
 			The script editor's comment color.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1048,6 +1048,7 @@ void CodeTextEditor::update_editor_settings() {
 	} else {
 		text_editor->set_line_length_guidelines(TypedArray<int>());
 	}
+	text_editor->set_codeblock_guidelines_style((CodeEdit::CodeblockGuidelinesStyle)EditorSettings::get_singleton()->get("text_editor/appearance/guidelines/codeblock_guidelines_style").operator int());
 }
 
 void CodeTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -518,6 +518,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/appearance/guidelines/show_line_length_guidelines", true);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/guidelines/line_length_guideline_soft_column", 80, "20,160,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/guidelines/line_length_guideline_hard_column", 100, "20,160,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/guidelines/codeblock_guidelines_style", 0, "None,Line,Line (Close)")
 
 	// Appearance: Gutters
 	_initial_set("text_editor/appearance/gutters/show_line_numbers", true);
@@ -779,6 +780,8 @@ void EditorSettings::_load_godot2_text_editor_theme() {
 	_initial_set("text_editor/theme/highlighting/brace_mismatch_color", Color(1, 0.2, 0.2));
 	_initial_set("text_editor/theme/highlighting/current_line_color", Color(0.3, 0.5, 0.8, 0.15));
 	_initial_set("text_editor/theme/highlighting/line_length_guideline_color", Color(0.3, 0.5, 0.8, 0.1));
+	_initial_set("text_editor/theme/highlighting/codeblock_guideline_color", Color(0.8, 0.8, 0.8, 0.1));
+	_initial_set("text_editor/theme/highlighting/codeblock_guideline_active_color", Color(0.8, 0.8, 0.8, 0.25));
 	_initial_set("text_editor/theme/highlighting/word_highlighted_color", Color(0.8, 0.9, 0.9, 0.15));
 	_initial_set("text_editor/theme/highlighting/number_color", Color(0.92, 0.58, 0.2));
 	_initial_set("text_editor/theme/highlighting/function_color", Color(0.4, 0.64, 0.81));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1746,6 +1746,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color brace_mismatch_color = dark_theme ? error_color : Color(1, 0.08, 0, 1);
 	const Color current_line_color = alpha1;
 	const Color line_length_guideline_color = dark_theme ? base_color : background_color;
+	const Color codeblock_guideline_color = Color(mono_value, mono_value, mono_value, 0.125);
+	const Color codeblock_guideline_active_color = Color(mono_value, mono_value, mono_value, 0.2);
 	const Color word_highlighted_color = alpha1;
 	const Color number_color = dark_theme ? Color(0.63, 1, 0.88) : Color(0, 0.55, 0.28, 1);
 	const Color function_color = dark_theme ? Color(0.34, 0.7, 1.0) : Color(0, 0.225, 0.9, 1);
@@ -1786,6 +1788,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		setting->set_initial_value("text_editor/theme/highlighting/brace_mismatch_color", brace_mismatch_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/current_line_color", current_line_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/line_length_guideline_color", line_length_guideline_color, true);
+		setting->set_initial_value("text_editor/theme/highlighting/codeblock_guideline_color", codeblock_guideline_color, true);
+		setting->set_initial_value("text_editor/theme/highlighting/codeblock_guideline_active_color", codeblock_guideline_active_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/word_highlighted_color", word_highlighted_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/number_color", number_color, true);
 		setting->set_initial_value("text_editor/theme/highlighting/function_color", function_color, true);
@@ -1834,6 +1838,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("brace_mismatch_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/brace_mismatch_color"));
 	theme->set_color("current_line_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/current_line_color"));
 	theme->set_color("line_length_guideline_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/line_length_guideline_color"));
+	theme->set_color("codeblock_guideline_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/codeblock_guideline_color"));
+	theme->set_color("codeblock_guideline_active_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/codeblock_guideline_active_color"));
 	theme->set_color("word_highlighted_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/word_highlighted_color"));
 	theme->set_color("bookmark_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/bookmark_color"));
 	theme->set_color("breakpoint_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/breakpoint_color"));

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -52,6 +52,12 @@ public:
 		KIND_PLAIN_TEXT,
 	};
 
+	enum CodeblockGuidelinesStyle {
+		CODEBLOCK_GUIDE_STYLE_NONE,
+		CODEBLOCK_GUIDE_STYLE_LINE,
+		CODEBLOCK_GUIDE_STYLE_LINE_CLOSE
+	};
+
 private:
 	/* Indent management */
 	int indent_size = 4;
@@ -126,6 +132,13 @@ private:
 
 	/* Line Folding */
 	bool line_folding_enabled = false;
+	bool _can_fold_line(int p_line) const;
+	int _get_fold_line_ending(int p_line) const;
+
+	/* Codeblock Guidelines */
+	CodeblockGuidelinesStyle codeblock_guidelines_style = CODEBLOCK_GUIDE_STYLE_NONE;
+	Color codeblock_guideline_color;
+	Color codeblock_guideline_active_color;
 
 	/* Delimiters */
 	enum DelimiterType {
@@ -361,6 +374,10 @@ public:
 	bool is_line_folded(int p_line) const;
 	TypedArray<int> get_folded_lines() const;
 
+	/* Codeblock Guidelines */
+	void set_codeblock_guidelines_style(CodeblockGuidelinesStyle p_style);
+	CodeblockGuidelinesStyle get_codeblock_guidelines_style() const;
+
 	/* Delimiters */
 	void add_string_delimiter(const String &p_start_key, const String &p_end_key, bool p_line_only = false);
 	void remove_string_delimiter(const String &p_start_key);
@@ -432,5 +449,6 @@ public:
 };
 
 VARIANT_ENUM_CAST(CodeEdit::CodeCompletionKind);
+VARIANT_ENUM_CAST(CodeEdit::CodeblockGuidelinesStyle);
 
 #endif // CODE_EDIT_H

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -484,6 +484,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("executing_line_color", "CodeEdit", Color(0.98, 0.89, 0.27));
 	theme->set_color("current_line_color", "CodeEdit", Color(0.25, 0.25, 0.26, 0.8));
 	theme->set_color("code_folding_color", "CodeEdit", Color(0.8, 0.8, 0.8, 0.8));
+	theme->set_color("codeblock_guideline_color", "CodeEdit", Color(0.8, 0.8, 0.8, 0.1));
+	theme->set_color("codeblock_guideline_active_color", "CodeEdit", Color(0.8, 0.8, 0.8, 0.25));
 	theme->set_color("caret_color", "CodeEdit", control_font_color);
 	theme->set_color("caret_background_color", "CodeEdit", Color(0, 0, 0));
 	theme->set_color("brace_mismatch_color", "CodeEdit", Color(1, 0.2, 0.2));


### PR DESCRIPTION
Resurrects https://github.com/godotengine/godot/pull/20725, and https://github.com/godotengine/godot/pull/38833 somewhat.

In this PR,  `code_block_guidelines_style` is added in **CodeEdit**. When set, lines appear between the start and end of a foldable code block. The line is appropriately indented.

![image](https://user-images.githubusercontent.com/66727710/189960622-e1d65fee-d510-4d18-b748-1ef7dbf5bfcc.png)

Multiples guidelines may stack on top of each other, within reason, and prefer to connect to a bottom parenthesis.
The colour of the guideline becomes _slightly_ more noticeable when the caret is inside the code block:

![image](https://i.gyazo.com/151a456f5ab1cf32338e567688958984.gif)

It can be switched between "None", "Line" and "Line (Close)". This feature is set to "None" by default for the Editor. Its colors can be customised in the Editor Settings. _(good luck doing that without making **master** crash)_.

| Draw Tabs| Codeblock Guidelines |
|  ---  |  --- |
| ![image](https://user-images.githubusercontent.com/66727710/189982989-01e6a476-fbe3-4fd1-9f32-dc145a6ba8fd.png) | ![image](https://user-images.githubusercontent.com/66727710/189982730-9a4a5033-9749-47c0-9192-de11e14c0b8c.png)

Feedback is absolutely welcome.

#### Optional Todos(?)/Notes:
- Improve the way the caret is detected inside a code block. May require fetching all code blocks first, then drawing all line guides later. Currently, it is way too flashy, at least to my tastes. It may be worth removing this part outright.
- There's a desynchronisation issue when adding or removing lines at the end of the **Script**. This may likely not be addressed here. Rather, it seems like the v_scroll offset value is not updated properly.
- When this setting is enabled, possibly have "stray" leading tabs and spaces drawn regardless of their settings _(uneven or not belonging in any code block?)_.
- Any issue with the folding detection being somewhat weird is not my doing, it's just the same function as it was before this PR. It can be improved upon another time.

___

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/8592.*