### PR TITLE
Fix selected shader file not being highlighted in shader editor list

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -1366,6 +1366,7 @@ void ShaderEditorPlugin::_shader_selected(int p_index) {
 		edited_shaders[p_index].shader_editor->validate_script();
 	}
 	shader_tabs->set_current_tab(p_index);
+	shader_list->select(p_index);
 }
 
 void ShaderEditorPlugin::_shader_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Just a small fix so that the selected shader file gets correctly highlighted in shader editor list.

Before:

![godot_selected_shader_file_not_highlighted](https://user-images.githubusercontent.com/1949583/190865666-80c439bc-b496-49e6-a326-7f281eb19d8e.gif)

After:

![godot_selected_shader_file_not_highlighted_fixed](https://user-images.githubusercontent.com/1949583/190865667-bc4b4e44-0717-41d3-aff7-a752b8ec8032.gif)
