### PR TITLE
Revert `custom_minimum_size` type back to `Vector2` instead of `Vector2i`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -972,7 +972,7 @@
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" default="false">
 			Enables whether rendering of [CanvasItem] based children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered and won't receive input.
 		</member>
-		<member name="custom_minimum_size" type="Vector2i" setter="set_custom_minimum_size" getter="get_custom_minimum_size" default="Vector2i(0, 0)">
+		<member name="custom_minimum_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" default="Vector2(0, 0)">
 			The minimum size of the node's bounding rectangle. If you set it to a value greater than (0, 0), the node's bounding rectangle will always have at least this size, even if its content is smaller. If it's set to (0, 0), the node sizes automatically to fit its content, be it a texture or child nodes.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" enum="Control.FocusMode" default="0">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1564,7 +1564,7 @@ Size2 Control::get_minimum_size() const {
 	return Vector2();
 }
 
-void Control::set_custom_minimum_size(const Size2i &p_custom) {
+void Control::set_custom_minimum_size(const Size2 &p_custom) {
 	if (p_custom == data.custom_minimum_size) {
 		return;
 	}
@@ -1572,7 +1572,7 @@ void Control::set_custom_minimum_size(const Size2i &p_custom) {
 	update_minimum_size();
 }
 
-Size2i Control::get_custom_minimum_size() const {
+Size2 Control::get_custom_minimum_size() const {
 	return data.custom_minimum_size;
 }
 
@@ -3132,7 +3132,7 @@ void Control::_bind_methods() {
 
 	ADD_GROUP("Layout", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_contents"), "set_clip_contents", "is_clipping_contents");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "custom_minimum_size", PROPERTY_HINT_NONE, "suffix:px"), "set_custom_minimum_size", "get_custom_minimum_size");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "custom_minimum_size", PROPERTY_HINT_NONE, "suffix:px"), "set_custom_minimum_size", "get_custom_minimum_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_direction", PROPERTY_HINT_ENUM, "Inherited,Locale,Left-to-Right,Right-to-Left"), "set_layout_direction", "get_layout_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layout_mode", PROPERTY_HINT_ENUM, "Position,Anchors,Container,Uncontrolled", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_INTERNAL), "_set_layout_mode", "_get_layout_mode");
 	ADD_PROPERTY_DEFAULT("layout_mode", LayoutMode::LAYOUT_MODE_POSITION);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -200,7 +200,7 @@ private:
 		int h_size_flags = SIZE_FILL;
 		int v_size_flags = SIZE_FILL;
 		real_t expand = 1.0;
-		Point2i custom_minimum_size;
+		Point2 custom_minimum_size;
 
 		// Input events and rendering.
 
@@ -460,8 +460,8 @@ public:
 	virtual Size2 get_minimum_size() const;
 	virtual Size2 get_combined_minimum_size() const;
 
-	void set_custom_minimum_size(const Size2i &p_custom);
-	Size2i get_custom_minimum_size() const;
+	void set_custom_minimum_size(const Size2 &p_custom);
+	Size2 get_custom_minimum_size() const;
 
 	// Container sizing.
 


### PR DESCRIPTION
This change introduced in #64373 was causing me multiple problems, since my code depends on this value being float (Vector2 / Size2). I have code that lerps from the current minimum size to a target by delta to create a smooth animated size change. With integers, any change of less than one pixel results in the animation freezing near the end.

Without this PR, my best work-around is to store my size value separately, but even then the final value will still be an integer so at 200% scaling the animation will still not be smooth since it jumps multiples of 2 pixels.

Also, all of the other size code in Control uses floats (Vector2 / Size2), it was just this one value changed for some reason.

This work was sponsored by The Mirror.