### PR TITLE
Port `Input.action_press/release()` changes

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -613,6 +613,8 @@ void InputDefault::action_press(const StringName &p_action, float p_strength) {
 	action.idle_frame = Engine::get_singleton()->get_idle_frames();
 	action.pressed = true;
 	action.strength = p_strength;
+	action.raw_strength = p_strength;
+	action.exact = true;
 
 	action_state[p_action] = action;
 }
@@ -624,6 +626,8 @@ void InputDefault::action_release(const StringName &p_action) {
 	action.idle_frame = Engine::get_singleton()->get_idle_frames();
 	action.pressed = false;
 	action.strength = 0.f;
+	action.raw_strength = 0.f;
+	action.exact = true;
 
 	action_state[p_action] = action;
 }


### PR DESCRIPTION
This ports the changes made in PR to 4.0 (#59911) related to the `Input.action_press/release()` functions to 3.x. Mainly, setting the raw strength together with the non-raw one.

Fixes #62593 for 3.x.