### PR TITLE
Fix OpenXR layer composition blending

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1557,7 +1557,7 @@ void OpenXRAPI::end_frame() {
 	XrCompositionLayerProjection projection_layer = {
 		XR_TYPE_COMPOSITION_LAYER_PROJECTION, // type
 		nullptr, // next
-		layers_list.size() > 1 ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT | XR_COMPOSITION_LAYER_CORRECT_CHROMATIC_ABERRATION_BIT : XR_COMPOSITION_LAYER_CORRECT_CHROMATIC_ABERRATION_BIT, // layerFlags
+		layers_list.size() > 0 ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT | XR_COMPOSITION_LAYER_CORRECT_CHROMATIC_ABERRATION_BIT : XR_COMPOSITION_LAYER_CORRECT_CHROMATIC_ABERRATION_BIT, // layerFlags
 		play_space, // space
 		view_count, // viewCount
 		projection_views, // views


### PR DESCRIPTION
This PR fixes a bug in the OpenXR layer composition, which causes the projection layer to have incorrect blending settings if there is only a single layer provided by the composition layer providers.

This fix is required for the implementation of OpenXR passthrough functionality.
