### PR TITLE
SCons: Unify tools/target build type configuration

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -2,16 +2,13 @@ name: Build Godot
 description: Build Godot with the provided options.
 inputs:
   target:
-    description: The scons target (debug/release_debug/release).
-    default: "debug"
-  tools:
-    description: If tools are to be built.
-    default: false
+    description: Build target (editor, template_release, template_debug).
+    default: "editor"
   tests:
-    description: If tests are to be built.
+    description: Unit tests.
     default: false
   platform:
-    description: The Godot platform to build.
+    description: Target platform.
     required: false
   sconsflags:
     default: ""
@@ -33,7 +30,7 @@ runs:
           SCONS_CACHE: ${{ inputs.scons-cache }}
           SCONS_CACHE_LIMIT: ${{ inputs.scons-cache-limit }}
       run: |
-        echo "Building with flags:" ${{ env.SCONSFLAGS }}
-        if ! ${{ inputs.tools }}; then rm -rf editor; fi  # Ensure we don't include editor code.
-        scons p=${{ inputs.platform }} target=${{ inputs.target }} tools=${{ inputs.tools }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
+        echo "Building with flags:" platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
+        if [ "${{ inputs.target }}" != "editor" ]; then rm -rf editor; fi  # Ensure we don't include editor code.
+        scons platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }}
         ls -l bin/

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   android-template:
     runs-on: "ubuntu-20.04"
-    name: Template (target=release, tools=no)
+    name: Template (target=template_release)
 
     steps:
       - uses: actions/checkout@v3
@@ -44,8 +44,7 @@ jobs:
         with:
           sconsflags: ${{ env.SCONSFLAGS }} arch=arm32
           platform: android
-          target: release
-          tools: false
+          target: template_release
           tests: false
 
       - name: Compilation (arm64)
@@ -53,8 +52,7 @@ jobs:
         with:
           sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
           platform: android
-          target: release
-          tools: false
+          target: template_release
           tests: false
 
       - name: Generate Godot templates

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   ios-template:
     runs-on: "macos-latest"
-    name: Template (target=release, tools=no)
+    name: Template (target=template_release)
 
     steps:
       - uses: actions/checkout@v3
@@ -31,8 +31,7 @@ jobs:
         with:
           sconsflags: ${{ env.SCONSFLAGS }}
           platform: ios
-          target: release
-          tools: false
+          target: template_release
           tests: false
 
       - name: Upload artifact

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -7,7 +7,7 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
   DOTNET_NOLOGO: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: false
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux
@@ -21,57 +21,52 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor w Mono (target=release_debug, tools=yes, tests=yes)
+          - name: Editor w/ Mono (target=editor)
             cache-name: linux-editor-mono
-            target: release_debug
-            tools: true
+            target: editor
             tests: false # Disabled due freeze caused by mix Mono build and CI
             sconsflags: module_mono_enabled=yes
             doc-test: true
-            bin: "./bin/godot.linuxbsd.opt.tools.x86_64.mono"
+            bin: "./bin/godot.linuxbsd.editor.x86_64.mono"
             build-mono: true
             proj-conv: true
             artifact: true
 
-          - name: Editor with doubles and GCC sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=yes, use_ubsan=yes, linker=gold)
+          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, float=64, use_asan=yes, use_ubsan=yes, linker=gold)
             cache-name: linux-editor-double-sanitizers
-            target: debug
-            tools: true
+            target: editor
             tests: true
-            sconsflags: float=64 use_asan=yes use_ubsan=yes linker=gold
+            sconsflags: dev_build=yes float=64 use_asan=yes use_ubsan=yes linker=gold
             proj-test: true
             # Can be turned off for PRs that intentionally break compat with godot-cpp,
             # until both the upstream PR and the matching godot-cpp changes are merged.
             godot-cpp-test: true
-            bin: "./bin/godot.linuxbsd.double.tools.x86_64.san"
+            bin: "./bin/godot.linuxbsd.editor.dev.double.x86_64.san"
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-          - name: Editor with clang sanitizers (target=debug, tools=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
+          - name: Editor with clang sanitizers (target=editor, tests=yes, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-llvm-sanitizers
-            target: debug
-            tools: true
+            target: editor
             tests: true
-            sconsflags: use_asan=yes use_ubsan=yes use_llvm=yes linker=lld
-            bin: "./bin/godot.linuxbsd.tools.x86_64.llvm.san"
+            sconsflags: dev_build=yes use_asan=yes use_ubsan=yes use_llvm=yes linker=lld
+            bin: "./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san"
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-          - name: Template w/ Mono (target=release, tools=no)
+          - name: Template w/ Mono (target=template_release)
             cache-name: linux-template-mono
-            target: release
-            tools: false
+            target: template_release
             tests: false
-            sconsflags: module_mono_enabled=yes debug_symbols=no
+            sconsflags: module_mono_enabled=yes
             build-mono: false
             artifact: true
 
-          - name: Minimal Template (target=release, tools=no, everything disabled)
+          - name: Minimal template (target=template_release, everything disabled)
             cache-name: linux-template-minimal
-            target: release
-            tools: false
+            target: template_release
             tests: false
             sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no minizip=no
             artifact: true
@@ -113,7 +108,6 @@ jobs:
           sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
           platform: linuxbsd
           target: ${{ matrix.target }}
-          tools: ${{ matrix.tools }}
           tests: ${{ matrix.tests }}
 
       - name: Generate C# glue
@@ -221,7 +215,7 @@ jobs:
         if: ${{ matrix.godot-cpp-test }}
         run: |
           cd godot-cpp/test
-          scons target=${{ matrix.target }}
+          scons target=debug
           cd ../..
 
       - name: Prepare artifact

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -19,17 +19,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=release_debug, tools=yes, tests=yes)
+          - name: Editor (target=editor, tests=yes)
             cache-name: macos-editor
-            target: release_debug
-            tools: true
+            target: editor
             tests: true
-            bin: "./bin/godot.macos.opt.tools.x86_64"
+            bin: "./bin/godot.macos.editor.x86_64"
 
-          - name: Template (target=release, tools=no)
+          - name: Template (target=template_release)
             cache-name: macos-template
-            target: release
-            tools: false
+            target: template_release
             tests: false
             sconsflags: debug_symbols=no
 
@@ -55,7 +53,6 @@ jobs:
           sconsflags: ${{ env.SCONSFLAGS }}
           platform: macos
           target: ${{ matrix.target }}
-          tools: ${{ matrix.tools }}
           tests: ${{ matrix.tests }}
 
       # Execute unit tests for the editor

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   web-template:
     runs-on: "ubuntu-20.04"
-    name: Template (target=release, tools=no)
+    name: Template (target=template_release)
 
     steps:
       - uses: actions/checkout@v3
@@ -43,8 +43,7 @@ jobs:
         with:
           sconsflags: ${{ env.SCONSFLAGS }}
           platform: web
-          target: release
-          tools: false
+          target: template_release
           tests: false
 
       - name: Upload artifact

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -22,19 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=release_debug, tools=yes, tests=yes)
+          - name: Editor (target=editor, tests=yes)
             cache-name: windows-editor
