### PR TITLE
Expose `EditorProperty._set_read_only` virtual method

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_set_read_only" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="read_only" type="bool" />
+			<description>
+				Called when the read-only status of the property is changed. It may be used to change custom controls into a read-only or modifiable state.
+			</description>
+		</method>
 		<method name="_update_property" qualifiers="virtual">
 			<return type="void" />
 			<description>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -426,6 +426,9 @@ void EditorProperty::_set_read_only(bool p_read_only) {
 
 void EditorProperty::set_read_only(bool p_read_only) {
 	read_only = p_read_only;
+	if (GDVIRTUAL_CALL(_set_read_only, p_read_only)) {
+		return;
+	}
 	_set_read_only(p_read_only);
 }
 
@@ -985,6 +988,8 @@ void EditorProperty::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::STRING, "path"), PropertyInfo(Variant::INT, "focusable_idx")));
 
 	GDVIRTUAL_BIND(_update_property)
+	GDVIRTUAL_BIND(_set_read_only, "read_only")
+
 	ClassDB::bind_method(D_METHOD("_update_editor_property_status"), &EditorProperty::update_editor_property_status);
 }
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -120,6 +120,8 @@ private:
 	HashMap<StringName, Variant> cache;
 
 	GDVIRTUAL0(_update_property)
+	GDVIRTUAL1(_set_read_only, bool)
+
 	void _update_pin_flags();
 
 protected:


### PR DESCRIPTION
This is required for supporting read-only state in custom EditorProperties.