### PR TITLE
CPUParticles initialize data on set_amount

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -62,6 +62,11 @@ void CPUParticles2D::set_amount(int p_amount) {
 	}
 
 	particle_data.resize((8 + 4 + 1) * p_amount);
+	// We must fill immediately to prevent garbage data and Nans
+	// being sent to the visual server with set_as_bulk_array,
+	// if this is sent before being regularly updated.
+	particle_data.fill(0);
+
 	VS::get_singleton()->multimesh_allocate(multimesh, p_amount, VS::MULTIMESH_TRANSFORM_2D, VS::MULTIMESH_COLOR_8BIT, VS::MULTIMESH_CUSTOM_DATA_FLOAT);
 
 	particle_order.resize(p_amount);

--- a/scene/3d/cpu_particles.cpp
+++ b/scene/3d/cpu_particles.cpp
@@ -85,6 +85,13 @@ void CPUParticles::set_amount(int p_amount) {
 
 	particle_data.resize((12 + 4 + 1) * p_amount);
 	particle_data_prev.resize(particle_data.size());
+
+	// We must fill immediately to prevent garbage data and Nans
+	// being sent to the visual server with set_as_bulk_array,
+	// if this is sent before being regularly updated.
+	particle_data.fill(0);
+	particle_data_prev.fill(0);
+
 	VS::get_singleton()->multimesh_allocate(multimesh, p_amount, VS::MULTIMESH_TRANSFORM_3D, VS::MULTIMESH_COLOR_8BIT, VS::MULTIMESH_CUSTOM_DATA_FLOAT);
 
 	particle_order.resize(p_amount);


### PR DESCRIPTION
Fills particle data with zeroes on resize using set_amount(), to prevent garbage data including Nans being sent to VisualServer, which can corrupt the spatial partitioning.

Fixes #65841

## Notes
* Interesting this had never been spotted before.
* I checked and it existed in 3.4, before any changes due to physics interpolation (indeed the same bug exists in 2D which has no interpolation).
* The bug occurs because `set_bulk_array` can be called for the multimesh before the particle data is properly filled.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
