### PR TITLE
`Callable`: add `callv` method

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -63,6 +63,21 @@ void Callable::callp(const Variant **p_arguments, int p_argcount, Variant &r_ret
 	}
 }
 
+Variant Callable::callv(const Array &p_arguments) const {
+	int argcount = p_arguments.size();
+	const Variant **argptrs = nullptr;
+	if (argcount) {
+		argptrs = (const Variant **)alloca(sizeof(Variant *) * argcount);
+		for (int i = 0; i < argcount; i++) {
+			argptrs[i] = &p_arguments[i];
+		}
+	}
+	CallError ce;
+	Variant ret;
+	callp(argptrs, argcount, ret, ce);
+	return ret;
+}
+
 Error Callable::rpcp(int p_id, const Variant **p_arguments, int p_argcount, CallError &r_call_error) const {
 	if (is_null()) {
 		r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -71,6 +71,7 @@ public:
 
 	void callp(const Variant **p_arguments, int p_argcount, Variant &r_return_value, CallError &r_call_error) const;
 	void call_deferredp(const Variant **p_arguments, int p_argcount) const;
+	Variant callv(const Array &p_arguments) const;
 
 	Error rpcp(int p_id, const Variant **p_arguments, int p_argcount, CallError &r_call_error) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1859,6 +1859,7 @@ static void _register_variant_builtin_methods() {
 
 	/* Callable */
 
+	bind_method(Callable, callv, sarray("arguments"), varray());
 	bind_method(Callable, is_null, sarray(), varray());
 	bind_method(Callable, is_custom, sarray(), varray());
 	bind_method(Callable, is_standard, sarray(), varray());

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -81,6 +81,13 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="callv" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="arguments" type="Array" />
+			<description>
+				Calls the method represented by this [Callable]. Contrary to [method call], this method does not take a variable number of arguments but expects all arguments to be passed via a single [Array].
+			</description>
+		</method>
 		<method name="get_method" qualifiers="const">
 			<return type="StringName" />
 			<description>


### PR DESCRIPTION
Analogous to the existing [callv](https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-callv) method on `Object`, this new method on `Callable` takes a single array of arguments.

This method has the advantage that it can be called from GDExtension without vararg template shenanigans. For example, the automatically generated bindings in [godot-cpp](https://github.com/godotengine/godot-cpp) will work out of the box. This is important as it provides the first way to actually call a `Callable` using godot-cpp. (Better ways may be implemented later.)

Together with https://github.com/godotengine/godot/pull/65828, this will unblock ongoing work on custom physics servers.