### PR TITLE
Fix sub-scene root nodes not getting the correct inheritance chain when exporting

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -710,7 +710,7 @@ String EditorExportPlatform::_export_customize(const String &p_path, LocalVector
 	if (type == "PackedScene") { // Its a scene.
 		Ref<PackedScene> ps = ResourceLoader::load(p_path, "PackedScene", ResourceFormatLoader::CACHE_MODE_IGNORE);
 		ERR_FAIL_COND_V(ps.is_null(), p_path);
-		Node *node = ps->instantiate();
+		Node *node = ps->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE); // Make sure the child scene root gets the correct inheritance chain.
 		ERR_FAIL_COND_V(node == nullptr, p_path);
 		if (customize_scenes_plugins.size()) {
 			for (uint32_t i = 0; i < customize_scenes_plugins.size(); i++) {


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/66154#issuecomment-1254649435.

Fix #66154.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
