### PR TITLE
Add negative collision shapes

### DIFF
--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -65,6 +65,13 @@ void GodotBody3D::update_mass_properties() {
 
 				total_area += get_shape_area(i);
 			}
+			for (int i = 0; i < get_negative_shape_count(); i++) {
+				if (is_negative_shape_disabled(i)) {
+					continue;
+				}
+
+				total_area -= get_negative_shape_area(i);
+			}
 
 			if (calculate_center_of_mass) {
 				// We have to recompute the center of mass.
@@ -82,6 +89,18 @@ void GodotBody3D::update_mass_properties() {
 
 						// NOTE: we assume that the shape origin is also its center of mass.
 						center_of_mass_local += mass * get_shape_transform(i).origin;
+					}
+					for (int i = 0; i < get_negative_shape_count(); i++) {
+						if (is_negative_shape_disabled(i)) {
+							continue;
+						}
+
+						real_t area = get_negative_shape_area(i);
+
+						real_t mass = area * this->mass / total_area;
+
+						// NOTE: we assume that the shape origin is also its center of mass.
+						center_of_mass_local -= mass * get_negative_shape_transform(i).origin;
 					}
 
 					center_of_mass_local /= mass;
@@ -119,6 +138,32 @@ void GodotBody3D::update_mass_properties() {
 
 					Vector3 shape_origin = shape_transform.origin - center_of_mass_local;
 					inertia_tensor += shape_inertia_tensor + (Basis() * shape_origin.dot(shape_origin) - shape_origin.outer(shape_origin)) * mass;
+				}
+				for (int i = 0; i < get_negative_shape_count(); i++) {
+					if (is_negative_shape_disabled(i)) {
+						continue;
+					}
+
+					real_t area = get_negative_shape_area(i);
+					if (area == 0.0) {
+						continue;
+					}
+
+					inertia_set = true;
+
+					const GodotShape3D *shape = get_negative_shape(i);
+
+					real_t mass = area * this->mass / total_area;
+
+					Basis shape_inertia_tensor = Basis::from_scale(shape->get_moment_of_inertia(mass));
+					Transform3D shape_transform = get_negative_shape_transform(i);
+					Basis shape_basis = shape_transform.basis.orthonormalized();
+
+					// NOTE: we don't take the scale of collision shapes into account when computing the inertia tensor!
+					shape_inertia_tensor = shape_basis * shape_inertia_tensor * shape_basis.transposed();
+
+					Vector3 shape_origin = shape_transform.origin - center_of_mass_local;
+					inertia_tensor -= shape_inertia_tensor + (Basis() * shape_origin.dot(shape_origin) - shape_origin.outer(shape_origin)) * mass;
 				}
 
 				// Set the inertia to a valid value when there are no valid shapes.

--- a/servers/physics_3d/godot_collision_object_3d.cpp
+++ b/servers/physics_3d/godot_collision_object_3d.cpp
@@ -48,10 +48,36 @@ void GodotCollisionObject3D::add_shape(GodotShape3D *p_shape, const Transform3D 
 	}
 }
 
+void GodotCollisionObject3D::add_negative_shape(GodotShape3D *p_shape, const Transform3D &p_transform, bool p_disabled) {
+	Shape s;
+	s.shape = p_shape;
+	s.xform = p_transform;
+	s.xform_inv = s.xform.affine_inverse();
+	s.bpid = 0; //needs update
+	s.disabled = p_disabled;
+	negative_shapes.push_back(s);
+	p_shape->add_owner(this);
+
+	if (!pending_shape_update_list.in_list()) {
+		GodotPhysicsServer3D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
+	}
+}
+
 void GodotCollisionObject3D::set_shape(int p_index, GodotShape3D *p_shape) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 	shapes[p_index].shape->remove_owner(this);
 	shapes.write[p_index].shape = p_shape;
