### PR TITLE
Fix debanding strength being affected by environment adjustments (3.x)

### DIFF
--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -467,12 +467,6 @@ void main() {
 	color.rgb = apply_cas(color.rgb, full_exposure, uv_interp, sharpen_intensity);
 #endif
 
-#ifdef USE_DEBANDING
-	// For best results, debanding should be done before tonemapping.
-	// Otherwise, we're adding noise to an already-quantized image.
-	color.rgb += screen_space_dither(gl_FragCoord.xy);
-#endif
-
 	// Early Tonemap & SRGB Conversion; note that Linear tonemapping does not clamp to [0, 1]; some operations below expect a [0, 1] range and will clamp
 	color.rgb = apply_tonemapping(color.rgb, white);
 
@@ -505,6 +499,12 @@ void main() {
 
 #ifdef USE_COLOR_CORRECTION
 	color.rgb = apply_color_correction(color.rgb, color_correction);
+#endif
+
+#ifdef USE_DEBANDING
+	// Debanding should be done at the end of tonemapping, but before writing to the LDR buffer.
+	// Otherwise, we're adding noise to an already-quantized image.
+	color.rgb += screen_space_dither(gl_FragCoord.xy);
 #endif
 
 	frag_color = color;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/66317.

**Testing project:** [test_debanding_adjustments_3.x.zip](https://github.com/godotengine/godot/files/9637297/test_debanding_adjustments_3.x.zip)

## Preview

*Click to view at full size.*

## No adjustments

Before | After
-|-
![2022-09-24_00 00 39](https://user-images.githubusercontent.com/180032/192062966-2fe64f1c-c2e3-479a-90d5-c53829064432.png) | ![2022-09-24_00 01 50](https://user-images.githubusercontent.com/180032/192062968-f196a44d-6d37-4351-b36a-65d2c87cc152.png)

### With adjustments (Brightness = 2.75, Contrast = 8.0)

Before | After
-|-
![2022-09-24_00 01 10](https://user-images.githubusercontent.com/180032/192063004-ffe3b862-6bd9-4c69-8e2d-b201f578cbce.png) | ![2022-09-24_00 01 42](https://user-images.githubusercontent.com/180032/192063009-7678b3bc-2af4-4247-967b-48e86a977f64.png)

### No adjustments, with ACES Fitted tonemap (Exposure = 4.0, White = 16.0)

Before | After
-|-
![2022-09-24_00 02 22](https://user-images.githubusercontent.com/180032/192063013-f04432d9-824b-4fbe-b7c3-cecead7cd456.png) | ![2022-09-24_00 02 35](https://user-images.githubusercontent.com/180032/192063020-10c114e6-bec7-4185-ab68-fffe67cefe3a.png)