### PR TITLE
Fix various -Wmaybe-uninitialized warnings from GCC 12.2.1

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -215,7 +215,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 				String name = t == Variant::VARIANT_MAX ? String("Variant") : Variant::get_type_name(t);
 				Dictionary d2;
 				d2["name"] = name;
-				uint32_t size;
+				uint32_t size = 0;
 				switch (i) {
 					case 0:
 						size = type_size_array[j].size_32_bits_real_float;
@@ -330,7 +330,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 					last_type = t;
 				}
 				Dictionary d3;
-				uint32_t offset;
+				uint32_t offset = 0;
 				switch (i) {
 					case 0:
 						offset = member_offset_array[idx].offset_32_bits_real_float;

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -763,7 +763,7 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 	TreeItem *root = class_list->create_item();
 
 	TreeItem *features = class_list->create_item(root);
-	TreeItem *last_feature;
+	TreeItem *last_feature = nullptr;
 	features->set_text(0, TTR("Main Features:"));
 	for (int i = 0; i < EditorFeatureProfile::FEATURE_MAX; i++) {
 		TreeItem *feature;

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -134,7 +134,7 @@ void ThemeItemImportTree::_update_items_tree() {
 			data_type_node->set_checked(IMPORT_ITEM_DATA, false);
 			data_type_node->set_editable(IMPORT_ITEM_DATA, true);
 
-			List<TreeItem *> *item_list;
+			List<TreeItem *> *item_list = nullptr;
 
 			switch (dt) {
 				case Theme::DATA_TYPE_COLOR:
@@ -398,7 +398,7 @@ void ThemeItemImportTree::_restore_selected_item(TreeItem *p_tree_item) {
 void ThemeItemImportTree::_update_total_selected(Theme::DataType p_data_type) {
 	ERR_FAIL_INDEX_MSG(p_data_type, Theme::DATA_TYPE_MAX, "Theme item data type is out of bounds.");
 
-	Label *total_selected_items_label;
+	Label *total_selected_items_label = nullptr;
 	switch (p_data_type) {
 		case Theme::DATA_TYPE_COLOR:
 			total_selected_items_label = total_selected_colors_label;
@@ -562,7 +562,7 @@ void ThemeItemImportTree::_select_all_data_type_pressed(int p_data_type) {
 	}
 
 	Theme::DataType data_type = (Theme::DataType)p_data_type;
-	List<TreeItem *> *item_list;
+	List<TreeItem *> *item_list = nullptr;
 
 	switch (data_type) {
 		case Theme::DATA_TYPE_COLOR:
@@ -617,7 +617,7 @@ void ThemeItemImportTree::_select_full_data_type_pressed(int p_data_type) {
 	}
 
 	Theme::DataType data_type = (Theme::DataType)p_data_type;
-	List<TreeItem *> *item_list;
+	List<TreeItem *> *item_list = nullptr;
 
 	switch (data_type) {
 		case Theme::DATA_TYPE_COLOR:
@@ -674,7 +674,7 @@ void ThemeItemImportTree::_deselect_all_data_type_pressed(int p_data_type) {
 	}
 
 	Theme::DataType data_type = (Theme::DataType)p_data_type;
-	List<TreeItem *> *item_list;
+	List<TreeItem *> *item_list = nullptr;
 
 	switch (data_type) {
 		case Theme::DATA_TYPE_COLOR:
@@ -982,17 +982,17 @@ ThemeItemImportTree::ThemeItemImportTree() {
 	for (int i = 0; i < Theme::DATA_TYPE_MAX; i++) {
 		Theme::DataType dt = (Theme::DataType)i;
 
-		TextureRect *select_items_icon;
-		Label *select_items_label;
-		Button *deselect_all_items_button;
-		Button *select_all_items_button;
-		Button *select_full_items_button;
-		Label *total_selected_items_label;
+		TextureRect *select_items_icon = nullptr;
+		Label *select_items_label = nullptr;
+		Button *deselect_all_items_button = nullptr;
+		Button *select_all_items_button = nullptr;
+		Button *select_full_items_button = nullptr;
+		Label *total_selected_items_label = nullptr;
 
-		String items_title = "";
-		String select_all_items_tooltip = "";
-		String select_full_items_tooltip = "";
-		String deselect_all_items_tooltip = "";
+		String items_title;
+		String select_all_items_tooltip;
+		String select_full_items_tooltip;
+		String deselect_all_items_tooltip;
 
 		switch (dt) {
 			case Theme::DATA_TYPE_COLOR:

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -90,11 +90,10 @@ public:
 
 	struct Varying {
 		String name;
-		VaryingMode mode;
-		VaryingType type;
+		VaryingMode mode = VARYING_MODE_MAX;
+		VaryingType type = VARYING_TYPE_MAX;
 
-		Varying() {
-		}
+		Varying() {}
 
 		Varying(String p_name, VaryingMode p_mode, VaryingType p_type) :
 				name(p_name), mode(p_mode), type(p_type) {}

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3302,7 +3302,7 @@ void RendererSceneRenderRD::_render_shadow_pass(RID p_light, RID p_shadow_atlas,
 	ERR_FAIL_COND(!light_instance);
 
 	Rect2i atlas_rect;
-	uint32_t atlas_size;
+	uint32_t atlas_size = 1;
 	RID atlas_fb;
 
 	bool using_dual_paraboloid = false;

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -795,6 +795,8 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 		case RS::TEXTURE_LAYERED_CUBEMAP_ARRAY: {
 			texture.rd_type = RD::TEXTURE_TYPE_CUBE_ARRAY;
 		} break;
+		default:
+			ERR_FAIL(); // Shouldn't happen, silence warnings.
 	}
 
 	texture.rd_format = ret_format.format;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -743,7 +743,7 @@ void RenderingServer::mesh_surface_make_offsets_from_format(uint32_t p_format, i
 	r_attrib_element_size = 0;
 	r_skin_element_size = 0;
 
-	uint32_t *size_accum;
+	uint32_t *size_accum = nullptr;
 
 	for (int i = 0; i < RS::ARRAY_MAX; i++) {
 		r_offsets[i] = 0; // Reset
@@ -847,8 +847,12 @@ void RenderingServer::mesh_surface_make_offsets_from_format(uint32_t p_format, i
 			}
 		}
 
-		r_offsets[i] = (*size_accum);
-		(*size_accum) += elem_size;
+		if (size_accum != nullptr) {
+			r_offsets[i] = (*size_accum);
+			(*size_accum) += elem_size;
+		} else {
+			r_offsets[i] = 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Not sure why I didn't get those before, it may be due to upstream changes (12.2.1 is a moving target, it's basically 12.3-dev), or simply rebuilding Godot from scratch with different options.

*Edit:* I got those while testing #66242, I think the difference is that dev builds now default to `-Og` optimization on Linux (debugging) instead of `-O0` (no optimization). GCC finds more/different warnings with optimizations enabled.