### PR TITLE
Format HTML files with EsLint

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 <html xmlns="https://www.w3.org/1999/xhtml" lang="en">
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no" />
-	<meta name="author" content="Godot Engine" />
-	<meta name="description" content="Use the Godot Engine editor directly in your web browser, without having to install anything." />
-	<meta name="mobile-web-app-capable" content="yes" />
-	<meta name="apple-mobile-web-app-capable" content="yes" />
-	<meta name="application-name" content="Godot" />
-	<meta name="apple-mobile-web-app-title" content="Godot" />
-	<meta name="theme-color" content="#202531" />
-	<meta name="msapplication-navbutton-color" content="#202531" />
-	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-	<meta name="msapplication-starturl" content="/latest" />
-	<meta property="og:site_name" content="Godot Engine Web Editor" />
-	<meta property="og:url" name="twitter:url" content="https://editor.godotengine.org/releases/latest/" />
-	<meta property="og:title" name="twitter:title" content="Free and open source 2D and 3D game engine" />
-	<meta property="og:description" name="twitter:description" content="Use the Godot Engine editor directly in your web browser, without having to install anything." />
-	<meta property="og:image" name="twitter:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png" />
-	<meta property="og:type" content="website" />
-	<meta name="twitter:card" content="summary" />
-	<link id="-gd-engine-icon" rel="icon" type="image/png" href="favicon.png" />
-	<link rel="apple-touch-icon" type="image/png" href="favicon.png" />
-	<link rel="manifest" href="manifest.json" />
-	<title>Godot Engine Web Editor (@GODOT_VERSION@)</title>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
+        <meta name="author" content="Godot Engine">
+        <meta name="description" content="Use the Godot Engine editor directly in your web browser, without having to install anything.">
+        <meta name="mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="application-name" content="Godot">
+        <meta name="apple-mobile-web-app-title" content="Godot">
+        <meta name="theme-color" content="#202531">
+        <meta name="msapplication-navbutton-color" content="#202531">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <meta name="msapplication-starturl" content="/latest">
+        <meta property="og:site_name" content="Godot Engine Web Editor">
+        <meta property="og:url" name="twitter:url" content="https://editor.godotengine.org/releases/latest/">
+        <meta property="og:title" name="twitter:title" content="Free and open source 2D and 3D game engine">
+        <meta property="og:description" name="twitter:description" content="Use the Godot Engine editor directly in your web browser, without having to install anything.">
+        <meta property="og:image" name="twitter:image" content="https://godotengine.org/themes/godotengine/assets/og_image.png">
+        <meta property="og:type" content="website">
+        <meta name="twitter:card" content="summary">
+        <link id="-gd-engine-icon" rel="icon" type="image/png" href="favicon.png">
+        <link rel="apple-touch-icon" type="image/png" href="favicon.png">
+        <link rel="manifest" href="manifest.json">
+        <title>Godot Engine Web Editor (@GODOT_VERSION@)</title>
 	<style>
 		*:focus {
 			/* More visible outline for better keyboard navigation. */
@@ -60,7 +60,7 @@
 
 		.welcome-modal {
 			display: none;
- 			position: fixed;
+			position: fixed;
 			z-index: 1;
 			left: 0;
 			top: 0;
@@ -157,7 +157,7 @@
 
 
 		/* Status display
-		 * ============== */
+		*  ============== */
 
 		#status {
 			position: absolute;
@@ -168,7 +168,7 @@
 			display: flex;
 			justify-content: center;
 			align-items: center;
-			/* don't consume click events - make children visible explicitly */
+			/* Don't consume click events - make children visible explicitly */
 			visibility: hidden;
 		}
 
@@ -232,122 +232,125 @@
 			visibility: visible;
 		}
 	</style>
