### PR TITLE
Improve bookmark and breakpoint indicators

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1248,37 +1248,41 @@ bool CodeEdit::is_drawing_executing_lines_gutter() const {
 }
 
 void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 &p_region) {
-	bool shift_pressed = Input::get_singleton()->is_key_pressed(Key::SHIFT);
-
 	if (draw_breakpoints && breakpoint_icon.is_valid()) {
-		bool hovering = p_region.has_point(get_local_mouse_pos());
 		bool breakpointed = is_line_breakpointed(p_line);
+		bool hovering = p_region.has_point(get_local_mouse_pos());
+		bool shift_pressed = Input::get_singleton()->is_key_pressed(Key::SHIFT);
 
 		if (breakpointed || (hovering && !is_dragging_cursor() && !shift_pressed)) {
 			int padding = p_region.size.x / 6;
+
+			Color use_color = breakpoint_color;
+			if (hovering && !shift_pressed) {
+				use_color = breakpointed ? use_color.lightened(0.3) : use_color.darkened(0.5);
+			}
 			Rect2 icon_region = p_region;
 			icon_region.position += Point2(padding, padding);
 			icon_region.size -= Point2(padding, padding) * 2;
-
-			// Darken icon when hovering, shift not pressed & not yet breakpointed.
-			Color use_color = hovering && !breakpointed && !shift_pressed ? breakpoint_color.darkened(0.4) : breakpoint_color;
 			breakpoint_icon->draw_rect(get_canvas_item(), icon_region, false, use_color);
 		}
 	}
 
 	if (draw_bookmarks && bookmark_icon.is_valid()) {
-		bool hovering = p_region.has_point(get_local_mouse_pos());
 		bool bookmarked = is_line_bookmarked(p_line);
+		bool hovering = p_region.has_point(get_local_mouse_pos());
+		bool shift_pressed = Input::get_singleton()->is_key_pressed(Key::SHIFT);
 
 		if (bookmarked || (hovering && !is_dragging_cursor() && shift_pressed)) {
 			int horizontal_padding = p_region.size.x / 2;
 			int vertical_padding = p_region.size.y / 4;
+
+			Color use_color = bookmark_color;
+			if (hovering && shift_pressed) {
+				use_color = bookmarked ? use_color.lightened(0.3) : use_color.darkened(0.5);
+			}
 			Rect2 icon_region = p_region;
 			icon_region.position += Point2(horizontal_padding, 0);
 			icon_region.size -= Point2(horizontal_padding * 1.1, vertical_padding);
-
-			// Darken icon when hovering, shift pressed & not yet bookmarked.
-			Color use_color = hovering && !bookmarked && shift_pressed ? bookmark_color.darkened(0.4) : bookmark_color;
 			bookmark_icon->draw_rect(get_canvas_item(), icon_region, false, use_color);
 		}
 	}
@@ -1287,10 +1291,10 @@ void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 
 		int horizontal_padding = p_region.size.x / 10;
 		int vertical_padding = p_region.size.y / 4;
 
-		Rect2 executing_line_region = p_region;
-		executing_line_region.position += Point2(horizontal_padding, vertical_padding);
-		executing_line_region.size -= Point2(horizontal_padding, vertical_padding) * 2;
-		executing_line_icon->draw_rect(get_canvas_item(), executing_line_region, false, executing_line_color);
+		Rect2 icon_region = p_region;
+		icon_region.position += Point2(horizontal_padding, vertical_padding);
+		icon_region.size -= Point2(horizontal_padding, vertical_padding) * 2;
+		executing_line_icon->draw_rect(get_canvas_item(), icon_region, false, executing_line_color);
 	}
 }
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1692,7 +1692,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 						continue;
 					}
 
-					if (mpos.x > left_margin && mpos.x <= (left_margin + gutters[i].width) - 3) {
+					if (mpos.x >= left_margin && mpos.x <= left_margin + gutters[i].width) {
 						emit_signal(SNAME("gutter_clicked"), row, i);
 						return;
 					}
@@ -1933,7 +1933,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					continue;
 				}
 
-				if (mpos.x > left_margin && mpos.x <= (left_margin + gutters[i].width) - 3) {
+				if (mpos.x >= left_margin && mpos.x < left_margin + gutters[i].width) {
 					// We are in this gutter i's horizontal area.
 					current_hovered_gutter = Vector2i(i, hovered_row);
 					break;
@@ -2997,7 +2997,7 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 				continue;
 			}
 
-			if (p_pos.x > left_margin && p_pos.x <= (left_margin + gutters[i].width) - 3) {
+			if (p_pos.x >= left_margin && p_pos.x < left_margin + gutters[i].width) {
 				if (gutters[i].clickable || is_line_gutter_clickable(row, i)) {
 					return CURSOR_POINTING_HAND;
 				}


### PR DESCRIPTION
Addresses the first problem in https://github.com/godotengine/godot/issues/65517.

For vertical disparities a bigger change may be needed.

Also makes the breakpoint icon a little brighter when toggled on and hovered, just a small QoL change.