### PR TITLE
Fix atlas view drawing roots having zoom applied twice

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -403,6 +403,9 @@ void TileAtlasView::set_atlas_source(TileSet *p_tile_set, TileSetAtlasSource *p_
 	// Update everything.
 	_update_zoom_and_panning();
 
+	base_tiles_drawing_root->set_size(_compute_base_tiles_control_size());
+	alternative_tiles_drawing_root->set_size(_compute_alternative_tiles_control_size());
+
 	// Update.
 	base_tiles_draw->queue_redraw();
 	base_tiles_texture_grid->queue_redraw();
@@ -601,7 +604,6 @@ TileAtlasView::TileAtlasView() {
 
 	base_tiles_drawing_root = memnew(Control);
 	base_tiles_drawing_root->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-	base_tiles_drawing_root->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	base_tiles_drawing_root->set_texture_filter(TEXTURE_FILTER_NEAREST);
 	base_tiles_root_control->add_child(base_tiles_drawing_root);
 
@@ -645,7 +647,6 @@ TileAtlasView::TileAtlasView() {
 
 	alternative_tiles_drawing_root = memnew(Control);
 	alternative_tiles_drawing_root->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-	alternative_tiles_drawing_root->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	alternative_tiles_drawing_root->set_texture_filter(TEXTURE_FILTER_NEAREST);
 	alternative_tiles_root_control->add_child(alternative_tiles_drawing_root);
 


### PR DESCRIPTION
Fixes #65941

`base_tiles_drawing_root` and `alternative_tiles_drawing_root` had an incorrect size, because the zoom was applied twice on them:
- They were `FULL_RECT` children of the `*_tiles_root_control`, which includes zoom inside its custom minimum size.
- Their `scale` was being set to the zoom value (this was needed so the tiles can appear smaller or bigger).

I fixed this by keeping the zoom within the scale, but removing the `FULL_RECT` anchor, and setting their size manually to the unzoomed `*_tiles_control_size`.