### PR TITLE
Fix TileMaps placing baked NavigationPolygons with wrong offset without a Navigation2D node

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -160,7 +160,7 @@ void TileMap::_update_quadrant_transform() {
 		if (navigation) {
 			nav_rel = get_relative_transform_to_parent(navigation);
 		} else {
-			nav_rel = get_transform();
+			nav_rel = get_global_transform();
 		}
 	}
 
@@ -346,7 +346,7 @@ void TileMap::update_dirty_quadrants() {
 		if (navigation) {
 			nav_rel = get_relative_transform_to_parent(navigation);
 		} else {
-			nav_rel = get_transform();
+			nav_rel = get_global_transform();
 		}
 	}
 


### PR DESCRIPTION
Fixes #66235

The legacy navigation is positioning baked TileMap navpolygons relative to the current Navigation2D node assuming that it is usually one of the parent nodes.

Without the deprecated Navigation2D node the default navigation map is used. This navigation map has no relative Node2D as it is part of the world_2d. It needs to use the global_transform of the TileMap to place navregions with the correct offset in case the TileMap is moved from the origin.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
