### PR TITLE
Print each migrated project path instead of always printing "migrating" when there are none

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1253,7 +1253,6 @@ void ProjectList::migrate_config() {
 	if (FileAccess::exists(_config_path)) {
 		return;
 	}
-	print_line("Migrating legacy project list");
 
 	List<PropertyInfo> properties;
 	EditorSettings::get_singleton()->get_property_list(&properties);
@@ -1266,6 +1265,8 @@ void ProjectList::migrate_config() {
 		}
 
 		String path = EDITOR_GET(property_key);
+		print_line("Migrating legacy project '" + path + "'.");
+
 		String favoriteKey = "favorite_projects/" + property_key.get_slice("/", 1);
 		bool favorite = EditorSettings::get_singleton()->has_setting(favoriteKey);
 		add_project(path, favorite);


### PR DESCRIPTION
Previously, `Migrating legacy project list` was always printed when first starting the editor (Test it out by putting a file named `_sc_` next to the binary).

Now, the project manager will print out each project as it converts them. This way, "migrating" will only be printed if there are actual projects being migrated, and not just because `_config_path` doesn't exist.

(Not sure if it should be `print_verbose`, but there are multiple other `print_line`s in the project manager code (e.g. opening project).