### PR TITLE
Add AnimatedSprite2D/3D `pause()` & change `stop()`

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -6,7 +6,7 @@
 	<description>
 		[AnimatedSprite2D] is similar to the [Sprite2D] node, except it carries multiple textures as animation frames. Animations are created using a [SpriteFrames] resource, which allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames bottom panel.
 		After setting up [member frames], [method play] may be called. It's also possible to select an [member animation] and toggle [member playing], even within the editor.
-		To pause the current animation, call [method stop] or set [member playing] to [code]false[/code]. Alternatively, setting [member speed_scale] to [code]0[/code] also preserves the current frame's elapsed time.
+		To pause the current animation, call [method pause] or set [member playing] to [code]false[/code]. Alternatively, set [member speed_scale] to [code]0[/code].
 		[b]Note:[/b] You can associate a set of normal or specular maps by creating additional [SpriteFrames] resources with a [code]_normal[/code] or [code]_specular[/code] suffix. For example, having 3 [SpriteFrames] resources [code]run[/code], [code]run_normal[/code], and [code]run_specular[/code] will make it so the [code]run[/code] animation uses normal and specular maps.
 	</description>
 	<tutorials>
@@ -14,6 +14,12 @@
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>
 	</tutorials>
 	<methods>
+		<method name="pause">
+			<return type="void" />
+			<description>
+				Pauses the current [member animation] at the current [member frame], preserving the elapsed time. This is equivalent to setting [member playing] to [code]false[/code].
+			</description>
+		</method>
 		<method name="play">
 			<return type="void" />
 			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
@@ -25,8 +31,7 @@
 		<method name="stop">
 			<return type="void" />
 			<description>
-				Stops the current [member animation] at the current [member frame].
-				[b]Note:[/b] This method resets the current frame's elapsed time. If this behavior is undesired, consider setting [member speed_scale] to [code]0[/code], instead.
+				Pauses and restarts the current [member animation], back to the beginning. See also [method pause].
 			</description>
 		</method>
 	</methods>
@@ -53,7 +58,7 @@
 			The texture's drawing offset.
 		</member>
 		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
-			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] is the equivalent of calling [method stop].
+			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] is the equivalent of calling [method pause].
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The animation speed is multiplied by this value. If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation is paused, preserving the current frame's elapsed time.

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -6,12 +6,18 @@
 	<description>
 		[AnimatedSprite3D] is similar to the [Sprite3D] node, except it carries multiple textures as animation [member frames]. Animations are created using a [SpriteFrames] resource, which allows you to import image files (or a folder containing said files) to provide the animation frames for the sprite. The [SpriteFrames] resource can be configured in the editor via the SpriteFrames bottom panel.
 		After setting up [member frames], [method play] may be called. It's also possible to select an [member animation] and toggle [member playing], even within the editor.
-		To pause the current animation, call [method stop] or set [member playing] to [code]false[/code]. Alternatively, setting [member speed_scale] to [code]0[/code] also preserves the current frame's elapsed time.
+		To pause the current animation, call [method pause] or set [member playing] to [code]false[/code]. Alternatively, set [member speed_scale] to [code]0[/code].
 	</description>
 	<tutorials>
 		<link title="2D Sprite animation (also applies to 3D)">$DOCS_URL/tutorials/2d/2d_sprite_animation.html</link>
 	</tutorials>
 	<methods>
+		<method name="pause">
+			<return type="void" />
+			<description>
+				Pauses the current [member animation] at the current [member frame], preserving the elapsed time. This is equivalent to setting [member playing] to [code]false[/code].
+			</description>
+		</method>
 		<method name="play">
 			<return type="void" />
 			<param index="0" name="anim" type="StringName" default="&amp;&quot;&quot;" />
@@ -23,8 +29,7 @@
 		<method name="stop">
 			<return type="void" />
 			<description>
-				Stops the current [member animation] at the current [member frame].
-				[b]Note:[/b] This method resets the current frame's elapsed time. If this behavior is undesired, consider setting [member speed_scale] to [code]0[/code], instead.
+				Pauses and restarts the current [member animation], back to the beginning. See also [method pause].
 			</description>
 		</method>
 	</methods>
