### PR TITLE
Implement multi-window icon customization

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -861,12 +861,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_icon">
-			<return type="void" />
-			<param index="0" name="image" type="Image" />
-			<description>
-			</description>
-		</method>
 		<method name="set_native_icon">
 			<return type="void" />
 			<param index="0" name="filename" type="String" />
@@ -1192,6 +1186,13 @@
 			<param index="2" name="window_id" type="int" default="0" />
 			<description>
 				Enables or disables the given window's given [param flag]. See [enum WindowFlags] for possible values and their behavior.
+			</description>
+		</method>
+		<method name="window_set_icon">
+			<return type="void" />
+			<param index="0" name="image" type="Image" />
+			<param index="1" name="window_id" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="window_set_ime_active">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -345,6 +345,10 @@
 		<member name="extend_to_title" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] contents is expanded to the full size of the window, window title bar is transparent.
 		</member>
+		<member name="icon" type="Image" setter="set_icon" getter="get_icon">
+			The [Window] icon.
+			[b]Note:[/b] If no icon is set, the [Window] will inherit the main window icon.
+		</member>
 		<member name="max_size" type="Vector2i" setter="set_max_size" getter="get_max_size" default="Vector2i(0, 0)">
 			If non-zero, the [Window] can't be resized to be bigger than this size.
 			[b]Note:[/b] This property will be ignored if the value is lower than [member min_size].

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2151,7 +2151,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 #ifdef TOOLS_ENABLED
 		if (OS::get_singleton()->get_bundle_icon_path().is_empty()) {
 			Ref<Image> icon = memnew(Image(app_icon_png));
-			DisplayServer::get_singleton()->set_icon(icon);
+			DisplayServer::get_singleton()->window_set_icon(icon, DisplayServer::MAIN_WINDOW_ID);
 		}
 #endif
 	}
@@ -2952,7 +2952,7 @@ bool Main::start() {
 					Ref<Image> icon;
 					icon.instantiate();
 					if (ImageLoader::load_image(iconpath, icon) == OK) {
-						DisplayServer::get_singleton()->set_icon(icon);
+						DisplayServer::get_singleton()->window_set_icon(icon, DisplayServer::MAIN_WINDOW_ID);
 						hasicon = true;
 					}
 				}
@@ -2983,7 +2983,7 @@ bool Main::start() {
 
 	if (!hasicon && OS::get_singleton()->get_bundle_icon_path().is_empty()) {
 		Ref<Image> icon = memnew(Image(app_icon_png));
-		DisplayServer::get_singleton()->set_icon(icon);
+		DisplayServer::get_singleton()->window_set_icon(icon, DisplayServer::MAIN_WINDOW_ID);
 	}
 
 	OS::get_singleton()->set_main_loop(main_loop);

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -339,6 +339,10 @@ void DisplayServerAndroid::window_set_title(const String &p_title, DisplayServer
 	// Not supported on Android.
 }
 
+void DisplayServerAndroid::window_set_icon(const Ref<Image> &p_icon, WindowID p_window) {
+	// Not supported on Android.
+}
+
 int DisplayServerAndroid::window_get_current_screen(DisplayServer::WindowID p_window) const {
 	return SCREEN_OF_MAIN_WINDOW;
 }

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -145,6 +145,7 @@ public:
 	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) override;
 
+	virtual void window_set_icon(const Ref<Image> &p_icon, WindowID p_window) override;
 	virtual int window_get_current_screen(WindowID p_window = MAIN_WINDOW_ID) const override;
 	virtual void window_set_current_screen(int p_screen, WindowID p_window = MAIN_WINDOW_ID) override;
 

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -195,6 +195,7 @@ public:
 	virtual bool can_any_window_draw() const override;
 
 	virtual void window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_set_icon(const Ref<Image> &p_icon, WindowID p_window) override;
 	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;
 
 	virtual bool screen_is_touchscreen(int p_screen) const override;

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -484,6 +484,10 @@ void DisplayServerIOS::window_set_title(const String &p_title, WindowID p_window
 	// Probably not supported for iOS
 }
 
+void DisplayServerIOS::window_set_icon(const Ref<Image> &p_icon, WindowID p_window) {
+	// Not supported for iOS
+}
+
 int DisplayServerIOS::window_get_current_screen(WindowID p_window) const {
 	return SCREEN_OF_MAIN_WINDOW;
 }

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -4310,7 +4310,7 @@ int set_icon_errorhandler(Display *dpy, XErrorEvent *ev) {
 	return 0;
 }
 
