### PR TITLE
SCons: Add `methods.get_version_info()` method returning a Dict

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -737,7 +737,7 @@ if selected_platform in platform_list:
     env.module_list = modules_enabled
     methods.sort_module_list(env)
 
-    methods.update_version(env.module_version_string)
+    methods.generate_version_header(env.module_version_string)
 
     env["PROGSUFFIX"] = suffix + env.module_version_string + env["PROGSUFFIX"]
     env["OBJSUFFIX"] = suffix + env["OBJSUFFIX"]


### PR DESCRIPTION
This makes it possible to retrieve all relevant versioning info used to generate `core/version_generated.gen.h` in the buildsystem.

Notably it makes the custom logic parsing the `GODOT_VERSION_STATUS` environment variable to override status easy to reuse.

---

@neikeq This is what I was referring to in the chat yesterday, I think you could then reuse this `methods.get_version_info()` in `modules/mono/build_scripts/build_assemblies.py` to get the relevant `major`, `minor`, `patch` and `status` which takes `GODOT_VERSION_STATUS` into account.

@m4gr3d Similarly, this may be useful to handle the Android editor versioning at build time as discussed in https://github.com/godotengine/godot/pull/65682#issuecomment-1243452793 and https://github.com/godotengine/godot-proposals/issues/5410.

Note to self: If we want to cherry-pick this I'll need to make sure to remove the f-Strings usage since we're still compatible with Python 3.5 in the `3.x` branch.