### PR TITLE
Exclude disabled StaticBody CollisionShapes from Navigationmesh baking

### DIFF
--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -209,6 +209,9 @@ void NavigationMeshGenerator::_parse_geometry(const Transform3D &p_navmesh_trans
 			for (uint32_t shape_owner : shape_owners) {
 				const int shape_count = static_body->shape_owner_get_shape_count(shape_owner);
 				for (int i = 0; i < shape_count; i++) {
+					if (static_body->is_shape_owner_disabled(i)) {
+						continue;
+					}
 					Ref<Shape3D> s = static_body->shape_owner_get_shape(shape_owner, i);
 					if (s.is_null()) {
 						continue;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/65765

Excludes user disabled StaticBody CollisionShapes from the geometry parsing for the NavigationMesh baking.

Works the same in 3.5. so should be added there as well.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
