### PR TITLE
Fix code examples for @tool annotation

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -9,7 +9,7 @@
 		Below is an example EditorImportPlugin that imports a [Mesh] from a file with the extension ".special" or ".spec":
 		[codeblocks]
 		[gdscript]
-		tool
+		@tool
 		extends EditorImportPlugin
 
 		func _get_importer_name():

--- a/doc/classes/EditorScenePostImport.xml
+++ b/doc/classes/EditorScenePostImport.xml
@@ -8,7 +8,7 @@
 		The [method _post_import] callback receives the imported scene's root node and returns the modified version of the scene. Usage example:
 		[codeblocks]
 		[gdscript]
-		tool # Needed so it runs in editor.
+		@tool # Needed so it runs in editor.
 		extends EditorScenePostImport
 		# This sample changes all node names.
 		# Called right after the scene is imported and gets the root node.

--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -9,7 +9,7 @@
 		[b]Example script:[/b]
 		[codeblocks]
 		[gdscript]
-		tool
+		@tool
 		extends EditorScript
 
 		func _run():

--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -11,7 +11,7 @@
 		Below shows an example of a custom parser that extracts strings from a CSV file to write into a POT.
 		[codeblocks]
 		[gdscript]
-		tool
+		@tool
 		extends EditorTranslationParserPlugin
 
 		func _parse_file(path, msgids, msgids_context_plural):


### PR DESCRIPTION
Fix some code examples that were still using the tool keyword and not the @tool annotation.

See also https://github.com/godotengine/godot-docs/pull/6211 for a similar update on the docs.