### PR TITLE
Particles: adds amount property to collision sub particles.

### DIFF
--- a/doc/classes/ParticleProcessMaterial.xml
+++ b/doc/classes/ParticleProcessMaterial.xml
@@ -259,6 +259,10 @@
 		<member name="spread" type="float" setter="set_spread" getter="get_spread" default="45.0">
 			Each particle's initial direction range from [code]+spread[/code] to [code]-spread[/code] degrees.
 		</member>
+		<member name="sub_emitter_amount_at_collision" type="int" setter="set_sub_emitter_amount_at_collision" getter="get_sub_emitter_amount_at_collision">
+			Sub particle amount on collision.
+			Maximum amount set in the sub particles emitter.
+		</member>
 		<member name="sub_emitter_amount_at_end" type="int" setter="set_sub_emitter_amount_at_end" getter="get_sub_emitter_amount_at_end">
 		</member>
 		<member name="sub_emitter_frequency" type="float" setter="set_sub_emitter_frequency" getter="get_sub_emitter_frequency">

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -115,6 +115,7 @@ void ParticleProcessMaterial::init_shaders() {
 
 	shader_names->sub_emitter_frequency = "sub_emitter_frequency";
 	shader_names->sub_emitter_amount_at_end = "sub_emitter_amount_at_end";
+	shader_names->sub_emitter_amount_at_collision = "sub_emitter_amount_at_collision";
 	shader_names->sub_emitter_keep_velocity = "sub_emitter_keep_velocity";
 
 	shader_names->collision_friction = "collision_friction";
@@ -234,6 +235,9 @@ void ParticleProcessMaterial::_update_shader() {
 		}
 		if (sub_emitter_mode == SUB_EMITTER_AT_END) {
 			code += "uniform int sub_emitter_amount_at_end;\n";
+		}
+		if (sub_emitter_mode == SUB_EMITTER_AT_COLLISION) {
+			code += "uniform int sub_emitter_amount_at_collision;\n";
 		}
 		code += "uniform bool sub_emitter_keep_velocity;\n";
 	}
