### PR TITLE
Added option to force agent collision avoidance processing

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -16,6 +16,13 @@
 				Returns the distance to the target location, using the agent's global position. The user must set the target location with [method set_target_location] in order for this to be accurate.
 			</description>
 		</method>
+		<method name="force_process_avoidance">
+			<return type="Vector2" />
+			<param index="0" name="delta" type="float" />
+			<description>
+				Performs collision avoidance immediately for this agent with the provided [param delta]. This function runs slow and should only be used as a last resort to solve specific edge cases. This function will calculate the avoidance with the number of agent's and their positions and velocities from the last regular update.
+			</description>
+		</method>
 		<method name="get_final_location">
 			<return type="Vector2" />
 			<description>

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -16,6 +16,13 @@
 				Returns the distance to the target location, using the agent's global position. The user must set the target location with [method set_target_location] in order for this to be accurate.
 			</description>
 		</method>
+		<method name="force_process_avoidance">
+			<return type="Vector3" />
+			<param index="0" name="delta" type="float" />
+			<description>
+				Performs collision avoidance immediately for this agent with the provided [param delta]. This function runs slow and should only be used as a last resort to solve specific edge cases. This function will calculate the avoidance with the number of agent's and their positions and velocities from the last regular update.
+			</description>
+		</method>
 		<method name="get_final_location">
 			<return type="Vector3" />
 			<description>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -23,6 +23,14 @@
 				Creates the agent.
 			</description>
 		</method>
+		<method name="agent_force_process_avoidance" qualifiers="const">
+			<return type="Vector2" />
+			<param index="0" name="agent" type="RID" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Performs collision avoidance immediately for the specified [param agent] with the provided [param delta]. This function runs slow and should only be used as a last resort to solve specific edge cases. This function will calculate the avoidance with the number of agent's and their positions and velocities from the last regular update.
+			</description>
+		</method>
 		<method name="agent_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="agent" type="RID" />

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -23,6 +23,14 @@
 				Creates the agent.
 			</description>
 		</method>
+		<method name="agent_force_process_avoidance" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="agent" type="RID" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Performs collision avoidance immediately for the specified [param agent] with the provided [param delta]. This function runs slow and should only be used as a last resort to solve specific edge cases. This function will calculate the avoidance with the number of agent's and their positions and velocities from the last regular update.
+			</description>
+		</method>
 		<method name="agent_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="agent" type="RID" />

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -691,6 +691,21 @@ COMMAND_4(agent_set_callback, RID, p_agent, Object *, p_receiver, StringName, p_
 	}
 }
 
