### PR TITLE
Add QuadMesh back as a subclass of PlaneMesh.

### DIFF
--- a/doc/classes/PlaneMesh.xml
+++ b/doc/classes/PlaneMesh.xml
@@ -31,10 +31,10 @@
 			[PlaneMesh] will face the positive X-axis.
 		</constant>
 		<constant name="FACE_Y" value="1" enum="Orientation">
-			[PlaneMesh] will face the positive Y-axis. This matches the behaviour of the [PlaneMesh] in Godot 3.x.
+			[PlaneMesh] will face the positive Y-axis. This matches the behavior of the [PlaneMesh] in Godot 3.x.
 		</constant>
 		<constant name="FACE_Z" value="2" enum="Orientation">
-			[PlaneMesh] will face the positive Z-axis. This matches the behvaiour of the QuadMesh in Godot 3.x.
+			[PlaneMesh] will face the positive Z-axis. This matches the behavior of the QuadMesh in Godot 3.x.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/QuadMesh.xml
+++ b/doc/classes/QuadMesh.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="QuadMesh" inherits="PlaneMesh" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Class representing a square mesh facing the camera.
+	</brief_description>
+	<description>
+		Class representing a square [PrimitiveMesh]. This flat mesh does not have a thickness. By default, this mesh is aligned on the X and Y axes; this rotation is more suited for use with billboarded materials. A [QuadMesh] is equivalent to a [PlaneMesh] except its default [member PlaneMesh.orientation] is [constant PlaneMesh.FACE_Z].
+	</description>
+	<tutorials>
+		<link title="GUI in 3D Demo">https://godotengine.org/asset-library/asset/127</link>
+		<link title="2D in 3D Demo">https://godotengine.org/asset-library/asset/129</link>
+	</tutorials>
+	<members>
+		<member name="orientation" type="int" setter="set_orientation" getter="get_orientation" overrides="PlaneMesh" enum="PlaneMesh.Orientation" default="2" />
+	</members>
+</class>

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -794,6 +794,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CylinderMesh);
 	GDREGISTER_CLASS(PlaneMesh);
 	GDREGISTER_CLASS(PrismMesh);
+	GDREGISTER_CLASS(QuadMesh);
 	GDREGISTER_CLASS(SphereMesh);
 	GDREGISTER_CLASS(TextMesh);
 	GDREGISTER_CLASS(TorusMesh);
@@ -959,7 +960,6 @@ void register_scene_types() {
 	ClassDB::add_compatibility_class("Navigation3D", "Node3D");
 	ClassDB::add_compatibility_class("Navigation2D", "Node2D");
 	ClassDB::add_compatibility_class("OpenSimplexNoise", "FastNoiseLite");
-	ClassDB::add_compatibility_class("QuadMesh", "PlaneMesh");
 	ClassDB::add_compatibility_class("ToolButton", "Button");
 	ClassDB::add_compatibility_class("YSort", "Node2D");
 	// Portal and room occlusion was replaced by raster occlusion (OccluderInstance3D node).

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -262,6 +262,18 @@ public:
 
 VARIANT_ENUM_CAST(PlaneMesh::Orientation)
 
+/*
+	A flat rectangle, inherits from PlaneMesh but defaults to facing the Z-plane.
+*/
+class QuadMesh : public PlaneMesh {
+	GDCLASS(QuadMesh, PlaneMesh);
+
+public:
+	QuadMesh() {
+		set_orientation(FACE_Z);
+	}
+};
+
 /**
 	A prism shapen, handy for ramps, triangles, etc.
 */


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/65186

In https://github.com/godotengine/godot/pull/64801 we removed the QuadMesh in favour of PlaneMesh. However, this has led to confusion for many users as the button is suddenly gone. Even for users who were aware of the change, the extra steps to get a screen-aligned quad are seen as annoying. Changing the default orientation of PlaneMesh is not a good option as some users prefer it stay the way it is. 

Overall, our goal behind https://github.com/godotengine/godot/pull/64801 was to remove code overhead and to bring features from PlaneMesh over to QuadMesh (namely subdivision and center). I believe this is achieved by exposing QuadMesh as a subclass of PlaneMesh. QuadMesh will still have all the features of PlaneMesh without us having to maintain two separate classes. 

cc @QbieShay @RPicster @BastiaanOlij 
