### PR TITLE
Add `loop_mode` to AudioStreamPlayer & AudioStreamPlayback

### DIFF
--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -56,4 +56,24 @@
 			</description>
 		</method>
 	</methods>
+	<constants>
+		<constant name="LOOP_DETECT" value="0" enum="LoopMode">
+			If supported, looping is automatically detected depending on the associated [AudioStream].
+		</constant>
+		<constant name="LOOP_DISABLED" value="1" enum="LoopMode">
+			The [AudioStream] does not loop.
+		</constant>
+		<constant name="LOOP_FORWARD" value="2" enum="LoopMode">
+			If supported, the [AudioStream] loops when it reaches the end.
+		</constant>
+		<constant name="LOOP_PINGPONG" value="3" enum="LoopMode">
+			If supported, the [AudioStream] switches between playing forward and backwards, after reaching either sides.
+		</constant>
+		<constant name="LOOP_BACKWARD" value="4" enum="LoopMode">
+			If supported, the [AudioStream] plays backwards and loops when it reaches the beginning.
+		</constant>
+		<constant name="LOOP_MAX" value="5" enum="LoopMode">
+			Represents the size of the [enum LoopMode] enum.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -57,6 +57,10 @@
 			Bus on which this audio is playing.
 			[b]Note:[/b] When setting this property, keep in mind that no validation is performed to see if the given name matches an existing bus. This is because audio bus layouts might be loaded after this property is set. If this given name can't be resolved at runtime, it will fall back to [code]"Master"[/code].
 		</member>
+		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="AudioStreamPlayback.LoopMode" default="0">
+			The way the audio should loop. If set to [constant AudioStreamPlayback.LOOP_DETECT], it is inferred from the [member stream]. See [enum AudioStreamPlayback.LoopMode] for possible modes.
+			[b]Note:[/b] Not all [AudioStream]s support all looping modes.
+		</member>
 		<member name="max_polyphony" type="int" setter="set_max_polyphony" getter="get_max_polyphony" default="1">
 			The maximum number of sounds this node can play at the same time. Playing additional sounds after this value is reached will cut off the oldest sounds.
 		</member>

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -60,6 +60,10 @@
 			Bus on which this audio is playing.
 			[b]Note:[/b] When setting this property, keep in mind that no validation is performed to see if the given name matches an existing bus. This is because audio bus layouts might be loaded after this property is set. If this given name can't be resolved at runtime, it will fall back to [code]"Master"[/code].
 		</member>
+		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="AudioStreamPlayback.LoopMode" default="0">
+			The way the audio should loop. If set to [constant AudioStreamPlayback.LOOP_DETECT], it is inferred from the [member stream]. See [enum AudioStreamPlayback.LoopMode] for possible values.
+			[b]Note:[/b] Not all [AudioStream]s support all looping modes.
+		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="2000.0">
 			Maximum distance from which audio is still hearable.
 		</member>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -78,6 +78,10 @@
 		<member name="emission_angle_filter_attenuation_db" type="float" setter="set_emission_angle_filter_attenuation_db" getter="get_emission_angle_filter_attenuation_db" default="-12.0">
 			Dampens audio if camera is outside of [member emission_angle_degrees] and [member emission_angle_enabled] is set by this factor, in decibels.
 		</member>
+		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="AudioStreamPlayback.LoopMode" default="0">
+			The way the audio should loop. If set to [constant AudioStreamPlayback.LOOP_DETECT], it is inferred from the [member stream]. See [enum AudioStreamPlayback.LoopMode] for possible values.
+			[b]Note:[/b] Not all [AudioStream]s support all looping modes.
+		</member>
 		<member name="max_db" type="float" setter="set_max_db" getter="get_max_db" default="3.0">
 			Sets the absolute maximum of the soundlevel, in decibels.
 		</member>

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -260,6 +260,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			}
 		}
 
