### PR TITLE
Use `Vector2i` when returning atlas size in `Geometry2D::make_atlas`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -810,14 +810,13 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 
 	::Geometry2D::make_atlas(rects, result, size);
 
-	Size2 r_size = size;
 	Vector<Point2> r_result;
 	for (int i = 0; i < result.size(); i++) {
 		r_result.push_back(result[i]);
 	}
 
 	ret["points"] = r_result;
-	ret["size"] = r_size;
+	ret["size"] = size;
 
 	return ret;
 }

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -126,7 +126,7 @@
 			<return type="Dictionary" />
 			<param index="0" name="sizes" type="PackedVector2Array" />
 			<description>
-				Given an array of [Vector2]s representing tiles, builds an atlas. The returned dictionary has two keys: [code]points[/code] is an array of [Vector2] that specifies the positions of each tile, [code]size[/code] contains the overall size of the whole atlas as [Vector2].
+				Given an array of [Vector2]s representing tiles, builds an atlas. The returned dictionary has two keys: [code]points[/code] is a [PackedVector2Array] that specifies the positions of each tile, [code]size[/code] contains the overall size of the whole atlas as [Vector2i].
 			</description>
 		</method>
 		<method name="merge_polygons">


### PR DESCRIPTION
I also wanted to change the array of `Vector2` `points` into a `PackedVector2iArray`, but that type wasn't added to `Variant`. Will have to keep converting the data from `float` to `int` in GDExtension.