### PR TITLE
[MP] Add warnings to spawner and synchronizer.

### DIFF
--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -86,6 +86,23 @@ void MultiplayerSpawner::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 #endif
+
+TypedArray<String> MultiplayerSpawner::get_configuration_warnings() const {
+	TypedArray<String> warnings = Node::get_configuration_warnings();
+
+	if (spawn_path.is_empty() || !has_node(spawn_path)) {
+		warnings.push_back(RTR("A valid NodePath must be set in the \"Spawn Path\" property in order for MultiplayerSpawner to be able to spawn Nodes."));
+	}
+	bool has_scenes = get_spawnable_scene_count() > 0;
+	// Can't check if method is overriden in placeholder scripts.
+	bool has_placeholder_script = get_script_instance() && get_script_instance()->is_placeholder();
+	if (!has_scenes && !GDVIRTUAL_IS_OVERRIDDEN(_spawn_custom) && !has_placeholder_script) {
+		warnings.push_back(RTR("A list of PackedScenes must be set in the \"Auto Spawn List\" property in order for MultiplayerSpawner to automatically spawn them remotely when added as child of \"spawn_path\"."));
+		warnings.push_back(RTR("Alternatively, a Script implementing the function \"_spawn_custom\" must be set for this MultiplayerSpawner, and \"spawn\" must be called explicitly in code."));
+	}
+	return warnings;
+}
+
 void MultiplayerSpawner::add_spawnable_scene(const String &p_path) {
 	SpawnableScene sc;
 	sc.path = p_path;
@@ -94,13 +111,16 @@ void MultiplayerSpawner::add_spawnable_scene(const String &p_path) {
 	}
 	spawnable_scenes.push_back(sc);
 }
+
 int MultiplayerSpawner::get_spawnable_scene_count() const {
 	return spawnable_scenes.size();
 }
+
 String MultiplayerSpawner::get_spawnable_scene(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, (int)spawnable_scenes.size(), "");
 	return spawnable_scenes[p_idx].path;
 }
+
 void MultiplayerSpawner::clear_spawnable_scenes() {
 	spawnable_scenes.clear();
 }

--- a/modules/multiplayer/multiplayer_spawner.h
+++ b/modules/multiplayer/multiplayer_spawner.h
@@ -91,6 +91,8 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 #endif
 public:
+	TypedArray<String> get_configuration_warnings() const override;
+
 	Node *get_spawn_node() const {
 		return spawn_node.is_valid() ? Object::cast_to<Node>(ObjectDB::get_instance(spawn_node)) : nullptr;
 	}

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -94,6 +94,16 @@ void MultiplayerSynchronizer::_update_process() {
 	}
 }
 
+TypedArray<String> MultiplayerSynchronizer::get_configuration_warnings() const {
+	TypedArray<String> warnings = Node::get_configuration_warnings();
+
+	if (root_path.is_empty() || !has_node(root_path)) {
+		warnings.push_back(RTR("A valid NodePath must be set in the \"Root Path\" property in order for MultiplayerSynchronizer to be able to synchronize properties."));
+	}
+
+	return warnings;
+}
+
 Error MultiplayerSynchronizer::get_state(const List<NodePath> &p_properties, Object *p_obj, Vector<Variant> &r_variant, Vector<const Variant *> &r_variant_ptrs) {
 	ERR_FAIL_COND_V(!p_obj, ERR_INVALID_PARAMETER);
 	r_variant.resize(p_properties.size());

--- a/modules/multiplayer/multiplayer_synchronizer.h
+++ b/modules/multiplayer/multiplayer_synchronizer.h
@@ -66,6 +66,8 @@ public:
 	static Error get_state(const List<NodePath> &p_properties, Object *p_obj, Vector<Variant> &r_variant, Vector<const Variant *> &r_variant_ptrs);
 	static Error set_state(const List<NodePath> &p_properties, Object *p_obj, const Vector<Variant> &p_state);
 
+	TypedArray<String> get_configuration_warnings() const override;
+
 	void set_replication_interval(double p_interval);
 	double get_replication_interval() const;
 	uint64_t get_replication_interval_msec() const;


### PR DESCRIPTION
MultiplayerSpawner:
- When `spawn_path` is invalid.
- When the "Auto Spawn List" is empty and _spawn_custom is not overridden.
  Note: We remove the warning for placeholder scripts since there's no way of knowing if they have a certain method.

MultiplayerSynchronizer:
- When `root_path` is invalid.

![warnings](https://user-images.githubusercontent.com/1687918/190811690-9fd0cecb-b5c2-4941-a8f4-fb471e4f13cd.png)

![spawner-err](https://user-images.githubusercontent.com/1687918/190811616-9571a2d4-c9da-425b-9e6d-eb49ead307d7.png)

![synchronizer-err](https://user-images.githubusercontent.com/1687918/190811655-c79c20c0-7f3f-43bb-a5ab-874019978542.png)
