### PR TITLE
Add missing initial window flags and window mode to the project settings.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1201,10 +1201,16 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC("display/window/size/viewport_height", 648);
 	custom_prop_info["display/window/size/viewport_height"] = PropertyInfo(Variant::INT, "display/window/size/viewport_height", PROPERTY_HINT_RANGE, "0,4320,1,or_greater"); // 8K resolution
 
+	GLOBAL_DEF_BASIC("display/window/size/mode", 0);
+	custom_prop_info["display/window/size/mode"] = PropertyInfo(Variant::INT, "display/window/size/mode", PROPERTY_HINT_ENUM, "Windowed,Minimized,Maximized,Fullscreen,Exclusive Fullscreen");
+
 	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
 	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
-	GLOBAL_DEF_BASIC("display/window/size/fullscreen", false);
 	GLOBAL_DEF("display/window/size/always_on_top", false);
+	GLOBAL_DEF("display/window/size/transparent", false);
+	GLOBAL_DEF("display/window/size/extend_to_title", false);
+	GLOBAL_DEF("display/window/size/no_focus", false);
+
 	GLOBAL_DEF("display/window/size/window_width_override", 0);
 	custom_prop_info["display/window/size/window_width_override"] = PropertyInfo(Variant::INT, "display/window/size/window_width_override", PROPERTY_HINT_RANGE, "0,7680,1,or_greater"); // 8K resolution
 	GLOBAL_DEF("display/window/size/window_height_override", 0);

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1324,6 +1324,7 @@
 			<param index="0" name="window_id" type="int" />
 			<param index="1" name="parent_window_id" type="int" />
 			<description>
+				Sets window transient parent. Transient window is will be destroyed with its transient parent and displayed on top of non-exclusive full-screen parent window. Transient windows can't enter full-screen mode.
 			</description>
 		</method>
 		<method name="window_set_vsync_mode">
@@ -1509,7 +1510,8 @@
 			Window is floating above other regular windows. This flag is ignored for full-screen windows.
 		</constant>
 		<constant name="WINDOW_FLAG_TRANSPARENT" value="3" enum="WindowFlags">
-			Window is will be destroyed with its transient parent and displayed on top of non-exclusive full-screen parent window. Transient windows can't enter full-screen mode.
+			Window background can be transparent.
+			[b]Note:[/b] This flag has no effect if [member ProjectSettings.display/window/per_pixel_transparency/allowed] is set to [code]false[/code].
 		</constant>
 		<constant name="WINDOW_FLAG_NO_FOCUS" value="4" enum="WindowFlags">
 			Window can't be focused. No-focus window will ignore all input, except mouse clicks.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -562,14 +562,24 @@
 			Forces the main window to be borderless.
 			[b]Note:[/b] This setting is ignored on iOS, Android, and Web.
 		</member>
-		<member name="display/window/size/fullscreen" type="bool" setter="" getter="" default="false">
-			Sets the main window to full screen when the project starts. Note that this is not [i]exclusive[/i] fullscreen. On Windows and Linux, a borderless window is used to emulate fullscreen. On macOS, a new desktop is used to display the running project.
-			Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] when enabling fullscreen mode.
-			[b]Note:[/b] This setting is ignored on iOS, Android, and Web.
+		<member name="display/window/size/extend_to_title" type="bool" setter="" getter="" default="false">
+			Main window content is expanded to the full size of the window. Unlike borderless window, the frame is left intact and can be used to resize the window, title bar is transparent, but have minimize/maximize/close buttons.
+			[b]Note:[/b] This setting is implemented on macOS.
+		</member>
+		<member name="display/window/size/mode" type="int" setter="" getter="" default="0">
+			Main window mode. See [enum DisplayServer.WindowMode] for possible values and how each mode behaves.
+		</member>
+		<member name="display/window/size/no_focus" type="bool" setter="" getter="" default="false">
+			Main window can't be focused. No-focus window will ignore all input, except mouse clicks.
 		</member>
 		<member name="display/window/size/resizable" type="bool" setter="" getter="" default="true">
 			Allows the window to be resizable by default.
 			[b]Note:[/b] This setting is ignored on iOS.
+		</member>
+		<member name="display/window/size/transparent" type="bool" setter="" getter="" default="false">
+			Main window background can be transparent.
+			[b]Note:[/b] To use transparent splash screen, set [member application/boot_splash/bg_color] to [code]Color(0, 0, 0, 0)[/code].
+			[b]Note:[/b] This setting has no effect if [member display/window/per_pixel_transparency/allowed] is set to [code]false[/code].
 		</member>
 		<member name="display/window/size/viewport_height" type="int" setter="" getter="" default="648">
 			Sets the game's main viewport height. On desktop platforms, this is also the initial window height, represented by an indigo-colored rectangle in the 2D editor. Stretch mode settings also use this as a reference when using the [code]canvas_items[/code] or [code]viewport[/code] stretch modes. See also [member display/window/size/viewport_width], [member display/window/size/window_width_override] and [member display/window/size/window_height_override].

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -381,7 +381,8 @@
 			Note that behavior might be different depending on the platform.
 		</member>
 		<member name="transparent" type="bool" setter="set_flag" getter="get_flag" default="false">
