### PR TITLE
Remove unused struct in GradientTexture1D

### DIFF
--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -769,15 +769,6 @@ public:
 class GradientTexture1D : public Texture2D {
 	GDCLASS(GradientTexture1D, Texture2D);
 
-public:
-	struct Point {
-		float offset = 0.0;
-		Color color;
-		bool operator<(const Point &p_ponit) const {
-			return offset < p_ponit.offset;
-		}
-	};
-
 private:
 	Ref<Gradient> gradient;
 	bool update_pending = false;


### PR DESCRIPTION
While working on a PR, I noticed this Point struct isn't used anywhere inside or outside of **GradientTexture1D**, and is in fact just a duplicate of the very same Point struct of **Gradient**.

I can speculate it was put there for future reference, but left there by accident. The engine compiles just fine without it.