-</head>
-<body>
-	<div
-		id="welcome-modal"
-		class="welcome-modal"
-		role="dialog"
-		aria-labelledby="welcome-modal-title"
-		aria-describedby="welcome-modal-description"
-		onclick="if (event.target === this) closeWelcomeModal(false)"
-	>
-		<div class="welcome-modal-content">
-			<h2 id="welcome-modal-title" class="welcome-modal-title">Important - Please read before continuing</h2>
-			<div id="welcome-modal-description">
-				<p>
-					The Godot Web Editor has some limitations compared to the native version.
-					Its main focus is education and experimentation;
-					<strong>it is not recommended for production</strong>.
-				</p>
-				<p>
-					Refer to the
-					<a
-						href="https://docs.godotengine.org/en/latest/tutorials/editor/using_the_web_editor.html"
-						target="_blank"
-						rel="noopener"
-					>Web editor documentation</a> for usage instructions and limitations.
-				</p>
-			</div>
-			<div id="welcome-modal-missing-description" style="display: none">
-				<p>
-					<strong>The following features required by the Godot Web Editor are missing:</strong>
-					<ul id="welcome-modal-missing-list">
-					</ul>
-				</p>
-				<p>
-					If you are self-hosting the web editor,
-					refer to
-					<a
-						href="https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_web.html"
-						target="_blank"
-						rel="noopener"
-					>Exporting for the Web</a> for more information.
-				</p>
-			</div>
-			<div style="text-align: center">
-				<button id="welcome-modal-dismiss" class="btn" type="button" onclick="closeWelcomeModal(true)" style="margin-top: 1rem">
-					OK, don't show again
-				</button>
-			</div>
-		</div>
-	</div>
-	<div id="tabs-buttons">
-		<button id="btn-tab-loader" class="btn tab-btn" onclick="showTab('loader')">Loader</button>
-		<button id="btn-tab-editor" class="btn tab-btn" disabled="disabled" onclick="showTab('editor')">Editor</button>
-		<button id="btn-close-editor" class="btn close-btn" disabled="disabled" onclick="closeEditor()">×</button>
-		<button id="btn-tab-game" class="btn tab-btn" disabled="disabled" onclick="showTab('game')">Game</button>
-		<button id="btn-close-game" class="btn close-btn"  disabled="disabled" onclick="closeGame()">×</button>
-		<button id="btn-tab-update" class="btn tab-btn" style="display: none;">Update</button>
-	</div>
-	<div id="tabs">
-		<div id="tab-loader">
-			<div style="color: #e0e0e0;" id="persistence">
-				<br />
-				<img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: min(85%, 50vh); max-height: 250px" />
-				<br />
-				@GODOT_VERSION@
-				<br />
-				<a href="releases/">Need an old version?</a>
-				<br />
-				<br />
-				<br />
-				<label for="videoMode" style="margin-right: 1rem">Video driver:</label>
-				<select id="videoMode">
-					<option value="" selected="selected">Auto</option>
-					<option value="opengl3">WebGL 2</option>
-				</select>
-				<br />
-				<br />
-				<label for="zip-file" style="margin-right: 1rem">Preload project ZIP:</label> <input id="zip-file" type="file" name="files" style="margin-bottom: 1rem"/>
-				<br />
-<a href="demo.zip">(Try this for example)</a>
-				<br />
-				<br />
-				<button id="startButton" class="btn" style="margin-bottom: 4rem; font-weight: 700">Start Godot editor</button>
-				<br />
-				<button class="btn" onclick="clearPersistence()" style="margin-bottom: 1.5rem">Clear persistent data</button>
-				<br />
-				<a href="https://docs.godotengine.org/en/latest/tutorials/editor/using_the_web_editor.html">Web editor documentation</a>
-			</div>
-		</div>
-		<div id="tab-editor" style="display: none;">
-			<canvas id="editor-canvas" tabindex="1">
-				HTML5 canvas appears to be unsupported in the current browser.<br />
-				Please try updating or use a different browser.
-			</canvas>
-		</div>
-		<div id="tab-game" style="display: none;">
-			<canvas id="game-canvas" tabindex="2">
-				HTML5 canvas appears to be unsupported in the current browser.<br />
-				Please try updating or use a different browser.
-			</canvas>
-		</div>
-		<div id="tab-status" style="display: none;">
-			<div id="status-progress" style="display: none;" oncontextmenu="event.preventDefault();"><div id="status-progress-inner"></div></div>
-			<div id="status-indeterminate" style="display: none;" oncontextmenu="event.preventDefault();">
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-				<div></div>
-			</div>
-			<div id="status-notice" class="godot" style="display: none;"></div>
-		</div>
-	</div>
+    </head>
+    <body>
+        <div
+            id="welcome-modal"
+            class="welcome-modal"
+            role="dialog"
+            aria-labelledby="welcome-modal-title"
+            aria-describedby="welcome-modal-description"
+            onclick="if (event.target === this) closeWelcomeModal(false)"
+        >
+            <div class="welcome-modal-content">
+                <h2 id="welcome-modal-title" class="welcome-modal-title">Important - Please read before continuing</h2>
+                <div id="welcome-modal-description">
+                    <p>
+                        The Godot Web Editor has some limitations compared to the native version.
+                        Its main focus is education and experimentation;
+                        <strong>it is not recommended for production</strong>.
+                    </p>
+                    <p>
+                        Refer to the
+                        <a
+                            href="https://docs.godotengine.org/en/latest/tutorials/editor/using_the_web_editor.html"
+                            target="_blank"
+                            rel="noopener"
+                        >Web editor documentation</a> for usage instructions and limitations.
+                    </p>
+                </div>
+                <div id="welcome-modal-missing-description" style="display: none">
+                    <p>
+                        <strong>The following features required by the Godot Web Editor are missing:</strong>
+                        <ul id="welcome-modal-missing-list">
+                        </ul>
+                    </p>
+                    <p>
+                        If you are self-hosting the web editor,
+                        refer to
+                        <a
+                            href="https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_web.html"
+                            target="_blank"
+                            rel="noopener"
+                        >Exporting for the Web</a> for more information.
+                    </p>
+                </div>
+                <div style="text-align: center">
+                    <button id="welcome-modal-dismiss" class="btn" type="button" onclick="closeWelcomeModal(true)" style="margin-top: 1rem">
+                        OK, don't show again
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div id="tabs-buttons">
+            <button id="btn-tab-loader" class="btn tab-btn" onclick="showTab('loader')">Loader</button>
+            <button id="btn-tab-editor" class="btn tab-btn" disabled="disabled" onclick="showTab('editor')">Editor</button>
+            <button id="btn-close-editor" class="btn close-btn" disabled="disabled" onclick="closeEditor()">×</button>
+            <button id="btn-tab-game" class="btn tab-btn" disabled="disabled" onclick="showTab('game')">Game</button>
+            <button id="btn-close-game" class="btn close-btn" disabled="disabled" onclick="closeGame()">×</button>
+            <button id="btn-tab-update" class="btn tab-btn" style="display: none;">Update</button>
+        </div>
+        <div id="tabs">
+            <div id="tab-loader">
+                <div style="color: #e0e0e0;" id="persistence">
+                    <br >
+                    <img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: min(85%, 50vh); max-height: 250px">
+                    <br >
+                    @GODOT_VERSION@
+                    <br >
+                    <a href="releases/">Need an old version?</a>
+                    <br >
+                    <br >
+                    <br >
+                    <label for="videoMode" style="margin-right: 1rem">Video driver:</label>
+                    <select id="videoMode">
+                        <option value="" selected="selected">Auto</option>
+                        <option value="opengl3">WebGL 2</option>
+                    </select>
+                    <br >
+                    <br >
+                    <label for="zip-file" style="margin-right: 1rem">Preload project ZIP:</label>
+                    <input id="zip-file" type="file" name="files" style="margin-bottom: 1rem">
+                    <br >
+                    <a href="demo.zip">(Try this for example)</a>
+                    <br >
+                    <br >
+                    <button id="startButton" class="btn" style="margin-bottom: 4rem; font-weight: 700">Start Godot editor</button>
+                    <br >
+                    <button class="btn" onclick="clearPersistence()" style="margin-bottom: 1.5rem">Clear persistent data</button>
+                    <br >
+                    <a href="https://docs.godotengine.org/en/latest/tutorials/editor/using_the_web_editor.html">Web editor documentation</a>
+                </div>
+            </div>
+            <div id="tab-editor" style="display: none;">
+                <canvas id="editor-canvas" tabindex="1">
+                    HTML5 canvas appears to be unsupported in the current browser.<br >
+                    Please try updating or use a different browser.
+                </canvas>
+            </div>
+            <div id="tab-game" style="display: none;">
+                <canvas id="game-canvas" tabindex="2">
+                    HTML5 canvas appears to be unsupported in the current browser.<br >
+                    Please try updating or use a different browser.
+                </canvas>
+            </div>
+            <div id="tab-status" style="display: none;">
+                <div id="status-progress" style="display: none;" oncontextmenu="event.preventDefault();">
+                    <div id="status-progress-inner"></div>
+                </div>
+                <div id="status-indeterminate" style="display: none;" oncontextmenu="event.preventDefault();">
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                </div>
+                <div id="status-notice" class="godot" style="display: none;"></div>
+            </div>
+        </div>
 	<script>//<![CDATA[
 		window.addEventListener("load", () => {
 			function notifyUpdate(sw) {
@@ -672,7 +675,7 @@
 						statusProgressInner.style.width = current/total * 100 + '%';
 						setStatusMode('progress');
 						if (current === total) {
-							// wait for progress bar animation
+							// Wait for progress bar animation.
 							setTimeout(() => {
 								setStatusMode('indeterminate');
 							}, 100);
@@ -748,5 +751,5 @@
 			});
 		}
 	//]]></script>
-</body>
+    </body>
 </html>

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html xmlns='https://www.w3.org/1999/xhtml' lang='' xml:lang=''>
-<head>
-	<meta charset='utf-8' />
-	<meta name='viewport' content='width=device-width, user-scalable=no' />
-	<title>$GODOT_PROJECT_NAME</title>
-	<style type='text/css'>
+<html xmlns="https://www.w3.org/1999/xhtml" lang="en" xml:lang="">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no">
+        <title>$GODOT_PROJECT_NAME</title>
+	<style type="text/css">
 
 		body {
 			touch-action: none;
@@ -36,7 +36,7 @@
 
 
 		/* Status display
-		 * ============== */
+		*  ============== */
 
 		#status {
 			position: absolute;
@@ -47,7 +47,7 @@
 			display: flex;
 			justify-content: center;
 			align-items: center;
-			/* don't consume click events - make children visible explicitly */
+			/* Don't consume click events - make children visible explicitly */
 			visibility: hidden;
 		}
 
@@ -112,30 +112,32 @@
 			visibility: visible;
 		}
 	</style>
