### PR TITLE
Prevent loading a zip with `--main-pack` from causing a stack overflow

### DIFF
--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -337,7 +337,7 @@ bool FileAccessZip::file_exists(const String &p_name) {
 }
 
 FileAccessZip::FileAccessZip(const String &p_path, const PackedData::PackedFile &p_file) {
-	_open(p_path, FileAccess::READ);
+	open_internal(p_path, FileAccess::READ);
 }
 
 FileAccessZip::~FileAccessZip() {


### PR DESCRIPTION
Attempting to load a zip with `--main-pack` causes a stack overflow.

The issue is here: https://github.com/godotengine/godot/pull/65271/files#r980701205

when `_open()` was renamed to `open_internal()`, the [`_open()` call below](https://github.com/godotengine/godot/blob/6f5704d86f95171ba8b6b2ac9f56e284c4d35d7a/core/io/file_access_zip.cpp#L340) was left in place, which ends up calling `FileAccess::_open()`, which becomes an infinite recursion and causes a stack overflow.

renaming the `_open()` call in the constructor to `open_internal()` fixes the issue.