-void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
+void DisplayServerX11::window_set_icon(const Ref<Image> &p_icon, WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
 	WindowData &wd = windows[MAIN_WINDOW_ID];

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -443,7 +443,7 @@ public:
 	virtual void set_context(Context p_context) override;
 
 	virtual void set_native_icon(const String &p_filename) override;
-	virtual void set_icon(const Ref<Image> &p_icon) override;
+	virtual void window_set_icon(const Ref<Image> &p_icon, WindowID p_window) override;
 
 	static DisplayServer *create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error);
 	static Vector<String> get_rendering_drivers_func();

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -421,7 +421,7 @@ public:
 	virtual void swap_buffers() override;
 
 	virtual void set_native_icon(const String &p_filename) override;
-	virtual void set_icon(const Ref<Image> &p_icon) override;
+	virtual void window_set_icon(const Ref<Image> &p_icon, WindowID p_window) override;
 
 	static DisplayServer *create_func(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i &p_resolution, Error &r_error);
 	static Vector<String> get_rendering_drivers_func();

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3322,8 +3322,12 @@ void DisplayServerMacOS::set_native_icon(const String &p_filename) {
 	[NSApp setApplicationIconImage:icon];
 }
 
-void DisplayServerMacOS::set_icon(const Ref<Image> &p_icon) {
+void DisplayServerMacOS::window_set_icon(const Ref<Image> &p_icon, WindowID p_window) {
 	_THREAD_SAFE_METHOD_
+
+	if (p_window != MAIN_WINDOW_ID) {
+		return; // Ignore attempts to change non-main window icons, macOS windows don't have icons.
+	}
 
 	Ref<Image> img = p_icon;
 	img = img->duplicate();

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -695,7 +695,7 @@ void DisplayServerWeb::send_window_event_callback(int p_notification) {
 	}
 }
 
-void DisplayServerWeb::set_icon(const Ref<Image> &p_icon) {
+void DisplayServerWeb::window_set_icon(const Ref<Image> &p_icon, WindowID p_window) {
 	ERR_FAIL_COND(p_icon.is_null());
 	Ref<Image> icon = p_icon;
 	if (icon->is_compressed()) {

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -214,7 +214,7 @@ public:
 	virtual void process_events() override;
 
 	// icon
-	virtual void set_icon(const Ref<Image> &p_icon) override;
+	virtual void window_set_icon(const Ref<Image> &p_icon, WindowID p_window) override;
 
 	// others
 	virtual bool get_swap_cancel_ok() override;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -663,14 +663,18 @@ DisplayServer::WindowID DisplayServerWindows::create_sub_window(WindowMode p_mod
 		wd.is_popup = true;
 	}
 
-	// Inherit icons from MAIN_WINDOW for all sub windows.
-	HICON mainwindow_icon = (HICON)SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_GETICON, ICON_SMALL, 0);
-	if (mainwindow_icon) {
-		SendMessage(windows[window_id].hWnd, WM_SETICON, ICON_SMALL, (LPARAM)mainwindow_icon);
-	}
-	mainwindow_icon = (HICON)SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_GETICON, ICON_BIG, 0);
-	if (mainwindow_icon) {
-		SendMessage(windows[window_id].hWnd, WM_SETICON, ICON_BIG, (LPARAM)mainwindow_icon);
+	if (wd.icon.is_valid()) { // Make sure there is a valid icon specified, if not, use the main window icon
+		window_set_icon(wd.icon, window_id);
+	} else {
+		// Inherit icons from MAIN_WINDOW for all sub windows without a specified icon.
+		HICON mainwindow_icon = (HICON)SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_GETICON, ICON_SMALL, 0);
+		if (mainwindow_icon) {
+			SendMessage(windows[window_id].hWnd, WM_SETICON, ICON_SMALL, (LPARAM)mainwindow_icon);
+		}
+		mainwindow_icon = (HICON)SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_GETICON, ICON_BIG, 0);
+		if (mainwindow_icon) {
+			SendMessage(windows[window_id].hWnd, WM_SETICON, ICON_BIG, (LPARAM)mainwindow_icon);
+		}
 	}
 	return window_id;
 }