-            target: release_debug
-            tools: true
+            target: editor
             tests: true
             # Skip debug symbols, they're way too big with MSVC.
             sconsflags: debug_symbols=no
-            bin: "./bin/godot.windows.opt.tools.x86_64.exe"
+            bin: "./bin/godot.windows.editor.x86_64.exe"
 
-          - name: Template (target=release, tools=no)
+          - name: Template (target=template_release, tools=no)
             cache-name: windows-template
-            target: release
-            tools: false
+            target: template_release
             tests: false
             sconsflags: debug_symbols=no
 
@@ -57,7 +55,6 @@ jobs:
           sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
           platform: windows
           target: ${{ matrix.target }}
-          tools: ${{ matrix.tools }}
           tests: ${{ matrix.tests }}
 
       # Execute unit tests for the editor

--- a/core/SCsub
+++ b/core/SCsub
@@ -85,7 +85,7 @@ if env["builtin_zlib"]:
     env_thirdparty.Prepend(CPPPATH=[thirdparty_zlib_dir])
     # Needs to be available in main env too
     env.Prepend(CPPPATH=[thirdparty_zlib_dir])
-    if env["target"] == "debug":
+    if env.dev_build:
         env_thirdparty.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_zlib_sources)

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -24,7 +24,7 @@ def _make_doc_data_class_path(to_path):
     g.close()
 
 
-if env["tools"]:
+if env.editor_build:
     # Register exporters
     reg_exporters_inc = '#include "register_exporters.h"\n'
     reg_exporters = "void register_exporters() {\n"

--- a/methods.py
+++ b/methods.py
@@ -64,7 +64,7 @@ def disable_warnings(self):
 
 def force_optimization_on_debug(self):
     # 'self' is the environment
-    if self["target"] != "debug":
+    if self["target"] != "template-release":
         return
 
     if self.msvc:
@@ -737,20 +737,19 @@ def generate_vs_project(env, num_jobs):
     if batch_file:
 
         class ModuleConfigs(Mapping):
-            # This version information (Win32, x64, Debug, Release, Release_Debug seems to be
+            # This version information (Win32, x64, Debug, Release) seems to be
             # required for Visual Studio to understand that it needs to generate an NMAKE
             # project. Do not modify without knowing what you are doing.
             PLATFORMS = ["Win32", "x64"]
             PLATFORM_IDS = ["x86_32", "x86_64"]
-            CONFIGURATIONS = ["debug", "release", "release_debug"]
-            CONFIGURATION_IDS = ["tools", "opt", "opt.tools"]
+            CONFIGURATIONS = ["editor", "template_release", "template_debug"]
+            DEV_SUFFIX = ["", ".dev"]
 
             @staticmethod
             def for_every_variant(value):
                 return [value for _ in range(len(ModuleConfigs.CONFIGURATIONS) * len(ModuleConfigs.PLATFORMS))]
 
             def __init__(self):
-
                 shared_targets_array = []
                 self.names = []
                 self.arg_dict = {
@@ -779,16 +778,16 @@ def generate_vs_project(env, num_jobs):
                     for platform in ModuleConfigs.PLATFORMS
                 ]
                 self.arg_dict["runfile"] += [
-                    f'bin\\godot.windows.{config_id}.{plat_id}{f".{name}" if name else ""}.exe'
-                    for config_id in ModuleConfigs.CONFIGURATION_IDS
+                    f'bin\\godot.windows.{config}{dev}.{plat_id}{f".{name}" if name else ""}.exe'
+                    for config in ModuleConfigs.CONFIGURATIONS
                     for plat_id in ModuleConfigs.PLATFORM_IDS
+                    for dev in ModuleConfig.DEV_SUFFIX
                 ]
                 self.arg_dict["cpppaths"] += ModuleConfigs.for_every_variant(env["CPPPATH"] + [includes])
                 self.arg_dict["cppdefines"] += ModuleConfigs.for_every_variant(env["CPPDEFINES"] + defines)
                 self.arg_dict["cmdargs"] += ModuleConfigs.for_every_variant(cli_args)
 
             def build_commandline(self, commands):
