### PR TITLE
World3D.direct_space_state add multithreaded warning

### DIFF
--- a/doc/classes/World2D.xml
+++ b/doc/classes/World2D.xml
@@ -14,7 +14,7 @@
 			The [RID] of this world's canvas resource. Used by the [RenderingServer] for 2D drawing.
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState2D" setter="" getter="get_direct_space_state">
-			Direct access to the world's physics 2D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [code]_physics_process(delta)[/code] in the main thread.
+			Direct access to the world's physics 2D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [method Node._physics_process] in the main thread.
 		</member>
 		<member name="navigation_map" type="RID" setter="" getter="get_navigation_map">
 			The [RID] of this world's navigation map. Used by the [NavigationServer2D].

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -14,7 +14,7 @@
 			The default [CameraAttributes] resource to use if none set on the [Camera3D].
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState3D" setter="" getter="get_direct_space_state">
-			Direct access to the world's physics 3D space state. Used for querying current and potential collisions.
+			Direct access to the world's physics 3D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [method Node._physics_process] in the main thread.
 		</member>
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
 			The World3D's [Environment].


### PR DESCRIPTION
Mirrors World2D documentation introduced by #42167 onto World3D after 3D physics was made multithreaded by #45852.
