### PR TITLE
[3.x] Fix NavigationObstacle not registering to default navigation map

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -134,7 +134,7 @@ NavigationObstacle2D::~NavigationObstacle2D() {
 }
 
 void NavigationObstacle2D::set_navigation(Navigation2D *p_nav) {
-	if (navigation == p_nav) {
+	if (navigation == p_nav && navigation != nullptr) {
 		return; // Pointless
 	}
 

--- a/scene/3d/navigation_obstacle.cpp
+++ b/scene/3d/navigation_obstacle.cpp
@@ -140,7 +140,7 @@ NavigationObstacle::~NavigationObstacle() {
 }
 
 void NavigationObstacle::set_navigation(Navigation *p_nav) {
-	if (navigation == p_nav) {
+	if (navigation == p_nav && navigation != nullptr) {
 		return; // Pointless
 	}
 


### PR DESCRIPTION
Fixes #64185

https://github.com/godotengine/godot/blob/faade5f1c365362302c81721064cf4caa011313c/scene/3d/navigation_obstacle.cpp#L142-L154

Don't skip `set_navigation()` when `navigation` is null. The else if branch should be executed as it does not depend on `navigation`.