### PR TITLE
Implement automatic FPS limiting based on highest display refresh rate

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -68,12 +68,42 @@ double Engine::get_physics_jitter_fix() const {
 	return physics_jitter_fix;
 }
 
-void Engine::set_max_fps(int p_fps) {
+void Engine::set_max_fps_mode(MaxFPSMode p_mode) {
+	max_fps_mode = p_mode;
+}
+
+Engine::MaxFPSMode Engine::get_max_fps_mode() const {
+	return max_fps_mode;
+}
+
+void Engine::set_max_fps_custom(int p_fps) {
 	_max_fps = p_fps > 0 ? p_fps : 0;
 }
 
-int Engine::get_max_fps() const {
+int Engine::get_max_fps_custom() const {
 	return _max_fps;
+}
+
+void Engine::set_automatic_max_fps(int p_fps) {
+	_automatic_max_fps = p_fps;
+}
+
+void Engine::set_automatic_max_fps_vrr(int p_fps) {
+	_automatic_max_fps_vrr = p_fps;
+}
+
+int Engine::get_effective_max_fps() const {
+	switch (max_fps_mode) {
+		case MAX_FPS_MODE_UNLIMITED:
+			return 0;
+		case MAX_FPS_MODE_AUTOMATIC:
+			return _automatic_max_fps;
+		case MAX_FPS_MODE_AUTOMATIC_VRR:
+			return _automatic_max_fps_vrr;
+		case MAX_FPS_MODE_CUSTOM:
+		default:
+			return _max_fps;
+	}
 }
 
 uint64_t Engine::get_frames_drawn() {

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -49,6 +49,13 @@ public:
 		Singleton(const StringName &p_name = StringName(), Object *p_ptr = nullptr, const StringName &p_class_name = StringName());
 	};
 
+	enum MaxFPSMode {
+		MAX_FPS_MODE_UNLIMITED,
+		MAX_FPS_MODE_AUTOMATIC,
+		MAX_FPS_MODE_AUTOMATIC_VRR,
+		MAX_FPS_MODE_CUSTOM,
+	};
+
 private:
 	friend class Main;
 
@@ -60,7 +67,10 @@ private:
 	int ips = 60;
 	double physics_jitter_fix = 0.5;
 	double _fps = 1;
+	int _automatic_max_fps = 0;
+	int _automatic_max_fps_vrr = 0;
 	int _max_fps = 0;
+	MaxFPSMode max_fps_mode = MAX_FPS_MODE_AUTOMATIC;
 	double _time_scale = 1.0;
 	uint64_t _physics_frames = 0;
 	int max_physics_steps_per_frame = 8;
@@ -100,8 +110,19 @@ public:
 	void set_physics_jitter_fix(double p_threshold);
 	double get_physics_jitter_fix() const;
 
-	virtual void set_max_fps(int p_fps);
-	virtual int get_max_fps() const;
+	virtual void set_max_fps_mode(MaxFPSMode p_mode);
+	virtual MaxFPSMode get_max_fps_mode() const;
+
+	virtual void set_max_fps_custom(int p_fps);
+	virtual int get_max_fps_custom() const;
+
+	// Not exposed to scripting, as this is set by the engine on startup only.
+	virtual void set_automatic_max_fps(int p_fps);
+
+	// Not exposed to scripting, as this is set by the engine on startup only.
+	virtual void set_automatic_max_fps_vrr(int p_fps);
+
+	virtual int get_effective_max_fps() const;
 
 	virtual double get_frames_per_second() const { return _fps; }
 
@@ -171,5 +192,7 @@ public:
 	Engine();
 	virtual ~Engine() {}
 };
+
+VARIANT_ENUM_CAST(Engine::MaxFPSMode);
 
 #endif // ENGINE_H

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1486,12 +1486,24 @@ double Engine::get_physics_interpolation_fraction() const {
 	return ::Engine::get_singleton()->get_physics_interpolation_fraction();
 }
 
-void Engine::set_max_fps(int p_fps) {
-	::Engine::get_singleton()->set_max_fps(p_fps);
+void Engine::set_max_fps_mode(MaxFPSMode p_mode) {
+	::Engine::get_singleton()->set_max_fps_mode(::Engine::MaxFPSMode(p_mode));
 }
 
-int Engine::get_max_fps() const {
-	return ::Engine::get_singleton()->get_max_fps();
+::Engine::MaxFPSMode Engine::get_max_fps_mode() const {
+	return ::Engine::get_singleton()->get_max_fps_mode();
+}
+
+void Engine::set_max_fps_custom(int p_fps) {
+	::Engine::get_singleton()->set_max_fps_custom(p_fps);
+}
+
+int Engine::get_max_fps_custom() const {
+	return ::Engine::get_singleton()->get_max_fps_custom();
+}
+
+int Engine::get_effective_max_fps() const {
+	return ::Engine::get_singleton()->get_effective_max_fps();
 }
 
 double Engine::get_frames_per_second() const {
@@ -1634,8 +1646,11 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_physics_jitter_fix", "physics_jitter_fix"), &Engine::set_physics_jitter_fix);
 	ClassDB::bind_method(D_METHOD("get_physics_jitter_fix"), &Engine::get_physics_jitter_fix);
 	ClassDB::bind_method(D_METHOD("get_physics_interpolation_fraction"), &Engine::get_physics_interpolation_fraction);
-	ClassDB::bind_method(D_METHOD("set_max_fps", "max_fps"), &Engine::set_max_fps);
-	ClassDB::bind_method(D_METHOD("get_max_fps"), &Engine::get_max_fps);
+	ClassDB::bind_method(D_METHOD("set_max_fps_mode", "mode"), &Engine::set_max_fps_mode);
+	ClassDB::bind_method(D_METHOD("get_max_fps_mode"), &Engine::get_max_fps_mode);
+	ClassDB::bind_method(D_METHOD("set_max_fps_custom", "max_fps"), &Engine::set_max_fps_custom);
+	ClassDB::bind_method(D_METHOD("get_max_fps_custom"), &Engine::get_max_fps_custom);
+	ClassDB::bind_method(D_METHOD("get_effective_max_fps"), &Engine::get_effective_max_fps);
 
 	ClassDB::bind_method(D_METHOD("set_time_scale", "time_scale"), &Engine::set_time_scale);
 	ClassDB::bind_method(D_METHOD("get_time_scale"), &Engine::get_time_scale);
@@ -1680,9 +1695,15 @@ void Engine::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "print_error_messages"), "set_print_error_messages", "is_printing_error_messages");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "physics_ticks_per_second"), "set_physics_ticks_per_second", "get_physics_ticks_per_second");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_physics_steps_per_frame"), "set_max_physics_steps_per_frame", "get_max_physics_steps_per_frame");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_fps"), "set_max_fps", "get_max_fps");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_fps_mode", PROPERTY_HINT_ENUM, "Unlimited,Automatic (Use Highest Display Refresh Rate),Automatic Variable (Use VRR-Optimized Cap), Custom"), "set_max_fps_mode", "get_max_fps_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_fps_custom"), "set_max_fps_custom", "get_max_fps_custom");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_scale"), "set_time_scale", "get_time_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "physics_jitter_fix"), "set_physics_jitter_fix", "get_physics_jitter_fix");
+
+	BIND_ENUM_CONSTANT(MAX_FPS_MODE_UNLIMITED);
+	BIND_ENUM_CONSTANT(MAX_FPS_MODE_AUTOMATIC);
+	BIND_ENUM_CONSTANT(MAX_FPS_MODE_AUTOMATIC_VRR);
+	BIND_ENUM_CONSTANT(MAX_FPS_MODE_CUSTOM);
 }
 
 Engine *Engine::singleton = nullptr;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -457,6 +457,13 @@ protected:
 	static Engine *singleton;
 
 public:
