### PR TITLE
Rename Image's `get_rect` to `get_region`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2636,9 +2636,9 @@ Rect2i Image::get_used_rect() const {
 	}
 }
 
-Ref<Image> Image::get_rect(const Rect2i &p_area) const {
-	Ref<Image> img = memnew(Image(p_area.size.x, p_area.size.y, mipmaps, format));
-	img->blit_rect(Ref<Image>((Image *)this), p_area, Point2i(0, 0));
+Ref<Image> Image::get_region(const Rect2i &p_region) const {
+	Ref<Image> img = memnew(Image(p_region.size.x, p_region.size.y, mipmaps, format));
+	img->blit_rect(Ref<Image>((Image *)this), p_region, Point2i(0, 0));
 	return img;
 }
 
@@ -3362,7 +3362,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("fill_rect", "rect", "color"), &Image::fill_rect);
 
 	ClassDB::bind_method(D_METHOD("get_used_rect"), &Image::get_used_rect);
-	ClassDB::bind_method(D_METHOD("get_rect", "rect"), &Image::get_rect);
+	ClassDB::bind_method(D_METHOD("get_region", "region"), &Image::get_region);
 
 	ClassDB::bind_method(D_METHOD("copy_from", "src"), &Image::copy_internals_from);
 

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -377,7 +377,7 @@ public:
 	void fill_rect(const Rect2i &p_rect, const Color &p_color);
 
 	Rect2i get_used_rect() const;
-	Ref<Image> get_rect(const Rect2i &p_area) const;
+	Ref<Image> get_region(const Rect2i &p_area) const;
 
 	static void set_compress_bc_func(void (*p_compress_func)(Image *, float, UsedChannels));
 	static void set_compress_bptc_func(void (*p_compress_func)(Image *, float, UsedChannels));

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -241,11 +241,11 @@
 				This is the same as [method get_pixel], but with a [Vector2i] argument instead of two integer arguments.
 			</description>
 		</method>
-		<method name="get_rect" qualifiers="const">
+		<method name="get_region" qualifiers="const">
 			<return type="Image" />
-			<param index="0" name="rect" type="Rect2i" />
+			<param index="0" name="region" type="Rect2i" />
 			<description>
-				Returns a new image that is a copy of the image's area specified with [param rect].
+				Returns a new [Image] that is a copy of this [Image]'s area specified with [param region].
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -368,7 +368,7 @@ Error ResourceImporterLayeredTexture::import(const String &p_source_file, const 
 		for (int j = 0; j < hslices; j++) {
 			int x = slice_w * j;
 			int y = slice_h * i;
-			Ref<Image> slice = image->get_rect(Rect2i(x, y, slice_w, slice_h));
+			Ref<Image> slice = image->get_region(Rect2i(x, y, slice_w, slice_h));
 			ERR_CONTINUE(slice.is_null() || slice->is_empty());
 			if (slice->get_width() != slice_w || slice->get_height() != slice_h) {
 				slice->resize(slice_w, slice_h);

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -93,7 +93,7 @@ Ref<Texture2D> EditorTexturePreviewPlugin::generate(const Ref<Resource> &p_from,
 			return Ref<Texture2D>();
 		}
 
-		img = atlas->get_rect(atex->get_region());
+		img = atlas->get_region(atex->get_region());
 	} else {
 		Ref<Texture2D> tex = p_from;
 		if (tex.is_valid()) {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1663,7 +1663,7 @@ Ref<Image> AtlasTexture::get_image() const {
 		return Ref<Image>();
 	}
 
-	return atlas->get_image()->get_rect(region);
+	return atlas->get_image()->get_region(region);
 }
 
 AtlasTexture::AtlasTexture() {}

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -162,7 +162,7 @@ TEST_CASE("[Image] Basic getters") {
 	CHECK(image->get_size() == Vector2(8, 4));
 	CHECK(image->get_format() == Image::FORMAT_LA8);
 	CHECK(image->get_used_rect() == Rect2i(0, 0, 0, 0));
-	Ref<Image> image_get_rect = image->get_rect(Rect2i(0, 0, 2, 1));
+	Ref<Image> image_get_rect = image->get_region(Rect2i(0, 0, 2, 1));
 	CHECK(image_get_rect->get_size() == Vector2(2, 1));
 }
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5421.

This PR renames Image's `get_rect()` to  `get_region()` because the former is very vague, in the grand scheme of things. You may have just barely been able to tell what it does by looking at it.
Also renames its parameter to from "_rect_" to "_region_".
Do note that the reason this name was chosen over `copy_rect()` was because I felt like [it didn't quite solve the issue brought up on the proposal](https://github.com/godotengine/godot-proposals/issues/5421#issuecomment-1250079427). This PR can easily be changed if approved and if there's a clear consensus.