@@ -1189,8 +1193,8 @@ void DisplayServerWindows::_update_window_style(WindowID p_window, bool p_repain
 	SetWindowLongPtr(wd.hWnd, GWL_STYLE, style);
 	SetWindowLongPtr(wd.hWnd, GWL_EXSTYLE, style_ex);
 
-	if (icon.is_valid()) {
-		set_icon(icon);
+	if (wd.icon.is_valid()) {
+		window_set_icon(wd.icon, p_window);
 	}
 
 	SetWindowPos(wd.hWnd, wd.always_on_top ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | ((wd.no_focus || wd.is_popup) ? SWP_NOACTIVATE : 0));
@@ -1957,18 +1961,31 @@ void DisplayServerWindows::set_native_icon(const String &p_filename) {
 	memdelete(icon_dir);
 }
 
-void DisplayServerWindows::set_icon(const Ref<Image> &p_icon) {
+void DisplayServerWindows::window_set_icon(const Ref<Image> &p_icon, WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
-	ERR_FAIL_COND(!p_icon.is_valid());
-	if (icon != p_icon) {
-		icon = p_icon->duplicate();
-		if (icon->get_format() != Image::FORMAT_RGBA8) {
-			icon->convert(Image::FORMAT_RGBA8);
+	WindowData &wd = windows[p_window];
+
+	if (p_icon.is_null()) { // If the icon is null, we set the default icon.
+		HICON mainwindow_icon = (HICON)SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_GETICON, ICON_SMALL, 0);
+		if (mainwindow_icon) {
+			SendMessage(windows[p_window].hWnd, WM_SETICON, ICON_SMALL, (LPARAM)mainwindow_icon);
+		}
+		mainwindow_icon = (HICON)SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_GETICON, ICON_BIG, 0);
+		if (mainwindow_icon) {
+			SendMessage(windows[p_window].hWnd, WM_SETICON, ICON_BIG, (LPARAM)mainwindow_icon);
+		}
+		return;
+	} else {
+		if (wd.icon != p_icon) {
+			wd.icon = p_icon->duplicate();
+			if (wd.icon->get_format() != Image::FORMAT_RGBA8) {
+				wd.icon->convert(Image::FORMAT_RGBA8);
+			}
 		}
 	}
-	int w = icon->get_width();
-	int h = icon->get_height();
+	int w = wd.icon->get_width();
+	int h = wd.icon->get_height();
 
 	// Create temporary bitmap buffer.
 	int icon_len = 40 + h * w * 4;
@@ -1989,7 +2006,7 @@ void DisplayServerWindows::set_icon(const Ref<Image> &p_icon) {
 	encode_uint32(0, &icon_bmp[36]);
 
 	uint8_t *wr = &icon_bmp[40];
-	const uint8_t *r = icon->get_data().ptr();
+	const uint8_t *r = wd.icon->get_data().ptr();
 
 	for (int i = 0; i < h; i++) {
 		for (int j = 0; j < w; j++) {
@@ -2005,10 +2022,10 @@ void DisplayServerWindows::set_icon(const Ref<Image> &p_icon) {
 	HICON hicon = CreateIconFromResource(icon_bmp, icon_len, TRUE, 0x00030000);
 
 	// Set the icon for the window.
-	SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_SETICON, ICON_SMALL, (LPARAM)hicon);
+	SendMessage(windows[p_window].hWnd, WM_SETICON, ICON_SMALL, (LPARAM)hicon);
 
 	// Set the icon in the task manager (should we do this?).
-	SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_SETICON, ICON_BIG, (LPARAM)hicon);
+	SendMessage(windows[p_window].hWnd, WM_SETICON, ICON_BIG, (LPARAM)hicon);
 }
 
 void DisplayServerWindows::window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window) {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -354,6 +354,7 @@ class DisplayServerWindows : public DisplayServer {
 		HWND hWnd;
 
 		Vector<Vector2> mpath;
+		Ref<Image> icon;
 
 		bool pre_fs_valid = false;
 		RECT pre_fs_rect;
@@ -424,7 +425,6 @@ class DisplayServerWindows : public DisplayServer {
 	HHOOK mouse_monitor = nullptr;
 	List<WindowID> popup_list;
 	uint64_t time_since_popup = 0;
-	Ref<Image> icon;
 
 	WindowID _create_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect);
 	WindowID window_id_counter = MAIN_WINDOW_ID;
@@ -622,7 +622,8 @@ public:
 	virtual void swap_buffers() override;
 
 	virtual void set_native_icon(const String &p_filename) override;
-	virtual void set_icon(const Ref<Image> &p_icon) override;
+
+	virtual void window_set_icon(const Ref<Image> &p_icon, WindowID p_window) override;
 
 	virtual void set_context(Context p_context) override;
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -63,6 +63,18 @@ String Window::get_title() const {
 	return title;
 }
 
+void Window::set_icon(const Ref<Image> &p_icon) {
+	icon = p_icon;
+
+#ifdef WINDOWS_ENABLED // Only works on windows
+	DisplayServer::get_singleton()->window_set_icon(p_icon, window_id);
+#endif
+}
+
+Ref<Image> Window::get_icon() const {
+	return icon;
+}
+
 void Window::set_current_screen(int p_screen) {
 	current_screen = p_screen;
 	if (window_id == DisplayServer::INVALID_WINDOW_ID) {
@@ -258,6 +270,9 @@ void Window::_make_window() {
 	}
 #endif
 	DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
+	if (icon.is_valid()) { // If there is a specified icon, set it to be the window icon, otherwise, do nothing.
+		DisplayServer::get_singleton()->window_set_icon(icon, window_id);
+	}
 	DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
 #ifdef TOOLS_ENABLED
 	if (!(Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && (get_tree()->get_edited_scene_root()->is_ancestor_of(this) || get_tree()->get_edited_scene_root() == this))) {
@@ -1624,6 +1639,9 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &Window::set_title);
 	ClassDB::bind_method(D_METHOD("get_title"), &Window::get_title);
 
+	ClassDB::bind_method(D_METHOD("set_icon", "icon"), &Window::set_icon);
+	ClassDB::bind_method(D_METHOD("get_icon"), &Window::get_icon);
+
 	ClassDB::bind_method(D_METHOD("set_current_screen", "index"), &Window::set_current_screen);
 	ClassDB::bind_method(D_METHOD("get_current_screen"), &Window::get_current_screen);
 
@@ -1736,6 +1754,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_centered_clamped", "minsize", "fallback_ratio"), &Window::popup_centered_clamped, DEFVAL(Size2i()), DEFVAL(0.75));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "title"), "set_title", "get_title");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Image"), "set_icon", "get_icon");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "position", PROPERTY_HINT_NONE, "suffix:px"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size", PROPERTY_HINT_NONE, "suffix:px"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Windowed,Minimized,Maximized,Fullscreen"), "set_mode", "get_mode");

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -91,6 +91,7 @@ private:
 	DisplayServer::WindowID window_id = DisplayServer::INVALID_WINDOW_ID;
 
 	String title;
+	Ref<Image> icon;
 	mutable int current_screen = 0;
 	mutable Vector2i position;
 	mutable Size2i size = Size2i(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
@@ -187,6 +188,9 @@ public:
 
 	void set_title(const String &p_title);
 	String get_title() const;
+
+	void set_icon(const Ref<Image> &p_icon);
+	Ref<Image> get_icon() const;
 
 	void set_current_screen(int p_screen);
 	int get_current_screen() const;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -511,7 +511,7 @@ void DisplayServer::set_native_icon(const String &p_filename) {
 	WARN_PRINT("Native icon not supported by this display server.");
 }
 
-void DisplayServer::set_icon(const Ref<Image> &p_icon) {
+void DisplayServer::window_set_icon(const Ref<Image> &p_icon, WindowID p_window) {
 	WARN_PRINT("Icon not supported by this display server.");
 }
 
@@ -728,7 +728,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_process_and_drop_events"), &DisplayServer::force_process_and_drop_events);
 
 	ClassDB::bind_method(D_METHOD("set_native_icon", "filename"), &DisplayServer::set_native_icon);
-	ClassDB::bind_method(D_METHOD("set_icon", "image"), &DisplayServer::set_icon);
+	ClassDB::bind_method(D_METHOD("window_set_icon", "image", "window_id"), &DisplayServer::window_set_icon);
 
 	ClassDB::bind_method(D_METHOD("tablet_get_driver_count"), &DisplayServer::tablet_get_driver_count);
 	ClassDB::bind_method(D_METHOD("tablet_get_driver_name", "idx"), &DisplayServer::tablet_get_driver_name);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -468,7 +468,7 @@ public:
 	virtual void swap_buffers();
 
 	virtual void set_native_icon(const String &p_filename);
-	virtual void set_icon(const Ref<Image> &p_icon);
+	virtual void window_set_icon(const Ref<Image> &p_icon, WindowID p_window = MAIN_WINDOW_ID) = 0;
 
 	enum Context {
 		CONTEXT_EDITOR,

--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -127,7 +127,7 @@ public:
 
 	void process_events() override {}
 
-	void set_icon(const Ref<Image> &p_icon) override {}
+	void window_set_icon(const Ref<Image> &p_icon, WindowID p_window = MAIN_WINDOW_ID) override {}
 
 	DisplayServerHeadless() {}
 	~DisplayServerHeadless() {}


### PR DESCRIPTION
Add multi-window icon customization for non-embedded sub-windows.

Currently only works on Windows OS.

<img width="325" alt="inspector icon" src="https://user-images.githubusercontent.com/62965063/191372849-dde6abf5-7391-4dc4-9014-5513ff302df1.png">
<img width="468" alt="multi-window icons" src="https://user-images.githubusercontent.com/62965063/191372845-2e443fcb-bbed-4bd8-9dab-ce46005884ff.png">

This will require a per-platform implementation because the display server creates native windows differently for each OS. I've already got the Windows implementation done.

This is the implementation of my proposal: https://github.com/godotengine/godot-proposals/issues/5454