-$GODOT_HEAD_INCLUDE
-</head>
-<body>
-	<canvas id='canvas'>
-		HTML5 canvas appears to be unsupported in the current browser.<br />
-		Please try updating or use a different browser.
-	</canvas>
-	<div id='status'>
-		<div id='status-progress' style='display: none;' oncontextmenu='event.preventDefault();'><div id ='status-progress-inner'></div></div>
-		<div id='status-indeterminate' style='display: none;' oncontextmenu='event.preventDefault();'>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-			<div></div>
-		</div>
-		<div id='status-notice' class='godot' style='display: none;'></div>
-	</div>
+        $GODOT_HEAD_INCLUDE
+    </head>
+    <body>
+        <canvas id="canvas">
+            HTML5 canvas appears to be unsupported in the current browser.<br >
+            Please try updating or use a different browser.
+        </canvas>
+        <div id="status">
+            <div id="status-progress" style="display: none;" oncontextmenu="event.preventDefault();">
+                <div id ="status-progress-inner"></div>
+            </div>
+            <div id="status-indeterminate" style="display: none;" oncontextmenu="event.preventDefault();">
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
+            </div>
+            <div id="status-notice" class="godot" style="display: none;"></div>
+        </div>
 
-	<script type='text/javascript' src='$GODOT_URL'></script>
-	<script type='text/javascript'>//<![CDATA[
+	<script type="text/javascript" src="$GODOT_URL"></script>
+	<script type="text/javascript">//<![CDATA[
 
 		const GODOT_CONFIG = $GODOT_CONFIG;
 		var engine = new Engine(GODOT_CONFIG);
