### PR TITLE
Fix project manager not working in self-contained mode

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -157,6 +157,7 @@ static bool show_help = false;
 static bool auto_quit = false;
 static OS::ProcessID editor_pid = 0;
 #ifdef TOOLS_ENABLED
+static bool found_project = false;
 static bool auto_build_solutions = false;
 static String debug_server_uri;
 static int converter_max_kb_file = 4 * 1024; // 4MB
@@ -707,9 +708,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Vector<String> breakpoints;
 	bool use_custom_res = true;
 	bool force_res = false;
-#ifdef TOOLS_ENABLED
-	bool found_project = false;
-#endif
 
 	String default_renderer = "";
 	String renderer_hints = "";
@@ -1938,7 +1936,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 #ifdef TOOLS_ENABLED
 	if (editor || project_manager || cmdline_tool) {
 		EditorPaths::create();
-		if (EditorPaths::get_singleton()->is_self_contained()) {
+		if (found_project && EditorPaths::get_singleton()->is_self_contained()) {
 			if (ProjectSettings::get_singleton()->get_resource_path() == OS::get_singleton()->get_executable_path().get_base_dir()) {
 				ERR_PRINT("You are trying to run a self-contained editor at the same location as a project. This is not allowed, since editor files will mix with project files.");
 				OS::get_singleton()->set_exit_code(EXIT_FAILURE);


### PR DESCRIPTION
The behavior of `ProjectSettings::get_singleton()->get_resource_path()` was not as I expected in the project manager. This PR changes the code so that this only runs for editor and cmdline_tool but not project_manager. Fixes #66344