### PR TITLE
Expose custom vertex attributes to MeshDataTool

### DIFF
--- a/doc/classes/MeshDataTool.xml
+++ b/doc/classes/MeshDataTool.xml
@@ -180,6 +180,14 @@
 				Returns the total number of vertices in [Mesh].
 			</description>
 		</method>
+		<method name="get_vertex_custom" qualifiers="const">
+			<return type="Color" />
+			<argument index="0" name="idx" type="int" />
+			<argument index="1" name="custom_idx" type="int" />
+			<description>
+				Returns the floating point representation of the custom attribute (specified by [code]custom_idx[/code]) of the given vertex (specified by [code]idx[/code]). [code]custom_idx[/code] can range from 0 to 3.
+			</description>
+		</method>
 		<method name="get_vertex_edges" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="idx" type="int" />
@@ -236,6 +244,13 @@
 				Returns bone weights of the given vertex.
 			</description>
 		</method>
+		<method name="has_custom" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="custom_idx" type="int" />
+			<description>
+				Returns [code]true[/code] if the corresponding custom attribute (selected by [code]custom_idx[/code]) exists, returns false otherwise.
+			</description>
+		</method>
 		<method name="set_edge_meta">
 			<return type="void" />
 			<param index="0" name="idx" type="int" />
@@ -281,6 +296,15 @@
 			<param index="1" name="color" type="Color" />
 			<description>
 				Sets the color of the given vertex.
+			</description>
+		</method>
+		<method name="set_vertex_custom">
+			<return type="int" enum="Error" />
+			<argument index="0" name="idx" type="int" />
+			<argument index="1" name="custom_idx" type="int" />
+			<argument index="2" name="custom_float" type="Color" />
+			<description>
+				Sets the 32-bit floating point representation of the custom attribute(specified by [code]custom_idx[/code]) of the given vertex (specified by [code]idx[/code]). [code]custom_idx[/code] can range from 0 to 3.
 			</description>
 		</method>
 		<method name="set_vertex_meta">

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -101,6 +101,10 @@ public:
 
 	};
 
+	enum {
+		ARRAY_CUSTOM_COUNT = RenderingServer::ARRAY_CUSTOM_COUNT
+	};
+
 	enum ArrayCustomFormat {
 		ARRAY_CUSTOM_RGBA8_UNORM,
 		ARRAY_CUSTOM_RGBA8_SNORM,

--- a/scene/resources/mesh_data_tool.h
+++ b/scene/resources/mesh_data_tool.h
@@ -37,6 +37,7 @@ class MeshDataTool : public RefCounted {
 	GDCLASS(MeshDataTool, RefCounted);
 
 	int format = 0;
+
 	struct Vertex {
 		Vector3 vertex;
 		Color color;
@@ -49,6 +50,7 @@ class MeshDataTool : public RefCounted {
 		Vector<int> edges;
 		Vector<int> faces;
 		Variant meta;
+		Color custom[Mesh::ARRAY_CUSTOM_COUNT];
 	};
 
 	Vector<Vertex> vertices;
@@ -112,6 +114,11 @@ public:
 	Variant get_vertex_meta(int p_idx) const;
 	void set_vertex_meta(int p_idx, const Variant &p_meta);
 
+	Color get_vertex_custom(int p_idx, int p_custom_idx) const;
+	Error set_vertex_custom(int p_idx, int p_custom_idx, const Color &p_custom_float);
+
+	int has_custom(int p_custom_idx) const;
+	
 	Vector<int> get_vertex_edges(int p_idx) const;
 	Vector<int> get_vertex_faces(int p_idx) const;
 


### PR DESCRIPTION
Salvaged PR by @fire: Add support for custom vertex attributes to MeshDataTool
Color is used as an array of 4 floating point numbers.
