### PR TITLE
Set `collision->owner` in `test_move`, fixes return of `KinematicCollision2D.get_local_shape()`

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -128,14 +128,14 @@ bool PhysicsBody2D::move_and_collide(const PhysicsServer2D::MotionParameters &p_
 	return colliding;
 }
 
-bool PhysicsBody2D::test_move(const Transform2D &p_from, const Vector2 &p_distance, const Ref<KinematicCollision2D> &r_collision, real_t p_margin, bool p_recovery_as_collision) {
+bool PhysicsBody2D::test_move(const Transform2D &p_from, const Vector2 &p_distance, Ref<KinematicCollision2D> r_collision, real_t p_margin, bool p_recovery_as_collision) {
 	ERR_FAIL_COND_V(!is_inside_tree(), false);
 
 	PhysicsServer2D::MotionResult *r = nullptr;
 	PhysicsServer2D::MotionResult temp_result;
 	if (r_collision.is_valid()) {
-		// Needs const_cast because method bindings don't support non-const Ref.
-		r = const_cast<PhysicsServer2D::MotionResult *>(&r_collision->result);
+		r_collision->owner = this;
+		r = &r_collision->result;
 	} else {
 		r = &temp_result;
 	}

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -51,7 +51,7 @@ protected:
 
 public:
 	bool move_and_collide(const PhysicsServer2D::MotionParameters &p_parameters, PhysicsServer2D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);
-	bool test_move(const Transform2D &p_from, const Vector2 &p_distance, const Ref<KinematicCollision2D> &r_collision = Ref<KinematicCollision2D>(), real_t p_margin = 0.08, bool p_recovery_as_collision = false);
+	bool test_move(const Transform2D &p_from, const Vector2 &p_distance, Ref<KinematicCollision2D> r_collision = Ref<KinematicCollision2D>(), real_t p_margin = 0.08, bool p_recovery_as_collision = false);
 
 	TypedArray<PhysicsBody2D> get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node); //must be physicsbody


### PR DESCRIPTION
Also simplifies the function parameter to use non-const Ref

Scene: CharacterBody2D that is intersecting a StaticBody2D
Script:

```gdscript
extends CharacterBody2D

func _ready() -> void:
        var collision := KinematicCollision2D.new()
        if test_move(transform, Vector2.ZERO, collision):
                print(collision.get_local_shape())
```

Before:
```
Godot Engine v4.0.beta.custom_build.62792eeb9 - https://godotengine.org
Vulkan API 1.2.0 - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 960M
 
<Object#null>

```

After:
```
Godot Engine v4.0.beta.custom_build.9436928b2 - https://godotengine.org
Vulkan API 1.2.0 - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 960M
 
CollisionShape2D:<CollisionShape2D#26776437132>

```

MRP:
[test-test-move.zip](https://github.com/godotengine/godot/files/9629565/test-test-move.zip)
