### PR TITLE
Expose and warn about Node Filters in Scene Tree Dock

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -160,7 +160,13 @@ class SceneTreeDock : public VBoxContainer {
 	EditorQuickOpen *quick_open = nullptr;
 	EditorFileDialog *new_scene_from_dialog = nullptr;
 
+	enum FilterMenuItems {
+		FILTER_BY_TYPE = 64, // Used in the same menus as the Tool enum.
+		FILTER_BY_GROUP,
+	};
+
 	LineEdit *filter = nullptr;
+	PopupMenu *filter_quick_menu = nullptr;
 	TextureRect *filter_icon = nullptr;
 
 	PopupMenu *menu = nullptr;
@@ -243,8 +249,12 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _tree_rmb(const Vector2 &p_menu_pos);
 	void _update_tree_menu();
+	void _update_filter_menu();
 
 	void _filter_changed(const String &p_filter);
+	void _filter_gui_input(const Ref<InputEvent> &p_event);
+	void _filter_option_selected(int option);
+	void _append_filter_options_to(PopupMenu *p_menu, bool p_include_separator = true);
 
 	void _perform_instantiate_scenes(const Vector<String> &p_files, Node *parent, int p_pos);
 	void _replace_with_branch_scene(const String &p_file, Node *base);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -612,6 +612,7 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_selected) {
 	if (!p_parent) {
 		p_parent = tree->get_root();
+		filter_term_warning.clear();
 	}
 
 	if (!p_parent) {
@@ -704,8 +705,8 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, PackedStringArra
 						return false;
 					}
 				}
-			} else {
-				WARN_PRINT(vformat(TTR("Special Node filter \"%s\" is not recognised. Available filters include \"type\" and \"group\"."), parameter));
+			} else if (filter_term_warning.is_empty()) {
+				filter_term_warning = vformat(TTR("\"%s\" is not a known filter."), parameter);
 				continue;
 			}
 		} else {
@@ -1027,6 +1028,10 @@ void SceneTreeEditor::set_filter(const String &p_filter) {
 
 String SceneTreeEditor::get_filter() const {
 	return filter;
+}
+
+String SceneTreeEditor::get_filter_term_warning() {
+	return filter_term_warning;
 }
 
 void SceneTreeEditor::set_undo_redo(Ref<EditorUndoRedoManager> p_undo_redo) {

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -62,6 +62,7 @@ class SceneTreeEditor : public Control {
 	ObjectID instance_node;
 
 	String filter;
+	String filter_term_warning;
 
 	AcceptDialog *error = nullptr;
 	AcceptDialog *warning = nullptr;
@@ -142,6 +143,7 @@ public:
 
 	void set_filter(const String &p_filter);
 	String get_filter() const;
+	String get_filter_term_warning();
 
 	void set_undo_redo(Ref<EditorUndoRedoManager> p_undo_redo);
 	void set_display_foreign_nodes(bool p_display);


### PR DESCRIPTION
Continuation of #65352. (see also https://github.com/godotengine/godot/pull/65352#pullrequestreview-1100948259)

This PR adds "**Filter by Type**" and "**Filter by Group**"  in the Scene Tree Dock's **MenuButton** (the one on the top right featuring 3 dots), exposing them to everyone that doesn't _religiously_ look at this engine's source code.

| Menu | Tooltip |
| :---: | :---: |
| ![image](https://user-images.githubusercontent.com/66727710/190711678-2fd4f2da-d8d7-4602-bf81-9e2db7b7f03c.png) | ![image](https://user-images.githubusercontent.com/66727710/190712072-a4b6656a-353f-4315-9e11-e2330b09d56e.png)|
| |  Hovering on them displays an useful tooltip. |

| Behavior | Warning |
| :---: | :---: |
| ![Showcase](https://i.gyazo.com/b9ecf539cfa1e88223032ef31ce5da3b.gif)  | ![image](https://user-images.githubusercontent.com/66727710/193866518-d213f97a-5ef7-4bef-8146-a1b79cc65fef.png) |
| When clicking on either of these, the matching parameter is appended to the terms, and the caret is automatically brought to the end. | When typing a filter that cannot be identified, a warning icon is displayed. The reason is explained in the tooltip. Before this, the temporary solution of #65352 is to spam warnings to the console. 

And lastly, the same options are also quickly available by **right-clicking** or **middle-clicking** in the text field.
| Right Click | Middle Click |
| :---: | :---: |
| ![image](https://user-images.githubusercontent.com/66727710/190725688-4a135fd2-115f-4236-a062-fa3f800f8094.png) | ![MiddleClick](https://user-images.githubusercontent.com/66727710/190724570-81f49494-52ec-4c22-afb1-bc6c69e726a9.png) |