-			If [code]true[/code], the [Window]'s background can be transparent. This is best used with embedded windows. Currently non-embedded [Window] transparency is implemented only for MacOS.
+			If [code]true[/code], the [Window]'s background can be transparent. This is best used with embedded windows.
+			[b]Note:[/b] This flag has no effect if [member ProjectSettings.display/window/per_pixel_transparency/allowed] is set to [code]false[/code].
 		</member>
 		<member name="unfocusable" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] can't be focused nor interacted with. It can still be visible.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1552,13 +1552,19 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		if (bool(GLOBAL_GET("display/window/size/borderless"))) {
 			window_flags |= DisplayServer::WINDOW_FLAG_BORDERLESS_BIT;
 		}
-		if (bool(GLOBAL_GET("display/window/size/fullscreen"))) {
-			window_mode = DisplayServer::WINDOW_MODE_FULLSCREEN;
-		}
-
 		if (bool(GLOBAL_GET("display/window/size/always_on_top"))) {
 			window_flags |= DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP_BIT;
 		}
+		if (bool(GLOBAL_GET("display/window/size/transparent"))) {
+			window_flags |= DisplayServer::WINDOW_FLAG_TRANSPARENT_BIT;
+		}
+		if (bool(GLOBAL_GET("display/window/size/extend_to_title"))) {
+			window_flags |= DisplayServer::WINDOW_FLAG_EXTEND_TO_TITLE_BIT;
+		}
+		if (bool(GLOBAL_GET("display/window/size/no_focus"))) {
+			window_flags |= DisplayServer::WINDOW_FLAG_NO_FOCUS_BIT;
+		}
+		window_mode = (DisplayServer::WindowMode)(GLOBAL_GET("display/window/size/mode").operator int());
 	}
 
 	GLOBAL_DEF_RST("internationalization/rendering/force_right_to_left_layout_direction", false);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -2212,7 +2212,9 @@ void DisplayServerMacOS::show_window(WindowID p_id) {
 	WindowData &wd = windows[p_id];
 
 	popup_open(p_id);
-	if (wd.no_focus || wd.is_popup) {
+	if ([wd.window_object isMiniaturized]) {
+		return;
+	} else if (wd.no_focus || wd.is_popup) {
 		[wd.window_object orderFront:nil];
 	} else {
 		[wd.window_object makeKeyAndOrderFront:nil];
@@ -2369,6 +2371,10 @@ void DisplayServerMacOS::window_set_position(const Point2i &p_position, WindowID
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
+	if ([wd.window_object isZoomed]) {
+		return;
+	}
+
 	Point2i position = p_position;
 	// OS X native y-coordinate relative to _get_screens_origin() is negative,
 	// Godot passes a positive value.
@@ -2492,6 +2498,10 @@ void DisplayServerMacOS::window_set_size(const Size2i p_size, WindowID p_window)
 
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
+
+	if ([wd.window_object isZoomed]) {
+		return;
+	}
 
 	Size2i size = p_size / screen_get_max_scale();
 
@@ -2711,7 +2721,9 @@ void DisplayServerMacOS::window_set_flag(WindowFlags p_flag, bool p_enabled, Win
 			}
 			_update_window_style(wd);
 			if ([wd.window_object isVisible]) {
-				if (wd.no_focus || wd.is_popup) {
+				if ([wd.window_object isMiniaturized]) {
+					return;
+				} else if (wd.no_focus || wd.is_popup) {
 					[wd.window_object orderFront:nil];
 				} else {
 					[wd.window_object makeKeyAndOrderFront:nil];

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -685,7 +685,13 @@ void DisplayServerWindows::show_window(WindowID p_id) {
 		_update_window_style(p_id);
 	}
 
-	if (wd.no_focus || wd.is_popup) {
+	if (wd.maximized) {
+		ShowWindow(wd.hWnd, SW_SHOWMAXIMIZED);
+		SetForegroundWindow(wd.hWnd); // Slightly higher priority.
+		SetFocus(wd.hWnd); // Set keyboard focus.
+	} else if (wd.minimized) {
+		ShowWindow(wd.hWnd, SW_SHOWMINIMIZED);
+	} else if (wd.no_focus || wd.is_popup) {
 		// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
 		ShowWindow(wd.hWnd, SW_SHOWNA);
 	} else {
@@ -926,7 +932,7 @@ void DisplayServerWindows::window_set_position(const Point2i &p_position, Window
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
-	if (wd.fullscreen) {
+	if (wd.fullscreen || wd.maximized) {
 		return;
 	}
 
@@ -1059,6 +1065,10 @@ void DisplayServerWindows::window_set_size(const Size2i p_size, WindowID p_windo
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
+	if (wd.fullscreen || wd.maximized) {
+		return;
+	}
+
 	int w = p_size.width;
 	int h = p_size.height;
 
@@ -1075,10 +1085,6 @@ void DisplayServerWindows::window_set_size(const Size2i p_size, WindowID p_windo
 		gl_manager->window_resize(p_window, w, h);
 	}
 #endif
-
-	if (wd.fullscreen) {
-		return;
-	}
 
 	RECT rect;
 	GetWindowRect(wd.hWnd, &rect);
@@ -3597,6 +3603,16 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			}
 		} else {
 			wd.wtctx = 0;
+		}
+
+		if (p_mode == WINDOW_MODE_MAXIMIZED) {
+			wd.maximized = true;
+			wd.minimized = false;
+		}
+
+		if (p_mode == WINDOW_MODE_MINIMIZED) {
+			wd.maximized = false;
+			wd.minimized = true;
 		}
 
 		wd.last_pressure = 0;


### PR DESCRIPTION
Adds missing initial main window settings, allow transparent splash screen.

### TODO:
- Test initial Maximized/Minimized modes on all platforms:
  - [x] macOS.
  - [x] Windows.
  - [x] Linux.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/4413.*