### PR TITLE
Add new C# code blocks to class ref pages

### DIFF
--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -6,14 +6,24 @@
 	<description>
 		Compared to [AStar2D] you don't need to manually create points or connect them together. It also supports multiple type of heuristics and modes for diagonal movement. This class also provides a jumping mode which is faster to calculate than without it in the [AStar2D] class.
 		In contrast to [AStar2D], you only need set the [member size] of the grid, optionally set the [member cell_size] and then call the [method update] method:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var astar_grid = AStarGrid2D.new()
 		astar_grid.size = Vector2i(32, 32)
 		astar_grid.cell_size = Vector2(16, 16)
 		astar_grid.update()
 		print(astar_grid.get_id_path(Vector2i(0, 0), Vector2i(3, 4))) # prints (0, 0), (1, 1), (2, 2), (3, 3), (3, 4)
 		print(astar_grid.get_point_path(Vector2i(0, 0), Vector2i(3, 4))) # prints (0, 0), (16, 16), (32, 32), (48, 48), (48, 64)
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		AStarGrid2D astarGrid = new AStarGrid2D();
+		astarGrid.Size = new Vector2i(32, 32);
+		astarGrid.CellSize = new Vector2i(16, 16);
+		astarGrid.Update();
+		GD.Print(astarGrid.GetIdPath(Vector2i.Zero, new Vector2i(3, 4))); // prints (0, 0), (1, 1), (2, 2), (3, 3), (3, 4)
+		GD.Print(astarGrid.GetPointPath(Vector2i.Zero, new Vector2i(3, 4))); // prints (0, 0), (16, 16), (32, 32), (48, 48), (48, 64)
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -14,12 +14,20 @@
 			<description>
 				Returns the name of the CPU architecture the Godot binary was built for. Possible return values are [code]x86_64[/code], [code]x86_32[/code], [code]arm64[/code], [code]armv7[/code], [code]rv64[/code], [code]riscv[/code], [code]ppc64[/code], [code]ppc[/code], [code]wasm64[/code] and [code]wasm32[/code].
 				To detect whether the current CPU architecture is 64-bit, you can use the fact that all 64-bit architecture names have [code]64[/code] in their name:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				if "64" in Engine.get_architecture_name():
 				    print("Running on 64-bit CPU.")
 				else:
 				    print("Running on 32-bit CPU.")
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				if (Engine.GetArchitectureName().Contains("64"))
+				    GD.Print("Running on 64-bit CPU.");
+				else
+				    GD.Print("Running on 32-bit CPU.");
+				[/csharp]
+				[/codeblocks]
 				[b]Note:[/b] [method get_architecture_name] does [i]not[/i] return the name of the host CPU architecture. For example, if running an x86_32 Godot binary on a x86_64 system, the returned value will be [code]x86_32[/code].
 			</description>
 		</method>
@@ -83,11 +91,24 @@
 			<description>
 				Returns the total number of frames passed since engine initialization which is advanced on each [b]physics frame[/b]. See also [method get_process_frames].
 				[method get_physics_frames] can be used to run expensive logic less often without relying on a [Timer]:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _physics_process(_delta):
 				    if Engine.get_physics_frames() % 2 == 0:
 				        pass  # Run expensive logic only once every 2 physics frames here.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override void _PhysicsProcess(double delta)