+	enum MaxFPSMode {
+		MAX_FPS_MODE_UNLIMITED,
+		MAX_FPS_MODE_AUTOMATIC,
+		MAX_FPS_MODE_AUTOMATIC_VRR,
+		MAX_FPS_MODE_CUSTOM,
+	};
+
 	static Engine *get_singleton() { return singleton; }
 	void set_physics_ticks_per_second(int p_ips);
 	int get_physics_ticks_per_second() const;
@@ -468,8 +475,11 @@ public:
 	double get_physics_jitter_fix() const;
 	double get_physics_interpolation_fraction() const;
 
-	void set_max_fps(int p_fps);
-	int get_max_fps() const;
+	void set_max_fps_mode(MaxFPSMode p_mode);
+	::Engine::MaxFPSMode get_max_fps_mode() const;
+	void set_max_fps_custom(int p_fps);
+	int get_max_fps_custom() const;
+	int get_effective_max_fps() const;
 
 	double get_frames_per_second() const;
 	uint64_t get_physics_frames() const;
@@ -565,5 +575,7 @@ VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyJoinType);
 VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyEndType);
 
 VARIANT_ENUM_CAST(core_bind::Thread::Priority);
+
+VARIANT_ENUM_CAST(core_bind::Engine::MaxFPSMode);
 
 #endif // CORE_BIND_H

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -534,7 +534,7 @@ void OS::add_frame_delay(bool p_can_draw) {
 	if (is_in_low_processor_usage_mode() || !p_can_draw) {
 		dynamic_delay = get_low_processor_usage_mode_sleep_usec();
 	}
-	const int max_fps = Engine::get_singleton()->get_max_fps();
+	const int max_fps = Engine::get_singleton()->get_effective_max_fps();
 	if (max_fps > 0 && !Engine::get_singleton()->is_editor_hint()) {
 		// Override the low processor usage mode sleep delay if the target FPS is lower.
 		dynamic_delay = MAX(dynamic_delay, (uint64_t)(1000000 / max_fps));

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1753,16 +1753,16 @@
 			[b]Note:[/b] This flag is implemented on macOS.
 		</constant>
 		<constant name="VSYNC_DISABLED" value="0" enum="VSyncMode">
-			No vertical synchronization, which means the engine will display frames as fast as possible (tearing may be visible). Framerate is unlimited (nonwithstanding [member Engine.max_fps]).
+			No vertical synchronization, which means the engine will display frames as fast as possible (tearing may be visible). Framerate is unlimited if [member Engine.max_fps_mode] is set to [b]Unlimited[/b].
 		</constant>
 		<constant name="VSYNC_ENABLED" value="1" enum="VSyncMode">
-			Default vertical synchronization mode, the image is displayed only on vertical blanking intervals (no tearing is visible). Framerate is limited by the monitor refresh rate (nonwithstanding [member Engine.max_fps]).
+			Default vertical synchronization mode, the image is displayed only on vertical blanking intervals (no tearing is visible). Framerate is limited by the monitor refresh rate even if [member Engine.max_fps_mode] is set to [b]Unlimited[/b].
 		</constant>
 		<constant name="VSYNC_ADAPTIVE" value="2" enum="VSyncMode">
-			Behaves like [constant VSYNC_DISABLED] when the framerate drops below the screen's refresh rate to reduce stuttering (tearing may be visible). Otherwise, vertical synchronization is enabled to avoid tearing. Framerate is limited by the monitor refresh rate (nonwithstanding [member Engine.max_fps]). Behaves like [constant VSYNC_ENABLED] when using the Compatibility rendering method.
+			Behaves like [constant VSYNC_DISABLED] when the framerate drops below the screen's refresh rate to reduce stuttering (tearing may be visible). Otherwise, vertical synchronization is enabled to avoid tearing. Framerate is limited by the monitor refresh rate even if [member Engine.max_fps_mode] is set to [b]Unlimited[/b]. Behaves like [constant VSYNC_ENABLED] when using the Compatibility rendering method.
 		</constant>
 		<constant name="VSYNC_MAILBOX" value="3" enum="VSyncMode">
-			Displays the most recent image in the queue on vertical blanking intervals, while rendering to the other images (no tearing is visible). Framerate is unlimited (nonwithstanding [member Engine.max_fps]).
+			Displays the most recent image in the queue on vertical blanking intervals, while rendering to the other images (no tearing is visible). Framerate is unlimited if [member Engine.max_fps_mode] is set to [b]Unlimited[/b].
 			Although not guaranteed, the images can be rendered as fast as possible, which may reduce input lag (also called "Fast" V-Sync mode). [constant VSYNC_MAILBOX] works best when at least twice as many frames as the display refresh rate are rendered. Behaves like [constant VSYNC_ENABLED] when using the Compatibility rendering method.
 		</constant>
 		<constant name="DISPLAY_HANDLE" value="0" enum="HandleType">

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -56,6 +56,12 @@
 				{[code]platinum_sponsors[/code], [code]gold_sponsors[/code], [code]silver_sponsors[/code], [code]bronze_sponsors[/code], [code]mini_sponsors[/code], [code]gold_donors[/code], [code]silver_donors[/code], [code]bronze_donors[/code]}
 			</description>
 		</method>
+		<method name="get_effective_max_fps" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the effective maximum number of frames per second that can be rendered. This is different from [member max_fps_custom] as it takes the current [member max_fps_mode] into account.
+			</description>
+		</method>
 		<method name="get_frames_drawn">
 			<return type="int" />
 			<description>
@@ -281,13 +287,17 @@
 		</method>
 	</methods>
 	<members>
-		<member name="max_fps" type="int" setter="set_max_fps" getter="get_max_fps" default="0">
+		<member name="max_fps_custom" type="int" setter="set_max_fps_custom" getter="get_max_fps_custom" default="0">
 			The maximum number of frames per second that can be rendered. A value of [code]0[/code] means "no limit". The actual number of frames per second may still be below this value if the CPU or GPU cannot keep up with the project logic and rendering.
 			Limiting the FPS can be useful to reduce system power consumption, which reduces heat and noise emissions (and improves battery life on mobile devices).
 			If [member ProjectSettings.display/window/vsync/vsync_mode] is [code]Enabled[/code] or [code]Adaptive[/code], it takes precedence and the forced FPS number cannot exceed the monitor's refresh rate.
 			If [member ProjectSettings.display/window/vsync/vsync_mode] is [code]Enabled[/code], on monitors with variable refresh rate enabled (G-Sync/FreeSync), using a FPS limit a few frames lower than the monitor's refresh rate will [url=https://blurbusters.com/howto-low-lag-vsync-on/]reduce input lag while avoiding tearing[/url].
 			If [member ProjectSettings.display/window/vsync/vsync_mode] is [code]Disabled[/code], limiting the FPS to a high value that can be consistently reached on the system can reduce input lag compared to an uncapped framerate. Since this works by ensuring the GPU load is lower than 100%, this latency reduction is only effective in GPU-bottlenecked scenarios, not CPU-bottlenecked scenarios.
-			See also [member physics_ticks_per_second] and [member ProjectSettings.application/run/max_fps].
+			See also [member physics_ticks_per_second] and [member ProjectSettings.application/run/max_fps_custom].
+			[b]Note:[/b] This value is ignored if [member max_fps_mode] is not [constant MAX_FPS_MODE_CUSTOM].
+		</member>
+		<member name="max_fps_mode" type="int" setter="set_max_fps_mode" getter="get_max_fps_mode" enum="Engine.MaxFPSMode" default="1">
+			The FPS limit mode to use. See [enum MaxFPSMode] descriptions for details.
 		</member>
 		<member name="max_physics_steps_per_frame" type="int" setter="set_max_physics_steps_per_frame" getter="get_max_physics_steps_per_frame" default="8">
 			Controls the maximum number of physics steps that can be simulated each rendered frame. The default value is tuned to avoid "spiral of death" situations where expensive physics simulations trigger more expensive simulations indefinitely. However, the game will appear to slow down if the rendering FPS is less than [code]1 / max_physics_steps_per_frame[/code] of [member physics_ticks_per_second]. This occurs even if [code]delta[/code] is consistently used in physics calculations. To avoid this, increase [member max_physics_steps_per_frame] if you have increased [member physics_ticks_per_second] significantly above its default value.
@@ -297,7 +307,7 @@
 			[b]Note:[/b] For best results, when using a custom physics interpolation solution, the physics jitter fix should be disabled by setting [member physics_jitter_fix] to [code]0[/code].
 		</member>
 		<member name="physics_ticks_per_second" type="int" setter="set_physics_ticks_per_second" getter="get_physics_ticks_per_second" default="60">
-			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run. This value should generally always be set to [code]60[/code] or above, as Godot doesn't interpolate the physics step. As a result, values lower than [code]60[/code] will look stuttery. This value can be increased to make input more reactive or work around collision tunneling issues, but keep in mind doing so will increase CPU usage. See also [member max_fps] and [member ProjectSettings.physics/common/physics_ticks_per_second].
+			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run. This value should generally always be set to [code]60[/code] or above, as Godot doesn't interpolate the physics step. As a result, values lower than [code]60[/code] will look stuttery. This value can be increased to make input more reactive or work around collision tunneling issues, but keep in mind doing so will increase CPU usage. See also [member max_fps_custom] and [member ProjectSettings.physics/common/physics_ticks_per_second].
 			[b]Note:[/b] Only [member max_physics_steps_per_frame] physics ticks may be simulated per rendered frame at most. If more physics ticks have to be simulated per rendered frame to keep up with rendering, the project will appear to slow down (even if [code]delta[/code] is used consistently in physics calculations). Therefore, it is recommended to also increase [member max_physics_steps_per_frame] if increasing [member physics_ticks_per_second] significantly above its default value.
 		</member>
 		<member name="print_error_messages" type="bool" setter="set_print_error_messages" getter="is_printing_error_messages" default="true">
@@ -309,4 +319,18 @@
 			Controls how fast or slow the in-game clock ticks versus the real life one. It defaults to 1.0. A value of 2.0 means the game moves twice as fast as real life, whilst a value of 0.5 means the game moves at half the regular speed.
 		</member>
 	</members>
+	<constants>
+		<constant name="MAX_FPS_MODE_UNLIMITED" value="0" enum="MaxFPSMode">
+			Do not limit the number of frames per second that can be rendered. This leads to the lowest input lag in CPU-bound scenarios, but can increase input lag in GPU-bound scenarios due to render pipeline stalls. Unlimited framerate also results in the highest system power consumption.
+		</constant>
+		<constant name="MAX_FPS_MODE_AUTOMATIC" value="1" enum="MaxFPSMode">
+			Limit the number of rendered frames per second to [code]highest_display_refresh_rate + 1[/code]. This is done to handle multi-monitor setups with different refresh rates while reducing tearing when V-Sync is disabled.
+		</constant>
+		<constant name="MAX_FPS_MODE_AUTOMATIC_VRR" value="2" enum="MaxFPSMode">
+			Limit the number of rendered frames per second to a value slightly lower than the fastest display's maximum refresh rate. The formula used is [code]highest_display_refresh_rate - (int(highest_display_refresh_rate / 60.0) + 1)[/code]. This mode allows [url=https://blurbusters.com/howto-low-lag-vsync-on/]reducing input lag while avoiding tearing[/url] when variable refresh rate is enabled. This mode should only be used when the V-Sync mode is [b]Enabled[/b] and VRR (G-Sync/FreeSync) is enabled by the user.
+		</constant>
+		<constant name="MAX_FPS_MODE_CUSTOM" value="3" enum="MaxFPSMode">
+			Limit the number of rendered frames per second to the value set in [member max_fps_custom].
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -308,14 +308,18 @@
 		<member name="application/run/main_scene" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to the main scene file that will be loaded when the project runs.
 		</member>
-		<member name="application/run/max_fps" type="int" setter="" getter="" default="0">
+		<member name="application/run/max_fps_custom" type="int" setter="" getter="" default="0">
 			Maximum number of frames per second allowed. A value of [code]0[/code] means "no limit". The actual number of frames per second may still be below this value if the CPU or GPU cannot keep up with the project logic and rendering.
 			Limiting the FPS can be useful to reduce system power consumption, which reduces heat and noise emissions (and improves battery life on mobile devices).
 			If [member display/window/vsync/vsync_mode] is set to [code]Enabled[/code] or [code]Adaptive[/code], it takes precedence and the forced FPS number cannot exceed the monitor's refresh rate.
 			If [member display/window/vsync/vsync_mode] is [code]Enabled[/code], on monitors with variable refresh rate enabled (G-Sync/FreeSync), using a FPS limit a few frames lower than the monitor's refresh rate will [url=https://blurbusters.com/howto-low-lag-vsync-on/]reduce input lag while avoiding tearing[/url].
 			If [member display/window/vsync/vsync_mode] is [code]Disabled[/code], limiting the FPS to a high value that can be consistently reached on the system can reduce input lag compared to an uncapped framerate. Since this works by ensuring the GPU load is lower than 100%, this latency reduction is only effective in GPU-bottlenecked scenarios, not CPU-bottlenecked scenarios.
 			See also [member physics/common/physics_ticks_per_second].
-			[b]Note:[/b] This property is only read when the project starts. To change the rendering FPS cap at runtime, set [member Engine.max_fps] instead.
+			[b]Note:[/b] This value is ignored if [member application/run/max_fps_mode] is not [b]Custom[/b].
+			[b]Note:[/b] This property is only read when the project starts. To change the rendering FPS cap at runtime, set [member Engine.max_fps_custom] instead.
+		</member>
+		<member name="application/run/max_fps_mode" type="int" setter="" getter="" default="1">
+			The FPS limit mode to use. See [enum Engine.MaxFPSMode] descriptions for details.
 		</member>
 		<member name="audio/buses/channel_disable_threshold_db" type="float" setter="" getter="" default="-60.0">
 			Audio buses will disable automatically when sound goes below a given dB threshold for a given time. This saves CPU as effects assigned to that bus will no longer do any processing.
@@ -1907,7 +1911,7 @@
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_jitter_fix] instead.
 		</member>
 		<member name="physics/common/physics_ticks_per_second" type="int" setter="" getter="" default="60">
-			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run. See also [member application/run/max_fps].
+			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run. See also [member application/run/max_fps_custom].
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_ticks_per_second] instead.
 			[b]Note:[/b] Only [member physics/common/max_physics_steps_per_frame] physics ticks may be simulated per rendered frame at most. If more physics ticks have to be simulated per rendered frame to keep up with rendering, the project will appear to slow down (even if [code]delta[/code] is used consistently in physics calculations). Therefore, it is recommended to also increase [member physics/common/max_physics_steps_per_frame] if increasing [member physics/common/physics_ticks_per_second] significantly above its default value.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1824,7 +1824,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Engine::get_singleton()->set_physics_ticks_per_second(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "physics/common/physics_ticks_per_second", PROPERTY_HINT_RANGE, "1,1000,1"), 60));
 	Engine::get_singleton()->set_max_physics_steps_per_frame(GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "physics/common/max_physics_steps_per_frame", PROPERTY_HINT_RANGE, "1,100,1"), 8));
 	Engine::get_singleton()->set_physics_jitter_fix(GLOBAL_DEF("physics/common/physics_jitter_fix", 0.5));
