### PR TITLE
[macOS] Fix redraw lag at the edge of the resizing window.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -85,6 +85,8 @@ public:
 		Size2i max_size;
 		Size2i size;
 
+		NSRect last_frame_rect;
+
 		bool im_active = false;
 		Size2i im_position;
 

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -61,6 +61,24 @@
 @implementation GodotContentView
 
 - (void)setFrameSize:(NSSize)newSize {
+	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	if (ds && ds->has_window(window_id)) {
+		DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
+		NSRect frameRect = [wd.window_object frame];
+		bool left = (wd.last_frame_rect.origin.x != frameRect.origin.x);
+		bool top = (wd.last_frame_rect.origin.y == frameRect.origin.y);
+		if (left && top) {
+			self.layerContentsPlacement = NSViewLayerContentsPlacementBottomRight;
+		} else if (left && !top) {
+			self.layerContentsPlacement = NSViewLayerContentsPlacementTopRight;
+		} else if (!left && top) {
+			self.layerContentsPlacement = NSViewLayerContentsPlacementBottomLeft;
+		} else {
+			self.layerContentsPlacement = NSViewLayerContentsPlacementTopLeft;
+		}
+		wd.last_frame_rect = frameRect;
+	}
+
 	[super setFrameSize:newSize];
 	[self.layer setNeedsDisplay]; // Force "drawRect" call.
 }

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -151,7 +151,9 @@
 
 - (void)windowWillStartLiveResize:(NSNotification *)notification {
 	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
-	if (ds) {
+	if (ds && ds->has_window(window_id)) {
+		DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
+		wd.last_frame_rect = [wd.window_object frame];
 		ds->set_is_resizing(true);
 	}
 }


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/61901, should fix the rest of live resizing issues for Vulkan renderer.
