### PR TITLE
GLTF: Store extensions in GLTFState and get supported extensions from GLTFDocumentExtension

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocumentExtension.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtension.xml
@@ -30,6 +30,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_supported_extensions" qualifiers="virtual">
+			<return type="PackedStringArray" />
+			<description>
+				Returns an array of the GLTF extensions supported by this GLTFDocumentExtension class. This is used to validate if a GLTF file with required extensions can be loaded.
+			</description>
+		</method>
 		<method name="_import_node" qualifiers="virtual">
 			<return type="int" />
 			<param index="0" name="state" type="GLTFState" />

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -7,6 +7,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="add_used_extension">
+			<return type="void" />
+			<param index="0" name="extension_name" type="String" />
+			<param index="1" name="required" type="bool" />
+			<description>
+				Appends an extension to the list of extensions used by this GLTF file during serialization. If [param required] is true, the extension will also be added to the list of required extensions. Do not run this in [method GLTFDocumentExtension._export_post], as that stage is too late to add extensions. The final list is sorted alphabetically.
+			</description>
+		</method>
 		<method name="get_accessors">
 			<return type="GLTFAccessor[]" />
 			<description>

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -265,7 +265,7 @@ private:
 	Dictionary _serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_material);
 	Error _serialize_version(Ref<GLTFState> state);
 	Error _serialize_file(Ref<GLTFState> state, const String p_path);
-	Error _serialize_extensions(Ref<GLTFState> state) const;
+	Error _serialize_gltf_extensions(Ref<GLTFState> state) const;
 
 public:
 	// https://www.itu.int/rec/R-REC-BT.601

--- a/modules/gltf/gltf_document_extension.cpp
+++ b/modules/gltf/gltf_document_extension.cpp
@@ -31,6 +31,7 @@
 #include "gltf_document_extension.h"
 
 void GLTFDocumentExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_get_supported_extensions);
 	GDVIRTUAL_BIND(_import_preflight, "state");
 	GDVIRTUAL_BIND(_import_post_parse, "state");
 	GDVIRTUAL_BIND(_import_node, "state", "gltf_node", "json", "node");
@@ -38,6 +39,12 @@ void GLTFDocumentExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_export_preflight, "root");
 	GDVIRTUAL_BIND(_export_node, "state", "gltf_node", "json", "node");
 	GDVIRTUAL_BIND(_export_post, "state");
+}
+
+Vector<String> GLTFDocumentExtension::get_supported_extensions() {
+	Vector<String> ret;
+	GDVIRTUAL_CALL(_get_supported_extensions, ret);
+	return ret;
 }
 
 Error GLTFDocumentExtension::import_post(Ref<GLTFState> p_state, Node *p_root) {

--- a/modules/gltf/gltf_document_extension.h
+++ b/modules/gltf/gltf_document_extension.h
@@ -41,6 +41,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Vector<String> get_supported_extensions();
 	virtual Error import_preflight(Ref<GLTFState> p_state);
 	virtual Error import_post_parse(Ref<GLTFState> p_state);
 	virtual Error export_post(Ref<GLTFState> p_state);
@@ -48,6 +49,7 @@ public:
 	virtual Error export_preflight(Node *p_state);
 	virtual Error import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node);
 	virtual Error export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node);
+	GDVIRTUAL0R(Vector<String>, _get_supported_extensions);
 	GDVIRTUAL1R(int, _import_preflight, Ref<GLTFState>);
 	GDVIRTUAL1R(int, _import_post_parse, Ref<GLTFState>);
 	GDVIRTUAL4R(int, _import_node, Ref<GLTFState>, Ref<GLTFNode>, Dictionary, Node *);

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -31,6 +31,7 @@
 #include "gltf_state.h"
 
 void GLTFState::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_used_extension", "extension_name", "required"), &GLTFState::add_used_extension);
 	ClassDB::bind_method(D_METHOD("get_json"), &GLTFState::get_json);
 	ClassDB::bind_method(D_METHOD("set_json", "json"), &GLTFState::set_json);
 	ClassDB::bind_method(D_METHOD("get_major_version"), &GLTFState::get_major_version);
@@ -110,6 +111,17 @@ void GLTFState::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "skeleton_to_node", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_skeleton_to_node", "get_skeleton_to_node"); // RBMap<GLTFSkeletonIndex,
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "create_animations"), "set_create_animations", "get_create_animations"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "animations", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_animations", "get_animations"); // Vector<Ref<GLTFAnimation>>
+}
+
+void GLTFState::add_used_extension(const String &p_extension_name, bool p_required) {
+	if (!extensions_used.has(p_extension_name)) {
+		extensions_used.push_back(p_extension_name);
+	}
+	if (p_required) {
+		if (!extensions_required.has(p_extension_name)) {
+			extensions_required.push_back(p_extension_name);
+		}
+	}
 }
 
 Dictionary GLTFState::get_json() {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -78,6 +78,8 @@ class GLTFState : public Resource {
 	Vector<int> root_nodes;
 	Vector<Ref<GLTFTexture>> textures;
 	Vector<Ref<Texture2D>> images;
+	Vector<String> extensions_used;
+	Vector<String> extensions_required;
 
 	Vector<Ref<GLTFSkin>> skins;
 	Vector<Ref<GLTFCamera>> cameras;
@@ -97,6 +99,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	void add_used_extension(const String &p_extension, bool p_required = false);
+
 	Dictionary get_json();
 	void set_json(Dictionary p_json);
 


### PR DESCRIPTION
* Make used extensions be stored in GLTFState. This allows GLTFDocumentExtension classes to add to the used extensions array.
* Add a way to get the GLTF extensions supported by GLTFDocumentExtension. It will check the required extensions during import, and print a message for each unsupported required extension.

These changes were built with https://github.com/godotengine/godot/pull/66026 in mind, in fact this PR is a subset of it. These changes are mostly useful with that PR, but technically changing how the list of GLTF extensions is stored, and adding the ability for GLTFDocumentExtension to say which GLTF extensions it supports, is not dependent on refactoring how GLTFDocumentExtension classes are registered with GLTFDocument. So I split out this PR for easier reviewing.

This work was sponsored by The Mirror.