### PR TITLE
Make *_operator_index in gdnative_interface not logging an error if called with an out-of-bound index

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -680,13 +680,17 @@ static GDExtensionInt gdextension_string_to_wide_chars(GDExtensionConstStringPtr
 
 static char32_t *gdextension_string_operator_index(GDExtensionStringPtr p_self, GDExtensionInt p_index) {
 	String *self = (String *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->length() + 1, nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->length() + 1)) {
+		return nullptr;
+	}
 	return &self->ptrw()[p_index];
 }
 
 static const char32_t *gdextension_string_operator_index_const(GDExtensionConstStringPtr p_self, GDExtensionInt p_index) {
 	const String *self = (const String *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->length() + 1, nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->length() + 1)) {
+		return nullptr;
+	}
 	return &self->ptr()[p_index];
 }
 
@@ -747,121 +751,161 @@ static int64_t gdextension_worker_thread_pool_add_native_task(GDExtensionObjectP
 
 static uint8_t *gdextension_packed_byte_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedByteArray *self = (PackedByteArray *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptrw()[p_index];
 }
 
 static const uint8_t *gdextension_packed_byte_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedByteArray *self = (const PackedByteArray *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptr()[p_index];
 }
 
 static GDExtensionTypePtr gdextension_packed_color_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedColorArray *self = (PackedColorArray *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionTypePtr)&self->ptrw()[p_index];
 }
 
 static GDExtensionTypePtr gdextension_packed_color_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedColorArray *self = (const PackedColorArray *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionTypePtr)&self->ptr()[p_index];
 }
 
 static float *gdextension_packed_float32_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedFloat32Array *self = (PackedFloat32Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptrw()[p_index];
 }
 
 static const float *gdextension_packed_float32_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedFloat32Array *self = (const PackedFloat32Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptr()[p_index];
 }
 
 static double *gdextension_packed_float64_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedFloat64Array *self = (PackedFloat64Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptrw()[p_index];
 }
 
 static const double *gdextension_packed_float64_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedFloat64Array *self = (const PackedFloat64Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptr()[p_index];
 }
 
 static int32_t *gdextension_packed_int32_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedInt32Array *self = (PackedInt32Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptrw()[p_index];
 }
 
 static const int32_t *gdextension_packed_int32_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedInt32Array *self = (const PackedInt32Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptr()[p_index];
 }
 
 static int64_t *gdextension_packed_int64_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedInt64Array *self = (PackedInt64Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptrw()[p_index];
 }
 
 static const int64_t *gdextension_packed_int64_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedInt64Array *self = (const PackedInt64Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return &self->ptr()[p_index];
 }
 
 static GDExtensionStringPtr gdextension_packed_string_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedStringArray *self = (PackedStringArray *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionStringPtr)&self->ptrw()[p_index];
 }
 
 static GDExtensionStringPtr gdextension_packed_string_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedStringArray *self = (const PackedStringArray *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionStringPtr)&self->ptr()[p_index];
 }
 
 static GDExtensionTypePtr gdextension_packed_vector2_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedVector2Array *self = (PackedVector2Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionTypePtr)&self->ptrw()[p_index];
 }
 
 static GDExtensionTypePtr gdextension_packed_vector2_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedVector2Array *self = (const PackedVector2Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionTypePtr)&self->ptr()[p_index];
 }
 
 static GDExtensionTypePtr gdextension_packed_vector3_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	PackedVector3Array *self = (PackedVector3Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionTypePtr)&self->ptrw()[p_index];
 }
 
 static GDExtensionTypePtr gdextension_packed_vector3_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const PackedVector3Array *self = (const PackedVector3Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionTypePtr)&self->ptr()[p_index];
 }
 
 static GDExtensionVariantPtr gdextension_array_operator_index(GDExtensionTypePtr p_self, GDExtensionInt p_index) {
 	Array *self = (Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionVariantPtr)&self->operator[](p_index);
 }
 
 static GDExtensionVariantPtr gdextension_array_operator_index_const(GDExtensionConstTypePtr p_self, GDExtensionInt p_index) {
 	const Array *self = (const Array *)p_self;
-	ERR_FAIL_INDEX_V(p_index, self->size(), nullptr);
+	if (unlikely(p_index < 0 || p_index >= self->size())) {
+		return nullptr;
+	}
 	return (GDExtensionVariantPtr)&self->operator[](p_index);
 }
 


### PR DESCRIPTION
Currently an error is logged if `*_operator_index` is called with an out-of-bound index, for instance:
https://github.com/godotengine/godot/blob/b809b6d97e94d6c15760146117525398034abeb8/core/extension/gdnative_interface.cpp#L665-L669

However this prevent from having a clean way to do "better say sorry than ask for permission" pattern.

For instance in Godot-Python we check the return value and raise an `IndexError` if it is `nullptr`