### PR TITLE
QuickOpen: Disable loading resources for now, too slow

### DIFF
--- a/editor/editor_quick_open.h
+++ b/editor/editor_quick_open.h
@@ -43,7 +43,7 @@ class EditorQuickOpen : public ConfirmationDialog {
 	Tree *search_options = nullptr;
 	StringName base_type;
 	bool allow_multi_select = false;
-	bool _load_resources = true;
+	bool _load_resources = false; // Prohibitively slow for now.
 
 	Vector<String> files;
 	OAHashMap<String, Ref<Texture2D>> icons;


### PR DESCRIPTION
As expected while reviewing #62417 this is indeed not practical without a better system to retrieve this information.

Fixes #66179.

Please confirm that it solves the issue, didn't test.