### PR TITLE
implement 'OS::shell_show_in_explore()' for FilesystemDock and expose…

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -252,6 +252,14 @@ Error OS::shell_open(String p_uri) {
 	}
 	return ::OS::get_singleton()->shell_open(p_uri);
 }
+Error OS::shell_show_in_explorer(String p_fpath) {
+	if (p_fpath.begins_with("res://")) {
+		WARN_PRINT("Attempting to navigate to a file path with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explorer()`.");
+	} else if (p_fpath.begins_with("user://")) {
+		WARN_PRINT("Attempting to navigate to a file path with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explorer()`.");
+	}
+	return ::OS::get_singleton()->shell_show_in_explorer(p_fpath);
+}
 
 int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr, bool p_open_console) {
 	List<String> args;
@@ -527,6 +535,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_instance", "arguments"), &OS::create_instance);
 	ClassDB::bind_method(D_METHOD("kill", "pid"), &OS::kill);
 	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &OS::shell_open);
+	ClassDB::bind_method(D_METHOD("shell_show_in_explorer", "file_path"), &OS::shell_show_in_explorer);
 	ClassDB::bind_method(D_METHOD("is_process_running", "pid"), &OS::is_process_running);
 	ClassDB::bind_method(D_METHOD("get_process_id"), &OS::get_process_id);
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -252,6 +252,32 @@ Error OS::shell_open(String p_uri) {
 	}
 	return ::OS::get_singleton()->shell_open(p_uri);
 }
+<<<<<<< HEAD
+<<<<<<< HEAD
+Error OS::shell_show_in_explorer(String p_fpath) {
+	if (p_fpath.begins_with("res://")) {
+		WARN_PRINT("Attempting to navigate to a file path with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explorer()`.");
+	} else if (p_fpath.begins_with("user://")) {
+		WARN_PRINT("Attempting to navigate to a file path with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explorer()`.");
+	}
+	return ::OS::get_singleton()->shell_show_in_explorer(p_fpath);
+=======
+Error OS::shell_show_in_explore(String p_fpath) {
+=======
+Error OS::shell_show_in_explorer(String p_fpath) {
+>>>>>>> 440daa8426 (fix methods names)
+	if (p_fpath.begins_with("res://")) {
+		WARN_PRINT("Attempting to navigate to a file path with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explorer()`.");
+	} else if (p_fpath.begins_with("user://")) {
+		WARN_PRINT("Attempting to navigate to a file path with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explorer()`.");
+	}
+<<<<<<< HEAD
+	return ::OS::get_singleton()->shell_show_in_explore(p_fpath);
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+	return ::OS::get_singleton()->shell_show_in_explorer(p_fpath);
+>>>>>>> 440daa8426 (fix methods names)
+}
 
 int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr, bool p_open_console) {
 	List<String> args;
@@ -527,6 +553,15 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_instance", "arguments"), &OS::create_instance);
 	ClassDB::bind_method(D_METHOD("kill", "pid"), &OS::kill);
 	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &OS::shell_open);
+<<<<<<< HEAD
+<<<<<<< HEAD
+	ClassDB::bind_method(D_METHOD("shell_show_in_explorer", "file_path"), &OS::shell_show_in_explorer);
+=======
+	ClassDB::bind_method(D_METHOD("shell_show_in_explore", "file_path"), &OS::shell_show_in_explore);
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+	ClassDB::bind_method(D_METHOD("shell_show_in_explorer", "file_path"), &OS::shell_show_in_explorer);
+>>>>>>> 440daa8426 (fix methods names)
 	ClassDB::bind_method(D_METHOD("is_process_running", "pid"), &OS::is_process_running);
 	ClassDB::bind_method(D_METHOD("get_process_id"), &OS::get_process_id);
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -252,13 +252,13 @@ Error OS::shell_open(String p_uri) {
 	}
 	return ::OS::get_singleton()->shell_open(p_uri);
 }
