### PR TITLE
Add passthrough extension wrapper

### DIFF
--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -69,11 +69,36 @@
 				Is [code]true[/code] if this interface has been initialised.
 			</description>
 		</method>
+		<method name="is_passthrough_enabled">
+			<return type="bool" />
+			<description>
+				Is [code]true[/code] if passthrough is enabled.
+			</description>
+		</method>
+		<method name="is_passthrough_supported">
+			<return type="bool" />
+			<description>
+				Is [code]true[/code] if this interface supports passthrough.
+			</description>
+		</method>
 		<method name="set_play_area_mode">
 			<return type="bool" />
 			<param index="0" name="mode" type="int" enum="XRInterface.PlayAreaMode" />
 			<description>
 				Sets the active play area mode, will return [code]false[/code] if the mode can't be used with this interface.
+			</description>
+		</method>
+		<method name="start_passthrough">
+			<return type="bool" />
+			<description>
+				Starts passthrough, will return [code]false[/code] if passthrough couldn't be started.
+				[b]Note:[/b] The viewport used for XR must have a transparent background, otherwise passthrough may not properly render.
+			</description>
+		</method>
+		<method name="stop_passthrough">
+			<return type="void" />
+			<description>
+				Stops passthrough.
 			</description>
 		</method>
 		<method name="supports_play_area_mode">

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -94,6 +94,7 @@ if env["vulkan"]:
 env_openxr.add_source_files(module_obj, "extensions/openxr_palm_pose_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_htc_vive_tracker_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_hand_tracking_extension.cpp")
+env_openxr.add_source_files(module_obj, "extensions/openxr_fb_passthrough_extension_wrapper.cpp")
 
 env.modules_sources += module_obj
 

--- a/modules/openxr/extensions/openxr_composition_layer_provider.h
+++ b/modules/openxr/extensions/openxr_composition_layer_provider.h
@@ -36,10 +36,9 @@
 // Interface for OpenXR extensions that provide a composition layer.
 class OpenXRCompositionLayerProvider {
 public:
-	// TODO changed to normal method definition for now
-	// CI complains until we implement this, haven't ported it yet from plugin
-	// virtual XrCompositionLayerBaseHeader *get_composition_layer() = 0;
-	XrCompositionLayerBaseHeader *get_composition_layer() { return nullptr; };
+	virtual XrCompositionLayerBaseHeader *get_composition_layer() = 0;
+
+	virtual ~OpenXRCompositionLayerProvider() {}
 };
 
 #endif // OPENXR_COMPOSITION_LAYER_PROVIDER_H

