### PR TITLE
Getters for TextEdit scroll bars

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -240,6 +240,12 @@
 				Returns the width of the gutter at the given index.
 			</description>
 		</method>
+		<method name="get_h_scroll_bar" qualifiers="const">
+			<return type="HScrollBar" />
+			<description>
+				Returns the [HScrollBar] used by [TextEdit].
+			</description>
+		</method>
 		<method name="get_indent_level" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="line" type="int" />
@@ -507,6 +513,12 @@
 			<return type="int" />
 			<description>
 				Returns the number of lines that may be drawn.
+			</description>
+		</method>
+		<method name="get_v_scroll_bar" qualifiers="const">
+			<return type="VScrollBar" />
+			<description>
+				Returns the [VScrollBar] of the [TextEdit].
 			</description>
 		</method>
 		<method name="get_version" qualifiers="const">

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5088,6 +5088,14 @@ bool TextEdit::is_scroll_past_end_of_file_enabled() const {
 	return scroll_past_end_of_file_enabled;
 }
 
+VScrollBar *TextEdit::get_v_scroll_bar() const {
+	return v_scroll;
+}
+
+HScrollBar *TextEdit::get_h_scroll_bar() const {
+	return h_scroll;
+}
+
 void TextEdit::set_v_scroll(double p_scroll) {
 	v_scroll->set_value(p_scroll);
 	int max_v_scroll = v_scroll->get_max() - v_scroll->get_page();
@@ -6019,6 +6027,9 @@ void TextEdit::_bind_methods() {
 	// Scrolling.
 	ClassDB::bind_method(D_METHOD("set_smooth_scroll_enabled", "enable"), &TextEdit::set_smooth_scroll_enabled);
 	ClassDB::bind_method(D_METHOD("is_smooth_scroll_enabled"), &TextEdit::is_smooth_scroll_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_v_scroll_bar"), &TextEdit::get_v_scroll_bar);
+	ClassDB::bind_method(D_METHOD("get_h_scroll_bar"), &TextEdit::get_h_scroll_bar);
 
 	ClassDB::bind_method(D_METHOD("set_v_scroll", "value"), &TextEdit::set_v_scroll);
 	ClassDB::bind_method(D_METHOD("get_v_scroll"), &TextEdit::get_v_scroll);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -886,6 +886,9 @@ public:
 	void set_scroll_past_end_of_file_enabled(const bool p_enabled);
 	bool is_scroll_past_end_of_file_enabled() const;
 
+	VScrollBar *get_v_scroll_bar() const;
+	HScrollBar *get_h_scroll_bar() const;
+
 	void set_v_scroll(double p_scroll);
 	double get_v_scroll() const;
 


### PR DESCRIPTION
## Overview

This PR adds getters for TextEdit's scrollbars, along with doc updates.

### Purpose

This brings TextEdit to parity with ScrollContainer, which has a getter for the internal scroll bars. 

This feature has been previously requested [here](https://github.com/godotengine/godot-proposals/issues/3737). The issue was closed but I believe there is still a purpose with exposing the scroll bars directly. This allows devs to more easily modify scroll bar properties other than the value. 