### PR TITLE
Rename Camera2D's `smoothing` to `position_smoothing`

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -52,14 +52,14 @@
 			<return type="Vector2" />
 			<description>
 				Returns this camera's target position, in global coordinates.
-				[b]Note:[/b] The returned value is not the same as [member Node2D.global_position], as it is affected by the drag properties. It is also not the same as the current position if [member smoothing_enabled] is [code]true[/code] (see [method get_screen_center_position]).
+				[b]Note:[/b] The returned value is not the same as [member Node2D.global_position], as it is affected by the drag properties. It is also not the same as the current position if [member position_smoothing_enabled] is [code]true[/code] (see [method get_screen_center_position]).
 			</description>
 		</method>
 		<method name="reset_smoothing">
 			<return type="void" />
 			<description>
 				Sets the camera's position immediately to its current smoothing destination.
-				This method has no effect if [member smoothing_enabled] is [code]false[/code].
+				This method has no effect if [member position_smoothing_enabled] is [code]false[/code].
 			</description>
 		</method>
 		<method name="set_drag_margin">
@@ -138,7 +138,7 @@
 		</member>
 		<member name="limit_smoothed" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
 			If [code]true[/code], the camera smoothly stops when reaches its limits.
-			This property has no effect if [member smoothing_enabled] is [code]false[/code].
+			This property has no effect if [member position_smoothing_enabled] is [code]false[/code].
 			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_smoothing].
 		</member>
 		<member name="limit_top" type="int" setter="set_limit" getter="get_limit" default="-10000000">
@@ -146,6 +146,12 @@
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The camera's relative offset. Useful for looking around or camera shake animations. The offsetted camera can go past the limits defined in [member limit_top], [member limit_bottom], [member limit_left] and [member limit_right].
+		</member>
+		<member name="position_smoothing_enabled" type="bool" setter="set_position_smoothing_enabled" getter="is_position_smoothing_enabled" default="false">
+			If [code]true[/code], the camera's view smoothly moves towards its target position at [member position_smoothing_speed].
+		</member>
+		<member name="position_smoothing_speed" type="float" setter="set_position_smoothing_speed" getter="get_position_smoothing_speed" default="5.0">
+			Speed in pixels per second of the camera's smoothing effect when [member position_smoothing_enabled] is [code]true[/code].
 		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="Camera2D.Camera2DProcessCallback" default="1">
 			The camera's process callback. See [enum Camera2DProcessCallback].
@@ -156,12 +162,6 @@
 		</member>
 		<member name="rotation_smoothing_speed" type="float" setter="set_rotation_smoothing_speed" getter="get_rotation_smoothing_speed" default="5.0">
 			The angular, asymptotic speed of the camera's rotation smoothing effect when [member rotation_smoothing_enabled] is [code]true[/code].
-		</member>
-		<member name="smoothing_enabled" type="bool" setter="set_enable_follow_smoothing" getter="is_follow_smoothing_enabled" default="false">
-			If [code]true[/code], the camera smoothly moves towards the target at [member smoothing_speed].
-		</member>
-		<member name="smoothing_speed" type="float" setter="set_follow_smoothing" getter="get_follow_smoothing" default="5.0">
-			Speed in pixels per second of the camera's smoothing effect when [member smoothing_enabled] is [code]true[/code].
 		</member>
 		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom" default="Vector2(1, 1)">
 			The camera's zoom. A zoom of [code]Vector(2, 2)[/code] doubles the size seen in the viewport. A zoom of [code]Vector(0.5, 0.5)[/code] halves the size seen in the viewport.

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -310,6 +310,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "get_error_string", "get_error_message" }, // JSON
 	{ "get_filename", "get_scene_file_path" }, // Node, WARNING, this may be used in a lot of other places
 	{ "get_focus_neighbour", "get_focus_neighbor" }, // Control
+	{ "get_follow_smoothing", "get_position_smoothing_speed" }, // Camera2D
 	{ "get_font_types", "get_font_type_list" }, // Theme
 	{ "get_frame_color", "get_color" }, // ColorRect
 	{ "get_global_rate_scale", "get_playback_speed_scale" }, // AudioServer
