### PR TITLE
C#: Guard against null assemblies

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -29,7 +29,7 @@ namespace Godot.SourceGenerators
         {
             while (symbol != null)
             {
-                if (symbol.ContainingAssembly.Name == assemblyName &&
+                if (symbol.ContainingAssembly?.Name == assemblyName &&
                     symbol.ToString() == typeFullName)
                 {
                     return true;
@@ -47,7 +47,7 @@ namespace Godot.SourceGenerators
 
             while (symbol != null)
             {
-                if (symbol.ContainingAssembly.Name == "GodotSharp")
+                if (symbol.ContainingAssembly?.Name == "GodotSharp")
                     return symbol;
 
                 symbol = symbol.BaseType;

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/MarshalUtils.cs
@@ -124,8 +124,8 @@ namespace Godot.SourceGenerators
 
                     if (typeKind == TypeKind.Struct)
                     {
-                        if (type.ContainingAssembly.Name == "GodotSharp" &&
-                            type.ContainingNamespace.Name == "Godot")
+                        if (type.ContainingAssembly?.Name == "GodotSharp" &&
+                            type.ContainingNamespace?.Name == "Godot")
                         {
                             return type switch
                             {
@@ -208,9 +208,9 @@ namespace Godot.SourceGenerators
                         if (type.SimpleDerivesFrom(typeCache.GodotObjectType))
                             return MarshalType.GodotObjectOrDerived;
 
-                        if (type.ContainingAssembly.Name == "GodotSharp")
+                        if (type.ContainingAssembly?.Name == "GodotSharp")
                         {
-                            switch (type.ContainingNamespace.Name)
+                            switch (type.ContainingNamespace?.Name)
                             {
                                 case "Godot":
                                     return type switch
@@ -220,7 +220,7 @@ namespace Godot.SourceGenerators
                                         _ => null
                                     };
                                 case "Collections"
-                                    when type.ContainingNamespace.FullQualifiedName() == "Godot.Collections":
+                                    when type.ContainingNamespace?.FullQualifiedName() == "Godot.Collections":
                                     return type switch
                                     {
                                         { Name: "Dictionary" } =>


### PR DESCRIPTION
A symbol's containing assembly will be null if the symbol is shared across multiple assemblies.

- Fixes https://github.com/godotengine/godot/issues/66223
