### PR TITLE
Update source_code script buffer with change

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2120,6 +2120,14 @@ ScriptTextEditor::ScriptTextEditor() {
 	connection_info_dialog = memnew(ConnectionInfoDialog);
 
 	code_editor->get_text_editor()->set_drag_forwarding(this);
+
+	// Connect to signal text_changed to apply source code
+	code_editor->get_text_editor()->connect("text_changed", callable_mp(this, &ScriptTextEditor::_on_text_changed));
+}
+
+// Callback method for signal text_changed
+void ScriptTextEditor::_on_text_changed() {
+	apply_code();
 }
 
 ScriptTextEditor::~ScriptTextEditor() {

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -150,7 +150,10 @@ class ScriptTextEditor : public ScriptEditorBase {
 	};
 
 	void _enable_code_editor();
-
+    
+    // On every change to the script editor, execute this connected method
+    virtual void _on_text_changed();
+    
 protected:
 	void _update_breakpoint_list();
 	void _breakpoint_item_pressed(int p_idx);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/65450

The script editor when using tools, would not fetch the source_code. That's because it did not get updated in real time.



