### PR TITLE
2D and 3D Skeleton modification docs, and small fixes.

### DIFF
--- a/doc/class.xsd
+++ b/doc/class.xsd
@@ -95,6 +95,8 @@
 									</xs:sequence>
 									<xs:attribute type="xs:string" name="name" use="optional" />
 									<xs:attribute type="xs:string" name="qualifiers" use="optional" />
+									<xs:attribute type="xs:boolean" name="is_deprecated" use="optional" />
+									<xs:attribute type="xs:boolean" name="is_experimental" use="optional" />
 								</xs:complexType>
 							</xs:element>
 						</xs:sequence>
@@ -114,6 +116,8 @@
 											<xs:attribute type="xs:string" name="overrides" use="optional" />
 											<xs:attribute type="xs:string" name="enum" use="optional" />
 											<xs:attribute type="xs:string" name="default" use="optional" />
+											<xs:attribute type="xs:boolean" name="is_deprecated" use="optional" />
+											<xs:attribute type="xs:boolean" name="is_experimental" use="optional" />
 										</xs:extension>
 									</xs:simpleContent>
 								</xs:complexType>
@@ -156,6 +160,8 @@
 											<xs:attribute type="xs:string" name="value" />
 											<xs:attribute type="xs:string" name="enum" use="optional" />
 											<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
+											<xs:attribute type="xs:boolean" name="is_deprecated" use="optional" />
+											<xs:attribute type="xs:boolean" name="is_experimental" use="optional" />
 										</xs:extension>
 									</xs:simpleContent>
 								</xs:complexType>
@@ -256,6 +262,8 @@
 			</xs:sequence>
 			<xs:attribute type="xs:string" name="name" />
 			<xs:attribute type="xs:string" name="inherits" />
+			<xs:attribute type="xs:boolean" name="is_deprecated" use="optional" />
+			<xs:attribute type="xs:boolean" name="is_experimental" use="optional" />
 			<xs:attribute type="xs:float" name="version" />
 		</xs:complexType>
 	</xs:element>

--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -16,10 +16,11 @@
 				Returns the [NodePath] to the external [Skeleton3D] node, if one has been set.
 			</description>
 		</method>
-		<method name="get_override_mode" qualifiers="const">
+		<method name="get_override_mode" qualifiers="const" is_deprecated="true">
 			<return type="int" />
 			<description>
-				Returns the override mode for the BoneAttachment3D node.
+				Deprecated. Local pose overrides will be removed.
+				Returns the override mode for the BoneAttachment3D node (0=global / 1=local).
 			</description>
 		</method>
 		<method name="get_override_pose" qualifiers="const">
@@ -48,11 +49,12 @@
 				Sets the [NodePath] to the external skeleton that the BoneAttachment3D node should use. The external [Skeleton3D] node is only used when [code]use_external_skeleton[/code] is set to [code]true[/code].
 			</description>
 		</method>
-		<method name="set_override_mode">
+		<method name="set_override_mode" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="override_mode" type="int" />
 			<description>
-				Sets the override mode for the BoneAttachment3D node. The override mode defines which of the bone poses the BoneAttachment3D node will override.
+				Deprecated. Local pose overrides will be removed.
+				Sets the override mode for the BoneAttachment3D node (0=global / 1=local). The override mode defines which of the bone poses the BoneAttachment3D node will override.
 			</description>
 		</method>
 		<method name="set_override_pose">

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -32,9 +32,10 @@
 				Removes the global pose override on all bones in the skeleton.
 			</description>
 		</method>
-		<method name="clear_bones_local_pose_override">
+		<method name="clear_bones_local_pose_override" is_deprecated="true">
 			<return type="void" />
 			<description>
+				Deprecated. Local pose overrides will be removed.
 				Removes the local pose override on all bones in the skeleton.
 			</description>
 		</method>
@@ -43,7 +44,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="execute_modifications">
+		<method name="execute_modifications" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
 			<param index="1" name="execution_mode" type="int" />
@@ -58,7 +59,7 @@
 				Returns the bone index that matches [param name] as its name.
 			</description>
 		</method>
-		<method name="force_update_all_bone_transforms">
+		<method name="force_update_all_bone_transforms" is_deprecated="true">
 			<return type="void" />
 			<description>
 				Force updates the bone transforms/poses for all bones in the skeleton.
