### PR TITLE
[3.x] Fix crash when ScriptEditor accesses Script with no language set

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3595,8 +3595,9 @@ bool ScriptEditorPlugin::handles(Object *p_object) const {
 		return true;
 	}
 
-	if (Object::cast_to<Script>(p_object)) {
-		return true;
+	Script *script = Object::cast_to<Script>(p_object);
+	if (script) {
+		return script->get_language() != nullptr; // Could be a PluginScript with no language attached.
 	}
 
 	return p_object->is_class("Script");


### PR DESCRIPTION
Fixes #46566.
Brings #46804 back from the dead.

Not relevant in `master`.