### PR TITLE
Fix theme methods usage in docs

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -310,16 +310,16 @@
 				# If using this method in a script that redraws constantly, move the
 				# `default_font` declaration to a member variable assigned in `_ready()`
 				# so the Control is only created once.
-				var default_font = Control.new().get_font("font")
-				var default_font_size = Control.new().get_font_size("font_size")
-				draw_string(default_font, Vector2(64, 64), "Hello world", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size)
+				var default_font = ThemeDB.fallback_font
+				var default_font_size = ThemeDB.fallback_font_size
+				draw_string(default_font, Vector2(64, 64), "Hello world", HORIZONTAL_ALIGNMENT_LEFT, -1, default_font_size)
 				[/gdscript]
 				[csharp]
 				// If using this method in a script that redraws constantly, move the
-				// `default_font` declaration to a member variable assigned in `_ready()`
+				// `default_font` declaration to a member variable assigned in `_Ready()`
 				// so the Control is only created once.
-				Font defaultFont = new Control().GetFont("font");
-				int defaultFontSize = new Control().GetFontSize("font_size");
+				Font defaultFont = ThemeDB.FallbackFont;
+				int defaultFontSize = ThemeDB.FallbackFontSize;
 				DrawString(defaultFont, new Vector2(64, 64), "Hello world", HORIZONTAL_ALIGNMENT_LEFT, -1, defaultFontSize);
 				[/csharp]
 				[/codeblocks]

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -237,7 +237,7 @@
 				    # You can use a custom icon:
 				    return preload("res://addons/my_plugin/my_plugin_icon.svg")
 				    # Or use a built-in icon:
-				    return get_editor_interface().get_base_control().get_icon("Node", "EditorIcons")
+				    return get_editor_interface().get_base_control().get_theme_icon("Node", "EditorIcons")
 				[/gdscript]
 				[csharp]
 				public override Texture2D GetPluginIcon()
@@ -245,7 +245,7 @@
 				    // You can use a custom icon:
 				    return ResourceLoader.Load&lt;Texture2D&gt;("res://addons/my_plugin/my_plugin_icon.svg");
 				    // Or use a built-in icon:
-				    return GetEditorInterface().GetBaseControl().GetIcon("Node", "EditorIcons");
+				    return GetEditorInterface().GetBaseControl().GetThemeIcon("Node", "EditorIcons");
 				}
 				[/csharp]
 				[/codeblocks]


### PR DESCRIPTION
Fix usages of `get_icon` and `get_font` that were renamed `get_theme_icon` and `get_theme_font`.

