### PR TITLE
C#: Fix Generated ScriptProperty Error.

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedProperties.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/ExportedProperties.cs
@@ -12,6 +12,95 @@ namespace Godot.SourceGenerators.Sample
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public partial class ExportedProperties : Godot.Object
     {
+        // Do not generate default value
+        private String _notGenerate_Property_String = new string("not generate");
+        [Export]
+        public String NotGenerate_Complex_Lamda_Property
+        {
+            get => _notGenerate_Property_String + Convert.ToInt32("1");
+            set => _notGenerate_Property_String = value;
+        }
+
+        [Export]
+        public String NotGenerate_Lamda_NoField_Property
+        {
+            get => new string("not generate");
+            set => _notGenerate_Property_String = value;
+        }
+
+        [Export]
+        public String NotGenerate_Complex_Return_Property
+        {
+            get
+            {
+                return _notGenerate_Property_String + Convert.ToInt32("1");
+            }
+            set
+            {
+                _notGenerate_Property_String = value;
+            }
+        }
+
+        private int _notGenerate_Property_Int = 1;
+        [Export]
+        public string NotGenerate_Returns_Property
+        {
+            get
+            {
+                if (_notGenerate_Property_Int == 1)
+                {
+                    return "a";
+                }
+                else
+                {
+                    return "b";
+                }
+            }
+            set
+            {
+                _notGenerate_Property_Int = value == "a" ? 1 : 2;
+            }
+        }
+
+        // Full Property
+        private String _fullProperty_String = "FullProperty_String";
+        [Export]
+        public String FullProperty_String
+        {
+            get
+            {
+                return _fullProperty_String;
+            }
+            set
+            {
+                _fullProperty_String = value;
+            }
+        }
+
+        private String _fullProperty_String_Complex = new string("FullProperty_String_Complex") + Convert.ToInt32("1");
+        [Export]
+        public String FullProperty_String_Complex
+        {
+            get
+            {
+                return _fullProperty_String_Complex;
+            }
+            set
+            {
+                _fullProperty_String_Complex = value;
+            }
+        }
+
+        // Lamda Property
+        private String _lamdaProperty_String = "LamdaProperty_String";
+        [Export]
+        public String LamdaProperty_String
+        {
+            get => _lamdaProperty_String;
+            set => _lamdaProperty_String = value;
+        }
+
+        // Auto Property
         [Export] private Boolean property_Boolean { get; set; } = true;
         [Export] private Char property_Char { get; set; } = 'f';
         [Export] private SByte property_SByte { get; set; } = 10;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -292,7 +292,7 @@ namespace Godot.SourceGenerators
             source.Append("if (name == PropertyName.")
                 .Append(propertyMemberName)
                 .Append(") {\n")
-                .Append("            ")
+                .Append("            this.")
                 .Append(propertyMemberName)
                 .Append(" = ")
                 .AppendNativeVariantToManagedExpr("value", propertyTypeSymbol, propertyMarshalType)
@@ -317,7 +317,7 @@ namespace Godot.SourceGenerators
                 .Append(propertyMemberName)
                 .Append(") {\n")
                 .Append("            value = ")
-                .AppendManagedToNativeVariantExpr(propertyMemberName, propertyMarshalType)
+                .AppendManagedToNativeVariantExpr("this." + propertyMemberName, propertyMarshalType)
                 .Append(";\n")
                 .Append("            return true;\n")
                 .Append("        }\n");

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
@@ -163,19 +164,68 @@ namespace Godot.SourceGenerators
                     continue;
                 }
 
-                // TODO: Detect default value from simple property getters (currently we only detect from initializers)
-
-                EqualsValueClauseSyntax? initializer = property.DeclaringSyntaxReferences
-                    .Select(r => r.GetSyntax() as PropertyDeclarationSyntax)
-                    .Select(s => s?.Initializer ?? null)
-                    .FirstOrDefault();
+                var propertyDeclarationSyntax = property.DeclaringSyntaxReferences
+                    .Select(r => r.GetSyntax() as PropertyDeclarationSyntax).FirstOrDefault();
 
                 // Fully qualify the value to avoid issues with namespaces.
                 string? value = null;
-                if (initializer != null)
+                if (propertyDeclarationSyntax != null)
                 {
-                    var sm = context.Compilation.GetSemanticModel(initializer.SyntaxTree);
-                    value = initializer.Value.FullQualifiedSyntax(sm);
+                    if (propertyDeclarationSyntax.Initializer != null)
+                    {
+                        var sm = context.Compilation.GetSemanticModel(propertyDeclarationSyntax.Initializer.SyntaxTree);
+                        value = propertyDeclarationSyntax.Initializer.Value.FullQualifiedSyntax(sm);
+                    }
+                    else
+                    {
+                        var propertyGet = propertyDeclarationSyntax.AccessorList?.Accessors.Where(a => a.Keyword.IsKind(SyntaxKind.GetKeyword)).FirstOrDefault();
+                        if (propertyGet != null)
+                        {
+                            if (propertyGet.ExpressionBody != null)
+                            {
+                                if (propertyGet.ExpressionBody.Expression is IdentifierNameSyntax identifierNameSyntax)
+                                {
+                                    var sm = context.Compilation.GetSemanticModel(identifierNameSyntax.SyntaxTree);
+                                    var fieldSymbol = sm.GetSymbolInfo(identifierNameSyntax).Symbol as IFieldSymbol;
+                                    EqualsValueClauseSyntax? initializer = fieldSymbol?.DeclaringSyntaxReferences
+                                        .Select(r => r.GetSyntax())
+                                        .OfType<VariableDeclaratorSyntax>()
+                                        .Select(s => s.Initializer)
+                                        .FirstOrDefault(i => i != null);
+
+                                    if (initializer != null)
+                                    {
+                                        sm = context.Compilation.GetSemanticModel(initializer.SyntaxTree);
+                                        value = initializer.Value.FullQualifiedSyntax(sm);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                var returns = propertyGet.DescendantNodes().OfType<ReturnStatementSyntax>();
+                                if (returns.Count() == 1)
+                                {// Generate only single return
+                                    var returnStatementSyntax = returns.Single();
+                                    if (returnStatementSyntax.Expression is IdentifierNameSyntax identifierNameSyntax)
+                                    {
+                                        var sm = context.Compilation.GetSemanticModel(identifierNameSyntax.SyntaxTree);
+                                        var fieldSymbol = sm.GetSymbolInfo(identifierNameSyntax).Symbol as IFieldSymbol;
+                                        EqualsValueClauseSyntax? initializer = fieldSymbol?.DeclaringSyntaxReferences
+                                            .Select(r => r.GetSyntax())
+                                            .OfType<VariableDeclaratorSyntax>()
+                                            .Select(s => s.Initializer)
+                                            .FirstOrDefault(i => i != null);
+
+                                        if (initializer != null)
+                                        {
+                                            sm = context.Compilation.GetSemanticModel(initializer.SyntaxTree);
+                                            value = initializer.Value.FullQualifiedSyntax(sm);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 exportedMembers.Add(new ExportedPropertyMetadata(


### PR DESCRIPTION
Add "this." to prevent errors caused by duplicate variable names.
Try to find the default value of property getters.

加上"this.",防止和生成的变量名重名导致的错误.
尝试查找属性的默认值.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/66819.