### PR TITLE
Define AXIS_COUNT in all vector math types

### DIFF
--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -38,6 +38,8 @@ class String;
 struct Vector2;
 
 struct _NO_DISCARD_ Vector2i {
+	static const int AXIS_COUNT = 2;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -38,6 +38,8 @@ class String;
 struct Vector3;
 
 struct _NO_DISCARD_ Vector3i {
+	static const int AXIS_COUNT = 3;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -37,6 +37,8 @@
 #include "core/string/ustring.h"
 
 struct _NO_DISCARD_ Vector4 {
+	static const int AXIS_COUNT = 4;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -38,6 +38,8 @@ class String;
 struct Vector4;
 
 struct _NO_DISCARD_ Vector4i {
+	static const int AXIS_COUNT = 4;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,


### PR DESCRIPTION
`AXIS_COUNT` is currently defined on Vector2 and Vector3 but missing from Vector4 and Vector2i/3i/4i. This PR fixes that.