### PR TITLE
Change UndoRedo to use Callables

### DIFF
--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -46,8 +46,6 @@ public:
 	};
 
 	typedef void (*CommitNotifyCallback)(void *p_ud, const String &p_name);
-	void _add_do_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	void _add_undo_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	typedef void (*MethodNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_name, const Variant **p_args, int p_argcount);
 	typedef void (*PropertyNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_property, const Variant &p_value);
@@ -58,14 +56,14 @@ private:
 			TYPE_METHOD,
 			TYPE_PROPERTY,
 			TYPE_REFERENCE
-		};
+		} type;
 
-		Type type;
 		bool force_keep_in_merge_ends;
 		Ref<RefCounted> ref;
 		ObjectID object;
 		StringName name;
-		Vector<Variant> args;
+		Callable callable;
+		Variant value;
 
 		void delete_reference();
 	};
@@ -106,30 +104,8 @@ protected:
 public:
 	void create_action(const String &p_name = "", MergeMode p_mode = MERGE_DISABLE);
 
-	void add_do_methodp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount);
-	void add_undo_methodp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount);
-
-	template <typename... VarArgs>
-	void add_do_method(Object *p_object, const StringName &p_method, VarArgs... p_args) {
-		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
-		const Variant *argptrs[sizeof...(p_args) + 1];
-		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
-			argptrs[i] = &args[i];
-		}
-
-		add_do_methodp(p_object, p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
-	}
-	template <typename... VarArgs>
-	void add_undo_method(Object *p_object, const StringName &p_method, VarArgs... p_args) {
-		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
-		const Variant *argptrs[sizeof...(p_args) + 1];
-		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
-			argptrs[i] = &args[i];
-		}
-
-		add_undo_methodp(p_object, p_method, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
-	}
-
+	void add_do_method(const Callable &p_callable);
+	void add_undo_method(const Callable &p_callable);
 	void add_do_property(Object *p_object, const StringName &p_property, const Variant &p_value);
 	void add_undo_property(Object *p_object, const StringName &p_property, const Variant &p_value);
 	void add_do_reference(Object *p_object);

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -62,12 +62,11 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="add_do_method" qualifiers="vararg">
+		<method name="add_do_method">
 			<return type="void" />
-			<param index="0" name="object" type="Object" />
-			<param index="1" name="method" type="StringName" />
+			<param index="0" name="callable" type="Callable" />
 			<description>
-				Register a [param method] that will be called when the action is committed.
+				Register a [Callable] that will be called when the action is committed.
 			</description>
 		</method>
 		<method name="add_do_property">
@@ -86,12 +85,11 @@
 				Register a reference for "do" that will be erased if the "do" history is lost. This is useful mostly for new nodes created for the "do" call. Do not use for resources.
 			</description>
 		</method>
-		<method name="add_undo_method" qualifiers="vararg">
+		<method name="add_undo_method">
 			<return type="void" />
-			<param index="0" name="object" type="Object" />
-			<param index="1" name="method" type="StringName" />
+			<param index="0" name="callable" type="Callable" />
 			<description>
-				Register a [param method] that will be called when the action is undone.
+				Register a [Callable] that will be called when the action is undone.
 			</description>
 		</method>
 		<method name="add_undo_property">

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -131,12 +131,12 @@ void EditorUndoRedoManager::create_action(const String &p_name, UndoRedo::MergeM
 
 void EditorUndoRedoManager::add_do_methodp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount) {
 	UndoRedo *undo_redo = get_history_for_object(p_object).undo_redo;
-	undo_redo->add_do_methodp(p_object, p_method, p_args, p_argcount);
+	undo_redo->add_do_method(Callable(p_object, p_method).bindp(p_args, p_argcount));
 }
 
 void EditorUndoRedoManager::add_undo_methodp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount) {
 	UndoRedo *undo_redo = get_history_for_object(p_object).undo_redo;
-	undo_redo->add_undo_methodp(p_object, p_method, p_args, p_argcount);
+	undo_redo->add_undo_method(Callable(p_object, p_method).bindp(p_args, p_argcount));
 }
 
 void EditorUndoRedoManager::_add_do_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {


### PR DESCRIPTION
This PR makes UndoRedo use Callables. Everything now uses EditorUndoRedoManager, so this is a pretty low-impact change. But it paves the road for changing EditorUndoRedoManager too in the future.

Note that, while you can use GDScript lambdas in UndoRedo and it works, right now it will print an error, because the method name can't be obtained. We need some sort of "get method safe" in CallableCustom to prevent this. For now it's not important though.

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/5038