### PR TITLE
Fix MIDI note-on events being converted to note-off events

### DIFF
--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -86,11 +86,6 @@ void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_
 			if (length >= 2 + param_position) {
 				event->set_pitch(data[param_position]);
 				event->set_velocity(data[param_position + 1]);
-
-				if (event->get_message() == MIDIMessage::NOTE_ON && event->get_velocity() == 0) {
-					// https://www.midi.org/forum/228-writing-midi-software-send-note-off,-or-zero-velocity-note-on
-					event->set_message(MIDIMessage::NOTE_OFF);
-				}
 			}
 			break;
 

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -90,7 +90,7 @@
 			The pressure of the MIDI signal. This value ranges from 0 to 127. For many devices, this value is always zero.
 		</member>
 		<member name="velocity" type="int" setter="set_velocity" getter="get_velocity" default="0">
-			The velocity of the MIDI signal. This value ranges from 0 to 127. For a piano, this corresponds to how quickly the key was pressed, and is rarely above about 110 in practice.
+			The velocity of the MIDI signal. This value ranges from 0 to 127. For a piano, this corresponds to how quickly the key was pressed, and is rarely above about 110 in practice. Note that some MIDI devices may send a [constant MIDI_MESSAGE_NOTE_ON] message with zero velocity and expect this to be treated the same as a [constant MIDI_MESSAGE_NOTE_OFF] message, but device implementations vary so Godot reports event data exactly as received.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
This PR fixes a bug in Godot's MIDI processing logic that destroys information as it flows from device to application. The engine converts note-on events with velocity 0 to note-off for programmer convenience, which is sometimes helpful and sometimes confounding. In fact, MIDI device implementations vary and some MIDI devices intend for note-on to mean note-on regardless of velocity. So the only way to support such devices is to faithfully pass MIDI information to the application exactly as it is received from the device.

It's up to application developers to decide how to handle received MIDI data and it's a very minor inconvenience to convert if needed, but having the engine interfere and mutate event data before it reaches the application makes some use cases impossible.

I commented on this before but the issues were closed, so now I'm submitting a fix directly:
* https://github.com/godotengine/godot/issues/27199#issuecomment-942071469
* https://github.com/godotengine/godot/pull/27214#issuecomment-942063417