### PR TITLE
Project converter: fix convertion for project.godot file

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1931,6 +1931,7 @@ struct ProjectConverter3To4::ConfigSection {
 	struct Element {
 		int line_number;
 
+		virtual ~Element() = default;
 		virtual Vector<String> dump() const = 0;
 		virtual Type get_type() const = 0;
 	};
@@ -2455,9 +2456,9 @@ private:
 		}
 
 		if (found) {
-			ConfigSection *section = settings.get(i);
-			section->clear();
-			memdelete(section);
+			ConfigSection *E = settings.get(i);
+			E->clear();
+			memdelete(E);
 			settings.remove_at(i);
 		}
 	}

--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -41,10 +41,15 @@ class RegEx;
 class ProjectConverter3To4 {
 public:
 	class RegExContainer;
+	struct ConfigSection;
+	class ProjectSettings;
 
 private:
 	uint64_t maximum_file_size;
 	uint64_t maximum_line_length;
+
+	void parse_project_godot(Vector<String> &lines, RegExContainer &reg_container);
+	Vector<String> validate_conversion_project_godot(Vector<String> &lines, RegExContainer &reg_container);
 
 	void rename_colors(Vector<String> &lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_colors(Vector<String> &lines, const RegExContainer &reg_container);


### PR DESCRIPTION
This PR is intended to fixes #66125.

While testing this issue, I noticed that adding `{ "display/window/size/width", "display/window/size/viewport_width" },` to the `project_settings_renames` array, do not have any effect.

After a closer look, I think this is because `project.godot` is an INI file
```
[display]

window/size/width=1280
```

In this PR, I decided to parse the existing project settings renames into a new structure (so substitutions for ".gd" and ".tscn" files are not affected).

Apart from solving the initial issue, this PR also supports remove keys or move a key to another/new section, based on the original rename config format. Because of that, the `project.godot` file is fully rewritten at the end of the conversion process.

As a _dummy_ example, adding these lines to the existing config
```
{ "display/window/size/width", "display/window/size/viewport_width" },
{ "display/window/size/height", "toto/window/size/viewport_height" },
{ "application/config/icon", nullptr },
{ "application/config/name", nullptr },
{ "gui/common/drop_mouse_on_gui_input_disabled", "gui_input_disabled" },
{ "config_version", "physics/version" },
```
with this `project.godot` file:
```
; Engine configuration file.
; It's best edited using the editor UI and not directly,
; since the parameters that go here are not all obvious.
;
; Format:
;   [section] ; section goes between []
;   param=value ; assign values to parameters

config_version=4

[application]

config/name="project_converter_3_to_4-bug3"

config/icon="res://icon.png"

[gui]

common/drop_mouse_on_gui_input_disabled=true

[display]

window/size/width=1280
window/size/height=720 ; move this comment as well

[physics]

common/enable_pause_aware_picking=true

[rendering]

environment/defaults/default_environment="res://default_env.tres"
```
will produce the following validation check
```
 2 2 project.godot 0
    Checking file took      0.001 ms.
                - Remove section 'application'
                - Remove section 'gui'
                - Create section 'toto'
                - In 'display', rename 'window/size/width' to 'window/size/viewport_width'
                - In 'rendering', rename 'environment/default_environment' to 'environment/defaults/default_environment'
                - In 'display', remove 'window/size/height=720 ; move this comment as well'
                - In root, remove 'config_version=4'
                - In 'toto', insert 'window/size/viewport_height=720 ; move this comment as well'
                - In root, insert 'gui_input_disabled=true'
                - In 'physics', insert 'version=4'
```

When converting, the file is rewritten according to the actions detected during the analyze stage.

Any comments are welcomed!
