### PR TITLE
[TextServer] Always prefer main font over fallbacks, regardless of script/language support.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -5430,7 +5430,10 @@ bool TextServerAdvanced::shaped_text_shape(const RID &p_shaped) {
 							Array fonts_scr_only;
 							Array fonts_no_match;
 							int font_count = span.fonts.size();
-							for (int l = 0; l < font_count; l++) {
+							if (font_count > 0) {
+								fonts.push_back(sd->spans[k].fonts[0]);
+							}
+							for (int l = 1; l < font_count; l++) {
 								if (font_is_script_supported(span.fonts[l], script)) {
 									if (font_is_language_supported(span.fonts[l], span.language)) {
 										fonts.push_back(sd->spans[k].fonts[l]);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -2844,7 +2844,10 @@ bool TextServerFallback::shaped_text_add_string(const RID &p_shaped, const Strin
 	// Pre-sort fonts, push fonts with the language support first.
 	Array fonts_no_match;
 	int font_count = p_fonts.size();
-	for (int i = 0; i < font_count; i++) {
+	if (font_count > 0) {
+		span.fonts.push_back(p_fonts[0]);
+	}
+	for (int i = 1; i < font_count; i++) {
 		if (font_is_language_supported(p_fonts[i], p_language)) {
 			span.fonts.push_back(p_fonts[i]);
 		} else {


### PR DESCRIPTION
Fixes #66019

<img width="199" alt="Screenshot 2022-09-25 at 23 02 41" src="https://user-images.githubusercontent.com/7645683/192164733-4f05833e-33ea-4a86-ae4f-49671ee08309.png">

A bit less efficient, but ensures consistent punctuation when fallback font includes punctuation as well, like in case of editor fonts, CJK font have punctuation and is from a different font family (Droid Sans vs Noto Sans).