### PR TITLE
Fix array-bounds warning in BVH

### DIFF
--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -100,7 +100,11 @@ public:
 			num_items++;
 			return id;
 		}
+#ifdef DEV_ENABLED
 		return -1;
+#else
+		ERR_FAIL_V_MSG(0, "BVH request_item error.");
+#endif
 	}
 };
 


### PR DESCRIPTION
Provides a workaround to prevent tripping a compiler warning.

Fixes #66252

## Description
A new compiler warning for `-Werror=array-bounds` was occurring in GCC 12.2.1. Investigation suggests this was an understandable false flag caused by some `DEV_ENABLED` only debugging code.

This fix alters the error condition code slightly to prevent tripping the warning.

There is no evidence of this being a genuine bug at runtime, because earlier code in `_logic_choose_item_add_node()` prevents this condition occurring (`request_item()` failing).

## Notes
* It would probably go horribly wrong shortly after such an error condition occurred, so I did consider making it a `CRASH_COND`, however, there's some chance the error message might print before things got that bad.
* We could add this to 3.x too, depending if we are upgrading GCC there at any point in the immediate future, as the BVH code is mostly shared.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
