### PR TITLE
Add editor settings for autocompletion with NodePath and StringName

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1031,6 +1031,12 @@
 			The number of pixels to scroll with every mouse wheel increment. Higher values make the script scroll by faster when using the mouse wheel.
 			[b]Note:[/b] You can hold down [kbd]Alt[/kbd] while using the mouse wheel to temporarily scroll 5 times faster.
 		</member>
+		<member name="text_editor/completion/add_node_path_literals" type="bool" setter="" getter="">
+			If [code]true[/code], uses [NodePath] instead of [String] when appropriate for code autocompletion or for drag and dropping object properties into the script editor.
+		</member>
+		<member name="text_editor/completion/add_string_name_literals" type="bool" setter="" getter="">
+			If [code]true[/code], uses [StringName] instead of [String] when appropriate for code autocompletion.
+		</member>
 		<member name="text_editor/completion/add_type_hints" type="bool" setter="" getter="">
 			If [code]true[/code], adds [url=$DOCS_URL/tutorials/scripting/gdscript/static_typing.html]GDScript static typing[/url] hints such as [code]-&gt; void[/code] and [code]: int[/code] when using code autocompletion or when creating onready variables by drag and dropping nodes into the script editor while pressing the [kbd]Ctrl[/kbd] key. If [code]true[/code], newly created scripts will also automatically have type hints added to their method parameters and return types.
 		</member>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -941,6 +941,10 @@ void CodeTextEditor::_complete_request() {
 			font_color = completion_string_color;
 		} else if (e.insert_text.begins_with("##") || e.insert_text.begins_with("///")) {
 			font_color = completion_doc_comment_color;
+		} else if (e.insert_text.begins_with("&")) {
+			font_color = completion_string_name_color;
+		} else if (e.insert_text.begins_with("^")) {
+			font_color = completion_node_path_color;
 		} else if (e.insert_text.begins_with("#") || e.insert_text.begins_with("//")) {
 			font_color = completion_comment_color;
 		}
@@ -997,6 +1001,8 @@ void CodeTextEditor::update_editor_settings() {
 	// Theme: Highlighting
 	completion_font_color = EDITOR_GET("text_editor/theme/highlighting/completion_font_color");
 	completion_string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
+	completion_string_name_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/string_name_color");
+	completion_node_path_color = EDITOR_GET("text_editor/theme/highlighting/gdscript/node_path_color");
 	completion_comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
 	completion_doc_comment_color = EDITOR_GET("text_editor/theme/highlighting/doc_comment_color");
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -184,6 +184,8 @@ class CodeTextEditor : public VBoxContainer {
 
 	Color completion_font_color;
 	Color completion_string_color;
+	Color completion_string_name_color;
+	Color completion_node_path_color;
 	Color completion_comment_color;
 	Color completion_doc_comment_color;
 	CodeTextEditorCodeCompleteFunc code_complete_func;

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -653,6 +653,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
 	_initial_set("text_editor/completion/complete_file_paths", true);
 	_initial_set("text_editor/completion/add_type_hints", true);
+	_initial_set("text_editor/completion/add_string_name_literals", false);
+	_initial_set("text_editor/completion/add_node_path_literals", false);
 	_initial_set("text_editor/completion/use_single_quotes", false);
 	_initial_set("text_editor/completion/colorize_suggestions", true);
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1946,9 +1946,12 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 
 	if (d.has("type") && String(d["type"]) == "obj_property") {
 		te->remove_secondary_carets();
+
+		bool add_literal = EDITOR_GET("text_editor/completion/add_node_path_literals");
+		String text_to_drop = add_literal ? "^" : "";
 		// It is unclear whether properties may contain single or double quotes.
 		// Assume here that double-quotes may not exist. We are escaping single-quotes if necessary.
-		const String text_to_drop = _quote_drop_data(String(d["property"]));
+		text_to_drop += _quote_drop_data(String(d["property"]));
 
 		te->set_caret_line(row);
 		te->set_caret_column(col);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2665,6 +2665,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	GDScriptParser::DataType base_type = p_base.type;
 
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const bool use_string_names = EDITOR_GET("text_editor/completion/add_string_name_literals");
+	const bool use_node_paths = EDITOR_GET("text_editor/completion/add_node_path_literals");
 
 	while (base_type.is_set() && !base_type.is_variant()) {
 		switch (base_type.kind) {
@@ -2698,8 +2700,14 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 							List<String> options;
 							obj->get_argument_options(p_method, p_argidx, &options);
 							for (String &opt : options) {
+								// Handle user preference.
 								if (opt.is_quoted()) {
-									opt = opt.unquote().quote(quote_style); // Handle user preference.
+									opt = opt.unquote().quote(quote_style);
+									if (use_string_names && info.arguments[p_argidx].type == Variant::STRING_NAME) {
+										opt = opt.indent("&");
+									} else if (use_node_paths && info.arguments[p_argidx].type == Variant::NODE_PATH) {
+										opt = opt.indent("^");
+									}
 								}
 								ScriptLanguage::CodeCompletionOption option(opt, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 								r_result.insert(option.display, option);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3398,9 +3398,16 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 		int offset = option.default_value.get_type() == Variant::COLOR ? line_height : 0;
 
 		if (in_string != -1) {
+			// The completion string may have a literal behind it, which should be removed before re-quoting.
+			String literal;
+			if (option.insert_text.substr(1).is_quoted()) {
+				literal = option.display.left(1);
+				option.display = option.display.substr(1);
+				option.insert_text = option.insert_text.substr(1);
+			}
 			String quote = single_quote ? "'" : "\"";
-			option.display = option.display.unquote().quote(quote);
-			option.insert_text = option.insert_text.unquote().quote(quote);
+			option.display = literal + (option.display.unquote().quote(quote));
+			option.insert_text = literal + (option.insert_text.unquote().quote(quote));
 		}
 
 		if (option.display.length() == 0) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5496

This is built into the autocompletion algorithm – if you're in a function and autocompletion gives a string, it checks whether the editor setting is on. If it is, it adds the literals `&` or `^` as prefixes, based on if the argument is a NodePath or a StringName. Works in any situation, no adaptation is needed to specific functions.

https://user-images.githubusercontent.com/85438892/192419652-864ee866-b797-474a-9926-acee2fe7b1a4.mp4