@@ -166,7 +167,7 @@
 				Returns the rest transform for a bone [param bone_idx].
 			</description>
 		</method>
-		<method name="get_modification_stack">
+		<method name="get_modification_stack" is_deprecated="true">
 			<return type="SkeletonModificationStack3D" />
 			<description>
 				Returns the modification stack attached to this skeleton, if one exists.
@@ -178,7 +179,7 @@
 				Returns an array with all of the bones that are parentless. Another way to look at this is that it returns the indexes of all the bones that are not dependent or modified by other bones in the Skeleton.
 			</description>
 		</method>
-		<method name="global_pose_to_local_pose">
+		<method name="global_pose_to_local_pose" is_deprecated="true">
 			<return type="Transform3D" />
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="global_pose" type="Transform3D" />
@@ -187,15 +188,16 @@
 				This can be used to easily convert a global pose from [method get_bone_global_pose] to a global transform in [method set_bone_local_pose_override].
 			</description>
 		</method>
-		<method name="global_pose_to_world_transform">
+		<method name="global_pose_to_world_transform" is_deprecated="true">
 			<return type="Transform3D" />
 			<param index="0" name="global_pose" type="Transform3D" />
 			<description>
+				Deprecated. Use [Node3D] apis instead.
 				Takes the passed-in global pose and converts it to a world transform.
 				This can be used to easily convert a global pose from [method get_bone_global_pose] to a global transform usable with a node's transform, like [member Node3D.global_transform] for example.
 			</description>
 		</method>
-		<method name="global_pose_z_forward_to_bone_forward">
+		<method name="global_pose_z_forward_to_bone_forward" is_deprecated="true">
 			<return type="Basis" />
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="basis" type="Basis" />
@@ -211,7 +213,7 @@
 				Returns whether the bone pose for the bone at [param bone_idx] is enabled.
 			</description>
 		</method>
-		<method name="local_pose_to_global_pose">
+		<method name="local_pose_to_global_pose" is_deprecated="true">
 			<return type="Transform3D" />
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="local_pose" type="Transform3D" />
@@ -293,16 +295,17 @@
 			<description>
 				Sets the global pose transform, [param pose], for the bone at [param bone_idx].
 				[param amount] is the interpolation strength that will be used when applying the pose, and [param persistent] determines if the applied pose will remain.
-				[b]Note:[/b] The pose transform needs to be a global pose! Use [method world_transform_to_global_pose] to convert a world transform, like one you can get from a [Node3D], to a global pose.
+				[b]Note:[/b] The pose transform needs to be a global pose! To convert a world transform from a [Node3D] to a global bone pose, multiply the [method Transform3D.affine_inverse] of the node's [member Node3D.global_transform] by the desired world transform
 			</description>
 		</method>
-		<method name="set_bone_local_pose_override">
+		<method name="set_bone_local_pose_override" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="bone_idx" type="int" />
 			<param index="1" name="pose" type="Transform3D" />
 			<param index="2" name="amount" type="float" />
 			<param index="3" name="persistent" type="bool" default="false" />
 			<description>
+				Deprecated. Local pose overrides will be removed.
 				Sets the local pose transform, [param pose], for the bone at [param bone_idx].
 				[param amount] is the interpolation strength that will be used when applying the pose, and [param persistent] determines if the applied pose will remain.
 				[b]Note:[/b] The pose transform needs to be a local pose! Use [method global_pose_to_local_pose] to convert a global pose to a local pose.
@@ -353,7 +356,7 @@
 				Sets the rest transform for bone [param bone_idx].
 			</description>
 		</method>
-		<method name="set_modification_stack">
+		<method name="set_modification_stack" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="modification_stack" type="SkeletonModificationStack3D" />
 			<description>
@@ -367,10 +370,11 @@
 				Unparents the bone at [param bone_idx] and sets its rest position to that of its parent prior to being reset.
 			</description>
 		</method>
-		<method name="world_transform_to_global_pose">
+		<method name="world_transform_to_global_pose" is_deprecated="true">
 			<return type="Transform3D" />
 			<param index="0" name="world_transform" type="Transform3D" />
 			<description>
