### PR TITLE
Add to_vectorX_array methods to PackedByteArray

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -806,6 +806,34 @@ struct _VariantCall {
 		return dest;
 	}
 
+	static PackedVector2Array func_PackedByteArray_decode_vector2_array(PackedByteArray *p_instance) {
+		uint64_t size = p_instance->size();
+		PackedVector2Array dest;
+		if (size == 0) {
+			return dest;
+		}
+		ERR_FAIL_COND_V_MSG(size % sizeof(Vector2), dest, "PackedByteArray size must be a multiple of 8 (size of Vector2) to convert to PackedFloat32Array.");
+		const uint8_t *r = p_instance->ptr();
+		dest.resize(size / sizeof(Vector2));
+		ERR_FAIL_COND_V(dest.size() == 0, dest); // Avoid UB in case resize failed.
+		memcpy(dest.ptrw(), r, dest.size() * sizeof(Vector2));
+		return dest;
+	}
+
+	static PackedVector3Array func_PackedByteArray_decode_vector3_array(PackedByteArray *p_instance) {
+		uint64_t size = p_instance->size();
+		PackedVector3Array dest;
+		if (size == 0) {
+			return dest;
+		}
+		ERR_FAIL_COND_V_MSG(size % sizeof(Vector3), dest, "PackedByteArray size must be a multiple of 12 (size of Vector3) to convert to PackedFloat32Array.");
+		const uint8_t *r = p_instance->ptr();
+		dest.resize(size / sizeof(Vector3));
+		ERR_FAIL_COND_V(dest.size() == 0, dest); // Avoid UB in case resize failed.
+		memcpy(dest.ptrw(), r, dest.size() * sizeof(Vector3));
+		return dest;
+	}
+
 	static void func_PackedByteArray_encode_u8(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 1);
