### PR TITLE
Delete `set_all`, `set_axis`, and `get_axis` methods from Vector2/3/3i/4/4i

### DIFF
--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -251,7 +251,9 @@ struct BVH_ABB {
 
 	void expand(real_t p_change) {
 		POINT change;
-		change.set_all(p_change);
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+			change[axis] = p_change;
+		}
 		grow(change);
 	}
 
@@ -262,7 +264,9 @@ struct BVH_ABB {
 	}
 
 	void set_to_max_opposite_extents() {
-		neg_max.set_all(FLT_MAX);
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+			neg_max[axis] = FLT_MAX;
+		}
 		min = neg_max;
 	}
 

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -69,10 +69,6 @@ struct _NO_DISCARD_ Vector2 {
 		return coord[p_idx];
 	}
 
-	_FORCE_INLINE_ void set_all(const real_t p_value) {
-		x = y = p_value;
-	}
-
 	_FORCE_INLINE_ Vector2::Axis min_axis_index() const {
 		return x < y ? Vector2::AXIS_X : Vector2::AXIS_Y;
 	}

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -45,16 +45,6 @@ Vector3 Vector3::rotated(const Vector3 &p_axis, const real_t p_angle) const {
 	return r;
 }
 
-void Vector3::set_axis(const int p_axis, const real_t p_value) {
-	ERR_FAIL_INDEX(p_axis, 3);
-	coord[p_axis] = p_value;
-}
-
-real_t Vector3::get_axis(const int p_axis) const {
-	ERR_FAIL_INDEX_V(p_axis, 3, 0);
-	return operator[](p_axis);
-}
-
 Vector3 Vector3::clamp(const Vector3 &p_min, const Vector3 &p_max) const {
 	return Vector3(
 			CLAMP(x, p_min.x, p_max.x),

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -68,10 +68,6 @@ struct _NO_DISCARD_ Vector3 {
 		return coord[p_axis];
 	}
 
-	_FORCE_INLINE_ void set_all(const real_t p_value) {
-		x = y = z = p_value;
-	}
-
 	_FORCE_INLINE_ Vector3::Axis min_axis_index() const {
 		return x < y ? (x < z ? Vector3::AXIS_X : Vector3::AXIS_Z) : (y < z ? Vector3::AXIS_Y : Vector3::AXIS_Z);
 	}

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -68,9 +68,6 @@ struct _NO_DISCARD_ Vector3 {
 		return coord[p_axis];
 	}
 
-	void set_axis(const int p_axis, const real_t p_value);
-	real_t get_axis(const int p_axis) const;
-
 	_FORCE_INLINE_ void set_all(const real_t p_value) {
 		x = y = z = p_value;
 	}

--- a/core/math/vector3i.cpp
+++ b/core/math/vector3i.cpp
@@ -33,16 +33,6 @@
 #include "core/math/vector3.h"
 #include "core/string/ustring.h"
 
-void Vector3i::set_axis(const int p_axis, const int32_t p_value) {
-	ERR_FAIL_INDEX(p_axis, 3);
-	coord[p_axis] = p_value;
-}
-
-int32_t Vector3i::get_axis(const int p_axis) const {
-	ERR_FAIL_INDEX_V(p_axis, 3, 0);
-	return operator[](p_axis);
-}
-
 Vector3i::Axis Vector3i::min_axis_index() const {
 	return x < y ? (x < z ? Vector3i::AXIS_X : Vector3i::AXIS_Z) : (y < z ? Vector3i::AXIS_Y : Vector3i::AXIS_Z);
 }

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -64,9 +64,6 @@ struct _NO_DISCARD_ Vector3i {
 		return coord[p_axis];
 	}
 
-	void set_axis(const int p_axis, const int32_t p_value);
-	int32_t get_axis(const int p_axis) const;
-
 	Vector3i::Axis min_axis_index() const;
 	Vector3i::Axis max_axis_index() const;
 

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -33,16 +33,6 @@
 #include "core/math/basis.h"
 #include "core/string/print_string.h"
 
-void Vector4::set_axis(const int p_axis, const real_t p_value) {
-	ERR_FAIL_INDEX(p_axis, 4);
-	components[p_axis] = p_value;
-}
-
-real_t Vector4::get_axis(const int p_axis) const {
-	ERR_FAIL_INDEX_V(p_axis, 4, 0);
-	return operator[](p_axis);
-}
-
 Vector4::Axis Vector4::min_axis_index() const {
 	uint32_t min_index = 0;
 	real_t min_value = x;

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -63,8 +63,6 @@ struct _NO_DISCARD_ Vector4 {
 		return components[p_axis];
 	}
 
-	_FORCE_INLINE_ void set_all(const real_t p_value);
-
 	Vector4::Axis min_axis_index() const;
 	Vector4::Axis max_axis_index() const;
 
@@ -144,10 +142,6 @@ struct _NO_DISCARD_ Vector4 {
 		w = p_vec4.w;
 	}
 };
-
-void Vector4::set_all(const real_t p_value) {
-	x = y = z = p_value;
-}
 
 real_t Vector4::dot(const Vector4 &p_vec4) const {
 	return x * p_vec4.x + y * p_vec4.y + z * p_vec4.z + w * p_vec4.w;

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -65,9 +65,6 @@ struct _NO_DISCARD_ Vector4 {
 
 	_FORCE_INLINE_ void set_all(const real_t p_value);
 
-	void set_axis(const int p_axis, const real_t p_value);
-	real_t get_axis(const int p_axis) const;
-
 	Vector4::Axis min_axis_index() const;
 	Vector4::Axis max_axis_index() const;
 

--- a/core/math/vector4i.cpp
+++ b/core/math/vector4i.cpp
@@ -33,16 +33,6 @@
 #include "core/math/vector4.h"
 #include "core/string/ustring.h"
 
-void Vector4i::set_axis(const int p_axis, const int32_t p_value) {
-	ERR_FAIL_INDEX(p_axis, 4);
-	coord[p_axis] = p_value;
-}
-
-int32_t Vector4i::get_axis(const int p_axis) const {
-	ERR_FAIL_INDEX_V(p_axis, 4, 0);
-	return operator[](p_axis);
-}
-
 Vector4i::Axis Vector4i::min_axis_index() const {
 	uint32_t min_index = 0;
 	int32_t min_value = x;

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -66,9 +66,6 @@ struct _NO_DISCARD_ Vector4i {
 		return coord[p_axis];
 	}
 
-	void set_axis(const int p_axis, const int32_t p_value);
-	int32_t get_axis(const int p_axis) const;
-
 	Vector4i::Axis min_axis_index() const;
 	Vector4i::Axis max_axis_index() const;
 

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -76,16 +76,12 @@ TEST_CASE("[Vector3] Axis methods") {
 			vector.min_axis_index() == Vector3::Axis::AXIS_X,
 			"Vector3 min_axis_index should work as expected.");
 	CHECK_MESSAGE(
-			vector.get_axis(vector.max_axis_index()) == (real_t)5.6,
-			"Vector3 get_axis should work as expected.");
+			vector[vector.max_axis_index()] == (real_t)5.6,
+			"Vector3 array operator should work as expected.");
 	CHECK_MESSAGE(
 			vector[vector.min_axis_index()] == (real_t)1.2,
 			"Vector3 array operator should work as expected.");
 
-	vector.set_axis(Vector3::Axis::AXIS_Y, 4.7);
-	CHECK_MESSAGE(
-			vector.get_axis(Vector3::Axis::AXIS_Y) == (real_t)4.7,
-			"Vector3 set_axis should work as expected.");
 	vector[Vector3::Axis::AXIS_Y] = 3.7;
 	CHECK_MESSAGE(
 			vector[Vector3::Axis::AXIS_Y] == (real_t)3.7,

--- a/tests/core/math/test_vector3i.h
+++ b/tests/core/math/test_vector3i.h
@@ -45,16 +45,12 @@ TEST_CASE("[Vector3i] Axis methods") {
 			vector.min_axis_index() == Vector3i::Axis::AXIS_X,
 			"Vector3i min_axis_index should work as expected.");
 	CHECK_MESSAGE(
-			vector.get_axis(vector.max_axis_index()) == 3,
-			"Vector3i get_axis should work as expected.");
+			vector[vector.max_axis_index()] == 3,
+			"Vector3i array operator should work as expected.");
 	CHECK_MESSAGE(
 			vector[vector.min_axis_index()] == 1,
 			"Vector3i array operator should work as expected.");
 
-	vector.set_axis(Vector3i::Axis::AXIS_Y, 4);
-	CHECK_MESSAGE(
-			vector.get_axis(Vector3i::Axis::AXIS_Y) == 4,
-			"Vector3i set_axis should work as expected.");
 	vector[Vector3i::Axis::AXIS_Y] = 5;
 	CHECK_MESSAGE(
 			vector[Vector3i::Axis::AXIS_Y] == 5,

--- a/tests/core/math/test_vector4.h
+++ b/tests/core/math/test_vector4.h
@@ -47,16 +47,12 @@ TEST_CASE("[Vector4] Axis methods") {
 			vector.min_axis_index() == Vector4::Axis::AXIS_W,
 			"Vector4 min_axis_index should work as expected.");
 	CHECK_MESSAGE(
-			vector.get_axis(vector.max_axis_index()) == (real_t)5.6,
-			"Vector4 get_axis should work as expected.");
+			vector[vector.max_axis_index()] == (real_t)5.6,
+			"Vector4 array operator should work as expected.");
 	CHECK_MESSAGE(
 			vector[vector.min_axis_index()] == (real_t)-0.9,
 			"Vector4 array operator should work as expected.");
 
-	vector.set_axis(Vector4::Axis::AXIS_Y, 4.7);
-	CHECK_MESSAGE(
-			vector.get_axis(Vector4::Axis::AXIS_Y) == (real_t)4.7,
-			"Vector4 set_axis should work as expected.");
 	vector[Vector4::Axis::AXIS_Y] = 3.7;
 	CHECK_MESSAGE(
 			vector[Vector4::Axis::AXIS_Y] == (real_t)3.7,

--- a/tests/core/math/test_vector4i.h
+++ b/tests/core/math/test_vector4i.h
@@ -45,16 +45,12 @@ TEST_CASE("[Vector4i] Axis methods") {
 			vector.min_axis_index() == Vector4i::Axis::AXIS_X,
 			"Vector4i min_axis_index should work as expected.");
 	CHECK_MESSAGE(
-			vector.get_axis(vector.max_axis_index()) == 4,
-			"Vector4i get_axis should work as expected.");
+			vector[vector.max_axis_index()] == 4,
+			"Vector4i array operator should work as expected.");
 	CHECK_MESSAGE(
 			vector[vector.min_axis_index()] == 1,
 			"Vector4i array operator should work as expected.");
 
-	vector.set_axis(Vector4i::Axis::AXIS_Y, 5);
-	CHECK_MESSAGE(
-			vector.get_axis(Vector4i::Axis::AXIS_Y) == 5,
-			"Vector4i set_axis should work as expected.");
 	vector[Vector4i::Axis::AXIS_Y] = 5;
 	CHECK_MESSAGE(
 			vector[Vector4i::Axis::AXIS_Y] == 5,


### PR DESCRIPTION
`set_all` is not a very useful method, it was only used in one place in BVH. However, the rest of the BVH code just iterates over the axis count, so this PR changes the `set_all` code to use this approach and removes `set_all`. Also, `set_all` was broken in Vector4, which is what got me investigating this method in the first place.

I deleted the `set_axis` and `get_axis` methods because they are not used internally anywhere (except for the tests) and they do the same thing as the array operator anyway. Also, Vector2i did not have it.