### PR TITLE
SCons: Cleanup `DEBUG`, `_DEBUG` and `NDEBUG` defines

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -386,6 +386,9 @@ if env_base["target"] == "debug":
     # DEV_ENABLED enables *engine developer* code which should only be compiled for those
     # working on the engine itself.
     env_base.Append(CPPDEFINES=["DEV_ENABLED"])
+else:
+    # Disable assert() for production targets (only used in thirdparty code).
+    env_base.Append(CPPDEFINES=["NDEBUG"])
 
 # SCons speed optimization controlled by the `fast_unsafe` option, which provide
 # more than 10 s speed up for incremental rebuilds.
@@ -669,7 +672,6 @@ if selected_platform in platform_list:
             print("       Use `tools=no target=release` to build a release export template.")
             Exit(255)
         suffix += ".opt"
-        env.Append(CPPDEFINES=["NDEBUG"])
     elif env["target"] == "release_debug":
         if env["tools"]:
             suffix += ".opt.tools"

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -54,10 +54,6 @@ double OS::get_unix_time() const {
 	return 0;
 }
 
-void OS::debug_break() {
-	// something
-}
-
 void OS::_set_logger(CompositeLogger *p_logger) {
 	if (_logger) {
 		memdelete(_logger);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -287,8 +287,6 @@ public:
 
 	virtual Error move_to_trash(const String &p_path) { return FAILED; }
 
-	virtual void debug_break();
-
 	virtual int get_exit_code() const;
 	// `set_exit_code` should only be used from `SceneTree` (or from a similar
 	// level, e.g. from the `Main::start` if leaving without creating a `SceneTree`).

--- a/core/os/pool_allocator.cpp
+++ b/core/os/pool_allocator.cpp
@@ -35,8 +35,6 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
-#include <assert.h>
-
 #define COMPACT_CHUNK(m_entry, m_to_pos)                      \
 	do {                                                      \
 		void *_dst = &((unsigned char *)pool)[m_to_pos];      \
@@ -169,11 +167,6 @@ bool PoolAllocator::find_entry_index(EntryIndicesPos *p_map_pos, const Entry *p_
 
 PoolAllocator::ID PoolAllocator::alloc(int p_size) {
 	ERR_FAIL_COND_V(p_size < 1, POOL_ALLOCATOR_INVALID_ID);
-#ifdef DEBUG_ENABLED
-	if (p_size > free_mem) {
-		OS::get_singleton()->debug_break();
-	}
-#endif
 	ERR_FAIL_COND_V(p_size > free_mem, POOL_ALLOCATOR_INVALID_ID);
 
 	mt_lock();
@@ -482,7 +475,6 @@ void *PoolAllocator::get(ID p_mem) {
 		ERR_FAIL_COND_V(!e, nullptr);
 	}
 	if (e->lock == 0) {
-		//assert(0);
 		mt_unlock();
 		ERR_PRINT("e->lock == 0");
 		return nullptr;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -51,7 +51,6 @@
 #include <sys/sysctl.h>
 #endif
 
-#include <assert.h>
 #include <dlfcn.h>
 #include <errno.h>
 #include <poll.h>
@@ -103,10 +102,6 @@ static void _setup_clock() {
 	_clock_start = ((uint64_t)tv_now.tv_nsec / 1000L) + (uint64_t)tv_now.tv_sec * 1000000L;
 }
 #endif
-
-void OS_Unix::debug_break() {
-	assert(false);
-}
 
 static void handle_interrupt(int sig) {
 	if (!EngineDebugger::is_active()) {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -86,7 +86,6 @@ public:
 
 	virtual int get_processor_count() const override;
 
-	virtual void debug_break() override;
 	virtual void initialize_debugging() override;
 
 	virtual String get_executable_path() const override;

--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -249,7 +249,6 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;

--- a/modules/denoise/SCsub
+++ b/modules/denoise/SCsub
@@ -103,9 +103,9 @@ env_oidn.Append(
         "__STDC_LIMIT_MACROS",
         "DISABLE_VERBOSE",
         "MKLDNN_ENABLE_CONCURRENT_EXEC",
-        "NDEBUG",
     ]
 )
+env_oidn.AppendUnique(CPPDEFINES=["NDEBUG"])  # No assert() even in debug builds.
 
 env_thirdparty = env_oidn.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -63,7 +63,8 @@ if env["builtin_embree"]:
     thirdparty_sources = [thirdparty_dir + file for file in embree_src]
 
     env_raycast.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "include"])
-    env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL", "NDEBUG"])
+    env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL"])
+    env_raycast.AppendUnique(CPPDEFINES=["NDEBUG"])  # No assert() even in debug builds.
 
     if not env.msvc:
         if env["arch"] == "x86_64":

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -124,12 +124,9 @@ def configure(env):
             env.Append(CCFLAGS=[opt])
         elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["-Oz"])
-        env.Append(CPPDEFINES=["NDEBUG"])
     elif env["target"] == "debug":
         env.Append(LINKFLAGS=["-O0"])
-        env.Append(CCFLAGS=["-O0", "-g", "-fno-limit-debug-info"])
-        env.Append(CPPDEFINES=["_DEBUG"])
-        env.Append(CPPFLAGS=["-UNDEBUG"])
+        env.Append(CCFLAGS=["-O0", "-g"])
 
     # LTO
 

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -55,7 +55,7 @@ def configure(env):
     ## Build type
 
     if env["target"].startswith("release"):
-        env.Append(CPPDEFINES=["NDEBUG", ("NS_BLOCK_ASSERTIONS", 1)])
+        env.Append(CPPDEFINES=[("NS_BLOCK_ASSERTIONS", 1)])
         if env["optimize"] == "speed":  # optimize for speed (default)
             # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces
             # when using `target=release_debug`.
@@ -67,8 +67,7 @@ def configure(env):
             env.Append(LINKFLAGS=["-Os"])
 
     elif env["target"] == "debug":
-        env.Append(CCFLAGS=["-gdwarf-2", "-O0"])
-        env.Append(CPPDEFINES=["_DEBUG", ("DEBUG", 1)])
+        env.Append(CCFLAGS=["-g", "-O0"])
 
     ## LTO
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -350,7 +350,6 @@ def configure_msvc(env, vcvars_msvc_config):
 
     elif env["target"] == "debug":
         env.AppendUnique(CCFLAGS=["/Zi", "/FS", "/Od", "/EHsc"])
-        # Allow big objects. Only needed for debug, see MinGW branch for rationale.
         env.Append(LINKFLAGS=["/DEBUG"])
 
     if env["debug_symbols"]:


### PR DESCRIPTION
- `_DEBUG` is MSVC specific so it didn't make much sense to define for Android and iOS builds.
- iOS was the only platform to define `DEBUG`. We don't use it anywhere outside thirdparty code, which we usually don't intend to debug, so it seems better to be consistent with other platforms.
- Consistently define `NDEBUG` to disable assert behavior in both `release` and `release_debug` targets. This used to be set for `release` for all platforms, and `release_debug` for Android and iOS only.
- Due to the above, I removed the only use we made of `assert()` in Godot code, which was only implemented for Unix anyway, should have been `DEV_ENABLED`, and is in PoolAllocator which we don't actually use.
- The denoise and recast modules keep defining `NDEBUG` even for the `debug` target as we don't want OIDN and Embree asserting all over the place.