### PR TITLE
Support chaining AtlasTextures inside other AtlasTextures

### DIFF
--- a/doc/classes/AtlasTexture.xml
+++ b/doc/classes/AtlasTexture.xml
@@ -6,13 +6,13 @@
 	<description>
 		[Texture2D] resource that draws only part of its [member atlas] texture, as defined by the [member region]. An additional [member margin] can also be set, which is useful for small adjustments.
 		Multiple [AtlasTexture] resources can be cropped from the same [member atlas]. Packing many smaller textures into a singular large texture helps to optimize video memory costs and render calls.
-		[b]Note:[/b] [AtlasTexture] cannot be used in an [AnimatedTexture], and does not work properly if used inside of other [AtlasTexture] resources.
+		[b]Note:[/b] [AtlasTexture] cannot be used in an [AnimatedTexture], and may not tile properly in nodes such as [TextureRect], when inside other [AtlasTexture] resources.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="atlas" type="Texture2D" setter="set_atlas" getter="get_atlas">
-			The texture that contains the atlas. Can be any type inheriting from [Texture2D]. Nesting [AtlasTexture] resources is not supported.
+			The texture that contains the atlas. Can be any type inheriting from [Texture2D], including another [AtlasTexture].
 		</member>
 		<member name="filter_clip" type="bool" setter="set_filter_clip" getter="has_filter_clip" default="false">
 			If [code]true[/code], the area outside of the [member region] is clipped to avoid bleeding of the surrounding texture pixels.

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1489,7 +1489,15 @@ void AtlasTexture::set_atlas(const Ref<Texture2D> &p_atlas) {
 	if (atlas == p_atlas) {
 		return;
 	}
+	// Support recursive AtlasTextures.
+	if (Ref<AtlasTexture>(atlas).is_valid()) {
+		atlas->disconnect(CoreStringNames::get_singleton()->changed, callable_mp((Resource *)this, &AtlasTexture::emit_changed));
+	}
 	atlas = p_atlas;
+	if (Ref<AtlasTexture>(atlas).is_valid()) {
+		atlas->connect(CoreStringNames::get_singleton()->changed, callable_mp((Resource *)this, &AtlasTexture::emit_changed));
+	}
+
 	emit_changed();
 }
 


### PR DESCRIPTION
[Nevermind](https://github.com/godotengine/godot/pull/66488).
Yeah that was... uh... Yeah.

This PR connects **AtlasTexture** to its own `atlas`'s "_changed_" signal, when it is another **AtlasTexture**, allowing it to detect property changes to `atlas`, emit its own "_changed_" signal, and update any interested Object accordingly, when the project is running and in the editor, as well.

Before this PR, **AtlasTexture** would only update once when loaded, giving inconsistent results. For example, only when closing and reopening the Scene, the **AtlasTexture** would display its _utter, true, final form_.

<details>
<summary> Big image, click here to expand.</summary>

![image](https://user-images.githubusercontent.com/66727710/192593302-13e093c9-5f14-4e0b-8565-befcb9f710f4.png)

</details>

### Known oddities:
- `CanvasItem.repeat` on chained **AtlasTexture**s  doesn't quite work as expected. 
    - Unlike what https://github.com/godotengine/godot/issues/5660 suggests, the property works completely fine in 4.0. However, only the _deepest_ **AtlasTexture** of the chain has repetition applied, whereas it should probably be the highest one, which would be what is drawn in the end.
      <details>
      <summary> Big image, click here to expand.</summary>

       ![image](https://user-images.githubusercontent.com/66727710/192605918-154325c1-2c36-4036-84d0-ed0be390476e.png)
      </details>
- **This was actually already an issue before**: chaining the same **AtlasTexture** more than once is problematic.
    - For example, "_**Atlas1**_"<-"_Atlas2_"<-"_Atlas3_"<-"_**Atlas1**_" results in a crash.