### PR TITLE
Move Shortcut Context to control and fix `shortcut_input` with `shortcut_context`

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -68,9 +68,6 @@
 		<member name="shortcut" type="Shortcut" setter="set_shortcut" getter="get_shortcut">
 			[Shortcut] associated to the button.
 		</member>
-		<member name="shortcut_context" type="Node" setter="set_shortcut_context" getter="get_shortcut_context">
-			The [Node] which must be a parent of the focused GUI [Control] for the shortcut to be activated. If [code]null[/code], the shortcut can be activated when any control is focused (a global shortcut). This allows shortcuts to be accepted only when the user has a certain area of the GUI focused.
-		</member>
 		<member name="shortcut_in_tooltip" type="bool" setter="set_shortcut_in_tooltip" getter="is_shortcut_in_tooltip_enabled">
 			If [code]true[/code], the button will add information about its shortcut in the tooltip.
 		</member>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1051,6 +1051,9 @@
 			[b]Note:[/b] This property is mainly intended to be used for animation purposes. Text inside the Control will look pixelated or blurry when the Control is scaled. To support multiple resolutions in your project, use an appropriate viewport stretch mode as described in the [url=$DOCS_URL/tutorials/viewports/multiple_resolutions.html]documentation[/url] instead of scaling Controls individually.
 			[b]Note:[/b] If the Control node is a child of a [Container] node, the scale will be reset to [code]Vector2(1, 1)[/code] when the scene is instantiated. To set the Control's scale when it's instantiated, wait for one frame using [code]await get_tree().process_frame[/code] then set its [member scale] property.
 		</member>
+		<member name="shortcut_context" type="Node" setter="set_shortcut_context" getter="get_shortcut_context">
+			The [Node] which must be a parent of the focused [Control] for the shortcut to be activated. If [code]null[/code], the shortcut can be activated when any control is focused (a global shortcut). This allows shortcuts to be accepted only when the user has a certain area of the GUI focused.
+		</member>
 		<member name="size" type="Vector2" setter="_set_size" getter="get_size" default="Vector2(0, 0)">
 			The size of the node's bounding rectangle, in pixels. [Container] nodes update this property automatically.
 		</member>

--- a/doc/classes/MenuBar.xml
+++ b/doc/classes/MenuBar.xml
@@ -106,9 +106,6 @@
 		<member name="prefer_global_menu" type="bool" setter="set_prefer_global_menu" getter="is_prefer_global_menu" default="true">
 			If [code]true[/code], [MenuBar] will use system global menu when supported.
 		</member>
-		<member name="shortcut_context" type="Node" setter="set_shortcut_context" getter="get_shortcut_context">
-			The [Node] which must be a parent of the focused GUI [Control] for the shortcut to be activated. If [code]null[/code], the shortcut can be activated when any control is focused (a global shortcut). This allows shortcuts to be accepted only when the user has a certain area of the GUI focused.
-		</member>
 		<member name="start_index" type="int" setter="set_start_index" getter="get_start_index" default="-1">
 			Position in the global menu to insert first [MenuBar] item at.
 		</member>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -349,10 +349,6 @@ Ref<Shortcut> BaseButton::get_shortcut() const {
 void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!_is_focus_owner_in_shortcut_context()) {
-		return;
-	}
-
 	if (!is_disabled() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
 		on_action_event(p_event);
 		accept_event();
@@ -389,34 +385,6 @@ Ref<ButtonGroup> BaseButton::get_button_group() const {
 	return button_group;
 }
 
-void BaseButton::set_shortcut_context(Node *p_node) {
-	if (p_node != nullptr) {
-		shortcut_context = p_node->get_instance_id();
-	} else {
-		shortcut_context = ObjectID();
-	}
-}
-
-Node *BaseButton::get_shortcut_context() const {
-	Object *ctx_obj = ObjectDB::get_instance(shortcut_context);
-	Node *ctx_node = Object::cast_to<Node>(ctx_obj);
-
-	return ctx_node;
-}
-
-bool BaseButton::_is_focus_owner_in_shortcut_context() const {
-	if (shortcut_context == ObjectID()) {
-		// No context, therefore global - always "in" context.
-		return true;
-	}
-
-	Node *ctx_node = get_shortcut_context();
-	Control *vp_focus = get_viewport() ? get_viewport()->gui_get_focus_owner() : nullptr;
-
-	// If the context is valid and the viewport focus is valid, check if the context is the focus or is a parent of it.
-	return ctx_node && vp_focus && (ctx_node == vp_focus || ctx_node->is_ancestor_of(vp_focus));
-}
-
 bool BaseButton::_was_pressed_by_mouse() const {
 	return was_mouse_pressed;
 }
@@ -446,9 +414,6 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button_group", "button_group"), &BaseButton::set_button_group);
 	ClassDB::bind_method(D_METHOD("get_button_group"), &BaseButton::get_button_group);
 
-	ClassDB::bind_method(D_METHOD("set_shortcut_context", "node"), &BaseButton::set_shortcut_context);
-	ClassDB::bind_method(D_METHOD("get_shortcut_context"), &BaseButton::get_shortcut_context);
-
 	GDVIRTUAL_BIND(_pressed);
 	GDVIRTUAL_BIND(_toggled, "button_pressed");
 
@@ -466,7 +431,6 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "Shortcut"), "set_shortcut", "get_shortcut");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "button_group", PROPERTY_HINT_RESOURCE_TYPE, "ButtonGroup"), "set_button_group", "get_button_group");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut_context", PROPERTY_HINT_NODE_TYPE, "Node"), "set_shortcut_context", "get_shortcut_context");
 
 	BIND_ENUM_CONSTANT(DRAW_NORMAL);
 	BIND_ENUM_CONSTANT(DRAW_PRESSED);

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -81,7 +81,6 @@ protected:
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
 
