### PR TITLE
libpng: Update to upstream 1.6.38

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -276,7 +276,7 @@ Files extracted from upstream source:
 ## libpng
 
 - Upstream: http://libpng.org/pub/png/libpng.html
-- Version: 1.6.37 (a40189cf881e9f0db80511c382292a5604c3c3d1, 2019)
+- Version: 1.6.38 (0a158f3506502dfa23edfc42790dfaed82efba17, 2022)
 - License: libpng/zlib
 
 Files extracted from upstream source:

--- a/thirdparty/libpng/LICENSE
+++ b/thirdparty/libpng/LICENSE
@@ -4,8 +4,8 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
 PNG Reference Library License version 2
 ---------------------------------------
 
- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- * Copyright (c) 2018-2019 Cosmin Truta.
+ * Copyright (c) 1995-2022 The PNG Reference Library Authors.
+ * Copyright (c) 2018-2022 Cosmin Truta.
  * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
  * Copyright (c) 1996-1997 Andreas Dilger.
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.

--- a/thirdparty/libpng/arm/arm_init.c
+++ b/thirdparty/libpng/arm/arm_init.c
@@ -1,7 +1,7 @@
 
 /* arm_init.c - NEON optimised filter functions
  *
- * Copyright (c) 2018 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 2014,2016 Glenn Randers-Pehrson
  * Written by Mans Rullgard, 2011.
  *
@@ -10,9 +10,7 @@
  * and license in png.h
  */
 
-/* Below, after checking __linux__, various non-C90 POSIX 1003.1 functions are
- * called.
- */
+/* This module requires POSIX 1003.1 functions. */
 #define _POSIX_SOURCE 1
 
 #include "../pngpriv.h"
@@ -33,21 +31,23 @@
  * has partial support is contrib/arm-neon/linux.c - a generic Linux
  * implementation which reads /proc/cpufino.
  */
+#include <signal.h> /* for sig_atomic_t */
+
 #ifndef PNG_ARM_NEON_FILE
-#  ifdef __linux__
-#     define PNG_ARM_NEON_FILE "contrib/arm-neon/linux.c"
+#  if defined(__aarch64__) || defined(_M_ARM64)
+     /* ARM Neon is expected to be unconditionally available on ARM64. */
+#    error "PNG_ARM_NEON_CHECK_SUPPORTED must not be defined on this platform"
+#  elif defined(__linux__)
+#    define PNG_ARM_NEON_FILE "contrib/arm-neon/linux.c"
+#  else
+#    error "No support for run-time ARM Neon checking; use compile-time options"
 #  endif
 #endif
 
-#ifdef PNG_ARM_NEON_FILE
-
-#include <signal.h> /* for sig_atomic_t */
 static int png_have_neon(png_structp png_ptr);
-#include PNG_ARM_NEON_FILE
-
-#else  /* PNG_ARM_NEON_FILE */
-#  error "PNG_ARM_NEON_FILE undefined: no support for run-time ARM NEON checks"
-#endif /* PNG_ARM_NEON_FILE */
+#ifdef PNG_ARM_NEON_FILE
+#  include PNG_ARM_NEON_FILE
+#endif
 #endif /* PNG_ARM_NEON_CHECK_SUPPORTED */
 
 #ifndef PNG_ALIGNED_MEMORY_SUPPORTED

--- a/thirdparty/libpng/arm/filter_neon_intrinsics.c
+++ b/thirdparty/libpng/arm/filter_neon_intrinsics.c
@@ -18,7 +18,7 @@
 /* This code requires -mfpu=neon on the command line: */
 #if PNG_ARM_NEON_IMPLEMENTATION == 1 /* intrinsics code from pngpriv.h */
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && !defined(__clang__) && defined(_M_ARM64)
 #  include <arm64_neon.h>
 #else
 #  include <arm_neon.h>

--- a/thirdparty/libpng/arm/palette_neon_intrinsics.c
+++ b/thirdparty/libpng/arm/palette_neon_intrinsics.c
@@ -14,7 +14,7 @@
 
 #if PNG_ARM_NEON_IMPLEMENTATION == 1
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && !defined(__clang__) && defined(_M_ARM64)
 #  include <arm64_neon.h>
 #else
 #  include <arm_neon.h>
@@ -30,8 +30,6 @@ png_riffle_palette_neon(png_structrp png_ptr)
    int num_trans = png_ptr->num_trans;
    int i;
 
-   png_debug(1, "in png_riffle_palette_neon");
-
    /* Initially black, opaque. */
    uint8x16x4_t w = {{
       vdupq_n_u8(0x00),
@@ -39,6 +37,8 @@ png_riffle_palette_neon(png_structrp png_ptr)
       vdupq_n_u8(0x00),
       vdupq_n_u8(0xff),
    }};
+
+   png_debug(1, "in png_riffle_palette_neon");
 
    /* First, riffle the RGB colours into an RGBA8 palette.
     * The alpha component is set to opaque for now.
@@ -65,11 +65,12 @@ png_do_expand_palette_rgba8_neon(png_structrp png_ptr, png_row_infop row_info,
    png_uint_32 row_width = row_info->width;
    const png_uint_32 *riffled_palette =
       (const png_uint_32 *)png_ptr->riffled_palette;
-   const png_int_32 pixels_per_chunk = 4;
-   int i;
+   const png_uint_32 pixels_per_chunk = 4;
+   png_uint_32 i;
 
    png_debug(1, "in png_do_expand_palette_rgba8_neon");
 
+   PNG_UNUSED(row)
    if (row_width < pixels_per_chunk)
       return 0;
 
@@ -109,10 +110,11 @@ png_do_expand_palette_rgb8_neon(png_structrp png_ptr, png_row_infop row_info,
    png_uint_32 row_width = row_info->width;
    png_const_bytep palette = (png_const_bytep)png_ptr->palette;
    const png_uint_32 pixels_per_chunk = 8;
-   int i;
+   png_uint_32 i;
 
    png_debug(1, "in png_do_expand_palette_rgb8_neon");
 
+   PNG_UNUSED(row)
    if (row_width <= pixels_per_chunk)
       return 0;
 

--- a/thirdparty/libpng/png.c
+++ b/thirdparty/libpng/png.c
@@ -1,7 +1,7 @@
 
 /* png.c - location for general purpose libpng functions
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -14,7 +14,7 @@
 #include "pngpriv.h"
 
 /* Generate a compiler error if there is an old png.h in the search path. */
-typedef png_libpng_version_1_6_37 Your_png_h_is_not_version_1_6_37;
+typedef png_libpng_version_1_6_38 Your_png_h_is_not_version_1_6_38;
 
 #ifdef __GNUC__
 /* The version tests may need to be added to, but the problem warning has
@@ -720,7 +720,7 @@ png_init_io(png_structrp png_ptr, png_FILE_p fp)
  *
  * Where UNSIGNED_MAX is the appropriate maximum unsigned value, so when the
  * negative integral value is added the result will be an unsigned value
- * correspnding to the 2's complement representation.
+ * corresponding to the 2's complement representation.
  */
 void PNGAPI
 png_save_int_32(png_bytep buf, png_int_32 i)
@@ -815,8 +815,8 @@ png_get_copyright(png_const_structrp png_ptr)
    return PNG_STRING_COPYRIGHT
 #else
    return PNG_STRING_NEWLINE \
-      "libpng version 1.6.37" PNG_STRING_NEWLINE \
-      "Copyright (c) 2018-2019 Cosmin Truta" PNG_STRING_NEWLINE \
+      "libpng version 1.6.38" PNG_STRING_NEWLINE \
+      "Copyright (c) 2018-2022 Cosmin Truta" PNG_STRING_NEWLINE \
       "Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson" \
       PNG_STRING_NEWLINE \
       "Copyright (c) 1996-1997 Andreas Dilger" PNG_STRING_NEWLINE \
