### PR TITLE
SceneTreeDialog: focus search bar by default

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1437,6 +1437,9 @@ void SceneTreeDialog::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
 				tree->update_tree();
+
+				// Select the search bar by default.
+				filter->call_deferred(SNAME("grab_focus"));
 			}
 		} break;
 


### PR DESCRIPTION
So you can start typing the moment the dialog opens up
![image](https://user-images.githubusercontent.com/5117197/192004326-56311e82-2231-4c37-a95d-84d9123e5463.png)