-	bool _is_focus_owner_in_shortcut_context() const;
 	bool _was_pressed_by_mouse() const;
 
 	GDVIRTUAL0(_pressed)
@@ -131,9 +130,6 @@ public:
 
 	void set_button_group(const Ref<ButtonGroup> &p_group);
 	Ref<ButtonGroup> get_button_group() const;
-
-	void set_shortcut_context(Node *p_node);
-	Node *get_shortcut_context() const;
 
 	BaseButton();
 	~BaseButton();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1759,6 +1759,34 @@ void Control::warp_mouse(const Point2 &p_position) {
 	get_viewport()->warp_mouse(get_global_transform_with_canvas().xform(p_position));
 }
 
+void Control::set_shortcut_context(const Node *p_node) {
+	if (p_node != nullptr) {
+		data.shortcut_context = p_node->get_instance_id();
+	} else {
+		data.shortcut_context = ObjectID();
+	}
+}
+
+Node *Control::get_shortcut_context() const {
+	Object *ctx_obj = ObjectDB::get_instance(data.shortcut_context);
+	Node *ctx_node = Object::cast_to<Node>(ctx_obj);
+
+	return ctx_node;
+}
+
+bool Control::is_focus_owner_in_shortcut_context() const {
+	if (data.shortcut_context == ObjectID()) {
+		// No context, therefore global - always "in" context.
+		return true;
+	}
+
+	const Node *ctx_node = get_shortcut_context();
+	const Control *vp_focus = get_viewport() ? get_viewport()->gui_get_focus_owner() : nullptr;
+
+	// If the context is valid and the viewport focus is valid, check if the context is the focus or is a parent of it.
+	return ctx_node && vp_focus && (ctx_node == vp_focus || ctx_node->is_ancestor_of(vp_focus));
+}
+
 // Drag and drop handling.
 
 void Control::set_drag_forwarding(Object *p_target) {
@@ -3133,6 +3161,9 @@ void Control::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("warp_mouse", "position"), &Control::warp_mouse);
 
+	ClassDB::bind_method(D_METHOD("set_shortcut_context", "node"), &Control::set_shortcut_context);
+	ClassDB::bind_method(D_METHOD("get_shortcut_context"), &Control::get_shortcut_context);
+
 	ClassDB::bind_method(D_METHOD("update_minimum_size"), &Control::update_minimum_size);
 
 	ClassDB::bind_method(D_METHOD("set_layout_direction", "direction"), &Control::set_layout_direction);
