### PR TITLE
Prevent a crash in the LSP when a function's return datatype is not resolved

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4001,7 +4001,7 @@ String GDScriptParser::DataType::to_string() const {
 			if (is_meta_type) {
 				return script_type->get_class_name().operator String();
 			}
-			String name = script_type->get_name();
+			String name = script_type != nullptr ? script_type->get_name() : "";
 			if (!name.is_empty()) {
 				return name;
 			}


### PR DESCRIPTION
The datatype's "script type" would be null and the to_string() function, instead of resolving to an empty string, just crashed instead.

Fixes #55858