+				Deprecated. Use [Node3D] apis instead.
 				Takes the passed-in global transform and converts it to a global pose.
 				This can be used to easily convert a global transform from [member Node3D.global_transform] to a global pose usable with [method set_bone_global_pose_override], for example.
 			</description>

--- a/doc/classes/SkeletonIK3D.xml
+++ b/doc/classes/SkeletonIK3D.xml
@@ -1,8 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonIK3D" inherits="Node" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonIK3D" inherits="Node" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		SkeletonIK3D is used to place the end bone of a [Skeleton3D] bone chain at a certain point in 3D by rotating all bones in the chain accordingly.
 	</brief_description>
 	<description>
+		SkeletonIK3D is used to place the end bone of a [Skeleton3D] bone chain at a certain point in 3D by rotating all bones in the chain accordingly. A typical scenario for IK in games is to place a characters feet on the ground or a characters hands on a currently hold object. SkeletonIK uses FabrikInverseKinematic internally to solve the bone chain and applies the results to the [Skeleton3D] [code]bones_global_pose_override[/code] property for all affected bones in the chain. If fully applied this overwrites any bone transform from [Animation]s or bone custom poses set by users. The applied amount can be controlled with the [code]interpolation[/code] property.
+		[codeblock]
+		# Apply IK effect automatically on every new frame (not the current)
+		skeleton_ik_node.start()
+
+		# Apply IK effect only on the current frame
+		skeleton_ik_node.start(true)
+
+		# Stop IK effect and reset bones_global_pose_override on Skeleton
+		skeleton_ik_node.stop()
+
+		# Apply full IK effect
+		skeleton_ik_node.set_interpolation(1.0)
+
+		# Apply half IK effect
+		skeleton_ik_node.set_interpolation(0.5)
+
+		# Apply zero IK effect (a value at or below 0.01 also removes bones_global_pose_override on Skeleton)
+		skeleton_ik_node.set_interpolation(0.0)
+		[/codeblock]
 	</description>
 	<tutorials>
 		<link title="3D Inverse Kinematics Demo">https://godotengine.org/asset-library/asset/523</link>
@@ -11,45 +32,59 @@
 		<method name="get_parent_skeleton" qualifiers="const">
 			<return type="Skeleton3D" />
 			<description>
+				Returns the parent [Skeleton3D] Node that was present when SkeletonIK entered the [SceneTree]. Returns null if the parent node was not a [Skeleton3D] Node when SkeletonIK3D entered the [SceneTree].
 			</description>
 		</method>
 		<method name="is_running">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] if SkeletonIK is applying IK effects on continues frames to the [Skeleton3D] bones. Returns [code]false[/code] if SkeletonIK is stopped or [method start] was used with the [code]one_time[/code] parameter set to [code]true[/code].
 			</description>
 		</method>
 		<method name="start">
 			<return type="void" />
 			<param index="0" name="one_time" type="bool" default="false" />
 			<description>
+				Starts applying IK effects on each frame to the [Skeleton3D] bones but will only take effect starting on the next frame. If [code]one_time[/code] is [code]true[/code], this will take effect immediately but also reset on the next frame.
 			</description>
 		</method>
 		<method name="stop">
 			<return type="void" />
 			<description>
+				Stops applying IK effects on each frame to the [Skeleton3D] bones and also calls [method Skeleton3D.clear_bones_global_pose_override] to remove existing overrides on all bones.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="interpolation" type="float" setter="set_interpolation" getter="get_interpolation" default="1.0">
+			Interpolation value for how much the IK results are applied to the current skeleton bone chain. A value of [code]1.0[/code] will overwrite all skeleton bone transforms completely while a value of [code]0.0[/code] will visually disable the SkeletonIK. A value at or below [code]0.01[/code] also calls [method Skeleton3D.clear_bones_global_pose_override].
 		</member>
 		<member name="magnet" type="Vector3" setter="set_magnet_position" getter="get_magnet_position" default="Vector3(0, 0, 0)">
+			Secondary target position (first is [member target] property or [member target_node]) for the IK chain. Use magnet position (pole target) to control the bending of the IK chain. Only works if the bone chain has more than 2 bones. The middle chain bone position will be linearly interpolated with the magnet position.
 		</member>
 		<member name="max_iterations" type="int" setter="set_max_iterations" getter="get_max_iterations" default="10">