+				{
+				    base._PhysicsProcess(delta);
+
+				    if (Engine.GetPhysicsFrames() % 2 == 0)
+				    {
+				        // Run expensive logic only once every 2 physics frames here.
+				    }
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_physics_interpolation_fraction" qualifiers="const">
@@ -101,11 +122,24 @@
 			<description>
 				Returns the total number of frames passed since engine initialization which is advanced on each [b]process frame[/b], regardless of whether the render loop is enabled. See also [method get_frames_drawn] and [method get_physics_frames].
 				[method get_process_frames] can be used to run expensive logic less often without relying on a [Timer]:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _process(_delta):
 				    if Engine.get_process_frames() % 2 == 0:
 				        pass  # Run expensive logic only once every 2 process (render) frames here.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override void _Process(double delta)
+				{
+				    base._Process(delta);
+
+				    if (Engine.GetProcessFrames() % 2 == 0)
+				    {
+				        // Run expensive logic only once every 2 physics frames here.
+				    }
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_script_language" qualifiers="const">
@@ -182,12 +216,20 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the script is currently running inside the editor, [code]false[/code] otherwise. This is useful for [code]@tool[/code] scripts to conditionally draw editor helpers, or prevent accidentally running "game" code that would affect the scene state while in the editor:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				if Engine.is_editor_hint():
 				    draw_gizmos()
 				else:
 				    simulate_physics()
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				if (Engine.IsEditorHint())
+				    DrawGizmos();
+				else
+				    SimulatePhysics();
+				[/csharp]
+				[/codeblocks]
 				See [url=$DOCS_URL/tutorials/plugins/running_code_in_the_editor.html]Running code in the editor[/url] in the documentation for more information.
 				[b]Note:[/b] To detect whether the script is run from an editor [i]build[/i] (e.g. when pressing [kbd]F5[/kbd]), use [method OS.has_feature] with the [code]"editor"[/code] argument instead. [code]OS.has_feature("editor")[/code] will evaluate to [code]true[/code] both when the code is running in the editor and when running the project from the editor, but it will evaluate to [code]false[/code] when the code is run from an exported project.
 			</description>

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -228,9 +228,15 @@
 			<description>
 				Returns the size of a bounding box of a single-line string, taking kerning and advance into account. See also [method get_multiline_string_size] and [method draw_string].
 				For example, to get the string size as displayed by a single-line Label, use:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var string_size = $Label.get_theme_font("font").get_string_size($Label.text, HORIZONTAL_ALIGNMENT_LEFT, -1, $Label.get_theme_font_size("font_size"))
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Label label = GetNode&lt;Label&gt;("Label");
+				Vector2 stringSize = label.GetThemeFont("font").GetStringSize(label.Text, HorizontalAlignment.Left, -1, label.GetThemeFontSize("font_size"));
+				[/csharp]
+				[/codeblocks]
 				[b]Note:[/b] Real height of the string is context-dependent and can be significantly different from the value returned by [method get_height].
 			</description>
 		</method>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -179,9 +179,14 @@
 			<return type="Tween" />
 			<description>
 				Creates a new [Tween] and binds it to this node. This is equivalent of doing:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				get_tree().create_tween().bind_node(self)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				GetTree().CreateTween().BindNode(this);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="duplicate" qualifiers="const">
@@ -267,13 +272,24 @@
 				Returns an array listing the groups that the node is a member of.
 				[b]Note:[/b] For performance reasons, the order of node groups is [i]not[/i] guaranteed. The order of node groups should not be relied upon as it can vary across project runs.
 				[b]Note:[/b] The engine uses some group names internally (all starting with an underscore). To avoid conflicts with internal groups, do not add custom groups whose name starts with an underscore. To exclude internal groups while looping over [method get_groups], use the following snippet:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# Stores the node's non-internal groups only (as an array of Strings).
 				var non_internal_groups = []
 				for group in get_groups():
 				    if not group.begins_with("_"):
 				        non_internal_groups.push_back(group)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// Stores the node's non-internal groups only (as a List of strings).
+				List&lt;string&gt; nonInternalGroups = new List&lt;string&gt;();
+				foreach (string group in GetGroups())
+				{
+				    if (!group.BeginsWith("_"))
+				        nonInternalGroups.Add(group);
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_index" qualifiers="const">

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -525,10 +525,16 @@
 				Moves the file or directory to the system's recycle bin. See also [method DirAccess.remove].
 				The method takes only global paths, so you may need to use [method ProjectSettings.globalize_path]. Do not use it for files in [code]res://[/code] as it will not work in exported project.
 				[b]Note:[/b] If the user has disabled the recycle bin on their system, the file will be permanently deleted instead.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var file_to_remove = "user://slot1.sav"
 				OS.move_to_trash(ProjectSettings.globalize_path(file_to_remove))
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				var fileToRemove = "user://slot1.sav";
+				OS.MoveToTrash(ProjectSettings.GlobalizePath(fileToRemove));
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="open_midi_inputs">

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -8,42 +8,85 @@
 		[Tween] is more suited than [AnimationPlayer] for animations where you don't know the final values in advance. For example, interpolating a dynamically-chosen camera zoom value is best done with a [Tween]; it would be difficult to do the same thing with an [AnimationPlayer] node. Tweens are also more light-weight than [AnimationPlayer], so they are very much suited for simple animations or general tasks that don't require visual tweaking provided by the editor. They can be used in a fire-and-forget manner for some logic that normally would be done by code. You can e.g. make something shoot periodically by using a looped [CallbackTweener] with a delay.
 		A [Tween] can be created by using either [method SceneTree.create_tween] or [method Node.create_tween]. [Tween]s created manually (i.e. by using [code]Tween.new()[/code]) are invalid and can't be used for tweening values.
 		A tween animation is created by adding [Tweener]s to the [Tween] object, using [method tween_property], [method tween_interval], [method tween_callback] or [method tween_method]:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var tween = get_tree().create_tween()
 		tween.tween_property($Sprite, "modulate", Color.red, 1)
 		tween.tween_property($Sprite, "scale", Vector2(), 1)
 		tween.tween_callback($Sprite.queue_free)
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		Tween tween = GetTree().CreateTween();
+		tween.TweenProperty(GetNode("Sprite"), "modulate", Colors.Red, 1.0f);
+		tween.TweenProperty(GetNode("Sprite"), "scale", Vector2.Zero, 1.0f);
+		tween.TweenCallback(new Callable(GetNode("Sprite").QueueFree));
+		[/csharp]
+		[/codeblocks]
 		This sequence will make the [code]$Sprite[/code] node turn red, then shrink, before finally calling [method Node.queue_free] to free the sprite. [Tweener]s are executed one after another by default. This behavior can be changed using [method parallel] and [method set_parallel].
 		When a [Tweener] is created with one of the [code]tween_*[/code] methods, a chained method call can be used to tweak the properties of this [Tweener]. For example, if you want to set a different transition type in the above example, you can use [method set_trans]:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var tween = get_tree().create_tween()
 		tween.tween_property($Sprite, "modulate", Color.red, 1).set_trans(Tween.TRANS_SINE)
 		tween.tween_property($Sprite, "scale", Vector2(), 1).set_trans(Tween.TRANS_BOUNCE)
 		tween.tween_callback($Sprite.queue_free)
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		Tween tween = GetTree().CreateTween();
+		tween.TweenProperty(GetNode("Sprite"), "modulate", Colors.Red, 1.0f).SetTrans(Tween.TransitionType.Sine);
+		tween.TweenProperty(GetNode("Sprite"), "scale", Vector2.Zero, 1.0f).SetTrans(Tween.TransitionType.Bounce);
+		tween.TweenCallback(new Callable(GetNode("Sprite").QueueFree));
+		[/csharp]
+		[/codeblocks]
 		Most of the [Tween] methods can be chained this way too. In the following example the [Tween] is bound to the running script's node and a default transition is set for its [Tweener]s:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var tween = get_tree().create_tween().bind_node(self).set_trans(Tween.TRANS_ELASTIC)
 		tween.tween_property($Sprite, "modulate", Color.red, 1)
 		tween.tween_property($Sprite, "scale", Vector2(), 1)
 		tween.tween_callback($Sprite.queue_free)
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		var tween = GetTree().CreateTween().BindNode(this).SetTrans(Tween.TransitionType.Elastic);
+		tween.TweenProperty(GetNode("Sprite"), "modulate", Colors.Red, 1.0f);
+		tween.TweenProperty(GetNode("Sprite"), "scale", Vector2.Zero, 1.0f);
+		tween.TweenCallback(new Callable(GetNode("Sprite").QueueFree));
+		[/csharp]
+		[/codeblocks]
 		Another interesting use for [Tween]s is animating arbitrary sets of objects:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var tween = create_tween()
 		for sprite in get_children():
 		    tween.tween_property(sprite, "position", Vector2(0, 0), 1)
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		Tween tween = CreateTween();
+		foreach (Node sprite in GetChildren())
+		    tween.TweenProperty(sprite, "position", Vector2.Zero, 1.0f);
+		[/csharp]
+		[/codeblocks]
 		In the example above, all children of a node are moved one after another to position (0, 0).
 		You should avoid using more than one [Tween] per object's property. If two or more tweens animate one property at the same time, the last one created will take priority and assign the final value. If you want to interrupt and restart an animation, consider assigning the [Tween] to a variable:
-		[codeblock]
+		[codeblocks]
+		[gdscript]
 		var tween
 		func animate():
 		    if tween:
 		        tween.kill() # Abort the previous animation.
 		    tween = create_tween()
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		private Tween tween;
+
+		public void Animate()
+		{
+		    if (tween != null)
+		        tween.Kill(); // Abort the previous animation
+		    tween = CreateTween();
+		}
+		[/csharp]
+		[/codeblocks]
 		Some [Tweener]s use transitions and eases. The first accepts a [enum TransitionType] constant, and refers to the way the timing of the animation is handled (see [url=https://easings.net/]easings.net[/url] for some examples). The second accepts an [enum EaseType] constant, and controls where the [code]trans_type[/code] is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different [enum TransitionType] constants with [constant EASE_IN_OUT], and use the one that looks best.
 		[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/tween_cheatsheet.png]Tween easing and transition types cheatsheet[/url]
 		[b]Note:[/b] All [Tween]s will automatically start by default. To prevent a [Tween] from autostarting, you can call [method stop] immediately after it is created.
@@ -64,12 +107,20 @@
 			<return type="Tween" />
 			<description>
 				Used to chain two [Tweener]s after [method set_parallel] is called with [code]true[/code].
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween().set_parallel(true)
 				tween.tween_property(...)
 				tween.tween_property(...) # Will run parallelly with above.
 				tween.chain().tween_property(...) # Will run after two above are finished.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween().SetParallel(true);
+				tween.TweenProperty(...);
+				tween.TweenProperty(...); // Will run parallelly with above.
+				tween.Chain().TweenProperty(...); // Will run after two above are finished.
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="custom_step">
@@ -127,12 +178,20 @@
 			<return type="Tween" />
 			<description>
 				Makes the next [Tweener] run parallelly to the previous one. Example:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 				tween.tween_property(...)
 				tween.parallel().tween_property(...)
 				tween.parallel().tween_property(...)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenProperty(...);
+				tween.Parallel().TweenProperty(...);
+				tween.Parallel().TweenProperty(...);
+				[/csharp]
+				[/codeblocks]
 				All [Tweener]s in the example will run at the same time.
 				You can make the [Tween] parallel by default by using [method set_parallel].
 			</description>
@@ -214,16 +273,30 @@
 			<description>
 				Creates and appends a [CallbackTweener]. This method can be used to call an arbitrary method in any object. Use [method Callable.bind] to bind additional arguments for the call.
 				Example: object that keeps shooting every 1 second.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = get_tree().create_tween().set_loops()
 				tween.tween_callback(shoot).set_delay(1)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = GetTree().CreateTween().SetLoops();
+				tween.TweenCallback(new Callable(Shoot)).SetDelay(1.0f);
+				[/csharp]
+				[/codeblocks]
 				Example: turning a sprite red and then blue, with 2 second delay.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = get_tree().create_tween()
 				tween.tween_callback($Sprite.set_modulate.bind(Color.red)).set_delay(2)
 				tween.tween_callback($Sprite.set_modulate.bind(Color.blue)).set_delay(2)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = GetTree().CreateTween();
+				Sprite2D sprite = GetNode&lt;Sprite2D&gt;("Sprite");
+				tween.TweenCallback(new Callable(() =&gt; sprite.Modulate = Colors.Red)).SetDelay(2.0f);
+				tween.TweenCallback(new Callable(() =&gt; sprite.Modulate = Colors.Blue)).SetDelay(2.0f);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="tween_interval">
@@ -232,13 +305,21 @@
 			<description>
 				Creates and appends an [IntervalTweener]. This method can be used to create delays in the tween animation, as an alternative to using the delay in other [Tweener]s, or when there's no animation (in which case the [Tween] acts as a timer). [param time] is the length of the interval, in seconds.
 				Example: creating an interval in code execution.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				# ... some code
 				await create_tween().tween_interval(2).finished
 				# ... more code
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				// ... some code
+				await ToSignal(CreateTween().TweenInterval(2.0f), Tween.SignalName.Finished);
+				// ... more code
+				[/csharp]
+				[/codeblocks]
 				Example: creating an object that moves back and forth and jumps every few seconds.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween().set_loops()
 				tween.tween_property($Sprite, "position:x", 200.0, 1).as_relative()
 				tween.tween_callback(jump)
@@ -246,7 +327,17 @@
 				tween.tween_property($Sprite, "position:x", -200.0, 1).as_relative()
 				tween.tween_callback(jump)
 				tween.tween_interval(2)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween().SetLoops();
+				tween.TweenProperty(GetNode("Sprite"), "position:x", 200.0f, 1.0f).AsRelative();
+				tween.TweenCallback(new Callable(Jump));
+				tween.TweenInterval(2.0f);
+				tween.TweenProperty(GetNode("Sprite"), "position:x", -200.0f, 1.0f).AsRelative();
+				tween.TweenCallback(new Callable(Jump));
+				tween.TweenInterval(2.0f);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="tween_method">
@@ -258,19 +349,41 @@
 			<description>
 				Creates and appends a [MethodTweener]. This method is similar to a combination of [method tween_callback] and [method tween_property]. It calls a method over time with a tweened value provided as an argument. The value is tweened between [param from] and [param to] over the time specified by [param duration], in seconds. Use [method Callable.bind] to bind additional arguments for the call. You can use [method MethodTweener.set_ease] and [method MethodTweener.set_trans] to tweak the easing and transition of the value or [method MethodTweener.set_delay] to delay the tweening.
 				Example: making a 3D object look from one point to another point.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 				tween.tween_method(look_at.bind(Vector3.UP), Vector3(-1, 0, -1), Vector3(1, 0, -1), 1) # The look_at() method takes up vector as second argument.
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenMethod(new Callable(() =&gt; LookAt(Vector3.Up)), new Vector3(-1.0f, 0.0f, -1.0f), new Vector3(1.0f, 0.0f, -1.0f), 1.0f); // The LookAt() method takes up vector as second argument.
+				[/csharp]
+				[/codeblocks]
 				Example: setting a text of a [Label], using an intermediate method and after a delay.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				func _ready():
 				    var tween = create_tween()
 				    tween.tween_method(set_label_text, 0, 10, 1).set_delay(1)
 
 				func set_label_text(value: int):
 				    $Label.text = "Counting " + str(value)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				public override void _Ready()
+				{
+				    base._Ready();
+
+				    Tween tween = CreateTween();
+				    tween.TweenMethod(new Callable(SetLabelText), 0.0f, 10.0f, 1.0f).SetDelay(1.0f);
+				}
+
+				private void SetLabelText(int value)
+				{
+				    GetNode&lt;Label&gt;("Label").Text = $"Counting {value}";
+				}
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="tween_property">
@@ -281,19 +394,33 @@
 			<param index="3" name="duration" type="float" />
 			<description>
 				Creates and appends a [PropertyTweener]. This method tweens a [param property] of an [param object] between an initial value and [param final_val] in a span of time equal to [param duration], in seconds. The initial value by default is the property's value at the time the tweening of the [PropertyTweener] starts. For example:
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 				tween.tween_property($Sprite, "position", Vector2(100, 200), 1)
 				tween.tween_property($Sprite, "position", Vector2(200, 300), 1)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenProperty(GetNode("Sprite"), "position", new Vector2(100.0f, 200.0f), 1.0f);
+				tween.TweenProperty(GetNode("Sprite"), "position", new Vector2(200.0f, 300.0f), 1.0f);
+				[/csharp]
+				[/codeblocks]
 				will move the sprite to position (100, 200) and then to (200, 300). If you use [method PropertyTweener.from] or [method PropertyTweener.from_current], the starting position will be overwritten by the given value instead. See other methods in [PropertyTweener] to see how the tweening can be tweaked further.
 				[b]Note:[/b] You can find the correct property name by hovering over the property in the Inspector. You can also provide the components of a property directly by using [code]"property:component"[/code] (eg. [code]position:x[/code]), where it would only apply to that particular component.
 				Example: moving object twice from the same position, with different transition types.
-				[codeblock]
+				[codeblocks]
+				[gdscript]
 				var tween = create_tween()
 				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300, 1).as_relative().set_trans(Tween.TRANS_SINE)
 				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300, 1).as_relative().from_current().set_trans(Tween.TRANS_EXPO)
-				[/codeblock]
+				[/gdscript]
+				[csharp]
+				Tween tween = CreateTween();
+				tween.TweenProperty(GetNode("Sprite"), "position", Vector2.Right * 300.0f, 1.0f).AsRelative().SetTrans(Tween.TransitionType.Sine);
+				tween.TweenProperty(GetNode("Sprite"), "position", Vector2.Right * 300.0f, 1.0f).AsRelative().FromCurrent().SetTrans(Tween.TransitionType.Expo);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Modified the following class ref pages:
- AStarGrid2D
- Engine
- Font
- Node
- OS
- Tween

There are a couple of workarounds in the Tween page, that'll need to be updated when `Callable.Bind` gets implemented.
