### PR TITLE
Fix the crash when closing a scene with a visible window

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -810,7 +810,6 @@ void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override,
 #endif
 
 	_update_global_transform();
-	update_configuration_warnings();
 
 	update_canvas_items();
 
@@ -4082,6 +4081,7 @@ void SubViewport::set_size(const Size2i &p_size) {
 	if (c) {
 		c->update_minimum_size();
 	}
+	update_configuration_warnings();
 }
 
 Size2i SubViewport::get_size() const {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -96,6 +96,7 @@ Point2i Window::get_position() const {
 void Window::set_size(const Size2i &p_size) {
 	size = p_size;
 	_update_window_size();
+	update_configuration_warnings();
 }
 
 Size2i Window::get_size() const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fix #65146.

Edit: 

We should only warn about incorrect values that are manually set.
