### PR TITLE
Add documentation note about `JSON.parse` not being spec compliant

### DIFF
--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -28,6 +28,11 @@
 		[codeblock]
 		var data = JSON.parse_string(json_string) # Returns null if parsing failed.
 		[/codeblock]
+		[b]Note:[/b] Both parse methods do not fully comply with the JSON specification:
+		- Trailing commas in arrays or objects are ignored, instead of causing a parser error.
+		- New line and tab characters are accepted in string literals, and are treated like their corresponding escape sequences [code]\n[/code] and [code]\t[/code].
+		- Numbers are parsed using [method String.to_float] which is generally more lax than the JSON specification.
+		- Certain errors, such as invalid Unicode sequences, do not cause a parser error. Instead, the string is cleansed and an error is logged to the console.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Part of #66114 
Fixes #40394

List all known differences between Godot's JSON parser and the specs, as taken from #66114.
The crashes are not listed here as they are fixed in #66117. Invalid escape sequences are fixed in #66170.