-Error OS::shell_show_in_explore(String p_fpath) {
+Error OS::shell_show_in_explorer(String p_fpath) {
 	if (p_fpath.begins_with("res://")) {
-		WARN_PRINT("Attempting to navigate to a file path with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explore()`.");
+		WARN_PRINT("Attempting to navigate to a file path with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explorer()`.");
 	} else if (p_fpath.begins_with("user://")) {
-		WARN_PRINT("Attempting to navigate to a file path with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explore()`.");
+		WARN_PRINT("Attempting to navigate to a file path with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explorer()`.");
 	}
-	return ::OS::get_singleton()->shell_show_in_explore(p_fpath);
+	return ::OS::get_singleton()->shell_show_in_explorer(p_fpath);
 }
 
 int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr, bool p_open_console) {
@@ -535,7 +535,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_instance", "arguments"), &OS::create_instance);
 	ClassDB::bind_method(D_METHOD("kill", "pid"), &OS::kill);
 	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &OS::shell_open);
-	ClassDB::bind_method(D_METHOD("shell_show_in_explore", "file_path"), &OS::shell_show_in_explore);
+	ClassDB::bind_method(D_METHOD("shell_show_in_explorer", "file_path"), &OS::shell_show_in_explorer);
 	ClassDB::bind_method(D_METHOD("is_process_running", "pid"), &OS::is_process_running);
 	ClassDB::bind_method(D_METHOD("get_process_id"), &OS::get_process_id);
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -252,6 +252,14 @@ Error OS::shell_open(String p_uri) {
 	}
 	return ::OS::get_singleton()->shell_open(p_uri);
 }
