### PR TITLE
SCons: Remove redundant `-fomit-frame-pointer` and `-ftree-vectorize`

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -121,11 +121,10 @@ def configure(env):
             # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces
             # when using `target=release_debug`.
             opt = "-O3" if env["target"] == "release" else "-O2"
-            env.Append(CCFLAGS=[opt, "-fomit-frame-pointer"])
+            env.Append(CCFLAGS=[opt])
         elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["-Oz"])
         env.Append(CPPDEFINES=["NDEBUG"])
-        env.Append(CCFLAGS=["-ftree-vectorize"])
     elif env["target"] == "debug":
         env.Append(LINKFLAGS=["-O0"])
         env.Append(CCFLAGS=["-O0", "-g", "-fno-limit-debug-info"])

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -60,10 +60,10 @@ def configure(env):
             # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces
             # when using `target=release_debug`.
             opt = "-O3" if env["target"] == "release" else "-O2"
-            env.Append(CCFLAGS=[opt, "-ftree-vectorize", "-fomit-frame-pointer"])
+            env.Append(CCFLAGS=[opt])
             env.Append(LINKFLAGS=[opt])
         elif env["optimize"] == "size":  # optimize for size
-            env.Append(CCFLAGS=["-Os", "-ftree-vectorize"])
+            env.Append(CCFLAGS=["-Os"])
             env.Append(LINKFLAGS=["-Os"])
 
     elif env["target"] == "debug":

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -88,9 +88,9 @@ def configure(env):
 
     if env["target"] == "release":
         if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Prepend(CCFLAGS=["-O3", "-fomit-frame-pointer", "-ftree-vectorize"])
+            env.Prepend(CCFLAGS=["-O3"])
         elif env["optimize"] == "size":  # optimize for size
-            env.Prepend(CCFLAGS=["-Os", "-ftree-vectorize"])
+            env.Prepend(CCFLAGS=["-Os"])
         if env["arch"] != "arm64":
             env.Prepend(CCFLAGS=["-msse2"])
 


### PR DESCRIPTION
- `-fomit-frame-pointer` is included automatically by both GCC and Clang in `-O1` and above.
- `-ftree-vectorize` is included automatically by GCC in `-O2` and beyond, and seems always enabled by Clang.

Closes #66296. See that issue for a detailed investigation.