### PR TITLE
Make `EditorInterface.get_editor_scale()` static

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -72,7 +72,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_editor_scale" qualifiers="const">
+		<method name="get_editor_scale" qualifiers="static">
 			<return type="float" />
 			<description>
 				Returns the actual scale of the editor UI ([code]1.0[/code] being 100% scale). This can be used to adjust position and dimensions of the UI added by plugins.

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -277,7 +277,7 @@ Control *EditorInterface::get_base_control() {
 	return EditorNode::get_singleton()->get_gui_base();
 }
 
-float EditorInterface::get_editor_scale() const {
+float EditorInterface::get_editor_scale() {
 	return EDSCALE;
 }
 
@@ -336,7 +336,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
 	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
 	ClassDB::bind_method(D_METHOD("get_base_control"), &EditorInterface::get_base_control);
-	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
+	ClassDB::bind_static_method(EditorInterface::get_class_static(), D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
 	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
 	ClassDB::bind_method(D_METHOD("edit_node", "node"), &EditorInterface::edit_node);
 	ClassDB::bind_method(D_METHOD("edit_script", "script", "line", "column", "grab_focus"), &EditorInterface::edit_script, DEFVAL(-1), DEFVAL(0), DEFVAL(true));

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -108,7 +108,7 @@ public:
 	FileSystemDock *get_file_system_dock();
 
 	Control *get_base_control();
-	float get_editor_scale() const;
+	static float get_editor_scale();
 
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;


### PR DESCRIPTION
To avoid having to do workarounds like this https://github.com/Zylann/godot_voxel/blob/41e364624fd5b038ad296eefeb7bfddebea9c697/util/godot/editor_scale.cpp#L10

`EditorInterface` is internally a singleton though, so if it is desired to expose it entirely as a singleton, it could be changed.