### PR TITLE
[3.x] Enable ANSI escape code processing on Windows 10 and later

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3998,6 +3998,21 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	AudioDriverManager::add_driver(&driver_xaudio2);
 #endif
 
+	// Enable ANSI escape code support on Windows 10 v1607 (Anniversary Update) and later.
+	// This lets the engine and projects use ANSI escape codes to color text just like on macOS and Linux.
+	//
+	// NOTE: The engine does not use ANSI escape codes to color error/warning messages; it uses Windows API calls instead.
+	// Therefore, error/warning messages are still colored on Windows versions older than 10.
+	HANDLE stdoutHandle;
+	stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+	DWORD outMode = 0;
+	outMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+	if (!SetConsoleMode(stdoutHandle, outMode)) {
+		// Windows 8.1 or below, or Windows 10 prior to Anniversary Update.
+		print_verbose("Can't set the ENABLE_VIRTUAL_TERMINAL_PROCESSING Windows console mode.");
+	}
+
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(WindowsTerminalLogger));
 	_set_logger(memnew(CompositeLogger(loggers)));


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/44118.

This lets the engine and projects use the same color codes in the terminal on all platforms.

I tested this on Windows 10 (where it works) and on Windows 7 (where ANSI escape codes are printed as-is). Since Windows versions older than 10 are now EOL, this is probably acceptable, but feel free to improve on this in a future PR (e.g. by stripping ANSI escape codes).

Note that this PR does not include [`print_rich()`](https://github.com/godotengine/godot/pull/60675), as it's difficult to backport. You can still print colored text to the terminal using the following approach:

```gdscript
var escape = PoolByteArray([0x1b]).get_string_from_ascii()
var code = "[1;32m"
print(escape + code + "Bold green text")
```