### PR TITLE
Document Mesh vertex color compression clamping overbright/HDR colors

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -46,6 +46,8 @@
 				Creates a new surface.
 				Surfaces are created to be rendered using a [code]primitive[/code], which may be any of the types defined in [enum Mesh.PrimitiveType]. (As a note, when using indices, it is recommended to only use points, lines, or triangles.) [method Mesh.get_surface_count] will become the [code]surf_idx[/code] for this new surface.
 				The [code]arrays[/code] argument is an array of arrays. See [enum ArrayType] for the values used in this array. For example, [code]arrays[0][/code] is the array of vertices. That first vertex sub-array is always required; the others are optional. Adding an index array puts this function into "index mode" where the vertex and other arrays become the sources of data and the index array defines the vertex order. All sub-arrays must have the same length as the vertex array or be empty, except for [constant ARRAY_INDEX] if it is used.
+				[code]compress_flags[/code] is a bitfield made of [enum Mesh.ArrayFormat] values. It defaults to [constant Mesh.ARRAY_COMPRESS_DEFAULT].
+				[b]Note:[/b] The default [code]compress_flags[/code] enable [constant Mesh.ARRAY_COMPRESS_COLOR], which makes vertex colors stored as 8-bit unsigned integers. This will clamp overbright vertex colors to [code]Color(1, 1, 1, 1)[/code] and reduce their precision. To store HDR vertex colors, remove the vertex color compression flag by passing [code]Mesh.ARRAY_COMPRESS_DEFAULT ^ Mesh.ARRAY_COMPRESS_COLOR[/code] as the value of [code]compress_flags[/code].
 			</description>
 		</method>
 		<method name="clear_blend_shapes">

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -166,6 +166,7 @@
 		</constant>
 		<constant name="ARRAY_COMPRESS_COLOR" value="4096" enum="ArrayFormat">
 			Flag used to mark a compressed (half float) color array.
+			[b]Note:[/b] If this flag is enabled, vertex colors will be stored as 8-bit unsigned integers. This will clamp overbright colors to [code]Color(1, 1, 1, 1)[/code] and reduce colors' precision.
 		</constant>
 		<constant name="ARRAY_COMPRESS_TEX_UV" value="8192" enum="ArrayFormat">
 			Flag used to mark a compressed (half float) UV coordinates array.
@@ -193,6 +194,7 @@
 		</constant>
 		<constant name="ARRAY_COMPRESS_DEFAULT" value="2194432" enum="ArrayFormat">
 			Used to set flags [constant ARRAY_COMPRESS_VERTEX], [constant ARRAY_COMPRESS_NORMAL], [constant ARRAY_COMPRESS_TANGENT], [constant ARRAY_COMPRESS_COLOR], [constant ARRAY_COMPRESS_TEX_UV], [constant ARRAY_COMPRESS_TEX_UV2], [constant ARRAY_COMPRESS_WEIGHTS], and [constant ARRAY_FLAG_USE_OCTAHEDRAL_COMPRESSION] quickly.
+			[b]Note:[/b] Since this flag enables [constant ARRAY_COMPRESS_COLOR], vertex colors will be stored as 8-bit unsigned integers. This will clamp overbright colors to [code]Color(1, 1, 1, 1)[/code] and reduce colors' precision.
 		</constant>
 		<constant name="ARRAY_VERTEX" value="0" enum="ArrayType">
 			Array of vertices.


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/66197.

As far as I know, this is not relevant for `master` as [vertex color data is always 8-bit unsigned there](https://github.com/godotengine/godot/pull/50037) (even with compression disabled).