### PR TITLE
Fix Editor Description tooltip not changing until scene is reopened

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1987,7 +1987,16 @@ String Node::get_scene_file_path() const {
 }
 
 void Node::set_editor_description(const String &p_editor_description) {
+	if (data.editor_description == p_editor_description) {
+		return;
+	}
+
 	data.editor_description = p_editor_description;
+
+	if (Engine::get_singleton()->is_editor_hint() && is_inside_tree()) {
+		// Update tree so the tooltip in the Scene tree dock is also updated in the editor.
+		get_tree()->tree_changed();
+	}
 }
 
 String Node::get_editor_description() const {


### PR DESCRIPTION
You still need to select another node to see the tooltip updated first, but you no longer need to save and reopen the scene to view the updated tooltip.

The solution is based on https://github.com/godotengine/godot/pull/61531 (thanks @Dentyr), but is only applied in the editor as it's not needed outside the editor.

This closes https://github.com/godotengine/godot/issues/61521.