-
                 configuration_getter = (
                     "$(Configuration"
                     + "".join([f'.Replace("{name}", "")' for name in self.names[1:]])
@@ -799,8 +798,6 @@ def generate_vs_project(env, num_jobs):
                 common_build_prefix = [
                     'cmd /V /C set "plat=$(PlatformTarget)"',
                     '(if "$(PlatformTarget)"=="x64" (set "plat=x86_amd64"))',
-                    'set "tools=%s"' % env["tools"],
-                    f'(if "{configuration_getter}"=="release" (set "tools=no"))',
                     'call "' + batch_file + '" !plat!',
                 ]
 
@@ -813,9 +810,11 @@ def generate_vs_project(env, num_jobs):
                     "platform=windows",
                     f"target={configuration_getter}",
                     "progress=no",
-                    "tools=!tools!",
                     "-j%s" % num_jobs,
                 ]
+
+                if env["dev_build"]:
+                    common_build_postfix.append("dev_build=yes")
 
                 if env["tests"]:
                     common_build_postfix.append("tests=yes")
@@ -846,7 +845,7 @@ def generate_vs_project(env, num_jobs):
         add_to_vs_project(env, env.servers_sources)
         if env["tests"]:
             add_to_vs_project(env, env.tests_sources)
-        if env["tools"]:
+        if env.editor_build:
             add_to_vs_project(env, env.editor_sources)
 
         for header in glob_recursive("**/*.h"):
@@ -855,7 +854,7 @@ def generate_vs_project(env, num_jobs):
         module_configs = ModuleConfigs()
 
         if env.get("module_mono_enabled"):
-            mono_defines = [("GD_MONO_HOT_RELOAD",)] if env["tools"] else []
+            mono_defines = [("GD_MONO_HOT_RELOAD",)] if env.editor_build else []
             module_configs.add_mode(
                 "mono",
                 cli_args="module_mono_enabled=yes",

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -411,7 +411,7 @@
 			}
 		}
 	//]]></script>
-	<script src="godot.tools.js"></script>
+	<script src="godot.editor.js"></script>
 	<script>//<![CDATA[
 
 		var editor = null;