+			Number of iteration loops used by the IK solver to produce more accurate (and elegant) bone chain results.
 		</member>
 		<member name="min_distance" type="float" setter="set_min_distance" getter="get_min_distance" default="0.01">
+			The minimum distance between bone and goal target. If the distance is below this value, the IK solver stops further iterations.
 		</member>
 		<member name="override_tip_basis" type="bool" setter="set_override_tip_basis" getter="is_override_tip_basis" default="true">
+			If [code]true[/code] overwrites the rotation of the tip bone with the rotation of the [member target] (or [member target_node] if defined).
 		</member>
 		<member name="root_bone" type="StringName" setter="set_root_bone" getter="get_root_bone" default="&amp;&quot;&quot;">
+			The name of the current root bone, the first bone in the IK chain.
 		</member>
 		<member name="target" type="Transform3D" setter="set_target_transform" getter="get_target_transform" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
+			First target of the IK chain where the tip bone is placed and, if [member override_tip_basis] is [code]true[/code], how the tip bone is rotated. If a [member target_node] path is available the nodes transform is used instead and this property is ignored.
 		</member>
 		<member name="target_node" type="NodePath" setter="set_target_node" getter="get_target_node" default="NodePath(&quot;&quot;)">
+			Target node [NodePath] for the IK chain. If available, the node's current [Transform3D] is used instead of the [member target] property.
 		</member>
 		<member name="tip_bone" type="StringName" setter="set_tip_bone" getter="get_tip_bone" default="&amp;&quot;&quot;">
+			The name of the current tip bone, the last bone in the IK chain placed at the [member target] transform (or [member target_node] if defined).
 		</member>
 		<member name="use_magnet" type="bool" setter="set_use_magnet" getter="is_using_magnet" default="false">
+			If [code]true[/code], instructs the IK solver to consider the secondary magnet target (pole target) when calculating the bone chain. Use the magnet position (pole target) to control the bending of the IK chain.
 		</member>
 	</members>
 </class>

--- a/doc/classes/SkeletonModification2D.xml
+++ b/doc/classes/SkeletonModification2D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2D" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2D" inherits="Resource" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A resource that operates on [Bone2D] nodes in a [Skeleton2D].
 	</brief_description>

--- a/doc/classes/SkeletonModification2DCCDIK.xml
+++ b/doc/classes/SkeletonModification2DCCDIK.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2DCCDIK" inherits="SkeletonModification2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2DCCDIK" inherits="SkeletonModification2D" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that uses CCDIK to manipulate a series of bones to reach a target in 2D.
 	</brief_description>

--- a/doc/classes/SkeletonModification2DFABRIK.xml
+++ b/doc/classes/SkeletonModification2DFABRIK.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2DFABRIK" inherits="SkeletonModification2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2DFABRIK" inherits="SkeletonModification2D" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that uses FABRIK to manipulate a series of [Bone2D] nodes to reach a target.
 	</brief_description>

--- a/doc/classes/SkeletonModification2DJiggle.xml
+++ b/doc/classes/SkeletonModification2DJiggle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2DJiggle" inherits="SkeletonModification2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2DJiggle" inherits="SkeletonModification2D" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that jiggles [Bone2D] nodes as they move towards a target.
 	</brief_description>

--- a/doc/classes/SkeletonModification2DLookAt.xml
+++ b/doc/classes/SkeletonModification2DLookAt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2DLookAt" inherits="SkeletonModification2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2DLookAt" inherits="SkeletonModification2D" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that rotates a [Bone2D] node to look at a target.
 	</brief_description>

--- a/doc/classes/SkeletonModification2DPhysicalBones.xml
+++ b/doc/classes/SkeletonModification2DPhysicalBones.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2DPhysicalBones" inherits="SkeletonModification2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2DPhysicalBones" inherits="SkeletonModification2D" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that applies the transforms of [PhysicalBone2D] nodes to [Bone2D] nodes.
 	</brief_description>
 	<description>
 		This modification takes the transforms of [PhysicalBone2D] nodes and applies them to [Bone2D] nodes. This allows the [Bone2D] nodes to react to physics thanks to the linked [PhysicalBone2D] nodes.