+
+	p_shape->add_owner(this);
+	if (!pending_shape_update_list.in_list()) {
+		GodotPhysicsServer3D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
+	}
+}
+
+void GodotCollisionObject3D::set_negative_shape(int p_index, GodotShape3D *p_shape) {
+	ERR_FAIL_INDEX(p_index, negative_shapes.size());
+	negative_shapes[p_index].shape->remove_owner(this);
+	negative_shapes.write[p_index].shape = p_shape;
 
 	p_shape->add_owner(this);
 	if (!pending_shape_update_list.in_list()) {
@@ -64,6 +90,16 @@ void GodotCollisionObject3D::set_shape_transform(int p_index, const Transform3D 
 
 	shapes.write[p_index].xform = p_transform;
 	shapes.write[p_index].xform_inv = p_transform.affine_inverse();
+	if (!pending_shape_update_list.in_list()) {
+		GodotPhysicsServer3D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
+	}
+}
+
+void GodotCollisionObject3D::set_negative_shape_transform(int p_index, const Transform3D &p_transform) {
+	ERR_FAIL_INDEX(p_index, negative_shapes.size());
+
+	negative_shapes.write[p_index].xform = p_transform;
+	negative_shapes.write[p_index].xform_inv = p_transform.affine_inverse();
 	if (!pending_shape_update_list.in_list()) {
 		GodotPhysicsServer3D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
 	}
@@ -96,11 +132,44 @@ void GodotCollisionObject3D::set_shape_disabled(int p_idx, bool p_disabled) {
 	}
 }
 
+void GodotCollisionObject3D::set_negative_shape_disabled(int p_idx, bool p_disabled) {
+	ERR_FAIL_INDEX(p_idx, negative_shapes.size());
+
+	GodotCollisionObject3D::Shape &shape = negative_shapes.write[p_idx];
+	if (shape.disabled == p_disabled) {
+		return;
+	}
+
+	shape.disabled = p_disabled;
+
+	if (!space) {
+		return;
+	}
+
+	if (p_disabled && shape.bpid != 0) {
+		space->get_broadphase()->remove(shape.bpid);
+		shape.bpid = 0;
+		if (!pending_shape_update_list.in_list()) {
+			GodotPhysicsServer3D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
+		}
+	} else if (!p_disabled && shape.bpid == 0) {
+		if (!pending_shape_update_list.in_list()) {
+			GodotPhysicsServer3D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
+		}
+	}
+}
+
 void GodotCollisionObject3D::remove_shape(GodotShape3D *p_shape) {
 	//remove a shape, all the times it appears
 	for (int i = 0; i < shapes.size(); i++) {
 		if (shapes[i].shape == p_shape) {
 			remove_shape(i);
+			i--;
+		}
+	}
+	for (int i = 0; i < negative_shapes.size(); i++) {
+		if (negative_shapes[i].shape == p_shape) {
+			remove_negative_shape(i);
 			i--;
 		}
 	}
@@ -125,6 +194,25 @@ void GodotCollisionObject3D::remove_shape(int p_index) {
 	}
 }
 
+void GodotCollisionObject3D::remove_negative_shape(int p_index) {
+	//remove anything from shape to be erased to end, so subindices don't change
+	ERR_FAIL_INDEX(p_index, negative_shapes.size());
+	for (int i = p_index; i < negative_shapes.size(); i++) {
+		if (shapes[i].bpid == 0) {
+			continue;
+		}
+		//should never get here with a null owner
+		space->get_broadphase()->remove(negative_shapes[i].bpid);
+		negative_shapes.write[i].bpid = 0;
+	}
+	negative_shapes[p_index].shape->remove_owner(this);
+	negative_shapes.remove_at(p_index);
+
+	if (!pending_shape_update_list.in_list()) {
+		GodotPhysicsServer3D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
+	}
+}
+
 void GodotCollisionObject3D::_set_static(bool p_static) {
 	if (_static == p_static) {
 		return;
@@ -140,11 +228,26 @@ void GodotCollisionObject3D::_set_static(bool p_static) {
 			space->get_broadphase()->set_static(s.bpid, _static);
 		}
 	}
+
+	for (int i = 0; i < get_negative_shape_count(); i++) {
+		const Shape &s = negative_shapes[i];
+		if (s.bpid > 0) {
+			space->get_broadphase()->set_static(s.bpid, _static);
+		}
+	}
 }
 
 void GodotCollisionObject3D::_unregister_shapes() {
 	for (int i = 0; i < shapes.size(); i++) {
 		Shape &s = shapes.write[i];
+		if (s.bpid > 0) {
+			space->get_broadphase()->remove(s.bpid);
+			s.bpid = 0;
+		}
+	}
+	
+	for (int i = 0; i < negative_shapes.size(); i++) {
+		Shape &s = negative_shapes.write[i];
 		if (s.bpid > 0) {
 			space->get_broadphase()->remove(s.bpid);
 			s.bpid = 0;
@@ -159,6 +262,30 @@ void GodotCollisionObject3D::_update_shapes() {
 
 	for (int i = 0; i < shapes.size(); i++) {
 		Shape &s = shapes.write[i];
+		if (s.disabled) {
+			continue;
+		}
+
+		//not quite correct, should compute the next matrix..
+		AABB shape_aabb = s.shape->get_aabb();
+		Transform3D xform = transform * s.xform;
+		shape_aabb = xform.xform(shape_aabb);
+		shape_aabb.grow_by((s.aabb_cache.size.x + s.aabb_cache.size.y) * 0.5 * 0.05);
+		s.aabb_cache = shape_aabb;
+
+		Vector3 scale = xform.get_basis().get_scale();
+		s.area_cache = s.shape->get_volume() * scale.x * scale.y * scale.z;
+
+		if (s.bpid == 0) {
+			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static);
+			space->get_broadphase()->set_static(s.bpid, _static);
+		}
+
+		space->get_broadphase()->move(s.bpid, shape_aabb);
+	}
+
+	for (int i = 0; i < negative_shapes.size(); i++) {
+		Shape &s = negative_shapes.write[i];
 		if (s.disabled) {
 			continue;
 		}
@@ -207,6 +334,27 @@ void GodotCollisionObject3D::_update_shapes_with_motion(const Vector3 &p_motion)
 
 		space->get_broadphase()->move(s.bpid, shape_aabb);
 	}
+
+	for (int i = 0; i < negative_shapes.size(); i++) {
+		Shape &s = negative_shapes.write[i];
+		if (s.disabled) {
+			continue;
+		}
+
+		//not quite correct, should compute the next matrix..
+		AABB shape_aabb = s.shape->get_aabb();
+		Transform3D xform = transform * s.xform;
+		shape_aabb = xform.xform(shape_aabb);
+		shape_aabb.merge_with(AABB(shape_aabb.position + p_motion, shape_aabb.size)); //use motion
+		s.aabb_cache = shape_aabb;
+
+		if (s.bpid == 0) {
+			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static);
+			space->get_broadphase()->set_static(s.bpid, _static);
+		}
+
+		space->get_broadphase()->move(s.bpid, shape_aabb);
+	}
 }
 
 void GodotCollisionObject3D::_set_space(GodotSpace3D *p_space) {
@@ -215,6 +363,14 @@ void GodotCollisionObject3D::_set_space(GodotSpace3D *p_space) {
 
 		for (int i = 0; i < shapes.size(); i++) {
 			Shape &s = shapes.write[i];
+			if (s.bpid) {
+				space->get_broadphase()->remove(s.bpid);
+				s.bpid = 0;
+			}
+		}
+
+		for (int i = 0; i < negative_shapes.size(); i++) {
+			Shape &s = negative_shapes.write[i];
 			if (s.bpid) {
 				space->get_broadphase()->remove(s.bpid);
 				s.bpid = 0;

--- a/servers/physics_3d/godot_collision_object_3d.h
+++ b/servers/physics_3d/godot_collision_object_3d.h
@@ -72,6 +72,7 @@ private:
 	};
 
 	Vector<Shape> shapes;
+	Vector<Shape> negative_shapes;
 	GodotSpace3D *space = nullptr;
 	Transform3D transform;
 	Transform3D inv_transform;
@@ -117,28 +118,52 @@ public:
 
 	_FORCE_INLINE_ Type get_type() const { return type; }
 	void add_shape(GodotShape3D *p_shape, const Transform3D &p_transform = Transform3D(), bool p_disabled = false);
+	void add_negative_shape(GodotShape3D *p_shape, const Transform3D &p_transform = Transform3D(), bool p_disabled = false);
 	void set_shape(int p_index, GodotShape3D *p_shape);
+	void set_negative_shape(int p_index, GodotShape3D *p_shape);
 	void set_shape_transform(int p_index, const Transform3D &p_transform);
+	void set_negative_shape_transform(int p_index, const Transform3D &p_transform);
+	_FORCE_INLINE_ int get_negative_shape_count() const { return negative_shapes.size(); }
 	_FORCE_INLINE_ int get_shape_count() const { return shapes.size(); }
 	_FORCE_INLINE_ GodotShape3D *get_shape(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].shape;
 	}
+	_FORCE_INLINE_ GodotShape3D *get_negative_shape(int p_index) const {
+		CRASH_BAD_INDEX(p_index, negative_shapes.size());
+		return negative_shapes[p_index].shape;
+	}
 	_FORCE_INLINE_ const Transform3D &get_shape_transform(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].xform;
+	}
+	_FORCE_INLINE_ const Transform3D &get_negative_shape_transform(int p_index) const {
+		CRASH_BAD_INDEX(p_index, negative_shapes.size());
+		return negative_shapes[p_index].xform;
 	}
 	_FORCE_INLINE_ const Transform3D &get_shape_inv_transform(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].xform_inv;
 	}
+	_FORCE_INLINE_ const Transform3D &get_negative_shape_inv_transform(int p_index) const {
+		CRASH_BAD_INDEX(p_index, negative_shapes.size());
+		return negative_shapes[p_index].xform_inv;
+	}
 	_FORCE_INLINE_ const AABB &get_shape_aabb(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].aabb_cache;
 	}
+	_FORCE_INLINE_ const AABB &get_negative_shape_aabb(int p_index) const {
+		CRASH_BAD_INDEX(p_index, negative_shapes.size());
+		return negative_shapes[p_index].aabb_cache;
+	}
 	_FORCE_INLINE_ real_t get_shape_area(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].area_cache;
+	}
+	_FORCE_INLINE_ real_t get_negative_shape_area(int p_index) const {
+		CRASH_BAD_INDEX(p_index, negative_shapes.size());
+		return negative_shapes[p_index].area_cache;
 	}
 
 	_FORCE_INLINE_ const Transform3D &get_transform() const { return transform; }
@@ -149,9 +174,14 @@ public:
 	_FORCE_INLINE_ bool is_ray_pickable() const { return ray_pickable; }
 
 	void set_shape_disabled(int p_idx, bool p_disabled);
+	void set_negative_shape_disabled(int p_idx, bool p_disabled);
 	_FORCE_INLINE_ bool is_shape_disabled(int p_idx) const {
 		ERR_FAIL_INDEX_V(p_idx, shapes.size(), false);
 		return shapes[p_idx].disabled;
+	}
+	_FORCE_INLINE_ bool is_negative_shape_disabled(int p_idx) const {
+		ERR_FAIL_INDEX_V(p_idx, negative_shapes.size(), false);
+		return negative_shapes[p_idx].disabled;
 	}
 
 	_FORCE_INLINE_ void set_collision_layer(uint32_t p_layer) {
@@ -183,6 +213,7 @@ public:
 
 	void remove_shape(GodotShape3D *p_shape) override;
 	void remove_shape(int p_index);
+	void remove_negative_shape(int p_index);
 
 	virtual void set_space(GodotSpace3D *p_space) = 0;
 

--- a/servers/physics_3d/godot_physics_server_3d.cpp
+++ b/servers/physics_3d/godot_physics_server_3d.cpp
@@ -485,6 +485,17 @@ void GodotPhysicsServer3D::body_add_shape(RID p_body, RID p_shape, const Transfo
 	body->add_shape(shape, p_transform, p_disabled);
 }
 
+
+void GodotPhysicsServer3D::body_add_negative_shape(RID p_body, RID p_shape, const Transform3D &p_transform, bool p_disabled) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND(!body);
+
+	GodotShape3D *shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_COND(!shape);
+
+	body->add_negative_shape(shape, p_transform, p_disabled);
+}
+
 void GodotPhysicsServer3D::body_set_shape(RID p_body, int p_shape_idx, RID p_shape) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!body);