@@ -706,7 +706,7 @@
 				displayFailureNotice('WebGL not available');
 			} else {
 				setStatusMode('indeterminate');
-				editor.init('godot.tools').then(function() {
+				editor.init('godot.editor').then(function() {
 					if (zip) {
 						editor.copyToFS("/tmp/preload.zip", zip);
 					}

--- a/misc/dist/html/manifest.json
+++ b/misc/dist/html/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Godot",
   "description": "Multi-platform 2D and 3D game engine with a feature-rich editor (Web edition)",
   "lang": "en",
-  "start_url": "./godot.tools.html",
+  "start_url": "./godot.editor.html",
   "display": "standalone",
   "theme_color": "#202531",
   "icons": [

--- a/modules/basis_universal/SCsub
+++ b/modules/basis_universal/SCsub
@@ -40,12 +40,12 @@ if not env.msvc:
 else:
     env_basisu.Prepend(CPPPATH=[thirdparty_dir])
 
-if env["target"] == "debug":
+if env.dev_build:
     env_basisu.Append(CPPDEFINES=[("BASISU_DEVEL_MESSAGES", 1), ("BASISD_ENABLE_DEBUG_FLAGS", 1)])
 
 env_thirdparty = env_basisu.Clone()
 env_thirdparty.disable_warnings()
-if env["tools"]:
+if env.editor_build:
     env_thirdparty.Append(CPPDEFINES=["BASISU_NO_IMG_LOADERS"])
     env_thirdparty.add_source_files(thirdparty_obj, encoder_sources)
 env_thirdparty.add_source_files(thirdparty_obj, transcoder_sources)

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -7,5 +7,5 @@ env_csg = env_modules.Clone()
 
 # Godot source files
 env_csg.add_source_files(env.modules_sources, "*.cpp")
-if env["tools"]:
+if env.editor_build:
     env_csg.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/cvtt/config.py
+++ b/modules/cvtt/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env["tools"]
+    return env.editor_build
 
 
 def configure(env):

--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -5,7 +5,7 @@ def can_build(env, platform):
     # as doing lightmap generation and denoising on Android or Web
     # would be a bit far-fetched.
     desktop_platforms = ["linuxbsd", "macos", "windows"]
-    return env["tools"] and platform in desktop_platforms and env["arch"] == "x86_64"
+    return env.editor_build and platform in desktop_platforms and env["arch"] == "x86_64"
 
 
 def configure(env):

--- a/modules/etcpak/config.py
+++ b/modules/etcpak/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env["tools"]
+    return env.editor_build
 
 
 def configure(env):

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -90,7 +90,7 @@ if env["builtin_freetype"]:
     env.Prepend(CPPPATH=[thirdparty_dir + "/include"])
 
     env_freetype.Append(CPPDEFINES=["FT2_BUILD_LIBRARY", "FT_CONFIG_OPTION_USE_PNG", "FT_CONFIG_OPTION_SYSTEM_ZLIB"])
-    if env["target"] == "debug":
+    if env.dev_build:
         env_freetype.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
     # Also requires libpng headers

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -7,7 +7,7 @@ env_gdscript = env_modules.Clone()
 
 env_gdscript.add_source_files(env.modules_sources, "*.cpp")
 
-if env["tools"]:
+if env.editor_build:
     env_gdscript.add_source_files(env.modules_sources, "./editor/*.cpp")
 
     SConscript("editor/script_templates/SCsub")

--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -9,5 +9,5 @@ env_gltf = env_modules.Clone()
 env_gltf.add_source_files(env.modules_sources, "*.cpp")
 env_gltf.add_source_files(env.modules_sources, "structures/*.cpp")
 SConscript("extensions/SCsub")
-if env["tools"]:
+if env.editor_build:
     env_gltf.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -7,5 +7,5 @@ env_gridmap = env_modules.Clone()
 
 # Godot source files
 env_gridmap.add_source_files(env.modules_sources, "*.cpp")
-if env["tools"]:
+if env.editor_build:
     env_gridmap.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -26,6 +26,6 @@ if env["platform"] in ["macos", "ios"]:
 elif env["platform"] == "android":
     env_mono.add_source_files(env.modules_sources, "mono_gd/android_mono_config.gen.cpp")
 
-if env["tools"]:
+if env.editor_build:
     env_mono.add_source_files(env.modules_sources, "editor/*.cpp")
     SConscript("editor/script_templates/SCsub")

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -20,10 +20,7 @@ def configure(env, env_mono):
     # is_ios = env["platform"] == "ios"
     # is_ios_sim = is_ios and env["arch"] in ["x86_32", "x86_64"]
 
-    tools_enabled = env["tools"]
-
-    if tools_enabled and not module_supports_tools_on(env["platform"]):
-        raise RuntimeError("This module does not currently support building for this platform with tools enabled")
-
-    if env["tools"]:
+    if env.editor_build:
+        if not module_supports_tools_on(env["platform"]):
+            raise RuntimeError("This module does not currently support building for this platform for editor builds.")
         env_mono.Append(CPPDEFINES=["GD_MONO_HOT_RELOAD"])

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -7,7 +7,7 @@ def can_build(env, platform):
     if env["arch"].startswith("rv"):
         return False
 
-    if env["tools"]:
+    if env.editor_build:
         env.module_add_dependencies("mono", ["regex"])
 
     return True

--- a/modules/multiplayer/SCsub
+++ b/modules/multiplayer/SCsub
@@ -8,7 +8,7 @@ env_mp = env_modules.Clone()
 module_obj = []
 env_mp.add_source_files(module_obj, "*.cpp")
 
-if env["tools"]:
+if env.editor_build:
     env_mp.add_source_files(module_obj, "editor/*.cpp")
 
 env.modules_sources += module_obj

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -57,7 +57,7 @@ env.modules_sources += thirdparty_obj
 module_obj = []
 
 env_navigation.add_source_files(module_obj, "*.cpp")
-if env["tools"]:
+if env.editor_build:
     env_navigation.add_source_files(module_obj, "editor/*.cpp")
 env.modules_sources += module_obj
 

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -96,7 +96,7 @@ env_openxr.add_source_files(module_obj, "extensions/openxr_hand_tracking_extensi
 
 env.modules_sources += module_obj
 
-if env["tools"]:
+if env.editor_build:
     SConscript("editor/SCsub")
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -445,7 +445,7 @@ if env["builtin_icu"]:
 
     icu_data_name = "icudt71l.dat"
 
-    if env_icu["tools"]:
+    if env.editor_build:
         env_icu.Depends("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name)
         env_icu.Command("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name, make_icu_data)
         env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/"])
@@ -479,7 +479,7 @@ if env["builtin_icu"]:
             "-DICU_DATA_NAME=" + icu_data_name,
         ]
     )
-    if env_text_server_adv["tools"]:
+    if env.editor_build:
         env_text_server_adv.Append(CXXFLAGS=["-DICU_STATIC_DATA"])
 
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -193,7 +193,7 @@ if env["freetype_enabled"]:
             "FT_CONFIG_OPTION_SYSTEM_ZLIB",
         ]
     )
-    if env["target"] == "debug":
+    if env.dev_build:
         env_freetype.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
     env.Append(CPPDEFINES=["MODULE_FREETYPE_ENABLED"])

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -188,7 +188,7 @@ if env["freetype_enabled"]:
             "FT_CONFIG_OPTION_SYSTEM_ZLIB",
         ]
     )
-    if env["target"] == "debug":
+    if env.dev_build:
         env_freetype.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
     env.Append(CPPDEFINES=["MODULE_FREETYPE_ENABLED"])

--- a/modules/tinyexr/config.py
+++ b/modules/tinyexr/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env["tools"]
+    return env.editor_build
 
 
 def configure(env):

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -41,7 +41,7 @@ elif env["builtin_wslay"]:
 module_obj = []
 
 env_ws.add_source_files(module_obj, "*.cpp")
-if env["tools"]:
+if env.editor_build:
     env_ws.add_source_files(module_obj, "editor/*.cpp")
 env.modules_sources += module_obj
 

--- a/modules/xatlas_unwrap/config.py
+++ b/modules/xatlas_unwrap/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env["tools"] and platform not in ["android", "ios"]
+    return env.editor_build and platform not in ["android", "ios"]
 
 
 def configure(env):

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -53,14 +53,14 @@ else:
     print("WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin")
 
 if lib_arch_dir != "":
-    if env["target"] == "release":
-        lib_type_dir = "release"
-    elif env["target"] == "release_debug":
+    if env.debug_features:
         lib_type_dir = "debug"
-    else:  # debug
+    elif env.dev_build:
         lib_type_dir = "dev"
+    else:  # Release
+        lib_type_dir = "release"
 
-    if env["tools"]:
+    if env.editor_build:
         lib_tools_dir = "tools/"
     else:
         lib_tools_dir = ""

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -46,7 +46,7 @@ def get_ndk_version():
 def get_flags():
     return [
         ("arch", "arm64"),  # Default for convenience.
-        ("tools", False),
+        ("target", "template_debug"),
     ]
 
 
@@ -114,20 +114,6 @@ def configure(env):
     env.Append(CCFLAGS=target_option)
     env.Append(LINKFLAGS=target_option)
 
-    # Build type
-
-    if env["target"].startswith("release"):
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces
-            # when using `target=release_debug`.
-            opt = "-O3" if env["target"] == "release" else "-O2"
-            env.Append(CCFLAGS=[opt])
-        elif env["optimize"] == "size":  # optimize for size
-            env.Append(CCFLAGS=["-Oz"])
-    elif env["target"] == "debug":
-        env.Append(LINKFLAGS=["-O0"])
-        env.Append(CCFLAGS=["-O0", "-g"])
-
     # LTO
 
     if env["lto"] == "auto":  # LTO benefits for Android (size, performance) haven't been clearly established yet.
@@ -168,7 +154,7 @@ def configure(env):
     env["AS"] = compiler_path + "/clang"
 
     # Disable exceptions and rtti on non-tools (template) builds
-    if env["tools"]:
+    if env.editor_build:
         env.Append(CXXFLAGS=["-frtti"])
     elif env["builtin_icu"]:
         env.Append(CXXFLAGS=["-frtti", "-fno-exceptions"])

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -37,7 +37,7 @@ def get_opts():
 def get_flags():
     return [
         ("arch", "arm64"),  # Default for convenience.
-        ("tools", False),
+        ("target", "template_debug"),
         ("use_volk", False),
     ]
 
@@ -51,23 +51,6 @@ def configure(env):
             % (env["arch"], ", ".join(supported_arches))
         )
         sys.exit()
-
-    ## Build type
-
-    if env["target"].startswith("release"):
-        env.Append(CPPDEFINES=[("NS_BLOCK_ASSERTIONS", 1)])
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces
-            # when using `target=release_debug`.
-            opt = "-O3" if env["target"] == "release" else "-O2"
-            env.Append(CCFLAGS=[opt])
-            env.Append(LINKFLAGS=[opt])
-        elif env["optimize"] == "size":  # optimize for size
-            env.Append(CCFLAGS=["-Os"])
-            env.Append(LINKFLAGS=["-Os"])
-
-    elif env["target"] == "debug":
-        env.Append(CCFLAGS=["-g", "-O0"])
 
     ## LTO
 
@@ -145,12 +128,10 @@ def configure(env):
         env.Append(ASFLAGS=["-arch", "arm64"])
         env.Append(CPPDEFINES=["NEED_LONG_INT"])
 
-    # Disable exceptions on non-tools (template) builds
-    if not env["tools"]:
-        if env["ios_exceptions"]:
-            env.Append(CCFLAGS=["-fexceptions"])
-        else:
-            env.Append(CCFLAGS=["-fno-exceptions"])
+    if env["ios_exceptions"]:
+        env.Append(CCFLAGS=["-fexceptions"])
+    else:
+        env.Append(CCFLAGS=["-fno-exceptions"])
 
     # Temp fix for ABS/MAX/MIN macros in iOS SDK blocking compilation
     env.Append(CCFLAGS=["-Wno-ambiguous-macro"])

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -44,8 +44,6 @@ def get_opts():
         BoolVariable("fontconfig", "Detect and use fontconfig for system fonts support", True),
         BoolVariable("udev", "Use udev for gamepad connection callbacks", True),
         BoolVariable("x11", "Enable X11 display", True),
-        BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
-        BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("touch", "Enable touch events", True),
         BoolVariable("execinfo", "Use libexecinfo on systems where glibc is not available", False),
     ]
@@ -69,26 +67,9 @@ def configure(env):
 
     ## Build type
 
-    if env["target"] == "release":
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Prepend(CCFLAGS=["-O3"])
-        elif env["optimize"] == "size":  # optimize for size
-            env.Prepend(CCFLAGS=["-Os"])
-
-        if env["debug_symbols"]:
-            env.Prepend(CCFLAGS=["-g2"])
-
-    elif env["target"] == "release_debug":
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Prepend(CCFLAGS=["-O2"])
-        elif env["optimize"] == "size":  # optimize for size
-            env.Prepend(CCFLAGS=["-Os"])
-
-        if env["debug_symbols"]:
-            env.Prepend(CCFLAGS=["-g2"])
-
-    elif env["target"] == "debug":
-        env.Prepend(CCFLAGS=["-g3"])
+    if env.dev_build:
+        # This is needed for our crash handler to work properly.
+        # gdb works fine without it though, so maybe our crash handler could too.
         env.Append(LINKFLAGS=["-rdynamic"])
 
     # CPU architecture flags.
@@ -383,7 +364,7 @@ def configure(env):
     if env["execinfo"]:
         env.Append(LIBS=["execinfo"])
 
-    if not env["tools"]:
+    if not env.editor_build:
         import subprocess
         import re
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -27,8 +27,6 @@ def get_opts():
         ("MACOS_SDK_PATH", "Path to the macOS SDK", ""),
         ("vulkan_sdk_path", "Path to the Vulkan SDK", ""),
         EnumVariable("macports_clang", "Build using Clang from MacPorts", "no", ("no", "5.0", "devel")),
-        BoolVariable("debug_symbols", "Add debugging symbols to release/release_debug builds", True),
-        BoolVariable("separate_debug_symbols", "Create a separate file containing debugging symbols", False),
         BoolVariable("use_ubsan", "Use LLVM/GCC compiler undefined behavior sanitizer (UBSAN)", False),
         BoolVariable("use_asan", "Use LLVM/GCC compiler address sanitizer (ASAN)", False),
         BoolVariable("use_tsan", "Use LLVM/GCC compiler thread sanitizer (TSAN)", False),
@@ -86,27 +84,10 @@ def configure(env):
 
     ## Build type
 
-    if env["target"] == "release":
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Prepend(CCFLAGS=["-O3"])
-        elif env["optimize"] == "size":  # optimize for size
-            env.Prepend(CCFLAGS=["-Os"])
+    if env["target"] == "template_release":
         if env["arch"] != "arm64":
             env.Prepend(CCFLAGS=["-msse2"])
-
-        if env["debug_symbols"]:
-            env.Prepend(CCFLAGS=["-g2"])
-
-    elif env["target"] == "release_debug":
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Prepend(CCFLAGS=["-O2"])
-        elif env["optimize"] == "size":  # optimize for size
-            env.Prepend(CCFLAGS=["-Os"])
-        if env["debug_symbols"]:
-            env.Prepend(CCFLAGS=["-g2"])
-
-    elif env["target"] == "debug":
-        env.Prepend(CCFLAGS=["-g3"])
+    elif env.dev_build:
         env.Prepend(LINKFLAGS=["-Xlinker", "-no_deduplicate"])
 
     ## Compiler configuration

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -47,7 +47,7 @@ def get_opts():
 def get_flags():
     return [
         ("arch", "wasm32"),
-        ("tools", False),
+        ("target", "template_debug"),
         ("builtin_pcre2_with_jit", False),
         ("vulkan", False),
         # Use -Os to prioritize optimizing for reduced file size. This is
@@ -77,26 +77,17 @@ def configure(env):
         sys.exit(255)
 
     ## Build type
-    if env["target"].startswith("release"):
-        if env["optimize"] == "size":
-            env.Append(CCFLAGS=["-Os"])
-            env.Append(LINKFLAGS=["-Os"])
-        elif env["optimize"] == "speed":
-            env.Append(CCFLAGS=["-O3"])
-            env.Append(LINKFLAGS=["-O3"])
 
-        if env["target"] == "release_debug":
-            # Retain function names for backtraces at the cost of file size.
-            env.Append(LINKFLAGS=["--profiling-funcs"])
-    else:  # "debug"
-        env.Append(CCFLAGS=["-O1", "-g"])
-        env.Append(LINKFLAGS=["-O1", "-g"])
+    if env.debug_features:
+        # Retain function names for backtraces at the cost of file size.
+        env.Append(LINKFLAGS=["--profiling-funcs"])
+    else:
         env["use_assertions"] = True
 
     if env["use_assertions"]:
         env.Append(LINKFLAGS=["-s", "ASSERTIONS=1"])
 
-    if env["tools"]:
+    if env.editor_build:
         if env["initial_memory"] < 64:
             print('Note: Forcing "initial_memory=64" as it is required for the web editor.')
             env["initial_memory"] = 64

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -38,7 +38,7 @@ def create_engine_file(env, target, source, externs):
 
 
 def create_template_zip(env, js, wasm, worker, side):
-    binary_name = "godot.tools" if env["tools"] else "godot"
+    binary_name = "godot.editor" if env.editor_build else "godot"
     zip_dir = env.Dir("#bin/.web_zip")
     in_files = [
         js,
@@ -58,19 +58,19 @@ def create_template_zip(env, js, wasm, worker, side):
         out_files.append(zip_dir.File(binary_name + ".side.wasm"))
 
     service_worker = "#misc/dist/html/service-worker.js"
-    if env["tools"]:
+    if env.editor_build:
         # HTML
         html = "#misc/dist/html/editor.html"
         cache = [
-            "godot.tools.html",
+            "godot.editor.html",
             "offline.html",
-            "godot.tools.js",
-            "godot.tools.worker.js",
-            "godot.tools.audio.worklet.js",
+            "godot.editor.js",
+            "godot.editor.worker.js",
+            "godot.editor.audio.worklet.js",
             "logo.svg",
             "favicon.png",
         ]
-        opt_cache = ["godot.tools.wasm"]
+        opt_cache = ["godot.editor.wasm"]
         subst_dict = {
             "@GODOT_VERSION@": get_build_version(),
             "@GODOT_NAME@": "GodotEngine",

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -173,17 +173,7 @@ def get_opts():
             "Targeted Windows version, >= 0x0601 (Windows 7)",
             "0x0601",
         ),
-        BoolVariable(
-            "debug_symbols",
-            "Add debugging symbols to release/release_debug builds",
-            True,
-        ),
         EnumVariable("windows_subsystem", "Windows subsystem", "gui", ("gui", "console")),
-        BoolVariable(
-            "separate_debug_symbols",
-            "Create a separate file containing debugging symbols",
-            False,
-        ),
         (
             "msvc_version",
             "MSVC version to use. Ignored if VCINSTALLDIR is set in shell env.",
@@ -330,31 +320,11 @@ def setup_mingw(env):
 def configure_msvc(env, vcvars_msvc_config):
     """Configure env to work with MSVC"""
 
-    # Build type
-    if env["target"] == "release":
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Append(CCFLAGS=["/O2"])
-            env.Append(LINKFLAGS=["/OPT:REF"])
-        elif env["optimize"] == "size":  # optimize for size
-            env.Append(CCFLAGS=["/O1"])
-            env.Append(LINKFLAGS=["/OPT:REF"])
+    ## Build type
+
+    # TODO: Re-evaluate the need for this / streamline with common config.
+    if env["target"] == "template_release":
         env.Append(LINKFLAGS=["/ENTRY:mainCRTStartup"])
-
-    elif env["target"] == "release_debug":
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Append(CCFLAGS=["/O2"])
-            env.Append(LINKFLAGS=["/OPT:REF"])
-        elif env["optimize"] == "size":  # optimize for size
-            env.Append(CCFLAGS=["/O1"])
-            env.Append(LINKFLAGS=["/OPT:REF"])
-
-    elif env["target"] == "debug":
-        env.AppendUnique(CCFLAGS=["/Zi", "/FS", "/Od", "/EHsc"])
-        env.Append(LINKFLAGS=["/DEBUG"])
-
-    if env["debug_symbols"]:
-        env.AppendUnique(CCFLAGS=["/Zi", "/FS"])
-        env.AppendUnique(LINKFLAGS=["/DEBUG"])
 
     if env["windows_subsystem"] == "gui":
         env.Append(LINKFLAGS=["/SUBSYSTEM:WINDOWS"])
@@ -491,31 +461,10 @@ def configure_mingw(env):
     if env["use_llvm"] and not try_cmd("clang --version", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = False
 
-    if env["target"] == "release":
+    # TODO: Re-evaluate the need for this / streamline with common config.
+    if env["target"] == "template_release":
         env.Append(CCFLAGS=["-msse2"])
-
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            if env["arch"] == "x86_32":
-                env.Append(CCFLAGS=["-O2"])
-            else:
-                env.Append(CCFLAGS=["-O3"])
-        else:  # optimize for size
-            env.Prepend(CCFLAGS=["-Os"])
-
-        if env["debug_symbols"]:
-            env.Prepend(CCFLAGS=["-g2"])
-
-    elif env["target"] == "release_debug":
-        env.Append(CCFLAGS=["-O2"])
-        if env["debug_symbols"]:
-            env.Prepend(CCFLAGS=["-g2"])
-        if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Append(CCFLAGS=["-O2"])
-        else:  # optimize for size
-            env.Prepend(CCFLAGS=["-Os"])
-
-    elif env["target"] == "debug":
-        env.Append(CCFLAGS=["-g3"])
+    elif env.dev_build:
         # Allow big objects. It's supposed not to have drawbacks but seems to break
         # GCC LTO, so enabling for debug builds only (which are not built with LTO
         # and are the only ones with too big objects).


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/3371.

TL;DR:
- To build the Godot editor for engine development, use `scons target=editor dev_build=yes`
  * You might also want to add `dev_mode=yes` which is an alias for `verbose=yes warnings=extra werror=yes tests=yes`
- To build the Godot editor to use while developing your game, use `scons target=editor`
  * If you get crashes and want to get a useful stacktrace to report a bug, rebuild with `scons target=editor debug_symbols=yes`
- Both the intermediate object files (`.o`, `.a`, `.obj`, `.lib`) and the Godot binary in bin are changing names, so you might want to clean your Git checkout to remove the old ones to save disk space, and adjust any scripts/config you might have that runs the Godot binary to use the new name.

### New `target` presets

The `tools` option is removed and `target` changes to use three new presets,
which match the builds users are familiar with. These targets control the
default optimization level and enable editor-specific and debugging code:

- `editor`: Replaces `tools=yes target=release_debug`.
  * Defines: `TOOLS_ENABLED`, `DEBUG_ENABLED`, `-O2`/`/O2`
- `template_debug`: Replaces `tools=no target=release_debug`.
  * Defines: `DEBUG_ENABLED`, `-O2`/`/O2`
- `template_release`: Replaces `tools=no target=release`.
  * Defines: `-O3`/`/O2`

### New `dev_build` option

The previous `target=debug` is now replaced by a separate `dev_build=yes`
option, which can be used in combination with either of the three targets,
and changes the following:

- `dev_build`: Defines `DEV_ENABLED`, disables optimization (`-O0`/`/0d`),
  enables generating debug symbols, does not define `NDEBUG` so `assert()`
  works in thirdparty libraries, adds a `.dev` suffix to the binary name.

Note: Unlike previously, `dev_build` defaults to off so that users who
compile Godot from source get an optimized and small build by default.
Engine contributors should now set `dev_build=yes` in their build scripts or
IDE configuration manually.

### Changed binary names

The name of generated binaries and object files are changed too, to follow
this format:

`godot.<platform>.<target>[.dev][.double].<arch>[.<extra_suffix>][.<ext>]`

For example:
- `godot.linuxbsd.editor.dev.arm64`
- `godot.windows.template_release.double.x86_64.mono.exe`

Be sure to update your links/scripts/IDE config accordingly.

### More flexible `optimize` and `debug_symbols` options

The optimization level and whether to generate debug symbols can be further
specified with the `optimize` and `debug_symbols` options. So the default
values listed above for the various `target` and `dev_build` combinations
are indicative and can be replaced when compiling, e.g.:

`scons p=linuxbsd target=template_debug dev_build=yes optimize=debug`
will make a "debug" export template with dev-only code enabled, `-Og`
optimization level for GCC/Clang, and debug symbols. Perfect for debugging
complex crashes at runtime in an exported project.

-----

The above description was updated to match the latest state of this PR.

<details>
<summary>Original description and comments</summary>

There's a lot to discuss there, I'll try to make a list of the main point.

As described in the proposal, this PR unifies the current `tools` and `target` combinations in a single `target` enum, with the intention of making the valid build targets clearer, and to clarify the confusion around the meaning of the word "debug".

The targets implemented here are therefore:
```
target:
    editor:
        editor: yes (TOOLS_ENABLED)
        debug-features: yes (DEBUG_ENABLED)
        dev-features: no
        optimize: speed-debug (-O2)
        debug_symbols: yes (-g2)
    editor-dev:
        editor: yes (TOOLS_ENABLED)
        debug-features: yes (DEBUG_ENABLED)
        dev-features: yes (DEV_ENABLED)
        optimize: debug (-Og)
        debug_symbols: yes (-g3)
    template-release:
        editor: no
        debug-features: no
        dev-features: no
        optimize: speed (-O3) / size (-Os) on Web
        debug_symbols: no
    template-debug:
        editor: no
        debug-features: yes (DEBUG_ENABLED)
        optimize: speed-debug (-O2) / size (-Os) on Web
        debug_symbols: yes (-g2)
    template-dev:
        editor: no
        debug-features: yes (DEBUG_ENABLED)
        dev-features: yes (DEV_ENABLED)
        optimize: debug (-Og)
        debug_symbols: yes (-g3)
```

### Notes

- The new `target` mostly governs three things:
  * Editor or export template
  * Debugging features (always true for editor, true for "debug" export template)
  * Dev build with full debugging symbols (`-g3 -Og`)
    - This one could possibly be split into a separate `dev_build=yes` option, which would bring down the `target` enum to `"editor", "template-release", "template-debug"`, which are effectively what we ship. Thoughts? This idea is growing on me as I type it.
- `optimize` and `debug_symbols` can be overridden for any target.
   * So if you want, you can build `target=editor-dev optimize=size debug_symbols=no` or something. It doesn't make much sense per se but the flexibility can be useful in other situations like `target=template-release optimize=speed-debug debug_symbols=yes`. This is not exactly the same as `template-debug` as the debug features are still off - so it can be pertinent to debug an issue that only happens in release export templates and may be linked to not have `DEBUG_ENABLED` code.
- The object suffix was changed from the previous mix of `opt`, `tools` and `debug` to just use `target`, so the build objects and final binary names are changing. E.g. `scons p=linuxbsd target=editor-dev arch=x86_64` will produce `bin/godot.linuxbsd.editor-dev.x86_64`.
- The default option for `scons` without target is now `target=editor`, which will imply `optimize=speed-debug debug_symbols=yes`
  * This is different to the current default which is `tools=yes target=debug debug_symbols=yes` which means a debug-optimized (`-Og`) (or actually one some platforms it would be unoptimized `-O0`) build with `DEV_ENABLED`.
  * Basically this makes the default more end-user friendly (they get a usable editor build for using Godot), and contributors will have to specify `target=editor-dev` to get back the previous behavior.
  * The default values for `optimize` and `debug_symbols` in the SCons help are not really accurate as they eventually depend on the `target`. I could add `auto` as a default to clarify this, though this can be a bit tricky to handle properly.
- Compiler and linker flags for the different `optimize` and `debug_symbols` levels are now unified in `SConstruct`, right after `configure` (needs to be after for `env.msvc` to be valid).
  * This should be refactored eventually to reduce the size of the SConstruct and make the code more readable. Could be in a dedicated function / SCons `Tool`.
  * All platforms used to do their own handling of flags for all targets, I did my best to unify what can be but there are some platform-specific tweaks that remain in the various `detect.py`, which should be assessed. There are also some default values changed which I'll point out in review comments.
- `godot-cpp` would need to be ported to support something similar probably. Whether or not it can/should might also inform us on whether the set of target presets proposed here is actually the best design or not.
  * I didn't port the GDExtension compatibility build script for TextServers, it does some reimplementation of the `SHLIBSUFFIX`
- We have a mess of platform-specific defines of `DEBUG=1`, `DEBUG:FULL` `_DEBUG`, `NDEBUG`... this needs a thorough review and unification to make sure we do the right thing in the right situation. Notably, it used to be tied to either using `debug_symbols=yes` or `target=debug` but I'm not sure it's a good idea for all of these.
  * See #66303.
- All these configuration options could possibly be handled a bit more elegantly with e.g. a Python class that keeps track of this data and can be accessed from `SCsub`s via the env, e.g. `env.target.editor_build` / `env.target.template_build` / `env.target.debug_features`, etc.
- Some platforms (Web and iOS) used to set their optimization flags both for the compiler and the linker (`CCFLAGS` and `LINKFLAGS`). I don't know why, but I guess the `LINKFLAGS` lines can be safely dropped?
- Clang based platforms (Android, iOS and macOS) all defined `-ftree-vectorize` for both speed and size optimizations, and `-fomit-frame-pointer` for speed optimizations. This is apparently supported by GCC too, and possibly by Emscripten (LLVM based too), so should we define them consistently for all platforms? On MSVC they're somewhat part of `/O1`/`/O2` already by way of `/Oy`.
  * See #66296 and #66297.

</details>