### PR TITLE
EditorScenePostImportPlugin scene import API additions

### DIFF
--- a/doc/classes/EditorScenePostImportPlugin.xml
+++ b/doc/classes/EditorScenePostImportPlugin.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_get_custom_scene_root" qualifiers="virtual">
+			<return type="NodePath" />
+			<param index="0" name="scene" type="Node" />
+			<description>
+				Return the NodePath of the node that should be the root of the imported scene tree. Only one EditorPostImportPlugin may use of this feature at a time per scene import, otherwise further custom roots will be ignored. The scene importer will take care of freeing the remainder of the discarded scene tree.
+			</description>
+		</method>
 		<method name="_get_import_options" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
@@ -98,6 +105,12 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Query the value of an option. This function can only be called from those querying visibility, or processing.
+			</description>
+		</method>
+		<method name="get_source_file" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the source file path which got imported (e.g. [code]res://scene.dae[/code]).
 			</description>
 		</method>
 	</methods>

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -119,6 +119,7 @@ private:
 	mutable const Dictionary *current_options_dict = nullptr;
 	List<ResourceImporter::ImportOption> *current_option_list = nullptr;
 	InternalImportCategory current_category = INTERNAL_IMPORT_CATEGORY_MAX;
+	String source_file;
 
 protected:
 	GDVIRTUAL1(_get_internal_import_options, int)
@@ -129,6 +130,7 @@ protected:
 	GDVIRTUAL3RC(Variant, _get_option_visibility, String, bool, String)
 	GDVIRTUAL1(_pre_process, Node *)
 	GDVIRTUAL1(_post_process, Node *)
+	GDVIRTUAL1R(Variant, _get_custom_scene_root, Node *)
 
 	static void _bind_methods();
 
@@ -148,6 +150,10 @@ public:
 
 	virtual void pre_process(Node *p_scene, const HashMap<StringName, Variant> &p_options);
 	virtual void post_process(Node *p_scene, const HashMap<StringName, Variant> &p_options);
+	virtual NodePath get_custom_scene_root(Node *p_scene, const HashMap<StringName, Variant> &p_options);
+
+	void set_source_file(const String &p_source_file) { source_file = p_source_file; }
+	String get_source_file() const;
 
 	EditorScenePostImportPlugin() {}
 };


### PR DESCRIPTION
* Let EditorScenePostImportPlugin set a custom root node
* Make EditorScenePostImport run _post_import only after all EditorScenePostImportPlugin plugins have ended processing
* Make EditorScenePostImportPlugin aware of the source file
* Set NavigationRegion3D name when in Navmesh only import mode

Fixes godotengine/godot-proposals#5093
