### PR TITLE
Fix Shader Editor not marking files saved

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -264,6 +264,9 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 			} else {
 				EditorNode::get_singleton()->save_resource(edited_shaders[index].shader_inc);
 			}
+			if (edited_shaders[index].shader_editor) {
+				edited_shaders[index].shader_editor->tag_saved_version();
+			}
 		} break;
 		case FILE_SAVE_AS: {
 			int index = shader_tabs->get_current_tab();
@@ -281,6 +284,9 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 					path = "";
 				}
 				EditorNode::get_singleton()->save_resource_as(edited_shaders[index].shader_inc, path);
+			}
+			if (edited_shaders[index].shader_editor) {
+				edited_shaders[index].shader_editor->tag_saved_version();
 			}
 		} break;
 		case FILE_INSPECT: {

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -917,6 +917,10 @@ bool TextShaderEditor::is_unsaved() const {
 	return shader_editor->get_text_editor()->get_saved_version() != shader_editor->get_text_editor()->get_version();
 }
 
+void TextShaderEditor::tag_saved_version() {
+	shader_editor->get_text_editor()->tag_saved_version();
+}
+
 void TextShaderEditor::apply_shaders() {
 	String editor_code = shader_editor->get_text_editor()->get_text();
 	if (shader.is_valid()) {

--- a/editor/plugins/text_shader_editor.h
+++ b/editor/plugins/text_shader_editor.h
@@ -190,6 +190,7 @@ public:
 	void save_external_data(const String &p_str = "");
 	void validate_script();
 	bool is_unsaved() const;
+	void tag_saved_version();
 
 	virtual Size2 get_minimum_size() const override { return Size2(0, 200); }
 


### PR DESCRIPTION
Closes #66165

Saving is currently done through `EditorNode`, which doesn't know enough to tag the text editor item as saved. This exposes save tagging from the `ShaderTextEditor` and calls it explicitly after calling save.

Another option would be to use `save_external_data()` for the dropdown, but it lacks the more robust handling in `EditorNode` and might be less suitable for this case.