### PR TITLE
Add `mouse_force_focus_from_keyboard` property

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -996,6 +996,9 @@
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" enum="Control.MouseFilter" default="0">
 			Controls whether the control will be able to receive mouse button input events through [method _gui_input] and how these events should be handled. Also controls whether the control can receive the [signal mouse_entered], and [signal mouse_exited] signals. See the constants to learn what each does.
 		</member>
+		<member name="mouse_force_focus_from_keyboard" type="bool" setter="set_mouse_force_focus_from_keyboard" getter="is_mouse_force_focus_from_keyboard" default="false">
+			If [code]true[/code], [Control] will have mouse focus if it has key focus, so it can e.g. receive mouse motion events while cursor is outside. The [Control] with actual mouse focus will have priority.
+		</member>
 		<member name="mouse_force_pass_scroll_events" type="bool" setter="set_force_pass_scroll_events" getter="is_force_pass_scroll_events" default="true">
 			When enabled, scroll wheel events processed by [method _gui_input] will be passed to the parent control even if [member mouse_filter] is set to [constant MOUSE_FILTER_STOP].
 			You should disable it on the root of your UI if you do not want scroll events to go to the [method Node._unhandled_input] processing.

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2728,12 +2728,21 @@ bool CanvasItemEditor::_gui_input_hover(const Ref<InputEvent> &p_event) {
 }
 
 void CanvasItemEditor::_gui_input_viewport(const Ref<InputEvent> &p_event) {
+	bool simple_panning = EDITOR_GET("editors/panning/simple_panning");
+
+	Ref<InputEventKey> k = p_event;
+	if (simple_panning && k.is_valid() && !k->is_echo()) {
+		if (ED_GET_SHORTCUT("canvas_item_editor/pan_view")->matches_event(k)) {
+			viewport->set_mouse_force_focus_from_keyboard(k->is_pressed());
+		}
+	}
+
 	bool accepted = false;
 
 	Ref<InputEventMouseButton> mb = p_event;
 	bool release_lmb = (mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT); // Required to properly release some stuff (e.g. selection box) while panning.
 
-	if (EDITOR_GET("editors/panning/simple_panning") || !pan_pressed || release_lmb) {
+	if (simple_panning || !pan_pressed || release_lmb) {
 		accepted = true;
 		if (_gui_input_rulers_and_guides(p_event)) {
 			// print_line("Rulers and guides");

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1876,6 +1876,14 @@ bool Control::is_force_pass_scroll_events() const {
 	return data.force_pass_scroll_events;
 }
 
+void Control::set_mouse_force_focus_from_keyboard(bool p_mouse_force_focus_from_keyboard) {
+	data.mouse_force_focus_from_keyboard = p_mouse_force_focus_from_keyboard;
+}
+
+bool Control::is_mouse_force_focus_from_keyboard() const {
+	return data.mouse_force_focus_from_keyboard;
+}
+
 void Control::warp_mouse(const Point2 &p_position) {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_COND(!is_inside_tree());
@@ -3604,6 +3612,9 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_force_pass_scroll_events", "force_pass_scroll_events"), &Control::set_force_pass_scroll_events);
 	ClassDB::bind_method(D_METHOD("is_force_pass_scroll_events"), &Control::is_force_pass_scroll_events);
 
+	ClassDB::bind_method(D_METHOD("set_mouse_force_focus_from_keyboard", "mouse_force_focus_from_keyboard"), &Control::set_mouse_force_focus_from_keyboard);
+	ClassDB::bind_method(D_METHOD("is_mouse_force_focus_from_keyboard"), &Control::is_mouse_force_focus_from_keyboard);
+
 	ClassDB::bind_method(D_METHOD("set_clip_contents", "enable"), &Control::set_clip_contents);
 	ClassDB::bind_method(D_METHOD("is_clipping_contents"), &Control::is_clipping_contents);
 
@@ -3700,6 +3711,7 @@ void Control::_bind_methods() {
 	ADD_GROUP("Mouse", "mouse_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_filter", PROPERTY_HINT_ENUM, "Stop,Pass (Propagate Up),Ignore"), "set_mouse_filter", "get_mouse_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_force_pass_scroll_events"), "set_force_pass_scroll_events", "is_force_pass_scroll_events");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_force_focus_from_keyboard"), "set_mouse_force_focus_from_keyboard", "is_mouse_force_focus_from_keyboard");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_default_cursor_shape", PROPERTY_HINT_ENUM, "Arrow,I-Beam,Pointing Hand,Cross,Wait,Busy,Drag,Can Drop,Forbidden,Vertical Resize,Horizontal Resize,Secondary Diagonal Resize,Main Diagonal Resize,Move,Vertical Split,Horizontal Split,Help"), "set_default_cursor_shape", "get_default_cursor_shape");
 
 	ADD_GROUP("Input", "");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -219,6 +219,7 @@ private:
 
 		MouseFilter mouse_filter = MOUSE_FILTER_STOP;
 		bool force_pass_scroll_events = true;
+		bool mouse_force_focus_from_keyboard = false;
 
 		bool clip_contents = false;
 		bool disable_visibility_clip = false;
@@ -518,6 +519,9 @@ public:
 
 	void set_force_pass_scroll_events(bool p_force_pass_scroll_events);
 	bool is_force_pass_scroll_events() const;
+
+	void set_mouse_force_focus_from_keyboard(bool p_mouse_force_focus_from_keyboard);
+	bool is_mouse_force_focus_from_keyboard() const;
 
 	void warp_mouse(const Point2 &p_position);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1950,6 +1950,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		Control *over = nullptr;
 		if (gui.mouse_focus) {
 			over = gui.mouse_focus;
+		} else if (gui.key_focus && gui.key_focus->is_mouse_force_focus_from_keyboard()) {
+			over = gui.key_focus;
 		} else if (gui.mouse_in_viewport) {
 			over = gui_find_control(mpos);
 		}


### PR DESCRIPTION
When you hold a mouse button, the clicked control will receive InputEventMouseMotion even if the cursor leaves its area. This PR adds a property `mouse_force_focus_from_keyboard` that does this for keyboard, i.e. when the control has key focus, it will act as if it was hovered even if cursor leaves it.

Fixes #54009
Supersedes #54019