### PR TITLE
Remove `convert()` utility method

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -58,22 +58,6 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="convert">
-			<return type="Variant" />
-			<param index="0" name="what" type="Variant" />
-			<param index="1" name="type" type="int" />
-			<description>
-				Converts from a type to another in the best way possible. The [code]type[/code] parameter uses the [enum Variant.Type] values.
-				[codeblock]
-				a = Vector2(1, 0)
-				# Prints 1
-				print(a.length())
-				a = convert(a, TYPE_STRING)
-				# Prints 6 as "(1, 0)" is 6 characters
-				print(a.length())
-				[/codeblock]
-			</description>
-		</method>
 		<method name="dict_to_inst">
 			<return type="Object" />
 			<param index="0" name="dictionary" type="Dictionary" />

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -84,22 +84,6 @@
 #endif
 
 struct GDScriptUtilityFunctionsDefinitions {
-	static inline void convert(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		VALIDATE_ARG_COUNT(2);
-		VALIDATE_ARG_INT(1);
-		int type = *p_args[1];
-		if (type < 0 || type >= Variant::VARIANT_MAX) {
-			*r_ret = RTR("Invalid type argument to convert(), use TYPE_* constants.");
-			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
-			r_error.argument = 0;
-			r_error.expected = Variant::INT;
-			return;
-
-		} else {
-			Variant::construct(Variant::Type(type), *r_ret, p_args, 1, r_error);
-		}
-	}
-
 	static inline void type_exists(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 		*r_ret = ClassDB::class_exists(*p_args[0]);
@@ -647,7 +631,6 @@ static void _register_function(const String &p_name, const MethodInfo &p_method_
 	PropertyInfo(Variant::NIL, m_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT)
 
 void GDScriptUtilityFunctions::register_functions() {
-	REGISTER_VARIANT_FUNC(convert, true, VARARG("what"), ARG("type", Variant::INT));
 	REGISTER_FUNC(type_exists, true, Variant::BOOL, ARG("type", Variant::STRING_NAME));
 	REGISTER_FUNC(_char, true, Variant::STRING, ARG("char", Variant::INT));
 	REGISTER_VARARG_FUNC(str, true, Variant::STRING);


### PR DESCRIPTION
This method simply calls the constructor of the target type. It *might* be useful e.g. if you want to pass the type as parameter to have some generic conversion function, but it's some weird edge case and it's unsafe. You can achieve the same using a series of ifs..

Closes #5523
Closes #65919