+		// Detect loop mode from file (default).
 		if (import_loop_mode == 0 && chunkID[0] == 's' && chunkID[1] == 'm' && chunkID[2] == 'p' && chunkID[3] == 'l') {
 			// Loop point info!
 
@@ -431,7 +432,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 	}
 
 	if (import_loop_mode >= 2) {
-		loop_mode = (AudioStreamWAV::LoopMode)(import_loop_mode - 1);
+		loop_mode = (AudioStreamWAV::LoopMode)(import_loop_mode - 1); // Not counting "Detect from WAV" option.
 		loop_begin = p_options["edit/loop_begin"];
 		loop_end = p_options["edit/loop_end"];
 		// Wrap around to max frames, so `-1` can be used to select the end, etc.

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -47,7 +47,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 	int frames_mixed_this_step = p_frames;
 
 	int beat_length_frames = -1;
-	bool beat_loop = mp3_stream->has_loop() && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
+	bool beat_loop = loop_mode == LOOP_FORWARD && mp3_stream->get_bpm() > 0 && mp3_stream->get_beat_count() > 0;
 	if (beat_loop) {
 		beat_length_frames = mp3_stream->get_beat_count() * mp3_stream->sample_rate * 60 / mp3_stream->get_bpm();
 	}
@@ -117,6 +117,17 @@ void AudioStreamPlaybackMP3::stop() {
 
 bool AudioStreamPlaybackMP3::is_playing() const {
 	return active;
+}
+
+void AudioStreamPlaybackMP3::set_loop_mode(const LoopMode p_loop_mode) {
+	if (p_loop_mode == LOOP_PINGPONG || p_loop_mode == LOOP_BACKWARD) {
+		WARN_PRINT("AudioStreamPlaybackMP3 does not support Ping-Pong or Backward Loop Mode! Looping forward.");
+		loop_mode = LOOP_FORWARD;
+	} else if (p_loop_mode == LOOP_DETECT) {
+		loop_mode = mp3_stream->has_loop() ? LOOP_FORWARD : LOOP_DISABLED;
+	} else {
+		loop_mode = p_loop_mode;
+	}
 }
 
 int AudioStreamPlaybackMP3::get_loop_count() const {
@@ -228,6 +239,13 @@ float AudioStreamMP3::get_loop_offset() const {
 float AudioStreamMP3::get_length() const {
 	return length;
 }
+
+Vector<AudioStreamPlayback::LoopMode> AudioStreamMP3::get_unsupported_loop_modes() const {
+	Vector<AudioStreamPlayback::LoopMode> unsupported_modes;
+	unsupported_modes.append(AudioStreamPlayback::LoopMode::LOOP_BACKWARD);
+	unsupported_modes.append(AudioStreamPlayback::LoopMode::LOOP_PINGPONG);
+	return unsupported_modes;
+};
 
 bool AudioStreamMP3::is_monophonic() const {
 	return false;

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -65,6 +65,7 @@ public:
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 
+	virtual void set_loop_mode(const LoopMode p_loop_mode) override;
 	virtual int get_loop_count() const override; //times it looped
 
 	virtual float get_playback_position() const override;
@@ -125,6 +126,9 @@ public:
 	virtual float get_length() const override;
 
 	virtual bool is_monophonic() const override;
+
+	// MP3 does not support LOOP_BACKWARD and LOOP_PINGPONG.
+	virtual Vector<AudioStreamPlayback::LoopMode> get_unsupported_loop_modes() const override;
 
 	AudioStreamMP3();
 	virtual ~AudioStreamMP3();

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -44,7 +44,7 @@ int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 	int todo = p_frames;
 
 	int beat_length_frames = -1;
-	bool beat_loop = vorbis_stream->has_loop();
+	bool beat_loop = loop_mode == LOOP_FORWARD;
 	if (beat_loop && vorbis_stream->get_bpm() > 0 && vorbis_stream->get_beat_count() > 0) {
 		beat_length_frames = vorbis_stream->get_beat_count() * vorbis_data->get_sampling_rate() * 60 / vorbis_stream->get_bpm();
 	}
@@ -238,6 +238,17 @@ void AudioStreamPlaybackOggVorbis::stop() {
 
 bool AudioStreamPlaybackOggVorbis::is_playing() const {
 	return active;
+}
+
+void AudioStreamPlaybackOggVorbis::set_loop_mode(const LoopMode p_loop_mode) {
+	if (p_loop_mode == LOOP_PINGPONG || p_loop_mode == LOOP_BACKWARD) {
+		WARN_PRINT("AudioStreamPlaybackOggVorbis does not support Ping-Pong or Backward Loop Mode! Looping forward.");
+		loop_mode = LOOP_FORWARD;
+	} else if (p_loop_mode == LOOP_DETECT) {
+		loop_mode = vorbis_stream->has_loop() ? LOOP_FORWARD : LOOP_DISABLED;
+	} else {
+		loop_mode = p_loop_mode;
+	}
 }
 
 int AudioStreamPlaybackOggVorbis::get_loop_count() const {
@@ -507,6 +518,13 @@ int AudioStreamOggVorbis::get_bar_beats() const {
 
 bool AudioStreamOggVorbis::is_monophonic() const {
 	return false;
+}
+
+Vector<AudioStreamPlayback::LoopMode> AudioStreamOggVorbis::get_unsupported_loop_modes() const {
+	Vector<AudioStreamPlayback::LoopMode> unsupported_modes;
+	unsupported_modes.append(AudioStreamPlayback::LoopMode::LOOP_BACKWARD);
+	unsupported_modes.append(AudioStreamPlayback::LoopMode::LOOP_PINGPONG);
+	return unsupported_modes;
 }
 
 void AudioStreamOggVorbis::_bind_methods() {

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -87,6 +87,7 @@ public:
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 
+	virtual void set_loop_mode(const LoopMode p_loop_mode) override;
 	virtual int get_loop_count() const override; //times it looped
 
 	virtual float get_playback_position() const override;
@@ -148,6 +149,9 @@ public:
 	virtual float get_length() const override; //if supported, otherwise return 0
 
 	virtual bool is_monophonic() const override;
+
+	// OGG does not support LOOP_BACKWARD and LOOP_PINGPONG.
+	virtual Vector<AudioStreamPlayback::LoopMode> get_unsupported_loop_modes() const override;
 
 	AudioStreamOggVorbis();
 	virtual ~AudioStreamOggVorbis();

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -67,6 +67,8 @@ private:
 	StringName default_bus = SNAME("Master");
 	int max_polyphony = 1;
 
+	AudioStreamPlayback::LoopMode loop_mode = AudioStreamPlayback::LOOP_DETECT;
+
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
 
@@ -105,6 +107,9 @@ public:
 	bool is_playing() const;
 	float get_playback_position();
 
+	void set_loop_mode(const AudioStreamPlayback::LoopMode p_loop_mode);
+	AudioStreamPlayback::LoopMode get_loop_mode() const;
+
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
 
@@ -130,6 +135,8 @@ public:
 	float get_panning_strength() const;
 
 	Ref<AudioStreamPlayback> get_stream_playback();
+
+	TypedArray<String> get_configuration_warnings() const override;
 
 	AudioStreamPlayer2D();
 	~AudioStreamPlayer2D();

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -81,6 +81,8 @@ private:
 	StringName bus = SNAME("Master");
 	int max_polyphony = 1;
 
+	AudioStreamPlayback::LoopMode loop_mode = AudioStreamPlayback::LOOP_DETECT;
+
 	uint64_t last_mix_count = -1;
 	bool force_update_panning = false;
 
@@ -146,6 +148,9 @@ public:
 	bool is_playing() const;
 	float get_playback_position();
 
+	void set_loop_mode(const AudioStreamPlayback::LoopMode p_loop_mode);
+	AudioStreamPlayback::LoopMode get_loop_mode() const;
+
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
 
@@ -189,6 +194,8 @@ public:
 	float get_panning_strength() const;
 
 	Ref<AudioStreamPlayback> get_stream_playback();
+
+	TypedArray<String> get_configuration_warnings() const override;
 
 	AudioStreamPlayer3D();
 	~AudioStreamPlayer3D();

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -57,6 +57,8 @@ private:
 	StringName bus = SNAME("Master");
 	int max_polyphony = 1;
 
+	AudioStreamPlayback::LoopMode loop_mode = AudioStreamPlayback::LOOP_DETECT;
+
 	MixTarget mix_target = MIX_TARGET_STEREO;
 
 	void _mix_internal(bool p_fadeout);
@@ -95,6 +97,9 @@ public:
 	bool is_playing() const;
 	float get_playback_position();
 
+	void set_loop_mode(const AudioStreamPlayback::LoopMode p_loop_mode);
+	AudioStreamPlayback::LoopMode get_loop_mode() const;
+
 	void set_bus(const StringName &p_bus);
 	StringName get_bus() const;
 
@@ -108,6 +113,8 @@ public:
 	bool get_stream_paused() const;
 
 	Ref<AudioStreamPlayback> get_stream_playback();
+
+	TypedArray<String> get_configuration_warnings() const override;
 
 	AudioStreamPlayer();
 	~AudioStreamPlayer();

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -73,6 +73,7 @@ public:
 	virtual float get_playback_position() const override;
 	virtual void seek(float p_time) override;
 
+	virtual void set_loop_mode(LoopMode p_loop_mode) override;
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
 	virtual void tag_used_streams() override;
@@ -92,6 +93,8 @@ public:
 	};
 
 	// Keep the ResourceImporterWAV `edit/loop_mode` enum hint in sync with these options.
+	// Note: Not to be confused with AudioStreamPlayer's LoopMode.
+	// AudioStreamWAV is the only AudioStream that supports looping this way.
 	enum LoopMode {
 		LOOP_DISABLED,
 		LOOP_FORWARD,
@@ -140,6 +143,9 @@ public:
 	virtual float get_length() const override; //if supported, otherwise return 0
 
 	virtual bool is_monophonic() const override;
+
+	// WAV supports all loop modes.
+	virtual Vector<AudioStreamPlayback::LoopMode> get_unsupported_loop_modes() const override;
 
 	void set_data(const Vector<uint8_t> &p_data);
 	Vector<uint8_t> get_data() const;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -83,6 +83,15 @@ int AudioStreamPlayback::mix(AudioFrame *p_buffer, float p_rate_scale, int p_fra
 	return 0;
 }
 
+void AudioStreamPlayback::set_loop_mode(const LoopMode p_loop_mode) {
+	loop_mode = LOOP_DISABLED;
+	WARN_PRINT(String(get_class_name()) + "::set_loop_mode unimplemented!");
+}
+
+AudioStreamPlayback::LoopMode AudioStreamPlayback::get_loop_mode() const {
+	return loop_mode;
+}
+
 void AudioStreamPlayback::tag_used_streams() {
 	GDVIRTUAL_CALL(_tag_used_streams);
 }
@@ -96,6 +105,13 @@ void AudioStreamPlayback::_bind_methods() {
 	GDVIRTUAL_BIND(_seek, "position")
 	GDVIRTUAL_BIND(_mix, "buffer", "rate_scale", "frames");
 	GDVIRTUAL_BIND(_tag_used_streams);
+
+	BIND_ENUM_CONSTANT(LOOP_DETECT);
+	BIND_ENUM_CONSTANT(LOOP_DISABLED);
+	BIND_ENUM_CONSTANT(LOOP_FORWARD);
+	BIND_ENUM_CONSTANT(LOOP_PINGPONG);
+	BIND_ENUM_CONSTANT(LOOP_BACKWARD);
+	BIND_ENUM_CONSTANT(LOOP_MAX);
 }
 //////////////////////////////
 
@@ -221,6 +237,16 @@ bool AudioStream::is_monophonic() const {
 		return ret;
 	}
 	return true;
+}
+
+Vector<AudioStreamPlayback::LoopMode> AudioStream::get_unsupported_loop_modes() const {
+	Vector<AudioStreamPlayback::LoopMode> unsupported_modes;
+	unsupported_modes.resize(4);
+	unsupported_modes.set(0, AudioStreamPlayback::LoopMode::LOOP_FORWARD);
+	unsupported_modes.set(1, AudioStreamPlayback::LoopMode::LOOP_PINGPONG);
+	unsupported_modes.set(2, AudioStreamPlayback::LoopMode::LOOP_BACKWARD);
+	unsupported_modes.set(3, AudioStreamPlayback::LoopMode::LOOP_DETECT);
+	return unsupported_modes;
 }
 
 double AudioStream::get_bpm() const {

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -56,18 +56,36 @@ protected:
 	GDVIRTUAL3R(int, _mix, GDNativePtr<AudioFrame>, float, int)
 	GDVIRTUAL0(_tag_used_streams)
 public:
+	enum LoopMode {
+		// LOOP_DETECT should only be assigned in AudioStreamPlayer & ResourceImporterWAV's imports.
+		// When passed in AudioStreamPlayback.set_loop_mode(),
+		// Another LoopMode should be assigned, instead.
+		LOOP_DETECT,
+		LOOP_DISABLED,
+		LOOP_FORWARD,
+		LOOP_PINGPONG,
+		LOOP_BACKWARD,
+		LOOP_MAX,
+	};
+
 	virtual void start(float p_from_pos = 0.0);
 	virtual void stop();
 	virtual bool is_playing() const;
 
-	virtual int get_loop_count() const; //times it looped
+	virtual int get_loop_count() const; // Times it looped.
 
 	virtual float get_playback_position() const;
 	virtual void seek(float p_time);
 
 	virtual void tag_used_streams();
 
+	virtual void set_loop_mode(const LoopMode p_loop_mode);
+	LoopMode get_loop_mode() const;
+
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
+
+protected:
+	LoopMode loop_mode = LOOP_DISABLED;
 };
 
 class AudioStreamPlaybackResampled : public AudioStreamPlayback {
@@ -137,6 +155,7 @@ public:
 
 	virtual float get_length() const;
 	virtual bool is_monophonic() const;
+	virtual Vector<AudioStreamPlayback::LoopMode> get_unsupported_loop_modes() const;
 
 	void tag_used(float p_offset);
 	uint64_t get_tagged_frame() const;
@@ -299,6 +318,7 @@ public:
 	~AudioStreamPlaybackRandomizer();
 };
 
+VARIANT_ENUM_CAST(AudioStreamPlayback::LoopMode);
 VARIANT_ENUM_CAST(AudioStreamRandomizer::PlaybackMode);
 
 #endif // AUDIO_STREAM_H

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -347,7 +347,7 @@ void AudioServer::_mix_step() {
 			buf[i] = playback->lookahead[i];
 		}
 
-		// Mix the audio stream
+		// Mix the audio stream.
 		unsigned int mixed_frames = playback->stream_playback->mix(&buf[LOOKAHEAD_BUFFER_SIZE], playback->pitch_scale.get(), buffer_size);
 
 		if (tag_used_audio_streams && playback->stream_playback->is_playing()) {


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/3120, (minus actually stripping the import)

This PR implemets `loop_mode` for  **AudioStreamPlayer**, **AudioStreamPlayer2D**, **AudioStreamPlayer3D** and  **AudioStreamPlayback**.

This allows changing the looping mode of the **AudioStream**, regardless of how it was imported, even as the stream is playing, which leads to pretty interesting results! Imagine playing a sound, keep it looping continuously, until a key is released.

https://user-images.githubusercontent.com/66727710/190255193-f79c8d16-41c2-44ed-b623-baa1ea9da6bd.mp4

By default, for the **AudioStreamPlayer**'s, this property is set to "_Detect_", which lets any generated **AudioStreamPlayback** automatically figure out the `loop_mode`, based on their respective **AudioStream** Resource. 

![image](https://user-images.githubusercontent.com/66727710/190252221-0b706f96-51f3-4e68-a0d3-177c8828bcc3.png)

Note is that, the streams may vary a lot _(MP3, Ogg, WAV...)_. Their implementation has been mostly unchanged in this PR, so it is not guaranteed that the given `loop_mode` is supported, if at all, in fact. Whenever this is the case, a warning configuration is issued. When actually playing the AudioStream with AudioStreamPlayback, the variable is internally reassigned to its closest equivalent and a warning is sent to the console (this has been configured manually).

| Configuration Warning | Console Warning |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/66727710/190376327-aa3f5e7f-744b-4c92-a768-d33b18f58251.png) ![image](https://user-images.githubusercontent.com/66727710/190370744-5a42efac-7990-4b8d-8f43-f95ea3a93d2d.png) | ![image](https://user-images.githubusercontent.com/66727710/190377641-ba738cfa-b371-4c6a-8e2d-3fcc1f616930.png) |


The way **AudioStreams** are imported into the editor is left unchanged. This feature is all on top of it.

## What I would like to do:
- [x] Fix **AudioStreamPlaybackWAV** not resuming forward as expected after switching from Ping Pong/Backward to Forward (as if stuck looping backwards).
- [x] ~Hide unsupported Loop Modes from selection when the **AudioStream** of **AudioStreamPlayer** does not support them _(I believe `validate_property()` allows you to do this)_.~ PROPERTY_TYPE_ENUM does not support skipping options _(adding that to my list, I suppose)_. The closest thing is a reminder next to each option.
- [x] Move LoopMode::DETECT to the top of the enum.
- [x] Manage detecting unsupported loop modes outside of **AudioStreamPlayback**, and into **AudioStreamPlayer** (Have **AudioStream** return a list of supported modes).
- [x] Clean-up this code considerably.
- [x] Add and update the documentation.

## Optional ideas:
- Default most **AudioStreamPlayback**s created with `AudioStream.instantiate_playback()` to `LoopMode.DETECT`.
- Expose virtual `_set_loop_mode()` and  `_get_unsupported_loop_modes()` methods to GDScript.
- Allow overriding `loop_begin` and `loop_end` (if supported).
- Remove (now) unnecessary enum from **AudioStreamWAV** _(the only **AudioStream** that supports all modes)_.
- Move the **LoopMode** enum to **AudioStreamPlayer** itself(?).

Feedback is absolutely appreciated. 
I am particularly concerned about the naming. Perhaps it should be called `loop_mode_override, `or something along those lines in the **AudioStreamPlayers**. Or `playback_mode` (renaming the constants accordingly, too) because that's technically what it is, actually? I was getting confused a bit while working on it,