### PR TITLE
Add DisplayServer Window Center functions

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1286,6 +1286,13 @@
 				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
+		<method name="window_move_to_center">
+			<return type="void" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Centers the window on the screen the window is currently on.
+			</description>
+		</method>
 		<method name="window_move_to_foreground">
 			<return type="void" />
 			<param index="0" name="window_id" type="int" default="0" />

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1646,6 +1646,20 @@ void DisplayServerX11::window_set_drop_files_callback(const Callable &p_callable
 	wd.drop_files_callback = p_callable;
 }
 
+void DisplayServerX11::window_move_to_center(WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+
+	int p_screen = window_get_current_screen(p_window);
+
+	Point2i screen_size = screen_get_size(p_screen);
+	Point2i window_size = window_get_size(p_window);
+	Point2i position = screen_get_position(p_screen) + screen_size / 2 - window_size / 2;
+
+	window_set_position(position, p_window);
+}
+
 int DisplayServerX11::window_get_current_screen(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -446,6 +446,8 @@ public:
 	virtual void window_set_input_text_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_drop_files_callback(const Callable &p_callable, WindowID p_window = MAIN_WINDOW_ID) override;
 
+	virtual void window_move_to_center(WindowID p_window = MAIN_WINDOW_ID) override;
+
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -361,6 +361,8 @@ public:
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
 
+	virtual void window_move_to_center(WindowID p_window = MAIN_WINDOW_ID) override;
+
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
 

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -2413,6 +2413,20 @@ void DisplayServerMacOS::window_set_mouse_passthrough(const Vector<Vector2> &p_r
 	wd.mpath = p_region;
 }
 
+void DisplayServerMacOS::window_move_to_center(WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+
+	int p_screen = window_get_current_screen(p_window);
+
+	Point2i screen_size = screen_get_size(p_screen);
+	Point2i window_size = window_get_size(p_window);
+	Point2i position = screen_get_position(p_screen) + screen_size / 2 - window_size / 2;
+
+	window_set_position(position, p_window);
+}
+
 int DisplayServerMacOS::window_get_current_screen(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 	ERR_FAIL_COND_V(!windows.has(p_window), -1);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1017,6 +1017,20 @@ void DisplayServerWindows::_update_window_mouse_passthrough(WindowID p_window) {
 	}
 }
 
+void DisplayServerWindows::window_move_to_center(WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+
+	int p_screen = window_get_current_screen(p_window);
+
+	Point2i screen_size = screen_get_size(p_screen);
+	Point2i window_size = window_get_size(p_window);
+	Point2i position = screen_get_position(p_screen) + screen_size / 2 - window_size / 2;
+
+	window_set_position(position, p_window);
+}
+
 int DisplayServerWindows::window_get_current_screen(WindowID p_window) const {
 	_THREAD_SAFE_METHOD_
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -564,6 +564,8 @@ public:
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID) override;
 
+	virtual void window_move_to_center(WindowID p_window = MAIN_WINDOW_ID) override;
+
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -427,6 +427,10 @@ void DisplayServer::delete_sub_window(WindowID p_id) {
 	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
 }
 
+void DisplayServer::window_move_to_center(WindowID p_window) {
+	// Do nothing, if not supported.
+}
+
 void DisplayServer::window_set_exclusive(WindowID p_window, bool p_exclusive) {
 	// Do nothing, if not supported.
 }
@@ -678,6 +682,8 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("window_set_title", "title", "window_id"), &DisplayServer::window_set_title, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_mouse_passthrough", "region", "window_id"), &DisplayServer::window_set_mouse_passthrough, DEFVAL(MAIN_WINDOW_ID));
+
+	ClassDB::bind_method(D_METHOD("window_move_to_center", "window_id"), &DisplayServer::window_move_to_center, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_get_current_screen", "window_id"), &DisplayServer::window_get_current_screen, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_current_screen", "screen", "window_id"), &DisplayServer::window_set_current_screen, DEFVAL(MAIN_WINDOW_ID));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -391,6 +391,8 @@ public:
 
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID);
 
+	virtual void window_move_to_center(WindowID p_window = MAIN_WINDOW_ID);
+
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) = 0;
 


### PR DESCRIPTION
Re-Adds an equivalent to 3.x's `OS.center_window()`, which was lost in the DisplayServer refactoring.

Testing is required for Windows and Linux, I only have a Mac.

~~Test project, press space to center the window.
[DisplayServer Center.zip](https://github.com/godotengine/godot/files/9578435/DisplayServer.Center.zip)~~ See below.

Closes https://github.com/godotengine/godot-proposals/issues/5232.