### PR TITLE
Disable menus and functionality that are not relevant on the Android Editor port

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6750,8 +6750,10 @@ EditorNode::EditorNode() {
 
 	project_menu->add_separator();
 	project_menu->add_shortcut(ED_SHORTCUT_AND_COMMAND("editor/export", TTR("Export..."), Key::NONE, TTR("Export")), FILE_EXPORT_PROJECT);
+#ifndef ANDROID_ENABLED
 	project_menu->add_item(TTR("Install Android Build Template..."), FILE_INSTALL_ANDROID_SOURCE);
 	project_menu->add_item(TTR("Open User Data Folder"), RUN_USER_DATA_FOLDER);
+#endif
 
 	project_menu->add_separator();
 	project_menu->add_item(TTR("Customize Engine Build Configuration..."), TOOLS_BUILD_PROFILE_MANAGER);
@@ -6814,12 +6816,14 @@ EditorNode::EditorNode() {
 
 	settings_menu->set_item_tooltip(-1, TTR("Screenshots are stored in the Editor Data/Settings Folder."));
 
+#ifndef ANDROID_ENABLED
 	ED_SHORTCUT_AND_COMMAND("editor/fullscreen_mode", TTR("Toggle Fullscreen"), KeyModifierMask::SHIFT | Key::F11);
 	ED_SHORTCUT_OVERRIDE("editor/fullscreen_mode", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::F);
 	settings_menu->add_shortcut(ED_GET_SHORTCUT("editor/fullscreen_mode"), SETTINGS_TOGGLE_FULLSCREEN);
-
+#endif
 	settings_menu->add_separator();
 
+#ifndef ANDROID_ENABLED
 	if (OS::get_singleton()->get_data_path() == OS::get_singleton()->get_config_path()) {
 		// Configuration and data folders are located in the same place (Windows/MacOS).
 		settings_menu->add_item(TTR("Open Editor Data/Settings Folder"), SETTINGS_EDITOR_DATA_FOLDER);
@@ -6829,9 +6833,12 @@ EditorNode::EditorNode() {
 		settings_menu->add_item(TTR("Open Editor Settings Folder"), SETTINGS_EDITOR_CONFIG_FOLDER);
 	}
 	settings_menu->add_separator();
+#endif
 
 	settings_menu->add_item(TTR("Manage Editor Features..."), SETTINGS_MANAGE_FEATURE_PROFILES);
+#ifndef ANDROID_ENABLED
 	settings_menu->add_item(TTR("Manage Export Templates..."), SETTINGS_MANAGE_EXPORT_TEMPLATES);
+#endif
 
 	help_menu = memnew(PopupMenu);
 	help_menu->set_name(TTR("Help"));

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1619,21 +1619,24 @@ void EditorExportPlatform::gen_export_flags(Vector<String> &r_flags, int p_flags
 }
 
 bool EditorExportPlatform::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {
+	bool valid = true;
+#ifndef ANDROID_ENABLED
 	String templates_error;
-	bool valid_export_configuration = has_valid_export_configuration(p_preset, templates_error, r_missing_templates);
-
-	String project_configuration_error;
-	bool valid_project_configuration = has_valid_project_configuration(p_preset, project_configuration_error);
+	valid = valid && has_valid_export_configuration(p_preset, templates_error, r_missing_templates);
 
 	if (!templates_error.is_empty()) {
 		r_error += templates_error;
 	}
+#endif
+
+	String project_configuration_error;
+	valid = valid && has_valid_project_configuration(p_preset, project_configuration_error);
 
 	if (!project_configuration_error.is_empty()) {
 		r_error += project_configuration_error;
 	}
 
-	return valid_export_configuration && valid_project_configuration;
+	return valid;
 }
 
 EditorExportPlatform::EditorExportPlatform() {

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -932,8 +932,10 @@ void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 }
 
 void ProjectExportDialog::_export_all_dialog() {
+#ifndef ANDROID_ENABLED
 	export_all_dialog->show();
 	export_all_dialog->popup_centered(Size2(300, 80));
+#endif
 }
 
 void ProjectExportDialog::_export_all_dialog_action(const String &p_str) {
@@ -1194,11 +1196,16 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	set_cancel_button_text(TTR("Close"));
 	set_ok_button_text(TTR("Export PCK/ZIP..."));
+	get_ok_button()->set_disabled(true);
+#ifdef ANDROID_ENABLED
+	export_button = memnew(Button);
+	export_button->hide();
+#else
 	export_button = add_button(TTR("Export Project..."), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "export");
+#endif
 	export_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_export_project));
 	// Disable initially before we select a valid preset
 	export_button->set_disabled(true);
-	get_ok_button()->set_disabled(true);
 
 	export_all_dialog = memnew(ConfirmationDialog);
 	add_child(export_all_dialog);
@@ -1208,8 +1215,14 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_all_dialog->add_button(TTR("Debug"), true, "debug");
 	export_all_dialog->add_button(TTR("Release"), true, "release");
 	export_all_dialog->connect("custom_action", callable_mp(this, &ProjectExportDialog::_export_all_dialog_action));
+#ifdef ANDROID_ENABLED
+	export_all_dialog->hide();
 
+	export_all_button = memnew(Button);
+	export_all_button->hide();
+#else
 	export_all_button = add_button(TTR("Export All..."), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "export");
+#endif
 	export_all_button->connect("pressed", callable_mp(this, &ProjectExportDialog::_export_all_dialog));
 	export_all_button->set_disabled(true);
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -36,6 +36,7 @@
 #include "export_plugin.h"
 
 void register_android_exporter() {
+#ifndef ANDROID_ENABLED
 	EDITOR_DEF("export/android/android_sdk_path", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 	EDITOR_DEF("export/android/debug_keystore", "");
@@ -47,6 +48,7 @@ void register_android_exporter() {
 	EDITOR_DEF("export/android/shutdown_adb_on_exit", true);
 
 	EDITOR_DEF("export/android/one_click_deploy_clear_previous_install", false);
+#endif
 
 	Ref<EditorExportPlatformAndroid> exporter = Ref<EditorExportPlatformAndroid>(memnew(EditorExportPlatformAndroid));
 	EditorExport::get_singleton()->add_export_platform(exporter);

--- a/platform/macos/export/export.cpp
+++ b/platform/macos/export/export.cpp
@@ -33,11 +33,13 @@
 #include "export_plugin.h"
 
 void register_macos_exporter() {
+#ifndef ANDROID_ENABLED
 	EDITOR_DEF("export/macos/rcodesign", "");
 #ifdef WINDOWS_ENABLED
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/macos/rcodesign", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
 #else
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/macos/rcodesign", PROPERTY_HINT_GLOBAL_FILE));
+#endif
 #endif
 
 	Ref<EditorExportPlatformMacOS> platform;

--- a/platform/web/export/export.cpp
+++ b/platform/web/export/export.cpp
@@ -34,6 +34,7 @@
 #include "export_plugin.h"
 
 void register_web_exporter() {
+#ifndef ANDROID_ENABLED
 	EDITOR_DEF("export/web/http_host", "localhost");
 	EDITOR_DEF("export/web/http_port", 8060);
 	EDITOR_DEF("export/web/use_tls", false);
@@ -42,6 +43,7 @@ void register_web_exporter() {
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "export/web/http_port", PROPERTY_HINT_RANGE, "1,65535,1"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/web/tls_key", PROPERTY_HINT_GLOBAL_FILE, "*.key"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/web/tls_certificate", PROPERTY_HINT_GLOBAL_FILE, "*.crt,*.pem"));
+#endif
 
 	Ref<EditorExportPlatformWeb> platform;
 	platform.instantiate();

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -34,6 +34,7 @@
 #include "export_plugin.h"
 
 void register_windows_exporter() {
+#ifndef ANDROID_ENABLED
 	EDITOR_DEF("export/windows/rcedit", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/rcedit", PROPERTY_HINT_GLOBAL_FILE, "*.exe"));
 #ifdef WINDOWS_ENABLED
@@ -45,6 +46,7 @@ void register_windows_exporter() {
 	// On non-Windows we need WINE to run rcedit
 	EDITOR_DEF("export/windows/wine", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/windows/wine", PROPERTY_HINT_GLOBAL_FILE));
+#endif
 #endif
 
 	Ref<EditorExportPlatformWindows> platform;


### PR DESCRIPTION
For the initial version of the Android editor, we'll only support exporting a `pck/zip` archive.
As such, the rest of the export functionality is disabled when running on Android since it's not being used.

Polish work for https://github.com/godotengine/godot-proposals/issues/3931

master version of https://github.com/godotengine/godot/pull/63085.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
