### PR TITLE
Expose `SceneTree.get_process_time()`

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -124,6 +124,12 @@
 				Returns a list of all nodes assigned to the given group.
 			</description>
 		</method>
+		<method name="get_process_time" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the time elapsed since the last rendering frame, in seconds.
+			</description>
+		</method>
 		<method name="get_processed_tweens">
 			<return type="Tween[]" />
 			<description>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1272,6 +1272,8 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_multiplayer_poll_enabled", "enabled"), &SceneTree::set_multiplayer_poll_enabled);
 	ClassDB::bind_method(D_METHOD("is_multiplayer_poll_enabled"), &SceneTree::is_multiplayer_poll_enabled);
 
+	ClassDB::bind_method(D_METHOD("get_process_time"), &SceneTree::get_process_time);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_accept_quit"), "set_auto_accept_quit", "is_auto_accept_quit");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "quit_on_go_back"), "set_quit_on_go_back", "is_quit_on_go_back");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_collisions_hint"), "set_debug_collisions_hint", "is_debugging_collisions_hint");


### PR DESCRIPTION
This allows to access a `delta` time equivalent when using `_notification` instead of `_process`, mainly for convenience to keep source compatible when compiling C++ as a module or a GDExtension.