### PR TITLE
Add strip_bbcode() method to String

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3582,6 +3582,51 @@ String String::dedent() const {
 	return new_string;
 }
 
+String String::strip_bbcode() const {
+	String new_string;
+	for (int i = 0; i < length(); i++) {
+		bool found_close = false;
+
+		// Checks for "["
+		if (operator[](i) == '[') {
+			int skip_char = 0;
+
+			//Check for [rb] and [lb].
+			String check_escape = "";
+			for (int k = i + 1; k <= i + 3 && k < length(); k++) {
+				check_escape += operator[](k);
+			}
+			if (check_escape == "rb]") {
+				skip_char += 3;
+				found_close = true;
+				new_string += "]";
+			} else if (check_escape == "lb]") {
+				skip_char += 3;
+				found_close = true;
+				new_string += "[";
+			} else { //If not [rb] or [lb].
+				for (int j = i + 1; j < length(); j++) {
+					skip_char++;
+					// Checks for "]"
+					if (operator[](j) == ']') {
+						found_close = true;
+						break;
+					} else if (operator[](j) == '[') {
+						break;
+					}
+				}
+			}
+			// Skip characters.
+			if (found_close) {
+				i = i + skip_char;
+				continue;
+			}
+		}
+		new_string += operator[](i);
+	}
+	return new_string;
+}
+
 String String::strip_edges(bool left, bool right) const {
 	int len = length();
 	int beg = 0, end = len;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -367,6 +367,7 @@ public:
 	String right(int p_len) const;
 	String indent(const String &p_prefix) const;
 	String dedent() const;
+	String strip_bbcode() const;
 	String strip_edges(bool left = true, bool right = true) const;
 	String strip_escapes() const;
 	String lstrip(const String &p_chars) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1520,6 +1520,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(String, left, sarray("length"), varray());
 	bind_method(String, right, sarray("length"), varray());
 
+	bind_method(String, strip_bbcode, sarray(), varray());
 	bind_method(String, strip_edges, sarray("left", "right"), varray(true, true));
 	bind_method(String, strip_escapes, sarray(), varray());
 	bind_method(String, lstrip, sarray("chars"), varray());

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -747,6 +747,12 @@
 				If [param allow_empty] is [code]true[/code], and there are two adjacent delimiters in the string, it will add an empty string to the array of substrings at this position.
 			</description>
 		</method>
+		<method name="strip_bbcode" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns a copy of the string stripped of any bbcode tags. This includes all text between pairs of brackets.
+			</description>
+		</method>
 		<method name="strip_edges" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="left" type="bool" default="true" />

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1544,6 +1544,11 @@ TEST_CASE("[String] Similarity") {
 	CHECK(a.similarity(b) > a.similarity(c));
 }
 
+TEST_CASE("[String] Strip bbcode") {
+	String s = "[color=#ffffff]Test[/color]";
+	CHECK(s.strip_bbcode() == "Test");
+}
+
 TEST_CASE("[String] Strip edges") {
 	String s = "\t Test Test   ";
 	CHECK(s.strip_edges(true, false) == "Test Test   ");


### PR DESCRIPTION
Replaces #65384.

Adds a function to strip bbcode tags out of strings.

Example Code:
```
var s = "[color=#ffffff]Hello![/color]
print(s.strip_bbcode())
```

Result: `Hello`

Closes https://github.com/godotengine/godot-proposals/issues/5056