+Vector3 GodotNavigationServer::agent_force_process_avoidance(RID p_agent, real_t p_delta) const {
+	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_COND_V(agent == nullptr, Vector3());
+	ERR_FAIL_COND_V(agent->get_map() == nullptr, Vector3());
+
+	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
+	MutexLock lock(mut_this->operations_mutex);
+	agent->get_map()->step_agent(agent, p_delta);
+
+	return Vector3(
+			agent->get_agent()->newVelocity_.x(),
+			agent->get_agent()->newVelocity_.y(),
+			agent->get_agent()->newVelocity_.z());
+}
+
 COMMAND_1(free, RID, p_object) {
 	if (map_owner.owns(p_object)) {
 		NavMap *map = map_owner.get_or_null(p_object);

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -168,6 +168,7 @@ public:
 	COMMAND_2(agent_set_ignore_y, RID, p_agent, bool, p_ignore);
 	virtual bool agent_is_map_changed(RID p_agent) const override;
 	COMMAND_4_DEF(agent_set_callback, RID, p_agent, Object *, p_receiver, StringName, p_method, Variant, p_udata, Variant());
+	virtual Vector3 agent_force_process_avoidance(RID p_agent, real_t p_delta) const override;
 
 	COMMAND_1(free, RID, p_object);
 

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -535,6 +535,11 @@ void NavMap::remove_agent_as_controlled(RvoAgent *agent) {
 	}
 }
 
+void NavMap::step_agent(RvoAgent *agent, real_t p_delta) {
+	agent->get_agent()->computeNeighbors(&rvo);
+	agent->get_agent()->computeNewVelocity(p_delta);
+}
+
 void NavMap::sync() {
 	// Check if we need to update the links.
 	if (regenerate_polygons) {

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -148,6 +148,8 @@ public:
 		return map_update_id;
 	}
 
+	void step_agent(RvoAgent *agent, real_t p_deltatime);
+
 	void sync();
 	void step(real_t p_deltatime);
 	void dispatch_callbacks();

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -85,6 +85,7 @@ void NavigationAgent2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_navigation_finished"), &NavigationAgent2D::is_navigation_finished);
 	ClassDB::bind_method(D_METHOD("get_final_location"), &NavigationAgent2D::get_final_location);
 
+	ClassDB::bind_method(D_METHOD("force_process_avoidance", "delta"), &NavigationAgent2D::force_process_avoidance);
 	ClassDB::bind_method(D_METHOD("_avoidance_done", "new_velocity"), &NavigationAgent2D::_avoidance_done);
 
 	ADD_GROUP("Pathfinding", "");
@@ -366,6 +367,17 @@ void NavigationAgent2D::_avoidance_done(Vector3 p_new_velocity) {
 	velocity_submitted = false;
 
 	emit_signal(SNAME("velocity_computed"), velocity);
+}
+
+Vector2 NavigationAgent2D::force_process_avoidance(real_t p_delta) {
+	if (!velocity_submitted) {
+		ERR_PRINT("Forced avoidance processing failed due to no velocity submitted. Use set_velocity() before calling the avoidance processing.");
+		target_velocity = Vector2();
+		return Vector2();
+	}
+	velocity_submitted = false;
+
+	return NavigationServer2D::get_singleton()->agent_force_process_avoidance(agent, p_delta);
 }
 
 PackedStringArray NavigationAgent2D::get_configuration_warnings() const {

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -155,6 +155,8 @@ public:
 	void set_velocity(Vector2 p_velocity);
 	void _avoidance_done(Vector3 p_new_velocity);
 
+	Vector2 force_process_avoidance(real_t p_delta);
+
 	PackedStringArray get_configuration_warnings() const override;
 
 private:

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -89,6 +89,7 @@ void NavigationAgent3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_navigation_finished"), &NavigationAgent3D::is_navigation_finished);
 	ClassDB::bind_method(D_METHOD("get_final_location"), &NavigationAgent3D::get_final_location);
 
+	ClassDB::bind_method(D_METHOD("force_process_avoidance", "delta"), &NavigationAgent3D::force_process_avoidance);
 	ClassDB::bind_method(D_METHOD("_avoidance_done", "new_velocity"), &NavigationAgent3D::_avoidance_done);
 
 	ADD_GROUP("Pathfinding", "");
@@ -381,6 +382,17 @@ void NavigationAgent3D::_avoidance_done(Vector3 p_new_velocity) {
 	velocity_submitted = false;
 
 	emit_signal(SNAME("velocity_computed"), p_new_velocity);
+}
+
+Vector3 NavigationAgent3D::force_process_avoidance(real_t p_delta) {
+	if (!velocity_submitted) {
+		ERR_PRINT("Forced avoidance processing failed due to no velocity submitted. Use set_velocity() before calling the avoidance processing.");
+		target_velocity = Vector3();
+		return Vector3();
+	}
+	velocity_submitted = false;
+
+	return NavigationServer3D::get_singleton()->agent_force_process_avoidance(agent, p_delta);
 }
 
 PackedStringArray NavigationAgent3D::get_configuration_warnings() const {

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -167,6 +167,8 @@ public:
 	void set_velocity(Vector3 p_velocity);
 	void _avoidance_done(Vector3 p_new_velocity);
 
+	Vector3 force_process_avoidance(real_t p_delta);
+
 	PackedStringArray get_configuration_warnings() const override;
 
 private:

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -290,6 +290,7 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_set_position", "agent", "position"), &NavigationServer2D::agent_set_position);
 	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer2D::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_callback", "agent", "receiver", "method", "userdata"), &NavigationServer2D::agent_set_callback, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("agent_force_process_avoidance", "agent", "delta"), &NavigationServer2D::agent_force_process_avoidance);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer2D::free);
 
@@ -409,6 +410,8 @@ void FORWARD_2_C(agent_set_ignore_y, RID, p_agent, bool, p_ignore, rid_to_rid, b
 bool FORWARD_1_C(agent_is_map_changed, RID, p_agent, rid_to_rid);
 
 void FORWARD_4_C(agent_set_callback, RID, p_agent, Object *, p_receiver, StringName, p_method, Variant, p_udata, rid_to_rid, obj_to_obj, sn_to_sn, var_to_var);
+
+Vector2 FORWARD_2_R_C(v3_to_v2, agent_force_process_avoidance, RID, p_agent, real_t, p_delta, rid_to_rid, real_to_real);
 
 void FORWARD_1_C(free, RID, p_object, rid_to_rid);
 

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -220,6 +220,10 @@ public:
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_callback(RID p_agent, Object *p_receiver, StringName p_method, Variant p_udata = Variant()) const;
 
+	/// Force collision avoidance now.
+	/// When possible it's better to avoid this function.
+	virtual Vector2 agent_force_process_avoidance(RID p_agent, real_t p_delta) const;
+
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const;
 
 	/// Destroy the `RID`

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -110,6 +110,7 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_set_position", "agent", "position"), &NavigationServer3D::agent_set_position);
 	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer3D::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_callback", "agent", "receiver", "method", "userdata"), &NavigationServer3D::agent_set_callback, DEFVAL(Variant()));
+	ClassDB::bind_method(D_METHOD("agent_force_process_avoidance", "agent", "delta"), &NavigationServer3D::agent_force_process_avoidance);
 
 	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer3D::free);
 

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -235,6 +235,10 @@ public:
 	/// Callback called at the end of the RVO process
 	virtual void agent_set_callback(RID p_agent, Object *p_receiver, StringName p_method, Variant p_udata = Variant()) const = 0;
 
+	/// Force collision avoidance now.
+	/// When possible it's better to avoid this function.
+	virtual Vector3 agent_force_process_avoidance(RID p_agent, real_t p_delta) const = 0;
+
 	/// Destroy the `RID`
 	virtual void free(RID p_object) const = 0;
 


### PR DESCRIPTION
Recycles #36962 as shortly discussed with @AndreaCatania on rocketchat to create a new pr instead of fixing the old one.

Adds option to performs collision avoidance immediately for a specified avoidance agent with a provided  delta value. Added for some particular cases when it's not really possible to wait for the computation to happen naturally. This function runs slow and should only be used as a last resort to solve specific edge cases.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
