### PR TITLE
Add missing constructor, to compile editor without regex module

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -3950,6 +3950,8 @@ String ProjectConverter3To4::collect_string_from_vector(Vector<String> &vector) 
 
 #else // No RegEx.
 
+ProjectConverter3To4::ProjectConverter3To4(int _p_maximum_file_size_kb, int _p_maximum_line_length) {}
+
 int ProjectConverter3To4::convert() {
 	ERR_FAIL_V_MSG(ERROR_CODE, "Can't run converter for Godot 3.x projects, because RegEx module is disabled.");
 }


### PR DESCRIPTION
```
/usr/bin/ld: main/libmain.linuxbsd.tools.x86_64.a(main.linuxbsd.tools.x86_64.o): in function `Main::start()':
/home/runner/work/GodotBuilds/GodotBuilds/godot/main/main.cpp:2428: undefined reference to `ProjectConverter3To4::ProjectConverter3To4(int, int)'
/usr/bin/ld: /home/runner/work/GodotBuilds/GodotBuilds/godot/main/main.cpp:2433: undefined reference to `ProjectConverter3To4::ProjectConverter3To4(int, int)'
collect2: error: ld returned 1 exit status
```