### PR TITLE
Clean up Basis from Euler code

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1930,7 +1930,7 @@ static void _register_variant_builtin_methods() {
 	bind_methodv(Basis, rotated, static_cast<Basis (Basis::*)(const Vector3 &, real_t) const>(&Basis::rotated), sarray("axis", "angle"), varray());
 	bind_method(Basis, scaled, sarray("scale"), varray());
 	bind_method(Basis, get_scale, sarray(), varray());
-	bind_method(Basis, get_euler, sarray("order"), varray(Basis::EULER_ORDER_YXZ));
+	bind_method(Basis, get_euler, sarray("order"), varray((int64_t)Basis::EULER_ORDER_YXZ));
 	bind_method(Basis, tdotx, sarray("with"), varray());
 	bind_method(Basis, tdoty, sarray("with"), varray());
 	bind_method(Basis, tdotz, sarray("with"), varray());
@@ -1940,7 +1940,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Basis, get_rotation_quaternion, sarray(), varray());
 	bind_static_method(Basis, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
 	bind_static_method(Basis, from_scale, sarray("scale"), varray());
-	bind_static_method(Basis, from_euler, sarray("euler", "order"), varray(Basis::EULER_ORDER_YXZ));
+	bind_static_method(Basis, from_euler, sarray("euler", "order"), varray((int64_t)Basis::EULER_ORDER_YXZ));
 
 	/* AABB */
 

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -826,7 +826,7 @@ VARIANT_ACCESSOR_NUMBER(Projection::Planes)
 template <>
 struct VariantInternalAccessor<Basis::EulerOrder> {
 	static _FORCE_INLINE_ Basis::EulerOrder get(const Variant *v) { return Basis::EulerOrder(*VariantInternal::get_int(v)); }
-	static _FORCE_INLINE_ void set(Variant *v, Basis::EulerOrder p_value) { *VariantInternal::get_int(v) = p_value; }
+	static _FORCE_INLINE_ void set(Variant *v, Basis::EulerOrder p_value) { *VariantInternal::get_int(v) = (int64_t)p_value; }
 };
 
 template <>

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -70,7 +70,7 @@
 			<param index="0" name="euler" type="Vector3" />
 			<param index="1" name="order" type="int" default="2" />
 			<description>
-				Creates a [Basis] from the given [Vector3] representing Euler angles. [param order] determines in what order rotation components are applied. Defaults to [constant EULER_ORDER_YXZ].
+				Constructs a pure rotation Basis matrix from Euler angles in the specified Euler rotation order. By default, use YXZ order (most common).
 			</description>
 		</method>
 		<method name="from_scale" qualifiers="static">

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -474,7 +474,7 @@ Transform3D ResourceImporterScene::get_collision_shapes_transform(const M &p_opt
 		}
 
 		if (p_options.has(SNAME("primitive/rotation"))) {
-			transform.basis.set_euler((p_options[SNAME("primitive/rotation")].operator Vector3() / 180.0) * Math_PI);
+			transform.basis = Basis::from_euler(p_options[SNAME("primitive/rotation")].operator Vector3() * (Math_PI / 180.0));
 		}
 	}
 	return transform;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2986,7 +2986,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 				Transform3D xform;
 				if (orthogonal) {
 					xform = sp->get_global_transform();
-					xform.basis.set_euler(camera_transform.basis.get_euler());
+					xform.basis = Basis::from_euler(camera_transform.basis.get_euler());
 				} else {
 					xform = camera_transform;
 					xform.scale_basis(sp->get_scale());
@@ -7615,7 +7615,7 @@ void Node3DEditor::_preview_settings_changed() {
 
 	{ // preview sun
 		Transform3D t;
-		t.basis = Basis(Vector3(sun_rotation.x, sun_rotation.y, 0));
+		t.basis = Basis::from_euler(Vector3(sun_rotation.x, sun_rotation.y, 0));
 		preview_sun->set_transform(t);
 		sun_direction->queue_redraw();
 		preview_sun->set_param(Light3D::PARAM_ENERGY, sun_energy->get_value());

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -253,9 +253,7 @@ Vector3 Node3D::get_global_rotation() const {
 
 void Node3D::set_global_rotation(const Vector3 &p_euler_rad) {
 	Transform3D transform = get_global_transform();
-	Basis new_basis = transform.get_basis();
-	new_basis.set_euler(p_euler_rad);
-	transform.set_basis(new_basis);
+	transform.basis = Basis::from_euler(p_euler_rad);
 	set_global_transform(transform);
 }
 

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -78,7 +78,7 @@ float Environment::get_sky_custom_fov() const {
 
 void Environment::set_sky_rotation(const Vector3 &p_rotation) {
 	bg_sky_rotation = p_rotation;
-	RS::get_singleton()->environment_set_sky_orientation(environment, Basis(p_rotation));
+	RS::get_singleton()->environment_set_sky_orientation(environment, Basis::from_euler(p_rotation));
 }
 
 Vector3 Environment::get_sky_rotation() const {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1620,7 +1620,7 @@ void RendererCanvasRenderRD::light_update_shadow(RID p_rid, int p_shadow_index, 
 			projection.set_frustum(xmin, xmax, ymin, ymax, nearp, farp);
 		}
 
-		Vector3 cam_target = Basis(Vector3(0, 0, Math_TAU * ((i + 3) / 4.0))).xform(Vector3(0, 1, 0));
+		Vector3 cam_target = Basis::from_euler(Vector3(0, 0, Math_TAU * ((i + 3) / 4.0))).xform(Vector3(0, 1, 0));
 		projection = projection * Projection(Transform3D().looking_at(cam_target, Vector3(0, 0, -1)).affine_inverse());
 
 		ShadowRenderPushConstant push_constant;

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -170,8 +170,7 @@ void test_rotation(Vector3 deg_original_euler, RotOrder rot_order) {
 
 	// Double check `to_rotation` decomposing with XYZ rotation order.
 	const Vector3 euler_xyz_from_rotation = to_rotation.get_euler(Basis::EULER_ORDER_XYZ);
-	Basis rotation_from_xyz_computed_euler;
-	rotation_from_xyz_computed_euler.set_euler(euler_xyz_from_rotation, Basis::EULER_ORDER_XYZ);
+	Basis rotation_from_xyz_computed_euler = Basis::from_euler(euler_xyz_from_rotation, Basis::EULER_ORDER_XYZ);
 
 	res = to_rotation.inverse() * rotation_from_xyz_computed_euler;
 

--- a/tests/core/math/test_quaternion.h
+++ b/tests/core/math/test_quaternion.h
@@ -192,7 +192,7 @@ TEST_CASE("[Quaternion] Construct Basis Euler") {
 	double roll = Math::deg_to_rad(10.0);
 	Vector3 euler_yxz(pitch, yaw, roll);
 	Quaternion q_yxz(euler_yxz);
-	Basis basis_axes(euler_yxz);
+	Basis basis_axes = Basis::from_euler(euler_yxz);
 	Quaternion q(basis_axes);
 	CHECK(q.is_equal_approx(q_yxz));
 }
@@ -218,7 +218,7 @@ TEST_CASE("[Quaternion] Construct Basis Axes") {
 	// This is by design, but may be subject to change.
 	// Workaround by constructing Basis from Euler angles.
 	// basis_axes = Basis(i_unit, j_unit, k_unit);
-	Basis basis_axes(euler_yxz);
+	Basis basis_axes = Basis::from_euler(euler_yxz);
 	Quaternion q(basis_axes);
 
 	CHECK(basis_axes.get_column(0).is_equal_approx(i_unit));
@@ -334,7 +334,7 @@ TEST_CASE("[Quaternion] xform unit vectors") {
 TEST_CASE("[Quaternion] xform vector") {
 	// Arbitrary quaternion rotates an arbitrary vector.
 	Vector3 euler_yzx(Math::deg_to_rad(31.41), Math::deg_to_rad(-49.16), Math::deg_to_rad(12.34));
-	Basis basis_axes(euler_yzx);
+	Basis basis_axes = Basis::from_euler(euler_yzx);
 	Quaternion q(basis_axes);
 
 	Vector3 v_arb(3.0, 4.0, 5.0);
@@ -347,7 +347,7 @@ TEST_CASE("[Quaternion] xform vector") {
 
 // Test vector xform for a single combination of Quaternion and Vector.
 void test_quat_vec_rotate(Vector3 euler_yzx, Vector3 v_in) {
-	Basis basis_axes(euler_yzx);
+	Basis basis_axes = Basis::from_euler(euler_yzx);
 	Quaternion q(basis_axes);
 
 	Vector3 v_rot = q.xform(v_in);


### PR DESCRIPTION
* Fix Basis being created from Euler angles via the constructor. The Euler constructor was removed in #54084, but there were still a few places using it. What's actually going on is that it was being auto-converted to Quaternion and then that was used to construct Basis (meaning, it was Euler -> Quaternion -> Basis instead of Euler -> Basis), which is less performant and less precise.
* Use `from_euler` instead of `set_euler` when relevant to make it clear that this method erases the existing Basis. This also fixes an issue (not sure if I'd call it a bug per se) in `Node3D::set_global_rotation` where it was running `transform.get_basis()` and then this value was never used.
* Group together scalar math in `resource_importer_scene.h` for increased performance, precision, and readability.
* Use explicit casts from `EulerOrder` to `int64_t` instead of implicit ones.
* Document `Basis.from_euler`.