@@ -1843,12 +1843,12 @@ png_icc_profile_error(png_const_structrp png_ptr, png_colorspacerp colorspace,
 #  ifdef PNG_WARNINGS_SUPPORTED
    else
       {
-         char number[PNG_NUMBER_BUFFER_SIZE]; /* +24 = 114*/
+         char number[PNG_NUMBER_BUFFER_SIZE]; /* +24 = 114 */
 
          pos = png_safecat(message, (sizeof message), pos,
              png_format_number(number, number+(sizeof number),
              PNG_NUMBER_FORMAT_x, value));
-         pos = png_safecat(message, (sizeof message), pos, "h: "); /*+2 = 116*/
+         pos = png_safecat(message, (sizeof message), pos, "h: "); /* +2 = 116 */
       }
 #  endif
    /* The 'reason' is an arbitrary message, allow +79 maximum 195 */

--- a/thirdparty/libpng/png.h
+++ b/thirdparty/libpng/png.h
@@ -1,9 +1,9 @@
 
 /* png.h - header file for PNG reference library
  *
- * libpng version 1.6.37 - April 14, 2019
+ * libpng version 1.6.38 - September 14, 2022
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -15,7 +15,7 @@
  *   libpng versions 0.89, June 1996, through 0.96, May 1997: Andreas Dilger
  *   libpng versions 0.97, January 1998, through 1.6.35, July 2018:
  *     Glenn Randers-Pehrson
- *   libpng versions 1.6.36, December 2018, through 1.6.37, April 2019:
+ *   libpng versions 1.6.36, December 2018, through 1.6.38, September 2022:
  *     Cosmin Truta
  *   See also "Contributing Authors", below.
  */
@@ -27,8 +27,8 @@
  * PNG Reference Library License version 2
  * ---------------------------------------
  *
- *  * Copyright (c) 1995-2019 The PNG Reference Library Authors.
- *  * Copyright (c) 2018-2019 Cosmin Truta.
+ *  * Copyright (c) 1995-2022 The PNG Reference Library Authors.
+ *  * Copyright (c) 2018-2022 Cosmin Truta.
  *  * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
  *  * Copyright (c) 1996-1997 Andreas Dilger.
  *  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -239,7 +239,7 @@
  *    ...
  *    1.5.30                  15    10530  15.so.15.30[.0]
  *    ...
- *    1.6.37                  16    10637  16.so.16.37[.0]
+ *    1.6.38                  16    10638  16.so.16.38[.0]
  *
  *    Henceforth the source version will match the shared-library major and
  *    minor numbers; the shared-library major version number will be used for
@@ -278,8 +278,8 @@
  */
 
 /* Version information for png.h - this should match the version in png.c */
-#define PNG_LIBPNG_VER_STRING "1.6.37"
-#define PNG_HEADER_VERSION_STRING " libpng version 1.6.37 - April 14, 2019\n"
+#define PNG_LIBPNG_VER_STRING "1.6.38"
+#define PNG_HEADER_VERSION_STRING " libpng version 1.6.38 - September 14, 2022\n"
 
 #define PNG_LIBPNG_VER_SONUM   16
 #define PNG_LIBPNG_VER_DLLNUM  16
@@ -287,7 +287,7 @@
 /* These should match the first 3 components of PNG_LIBPNG_VER_STRING: */
 #define PNG_LIBPNG_VER_MAJOR   1
 #define PNG_LIBPNG_VER_MINOR   6
-#define PNG_LIBPNG_VER_RELEASE 37
+#define PNG_LIBPNG_VER_RELEASE 38
 
 /* This should be zero for a public release, or non-zero for a
  * development version.  [Deprecated]
@@ -318,7 +318,7 @@
  * From version 1.0.1 it is:
  * XXYYZZ, where XX=major, YY=minor, ZZ=release
  */
-#define PNG_LIBPNG_VER 10637 /* 1.6.37 */
+#define PNG_LIBPNG_VER 10638 /* 1.6.38 */
 
 /* Library configuration: these options cannot be changed after
  * the library has been built.
@@ -329,10 +329,6 @@
  */
 #   include "pnglibconf.h"
 #endif
-
-#define PNG_APNG_SUPPORTED
-#define PNG_READ_APNG_SUPPORTED
-#define PNG_WRITE_APNG_SUPPORTED
 
 #ifndef PNG_VERSION_INFO_ONLY
 /* Machine specific configuration. */
@@ -429,21 +425,10 @@ extern "C" {
  * See pngconf.h for base types that vary by machine/system
  */
 
-#ifdef PNG_APNG_SUPPORTED
-/* dispose_op flags from inside fcTL */
-#define PNG_DISPOSE_OP_NONE        0x00U
-#define PNG_DISPOSE_OP_BACKGROUND  0x01U
-#define PNG_DISPOSE_OP_PREVIOUS    0x02U
-
-/* blend_op flags from inside fcTL */
-#define PNG_BLEND_OP_SOURCE        0x00U
-#define PNG_BLEND_OP_OVER          0x01U
-#endif /* PNG_APNG_SUPPORTED */
-
 /* This triggers a compiler error in png.c, if png.c and png.h
  * do not agree upon the version number.
  */
-typedef char* png_libpng_version_1_6_37;
+typedef char* png_libpng_version_1_6_38;
 
 /* Basic control structions.  Read libpng-manual.txt or libpng.3 for more info.
  *
@@ -761,10 +746,6 @@ typedef png_unknown_chunk * * png_unknown_chunkpp;
 #define PNG_INFO_sCAL 0x4000U  /* ESR, 1.0.6 */
 #define PNG_INFO_IDAT 0x8000U  /* ESR, 1.0.6 */
 #define PNG_INFO_eXIf 0x10000U /* GR-P, 1.6.31 */
-#ifdef PNG_APNG_SUPPORTED
-#define PNG_INFO_acTL 0x20000U
-#define PNG_INFO_fcTL 0x40000U
-#endif
 
 /* This is used for the transformation routines, as some of them
  * change these values for the row.  It also should enable using
@@ -802,10 +783,6 @@ typedef PNG_CALLBACK(void, *png_write_status_ptr, (png_structp, png_uint_32,
 #ifdef PNG_PROGRESSIVE_READ_SUPPORTED
 typedef PNG_CALLBACK(void, *png_progressive_info_ptr, (png_structp, png_infop));
 typedef PNG_CALLBACK(void, *png_progressive_end_ptr, (png_structp, png_infop));
-#ifdef PNG_APNG_SUPPORTED
-typedef PNG_CALLBACK(void, *png_progressive_frame_ptr, (png_structp,
-    png_uint_32));
-#endif
 
 /* The following callback receives png_uint_32 row_number, int pass for the
  * png_bytep data of the row.  When transforming an interlaced image the
@@ -1469,7 +1446,7 @@ PNG_EXPORT(66, void, png_set_crc_action, (png_structrp png_ptr, int crit_action,
  * mainly useful for testing, as the defaults should work with most users.
  * Those users who are tight on memory or want faster performance at the
  * expense of compression can modify them.  See the compression library
- * header file (zlib.h) for an explination of the compression functions.
+ * header file (zlib.h) for an explanation of the compression functions.
  */
 
 /* Set the filtering method(s) used by libpng.  Currently, the only valid
@@ -1524,7 +1501,7 @@ PNG_FIXED_EXPORT(209, void, png_set_filter_heuristics_fixed,
  * 0 - 9, corresponding directly to the zlib compression levels 0 - 9
  * (0 - no compression, 9 - "maximal" compression).  Note that tests have
  * shown that zlib compression levels 3-6 usually perform as well as level 9
- * for PNG images, and do considerably fewer caclulations.  In the future,
+ * for PNG images, and do considerably fewer calculations.  In the future,
  * these values may not correspond directly to the zlib compression levels.
  */
 #ifdef PNG_WRITE_CUSTOMIZE_COMPRESSION_SUPPORTED
@@ -3249,74 +3226,6 @@ PNG_EXPORT(244, int, png_set_option, (png_structrp png_ptr, int option,
 /*******************************************************************************
  *  END OF HARDWARE AND SOFTWARE OPTIONS
  ******************************************************************************/
-#ifdef PNG_APNG_SUPPORTED
-PNG_EXPORT(250, png_uint_32, png_get_acTL, (png_structp png_ptr,
-   png_infop info_ptr, png_uint_32 *num_frames, png_uint_32 *num_plays));
-
-PNG_EXPORT(251, png_uint_32, png_set_acTL, (png_structp png_ptr,
-   png_infop info_ptr, png_uint_32 num_frames, png_uint_32 num_plays));
-
-PNG_EXPORT(252, png_uint_32, png_get_num_frames, (png_structp png_ptr,
-   png_infop info_ptr));
-
-PNG_EXPORT(253, png_uint_32, png_get_num_plays, (png_structp png_ptr,
-   png_infop info_ptr));
-
-PNG_EXPORT(254, png_uint_32, png_get_next_frame_fcTL,
-   (png_structp png_ptr, png_infop info_ptr, png_uint_32 *width,
-   png_uint_32 *height, png_uint_32 *x_offset, png_uint_32 *y_offset,
-   png_uint_16 *delay_num, png_uint_16 *delay_den, png_byte *dispose_op,
-   png_byte *blend_op));
-
-PNG_EXPORT(255, png_uint_32, png_set_next_frame_fcTL,
-   (png_structp png_ptr, png_infop info_ptr, png_uint_32 width,
-   png_uint_32 height, png_uint_32 x_offset, png_uint_32 y_offset,
-   png_uint_16 delay_num, png_uint_16 delay_den, png_byte dispose_op,
-   png_byte blend_op));
-
-PNG_EXPORT(256, png_uint_32, png_get_next_frame_width,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(257, png_uint_32, png_get_next_frame_height,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(258, png_uint_32, png_get_next_frame_x_offset,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(259, png_uint_32, png_get_next_frame_y_offset,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(260, png_uint_16, png_get_next_frame_delay_num,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(261, png_uint_16, png_get_next_frame_delay_den,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(262, png_byte, png_get_next_frame_dispose_op,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(263, png_byte, png_get_next_frame_blend_op,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(264, png_byte, png_get_first_frame_is_hidden,
-   (png_structp png_ptr, png_infop info_ptr));
-PNG_EXPORT(265, png_uint_32, png_set_first_frame_is_hidden,
-   (png_structp png_ptr, png_infop info_ptr, png_byte is_hidden));
-
-#ifdef PNG_READ_APNG_SUPPORTED
-PNG_EXPORT(266, void, png_read_frame_head, (png_structp png_ptr,
-   png_infop info_ptr));
-#ifdef PNG_PROGRESSIVE_READ_SUPPORTED
-PNG_EXPORT(267, void, png_set_progressive_frame_fn, (png_structp png_ptr,
-   png_progressive_frame_ptr frame_info_fn,
-   png_progressive_frame_ptr frame_end_fn));
-#endif /* PNG_PROGRESSIVE_READ_SUPPORTED */
-#endif /* PNG_READ_APNG_SUPPORTED */
-
-#ifdef PNG_WRITE_APNG_SUPPORTED
-PNG_EXPORT(268, void, png_write_frame_head, (png_structp png_ptr,
-   png_infop info_ptr, png_bytepp row_pointers,
-   png_uint_32 width, png_uint_32 height,
-   png_uint_32 x_offset, png_uint_32 y_offset,
-   png_uint_16 delay_num, png_uint_16 delay_den, png_byte dispose_op,
-   png_byte blend_op));
-
-PNG_EXPORT(269, void, png_write_frame_tail, (png_structp png_ptr,
-   png_infop info_ptr));
-#endif /* PNG_WRITE_APNG_SUPPORTED */
-#endif /* PNG_APNG_SUPPORTED */
 
 /* Maintainer: Put new public prototypes here ^, in libpng.3, in project
  * defs, and in scripts/symbols.def.
@@ -3326,11 +3235,7 @@ PNG_EXPORT(269, void, png_write_frame_tail, (png_structp png_ptr,
  * one to use is one more than this.)
  */
 #ifdef PNG_EXPORT_LAST_ORDINAL
-#ifdef PNG_APNG_SUPPORTED
-  PNG_EXPORT_LAST_ORDINAL(269);
-#else
   PNG_EXPORT_LAST_ORDINAL(249);
-#endif /* PNG_APNG_SUPPORTED */
 #endif
 
 #ifdef __cplusplus

--- a/thirdparty/libpng/pngconf.h
+++ b/thirdparty/libpng/pngconf.h
@@ -1,9 +1,9 @@
 
 /* pngconf.h - machine-configurable file for libpng
  *
- * libpng version 1.6.37
+ * libpng version 1.6.38
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2016,2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -180,8 +180,8 @@
  * compiler-specific macros to the values required to change the calling
  * conventions of the various functions.
  */
-#if defined(_Windows) || defined(_WINDOWS) || defined(WIN32) ||\
-    defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || \
+    defined(__CYGWIN__)
   /* Windows system (DOS doesn't support DLLs).  Includes builds under Cygwin or
    * MinGW on any architecture currently supported by Windows.  Also includes
    * Watcom builds but these need special treatment because they are not

--- a/thirdparty/libpng/pngget.c
+++ b/thirdparty/libpng/pngget.c
@@ -1151,7 +1151,7 @@ png_get_unknown_chunks(png_const_structrp png_ptr, png_inforp info_ptr,
 
 #ifdef PNG_READ_RGB_TO_GRAY_SUPPORTED
 png_byte PNGAPI
-png_get_rgb_to_gray_status (png_const_structrp png_ptr)
+png_get_rgb_to_gray_status(png_const_structrp png_ptr)
 {
    return (png_byte)(png_ptr ? png_ptr->rgb_to_gray_status : 0);
 }
@@ -1192,27 +1192,27 @@ png_get_compression_buffer_size(png_const_structrp png_ptr)
 /* These functions were added to libpng 1.2.6 and were enabled
  * by default in libpng-1.4.0 */
 png_uint_32 PNGAPI
-png_get_user_width_max (png_const_structrp png_ptr)
+png_get_user_width_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_width_max : 0);
 }
 
 png_uint_32 PNGAPI
-png_get_user_height_max (png_const_structrp png_ptr)
+png_get_user_height_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_height_max : 0);
 }
 
 /* This function was added to libpng 1.4.0 */
 png_uint_32 PNGAPI
-png_get_chunk_cache_max (png_const_structrp png_ptr)
+png_get_chunk_cache_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_chunk_cache_max : 0);
 }
 
 /* This function was added to libpng 1.4.1 */
 png_alloc_size_t PNGAPI
-png_get_chunk_malloc_max (png_const_structrp png_ptr)
+png_get_chunk_malloc_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_chunk_malloc_max : 0);
 }
@@ -1221,13 +1221,13 @@ png_get_chunk_malloc_max (png_const_structrp png_ptr)
 /* These functions were added to libpng 1.4.0 */
 #ifdef PNG_IO_STATE_SUPPORTED
 png_uint_32 PNGAPI
-png_get_io_state (png_const_structrp png_ptr)
+png_get_io_state(png_const_structrp png_ptr)
 {
    return png_ptr->io_state;
 }
 
 png_uint_32 PNGAPI
-png_get_io_chunk_type (png_const_structrp png_ptr)
+png_get_io_chunk_type(png_const_structrp png_ptr)
 {
    return png_ptr->chunk_name;
 }
@@ -1246,166 +1246,4 @@ png_get_palette_max(png_const_structp png_ptr, png_const_infop info_ptr)
 #  endif
 #endif
 
-#ifdef PNG_APNG_SUPPORTED
-png_uint_32 PNGAPI
-png_get_acTL(png_structp png_ptr, png_infop info_ptr,
-             png_uint_32 *num_frames, png_uint_32 *num_plays)
-{
-    png_debug1(1, "in %s retrieval function", "acTL");
-
-    if (png_ptr != NULL && info_ptr != NULL &&
-        (info_ptr->valid & PNG_INFO_acTL) &&
-        num_frames != NULL && num_plays != NULL)
-    {
-        *num_frames = info_ptr->num_frames;
-        *num_plays = info_ptr->num_plays;
-        return (1);
-    }
-
-    return (0);
-}
-
-png_uint_32 PNGAPI
-png_get_num_frames(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_num_frames()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->num_frames);
-    return (0);
-}
-
-png_uint_32 PNGAPI
-png_get_num_plays(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_num_plays()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->num_plays);
-    return (0);
-}
-
-png_uint_32 PNGAPI
-png_get_next_frame_fcTL(png_structp png_ptr, png_infop info_ptr,
-             png_uint_32 *width, png_uint_32 *height,
-             png_uint_32 *x_offset, png_uint_32 *y_offset,
-             png_uint_16 *delay_num, png_uint_16 *delay_den,
-             png_byte *dispose_op, png_byte *blend_op)
-{
-    png_debug1(1, "in %s retrieval function", "fcTL");
-
-    if (png_ptr != NULL && info_ptr != NULL &&
-        (info_ptr->valid & PNG_INFO_fcTL) &&
-        width != NULL && height != NULL &&
-        x_offset != NULL && y_offset != NULL &&
-        delay_num != NULL && delay_den != NULL &&
-        dispose_op != NULL && blend_op != NULL)
-    {
-        *width = info_ptr->next_frame_width;
-        *height = info_ptr->next_frame_height;
-        *x_offset = info_ptr->next_frame_x_offset;
-        *y_offset = info_ptr->next_frame_y_offset;
-        *delay_num = info_ptr->next_frame_delay_num;
-        *delay_den = info_ptr->next_frame_delay_den;
-        *dispose_op = info_ptr->next_frame_dispose_op;
-        *blend_op = info_ptr->next_frame_blend_op;
-        return (1);
-    }
-
-    return (0);
-}
-
-png_uint_32 PNGAPI
-png_get_next_frame_width(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_next_frame_width()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->next_frame_width);
-    return (0);
-}
-
-png_uint_32 PNGAPI
-png_get_next_frame_height(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_next_frame_height()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->next_frame_height);
-    return (0);
-}
-
-png_uint_32 PNGAPI
-png_get_next_frame_x_offset(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_next_frame_x_offset()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->next_frame_x_offset);
-    return (0);
-}
-
-png_uint_32 PNGAPI
-png_get_next_frame_y_offset(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_next_frame_y_offset()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->next_frame_y_offset);
-    return (0);
-}
-
-png_uint_16 PNGAPI
-png_get_next_frame_delay_num(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_next_frame_delay_num()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->next_frame_delay_num);
-    return (0);
-}
-
-png_uint_16 PNGAPI
-png_get_next_frame_delay_den(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_next_frame_delay_den()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->next_frame_delay_den);
-    return (0);
-}
-
-png_byte PNGAPI
-png_get_next_frame_dispose_op(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_next_frame_dispose_op()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->next_frame_dispose_op);
-    return (0);
-}
-
-png_byte PNGAPI
-png_get_next_frame_blend_op(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_get_next_frame_blend_op()");
-
-    if (png_ptr != NULL && info_ptr != NULL)
-        return (info_ptr->next_frame_blend_op);
-    return (0);
-}
-
-png_byte PNGAPI
-png_get_first_frame_is_hidden(png_structp png_ptr, png_infop info_ptr)
-{
-    png_debug(1, "in png_first_frame_is_hidden()");
-
-    if (png_ptr != NULL)
-       return (png_byte)(png_ptr->apng_flags & PNG_FIRST_FRAME_HIDDEN);
-
-    PNG_UNUSED(info_ptr)
-
-    return 0;
-}
-#endif /* PNG_APNG_SUPPORTED */
 #endif /* READ || WRITE */