+Error OS::shell_show_in_explore(String p_fpath) {
+	if (p_fpath.begins_with("res://")) {
+		WARN_PRINT("Attempting to navigate to a file path with the \"res://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explore()`.");
+	} else if (p_fpath.begins_with("user://")) {
+		WARN_PRINT("Attempting to navigate to a file path with the \"user://\" protocol. Use `ProjectSettings.globalize_path()` to convert a Godot-specific path to a system path before opening it with `OS.shell_show_in_explore()`.");
+	}
+	return ::OS::get_singleton()->shell_show_in_explore(p_fpath);
+}
 
 int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr, bool p_open_console) {
 	List<String> args;
@@ -527,6 +535,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_instance", "arguments"), &OS::create_instance);
 	ClassDB::bind_method(D_METHOD("kill", "pid"), &OS::kill);
 	ClassDB::bind_method(D_METHOD("shell_open", "uri"), &OS::shell_open);
+	ClassDB::bind_method(D_METHOD("shell_show_in_explore", "file_path"), &OS::shell_show_in_explore);
 	ClassDB::bind_method(D_METHOD("is_process_running", "pid"), &OS::is_process_running);
 	ClassDB::bind_method(D_METHOD("get_process_id"), &OS::get_process_id);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -180,6 +180,7 @@ public:
 	int create_instance(const Vector<String> &p_arguments);
 	Error kill(int p_pid);
 	Error shell_open(String p_uri);
+	Error shell_show_in_explorer(String p_fpath);
 
 	bool is_process_running(int p_pid) const;
 	int get_process_id() const;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -180,6 +180,15 @@ public:
 	int create_instance(const Vector<String> &p_arguments);
 	Error kill(int p_pid);
 	Error shell_open(String p_uri);
+<<<<<<< HEAD
+<<<<<<< HEAD
+	Error shell_show_in_explorer(String p_fpath);
+=======
+	Error shell_show_in_explore(String p_fpath);
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+	Error shell_show_in_explorer(String p_fpath);
+>>>>>>> 440daa8426 (fix methods names)
 
 	bool is_process_running(int p_pid) const;
 	int get_process_id() const;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -180,6 +180,7 @@ public:
 	int create_instance(const Vector<String> &p_arguments);
 	Error kill(int p_pid);
 	Error shell_open(String p_uri);
+	Error shell_show_in_explore(String p_fpath);
 
 	bool is_process_running(int p_pid) const;
 	int get_process_id() const;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -180,7 +180,7 @@ public:
 	int create_instance(const Vector<String> &p_arguments);
 	Error kill(int p_pid);
 	Error shell_open(String p_uri);
-	Error shell_show_in_explore(String p_fpath);
+	Error shell_show_in_explorer(String p_fpath);
 
 	bool is_process_running(int p_pid) const;
 	int get_process_id() const;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -278,6 +278,13 @@ Error OS::shell_open(String p_uri) {
 	return ERR_UNAVAILABLE;
 }
 
+Error OS::shell_show_in_explorer(String p_fpath) {
+	p_fpath = String("file://") + p_fpath;
+	if (!p_fpath.ends_with("/")) {
+		p_fpath = p_fpath.get_base_dir();
+	}
+	return shell_open(p_fpath);
+};
 // implement these with the canvas?
 
 uint64_t OS::get_static_memory_usage() const {

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -278,6 +278,12 @@ Error OS::shell_open(String p_uri) {
 	return ERR_UNAVAILABLE;
 }
 
+Error OS::shell_show_in_explore(String p_fpath) {
+	if (!p_fpath.ends_with("/")) {
+		p_fpath = p_fpath.get_base_dir();
+	}
+	return shell_open(p_fpath);
+};
 // implement these with the canvas?
 
 uint64_t OS::get_static_memory_usage() const {

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -278,6 +278,22 @@ Error OS::shell_open(String p_uri) {
 	return ERR_UNAVAILABLE;
 }
 
+<<<<<<< HEAD
+<<<<<<< HEAD
+Error OS::shell_show_in_explorer(String p_fpath) {
+	p_fpath = String("file://") + p_fpath;
+=======
+Error OS::shell_show_in_explore(String p_fpath) {
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+Error OS::shell_show_in_explorer(String p_fpath) {
+	p_fpath = String("file://") + p_fpath;
+>>>>>>> 440daa8426 (fix methods names)
+	if (!p_fpath.ends_with("/")) {
+		p_fpath = p_fpath.get_base_dir();
+	}
+	return shell_open(p_fpath);
+};
 // implement these with the canvas?
 
 uint64_t OS::get_static_memory_usage() const {

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -278,7 +278,8 @@ Error OS::shell_open(String p_uri) {
 	return ERR_UNAVAILABLE;
 }
 
-Error OS::shell_show_in_explore(String p_fpath) {
+Error OS::shell_show_in_explorer(String p_fpath) {
+	p_fpath = String("file://") + p_fpath;
 	if (!p_fpath.ends_with("/")) {
 		p_fpath = p_fpath.get_base_dir();
 	}

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -154,6 +154,7 @@ public:
 	virtual void vibrate_handheld(int p_duration_ms = 500);
 
 	virtual Error shell_open(String p_uri);
+	virtual Error shell_show_in_explorer(String p_fpath);
 	virtual Error set_cwd(const String &p_cwd);
 
 	virtual bool has_environment(const String &p_var) const = 0;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -154,7 +154,7 @@ public:
 	virtual void vibrate_handheld(int p_duration_ms = 500);
 
 	virtual Error shell_open(String p_uri);
-	virtual Error shell_show_in_explore(String p_fpath);
+	virtual Error shell_show_in_explorer(String p_fpath);
 	virtual Error set_cwd(const String &p_cwd);
 
 	virtual bool has_environment(const String &p_var) const = 0;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -154,6 +154,15 @@ public:
 	virtual void vibrate_handheld(int p_duration_ms = 500);
 
 	virtual Error shell_open(String p_uri);
+<<<<<<< HEAD
+<<<<<<< HEAD
+	virtual Error shell_show_in_explorer(String p_fpath);
+=======
+	virtual Error shell_show_in_explore(String p_fpath);
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+	virtual Error shell_show_in_explorer(String p_fpath);
+>>>>>>> 440daa8426 (fix methods names)
 	virtual Error set_cwd(const String &p_cwd);
 
 	virtual bool has_environment(const String &p_var) const = 0;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -154,6 +154,7 @@ public:
 	virtual void vibrate_handheld(int p_duration_ms = 500);
 
 	virtual Error shell_open(String p_uri);
+	virtual Error shell_show_in_explore(String p_fpath);
 	virtual Error set_cwd(const String &p_cwd);
 
 	virtual bool has_environment(const String &p_var) const = 0;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -577,11 +577,11 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux, macOS and Windows.
 			</description>
 		</method>
-		<method name="shell_show_in_explore">
+		<method name="shell_show_in_explorer">
 			<return type="int" enum="Error" />
 			<param index="0" name="file_path" type="String" />
 			<description>
-				Requests the OS to open a explore( file resource manager), then navigate to the given [param file_path] and select target file. 
+				Requests the OS to open a explorer( file resource manager), then navigate to the given [param file_path] and select target file. 
 				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
 				[b]Note:[/b] Currently this method is only implemented on Windows, in other platforms, it will fallback to [method shell_open] with a directory path for [param file_path] .
 			</description>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -577,6 +577,15 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux, macOS and Windows.
 			</description>
 		</method>
+		<method name="shell_show_in_explore">
+			<return type="int" enum="Error" />
+			<param index="0" name="file_path" type="String" />
+			<description>
+				Requests the OS to open a explore( file resource manager), then navigate to the given [param file_path] and select target file. 
+				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
+				[b]Note:[/b] Currently this method is only implemented on Windows, in other platforms, it will fallback to [method shell_open] with a directory path for [param file_path] .
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="low_processor_usage_mode" type="bool" setter="set_low_processor_usage_mode" getter="is_in_low_processor_usage_mode" default="false">

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -577,6 +577,15 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux, macOS and Windows.
 			</description>
 		</method>
+		<method name="shell_show_in_explorer">
+			<return type="int" enum="Error" />
+			<param index="0" name="file_path" type="String" />
+			<description>
+				Requests the OS to open a explorer( file resource manager), then navigate to the given [param file_path] and select target file. 
+				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
+				[b]Note:[/b] Currently this method is only implemented on Windows, in other platforms, it will fallback to [method shell_open] with a directory path for [param file_path] .
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="low_processor_usage_mode" type="bool" setter="set_low_processor_usage_mode" getter="is_in_low_processor_usage_mode" default="false">

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -577,6 +577,31 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux, macOS and Windows.
 			</description>
 		</method>
+<<<<<<< HEAD
+<<<<<<< HEAD
+		<method name="shell_show_in_explorer">
+			<return type="int" enum="Error" />
+			<param index="0" name="file_path" type="String" />
+			<description>
+				Requests the OS to open a explorer( file resource manager), then navigate to the given [param file_path] and select target file. 
+=======
+		<method name="shell_show_in_explore">
+			<return type="int" enum="Error" />
+			<param index="0" name="file_path" type="String" />
+			<description>
+				Requests the OS to open a explore( file resource manager), then navigate to the given [param file_path] and select target file. 
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+		<method name="shell_show_in_explorer">
+			<return type="int" enum="Error" />
+			<param index="0" name="file_path" type="String" />
+			<description>
+				Requests the OS to open a explorer( file resource manager), then navigate to the given [param file_path] and select target file. 
+>>>>>>> 440daa8426 (fix methods names)
+				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
+				[b]Note:[/b] Currently this method is only implemented on Windows, in other platforms, it will fallback to [method shell_open] with a directory path for [param file_path] .
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="low_processor_usage_mode" type="bool" setter="set_low_processor_usage_mode" getter="is_in_low_processor_usage_mode" default="false">

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1795,11 +1795,8 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				fpath = p_selected[0];
 			}
 
-			if (!fpath.ends_with("/")) {
-				fpath = fpath.get_base_dir();
-			}
 			String dir = ProjectSettings::get_singleton()->globalize_path(fpath);
-			OS::get_singleton()->shell_open(String("file://") + dir);
+			OS::get_singleton()->shell_show_in_explorer(dir);
 		} break;
 
 		case FILE_OPEN: {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1795,11 +1795,8 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				fpath = p_selected[0];
 			}
 
-			if (!fpath.ends_with("/")) {
-				fpath = fpath.get_base_dir();
-			}
 			String dir = ProjectSettings::get_singleton()->globalize_path(fpath);
-			OS::get_singleton()->shell_open(String("file://") + dir);
+			OS::get_singleton()->shell_show_in_explore(String("file://") + dir);
 		} break;
 
 		case FILE_OPEN: {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1796,7 +1796,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			}
 
 			String dir = ProjectSettings::get_singleton()->globalize_path(fpath);
-			OS::get_singleton()->shell_show_in_explore(String("file://") + dir);
+			OS::get_singleton()->shell_show_in_explorer(dir);
 		} break;
 
 		case FILE_OPEN: {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1795,11 +1795,16 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				fpath = p_selected[0];
 			}
 
-			if (!fpath.ends_with("/")) {
-				fpath = fpath.get_base_dir();
-			}
 			String dir = ProjectSettings::get_singleton()->globalize_path(fpath);
-			OS::get_singleton()->shell_open(String("file://") + dir);
+<<<<<<< HEAD
+<<<<<<< HEAD
+			OS::get_singleton()->shell_show_in_explorer(dir);
+=======
+			OS::get_singleton()->shell_show_in_explore(String("file://") + dir);
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+			OS::get_singleton()->shell_show_in_explorer(dir);
+>>>>>>> 440daa8426 (fix methods names)
 		} break;
 
 		case FILE_OPEN: {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -805,6 +805,31 @@ Error OS_Windows::shell_open(String p_uri) {
 	}
 }
 
+Error OS_Windows::shell_show_in_explore(String p_fpath) {
+	INT_PTR ret = (INT_PTR)ShellExecuteW(nullptr, nullptr, LPCWSTR(String("explorer.exe").utf16().get_data()), LPCWSTR((String("/select,")+p_fpath).utf16().get_data()), nullptr, SW_SHOWNORMAL);
+	if (ret > 32) {
+		return OK;
+	} else {
+		switch (ret) {
+			case ERROR_FILE_NOT_FOUND:
+			case SE_ERR_DLLNOTFOUND:
+				return ERR_FILE_NOT_FOUND;
+			case ERROR_PATH_NOT_FOUND:
+				return ERR_FILE_BAD_PATH;
+			case ERROR_BAD_FORMAT:
+				return ERR_FILE_CORRUPT;
+			case SE_ERR_ACCESSDENIED:
+				return ERR_UNAUTHORIZED;
+			case 0:
+			case SE_ERR_OOM:
+				return ERR_OUT_OF_MEMORY;
+			default:
+				return FAILED;
+		}
+	}
+}
+
+
 String OS_Windows::get_locale() const {
 	const _WinLocale *wl = &_win_locales[0];
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -805,7 +805,8 @@ Error OS_Windows::shell_open(String p_uri) {
 	}
 }
 
-Error OS_Windows::shell_show_in_explore(String p_fpath) {
+Error OS_Windows::shell_show_in_explorer(String p_fpath) {
+	p_fpath = String("file://") + p_fpath;
 	INT_PTR ret = (INT_PTR)ShellExecuteW(nullptr, nullptr, LPCWSTR(String("explorer.exe").utf16().get_data()), LPCWSTR((String("/select,")+p_fpath).utf16().get_data()), nullptr, SW_SHOWNORMAL);
 	if (ret > 32) {
 		return OK;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -805,6 +805,41 @@ Error OS_Windows::shell_open(String p_uri) {
 	}
 }
 
+<<<<<<< HEAD
+<<<<<<< HEAD
+Error OS_Windows::shell_show_in_explorer(String p_fpath) {
+	p_fpath = String("file://") + p_fpath;
+=======
+Error OS_Windows::shell_show_in_explore(String p_fpath) {
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+Error OS_Windows::shell_show_in_explorer(String p_fpath) {
+	p_fpath = String("file://") + p_fpath;
+>>>>>>> 440daa8426 (fix methods names)
+	INT_PTR ret = (INT_PTR)ShellExecuteW(nullptr, nullptr, LPCWSTR(String("explorer.exe").utf16().get_data()), LPCWSTR((String("/select,")+p_fpath).utf16().get_data()), nullptr, SW_SHOWNORMAL);
+	if (ret > 32) {
+		return OK;
+	} else {
+		switch (ret) {
+			case ERROR_FILE_NOT_FOUND:
+			case SE_ERR_DLLNOTFOUND:
+				return ERR_FILE_NOT_FOUND;
+			case ERROR_PATH_NOT_FOUND:
+				return ERR_FILE_BAD_PATH;
+			case ERROR_BAD_FORMAT:
+				return ERR_FILE_CORRUPT;
+			case SE_ERR_ACCESSDENIED:
+				return ERR_UNAUTHORIZED;
+			case 0:
+			case SE_ERR_OOM:
+				return ERR_OUT_OF_MEMORY;
+			default:
+				return FAILED;
+		}
+	}
+}
+
+
 String OS_Windows::get_locale() const {
 	const _WinLocale *wl = &_win_locales[0];
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -805,6 +805,32 @@ Error OS_Windows::shell_open(String p_uri) {
 	}
 }
 
+Error OS_Windows::shell_show_in_explorer(String p_fpath) {
+	p_fpath = String("file://") + p_fpath;
+	INT_PTR ret = (INT_PTR)ShellExecuteW(nullptr, nullptr, LPCWSTR(String("explorer.exe").utf16().get_data()), LPCWSTR((String("/select,")+p_fpath).utf16().get_data()), nullptr, SW_SHOWNORMAL);
+	if (ret > 32) {
+		return OK;
+	} else {
+		switch (ret) {
+			case ERROR_FILE_NOT_FOUND:
+			case SE_ERR_DLLNOTFOUND:
+				return ERR_FILE_NOT_FOUND;
+			case ERROR_PATH_NOT_FOUND:
+				return ERR_FILE_BAD_PATH;
+			case ERROR_BAD_FORMAT:
+				return ERR_FILE_CORRUPT;
+			case SE_ERR_ACCESSDENIED:
+				return ERR_UNAUTHORIZED;
+			case 0:
+			case SE_ERR_OOM:
+				return ERR_OUT_OF_MEMORY;
+			default:
+				return FAILED;
+		}
+	}
+}
+
+
 String OS_Windows::get_locale() const {
 	const _WinLocale *wl = &_win_locales[0];
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -188,6 +188,7 @@ public:
 	virtual String get_unique_id() const override;
 
 	virtual Error shell_open(String p_uri) override;
+	virtual Error shell_show_in_explorer(String p_fpath);
 
 	void run();
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -188,6 +188,7 @@ public:
 	virtual String get_unique_id() const override;
 
 	virtual Error shell_open(String p_uri) override;
+	virtual Error shell_show_in_explore(String p_fpath);
 
 	void run();
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -188,7 +188,7 @@ public:
 	virtual String get_unique_id() const override;
 
 	virtual Error shell_open(String p_uri) override;
-	virtual Error shell_show_in_explore(String p_fpath);
+	virtual Error shell_show_in_explorer(String p_fpath);
 
 	void run();
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -188,6 +188,15 @@ public:
 	virtual String get_unique_id() const override;
 
 	virtual Error shell_open(String p_uri) override;
+<<<<<<< HEAD
+<<<<<<< HEAD
+	virtual Error shell_show_in_explorer(String p_fpath);
+=======
+	virtual Error shell_show_in_explore(String p_fpath);
+>>>>>>> 9905764c62 (implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript)
+=======
+	virtual Error shell_show_in_explorer(String p_fpath);
+>>>>>>> 440daa8426 (fix methods names)
 
 	void run();
 


### PR DESCRIPTION
Implement 'OS::shell_show_in_explore()' for FilesystemDock and expose to GDScript.

Currently only implement for Windows, because I only have a windows device.
On other platforms, it will fallback to origin action.

I hope someone can implement for other platforms.



https://user-images.githubusercontent.com/61624558/190620562-66997ebe-1ba5-4b18-81f0-7f796c02d838.mp4
