### PR TITLE
Move deband to end of tonemapping.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -462,12 +462,6 @@ void main() {
 	}
 #endif
 
-	if (params.use_debanding) {
-		// For best results, debanding should be done before tonemapping.
-		// Otherwise, we're adding noise to an already-quantized image.
-		color.rgb += screen_space_dither(gl_FragCoord.xy);
-	}
-
 	color.rgb = apply_tonemapping(color.rgb, params.white);
 
 	color.rgb = linear_to_srgb(color.rgb); // regular linear -> SRGB conversion
@@ -496,6 +490,12 @@ void main() {
 
 	if (params.use_color_correction) {
 		color.rgb = apply_color_correction(color.rgb);
+	}
+
+	if (params.use_debanding) {
+		// Debanding should be done at the end of tonemapping, but before writing to the LDR buffer.
+		// Otherwise, we're adding noise to an already-quantized image.
+		color.rgb += screen_space_dither(gl_FragCoord.xy);
 	}
 
 	frag_color = color;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/66316

This avoids artifacts when using adjustments and color correction

Dither was incorrectly added before the tonemapping step (and thus before the adjustments and color correction). Dither should be applied right before quantization (i.e. before writing to the LDR framebuffer). Otherwise the debanding effect becomes stronger or weaker depending on the scene brightness and the adjustments/color correction steps. 

As a bonus this also increases the quality of the debanding (but only very slightly).

Before:

![Screenshot from 2022-09-23 11-48-48](https://user-images.githubusercontent.com/16521339/192037150-697fc1c8-5660-4de8-971d-f2abf9b26ce3.png)

After:
![Screenshot from 2022-09-23 11-50-23](https://user-images.githubusercontent.com/16521339/192037144-cd4f04af-e9f8-4a76-ac43-f8ade7a5944a.png)

Without the extreme adjustments:
Before:

![Screenshot from 2022-09-23 11-41-19](https://user-images.githubusercontent.com/16521339/192037154-8c2b1372-2e5f-4852-86a8-7e0cab7a1044.png)

After (if you zoom in you will notice a very small increase in quality here):

![Screenshot from 2022-09-23 11-40-18](https://user-images.githubusercontent.com/16521339/192037156-59d4532e-fa63-49f2-a325-14d589263a47.png)

This change is not relevant for GLES3 in 4.0, but is relevant for 3.x. It won't be able to be cherrypicked but it is a simple fix