### PR TITLE
Print an error if trying to run a self-contained editor in a project folder

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1932,6 +1932,13 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 #ifdef TOOLS_ENABLED
 	if (editor || project_manager || cmdline_tool) {
 		EditorPaths::create();
+		if (EditorPaths::get_singleton()->is_self_contained()) {
+			if (ProjectSettings::get_singleton()->get_resource_path() == OS::get_singleton()->get_executable_path().get_base_dir()) {
+				ERR_PRINT("You are trying to run a self-contained editor at the same location as a project. This is not allowed, since editor files will mix with project files.");
+				OS::get_singleton()->set_exit_code(EXIT_FAILURE);
+				return FAILED;
+			}
+		}
 	}
 #endif
 


### PR DESCRIPTION
This scenario is invalid, but previously Godot did not prevent doing this, leading to silent failure. Fixes #66176.

Note 1: The error is actually printed twice, which is a bit weird, but it's fine.

Note 2: The editor files being inside of the export is not the only reason for doing this, but it's the easiest reason to explain. We encountered problems because there were some files *not* being exported. This is likely a bug unto itself, but I guess it's not a big deal to fix a bug that only happens in an invalid configuration anyway, so my suggestion is to consider that "WONTFIX" and instead just have this error message for the invalid situation.

EDIT: Fixed in https://github.com/godotengine/godot/pull/66364