### PR TITLE
Make dependencies with shader includes in subfolders

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/SCsub
@@ -4,7 +4,7 @@ Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:
     # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
+    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
 
     # find all shader code(all glsl files excluding our include files)
     glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]

--- a/servers/rendering/renderer_rd/shaders/environment/SCsub
+++ b/servers/rendering/renderer_rd/shaders/environment/SCsub
@@ -4,7 +4,7 @@ Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:
     # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
+    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
 
     # find all shader code(all glsl files excluding our include files)
     glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
@@ -4,7 +4,7 @@ Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:
     # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
+    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
 
     # find all shader code(all glsl files excluding our include files)
     glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
@@ -4,7 +4,7 @@ Import("env")
 
 if "RD_GLSL" in env["BUILDERS"]:
     # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
+    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
 
     # find all shader code(all glsl files excluding our include files)
     glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]


### PR DESCRIPTION
Now that we've moved a number of shaders into subfolders to better be able to find things, we need to make sure that the shaders are recompiled when include files in the shader root folder are changed.

This PR adds additional dependency checks for this.