### PR TITLE
Expose the "restart on exit" OS functionality (3.x)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -576,6 +576,29 @@ Vector<String> _OS::get_cmdline_args() {
 	return cmdlinev;
 }
 
+void _OS::set_restart_on_exit(bool p_restart, const Vector<String> &p_restart_arguments) {
+	List<String> args_list;
+	for (int i = 0; i < p_restart_arguments.size(); i++) {
+		args_list.push_back(p_restart_arguments[i]);
+	}
+
+	::OS::get_singleton()->set_restart_on_exit(p_restart, args_list);
+}
+
+bool _OS::is_restart_on_exit_set() const {
+	return ::OS::get_singleton()->is_restart_on_exit_set();
+}
+
+Vector<String> _OS::get_restart_on_exit_arguments() const {
+	List<String> args = ::OS::get_singleton()->get_restart_on_exit_arguments();
+	Vector<String> args_vector;
+	for (List<String>::Element *E = args.front(); E; E = E->next()) {
+		args_vector.push_back(E->get());
+	}
+
+	return args_vector;
+}
+
 String _OS::get_locale() const {
 	return OS::get_singleton()->get_locale();
 }
@@ -1404,6 +1427,10 @@ void _OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_name"), &_OS::get_name);
 	ClassDB::bind_method(D_METHOD("get_cmdline_args"), &_OS::get_cmdline_args);
+
+	ClassDB::bind_method(D_METHOD("set_restart_on_exit", "restart", "arguments"), &_OS::set_restart_on_exit, DEFVAL(Vector<String>()));
+	ClassDB::bind_method(D_METHOD("is_restart_on_exit_set"), &_OS::is_restart_on_exit_set);
+	ClassDB::bind_method(D_METHOD("get_restart_on_exit_arguments"), &_OS::get_restart_on_exit_arguments);
 
 	ClassDB::bind_method(D_METHOD("get_datetime", "utc"), &_OS::get_datetime, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_date", "utc"), &_OS::get_date, DEFVAL(false));

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -272,6 +272,10 @@ public:
 	bool is_process_running(int p_pid) const;
 	int get_process_id() const;
 
+	void set_restart_on_exit(bool p_restart, const Vector<String> &p_restart_arguments = Vector<String>());
+	bool is_restart_on_exit_set() const;
+	Vector<String> get_restart_on_exit_arguments() const;
+
 	bool has_environment(const String &p_var) const;
 	String get_environment(const String &p_var) const;
 	bool set_environment(const String &p_var, const String &p_value) const;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -372,6 +372,12 @@
 				Returns the window size including decorations like window borders.
 			</description>
 		</method>
+		<method name="get_restart_on_exit_arguments" qualifiers="const">
+			<return type="PoolStringArray" />
+			<description>
+				Returns the list of command line arguments that will be used when the project automatically restarts using [method set_restart_on_exit]. See also [method is_restart_on_exit_set].
+			</description>
+		</method>
 		<method name="get_scancode_string" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="code" type="int" />
@@ -700,6 +706,12 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>
 		</method>
+		<method name="is_restart_on_exit_set" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the project will automatically restart when it exits for any reason, [code]false[/code] otherwise. See also [method set_restart_on_exit] and [method get_restart_on_exit_arguments].
+			</description>
+		</method>
 		<method name="is_scancode_unicode" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="code" type="int" />
@@ -945,6 +957,17 @@
 				Sets the game's icon using a multi-size platform-specific icon file ([code]*.ico[/code] on Windows and [code]*.icns[/code] on macOS).
 				Appropriate size sub-icons are used for window caption, taskbar/dock and window selection dialog.
 				[b]Note:[/b] This method is implemented on macOS and Windows.
+			</description>
+		</method>
+		<method name="set_restart_on_exit">
+			<return type="void" />
+			<argument index="0" name="restart" type="bool" />
+			<argument index="1" name="arguments" type="PoolStringArray" default="PoolStringArray(  )" />
+			<description>
+				If [code]restart[/code] is [code]true[/code], restarts the project automatically when it is exited with [method SceneTree.quit] or [constant Node.NOTIFICATION_WM_QUIT_REQUEST]. Command line [code]arguments[/code] can be supplied. To restart the project with the same command line arguments as originally used to run the project, pass [method get_cmdline_args] as the value for [code]arguments[/code].
+				[method set_restart_on_exit] can be used to apply setting changes that require a restart. See also [method is_restart_on_exit_set] and [method get_restart_on_exit_arguments].
+				[b]Note:[/b] This method is only effective on desktop platforms, and only when the project isn't started from the editor. It will have no effect on mobile and Web platforms, or when the project is started from the editor.
+				[b]Note:[/b] If the project process crashes or is [i]killed[/i] by the user (by sending [code]SIGKILL[/code] instead of the usual [code]SIGTERM[/code]), the project won't restart automatically.
 			</description>
 		</method>
 		<method name="set_thread_name">


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/54738.

This can be used to restart a project with specific command line arguments applied. This can work in tandem with `OS.get_cmdline_args()` to restart with the same command line arguments as used to originally run the project.

Example use cases:

- Restart to apply an user setting change that requires a restart to work.
- Restart with a Godot command line argument to change the video driver, audio driver, etc.

*This currently only works if the project is **not** started from the editor.* (It can be started from an editor *binary* via the command-line still.)
I don't know why this happens – help is welcome for troubleshooting this.

**Testing project (`3.x`):** [test_restart_on_exit_3.x.zip](https://github.com/godotengine/godot/files/9609091/test_restart_on_exit_3.x.zip)
