### PR TITLE
Expose ProjectSettings.set_restart_if_changed(name, restart)

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1139,6 +1139,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_order", "name"), &ProjectSettings::get_order);
 	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value"), &ProjectSettings::set_initial_value);
 	ClassDB::bind_method(D_METHOD("add_property_info", "hint"), &ProjectSettings::_add_property_info_bind);
+	ClassDB::bind_method(D_METHOD("set_restart_if_changed", "name", "restart"), &ProjectSettings::set_restart_if_changed);
 	ClassDB::bind_method(D_METHOD("clear", "name"), &ProjectSettings::clear);
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -159,6 +159,15 @@
 				Sets the order of a configuration value (influences when saved to the config file).
 			</description>
 		</method>
+		<method name="set_restart_if_changed">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="restart" type="bool" />
+			<description>
+				Sets whether a setting requires restarting the editor to properly take effect.
+				[b]Note:[/b] This is just a hint to display to the user that the editor must be restarted for changes to take effect. Enabling [method set_restart_if_changed] does [i]not[/i] delay the setting being set when changed.
+			</description>
+		</method>
 		<method name="set_setting">
 			<return type="void" />
 			<param index="0" name="name" type="String" />


### PR DESCRIPTION
This is necessary for plugins and extensions to define project settings that require an editor restart.

Initially, I wanted to introduce this to the `add_property_info` function by supporting `usage`, since `PROPERTY_USAGE_RESTART_IF_CHANGED` exists and all can be specified in a single call. But then I found that `ProjectSettings` stores settings information differently for "custom" properties, and didn't use `usage` at all. Instead `restart_if_changed` is a separate boolean in a separate struct `VariantContainer`, set with another method, `set_restart_if_changed`. No idea why that is, so I thought of exposing that one then.