@@ -495,11 +506,30 @@ void GodotPhysicsServer3D::body_set_shape(RID p_body, int p_shape_idx, RID p_sha
 
 	body->set_shape(p_shape_idx, shape);
 }
+
+void GodotPhysicsServer3D::body_set_negative_shape(RID p_body, int p_shape_idx, RID p_shape) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND(!body);
+
+	GodotShape3D *shape = shape_owner.get_or_null(p_shape);
+	ERR_FAIL_COND(!shape);
+	ERR_FAIL_COND(!shape->is_configured());
+
+	body->set_negative_shape(p_shape_idx, shape);
+}
+
 void GodotPhysicsServer3D::body_set_shape_transform(RID p_body, int p_shape_idx, const Transform3D &p_transform) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!body);
 
 	body->set_shape_transform(p_shape_idx, p_transform);
+}
+
+void GodotPhysicsServer3D::body_set_negative_shape_transform(RID p_body, int p_shape_idx, const Transform3D &p_transform) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND(!body);
+
+	body->set_negative_shape_transform(p_shape_idx, p_transform);
 }
 
 int GodotPhysicsServer3D::body_get_shape_count(RID p_body) const {
@@ -509,11 +539,28 @@ int GodotPhysicsServer3D::body_get_shape_count(RID p_body) const {
 	return body->get_shape_count();
 }
 
+int GodotPhysicsServer3D::body_get_negative_shape_count(RID p_body) const {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND_V(!body, -1);
+
+	return body->get_negative_shape_count();
+}
+
 RID GodotPhysicsServer3D::body_get_shape(RID p_body, int p_shape_idx) const {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_COND_V(!body, RID());
 
 	GodotShape3D *shape = body->get_shape(p_shape_idx);
+	ERR_FAIL_COND_V(!shape, RID());
+
+	return shape->get_self();
+}
+
+RID GodotPhysicsServer3D::body_get_negative_shape(RID p_body, int p_shape_idx) const {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND_V(!body, RID());
+
+	GodotShape3D *shape = body->get_negative_shape(p_shape_idx);
 	ERR_FAIL_COND_V(!shape, RID());
 
 	return shape->get_self();
@@ -528,11 +575,27 @@ void GodotPhysicsServer3D::body_set_shape_disabled(RID p_body, int p_shape_idx, 
 	body->set_shape_disabled(p_shape_idx, p_disabled);
 }
 
+void GodotPhysicsServer3D::body_set_negative_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND(!body);
+	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
+	FLUSH_QUERY_CHECK(body);
+
+	body->set_negative_shape_disabled(p_shape_idx, p_disabled);
+}
+
 Transform3D GodotPhysicsServer3D::body_get_shape_transform(RID p_body, int p_shape_idx) const {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_COND_V(!body, Transform3D());
 
 	return body->get_shape_transform(p_shape_idx);
+}
+
+Transform3D GodotPhysicsServer3D::body_get_negative_shape_transform(RID p_body, int p_shape_idx) const {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND_V(!body, Transform3D());
+
+	return body->get_negative_shape_transform(p_shape_idx);
 }
 
 void GodotPhysicsServer3D::body_remove_shape(RID p_body, int p_shape_idx) {
@@ -542,12 +605,23 @@ void GodotPhysicsServer3D::body_remove_shape(RID p_body, int p_shape_idx) {
 	body->remove_shape(p_shape_idx);
 }
 
+void GodotPhysicsServer3D::body_remove_negative_shape(RID p_body, int p_shape_idx) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND(!body);
+
+	body->remove_negative_shape(p_shape_idx);
+}
+
 void GodotPhysicsServer3D::body_clear_shapes(RID p_body) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!body);
 
 	while (body->get_shape_count()) {
 		body->remove_shape(0);
+	}
+
+	while (body->get_negative_shape_count()) {
+		body->remove_negative_shape(0);
 	}
 }
 

