### PR TITLE
Unexpose confusing `String + int` and `int + String` operations

### DIFF
--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -240,8 +240,6 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorAdd<double, double, int64_t>>(Variant::OP_ADD, Variant::FLOAT, Variant::INT);
 	register_op<OperatorEvaluatorAdd<double, double, double>>(Variant::OP_ADD, Variant::FLOAT, Variant::FLOAT);
 	register_op<OperatorEvaluatorAdd<String, String, String>>(Variant::OP_ADD, Variant::STRING, Variant::STRING);
-	register_op<OperatorEvaluatorAdd<String, char32_t, String>>(Variant::OP_ADD, Variant::INT, Variant::STRING);
-	register_op<OperatorEvaluatorAdd<String, String, char32_t>>(Variant::OP_ADD, Variant::STRING, Variant::INT);
 	register_op<OperatorEvaluatorAdd<Vector2, Vector2, Vector2>>(Variant::OP_ADD, Variant::VECTOR2, Variant::VECTOR2);
 	register_op<OperatorEvaluatorAdd<Vector2i, Vector2i, Vector2i>>(Variant::OP_ADD, Variant::VECTOR2I, Variant::VECTOR2I);
 	register_op<OperatorEvaluatorAdd<Vector3, Vector3, Vector3>>(Variant::OP_ADD, Variant::VECTOR3, Variant::VECTOR3);

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -940,12 +940,6 @@
 			<description>
 			</description>
 		</operator>
-		<operator name="operator +">
-			<return type="String" />
-			<param index="0" name="right" type="int" />
-			<description>
-			</description>
-		</operator>
 		<operator name="operator &lt;">
 			<return type="bool" />
 			<param index="0" name="right" type="String" />

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -196,13 +196,6 @@
 			</description>
 		</operator>
 		<operator name="operator +">
-			<return type="String" />
-			<param index="0" name="right" type="String" />
-			<description>
-				Adds Unicode character with code [int] to the [String].
-			</description>
-		</operator>
-		<operator name="operator +">
 			<return type="float" />
 			<param index="0" name="right" type="float" />
 			<description>


### PR DESCRIPTION
These operators have been added in #57795 and #58233. This behavior can lead to unexpected errors, including in GDScript (I found this when I accidentally forgot to cast an `int` to a `String`).

![](https://user-images.githubusercontent.com/47700418/192105726-1187a527-ad1e-4781-845d-f33daebcddd9.png)

Instead of these operators, you should use the `String.chr` static method or the `char` function in GDScript.

```gdscript
print(char(65) + "a") # "Aa"
print(str(65) + "a")  # "65a"
print(65 + "a") # Error
```