+		Experimental. Physical bones may be changed in the future to perform the position update of [Bone2D] on their own.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SkeletonModification2DStackHolder.xml
+++ b/doc/classes/SkeletonModification2DStackHolder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2DStackHolder" inherits="SkeletonModification2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2DStackHolder" inherits="SkeletonModification2D" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that holds and executes a [SkeletonModificationStack2D].
 	</brief_description>

--- a/doc/classes/SkeletonModification2DTwoBoneIK.xml
+++ b/doc/classes/SkeletonModification2DTwoBoneIK.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification2DTwoBoneIK" inherits="SkeletonModification2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification2DTwoBoneIK" inherits="SkeletonModification2D" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that rotates two bones using the law of cosigns to reach the target.
 	</brief_description>

--- a/doc/classes/SkeletonModification3D.xml
+++ b/doc/classes/SkeletonModification3D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification3D" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification3D" inherits="Resource" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A resource that operates on bones in a [Skeleton3D].
 	</brief_description>

--- a/doc/classes/SkeletonModification3DCCDIK.xml
+++ b/doc/classes/SkeletonModification3DCCDIK.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification3DCCDIK" inherits="SkeletonModification3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification3DCCDIK" inherits="SkeletonModification3D" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that uses CCDIK to manipulate a series of bones to reach a target.
 	</brief_description>

--- a/doc/classes/SkeletonModification3DFABRIK.xml
+++ b/doc/classes/SkeletonModification3DFABRIK.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification3DFABRIK" inherits="SkeletonModification3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification3DFABRIK" inherits="SkeletonModification3D" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that uses FABRIK to manipulate a series of bones to reach a target.
 	</brief_description>

--- a/doc/classes/SkeletonModification3DJiggle.xml
+++ b/doc/classes/SkeletonModification3DJiggle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification3DJiggle" inherits="SkeletonModification3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification3DJiggle" inherits="SkeletonModification3D" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that jiggles bones as they move towards a target.
 	</brief_description>

--- a/doc/classes/SkeletonModification3DLookAt.xml
+++ b/doc/classes/SkeletonModification3DLookAt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification3DLookAt" inherits="SkeletonModification3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification3DLookAt" inherits="SkeletonModification3D" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that rotates a bone to look at a target.
 	</brief_description>

--- a/doc/classes/SkeletonModification3DStackHolder.xml
+++ b/doc/classes/SkeletonModification3DStackHolder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification3DStackHolder" inherits="SkeletonModification3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification3DStackHolder" inherits="SkeletonModification3D" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that holds and executes a [SkeletonModificationStack3D].
 	</brief_description>

--- a/doc/classes/SkeletonModification3DTwoBoneIK.xml
+++ b/doc/classes/SkeletonModification3DTwoBoneIK.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModification3DTwoBoneIK" inherits="SkeletonModification3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModification3DTwoBoneIK" inherits="SkeletonModification3D" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A modification that moves two bones to reach the target.
 	</brief_description>

--- a/doc/classes/SkeletonModificationStack2D.xml
+++ b/doc/classes/SkeletonModificationStack2D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModificationStack2D" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModificationStack2D" inherits="Resource" is_experimental="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A resource that holds a stack of [SkeletonModification2D]s.
 	</brief_description>

