### PR TITLE
`ScriptTextEditor` Fix checking if script is attached to any node belonging to scene

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1487,16 +1487,17 @@ bool ScriptTextEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_
 }
 
 static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script) {
-	if (p_edited_scene != p_current_node && p_current_node->get_owner() != p_edited_scene) {
-		return nullptr;
+	// Check scripts only for the nodes belonging to the edited scene.
+	if (p_current_node == p_edited_scene || p_current_node->get_owner() == p_edited_scene) {
+		Ref<Script> scr = p_current_node->get_script();
+		if (scr.is_valid() && scr == script) {
+			return p_current_node;
+		}
 	}
 
-	Ref<Script> scr = p_current_node->get_script();
-
-	if (scr.is_valid() && scr == script) {
-		return p_current_node;
-	}
-
+	// Traverse all children, even the ones not owned by the edited scene as they
+	// can still have child nodes added within the edited scene and thus owned by
+	// it (e.g. nodes added to subscene's root or to its editable children).
 	for (int i = 0; i < p_current_node->get_child_count(); i++) {
 		Node *n = _find_script_node(p_edited_scene, p_current_node->get_child(i), script);
 		if (n) {


### PR DESCRIPTION
Fixes #66209.

`_find_script_node` function was not traversing children not owned by the given scene so nodes added in the given scene to a subscene's root / its editable children weren't reached and thus their scripts were not checked. Now it traverses all children but checks the scripts only for the nodes owned by the given scene.

The changed `_find_script_node` function is used only for this check so it shouldn't break anything:
https://github.com/godotengine/godot/blob/74765691cb4b5989df73d48acf547d120aa46779/editor/plugins/script_text_editor.cpp#L1567-L1571