### PR TITLE
Fixed detecting invalid root names in scene creation dialog, issue #66158

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3772,13 +3772,6 @@ bool String::is_absolute_path() const {
 	}
 }
 
-static _FORCE_INLINE_ bool _is_valid_identifier_bit(int p_index, char32_t p_char) {
-	if (p_index == 0 && is_digit(p_char)) {
-		return false; // No start with number plz.
-	}
-	return is_ascii_identifier_char(p_char);
-}
-
 String String::validate_identifier() const {
 	if (is_empty()) {
 		return "_"; // Empty string is not a valid identifier;
@@ -3789,7 +3782,7 @@ String String::validate_identifier() const {
 	char32_t *buffer = result.ptrw();
 
 	for (int i = 0; i < len; i++) {
-		if (!_is_valid_identifier_bit(i, buffer[i])) {
+		if (!is_ascii_identifier_char(buffer[i])) {
 			buffer[i] = '_';
 		}
 	}
@@ -3807,7 +3800,7 @@ bool String::is_valid_identifier() const {
 	const char32_t *str = &operator[](0);
 
 	for (int i = 0; i < len; i++) {
-		if (!_is_valid_identifier_bit(i, str[i])) {
+		if (!is_ascii_identifier_char(str[i])) {
 			return false;
 		}
 	}

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1603,7 +1603,7 @@ TEST_CASE("[String] Is_*") {
 	static bool ishex[12] = { true, true, false, false, true, false, true, false, true, false, false, false };
 	static bool ishex_p[12] = { false, false, false, false, false, false, false, true, false, false, false, false };
 	static bool isflt[12] = { true, true, true, false, true, true, false, false, false, false, false, false };
-	static bool isid[12] = { false, false, false, false, false, false, false, false, true, true, false, false };
+	static bool isid[12] = { false, true, false, false, true, false, true, true, true, true, true, false };
 	for (int i = 0; i < 12; i++) {
 		String s = String(data[i]);
 		CHECK(s.is_numeric() == isnum[i]);
@@ -1642,7 +1642,7 @@ TEST_CASE("[String] validate_identifier") {
 	CHECK(empty_string.validate_identifier() == "_");
 
 	String numeric_only = "12345";
-	CHECK(numeric_only.validate_identifier() == "_2345");
+	CHECK(numeric_only.validate_identifier() == "12345");
 
 	String name_with_spaces = "Name with spaces";
 	CHECK(name_with_spaces.validate_identifier() == "Name_with_spaces");


### PR DESCRIPTION
I made solution to issue [#66158](https://github.com/godotengine/godot/issues/66158). 

I removed `_is_valid_identifier_bit` function and changed its occurrences to `is_ascii_identifier_char`.
