### PR TITLE
Swap arguments of ResourceSaver.save() in documentation

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -44,7 +44,7 @@
 		    # Fill the Mesh with data read in "file", left as an exercise to the reader.
 
 		    var filename = save_path + "." + _get_save_extension()
-		    return ResourceSaver.save(filename, mesh)
+		    return ResourceSaver.save(mesh, filename)
 		[/gdscript]
 		[csharp]
 		using Godot;
@@ -103,7 +103,7 @@
 		        var mesh = new ArrayMesh();
 		        // Fill the Mesh with data read in "file", left as an exercise to the reader.
 		        String filename = savePath + "." + GetSaveExtension();
-		        return (int)ResourceSaver.Save(filename, mesh);
+		        return (int)ResourceSaver.Save(mesh, filename);
 		    }
 		}
 		[/csharp]

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -41,7 +41,7 @@
 		# Only `node` and `body` are now packed.
 		var result = scene.pack(node)
 		if result == OK:
-		    var error = ResourceSaver.save("res://path/name.tscn", scene)  # Or "user://..."
+		    var error = ResourceSaver.save(scene, "res://path/name.tscn")  # Or "user://..."
 		    if error != OK:
 		        push_error("An error occurred while saving the scene to disk.")
 		[/gdscript]
@@ -63,7 +63,7 @@
 		Error result = scene.Pack(node);
 		if (result == Error.Ok)
 		{
-		    Error error = ResourceSaver.Save("res://path/name.tscn", scene); // Or "user://..."
+		    Error error = ResourceSaver.Save(scene, "res://path/name.tscn"); // Or "user://..."
 		    if (error != Error.Ok)
 		    {
 		        GD.PushError("An error occurred while saving the scene to disk.");


### PR DESCRIPTION
Update code examples to match new argument order following https://github.com/godotengine/godot/pull/61647

See also https://github.com/godotengine/godot-docs/pull/6203 for the docs update.