### PR TITLE
Changed the rest definition of SkeletonProfileHumanoid thumb to be more suitable for the game engine

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -5561,7 +5561,7 @@ bool Animation::_fetch_compressed_by_index(uint32_t p_compressed_track, int p_in
 	return false;
 }
 
-// Helper math fuctions for Variant.
+// Helper math functions for Variant.
 Variant Animation::add_variant(const Variant &a, const Variant &b) {
 	if (a.get_type() != b.get_type()) {
 		return a;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -496,7 +496,7 @@ public:
 	void optimize(real_t p_allowed_velocity_err = 0.01, real_t p_allowed_angular_err = 0.01, int p_precision = 3);
 	void compress(uint32_t p_page_size = 8192, uint32_t p_fps = 120, float p_split_tolerance = 4.0); // 4.0 seems to be the split tolerance sweet spot from many tests
 
-	// Helper math fuctions for Variant.
+	// Helper math functions for Variant.
 	static Variant add_variant(const Variant &a, const Variant &b);
 	static Variant subtract_variant(const Variant &a, const Variant &b);
 	static Variant blend_variant(const Variant &a, const Variant &b, float c);

--- a/scene/resources/skeleton_profile.cpp
+++ b/scene/resources/skeleton_profile.cpp
@@ -566,7 +566,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 
 	bones.write[14].bone_name = "LeftThumbMetacarpal";
 	bones.write[14].bone_parent = "LeftHand";
-	bones.write[14].reference_pose = Transform3D(0, -0.577, 0.816, 0.707, 0.577, 0.408, -0.707, 0.577, 0.408, -0.025, 0, 0);
+	bones.write[14].reference_pose = Transform3D(0, -0.577, 0.816, 0, 0.816, 0.577, -1, 0, 0, -0.025, 0.025, 0);
 	bones.write[14].handle_offset = Vector2(0.4, 0.8);
 	bones.write[14].group = "LeftHand";
 
@@ -686,7 +686,7 @@ SkeletonProfileHumanoid::SkeletonProfileHumanoid() {
 
 	bones.write[33].bone_name = "RightThumbMetacarpal";
 	bones.write[33].bone_parent = "RightHand";
-	bones.write[33].reference_pose = Transform3D(0, 0.577, -0.816, -0.707, 0.577, 0.408, 0.707, 0.577, 0.408, 0.025, 0, 0);
+	bones.write[33].reference_pose = Transform3D(0, 0.577, -0.816, 0, 0.816, 0.577, 1, 0, 0, 0.025, 0.025, 0);
 	bones.write[33].handle_offset = Vector2(0.6, 0.8);
 	bones.write[33].group = "RightHand";
 


### PR DESCRIPTION
SkeletonProfileHumanoid thumb rest was defined as 45 degrees from all (XYZ) axes, but in Unity and UnrealEngine, the following definition seems to be recommended.

> -Thumbs straight parallel to the ground half way (45 degrees) between x and z axis

Unity:
https://blog.unity.com/technology/mecanim-humanoids

Microsoft Mixed Reality with Unreal
https://learn.microsoft.com/en-us/windows/mixed-reality/develop/unreal/unreal-hand-tracking?tabs=426

This PR makes Humanoid's thumb definition close to that. This change mainly affects T-posers.

![image](https://user-images.githubusercontent.com/61938263/190829822-9277ea2d-bc6f-48ad-bda8-55058d3a9c8b.png)

![image](https://user-images.githubusercontent.com/61938263/190829568-c0fbb3ee-9178-4f39-86be-fc8d3e8938c9.png)

Edited:
Including fixing a silly typo I have done in the comment a few days ago😛

---
#### Test model

Blender Chan! / CC by [SearKitchen](https://sketchfab.com/searkitchen)
https://sketchfab.com/3d-models/blender-chan-6835f0d60e0c4813812c0247e3b73da7

