### PR TITLE
Style: Ensure consistent formatting with clang-format 15

### DIFF
--- a/core/math/math_fieldwise.cpp
+++ b/core/math/math_fieldwise.cpp
@@ -76,6 +76,7 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 
 			return target;
 		}
+
 		case Variant::VECTOR3I: {
 			SETUP_TYPE(Vector3i)
 
@@ -85,6 +86,7 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 
 			return target;
 		}
+
 		case Variant::VECTOR4: {
 			SETUP_TYPE(Vector4)
 
@@ -95,6 +97,7 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 
 			return target;
 		}
+
 		case Variant::VECTOR4I: {
 			SETUP_TYPE(Vector4i)
 
@@ -105,7 +108,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 
 			return target;
 		}
-
 
 		case Variant::PLANE: {
 			SETUP_TYPE(Plane)

--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -76,8 +76,8 @@ fi
 
 # To get consistent formatting, we recommend contributors to use the same
 # clang-format version as CI.
-RECOMMENDED_CLANG_FORMAT_MAJOR_MIN="12"
-RECOMMENDED_CLANG_FORMAT_MAJOR_MAX="14"
+RECOMMENDED_CLANG_FORMAT_MAJOR_MIN="13"
+RECOMMENDED_CLANG_FORMAT_MAJOR_MAX="15"
 
 if [ ! -x "$CLANG_FORMAT" ] ; then
 	message="Error: clang-format executable not found. Please install clang-format $RECOMMENDED_CLANG_FORMAT_MAJOR_MAX."

--- a/modules/websocket/websocket_macros.h
+++ b/modules/websocket/websocket_macros.h
@@ -35,34 +35,32 @@
 #define DEF_PKT_SHIFT 10
 #define DEF_BUF_SHIFT 16
 
-/* clang-format off */
-#define GDCICLASS(CNAME) \
-public:\
-	static CNAME *(*_create)();\
-\
-	static Ref<CNAME > create_ref() {\
-\
-		if (!_create)\
-			return Ref<CNAME >();\
-		return Ref<CNAME >(_create());\
-	}\
-\
-	static CNAME *create() {\
-\
-		if (!_create)\
-			return nullptr;\
-		return _create();\
-	}\
-protected:\
+#define GDCICLASS(CNAME)              \
+public:                               \
+	static CNAME *(*_create)();       \
+                                      \
+	static Ref<CNAME> create_ref() {  \
+		if (!_create)                 \
+			return Ref<CNAME>();      \
+		return Ref<CNAME>(_create()); \
+	}                                 \
+                                      \
+	static CNAME *create() {          \
+		if (!_create)                 \
+			return nullptr;           \
+		return _create();             \
+	}                                 \
+                                      \
+protected:
 
 #define GDCINULL(CNAME) \
-CNAME *(*CNAME::_create)() = nullptr;
+	CNAME *(*CNAME::_create)() = nullptr;
 
-#define GDCIIMPL(IMPNAME, CNAME) \
-public:\
-	static CNAME *_create() { return memnew(IMPNAME); }\
-	static void make_default() { CNAME::_create = IMPNAME::_create; }\
-protected:\
-/* clang-format on */
+#define GDCIIMPL(IMPNAME, CNAME)                                      \
+public:                                                               \
+	static CNAME *_create() { return memnew(IMPNAME); }               \
+	static void make_default() { CNAME::_create = IMPNAME::_create; } \
+                                                                      \
+protected:
 
 #endif // WEBSOCKET_MACROS_H


### PR DESCRIPTION
When going from version 14 to 15 it would introduce a tiny change in `websocket_macros.h` just before the comment re-enabling clang-format, but this can be solved by just letting it do its work.

Bonus cosmetic change in `math_fieldwise.cpp` where clang-format isn't used, and bump recommended versions for pre-commit hook to [13; 15].

As a bonus, while reviewing cases where we currently disable clang-format, I found one in `modules/mono/managed_callable.cpp` where we workaround a bug so I reported it upstream: https://github.com/llvm/llvm-project/issues/57868