### PR TITLE
Fix ColorPicker always emitting color_changed on html submit

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -427,12 +427,15 @@ void ColorPicker::_html_submitted(const String &p_html) {
 		return;
 	}
 
-	float last_alpha = color.a;
+	Color previous_color = color;
 	color = Color::html(p_html);
 	if (!is_editing_alpha()) {
-		color.a = last_alpha;
+		color.a = previous_color.a;
 	}
 
+	if (color == previous_color) {
+		return;
+	}
 	if (!is_inside_tree()) {
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/66312.

This is because the HTML TextEdit is set to always submit its text when the modal closes, but what wasn't good is that it still emitted the `color_change` signal even if the color was the same as before. In a way, this PR gets two birds with one stone.

Can probably be cherrypicked to 3.x?