### PR TITLE
Use variadic template in `vformat()` (allow more than 5 arguments)

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3727,36 +3727,6 @@ String Variant::get_callable_error_text(const Callable &p_callable, const Varian
 	return get_call_error_text(p_callable.get_object(), p_callable.get_method(), p_argptrs, p_argcount, ce);
 }
 
-String vformat(const String &p_text, const Variant &p1, const Variant &p2, const Variant &p3, const Variant &p4, const Variant &p5) {
-	Array args;
-	if (p1.get_type() != Variant::NIL) {
-		args.push_back(p1);
-
-		if (p2.get_type() != Variant::NIL) {
-			args.push_back(p2);
-
-			if (p3.get_type() != Variant::NIL) {
-				args.push_back(p3);
-
-				if (p4.get_type() != Variant::NIL) {
-					args.push_back(p4);
-
-					if (p5.get_type() != Variant::NIL) {
-						args.push_back(p5);
-					}
-				}
-			}
-		}
-	}
-
-	bool error = false;
-	String fmt = p_text.sprintf(args, &error);
-
-	ERR_FAIL_COND_V_MSG(error, String(), fmt);
-
-	return fmt;
-}
-
 void Variant::register_types() {
 	_register_variant_operators();
 	_register_variant_methods();

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -807,7 +807,22 @@ const Variant::ObjData &Variant::_get_obj() const {
 	return *reinterpret_cast<const ObjData *>(&_data._mem[0]);
 }
 
-String vformat(const String &p_text, const Variant &p1 = Variant(), const Variant &p2 = Variant(), const Variant &p3 = Variant(), const Variant &p4 = Variant(), const Variant &p5 = Variant());
+template <typename... VarArgs>
+String vformat(const String &p_text, const VarArgs... p_args) {
+	Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
+	Array args_array;
+	args_array.resize(sizeof...(p_args));
+	for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+		args_array[i] = args[i];
+	}
+
+	bool error = false;
+	String fmt = p_text.sprintf(args_array, &error);
+
+	ERR_FAIL_COND_V_MSG(error, String(), fmt);
+
+	return fmt;
+}
 
 template <typename... VarArgs>
 Callable Callable::bind(VarArgs... p_args) {


### PR DESCRIPTION
Salvages https://github.com/godotengine/godot/pull/32968.

Allows `vformat()` to take more than 5 arguments. as well as being a general optimisation that avoids redundant empty **Variant** checks.