--- a/servers/physics_3d/godot_physics_server_3d.h
+++ b/servers/physics_3d/godot_physics_server_3d.h
@@ -168,16 +168,24 @@ public:
 	virtual BodyMode body_get_mode(RID p_body) const override;
 
 	virtual void body_add_shape(RID p_body, RID p_shape, const Transform3D &p_transform = Transform3D(), bool p_disabled = false) override;
+	void body_add_negative_shape(RID p_body, RID p_shape, const Transform3D &p_transform = Transform3D(), bool p_disabled = false);
 	virtual void body_set_shape(RID p_body, int p_shape_idx, RID p_shape) override;
+	void body_set_negative_shape(RID p_body, int p_shape_idx, RID p_shape);
 	virtual void body_set_shape_transform(RID p_body, int p_shape_idx, const Transform3D &p_transform) override;
+	void body_set_negative_shape_transform(RID p_body, int p_shape_idx, const Transform3D &p_transform);
 
 	virtual int body_get_shape_count(RID p_body) const override;
+ 	int body_get_negative_shape_count(RID p_body) const;
 	virtual RID body_get_shape(RID p_body, int p_shape_idx) const override;
+	RID body_get_negative_shape(RID p_body, int p_shape_idx) const;
 	virtual Transform3D body_get_shape_transform(RID p_body, int p_shape_idx) const override;
+	Transform3D body_get_negative_shape_transform(RID p_body, int p_shape_idx) const;
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
+	void body_set_negative_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled);
 
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override;
+	void body_remove_negative_shape(RID p_body, int p_shape_idx);
 	virtual void body_clear_shapes(RID p_body) override;
 
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override;


### PR DESCRIPTION
This adds a way to specify shapes where collisions are *not* reported. Closes https://github.com/godotengine/godot-proposals/issues/5407.

To do:

- [ ] Implement in `GodotPhysicsServer3D` for bodies
- [ ] Implement for areas
- [ ] Decide on server API (separate methods vs boolean property)
- [ ] Decide on behavior for CoM and inertia calculation
- [ ] Add property to `CollisionShape3D`
