### PR TITLE
Fix heap-use-after-free in `NavMap::get_path()`

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -140,20 +140,17 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 
 	// This is an implementation of the A* algorithm.
 	int least_cost_id = 0;
+	int prev_least_cost_id = -1;
 	bool found_route = false;
 
 	const gd::Polygon *reachable_end = nullptr;
 	float reachable_d = 1e30;
 	bool is_reachable = true;
 
-	gd::NavigationPoly *prev_least_cost_poly = nullptr;
-
 	while (true) {
 		// Takes the current least_cost_poly neighbors (iterating over its edges) and compute the traveled_distance.
 		for (size_t i = 0; i < navigation_polys[least_cost_id].poly->edges.size(); i++) {
-			gd::NavigationPoly *least_cost_poly = &navigation_polys[least_cost_id];
-
-			const gd::Edge &edge = least_cost_poly->poly->edges[i];
+			const gd::Edge &edge = navigation_polys[least_cost_id].poly->edges[i];
 
 			// Iterate over connections in this edge, then compute the new optimized travel distance assigned to this polygon.
 			for (int connection_index = 0; connection_index < edge.connections.size(); connection_index++) {
@@ -164,17 +161,18 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 					continue;
 				}
 
+				const gd::NavigationPoly &least_cost_poly = navigation_polys[least_cost_id];
 				float poly_enter_cost = 0.0;
-				float poly_travel_cost = least_cost_poly->poly->owner->get_travel_cost();
+				float poly_travel_cost = least_cost_poly.poly->owner->get_travel_cost();
 
-				if (prev_least_cost_poly != nullptr && (prev_least_cost_poly->poly->owner->get_self() != least_cost_poly->poly->owner->get_self())) {
-					poly_enter_cost = least_cost_poly->poly->owner->get_enter_cost();
+				if (prev_least_cost_id != -1 && (navigation_polys[prev_least_cost_id].poly->owner->get_self() != least_cost_poly.poly->owner->get_self())) {
+					poly_enter_cost = least_cost_poly.poly->owner->get_enter_cost();
 				}
-				prev_least_cost_poly = least_cost_poly;
+				prev_least_cost_id = least_cost_id;
 
 				Vector3 pathway[2] = { connection.pathway_start, connection.pathway_end };
-				const Vector3 new_entry = Geometry3D::get_closest_point_to_segment(least_cost_poly->entry, pathway);
-				const float new_distance = (least_cost_poly->entry.distance_to(new_entry) * poly_travel_cost) + poly_enter_cost + least_cost_poly->traveled_distance;
+				const Vector3 new_entry = Geometry3D::get_closest_point_to_segment(least_cost_poly.entry, pathway);
+				const float new_distance = (least_cost_poly.entry.distance_to(new_entry) * poly_travel_cost) + poly_enter_cost + least_cost_poly.traveled_distance;
 
 				int64_t already_visited_polygon_index = navigation_polys.find(gd::NavigationPoly(connection.polygon));
 


### PR DESCRIPTION
This PR fixes a `heap-use-after-free` error when using the navigation system. Also affects 3.x.

I think any navigation project can trigger this error, here is a MRP: [test-4.zip](https://github.com/godotengine/godot/files/9654742/test-4.zip)


<details><summary>AddressSanitizer output</summary>

```
==21798==ERROR: AddressSanitizer: heap-use-after-free on address 0x61200093a198 at pc 0x56123bca4d9f bp 0x7ffd672b9df0 sp 0x7ffd672b9de0
READ of size 8 at 0x61200093a198 thread T0
    #0 0x56123bca4d9e in NavMap::get_path(Vector3, Vector3, bool, unsigned int) const modules/navigation/nav_map.cpp:170
    #1 0x56123bc7dafa in GodotNavigationServer::map_get_path(RID, Vector3, Vector3, bool, unsigned int) const modules/navigation/godot_navigation_server.cpp:231
    #2 0x561240bb3c32 in NavigationAgent3D::update_navigation() scene/3d/navigation_agent_3d.cpp:437
    #3 0x561240bb1c1b in NavigationAgent3D::is_navigation_finished() scene/3d/navigation_agent_3d.cpp:355
    #4 0x56123a6bed5d in void call_with_ptr_args_ret_helper<__UnexistingClass, bool>(__UnexistingClass*, bool (__UnexistingClass::*)(), void const**, void*, IndexSequence<>) core/variant/binder_common.h:293
    #5 0x56123a6b208d in void call_with_ptr_args_ret<__UnexistingClass, bool>(__UnexistingClass*, bool (__UnexistingClass::*)(), void const**, void*) core/variant/binder_common.h:541
    #6 0x56123a6a6888 in MethodBindTR<bool>::ptrcall(Object*, void const**, void*) core/object/method_bind.h:498
    #7 0x56123b0d2d29 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:1831
    #8 0x56123ad918d8 in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1629
    #9 0x56123fe93dca in bool Node::_gdvirtual__physics_process_call<false>(double) scene/main/node.h:238
    #10 0x56123fe52d69 in Node::_notification(int) scene/main/node.cpp:60
    #11 0x56123a67aee9 in Node::_notificationv(int, bool) scene/main/node.h:45
    #12 0x56123a67bb20 in Node3D::_notificationv(int, bool) scene/3d/node_3d.h:52
    #13 0x56124086f75a in CollisionObject3D::_notificationv(int, bool) scene/3d/collision_object_3d.h:38
    #14 0x561240cc640e in PhysicsBody3D::_notificationv(int, bool) scene/3d/physics_body_3d.h:43
    #15 0x561240ccb082 in CharacterBody3D::_notificationv(int, bool) scene/3d/physics_body_3d.h:344
    #16 0x561244f00141 in Object::notification(int, bool) core/object/object.cpp:790
    #17 0x56123fee79be in SceneTree::_notify_group_pause(StringName const&, int) scene/main/scene_tree.cpp:867
    #18 0x56123fee31c3 in SceneTree::physics_process(double) scene/main/scene_tree.cpp:427
    #19 0x5612395a5adb in Main::iteration() main/main.cpp:3106
    #20 0x5612394d1a9b in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:575
    #21 0x5612394c3ff1 in main platform/linuxbsd/godot_linuxbsd.cpp:72
    #22 0x7fb7e381128f  (/usr/lib/libc.so.6+0x2328f)
    #23 0x7fb7e3811349 in __libc_start_main (/usr/lib/libc.so.6+0x23349)
    #24 0x5612394c3be4 in _start ../sysdeps/x86_64/start.S:115

0x61200093a198 is located 216 bytes inside of 272-byte region [0x61200093a0c0,0x61200093a1d0)
freed by thread T0 here:
    #0 0x7fb7e3cbe7ea in __interceptor_realloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:85
    #1 0x5612441c697d in Memory::realloc_static(void*, unsigned long, bool) core/os/memory.cpp:129
    #2 0x56123bcb2d34 in LocalVector<gd::NavigationPoly, unsigned int, false, false>::push_back(gd::NavigationPoly) core/templates/local_vector.h:67
    #3 0x56123bca5ccc in NavMap::get_path(Vector3, Vector3, bool, unsigned int) const modules/navigation/nav_map.cpp:202
    #4 0x56123bc7dafa in GodotNavigationServer::map_get_path(RID, Vector3, Vector3, bool, unsigned int) const modules/navigation/godot_navigation_server.cpp:231
    #5 0x561240bb3c32 in NavigationAgent3D::update_navigation() scene/3d/navigation_agent_3d.cpp:437
    #6 0x561240bb1c1b in NavigationAgent3D::is_navigation_finished() scene/3d/navigation_agent_3d.cpp:355
    #7 0x56123a6bed5d in void call_with_ptr_args_ret_helper<__UnexistingClass, bool>(__UnexistingClass*, bool (__UnexistingClass::*)(), void const**, void*, IndexSequence<>) core/variant/binder_common.h:293
    #8 0x56123a6b208d in void call_with_ptr_args_ret<__UnexistingClass, bool>(__UnexistingClass*, bool (__UnexistingClass::*)(), void const**, void*) core/variant/binder_common.h:541
    #9 0x56123a6a6888 in MethodBindTR<bool>::ptrcall(Object*, void const**, void*) core/object/method_bind.h:498
    #10 0x56123b0d2d29 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:1831
    #11 0x56123ad918d8 in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1629
    #12 0x56123fe93dca in bool Node::_gdvirtual__physics_process_call<false>(double) scene/main/node.h:238
    #13 0x56123fe52d69 in Node::_notification(int) scene/main/node.cpp:60
    #14 0x56123a67aee9 in Node::_notificationv(int, bool) scene/main/node.h:45
    #15 0x56123a67bb20 in Node3D::_notificationv(int, bool) scene/3d/node_3d.h:52
    #16 0x56124086f75a in CollisionObject3D::_notificationv(int, bool) scene/3d/collision_object_3d.h:38
    #17 0x561240cc640e in PhysicsBody3D::_notificationv(int, bool) scene/3d/physics_body_3d.h:43
    #18 0x561240ccb082 in CharacterBody3D::_notificationv(int, bool) scene/3d/physics_body_3d.h:344
    #19 0x561244f00141 in Object::notification(int, bool) core/object/object.cpp:790
    #20 0x56123fee79be in SceneTree::_notify_group_pause(StringName const&, int) scene/main/scene_tree.cpp:867
    #21 0x56123fee31c3 in SceneTree::physics_process(double) scene/main/scene_tree.cpp:427
    #22 0x5612395a5adb in Main::iteration() main/main.cpp:3106
    #23 0x5612394d1a9b in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:575
    #24 0x5612394c3ff1 in main platform/linuxbsd/godot_linuxbsd.cpp:72
    #25 0x7fb7e381128f  (/usr/lib/libc.so.6+0x2328f)

previously allocated by thread T0 here:
    #0 0x7fb7e3cbfa89 in __interceptor_malloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x5612441c6094 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:75
    #2 0x5612441c6559 in Memory::realloc_static(void*, unsigned long, bool) core/os/memory.cpp:99
    #3 0x56123bcb2a33 in LocalVector<gd::NavigationPoly, unsigned int, false, false>::reserve(unsigned int) core/templates/local_vector.h:130
    #4 0x56123bca46ea in NavMap::get_path(Vector3, Vector3, bool, unsigned int) const modules/navigation/nav_map.cpp:127
    #5 0x56123bc7dafa in GodotNavigationServer::map_get_path(RID, Vector3, Vector3, bool, unsigned int) const modules/navigation/godot_navigation_server.cpp:231
    #6 0x561240bb3c32 in NavigationAgent3D::update_navigation() scene/3d/navigation_agent_3d.cpp:437
    #7 0x561240bb1c1b in NavigationAgent3D::is_navigation_finished() scene/3d/navigation_agent_3d.cpp:355
    #8 0x56123a6bed5d in void call_with_ptr_args_ret_helper<__UnexistingClass, bool>(__UnexistingClass*, bool (__UnexistingClass::*)(), void const**, void*, IndexSequence<>) core/variant/binder_common.h:293
    #9 0x56123a6b208d in void call_with_ptr_args_ret<__UnexistingClass, bool>(__UnexistingClass*, bool (__UnexistingClass::*)(), void const**, void*) core/variant/binder_common.h:541
    #10 0x56123a6a6888 in MethodBindTR<bool>::ptrcall(Object*, void const**, void*) core/object/method_bind.h:498
    #11 0x56123b0d2d29 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:1831
    #12 0x56123ad918d8 in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1629
    #13 0x56123fe93dca in bool Node::_gdvirtual__physics_process_call<false>(double) scene/main/node.h:238
    #14 0x56123fe52d69 in Node::_notification(int) scene/main/node.cpp:60
    #15 0x56123a67aee9 in Node::_notificationv(int, bool) scene/main/node.h:45
    #16 0x56123a67bb20 in Node3D::_notificationv(int, bool) scene/3d/node_3d.h:52
    #17 0x56124086f75a in CollisionObject3D::_notificationv(int, bool) scene/3d/collision_object_3d.h:38
    #18 0x561240cc640e in PhysicsBody3D::_notificationv(int, bool) scene/3d/physics_body_3d.h:43
    #19 0x561240ccb082 in CharacterBody3D::_notificationv(int, bool) scene/3d/physics_body_3d.h:344
    #20 0x561244f00141 in Object::notification(int, bool) core/object/object.cpp:790
    #21 0x56123fee79be in SceneTree::_notify_group_pause(StringName const&, int) scene/main/scene_tree.cpp:867
    #22 0x56123fee31c3 in SceneTree::physics_process(double) scene/main/scene_tree.cpp:427
    #23 0x5612395a5adb in Main::iteration() main/main.cpp:3106
    #24 0x5612394d1a9b in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:575
    #25 0x5612394c3ff1 in main platform/linuxbsd/godot_linuxbsd.cpp:72
    #26 0x7fb7e381128f  (/usr/lib/libc.so.6+0x2328f)

SUMMARY: AddressSanitizer: heap-use-after-free modules/navigation/nav_map.cpp:170 in NavMap::get_path(Vector3, Vector3, bool, unsigned int) const
Shadow bytes around the buggy address:
  0x0c248011f3e0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c248011f3f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c248011f400: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa
  0x0c248011f410: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c248011f420: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c248011f430: fd fd fd[fd]fd fd fd fd fd fd fa fa fa fa fa fa
  0x0c248011f440: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c248011f450: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c248011f460: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c248011f470: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c248011f480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==21798==ABORTING
```

</details>

Cause: pointers to `LocalVector` elements were stored, but the vector later got reallocated when `push_back()` is called. So the pointers are invalidated. Accessing the stored pointers is a heap-use-after-free error, which results in a crash when using a sanitizer build.