### PR TITLE
Set QuadMesh default size back to 1

### DIFF
--- a/doc/classes/QuadMesh.xml
+++ b/doc/classes/QuadMesh.xml
@@ -12,5 +12,6 @@
 	</tutorials>
 	<members>
 		<member name="orientation" type="int" setter="set_orientation" getter="get_orientation" overrides="PlaneMesh" enum="PlaneMesh.Orientation" default="2" />
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" overrides="PlaneMesh" default="Vector2(1, 1)" />
 	</members>
 </class>

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -271,6 +271,7 @@ class QuadMesh : public PlaneMesh {
 public:
 	QuadMesh() {
 		set_orientation(FACE_Z);
+		set_size(Size2(1, 1));
 	}
 };
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/66305