### PR TITLE
Rename PathFollow's offsets to be more explicit

### DIFF
--- a/doc/classes/PathFollow2D.xml
+++ b/doc/classes/PathFollow2D.xml
@@ -15,14 +15,17 @@
 			The points along the [Curve2D] of the [Path2D] are precomputed before use, for faster calculations. The point at the requested offset is then calculated interpolating between two adjacent cached points. This may present a problem if the curve makes sharp turns, as the cached points may not follow the curve closely enough.
 			There are two answers to this problem: either increase the number of cached points and increase memory consumption, or make a cubic interpolation between two points at the cost of (slightly) slower calculations.
 		</member>
-		<member name="h_offset" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">
-			The node's offset along the curve.
-		</member>
 		<member name="lookahead" type="float" setter="set_lookahead" getter="get_lookahead" default="4.0">
 			How far to look ahead of the curve to calculate the tangent if the node is rotating. E.g. shorter lookaheads will lead to faster rotations.
 		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="true">
 			If [code]true[/code], any offset outside the path's length will wrap around, instead of stopping at the ends. Use it for cyclic paths.
+		</member>
+		<member name="offset_parallel" type="float" setter="set_offset_parallel" getter="get_offset_parallel" default="0.0">
+			The node's offset along the curve.
+		</member>
+		<member name="offset_perpendicular" type="float" setter="set_offset_perpendicular" getter="get_offset_perpendicular" default="0.0">
+			The node's offset perpendicular to the curve.
 		</member>
 		<member name="progress" type="float" setter="set_progress" getter="get_progress" default="0.0">
 			The distance along the path, in pixels. Changing this value sets this node's position to a point within the path.
@@ -32,9 +35,6 @@
 		</member>
 		<member name="rotates" type="bool" setter="set_rotates" getter="is_rotating" default="true">
 			If [code]true[/code], this node rotates to follow the path, with the +X direction facing forward on the path.
-		</member>
-		<member name="v_offset" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
-			The node's offset perpendicular to the curve.
 		</member>
 	</members>
 </class>

--- a/doc/classes/PathFollow3D.xml
+++ b/doc/classes/PathFollow3D.xml
@@ -15,11 +15,17 @@
 			The points along the [Curve3D] of the [Path3D] are precomputed before use, for faster calculations. The point at the requested offset is then calculated interpolating between two adjacent cached points. This may present a problem if the curve makes sharp turns, as the cached points may not follow the curve closely enough.
 			There are two answers to this problem: either increase the number of cached points and increase memory consumption, or make a cubic interpolation between two points at the cost of (slightly) slower calculations.
 		</member>
-		<member name="h_offset" type="float" setter="set_h_offset" getter="get_h_offset" default="0.0">
-			The node's offset along the curve.
-		</member>
 		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="true">
 			If [code]true[/code], any offset outside the path's length will wrap around, instead of stopping at the ends. Use it for cyclic paths.
+		</member>
+		<member name="offset_forward" type="float" setter="set_offset_forward" getter="get_offset_forward" default="0.0">
+			The node's offset along the curve.
+		</member>
+		<member name="offset_perpendicular" type="float" setter="set_offset_perpendicular" getter="get_offset_perpendicular" default="0.0">
+			The node's offset perpendicular to the curve.
+		</member>
+		<member name="offset_side" type="float" setter="set_offset_side" getter="get_offset_side" default="0.0">
+			The node's offset to the sides of the curve.
 		</member>
 		<member name="progress" type="float" setter="set_progress" getter="get_progress" default="0.0">
 			The distance from the first vertex, measured in 3D units along the path. Changing this value sets this node's position to a point within the path.
@@ -29,9 +35,6 @@
 		</member>
 		<member name="rotation_mode" type="int" setter="set_rotation_mode" getter="get_rotation_mode" enum="PathFollow3D.RotationMode" default="3">
 			Allows or forbids rotation on one or more axes, depending on the [enum RotationMode] constants being used.
-		</member>
-		<member name="v_offset" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
-			The node's offset perpendicular to the curve.
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -209,14 +209,14 @@ void PathFollow2D::_update_transform() {
 
 		Vector2 normal_of_curve = -tangent_to_curve.orthogonal();
 
-		pos += tangent_to_curve * h_offset;
-		pos += normal_of_curve * v_offset;
+		pos += tangent_to_curve * offset_parallel;
+		pos += normal_of_curve * offset_perpendicular;
 
 		set_rotation(tangent_to_curve.angle());
 
 	} else {
-		pos.x += h_offset;
-		pos.y += v_offset;
+		pos.x += offset_parallel;
+		pos.y += offset_perpendicular;
 	}
 
 	set_position(pos);
