### PR TITLE
Fix possible crash in editor help

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -324,11 +324,16 @@ bool EditorHelpSearch::Runner::_phase_match_classes_init() {
 }
 
 bool EditorHelpSearch::Runner::_phase_match_classes() {
+	if (!iterator_doc) {
+		return true;
+	}
+
 	DocData::ClassDoc &class_doc = iterator_doc->value;
 	if (class_doc.name.is_empty()) {
 		++iterator_doc;
 		return false;
 	}
+
 	if (!_is_class_disabled_by_feature_profile(class_doc.name)) {
 		ClassMatch match;
 		match.doc = &class_doc;


### PR DESCRIPTION
Fixes the crash mentioned in https://github.com/godotengine/godot/issues/63129#issuecomment-1248759466

It crashes on the `if (class_doc.name.is_empty())` line. This condition was already sus for me, but the crash requires a specific setup, so I didn't detect it before.