### PR TITLE
Change default 2D Panning Scheme to "Scroll Pans" & increase pan speed

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -661,12 +661,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Panning
 	// Enum should be in sync with ControlScheme in ViewPanner.
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/panning/2d_editor_panning_scheme", 0, "Scroll Zooms,Scroll Pans");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/panning/2d_editor_panning_scheme", 1, "Scroll Zooms,Scroll Pans");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/panning/sub_editors_panning_scheme", 0, "Scroll Zooms,Scroll Pans");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/panning/animation_editors_panning_scheme", 1, "Scroll Zooms,Scroll Pans");
 	_initial_set("editors/panning/simple_panning", false);
 	_initial_set("editors/panning/warped_mouse_panning", true);
-	_initial_set("editors/panning/2d_editor_pan_speed", 20);
+	_initial_set("editors/panning/2d_editor_pan_speed", 75);
 
 	// Tiles editor
 	_initial_set("editors/tiles_editor/display_grid", true);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5470 (see also comments for reasoning).

This PR also increases the 2D editor panning speed to **75** _(it was 20, which is awkwardly slow)_. This one may need testing.