--- a/doc/classes/SkeletonModificationStack3D.xml
+++ b/doc/classes/SkeletonModificationStack3D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SkeletonModificationStack3D" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="SkeletonModificationStack3D" inherits="Resource" is_deprecated="true" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A resource that holds a stack of [SkeletonModification3D]s.
 	</brief_description>

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1162,13 +1162,11 @@ Error DocTools::_load(Ref<XMLParser> parser) {
 		}
 
 		if (parser->has_attribute("is_deprecated")) {
-			String result = parser->get_attribute_value("is_deprecated");
-			c.is_deprecated = (result == "true" || result == "True" || result == "TRUE" || result == "1");
+			c.is_deprecated = parser->get_attribute_value("is_deprecated").to_lower() == "true";
 		}
 
 		if (parser->has_attribute("is_experimental")) {
-			String result = parser->get_attribute_value("is_experimental");
-			c.is_experimental = (result == "true" || result == "True" || result == "TRUE" || result == "1");
+			c.is_experimental = parser->get_attribute_value("is_experimental").to_lower() == "true";
 		}
 
 		while (parser->read() == OK) {
@@ -1315,12 +1313,10 @@ Error DocTools::_load(Ref<XMLParser> parser) {
 									constant2.is_bitfield = parser->get_attribute_value("is_bitfield").to_lower() == "true";
 								}
 								if (parser->has_attribute("is_deprecated")) {
-									String result = parser->get_attribute_value("is_deprecated");
-									constant2.is_deprecated = (result == "true" || result == "True" || result == "TRUE" || result == "1");
+									constant2.is_deprecated = parser->get_attribute_value("is_deprecated").to_lower() == "true";
 								}
 								if (parser->has_attribute("is_experimental")) {
-									String result = parser->get_attribute_value("is_experimental");
-									constant2.is_experimental = (result == "true" || result == "True" || result == "TRUE" || result == "1");
+									constant2.is_experimental = parser->get_attribute_value("is_experimental").to_lower() == "true";
 								}
 								if (!parser->is_empty()) {
 									parser->read();
@@ -1376,10 +1372,10 @@ static void _write_method_doc(Ref<FileAccess> f, const String &p_name, Vector<Do
 
 			String additional_attributes;
 			if (m.is_deprecated) {
-				additional_attributes += " is_deprecated=\"True\"";
+				additional_attributes += " is_deprecated=\"true\"";
 			}
 			if (m.is_experimental) {
-				additional_attributes += " is_experimental=\"True\"";
+				additional_attributes += " is_experimental=\"true\"";
 			}
 
 			_write_string(f, 2, "<" + p_name + " name=\"" + m.name.xml_escape() + "\"" + qualifiers + additional_attributes + ">");
@@ -1446,10 +1442,10 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 		if (!c.inherits.is_empty()) {
 			header += " inherits=\"" + c.inherits + "\"";
 			if (c.is_deprecated) {
-				header += " is_deprecated=\"True\"";
+				header += " is_deprecated=\"true\"";
 			}
 			if (c.is_experimental) {
-				header += " is_experimental=\"True\"";
+				header += " is_experimental=\"true\"";
 			}
 		}
 		header += String(" version=\"") + VERSION_BRANCH + "\"";
@@ -1495,10 +1491,10 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 					additional_attributes += " default=\"" + c.properties[i].default_value.xml_escape(true) + "\"";
 				}
 				if (c.properties[i].is_deprecated) {
-					additional_attributes += " is_deprecated=\"True\"";
+					additional_attributes += " is_deprecated=\"true\"";
 				}
 				if (c.properties[i].is_experimental) {
-					additional_attributes += " is_experimental=\"True\"";
+					additional_attributes += " is_experimental=\"true\"";
 				}
 
 				const DocData::PropertyDoc &p = c.properties[i];
@@ -1523,10 +1519,10 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 
 				String additional_attributes;
 				if (c.constants[i].is_deprecated) {
-					additional_attributes += " is_deprecated=\"True\"";
+					additional_attributes += " is_deprecated=\"true\"";
 				}
 				if (c.constants[i].is_experimental) {
-					additional_attributes += " is_experimental=\"True\"";
+					additional_attributes += " is_experimental=\"true\"";
 				}
 
 				if (k.is_value_valid) {

--- a/scene/resources/skeleton_modification_stack_2d.cpp
+++ b/scene/resources/skeleton_modification_stack_2d.cpp
@@ -182,11 +182,11 @@ void SkeletonModificationStack2D::delete_modification(int p_mod_idx) {
 void SkeletonModificationStack2D::set_modification(int p_mod_idx, Ref<SkeletonModification2D> p_mod) {
 	ERR_FAIL_INDEX(p_mod_idx, modifications.size());
 
-	if (p_mod == nullptr) {
-		modifications.insert(p_mod_idx, nullptr);
+	if (p_mod.is_null()) {
+		modifications.write[p_mod_idx] = Ref<SkeletonModification2D>();
 	} else {
+		modifications.write[p_mod_idx] = p_mod;
 		p_mod->_setup_modification(this);
-		modifications.insert(p_mod_idx, p_mod);
 	}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Mark SkeletonModificationStack3D and related as deprecated.
Mark local bone override and axis functions deprecated in Skeleton3D api.
Mark SkeletonModificationStack2D and related APIs as experimental.
Mark SkeletonIK3D as deprecated.

Fix array property glitch in SkeletonModificationStack2D and some schema validation errors.
