### PR TITLE
Remove redundant "if" condition in GDScriptCompiler::_parse_function()

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2041,7 +2041,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 				codegen.generator->write_newline(field->initializer->start_line);
 
 				// For typed arrays we need to make sure this is already initialized correctly so typed assignment work.
-				if (field_type.is_hard_type() && field_type.builtin_type == Variant::ARRAY && field_type.has_container_element_type()) {
+				if (field_type.is_hard_type() && field_type.builtin_type == Variant::ARRAY) {
 					if (field_type.has_container_element_type()) {
 						codegen.generator->write_construct_typed_array(dst_address, _gdtype_from_datatype(field_type.get_container_element_type(), codegen.script), Vector<GDScriptCodeGenerator::Address>());
 					} else {


### PR DESCRIPTION
Looking at the [original PR](46830), I believe this is the original intent, but it now means that previously dead code is now executed.

If I'm incorrect, then it means that we can go the other way and remove the dead code:

```cpp
if (field_type.is_hard_type() && field_type.builtin_type == Variant::ARRAY && field_type.has_container_element_type()) {
    codegen.generator->write_construct_typed_array(dst_address, _gdtype_from_datatype(field_type.get_container_element_type(), codegen.script), Vector<GDScriptCodeGenerator::Address>());
}
```
