### PR TITLE
Prevent unsaved inherited scenes from being detected as the 'placeholder' scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3751,7 +3751,7 @@ int EditorNode::new_scene() {
 	if (editor_data.get_edited_scene_count() > 1) {
 		for (int i = 0; i < editor_data.get_edited_scene_count() - 1; i++) {
 			bool unsaved = get_undo_redo()->is_history_unsaved(editor_data.get_scene_history_id(i));
-			if (!unsaved && editor_data.get_scene_path(i).is_empty()) {
+			if (!unsaved && editor_data.get_scene_path(i).is_empty() && editor_data.get_edited_scene_root(i) == nullptr) {
 				editor_data.remove_scene(i);
 				idx--;
 			}


### PR DESCRIPTION
Fixes #65547

Unsaved inherited scenes were detected as the 'placeholder' scene, because checking if the scene has no path and no history is not sufficient. I added a "scene_root == nullptr" check to fix this.