### PR TITLE
[3.x] GDNative: Fix `script_data` error when updating placeholder scripts for GDNative libraries

### DIFF
--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1757,6 +1757,15 @@ void NativeReloadNode::_notification(int p_what) {
 				}
 
 				for (Map<String, Set<NativeScript *>>::Element *U = NSL->library_script_users.front(); U; U = U->next()) {
+					// Multiple GDNative libraries may be reloaded. The library and script
+					// path should match to prevent failing `NSL->library_classes` lookup
+					// from `get_script_desc()` in `script->_update_placeholder` below.
+					// This check also prevents "!script_data is true" error from occuring
+					// when e. g. re-focusing editor window.
+					if (L->key() != U->key()) {
+						continue;
+					}
+
 					for (Set<NativeScript *>::Element *S = U->get().front(); S; S = S->next()) {
 						NativeScript *script = S->get();
 


### PR DESCRIPTION
This PR is a backport of https://github.com/godotengine/godot/pull/46514

Tested with latest 3.x branch and several GDNative libraries. Auto-reloading when unfocusing/focusing the editor window still works properly and no error is printed.

Fixes https://github.com/godotengine/godot/issues/42948