--- a/thirdparty/libpng/pnginfo.h
+++ b/thirdparty/libpng/pnginfo.h
@@ -263,18 +263,5 @@ defined(PNG_READ_BACKGROUND_SUPPORTED)
    png_bytepp row_pointers;        /* the image bits */
 #endif
 
-#ifdef PNG_APNG_SUPPORTED
-   png_uint_32 num_frames; /* including default image */
-   png_uint_32 num_plays;
-   png_uint_32 next_frame_width;
-   png_uint_32 next_frame_height;
-   png_uint_32 next_frame_x_offset;
-   png_uint_32 next_frame_y_offset;
-   png_uint_16 next_frame_delay_num;
-   png_uint_16 next_frame_delay_den;
-   png_byte next_frame_dispose_op;
-   png_byte next_frame_blend_op;
-#endif
-
 };
 #endif /* PNGINFO_H */

--- a/thirdparty/libpng/pnglibconf.h
+++ b/thirdparty/libpng/pnglibconf.h
@@ -1,8 +1,8 @@
 /* pnglibconf.h - library build configuration */
 
-/* libpng version 1.6.37 */
+/* libpng version 1.6.38 */
 
-/* Copyright (c) 2018-2019 Cosmin Truta */
+/* Copyright (c) 2018-2022 Cosmin Truta */
 /* Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson */
 
 /* This code is released under the libpng license. */

--- a/thirdparty/libpng/pngpread.c
+++ b/thirdparty/libpng/pngpread.c
@@ -195,106 +195,6 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
 
    chunk_name = png_ptr->chunk_name;
 
