### PR TITLE
Make `Input.get_vector()` also read the non-raw strength values

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -346,6 +346,12 @@ Vector2 Input::get_vector(const StringName &p_negative_x, const StringName &p_po
 			get_action_raw_strength(p_positive_x) - get_action_raw_strength(p_negative_x),
 			get_action_raw_strength(p_positive_y) - get_action_raw_strength(p_negative_y));
 
+	if (vector == Vector2()) {
+		vector = Vector2(
+				get_action_strength(p_positive_x) - get_action_strength(p_negative_x),
+				get_action_strength(p_positive_y) - get_action_strength(p_negative_y));
+	}
+
 	if (p_deadzone < 0.0f) {
 		// If the deadzone isn't specified, get it from the average of the actions.
 		p_deadzone = 0.25 *


### PR DESCRIPTION
This PR makes `Input.get_vector()` fallback to the non-raw strength values if the raw ones are zero.

Fixes #62593.