### PR TITLE
[3.x] Style: Ensure consistent formatting with clang-format 15

### DIFF
--- a/core/math/math_fieldwise.cpp
+++ b/core/math/math_fieldwise.cpp
@@ -47,9 +47,7 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 	/* clang-format off */
 
 	switch (p_source.get_type()) {
-
 		case Variant::VECTOR2: {
-
 			SETUP_TYPE(Vector2)
 
 			/**/ TRY_TRANSFER_FIELD("x", x)
@@ -59,7 +57,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 		}
 
 		case Variant::RECT2: {
-
 			SETUP_TYPE(Rect2)
 
 			/**/ TRY_TRANSFER_FIELD("x", position.x)
@@ -71,7 +68,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 		}
 
 		case Variant::VECTOR3: {
-
 			SETUP_TYPE(Vector3)
 
 			/**/ TRY_TRANSFER_FIELD("x", x)
@@ -82,7 +78,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 		}
 
 		case Variant::PLANE: {
-
 			SETUP_TYPE(Plane)
 
 			/**/ TRY_TRANSFER_FIELD("x", normal.x)
@@ -94,7 +89,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 		}
 
 		case Variant::QUAT: {
-
 			SETUP_TYPE(Quat)
 
 			/**/ TRY_TRANSFER_FIELD("x", x)
@@ -106,7 +100,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 		}
 
 		case Variant::AABB: {
-
 			SETUP_TYPE(AABB)
 
 			/**/ TRY_TRANSFER_FIELD("px", position.x)
@@ -120,7 +113,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 		}
 
 		case Variant::TRANSFORM2D: {
-
 			SETUP_TYPE(Transform2D)
 
 			/**/ TRY_TRANSFER_FIELD("xx", elements[0][0])
@@ -134,7 +126,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 		}
 
 		case Variant::BASIS: {
-
 			SETUP_TYPE(Basis)
 
 			/**/ TRY_TRANSFER_FIELD("xx", elements[0][0])
@@ -151,7 +142,6 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 		}
 
 		case Variant::TRANSFORM: {
-
 			SETUP_TYPE(Transform)
 
 			/**/ TRY_TRANSFER_FIELD("xx", basis.elements[0][0])

--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -1727,8 +1727,12 @@ Variant Variant::get_named(const StringName &p_index, bool *r_valid) const {
 		}                                                                                \
 	} break;
 
+// clang-format 14 wants to add a space after the last return,
+// and clang-format 15 removes it...
+/* clang-format off */
 #define DEFAULT_OP_DVECTOR_SET(m_name, dv_type, skip_cond) \
-	DEFAULT_OP_ARRAY_CMD(m_name, PoolVector<dv_type>, if (skip_cond) return;, arr->set(index, p_value); return )
+	DEFAULT_OP_ARRAY_CMD(m_name, PoolVector<dv_type>, if (skip_cond) return;, arr->set(index, p_value); return)
+/* clang-format on */
 
 #define DEFAULT_OP_DVECTOR_GET(m_name, dv_type) \
 	DEFAULT_OP_ARRAY_CMD(m_name, const PoolVector<dv_type>, ;, return arr->get(index))
@@ -2192,7 +2196,11 @@ void Variant::set(const Variant &p_index, const Variant &p_value, bool *r_valid)
 			valid = true; //always valid, i guess? should this really be ok?
 			return;
 		} break;
-			DEFAULT_OP_ARRAY_CMD(ARRAY, Array, ;, (*arr)[index] = p_value; return ) // 20
+			// clang-format 14 wants to add a space after the last return,
+			// and clang-format 15 removes it...
+			/* clang-format off */
+			DEFAULT_OP_ARRAY_CMD(ARRAY, Array, ;, (*arr)[index] = p_value; return) // 20
+			/* clang-format on */
 			DEFAULT_OP_DVECTOR_SET(POOL_BYTE_ARRAY, uint8_t, p_value.type != Variant::REAL && p_value.type != Variant::INT)
 			DEFAULT_OP_DVECTOR_SET(POOL_INT_ARRAY, int, p_value.type != Variant::REAL && p_value.type != Variant::INT)
 			DEFAULT_OP_DVECTOR_SET(POOL_REAL_ARRAY, real_t, p_value.type != Variant::REAL && p_value.type != Variant::INT)

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1976,21 +1976,18 @@ FRAGMENT_SHADER_CODE
 #if defined(AMBIENT_LIGHT_DISABLED)
 	ambient_light = vec3(0.0, 0.0, 0.0);
 #else
