### PR TITLE
C#: inheritdoc the "///" comment from EventHandler to the generated event

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -235,6 +235,8 @@ namespace Godot.SourceGenerators
                     .Append(signalName)
                     .Append(";\n");
 
+                source.Append($"    /// <inheritdoc cref=\"{signalDelegate.DelegateSymbol.FullQualifiedName()}\"/>\n");
+
                 source.Append("    public event ")
                     .Append(signalDelegate.DelegateSymbol.FullQualifiedName())
                     .Append(" ")


### PR DESCRIPTION
Signal event is generated and cannot be commented.
Now copy the annotation of EventHandler.

![image](https://user-images.githubusercontent.com/14800320/190592411-1f1af488-8486-4793-9d14-db7f7eee9012.png)

![image](https://user-images.githubusercontent.com/14800320/190592461-b03d41c3-6931-4089-a1a2-545032bf71a2.png)


Signal的event是生成的,无法给其写注释.
现在把EventHandler的注释复制过去.