@@ -272,11 +272,11 @@ void PathFollow2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_progress", "progress"), &PathFollow2D::set_progress);
 	ClassDB::bind_method(D_METHOD("get_progress"), &PathFollow2D::get_progress);
 
-	ClassDB::bind_method(D_METHOD("set_h_offset", "h_offset"), &PathFollow2D::set_h_offset);
-	ClassDB::bind_method(D_METHOD("get_h_offset"), &PathFollow2D::get_h_offset);
+	ClassDB::bind_method(D_METHOD("set_offset_parallel", "offset"), &PathFollow2D::set_offset_parallel);
+	ClassDB::bind_method(D_METHOD("get_offset_parallel"), &PathFollow2D::get_offset_parallel);
 
-	ClassDB::bind_method(D_METHOD("set_v_offset", "v_offset"), &PathFollow2D::set_v_offset);
-	ClassDB::bind_method(D_METHOD("get_v_offset"), &PathFollow2D::get_v_offset);
+	ClassDB::bind_method(D_METHOD("set_offset_perpendicular", "offset"), &PathFollow2D::set_offset_perpendicular);
+	ClassDB::bind_method(D_METHOD("get_offset_perpendicular"), &PathFollow2D::get_offset_perpendicular);
 
 	ClassDB::bind_method(D_METHOD("set_progress_ratio", "ratio"), &PathFollow2D::set_progress_ratio);
 	ClassDB::bind_method(D_METHOD("get_progress_ratio"), &PathFollow2D::get_progress_ratio);
@@ -295,8 +295,11 @@ void PathFollow2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress", PROPERTY_HINT_RANGE, "0,10000,0.01,or_less,or_greater,suffix:px"), "set_progress", "get_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001,or_less,or_greater", PROPERTY_USAGE_EDITOR), "set_progress_ratio", "get_progress_ratio");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "h_offset"), "set_h_offset", "get_h_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_offset"), "set_v_offset", "get_v_offset");
+
+	ADD_GROUP("Offset", "offset_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "offset_parallel"), "set_offset_parallel", "get_offset_parallel");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "offset_perpendicular"), "set_offset_perpendicular", "get_offset_perpendicular");
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rotates"), "set_rotates", "is_rotating");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cubic_interp"), "set_cubic_interpolation", "get_cubic_interpolation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
@@ -324,26 +327,26 @@ void PathFollow2D::set_progress(real_t p_progress) {
 	}
 }
 
