### PR TITLE
Improve signal already connected error message

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1477,7 +1477,9 @@ Error Object::connect(const StringName &p_signal, Object *p_to_object, const Str
 			s->slot_map[target].reference_count++;
 			return OK;
 		} else {
-			ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, "Signal '" + p_signal + "' is already connected to given method '" + p_to_method + "' in that object.");
+			ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER,
+					vformat("Signal \"%s\" from \"%s\" is already connected to given method \"%s\" in \"%s\".",
+							p_signal, to_string(), p_to_method, p_to_object->to_string()));
 		}
 	}
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2126,6 +2126,8 @@ void Node::get_storable_properties(Set<StringName> &r_storable_properties) const
 }
 
 String Node::to_string() {
+	// This code doesn't print the script's name, it calls to_string() if you override it in a Node's script,
+	// which you only do if you specifically want to customize how the node should be represented by print().
 	if (get_script_instance()) {
 		bool valid;
 		String ret = get_script_instance()->to_string(&valid);


### PR DESCRIPTION
The signal already connected message is improved to provide the names of the objects involved.

## Notes
* It is important to know the objects that are involved rather than just the signals, in order to debug in any significantly complex project.
* This was originally added as part of the merging PR, in order to investigate a possible bug, which may be an existing engine bug (rather than caused by merging).

## Sample Output

### Before
```
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.
 Signal 'fired' is already connected to given method 'play' in that object.
 Signal 'out_of_ammo' is already connected to given method 'play' in that object.
 Signal 'released_clip_send_clip_obj_path' is already connected to given method 'spawn_clip' in that object.
 Signal 'released_clip_send_clip_obj_path' is already connected to given method 'spawn_clip' in that object.
 Signal 'velocity_updated' is already connected to given method 'update_velocity' in that object.
 Signal 'velocity_updated' is already connected to given method 'update_velocity' in that object.
 Signal 'visually_fired' is already connected to given method 'flash' in that object.
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.
 Signal 'fired' is already connected to given method 'play' in that object.
 Signal 'out_of_ammo' is already connected to given method 'play' in that object.
 Signal 'released_clip_send_clip_obj_path' is already connected to given method 'spawn_clip' in that object.
 Signal 'released_clip_send_clip_obj_path' is already connected to given method 'spawn_clip' in that object.
 Signal 'velocity_updated' is already connected to given method 'update_velocity' in that object.
 Signal 'velocity_updated' is already connected to given method 'update_velocity' in that object.
 Signal 'visually_fired' is already connected to given method 'flash' in that object.
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.
 Signal 'entered_attack_state' is already connected to given method 'play_alert_sound' in that object.

```

### After
```
 Signal "entered_attack_state" from "Colonist:[KinematicBody:44963]" is already connected to given method "play_alert_sound" in "Colonist:[KinematicBody:44963]".
 Signal "entered_attack_state" from "Colonist3:[KinematicBody:45502]" is already connected to given method "play_alert_sound" in "Colonist3:[KinematicBody:45502]".
 Signal "entered_attack_state" from "Colonist2:[KinematicBody:46041]" is already connected to given method "play_alert_sound" in "Colonist2:[KinematicBody:46041]".
 Signal "fired" from "DoubleBarrelShotgun:[RigidBody:46580]" is already connected to given method "play" in "GunShotSounds:[Spatial:46619]".
 Signal "out_of_ammo" from "DoubleBarrelShotgun:[RigidBody:46580]" is already connected to given method "play" in "OutOfAmmoSound:[AudioStreamPlayer3D:46632]".
 Signal "released_clip_send_clip_obj_path" from "DoubleBarrelShotgun:[RigidBody:46580]" is already connected to given method "spawn_clip" in "AmmoClipSpawner:[Spatial:46600]".
 Signal "released_clip_send_clip_obj_path" from "DoubleBarrelShotgun:[RigidBody:46580]" is already connected to given method "spawn_clip" in "AmmoClipSpawner2:[Spatial:46603]".
 Signal "velocity_updated" from "DoubleBarrelShotgun:[RigidBody:46580]" is already connected to given method "update_velocity" in "AmmoClipSpawner:[Spatial:46600]".
 Signal "velocity_updated" from "DoubleBarrelShotgun:[RigidBody:46580]" is already connected to given method "update_velocity" in "AmmoClipSpawner2:[Spatial:46603]".
 Signal "visually_fired" from "DoubleBarrelShotgun:[RigidBody:46580]" is already connected to given method "flash" in "MuzzleFlash:[Spatial:46592]".
 Signal "entered_attack_state" from "Colonist4:[KinematicBody:46742]" is already connected to given method "play_alert_sound" in "Colonist4:[KinematicBody:46742]".
 Signal "fired" from "DoubleBarrelShotgun:[RigidBody:47281]" is already connected to given method "play" in "GunShotSounds:[Spatial:47317]".
 Signal "out_of_ammo" from "DoubleBarrelShotgun:[RigidBody:47281]" is already connected to given method "play" in "OutOfAmmoSound:[AudioStreamPlayer3D:47330]".
 Signal "released_clip_send_clip_obj_path" from "DoubleBarrelShotgun:[RigidBody:47281]" is already connected to given method "spawn_clip" in "AmmoClipSpawner:[Spatial:47298]".
 Signal "released_clip_send_clip_obj_path" from "DoubleBarrelShotgun:[RigidBody:47281]" is already connected to given method "spawn_clip" in "AmmoClipSpawner2:[Spatial:47301]".
 Signal "velocity_updated" from "DoubleBarrelShotgun:[RigidBody:47281]" is already connected to given method "update_velocity" in "AmmoClipSpawner:[Spatial:47298]".
 Signal "velocity_updated" from "DoubleBarrelShotgun:[RigidBody:47281]" is already connected to given method "update_velocity" in "AmmoClipSpawner2:[Spatial:47301]".
 Signal "visually_fired" from "DoubleBarrelShotgun:[RigidBody:47281]" is already connected to given method "flash" in "MuzzleFlash:[Spatial:47290]".
 Signal "entered_attack_state" from "Colonist5:[KinematicBody:47440]" is already connected to given method "play_alert_sound" in "Colonist5:[KinematicBody:47440]".
```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
