### PR TITLE
Fix missing subclass paths

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -223,6 +223,7 @@ public:
 	virtual Error reload(bool p_keep_state = false) override;
 
 	void set_script_path(const String &p_path) { path = p_path; } //because subclasses need a path too...
+	String get_script_path() const { return path; }
 	Error load_source_code(const String &p_path);
 	Error load_byte_code(const String &p_path);
 

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -164,7 +164,7 @@ void GDScriptByteCodeGenerator::write_start(GDScript *p_script, const StringName
 
 	function->name = p_function_name;
 	function->_script = p_script;
-	function->source = p_script->get_path();
+	function->source = p_script->get_script_path();
 
 #ifdef DEBUG_ENABLED
 	function->func_cname = (String(function->source) + " - " + String(p_function_name)).utf8();

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2658,6 +2658,7 @@ void GDScriptCompiler::_make_scripts(GDScript *p_script, const GDScriptParser::C
 
 		subclass->_owner = p_script;
 		subclass->fully_qualified_name = fully_qualified_name;
+		subclass->set_script_path(p_script->get_script_path());
 		p_script->subclasses.insert(name, subclass);
 
 		_make_scripts(subclass.ptr(), inner_class, false);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #65486

This pull request attempts to fix the problem that the path of a subclass is not set during GDScript compilation.