### PR TITLE
[3.x] Don't store frame of playing AnimatedSprite

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -347,6 +347,11 @@ void AnimatedSprite::_validate_property(PropertyInfo &property) const {
 	}
 
 	if (property.name == "frame") {
+		if (playing) {
+			property.usage = PROPERTY_USAGE_EDITOR;
+			return;
+		}
+
 		property.hint = PROPERTY_HINT_RANGE;
 		if (frames->has_animation(animation) && frames->get_frame_count(animation) > 1) {
 			property.hint_string = "0," + itos(frames->get_frame_count(animation) - 1) + ",1";
@@ -590,6 +595,7 @@ void AnimatedSprite::set_playing(bool p_playing) {
 	playing = p_playing;
 	_reset_timeout();
 	set_process_internal(playing);
+	property_list_changed_notify();
 }
 
 bool AnimatedSprite::is_playing() const {

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -987,6 +987,11 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &property) const {
 	}
 
 	if (property.name == "frame") {
+		if (playing) {
+			property.usage = PROPERTY_USAGE_EDITOR;
+			return;
+		}
+
 		property.hint = PROPERTY_HINT_RANGE;
 		if (frames->has_animation(animation) && frames->get_frame_count(animation) > 1) {
 			property.hint_string = "0," + itos(frames->get_frame_count(animation) - 1) + ",1";
@@ -1139,6 +1144,7 @@ void AnimatedSprite3D::_set_playing(bool p_playing) {
 	playing = p_playing;
 	_reset_timeout();
 	set_process_internal(playing);
+	property_list_changed_notify();
 }
 
 bool AnimatedSprite3D::_is_playing() const {


### PR DESCRIPTION
Backport of #65720

Instead of disabling the property, it's being hidden:
![godot windows tools 64_nsHM8GZEV6](https://user-images.githubusercontent.com/2223172/191239218-d87458a8-3f79-4019-817c-f0394bb4056b.gif)
Alternatively we could still show it, but just don't store the value. But maybe that would be confusing, idk.