### PR TITLE
SCons: Silence MSVC C++17 deprecation warnings in Graphite

### DIFF
--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -215,6 +215,9 @@ if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
         ]
     )
 
+    if env.msvc:  # Not our business to fix.
+        env_graphite.Append(CCFLAGS=["-D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS"])
+
     lib = env_graphite.add_library("graphite_builtin", thirdparty_sources)
     thirdparty_obj += lib
 


### PR DESCRIPTION
Fixes #66497.

---

As a side note @bruvzg, I didn't refactor it in this commit to avoid scope creep but you should likely use `CPPDEFINES` instead of `CCFLAGS` to pass defines. Then you don't need to include the `-D` (which should be `/D` for MSVC but it seems to still be accepted with `-D`) and SCons will handle this properly for each compiler.