### PR TITLE
SCons: Fix MSVC warning LNK4042 about dupe objects in regex

### DIFF
--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -58,10 +58,10 @@ if env["builtin_pcre2"]:
         env_pcre2["OBJSUFFIX"] = "_" + width + env_pcre2["OBJSUFFIX"]
         env_pcre2.Append(CPPDEFINES=[("PCRE2_CODE_UNIT_WIDTH", width)])
         env_pcre2.add_source_files(thirdparty_obj, thirdparty_sources)
-        env.modules_sources += thirdparty_obj
 
     pcre2_builtin("16")
     pcre2_builtin("32")
+    env.modules_sources += thirdparty_obj
 
 
 # Godot source files


### PR DESCRIPTION
It would warn things like this:
```
thirdparty\pcre2\src\pcre2_auto_possess_16.windows.tools.x86_64.obj : warning LNK4042: object specified more than once; extras ignored
```

- Fixes #51293.