### PR TITLE
ProjectList remove project: handle move_to_trash error

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1751,11 +1751,15 @@ void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
 	for (int i = 0; i < _projects.size(); ++i) {
 		Item &item = _projects.write[i];
 		if (_selected_project_paths.has(item.path) && item.control->is_visible()) {
-			_config.erase_section(item.path);
-
 			if (p_delete_project_contents) {
-				OS::get_singleton()->move_to_trash(item.path);
+				Error err = OS::get_singleton()->move_to_trash(item.path);
+				if (err != OK) {
+					OS::get_singleton()->alert(vformat("An error occurred deleting \"%s\".\nIt will be kept in the project list.", item.project_name), "Failed to delete project");
+					continue;
+				}
 			}
+
+			_config.erase_section(item.path);
 
 			memdelete(item.control);
 			_projects.remove_at(i);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1753,8 +1753,8 @@ void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
 		if (_selected_project_paths.has(item.path) && item.control->is_visible()) {
 			if (p_delete_project_contents) {
 				Error err = OS::get_singleton()->move_to_trash(item.path);
-				if (err != OK) {
-					OS::get_singleton()->alert(vformat("An error occurred deleting \"%s\".\nIt will be kept in the project list.", item.project_name), "Failed to delete project");
+				if (err == ERR_SKIP) {
+					OS::get_singleton()->alert(vformat("User cancelled deletion of project \"%s\".\nIt will be kept in the project list.", item.project_name), "Cancelled operation");
 					continue;
 				}
 			}

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1124,6 +1124,11 @@ Error OS_Windows::move_to_trash(const String &p_path) {
 	int ret = SHFileOperationW(&sf);
 	delete[] from;
 
+	if (ret == ERROR_CANCELLED || sf.fAnyOperationsAborted) {
+		ERR_PRINT("User cancelled move_to_trash");
+		return ERR_SKIP;
+	}
+
 	if (ret) {
 		ERR_PRINT("SHFileOperation error: " + itos(ret));
 		return FAILED;


### PR DESCRIPTION
Fixes #65952

Sidenote: should there be a way to detect if the `move_to_trash` operation was canceled, through [`fAnyOperationsAborted`](https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shfileoperationw#return-value) ?