### PR TITLE
Allow to choose opening bottom panel on play

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -631,11 +631,11 @@
 		<member name="run/output/always_close_output_on_stop" type="bool" setter="" getter="">
 			If [code]true[/code], the editor will collapse the Output panel when stopping the project.
 		</member>
-		<member name="run/output/always_open_output_on_play" type="bool" setter="" getter="">
-			If [code]true[/code], the editor will expand the Output panel when running the project.
-		</member>
 		<member name="run/output/font_size" type="int" setter="" getter="">
 			The size of the font in the [b]Output[/b] panel at the bottom of the editor. This setting does not impact the font size of the script editor (see [member interface/editor/code_font_size]).
+		</member>
+		<member name="run/output/open_panel_on_play" type="int" setter="" getter="">
+			The editor will expand the selected panel when running the project.
 		</member>
 		<member name="run/window_placement/rect" type="int" setter="" getter="">
 			The window mode to use to display the project when starting the project from the editor.

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -209,9 +209,9 @@ String EditorDebuggerNode::get_server_uri() const {
 Error EditorDebuggerNode::start(const String &p_uri) {
 	stop();
 	ERR_FAIL_COND_V(p_uri.find("://") < 0, ERR_INVALID_PARAMETER);
-	if (EDITOR_GET("run/output/always_open_output_on_play")) {
+	if ((EditorDebuggerNode::OpenPanelOnPlay)(int)EDITOR_GET("run/output/open_panel_on_play") == EditorDebuggerNode::OpenPanelOnPlay::OUTPUT) {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
-	} else {
+	} else if ((EditorDebuggerNode::OpenPanelOnPlay)(int)EDITOR_GET("run/output/open_panel_on_play") == EditorDebuggerNode::OpenPanelOnPlay::DEBUGGER) {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(this);
 	}
 	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_uri.substr(0, p_uri.find("://") + 3)));

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -56,6 +56,12 @@ public:
 		OVERRIDE_3D_4 // 3D Viewport 4
 	};
 
+	enum OpenPanelOnPlay {
+		NONE,
+		OUTPUT,
+		DEBUGGER,
+	};
+
 private:
 	enum Options {
 		DEBUG_NEXT,

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2528,7 +2528,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		log->clear();
 	}
 
-	if (bool(EDITOR_GET("run/output/always_open_output_on_play"))) {
+	if ((EditorDebuggerNode::OpenPanelOnPlay)(int)EDITOR_GET("run/output/open_panel_on_play") == EditorDebuggerNode::OpenPanelOnPlay::OUTPUT) {
 		make_bottom_panel_item_visible(log);
 	}
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -706,7 +706,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Output
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "run/output/font_size", 13, "8,48,1")
 	_initial_set("run/output/always_clear_output_on_play", true);
-	_initial_set("run/output/always_open_output_on_play", true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "run/output/open_panel_on_play", 1, "None,Output,Debugger")
 	_initial_set("run/output/always_close_output_on_stop", false);
 
 	/* Network */


### PR DESCRIPTION
Fix #66496

### Issue fixed :
The editor setting ``run/output/always_open_output_on_play``  always open Debbuger panel when set to false.

### Fix proposal : 
Allow to choose opening panel between Output / Debugger / None (keeps panel unchanged on game launch)

![image](https://user-images.githubusercontent.com/3649998/192569660-d83729c4-90f0-44d3-addb-3d73a4b476fa.png)
