### PR TITLE
Use double instead of real_t type for time-related parameters and variables

### DIFF
--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -104,7 +104,7 @@ float AudioStreamPlaybackMP3::get_stream_sampling_rate() {
 	return mp3_stream->sample_rate;
 }
 
-void AudioStreamPlaybackMP3::start(float p_from_pos) {
+void AudioStreamPlaybackMP3::start(double p_from_pos) {
 	active = true;
 	seek(p_from_pos);
 	loops = 0;
@@ -123,11 +123,11 @@ int AudioStreamPlaybackMP3::get_loop_count() const {
 	return loops;
 }
 
-float AudioStreamPlaybackMP3::get_playback_position() const {
-	return float(frames_mixed) / mp3_stream->sample_rate;
+double AudioStreamPlaybackMP3::get_playback_position() const {
+	return double(frames_mixed) / mp3_stream->sample_rate;
 }
 
-void AudioStreamPlaybackMP3::seek(float p_time) {
+void AudioStreamPlaybackMP3::seek(double p_time) {
 	if (!active) {
 		return;
 	}
@@ -217,15 +217,15 @@ bool AudioStreamMP3::has_loop() const {
 	return loop;
 }
 
-void AudioStreamMP3::set_loop_offset(float p_seconds) {
+void AudioStreamMP3::set_loop_offset(double p_seconds) {
 	loop_offset = p_seconds;
 }
 
-float AudioStreamMP3::get_loop_offset() const {
+double AudioStreamMP3::get_loop_offset() const {
 	return loop_offset;
 }
 
-float AudioStreamMP3::get_length() const {
+double AudioStreamMP3::get_length() const {
 	return length;
 }
 

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -61,14 +61,14 @@ protected:
 	virtual float get_stream_sampling_rate() override;
 
 public:
-	virtual void start(float p_from_pos = 0.0) override;
+	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 
 	virtual int get_loop_count() const override; //times it looped
 
-	virtual float get_playback_position() const override;
-	virtual void seek(float p_time) override;
+	virtual double get_playback_position() const override;
+	virtual void seek(double p_time) override;
 
 	virtual void tag_used_streams() override;
 
@@ -104,8 +104,8 @@ public:
 	void set_loop(bool p_enable);
 	virtual bool has_loop() const override;
 
-	void set_loop_offset(float p_seconds);
-	float get_loop_offset() const;
+	void set_loop_offset(double p_seconds);
+	double get_loop_offset() const;
 
 	void set_bpm(double p_bpm);
 	virtual double get_bpm() const override;
@@ -122,7 +122,7 @@ public:
 	void set_data(const Vector<uint8_t> &p_data);
 	Vector<uint8_t> get_data() const;
 
-	virtual float get_length() const override;
+	virtual double get_length() const override;
 
 	virtual bool is_monophonic() const override;
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -357,7 +357,7 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 	audio_frames_wrote = 0;
 };
 
-float VideoStreamPlaybackTheora::get_time() const {
+double VideoStreamPlaybackTheora::get_time() const {
 	// FIXME: AudioServer output latency was fixed in af9bb0e, previously it used to
 	// systematically return 0. Now that it gives a proper latency, it broke this
 	// code where the delay compensation likely never really worked.
@@ -368,7 +368,7 @@ Ref<Texture2D> VideoStreamPlaybackTheora::get_texture() const {
 	return texture;
 }
 
-void VideoStreamPlaybackTheora::update(float p_delta) {
+void VideoStreamPlaybackTheora::update(double p_delta) {
 	if (file.is_null()) {
 		return;
 	}
@@ -529,7 +529,7 @@ void VideoStreamPlaybackTheora::update(float p_delta) {
 			//printf("frame at %f not ready (time %f), ready %i\n", (float)videobuf_time, get_time(), videobuf_ready);
 		}
 
-		float tdiff = videobuf_time - get_time();
+		double tdiff = videobuf_time - get_time();
 		/*If we have lots of extra time, increase the post-processing level.*/
 		if (tdiff > ti.fps_denominator * 0.25 / ti.fps_numerator) {
 			pp_inc = pp_level < pp_level_max ? 1 : 0;
@@ -581,7 +581,7 @@ bool VideoStreamPlaybackTheora::has_loop() const {
 	return false;
 };
 
-float VideoStreamPlaybackTheora::get_length() const {
+double VideoStreamPlaybackTheora::get_length() const {
 	return 0;
 };
 
@@ -593,11 +593,11 @@ int VideoStreamPlaybackTheora::get_loop_count() const {
 	return 0;
 };
 
-float VideoStreamPlaybackTheora::get_playback_position() const {
+double VideoStreamPlaybackTheora::get_playback_position() const {
 	return get_time();
 };
 
-void VideoStreamPlaybackTheora::seek(float p_time) {
+void VideoStreamPlaybackTheora::seek(double p_time) {
 	WARN_PRINT_ONCE("Seeking in Theora videos is not implemented yet (it's only supported for GDExtension-provided video streams).");
 }
 

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -64,7 +64,7 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 	int buffer_data();
 	int queue_page(ogg_page *page);
 	void video_write();
-	float get_time() const;
+	double get_time() const;
 
 	bool theora_eos = false;
 	bool vorbis_eos = false;
@@ -136,19 +136,19 @@ public:
 	virtual void set_loop(bool p_enable) override;
 	virtual bool has_loop() const override;
 
-	virtual float get_length() const override;
+	virtual double get_length() const override;
 
 	virtual String get_stream_name() const;
 
 	virtual int get_loop_count() const;
 
-	virtual float get_playback_position() const override;
-	virtual void seek(float p_time) override;
+	virtual double get_playback_position() const override;
+	virtual void seek(double p_time) override;
 
 	void set_file(const String &p_file);
 
 	virtual Ref<Texture2D> get_texture() const override;
-	virtual void update(float p_delta) override;
+	virtual void update(double p_delta) override;
 
 	virtual void set_mix_callback(AudioMixCallback p_callback, void *p_userdata) override;
 	virtual int get_channels() const override;

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -223,7 +223,7 @@ bool AudioStreamPlaybackOggVorbis::_alloc_vorbis() {
 	return true;
 }
 
-void AudioStreamPlaybackOggVorbis::start(float p_from_pos) {
+void AudioStreamPlaybackOggVorbis::start(double p_from_pos) {
 	ERR_FAIL_COND(!ready);
 	loop_fade_remaining = FADE_SIZE;
 	active = true;
@@ -244,15 +244,15 @@ int AudioStreamPlaybackOggVorbis::get_loop_count() const {
 	return loops;
 }
 
-float AudioStreamPlaybackOggVorbis::get_playback_position() const {
-	return float(frames_mixed) / vorbis_data->get_sampling_rate();
+double AudioStreamPlaybackOggVorbis::get_playback_position() const {
+	return double(frames_mixed) / (double)vorbis_data->get_sampling_rate();
 }
 
 void AudioStreamPlaybackOggVorbis::tag_used_streams() {
 	vorbis_stream->tag_used(get_playback_position());
 }
 
-void AudioStreamPlaybackOggVorbis::seek(float p_time) {
+void AudioStreamPlaybackOggVorbis::seek(double p_time) {
 	ERR_FAIL_COND(!ready);
 	ERR_FAIL_COND(vorbis_stream.is_null());
 	if (!active) {
@@ -462,15 +462,15 @@ bool AudioStreamOggVorbis::has_loop() const {
 	return loop;
 }
 
-void AudioStreamOggVorbis::set_loop_offset(float p_seconds) {
+void AudioStreamOggVorbis::set_loop_offset(double p_seconds) {
 	loop_offset = p_seconds;
 }
 
-float AudioStreamOggVorbis::get_loop_offset() const {
+double AudioStreamOggVorbis::get_loop_offset() const {
 	return loop_offset;
 }
 
-float AudioStreamOggVorbis::get_length() const {
+double AudioStreamOggVorbis::get_length() const {
 	ERR_FAIL_COND_V(packet_sequence.is_null(), 0);
 	return packet_sequence->get_length();
 }

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -83,14 +83,14 @@ protected:
 	virtual float get_stream_sampling_rate() override;
 
 public:
-	virtual void start(float p_from_pos = 0.0) override;
+	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 
 	virtual int get_loop_count() const override; //times it looped
 
-	virtual float get_playback_position() const override;
-	virtual void seek(float p_time) override;
+	virtual double get_playback_position() const override;
+	virtual void seek(double p_time) override;
 
 	virtual void tag_used_streams() override;
 
@@ -127,8 +127,8 @@ public:
 	void set_loop(bool p_enable);
 	virtual bool has_loop() const override;
 
-	void set_loop_offset(float p_seconds);
-	float get_loop_offset() const;
+	void set_loop_offset(double p_seconds);
+	double get_loop_offset() const;
 
 	void set_bpm(double p_bpm);
 	virtual double get_bpm() const override;
@@ -145,7 +145,7 @@ public:
 	void set_packet_sequence(Ref<OggPacketSequence> p_packet_sequence);
 	Ref<OggPacketSequence> get_packet_sequence() const;
 
-	virtual float get_length() const override; //if supported, otherwise return 0
+	virtual double get_length() const override; //if supported, otherwise return 0
 
 	virtual bool is_monophonic() const override;
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -217,19 +217,19 @@ Variant AnimationNodeOneShot::get_parameter_default_value(const StringName &p_pa
 	}
 }
 
-void AnimationNodeOneShot::set_fadein_time(float p_time) {
+void AnimationNodeOneShot::set_fadein_time(double p_time) {
 	fade_in = p_time;
 }
 
-void AnimationNodeOneShot::set_fadeout_time(float p_time) {
+void AnimationNodeOneShot::set_fadeout_time(double p_time) {
 	fade_out = p_time;
 }
 
-float AnimationNodeOneShot::get_fadein_time() const {
+double AnimationNodeOneShot::get_fadein_time() const {
 	return fade_in;
 }
 
-float AnimationNodeOneShot::get_fadeout_time() const {
+double AnimationNodeOneShot::get_fadeout_time() const {
 	return fade_out;
 }
 
@@ -237,11 +237,11 @@ void AnimationNodeOneShot::set_autorestart(bool p_active) {
 	autorestart = p_active;
 }
 
-void AnimationNodeOneShot::set_autorestart_delay(float p_time) {
+void AnimationNodeOneShot::set_autorestart_delay(double p_time) {
 	autorestart_delay = p_time;
 }
 
-void AnimationNodeOneShot::set_autorestart_random_delay(float p_time) {
+void AnimationNodeOneShot::set_autorestart_random_delay(double p_time) {
 	autorestart_random_delay = p_time;
 }
 
@@ -249,11 +249,11 @@ bool AnimationNodeOneShot::has_autorestart() const {
 	return autorestart;
 }
 
-float AnimationNodeOneShot::get_autorestart_delay() const {
+double AnimationNodeOneShot::get_autorestart_delay() const {
 	return autorestart_delay;
 }
 
-float AnimationNodeOneShot::get_autorestart_random_delay() const {
+double AnimationNodeOneShot::get_autorestart_random_delay() const {
 	return autorestart_random_delay;
 }
 
@@ -313,7 +313,7 @@ double AnimationNodeOneShot::process(double p_time, bool p_seek, bool p_seek_roo
 		set_parameter(this->prev_active, true);
 	}
 
-	float blend;
+	real_t blend;
 
 	if (time < fade_in) {
 		if (fade_in > 0) {
@@ -351,7 +351,7 @@ double AnimationNodeOneShot::process(double p_time, bool p_seek, bool p_seek_roo
 			set_parameter(this->active, false);
 			set_parameter(this->prev_active, false);
 			if (autorestart) {
-				float restart_sec = autorestart_delay + Math::randf() * autorestart_random_delay;
+				double restart_sec = autorestart_delay + Math::randd() * autorestart_random_delay;
 				set_parameter(this->time_to_restart, restart_sec);
 			}
 		}
@@ -676,11 +676,11 @@ String AnimationNodeTransition::get_input_caption(int p_input) const {
 	return inputs[p_input].name;
 }
 
-void AnimationNodeTransition::set_xfade_time(float p_fade) {
+void AnimationNodeTransition::set_xfade_time(double p_fade) {
 	xfade_time = p_fade;
 }
 
-float AnimationNodeTransition::get_xfade_time() const {
+double AnimationNodeTransition::get_xfade_time() const {
 	return xfade_time;
 }
 
@@ -748,7 +748,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_seek_
 
 	} else { // cross-fading from prev to current
 
-		float blend = xfade_time == 0 ? 0 : (prev_xfading / xfade_time);
+		real_t blend = xfade_time == 0 ? 0 : (prev_xfading / xfade_time);
 		if (xfade_curve.is_valid()) {
 			blend = xfade_curve->sample(blend);
 		}

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -102,18 +102,18 @@ public:
 	};
 
 private:
-	float fade_in = 0.0;
-	float fade_out = 0.0;
+	double fade_in = 0.0;
+	double fade_out = 0.0;
 
 	bool autorestart = false;
-	float autorestart_delay = 1.0;
-	float autorestart_random_delay = 0.0;
+	double autorestart_delay = 1.0;
+	double autorestart_random_delay = 0.0;
 	MixMode mix = MIX_MODE_BLEND;
 
 	/*	bool active;
 	bool do_start;
-	float time;
-	float remaining;*/
+	double time;
+	double remaining;*/
 
 	StringName active = PNAME("active");
 	StringName prev_active = "prev_active";
@@ -130,19 +130,19 @@ public:
 
 	virtual String get_caption() const override;
 
-	void set_fadein_time(float p_time);
-	void set_fadeout_time(float p_time);
+	void set_fadein_time(double p_time);
+	void set_fadeout_time(double p_time);
 
-	float get_fadein_time() const;
-	float get_fadeout_time() const;
+	double get_fadein_time() const;
+	double get_fadeout_time() const;
 
 	void set_autorestart(bool p_active);
-	void set_autorestart_delay(float p_time);
-	void set_autorestart_random_delay(float p_time);
+	void set_autorestart_delay(double p_time);
+	void set_autorestart_random_delay(double p_time);
 
 	bool has_autorestart() const;
-	float get_autorestart_delay() const;
-	float get_autorestart_random_delay() const;
+	double get_autorestart_delay() const;
+	double get_autorestart_random_delay() const;
 
 	void set_mix_mode(MixMode p_mix);
 	MixMode get_mix_mode() const;
@@ -285,9 +285,9 @@ class AnimationNodeTransition : public AnimationNodeSync {
 	int enabled_inputs = 0;
 
 	/*
-	float prev_xfading;
+	double prev_xfading;
 	int prev;
-	float time;
+	double time;
 	int current;
 	int prev_current; */
 
@@ -297,7 +297,7 @@ class AnimationNodeTransition : public AnimationNodeSync {
 	StringName current = PNAME("current");
 	StringName prev_current = "prev_current";
 
-	float xfade_time = 0.0;
+	double xfade_time = 0.0;
 	Ref<Curve> xfade_curve;
 	bool from_start = true;
 
@@ -322,8 +322,8 @@ public:
 	void set_input_caption(int p_input, const String &p_name);
 	String get_input_caption(int p_input) const;
 
-	void set_xfade_time(float p_fade);
-	float get_xfade_time() const;
+	void set_xfade_time(double p_fade);
+	double get_xfade_time() const;
 
 	void set_xfade_curve(const Ref<Curve> &p_curve);
 	Ref<Curve> get_xfade_curve() const;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -156,7 +156,7 @@ bool AnimationPlayer::_get(const StringName &p_name, Variant &r_ret) const {
 
 	} else if (name == "blend_times") {
 		Vector<BlendKey> keys;
-		for (const KeyValue<BlendKey, float> &E : blend_times) {
+		for (const KeyValue<BlendKey, double> &E : blend_times) {
 			keys.ordered_insert(E.key);
 		}
 
@@ -216,7 +216,7 @@ void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "blend_times", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 }
 
-void AnimationPlayer::advance(float p_time) {
+void AnimationPlayer::advance(double p_time) {
 	_animation_process(p_time);
 }
 
@@ -1287,7 +1287,7 @@ void AnimationPlayer::_animation_removed(const StringName &p_name, const StringN
 
 	// Erase blends if needed
 	List<BlendKey> to_erase;
-	for (const KeyValue<BlendKey, float> &E : blend_times) {
+	for (const KeyValue<BlendKey, double> &E : blend_times) {
 		BlendKey bk = E.key;
 		if (bk.from == name || bk.to == name) {
 			to_erase.push_back(bk);
@@ -1303,8 +1303,8 @@ void AnimationPlayer::_animation_removed(const StringName &p_name, const StringN
 void AnimationPlayer::_rename_animation(const StringName &p_from_name, const StringName &p_to_name) {
 	// Rename autoplay or blends if needed.
 	List<BlendKey> to_erase;
-	HashMap<BlendKey, float, BlendKey> to_insert;
-	for (const KeyValue<BlendKey, float> &E : blend_times) {
+	HashMap<BlendKey, double, BlendKey> to_insert;
+	for (const KeyValue<BlendKey, double> &E : blend_times) {
 		BlendKey bk = E.key;
 		BlendKey new_bk = bk;
 		bool erase = false;
@@ -1523,7 +1523,7 @@ void AnimationPlayer::get_animation_list(List<StringName> *p_animations) const {
 	}
 }
 
-void AnimationPlayer::set_blend_time(const StringName &p_animation1, const StringName &p_animation2, float p_time) {
+void AnimationPlayer::set_blend_time(const StringName &p_animation1, const StringName &p_animation2, double p_time) {
 	ERR_FAIL_COND_MSG(!animation_set.has(p_animation1), vformat("Animation not found: %s.", p_animation1));
 	ERR_FAIL_COND_MSG(!animation_set.has(p_animation2), vformat("Animation not found: %s.", p_animation2));
 	ERR_FAIL_COND_MSG(p_time < 0, "Blend time cannot be smaller than 0.");
@@ -1538,7 +1538,7 @@ void AnimationPlayer::set_blend_time(const StringName &p_animation1, const Strin
 	}
 }
 
-float AnimationPlayer::get_blend_time(const StringName &p_animation1, const StringName &p_animation2) const {
+double AnimationPlayer::get_blend_time(const StringName &p_animation1, const StringName &p_animation2) const {
 	BlendKey bk;
 	bk.from = p_animation1;
 	bk.to = p_animation2;
@@ -1571,11 +1571,11 @@ void AnimationPlayer::clear_queue() {
 	queued.clear();
 }
 
-void AnimationPlayer::play_backwards(const StringName &p_name, float p_custom_blend) {
+void AnimationPlayer::play_backwards(const StringName &p_name, double p_custom_blend) {
 	play(p_name, p_custom_blend, -1, true);
 }
 
-void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float p_custom_scale, bool p_from_end) {
+void AnimationPlayer::play(const StringName &p_name, double p_custom_blend, float p_custom_scale, bool p_from_end) {
 	StringName name = p_name;
 
 	if (String(name) == "") {
@@ -1587,7 +1587,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 	Playback &c = playback;
 
 	if (c.current.from) {
-		float blend_time = 0.0;
+		double blend_time = 0.0;
 		// find if it can blend
 		BlendKey bk;
 		bk.from = c.current.from->name;
@@ -1741,7 +1741,7 @@ void AnimationPlayer::seek(double p_time, bool p_update) {
 	}
 }
 
-void AnimationPlayer::seek_delta(double p_time, float p_delta) {
+void AnimationPlayer::seek_delta(double p_time, double p_delta) {
 	if (!playback.current.from) {
 		if (playback.assigned) {
 			ERR_FAIL_COND_MSG(!animation_set.has(playback.assigned), vformat("Animation not found: %s.", playback.assigned));
@@ -1762,12 +1762,12 @@ bool AnimationPlayer::is_valid() const {
 	return (playback.current.from);
 }
 
-float AnimationPlayer::get_current_animation_position() const {
+double AnimationPlayer::get_current_animation_position() const {
 	ERR_FAIL_COND_V_MSG(!playback.current.from, 0, "AnimationPlayer has no current animation");
 	return playback.current.pos;
 }
 
-float AnimationPlayer::get_current_animation_length() const {
+double AnimationPlayer::get_current_animation_length() const {
 	ERR_FAIL_COND_V_MSG(!playback.current.from, 0, "AnimationPlayer has no current animation");
 	return playback.current.from->animation->get_length();
 }
@@ -1933,11 +1933,11 @@ StringName AnimationPlayer::animation_get_next(const StringName &p_animation) co
 	return animation_set[p_animation].next;
 }
 
-void AnimationPlayer::set_default_blend_time(float p_default) {
+void AnimationPlayer::set_default_blend_time(double p_default) {
 	default_blend_time = p_default;
 }
 
-float AnimationPlayer::get_default_blend_time() const {
+double AnimationPlayer::get_default_blend_time() const {
 	return default_blend_time;
 }
 

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -191,7 +191,7 @@ private:
 
 	uint64_t accum_pass = 1;
 	float speed_scale = 1.0;
-	float default_blend_time = 0.0;
+	double default_blend_time = 0.0;
 
 	struct AnimationData {
 		String name;
@@ -230,7 +230,7 @@ private:
 		}
 	};
 
-	HashMap<BlendKey, float, BlendKey> blend_times;
+	HashMap<BlendKey, double, BlendKey> blend_times;
 
 	struct PlaybackData {
 		AnimationData *from = nullptr;
@@ -241,8 +241,8 @@ private:
 	struct Blend {
 		PlaybackData data;
 
-		float blend_time = 0.0;
-		float blend_left = 0.0;
+		double blend_time = 0.0;
+		double blend_left = 0.0;
 	};
 
 	struct Playback {
@@ -334,17 +334,17 @@ public:
 	void get_animation_list(List<StringName> *p_animations) const;
 	bool has_animation(const StringName &p_name) const;
 
-	void set_blend_time(const StringName &p_animation1, const StringName &p_animation2, float p_time);
-	float get_blend_time(const StringName &p_animation1, const StringName &p_animation2) const;
+	void set_blend_time(const StringName &p_animation1, const StringName &p_animation2, double p_time);
+	double get_blend_time(const StringName &p_animation1, const StringName &p_animation2) const;
 
 	void animation_set_next(const StringName &p_animation, const StringName &p_next);
 	StringName animation_get_next(const StringName &p_animation) const;
 
-	void set_default_blend_time(float p_default);
-	float get_default_blend_time() const;
+	void set_default_blend_time(double p_default);
+	double get_default_blend_time() const;
 
-	void play(const StringName &p_name = StringName(), float p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
-	void play_backwards(const StringName &p_name = StringName(), float p_custom_blend = -1);
+	void play(const StringName &p_name = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
+	void play_backwards(const StringName &p_name = StringName(), double p_custom_blend = -1);
 	void queue(const StringName &p_name);
 	Vector<String> get_queue();
 	void clear_queue();
@@ -378,11 +378,11 @@ public:
 	bool is_movie_quit_on_finish_enabled() const;
 
 	void seek(double p_time, bool p_update = false);
-	void seek_delta(double p_time, float p_delta);
-	float get_current_animation_position() const;
-	float get_current_animation_length() const;
+	void seek_delta(double p_time, double p_delta);
+	double get_current_animation_position() const;
+	double get_current_animation_length() const;
 
-	void advance(float p_time);
+	void advance(double p_time);
 
 	void set_root(const NodePath &p_root);
 	NodePath get_root() const;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1745,7 +1745,7 @@ Variant AnimationTree::_post_process_key_value(const Ref<Animation> &p_anim, int
 	return p_value;
 }
 
-void AnimationTree::advance(real_t p_time) {
+void AnimationTree::advance(double p_time) {
 	_process_graph(p_time);
 }
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -353,7 +353,7 @@ public:
 	Transform3D get_root_motion_transform() const;
 
 	real_t get_connection_activity(const StringName &p_path, int p_connection) const;
-	void advance(real_t p_time);
+	void advance(double p_time);
 
 	void rename_parameter(const String &p_base, const String &p_new_base);
 

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -42,13 +42,13 @@ class Tweener : public RefCounted {
 public:
 	virtual void set_tween(Ref<Tween> p_tween);
 	virtual void start() = 0;
-	virtual bool step(float &r_delta) = 0;
+	virtual bool step(double &r_delta) = 0;
 	void clear_tween();
 
 protected:
 	static void _bind_methods();
 	Ref<Tween> tween;
-	float elapsed_time = 0;
+	double elapsed_time = 0;
 	bool finished = false;
 };
 
@@ -103,7 +103,7 @@ private:
 	ObjectID bound_node;
 
 	Vector<List<Ref<Tweener>>> tweeners;
-	float total_time = 0;
+	double total_time = 0;
 	int current_step = -1;
 	int loops = 1;
 	int loops_done = 0;
@@ -129,13 +129,13 @@ protected:
 	static void _bind_methods();
 
 public:
-	Ref<PropertyTweener> tween_property(Object *p_target, NodePath p_property, Variant p_to, float p_duration);
-	Ref<IntervalTweener> tween_interval(float p_time);
+	Ref<PropertyTweener> tween_property(Object *p_target, NodePath p_property, Variant p_to, double p_duration);
+	Ref<IntervalTweener> tween_interval(double p_time);
 	Ref<CallbackTweener> tween_callback(Callable p_callback);
-	Ref<MethodTweener> tween_method(Callable p_callback, Variant p_from, Variant p_to, float p_duration);
+	Ref<MethodTweener> tween_method(Callable p_callback, Variant p_from, Variant p_to, double p_duration);
 	void append(Ref<Tweener> p_tweener);
 
-	bool custom_step(float p_delta);
+	bool custom_step(double p_delta);
 	void stop();
 	void pause();
 	void play();
@@ -163,12 +163,12 @@ public:
 	Ref<Tween> chain();
 
 	static real_t run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t t, real_t b, real_t c, real_t d);
-	static Variant interpolate_variant(Variant p_initial_val, Variant p_delta_val, float p_time, float p_duration, Tween::TransitionType p_trans, Tween::EaseType p_ease);
+	static Variant interpolate_variant(Variant p_initial_val, Variant p_delta_val, double p_time, double p_duration, Tween::TransitionType p_trans, Tween::EaseType p_ease);
 
-	bool step(float p_delta);
+	bool step(double p_delta);
 	bool can_process(bool p_tree_paused) const;
 	Node *get_bound_node() const;
-	float get_total_time() const;
+	double get_total_time() const;
 
 	Tween();
 	Tween(bool p_valid);
@@ -188,13 +188,13 @@ public:
 	Ref<PropertyTweener> as_relative();
 	Ref<PropertyTweener> set_trans(Tween::TransitionType p_trans);
 	Ref<PropertyTweener> set_ease(Tween::EaseType p_ease);
-	Ref<PropertyTweener> set_delay(float p_delay);
+	Ref<PropertyTweener> set_delay(double p_delay);
 
 	void set_tween(Ref<Tween> p_tween) override;
 	void start() override;
-	bool step(float &r_delta) override;
+	bool step(double &r_delta) override;
 
-	PropertyTweener(Object *p_target, NodePath p_property, Variant p_to, float p_duration);
+	PropertyTweener(Object *p_target, NodePath p_property, Variant p_to, double p_duration);
 	PropertyTweener();
 
 protected:
@@ -208,11 +208,11 @@ private:
 	Variant final_val;
 	Variant delta_val;
 
-	float duration = 0;
+	double duration = 0;
 	Tween::TransitionType trans_type = Tween::TRANS_MAX; // This is set inside set_tween();
 	Tween::EaseType ease_type = Tween::EASE_MAX;
 
-	float delay = 0;
+	double delay = 0;
 	bool do_continue = true;
 	bool relative = false;
 };
@@ -222,23 +222,23 @@ class IntervalTweener : public Tweener {
 
 public:
 	void start() override;
-	bool step(float &r_delta) override;
+	bool step(double &r_delta) override;
 
-	IntervalTweener(float p_time);
+	IntervalTweener(double p_time);
 	IntervalTweener();
 
 private:
-	float duration = 0;
+	double duration = 0;
 };
 
 class CallbackTweener : public Tweener {
 	GDCLASS(CallbackTweener, Tweener);
 
 public:
-	Ref<CallbackTweener> set_delay(float p_delay);
+	Ref<CallbackTweener> set_delay(double p_delay);
 
 	void start() override;
-	bool step(float &r_delta) override;
+	bool step(double &r_delta) override;
 
 	CallbackTweener(Callable p_callback);
 	CallbackTweener();
@@ -248,7 +248,7 @@ protected:
 
 private:
 	Callable callback;
-	float delay = 0;
+	double delay = 0;
 };
 
 class MethodTweener : public Tweener {
@@ -257,21 +257,21 @@ class MethodTweener : public Tweener {
 public:
 	Ref<MethodTweener> set_trans(Tween::TransitionType p_trans);
 	Ref<MethodTweener> set_ease(Tween::EaseType p_ease);
-	Ref<MethodTweener> set_delay(float p_delay);
+	Ref<MethodTweener> set_delay(double p_delay);
 
 	void set_tween(Ref<Tween> p_tween) override;
 	void start() override;
-	bool step(float &r_delta) override;
+	bool step(double &r_delta) override;
 
-	MethodTweener(Callable p_callback, Variant p_from, Variant p_to, float p_duration);
+	MethodTweener(Callable p_callback, Variant p_from, Variant p_to, double p_duration);
 	MethodTweener();
 
 protected:
 	static void _bind_methods();
 
 private:
-	float duration = 0;
-	float delay = 0;
+	double duration = 0;
+	double delay = 0;
 	Tween::TransitionType trans_type = Tween::TRANS_MAX;
 	Tween::EaseType ease_type = Tween::EASE_MAX;
 

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -381,14 +381,14 @@ String VideoStreamPlayer::get_stream_name() const {
 	return stream->get_name();
 }
 
-float VideoStreamPlayer::get_stream_position() const {
+double VideoStreamPlayer::get_stream_position() const {
 	if (playback.is_null()) {
 		return 0;
 	}
 	return playback->get_playback_position();
 }
 
-void VideoStreamPlayer::set_stream_position(float p_position) {
+void VideoStreamPlayer::set_stream_position(double p_position) {
 	if (playback.is_valid()) {
 		playback->seek(p_position);
 	}

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -105,8 +105,8 @@ public:
 	float get_volume_db() const;
 
 	String get_stream_name() const;
-	float get_stream_position() const;
-	void set_stream_position(float p_position);
+	double get_stream_position() const;
+	void set_stream_position(double p_position);
 
 	void set_autoplay(bool p_enable);
 	bool has_autoplay() const;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -510,7 +510,7 @@ bool SceneTree::process(double p_time) {
 	return _quit;
 }
 
-void SceneTree::process_timers(float p_delta, bool p_physics_frame) {
+void SceneTree::process_timers(double p_delta, bool p_physics_frame) {
 	List<Ref<SceneTreeTimer>>::Element *L = timers.back(); //last element
 
 	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E;) {
@@ -542,7 +542,7 @@ void SceneTree::process_timers(float p_delta, bool p_physics_frame) {
 	}
 }
 
-void SceneTree::process_tweens(float p_delta, bool p_physics) {
+void SceneTree::process_tweens(double p_delta, bool p_physics) {
 	// This methods works similarly to how SceneTreeTimers are handled.
 	List<Ref<Tween>>::Element *L = tweens.back();
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -180,8 +180,8 @@ private:
 	void node_added(Node *p_node);
 	void node_removed(Node *p_node);
 	void node_renamed(Node *p_node);
-	void process_timers(float p_delta, bool p_physics_frame);
-	void process_tweens(float p_delta, bool p_physics_frame);
+	void process_timers(double p_delta, bool p_physics_frame);
+	void process_tweens(double p_delta, bool p_physics_frame);
 
 	Group *add_to_group(const StringName &p_group, Node *p_node);
 	void remove_from_group(const StringName &p_group, Node *p_node);

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -33,7 +33,7 @@
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 
-void AudioStreamPlaybackWAV::start(float p_from_pos) {
+void AudioStreamPlaybackWAV::start(double p_from_pos) {
 	if (base->format == AudioStreamWAV::FORMAT_IMA_ADPCM) {
 		//no seeking in IMA_ADPCM
 		for (int i = 0; i < 2; i++) {
@@ -67,16 +67,16 @@ int AudioStreamPlaybackWAV::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamPlaybackWAV::get_playback_position() const {
+double AudioStreamPlaybackWAV::get_playback_position() const {
 	return float(offset >> MIX_FRAC_BITS) / base->mix_rate;
 }
 
-void AudioStreamPlaybackWAV::seek(float p_time) {
+void AudioStreamPlaybackWAV::seek(double p_time) {
 	if (base->format == AudioStreamWAV::FORMAT_IMA_ADPCM) {
 		return; //no seeking in ima-adpcm
 	}
 
-	float max = base->get_length();
+	double max = base->get_length();
 	if (p_time < 0) {
 		p_time = 0;
 	} else if (p_time >= max) {
@@ -463,7 +463,7 @@ bool AudioStreamWAV::is_stereo() const {
 	return stereo;
 }
 
-float AudioStreamWAV::get_length() const {
+double AudioStreamWAV::get_length() const {
 	int len = data_bytes;
 	switch (format) {
 		case AudioStreamWAV::FORMAT_8_BITS:
@@ -481,7 +481,7 @@ float AudioStreamWAV::get_length() const {
 		len /= 2;
 	}
 
-	return float(len) / mix_rate;
+	return double(len) / mix_rate;
 }
 
 bool AudioStreamWAV::is_monophonic() const {

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -64,14 +64,14 @@ class AudioStreamPlaybackWAV : public AudioStreamPlayback {
 	void do_resample(const Depth *p_src, AudioFrame *p_dst, int64_t &offset, int32_t &increment, uint32_t amount, IMA_ADPCM_State *ima_adpcm);
 
 public:
-	virtual void start(float p_from_pos = 0.0) override;
+	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 
 	virtual int get_loop_count() const override; //times it looped
 
-	virtual float get_playback_position() const override;
-	virtual void seek(float p_time) override;
+	virtual double get_playback_position() const override;
+	virtual void seek(double p_time) override;
 
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
@@ -137,7 +137,7 @@ public:
 	void set_stereo(bool p_enable);
 	bool is_stereo() const;
 
-	virtual float get_length() const override; //if supported, otherwise return 0
+	virtual double get_length() const override; //if supported, otherwise return 0
 
 	virtual bool is_monophonic() const override;
 

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -50,16 +50,16 @@ public:
 	virtual void set_loop(bool p_enable) = 0;
 	virtual bool has_loop() const = 0;
 
-	virtual float get_length() const = 0;
+	virtual double get_length() const = 0;
 
-	virtual float get_playback_position() const = 0;
-	virtual void seek(float p_time) = 0;
+	virtual double get_playback_position() const = 0;
+	virtual void seek(double p_time) = 0;
 
 	virtual void set_audio_track(int p_idx) = 0;
 
 	virtual Ref<Texture2D> get_texture() const = 0;
 
-	virtual void update(float p_delta) = 0;
+	virtual void update(double p_delta) = 0;
 
 	virtual void set_mix_callback(AudioMixCallback p_callback, void *p_userdata) = 0;
 	virtual int get_channels() const = 0;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -33,7 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 
-void AudioStreamPlayback::start(float p_from_pos) {
+void AudioStreamPlayback::start(double p_from_pos) {
 	if (GDVIRTUAL_CALL(_start, p_from_pos)) {
 		return;
 	}
@@ -61,14 +61,14 @@ int AudioStreamPlayback::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamPlayback::get_playback_position() const {
-	float ret;
+double AudioStreamPlayback::get_playback_position() const {
+	double ret;
 	if (GDVIRTUAL_CALL(_get_playback_position, ret)) {
 		return ret;
 	}
 	ERR_FAIL_V_MSG(0, "AudioStreamPlayback::get_playback_position unimplemented!");
 }
-void AudioStreamPlayback::seek(float p_time) {
+void AudioStreamPlayback::seek(double p_time) {
 	if (GDVIRTUAL_CALL(_seek, p_time)) {
 		return;
 	}
@@ -207,8 +207,8 @@ String AudioStream::get_stream_name() const {
 	return String();
 }
 
-float AudioStream::get_length() const {
-	float ret;
+double AudioStream::get_length() const {
+	double ret;
 	if (GDVIRTUAL_CALL(_get_length, ret)) {
 		return ret;
 	}
@@ -309,7 +309,7 @@ String AudioStreamMicrophone::get_stream_name() const {
 	return "Microphone";
 }
 
-float AudioStreamMicrophone::get_length() const {
+double AudioStreamMicrophone::get_length() const {
 	return 0;
 }
 
@@ -382,7 +382,7 @@ float AudioStreamPlaybackMicrophone::get_stream_sampling_rate() {
 	return AudioDriver::get_singleton()->get_mix_rate();
 }
 
-void AudioStreamPlaybackMicrophone::start(float p_from_pos) {
+void AudioStreamPlaybackMicrophone::start(double p_from_pos) {
 	if (active) {
 		return;
 	}
@@ -415,11 +415,11 @@ int AudioStreamPlaybackMicrophone::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamPlaybackMicrophone::get_playback_position() const {
+double AudioStreamPlaybackMicrophone::get_playback_position() const {
 	return 0;
 }
 
-void AudioStreamPlaybackMicrophone::seek(float p_time) {
+void AudioStreamPlaybackMicrophone::seek(double p_time) {
 	// Can't seek a microphone input
 }
 
@@ -664,7 +664,7 @@ String AudioStreamRandomizer::get_stream_name() const {
 	return "Randomizer";
 }
 
-float AudioStreamRandomizer::get_length() const {
+double AudioStreamRandomizer::get_length() const {
 	return 0;
 }
 
@@ -769,7 +769,7 @@ void AudioStreamRandomizer::_bind_methods() {
 
 AudioStreamRandomizer::AudioStreamRandomizer() {}
 
-void AudioStreamPlaybackRandomizer::start(float p_from_pos) {
+void AudioStreamPlaybackRandomizer::start(double p_from_pos) {
 	playing = playback;
 	{
 		float range_from = 1.0 / randomizer->random_pitch_scale;
@@ -812,7 +812,7 @@ int AudioStreamPlaybackRandomizer::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamPlaybackRandomizer::get_playback_position() const {
+double AudioStreamPlaybackRandomizer::get_playback_position() const {
 	if (playing.is_valid()) {
 		return playing->get_playback_position();
 	}
@@ -820,7 +820,7 @@ float AudioStreamPlaybackRandomizer::get_playback_position() const {
 	return 0;
 }
 
-void AudioStreamPlaybackRandomizer::seek(float p_time) {
+void AudioStreamPlaybackRandomizer::seek(double p_time) {
 	if (playing.is_valid()) {
 		playing->seek(p_time);
 	}

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -47,23 +47,23 @@ class AudioStreamPlayback : public RefCounted {
 
 protected:
 	static void _bind_methods();
-	GDVIRTUAL1(_start, float)
+	GDVIRTUAL1(_start, double)
 	GDVIRTUAL0(_stop)
 	GDVIRTUAL0RC(bool, _is_playing)
 	GDVIRTUAL0RC(int, _get_loop_count)
-	GDVIRTUAL0RC(float, _get_playback_position)
-	GDVIRTUAL1(_seek, float)
+	GDVIRTUAL0RC(double, _get_playback_position)
+	GDVIRTUAL1(_seek, double)
 	GDVIRTUAL3R(int, _mix, GDNativePtr<AudioFrame>, float, int)
 	GDVIRTUAL0(_tag_used_streams)
 public:
-	virtual void start(float p_from_pos = 0.0);
+	virtual void start(double p_from_pos = 0.0);
 	virtual void stop();
 	virtual bool is_playing() const;
 
 	virtual int get_loop_count() const; //times it looped
 
-	virtual float get_playback_position() const;
-	virtual void seek(float p_time);
+	virtual double get_playback_position() const;
+	virtual void seek(double p_time);
 
 	virtual void tag_used_streams();
 
@@ -119,7 +119,7 @@ protected:
 
 	GDVIRTUAL0RC(Ref<AudioStreamPlayback>, _instantiate_playback)
 	GDVIRTUAL0RC(String, _get_stream_name)
-	GDVIRTUAL0RC(float, _get_length)
+	GDVIRTUAL0RC(double, _get_length)
 	GDVIRTUAL0RC(bool, _is_monophonic)
 	GDVIRTUAL0RC(double, _get_bpm)
 	GDVIRTUAL0RC(bool, _has_loop)
@@ -135,7 +135,7 @@ public:
 	virtual int get_bar_beats() const;
 	virtual int get_beat_count() const;
 
-	virtual float get_length() const;
+	virtual double get_length() const;
 	virtual bool is_monophonic() const;
 
 	void tag_used(float p_offset);
@@ -161,7 +161,7 @@ public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
 	virtual String get_stream_name() const override;
 
-	virtual float get_length() const override; //if supported, otherwise return 0
+	virtual double get_length() const override; //if supported, otherwise return 0
 
 	virtual bool is_monophonic() const override;
 
@@ -180,18 +180,18 @@ class AudioStreamPlaybackMicrophone : public AudioStreamPlaybackResampled {
 protected:
 	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
 	virtual float get_stream_sampling_rate() override;
-	virtual float get_playback_position() const override;
+	virtual double get_playback_position() const override;
 
 public:
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
-	virtual void start(float p_from_pos = 0.0) override;
+	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 
 	virtual int get_loop_count() const override; //times it looped
 
-	virtual void seek(float p_time) override;
+	virtual void seek(double p_time) override;
 
 	virtual void tag_used_streams() override;
 
@@ -265,7 +265,7 @@ public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
 	virtual String get_stream_name() const override;
 
-	virtual float get_length() const override; //if supported, otherwise return 0
+	virtual double get_length() const override; //if supported, otherwise return 0
 	virtual bool is_monophonic() const override;
 
 	AudioStreamRandomizer();
@@ -283,14 +283,14 @@ class AudioStreamPlaybackRandomizer : public AudioStreamPlayback {
 	float volume_scale;
 
 public:
-	virtual void start(float p_from_pos = 0.0) override;
+	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 
 	virtual int get_loop_count() const override; //times it looped
 
-	virtual float get_playback_position() const override;
-	virtual void seek(float p_time) override;
+	virtual double get_playback_position() const override;
+	virtual void seek(double p_time) override;
 
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 

--- a/servers/audio/effects/audio_stream_generator.cpp
+++ b/servers/audio/effects/audio_stream_generator.cpp
@@ -60,7 +60,7 @@ String AudioStreamGenerator::get_stream_name() const {
 	return "UserFeed";
 }
 
-float AudioStreamGenerator::get_length() const {
+double AudioStreamGenerator::get_length() const {
 	return 0;
 }
 
@@ -167,7 +167,7 @@ float AudioStreamGeneratorPlayback::get_stream_sampling_rate() {
 	return generator->get_mix_rate();
 }
 
-void AudioStreamGeneratorPlayback::start(float p_from_pos) {
+void AudioStreamGeneratorPlayback::start(double p_from_pos) {
 	if (mixed == 0.0) {
 		begin_resample();
 	}
@@ -188,11 +188,11 @@ int AudioStreamGeneratorPlayback::get_loop_count() const {
 	return 0;
 }
 
-float AudioStreamGeneratorPlayback::get_playback_position() const {
+double AudioStreamGeneratorPlayback::get_playback_position() const {
 	return mixed;
 }
 
-void AudioStreamGeneratorPlayback::seek(float p_time) {
+void AudioStreamGeneratorPlayback::seek(double p_time) {
 	//no seek possible
 }
 

--- a/servers/audio/effects/audio_stream_generator.h
+++ b/servers/audio/effects/audio_stream_generator.h
@@ -53,7 +53,7 @@ public:
 	virtual Ref<AudioStreamPlayback> instantiate_playback() override;
 	virtual String get_stream_name() const override;
 
-	virtual float get_length() const override;
+	virtual double get_length() const override;
 	virtual bool is_monophonic() const override;
 	AudioStreamGenerator();
 };
@@ -74,14 +74,14 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void start(float p_from_pos = 0.0) override;
+	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
 
 	virtual int get_loop_count() const override; //times it looped
 
-	virtual float get_playback_position() const override;
-	virtual void seek(float p_time) override;
+	virtual double get_playback_position() const override;
+	virtual void seek(double p_time) override;
 
 	bool push_frame(const Vector2 &p_frame);
 	bool can_push_buffer(int p_frames) const;

--- a/tests/scene/test_audio_stream_wav.h
+++ b/tests/scene/test_audio_stream_wav.h
@@ -138,7 +138,7 @@ void run_test(String file_name, AudioStreamWAV::Format data_format, bool stereo,
 	CHECK(stream->get_data() == test_data);
 
 	SUBCASE("Stream length is computed properly") {
-		CHECK(Math::is_equal_approx(stream->get_length(), wav_count / wav_rate));
+		CHECK(Math::is_equal_approx(stream->get_length(), double(wav_count / wav_rate)));
 	}
 
 	SUBCASE("Stream can be saved as .wav") {


### PR DESCRIPTION
This is a draft pull request that addresses #65313 in that time-related variables and parameters types have been changed to use double type.
I changed everything I found except the Animation class and some Tween/Tweener types.
I left the Animation class alone as I ignore how much of its data is type delicate.
Tween/Tweener interpolators relies heavily on real_t values. I think it should be using double instead.

*Bugsquad edit:*
- Fixes #65313.