### PR TITLE
Fix crash when playing Tween right after finishing

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -315,6 +315,7 @@ bool Tween::step(float p_delta) {
 					running = false;
 					dead = true;
 					emit_signal(SNAME("finished"));
+					break;
 				} else {
 					emit_signal(SNAME("loop_finished"), loops_done);
 					current_step = 0;


### PR DESCRIPTION
Fixes #65891

This is fun edge case. The Tween normally gets initialized before the `while` loop, but if you restart it right after `finished` signal, it will be running again mid-loop and bypass the initialization logic. This caused it to access step outside of the defined animation., because the value wasn't reset.