-#ifdef PNG_READ_APNG_SUPPORTED
-   if (png_ptr->num_frames_read > 0 &&
-       png_ptr->num_frames_read < info_ptr->num_frames)
-   {
-      if (chunk_name == png_IDAT)
-      {
-         /* Discard trailing IDATs for the first frame */
-         if (png_ptr->mode & PNG_HAVE_fcTL || png_ptr->num_frames_read > 1)
-            png_error(png_ptr, "out of place IDAT");
-
-         if (png_ptr->push_length + 4 > png_ptr->buffer_size)
-         {
-            png_push_save_buffer(png_ptr);
-            return;
-         }
-
-         png_ptr->mode &= ~PNG_HAVE_CHUNK_HEADER;
-         return;
-      }
-      else if (chunk_name == png_fdAT)
-      {
-         if (png_ptr->buffer_size < 4)
-         {
-            png_push_save_buffer(png_ptr);
-            return;
-         }
-
-         png_ensure_sequence_number(png_ptr, 4);
-
-         if (!(png_ptr->mode & PNG_HAVE_fcTL))
-         {
-            /* Discard trailing fdATs for frames other than the first */
-            if (png_ptr->num_frames_read < 2)
-               png_error(png_ptr, "out of place fdAT");
-
-            if (png_ptr->push_length + 4 > png_ptr->buffer_size)
-            {
-               png_push_save_buffer(png_ptr);
-               return;
-            }
-
-            png_ptr->mode &= ~PNG_HAVE_CHUNK_HEADER;
-            return;
-         }
-
-         else
-         {
-            /* frame data follows */
-            png_ptr->idat_size = png_ptr->push_length - 4;
-            png_ptr->mode |= PNG_HAVE_IDAT;
-            png_ptr->process_mode = PNG_READ_IDAT_MODE;
-
-            return;
-         }
-      }
-
-      else if (chunk_name == png_fcTL)
-      {
-         if (png_ptr->push_length + 4 > png_ptr->buffer_size)
-         {
-            png_push_save_buffer(png_ptr);
-            return;
-         }
-
-         png_read_reset(png_ptr);
-         png_ptr->mode &= ~PNG_HAVE_fcTL;
-
-         png_handle_fcTL(png_ptr, info_ptr, png_ptr->push_length);
-
-         if (!(png_ptr->mode & PNG_HAVE_fcTL))
-            png_error(png_ptr, "missing required fcTL chunk");
-
-         png_read_reinit(png_ptr, info_ptr);
-         png_progressive_read_reset(png_ptr);
-
-         if (png_ptr->frame_info_fn != NULL)
-            (*(png_ptr->frame_info_fn))(png_ptr, png_ptr->num_frames_read);
-
-         png_ptr->mode &= ~PNG_HAVE_CHUNK_HEADER;
-
-         return;
-      }
-
-      else
-      {
-         if (png_ptr->push_length + 4 > png_ptr->buffer_size)
-         {
-            png_push_save_buffer(png_ptr);
-            return;
-         }
-         png_warning(png_ptr, "Skipped (ignored) a chunk "
-                              "between APNG chunks");
-         png_ptr->mode &= ~PNG_HAVE_CHUNK_HEADER;
-         return;
-      }
-
-      return;
-   }
-#endif /* PNG_READ_APNG_SUPPORTED */
-
    if (chunk_name == png_IDAT)
    {
       if ((png_ptr->mode & PNG_AFTER_IDAT) != 0)
@@ -361,9 +261,6 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
 
    else if (chunk_name == png_IDAT)
    {
-#ifdef PNG_READ_APNG_SUPPORTED
-      png_have_info(png_ptr, info_ptr);
-#endif
       png_ptr->idat_size = png_ptr->push_length;
       png_ptr->process_mode = PNG_READ_IDAT_MODE;
       png_push_have_info(png_ptr, info_ptr);
@@ -509,30 +406,6 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
       png_handle_iTXt(png_ptr, info_ptr, png_ptr->push_length);
    }
 #endif
-#ifdef PNG_READ_APNG_SUPPORTED
-   else if (chunk_name == png_acTL)
-   {
-      if (png_ptr->push_length + 4 > png_ptr->buffer_size)
-      {
-         png_push_save_buffer(png_ptr);
-         return;
-      }
-
-      png_handle_acTL(png_ptr, info_ptr, png_ptr->push_length);
-   }
-
-   else if (chunk_name == png_fcTL)
-   {
-      if (png_ptr->push_length + 4 > png_ptr->buffer_size)
-      {
-         png_push_save_buffer(png_ptr);
-         return;
-      }
-
-      png_handle_fcTL(png_ptr, info_ptr, png_ptr->push_length);
-   }
-
-#endif /* PNG_READ_APNG_SUPPORTED */
 
    else
    {
@@ -666,11 +539,7 @@ png_push_read_IDAT(png_structrp png_ptr)
       png_byte chunk_tag[4];
 
       /* TODO: this code can be commoned up with the same code in push_read */
-#ifdef PNG_READ_APNG_SUPPORTED
-      PNG_PUSH_SAVE_BUFFER_IF_LT(12)
-#else
       PNG_PUSH_SAVE_BUFFER_IF_LT(8)
-#endif
       png_push_fill_buffer(png_ptr, chunk_length, 4);
       png_ptr->push_length = png_get_uint_31(png_ptr, chunk_length);
       png_reset_crc(png_ptr);
@@ -678,64 +547,17 @@ png_push_read_IDAT(png_structrp png_ptr)
       png_ptr->chunk_name = PNG_CHUNK_FROM_STRING(chunk_tag);
       png_ptr->mode |= PNG_HAVE_CHUNK_HEADER;
 
-#ifdef PNG_READ_APNG_SUPPORTED
-      if (png_ptr->chunk_name != png_fdAT && png_ptr->num_frames_read > 0)
-      {
-          if (png_ptr->flags & PNG_FLAG_ZSTREAM_ENDED)
-          {
-              png_ptr->process_mode = PNG_READ_CHUNK_MODE;
-              if (png_ptr->frame_end_fn != NULL)
-                 (*(png_ptr->frame_end_fn))(png_ptr, png_ptr->num_frames_read);
-              png_ptr->num_frames_read++;
-              return;
-          }
-          else
-          {
-              if (png_ptr->chunk_name == png_IEND)
-                  png_error(png_ptr, "Not enough image data");
-              if (png_ptr->push_length + 4 > png_ptr->buffer_size)
-              {
-                 png_push_save_buffer(png_ptr);
-                 return;
-              }
-              png_warning(png_ptr, "Skipping (ignoring) a chunk between "
-                                   "APNG chunks");
-              png_crc_finish(png_ptr, png_ptr->push_length);
-              png_ptr->mode &= ~PNG_HAVE_CHUNK_HEADER;
-              return;
-          }
-      }
-      else
-#endif
-#ifdef PNG_READ_APNG_SUPPORTED
-      if (png_ptr->chunk_name != png_IDAT && png_ptr->num_frames_read == 0)
-#else
       if (png_ptr->chunk_name != png_IDAT)
-#endif
       {
          png_ptr->process_mode = PNG_READ_CHUNK_MODE;
 
          if ((png_ptr->flags & PNG_FLAG_ZSTREAM_ENDED) == 0)
             png_error(png_ptr, "Not enough compressed data");
 
-#ifdef PNG_READ_APNG_SUPPORTED
-         if (png_ptr->frame_end_fn != NULL)
-            (*(png_ptr->frame_end_fn))(png_ptr, png_ptr->num_frames_read);
-         png_ptr->num_frames_read++;
-#endif
-
          return;
       }
 
       png_ptr->idat_size = png_ptr->push_length;
-
-#ifdef PNG_READ_APNG_SUPPORTED
-      if (png_ptr->num_frames_read > 0)
-      {
-         png_ensure_sequence_number(png_ptr, 4);
-         png_ptr->idat_size -= 4;
-      }
-#endif
    }
 
    if (png_ptr->idat_size != 0 && png_ptr->save_buffer_size != 0)
@@ -808,15 +630,6 @@ png_process_IDAT_data(png_structrp png_ptr, png_bytep buffer,
    /* The caller checks for a non-zero buffer length. */
    if (!(buffer_length > 0) || buffer == NULL)
       png_error(png_ptr, "No IDAT data (internal error)");
-
-#ifdef PNG_READ_APNG_SUPPORTED
-   /* If the app is not APNG-aware, decode only the first frame */
-   if (!(png_ptr->apng_flags & PNG_APNG_APP) && png_ptr->num_frames_read > 0)
-   {
-     png_ptr->flags |= PNG_FLAG_ZSTREAM_ENDED;
-     return;
-   }
-#endif
 
    /* This routine must process all the data it has been given
     * before returning, calling the row callback as required to
@@ -1271,18 +1084,6 @@ png_set_progressive_read_fn(png_structrp png_ptr, png_voidp progressive_ptr,
 
    png_set_read_fn(png_ptr, progressive_ptr, png_push_fill_buffer);
 }
-
-#ifdef PNG_READ_APNG_SUPPORTED
-void PNGAPI
-png_set_progressive_frame_fn(png_structp png_ptr,
-   png_progressive_frame_ptr frame_info_fn,
-   png_progressive_frame_ptr frame_end_fn)
-{
-   png_ptr->frame_info_fn = frame_info_fn;
-   png_ptr->frame_end_fn = frame_end_fn;
-   png_ptr->apng_flags |= PNG_APNG_APP;
-}
-#endif
 
 png_voidp PNGAPI
 png_get_progressive_ptr(png_const_structrp png_ptr)

--- a/thirdparty/libpng/pngread.c
+++ b/thirdparty/libpng/pngread.c
@@ -161,9 +161,6 @@ png_read_info(png_structrp png_ptr, png_inforp info_ptr)
 
       else if (chunk_name == png_IDAT)
       {
-#ifdef PNG_READ_APNG_SUPPORTED
-         png_have_info(png_ptr, info_ptr);
-#endif
          png_ptr->idat_size = length;
          break;
       }
@@ -258,89 +255,12 @@ png_read_info(png_structrp png_ptr, png_inforp info_ptr)
          png_handle_iTXt(png_ptr, info_ptr, length);
 #endif
 
-#ifdef PNG_READ_APNG_SUPPORTED
-      else if (chunk_name == png_acTL)
-         png_handle_acTL(png_ptr, info_ptr, length);
-
-      else if (chunk_name == png_fcTL)
-         png_handle_fcTL(png_ptr, info_ptr, length);
-
-      else if (chunk_name == png_fdAT)
-         png_handle_fdAT(png_ptr, info_ptr, length);
-#endif
-
       else
          png_handle_unknown(png_ptr, info_ptr, length,
              PNG_HANDLE_CHUNK_AS_DEFAULT);
    }
 }
 #endif /* SEQUENTIAL_READ */
-
-#ifdef PNG_READ_APNG_SUPPORTED
-void PNGAPI
-png_read_frame_head(png_structp png_ptr, png_infop info_ptr)
-{
-    png_byte have_chunk_after_DAT; /* after IDAT or after fdAT */
-
-    png_debug(0, "Reading frame head");
-
-    if (!(png_ptr->mode & PNG_HAVE_acTL))
-        png_error(png_ptr, "attempt to png_read_frame_head() but "
-                           "no acTL present");
-
-    /* do nothing for the main IDAT */
-    if (png_ptr->num_frames_read == 0)
-        return;
-
-    png_read_reset(png_ptr);
-    png_ptr->flags &= ~PNG_FLAG_ROW_INIT;
-    png_ptr->mode &= ~PNG_HAVE_fcTL;
-
-    have_chunk_after_DAT = 0;
-    for (;;)
-    {
-        png_uint_32 length = png_read_chunk_header(png_ptr);
-
-        if (png_ptr->chunk_name == png_IDAT)
-        {
-            /* discard trailing IDATs for the first frame */
-            if (have_chunk_after_DAT || png_ptr->num_frames_read > 1)
-                png_error(png_ptr, "png_read_frame_head(): out of place IDAT");
-            png_crc_finish(png_ptr, length);
-        }
-
-        else if (png_ptr->chunk_name == png_fcTL)
-        {
-            png_handle_fcTL(png_ptr, info_ptr, length);
-            have_chunk_after_DAT = 1;
-        }
-
-        else if (png_ptr->chunk_name == png_fdAT)
-        {
-            png_ensure_sequence_number(png_ptr, length);
-
-            /* discard trailing fdATs for frames other than the first */
-            if (!have_chunk_after_DAT && png_ptr->num_frames_read > 1)
-                png_crc_finish(png_ptr, length - 4);
-            else if(png_ptr->mode & PNG_HAVE_fcTL)
-            {
-                png_ptr->idat_size = length - 4;
-                png_ptr->mode |= PNG_HAVE_IDAT;
-
-                break;
-            }
-            else
-                png_error(png_ptr, "png_read_frame_head(): out of place fdAT");
-        }
-        else
-        {
-            png_warning(png_ptr, "Skipped (ignored) a chunk "
-                                 "between APNG chunks");
-            png_crc_finish(png_ptr, length);
-        }
-    }
-}
-#endif /* PNG_READ_APNG_SUPPORTED */
 
 /* Optional call to update the users info_ptr structure */
 void PNGAPI
@@ -3532,7 +3452,6 @@ png_image_read_background(png_voidp argument)
 
             for (pass = 0; pass < passes; ++pass)
             {
-               png_bytep row = png_voidcast(png_bytep, display->first_row);
                unsigned int     startx, stepx, stepy;
                png_uint_32      y;
 
@@ -3637,8 +3556,6 @@ png_image_read_background(png_voidp argument)
 
                         inrow += 2; /* gray and alpha channel */
                      }
-
-                     row += display->row_bytes;
                   }
                }
             }

