### PR TITLE
Emulate double precision for regular rendering operation when REAL_T_IS_DOUBLE

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -711,6 +711,14 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 		instance_data.lightmap_uv_scale[2] = inst->lightmap_uv_scale.size.x;
 		instance_data.lightmap_uv_scale[3] = inst->lightmap_uv_scale.size.y;
 
+#ifdef REAL_T_IS_DOUBLE
+		// Split the origin into two components, the float approximation and the missing precision
+		// In the shader we will combine these back together to restore the lost precision.
+		RendererRD::MaterialStorage::split_double(inst->transform.origin.x, &instance_data.transform[12], &instance_data.transform[3]);
+		RendererRD::MaterialStorage::split_double(inst->transform.origin.y, &instance_data.transform[13], &instance_data.transform[7]);
+		RendererRD::MaterialStorage::split_double(inst->transform.origin.z, &instance_data.transform[14], &instance_data.transform[11]);
+#endif
+
 		bool cant_repeat = instance_data.flags & INSTANCE_DATA_FLAG_MULTIMESH || inst->mesh_instance.is_valid();
 
 		if (prev_surface != nullptr && !cant_repeat && prev_surface->sort.sort_key1 == surface->sort.sort_key1 && prev_surface->sort.sort_key2 == surface->sort.sort_key2 && repeats < RenderElementInfo::MAX_REPEATS) {
@@ -3036,6 +3044,11 @@ RenderForwardClustered::RenderForwardClustered() {
 		{
 			defines += "\n#define MATERIAL_UNIFORM_SET " + itos(MATERIAL_UNIFORM_SET) + "\n";
 		}
+#ifdef REAL_T_IS_DOUBLE
+		{
+			defines += "\n#define USE_DOUBLE_PRECISION \n";
+		}
+#endif
 
 		scene_shader.init(defines);
 	}

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -621,10 +621,10 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		//shader compiler
 		ShaderCompiler::DefaultIdentifierActions actions;
 
-		actions.renames["MODEL_MATRIX"] = "model_matrix";
+		actions.renames["MODEL_MATRIX"] = "read_model_matrix";
 		actions.renames["MODEL_NORMAL_MATRIX"] = "model_normal_matrix";
 		actions.renames["VIEW_MATRIX"] = "scene_data.view_matrix";
-		actions.renames["INV_VIEW_MATRIX"] = "scene_data.inv_view_matrix";
+		actions.renames["INV_VIEW_MATRIX"] = "inv_view_matrix";
 		actions.renames["PROJECTION_MATRIX"] = "projection_matrix";
 		actions.renames["INV_PROJECTION_MATRIX"] = "inv_projection_matrix";
 		actions.renames["MODELVIEW_MATRIX"] = "modelview";
@@ -756,6 +756,8 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 		actions.usage_defines["FOG"] = "#define CUSTOM_FOG_USED\n";
 		actions.usage_defines["RADIANCE"] = "#define CUSTOM_RADIANCE_USED\n";
 		actions.usage_defines["IRRADIANCE"] = "#define CUSTOM_IRRADIANCE_USED\n";
+
+		actions.usage_defines["MODEL_MATRIX"] = "#define MODEL_MATRIX_USED\n";
 
 		actions.render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
 		actions.render_mode_defines["world_vertex_coords"] = "#define VERTEX_WORLD_COORDS_USED\n";

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1757,6 +1757,14 @@ void RenderForwardMobile::_render_list_template(RenderingDevice::DrawListID p_dr
 			RendererRD::MaterialStorage::store_transform(Transform3D(), push_constant.transform);
 		}
 
+#ifdef REAL_T_IS_DOUBLE
+		// Split the origin into two components, the float approximation and the missing precision
+		// In the shader we will combine these back together to restore the lost precision.
+		RendererRD::MaterialStorage::split_double(inst->transform.origin.x, &push_constant.transform[12], &push_constant.transform[3]);
+		RendererRD::MaterialStorage::split_double(inst->transform.origin.y, &push_constant.transform[13], &push_constant.transform[7]);
+		RendererRD::MaterialStorage::split_double(inst->transform.origin.z, &push_constant.transform[14], &push_constant.transform[11]);
+#endif
+
 		push_constant.flags = inst->flags_cache;
 		push_constant.gi_offset = inst->gi_offset_cache;
 		push_constant.layer_mask = inst->layer_mask;
@@ -2472,6 +2480,11 @@ RenderForwardMobile::RenderForwardMobile() {
 	{
 		defines += "\n#define MATERIAL_UNIFORM_SET " + itos(MATERIAL_UNIFORM_SET) + "\n";
 	}
+#ifdef REAL_T_IS_DOUBLE
+	{
+		defines += "\n#define USE_DOUBLE_PRECISION \n";
+	}
+#endif
 
 	scene_shader.init(defines);
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -521,10 +521,10 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		//shader compiler
 		ShaderCompiler::DefaultIdentifierActions actions;
 
-		actions.renames["MODEL_MATRIX"] = "model_matrix";
+		actions.renames["MODEL_MATRIX"] = "read_model_matrix";
 		actions.renames["MODEL_NORMAL_MATRIX"] = "model_normal_matrix";
 		actions.renames["VIEW_MATRIX"] = "scene_data.view_matrix";
-		actions.renames["INV_VIEW_MATRIX"] = "scene_data.inv_view_matrix";
+		actions.renames["INV_VIEW_MATRIX"] = "inv_view_matrix";
 		actions.renames["PROJECTION_MATRIX"] = "projection_matrix";
 		actions.renames["INV_PROJECTION_MATRIX"] = "inv_projection_matrix";
 		actions.renames["MODELVIEW_MATRIX"] = "modelview";
@@ -656,6 +656,8 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.usage_defines["FOG"] = "#define CUSTOM_FOG_USED\n";
 		actions.usage_defines["RADIANCE"] = "#define CUSTOM_RADIANCE_USED\n";
 		actions.usage_defines["IRRADIANCE"] = "#define CUSTOM_IRRADIANCE_USED\n";
+
+		actions.usage_defines["MODEL_MATRIX"] = "#define MODEL_MATRIX_USED\n";
 
 		actions.render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
 		actions.render_mode_defines["world_vertex_coords"] = "#define VERTEX_WORLD_COORDS_USED\n";

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -129,10 +129,50 @@ invariant gl_Position;
 
 #GLOBALS
 
+#ifdef USE_DOUBLE_PRECISION
+// Helper functions for emulating double precision when adding floats.
+vec3 quick_two_sum(vec3 a, vec3 b, out vec3 out_p) {
+	vec3 s = a + b;
+	out_p = b - (s - a);
+	return s;
+}
+
+vec3 two_sum(vec3 a, vec3 b, out vec3 out_p) {
+	vec3 s = a + b;
+	vec3 v = s - a;
+	out_p = (a - (s - v)) + (b - v);
+	return s;
+}
+
+vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec3 out_precision) {
+	vec3 s, t, se, te;
+	s = two_sum(base_a, base_b, se);
+	t = two_sum(prec_a, prec_b, te);
+	se += t;
+	s = quick_two_sum(s, se, se);
+	se += te;
+	s = quick_two_sum(s, se, out_precision);
+	return s;
+}
+#endif
+
 void vertex_shader(in uint instance_index, in bool is_multimesh, in uint multimesh_offset, in SceneData scene_data, in mat4 model_matrix, out vec4 screen_pos) {
 	vec4 instance_custom = vec4(0.0);
 #if defined(COLOR_USED)
 	color_interp = color_attrib;
+#endif
+
+	mat4 inv_view_matrix = scene_data.inv_view_matrix;
+
+#ifdef USE_DOUBLE_PRECISION
+	vec3 model_precision = vec3(model_matrix[0][3], model_matrix[1][3], model_matrix[2][3]);
+	model_matrix[0][3] = 0.0;
+	model_matrix[1][3] = 0.0;
+	model_matrix[2][3] = 0.0;
+	vec3 view_precision = vec3(inv_view_matrix[0][3], inv_view_matrix[1][3], inv_view_matrix[2][3]);
+	inv_view_matrix[0][3] = 0.0;
+	inv_view_matrix[1][3] = 0.0;
+	inv_view_matrix[2][3] = 0.0;
 #endif
 
 	mat3 model_normal_matrix;
@@ -142,10 +182,11 @@ void vertex_shader(in uint instance_index, in bool is_multimesh, in uint multime
 		model_normal_matrix = mat3(model_matrix);
 	}
 
+	mat4 matrix;
+	mat4 read_model_matrix = model_matrix;
+
 	if (is_multimesh) {
 		//multimesh, instances are for it
-
-		mat4 matrix;
 
 #ifdef USE_PARTICLE_TRAILS
 		uint trail_size = (instances.data[instance_index].flags >> INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT) & INSTANCE_FLAGS_PARTICLE_TRAIL_MASK;
@@ -232,7 +273,14 @@ void vertex_shader(in uint instance_index, in bool is_multimesh, in uint multime
 #endif
 		//transpose
 		matrix = transpose(matrix);
-		model_matrix = model_matrix * matrix;
+#if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
+		// Normally we can bake the multimesh transform into the model matrix, but when using double precision
+		// we avoid baking it in so we can emulate high precision.
+		read_model_matrix = model_matrix * matrix;
+#if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
+		model_matrix = read_model_matrix;
+#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
+#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
@@ -297,7 +345,22 @@ void vertex_shader(in uint instance_index, in bool is_multimesh, in uint multime
 // using local coordinates (default)
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
+#ifdef USE_DOUBLE_PRECISION
+	// We separate the basis from the origin becasue the basis is fine with single point precision.
+	// Then we combine the translations from the model matrix and the view matrix using emulated doubles.
+	// We add the result to the vertex and ignore the final lost precision.
+	vec3 model_origin = model_matrix[3].xyz;
+	if (is_multimesh) {
+		vertex = mat3(matrix) * vertex;
+		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
+	}
+	vertex = mat3(model_matrix) * vertex;
+	vec3 temp_precision; // Will be ignored.
+	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
+	vertex = mat3(scene_data.view_matrix) * vertex;
+#else
 	vertex = (modelview * vec4(vertex, 1.0)).xyz;
+#endif
 #ifdef NORMAL_USED
 	normal = modelview_normal * normal;
 #endif
@@ -490,7 +553,6 @@ layout(location = 10) in flat uint instance_index_interp;
 
 //defines to keep compatibility with vertex
 
-#define model_matrix instances.data[draw_call.instance_index].transform
 #ifdef USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix_view[ViewIndex]
 #define inv_projection_matrix scene_data.inv_projection_matrix_view[ViewIndex]
@@ -736,6 +798,17 @@ void fragment_shader(in SceneData scene_data) {
 	float alpha_antialiasing_edge = 0.0;
 	vec2 alpha_texture_coordinate = vec2(0.0, 0.0);
 #endif // ALPHA_ANTIALIASING_EDGE_USED
+
+	mat4 inv_view_matrix = scene_data.inv_view_matrix;
+	mat4 read_model_matrix = instances.data[instance_index].transform;
+#ifdef USE_DOUBLE_PRECISION
+	read_model_matrix[0][3] = 0.0;
+	read_model_matrix[1][3] = 0.0;
+	read_model_matrix[2][3] = 0.0;
+	inv_view_matrix[0][3] = 0.0;
+	inv_view_matrix[1][3] = 0.0;
+	inv_view_matrix[2][3] = 0.0;
+#endif
 
 	{
 #CODE : FRAGMENT

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -123,6 +123,33 @@ invariant gl_Position;
 
 #define scene_data scene_data_block.data
 
+#ifdef USE_DOUBLE_PRECISION
+// Helper functions for emulating double precision when adding floats.
+vec3 quick_two_sum(vec3 a, vec3 b, out vec3 out_p) {
+	vec3 s = a + b;
+	out_p = b - (s - a);
+	return s;
+}
+
+vec3 two_sum(vec3 a, vec3 b, out vec3 out_p) {
+	vec3 s = a + b;
+	vec3 v = s - a;
+	out_p = (a - (s - v)) + (b - v);
+	return s;
+}
+
+vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec3 out_precision) {
+	vec3 s, t, se, te;
+	s = two_sum(base_a, base_b, se);
+	t = two_sum(prec_a, prec_b, te);
+	se += t;
+	s = quick_two_sum(s, se, se);
+	se += te;
+	s = quick_two_sum(s, se, out_precision);
+	return s;
+}
+#endif
+
 void main() {
 	vec4 instance_custom = vec4(0.0);
 #if defined(COLOR_USED)
@@ -132,6 +159,17 @@ void main() {
 	bool is_multimesh = bool(draw_call.flags & INSTANCE_FLAGS_MULTIMESH);
 
 	mat4 model_matrix = draw_call.transform;
+	mat4 inv_view_matrix = scene_data.inv_view_matrix;
+#ifdef USE_DOUBLE_PRECISION
+	vec3 model_precision = vec3(model_matrix[0][3], model_matrix[1][3], model_matrix[2][3]);
+	model_matrix[0][3] = 0.0;
+	model_matrix[1][3] = 0.0;
+	model_matrix[2][3] = 0.0;
+	vec3 view_precision = vec3(inv_view_matrix[0][3], inv_view_matrix[1][3], inv_view_matrix[2][3]);
+	inv_view_matrix[0][3] = 0.0;
+	inv_view_matrix[1][3] = 0.0;
+	inv_view_matrix[2][3] = 0.0;
+#endif
 
 	mat3 model_normal_matrix;
 	if (bool(draw_call.flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -140,10 +178,11 @@ void main() {
 		model_normal_matrix = mat3(model_matrix);
 	}
 
+	mat4 matrix;
+	mat4 read_model_matrix = model_matrix;
+
 	if (is_multimesh) {
 		//multimesh, instances are for it
-
-		mat4 matrix;
 
 #ifdef USE_PARTICLE_TRAILS
 		uint trail_size = (draw_call.flags >> INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT) & INSTANCE_FLAGS_PARTICLE_TRAIL_MASK;
@@ -230,7 +269,15 @@ void main() {
 #endif
 		//transpose
 		matrix = transpose(matrix);
-		model_matrix = model_matrix * matrix;
+
+#if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
+		// Normally we can bake the multimesh transform into the model matrix, but when using double precision
+		// we avoid baking it in so we can emulate high precision.
+		read_model_matrix = model_matrix * matrix;
+#if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
+		model_matrix = read_model_matrix;
+#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
+#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
@@ -297,7 +344,22 @@ void main() {
 // using local coordinates (default)
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
+#ifdef USE_DOUBLE_PRECISION
+	// We separate the basis from the origin becasue the basis is fine with single point precision.
+	// Then we combine the translations from the model matrix and the view matrix using emulated doubles.
+	// We add the result to the vertex and ignore the final lost precision.
+	vec3 model_origin = model_matrix[3].xyz;
+	if (is_multimesh) {
+		vertex = mat3(matrix) * vertex;
+		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
+	}
+	vertex = mat3(model_matrix) * vertex;
+	vec3 temp_precision;
+	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
+	vertex = mat3(scene_data.view_matrix) * vertex;
+#else
 	vertex = (modelview * vec4(vertex, 1.0)).xyz;
+#endif
 #ifdef NORMAL_USED
 	normal = modelview_normal * normal;
 #endif
@@ -468,7 +530,6 @@ layout(location = 9) highp in float dp_clip;
 
 //defines to keep compatibility with vertex
 
-#define model_matrix draw_call.transform
 #ifdef USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix_view[ViewIndex]
 #define inv_projection_matrix scene_data.inv_projection_matrix_view[ViewIndex]
@@ -684,6 +745,17 @@ void main() {
 	float alpha_antialiasing_edge = 0.0;
 	vec2 alpha_texture_coordinate = vec2(0.0, 0.0);
 #endif // ALPHA_ANTIALIASING_EDGE_USED
+
+	mat4 inv_view_matrix = scene_data.inv_view_matrix;
+	mat4 read_model_matrix = draw_call.transform;
+#ifdef USE_DOUBLE_PRECISION
+	read_model_matrix[0][3] = 0.0;
+	read_model_matrix[1][3] = 0.0;
+	read_model_matrix[2][3] = 0.0;
+	inv_view_matrix[0][3] = 0.0;
+	inv_view_matrix[1][3] = 0.0;
+	inv_view_matrix[2][3] = 0.0;
+#endif
 
 	{
 #CODE : FRAGMENT

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -311,6 +311,18 @@ public:
 		}
 	}
 
+	// http://andrewthall.org/papers/df64_qf128.pdf
+#ifdef REAL_T_IS_DOUBLE
+	static _FORCE_INLINE_ void split_double(double a, float *ahi, float *alo) {
+		const double SPLITTER = (1 << 29) + 1;
+		double t = a * SPLITTER;
+		double thi = t - (t - a);
+		double tlo = a - thi;
+		*ahi = (float)thi;
+		*alo = (float)tlo;
+	}
+#endif
+
 	/* Samplers */
 
 	_FORCE_INLINE_ RID sampler_rd_get_default(RS::CanvasItemTextureFilter p_filter, RS::CanvasItemTextureRepeat p_repeat) {

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -59,6 +59,12 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p
 	RendererRD::MaterialStorage::store_transform(cam_transform, ubo.inv_view_matrix);
 	RendererRD::MaterialStorage::store_transform(cam_transform.affine_inverse(), ubo.view_matrix);
 
+#ifdef REAL_T_IS_DOUBLE
+	RendererRD::MaterialStorage::split_double(-cam_transform.origin.x, &ubo.inv_view_matrix[12], &ubo.inv_view_matrix[3]);
+	RendererRD::MaterialStorage::split_double(-cam_transform.origin.y, &ubo.inv_view_matrix[13], &ubo.inv_view_matrix[7]);
+	RendererRD::MaterialStorage::split_double(-cam_transform.origin.z, &ubo.inv_view_matrix[14], &ubo.inv_view_matrix[11]);
+#endif
+
 	for (uint32_t v = 0; v < view_count; v++) {
 		projection = correction * view_projection[v];
 		RendererRD::MaterialStorage::store_camera(projection, ubo.projection_matrix_view[v]);

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -86,8 +86,8 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].main_function = true;
 
 	//builtins
-	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["MODEL_MATRIX"] = ShaderLanguage::TYPE_MAT4;
-	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["MODEL_NORMAL_MATRIX"] = ShaderLanguage::TYPE_MAT3;
+	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["MODEL_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["MODEL_NORMAL_MATRIX"] = constt(ShaderLanguage::TYPE_MAT3);
 	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["VIEW_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["INV_VIEW_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[RS::SHADER_SPATIAL].functions["vertex"].built_ins["PROJECTION_MATRIX"] = ShaderLanguage::TYPE_MAT4;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/58516
Finishes @fire 's 4 years 10 months 30 days journey of double support: https://github.com/godotengine/godot/pull/12299

We calculate the lost precision on the CPU and pass it into the GPU so that it can calculate an error-corrected version of the vertex position. The general approach is detailed here: http://andrewthall.org/papers/df64_qf128.pdf

This allows rendering very large worlds as if we were using double precision in the shader when we are not. 

We don't use doubles in the shader for two reasons:
1. Limited support for doubles. Metal shading language doesn't support them at all. On some devices using doubles in shaders causes them to crash (thats the case on my intel integrated GPU)
2. Even when GPUs do support doubles, performance can be poor 

This method works for "normal" rendering meaning it does not work with the render modes ``skip_vertex_transform`` or ``world_vertex_coords`` in either case you end up doing calculations totally in floating point and you lose the benefit of this. By the same token, any shader operations in world space will still be a problem as the shaders are 100% floats. This means that world triplanar is still limited by the bounds of single precision floats.

I have not implemented this yet in GLES3 as I want to flesh out the 3D renderer a bit more first. Particularly, I want to ensure that this won't conflict with our floating point precision needs.

~Lastly, as it is written, this approach does not work with particles/multimeshes. The same general approach can be used, but when applied to particles, this approach will result in many many times more calculations. Right now, for smaller ranges (<500km) this isn't a big deal, but once you approach 1000km the error becomes noticeable and above 10,000km the error is significant. I can add the relevant code for particles/multimeshes if desired.~

_Edit: I was wrong above, I thought that we would need to add a high precision path to the instance_transform * model matrix multiplication which would require decomposing the multiplication into a mat3 x mat3 multiplication and a high precision dot product (which would be a ton of calculations). However, I realized that when using the normal render path, we could keep the instance_transform separate and add its origin offset the same time we do the model/view multiplication. So I've added a code path that ensures the full model matrix is available if ``MODEL_MATRIX`` is read in the shader, if using world vertex coords, if skipping vertex transform, or if not using doubles. Finally, I made ``MODEL_MATRIX`` read only in shaders. Previously you could write to it and the value would be totally ignored._

CC @Zylann @reduz @BastiaanOlij 

<details>
<summary>Comparison</summary>

At origin
Before: (Ignore the triangle, it moves to show smooth particle movement)

![Screenshot from 2022-09-20 17-52-35](https://user-images.githubusercontent.com/16521339/191390814-68ae4778-9fdc-4cb4-9055-7bc81ad2ba25.png)

After:

![Screenshot from 2022-09-20 17-21-13](https://user-images.githubusercontent.com/16521339/191390816-d75f294b-a09b-4f7a-b514-cbd513da62ae.png)

1 billion units away!
Before:

![Screenshot from 2022-09-20 17-52-30](https://user-images.githubusercontent.com/16521339/191390815-228113d8-9849-4079-bdbc-159b5df56ea7.png)

After:

![Screenshot from 2022-09-20 17-21-09](https://user-images.githubusercontent.com/16521339/191390819-f2695f0c-5f9c-4772-a092-97589c4b3638.png)

</details>