### PR TITLE
Do not allow AtlasTexture's `atlas` to be another AtlasTexture

### DIFF
--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -5,13 +5,13 @@
 	</brief_description>
 	<description>
 		[Texture2D] resource that crops out one part of the [member atlas] texture, defined by [member region]. The main use case is cropping out textures from a texture atlas, which is a big texture file that packs multiple smaller textures. Consists of a [Texture2D] for the [member atlas], a [member region] that defines the area of [member atlas] to use, and a [member margin] that defines the border width.
-		[AtlasTexture] cannot be used in an [AnimatedTexture], cannot be tiled in nodes such as [TextureRect], and does not work properly if used inside of other [AtlasTexture] resources. Multiple [AtlasTexture] resources can be used to crop multiple textures from the atlas. Using a texture atlas helps to optimize video memory costs and render calls compared to using multiple small files.
+		[AtlasTexture] cannot be used in an [AnimatedTexture], cannot be tiled in nodes such as [TextureRect], and cannot be used inside of other [AtlasTexture] resources. Multiple [AtlasTexture] resources can be used to crop multiple textures from the atlas. Using a texture atlas helps to optimize video memory costs and render calls compared to using multiple small files.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="atlas" type="Texture2D" setter="set_atlas" getter="get_atlas">
-			The texture that contains the atlas. Can be any [Texture2D] subtype.
+			The texture that contains the atlas. Can be any [Texture2D] subtype, except another [AtlasTexture].
 		</member>
 		<member name="filter_clip" type="bool" setter="set_filter_clip" getter="has_filter_clip" default="false">
 			If [code]true[/code], clips the area outside of the region to avoid bleeding of the surrounding texture pixels.

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1485,10 +1485,11 @@ bool AtlasTexture::has_alpha() const {
 }
 
 void AtlasTexture::set_atlas(const Ref<Texture2D> &p_atlas) {
-	ERR_FAIL_COND(p_atlas == this);
 	if (atlas == p_atlas) {
 		return;
 	}
+	ERR_FAIL_COND_MSG(Ref<AtlasTexture>(p_atlas).is_valid(), "Nesting AtlasTexture inside another AtlasTexture is not supported.");
+
 	atlas = p_atlas;
 	emit_changed();
 }


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/66449#discussion_r980149639.

For the longest of time it's been documented that **AtlasTexture** does not work properly as another **AtlasTexture**'s `atlas`. In fact, at least in the current `master` build, applying this causes the texture to not draw at all.
While it may be possible to lift this limitation in the future, I feel like it would make sense _not_ to allow this in the first place, for the time being.

![image](https://user-images.githubusercontent.com/66727710/192504969-d0872399-d016-4bb0-9ae3-4a81b6d42f19.png)

Should be cherrypickable for 3.x.

**EDIT**: Upon further testing it really feels like **AtlasTexture** is supported but very sporadically. The solution to the issue may be simpler than realised. https://github.com/godotengine/godot/pull/66509