--- a/thirdparty/libpng/pngrtran.c
+++ b/thirdparty/libpng/pngrtran.c
@@ -21,7 +21,7 @@
 #ifdef PNG_ARM_NEON_IMPLEMENTATION
 #  if PNG_ARM_NEON_IMPLEMENTATION == 1
 #    define PNG_ARM_NEON_INTRINSICS_AVAILABLE
-#    if defined(_MSC_VER) && defined(_M_ARM64)
+#    if defined(_MSC_VER) && !defined(__clang__) && defined(_M_ARM64)
 #      include <arm64_neon.h>
 #    else
 #      include <arm_neon.h>

--- a/thirdparty/libpng/pngrutil.c
+++ b/thirdparty/libpng/pngrutil.c
@@ -1,7 +1,7 @@
 
 /* pngrutil.c - utilities to read a PNG file
  *
- * Copyright (c) 2018 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -301,7 +301,6 @@ png_read_buffer(png_structrp png_ptr, png_alloc_size_t new_size, int warn)
 
    if (buffer != NULL && new_size > png_ptr->read_buffer_size)
    {
-      png_ptr->read_buffer = NULL;
       png_ptr->read_buffer = NULL;
       png_ptr->read_buffer_size = 0;
       png_free(png_ptr, buffer);
@@ -864,11 +863,6 @@ png_handle_IHDR(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
    compression_type = buf[10];
    filter_type = buf[11];
    interlace_type = buf[12];
-
-#ifdef PNG_READ_APNG_SUPPORTED
-   png_ptr->first_frame_width = width;
-   png_ptr->first_frame_height = height;
-#endif
 
    /* Set internal variables */
    png_ptr->width = width;
@@ -2081,21 +2075,22 @@ png_handle_eXIf(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       png_byte buf[1];
       png_crc_read(png_ptr, buf, 1);
       info_ptr->eXIf_buf[i] = buf[0];
-      if (i == 1 && buf[0] != 'M' && buf[0] != 'I'
-                 && info_ptr->eXIf_buf[0] != buf[0])
+      if (i == 1)
       {
-         png_crc_finish(png_ptr, length);
-         png_chunk_benign_error(png_ptr, "incorrect byte-order specifier");
-         png_free(png_ptr, info_ptr->eXIf_buf);
-         info_ptr->eXIf_buf = NULL;
-         return;
+         if ((buf[0] != 'M' && buf[0] != 'I') ||
+             (info_ptr->eXIf_buf[0] != buf[0]))
+         {
+            png_crc_finish(png_ptr, length - 2);
+            png_chunk_benign_error(png_ptr, "incorrect byte-order specifier");
+            png_free(png_ptr, info_ptr->eXIf_buf);
+            info_ptr->eXIf_buf = NULL;
+            return;
+         }
       }
    }
 
-   if (png_crc_finish(png_ptr, 0) != 0)
-      return;
-
-   png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
+   if (png_crc_finish(png_ptr, 0) == 0)
+      png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
 
    png_free(png_ptr, info_ptr->eXIf_buf);
    info_ptr->eXIf_buf = NULL;
