### PR TITLE
Add more tests for Vector* types

### DIFF
--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -37,6 +37,14 @@
 
 namespace TestVector2 {
 
+TEST_CASE("[Vector2] Constructor methods") {
+	const Vector2 vector_empty = Vector2();
+	const Vector2 vector_zero = Vector2(0.0, 0.0);
+	CHECK_MESSAGE(
+			vector_empty == vector_zero,
+			"Vector2 Constructor with no inputs should return a zero Vector2.");
+}
+
 TEST_CASE("[Vector2] Angle methods") {
 	const Vector2 vector_x = Vector2(1, 0);
 	const Vector2 vector_y = Vector2(0, 1);
@@ -101,6 +109,9 @@ TEST_CASE("[Vector2] Interpolation methods") {
 	CHECK_MESSAGE(
 			Vector2(1, 1).slerp(Vector2(), 0.5) == Vector2(0.5, 0.5),
 			"Vector2 slerp with one input as zero should behave like a regular lerp.");
+	CHECK_MESSAGE(
+			Vector2(4, 6).slerp(Vector2(8, 10), 0.5).is_equal_approx(Vector2(5.9076470794008017626, 8.07918879020090480697)),
+			"Vector2 slerp should work as expected.");
 	CHECK_MESSAGE(
 			Math::is_equal_approx(vector1.slerp(vector2, 0.5).length(), (real_t)4.31959610746631919),
 			"Vector2 slerp with different length input should return a vector with an interpolated length.");
@@ -171,6 +182,15 @@ TEST_CASE("[Vector2] Normalization methods") {
 	CHECK_MESSAGE(
 			Vector2(1, 1).normalized().is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
 			"Vector2 normalized should work as expected.");
+
+	Vector2 vector = Vector2(3.2, -5.4);
+	vector.normalize();
+	CHECK_MESSAGE(
+			vector == Vector2(3.2, -5.4).normalized(),
+			"Vector2 normalize should convert same way as Vector2 normalized.");
+	CHECK_MESSAGE(
+			vector.is_equal_approx(Vector2(0.509802390301732898898, -0.860291533634174266891)),
+			"Vector2 normalize should work as expected.");
 }
 
 TEST_CASE("[Vector2] Operators") {
@@ -276,12 +296,14 @@ TEST_CASE("[Vector2] Other methods") {
 	CHECK_MESSAGE(
 			Math::is_equal_approx(vector.aspect(), (real_t)1.2 / (real_t)3.4),
 			"Vector2 aspect should work as expected.");
+
 	CHECK_MESSAGE(
 			vector.direction_to(Vector2()).is_equal_approx(-vector.normalized()),
 			"Vector2 direction_to should work as expected.");
 	CHECK_MESSAGE(
 			Vector2(1, 1).direction_to(Vector2(2, 2)).is_equal_approx(Vector2(Math_SQRT12, Math_SQRT12)),
 			"Vector2 direction_to should work as expected.");
+
 	CHECK_MESSAGE(
 			vector.posmod(2).is_equal_approx(Vector2(1.2, 1.4)),
 			"Vector2 posmod should work as expected.");
@@ -294,9 +316,20 @@ TEST_CASE("[Vector2] Other methods") {
 	CHECK_MESSAGE(
 			(-vector).posmodv(Vector2(2, 3)).is_equal_approx(Vector2(0.8, 2.6)),
 			"Vector2 posmodv should work as expected.");
+
+	CHECK_MESSAGE(
+			vector.rotated(Math_TAU).is_equal_approx(Vector2(1.2, 3.4)),
+			"Vector2 rotated should work as expected.");
 	CHECK_MESSAGE(
 			vector.rotated(Math_TAU / 4).is_equal_approx(Vector2(-3.4, 1.2)),
 			"Vector2 rotated should work as expected.");
+	CHECK_MESSAGE(
+			vector.rotated(Math_TAU / 3).is_equal_approx(Vector2(-3.544486372867091398996, -0.660769515458673623883)),
+			"Vector2 rotated should work as expected.");
+	CHECK_MESSAGE(
+			vector.rotated(Math_TAU / 2).is_equal_approx(vector.rotated(Math_TAU / -2)),
+			"Vector2 rotated should work as expected.");
+
 	CHECK_MESSAGE(
 			vector.snapped(Vector2(1, 1)) == Vector2(1, 3),
 			"Vector2 snapped to integers should be the same as rounding.");
@@ -306,23 +339,57 @@ TEST_CASE("[Vector2] Other methods") {
 	CHECK_MESSAGE(
 			vector.snapped(Vector2(0.25, 0.25)) == Vector2(1.25, 3.5),
 			"Vector2 snapped to 0.25 should give exact results.");
+
+	CHECK_MESSAGE(
+			Vector2(1.2, 2.5).is_equal_approx(vector.min(Vector2(3.0, 2.5))),
+			"Vector2 min should return expected value.");
+
+	CHECK_MESSAGE(
+			Vector2(5.3, 3.4).is_equal_approx(vector.max(Vector2(5.3, 2.0))),
+			"Vector2 max should return expected value.");
 }
 
 TEST_CASE("[Vector2] Plane methods") {
 	const Vector2 vector = Vector2(1.2, 3.4);
 	const Vector2 vector_y = Vector2(0, 1);
+	const Vector2 vector_normal = Vector2(0.95879811270838721622267, 0.2840883296913739899919);
+	const Vector2 vector_non_normal = Vector2(5.4, 1.6);
 	CHECK_MESSAGE(
 			vector.bounce(vector_y) == Vector2(1.2, -3.4),
 			"Vector2 bounce on a plane with normal of the Y axis should.");
 	CHECK_MESSAGE(
+			vector.bounce(vector_normal).is_equal_approx(Vector2(-2.85851197982345523329, 2.197477931904161412358)),
+			"Vector2 bounce with normal should return expected value.");
+	CHECK_MESSAGE(
 			vector.reflect(vector_y) == Vector2(-1.2, 3.4),
 			"Vector2 reflect on a plane with normal of the Y axis should.");
 	CHECK_MESSAGE(
+			vector.reflect(vector_normal).is_equal_approx(Vector2(2.85851197982345523329, -2.197477931904161412358)),
+			"Vector2 reflect with normal should return expected value.");
+	CHECK_MESSAGE(
 			vector.project(vector_y) == Vector2(0, 3.4),
-			"Vector2 projected on the X axis should only give the Y component.");
+			"Vector2 projected on the Y axis should only give the Y component.");
+	CHECK_MESSAGE(
+			vector.project(vector_normal).is_equal_approx(Vector2(2.0292559899117276166, 0.60126103404791929382)),
+			"Vector2 projected on a normal should return expected value.");
 	CHECK_MESSAGE(
 			vector.slide(vector_y) == Vector2(1.2, 0),
 			"Vector2 slide on a plane with normal of the Y axis should set the Y to zero.");
+	CHECK_MESSAGE(
+			vector.slide(vector_normal).is_equal_approx(Vector2(-0.8292559899117276166456, 2.798738965952080706179)),
+			"Vector2 slide with normal should return expected value.");
+	// There's probably a better way to test these ones?
+	ERR_PRINT_OFF;
+	CHECK_MESSAGE(
+			vector.bounce(vector_non_normal).is_equal_approx(Vector2()),
+			"Vector2 bounce should return empty Vector2 with non-normalised input.");
+	CHECK_MESSAGE(
+			vector.reflect(vector_non_normal).is_equal_approx(Vector2()),
+			"Vector2 reflect should return empty Vector2 with non-normalised input.");
+	CHECK_MESSAGE(
+			vector.slide(vector_non_normal).is_equal_approx(Vector2()),
+			"Vector2 slide should return empty Vector2 with non-normalised input.");
+	ERR_PRINT_ON;
 }
 
 TEST_CASE("[Vector2] Rounding methods") {
@@ -367,12 +434,20 @@ TEST_CASE("[Vector2] Rounding methods") {
 TEST_CASE("[Vector2] Linear algebra methods") {
 	const Vector2 vector_x = Vector2(1, 0);
 	const Vector2 vector_y = Vector2(0, 1);
+	const Vector2 a = Vector2(3.5, 8.5);
+	const Vector2 b = Vector2(5.2, 4.6);
 	CHECK_MESSAGE(
 			vector_x.cross(vector_y) == 1,
 			"Vector2 cross product of X and Y should give 1.");
 	CHECK_MESSAGE(
 			vector_y.cross(vector_x) == -1,
 			"Vector2 cross product of Y and X should give negative 1.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(a.cross(b), (real_t)-28.1),
+			"Vector2 cross should return expected value.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(Vector2(-a.x, a.y).cross(Vector2(b.x, -b.y)), (real_t)-28.1),
+			"Vector2 cross should return expected value.");
 
 	CHECK_MESSAGE(
 			vector_x.dot(vector_y) == 0.0,
@@ -383,6 +458,12 @@ TEST_CASE("[Vector2] Linear algebra methods") {
 	CHECK_MESSAGE(
 			(vector_x * 10).dot(vector_x * 10) == 100.0,
 			"Vector2 dot product of same direction vectors should behave as expected.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(a.dot(b), (real_t)57.3),
+			"Vector2 dot should return expected value.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(Vector2(-a.x, a.y).dot(Vector2(b.x, -b.y)), (real_t)-57.3),
+			"Vector2 dot should return expected value.");
 }
 } // namespace TestVector2
 

--- a/tests/core/math/test_vector2i.h
+++ b/tests/core/math/test_vector2i.h
@@ -37,6 +37,14 @@
 
 namespace TestVector2i {
 
+TEST_CASE("[Vector2i] Constructor methods") {
+	const Vector2i vector_empty = Vector2i();
+	const Vector2i vector_zero = Vector2i(0, 0);
+	CHECK_MESSAGE(
+			vector_empty == vector_zero,
+			"Vector2i Constructor with no inputs should return a zero Vector2i.");
+}
+
 TEST_CASE("[Vector2i] Axis methods") {
 	Vector2i vector = Vector2i(2, 3);
 	CHECK_MESSAGE(
@@ -121,6 +129,14 @@ TEST_CASE("[Vector2i] Other methods") {
 	CHECK_MESSAGE(
 			Math::is_equal_approx(vector.aspect(), (real_t)1.0 / (real_t)3.0),
 			"Vector2i aspect should work as expected.");
+
+	CHECK_MESSAGE(
+			Vector2i(1, 2) == vector.min(Vector2i(3, 2)),
+			"Vector2i min should return expected value.");
+
+	CHECK_MESSAGE(
+			Vector2i(5, 3) == vector.max(Vector2i(5, 2)),
+			"Vector2i max should return expected value.");
 }
 
 TEST_CASE("[Vector2i] Abs and sign methods") {

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -39,6 +39,14 @@
 
 namespace TestVector3 {
 
+TEST_CASE("[Vector3] Constructor methods") {
+	const Vector3 vector_empty = Vector3();
+	const Vector3 vector_zero = Vector3(0.0, 0.0, 0.0);
+	CHECK_MESSAGE(
+			vector_empty == vector_zero,
+			"Vector3 Constructor with no inputs should return a zero Vector3.");
+}
+
 TEST_CASE("[Vector3] Angle methods") {
 	const Vector3 vector_x = Vector3(1, 0, 0);
 	const Vector3 vector_y = Vector3(0, 1, 0);
@@ -123,6 +131,9 @@ TEST_CASE("[Vector3] Interpolation methods") {
 			Vector3(1, 1, 1).slerp(Vector3(), 0.5) == Vector3(0.5, 0.5, 0.5),
 			"Vector3 slerp with one input as zero should behave like a regular lerp.");
 	CHECK_MESSAGE(
+			Vector3(4, 6, 2).slerp(Vector3(8, 10, 3), 0.5).is_equal_approx(Vector3(5.90194219811429941053, 8.06758688849378394534, 2.558307894718317120038)),
+			"Vector3 slerp should work as expected.");
+	CHECK_MESSAGE(
 			Math::is_equal_approx(vector1.slerp(vector2, 0.5).length(), (real_t)6.25831088708303172),
 			"Vector3 slerp with different length input should return a vector with an interpolated length.");
 	CHECK_MESSAGE(
@@ -195,6 +206,15 @@ TEST_CASE("[Vector3] Normalization methods") {
 	CHECK_MESSAGE(
 			Vector3(1, 1, 1).normalized().is_equal_approx(Vector3(Math_SQRT13, Math_SQRT13, Math_SQRT13)),
 			"Vector3 normalized should work as expected.");
+
+	Vector3 vector = Vector3(3.2, -5.4, 6);
+	vector.normalize();
+	CHECK_MESSAGE(
+			vector == Vector3(3.2, -5.4, 6).normalized(),
+			"Vector3 normalize should convert same way as Vector3 normalized.");
+	CHECK_MESSAGE(
+			vector.is_equal_approx(Vector3(0.368522751763902980457, -0.621882143601586279522, 0.6909801595573180883585)),
+			"Vector3 normalize should work as expected.");
 }
 
 TEST_CASE("[Vector3] Operators") {
@@ -318,9 +338,20 @@ TEST_CASE("[Vector3] Other methods") {
 	CHECK_MESSAGE(
 			(-vector).posmodv(Vector3(2, 3, 4)).is_equal_approx(Vector3(0.8, 2.6, 2.4)),
 			"Vector3 posmodv should work as expected.");
+
+	CHECK_MESSAGE(
+			vector.rotated(Vector3(0, 1, 0), Math_TAU).is_equal_approx(vector),
+			"Vector3 rotated should work as expected.");
 	CHECK_MESSAGE(
 			vector.rotated(Vector3(0, 1, 0), Math_TAU / 4).is_equal_approx(Vector3(5.6, 3.4, -1.2)),
 			"Vector3 rotated should work as expected.");
+	CHECK_MESSAGE(
+			vector.rotated(Vector3(1, 0, 0), Math_TAU / 3).is_equal_approx(Vector3(1.2, -6.54974226119285642, 0.1444863728670914)),
+			"Vector3 rotated should work as expected.");
+	CHECK_MESSAGE(
+			vector.rotated(Vector3(0, 0, 1), Math_TAU / 2).is_equal_approx(vector.rotated(Vector3(0, 0, 1), Math_TAU / -2)),
+			"Vector3 rotated should work as expected.");
+
 	CHECK_MESSAGE(
 			vector.snapped(Vector3(1, 1, 1)) == Vector3(1, 3, 6),
 			"Vector3 snapped to integers should be the same as rounding.");
@@ -332,18 +363,44 @@ TEST_CASE("[Vector3] Other methods") {
 TEST_CASE("[Vector3] Plane methods") {
 	const Vector3 vector = Vector3(1.2, 3.4, 5.6);
 	const Vector3 vector_y = Vector3(0, 1, 0);
+	const Vector3 vector_normal = Vector3(0.88763458893247992491, 0.26300284116517923701, 0.37806658417494515320);
+	const Vector3 vector_non_normal = Vector3(5.4, 1.6, 2.3);
 	CHECK_MESSAGE(
 			vector.bounce(vector_y) == Vector3(1.2, -3.4, 5.6),
 			"Vector3 bounce on a plane with normal of the Y axis should.");
 	CHECK_MESSAGE(
+			vector.bounce(vector_normal).is_equal_approx(Vector3(-6.0369629829775736287, 1.25571467171034855444, 2.517589840583626047)),
+			"Vector3 bounce with normal should return expected value.");
+	CHECK_MESSAGE(
 			vector.reflect(vector_y) == Vector3(-1.2, 3.4, -5.6),
 			"Vector3 reflect on a plane with normal of the Y axis should.");
 	CHECK_MESSAGE(
+			vector.reflect(vector_normal).is_equal_approx(Vector3(6.0369629829775736287, -1.25571467171034855444, -2.517589840583626047)),
+			"Vector3 reflect with normal should return expected value.");
+	CHECK_MESSAGE(
 			vector.project(vector_y) == Vector3(0, 3.4, 0),
-			"Vector3 projected on the X axis should only give the Y component.");
+			"Vector3 projected on the Y axis should only give the Y component.");
+	CHECK_MESSAGE(
+			vector.project(vector_normal).is_equal_approx(Vector3(3.61848149148878681437, 1.0721426641448257227776, 1.54120507970818697649)),
+			"Vector3 projected on a normal should return expected value.");
 	CHECK_MESSAGE(
 			vector.slide(vector_y) == Vector3(1.2, 0, 5.6),
 			"Vector3 slide on a plane with normal of the Y axis should set the Y to zero.");
+	CHECK_MESSAGE(
+			vector.slide(vector_normal).is_equal_approx(Vector3(-2.41848149148878681437, 2.32785733585517427722237, 4.0587949202918130235)),
+			"Vector3 slide with normal should return expected value.");
+	// There's probably a better way to test these ones?
+	ERR_PRINT_OFF;
+	CHECK_MESSAGE(
+			vector.bounce(vector_non_normal).is_equal_approx(Vector3()),
+			"Vector3 bounce should return empty Vector3 with non-normalised input.");
+	CHECK_MESSAGE(
+			vector.reflect(vector_non_normal).is_equal_approx(Vector3()),
+			"Vector3 reflect should return empty Vector3 with non-normalised input.");
+	CHECK_MESSAGE(
+			vector.slide(vector_non_normal).is_equal_approx(Vector3()),
+			"Vector3 slide should return empty Vector3 with non-normalised input.");
+	ERR_PRINT_ON;
 }
 
 TEST_CASE("[Vector3] Rounding methods") {
@@ -389,6 +446,8 @@ TEST_CASE("[Vector3] Linear algebra methods") {
 	const Vector3 vector_x = Vector3(1, 0, 0);
 	const Vector3 vector_y = Vector3(0, 1, 0);
 	const Vector3 vector_z = Vector3(0, 0, 1);
+	const Vector3 a = Vector3(3.5, 8.5, 2.3);
+	const Vector3 b = Vector3(5.2, 4.6, 7.8);
 	CHECK_MESSAGE(
 			vector_x.cross(vector_y) == vector_z,
 			"Vector3 cross product of X and Y should give Z.");
@@ -401,6 +460,12 @@ TEST_CASE("[Vector3] Linear algebra methods") {
 	CHECK_MESSAGE(
 			vector_z.cross(vector_x) == vector_y,
 			"Vector3 cross product of Z and X should give Y.");
+	CHECK_MESSAGE(
+			a.cross(b).is_equal_approx(Vector3(55.72, -15.34, -28.1)),
+			"Vector3 cross should return expected value.");
+	CHECK_MESSAGE(
+			Vector3(-a.x, a.y, -a.z).cross(Vector3(b.x, -b.y, b.z)).is_equal_approx(Vector3(55.72, 15.34, -28.1)),
+			"Vector2 cross should return expected value.");
 
 	CHECK_MESSAGE(
 			vector_x.dot(vector_y) == 0.0,
@@ -411,6 +476,12 @@ TEST_CASE("[Vector3] Linear algebra methods") {
 	CHECK_MESSAGE(
 			(vector_x * 10).dot(vector_x * 10) == 100.0,
 			"Vector3 dot product of same direction vectors should behave as expected.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(a.dot(b), (real_t)75.24),
+			"Vector3 dot should return expected value.");
+	CHECK_MESSAGE(
+			Math::is_equal_approx(Vector3(-a.x, a.y, -a.z).dot(Vector3(b.x, -b.y, b.z)), (real_t)-75.24),
+			"Vector3 dot should return expected value.");
 }
 } // namespace TestVector3
 

--- a/tests/core/math/test_vector3i.h
+++ b/tests/core/math/test_vector3i.h
@@ -36,6 +36,14 @@
 
 namespace TestVector3i {
 
+TEST_CASE("[Vector3i] Constructor methods") {
+	const Vector3i vector_empty = Vector3i();
+	const Vector3i vector_zero = Vector3i(0, 0, 0);
+	CHECK_MESSAGE(
+			vector_empty == vector_zero,
+			"Vector3i Constructor with no inputs should return a zero Vector3i.");
+}
+
 TEST_CASE("[Vector3i] Axis methods") {
 	Vector3i vector = Vector3i(1, 2, 3);
 	CHECK_MESSAGE(

--- a/tests/core/math/test_vector4.h
+++ b/tests/core/math/test_vector4.h
@@ -38,6 +38,14 @@
 
 namespace TestVector4 {
 
+TEST_CASE("[Vector4] Constructor methods") {
+	const Vector4 vector_empty = Vector4();
+	const Vector4 vector_zero = Vector4(0.0, 0.0, 0.0, 0.0);
+	CHECK_MESSAGE(
+			vector_empty == vector_zero,
+			"Vector4 Constructor with no inputs should return a zero Vector4.");
+}
+
 TEST_CASE("[Vector4] Axis methods") {
 	Vector4 vector = Vector4(1.2, 3.4, 5.6, -0.9);
 	CHECK_MESSAGE(

--- a/tests/core/math/test_vector4i.h
+++ b/tests/core/math/test_vector4i.h
@@ -36,6 +36,14 @@
 
 namespace TestVector4i {
 
+TEST_CASE("[Vector4i] Constructor methods") {
+	const Vector4i vector_empty = Vector4i();
+	const Vector4i vector_zero = Vector4i(0, 0, 0, 0);
+	CHECK_MESSAGE(
+			vector_empty == vector_zero,
+			"Vector4i Constructor with no inputs should return a zero Vector4i.");
+}
+
 TEST_CASE("[Vector4i] Axis methods") {
 	Vector4i vector = Vector4i(1, 2, 3, 4);
 	CHECK_MESSAGE(


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot/pull/48138 and https://github.com/godotengine/godot/pull/47202 _(kind of salvages them)_.
 
 This PR adds more tests for **Vector2**, **Vector2i**, **Vector3**, **Vector3i**, **Vector4** and **Vector4i**.
 
Of note, among the new checks:
- Constructors.
- Every method requiring a normal Vector to return an empty Vector on error.
- **Vector2**/**Vector2i** `min()` and `max()` _(for some reason Vector3 doesn't have them)_.
- Several more tests with more "natural" Vectors, not just Vector3(0, 1, 0), for example.