### PR TITLE
Expose `EditorInspector.get_selected_path`

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -13,6 +13,14 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_selected_path" qualifiers="const">
+			<return type="String" />
+			<description>
+				Gets the path of the currently selected property.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="0" />
 	</members>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4060,6 +4060,7 @@ void EditorInspector::_show_add_meta_dialog() {
 
 void EditorInspector::_bind_methods() {
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
+	ClassDB::bind_method("get_selected_path", &EditorInspector::get_selected_path);
 
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::BOOL, "advance")));


### PR DESCRIPTION
Currently needed in cases similar to `GridMap`'s `MeshLibrary`, where removing an item in the inspector requires to know which property is selected.