### PR TITLE
Rename `script_instance` to `_script_instance` in the `GDVIRTUAL*` wrappers to avoid shadowing `Object` member.

### DIFF
--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -5,11 +5,11 @@ mutable bool _gdvirtual_##m_name##_initialized = false;\\
 mutable GDNativeExtensionClassCallVirtual _gdvirtual_##m_name = nullptr;\\
 template<bool required>\\
 _FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST { \\
-	ScriptInstance *script_instance = ((Object*)(this))->get_script_instance();\\
-	if (script_instance) {\\
+	ScriptInstance *_script_instance = ((Object*)(this))->get_script_instance();\\
+	if (_script_instance) {\\
 		Callable::CallError ce; \\
 		$CALLSIARGS\\
-		$CALLSIBEGINscript_instance->callp(_gdvirtual_##m_name##_sn, $CALLSIARGPASS, ce);\\
+		$CALLSIBEGIN_script_instance->callp(_gdvirtual_##m_name##_sn, $CALLSIARGPASS, ce);\\
 		if (ce.error == Callable::CallError::CALL_OK) {\\
 			$CALLSIRET\\
 			return true;\\
@@ -35,9 +35,9 @@ _FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST { \\
     return false;\\
 }\\
 _FORCE_INLINE_ bool _gdvirtual_##m_name##_overridden() const { \\
-	ScriptInstance *script_instance = ((Object*)(this))->get_script_instance();\\
-	if (script_instance) {\\
-	    return script_instance->has_method(_gdvirtual_##m_name##_sn);\\
+	ScriptInstance *_script_instance = ((Object*)(this))->get_script_instance();\\
+	if (_script_instance) {\\
+	    return _script_instance->has_method(_gdvirtual_##m_name##_sn);\\
 	}\\
     if (unlikely(_get_extension() && !_gdvirtual_##m_name##_initialized)) {\\
         _gdvirtual_##m_name = (_get_extension() && _get_extension()->get_virtual) ? _get_extension()->get_virtual(_get_extension()->class_userdata, #m_name) : (GDNativeExtensionClassCallVirtual) nullptr;\\


### PR DESCRIPTION
Should fix `warning C4458: declaration of 'script_instance' hides class member` warnings, cause by every `GDVIRTUAL*` binding - see https://github.com/godotengine/godot/issues/66537
