### PR TITLE
Make tooltip popup reusable

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -362,6 +362,7 @@ private:
 		Control *tooltip_control = nullptr;
 		Window *tooltip_popup = nullptr;
 		Label *tooltip_label = nullptr;
+		Control *custom_tooltip = nullptr;
 		Point2 tooltip_pos;
 		Point2 last_mouse_pos;
 		Point2 drag_accum;
@@ -414,7 +415,7 @@ private:
 
 	void _gui_remove_root_control(List<Control *>::Element *RI);
 
-	String _gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Control **r_tooltip_owner = nullptr);
+	String _gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Control **r_tooltip_serve_target = nullptr);
 	void _gui_cancel_tooltip();
 	void _gui_show_tooltip();
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1311,6 +1311,10 @@ void Window::set_theme_owner_node(Node *p_node) {
 	theme_owner->set_owner_node(p_node);
 }
 
+void Window::propagate_theme_changed(Node *p_theme_owner_node) {
+	theme_owner->propagate_theme_changed(this, p_theme_owner_node, is_inside_tree(), true);
+}
+
 Node *Window::get_theme_owner_node() const {
 	return theme_owner->get_owner_node();
 }

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -269,6 +269,7 @@ public:
 	void popup_centered_clamped(const Size2i &p_size = Size2i(), float p_fallback_ratio = 0.75);
 
 	void set_theme_owner_node(Node *p_node);
+	void propagate_theme_changed(Node *p_theme_owner_node);
 	Node *get_theme_owner_node() const;
 	bool has_theme_owner_node() const;
 


### PR DESCRIPTION
Previously, tooltips could be deleted either by the node tree deletion mechanism or by input events. This caused some problems.

Now, the tooltip will be reused and its reaction to input events will be to change its visibility.

Fix #59798, fix #60842. This might not be the best solution, it might be better to build a stable property tree.

~~The work is not done yet. If it's just for show, it will work just fine. There is a problem with the interaction.~~


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
