### PR TITLE
Fix out of sync when the script is edited externally via lsp

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2544,7 +2544,7 @@ void ScriptEditor::apply_scripts() const {
 	}
 }
 
-void ScriptEditor::reload_scripts() {
+void ScriptEditor::reload_scripts(bool p_refresh_only) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (!se) {
@@ -2557,30 +2557,33 @@ void ScriptEditor::reload_scripts() {
 			continue; //internal script, who cares
 		}
 
-		uint64_t last_date = edited_res->get_last_modified_time();
-		uint64_t date = FileAccess::get_modified_time(edited_res->get_path());
+		if (!p_refresh_only) {
+			uint64_t last_date = edited_res->get_last_modified_time();
+			uint64_t date = FileAccess::get_modified_time(edited_res->get_path());
 
-		if (last_date == date) {
-			continue;
+			if (last_date == date) {
+				continue;
+			}
+
+			Ref<Script> script = edited_res;
+			if (script != nullptr) {
+				Ref<Script> rel_script = ResourceLoader::load(script->get_path(), script->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
+				ERR_CONTINUE(!rel_script.is_valid());
+				script->set_source_code(rel_script->get_source_code());
+				script->set_last_modified_time(rel_script->get_last_modified_time());
+				script->reload(true);
+			}
+
+			Ref<TextFile> text_file = edited_res;
+			if (text_file != nullptr) {
+				Error err;
+				Ref<TextFile> rel_text_file = _load_text_file(text_file->get_path(), &err);
+				ERR_CONTINUE(!rel_text_file.is_valid());
+				text_file->set_text(rel_text_file->get_text());
+				text_file->set_last_modified_time(rel_text_file->get_last_modified_time());
+			}
 		}
 
-		Ref<Script> script = edited_res;
-		if (script != nullptr) {
-			Ref<Script> rel_script = ResourceLoader::load(script->get_path(), script->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-			ERR_CONTINUE(!rel_script.is_valid());
-			script->set_source_code(rel_script->get_source_code());
-			script->set_last_modified_time(rel_script->get_last_modified_time());
-			script->reload(true);
-		}
-
-		Ref<TextFile> text_file = edited_res;
-		if (text_file != nullptr) {
-			Error err;
-			Ref<TextFile> rel_text_file = _load_text_file(text_file->get_path(), &err);
-			ERR_CONTINUE(!rel_text_file.is_valid());
-			text_file->set_text(rel_text_file->get_text());
-			text_file->set_last_modified_time(rel_text_file->get_last_modified_time());
-		}
 		se->reload_text();
 	}
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -477,7 +477,7 @@ public:
 	bool toggle_scripts_panel();
 	bool is_scripts_panel_toggled();
 	void apply_scripts() const;
-	void reload_scripts();
+	void reload_scripts(bool p_refresh_only = false);
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);
 	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "");
 	Ref<Resource> open_file(const String &p_file);

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -422,6 +422,7 @@ void GDScriptTextDocument::sync_script_content(const String &p_path, const Strin
 	if (error == OK) {
 		if (script->load_source_code(path) == OK) {
 			script->reload(true);
+			ScriptEditor::get_singleton()->reload_scripts(true); // Refresh scripts opened in the internal editor.
 		}
 	}
 }


### PR DESCRIPTION
Previously, external editing via lsp would modify the modified time of the script, which caused the internal display of the script to not be refreshed when refocusing the engine.

Now saving the script externally via lsp will automatically refresh the internal display.

This is an addition to #63224, the external editing of **GDScript** can be roughly divided into two cases:

1. External editing without LSP (fixed by #63224);
2. External editing via LSP connection (fixed by this PR).



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
