### PR TITLE
Fix Signal parameters' type will now be correctly displayed in the node signal preview box.

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -880,12 +880,13 @@ bool GDScript::has_script_signal(const StringName &p_signal) const {
 	return false;
 }
 void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	for (const Map<StringName, Vector<StringName>>::Element *E = _signals.front(); E; E = E->next()) {
+	for (const Map<StringName, Vector<Pair<StringName, Variant::Type>>>::Element *E = _signals.front(); E; E = E->next()) {
 		MethodInfo mi;
 		mi.name = E->key();
 		for (int i = 0; i < E->get().size(); i++) {
 			PropertyInfo arg;
-			arg.name = E->get()[i];
+			arg.name = E->get()[i].first;
+			arg.type = E->get()[i].second;
 			mi.arguments.push_back(arg);
 		}
 		r_signals->push_back(mi);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -81,7 +81,7 @@ class GDScript : public Script {
 	Map<StringName, GDScriptFunction *> member_functions;
 	Map<StringName, MemberInfo> member_indices; //members are just indices to the instanced script.
 	Map<StringName, Ref<GDScript>> subclasses;
-	Map<StringName, Vector<StringName>> _signals;
+	Map<StringName, Vector<Pair<StringName, Variant::Type>>> _signals;
 
 #ifdef TOOLS_ENABLED
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4166,8 +4166,22 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 							return;
 						}
 
-						sig.arguments.push_back(tokenizer->get_token_identifier());
+						Pair<StringName, Variant::Type> parameter{};
+						parameter.first = tokenizer->get_token_identifier();
 						tokenizer->advance();
+
+						parameter.second = Variant::NIL;
+						if (tokenizer->get_token() == GDScriptTokenizer::TK_COLON) {
+							tokenizer->advance();
+							if (tokenizer->get_token() != GDScriptTokenizer::TK_BUILT_IN_TYPE) {
+								_set_error(String{ "Signal ({0})'s parameter ({1})'s type ({2}) is not a built-in type, currently only support built-in types." }.format(varray(sig.name, parameter.first, tokenizer->get_token_identifier())));
+								return;
+							} else {
+								parameter.second = tokenizer->get_token_type();
+							}
+							tokenizer->advance();
+						}
+						sig.arguments.push_back(parameter);
 
 						while (tokenizer->get_token() == GDScriptTokenizer::TK_NEWLINE) {
 							tokenizer->advance();

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -176,7 +176,7 @@ public:
 
 		struct Signal {
 			StringName name;
-			Vector<StringName> arguments;
+			Vector<Pair<StringName, Variant::Type>> arguments;
 			int emissions;
 			int line;
 		};

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -210,7 +210,9 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 			if (j > 0) {
 				symbol.detail += ", ";
 			}
-			symbol.detail += signal.arguments[j];
+			symbol.detail += signal.arguments[i].first;
+			symbol.detail += ": ";
+			symbol.detail += signal.arguments[i].second;
 		}
 		symbol.detail += ")";
 
@@ -747,9 +749,9 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 		const GDScriptParser::ClassNode::Signal &signal = p_class->_signals[i];
 		Dictionary api;
 		api["name"] = signal.name;
-		Array args;
+		Dictionary args;
 		for (int j = 0; j < signal.arguments.size(); j++) {
-			args.append(signal.arguments[j]);
+			args[signal.arguments[j].first] = signal.arguments[j].second;
 		}
 		api["arguments"] = args;
 		if (const lsp::DocumentSymbol *symbol = get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(signal.line))) {


### PR DESCRIPTION
Version of Godot based on:
v3.5.1.rc.custom_build [26a28d6bb]

> Fixes #65809 

Signal parameters' type will now be correctly displayed in the node signal preview box.

**This is a fix for the 3.x version, if the 3.x version does not require the ability to specify the parameter type of the signal, please close this PR**

> See also #65812 

![signal_arg_type_3 x_1](https://user-images.githubusercontent.com/52756109/190335663-4d04c076-701d-44bb-957c-1a81b9cf5828.png)
![signal_arg_type_3 x_2](https://user-images.githubusercontent.com/52756109/190335689-3299d54a-202f-43a7-a2d7-d2c794da328a.png)
