### PR TITLE
Fix Unshaded CanvasItem for Vulkan

### DIFF
--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -597,7 +597,7 @@ void main() {
 
 #ifdef MODE_LIGHT_ONLY
 	color = vec4(0.0);
-#else
+#elif !defined(MODE_UNSHADED)
 	color *= canvas_data.canvas_modulation;
 #endif
 


### PR DESCRIPTION
This pull request aims to address #60250 by skipping canvas modulation in case `MODE_UNSHADED` is set.

## Before this change
![163473354-ea32a64e-afe4-4d13-879d-75b7b21a0d43](https://user-images.githubusercontent.com/822035/192140740-2ef21e11-1f16-4875-b89b-20c0b1b0c2be.png)

## After this change

![fixed](https://user-images.githubusercontent.com/822035/192140747-4a3df995-c5df-4ea5-94df-733f87b2ab14.JPG)

*Bugsquad edit:*
- Fixes #60250 