### PR TITLE
AnimatedSprite: Do not always reset `frame` on animation switch

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -402,9 +402,12 @@ void AnimatedSprite2D::play(const StringName &p_animation, bool p_backwards) {
 	playing_backwards = signbit(speed_scale) != backwards;
 
 	if (p_animation) {
+		StringName previous_animation = animation;
 		set_animation(p_animation);
-		if (frames.is_valid() && playing_backwards && get_frame() == 0) {
-			set_frame(frames->get_frame_count(p_animation) - 1);
+		if (animation == previous_animation) {
+			// Animation has successfully changed.
+			_reset_timeout();
+			set_frame(playing_backwards ? frames->get_frame_count(animation) - 1 : 0);
 		}
 	}
 
@@ -437,15 +440,18 @@ void AnimatedSprite2D::_reset_timeout() {
 
 void AnimatedSprite2D::set_animation(const StringName &p_animation) {
 	ERR_FAIL_COND_MSG(frames == nullptr, vformat("There is no animation with name '%s'.", p_animation));
-	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(p_animation), vformat("There is no animation with name '%s'.", p_animation));
+	ERR_FAIL_COND_MSG(!frames->has_animation(p_animation), vformat("There is no animation with name '%s'.", p_animation));
 
 	if (animation == p_animation) {
 		return;
 	}
 
 	animation = p_animation;
-	_reset_timeout();
-	set_frame(0);
+
+	if (frame > frames->get_frame_count(animation) || Engine::get_singleton()->is_editor_hint()) {
+		set_frame(playing_backwards ? frames->get_frame_count(animation) - 1 : 0);
+		_reset_timeout();
+	}
 	notify_property_list_changed();
 	queue_redraw();
 }


### PR DESCRIPTION
Somewhat related to https://github.com/godotengine/godot/pull/65986 tackling a similar issue.

### Something that has bothering me for a bit:

Say, we have two almost identical animations in our **SpriteFrames** resource, `run`, and `run_hurt`. I want to dynamically switch between two as they're in motion. This means I want to change **only** the `animation`, but even by doing this, without calling `play()`, resets _everything_ back from the start. This is typically no issue, but it is in this decently common case. While `frame` can be set back to what it was, there's no way to set the elapsed frame time manually _(nor an actual need to in most cases)_. This causes the animation to play unexpectedly, which is especially noticeable the slower it is.

The odd thing here is that changing `animation` manually behaves almost exactly like `play("different_animation")`, which really feels like shouldn't be the case. **Only** the animation should change. I can only speculate it is done this way is to improve usability in the Editor, or because it is deemed to be the expected the behaviour...

#### Furthermore, as a consequence of the pieces of code responsible for this, another oddity is present:
If you set your animation to play in reverse, then call `play()` at frame **0**, the elapsed frame time is reset, as if the animation began from scratch. Typically, `play()` doesn't do anything if the animation is already playing, so what if you didn't intend to do that?

--------------------------
In this PR, changing `animation` resets `frame` & the _elapsed frame time_ only if the new animation doesn't have enough frames to sustain it, and is also dependent on the animation direction.

`play()` always resets `frame` if the `animation` successfully switches. In the Editor, for usability reason, the previous behaviour is retained.

Applies to both **AnimatedSprite2D** and **AnimatedSprite3D**.

###### _Also tweaks an ERR_FAIL_COND_MSG._