### PR TITLE
Clear last frame directional light buffer when number of lights changes.

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -683,6 +683,7 @@ void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, cons
 				light_data_dirty = true;
 				for (uint32_t i = sky_globals.directional_light_count; i < sky_globals.max_directional_lights; i++) {
 					sky_globals.directional_lights[i].enabled = false;
+					sky_globals.last_frame_directional_lights[i].enabled = false;
 				}
 			}
 

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1261,6 +1261,7 @@ void SkyRD::setup(RID p_env, Ref<RenderSceneBuffersRD> p_render_buffers, const P
 				light_data_dirty = true;
 				for (uint32_t i = sky_scene_state.ubo.directional_light_count; i < sky_scene_state.max_directional_lights; i++) {
 					sky_scene_state.directional_lights[i].enabled = false;
+					sky_scene_state.last_frame_directional_lights[i].enabled = false;
 				}
 			}
 


### PR DESCRIPTION
The issue here hasn't been reported, but essentially what was happening was in sky shaders with a structure like the following:
```
vec3 color = vec3(0.0,0.0,0.0);
	if (LIGHT0_ENABLED) {
		color += ...;
	}
	if (LIGHT1_ENABLED) {
		color += ...;
	}
	if (LIGHT2_ENABLED) {
		color += vec3(1.0,0.0,0.0);
	}
	if (LIGHT3_ENABLED) {
		color += vec3(0.0,1.0,0.0);;
	}
```
``LIGHT2`` and ``LIGHT3`` would seemingly become enabled at random when ``LIGHT0`` or ``LIGHT1`` were updated. 

I tracked the issue down to the directional light buffer and previous directional light buffer getting out of sync as the previous frame directional light buffer wasn't properly clearing the ``enabled`` property when the number of lights changed. This means that the last frame buffer could have ghost lights enabled depending on the hardware used (only NVidia exhibited the problem, Intel and AMD appear to be fine).

Bug reported directly to me by @groud 