@@ -417,6 +418,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "is_commiting_action", "is_committing_action" }, // UndoRedo
 	{ "is_doubleclick", "is_double_click" }, // InputEventMouseButton
 	{ "is_draw_red", "is_draw_warning" }, // EditorProperty
+	{ "is_follow_smoothing_enabled", "is_position_smoothing_enabled" }, // Camera2D
 	{ "is_h_drag_enabled", "is_drag_horizontal_enabled" }, // Camera2D
 	{ "is_handle_highlighted", "_is_handle_highlighted" }, // EditorNode3DGizmo, EditorNode3DGizmoPlugin
 	{ "is_inverting_faces", "get_flip_faces" }, // CSGPrimitive3D
@@ -497,11 +499,13 @@ static const char *gdscript_function_renames[][2] = {
 	{ "set_d", "set_distance" }, // WorldMarginShape2D
 	{ "set_doubleclick", "set_double_click" }, // InputEventMouseButton
 	{ "set_draw_red", "set_draw_warning" }, // EditorProperty
+	{ "set_enable_follow_smoothing", "set_position_smoothing_enabled" }, // Camera2D
 	{ "set_enabled_focus_mode", "set_focus_mode" }, // BaseButton
 	{ "set_endian_swap", "set_big_endian" }, // File
 	{ "set_expand_to_text_length", "set_expand_to_text_length_enabled" }, // LineEdit
 	{ "set_filename", "set_scene_file_path" }, // Node, WARNING, this may be used in a lot of other places
 	{ "set_focus_neighbour", "set_focus_neighbor" }, // Control
+	{ "set_follow_smoothing", "set_position_smoothing_speed" }, // Camera2D
 	{ "set_frame_color", "set_color" }, // ColorRect
 	{ "set_global_rate_scale", "set_playback_speed_scale" }, // AudioServer
 	{ "set_gravity_distance_scale", "set_gravity_point_distance_scale" }, // Area2D
@@ -747,6 +751,7 @@ static const char *csharp_function_renames[][2] = {
 	{ "GetEndianSwap", "IsBigEndian" }, // File
 	{ "GetErrorString", "GetErrorMessage" }, // JSON
 	{ "GetFocusNeighbour", "GetFocusNeighbor" }, // Control
+	{ "GetFollowSmoothing", "GetFollowSmoothingSpeed" }, // Camera2D
 	{ "GetFontTypes", "GetFontTypeList" }, // Theme
 	{ "GetFrameColor", "GetColor" }, // ColorRect
 	{ "GetGlobalRateScale", "GetPlaybackSpeedScale" }, // AudioServer
@@ -851,6 +856,7 @@ static const char *csharp_function_renames[][2] = {
 	{ "IsAParentOf", "IsAncestorOf" }, // Node
 	{ "IsCommitingAction", "IsCommittingAction" }, // UndoRedo
 	{ "IsDoubleclick", "IsDoubleClick" }, // InputEventMouseButton
+	{ "IsFollowSmoothingEnabled", "IsPositionSmoothingEnabled" }, // Camera2D
 	{ "IsHDragEnabled", "IsDragHorizontalEnabled" }, // Camera2D
 	{ "IsHandleHighlighted", "_IsHandleHighlighted" }, // EditorNode3DGizmo, EditorNode3DGizmoPlugin
 	{ "IsNetworkMaster", "IsMultiplayerAuthority" }, // Node
@@ -926,10 +932,12 @@ static const char *csharp_function_renames[][2] = {
 	{ "SetCursorPosition", "SetCaretColumn" }, // LineEdit
 	{ "SetD", "SetDistance" }, // WorldMarginShape2D
 	{ "SetDoubleclick", "SetDoubleClick" }, // InputEventMouseButton
+	{ "SetEnableFollowSmoothing", "SetFollowSmoothingEnabled" }, // Camera2D
 	{ "SetEnabledFocusMode", "SetFocusMode" }, // BaseButton
 	{ "SetEndianSwap", "SetBigEndian" }, // File
 	{ "SetExpandToTextLength", "SetExpandToTextLengthEnabled" }, // LineEdit
 	{ "SetFocusNeighbour", "SetFocusNeighbor" }, // Control
+	{ "SetFollowSmoothing", "SetFollowSmoothingSpeed" }, // Camera2D
 	{ "SetFrameColor", "SetColor" }, // ColorRect
 	{ "SetGlobalRateScale", "SetPlaybackSpeedScale" }, // AudioServer
 	{ "SetGravityDistanceScale", "SetGravityPointDistanceScale" }, // Area2D
@@ -1126,6 +1134,8 @@ static const char *gdscript_properties_renames[][2] = {
 	{ "selectedframe", "selected_frame" }, // Theme
 	{ "size_override_stretch", "size_2d_override_stretch" }, // SubViewport
 	{ "slips_on_slope", "slide_on_slope" }, // SeparationRayShape2D
+	{ "smoothing_enabled", "follow_smoothing_enabled" }, // Camera2D
+	{ "smoothing_speed", "position_smoothing_speed" }, // Camera2D
 	{ "ss_reflections_depth_tolerance", "ssr_depth_tolerance" }, // Environment
 	{ "ss_reflections_enabled", "ssr_enabled" }, // Environment
 	{ "ss_reflections_fade_in", "ssr_fade_in" }, // Environment
@@ -1217,6 +1227,8 @@ static const char *csharp_properties_renames[][2] = {
 	{ "Selectedframe", "SelectedFrame" }, // Theme
 	{ "SizeOverrideStretch", "Size2dOverrideStretch" }, // SubViewport
 	{ "SlipsOnSlope", "SlideOnSlope" }, // SeparationRayShape2D
+	{ "SmoothingEnabled", "FollowSmoothingEnabled" }, // Camera2D
+	{ "SmoothingSpeed", "FollowSmoothingSpeed" }, // Camera2D
 	{ "SsReflectionsDepthTolerance", "SsrDepthTolerance" }, // Environment
 	{ "SsReflectionsEnabled", "SsrEnabled" }, // Environment
 	{ "SsReflectionsFadeIn", "SsrFadeIn" }, // Environment

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -65,8 +65,8 @@ protected:
 	AnchorMode anchor_mode = ANCHOR_MODE_DRAG_CENTER;
 	bool ignore_rotation = true;
 	bool current = false;
-	real_t smoothing = 5.0;
-	bool smoothing_enabled = false;
+	real_t position_smoothing_speed = 5.0;
+	bool follow_smoothing_enabled = false;
 
 	real_t camera_angle = 0.0;
 	real_t rotation_smoothing_speed = 5.0;
@@ -140,11 +140,11 @@ public:
 	void set_drag_vertical_offset(real_t p_offset);
 	real_t get_drag_vertical_offset() const;
 
-	void set_enable_follow_smoothing(bool p_enabled);
-	bool is_follow_smoothing_enabled() const;
+	void set_position_smoothing_enabled(bool p_enabled);
+	bool is_position_smoothing_enabled() const;
 
-	void set_follow_smoothing(real_t p_speed);
-	real_t get_follow_smoothing() const;
+	void set_position_smoothing_speed(real_t p_speed);
+	real_t get_position_smoothing_speed() const;
 
 	void set_rotation_smoothing_speed(real_t p_speed);
 	real_t get_rotation_smoothing_speed() const;


### PR DESCRIPTION
If https://github.com/godotengine/godot/pull/65776 is merged _(it's been approved a while ago)_, it would make sense to, albeit very hastily and last minute, as beta is right here, to rename these ones. Even if not, the setter and getters of these properties were already confusingly named, for some mysterious reason.
I can only speculate that `smoothing_enabled` did not exist at some point, only  `smoothing` did. That would still leave some of the associated methods to call it `follow_smoothing`. Make it consistent!

For **Camera2D**:
`smoothing_enabled` -> `position_smoothing_enabled`
`set_enable_follow_smoothing` -> `set_position_smoothing_enabled`
`is_follow_smoothing_enabled` -> `is_position_smoothing_enabled`
`smoothing_speed` -> `position_smoothing_speed`
`set_follow_smoothing` -> `set_position_smoothing_speed`
`get_follow_smoothing` -> `get_position_smoothing_speed`

Also modifies the description, because with this name there's a bit of ambiguity, due of "position" being so commonly used all around the Node.

~This PR used to be "Rename Camera2D's `smoothing` to `follow_smoothing`"~
