### PR TITLE
Fix variables highlighting as types

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -235,7 +235,7 @@ Map<int, TextEdit::HighlighterInfo> GDScriptSyntaxHighlighter::_get_line_syntax_
 			}
 		}
 
-		if (is_symbol) {
+		if (is_symbol && in_region == -1) {
 			if (in_function_name) {
 				in_function_args = true;
 			}


### PR DESCRIPTION
Fixes #65960

The characters `:` or `->` cause the highlighter to think the next token is a type hint, and highlight it with the color `text_editor/highlighting/base_type_color`.

The fix is to skip looking for these characters when inside a color_region. The only color_regions used in Godot are for strings and comments, so this will not skip over valid `:` or `->` tokens.

<details><summary>Before and After comparison</summary><p>

Before:
![Screenshot of script editor showing incorrect behavior](https://user-images.githubusercontent.com/5725958/190847967-d2e8e198-a248-4c82-9fb6-975a6b1153e0.png)

After:
![Screenshot of script editor showing correct behavior](https://user-images.githubusercontent.com/5725958/190848241-98992442-28e8-48f7-8e90-2d374f3c90b9.png)


</p></details>

<details><summary>Test code (plaintext)</summary><p>

```
extends Node

func function(a, b):
	pass

func function2():
	var variable = 123

	function("normal", variable)

	function("test:", variable)
	function("test: ", variable)
	function("test:x", variable)
	function("test):", variable)
	function("test:)", variable)
	function("test:=", variable)

	function("test->", variable)
	function("test-> ", variable)
	function("test->x", variable)
	function("test)->", variable)
	function("test->)", variable)
	function("test->=", variable)

	function('test:', variable)

	function("""test:""", variable)

func test(a: String = ":", variable = 0):
	pass
```

</p></details>