--- a/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -1,0 +1,234 @@
+/*************************************************************************/
+/*  openxr_fb_passthrough_extension_wrapper.cpp                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "openxr_fb_passthrough_extension_wrapper.h"
+
+#include "core/os/os.h"
+#include "scene/main/viewport.h"
+#include "scene/main/window.h"
+
+using namespace godot;
+
+OpenXRFbPassthroughExtensionWrapper *OpenXRFbPassthroughExtensionWrapper::singleton = nullptr;
+
+OpenXRFbPassthroughExtensionWrapper *OpenXRFbPassthroughExtensionWrapper::get_singleton() {
+	return singleton;
+}
+
+OpenXRFbPassthroughExtensionWrapper::OpenXRFbPassthroughExtensionWrapper(OpenXRAPI *p_openxr_api) :
+		OpenXRExtensionWrapper(p_openxr_api) {
+	request_extensions[XR_FB_PASSTHROUGH_EXTENSION_NAME] = &fb_passthrough_ext;
+	request_extensions[XR_FB_TRIANGLE_MESH_EXTENSION_NAME] = &fb_triangle_mesh_ext;
+	singleton = this;
+}
+
+OpenXRFbPassthroughExtensionWrapper::~OpenXRFbPassthroughExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbPassthroughExtensionWrapper::cleanup() {
+	fb_passthrough_ext = false;
+	fb_triangle_mesh_ext = false;
+}
+
+Viewport *OpenXRFbPassthroughExtensionWrapper::get_main_viewport() {
+	MainLoop *main_loop = OS::get_singleton()->get_main_loop();
+	if (!main_loop) {
+		print_error("Unable to retrieve main loop");
+		return nullptr;
+	}
+
+	auto *scene_tree = Object::cast_to<SceneTree>(main_loop);
+	if (!scene_tree) {
+		print_error("Unable to retrieve scene tree");
+		return nullptr;
+	}
+
+	Viewport *viewport = scene_tree->get_root()->get_viewport();
+	return viewport;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::on_instance_created(const XrInstance instance) {
+	if (fb_passthrough_ext) {
+		bool result = initialize_fb_passthrough_extension(instance);
+		if (!result) {
+			print_error("Failed to initialize fb_passthrough extension");
+			fb_passthrough_ext = false;
+		}
+	}
+
+	if (fb_triangle_mesh_ext) {
+		bool result = initialize_fb_triangle_mesh_extension(instance);
+		if (!result) {
+			print_error("Failed to initialize fb_triangle_mesh extension");
+			fb_triangle_mesh_ext = false;
+		}
+	}
+
+	if (fb_passthrough_ext) {
+		openxr_api->register_composition_layer_provider(this);
+	}
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::is_passthrough_enabled() {
+	return fb_passthrough_ext && passthrough_handle != XR_NULL_HANDLE && passthrough_layer != XR_NULL_HANDLE;
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::is_composition_passthrough_layer_ready() {
+	return fb_passthrough_ext && passthrough_handle != XR_NULL_HANDLE && composition_passthrough_layer.layerHandle != XR_NULL_HANDLE;
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::start_passthrough() {
+	if (passthrough_handle == XR_NULL_HANDLE) {
+		return false;
+	}
+
+	if (is_passthrough_enabled()) {
+		return true;
+	}
+
+	// Start the passthrough feature
+	XrResult result = xrPassthroughStartFB(passthrough_handle);
+	if (!is_valid_passthrough_result(result, "Failed to start passthrough")) {
+		stop_passthrough();
+		return false;
+	}
+
+	// Create the passthrough layer
+	result = xrCreatePassthroughLayerFB(openxr_api->get_session(), &passthrough_layer_config, &passthrough_layer);
+	if (!is_valid_passthrough_result(result, "Failed to create the passthrough layer")) {
+		stop_passthrough();
+		return false;
+	}
+
+	// Check if the the viewport has transparent background
+	Viewport *viewport = get_main_viewport();
+	if (viewport && !viewport->has_transparent_background()) {
+		print_error("Main viewport doesn't have transparent background! Passthrough may not properly render.");
+	}
+
+	composition_passthrough_layer.layerHandle = passthrough_layer;
+
+	return true;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::on_session_created(const XrSession session) {
+	if (fb_passthrough_ext) {
+		// Create the passthrough feature and start it.
+		XrResult result = xrCreatePassthroughFB(openxr_api->get_session(), &passthrough_create_info, &passthrough_handle);
+		if (!openxr_api->xr_result(result, "Failed to create passthrough")) {
+			passthrough_handle = XR_NULL_HANDLE;
+			return;
+		}
+	}
+}
+
+XrCompositionLayerBaseHeader *OpenXRFbPassthroughExtensionWrapper::get_composition_layer() {
+	if (is_composition_passthrough_layer_ready()) {
+		return (XrCompositionLayerBaseHeader *)&composition_passthrough_layer;
+	} else {
+		return nullptr;
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::stop_passthrough() {
+	if (!fb_passthrough_ext) {
+		return;
+	}
+
+	composition_passthrough_layer.layerHandle = XR_NULL_HANDLE;
+
+	XrResult result;
+	if (passthrough_layer != XR_NULL_HANDLE) {
+		// Destroy the layer
+		result = xrDestroyPassthroughLayerFB(passthrough_layer);
+		openxr_api->xr_result(result, "Unable to destroy passthrough layer");
+		passthrough_layer = XR_NULL_HANDLE;
+	}
+
+	if (passthrough_handle != XR_NULL_HANDLE) {
+		result = xrPassthroughPauseFB(passthrough_handle);
+		openxr_api->xr_result(result, "Unable to stop passthrough feature");
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::on_session_destroyed() {
+	if (fb_passthrough_ext) {
+		stop_passthrough();
+
+		XrResult result;
+		if (passthrough_handle != XR_NULL_HANDLE) {
+			result = xrDestroyPassthroughFB(passthrough_handle);
+			openxr_api->xr_result(result, "Unable to destroy passthrough feature");
+			passthrough_handle = XR_NULL_HANDLE;
+		}
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::on_instance_destroyed() {
+	if (fb_passthrough_ext) {
+		openxr_api->unregister_composition_layer_provider(this);
+	}
+	cleanup();
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::initialize_fb_passthrough_extension(const XrInstance p_instance) {
+	ERR_FAIL_NULL_V(openxr_api, false);
+
+	EXT_INIT_XR_FUNC_V(xrCreatePassthroughFB);
+	EXT_INIT_XR_FUNC_V(xrDestroyPassthroughFB);
+	EXT_INIT_XR_FUNC_V(xrPassthroughStartFB);
+	EXT_INIT_XR_FUNC_V(xrPassthroughPauseFB);
+	EXT_INIT_XR_FUNC_V(xrCreatePassthroughLayerFB);
+	EXT_INIT_XR_FUNC_V(xrDestroyPassthroughLayerFB);
+	EXT_INIT_XR_FUNC_V(xrPassthroughLayerPauseFB);
+	EXT_INIT_XR_FUNC_V(xrPassthroughLayerResumeFB);
+	EXT_INIT_XR_FUNC_V(xrPassthroughLayerSetStyleFB);
+	EXT_INIT_XR_FUNC_V(xrCreateGeometryInstanceFB);
+	EXT_INIT_XR_FUNC_V(xrDestroyGeometryInstanceFB);
+	EXT_INIT_XR_FUNC_V(xrGeometryInstanceSetTransformFB);
+
+	return true;
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::initialize_fb_triangle_mesh_extension(const XrInstance p_instance) {
+	ERR_FAIL_NULL_V(openxr_api, false);
+
+	EXT_INIT_XR_FUNC_V(xrCreateTriangleMeshFB);
+	EXT_INIT_XR_FUNC_V(xrDestroyTriangleMeshFB);
+	EXT_INIT_XR_FUNC_V(xrTriangleMeshGetVertexBufferFB);
+	EXT_INIT_XR_FUNC_V(xrTriangleMeshGetIndexBufferFB);
+	EXT_INIT_XR_FUNC_V(xrTriangleMeshBeginUpdateFB);
+	EXT_INIT_XR_FUNC_V(xrTriangleMeshEndUpdateFB);
+	EXT_INIT_XR_FUNC_V(xrTriangleMeshBeginVertexBufferUpdateFB);
+	EXT_INIT_XR_FUNC_V(xrTriangleMeshEndVertexBufferUpdateFB);
+
+	return true;
+}

--- a/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.h
@@ -1,0 +1,254 @@
+/*************************************************************************/
+/*  openxr_fb_passthrough_extension_wrapper.h                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H
+#define OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H
+
+#include "../openxr_api.h"
+#include "../util.h"
+
+#include "openxr_composition_layer_provider.h"
+#include "openxr_extension_wrapper.h"
+
+#include <map>
+
+class Viewport;
+
+// Wrapper for the set of Facebook XR passthrough extensions.
+class OpenXRFbPassthroughExtensionWrapper : public OpenXRExtensionWrapper, public OpenXRCompositionLayerProvider {
+	friend class OpenXRAPI;
+
+public:
+	void on_instance_created(const XrInstance instance) override;
+
+	void on_session_created(const XrSession session) override;
+
+	void on_session_destroyed() override;
+
+	void on_instance_destroyed() override;
+
+	XrCompositionLayerBaseHeader *get_composition_layer() override;
+
+	bool is_passthrough_supported() {
+		return fb_passthrough_ext;
+	}
+
+	bool is_passthrough_enabled();
+
+	bool start_passthrough();
+
+	void stop_passthrough();
+
+	static OpenXRFbPassthroughExtensionWrapper *get_singleton();
+
+protected:
+	OpenXRFbPassthroughExtensionWrapper(OpenXRAPI *p_openxr_api);
+	~OpenXRFbPassthroughExtensionWrapper();
+
+private:
+	// Create a passthrough feature
+	EXT_PROTO_XRRESULT_FUNC3(xrCreatePassthroughFB,
+			(XrSession), session,
+			(const XrPassthroughCreateInfoFB *), create_info,
+			(XrPassthroughFB *), feature_out)
+
+	// Destroy a previously created passthrough feature
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyPassthroughFB, (XrPassthroughFB), feature)
+
+	//*** Passthrough feature state management functions *********
+	// Start the passthrough feature
+	EXT_PROTO_XRRESULT_FUNC1(xrPassthroughStartFB, (XrPassthroughFB), passthrough)
+	// Pause the passthrough feature
+	EXT_PROTO_XRRESULT_FUNC1(xrPassthroughPauseFB, (XrPassthroughFB), passthrough)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrCreatePassthroughLayerFB, (XrSession), session,
+			(const XrPassthroughLayerCreateInfoFB *), config,
+			(XrPassthroughLayerFB *), layer_out)
+
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyPassthroughLayerFB, (XrPassthroughLayerFB), layer)
+
+	EXT_PROTO_XRRESULT_FUNC1(xrPassthroughLayerPauseFB, (XrPassthroughLayerFB), layer)
+	EXT_PROTO_XRRESULT_FUNC1(xrPassthroughLayerResumeFB, (XrPassthroughLayerFB), layer)
+
+	// Set the style of an existing passthrough layer. If the enabled feature set
+	// doesn’t change, this is a lightweight operation that can be called in every
+	// frame to animate the style. Changes that may incur a bigger cost:
+	// - Enabling/disabling the color mapping, or changing the type of mapping
+	//   (monochromatic to RGBA or back).
+	// - Changing `textureOpacityFactor` from 0 to non-zero or vice versa
+	// - Changing `edgeColor[3]` from 0 to non-zero or vice versa
+	// NOTE: For XR_FB_passthrough, all color values are treated as linear.
+	EXT_PROTO_XRRESULT_FUNC2(xrPassthroughLayerSetStyleFB,
+			(XrPassthroughLayerFB), layer,
+			(const XrPassthroughStyleFB *), style)
+
+	// Create a geometry instance to be used as a projection surface for passthrough.
+	// A geometry instance assigns a triangle mesh as part of the specified layer's
+	// projection surface.
+	// The operation is only valid if the passthrough layer's purpose has been set to
+	// `XR_PASSTHROUGH_LAYER_PURPOSE_PROJECTED_FB`. Otherwise, the call this function will
+	// result in an error. In the specified layer, Passthrough will be visible where the view
+	// is covered by the user-specified geometries.
+	//
+	// A triangle mesh object can be instantiated multiple times - in the same or different layers'
+	// projection surface. Each instantiation has its own transformation, which
+	// can be updated using `xrGeometryInstanceSetTransformFB`.
+	EXT_PROTO_XRRESULT_FUNC3(xrCreateGeometryInstanceFB,
+			(XrSession), session,
+			(const XrGeometryInstanceCreateInfoFB *), create_info,
+			(XrGeometryInstanceFB *), out_geometry_instance)
+
+	// Destroys a previously created geometry instance from passthrough rendering.
+	// This removes the geometry instance from passthrough rendering.
+	// The operation has no effect on other instances or the underlying mesh.
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyGeometryInstanceFB, (XrGeometryInstanceFB), instance)
+
+	// Update the transformation of a passthrough geometry instance.
+	EXT_PROTO_XRRESULT_FUNC2(xrGeometryInstanceSetTransformFB,
+			(XrGeometryInstanceFB), instance,
+			(const XrGeometryInstanceTransformFB *), transformation)
+
+	// Create a triangle mesh geometry object.
+	// Depending on the behavior flags, the mesh could be created immutable (data is assigned
+	// at creation and cannot be changed) or mutable (the mesh is created empty and can be updated
+	// by calling begin/end update functions).
+	EXT_PROTO_XRRESULT_FUNC3(xrCreateTriangleMeshFB,
+			(XrSession), session,
+			(const XrTriangleMeshCreateInfoFB *), create_info,
+			(XrTriangleMeshFB *), out_triangle_mesh)
+
+	// Destroy an `XrTriangleMeshFB` object along with its data. The mesh buffers must not be
+	// accessed anymore after their parent mesh object has been destroyed.
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyTriangleMeshFB, (XrTriangleMeshFB), mesh)
+
+	// Retrieve a pointer to the vertex buffer. The vertex buffer is structured as an array of 3 floats
+	// per vertex representing x, y, and z: `[x0, y0, z0, x1, y1, z1, ...]`. The size of the buffer is
+	// `maxVertexCount * 3` floats. The application must call `xrTriangleMeshBeginUpdateFB` or
+	// `xrTriangleMeshBeginVertexBufferUpdateFB` before making modifications to the vertex
+	// buffer. The buffer location is guaranteed to remain constant over the lifecycle of the mesh
+	// object.
+	EXT_PROTO_XRRESULT_FUNC2(xrTriangleMeshGetVertexBufferFB,
+			(XrTriangleMeshFB), mesh,
+			(XrVector3f **), out_vertex_buffer)
+
+	// Retrieve the index buffer that defines the topology of the triangle mesh. Each triplet of
+	// consecutive elements point to three vertices in the vertex buffer and thus form a triangle. The
+	// size of each element is `indexElementSize` bytes, and thus the size of the buffer is
+	// `maxTriangleCount * 3 * indexElementSize` bytes. The application must call
+	// `xrTriangleMeshBeginUpdateFB` before making modifications to the index buffer. The buffer
+	// location is guaranteed to remain constant over the lifecycle of the mesh object.
+	EXT_PROTO_XRRESULT_FUNC2(xrTriangleMeshGetIndexBufferFB,
+			(XrTriangleMeshFB), mesh,
+			(uint32_t **), out_index_buffer)
+
+	// Begin updating the mesh buffer data. The application must call this function before it makes any
+	// modifications to the buffers retrieved by `xrTriangleMeshGetVertexBufferFB` and
+	// `xrTriangleMeshGetIndexBufferFB`. If only the vertex buffer needs to be updated,
+	// `xrTriangleMeshBeginVertexBufferUpdateFB` can be used instead. To commit the
+	// modifications, the application must call `xrTriangleMeshEndUpdateFB`.
+	EXT_PROTO_XRRESULT_FUNC1(xrTriangleMeshBeginUpdateFB, (XrTriangleMeshFB), mesh)
+
+	// Signal the API that the application has finished updating the mesh buffers after a call to
+	// `xrTriangleMeshBeginUpdateFB`. `vertexCount` and `triangleCount` specify the actual
+	// number of primitives that make up the mesh after the update. They must be larger than zero but
+	// smaller or equal to the maximum counts defined at create time. Buffer data beyond these counts
+	// is ignored.
+	EXT_PROTO_XRRESULT_FUNC3(xrTriangleMeshEndUpdateFB,
+			(XrTriangleMeshFB), mesh,
+			(uint32_t), vertexCount,
+			(uint32_t), triangle_count)
+
+	// Update the vertex positions of a triangle mesh. Can only be called once the mesh topology has
+	// been set using `xrTriangleMeshBeginUpdateFB`/`xrTriangleMeshEndUpdateFB`. The
+	// vertex count is defined by the last invocation to `xrTriangleMeshEndUpdateFB`. Once the
+	// modification is done, `xrTriangleMeshEndVertexBufferUpdateFB` must be called.
+	EXT_PROTO_XRRESULT_FUNC2(xrTriangleMeshBeginVertexBufferUpdateFB,
+			(XrTriangleMeshFB), mesh,
+			(uint32_t *), out_vertex_count)
+
+	// Signal the API that the contents of the vertex buffer data has been updated
+	// after a call to `xrTriangleMeshBeginVertexBufferUpdateFB`.
+	EXT_PROTO_XRRESULT_FUNC1(xrTriangleMeshEndVertexBufferUpdateFB, (XrTriangleMeshFB), mesh)
+
+	bool initialize_fb_passthrough_extension(const XrInstance instance);
+
+	bool initialize_fb_triangle_mesh_extension(const XrInstance instance);
+
+	void cleanup();
+
+	// TODO: Temporary workaround (https://github.com/GodotVR/godot_openxr/issues/138)
+	//  Address a bug in the passthrough api where XR_ERROR_UNEXPECTED_STATE_PASSTHROUGH_FB is
+	//  returned even when the operation is valid on Meta Quest devices.
+	//  The issue should be addressed on that platform in OS release v37.
+	inline bool is_valid_passthrough_result(XrResult result, const char *format) {
+		return openxr_api->xr_result(result, format) || result == XR_ERROR_UNEXPECTED_STATE_PASSTHROUGH_FB;
+	}
+
+	Viewport *get_main_viewport();
+
+	bool is_composition_passthrough_layer_ready();
+
+	static OpenXRFbPassthroughExtensionWrapper *singleton;
+
+	bool fb_passthrough_ext = false; // required for any passthrough functionality
+	bool fb_triangle_mesh_ext = false; // only use for projected passthrough
+
+	XrPassthroughCreateInfoFB passthrough_create_info = {
+		XR_TYPE_PASSTHROUGH_CREATE_INFO_FB,
+		nullptr,
+		0,
+	};
+	XrPassthroughFB passthrough_handle = XR_NULL_HANDLE;
+
+	XrPassthroughLayerCreateInfoFB passthrough_layer_config = {
+		XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB,
+		nullptr,
+		passthrough_handle,
+		XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
+		XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB,
+	};
+	XrPassthroughStyleFB passthrough_layer_style = {
+		XR_TYPE_PASSTHROUGH_STYLE_FB,
+		nullptr,
+		1,
+		{ 0, 0, 0, 0 },
+	};
+	XrPassthroughLayerFB passthrough_layer = XR_NULL_HANDLE;
+
+	XrCompositionLayerPassthroughFB composition_passthrough_layer = {
+		XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB,
+		nullptr,
+		XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT,
+		XR_NULL_HANDLE,
+		XR_NULL_HANDLE,
+	};
+};
+
+#endif // OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -36,6 +36,7 @@
 #include "core/math/transform_3d.h"
 #include "core/math/vector2.h"
 #include "core/os/memory.h"
+#include "core/string/print_string.h"
 #include "core/string/ustring.h"
 #include "core/templates/rb_map.h"
 #include "core/templates/rid_owner.h"
@@ -287,6 +288,8 @@ public:
 	XRPose::TrackingConfidence transform_from_location(const XrHandJointLocationEXT &p_location, Transform3D &r_transform);
 	void parse_velocities(const XrSpaceVelocity &p_velocity, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity);
 
+	bool xr_result(XrResult result, const char *format, Array args = Array()) const;
+
 	static bool openxr_is_enabled(bool p_check_run_in_editor = true);
 	static OpenXRAPI *get_singleton();
 
@@ -348,6 +351,9 @@ public:
 	Vector2 get_action_vector2(RID p_action, RID p_tracker);
 	XRPose::TrackingConfidence get_action_pose(RID p_action, RID p_tracker, Transform3D &r_transform, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity);
 	bool trigger_haptic_pulse(RID p_action, RID p_tracker, float p_frequency, float p_amplitude, XrDuration p_duration_ns);
+
+	void register_composition_layer_provider(OpenXRCompositionLayerProvider *provider);
+	void unregister_composition_layer_provider(OpenXRCompositionLayerProvider *provider);
 
 	OpenXRAPI();
 	~OpenXRAPI();

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -746,6 +746,24 @@ void OpenXRInterface::end_frame() {
 	}
 }
 
+bool OpenXRInterface::is_passthrough_supported() {
+	return passthrough_wrapper != nullptr && passthrough_wrapper->is_passthrough_supported();
+}
+
+bool OpenXRInterface::is_passthrough_enabled() {
+	return passthrough_wrapper != nullptr && passthrough_wrapper->is_passthrough_enabled();
+}
+
+bool OpenXRInterface::start_passthrough() {
+	return passthrough_wrapper != nullptr && passthrough_wrapper->start_passthrough();
+}
+
+void OpenXRInterface::stop_passthrough() {
+	if (passthrough_wrapper) {
+		passthrough_wrapper->stop_passthrough();
+	}
+}
+
 void OpenXRInterface::on_state_ready() {
 	emit_signal(SNAME("session_begun"));
 }
@@ -776,6 +794,8 @@ OpenXRInterface::OpenXRInterface() {
 	_set_default_pos(head_transform, 1.0, 0);
 	_set_default_pos(transform_for_view[0], 1.0, 1);
 	_set_default_pos(transform_for_view[1], 1.0, 2);
+
+	passthrough_wrapper = OpenXRFbPassthroughExtensionWrapper::get_singleton();
 }
 
 OpenXRInterface::~OpenXRInterface() {

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -37,6 +37,8 @@
 #include "action_map/openxr_action_map.h"
 #include "openxr_api.h"
 
+#include "extensions/openxr_fb_passthrough_extension_wrapper.h"
+
 // declare some default strings
 #define INTERACTION_PROFILE_NONE "/interaction_profiles/none"
 
@@ -47,6 +49,7 @@ private:
 	OpenXRAPI *openxr_api = nullptr;
 	bool initialized = false;
 	XRInterface::TrackingStatus tracking_state;
+	OpenXRFbPassthroughExtensionWrapper *passthrough_wrapper = nullptr;
 
 	// At a minimum we need a tracker for our head
 	Ref<XRPositionalTracker> head;
@@ -128,6 +131,11 @@ public:
 	bool pre_draw_viewport(RID p_render_target) override;
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
 	virtual void end_frame() override;
+
+	virtual bool is_passthrough_supported() override;
+	virtual bool is_passthrough_enabled() override;
+	virtual bool start_passthrough() override;
+	virtual void stop_passthrough() override;
 
 	void on_state_ready();
 	void on_state_visible();

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -68,6 +68,11 @@ void XRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_anchor_detection_is_enabled", "enable"), &XRInterface::set_anchor_detection_is_enabled);
 	ClassDB::bind_method(D_METHOD("get_camera_feed_id"), &XRInterface::get_camera_feed_id);
 
+	ClassDB::bind_method(D_METHOD("is_passthrough_supported"), &XRInterface::is_passthrough_supported);
+	ClassDB::bind_method(D_METHOD("is_passthrough_enabled"), &XRInterface::is_passthrough_enabled);
+	ClassDB::bind_method(D_METHOD("start_passthrough"), &XRInterface::start_passthrough);
+	ClassDB::bind_method(D_METHOD("stop_passthrough"), &XRInterface::stop_passthrough);
+
 	ADD_GROUP("AR", "ar_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ar_is_anchor_detection_enabled"), "set_anchor_detection_is_enabled", "get_anchor_detection_is_enabled");
 

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -130,6 +130,13 @@ public:
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* inform XR interface we finished our viewport draw process */
 	virtual void end_frame(){};
 
+	/** passthrough **/
+
+	virtual bool is_passthrough_supported() { return false; }
+	virtual bool is_passthrough_enabled() { return false; }
+	virtual bool start_passthrough() { return false; }
+	virtual void stop_passthrough() {}
+
 	virtual void notification(int p_what){};
 
 	XRInterface();


### PR DESCRIPTION
This PR adds the OpenXR FB passthrough extension wrapper, also extending `OpenXRInterface` with functions enabling the usage of passthrough functionality. It is a modification of `XRFbPassthroughExtensionWrapper` implemented in Godot 3.x.

This PR depends on https://github.com/godotengine/godot/pull/65798 and contains the commits of the mentioned PR, so only the latest commit ([3da37fc6ad6badde86891459041f78abc164db18](https://github.com/godotengine/godot/commit/3da37fc6ad6badde86891459041f78abc164db18)) needs review here.