### PR TITLE
Reorder parameters in `tr_n` and related methods

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1381,7 +1381,7 @@ String Object::tr(const StringName &p_message, const StringName &p_context) cons
 	return TranslationServer::get_singleton()->translate(p_message, p_context);
 }
 
-String Object::tr_n(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+String Object::tr_n(int p_n, const StringName &p_message, const StringName &p_message_plural, const StringName &p_context) const {
 	if (!_can_translate || !TranslationServer::get_singleton()) {
 		// Return message based on English plural rule if translation is not possible.
 		if (p_n == 1) {
@@ -1389,7 +1389,7 @@ String Object::tr_n(const StringName &p_message, const StringName &p_message_plu
 		}
 		return p_message_plural;
 	}
-	return TranslationServer::get_singleton()->translate_plural(p_message, p_message_plural, p_n, p_context);
+	return TranslationServer::get_singleton()->translate_plural(p_n, p_message, p_message_plural, p_context);
 }
 
 void Object::_clear_internal_resource_paths(const Variant &p_var) {
@@ -1537,7 +1537,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_message_translation", "enable"), &Object::set_message_translation);
 	ClassDB::bind_method(D_METHOD("can_translate_messages"), &Object::can_translate_messages);
 	ClassDB::bind_method(D_METHOD("tr", "message", "context"), &Object::tr, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("tr_n", "message", "plural_message", "n", "context"), &Object::tr_n, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("tr_n", "n", "message", "plural_message", "context"), &Object::tr_n, DEFVAL(""), DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("is_queued_for_deletion"), &Object::is_queued_for_deletion);
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -898,7 +898,7 @@ public:
 
 	// Translate message (internationalization).
 	String tr(const StringName &p_message, const StringName &p_context = "") const;
-	String tr_n(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
+	String tr_n(int p_n, const StringName &p_message, const StringName &p_message_plural = "", const StringName &p_context = "") const;
 
 	bool _is_queued_for_deletion = false; // Set to true by SceneTree::queue_delete().
 	bool is_queued_for_deletion() const;

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -300,7 +300,7 @@ Vector<String> OptimizedTranslation::get_translated_message_list() const {
 	return msgs;
 }
 
-StringName OptimizedTranslation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
+StringName OptimizedTranslation::get_plural_message(int p_n, const StringName &p_src_text, const StringName &p_plural_text, const StringName &p_context) const {
 	// The use of plurals translation is not yet supported in OptimizedTranslation.
 	return get_message(p_src_text, p_context);
 }

--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -80,7 +80,7 @@ protected:
 
 public:
 	virtual StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const override; //overridable for other implementations
-	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
+	virtual StringName get_plural_message(int p_n, const StringName &p_src_text, const StringName &p_plural_text = "", const StringName &p_context = "") const override;
 	virtual Vector<String> get_translated_message_list() const override;
 	void generate(const Ref<Translation> &p_from);
 

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -115,9 +115,9 @@ StringName Translation::get_message(const StringName &p_src_text, const StringNa
 	return E->value;
 }
 
-StringName Translation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
+StringName Translation::get_plural_message(int p_n, const StringName &p_src_text, const StringName &p_plural_text, const StringName &p_context) const {
 	StringName ret;
-	if (GDVIRTUAL_CALL(_get_plural_message, p_src_text, p_plural_text, p_n, p_context, ret)) {
+	if (GDVIRTUAL_CALL(_get_plural_message, p_n, p_src_text, p_plural_text, p_context, ret)) {
 		return ret;
 	}
 
@@ -149,7 +149,7 @@ void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_message", "src_message", "xlated_message", "context"), &Translation::add_message, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("add_plural_message", "src_message", "xlated_messages", "context"), &Translation::add_plural_message, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_message", "src_message", "context"), &Translation::get_message, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("get_plural_message", "src_message", "src_plural_message", "n", "context"), &Translation::get_plural_message, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("get_plural_message", "n", "src_message", "src_plural_message", "context"), &Translation::get_plural_message, DEFVAL(""), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("erase_message", "src_message", "context"), &Translation::erase_message, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_message_list"), &Translation::_get_message_list);
 	ClassDB::bind_method(D_METHOD("get_translated_message_list"), &Translation::get_translated_message_list);
@@ -157,7 +157,7 @@ void Translation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_messages", "messages"), &Translation::_set_messages);
 	ClassDB::bind_method(D_METHOD("_get_messages"), &Translation::_get_messages);
 
-	GDVIRTUAL_BIND(_get_plural_message, "src_message", "src_plural_message", "n", "context");
+	GDVIRTUAL_BIND(_get_plural_message, "n", "src_message", "src_plural_message", "context");
 	GDVIRTUAL_BIND(_get_message, "src_message", "context");
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "messages", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_messages", "_get_messages");
@@ -588,7 +588,7 @@ StringName TranslationServer::translate(const StringName &p_message, const Strin
 	return pseudolocalization_enabled ? pseudolocalize(res) : res;
 }
 
-StringName TranslationServer::translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+StringName TranslationServer::translate_plural(int p_n, const StringName &p_message, const StringName &p_message_plural, const StringName &p_context) const {
 	if (!enabled) {
 		if (p_n == 1) {
 			return p_message;
@@ -627,7 +627,7 @@ StringName TranslationServer::_get_message_from_translations(const StringName &p
 			if (!plural) {
 				r = t->get_message(p_message, p_context);
 			} else {
-				r = t->get_plural_message(p_message, p_message_plural, p_n, p_context);
+				r = t->get_plural_message(p_n, p_message, p_message_plural, p_context);
 			}
 			if (!r) {
 				continue;
@@ -726,9 +726,9 @@ StringName TranslationServer::tool_translate(const StringName &p_message, const 
 	return editor_pseudolocalization ? tool_pseudolocalize(p_message) : p_message;
 }
 
-StringName TranslationServer::tool_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+StringName TranslationServer::tool_translate_plural(int p_n, const StringName &p_message, const StringName &p_message_plural, const StringName &p_context) const {
 	if (tool_translation.is_valid()) {
-		StringName r = tool_translation->get_plural_message(p_message, p_message_plural, p_n, p_context);
+		StringName r = tool_translation->get_plural_message(p_n, p_message, p_message_plural, p_context);
 		if (r) {
 			return r;
 		}
@@ -754,9 +754,9 @@ StringName TranslationServer::doc_translate(const StringName &p_message, const S
 	return p_message;
 }
 
-StringName TranslationServer::doc_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+StringName TranslationServer::doc_translate_plural(int p_n, const StringName &p_message, const StringName &p_message_plural, const StringName &p_context) const {
 	if (doc_translation.is_valid()) {
-		StringName r = doc_translation->get_plural_message(p_message, p_message_plural, p_n, p_context);
+		StringName r = doc_translation->get_plural_message(p_n, p_message, p_message_plural, p_context);
 		if (r) {
 			return r;
 		}
@@ -977,7 +977,7 @@ void TranslationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_locale_name", "locale"), &TranslationServer::get_locale_name);
 
 	ClassDB::bind_method(D_METHOD("translate", "message", "context"), &TranslationServer::translate, DEFVAL(""));
-	ClassDB::bind_method(D_METHOD("translate_plural", "message", "plural_message", "n", "context"), &TranslationServer::translate_plural, DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("translate_plural", "n", "message", "plural_message", "context"), &TranslationServer::translate_plural, DEFVAL(""), DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("add_translation", "translation"), &TranslationServer::add_translation);
 	ClassDB::bind_method(D_METHOD("remove_translation", "translation"), &TranslationServer::remove_translation);

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -51,7 +51,7 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL2RC(StringName, _get_message, StringName, StringName);
-	GDVIRTUAL4RC(StringName, _get_plural_message, StringName, StringName, int, StringName);
+	GDVIRTUAL4RC(StringName, _get_plural_message, int, StringName, StringName, StringName);
 
 public:
 	void set_locale(const String &p_locale);
@@ -60,7 +60,7 @@ public:
 	virtual void add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context = "");
 	virtual void add_plural_message(const StringName &p_src_text, const Vector<String> &p_plural_xlated_texts, const StringName &p_context = "");
 	virtual StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const; //overridable for other implementations
-	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const;
+	virtual StringName get_plural_message(int p_n, const StringName &p_src_text, const StringName &p_plural_text = "", const StringName &p_context = "") const;
 	virtual void erase_message(const StringName &p_src_text, const StringName &p_context = "");
 	virtual void get_message_list(List<StringName> *r_messages) const;
 	virtual int get_message_count() const;
@@ -154,7 +154,7 @@ public:
 	void remove_translation(const Ref<Translation> &p_translation);
 
 	StringName translate(const StringName &p_message, const StringName &p_context = "") const;
-	StringName translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
+	StringName translate_plural(int p_n, const StringName &p_message, const StringName &p_message_plural = "", const StringName &p_context = "") const;
 
 	StringName pseudolocalize(const StringName &p_message) const;
 
@@ -171,10 +171,10 @@ public:
 	void set_tool_translation(const Ref<Translation> &p_translation);
 	Ref<Translation> get_tool_translation() const;
 	StringName tool_translate(const StringName &p_message, const StringName &p_context = "") const;
-	StringName tool_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
+	StringName tool_translate_plural(int p_n, const StringName &p_message, const StringName &p_message_plural, const StringName &p_context = "") const;
 	void set_doc_translation(const Ref<Translation> &p_translation);
 	StringName doc_translate(const StringName &p_message, const StringName &p_context = "") const;
-	StringName doc_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
+	StringName doc_translate_plural(int p_n, const StringName &p_message, const StringName &p_message_plural, const StringName &p_context = "") const;
 	void set_property_translation(const Ref<Translation> &p_translation);
 	StringName property_translate(const StringName &p_message) const;
 

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -241,7 +241,7 @@ StringName TranslationPO::get_message(const StringName &p_src_text, const String
 	return translation_map[p_context][p_src_text][0];
 }
 
-StringName TranslationPO::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
+StringName TranslationPO::get_plural_message(int p_n, const StringName &p_src_text, const StringName &p_plural_text, const StringName &p_context) const {
 	ERR_FAIL_COND_V_MSG(p_n < 0, StringName(), "N passed into translation to get a plural message should not be negative. For negative numbers, use singular translation please. Search \"gettext PO Plural Forms\" online for the documentation on translating negative numbers.");
 
 	// If the query is the same as last time, return the cached result.

--- a/core/string/translation_po.h
+++ b/core/string/translation_po.h
@@ -76,7 +76,7 @@ public:
 	void add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context = "") override;
 	void add_plural_message(const StringName &p_src_text, const Vector<String> &p_plural_xlated_texts, const StringName &p_context = "") override;
 	StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const override;
-	StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
+	StringName get_plural_message(int p_n, const StringName &p_src_text, const StringName &p_plural_text = "", const StringName &p_context = "") const override;
 	void erase_message(const StringName &p_src_text, const StringName &p_context = "") override;
 
 	void set_plural_rule(const String &p_plural_rule);

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5052,15 +5052,15 @@ String TTR(const String &p_text, const String &p_context) {
  * be specified to disambiguate between identical source strings in
  * translations. Use `TTR()` if the string doesn't need dynamic plural form.
  * When placeholders are desired, use
- * `vformat(TTRN("%d item", "%d items", some_integer), some_integer)`.
+ * `vformat(TTRN(some_integer, "%d item", "%d items"), some_integer)`.
  * The placeholder must be present in both strings to avoid run-time warnings in `vformat()`.
  *
  * NOTE: Only use `TTRN()` in editor-only code (typically within the `editor/` folder).
  * For translations that can be supplied by exported projects, use `RTRN()` instead.
  */
-String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+String TTRN(int p_n, const String &p_text, const String &p_text_plural, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
-		return TranslationServer::get_singleton()->tool_translate_plural(p_text, p_text_plural, p_n, p_context);
+		return TranslationServer::get_singleton()->tool_translate_plural(p_n, p_text, p_text_plural, p_context);
 	}
 
 	// Return message based on English plural rule if translation is not possible.
@@ -5093,12 +5093,12 @@ String DTR(const String &p_text, const String &p_context) {
  * It also replaces `$DOCS_URL` with the actual URL to the documentation's branch,
  * to allow dehardcoding it in the XML and doing proper substitutions everywhere.
  */
-String DTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+String DTRN(int p_n, const String &p_text, const String &p_text_plural, const String &p_context) {
 	const String text = p_text.dedent().strip_edges();
 	const String text_plural = p_text_plural.dedent().strip_edges();
 
 	if (TranslationServer::get_singleton()) {
-		return String(TranslationServer::get_singleton()->doc_translate_plural(text, text_plural, p_n, p_context)).replace("$DOCS_URL", VERSION_DOCS_URL);
+		return String(TranslationServer::get_singleton()->doc_translate_plural(p_n, text, text_plural, p_context)).replace("$DOCS_URL", VERSION_DOCS_URL);
 	}
 
 	// Return message based on English plural rule if translation is not possible.
@@ -5143,17 +5143,17 @@ String RTR(const String &p_text, const String &p_context) {
  * optionally be specified to disambiguate between identical source strings in
  * translations. Use `RTR()` if the string doesn't need dynamic plural form.
  * When placeholders are desired, use
- * `vformat(RTRN("%d item", "%d items", some_integer), some_integer)`.
+ * `vformat(RTRN(some_integer, "%d item", "%d items"), some_integer)`.
  * The placeholder must be present in both strings to avoid run-time warnings in `vformat()`.
  *
  * NOTE: Do not use `RTRN()` in editor-only code (typically within the `editor/`
  * folder). For editor translations, use `TTRN()` instead.
  */
-String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+String RTRN(int p_n, const String &p_text, const String &p_text_plural, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
-		String rtr = TranslationServer::get_singleton()->tool_translate_plural(p_text, p_text_plural, p_n, p_context);
+		String rtr = TranslationServer::get_singleton()->tool_translate_plural(p_n, p_text, p_text_plural, p_context);
 		if (rtr.is_empty() || rtr == p_text || rtr == p_text_plural) {
-			return TranslationServer::get_singleton()->translate_plural(p_text, p_text_plural, p_n, p_context);
+			return TranslationServer::get_singleton()->translate_plural(p_n, p_text, p_text_plural, p_context);
 		} else {
 			return rtr;
 		}

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -521,9 +521,9 @@ _FORCE_INLINE_ bool is_str_less(const L *l_ptr, const R *r_ptr) {
 #ifdef TOOLS_ENABLED
 // Gets parsed.
 String TTR(const String &p_text, const String &p_context = "");
-String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String TTRN(int p_n, const String &p_text, const String &p_text_plural = "", const String &p_context = "");
 String DTR(const String &p_text, const String &p_context = "");
-String DTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String DTRN(int p_n, const String &p_text, const String &p_text_plural = "", const String &p_context = "");
 // Use for C strings.
 #define TTRC(m_value) (m_value)
 // Use to avoid parsing (for use later with C strings).
@@ -546,7 +546,7 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 
 // Runtime translate for the public node API.
 String RTR(const String &p_text, const String &p_context = "");
-String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String RTRN(int p_n, const String &p_text, const String &p_text_plural = "", const String &p_context = "");
 
 bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end);
 

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -910,9 +910,9 @@
 		</method>
 		<method name="tr_n" qualifiers="const">
 			<return type="String" />
-			<param index="0" name="message" type="StringName" />
-			<param index="1" name="plural_message" type="StringName" />
-			<param index="2" name="n" type="int" />
+			<param index="0" name="n" type="int" />
+			<param index="1" name="message" type="StringName" />
+			<param index="2" name="plural_message" type="StringName" default="&quot;&quot;" />
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Translates a [param message] or [param plural_message], using the translation catalogs configured in the Project Settings. Further [param context] can be specified to help with the translation.

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -21,9 +21,9 @@
 		</method>
 		<method name="_get_plural_message" qualifiers="virtual const">
 			<return type="StringName" />
-			<param index="0" name="src_message" type="StringName" />
-			<param index="1" name="src_plural_message" type="StringName" />
-			<param index="2" name="n" type="int" />
+			<param index="0" name="n" type="int" />
+			<param index="1" name="src_message" type="StringName" />
+			<param index="2" name="src_plural_message" type="StringName" />
 			<param index="3" name="context" type="StringName" />
 			<description>
 				Virtual method to override [method get_plural_message].
@@ -79,9 +79,9 @@
 		</method>
 		<method name="get_plural_message" qualifiers="const">
 			<return type="StringName" />
-			<param index="0" name="src_message" type="StringName" />
-			<param index="1" name="src_plural_message" type="StringName" />
-			<param index="2" name="n" type="int" />
+			<param index="0" name="n" type="int" />
+			<param index="1" name="src_message" type="StringName" />
+			<param index="2" name="src_plural_message" type="StringName" default="&quot;&quot;" />
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Returns a message's translation involving plurals.

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -151,9 +151,9 @@
 		</method>
 		<method name="translate_plural" qualifiers="const">
 			<return type="StringName" />
-			<param index="0" name="message" type="StringName" />
-			<param index="1" name="plural_message" type="StringName" />
-			<param index="2" name="n" type="int" />
+			<param index="0" name="n" type="int" />
+			<param index="1" name="message" type="StringName" />
+			<param index="2" name="plural_message" type="StringName" default="&quot;&quot;" />
 			<param index="3" name="context" type="StringName" default="&quot;&quot;" />
 			<description>
 				Returns the current locale's translation for the given message (key), plural_message and context.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -419,9 +419,9 @@ void FindReplaceBar::_update_matches_label() {
 		if (results_count == 0) {
 			matches_label->set_text("No match");
 		} else if (results_count_to_current == -1) {
-			matches_label->set_text(vformat(TTRN("%d match", "%d matches", results_count), results_count));
+			matches_label->set_text(vformat(TTRN(results_count, "%d match", "%d matches"), results_count));
 		} else {
-			matches_label->set_text(vformat(TTRN("%d of %d match", "%d of %d matches", results_count), results_count_to_current, results_count));
+			matches_label->set_text(vformat(TTRN(results_count, "%d of %d match", "%d of %d matches"), results_count_to_current, results_count));
 		}
 	}
 }

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -227,7 +227,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	if (color_amount > 0) {
 		Array arr;
 		arr.push_back(color_amount);
-		select_colors_label->set_text(TTRN("1 color", "{num} colors", color_amount).format(arr, "{num}"));
+		select_colors_label->set_text(TTRN(color_amount, "1 color", "{num} colors").format(arr, "{num}"));
 		select_all_colors_button->set_visible(true);
 		select_full_colors_button->set_visible(true);
 		deselect_all_colors_button->set_visible(true);
@@ -241,7 +241,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	if (constant_amount > 0) {
 		Array arr;
 		arr.push_back(constant_amount);
-		select_constants_label->set_text(TTRN("1 constant", "{num} constants", constant_amount).format(arr, "{num}"));
+		select_constants_label->set_text(TTRN(constant_amount, "1 constant", "{num} constants").format(arr, "{num}"));
 		select_all_constants_button->set_visible(true);
 		select_full_constants_button->set_visible(true);
 		deselect_all_constants_button->set_visible(true);
@@ -255,7 +255,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	if (font_amount > 0) {
 		Array arr;
 		arr.push_back(font_amount);
-		select_fonts_label->set_text(TTRN("1 font", "{num} fonts", font_amount).format(arr, "{num}"));
+		select_fonts_label->set_text(TTRN(font_amount, "1 font", "{num} fonts").format(arr, "{num}"));
 		select_all_fonts_button->set_visible(true);
 		select_full_fonts_button->set_visible(true);
 		deselect_all_fonts_button->set_visible(true);
@@ -269,7 +269,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	if (font_size_amount > 0) {
 		Array arr;
 		arr.push_back(font_size_amount);
-		select_font_sizes_label->set_text(TTRN("1 font size", "{num} font sizes", font_size_amount).format(arr, "{num}"));
+		select_font_sizes_label->set_text(TTRN(font_size_amount, "1 font size", "{num} font sizes").format(arr, "{num}"));
 		select_all_font_sizes_button->set_visible(true);
 		select_full_font_sizes_button->set_visible(true);
 		deselect_all_font_sizes_button->set_visible(true);
@@ -283,7 +283,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	if (icon_amount > 0) {
 		Array arr;
 		arr.push_back(icon_amount);
-		select_icons_label->set_text(TTRN("1 icon", "{num} icons", icon_amount).format(arr, "{num}"));
+		select_icons_label->set_text(TTRN(icon_amount, "1 icon", "{num} icons").format(arr, "{num}"));
 		select_all_icons_button->set_visible(true);
 		select_full_icons_button->set_visible(true);
 		deselect_all_icons_button->set_visible(true);
@@ -299,7 +299,7 @@ void ThemeItemImportTree::_update_items_tree() {
 	if (stylebox_amount > 0) {
 		Array arr;
 		arr.push_back(stylebox_amount);
-		select_styleboxes_label->set_text(TTRN("1 stylebox", "{num} styleboxes", stylebox_amount).format(arr, "{num}"));
+		select_styleboxes_label->set_text(TTRN(stylebox_amount, "1 stylebox", "{num} styleboxes").format(arr, "{num}"));
 		select_all_styleboxes_button->set_visible(true);
 		select_full_styleboxes_button->set_visible(true);
 		deselect_all_styleboxes_button->set_visible(true);
@@ -447,7 +447,7 @@ void ThemeItemImportTree::_update_total_selected(Theme::DataType p_data_type) {
 	} else {
 		Array arr;
 		arr.push_back(count);
-		total_selected_items_label->set_text(TTRN("{num} currently selected", "{num} currently selected", count).format(arr, "{num}"));
+		total_selected_items_label->set_text(TTRN(count, "{num} currently selected", "{num} currently selected").format(arr, "{num}"));
 		total_selected_items_label->show();
 	}
 }

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -316,13 +316,13 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		if (num_connections >= 1) {
 			Array arr;
 			arr.push_back(num_connections);
-			msg_temp += TTRN("Node has one connection.", "Node has {num} connections.", num_connections).format(arr, "{num}");
+			msg_temp += TTRN(num_connections, "Node has one connection.", "Node has {num} connections.").format(arr, "{num}");
 			if (num_groups >= 1) {
 				msg_temp += "\n";
 			}
 		}
 		if (num_groups >= 1) {
-			msg_temp += TTRN("Node is in this group:", "Node is in the following groups:", num_groups) + "\n";
+			msg_temp += TTRN(num_groups, "Node is in this group:", "Node is in the following groups:") + "\n";
 
 			List<GroupInfo> groups;
 			p_node->get_groups(&groups);

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -267,11 +267,11 @@ void GDScriptEditorTranslationParserPlugin::_extract_from_call(GDScriptParser::C
 			ids_ctx_plural->push_back(id_ctx_plural);
 		}
 	} else if (function_name == trn_func) {
-		// Extract from tr_n(id, plural, n, ctx).
+		// Extract from tr_n(n, id, plural, ctx).
 		Vector<int> indices;
-		indices.push_back(0);
-		indices.push_back(3);
 		indices.push_back(1);
+		indices.push_back(3);
+		indices.push_back(2);
 		for (int i = 0; i < indices.size(); i++) {
 			if (indices[i] >= p_call->arguments.size()) {
 				continue;

--- a/tests/core/string/test_translation.h
+++ b/tests/core/string/test_translation.h
@@ -122,11 +122,11 @@ TEST_CASE("[TranslationPO] Plural messages") {
 	translation->add_plural_message("There are %d apples", plurals);
 	ERR_PRINT_OFF;
 	// This is invalid, as the number passed to `get_plural_message()` may not be negative.
-	CHECK(vformat(translation->get_plural_message("There are %d apples", "", -1), -1) == "");
+	CHECK(vformat(translation->get_plural_message(-1, "There are %d apples"), -1) == "");
 	ERR_PRINT_ON;
-	CHECK(vformat(translation->get_plural_message("There are %d apples", "", 0), 0) == "Il y a 0 pomme");
-	CHECK(vformat(translation->get_plural_message("There are %d apples", "", 1), 1) == "Il y a 1 pomme");
-	CHECK(vformat(translation->get_plural_message("There are %d apples", "", 2), 2) == "Il y a 2 pommes");
+	CHECK(vformat(translation->get_plural_message(0, "There are %d apples"), 0) == "Il y a 0 pomme");
+	CHECK(vformat(translation->get_plural_message(1, "There are %d apples"), 1) == "Il y a 1 pomme");
+	CHECK(vformat(translation->get_plural_message(2, "There are %d apples"), 2) == "Il y a 2 pommes");
 }
 
 TEST_CASE("[OptimizedTranslation] Generate from Translation and read messages") {
@@ -173,7 +173,7 @@ TEST_CASE("[Translation] CSV import") {
 
 	TranslationServer::get_singleton()->set_locale("de");
 
-	CHECK(Object().tr("GOOD_MORNING", "") == "Guten Morgen");
+	CHECK(Object().tr("GOOD_MORNING") == "Guten Morgen");
 }
 #endif // TOOLS_ENABLED
 


### PR DESCRIPTION
Make `n` parameter first and `plural_message` optional in the following methods:

* `Object.tr_n()`;
* `Translation._get_plural_message()` (only order);
* `Translation.get_plural_message()`;
* `TranslationServer.translate_plural()`;
* `TranslationServer::tool_translate_plural()`;
* `TranslationServer::doc_translate_plural()`;
* `TTRN()`, `RTRN()`, `DTRN()`.

---

When using translations based on identifiers, the `plural_message` parameter is not needed, so it makes sense to make the `n` parameter first and `plural_message` optional. In my opinion, this is logical and convenient, since the `n` parameter is "the most required" parameter in the `tr_n` function.

These changes are in PR #41519, but it's very likely that #41519 might not make it into the 4.0 release. This PR will avoid breaking compatibility if #41519 is implemented later. Also, it will be useful if someone decides to implement a custom translation format based on identifiers (it's possible, i'm going to implement my format instead of CSV).