@@ -2116,6 +2144,8 @@ static void _register_variant_builtin_methods() {
 	bind_function(PackedByteArray, to_int64_array, _VariantCall::func_PackedByteArray_decode_s64_array, sarray(), varray());
 	bind_function(PackedByteArray, to_float32_array, _VariantCall::func_PackedByteArray_decode_float_array, sarray(), varray());
 	bind_function(PackedByteArray, to_float64_array, _VariantCall::func_PackedByteArray_decode_double_array, sarray(), varray());
+	bind_function(PackedByteArray, to_vector2_array, _VariantCall::func_PackedByteArray_decode_vector2_array, sarray(), varray());
+	bind_function(PackedByteArray, to_vector3_array, _VariantCall::func_PackedByteArray_decode_vector3_array, sarray(), varray());
 
 	bind_functionnc(PackedByteArray, encode_u8, _VariantCall::func_PackedByteArray_encode_u8, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_s8, _VariantCall::func_PackedByteArray_encode_s8, sarray("byte_offset", "value"), varray());

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -812,7 +812,7 @@ struct _VariantCall {
 		if (size == 0) {
 			return dest;
 		}
-		ERR_FAIL_COND_V_MSG(size % sizeof(Vector2), dest, "PackedByteArray size must be a multiple of 8 (size of Vector2) to convert to PackedFloat32Array.");
+		ERR_FAIL_COND_V_MSG(size % sizeof(Vector2), dest, "PackedByteArray size must be a multiple of Vector2 size to convert to PackedVector2Array.");
 		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(Vector2));
 		ERR_FAIL_COND_V(dest.size() == 0, dest); // Avoid UB in case resize failed.
@@ -831,6 +831,20 @@ struct _VariantCall {
 		dest.resize(size / sizeof(Vector3));
 		ERR_FAIL_COND_V(dest.size() == 0, dest); // Avoid UB in case resize failed.
 		memcpy(dest.ptrw(), r, dest.size() * sizeof(Vector3));
+		return dest;
+	}
+
+	static PackedColorArray func_PackedByteArray_decode_color_array(PackedByteArray *p_instance) {
+		uint64_t size = p_instance->size();
+		PackedColorArray dest;
+		if (size == 0) {
+			return dest;
+		}
+		ERR_FAIL_COND_V_MSG(size % sizeof(Color), dest, "PackedByteArray size must be a multiple of 32 (size of Color) size to convert to PackedColorArray.");
+		const uint8_t *r = p_instance->ptr();
+		dest.resize(size / sizeof(Color));
+		ERR_FAIL_COND_V(dest.size() == 0, dest); // Avoid UB in case resize failed.
+		memcpy(dest.ptrw(), r, dest.size() * sizeof(Color));
 		return dest;
 	}
 
@@ -2146,6 +2160,7 @@ static void _register_variant_builtin_methods() {
 	bind_function(PackedByteArray, to_float64_array, _VariantCall::func_PackedByteArray_decode_double_array, sarray(), varray());
 	bind_function(PackedByteArray, to_vector2_array, _VariantCall::func_PackedByteArray_decode_vector2_array, sarray(), varray());
 	bind_function(PackedByteArray, to_vector3_array, _VariantCall::func_PackedByteArray_decode_vector3_array, sarray(), varray());
+	bind_function(PackedByteArray, to_color_array, _VariantCall::func_PackedByteArray_decode_color_array, sarray(), varray());
 
 	bind_functionnc(PackedByteArray, encode_u8, _VariantCall::func_PackedByteArray_encode_u8, sarray("byte_offset", "value"), varray());
 	bind_functionnc(PackedByteArray, encode_s8, _VariantCall::func_PackedByteArray_encode_s8, sarray("byte_offset", "value"), varray());

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -470,6 +470,22 @@
 				If the original data can't be converted to signed 64-bit integers, the resulting data is undefined.
 			</description>
 		</method>
+		<method name="to_vector2_array" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>
+				Returns a copy of the data converted to a [PackedVector2Array], where each block of 8 bytes has been converted to a [Vector2].
+				The size of the input array must be a multiple of 8 (size of Vector2). The size of the new array will be [code]byte_array.size() / 8[/code].
+				If the original data can't be converted to Vector2, the resulting data is undefined.
+			</description>
+		</method>
+		<method name="to_vector3_array" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<description>
+				Returns a copy of the data converted to a [PackedVector3Array], where each block of 12 bytes has been converted to a [Vector3].
+				The size of the input array must be a multiple of 12 (size of Vector3). The size of the new array will be [code]byte_array.size() / 12[/code].
+				If the original data can't be converted to Vector3, the resulting data is undefined.
+			</description>
+		</method>
 	</methods>
 	<operators>
 		<operator name="operator !=">

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -486,6 +486,14 @@
 				If the original data can't be converted to Vector3, the resulting data is undefined.
 			</description>
 		</method>
+		<method name="to_color_array" qualifiers="const">
+			<return type="PackedColorArray" />
+			<description>
+				Returns a copy of the data converted to a [PackedVector3Array], where each block of 12 bytes has been converted to a [Vector3].
+				The size of the input array must be a multiple of 12 (size of Vector3). The size of the new array will be [code]byte_array.size() / 12[/code].
+				If the original data can't be converted to Vector3, the resulting data is undefined.
+			</description>
+		</method>
 	</methods>
 	<operators>
 		<operator name="operator !=">

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -249,6 +249,103 @@ TEST_CASE("[Vector] To byte array") {
 	CHECK(byte_array[15] == 59);
 }
 
+TEST_CASE("[Vector] PackedByteArray to PackedInt32Array") {
+	PackedByteArray byte_array = { 
+		  0,   0,   0,   0, // 0
+		255, 255, 255, 255, // -1
+		216,   7,   0,   0, // 2008
+        255, 201, 154,  59, // 999999999
+		255, 255, 255, 127, // INT32_MAX
+		  0,   0,   0, 128, // INT32_MIN
+	};
+
+	PackedInt32Array int_array = Variant(byte_array).call("to_int32_array");
+
+	CHECK(int_array[0] == 0);
+	CHECK(int_array[1] == -1);
+	CHECK(int_array[2] == 2008);
+	CHECK(int_array[3] == 999999999);
+	CHECK(int_array[4] == INT32_MAX);
+	CHECK(int_array[5] == INT32_MIN);
+}
+
+TEST_CASE("[Vector] PackedByteArray to PackedVector2Array") {
+	
+	PackedByteArray vec2_byte_array = {
+		#ifdef REAL_T_IS_DOUBLE
+		0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, // 0, 0
+		0,   0,   0,   0,   0,   0, 240,  63,   0,   0,   0,   0,   0,   0, 240, 191, // 1, -1
+		0,   0,   0,   0,   0,  16,  96,  64, 205, 204, 204, 204, 204,  12,  89, 192, // 128.5, -100.200
+		56, 223,   6,   0,   0,   0, 240,  63, 144,  65, 242, 255, 255, 255, 239,  63, // 1.0 +/- CMP_EPSILON2
+		0,   0,   0,   0,   0,   0, 240, 127,   0,   0,   0,   0,   0,   0, 240, 255, // +/- infinity
+		0,   0,   0,   0,   0,   0, 248, 127,  32,  16,   0,   0,   0,   0, 248, 127, // various NaNs
+		#else
+		0,   0,   0,   0,   0,   0,   0,   0, // 0, 0
+		0,   0, 128,  63,   0,   0, 128, 191, // 1, -1
+		0, 128,   0,  67, 102, 102, 200, 194, // 128.5, -100.200
+		0,   0, 128,  63,   0,   0, 128,  63, // 1.0 +/- CMP_EPSILON2
+		0,   0, 128, 127,   0,   0, 128, 255, // +/- infinity
+		0,   0, 192, 127,  32,  16, 192, 127, // various NaNs
+		#endif // REAL_T_IS_DOUBLE
+	};
+
+	PackedVector2Array vector2_array = Variant(vec2_byte_array).call("to_vector2_array");
+	CHECK(vector2_array[0] == Vector2 {0, 0});
+	CHECK(vector2_array[1] == Vector2 {1, -1});
+	CHECK(vector2_array[2] == Vector2 {128.5, -100.200});
+	CHECK(vector2_array[3] == Vector2 {1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
+	CHECK(vector2_array[4] == Vector2 {INFINITY, -INFINITY});
+	CHECK(isnan(vector2_array[5].x));
+	CHECK(isnan(vector2_array[5].y));
+}
+
+
+TEST_CASE("[Vector] PackedByteArray to PackedVector3Array") {
+	#ifdef REAL_T_IS_DOUBLE
+	PackedByteArray vec3_byte_array = {
+		  0,   0,   0,   0,   0,   0, 240,  63,   0,   0,   0,   0,   0,   0, 240, 191,   0,   0,   0,   0,   0,   0,   0,   0, // 1, -1, 0
+		  0,   0,   0,   0,   0,  16,  96,  64, 205, 204, 204, 204, 204,  12,  89, 192,  11, 181, 166, 249, 129, 179, 245,  64, // 128.5, -100.200, 88888.12345
+		188, 189, 215, 217, 223, 124, 219,  61,  56, 223,   6,   0,   0,   0, 240,  63, 144,  65, 242, 255, 255, 255, 239,  63, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+		  0,   0,   0,   0,   0,   0, 240, 127,   0,   0,   0,   0,   0,   0, 240, 255,   0,   0,   0,   0,   0,   0, 248, 127, // +/- infinity, NaN
+	};
+	#else
+	PackedByteArray vec3_byte_array = {
+		  0,   0, 128,  63,   0,   0, 128, 191,   0,   0,   0,   0, // 1, -1, 0
+		  0, 128,   0,  67, 102, 102, 200, 194,  16, 156, 173,  71, // 128.5, -100.200, 88888.12345
+		255, 230, 219,  46,   0,   0, 128,  63,   0,   0, 128,  63, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+		  0,   0, 128, 127,   0,   0, 128, 255,   0,   0, 192, 127, // +/- infinity, NaN
+	};
+	#endif // REAL_T_IS_DOUBLE
+
+	PackedVector3Array vector3_array = Variant(vec3_byte_array).call("to_vector3_array");
+	CHECK(vector3_array[0] == Vector3 {1, -1, 0});
+	CHECK(vector3_array[1] == Vector3 {128.5, -100.200, 88888.12345});
+	CHECK(vector3_array[2] == Vector3 {CMP_EPSILON2, 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
+	CHECK(vector3_array[3].x == INFINITY);
+	CHECK(vector3_array[3].y == -INFINITY);
+	CHECK(isnan(vector3_array[3].z));
+}
+
+
+
+TEST_CASE("[Vector] PackedByteArray to PackedColorArray") {
+	PackedByteArray color_byte_array = {
+		  0,   0, 128,  63,   0,   0, 128, 191,   0,   0,   0,   0,   0,   0,   0, 128, // 1, -1, 0, -0
+		  0, 128,   0,  67, 102, 102, 200, 194,  16, 156, 173,  71,   5, 197, 119, 191, // 128.5, -100.200, 88888.12345, -0.96785
+		255, 230, 219,  46, 255, 230, 219, 174,   0,   0, 128,  63,   0,   0, 128,  63, // +/- CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+		  0,   0, 128, 127,   0,   0, 128, 255,   0,   0, 192, 127,  32,  16, 192, 127, // +/- infinity, various NaNs
+	};
+
+	PackedColorArray color_array = Variant(color_byte_array).call("to_color_array");
+	CHECK(color_array[0] == Color {1.f, -1.f, 0.f, -0.f});
+	CHECK(color_array[1] == Color {128.5, -100.200, 88888.12345, -0.96785});
+	CHECK(color_array[2] == Color {CMP_EPSILON2, -CMP_EPSILON2, 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
+	CHECK(color_array[3].r == INFINITY);
+	CHECK(color_array[3].g == -INFINITY);
+	CHECK(isnan(color_array[3].b));
+	CHECK(isnan(color_array[3].a));
+}
+
 TEST_CASE("[Vector] Slice") {
 	Vector<int> vector;
 	vector.push_back(0);

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -270,80 +270,74 @@ TEST_CASE("[Vector] PackedByteArray to PackedInt32Array") {
 }
 
 TEST_CASE("[Vector] PackedByteArray to PackedVector2Array") {
-	
-	PackedByteArray vec2_byte_array = {
-		#ifdef REAL_T_IS_DOUBLE
-		0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, // 0, 0
-		0,   0,   0,   0,   0,   0, 240,  63,   0,   0,   0,   0,   0,   0, 240, 191, // 1, -1
-		0,   0,   0,   0,   0,  16,  96,  64, 205, 204, 204, 204, 204,  12,  89, 192, // 128.5, -100.200
-		56, 223,   6,   0,   0,   0, 240,  63, 144,  65, 242, 255, 255, 255, 239,  63, // 1.0 +/- CMP_EPSILON2
-		0,   0,   0,   0,   0,   0, 240, 127,   0,   0,   0,   0,   0,   0, 240, 255, // +/- infinity
-		0,   0,   0,   0,   0,   0, 248, 127,  32,  16,   0,   0,   0,   0, 248, 127, // various NaNs
-		#else
-		0,   0,   0,   0,   0,   0,   0,   0, // 0, 0
-		0,   0, 128,  63,   0,   0, 128, 191, // 1, -1
-		0, 128,   0,  67, 102, 102, 200, 194, // 128.5, -100.200
-		0,   0, 128,  63,   0,   0, 128,  63, // 1.0 +/- CMP_EPSILON2
-		0,   0, 128, 127,   0,   0, 128, 255, // +/- infinity
-		0,   0, 192, 127,  32,  16, 192, 127, // various NaNs
-		#endif // REAL_T_IS_DOUBLE
-	};
+    PackedByteArray vector2_byte_array = {
+#ifdef REAL_T_IS_DOUBLE
+          0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, // 0, 0
+          0,   0,   0,   0,   0,   0, 240,  63,   0,   0,   0,   0,   0,   0, 240, 191, // 1, -1
+          0,   0,   0,   0,   0,  16,  96,  64,   0,   0,   0,   0,   0,   8,  89, 192, // 128.5, -100.125
+         56, 223,   6,   0,   0,   0, 240,  63, 144,  65, 242, 255, 255, 255, 239,  63, // 1.0 +/- CMP_EPSILON2
+          0,   0,   0,   0,   0,   0, 240, 127,   0,   0,   0,   0,   0,   0, 240, 255, // +/- infinity
+          0,   0,   0,   0,   0,   0, 248, 127,  32,  16,   0,   0,   0,   0, 248, 127, // various NaNs
+#else
+          0,   0,   0,   0,   0,   0,   0,   0, // 0, 0
+          0,   0, 128,  63,   0,   0, 128, 191, // 1, -1
+          0, 128,   0,  67,   0,  64, 200, 194, // 128.5, -100.125
+          0,   0, 128,  63,   0,   0, 128,  63, // 1.0 +/- CMP_EPSILON2
+          0,   0, 128, 127,   0,   0, 128, 255, // +/- infinity
+          0,   0, 192, 127,  32,  16, 192, 127, // various NaNs
+#endif // REAL_T_IS_DOUBLE
+    };
 
-	PackedVector2Array vector2_array = Variant(vec2_byte_array).call("to_vector2_array");
-	CHECK(vector2_array[0] == Vector2 {0, 0});
-	CHECK(vector2_array[1] == Vector2 {1, -1});
-	CHECK(vector2_array[2] == Vector2 {128.5, -100.200});
-	CHECK(vector2_array[3] == Vector2 {1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
-	CHECK(vector2_array[4] == Vector2 {INFINITY, -INFINITY});
-	CHECK(isnan(vector2_array[5].x));
-	CHECK(isnan(vector2_array[5].y));
+    PackedVector2Array vector2_array = Variant(vector2_byte_array).call("to_vector2_array");
+    CHECK(vector2_array[0] == Vector2 {0, 0});
+    CHECK(vector2_array[1] == Vector2 {1, -1});
+    CHECK(vector2_array[2] == Vector2 {128.5, -100.125});
+    CHECK(vector2_array[3] == Vector2 {1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2});
+    CHECK(vector2_array[4] == Vector2 {INFINITY, -(INFINITY)});
+    CHECK(isnan(vector2_array[5].x));
+    CHECK(isnan(vector2_array[5].y));
 }
-
 
 TEST_CASE("[Vector] PackedByteArray to PackedVector3Array") {
-	#ifdef REAL_T_IS_DOUBLE
-	PackedByteArray vec3_byte_array = {
-		  0,   0,   0,   0,   0,   0, 240,  63,   0,   0,   0,   0,   0,   0, 240, 191,   0,   0,   0,   0,   0,   0,   0,   0, // 1, -1, 0
-		  0,   0,   0,   0,   0,  16,  96,  64, 205, 204, 204, 204, 204,  12,  89, 192,  11, 181, 166, 249, 129, 179, 245,  64, // 128.5, -100.200, 88888.12345
-		188, 189, 215, 217, 223, 124, 219,  61,  56, 223,   6,   0,   0,   0, 240,  63, 144,  65, 242, 255, 255, 255, 239,  63, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
-		  0,   0,   0,   0,   0,   0, 240, 127,   0,   0,   0,   0,   0,   0, 240, 255,   0,   0,   0,   0,   0,   0, 248, 127, // +/- infinity, NaN
-	};
-	#else
-	PackedByteArray vec3_byte_array = {
-		  0,   0, 128,  63,   0,   0, 128, 191,   0,   0,   0,   0, // 1, -1, 0
-		  0, 128,   0,  67, 102, 102, 200, 194,  16, 156, 173,  71, // 128.5, -100.200, 88888.12345
-		255, 230, 219,  46,   0,   0, 128,  63,   0,   0, 128,  63, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
-		  0,   0, 128, 127,   0,   0, 128, 255,   0,   0, 192, 127, // +/- infinity, NaN
-	};
-	#endif // REAL_T_IS_DOUBLE
+    PackedByteArray vector3_byte_array = {
+#ifdef REAL_T_IS_DOUBLE
+          0,   0,   0,   0,   0,   0, 240,  63,   0,   0,   0,   0,   0,   0, 240, 191,   0,   0,   0,   0,   0,   0,   0,   0, // 1, -1, 0
+          0,   0,   0,   0,   0,  16,  96,  64,   0,   0,   0,   0,   0,   8,  89, 192,  11, 181, 166, 249, 129, 179, 245,  64, // 128.5, -100.125, 88888.12345
+        188, 189, 215, 217, 223, 124, 219,  61,  56, 223,   6,   0,   0,   0, 240,  63, 144,  65, 242, 255, 255, 255, 239,  63, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+          0,   0,   0,   0,   0,   0, 240, 127,   0,   0,   0,   0,   0,   0, 240, 255,   0,   0,   0,   0,   0,   0, 248, 127, // +/- infinity, NaN
+#else
+          0,   0, 128,  63,   0,   0, 128, 191,   0,   0,   0,   0, // 1, -1, 0
+          0, 128,   0,  67,   0,  64, 200, 194,  16, 156, 173,  71, // 128.5, -100.125, 88888.12345
+        255, 230, 219,  46,   0,   0, 128,  63,   0,   0, 128,  63, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+          0,   0, 128, 127,   0,   0, 128, 255,   0,   0, 192, 127, // +/- infinity, NaN
+#endif // REAL_T_IS_DOUBLE
+    };
 
-	PackedVector3Array vector3_array = Variant(vec3_byte_array).call("to_vector3_array");
-	CHECK(vector3_array[0] == Vector3 {1, -1, 0});
-	CHECK(vector3_array[1] == Vector3 {128.5, -100.200, 88888.12345});
-	CHECK(vector3_array[2] == Vector3 {CMP_EPSILON2, 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
-	CHECK(vector3_array[3].x == INFINITY);
-	CHECK(vector3_array[3].y == -INFINITY);
-	CHECK(isnan(vector3_array[3].z));
+    PackedVector3Array vector3_array = Variant(vector3_byte_array).call("to_vector3_array");
+    CHECK(vector3_array[0] == Vector3 {1, -1, 0});
+    CHECK(vector3_array[1] == Vector3 {128.5, -100.125, 88888.12345});
+    CHECK(vector3_array[2] == Vector3 {CMP_EPSILON2, 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2});
+    CHECK(vector3_array[3].x == INFINITY);
+    CHECK(vector3_array[3].y == -(INFINITY));
+    CHECK(isnan(vector3_array[3].z));
 }
 
-
-
 TEST_CASE("[Vector] PackedByteArray to PackedColorArray") {
-	PackedByteArray color_byte_array = {
-		  0,   0, 128,  63,   0,   0, 128, 191,   0,   0,   0,   0,   0,   0,   0, 128, // 1, -1, 0, -0
-		  0, 128,   0,  67, 102, 102, 200, 194,  16, 156, 173,  71,   5, 197, 119, 191, // 128.5, -100.200, 88888.12345, -0.96785
-		255, 230, 219,  46, 255, 230, 219, 174,   0,   0, 128,  63,   0,   0, 128,  63, // +/- CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
-		  0,   0, 128, 127,   0,   0, 128, 255,   0,   0, 192, 127,  32,  16, 192, 127, // +/- infinity, various NaNs
-	};
+    PackedByteArray color_byte_array = {
+          0,   0, 128,  63,   0,   0, 128, 191,   0,   0,   0,   0,   0,   0,   0,   0, // 1, -1, 0, -0
+          0, 128,   0,  67,   0,  64, 200, 194,  16, 156, 173,  71,   5, 197, 119, 191, // 128.5, -100.125, 88888.12345, -0.96785
+        255, 230, 219,  46, 255, 230, 219, 174,   0,   0, 128,  63,   0,   0, 128,  63, // +/- CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+          0,   0, 128, 127,   0,   0, 128, 255,   0,   0, 192, 127,  32,  16, 192, 127, // +/- infinity, various NaNs
+    };
 
-	PackedColorArray color_array = Variant(color_byte_array).call("to_color_array");
-	CHECK(color_array[0] == Color {1.f, -1.f, 0.f, -0.f});
-	CHECK(color_array[1] == Color {128.5, -100.200, 88888.12345, -0.96785});
-	CHECK(color_array[2] == Color {CMP_EPSILON2, -CMP_EPSILON2, 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
-	CHECK(color_array[3].r == INFINITY);
-	CHECK(color_array[3].g == -INFINITY);
-	CHECK(isnan(color_array[3].b));
-	CHECK(isnan(color_array[3].a));
+    PackedColorArray color_array = Variant(color_byte_array).call("to_color_array");
+    CHECK(color_array[0] == Color {1, -1, 0, 0});
+    CHECK(color_array[1] == Color {128.5, -100.125, 88888.12345, -0.96785});
+    CHECK(color_array[2] == Color {CMP_EPSILON2, -(CMP_EPSILON2), 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2});
+    CHECK(color_array[3].r == INFINITY);
+    CHECK(color_array[3].g == -(INFINITY));
+    CHECK(isnan(color_array[3].b));
+    CHECK(isnan(color_array[3].a));
 }
 
 TEST_CASE("[Vector] Slice") {

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -250,13 +250,13 @@ TEST_CASE("[Vector] To byte array") {
 }
 
 TEST_CASE("[Vector] PackedByteArray to PackedInt32Array") {
-	PackedByteArray byte_array = { 
-		  0,   0,   0,   0, // 0
-		255, 255, 255, 255, // -1
-		216,   7,   0,   0, // 2008
-        255, 201, 154,  59, // 999999999
-		255, 255, 255, 127, // INT32_MAX
-		  0,   0,   0, 128, // INT32_MIN
+	PackedByteArray byte_array = {
+		0x00, 0x00, 0x00, 0x00, // 0
+		0xff, 0xff, 0xff, 0xff, // -1
+		0xd8, 0x07, 0x00, 0x00, // 2008
+		0xff, 0xc9, 0x9a, 0x3b, // 999999999
+		0xff, 0xff, 0xff, 0x7f, // INT32_MAX
+		0x00, 0x00, 0x00, 0x80, // INT32_MIN
 	};
 
 	PackedInt32Array int_array = Variant(byte_array).call("to_int32_array");
@@ -270,74 +270,74 @@ TEST_CASE("[Vector] PackedByteArray to PackedInt32Array") {
 }
 
 TEST_CASE("[Vector] PackedByteArray to PackedVector2Array") {
-    PackedByteArray vector2_byte_array = {
+	PackedByteArray vector2_byte_array = {
 #ifdef REAL_T_IS_DOUBLE
-          0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0, // 0, 0
-          0,   0,   0,   0,   0,   0, 240,  63,   0,   0,   0,   0,   0,   0, 240, 191, // 1, -1
-          0,   0,   0,   0,   0,  16,  96,  64,   0,   0,   0,   0,   0,   8,  89, 192, // 128.5, -100.125
-         56, 223,   6,   0,   0,   0, 240,  63, 144,  65, 242, 255, 255, 255, 239,  63, // 1.0 +/- CMP_EPSILON2
-          0,   0,   0,   0,   0,   0, 240, 127,   0,   0,   0,   0,   0,   0, 240, 255, // +/- infinity
-          0,   0,   0,   0,   0,   0, 248, 127,  32,  16,   0,   0,   0,   0, 248, 127, // various NaNs
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 0, 0
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0xbf, // 1, -1
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x60, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x59, 0xc0, // 128.5, -100.125
+		0x38, 0xdf, 0x06, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x90, 0x41, 0xf2, 0xff, 0xff, 0xff, 0xef, 0x3f, // 1.0 +/- CMP_EPSILON2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x7f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0xff, // +/- infinity
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x7f, 0x20, 0x10, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x7f, // various NaNs
 #else
-          0,   0,   0,   0,   0,   0,   0,   0, // 0, 0
-          0,   0, 128,  63,   0,   0, 128, 191, // 1, -1
-          0, 128,   0,  67,   0,  64, 200, 194, // 128.5, -100.125
-          0,   0, 128,  63,   0,   0, 128,  63, // 1.0 +/- CMP_EPSILON2
-          0,   0, 128, 127,   0,   0, 128, 255, // +/- infinity
-          0,   0, 192, 127,  32,  16, 192, 127, // various NaNs
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 0, 0
+		0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0xbf, // 1, -1
+		0x00, 0x80, 0x00, 0x43, 0x00, 0x40, 0xc8, 0xc2, // 128.5, -100.125
+		0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f, // 1.0 +/- CMP_EPSILON2
+		0x00, 0x00, 0x80, 0x7f, 0x00, 0x00, 0x80, 0xff, // +/- infinity
+		0x00, 0x00, 0xc0, 0x7f, 0x20, 0x10, 0xc0, 0x7f, // various NaNs
 #endif // REAL_T_IS_DOUBLE
-    };
+	};
 
-    PackedVector2Array vector2_array = Variant(vector2_byte_array).call("to_vector2_array");
-    CHECK(vector2_array[0] == Vector2 {0, 0});
-    CHECK(vector2_array[1] == Vector2 {1, -1});
-    CHECK(vector2_array[2] == Vector2 {128.5, -100.125});
-    CHECK(vector2_array[3] == Vector2 {1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2});
-    CHECK(vector2_array[4] == Vector2 {INFINITY, -(INFINITY)});
-    CHECK(isnan(vector2_array[5].x));
-    CHECK(isnan(vector2_array[5].y));
+	PackedVector2Array vector2_array = Variant(vector2_byte_array).call("to_vector2_array");
+	CHECK(vector2_array[0] == Vector2{ 0, 0 });
+	CHECK(vector2_array[1] == Vector2{ 1, -1 });
+	CHECK(vector2_array[2] == Vector2{ 128.5, -100.125 });
+	CHECK(vector2_array[3] == Vector2{ 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
+	CHECK(vector2_array[4] == Vector2{ INFINITY, -(INFINITY) });
+	CHECK(isnan(vector2_array[5].x));
+	CHECK(isnan(vector2_array[5].y));
 }
 
 TEST_CASE("[Vector] PackedByteArray to PackedVector3Array") {
-    PackedByteArray vector3_byte_array = {
+	PackedByteArray vector3_byte_array = {
 #ifdef REAL_T_IS_DOUBLE
-          0,   0,   0,   0,   0,   0, 240,  63,   0,   0,   0,   0,   0,   0, 240, 191,   0,   0,   0,   0,   0,   0,   0,   0, // 1, -1, 0
-          0,   0,   0,   0,   0,  16,  96,  64,   0,   0,   0,   0,   0,   8,  89, 192,  11, 181, 166, 249, 129, 179, 245,  64, // 128.5, -100.125, 88888.12345
-        188, 189, 215, 217, 223, 124, 219,  61,  56, 223,   6,   0,   0,   0, 240,  63, 144,  65, 242, 255, 255, 255, 239,  63, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
-          0,   0,   0,   0,   0,   0, 240, 127,   0,   0,   0,   0,   0,   0, 240, 255,   0,   0,   0,   0,   0,   0, 248, 127, // +/- infinity, NaN
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0xbf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 1, -1, 0
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x60, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x59, 0xc0, 0x0b, 0xb5, 0xa6, 0xf9, 0x81, 0xb3, 0xf5, 0x40, // 128.5, -100.125, 88888.12345
+		0xbc, 0xbd, 0xd7, 0xd9, 0xdf, 0x7c, 0xdb, 0x3d, 0x38, 0xdf, 0x06, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x90, 0x41, 0xf2, 0xff, 0xff, 0xff, 0xef, 0x3f, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x7f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x7f, // +/- infinity, NaN
 #else
-          0,   0, 128,  63,   0,   0, 128, 191,   0,   0,   0,   0, // 1, -1, 0
-          0, 128,   0,  67,   0,  64, 200, 194,  16, 156, 173,  71, // 128.5, -100.125, 88888.12345
-        255, 230, 219,  46,   0,   0, 128,  63,   0,   0, 128,  63, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
-          0,   0, 128, 127,   0,   0, 128, 255,   0,   0, 192, 127, // +/- infinity, NaN
+		0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0xbf, 0x00, 0x00, 0x00, 0x00, // 1, -1, 0
+		0x00, 0x80, 0x00, 0x43, 0x00, 0x40, 0xc8, 0xc2, 0x10, 0x9c, 0xad, 0x47, // 128.5, -100.125, 88888.12345
+		0xff, 0xe6, 0xdb, 0x2e, 0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f, // CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+		0x00, 0x00, 0x80, 0x7f, 0x00, 0x00, 0x80, 0xff, 0x00, 0x00, 0xc0, 0x7f, // +/- infinity, NaN
 #endif // REAL_T_IS_DOUBLE
-    };
+	};
 
-    PackedVector3Array vector3_array = Variant(vector3_byte_array).call("to_vector3_array");
-    CHECK(vector3_array[0] == Vector3 {1, -1, 0});
-    CHECK(vector3_array[1] == Vector3 {128.5, -100.125, 88888.12345});
-    CHECK(vector3_array[2] == Vector3 {CMP_EPSILON2, 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2});
-    CHECK(vector3_array[3].x == INFINITY);
-    CHECK(vector3_array[3].y == -(INFINITY));
-    CHECK(isnan(vector3_array[3].z));
+	PackedVector3Array vector3_array = Variant(vector3_byte_array).call("to_vector3_array");
+	CHECK(vector3_array[0] == Vector3{ 1, -1, 0 });
+	CHECK(vector3_array[1] == Vector3{ 128.5, -100.125, 88888.12345 });
+	CHECK(vector3_array[2] == Vector3{ CMP_EPSILON2, 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
+	CHECK(vector3_array[3].x == INFINITY);
+	CHECK(vector3_array[3].y == -(INFINITY));
+	CHECK(isnan(vector3_array[3].z));
 }
 
 TEST_CASE("[Vector] PackedByteArray to PackedColorArray") {
-    PackedByteArray color_byte_array = {
-          0,   0, 128,  63,   0,   0, 128, 191,   0,   0,   0,   0,   0,   0,   0,   0, // 1, -1, 0, -0
-          0, 128,   0,  67,   0,  64, 200, 194,  16, 156, 173,  71,   5, 197, 119, 191, // 128.5, -100.125, 88888.12345, -0.96785
-        255, 230, 219,  46, 255, 230, 219, 174,   0,   0, 128,  63,   0,   0, 128,  63, // +/- CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
-          0,   0, 128, 127,   0,   0, 128, 255,   0,   0, 192, 127,  32,  16, 192, 127, // +/- infinity, various NaNs
-    };
+	PackedByteArray color_byte_array = {
+		0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0xbf, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 1, -1, 0, -0
+		0x00, 0x80, 0x00, 0x43, 0x00, 0x40, 0xc8, 0xc2, 0x10, 0x9c, 0xad, 0x47, 0x05, 0xc5, 0x77, 0xbf, // 128.5, -100.125, 88888.12345, -0.96785
+		0xff, 0xe6, 0xdb, 0x2e, 0xff, 0xe6, 0xdb, 0xae, 0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f, // +/- CMP_EPSILON2, 1.0 +/- CMP_EPSILON2
+		0x00, 0x00, 0x80, 0x7f, 0x00, 0x00, 0x80, 0xff, 0x00, 0x00, 0xc0, 0x7f, 0x20, 0x10, 0xc0, 0x7f, // +/- infinity, various NaNs
+	};
 
-    PackedColorArray color_array = Variant(color_byte_array).call("to_color_array");
-    CHECK(color_array[0] == Color {1, -1, 0, 0});
-    CHECK(color_array[1] == Color {128.5, -100.125, 88888.12345, -0.96785});
-    CHECK(color_array[2] == Color {CMP_EPSILON2, -(CMP_EPSILON2), 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2});
-    CHECK(color_array[3].r == INFINITY);
-    CHECK(color_array[3].g == -(INFINITY));
-    CHECK(isnan(color_array[3].b));
-    CHECK(isnan(color_array[3].a));
+	PackedColorArray color_array = Variant(color_byte_array).call("to_color_array");
+	CHECK(color_array[0] == Color{ 1, -1, 0, 0 });
+	CHECK(color_array[1] == Color{ 128.5, -100.125, 88888.12345, -0.96785 });
+	CHECK(color_array[2] == Color{ CMP_EPSILON2, -(CMP_EPSILON2), 1.0 + CMP_EPSILON2, 1.0 - CMP_EPSILON2 });
+	CHECK(color_array[3].r == INFINITY);
+	CHECK(color_array[3].g == -(INFINITY));
+	CHECK(isnan(color_array[3].b));
+	CHECK(isnan(color_array[3].a));
 }
 
 TEST_CASE("[Vector] Slice") {


### PR DESCRIPTION
This adds methods to convert from PackedByteArray to PackedVector2Array and PackedVector3Array.

I say in the commit that this completes the conversion methods between PackedByteArray and the other packed array types, but I maybe forgot about… all the rest. Still, this is an important step, as there was no way to get vector data back from compute shaders without this.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8139*