### PR TITLE
Fix broken 2D light blending, addresses #49922

### DIFF
--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -595,6 +595,8 @@ void main() {
 		color = vec4(0.0); //invisible by default due to using light mask
 	}
 
+	vec4 original_color = color;
+
 #ifdef MODE_LIGHT_ONLY
 	color = vec4(0.0);
 #else
@@ -635,6 +637,8 @@ void main() {
 #endif
 			);
 		}
+
+		light_color.rgb *= original_color.rgb;
 
 		light_blend_compute(light_base, light_color, color.rgb);
 	}
@@ -731,6 +735,8 @@ void main() {
 #endif
 			);
 		}
+
+		light_color.rgb *= original_color.rgb;
 
 		light_blend_compute(light_base, light_color, color.rgb);
 	}


### PR DESCRIPTION
This pull request aims to address issues raised in #49922 - the problem was that the `color` was already modified with the modulate color. It was impossible to then rely on the original color for lighting. To fix the issue I made sure to remember the original color for the light processing.

## Before this change
![before](https://user-images.githubusercontent.com/822035/192114899-d6be8109-61bf-495a-8ad4-bc14f6c2c99b.JPG)

## After this change
![after](https://user-images.githubusercontent.com/822035/192114903-be82b740-df36-4272-a237-2a68a0b2713a.JPG)

*Bugsquad edit:*
- Fixes #49922