### PR TITLE
Hide volumetric fog, SSIL and SDFGI on Mobile/Compatibility renderers

### DIFF
--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1097,8 +1097,11 @@ void Environment::_validate_property(PropertyInfo &p_property) const {
 	};
 
 	static const char *high_end_prefixes[] = {
+		"volumetric_fog",
 		"ssr_",
 		"ssao_",
+		"ssil_",
+		"sdfgi_",
 		nullptr
 
 	};


### PR DESCRIPTION
These features are only supported in the Clustered Forward renderer.

See https://github.com/godotengine/godot/issues/55880.