@@ -227,7 +229,7 @@ $GODOT_HEAD_INCLUDE
 							statusProgressInner.style.width = current/total * 100 + '%';
 							setStatusMode('progress');
 							if (current === total) {
-								// wait for progress bar animation
+								// Wait for progress bar animation.
 								setTimeout(() => {
 									setStatusMode('indeterminate');
 								}, 500);
@@ -243,5 +245,5 @@ $GODOT_HEAD_INCLUDE
 			}
 		})();
 	//]]></script>
-</body>
+    </body>
 </html>

--- a/misc/dist/html/offline-export.html
+++ b/misc/dist/html/offline-export.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>You are offline</title>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>You are offline</title>
 	<style>
 		html {
 			background-color: #000000;
@@ -26,17 +26,17 @@
 			margin: 3rem auto 0;
 		}
 	</style>
-</head>
-<body>
-	<h1>You are offline</h1>
-	<p>This application requires an Internet connection to run for the first time.</p>
-	<p>Press the button below to try reloading:</p>
-	<button type="button">Reload</button>
+    </head>
+    <body>
+        <h1>You are offline</h1>
+        <p>This application requires an Internet connection to run for the first time.</p>
+        <p>Press the button below to try reloading:</p>
+        <button type="button">Reload</button>
 
 	<script>
 		document.querySelector("button").addEventListener("click", () => {
 			window.location.reload();
 		});
 	</script>
-</body>
+    </body>
 </html>

--- a/misc/dist/html/offline.html
+++ b/misc/dist/html/offline.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<meta name="theme-color" content="#202531" />
-	<meta name="msapplication-navbutton-color" content="#202531" />
-	<title>You are offline</title>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="theme-color" content="#202531">
+        <meta name="msapplication-navbutton-color" content="#202531">
+        <title>You are offline</title>
 	<style>
 		html {
 			background-color: #333b4f;
@@ -28,17 +28,17 @@
 			margin: 3rem auto 0;
 		}
 	</style>
-</head>
-<body>
-	<h1>You are offline</h1>
-	<p>This application requires an Internet connection to run for the first time.</p>
-	<p>Press the button below to try reloading:</p>
-	<button type="button">Reload</button>
+    </head>
+    <body>
+        <h1>You are offline</h1>
+        <p>This application requires an Internet connection to run for the first time.</p>
+        <p>Press the button below to try reloading:</p>
+        <button type="button">Reload</button>
 
 	<script>
 		document.querySelector("button").addEventListener("click", () => {
 			window.location.reload();
 		});
 	</script>
-</body>
+    </body>
 </html>


### PR DESCRIPTION
Revival of https://github.com/godotengine/godot/pull/48488.

Uses EsLint and "_@html-eslint/eslint-plugin_" to format the engine's default HTML pages.

Also tidies up a few comments.

If the original PR could be cherrypicked for 3.x, I don't see why not this one, as well.