### PR TITLE
Simplify Euler order test code in test_basis.h

### DIFF
--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -38,15 +38,6 @@
 
 namespace TestBasis {
 
-enum RotOrder {
-	EulerXYZ,
-	EulerXZY,
-	EulerYZX,
-	EulerYXZ,
-	EulerZXY,
-	EulerZYX
-};
-
 Vector3 deg_to_rad(const Vector3 &p_rotation) {
 	return p_rotation / 180.0 * Math_PI;
 }
@@ -55,88 +46,26 @@ Vector3 rad2deg(const Vector3 &p_rotation) {
 	return p_rotation / Math_PI * 180.0;
 }
 
-Basis EulerToBasis(RotOrder mode, const Vector3 &p_rotation) {
-	Basis ret;
-	switch (mode) {
-		case EulerXYZ:
-			ret.set_euler(p_rotation, Basis::EULER_ORDER_XYZ);
-			break;
-
-		case EulerXZY:
-			ret.set_euler(p_rotation, Basis::EULER_ORDER_XZY);
-			break;
-
-		case EulerYZX:
-			ret.set_euler(p_rotation, Basis::EULER_ORDER_YZX);
-			break;
-
-		case EulerYXZ:
-			ret.set_euler(p_rotation, Basis::EULER_ORDER_YXZ);
-			break;
-
-		case EulerZXY:
-			ret.set_euler(p_rotation, Basis::EULER_ORDER_ZXY);
-			break;
-
-		case EulerZYX:
-			ret.set_euler(p_rotation, Basis::EULER_ORDER_ZYX);
-			break;
-
-		default:
-			// If you land here, Please integrate all rotation orders.
-			FAIL("This is not unreachable.");
-	}
-
-	return ret;
-}
-
-Vector3 BasisToEuler(RotOrder mode, const Basis &p_rotation) {
-	switch (mode) {
-		case EulerXYZ:
-			return p_rotation.get_euler(Basis::EULER_ORDER_XYZ);
-
-		case EulerXZY:
-			return p_rotation.get_euler(Basis::EULER_ORDER_XZY);
-
-		case EulerYZX:
-			return p_rotation.get_euler(Basis::EULER_ORDER_YZX);
-
-		case EulerYXZ:
-			return p_rotation.get_euler(Basis::EULER_ORDER_YXZ);
-
-		case EulerZXY:
-			return p_rotation.get_euler(Basis::EULER_ORDER_ZXY);
-
-		case EulerZYX:
-			return p_rotation.get_euler(Basis::EULER_ORDER_ZYX);
-
-		default:
-			// If you land here, Please integrate all rotation orders.
-			FAIL("This is not unreachable.");
-			return Vector3();
-	}
-}
-
-String get_rot_order_name(RotOrder ro) {
+String get_rot_order_name(Basis::EulerOrder ro) {
 	switch (ro) {
-		case EulerXYZ:
+		case Basis::EULER_ORDER_XYZ:
 			return "XYZ";
-		case EulerXZY:
+		case Basis::EULER_ORDER_XZY:
 			return "XZY";
-		case EulerYZX:
+		case Basis::EULER_ORDER_YZX:
 			return "YZX";
-		case EulerYXZ:
+		case Basis::EULER_ORDER_YXZ:
 			return "YXZ";
-		case EulerZXY:
+		case Basis::EULER_ORDER_ZXY:
 			return "ZXY";
-		case EulerZYX:
+		case Basis::EULER_ORDER_ZYX:
 			return "ZYX";
 		default:
 			return "[Not supported]";
 	}
 }
 
-void test_rotation(Vector3 deg_original_euler, RotOrder rot_order) {
+void test_rotation(Vector3 deg_original_euler, Basis::EulerOrder rot_order) {
 	// This test:
 	// 1. Converts the rotation vector from deg to rad.
 	// 2. Converts euler to basis.
@@ -156,11 +85,11 @@ void test_rotation(Vector3 deg_original_euler, RotOrder rot_order) {
 
 	// Euler to rotation
 	const Vector3 original_euler = deg_to_rad(deg_original_euler);
-	const Basis to_rotation = EulerToBasis(rot_order, original_euler);
+	const Basis to_rotation = Basis::from_euler(original_euler, rot_order);
 
 	// Euler from rotation
-	const Vector3 euler_from_rotation = BasisToEuler(rot_order, to_rotation);
-	const Basis rotation_from_computed_euler = EulerToBasis(rot_order, euler_from_rotation);
+	const Vector3 euler_from_rotation = to_rotation.get_euler(rot_order);
+	const Basis rotation_from_computed_euler = Basis::from_euler(euler_from_rotation, rot_order);
 
 	Basis res = to_rotation.inverse() * rotation_from_computed_euler;
 
@@ -184,13 +113,13 @@ void test_rotation(Vector3 deg_original_euler, RotOrder rot_order) {
 }
 
 TEST_CASE("[Basis] Euler conversions") {
-	Vector<RotOrder> rotorder_to_test;
-	rotorder_to_test.push_back(EulerXYZ);
-	rotorder_to_test.push_back(EulerXZY);
-	rotorder_to_test.push_back(EulerYZX);
-	rotorder_to_test.push_back(EulerYXZ);
-	rotorder_to_test.push_back(EulerZXY);
-	rotorder_to_test.push_back(EulerZYX);
+	Vector<Basis::EulerOrder> euler_order_to_test;
+	euler_order_to_test.push_back(Basis::EULER_ORDER_XYZ);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_XZY);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_YZX);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_YXZ);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_ZXY);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_ZYX);
 
 	Vector<Vector3> vectors_to_test;
 
@@ -248,21 +177,21 @@ TEST_CASE("[Basis] Euler conversions") {
 	vectors_to_test.push_back(Vector3(120.0, 150.0, -130.0));
 	vectors_to_test.push_back(Vector3(120.0, 150.0, 130.0));
 
-	for (int h = 0; h < rotorder_to_test.size(); h += 1) {
+	for (int h = 0; h < euler_order_to_test.size(); h += 1) {
 		for (int i = 0; i < vectors_to_test.size(); i += 1) {
-			test_rotation(vectors_to_test[i], rotorder_to_test[h]);
+			test_rotation(vectors_to_test[i], euler_order_to_test[h]);
 		}
 	}
 }
 
 TEST_CASE("[Stress][Basis] Euler conversions") {
-	Vector<RotOrder> rotorder_to_test;
-	rotorder_to_test.push_back(EulerXYZ);
-	rotorder_to_test.push_back(EulerXZY);
-	rotorder_to_test.push_back(EulerYZX);
-	rotorder_to_test.push_back(EulerYXZ);
-	rotorder_to_test.push_back(EulerZXY);
-	rotorder_to_test.push_back(EulerZYX);
+	Vector<Basis::EulerOrder> euler_order_to_test;
+	euler_order_to_test.push_back(Basis::EULER_ORDER_XYZ);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_XZY);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_YZX);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_YXZ);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_ZXY);
+	euler_order_to_test.push_back(Basis::EULER_ORDER_ZYX);
 
 	Vector<Vector3> vectors_to_test;
 	// Add 1000 random vectors with weirds numbers.
@@ -274,9 +203,9 @@ TEST_CASE("[Stress][Basis] Euler conversions") {
 				rng.randf_range(-1800, 1800)));
 	}
 
-	for (int h = 0; h < rotorder_to_test.size(); h += 1) {
+	for (int h = 0; h < euler_order_to_test.size(); h += 1) {
 		for (int i = 0; i < vectors_to_test.size(); i += 1) {
-			test_rotation(vectors_to_test[i], rotorder_to_test[h]);
+			test_rotation(vectors_to_test[i], euler_order_to_test[h]);
 		}
 	}
 }


### PR DESCRIPTION
This PR simplifies the test code in `test_basis.h` so that it doesn't have a duplicate enum for the Euler rotation order.