### PR TITLE
Fix Vulkan: SpotLight3D's and OmniLight3D's Projector doesn't work

### DIFF
--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -36,6 +36,7 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/rid_owner.h"
 #include "core/templates/self_list.h"
+#include "drivers/gles3/storage/texture_storage.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/storage/light_storage.h"
 #include "servers/rendering/storage/utilities.h"
@@ -246,7 +247,7 @@ public:
 		const Light *light = light_owner.get_or_null(p_light);
 		ERR_FAIL_COND_V(!light, RS::LIGHT_DIRECTIONAL);
 
-		return light_owner.owns(light->projector);
+		return TextureStorage::get_singleton()->owns_texture(light->projector);
 	}
 
 	_FORCE_INLINE_ bool light_is_negative(RID p_light) const {

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -34,6 +34,7 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/rid_owner.h"
 #include "core/templates/self_list.h"
+#include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
 #include "servers/rendering/storage/light_storage.h"
 #include "servers/rendering/storage/utilities.h"
 
@@ -235,7 +236,7 @@ public:
 		const Light *light = light_owner.get_or_null(p_light);
 		ERR_FAIL_COND_V(!light, RS::LIGHT_DIRECTIONAL);
 
-		return light_owner.owns(light->projector);
+		return TextureStorage::get_singleton()->owns_texture(light->projector);
 	}
 
 	_FORCE_INLINE_ bool light_is_negative(RID p_light) const {


### PR DESCRIPTION
Fix Vulkan: SpotLight3D's and OmniLight3D's Projector doesn't work (see #59488)
_Edit for updating description after amending commit_

**Important:** The PR shows a change for GLES3 as well to make sure the check for a valid projector texture is done. Please be aware that that doesn't change, that there doesn't exist an implementation for displaying a projector in GLES3 as of yet.

~~I'm not quite sure what the idea behind the previous implementation was, after looking at the `Light` class it doesn't make much sense to me. I looked for the easiest way to check if the property `projector` has any value and since it's of type `RID` as well, which gives us the `is_valid()` method to check if the internal `_id` property is non-ZERO, I went with that.~~

Previous implementation checked for a valid Light RID instead of a Texture RID. Adjusted that to make sure it checks against the correct storage type (see suggestion from Bastiaan below)

Tested on Windows 10 with Vulkan:

- Validation check: OK
- Display of projector: OK

Tested on Windows 10 with GLES3:

- Validation check: OK
- Display of projector: None (wasn't implemented in the first place) 

Prerequisites are still the same: Spotlight3D or OmniLight3D WITH shadows enabled (as per Notification in the Editor).
Info: The texture - should one be assigned - will be projected with shadows disabled as well from certain camera angles, just not correctly.

With projector:
![with_projector](https://user-images.githubusercontent.com/61805849/190922766-ba26fcc4-444c-40a4-a43c-31c872fe8b91.png)

Without projector:
![without-projector](https://user-images.githubusercontent.com/61805849/190922768-8880780c-aa91-4df9-a0ea-35039ea3bf54.png)

*Bugsquad edit:*
- Fixes #59488