### PR TITLE
Fix project run/stop buttons disappearing in the editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6957,6 +6957,8 @@ EditorNode::EditorNode() {
 	play_custom_scene_button->connect("pressed", callable_mp(this, &EditorNode::_menu_option).bind(RUN_PLAY_CUSTOM_SCENE));
 	play_custom_scene_button->set_tooltip_text(TTR("Run a specific scene."));
 
+	_reset_play_buttons();
+
 	ED_SHORTCUT_AND_COMMAND("editor/run_specific_scene", TTR("Run Specific Scene"), KeyModifierMask::META | KeyModifierMask::SHIFT | Key::F5);
 	ED_SHORTCUT_OVERRIDE("editor/run_specific_scene", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::R);
 	play_custom_scene_button->set_shortcut(ED_GET_SHORTCUT("editor/run_specific_scene"));

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -260,7 +260,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 
 	// Pass the debugger stop shortcut to the running instance(s).
 	String shortcut;
-	VariantWriter::write_to_string(ED_GET_SHORTCUT("editor/stop"), shortcut);
+	VariantWriter::write_to_string(ED_GET_SHORTCUT("editor/stop_running_project"), shortcut);
 	OS::get_singleton()->set_environment("__GODOT_EDITOR_STOP_SHORTCUT__", shortcut);
 
 	printf("Running: %s", exec.utf8().get_data());


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/66438. Fixes a rebase error from https://github.com/godotengine/godot/pull/64756 :slightly_frowning_face:

This also fixes the part mentioned in #66438:

> Running with the shortcut key prints the following error message.