@@ -39,7 +44,7 @@
 			The [SpriteFrames] resource containing the animation(s).
 		</member>
 		<member name="playing" type="bool" setter="set_playing" getter="is_playing" default="false">
-			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] is the equivalent of calling [method stop].
+			If [code]true[/code], the [member animation] is currently playing. Setting this property to [code]false[/code] is the equivalent of calling [method pause].
 		</member>
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			The animation speed is multiplied by this value. If set to a negative value, the animation is played in reverse. If set to [code]0[/code], the animation is paused, preserving the current frame's elapsed time.

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -388,7 +388,6 @@ void AnimatedSprite2D::set_playing(bool p_playing) {
 		return;
 	}
 	playing = p_playing;
-	_reset_timeout();
 	set_process_internal(playing);
 	notify_property_list_changed();
 }
@@ -412,7 +411,13 @@ void AnimatedSprite2D::play(const StringName &p_animation, bool p_backwards) {
 	set_playing(true);
 }
 
+void AnimatedSprite2D::pause() {
+	set_playing(false);
+}
+
 void AnimatedSprite2D::stop() {
+	_reset_timeout();
+	set_frame(0);
 	set_playing(false);
 }
 
@@ -486,6 +491,7 @@ void AnimatedSprite2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite2D::is_playing);
 
 	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite2D::play, DEFVAL(StringName()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("pause"), &AnimatedSprite2D::pause);
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite2D::stop);
 
 	ClassDB::bind_method(D_METHOD("set_centered", "centered"), &AnimatedSprite2D::set_centered);

--- a/scene/2d/animated_sprite_2d.h
+++ b/scene/2d/animated_sprite_2d.h
@@ -83,6 +83,7 @@ public:
 	Ref<SpriteFrames> get_sprite_frames() const;
 
 	void play(const StringName &p_animation = StringName(), bool p_backwards = false);
+	void pause();
 	void stop();
 
 	void set_playing(bool p_playing);

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1091,7 +1091,6 @@ void AnimatedSprite3D::set_playing(bool p_playing) {
 		return;
 	}
 	playing = p_playing;
-	_reset_timeout();
 	set_process_internal(playing);
 	notify_property_list_changed();
 }
@@ -1115,7 +1114,13 @@ void AnimatedSprite3D::play(const StringName &p_animation, bool p_backwards) {
 	set_playing(true);
 }
 
+void AnimatedSprite3D::pause() {
+	set_playing(false);
+}
+
 void AnimatedSprite3D::stop() {
+	_reset_timeout();
+	set_frame(0);
 	set_playing(false);
 }
 
@@ -1187,6 +1192,7 @@ void AnimatedSprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimatedSprite3D::is_playing);
 
 	ClassDB::bind_method(D_METHOD("play", "anim", "backwards"), &AnimatedSprite3D::play, DEFVAL(StringName()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("pause"), &AnimatedSprite3D::pause);
 	ClassDB::bind_method(D_METHOD("stop"), &AnimatedSprite3D::stop);
 
 	ClassDB::bind_method(D_METHOD("set_frame", "frame"), &AnimatedSprite3D::set_frame);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -237,6 +237,7 @@ public:
 	Ref<SpriteFrames> get_sprite_frames() const;
 
 	void play(const StringName &p_animation = StringName(), bool p_backwards = false);
+	void pause();
 	void stop();
 
 	void set_playing(bool p_playing);


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/56645#issuecomment-1253515208 and https://github.com/godotengine/godot/pull/56645#issuecomment-1254686360 (I'm aware it's **AnimationPlayer** but the three classes are fairly similar)
Supersedes #65986 (because it is incorporated).

In this PR, for **AnimatedSprite2D** and **AnimatedSprite3D**:
Changes the behaviour of setting `playing` to **false** to be like #65986. That is, elapsed frame time is also preserved when pausing, which means pausing and playing animations intermittently now shows to consistent timings.
The new method `pause()` acts as an alias to setting `playing` to **false** (very akin to `CanvasItem.hide()`). It's what `stop()` was before.

`stop()` now pauses and restarts the current animation from the beginning.