### PR TITLE
Document `print_stack()` and `get_stack()` requiring a debugger connection

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -84,7 +84,7 @@
 		<method name="get_stack">
 			<return type="Array" />
 			<description>
-				Returns an array of dictionaries representing the current call stack.
+				Returns an array of dictionaries representing the current call stack. See also [method print_stack].
 				[codeblock]
 				func _ready():
 				    foo()
@@ -99,6 +99,7 @@
 				[codeblock]
 				[{function:bar, line:12, source:res://script.gd}, {function:foo, line:9, source:res://script.gd}, {function:_ready, line:6, source:res://script.gd}]
 				[/codeblock]
+				[b]Note:[/b] [method get_stack] only works if the running instance is connected to a debugging server (i.e. an editor instance). [method get_stack] will not work in projects exported in release mode, or in projects exported in debug mode if not connected to a debugging server.
 				[b]Note:[/b] Not supported for calling from threads. Instead, this will return an empty array.
 			</description>
 		</method>
@@ -175,11 +176,12 @@
 		<method name="print_stack">
 			<return type="void" />
 			<description>
-				Prints a stack trace at the current code location. Only works when running with debugger turned on.
+				Prints a stack trace at the current code location. See also [method get_stack].
 				Output in the console would look something like this:
 				[codeblock]
 				Frame 0 - res://test.gd:16 in function '_process'
 				[/codeblock]
+				[b]Note:[/b] [method print_stack] only works if the running instance is connected to a debugging server (i.e. an editor instance). [method print_stack] will not work in projects exported in release mode, or in projects exported in debug mode if not connected to a debugging server.
 				[b]Note:[/b] Not supported for calling from threads. Instead of the stack trace, this will print the thread ID.
 			</description>
 		</method>


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/66437.