### PR TITLE
[macOS] Improve "extended to title" transition to / from fullscreen.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -85,7 +85,7 @@ public:
 		Size2i min_size;
 		Size2i max_size;
 		Size2i size;
-		Vector2i wb_offset = Vector2i(16, 16);
+		Vector2i wb_offset = Vector2i(14, 14);
 
 		NSRect last_frame_rect;
 
@@ -230,6 +230,7 @@ public:
 	void window_update(WindowID p_window);
 	void window_destroy(WindowID p_window);
 	void window_resize(WindowID p_window, int p_width, int p_height);
+	void window_set_custom_window_buttons(WindowData &p_wd, bool p_enabled);
 
 	virtual bool has_feature(Feature p_feature) const override;
 	virtual String get_name() const override;

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -77,9 +77,15 @@
 
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 	wd.fullscreen = true;
+
 	// Reset window size limits.
 	[wd.window_object setContentMinSize:NSMakeSize(0, 0)];
 	[wd.window_object setContentMaxSize:NSMakeSize(FLT_MAX, FLT_MAX)];
+
+	// Reset custom window buttons.
+	if ([wd.window_object styleMask] & NSWindowStyleMaskFullSizeContentView) {
+		ds->window_set_custom_window_buttons(wd, false);
+	}
 
 	// Force window resize event.
 	[self windowDidResize:notification];
@@ -103,6 +109,11 @@
 	if (wd.max_size != Size2i()) {
 		Size2i size = wd.max_size / scale;
 		[wd.window_object setContentMaxSize:NSMakeSize(size.x, size.y)];
+	}
+
+	// Restore custom window buttons.
+	if ([wd.window_object styleMask] & NSWindowStyleMaskFullSizeContentView) {
+		ds->window_set_custom_window_buttons(wd, true);
 	}
 
 	// Restore resizability state.


### PR DESCRIPTION
Hides custom window buttons, and restores title bar text while in the fullscreen mode to better match other macOS apps behavior.