### PR TITLE
Move self-contained editor in project folder check to export code

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -966,6 +966,13 @@ void EditorNode::_fs_changed() {
 	String export_error;
 	Error err = OK;
 	if (!export_defer.preset.is_empty() && !EditorFileSystem::get_singleton()->is_scanning()) {
+		if (EditorPaths::get_singleton()->is_self_contained()) {
+			if (ProjectSettings::get_singleton()->get_resource_path() == OS::get_singleton()->get_executable_path().get_base_dir()) {
+				ERR_PRINT("You are trying to export from a self-contained editor at the same location as the project. This is not allowed, since editor settings and other files would be in the export.");
+				_exit_editor(EXIT_FAILURE);
+				return;
+			}
+		}
 		String preset_name = export_defer.preset;
 		// Ensures export_project does not loop infinitely, because notifications may
 		// come during the export.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1936,13 +1936,6 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 #ifdef TOOLS_ENABLED
 	if (editor || project_manager || cmdline_tool) {
 		EditorPaths::create();
-		if (found_project && EditorPaths::get_singleton()->is_self_contained()) {
-			if (ProjectSettings::get_singleton()->get_resource_path() == OS::get_singleton()->get_executable_path().get_base_dir()) {
-				ERR_PRINT("You are trying to run a self-contained editor at the same location as a project. This is not allowed, since editor files will mix with project files.");
-				OS::get_singleton()->set_exit_code(EXIT_FAILURE);
-				return FAILED;
-			}
-		}
 	}
 #endif
 


### PR DESCRIPTION
This PR undoes the modifications to #66200 such that the behavior is the same as it was when I first opened the PR.

Should fix #66408.