### PR TITLE
Fix false flag compiler warning in bvh tree

### DIFF
--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -235,7 +235,7 @@ private:
 
 		// no need to keep back references for children at the moment
 
-		uint32_t sibling_id; // always a node id, as tnode is never a leaf
+		uint32_t sibling_id = 0; // always a node id, as tnode is never a leaf
 		bool sibling_present = false;
 
 		// if there are more children, or this is the root node, don't try and delete


### PR DESCRIPTION
Compiler wrongly warns that sibling_id may be used when uninitialized. This PR sets the value to silence the warning.

## Notes
* This will be optimized out and only serves to silence compiler warning mentioned in #66537

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
