### PR TITLE
Fix physics events being interpreted twice for nodes in canvas layer

### DIFF
--- a/doc/classes/PhysicsPointQueryParameters2D.xml
+++ b/doc/classes/PhysicsPointQueryParameters2D.xml
@@ -11,6 +11,7 @@
 	<members>
 		<member name="canvas_instance_id" type="int" setter="set_canvas_instance_id" getter="get_canvas_instance_id" default="0">
 			If different from [code]0[/code], restricts the query to a specific canvas layer specified by its instance ID. See [method Object.get_instance_id].
+			If [code]0[/code], restricts the query to the Viewport's default canvas layer.
 		</member>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
 			If [code]true[/code], the query will take [Area2D]s into account.

--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -83,7 +83,7 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PointParameters &p_par
 			continue;
 		}
 
-		if (p_parameters.canvas_instance_id.is_valid() && col_obj->get_canvas_instance_id() != p_parameters.canvas_instance_id) {
+		if (col_obj->get_canvas_instance_id() != p_parameters.canvas_instance_id) {
 			continue;
 		}
 


### PR DESCRIPTION
resolve #64652

Currently `GodotPhysicsDirectSpaceState2D::intersect_point` returns, when given the default viewport canvas layer as argument, also `ShapeResult`s that belong to other canvas layers within the current viewport.
Since canvas layer of these nodes can have a different transform, they may not intersect with the given point.

This patch introduces an additional parameter to `PhysicsPointQueryParameters2D`, which governs how `canvas_instance_id == 0` should be handled.

Updated 2022-12-12: Fix merge conflict