### PR TITLE
Use NodePath literal `^` when drag and dropping properties

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1637,7 +1637,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	}
 
 	if (d.has("type") && String(d["type"]) == "obj_property") {
-		const String text_to_drop = String(d["property"]).c_escape().quote(quote_style);
+		const String text_to_drop = "^" + String(d["property"]).c_escape().quote(quote_style);
 
 		te->set_caret_line(row);
 		te->set_caret_column(col);


### PR DESCRIPTION
Well, other other drag-and-drops are as specific as possible.

https://user-images.githubusercontent.com/85438892/192072634-8c73b76f-b230-41c8-b083-7f097d33eb52.mp4

~~recording this took me longer than the PR itself~~