-void PathFollow2D::set_h_offset(real_t p_h_offset) {
-	h_offset = p_h_offset;
+void PathFollow2D::set_offset_parallel(real_t p_offset) {
+	offset_parallel = p_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-real_t PathFollow2D::get_h_offset() const {
-	return h_offset;
+real_t PathFollow2D::get_offset_parallel() const {
+	return offset_parallel;
 }
 
-void PathFollow2D::set_v_offset(real_t p_v_offset) {
-	v_offset = p_v_offset;
+void PathFollow2D::set_offset_perpendicular(real_t p_offset) {
+	offset_perpendicular = p_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-real_t PathFollow2D::get_v_offset() const {
-	return v_offset;
+real_t PathFollow2D::get_offset_perpendicular() const {
+	return offset_perpendicular;
 }
 
 real_t PathFollow2D::get_progress() const {

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -66,8 +66,8 @@ public:
 private:
 	Path2D *path = nullptr;
 	real_t progress = 0.0;
-	real_t h_offset = 0.0;
-	real_t v_offset = 0.0;
+	real_t offset_parallel = 0.0;
+	real_t offset_perpendicular = 0.0;
 	real_t lookahead = 4.0;
 	bool cubic = true;
 	bool loop = true;
@@ -85,11 +85,11 @@ public:
 	void set_progress(real_t p_progress);
 	real_t get_progress() const;
 
-	void set_h_offset(real_t p_h_offset);
-	real_t get_h_offset() const;
+	void set_offset_parallel(real_t p_offset);
+	real_t get_offset_parallel() const;
 
-	void set_v_offset(real_t p_v_offset);
-	real_t get_v_offset() const;
+	void set_offset_perpendicular(real_t p_offset);
+	real_t get_offset_perpendicular() const;
 
 	void set_progress_ratio(real_t p_ratio);
 	real_t get_progress_ratio() const;

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -239,7 +239,7 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 		t.basis.set_columns(sideways, up, forward);
 		t.basis.scale_local(scale);
 
-		t.origin = pos + sideways * h_offset + up * v_offset;
+		t.origin = pos + sideways * offset_side + up * offset_perpendicular;
 	} else if (rotation_mode != ROTATION_NONE) {
 		// perform parallel transport
 		//
@@ -296,9 +296,9 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 			}
 		}
 
-		t.translate_local(Vector3(h_offset, v_offset, 0));
+		t.translate_local(Vector3(offset_side, offset_perpendicular, offset_forward));
 	} else {
-		t.origin = pos + Vector3(h_offset, v_offset, 0);
+		t.origin = pos + Vector3(offset_side, offset_perpendicular, offset_forward);
 	}
 
 	set_transform(t);
@@ -362,11 +362,14 @@ void PathFollow3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_progress", "progress"), &PathFollow3D::set_progress);
 	ClassDB::bind_method(D_METHOD("get_progress"), &PathFollow3D::get_progress);
 
-	ClassDB::bind_method(D_METHOD("set_h_offset", "h_offset"), &PathFollow3D::set_h_offset);
-	ClassDB::bind_method(D_METHOD("get_h_offset"), &PathFollow3D::get_h_offset);
+	ClassDB::bind_method(D_METHOD("set_offset_side", "offset"), &PathFollow3D::set_offset_side);
+	ClassDB::bind_method(D_METHOD("get_offset_side"), &PathFollow3D::get_offset_side);
 
-	ClassDB::bind_method(D_METHOD("set_v_offset", "v_offset"), &PathFollow3D::set_v_offset);
-	ClassDB::bind_method(D_METHOD("get_v_offset"), &PathFollow3D::get_v_offset);
+	ClassDB::bind_method(D_METHOD("set_offset_perpendicular", "offset"), &PathFollow3D::set_offset_perpendicular);
+	ClassDB::bind_method(D_METHOD("get_offset_perpendicular"), &PathFollow3D::get_offset_perpendicular);
+
+	ClassDB::bind_method(D_METHOD("set_offset_forward", "offset"), &PathFollow3D::set_offset_forward);
+	ClassDB::bind_method(D_METHOD("get_offset_forward"), &PathFollow3D::get_offset_forward);
 
 	ClassDB::bind_method(D_METHOD("set_progress_ratio", "ratio"), &PathFollow3D::set_progress_ratio);
 	ClassDB::bind_method(D_METHOD("get_progress_ratio"), &PathFollow3D::get_progress_ratio);
@@ -382,8 +385,12 @@ void PathFollow3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress", PROPERTY_HINT_RANGE, "0,10000,0.01,or_less,or_greater,suffix:m"), "set_progress", "get_progress");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "progress_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001,or_less,or_greater", PROPERTY_USAGE_EDITOR), "set_progress_ratio", "get_progress_ratio");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "h_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_h_offset", "get_h_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_v_offset", "get_v_offset");
+
+	ADD_GROUP("Offset", "offset_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "offset_side", PROPERTY_HINT_NONE, "suffix:m"), "set_offset_side", "get_offset_side");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "offset_perpendicular", PROPERTY_HINT_NONE, "suffix:m"), "set_offset_perpendicular", "get_offset_perpendicular");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "offset_forward", PROPERTY_HINT_NONE, "suffix:m"), "set_offset_forward", "get_offset_forward");
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rotation_mode", PROPERTY_HINT_ENUM, "None,Y,XY,XYZ,Oriented"), "set_rotation_mode", "get_rotation_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cubic_interp"), "set_cubic_interpolation", "get_cubic_interpolation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
@@ -418,26 +425,37 @@ void PathFollow3D::set_progress(real_t p_progress) {
 	}
 }
 
-void PathFollow3D::set_h_offset(real_t p_h_offset) {
-	h_offset = p_h_offset;
+void PathFollow3D::set_offset_side(real_t p_offset) {
+	offset_side = p_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-real_t PathFollow3D::get_h_offset() const {
-	return h_offset;
+real_t PathFollow3D::get_offset_side() const {
+	return offset_side;
 }
 
-void PathFollow3D::set_v_offset(real_t p_v_offset) {
-	v_offset = p_v_offset;
+void PathFollow3D::set_offset_perpendicular(real_t p_offset) {
+	offset_perpendicular = p_offset;
 	if (path) {
 		_update_transform();
 	}
 }
 
-real_t PathFollow3D::get_v_offset() const {
-	return v_offset;
+real_t PathFollow3D::get_offset_perpendicular() const {
+	return offset_perpendicular;
+}
+
+void PathFollow3D::set_offset_forward(real_t p_offset) {
+	offset_forward = p_offset;
+	if (path) {
+		_update_transform();
+	}
+}
+
+real_t PathFollow3D::get_offset_forward() const {
+	return offset_forward;
 }
 
 real_t PathFollow3D::get_progress() const {

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -76,8 +76,9 @@ private:
 	Path3D *path = nullptr;
 	real_t prev_offset = 0.0; // Offset during the last _update_transform.
 	real_t progress = 0.0;
-	real_t h_offset = 0.0;
-	real_t v_offset = 0.0;
+	real_t offset_side = 0.0;
+	real_t offset_perpendicular = 0.0;
+	real_t offset_forward = 0.0;
 	bool cubic = true;
 	bool loop = true;
 	RotationMode rotation_mode = ROTATION_XYZ;
@@ -94,11 +95,14 @@ public:
 	void set_progress(real_t p_progress);
 	real_t get_progress() const;
 
-	void set_h_offset(real_t p_h_offset);
-	real_t get_h_offset() const;
+	void set_offset_side(real_t p_offset);
+	real_t get_offset_side() const;
 
-	void set_v_offset(real_t p_v_offset);
-	real_t get_v_offset() const;
+	void set_offset_perpendicular(real_t p_offset);
+	real_t get_offset_perpendicular() const;
+
+	void set_offset_forward(real_t p_offset);
+	real_t get_offset_forward() const;
 
 	void set_progress_ratio(real_t p_ratio);
 	real_t get_progress_ratio() const;

--- a/tests/scene/test_path_follow_2d.h
+++ b/tests/scene/test_path_follow_2d.h
@@ -143,7 +143,7 @@ TEST_CASE("[PathFollow2D] Removal of a point in curve") {
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow2D] Setting h_offset and v_offset") {
+TEST_CASE("[PathFollow2D] Setting offset_parallel and offset_perpendicular") {
 	const Ref<Curve2D> &curve = memnew(Curve2D());
 	curve->add_point(Vector2(0, 0));
 	curve->add_point(Vector2(100, 0));
@@ -155,16 +155,16 @@ TEST_CASE("[PathFollow2D] Setting h_offset and v_offset") {
 	path_follow_2d->set_progress_ratio(0.5);
 	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(50, 0)));
 
-	path_follow_2d->set_h_offset(25);
+	path_follow_2d->set_offset_parallel(25);
 	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(75, 0)));
 
-	path_follow_2d->set_v_offset(25);
+	path_follow_2d->set_offset_perpendicular(25);
 	CHECK(path_follow_2d->get_transform().get_origin().is_equal_approx(Vector2(75, 25)));
 
 	memdelete(path);
 }
 
-TEST_CASE("[PathFollow2D] Unit offset out of range") {
+TEST_CASE("[PathFollow2D] Progress ratio out of range") {
 	const Ref<Curve2D> &curve = memnew(Curve2D());
 	curve->add_point(Vector2(0, 0));
 	curve->add_point(Vector2(100, 0));


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/64808.

The name of these properties is extremely vague and non-descriptive, especially in 3D. This PR attempts to addresses that. See https://github.com/godotengine/godot/pull/64808#issuecomment-1258361995.

For PathFollow2D:
- `h_offset` -> `offset_parallel`;
- `v_offset` -> `offset_perpendicular`. 

For PathFollow3D:
- `h_offset` -> `offset_side`;
- `v_offset` -> `offset_perpendicular`;
- **(new)** `offset_forward`.

Furthermore, the properties are also grouped together in the editor:
![image](https://user-images.githubusercontent.com/66727710/192390754-8da10773-a32f-46de-ab2b-d93280b701a3.png)

Do note that this is meant to be a better place to discuss an eventual rename than https://github.com/godotengine/godot/pull/64808. I am not convinced on these names myself. I find the choice of words to be too verbose for non-English speaking users, but an argument can be made that a new name is necessary. Do also note that **Camera3D** has an unrelated `h_offset` and `v_offset`, too, which means adding them to the Project Converter may be out of the question.  So, that's worth adding to the list, too.