### PR TITLE
Fix wrong DirAccess function in project converter

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2248,7 +2248,7 @@ Vector<String> ProjectConverter3To4::check_for_files() {
 		String path = directories_to_check.get(directories_to_check.size() - 1); // Is there any pop_back function?
 		directories_to_check.resize(directories_to_check.size() - 1); // Remove last element
 
-		Ref<DirAccess> dir = DirAccess::create_for_path(path);
+		Ref<DirAccess> dir = DirAccess::open(path);
 		if (dir.is_valid()) {
 			dir->set_include_hidden(true);
 			dir->list_dir_begin();


### PR DESCRIPTION
Fixes #66484

`create_for_path()` opens a DirAccess for root folder, e.g. for `res://something/`, it opens `res://`.