### PR TITLE
Fix some stuff with the editor features

### DIFF
--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -309,7 +309,11 @@ void EditorFeatureProfile::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEATURE_MAX);
 }
 
-EditorFeatureProfile::EditorFeatureProfile() {}
+EditorFeatureProfile::EditorFeatureProfile() {
+	for (int i = 0; i < FEATURE_MAX; i++) {
+		features_disabled[i] = false;
+	}
+}
 
 //////////////////////////
 
@@ -746,6 +750,8 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 	class_list->clear();
 
 	String profile = _get_selected_profile();
+	profile_actions[PROFILE_SET]->set_disabled(profile == current_profile);
+
 	if (profile.is_empty()) { //nothing selected, nothing edited
 		property_list->clear();
 		edited.unref();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5992,10 +5992,6 @@ void EditorNode::_feature_profile_changed() {
 		node_tabs->set_tab_hidden(node_tabs->get_tab_idx_from_control(NodeDock::get_singleton()), false);
 		fs_tabs->set_tab_hidden(fs_tabs->get_tab_idx_from_control(FileSystemDock::get_singleton()), false);
 		history_tabs->set_tab_hidden(history_tabs->get_tab_idx_from_control(history_dock), false);
-		history_dock->set_visible(true);
-		ImportDock::get_singleton()->set_visible(true);
-		NodeDock::get_singleton()->set_visible(true);
-		FileSystemDock::get_singleton()->set_visible(true);
 		main_editor_buttons[EDITOR_3D]->set_visible(true);
 		main_editor_buttons[EDITOR_SCRIPT]->set_visible(true);
 		if (AssetLibraryEditorPlugin::is_available()) {


### PR DESCRIPTION
- Fix docks glitching out when setting the profile to default.
- Fix feature checks being untoggled at random when creating a profile.
- Make the "Make Current" button be disabled when the current profile is selected.

_Bugsquad edit:_
- Supersedes/includes https://github.com/godotengine/godot/pull/65577
- Fixes #65567