@@ -874,7 +878,7 @@ void ParticleProcessMaterial::_update_shader() {
 				code += "	if (DELTA >= interval_rem) emit_count = 1;\n";
 			} break;
 			case SUB_EMITTER_AT_COLLISION: {
-				code += "	if (COLLIDED) emit_count = 1;\n";
+				code += "	if (COLLIDED) emit_count = sub_emitter_amount_at_collision;\n";
 			} break;
 			case SUB_EMITTER_AT_END: {
 				code += "	float unit_delta = DELTA/LIFETIME;\n";
@@ -1433,6 +1437,10 @@ void ParticleProcessMaterial::_validate_property(PropertyInfo &p_property) const
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
+	if (p_property.name == "sub_emitter_amount_at_collision" && sub_emitter_mode != SUB_EMITTER_AT_COLLISION) {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+
 	if (p_property.name.begins_with("orbit_") && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
@@ -1486,6 +1494,15 @@ void ParticleProcessMaterial::set_sub_emitter_amount_at_end(int p_amount) {
 
 int ParticleProcessMaterial::get_sub_emitter_amount_at_end() const {
 	return sub_emitter_amount_at_end;
+}
+
+void ParticleProcessMaterial::set_sub_emitter_amount_at_collision(int p_amount) {
+	sub_emitter_amount_at_collision = p_amount;
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->sub_emitter_amount_at_collision, p_amount);
+}
+
+int ParticleProcessMaterial::get_sub_emitter_amount_at_collision() const {
+	return sub_emitter_amount_at_collision;
 }
 
 void ParticleProcessMaterial::set_sub_emitter_keep_velocity(bool p_enable) {
@@ -1640,6 +1657,9 @@ void ParticleProcessMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_sub_emitter_amount_at_end"), &ParticleProcessMaterial::get_sub_emitter_amount_at_end);
 	ClassDB::bind_method(D_METHOD("set_sub_emitter_amount_at_end", "amount"), &ParticleProcessMaterial::set_sub_emitter_amount_at_end);
 
+	ClassDB::bind_method(D_METHOD("get_sub_emitter_amount_at_collision"), &ParticleProcessMaterial::get_sub_emitter_amount_at_collision);
+	ClassDB::bind_method(D_METHOD("set_sub_emitter_amount_at_collision", "amount"), &ParticleProcessMaterial::set_sub_emitter_amount_at_collision);
+
 	ClassDB::bind_method(D_METHOD("get_sub_emitter_keep_velocity"), &ParticleProcessMaterial::get_sub_emitter_keep_velocity);
 	ClassDB::bind_method(D_METHOD("set_sub_emitter_keep_velocity", "enable"), &ParticleProcessMaterial::set_sub_emitter_keep_velocity);
 
@@ -1752,6 +1772,7 @@ void ParticleProcessMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sub_emitter_mode", PROPERTY_HINT_ENUM, "Disabled,Constant,At End,At Collision"), "set_sub_emitter_mode", "get_sub_emitter_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sub_emitter_frequency", PROPERTY_HINT_RANGE, "0.01,100,0.01,suffix:Hz"), "set_sub_emitter_frequency", "get_sub_emitter_frequency");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sub_emitter_amount_at_end", PROPERTY_HINT_RANGE, "1,32,1"), "set_sub_emitter_amount_at_end", "get_sub_emitter_amount_at_end");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sub_emitter_amount_at_collision", PROPERTY_HINT_RANGE, "1,32,1"), "set_sub_emitter_amount_at_collision", "get_sub_emitter_amount_at_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sub_emitter_keep_velocity"), "set_sub_emitter_keep_velocity", "get_sub_emitter_keep_velocity");
 
 	ADD_GROUP("Attractor Interaction", "attractor_interaction_");
@@ -1859,6 +1880,7 @@ ParticleProcessMaterial::ParticleProcessMaterial() :
 	set_sub_emitter_mode(SUB_EMITTER_DISABLED);
 	set_sub_emitter_frequency(4);
 	set_sub_emitter_amount_at_end(1);
+	set_sub_emitter_amount_at_collision(1);
 	set_sub_emitter_keep_velocity(false);
 
 	set_attractor_interaction_enabled(true);

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -246,6 +246,7 @@ private:
 
 		StringName sub_emitter_frequency;
 		StringName sub_emitter_amount_at_end;
+		StringName sub_emitter_amount_at_collision;
 		StringName sub_emitter_keep_velocity;
 
 		StringName collision_friction;
@@ -304,6 +305,7 @@ private:
 	SubEmitterMode sub_emitter_mode;
 	double sub_emitter_frequency = 0.0;
 	int sub_emitter_amount_at_end = 0;
+	int sub_emitter_amount_at_collision = 0;
 	bool sub_emitter_keep_velocity = false;
 	//do not save emission points here
 
@@ -417,6 +419,9 @@ public:
 
 	void set_sub_emitter_amount_at_end(int p_amount);
 	int get_sub_emitter_amount_at_end() const;
+
+	void set_sub_emitter_amount_at_collision(int p_amount);
+	int get_sub_emitter_amount_at_collision() const;
 
 	void set_sub_emitter_keep_velocity(bool p_enable);
 	bool get_sub_emitter_keep_velocity() const;


### PR DESCRIPTION
Gives `collision sub particles` the same function as `at end sub particles` so you can select the amount you want instead of being hard coded to 1 particle.

Can be merged to 3.X if fully supports GPU particles / Collisions. 

Before:

[![I'm a video](https://user-images.githubusercontent.com/6450181/192100391-bc8cef66-3989-4754-9700-d0d06efdac68.png)](https://user-images.githubusercontent.com/6450181/192099725-57821e04-5bd8-4bba-907c-06740c05482c.mp4)

After:

[![I'm a video](https://user-images.githubusercontent.com/6450181/192100465-8192336b-44a3-47fd-8763-641cb4f10f59.png)
](https://user-images.githubusercontent.com/6450181/192099743-693bca03-1e45-4ff2-a435-97e7de14d712.mp4)