-	Engine::get_singleton()->set_max_fps(GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/max_fps", PROPERTY_HINT_RANGE, "0,1000,1"), 0));
+	Engine::get_singleton()->set_max_fps_mode(Engine::MaxFPSMode(int(GLOBAL_DEF(
+			PropertyInfo(Variant::INT,
+					"application/run/max_fps_mode",
+					PROPERTY_HINT_ENUM, "Unlimited,Automatic (Use Highest Display Refresh Rate),Automatic Variable (Use VRR-Optimized Cap),Custom"),
+			Engine::MAX_FPS_MODE_AUTOMATIC))));
+	Engine::get_singleton()->set_max_fps_custom(GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/max_fps_custom", PROPERTY_HINT_RANGE, "0,1000,1"), 0));
 
 	GLOBAL_DEF("debug/settings/stdout/print_fps", false);
 	GLOBAL_DEF("debug/settings/stdout/print_gpu_profile", false);
@@ -2116,6 +2121,36 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 #else
 	bool show_logo = true;
 #endif
+
+	int highest_refresh_rate = 0;
+	for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {
+		highest_refresh_rate = MAX(highest_refresh_rate, Math::ceil(DisplayServer::get_singleton()->screen_get_refresh_rate(i)));
+	}
+	print_verbose(vformat("Detected highest screen refresh rate (rounded up): %d Hz", highest_refresh_rate));
+
+	if (highest_refresh_rate >= 30) {
+		// If at least one refresh rate was successfully detected, limit the rendered framerate
+		// to (roughly) the monitor refresh rate by default. A slightly higher value is used to ensure
+		// the display is always fed with frames if the CPU and GPU can keep up, without introduing too much tearing.
+		//
+		// This is helpful to reduce power consumption, heat and noise emissions
+		// when V-Sync is disabled or fails to kick in.
+		// This can also reduce input lag in GPU-bottlenecked situations by preventing 100% GPU load
+		// (which causes pipeline stalls in most configurations).
+		Engine::get_singleton()->set_automatic_max_fps(highest_refresh_rate + 1);
+
+		// For displays with variable refresh rate enabled, a VRR-optimized framerate cap can optionally be used.
+		// This cap is slightly lower than the display's maximum refresh rate, with a greater safety margin
+		// for high refresh rates due to timing inaccuracies.
+		// This reduces input lag and stuttering on frame drops compared to traditional V-Sync, without introducing tearing.
+		// V-Sync should be set to Enabled and G-Sync/FreeSync must be enabled on the monitor for this to work.
+		// See <https://blurbusters.com/howto-low-lag-vsync-on/> for rationale.
+		Engine::get_singleton()->set_automatic_max_fps_vrr(highest_refresh_rate - (int(highest_refresh_rate / 60.0) + 1));
+	}
+
+	if (init_screen != -1) {
+		DisplayServer::get_singleton()->window_set_current_screen(init_screen);
+	}
 
 	if (init_windowed) {
 		//do none..

--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -72,7 +72,7 @@ void main_loop_callback() {
 		return; // Skip frame.
 	}
 
-	int max_fps = Engine::get_singleton()->get_max_fps();
+	int max_fps = Engine::get_singleton()->get_effective_max_fps();
 	if (max_fps > 0) {
 		if (current_ticks - target_ticks > 1000000) {
 			// When the window loses focus, we stop getting updates and accumulate delay.


### PR DESCRIPTION
The rationale is explained in detail in https://github.com/godotengine/godot-proposals/issues/5451, including for the VRR-optimized FPS cap mode.

This can be remade in a backwards-compatible way for `3.x` if desired.

- This closes https://github.com/godotengine/godot-proposals/issues/5451.

**Testing project:** [test_auto_fps_limit.zip](https://github.com/godotengine/godot/files/9740262/test_auto_fps_limit.zip)