### PR TITLE
Remove redefinition of `notification` method in `XRInterfaceExtension`

### DIFF
--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -141,13 +141,6 @@
 				Returns [code]true[/code] if this interface has been initialized.
 			</description>
 		</method>
-		<method name="_notification" qualifiers="virtual">
-			<return type="void" />
-			<param index="0" name="what" type="int" />
-			<description>
-				Informs the interface of an applicable system notification.
-			</description>
-		</method>
 		<method name="_post_draw_viewport" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="render_target" type="RID" />

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -138,8 +138,6 @@ public:
 	virtual bool start_passthrough() { return false; }
 	virtual void stop_passthrough() {}
 
-	virtual void notification(int p_what){};
-
 	XRInterface();
 	~XRInterface();
 

--- a/servers/xr/xr_interface_extension.cpp
+++ b/servers/xr/xr_interface_extension.cpp
@@ -58,8 +58,6 @@ void XRInterfaceExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_post_draw_viewport, "render_target", "screen_rect");
 	GDVIRTUAL_BIND(_end_frame);
 
-	GDVIRTUAL_BIND(_notification, "what");
-
 	/** input and output **/
 
 	GDVIRTUAL_BIND(_get_suggested_tracker_names);
@@ -307,10 +305,6 @@ Vector<BlitToScreen> XRInterfaceExtension::post_draw_viewport(RID p_render_targe
 
 void XRInterfaceExtension::end_frame() {
 	GDVIRTUAL_CALL(_end_frame);
-}
-
-void XRInterfaceExtension::notification(int p_what) {
-	GDVIRTUAL_CALL(_notification, p_what);
 }
 
 RID XRInterfaceExtension::get_render_target_texture(RID p_render_target) {

--- a/servers/xr/xr_interface_extension.h
+++ b/servers/xr/xr_interface_extension.h
@@ -123,15 +123,12 @@ public:
 	virtual bool pre_draw_viewport(RID p_render_target) override;
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
 	virtual void end_frame() override;
-	virtual void notification(int p_what) override;
 
 	GDVIRTUAL0(_process);
 	GDVIRTUAL0(_pre_render);
 	GDVIRTUAL1R(bool, _pre_draw_viewport, RID);
 	GDVIRTUAL2(_post_draw_viewport, RID, const Rect2 &);
 	GDVIRTUAL0(_end_frame);
-
-	GDVIRTUAL1(_notification, int);
 
 	/* access to some internals we need */
 	RID get_render_target_texture(RID p_render_target);


### PR DESCRIPTION
`XRInterfaceExtension` was re-exposing the `_notification` method which resulted in a new `_notification` method that shadowed the inherited one.