### PR TITLE
AnimatedSprite: Remove `play()`'s backwards, add methods to compensate

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -17,9 +17,22 @@
 		<method name="play">
 			<return type="void" />
 			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
-			<param index="1" name="backwards" type="bool" default="false" />
 			<description>
-				Plays the animation named [param anim]. If no [param anim] is provided, the current animation is played. If [param backwards] is [code]true[/code], the animation is played in reverse.
+				Plays the animation named [param anim]. If no [param anim] is provided, the current animation is played.
+			</description>
+		</method>
+		<method name="play_forward">
+			<return type="void" />
+			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Sets [member speed_scale] to a positive value, playing the current animation forward. If [param anim] is provided and is not currently playing, starts [param anim] from the first frame.
+			</description>
+		</method>
+		<method name="play_backwards">
+			<return type="void" />
+			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Sets [member speed_scale] to a negative value, playing the current animation in reverse. If [param anim] is provided and is not currently playing, starts [param anim] from the last frame.
 			</description>
 		</method>
 		<method name="stop">

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -15,9 +15,22 @@
 		<method name="play">
 			<return type="void" />
 			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
-			<param index="1" name="backwards" type="bool" default="false" />
 			<description>
-				Plays the animation named [param anim]. If no [param anim] is provided, the current animation is played. If [param backwards] is [code]true[/code], the animation is played in reverse.
+				Plays the animation named [param anim]. If no [param anim] is provided, the current animation is played.
+			</description>
+		</method>
+		<method name="play_forward">
+			<return type="void" />
+			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Sets [member speed_scale] to a positive value, playing the current animation forward. If [param anim] is provided and is not currently playing, starts [param anim] from the first frame.
+			</description>
+		</method>
+		<method name="play_backwards">
+			<return type="void" />
+			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
+			<description>
+				Sets [member speed_scale] to a negative value, playing the current animation in reverse. If [param anim] is provided and is not currently playing, starts [param anim] from the last frame.
 			</description>
 		</method>
 		<method name="stop">

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -328,7 +328,7 @@ void AnimatedSprite2D::set_speed_scale(double p_speed_scale) {
 	double elapsed = _get_frame_duration() - timeout;
 
 	speed_scale = p_speed_scale;
-	playing_backwards = signbit(speed_scale) != backwards;
+	playing_backwards = signbit(speed_scale);
 
 	// We adapt the timeout so that the animation speed adapts as soon as the speed scale is changed.
 	_reset_timeout();
@@ -397,15 +397,32 @@ bool AnimatedSprite2D::is_playing() const {
 	return playing;
 }
 
-void AnimatedSprite2D::play(const StringName &p_animation, bool p_backwards) {
-	backwards = p_backwards;
-	playing_backwards = signbit(speed_scale) != backwards;
-
+void AnimatedSprite2D::play(const StringName &p_animation) {
 	if (p_animation) {
 		set_animation(p_animation);
-		if (frames.is_valid() && playing_backwards && get_frame() == 0) {
-			set_frame(frames->get_frame_count(p_animation) - 1);
-		}
+	}
+
+	is_over = false;
+	set_playing(true);
+}
+
+void AnimatedSprite2D::play_forward(const StringName &p_animation) {
+	if (speed_scale < 0.0f) {
+		set_speed_scale(speed_scale * -1);
+	}
+
+	play(p_animation);
+}
+
+void AnimatedSprite2D::play_backwards(const StringName &p_animation) {
+	if (speed_scale > 0.0f) {
+		set_speed_scale(speed_scale * -1);
+	}
+
+	if (p_animation && animation == p_animation) {
+		set_animation(p_animation);
+		// set_animation() also sets frame to 0, so this needs to be done afterwards.
+		set_frame(frames->get_frame_count(p_animation) - 1);
 	}
 
 	is_over = false;
@@ -485,7 +502,9 @@ void AnimatedSprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_playing", "playing"), &AnimatedSprite2D::set_playing);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite2D::is_playing);
 
-	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite2D::play, DEFVAL(StringName()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("play", "anim"), &AnimatedSprite2D::play, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("play_forward", "anim"), &AnimatedSprite2D::play_forward, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("play_backwards", "anim"), &AnimatedSprite2D::play_backwards, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite2D::stop);
 
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &AnimatedSprite2D::set_centered);

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -40,7 +40,6 @@ class AnimatedSprite2D : public Node2D {
 	Ref<SpriteFrames> frames;
 	bool playing = false;
 	bool playing_backwards = false;
-	bool backwards = false;
 	StringName animation = "default";
 	int frame = 0;
 	float speed_scale = 1.0f;
@@ -82,7 +81,9 @@ public:
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;
 
-	void play(const StringName &p_animation = StringName(), bool p_backwards = false);
+	void play(const StringName &p_animation = StringName());
+	void play_forward(const StringName &p_animation = StringName());
+	void play_backwards(const StringName &p_animation = StringName());
 	void stop();
 
 	void set_playing(bool p_playing);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1169,7 +1169,7 @@ void AnimatedSprite3D::set_speed_scale(double p_speed_scale) {
 	double elapsed = _get_frame_duration() - timeout;
 
 	speed_scale = p_speed_scale;
-	playing_backwards = signbit(speed_scale) != backwards;
+	playing_backwards = signbit(speed_scale);
 
 	// We adapt the timeout so that the animation speed adapts as soon as the speed scale is changed.
 	_reset_timeout();
@@ -1229,15 +1229,32 @@ bool AnimatedSprite3D::is_playing() const {
 	return playing;
 }
 
-void AnimatedSprite3D::play(const StringName &p_animation, bool p_backwards) {
-	backwards = p_backwards;
-	playing_backwards = signbit(speed_scale) != backwards;
-
+void AnimatedSprite3D::play(const StringName &p_animation) {
 	if (p_animation) {
 		set_animation(p_animation);
-		if (frames.is_valid() && playing_backwards && get_frame() == 0) {
-			set_frame(frames->get_frame_count(p_animation) - 1);
-		}
+	}
+
+	is_over = false;
+	set_playing(true);
+}
+
+void AnimatedSprite3D::play_forward(const StringName &p_animation) {
+	if (speed_scale < 0.0f) {
+		set_speed_scale(speed_scale * -1);
+	}
+
+	play(p_animation);
+}
+
+void AnimatedSprite3D::play_backwards(const StringName &p_animation) {
+	if (speed_scale > 0.0f) {
+		set_speed_scale(speed_scale * -1);
+	}
+
+	if (p_animation && animation == p_animation) {
+		set_animation(p_animation);
+		// set_animation() also sets frame to 0, so this needs to be done afterwards.
+		set_frame(frames->get_frame_count(p_animation) - 1);
 	}
 
 	is_over = false;
@@ -1315,7 +1332,9 @@ void AnimatedSprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_playing", "playing"), &AnimatedSprite3D::set_playing);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite3D::is_playing);
 
-	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite3D::play, DEFVAL(StringName()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("play", "anim"), &AnimatedSprite3D::play, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("play_forward", "anim"), &AnimatedSprite3D::play_forward, DEFVAL(StringName()));
+	ClassDB::bind_method(D_METHOD("play_backwards", "anim"), &AnimatedSprite3D::play_backwards, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite3D::stop);
 
 	ClassDB::bind_method(D_METHOD("set_frame", "frame"), &AnimatedSprite3D::set_frame);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -210,7 +210,6 @@ class AnimatedSprite3D : public SpriteBase3D {
 	Ref<SpriteFrames> frames;
 	bool playing = false;
 	bool playing_backwards = false;
-	bool backwards = false;
 	StringName animation = "default";
 	int frame = 0;
 	float speed_scale = 1.0f;
@@ -238,7 +237,9 @@ public:
 	void set_sprite_frames(const Ref<SpriteFrames> &p_frames);
 	Ref<SpriteFrames> get_sprite_frames() const;
 
-	void play(const StringName &p_animation = StringName(), bool p_backwards = false);
+	void play(const StringName &p_animation);
+	void play_forward(const StringName &p_animation);
+	void play_backwards(const StringName &p_animation);
 	void stop();
 
 	void set_playing(bool p_playing);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5286 (see comments).
Closes https://github.com/godotengine/godot-proposals/issues/4506.
Supersedes https://github.com/godotengine/godot/pull/41821.

#### A bit of a backstory:
#65148 added the ability to set `speed_scale` to a negative value and if it is, the animation plays in reverse. This is good. However, the original intention of the proposal was to have `play()`'s second parameter, "_backwards_", implicitly switch `speed_scale`'s sign if necessary. Doing this would have closed the proposals above. This was **not** agreed upon. Instead, what ended up happening was that... basically, setting "_backwards_" to **true** and `speed_scale` to **-1** has the animation moving forward. This is not just confusing, but defeats the original purpose of that PR, because now there is one "backwards" that is not exposed to the user.

****

This PR outright removes `play()`'s second parameter from **AnimatedSprite2D** and **AnimatedSprite3D**. This makes `speed_scale > 0.0` the one consistent way to verify if an animation is playing in reverse.

To compensate, adds `play_forward()` and `play_backwards()` as shorthand methods. Both of these methods change the sign of `speed_scale` only when necessary, then call `play()`. This is like #65148 's original implementation, but split in two separate, way more explicit methods.

I should follow this up with a Proposal.