### PR TITLE
[3.x] Fix Signal parameters' type will now be correctly displayed in the node signal preview box.

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -880,12 +880,30 @@ bool GDScript::has_script_signal(const StringName &p_signal) const {
 	return false;
 }
 void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	for (const Map<StringName, Vector<StringName>>::Element *E = _signals.front(); E; E = E->next()) {
+	for (const Map<StringName, Vector<Pair<StringName, GDScriptParser::DataType>>>::Element *E = _signals.front(); E; E = E->next()) {
 		MethodInfo mi;
 		mi.name = E->key();
 		for (int i = 0; i < E->get().size(); i++) {
 			PropertyInfo arg;
-			arg.name = E->get()[i];
+			arg.name = E->get()[i].first;
+			arg.type = Variant::NIL;
+
+			const GDScriptParser::DataType &current_type = E->get()[i].second;
+			if (current_type.has_type) {
+				if (current_type.kind == GDScriptParser::DataType::BUILTIN) {
+					arg.type = current_type.builtin_type;
+				} else if (current_type.kind == GDScriptParser::DataType::NATIVE) {
+					arg.type = Variant::OBJECT;
+					arg.class_name = current_type.native_type;
+				} else if (current_type.kind == GDScriptParser::DataType::SCRIPT || current_type.kind == GDScriptParser::DataType::GDSCRIPT) {
+					arg.type = Variant::OBJECT;
+					arg.class_name = current_type.script_type->get_instance_base_type();
+				} else if (current_type.kind == GDScriptParser::DataType::CLASS) {
+					arg.type = Variant::OBJECT;
+					arg.class_name = current_type.class_type->name;
+				}
+			}
+
 			mi.arguments.push_back(arg);
 		}
 		r_signals->push_back(mi);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -35,6 +35,7 @@
 #include "core/io/resource_saver.h"
 #include "core/script_language.h"
 #include "gdscript_function.h"
+#include "gdscript_parser.h"
 
 class GDScriptNativeClass : public Reference {
 	GDCLASS(GDScriptNativeClass, Reference);
@@ -81,7 +82,7 @@ class GDScript : public Script {
 	Map<StringName, GDScriptFunction *> member_functions;
 	Map<StringName, MemberInfo> member_indices; //members are just indices to the instanced script.
 	Map<StringName, Ref<GDScript>> subclasses;
-	Map<StringName, Vector<StringName>> _signals;
+	Map<StringName, Vector<Pair<StringName, GDScriptParser::DataType>>> _signals;
 
 #ifdef TOOLS_ENABLED
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4206,8 +4206,17 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 							return;
 						}
 
-						sig.arguments.push_back(tokenizer->get_token_identifier());
+						Pair<StringName, DataType> parameter{};
+						parameter.first = tokenizer->get_token_identifier();
 						tokenizer->advance();
+
+						if (tokenizer->get_token() == GDScriptTokenizer::TK_COLON) {
+							if (!_parse_type(parameter.second)) {
+								_set_error(String{ "Signal ({0})'s parameter ({1})'s type ({2}) is not a built-in type, currently only support built-in types." }.format(varray(sig.name, parameter.first, tokenizer->get_token_identifier())));
+								return;
+							}
+						}
+						sig.arguments.push_back(parameter);
 
 						while (tokenizer->get_token() == GDScriptTokenizer::TK_NEWLINE) {
 							tokenizer->advance();
@@ -7399,6 +7408,12 @@ GDScriptParser::DataType GDScriptParser::_reduce_function_call_type(const Operat
 				for (int i = 0; i < current_class->_signals.size(); i++) {
 					if (current_class->_signals[i].name == emitted) {
 						current_class->_signals.write[i].emissions += 1;
+
+						// Add the parameter types required by the signal (because emit_signal actually only has one parameter)
+						for (int type_index = 0; type_index < current_class->_signals[i].arguments.size(); ++type_index) {
+							arg_types.push_back(current_class->_signals[i].arguments[type_index].second);
+						}
+
 						break;
 					}
 				}

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -176,7 +176,7 @@ public:
 
 		struct Signal {
 			StringName name;
-			Vector<StringName> arguments;
+			Vector<Pair<StringName, DataType>> arguments;
 			int emissions;
 			int line;
 		};

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -210,7 +210,9 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 			if (j > 0) {
 				symbol.detail += ", ";
 			}
-			symbol.detail += signal.arguments[j];
+			symbol.detail += signal.arguments[i].first;
+			symbol.detail += ": ";
+			symbol.detail += signal.arguments[i].second.to_string();
 		}
 		symbol.detail += ")";
 
@@ -747,9 +749,9 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 		const GDScriptParser::ClassNode::Signal &signal = p_class->_signals[i];
 		Dictionary api;
 		api["name"] = signal.name;
-		Array args;
+		Dictionary args;
 		for (int j = 0; j < signal.arguments.size(); j++) {
-			args.append(signal.arguments[j]);
+			args[signal.arguments[j].first] = signal.arguments[j].second.to_string();
 		}
 		api["arguments"] = args;
 		if (const lsp::DocumentSymbol *symbol = get_symbol_defined_at_line(LINE_NUMBER_TO_INDEX(signal.line))) {


### PR DESCRIPTION
Version of Godot based on:
v3.5.1.rc.custom_build [26a28d6bb]

> Fixes #65809 

Signal parameters' type will now be correctly displayed in the node signal preview box.

**This is a fix for the 3.x version, if the 3.x version does not require the ability to specify the parameter type of the signal, please close this PR**

> See also #65812 

![signal_arg_type_3 x_1](https://user-images.githubusercontent.com/52756109/190335663-4d04c076-701d-44bb-957c-1a81b9cf5828.png)
![signal_arg_type_3 x_2](https://user-images.githubusercontent.com/52756109/190335689-3299d54a-202f-43a7-a2d7-d2c794da328a.png)
