### PR TITLE
[3.x] `Sprite3D`/`AnimatedSprite3D` Fix drawing `AtlasTexture`s with vertical margins differently than in 2D

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -89,6 +89,139 @@ void SpriteBase3D::_notification(int p_what) {
 	}
 }
 
+void SpriteBase3D::draw_texture_rect(Ref<Texture> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect) {
+	ERR_FAIL_COND(p_texture.is_null());
+
+	Rect2 final_rect;
+	Rect2 final_src_rect;
+	if (!p_texture->get_rect_region(p_dst_rect, p_src_rect, final_rect, final_src_rect)) {
+		return;
+	}
+
+	if (final_rect.size.x == 0 || final_rect.size.y == 0) {
+		return;
+	}
+
+	Color color = _get_color_accum();
+	color.a *= get_opacity();
+
+	float pixel_size = get_pixel_size();
+
+	Vector2 vertices[4] = {
+		(final_rect.position + Vector2(0, final_rect.size.y)) * pixel_size,
+		(final_rect.position + final_rect.size) * pixel_size,
+		(final_rect.position + Vector2(final_rect.size.x, 0)) * pixel_size,
+		final_rect.position * pixel_size,
+	};
+
+	Vector2 src_tsize = p_texture->get_size();
+
+	// Properly setup UVs for impostor textures (AtlasTexture).
+	Ref<AtlasTexture> atlas_tex = p_texture;
+	if (atlas_tex != nullptr) {
+		src_tsize[0] = atlas_tex->get_atlas()->get_width();
+		src_tsize[1] = atlas_tex->get_atlas()->get_height();
+	}
+
+	Vector2 uvs[4] = {
+		final_src_rect.position / src_tsize,
+		(final_src_rect.position + Vector2(final_src_rect.size.x, 0)) / src_tsize,
+		(final_src_rect.position + final_src_rect.size) / src_tsize,
+		(final_src_rect.position + Vector2(0, final_src_rect.size.y)) / src_tsize,
+	};
+
+	if (is_flipped_h()) {
+		SWAP(uvs[0], uvs[1]);
+		SWAP(uvs[2], uvs[3]);
+	}
+	if (is_flipped_v()) {
+		SWAP(uvs[0], uvs[3]);
+		SWAP(uvs[1], uvs[2]);
+	}
+
+	Vector3 normal;
+	int axis = get_axis();
+	normal[axis] = 1.0;
+
+	Plane tangent;
+	if (axis == Vector3::AXIS_X) {
+		tangent = Plane(0, 0, -1, -1);
+	} else {
+		tangent = Plane(1, 0, 0, -1);
+	}
+
+	int x_axis = ((axis + 1) % 3);
+	int y_axis = ((axis + 2) % 3);
+
+	if (axis != Vector3::AXIS_Z) {
+		SWAP(x_axis, y_axis);
+
+		for (int i = 0; i < 4; i++) {
+			//uvs[i] = Vector2(1.0,1.0)-uvs[i];
+			//SWAP(vertices[i].x,vertices[i].y);
+			if (axis == Vector3::AXIS_Y) {
+				vertices[i].y = -vertices[i].y;
+			} else if (axis == Vector3::AXIS_X) {
+				vertices[i].x = -vertices[i].x;
+			}
+		}
+	}
+
+	AABB aabb;
+
+	// Everything except position, color, and UV is compressed
+	PoolVector<uint8_t>::Write write_buffer = mesh_buffer.write();
+
+	Vector2 normal_oct = VisualServer::get_singleton()->norm_to_oct(normal);
+	int8_t v_normal[2] = {
+		(int8_t)CLAMP(normal_oct.x * 127, -128, 127),
+		(int8_t)CLAMP(normal_oct.y * 127, -128, 127),
+	};
+
+	Vector2 tangent_oct = VisualServer::get_singleton()->tangent_to_oct(tangent.normal, tangent.d, false);
+	int8_t v_tangent[2] = {
+		(int8_t)CLAMP(tangent_oct.x * 127, -128, 127),
+		(int8_t)CLAMP(tangent_oct.y * 127, -128, 127),
+	};
+
+	for (int i = 0; i < 4; i++) {
+		Vector3 vtx;
+		vtx[x_axis] = vertices[i][0];
+		vtx[y_axis] = vertices[i][1];
+		if (i == 0) {
+			aabb.position = vtx;
+			aabb.size = Vector3();
+		} else {
+			aabb.expand_to(vtx);
+		}
+
+		float v_uv[2] = { uvs[i].x, uvs[i].y };
+		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_TEX_UV] + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
+
+		float v_vertex[3] = { vtx.x, vtx.y, vtx.z };
+		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_VERTEX] + mesh_surface_offsets[VS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
+		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_NORMAL] + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 2);
+		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_TANGENT] + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 2);
+		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_COLOR] + mesh_surface_offsets[VS::ARRAY_COLOR]], color.components, 4 * 4);
+	}
+
+	write_buffer.release();
+
+	RID mesh = get_mesh();
+	VS::get_singleton()->mesh_surface_update_region(mesh, 0, 0, mesh_buffer);
+
+	VS::get_singleton()->mesh_set_custom_aabb(mesh, aabb);
+	set_aabb(aabb);
+
+	RID mat = SpatialMaterial::get_material_rid_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == SpatialMaterial::BILLBOARD_ENABLED, get_billboard_mode() == SpatialMaterial::BILLBOARD_FIXED_Y, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE));
+	VS::get_singleton()->material_set_shader(get_material(), VS::get_singleton()->material_get_shader(mat));
+	VS::get_singleton()->material_set_param(get_material(), "texture_albedo", p_texture->get_rid());
+	if (get_alpha_cut_mode() == ALPHA_CUT_DISABLED) {
+		VS::get_singleton()->material_set_render_priority(get_material(), get_render_priority());
+	}
+	VS::get_singleton()->instance_set_surface_material(get_instance(), 0, get_material());
+}
+
 void SpriteBase3D::set_centered(bool p_center) {
 	centered = p_center;
 	_queue_update();
@@ -469,143 +602,15 @@ void Sprite3D::_draw() {
 	Point2 frame_offset = Point2(frame % hframes, frame / hframes);
 	frame_offset *= frame_size;
 
-	Point2 dest_offset = get_offset();
+	Point2 dst_offset = get_offset();
 	if (is_centered()) {
-		dest_offset -= frame_size / 2;
+		dst_offset -= frame_size / 2;
 	}
 
 	Rect2 src_rect(base_rect.position + frame_offset, frame_size);
-	Rect2 final_dst_rect(dest_offset, frame_size);
-	Rect2 final_rect;
-	Rect2 final_src_rect;
-	if (!texture->get_rect_region(final_dst_rect, src_rect, final_rect, final_src_rect)) {
-		return;
-	}
+	Rect2 dst_rect(dst_offset, frame_size);
 
-	if (final_rect.size.x == 0 || final_rect.size.y == 0) {
-		return;
-	}
-
-	Color color = _get_color_accum();
-	color.a *= get_opacity();
-
-	float pixel_size = get_pixel_size();
-
-	Vector2 vertices[4] = {
-
-		(final_rect.position + Vector2(0, final_rect.size.y)) * pixel_size,
-		(final_rect.position + final_rect.size) * pixel_size,
-		(final_rect.position + Vector2(final_rect.size.x, 0)) * pixel_size,
-		final_rect.position * pixel_size,
-
-	};
-
-	Vector2 src_tsize = tsize;
-
-	// Properly setup UVs for impostor textures (AtlasTexture).
-	Ref<AtlasTexture> atlas_tex = texture;
-	if (atlas_tex != nullptr) {
-		src_tsize[0] = atlas_tex->get_atlas()->get_width();
-		src_tsize[1] = atlas_tex->get_atlas()->get_height();
-	}
-
-	Vector2 uvs[4] = {
-		final_src_rect.position / src_tsize,
-		(final_src_rect.position + Vector2(final_src_rect.size.x, 0)) / src_tsize,
-		(final_src_rect.position + final_src_rect.size) / src_tsize,
-		(final_src_rect.position + Vector2(0, final_src_rect.size.y)) / src_tsize,
-	};
-
-	if (is_flipped_h()) {
-		SWAP(uvs[0], uvs[1]);
-		SWAP(uvs[2], uvs[3]);
-	}
-	if (is_flipped_v()) {
-		SWAP(uvs[0], uvs[3]);
-		SWAP(uvs[1], uvs[2]);
-	}
-
-	Vector3 normal;
-	int axis = get_axis();
-	normal[axis] = 1.0;
-
-	Plane tangent;
-	if (axis == Vector3::AXIS_X) {
-		tangent = Plane(0, 0, -1, 1);
-	} else {
-		tangent = Plane(1, 0, 0, 1);
-	}
-
-	int x_axis = ((axis + 1) % 3);
-	int y_axis = ((axis + 2) % 3);
-
-	if (axis != Vector3::AXIS_Z) {
-		SWAP(x_axis, y_axis);
-
-		for (int i = 0; i < 4; i++) {
-			//uvs[i] = Vector2(1.0,1.0)-uvs[i];
-			//SWAP(vertices[i].x,vertices[i].y);
-			if (axis == Vector3::AXIS_Y) {
-				vertices[i].y = -vertices[i].y;
-			} else if (axis == Vector3::AXIS_X) {
-				vertices[i].x = -vertices[i].x;
-			}
-		}
-	}
-
-	AABB aabb;
-
-	// Everything except position, color, and UV is compressed
-	PoolVector<uint8_t>::Write write_buffer = mesh_buffer.write();
-
-	Vector2 normal_oct = VisualServer::get_singleton()->norm_to_oct(normal);
-	int8_t v_normal[2] = {
-		(int8_t)CLAMP(normal_oct.x * 127, -128, 127),
-		(int8_t)CLAMP(normal_oct.y * 127, -128, 127),
-	};
-
-	Vector2 tangent_oct = VisualServer::get_singleton()->tangent_to_oct(tangent.normal, tangent.d, false);
-	int8_t v_tangent[2] = {
-		(int8_t)CLAMP(tangent_oct.x * 127, -128, 127),
-		(int8_t)CLAMP(tangent_oct.y * 127, -128, 127),
-	};
-
-	for (int i = 0; i < 4; i++) {
-		Vector3 vtx;
-		vtx[x_axis] = vertices[i][0];
-		vtx[y_axis] = vertices[i][1];
-		if (i == 0) {
-			aabb.position = vtx;
-			aabb.size = Vector3();
-		} else {
-			aabb.expand_to(vtx);
-		}
-
-		float v_uv[2] = { uvs[i].x, uvs[i].y };
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_TEX_UV] + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
-
-		float v_vertex[3] = { vtx.x, vtx.y, vtx.z };
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_VERTEX] + mesh_surface_offsets[VS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_NORMAL] + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 2);
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_TANGENT] + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 2);
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_COLOR] + mesh_surface_offsets[VS::ARRAY_COLOR]], color.components, 4 * 4);
-	}
-
-	write_buffer.release();
-
-	RID mesh = get_mesh();
-	VS::get_singleton()->mesh_surface_update_region(mesh, 0, 0, mesh_buffer);
-
-	VS::get_singleton()->mesh_set_custom_aabb(mesh, aabb);
-	set_aabb(aabb);
-
-	RID mat = SpatialMaterial::get_material_rid_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == SpatialMaterial::BILLBOARD_ENABLED, get_billboard_mode() == SpatialMaterial::BILLBOARD_FIXED_Y, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE));
-	VS::get_singleton()->material_set_shader(get_material(), VS::get_singleton()->material_get_shader(mat));
-	VS::get_singleton()->material_set_param(get_material(), "texture_albedo", texture->get_rid());
-	if (get_alpha_cut_mode() == ALPHA_CUT_DISABLED) {
-		VS::get_singleton()->material_set_render_priority(get_material(), get_render_priority());
-	}
-	VS::get_singleton()->instance_set_surface_material(get_instance(), 0, get_material());
+	draw_texture_rect(texture, dst_rect, src_rect);
 }
 
 void Sprite3D::set_texture(const Ref<Texture> &p_texture) {
@@ -822,136 +827,7 @@ void AnimatedSprite3D::_draw() {
 
 	Rect2 dst_rect(ofs, tsize);
 
-	Rect2 final_rect;
-	Rect2 final_src_rect;
-	if (!texture->get_rect_region(dst_rect, src_rect, final_rect, final_src_rect)) {
-		return;
-	}
-
-	if (final_rect.size.x == 0 || final_rect.size.y == 0) {
-		return;
-	}
-
-	Color color = _get_color_accum();
-	color.a *= get_opacity();
-
-	float pixel_size = get_pixel_size();
-
-	Vector2 vertices[4] = {
-
-		(final_rect.position + Vector2(0, final_rect.size.y)) * pixel_size,
-		(final_rect.position + final_rect.size) * pixel_size,
-		(final_rect.position + Vector2(final_rect.size.x, 0)) * pixel_size,
-		final_rect.position * pixel_size,
-
-	};
-
-	Vector2 src_tsize = tsize;
-
-	// Properly setup UVs for impostor textures (AtlasTexture).
-	Ref<AtlasTexture> atlas_tex = texture;
-	if (atlas_tex != nullptr) {
-		src_tsize[0] = atlas_tex->get_atlas()->get_width();
-		src_tsize[1] = atlas_tex->get_atlas()->get_height();
-	}
-
-	Vector2 uvs[4] = {
-		final_src_rect.position / src_tsize,
-		(final_src_rect.position + Vector2(final_src_rect.size.x, 0)) / src_tsize,
-		(final_src_rect.position + final_src_rect.size) / src_tsize,
-		(final_src_rect.position + Vector2(0, final_src_rect.size.y)) / src_tsize,
-	};
-
-	if (is_flipped_h()) {
-		SWAP(uvs[0], uvs[1]);
-		SWAP(uvs[2], uvs[3]);
-	}
-	if (is_flipped_v()) {
-		SWAP(uvs[0], uvs[3]);
-		SWAP(uvs[1], uvs[2]);
-	}
-
-	Vector3 normal;
-	int axis = get_axis();
-	normal[axis] = 1.0;
-
-	Plane tangent;
-	if (axis == Vector3::AXIS_X) {
-		tangent = Plane(0, 0, -1, -1);
-	} else {
-		tangent = Plane(1, 0, 0, -1);
-	}
-
-	int x_axis = ((axis + 1) % 3);
-	int y_axis = ((axis + 2) % 3);
-
-	if (axis != Vector3::AXIS_Z) {
-		SWAP(x_axis, y_axis);
-
-		for (int i = 0; i < 4; i++) {
-			//uvs[i] = Vector2(1.0,1.0)-uvs[i];
-			//SWAP(vertices[i].x,vertices[i].y);
-			if (axis == Vector3::AXIS_Y) {
-				vertices[i].y = -vertices[i].y;
-			} else if (axis == Vector3::AXIS_X) {
-				vertices[i].x = -vertices[i].x;
-			}
-		}
-	}
-
-	AABB aabb;
-
-	// Everything except position, color, and UV is compressed
-	PoolVector<uint8_t>::Write write_buffer = mesh_buffer.write();
-
-	Vector2 normal_oct = VisualServer::get_singleton()->norm_to_oct(normal);
-	int8_t v_normal[2] = {
-		(int8_t)CLAMP(normal_oct.x * 127, -128, 127),
-		(int8_t)CLAMP(normal_oct.y * 127, -128, 127),
-	};
-
-	Vector2 tangent_oct = VisualServer::get_singleton()->tangent_to_oct(tangent.normal, tangent.d, false);
-	int8_t v_tangent[2] = {
-		(int8_t)CLAMP(tangent_oct.x * 127, -128, 127),
-		(int8_t)CLAMP(tangent_oct.y * 127, -128, 127),
-	};
-
-	for (int i = 0; i < 4; i++) {
-		Vector3 vtx;
-		vtx[x_axis] = vertices[i][0];
-		vtx[y_axis] = vertices[i][1];
-		if (i == 0) {
-			aabb.position = vtx;
-			aabb.size = Vector3();
-		} else {
-			aabb.expand_to(vtx);
-		}
-
-		float v_uv[2] = { uvs[i].x, uvs[i].y };
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_TEX_UV] + mesh_surface_offsets[VS::ARRAY_TEX_UV]], v_uv, 8);
-
-		float v_vertex[3] = { vtx.x, vtx.y, vtx.z };
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_VERTEX] + mesh_surface_offsets[VS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_NORMAL] + mesh_surface_offsets[VS::ARRAY_NORMAL]], v_normal, 2);
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_TANGENT] + mesh_surface_offsets[VS::ARRAY_TANGENT]], v_tangent, 2);
-		memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_COLOR] + mesh_surface_offsets[VS::ARRAY_COLOR]], color.components, 4 * 4);
-	}
-
-	write_buffer.release();
-
-	RID mesh = get_mesh();
-	VS::get_singleton()->mesh_surface_update_region(mesh, 0, 0, mesh_buffer);
-
-	VS::get_singleton()->mesh_set_custom_aabb(mesh, aabb);
-	set_aabb(aabb);
-
-	RID mat = SpatialMaterial::get_material_rid_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == SpatialMaterial::BILLBOARD_ENABLED, get_billboard_mode() == SpatialMaterial::BILLBOARD_FIXED_Y, get_draw_flag(FLAG_DISABLE_DEPTH_TEST), get_draw_flag(FLAG_FIXED_SIZE));
-	VS::get_singleton()->material_set_shader(get_material(), VS::get_singleton()->material_get_shader(mat));
-	VS::get_singleton()->material_set_param(get_material(), "texture_albedo", texture->get_rid());
-	if (get_alpha_cut_mode() == ALPHA_CUT_DISABLED) {
-		VS::get_singleton()->material_set_render_priority(get_material(), get_render_priority());
-	}
-	VS::get_singleton()->instance_set_surface_material(get_instance(), 0, get_material());
+	draw_texture_rect(texture, dst_rect, src_rect);
 }
 
 void AnimatedSprite3D::_validate_property(PropertyInfo &property) const {

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -94,6 +94,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 	virtual void _draw() = 0;
+	void draw_texture_rect(Ref<Texture> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
 	_FORCE_INLINE_ RID &get_mesh() { return mesh; }
 	_FORCE_INLINE_ RID &get_material() { return material; }


### PR DESCRIPTION
Fixes #63520.

The actual fix is a single line of code added in the second commit, I've explained it in the comments. Exactly what I suggested in https://github.com/godotengine/godot/issues/63520#issuecomment-1196924264 (took me that long as I somehow forgot about it).

The first commit is moving common/duplicated drawing code from `Sprite3D`/`AnimatedSprite3D` to `SpriteBase3D`. Drawing `Sprite3D`/`AnimatedSprite3D` is the same besides the part determining what texture and rects to use.
If doing so is not desired I guess I can instead just add the exact same changes from the second commit to the `Sprite3D`/`AnimatedSprite3D` separately (making the duplicated code even longer). Or if separate PRs are desired I could split that too.

BTW currently drawing nested AtlasTextures (an `AtlasTexture` having its `atlas` set to another `AtlasTexture`) doesn't work for `Sprite3D`/`AnimatedSprite3D` (works for 2D counterparts) so the fix was obviously not tested for such cases. Supporting such nesting is for potential future PRs.

Some examples for animated sprites 2D/3D (didn't bother about texture import settings):

[SpriteBase3DVerticalMarginBug.zip](https://github.com/godotengine/godot/files/9594904/SpriteBase3DVerticalMarginBug.zip)
||Before:<br>(3.5.stable)|After:<br>(this PR)|
|-|-|-|
|2D (no change)|![Z33mFdVmst](https://user-images.githubusercontent.com/9283098/190918600-7b0060bf-38f1-4b1a-ba1a-f25cea823960.gif)|![l4QWb9cjUM](https://user-images.githubusercontent.com/9283098/190918609-f2feed81-5813-4c28-bf2d-9d49fa476de6.gif)|
|3D|![GtMgDQXG7c](https://user-images.githubusercontent.com/9283098/190918784-820579b5-db35-4af3-b0eb-b84cba0b13eb.gif)|![FLgqbxBptU](https://user-images.githubusercontent.com/9283098/190918811-f18c3a1e-2ce7-47a9-83d1-5f2ef99f30d0.gif)|

[MRP from #63520.zip](https://github.com/godotengine/godot/files/9199408/RepairBird_bug_3.3_rc7.zip)
||Before:<br>(3.5.stable)|After:<br>(this PR)|
|-|-|-|
|2D (no change)|`offset = (30, 150)`<br>![IcDRsGzdqs](https://user-images.githubusercontent.com/9283098/190919623-c81abed5-83f9-43e7-b4eb-ecf999727a33.gif)<br>(debug border drawn in script)|`offset = (30, 150)`<br>![yLAf2SkkYv](https://user-images.githubusercontent.com/9283098/190921462-84a8f656-c8da-4e1f-b161-539432fc28c8.gif)<br>(debug border drawn in script)|
|3D|`offset = (30, 100)`<br>(changed by the user to visually match 2D case)<br>![NZRjggVQMN](https://user-images.githubusercontent.com/9283098/190919304-11cdbc69-ea13-491d-ace4-85a3fc9353f7.gif)<br><br>`offset = (30, 150)`<br>![j2aMepkwNh](https://user-images.githubusercontent.com/9283098/190921709-546c7bd5-e041-43f0-90fc-5e3a07efbcf8.gif)|`offset = (30, 150)`<br>![TQDzDjOPHS](https://user-images.githubusercontent.com/9283098/190920052-6ab94441-7aae-4a36-a1f8-790e02675180.gif)|










