### PR TITLE
C#: Fix marshaling generic Godot collections

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -474,6 +474,11 @@ namespace Godot.Collections
         }
     }
 
+    internal interface IGenericGodotArray
+    {
+        public Array UnderlyingArray { get; }
+    }
+
     /// <summary>
     /// Typed wrapper around Godot's Array class, an array of Variant
     /// typed elements allocated in the engine in C++. Useful when
@@ -487,7 +492,8 @@ namespace Godot.Collections
         IList<T>,
         IReadOnlyList<T>,
         ICollection<T>,
-        IEnumerable<T>
+        IEnumerable<T>,
+        IGenericGodotArray
     {
         // ReSharper disable StaticMemberInGenericType
         // Warning is about unique static fields being created for each generic type combination:
@@ -515,6 +521,8 @@ namespace Godot.Collections
         }
 
         private readonly Array _underlyingArray;
+
+        Array IGenericGodotArray.UnderlyingArray => _underlyingArray;
 
         internal ref godot_array.movable NativeValue
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -344,6 +344,11 @@ namespace Godot.Collections
         }
     }
 
+    internal interface IGenericGodotDictionary
+    {
+        public Dictionary UnderlyingDictionary { get; }
+    }
+
     /// <summary>
     /// Typed wrapper around Godot's Dictionary class, a dictionary of Variant
     /// typed elements allocated in the engine in C++. Useful when
@@ -354,7 +359,8 @@ namespace Godot.Collections
     /// <typeparam name="TValue">The type of the dictionary's values.</typeparam>
     public class Dictionary<[MustBeVariant] TKey, [MustBeVariant] TValue> :
         IDictionary<TKey, TValue>,
-        IReadOnlyDictionary<TKey, TValue>
+        IReadOnlyDictionary<TKey, TValue>,
+        IGenericGodotDictionary
     {
         // ReSharper disable StaticMemberInGenericType
         // Warning is about unique static fields being created for each generic type combination:
@@ -392,6 +398,8 @@ namespace Godot.Collections
         }
 
         private readonly Dictionary _underlyingDict;
+
+        Dictionary IGenericGodotDictionary.UnderlyingDictionary => _underlyingDict;
 
         internal ref godot_dictionary.movable NativeValue
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -293,6 +293,10 @@ namespace Godot.NativeInterop
                     return VariantUtils.CreateFromDictionary(godotDictionary);
                 case Collections.Array godotArray:
                     return VariantUtils.CreateFromArray(godotArray);
+                case Collections.IGenericGodotDictionary godotDictionary:
+                    return VariantUtils.CreateFromDictionary(godotDictionary.UnderlyingDictionary);
+                case Collections.IGenericGodotArray godotArray:
+                    return VariantUtils.CreateFromArray(godotArray.UnderlyingArray);
                 case Variant variant:
                     return NativeFuncs.godotsharp_variant_new_copy((godot_variant)variant.NativeVar);
             }


### PR DESCRIPTION
Add support for generic Godot collections to `ConvertManagedObjectToVariant`.

- Fixes https://github.com/godotengine/godot/issues/65883