### PR TITLE
CSharp: Don't marshal multidimensional arrays

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
@@ -156,6 +156,10 @@ namespace Godot.SourceGenerators
                     else if (typeKind == TypeKind.Array)
                     {
                         var arrayType = (IArrayTypeSymbol)type;
+
+                        if (arrayType.Rank != 1)
+                            return null;
+
                         var elementType = arrayType.ElementType;
 
                         switch (elementType.SpecialType)
@@ -177,8 +181,8 @@ namespace Godot.SourceGenerators
                         if (elementType.SimpleDerivesFrom(typeCache.GodotObjectType))
                             return MarshalType.GodotObjectOrDerivedArray;
 
-                        if (elementType.ContainingAssembly.Name == "GodotSharp" &&
-                            elementType.ContainingNamespace.Name == "Godot")
+                        if (elementType.ContainingAssembly?.Name == "GodotSharp" &&
+                            elementType.ContainingNamespace?.Name == "Godot")
                         {
                             switch (elementType)
                             {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/65885

This merge disables marshaling for multidimensional arrays.
If marshaling is desired this could be used as a temporary bugfix to fix compile errors and source generators crashes.