### PR TITLE
Let the cached `TextLine` reset the width in `get_string_size`

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -272,13 +272,15 @@ Size2 Font::get_string_size(const String &p_text, HorizontalAlignment p_alignmen
 		buffer->set_direction(p_direction);
 		buffer->set_orientation(p_orientation);
 		buffer->add_string(p_text, Ref<Font>(this), p_font_size);
-		if (p_alignment == HORIZONTAL_ALIGNMENT_FILL) {
-			buffer->set_horizontal_alignment(p_alignment);
-			buffer->set_width(p_width);
-			buffer->set_flags(p_jst_flags);
-		}
 		cache.insert(hash, buffer);
 	}
+
+	buffer->set_width(p_width);
+	buffer->set_horizontal_alignment(p_alignment);
+	if (p_alignment == HORIZONTAL_ALIGNMENT_FILL) {
+		buffer->set_flags(p_jst_flags);
+	}
+
 	return buffer->get_size();
 }
 


### PR DESCRIPTION
Previously, the cached `TextLine` would set the width in `draw_string`, but not in `get_string_size`,  which resulted in unexpected results returned by `get_string_size` in some cases.

Now as in `draw_string`, width is also set.

Fix #65972.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
