### PR TITLE
Make the inner `TabBar` in a `TabContainer` behave like it is in a `Container`

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -519,11 +519,11 @@ void TabContainer::_refresh_tab_names() {
 }
 
 void TabContainer::add_child_notify(Node *p_child) {
+	Container::add_child_notify(p_child);
+
 	if (p_child == tab_bar) {
 		return;
 	}
-
-	Container::add_child_notify(p_child);
 
 	Control *c = Object::cast_to<Control>(p_child);
 	if (!c || c->is_set_as_top_level()) {


### PR DESCRIPTION
| Before | After |
| :-------: | :-----: |
| ![0](https://user-images.githubusercontent.com/30386067/190903904-3eec6d54-6fb1-4483-9df9-5f4df9aea46d.gif) | ![1](https://user-images.githubusercontent.com/30386067/190903908-9624b7f9-2d0b-4008-b7b7-af09b038ca07.gif) |



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
