### PR TITLE
[macOS] Process menu callback after event processing step to avoid event queue corruption.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -179,6 +179,12 @@ private:
 
 	IOPMAssertionID screen_keep_on_assertion = kIOPMNullAssertionID;
 
+	struct MenuCall {
+		Variant tag;
+		Callable callback;
+	};
+	Vector<MenuCall> deferred_menu_calls;
+
 	const NSMenu *_get_menu_root(const String &p_menu_root) const;
 	NSMenu *_get_menu_root(const String &p_menu_root);
 


### PR DESCRIPTION
macOS menu click event is called during `NSEvent` dequeue step, and if a callback is creating a new window. Calling `process_events` or otherwise accessing OS event queue, it will result in double-free and crash (e.g. `EditorProgress` in case of https://github.com/godotengine/godot/issues/66329), this PR caches all menu events and do all callbacks after dequeue step is completed to avoid it.

Fixes https://github.com/godotengine/godot/issues/66329