### PR TITLE
Close file under cursor when middle mouse clicking in shader editor f…

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -1376,11 +1376,10 @@ void ShaderEditorPlugin::_shader_list_clicked(int p_item, Vector2 p_local_mouse_
 }
 
 void ShaderEditorPlugin::_close_shader(int p_index) {
-	int index = shader_tabs->get_current_tab();
-	ERR_FAIL_INDEX(index, shader_tabs->get_tab_count());
-	Control *c = shader_tabs->get_tab_control(index);
+	ERR_FAIL_INDEX(p_index, shader_tabs->get_tab_count());
+	Control *c = shader_tabs->get_tab_control(p_index);
 	memdelete(c);
-	edited_shaders.remove_at(index);
+	edited_shaders.remove_at(p_index);
 	_update_shader_list();
 	EditorNode::get_singleton()->get_undo_redo()->clear_history(); // To prevent undo on deleted graphs.
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Clicking with middle mouse button in shader editor files list resulted in the currently selected file to be closed. Instead the file under cursor should be closed.

Before:

![close_file_under_cursor_with_middle_mouse_click](https://user-images.githubusercontent.com/1949583/190899445-3a2fb8e8-9f04-46ac-bfd5-1c9be031d23b.gif)

After:

![close_file_under_cursor_with_middle_mouse_click_fixed](https://user-images.githubusercontent.com/1949583/190899448-1f3cbebf-038e-4287-afc0-a1a4062d26e1.gif)