-	{
-		{ //read radiance from dual paraboloid
-
-			vec3 ref_vec = reflect(-eye_vec, normal);
-			float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
-			ref_vec = normalize((radiance_inverse_xform * vec4(ref_vec, 0.0)).xyz);
-			vec3 radiance;
+	{ //read radiance from dual paraboloid
+		vec3 ref_vec = reflect(-eye_vec, normal);
+		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
+		ref_vec = normalize((radiance_inverse_xform * vec4(ref_vec, 0.0)).xyz);
+		vec3 radiance;
 #ifdef USE_RADIANCE_MAP_ARRAY //ubershader-runtime
-			radiance = textureDualParaboloidArray(radiance_map_array, ref_vec, roughness) * bg_energy;
+		radiance = textureDualParaboloidArray(radiance_map_array, ref_vec, roughness) * bg_energy;
 #else //ubershader-runtime
-			radiance = textureDualParaboloid(radiance_map, ref_vec, roughness) * bg_energy;
+		radiance = textureDualParaboloid(radiance_map, ref_vec, roughness) * bg_energy;
 #endif //ubershader-runtime
-			env_reflection_light = radiance;
-			env_reflection_light *= horizon * horizon;
-		}
+		env_reflection_light = radiance;
+		env_reflection_light *= horizon * horizon;
 	}
 #ifndef USE_LIGHTMAP //ubershader-runtime
 	{
@@ -2257,7 +2254,6 @@ FRAGMENT_SHADER_CODE
 #ifdef USE_VERTEX_LIGHTING //ubershader-runtime
 	diffuse_light *= mix(vec3(1.0), light_attenuation, diffuse_light_interp.a);
 	specular_light *= mix(vec3(1.0), light_attenuation, specular_light_interp.a);
-
 #else //ubershader-runtime
 	light_compute(normal, -light_direction_attenuation.xyz, eye_vec, binormal, tangent, light_color_energy.rgb, light_attenuation, albedo, transmission, light_params.z * specular_blob_intensity, roughness, metallic, specular, rim, rim_tint, clearcoat, clearcoat_gloss, anisotropy, diffuse_light, specular_light, alpha);
 #endif //ubershader-runtime

--- a/misc/hooks/README.md
+++ b/misc/hooks/README.md
@@ -28,7 +28,7 @@ so they should work out of the box on Linux/macOS.
 #### Windows
 
 ##### clang-format
-- Download LLVM for Windows (version 8 or later) from
+- Download LLVM for Windows (version 13 or later) from
   <https://releases.llvm.org/download.html>
 - Make sure LLVM is added to the `PATH` during installation
 

--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -76,8 +76,8 @@ fi
 
 # To get consistent formatting, we recommend contributors to use the same
 # clang-format version as CI.
-RECOMMENDED_CLANG_FORMAT_MAJOR_MIN="12"
-RECOMMENDED_CLANG_FORMAT_MAJOR_MAX="14"
+RECOMMENDED_CLANG_FORMAT_MAJOR_MIN="13"
+RECOMMENDED_CLANG_FORMAT_MAJOR_MAX="15"
 
 if [ ! -x "$CLANG_FORMAT" ] ; then
 	message="Error: clang-format executable not found. Please install clang-format $RECOMMENDED_CLANG_FORMAT_MAJOR_MAX."

--- a/modules/websocket/websocket_macros.h
+++ b/modules/websocket/websocket_macros.h
@@ -41,34 +41,32 @@
 #define WSS_OUT_BUF PNAME("network/limits/websocket_server/max_out_buffer_kb")
 #define WSS_OUT_PKT PNAME("network/limits/websocket_server/max_out_packets")
 
-/* clang-format off */
-#define GDCICLASS(CNAME) \
-public:\
-	static CNAME *(*_create)();\
-\
-	static Ref<CNAME > create_ref() {\
-\
-		if (!_create)\
-			return Ref<CNAME >();\
-		return Ref<CNAME >(_create());\
-	}\
-\
-	static CNAME *create() {\
-\
-		if (!_create)\
-			return NULL;\
-		return _create();\
-	}\
-protected:\
+#define GDCICLASS(CNAME)              \
+public:                               \
+	static CNAME *(*_create)();       \
+                                      \
+	static Ref<CNAME> create_ref() {  \
+		if (!_create)                 \
+			return Ref<CNAME>();      \
+		return Ref<CNAME>(_create()); \
+	}                                 \
+                                      \
+	static CNAME *create() {          \
+		if (!_create)                 \
+			return NULL;              \
+		return _create();             \
+	}                                 \
+                                      \
+protected:
 
 #define GDCINULL(CNAME) \
-CNAME *(*CNAME::_create)() = NULL;
+	CNAME *(*CNAME::_create)() = NULL;
 
-#define GDCIIMPL(IMPNAME, CNAME) \
-public:\
-	static CNAME *_create() { return memnew(IMPNAME); }\
-	static void make_default() { CNAME::_create = IMPNAME::_create; }\
-protected:\
-/* clang-format on */
+#define GDCIIMPL(IMPNAME, CNAME)                                      \
+public:                                                               \
+	static CNAME *_create() { return memnew(IMPNAME); }               \
+	static void make_default() { CNAME::_create = IMPNAME::_create; } \
+                                                                      \
+protected:
 
 #endif // WEBSOCKET_MACROS_H


### PR DESCRIPTION
`3.x` version of #66206

It would make a weird mess of `drivers/gles3/shaders/scene.glsl` but removing the extra unnamed scope fixed it ¯\\\_(ツ)\_/¯