### PR TITLE
Add rotation smoothing to Camera2D

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -150,6 +150,13 @@
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="Camera2D.Camera2DProcessCallback" default="1">
 			The camera's process callback. See [enum Camera2DProcessCallback].
 		</member>
+		<member name="rotation_smoothing_enabled" type="bool" setter="set_rotation_smoothing_enabled" getter="is_rotation_smoothing_enabled" default="false">
+			If [code]true[/code], the camera's view smoothly rotates, via asymptotic smoothing, to align with its target rotation at [member rotation_smoothing_speed].
+			[b]Note:[/b] This property has no effect if [member ignore_rotation] is [code]true[/code].
+		</member>
+		<member name="rotation_smoothing_speed" type="float" setter="set_rotation_smoothing_speed" getter="get_rotation_smoothing_speed" default="5.0">
+			The angular, asymptotic speed of the camera's rotation smoothing effect when [member rotation_smoothing_enabled] is [code]true[/code].
+		</member>
 		<member name="smoothing_enabled" type="bool" setter="set_enable_follow_smoothing" getter="is_follow_smoothing_enabled" default="false">
 			If [code]true[/code], the camera smoothly moves towards the target at [member smoothing_speed].
 		</member>

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -67,6 +67,11 @@ protected:
 	bool current = false;
 	real_t smoothing = 5.0;
 	bool smoothing_enabled = false;
+
+	real_t camera_angle = 0.0;
+	real_t rotation_smoothing_speed = 5.0;
+	bool rotation_smoothing_enabled = false;
+
 	int limit[4];
 	bool limit_smoothing_enabled = false;
 
@@ -86,6 +91,8 @@ protected:
 	void set_current(bool p_current);
 
 	void _set_old_smoothing(real_t p_enable);
+
+	void _update_process_internal_for_smoothing();
 
 	bool screen_drawing_enabled = true;
 	bool limit_drawing_enabled = false;
@@ -138,6 +145,12 @@ public:
 
 	void set_follow_smoothing(real_t p_speed);
 	real_t get_follow_smoothing() const;
+
+	void set_rotation_smoothing_speed(real_t p_speed);
+	real_t get_rotation_smoothing_speed() const;
+
+	void set_rotation_smoothing_enabled(bool p_enabled);
+	bool is_rotation_smoothing_enabled() const;
 
 	void set_process_callback(Camera2DProcessCallback p_mode);
 	Camera2DProcessCallback get_process_callback() const;


### PR DESCRIPTION
Rebased version of https://github.com/godotengine/godot/pull/38277, complete with naming changes to fit the current naming scheme.
This PR **has already been approved**. But, because it's been 2 whole years, it needed rebasing, and the user is inactive.
Do not ask how I managed to pull the forked branch, rebase, merge, change head and keep the original user's credit because I won't be able to tell you now.

**Camera2D** has follow smoothing to interpolate towards a target position, but no rotation smoothing to align with the target rotation.

This adds rotation smoothing directly into the **Camera2D** API by having two new properties:
  - `rotation_smoothing_enabled`
  - `rotation_smoothing_speed`
