### PR TITLE
Remove unused `abort_scan` variable

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -690,7 +690,6 @@ void EditorFileSystem::scan() {
 
 	_update_extensions();
 
-	abort_scan = false;
 	if (!use_threads) {
 		scanning = true;
 		scan_total = 0;
@@ -1162,8 +1161,6 @@ void EditorFileSystem::scan_changes() {
 	scanning_changes = true;
 	scanning_changes_done = false;
 
-	abort_scan = false;
-
 	if (!use_threads) {
 		if (filesystem) {
 			EditorProgressBG pr("sources", TTR("ScanSources"), 1000);
@@ -1195,8 +1192,6 @@ void EditorFileSystem::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			Thread &active_thread = thread.is_started() ? thread : thread_sources;
 			if (use_threads && active_thread.is_started()) {
-				//abort thread if in progress
-				abort_scan = true;
 				while (scanning) {
 					OS::get_singleton()->delay_usec(1000);
 				}

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -168,7 +168,6 @@ class EditorFileSystem : public Node {
 
 	EditorFileSystemDirectory *new_filesystem = nullptr;
 
-	bool abort_scan = false;
 	bool scanning = false;
 	bool importing = false;
 	bool first_scan = true;


### PR DESCRIPTION
This variable is written to but never used, so this PR removes it.

It's possible that this PR is wrong and it was intended to do something, but I don't know where it would be read.