### PR TITLE
Split script navigation state and edit state

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1526,19 +1526,7 @@ void CodeTextEditor::clear_executing_line() {
 
 Variant CodeTextEditor::get_edit_state() {
 	Dictionary state;
-
-	state["scroll_position"] = text_editor->get_v_scroll();
-	state["h_scroll_position"] = text_editor->get_h_scroll();
-	state["column"] = text_editor->get_caret_column();
-	state["row"] = text_editor->get_caret_line();
-
-	state["selection"] = get_text_editor()->has_selection();
-	if (get_text_editor()->has_selection()) {
-		state["selection_from_line"] = text_editor->get_selection_from_line();
-		state["selection_from_column"] = text_editor->get_selection_from_column();
-		state["selection_to_line"] = text_editor->get_selection_to_line();
-		state["selection_to_column"] = text_editor->get_selection_to_column();
-	}
+	state.merge(get_navigation_state());
 
 	state["folded_lines"] = text_editor->get_folded_lines();
 	state["breakpoints"] = text_editor->get_breakpointed_lines();
@@ -1559,8 +1547,10 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 	text_editor->set_v_scroll(state["scroll_position"]);
 	text_editor->set_h_scroll(state["h_scroll_position"]);
 
-	if (state.has("selection")) {
+	if (state.get("selection", false)) {
 		text_editor->select(state["selection_from_line"], state["selection_from_column"], state["selection_to_line"], state["selection_to_column"]);
+	} else {
+		text_editor->deselect();
 	}
 
 	if (state.has("folded_lines")) {
@@ -1583,6 +1573,25 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 			text_editor->set_line_as_bookmarked(bookmarks[i], true);
 		}
 	}
+}
+
+Variant CodeTextEditor::get_navigation_state() {
+	Dictionary state;
+
+	state["scroll_position"] = text_editor->get_v_scroll();
+	state["h_scroll_position"] = text_editor->get_h_scroll();
+	state["column"] = text_editor->get_caret_column();
+	state["row"] = text_editor->get_caret_line();
+
+	state["selection"] = get_text_editor()->has_selection();
+	if (get_text_editor()->has_selection()) {
+		state["selection_from_line"] = text_editor->get_selection_from_line();
+		state["selection_from_column"] = text_editor->get_selection_from_column();
+		state["selection_to_line"] = text_editor->get_selection_to_line();
+		state["selection_to_column"] = text_editor->get_selection_to_column();
+	}
+
+	return state;
 }
 
 void CodeTextEditor::set_error(const String &p_error) {

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -246,6 +246,7 @@ public:
 
 	Variant get_edit_state();
 	void set_edit_state(const Variant &p_state);
+	Variant get_navigation_state();
 
 	void set_error_count(int p_error_count);
 	void set_warning_count(int p_warning_count);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -565,7 +565,7 @@ void ScriptEditor::_save_history() {
 		Node *n = tab_container->get_current_tab_control();
 
 		if (Object::cast_to<ScriptEditorBase>(n)) {
-			history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
+			history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_navigation_state();
 		}
 		if (Object::cast_to<EditorHelp>(n)) {
 			history.write[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
@@ -600,7 +600,7 @@ void ScriptEditor::_go_to_tab(int p_idx) {
 		Node *n = tab_container->get_current_tab_control();
 
 		if (Object::cast_to<ScriptEditorBase>(n)) {
-			history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
+			history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_navigation_state();
 		}
 		if (Object::cast_to<EditorHelp>(n)) {
 			history.write[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
@@ -3374,7 +3374,7 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 	Node *n = tab_container->get_current_tab_control();
 
 	if (Object::cast_to<ScriptEditorBase>(n)) {
-		history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_edit_state();
+		history.write[history_pos].state = Object::cast_to<ScriptEditorBase>(n)->get_navigation_state();
 	}
 	if (Object::cast_to<EditorHelp>(n)) {
 		history.write[history_pos].state = Object::cast_to<EditorHelp>(n)->get_scroll();
@@ -3385,11 +3385,12 @@ void ScriptEditor::_update_history_pos(int p_new_pos) {
 
 	n = history[history_pos].control;
 
-	if (Object::cast_to<ScriptEditorBase>(n)) {
-		Object::cast_to<ScriptEditorBase>(n)->set_edit_state(history[history_pos].state);
-		Object::cast_to<ScriptEditorBase>(n)->ensure_focus();
+	ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(n);
+	if (seb) {
+		seb->set_edit_state(history[history_pos].state);
+		seb->ensure_focus();
 
-		Ref<Script> script = Object::cast_to<ScriptEditorBase>(n)->get_edited_resource();
+		Ref<Script> script = seb->get_edited_resource();
 		if (script != nullptr) {
 			notify_script_changed(script);
 		}

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -146,6 +146,7 @@ public:
 	virtual bool is_unsaved() = 0;
 	virtual Variant get_edit_state() = 0;
 	virtual void set_edit_state(const Variant &p_state) = 0;
+	virtual Variant get_navigation_state() = 0;
 	virtual void goto_line(int p_line, bool p_with_error = false) = 0;
 	virtual void set_executing_line(int p_line) = 0;
 	virtual void clear_executing_line() = 0;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -346,6 +346,10 @@ void ScriptTextEditor::set_edit_state(const Variant &p_state) {
 	}
 }
 
+Variant ScriptTextEditor::get_navigation_state() {
+	return code_editor->get_navigation_state();
+}
+
 void ScriptTextEditor::_convert_case(CodeTextEditor::CaseStyle p_case) {
 	code_editor->convert_case(p_case);
 }

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -215,6 +215,7 @@ public:
 	virtual bool is_unsaved() override;
 	virtual Variant get_edit_state() override;
 	virtual void set_edit_state(const Variant &p_state) override;
+	virtual Variant get_navigation_state() override;
 	virtual void ensure_focus() override;
 	virtual void trim_trailing_whitespace() override;
 	virtual void insert_final_newline() override;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -221,6 +221,10 @@ void TextEditor::set_edit_state(const Variant &p_state) {
 	ensure_focus();
 }
 
+Variant TextEditor::get_navigation_state() {
+	return code_editor->get_navigation_state();
+}
+
 void TextEditor::trim_trailing_whitespace() {
 	code_editor->trim_trailing_whitespace();
 }

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -117,6 +117,7 @@ public:
 	virtual bool is_unsaved() override;
 	virtual Variant get_edit_state() override;
 	virtual void set_edit_state(const Variant &p_state) override;
+	virtual Variant get_navigation_state() override;
 	virtual Vector<String> get_functions() override;
 	virtual PackedInt32Array get_breakpoints() override;
 	virtual void set_breakpoint(int p_line, bool p_enabled) override{};


### PR DESCRIPTION
Right now when you move in script editor history, the editor will store everything, including bookmarks, breakpoints and current highlighter. This actually leads to some bugs, e.g. old bookmarks can be restored if you go back to previous script.

This PR adds a navigation state, which is a subset of script edit state. Script editor history will use it instead.

Helps #63515