### PR TITLE
Fix external material does not apply to mesh in import settings.

### DIFF
--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -200,6 +200,7 @@ protected:
 public:
 	bool is_editing_animation() const { return editing_animation; }
 	void update_view();
+	void update_state(ResourceImporterScene::InternalImportCategory p_state);
 	void open_settings(const String &p_path, bool p_for_animation = false);
 	static SceneImportSettings *get_singleton();
 	Node *get_selected_node();


### PR DESCRIPTION
Fixed #64974:
Causes:

1. The mesh does not consider that the material it uses has used the external material after it has been instantiated.

2. The material preview does not take into account the use of external materials by the material.

Solution:
1. Apply the external material to the mesh if `use_external` is enabled and is valid.
2. Apply external material to the `material_preview` if `use_external` is valid.