### PR TITLE
Fix DirAccessWindows::make_dir() choking on ".."

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -160,7 +160,7 @@ Error DirAccessWindows::make_dir(String p_dir) {
 		p_dir = current_dir.path_join(p_dir);
 	}
 
-	p_dir = p_dir.replace("/", "\\");
+	p_dir = p_dir.simplify_path().replace("/", "\\");
 
 	bool success;
 	int err;


### PR DESCRIPTION
`CreateDirectoryW()` chokes on absolute paths that contain "`..`". It returns an error 123: "The filename, directory name, or volume label syntax is incorrect."

Example: `C:\\workspace\\..\\games\\assets`

This causes `DirAccessWindows::make_dir()` to fail.
Simplifying the path before creating the dir fixes this.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
