### PR TITLE
Add configuration warning to GraphEdit regarding future refactoring

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -190,6 +190,14 @@ void GraphEditMinimap::_adjust_graph_scroll(const Vector2 &p_offset) {
 	ge->set_scroll_ofs(p_offset + graph_offset - camera_size / 2);
 }
 
+TypedArray<String> GraphEdit::get_configuration_warnings() const {
+	TypedArray<String> warnings = Control::get_configuration_warnings();
+
+	warnings.push_back(RTR("Please be aware that GraphEdit and GraphNode will undergo extensive refactoring in a future beta version involving compatibility-breaking API changes."));
+
+	return warnings;
+}
+
 Error GraphEdit::connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port) {
 	if (is_node_connected(p_from, p_from_port, p_to, p_to_port)) {
 		return OK;

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -287,6 +287,8 @@ protected:
 	GDVIRTUAL4R(bool, _is_node_hover_valid, StringName, int, StringName, int);
 
 public:
+	TypedArray<String> get_configuration_warnings() const override;
+
 	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	bool is_node_connected(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	void disconnect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);


### PR DESCRIPTION
As discussed via RC, users should be warned about the compatibility-breaking API changes that may be introduced in a future beta version (with the GraphEdit/GraphNode refactoring [godotengine/godot-proposals#5271] I am working on)