@@ -3205,6 +3236,9 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_filter", PROPERTY_HINT_ENUM, "Stop,Pass,Ignore"), "set_mouse_filter", "get_mouse_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_force_pass_scroll_events"), "set_force_pass_scroll_events", "is_force_pass_scroll_events");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_default_cursor_shape", PROPERTY_HINT_ENUM, "Arrow,I-Beam,Pointing Hand,Cross,Wait,Busy,Drag,Can Drop,Forbidden,Vertical Resize,Horizontal Resize,Secondary Diagonal Resize,Main Diagonal Resize,Move,Vertical Split,Horizontal Split,Help"), "set_default_cursor_shape", "get_default_cursor_shape");
+
+	ADD_GROUP("Input", "");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut_context", PROPERTY_HINT_NODE_TYPE, "Node"), "set_shortcut_context", "get_shortcut_context");
 
 	ADD_GROUP("Theme", "theme_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, "Theme"), "set_theme", "get_theme");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -218,6 +218,8 @@ private:
 		NodePath focus_next;
 		NodePath focus_prev;
 
+		ObjectID shortcut_context;
+
 		// Theming.
 
 		ThemeOwner *theme_owner = nullptr;
@@ -486,6 +488,10 @@ public:
 	bool is_force_pass_scroll_events() const;
 
 	void warp_mouse(const Point2 &p_position);
+
+	bool is_focus_owner_in_shortcut_context() const;
+	void set_shortcut_context(const Node *p_node);
+	Node *get_shortcut_context() const;
 
 	// Drag and drop handling.
 

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -149,10 +149,6 @@ void MenuBar::_open_popup(int p_index, bool p_focus_item) {
 void MenuBar::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!_is_focus_owner_in_shortcut_context()) {
-		return;
-	}
-
 	if (disable_shortcuts) {
 		return;
 	}
@@ -173,34 +169,6 @@ void MenuBar::shortcut_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 	}
-}
-
-void MenuBar::set_shortcut_context(Node *p_node) {
-	if (p_node != nullptr) {
-		shortcut_context = p_node->get_instance_id();
-	} else {
-		shortcut_context = ObjectID();
-	}
-}
-
-Node *MenuBar::get_shortcut_context() const {
-	Object *ctx_obj = ObjectDB::get_instance(shortcut_context);
-	Node *ctx_node = Object::cast_to<Node>(ctx_obj);
-
-	return ctx_node;
-}
-
-bool MenuBar::_is_focus_owner_in_shortcut_context() const {
-	if (shortcut_context == ObjectID()) {
-		// No context, therefore global - always "in" context.
-		return true;
-	}
-
-	Node *ctx_node = get_shortcut_context();
-	Control *vp_focus = get_viewport() ? get_viewport()->gui_get_focus_owner() : nullptr;
-
-	// If the context is valid and the viewport focus is valid, check if the context is the focus or is a parent of it.
-	return ctx_node && vp_focus && (ctx_node == vp_focus || ctx_node->is_ancestor_of(vp_focus));
 }
 
 void MenuBar::_popup_visibility_changed(bool p_visible) {
@@ -694,16 +662,12 @@ void MenuBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_menu_hidden", "menu", "hidden"), &MenuBar::set_menu_hidden);
 	ClassDB::bind_method(D_METHOD("is_menu_hidden", "menu"), &MenuBar::is_menu_hidden);
 
-	ClassDB::bind_method(D_METHOD("set_shortcut_context", "node"), &MenuBar::set_shortcut_context);
-	ClassDB::bind_method(D_METHOD("get_shortcut_context"), &MenuBar::get_shortcut_context);
-
 	ClassDB::bind_method(D_METHOD("get_menu_popup", "menu"), &MenuBar::get_menu_popup);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flat"), "set_flat", "is_flat");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "start_index"), "set_start_index", "get_start_index");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "switch_on_hover"), "set_switch_on_hover", "is_switch_on_hover");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "prefer_global_menu"), "set_prefer_global_menu", "is_prefer_global_menu");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut_context", PROPERTY_HINT_NODE_TYPE, "Node"), "set_shortcut_context", "get_shortcut_context");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -118,8 +118,6 @@ class MenuBar : public Control {
 	void _clear_menu();
 	void _update_menu();
 
-	bool _is_focus_owner_in_shortcut_context() const;
-
 protected:
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
@@ -169,9 +167,6 @@ public:
 
 	void set_menu_hidden(int p_menu, bool p_hidden);
 	bool is_menu_hidden(int p_menu) const;
-
-	void set_shortcut_context(Node *p_node);
-	Node *get_shortcut_context() const;
 
 	PopupMenu *get_menu_popup(int p_menu) const;
 

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -36,10 +36,6 @@
 void MenuButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!_is_focus_owner_in_shortcut_context()) {
-		return;
-	}
-
 	if (disable_shortcuts) {
 		return;
 	}


### PR DESCRIPTION
Fixes #66356

When iterating nodes for handling `shortcut_input`:
* Skip nodes which have no `shortcut_context` and leave them until the end.
* This ensures that all nodes which do have a `shortcut_context` are tried first, then the "global" shortcuts.
* Skip calling `shortcut_input` if the focus is not within the shortcut context.

See the reproduction project from the linked issue. If you run that without this PR, you should see the problems as explained in the issue. Build this PR and those issues are resolved.