### PR TITLE
Set scene tiles' position before adding them

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1861,7 +1861,6 @@ void TileMap::_scenes_update_dirty_quadrants(SelfList<TileMapQuadrant>::List &r_
 					Ref<PackedScene> packed_scene = scenes_collection_source->get_scene_tile_scene(c.alternative_tile);
 					if (packed_scene.is_valid()) {
 						Node *scene = packed_scene->instantiate();
-						add_child(scene);
 						Control *scene_as_control = Object::cast_to<Control>(scene);
 						Node2D *scene_as_node2d = Object::cast_to<Node2D>(scene);
 						if (scene_as_control) {
@@ -1871,6 +1870,7 @@ void TileMap::_scenes_update_dirty_quadrants(SelfList<TileMapQuadrant>::List &r_
 							xform.set_origin(map_to_local(E_cell));
 							scene_as_node2d->set_transform(xform * scene_as_node2d->get_transform());
 						}
+						add_child(scene);
 						q.scenes[E_cell] = scene->get_name();
 					}
 				}


### PR DESCRIPTION
Fixes #66171

No global position is used here, so it's safe to set it before adding to scene. This is consistent with how regular instances work.