### PR TITLE
AnimatedSprite: Preserve frame elapsed time when toggling `playing`

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -26,7 +26,7 @@
 			<return type="void" />
 			<description>
 				Stops the current [member animation] at the current [member frame].
-				[b]Note:[/b] This method resets the current frame's elapsed time. If this behavior is undesired, consider setting [member speed_scale] to [code]0[/code], instead.
+				[b]Note:[/b] This method resets the current frame's elapsed time. If this behavior is undesired, consider setting [member playing] to [code]false[/code], instead.
 			</description>
 		</method>
 	</methods>
@@ -53,7 +53,7 @@
 			The texture's drawing offset.
 		</member>
 		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
-			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] is the equivalent of calling [method stop].
+			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] preserves the current frame's elapsed time.
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The animation speed is multiplied by this value. If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation is paused, preserving the current frame's elapsed time.

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -24,7 +24,7 @@
 			<return type="void" />
 			<description>
 				Stops the current [member animation] at the current [member frame].
-				[b]Note:[/b] This method resets the current frame's elapsed time. If this behavior is undesired, consider setting [member speed_scale] to [code]0[/code], instead.
+				[b]Note:[/b] This method resets the current frame's elapsed time. If this behavior is undesired, consider setting [member playing] to [code]false[/code], instead.
 			</description>
 		</method>
 	</methods>
@@ -39,7 +39,7 @@
 			The [SpriteFrames] resource containing the animation(s).
 		</member>
 		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
-			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] is the equivalent of calling [method stop].
+			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] preserves the current frame's elapsed time.
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The animation speed is multiplied by this value. If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation is paused, preserving the current frame's elapsed time.

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -388,7 +388,6 @@ void AnimatedSprite2D::set_playing(bool p_playing) {
 		return;
 	}
 	playing = p_playing;
-	_reset_timeout();
 	set_process_internal(playing);
 	notify_property_list_changed();
 }
@@ -413,6 +412,7 @@ void AnimatedSprite2D::play(const StringName &p_animation, bool p_backwards) {
 }
 
 void AnimatedSprite2D::stop() {
+	_reset_timeout();
 	set_playing(false);
 }
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1220,7 +1220,6 @@ void AnimatedSprite3D::set_playing(bool p_playing) {
 		return;
 	}
 	playing = p_playing;
-	_reset_timeout();
 	set_process_internal(playing);
 	notify_property_list_changed();
 }
@@ -1245,6 +1244,7 @@ void AnimatedSprite3D::play(const StringName &p_animation, bool p_backwards) {
 }
 
 void AnimatedSprite3D::stop() {
+	_reset_timeout();
 	set_playing(false);
 }
 


### PR DESCRIPTION
Sometimes, **AnimatedSprite**s require pausing, whether it be for special effects, stylistical purposes, or just for the sake of it. However, there is no way to preserve the elapsed time between one frame and the next in a "nice way".  Certainly, you can actively stop internal processing, or set `speed_scale` to **0.0** which, until a while ago, wasn't even documented. 

Trying `stop()` resets it, and setting `playing` to false does the same thing. For the latter, it can be said that the animation really should only just pause and resume back where it left off. This oddity is especially noticeable for really slow animations.

This PR attempts to get rid of this oddity by preserving the current frame's elapsed time when `playing` is toggled off.

Calling `stop()`, changing animation or frames still resets the frame's elapsed_time.