### PR TITLE
Do not change node name if it is already pascal

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -942,9 +942,12 @@ String Node::validate_child_name(Node *p_child) {
 }
 #endif
 
-String Node::adjust_name_casing(const String &p_name) {
+String Node::adjust_name_casing(const String &p_name, const bool p_skip_pascal_case) {
 	switch (GLOBAL_GET("editor/node_naming/name_casing").operator int()) {
 		case NAME_CASING_PASCAL_CASE:
+			if (p_skip_pascal_case) {
+				break;
+			}
 			return p_name.to_pascal_case();
 		case NAME_CASING_CAMEL_CASE:
 			return p_name.to_camel_case();
@@ -1024,11 +1027,11 @@ String increase_numeric_string(const String &s) {
 
 void Node::_generate_serial_child_name(const Node *p_child, StringName &name) const {
 	if (name == StringName()) {
-		//no name and a new name is needed, create one.
-
+		// No name and a new name is needed, create one.
 		name = p_child->get_class();
+
 		// Adjust casing according to project setting.
-		name = adjust_name_casing(name);
+		name = adjust_name_casing(name, true);
 	}
 
 	//quickly test if proposed name exists

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -457,7 +457,7 @@ public:
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);
 #endif
-	static String adjust_name_casing(const String &p_name);
+	static String adjust_name_casing(const String &p_name, const bool p_skip_pascal_case = false);
 
 	void queue_delete();
 


### PR DESCRIPTION
Tentative fix to a regression caused by https://github.com/godotengine/godot/pull/64570

New node names (e.g. Node2D) by default were given the name `Node2d`. Now the new node name is unchanged from the class name, as it was before #64570

*Bugsquad edit:* Fixes #65803.