### PR TITLE
Fix: color of Command Palette shortcut text not visible in Light theme

### DIFF
--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -130,7 +130,7 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 		ti->set_metadata(0, entries[i].key_name);
 		ti->set_text_alignment(1, HORIZONTAL_ALIGNMENT_RIGHT);
 		ti->set_text(1, shortcut_text);
-		Color c = Color(1, 1, 1, 0.5);
+		Color c = get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5);
 		ti->set_custom_color(1, c);
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fixes #65874 

The shortcut text in the Command Palette is not visible with light themes as described in the issue.

For my proposed fix here, this shortcut text would use the `font_color` value modulated by 0.5, instead of the color white modulated by 0.5. This works with all themes and is in line with other "greyed out" texts in the editor being modulated by 0.5.

Here is the Command Palette with the "Light" theme with the fix applied:

![godot windows tools x86_64_dArBhUHnmg](https://user-images.githubusercontent.com/59402820/190678526-373dbbe1-b9b7-44f9-a753-2ce4484249cd.png)


