### PR TITLE
Remove unused `import_subscene()` in Scene Tree Dock

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -228,8 +228,6 @@ class SceneTreeDock : public VBoxContainer {
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
-	void _import_subscene();
-
 	void _new_scene_from(String p_file);
 	void _set_node_owner_recursive(Node *p_node, Node *p_owner);
 
@@ -292,7 +290,6 @@ public:
 
 	void _focus_node();
 
-	void import_subscene();
 	void add_root_node(Node *p_node);
 	void set_edited_scene(Node *p_scene);
 	void instantiate(const String &p_file);


### PR DESCRIPTION
While working on https://github.com/godotengine/godot/pull/65932, I noticed that the following two private methods methods were declared but were never defined. 
- `SceneTreeDock.import_subscene()`
- `SceneTreeDock._import_subscene()`

There's no comments about them, they're just kind of there. I can only assume they were used back in the day and left to stale. This PR just removes them for cleanness sake.