@@ -2131,8 +2126,9 @@ png_handle_hIST(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
 
    num = length / 2 ;
 
-   if (num != (unsigned int) png_ptr->num_palette ||
-       num > (unsigned int) PNG_MAX_PALETTE_LENGTH)
+   if (length != num * 2 ||
+       num != (unsigned int)png_ptr->num_palette ||
+       num > (unsigned int)PNG_MAX_PALETTE_LENGTH)
    {
       png_crc_finish(png_ptr, length);
       png_chunk_benign_error(png_ptr, "invalid");
@@ -2861,179 +2857,6 @@ png_handle_iTXt(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       png_chunk_benign_error(png_ptr, errmsg);
 }
 #endif
-
-#ifdef PNG_READ_APNG_SUPPORTED
-void /* PRIVATE */
-png_handle_acTL(png_structp png_ptr, png_infop info_ptr, png_uint_32 length)
-{
-    png_byte data[8];
-    png_uint_32 num_frames;
-    png_uint_32 num_plays;
-    png_uint_32 didSet;
-
-    png_debug(1, "in png_handle_acTL");
-
-    if (!(png_ptr->mode & PNG_HAVE_IHDR))
-    {
-        png_error(png_ptr, "Missing IHDR before acTL");
-    }
-    else if (png_ptr->mode & PNG_HAVE_IDAT)
-    {
-        png_warning(png_ptr, "Invalid acTL after IDAT skipped");
-        png_crc_finish(png_ptr, length);
-        return;
-    }
-    else if (png_ptr->mode & PNG_HAVE_acTL)
-    {
-        png_warning(png_ptr, "Duplicate acTL skipped");
-        png_crc_finish(png_ptr, length);
-        return;
-    }
-    else if (length != 8)
-    {
-        png_warning(png_ptr, "acTL with invalid length skipped");
-        png_crc_finish(png_ptr, length);
-        return;
-    }
-
-    png_crc_read(png_ptr, data, 8);
-    png_crc_finish(png_ptr, 0);
-
-    num_frames = png_get_uint_31(png_ptr, data);
-    num_plays = png_get_uint_31(png_ptr, data + 4);
-
-    /* the set function will do error checking on num_frames */
-    didSet = png_set_acTL(png_ptr, info_ptr, num_frames, num_plays);
-    if(didSet)
-        png_ptr->mode |= PNG_HAVE_acTL;
-}
-
-void /* PRIVATE */
-png_handle_fcTL(png_structp png_ptr, png_infop info_ptr, png_uint_32 length)
-{
-    png_byte data[22];
-    png_uint_32 width;
-    png_uint_32 height;
-    png_uint_32 x_offset;
-    png_uint_32 y_offset;
-    png_uint_16 delay_num;
-    png_uint_16 delay_den;
-    png_byte dispose_op;
-    png_byte blend_op;
-
-    png_debug(1, "in png_handle_fcTL");
-
-    png_ensure_sequence_number(png_ptr, length);
-
-    if (!(png_ptr->mode & PNG_HAVE_IHDR))
-    {
-        png_error(png_ptr, "Missing IHDR before fcTL");
-    }
-    else if (png_ptr->mode & PNG_HAVE_IDAT)
-    {
-        /* for any frames other then the first this message may be misleading,
-        * but correct. PNG_HAVE_IDAT is unset before the frame head is read
-        * i can't think of a better message */
-        png_warning(png_ptr, "Invalid fcTL after IDAT skipped");
-        png_crc_finish(png_ptr, length-4);
-        return;
-    }
-    else if (png_ptr->mode & PNG_HAVE_fcTL)
-    {
-        png_warning(png_ptr, "Duplicate fcTL within one frame skipped");
-        png_crc_finish(png_ptr, length-4);
-        return;
-    }
-    else if (length != 26)
-    {
-        png_warning(png_ptr, "fcTL with invalid length skipped");
-        png_crc_finish(png_ptr, length-4);
-        return;
-    }
-
-    png_crc_read(png_ptr, data, 22);
-    png_crc_finish(png_ptr, 0);
-
-    width = png_get_uint_31(png_ptr, data);
-    height = png_get_uint_31(png_ptr, data + 4);
-    x_offset = png_get_uint_31(png_ptr, data + 8);
-    y_offset = png_get_uint_31(png_ptr, data + 12);
-    delay_num = png_get_uint_16(data + 16);
-    delay_den = png_get_uint_16(data + 18);
-    dispose_op = data[20];
-    blend_op = data[21];
-
-    if (png_ptr->num_frames_read == 0 && (x_offset != 0 || y_offset != 0))
-    {
-        png_warning(png_ptr, "fcTL for the first frame must have zero offset");
-        return;
-    }
-
-    if (info_ptr != NULL)
-    {
-        if (png_ptr->num_frames_read == 0 &&
-            (width != info_ptr->width || height != info_ptr->height))
-        {
-            png_warning(png_ptr, "size in first frame's fcTL must match "
-                               "the size in IHDR");
-            return;
-        }
-
-        /* The set function will do more error checking */
-        png_set_next_frame_fcTL(png_ptr, info_ptr, width, height,
-                                x_offset, y_offset, delay_num, delay_den,
-                                dispose_op, blend_op);
-
-        png_read_reinit(png_ptr, info_ptr);
-
-        png_ptr->mode |= PNG_HAVE_fcTL;
-    }
-}
-
-void /* PRIVATE */
-png_have_info(png_structp png_ptr, png_infop info_ptr)
-{
-    if((info_ptr->valid & PNG_INFO_acTL) && !(info_ptr->valid & PNG_INFO_fcTL))
-    {
-        png_ptr->apng_flags |= PNG_FIRST_FRAME_HIDDEN;
-        info_ptr->num_frames++;
-    }
-}
-
-void /* PRIVATE */
-png_handle_fdAT(png_structp png_ptr, png_infop info_ptr, png_uint_32 length)
-{
-    png_ensure_sequence_number(png_ptr, length);
-
-    /* This function is only called from png_read_end(), png_read_info(),
-    * and png_push_read_chunk() which means that:
-    * - the user doesn't want to read this frame
-    * - or this is an out-of-place fdAT
-    * in either case it is safe to ignore the chunk with a warning */
-    png_warning(png_ptr, "ignoring fdAT chunk");
-    png_crc_finish(png_ptr, length - 4);
-    PNG_UNUSED(info_ptr)
-}
-
-void /* PRIVATE */
-png_ensure_sequence_number(png_structp png_ptr, png_uint_32 length)
-{
-    png_byte data[4];
-    png_uint_32 sequence_number;
-
-    if (length < 4)
-        png_error(png_ptr, "invalid fcTL or fdAT chunk found");
-
-    png_crc_read(png_ptr, data, 4);
-    sequence_number = png_get_uint_31(png_ptr, data);
-
-    if (sequence_number != png_ptr->next_seq_num)
-        png_error(png_ptr, "fcTL or fdAT chunk with out-of-order sequence "
-                           "number found");
-
-    png_ptr->next_seq_num++;
-}
-#endif /* PNG_READ_APNG_SUPPORTED */
 
 #ifdef PNG_READ_UNKNOWN_CHUNKS_SUPPORTED
 /* Utility function for png_handle_unknown; set up png_ptr::unknown_chunk */
@@ -4343,38 +4166,7 @@ png_read_IDAT_data(png_structrp png_ptr, png_bytep output,
       {
          uInt avail_in;
          png_bytep buffer;
-#ifdef PNG_READ_APNG_SUPPORTED
-         png_uint_32 bytes_to_skip = 0;
 
-         while (png_ptr->idat_size == 0 || bytes_to_skip != 0)
-         {
-            png_crc_finish(png_ptr, bytes_to_skip);
-            bytes_to_skip = 0;
-
-            png_ptr->idat_size = png_read_chunk_header(png_ptr);
-            if (png_ptr->num_frames_read == 0)
-            {
-               if (png_ptr->chunk_name != png_IDAT)
-                  png_error(png_ptr, "Not enough image data");
-            }
-            else
-            {
-               if (png_ptr->chunk_name == png_IEND)
-                  png_error(png_ptr, "Not enough image data");
-               if (png_ptr->chunk_name != png_fdAT)
-               {
-                  png_warning(png_ptr, "Skipped (ignored) a chunk "
-                                       "between APNG chunks");
-                  bytes_to_skip = png_ptr->idat_size;
-                  continue;
-               }
-
-               png_ensure_sequence_number(png_ptr, png_ptr->idat_size);
-
-               png_ptr->idat_size -= 4;
-            }
-         }
-#else
          while (png_ptr->idat_size == 0)
          {
             png_crc_finish(png_ptr, 0);
@@ -4386,7 +4178,7 @@ png_read_IDAT_data(png_structrp png_ptr, png_bytep output,
             if (png_ptr->chunk_name != png_IDAT)
                png_error(png_ptr, "Not enough image data");
          }
-#endif /* PNG_READ_APNG_SUPPORTED */
+
          avail_in = png_ptr->IDAT_read_size;
 
          if (avail_in > png_ptr->idat_size)
@@ -4449,9 +4241,6 @@ png_read_IDAT_data(png_structrp png_ptr, png_bytep output,
 
          png_ptr->mode |= PNG_AFTER_IDAT;
          png_ptr->flags |= PNG_FLAG_ZSTREAM_ENDED;
-#ifdef PNG_READ_APNG_SUPPORTED
-         png_ptr->num_frames_read++;
-#endif
 
          if (png_ptr->zstream.avail_in > 0 || png_ptr->idat_size > 0)
             png_chunk_benign_error(png_ptr, "Extra compressed data");
@@ -4833,14 +4622,13 @@ defined(PNG_USER_TRANSFORM_PTR_SUPPORTED)
        */
       {
          png_bytep temp = png_ptr->big_row_buf + 32;
-         int extra = (int)((temp - (png_bytep)0) & 0x0f);
+         size_t extra = (size_t)temp & 0x0f;
          png_ptr->row_buf = temp - extra - 1/*filter byte*/;
 
          temp = png_ptr->big_prev_row + 32;
-         extra = (int)((temp - (png_bytep)0) & 0x0f);
+         extra = (size_t)temp & 0x0f;
          png_ptr->prev_row = temp - extra - 1/*filter byte*/;
       }
-
 #else
       /* Use 31 bytes of padding before and 17 bytes after row_buf. */
       png_ptr->row_buf = png_ptr->big_row_buf + 31;
@@ -4890,80 +4678,4 @@ defined(PNG_USER_TRANSFORM_PTR_SUPPORTED)
 
    png_ptr->flags |= PNG_FLAG_ROW_INIT;
 }
-
-#ifdef PNG_READ_APNG_SUPPORTED
-/* This function is to be called after the main IDAT set has been read and
- * before a new IDAT is read. It resets some parts of png_ptr
- * to make them usable by the read functions again */
-void /* PRIVATE */
-png_read_reset(png_structp png_ptr)
-{
-    png_ptr->mode &= ~PNG_HAVE_IDAT;
-    png_ptr->mode &= ~PNG_AFTER_IDAT;
-    png_ptr->row_number = 0;
-    png_ptr->pass = 0;
-}
-
-void /* PRIVATE */
-png_read_reinit(png_structp png_ptr, png_infop info_ptr)
-{
-    png_ptr->width = info_ptr->next_frame_width;
-    png_ptr->height = info_ptr->next_frame_height;
-    png_ptr->rowbytes = PNG_ROWBYTES(png_ptr->pixel_depth,png_ptr->width);
-    png_ptr->info_rowbytes = PNG_ROWBYTES(info_ptr->pixel_depth,
-        png_ptr->width);
-    if (png_ptr->prev_row)
-        memset(png_ptr->prev_row, 0, png_ptr->rowbytes + 1);
-}
-
-#ifdef PNG_PROGRESSIVE_READ_SUPPORTED
-/* same as png_read_reset() but for the progressive reader */
-void /* PRIVATE */
-png_progressive_read_reset(png_structp png_ptr)
-{
-#ifdef PNG_READ_INTERLACING_SUPPORTED
-   /* Arrays to facilitate easy interlacing - use pass (0 - 6) as index */
-
-   /* Start of interlace block */
-    const int png_pass_start[] = {0, 4, 0, 2, 0, 1, 0};
-
-    /* Offset to next interlace block */
-    const int png_pass_inc[] = {8, 8, 4, 4, 2, 2, 1};
-
-    /* Start of interlace block in the y direction */
-    const int png_pass_ystart[] = {0, 0, 4, 0, 2, 0, 1};
-
-    /* Offset to next interlace block in the y direction */
-    const int png_pass_yinc[] = {8, 8, 8, 4, 4, 2, 2};
-
-    if (png_ptr->interlaced)
-    {
-        if (!(png_ptr->transformations & PNG_INTERLACE))
-            png_ptr->num_rows = (png_ptr->height + png_pass_yinc[0] - 1 -
-                                png_pass_ystart[0]) / png_pass_yinc[0];
-        else
-            png_ptr->num_rows = png_ptr->height;
-
-        png_ptr->iwidth = (png_ptr->width +
-                           png_pass_inc[png_ptr->pass] - 1 -
-                           png_pass_start[png_ptr->pass]) /
-                           png_pass_inc[png_ptr->pass];
-    }
-    else
-#endif /* PNG_READ_INTERLACING_SUPPORTED */
-    {
-        png_ptr->num_rows = png_ptr->height;
-        png_ptr->iwidth = png_ptr->width;
-    }
-    png_ptr->flags &= ~PNG_FLAG_ZSTREAM_ENDED;
-    if (inflateReset(&(png_ptr->zstream)) != Z_OK)
-        png_error(png_ptr, "inflateReset failed");
-    png_ptr->zstream.avail_in = 0;
-    png_ptr->zstream.next_in = 0;
-    png_ptr->zstream.next_out = png_ptr->row_buf;
-    png_ptr->zstream.avail_out = (uInt)PNG_ROWBYTES(png_ptr->pixel_depth,
-        png_ptr->iwidth) + 1;
-}
-#endif /* PNG_PROGRESSIVE_READ_SUPPORTED */
-#endif /* PNG_READ_APNG_SUPPORTED */
 #endif /* READ */

--- a/thirdparty/libpng/pngset.c
+++ b/thirdparty/libpng/pngset.c
@@ -1,7 +1,7 @@
 
 /* pngset.c - storage of image information into info struct
  *
- * Copyright (c) 2018 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -288,11 +288,6 @@ png_set_IHDR(png_const_structrp png_ptr, png_inforp info_ptr,
    info_ptr->pixel_depth = (png_byte)(info_ptr->channels * info_ptr->bit_depth);
 
    info_ptr->rowbytes = PNG_ROWBYTES(info_ptr->pixel_depth, width);
-
-#ifdef PNG_APNG_SUPPORTED
-   /* for non-animated png. this may be overwritten from an acTL chunk later */
-   info_ptr->num_frames = 1;
-#endif
 }
 
 #ifdef PNG_oFFs_SUPPORTED
@@ -1024,6 +1019,9 @@ png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
           info_ptr->trans_alpha = png_voidcast(png_bytep,
               png_malloc(png_ptr, PNG_MAX_PALETTE_LENGTH));
           memcpy(info_ptr->trans_alpha, trans_alpha, (size_t)num_trans);
+
+          info_ptr->valid |= PNG_INFO_tRNS;
+          info_ptr->free_me |= PNG_FREE_TRNS;
        }
        png_ptr->trans_alpha = info_ptr->trans_alpha;
    }
@@ -1162,147 +1160,6 @@ png_set_sPLT(png_const_structrp png_ptr,
       png_chunk_report(png_ptr, "sPLT out of memory", PNG_CHUNK_WRITE_ERROR);
 }
 #endif /* sPLT */
-
-#ifdef PNG_APNG_SUPPORTED
-png_uint_32 PNGAPI
-png_set_acTL(png_structp png_ptr, png_infop info_ptr,
-    png_uint_32 num_frames, png_uint_32 num_plays)
-{
-    png_debug1(1, "in %s storage function", "acTL");
-
-    if (png_ptr == NULL || info_ptr == NULL)
-    {
-        png_warning(png_ptr,
-                    "Call to png_set_acTL() with NULL png_ptr "
-                    "or info_ptr ignored");
-        return (0);
-    }
-    if (num_frames == 0)
-    {
-        png_warning(png_ptr,
-                    "Ignoring attempt to set acTL with num_frames zero");
-        return (0);
-    }
-    if (num_frames > PNG_UINT_31_MAX)
-    {
-        png_warning(png_ptr,
-                    "Ignoring attempt to set acTL with num_frames > 2^31-1");
-        return (0);
-    }
-    if (num_plays > PNG_UINT_31_MAX)
-    {
-        png_warning(png_ptr,
-                    "Ignoring attempt to set acTL with num_plays "
-                    "> 2^31-1");
-        return (0);
-    }
-
-    info_ptr->num_frames = num_frames;
-    info_ptr->num_plays = num_plays;
-
-    info_ptr->valid |= PNG_INFO_acTL;
-
-    return (1);
-}
-
-/* delay_num and delay_den can hold any 16-bit values including zero */
-png_uint_32 PNGAPI
-png_set_next_frame_fcTL(png_structp png_ptr, png_infop info_ptr,
-    png_uint_32 width, png_uint_32 height,
-    png_uint_32 x_offset, png_uint_32 y_offset,
-    png_uint_16 delay_num, png_uint_16 delay_den,
-    png_byte dispose_op, png_byte blend_op)
-{
-    png_debug1(1, "in %s storage function", "fcTL");
-
-    if (png_ptr == NULL || info_ptr == NULL)
-    {
-        png_warning(png_ptr,
-                    "Call to png_set_fcTL() with NULL png_ptr or info_ptr "
-                    "ignored");
-        return (0);
-    }
-
-    png_ensure_fcTL_is_valid(png_ptr, width, height, x_offset, y_offset,
-                             delay_num, delay_den, dispose_op, blend_op);
-
-    if (blend_op == PNG_BLEND_OP_OVER)
-    {
-        if (!(png_ptr->color_type & PNG_COLOR_MASK_ALPHA) &&
-            !(png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS)))
-        {
-          png_warning(png_ptr, "PNG_BLEND_OP_OVER is meaningless "
-                               "and wasteful for opaque images, ignored");
-          blend_op = PNG_BLEND_OP_SOURCE;
-        }
-    }
-
-    info_ptr->next_frame_width = width;
-    info_ptr->next_frame_height = height;
-    info_ptr->next_frame_x_offset = x_offset;
-    info_ptr->next_frame_y_offset = y_offset;
-    info_ptr->next_frame_delay_num = delay_num;
-    info_ptr->next_frame_delay_den = delay_den;
-    info_ptr->next_frame_dispose_op = dispose_op;
-    info_ptr->next_frame_blend_op = blend_op;
-
-    info_ptr->valid |= PNG_INFO_fcTL;
-
-    return (1);
-}
-
-void /* PRIVATE */
-png_ensure_fcTL_is_valid(png_structp png_ptr,
-    png_uint_32 width, png_uint_32 height,
-    png_uint_32 x_offset, png_uint_32 y_offset,
-    png_uint_16 delay_num, png_uint_16 delay_den,
-    png_byte dispose_op, png_byte blend_op)
-{
-    if (width == 0 || width > PNG_UINT_31_MAX)
-        png_error(png_ptr, "invalid width in fcTL (> 2^31-1)");
-    if (height == 0 || height > PNG_UINT_31_MAX)
-        png_error(png_ptr, "invalid height in fcTL (> 2^31-1)");
-    if (x_offset > PNG_UINT_31_MAX)
-        png_error(png_ptr, "invalid x_offset in fcTL (> 2^31-1)");
-    if (y_offset > PNG_UINT_31_MAX)
-        png_error(png_ptr, "invalid y_offset in fcTL (> 2^31-1)");
-    if (width + x_offset > png_ptr->first_frame_width ||
-        height + y_offset > png_ptr->first_frame_height)
-        png_error(png_ptr, "dimensions of a frame are greater than"
-                           "the ones in IHDR");
-
-    if (dispose_op != PNG_DISPOSE_OP_NONE &&
-        dispose_op != PNG_DISPOSE_OP_BACKGROUND &&
-        dispose_op != PNG_DISPOSE_OP_PREVIOUS)
-        png_error(png_ptr, "invalid dispose_op in fcTL");
-
-    if (blend_op != PNG_BLEND_OP_SOURCE &&
-        blend_op != PNG_BLEND_OP_OVER)
-        png_error(png_ptr, "invalid blend_op in fcTL");
-
-    PNG_UNUSED(delay_num)
-    PNG_UNUSED(delay_den)
-}
-
-png_uint_32 PNGAPI
-png_set_first_frame_is_hidden(png_structp png_ptr, png_infop info_ptr,
-                              png_byte is_hidden)
-{
-    png_debug(1, "in png_first_frame_is_hidden()");
-
-    if (png_ptr == NULL)
-        return 0;
-
-    if (is_hidden)
-        png_ptr->apng_flags |= PNG_FIRST_FRAME_HIDDEN;
-    else
-        png_ptr->apng_flags &= ~PNG_FIRST_FRAME_HIDDEN;
-
-    PNG_UNUSED(info_ptr)
-
-    return 1;
-}
-#endif /* PNG_APNG_SUPPORTED */
 
 #ifdef PNG_STORE_UNKNOWN_CHUNKS_SUPPORTED
 static png_byte
@@ -1472,7 +1329,7 @@ png_set_unknown_chunk_location(png_const_structrp png_ptr, png_inforp info_ptr,
 
 #ifdef PNG_MNG_FEATURES_SUPPORTED
 png_uint_32 PNGAPI
-png_permit_mng_features (png_structrp png_ptr, png_uint_32 mng_features)
+png_permit_mng_features(png_structrp png_ptr, png_uint_32 mng_features)
 {
    png_debug(1, "in png_permit_mng_features");
 
@@ -1779,7 +1636,7 @@ png_set_invalid(png_const_structrp png_ptr, png_inforp info_ptr, int mask)
 #ifdef PNG_SET_USER_LIMITS_SUPPORTED
 /* This function was added to libpng 1.2.6 */
 void PNGAPI
-png_set_user_limits (png_structrp png_ptr, png_uint_32 user_width_max,
+png_set_user_limits(png_structrp png_ptr, png_uint_32 user_width_max,
     png_uint_32 user_height_max)
 {
    /* Images with dimensions larger than these limits will be
@@ -1795,7 +1652,7 @@ png_set_user_limits (png_structrp png_ptr, png_uint_32 user_width_max,
 
 /* This function was added to libpng 1.4.0 */
 void PNGAPI
-png_set_chunk_cache_max (png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
+png_set_chunk_cache_max(png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
 {
    if (png_ptr != NULL)
       png_ptr->user_chunk_cache_max = user_chunk_cache_max;
@@ -1803,7 +1660,7 @@ png_set_chunk_cache_max (png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
 
 /* This function was added to libpng 1.4.1 */
 void PNGAPI
-png_set_chunk_malloc_max (png_structrp png_ptr,
+png_set_chunk_malloc_max(png_structrp png_ptr,
     png_alloc_size_t user_chunk_malloc_max)
 {
    if (png_ptr != NULL)

--- a/thirdparty/libpng/pngstruct.h
+++ b/thirdparty/libpng/pngstruct.h
@@ -1,7 +1,7 @@
 
 /* pngstruct.h - header file for PNG reference library
  *
- * Copyright (c) 2018-2019 Cosmin Truta
+ * Copyright (c) 2018-2022 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -334,17 +334,7 @@ struct png_struct_def
    size_t current_buffer_size;       /* amount of data now in current_buffer */
    int process_mode;                 /* what push library is currently doing */
    int cur_palette;                  /* current push library palette index */
-
 #endif /* PROGRESSIVE_READ */
-
-#if defined(__TURBOC__) && !defined(_Windows) && !defined(__FLAT__)
-/* For the Borland special 64K segment handler */
-   png_bytepp offset_table_ptr;
-   png_bytep offset_table;
-   png_uint_16 offset_table_number;
-   png_uint_16 offset_table_count;
-   png_uint_16 offset_table_count_free;
-#endif
 
 #ifdef PNG_READ_QUANTIZE_SUPPORTED
    png_bytep palette_lookup; /* lookup table for quantizing */
@@ -408,27 +398,6 @@ struct png_struct_def
 #ifdef PNG_MNG_FEATURES_SUPPORTED
    png_byte filter_type;
 #endif
-
-#ifdef PNG_APNG_SUPPORTED
-   png_uint_32 apng_flags;
-   png_uint_32 next_seq_num;         /* next fcTL/fdAT chunk sequence number */
-   png_uint_32 first_frame_width;
-   png_uint_32 first_frame_height;
-
-#ifdef PNG_READ_APNG_SUPPORTED
-   png_uint_32 num_frames_read;      /* incremented after all image data of */
-                                     /* a frame is read */
-#ifdef PNG_PROGRESSIVE_READ_SUPPORTED
-   png_progressive_frame_ptr frame_info_fn; /* frame info read callback */
-   png_progressive_frame_ptr frame_end_fn;  /* frame data read callback */
-#endif
-#endif
-
-#ifdef PNG_WRITE_APNG_SUPPORTED
-   png_uint_32 num_frames_to_write;
-   png_uint_32 num_frames_written;
-#endif
-#endif /* PNG_APNG_SUPPORTED */
 
 /* New members added in libpng-1.2.0 */
 

--- a/thirdparty/libpng/pngwutil.c
+++ b/thirdparty/libpng/pngwutil.c
@@ -821,11 +821,6 @@ png_write_IHDR(png_structrp png_ptr, png_uint_32 width, png_uint_32 height,
    /* Write the chunk */
    png_write_complete_chunk(png_ptr, png_IHDR, buf, 13);
 
-#ifdef PNG_WRITE_APNG_SUPPORTED
-   png_ptr->first_frame_width = width;
-   png_ptr->first_frame_height = height;
-#endif
-
    if ((png_ptr->do_filter) == PNG_NO_FILTERS)
    {
       if (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE ||
@@ -1007,17 +1002,8 @@ png_compress_IDAT(png_structrp png_ptr, png_const_bytep input,
                optimize_cmf(data, png_image_size(png_ptr));
 #endif
 
-            if (size > 0)
-#ifdef PNG_WRITE_APNG_SUPPORTED
-            {
-               if (png_ptr->num_frames_written == 0)
-#endif
-               png_write_complete_chunk(png_ptr, png_IDAT, data, size);
-#ifdef PNG_WRITE_APNG_SUPPORTED
-               else
-                  png_write_fdAT(png_ptr, data, size);
-            }
-#endif /* PNG_WRITE_APNG_SUPPORTED */
+         if (size > 0)
+            png_write_complete_chunk(png_ptr, png_IDAT, data, size);
          png_ptr->mode |= PNG_HAVE_IDAT;
 
          png_ptr->zstream.next_out = data;
@@ -1064,17 +1050,7 @@ png_compress_IDAT(png_structrp png_ptr, png_const_bytep input,
 #endif
 
          if (size > 0)
-#ifdef PNG_WRITE_APNG_SUPPORTED
-         {
-            if (png_ptr->num_frames_written == 0)
-#endif
             png_write_complete_chunk(png_ptr, png_IDAT, data, size);
-#ifdef PNG_WRITE_APNG_SUPPORTED
-            else
-               png_write_fdAT(png_ptr, data, size);
-         }
-#endif /* PNG_WRITE_APNG_SUPPORTED */
-
          png_ptr->zstream.avail_out = 0;
          png_ptr->zstream.next_out = NULL;
          png_ptr->mode |= PNG_HAVE_IDAT | PNG_AFTER_IDAT;
@@ -1908,82 +1884,6 @@ png_write_tIME(png_structrp png_ptr, png_const_timep mod_time)
    png_write_complete_chunk(png_ptr, png_tIME, buf, 7);
 }
 #endif
-
-#ifdef PNG_WRITE_APNG_SUPPORTED
-void /* PRIVATE */
-png_write_acTL(png_structp png_ptr,
-    png_uint_32 num_frames, png_uint_32 num_plays)
-{
-    png_byte buf[8];
-
-    png_debug(1, "in png_write_acTL");
-
-    png_ptr->num_frames_to_write = num_frames;
-
-    if (png_ptr->apng_flags & PNG_FIRST_FRAME_HIDDEN)
-        num_frames--;
-
-    png_save_uint_32(buf, num_frames);
-    png_save_uint_32(buf + 4, num_plays);
-
-    png_write_complete_chunk(png_ptr, png_acTL, buf, (png_size_t)8);
-}
-
-void /* PRIVATE */
-png_write_fcTL(png_structp png_ptr, png_uint_32 width, png_uint_32 height,
-    png_uint_32 x_offset, png_uint_32 y_offset,
-    png_uint_16 delay_num, png_uint_16 delay_den, png_byte dispose_op,
-    png_byte blend_op)
-{
-    png_byte buf[26];
-
-    png_debug(1, "in png_write_fcTL");
-
-    if (png_ptr->num_frames_written == 0 && (x_offset != 0 || y_offset != 0))
-        png_error(png_ptr, "x and/or y offset for the first frame aren't 0");
-    if (png_ptr->num_frames_written == 0 &&
-        (width != png_ptr->first_frame_width ||
-         height != png_ptr->first_frame_height))
-        png_error(png_ptr, "width and/or height in the first frame's fcTL "
-                           "don't match the ones in IHDR");
-
-    /* more error checking */
-    png_ensure_fcTL_is_valid(png_ptr, width, height, x_offset, y_offset,
-                             delay_num, delay_den, dispose_op, blend_op);
-
-    png_save_uint_32(buf, png_ptr->next_seq_num);
-    png_save_uint_32(buf + 4, width);
-    png_save_uint_32(buf + 8, height);
-    png_save_uint_32(buf + 12, x_offset);
-    png_save_uint_32(buf + 16, y_offset);
-    png_save_uint_16(buf + 20, delay_num);
-    png_save_uint_16(buf + 22, delay_den);
-    buf[24] = dispose_op;
-    buf[25] = blend_op;
-
-    png_write_complete_chunk(png_ptr, png_fcTL, buf, (png_size_t)26);
-
-    png_ptr->next_seq_num++;
-}
-
-void /* PRIVATE */
-png_write_fdAT(png_structp png_ptr,
-    png_const_bytep data, png_size_t length)
-{
-    png_byte buf[4];
-
-    png_write_chunk_header(png_ptr, png_fdAT, (png_uint_32)(4 + length));
-
-    png_save_uint_32(buf, png_ptr->next_seq_num);
-    png_write_chunk_data(png_ptr, buf, 4);
-
-    png_write_chunk_data(png_ptr, data, length);
-
-    png_write_chunk_end(png_ptr);
-
-    png_ptr->next_seq_num++;
-}
-#endif /* PNG_WRITE_APNG_SUPPORTED */
 
 /* Initializes the row writing capability of libpng */
 void /* PRIVATE */
@@ -2878,39 +2778,4 @@ png_write_filtered_row(png_structrp png_ptr, png_bytep filtered_row,
    }
 #endif /* WRITE_FLUSH */
 }
-
-#ifdef PNG_WRITE_APNG_SUPPORTED
-void /* PRIVATE */
-png_write_reset(png_structp png_ptr)
-{
-    png_ptr->row_number = 0;
-    png_ptr->pass = 0;
-    png_ptr->mode &= ~PNG_HAVE_IDAT;
-}
-
-void /* PRIVATE */
-png_write_reinit(png_structp png_ptr, png_infop info_ptr,
-                 png_uint_32 width, png_uint_32 height)
-{
-    if (png_ptr->num_frames_written == 0 &&
-        (width != png_ptr->first_frame_width ||
-         height != png_ptr->first_frame_height))
-        png_error(png_ptr, "width and/or height in the first frame's fcTL "
-                           "don't match the ones in IHDR");
-    if (width > png_ptr->first_frame_width ||
-        height > png_ptr->first_frame_height)
-        png_error(png_ptr, "width and/or height for a frame greater than"
-                           "the ones in IHDR");
-
-    png_set_IHDR(png_ptr, info_ptr, width, height,
-                 info_ptr->bit_depth, info_ptr->color_type,
-                 info_ptr->interlace_type, info_ptr->compression_type,
-                 info_ptr->filter_type);
-
-    png_ptr->width = width;
-    png_ptr->height = height;
-    png_ptr->rowbytes = PNG_ROWBYTES(png_ptr->pixel_depth, width);
-    png_ptr->usr_width = png_ptr->width;
-}
-#endif /* PNG_WRITE_APNG_SUPPORTED */
 #endif /* WRITE */


### PR DESCRIPTION
Minor maintenance update after 3 years, doesn't seem to be a security bugfix, but good to take anyway.

Changes:
```
Version 1.6.38 [September 14, 2022]
  Added configurations and scripts for continuous integration.
  Fixed various errors in the handling of tRNS, hIST and eXIf.
  Implemented many stability improvements across all platforms.
  Updated the internal documentation.
```