### PR TITLE
Fix MSVC warnings C4324, C4389, C4456, and C4459

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -1149,7 +1149,7 @@ TypedArray<Vector3i> GridMap::get_used_cells() const {
 TypedArray<Vector3i> GridMap::get_used_cells_by_item(int p_item) const {
 	TypedArray<Vector3i> a;
 	for (const KeyValue<IndexKey, Cell> &E : cell_map) {
-		if (E.value.item == p_item) {
+		if ((int)E.value.item == p_item) {
 			Vector3i p(E.key.x, E.key.y, E.key.z);
 			a.push_back(p);
 		}

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -79,6 +79,9 @@ if env["builtin_embree"]:
         else:
             env.Append(LIBS=["psapi"])
 
+    if env.msvc:  # Disable bogus warning about intentional struct padding.
+        env_raycast.Append(CCFLAGS=["/wd4324"])
+
     env_thirdparty = env_raycast.Clone()
     env_thirdparty.force_optimization_on_debug()
     env_thirdparty.disable_warnings()

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -43,6 +43,8 @@
 #include "modules/svg/image_loader_svg.h"
 #endif
 
+static const int default_font_size = 16;
+
 static float scale = 1.0;
 
 static const int default_margin = 4;

--- a/scene/resources/default_theme/default_theme.h
+++ b/scene/resources/default_theme/default_theme.h
@@ -33,8 +33,6 @@
 
 #include "scene/resources/theme.h"
 
-const int default_font_size = 16;
-
 void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const Ref<Font> &bold_font, const Ref<Font> &bold_italics_font, const Ref<Font> &italics_font, Ref<Texture2D> &default_icon, Ref<StyleBox> &default_style, float p_scale);
 void make_default_theme(float p_scale, Ref<Font> p_font, TextServer::SubpixelPositioning p_font_subpixel = TextServer::SUBPIXEL_POSITIONING_AUTO, TextServer::Hinting p_font_hinting = TextServer::HINTING_LIGHT, TextServer::FontAntialiasing p_font_antialiased = TextServer::FONT_ANTIALIASING_GRAY, bool p_font_msdf = false, bool p_font_generate_mipmaps = false);
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -38,6 +38,7 @@
 #include "scene/resources/bit_map.h"
 #include "scene/resources/mesh.h"
 #include "servers/camera/camera_feed.h"
+
 int Texture2D::get_width() const {
 	int ret;
 	if (GDVIRTUAL_REQUIRED_CALL(_get_width, ret)) {
@@ -3105,7 +3106,7 @@ Error CompressedTextureLayered::_load_data(const String &p_path, Vector<Ref<Imag
 
 	uint32_t layer_count = f->get_32(); //layer count
 	uint32_t type = f->get_32(); //layer count
-	ERR_FAIL_COND_V(type != layered_type, ERR_INVALID_DATA);
+	ERR_FAIL_COND_V((int)type != layered_type, ERR_INVALID_DATA);
 
 	uint32_t df = f->get_32(); //data format
 	mipmap_limit = int(f->get_32());

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -378,8 +378,8 @@ Files extracted from upstream repository:
 - `minimp3_ex.h`
 - `LICENSE`
 
-Some changes have been made in order to fix Windows on ARM build errors.
-They are marked with `// -- GODOT start --` and `// -- GODOT end --`
+Some changes have been made in order to fix Windows on ARM build errors, and
+to solve some MSVC warnings. See the patches in the `patches` directory.
 
 
 ## miniupnpc

--- a/thirdparty/minimp3/minimp3_ex.h
+++ b/thirdparty/minimp3/minimp3_ex.h
@@ -377,7 +377,7 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
         samples = hdr_frame_samples(hdr)*frame_info.channels;
         if (3 != frame_info.layer)
             break;
-        int ret = mp3dec_check_vbrtag(hdr, frame_size, &frames, &delay, &padding);
+        ret = mp3dec_check_vbrtag(hdr, frame_size, &frames, &delay, &padding);
         if (ret > 0)
         {
             padding *= frame_info.channels;
@@ -529,7 +529,8 @@ int mp3dec_iterate_buf(const uint8_t *buf, size_t buf_size, MP3D_ITERATE_CB call
 
         if (callback)
         {
-            if ((ret = callback(user_data, hdr, frame_size, free_format_bytes, buf_size, hdr - orig_buf, &frame_info)))
+            ret = callback(user_data, hdr, frame_size, free_format_bytes, buf_size, hdr - orig_buf, &frame_info);
+            if (ret != 0)
                 return ret;
         }
         buf      += frame_size;
@@ -562,7 +563,7 @@ int mp3dec_iterate_cb(mp3dec_io_t *io, uint8_t *buf, size_t buf_size, MP3D_ITERA
         readed += id3v2size;
     } else
     {
-        size_t readed = io->read(buf + MINIMP3_ID3_DETECT_SIZE, buf_size - MINIMP3_ID3_DETECT_SIZE, io->read_data);
+        readed = io->read(buf + MINIMP3_ID3_DETECT_SIZE, buf_size - MINIMP3_ID3_DETECT_SIZE, io->read_data);
         if (readed > (buf_size - MINIMP3_ID3_DETECT_SIZE))
             return MP3D_E_IOERROR;
         filled += readed;
@@ -590,7 +591,8 @@ int mp3dec_iterate_cb(mp3dec_io_t *io, uint8_t *buf, size_t buf_size, MP3D_ITERA
         readed += i;
         if (callback)
         {
-            if ((ret = callback(user_data, hdr, frame_size, free_format_bytes, filled - consumed, readed, &frame_info)))
+            ret = callback(user_data, hdr, frame_size, free_format_bytes, filled - consumed, readed, &frame_info);
+            if (ret != 0)
                 return ret;
         }
         readed += frame_size;
@@ -600,7 +602,7 @@ int mp3dec_iterate_cb(mp3dec_io_t *io, uint8_t *buf, size_t buf_size, MP3D_ITERA
             memmove(buf, buf + consumed, filled - consumed);
             filled -= consumed;
             consumed = 0;
-            size_t readed = io->read(buf + filled, buf_size - filled, io->read_data);
+            readed = io->read(buf + filled, buf_size - filled, io->read_data);
             if (readed > (buf_size - filled))
                 return MP3D_E_IOERROR;
             if (readed != (buf_size - filled))

--- a/thirdparty/minimp3/patches/msvc-arm-fix.patch
+++ b/thirdparty/minimp3/patches/msvc-arm-fix.patch
@@ -1,0 +1,43 @@
+diff --git a/thirdparty/minimp3/minimp3.h b/thirdparty/minimp3/minimp3.h
+index 3220ae1a85..2a9975cc86 100644
+--- a/thirdparty/minimp3/minimp3.h
++++ b/thirdparty/minimp3/minimp3.h
+@@ -1566,7 +1566,18 @@ static void mp3d_synth(float *xl, mp3d_sample_t *dstl, int nch, float *lins)
+ 
+ #else /* MINIMP3_FLOAT_OUTPUT */
+ 
++// -- GODOT start --
++#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM))
++            static f4 g_scale;
++            g_scale = vsetq_lane_f32(1.0f/32768.0f, g_scale, 0);
++            g_scale = vsetq_lane_f32(1.0f/32768.0f, g_scale, 1);
++            g_scale = vsetq_lane_f32(1.0f/32768.0f, g_scale, 2);
++            g_scale = vsetq_lane_f32(1.0f/32768.0f, g_scale, 3);
++#else
+             static const f4 g_scale = { 1.0f/32768.0f, 1.0f/32768.0f, 1.0f/32768.0f, 1.0f/32768.0f };
++#endif
++// -- GODOT end --
++
+             a = VMUL(a, g_scale);
+             b = VMUL(b, g_scale);
+ #if HAVE_SSE
+@@ -1813,7 +1824,19 @@ void mp3dec_f32_to_s16(const float *in, int16_t *out, int num_samples)
+     int aligned_count = num_samples & ~7;
+     for(; i < aligned_count; i += 8)
+     {
++
++// -- GODOT start --
++#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC) || defined(_M_ARM))
++            static f4 g_scale;
++            g_scale = vsetq_lane_f32(32768.0f, g_scale, 0);
++            g_scale = vsetq_lane_f32(32768.0f, g_scale, 1);
++            g_scale = vsetq_lane_f32(32768.0f, g_scale, 2);
++            g_scale = vsetq_lane_f32(32768.0f, g_scale, 3);
++#else
+         static const f4 g_scale = { 32768.0f, 32768.0f, 32768.0f, 32768.0f };
++#endif
++// -- GODOT end --
++
+         f4 a = VMUL(VLD(&in[i  ]), g_scale);
+         f4 b = VMUL(VLD(&in[i+4]), g_scale);
+ #if HAVE_SSE

--- a/thirdparty/minimp3/patches/msvc-warnings-fixes.patch
+++ b/thirdparty/minimp3/patches/msvc-warnings-fixes.patch
@@ -1,0 +1,51 @@
+diff --git a/thirdparty/minimp3/minimp3_ex.h b/thirdparty/minimp3/minimp3_ex.h
+index 2871705df3..2b207a25a7 100644
+--- a/thirdparty/minimp3/minimp3_ex.h
++++ b/thirdparty/minimp3/minimp3_ex.h
+@@ -377,7 +377,7 @@ int mp3dec_load_cb(mp3dec_t *dec, mp3dec_io_t *io, uint8_t *buf, size_t buf_size
+         samples = hdr_frame_samples(hdr)*frame_info.channels;
+         if (3 != frame_info.layer)
+             break;
+-        int ret = mp3dec_check_vbrtag(hdr, frame_size, &frames, &delay, &padding);
++        ret = mp3dec_check_vbrtag(hdr, frame_size, &frames, &delay, &padding);
+         if (ret > 0)
+         {
+             padding *= frame_info.channels;
+@@ -529,7 +529,8 @@ int mp3dec_iterate_buf(const uint8_t *buf, size_t buf_size, MP3D_ITERATE_CB call
+ 
+         if (callback)
+         {
+-            if ((ret = callback(user_data, hdr, frame_size, free_format_bytes, buf_size, hdr - orig_buf, &frame_info)))
++            ret = callback(user_data, hdr, frame_size, free_format_bytes, buf_size, hdr - orig_buf, &frame_info);
++            if (ret != 0)
+                 return ret;
+         }
+         buf      += frame_size;
+@@ -562,7 +563,7 @@ int mp3dec_iterate_cb(mp3dec_io_t *io, uint8_t *buf, size_t buf_size, MP3D_ITERA
+         readed += id3v2size;
+     } else
+     {
+-        size_t readed = io->read(buf + MINIMP3_ID3_DETECT_SIZE, buf_size - MINIMP3_ID3_DETECT_SIZE, io->read_data);
++        readed = io->read(buf + MINIMP3_ID3_DETECT_SIZE, buf_size - MINIMP3_ID3_DETECT_SIZE, io->read_data);
+         if (readed > (buf_size - MINIMP3_ID3_DETECT_SIZE))
+             return MP3D_E_IOERROR;
+         filled += readed;
+@@ -590,7 +591,8 @@ int mp3dec_iterate_cb(mp3dec_io_t *io, uint8_t *buf, size_t buf_size, MP3D_ITERA
+         readed += i;
+         if (callback)
+         {
+-            if ((ret = callback(user_data, hdr, frame_size, free_format_bytes, filled - consumed, readed, &frame_info)))
++            ret = callback(user_data, hdr, frame_size, free_format_bytes, filled - consumed, readed, &frame_info);
++            if (ret != 0)
+                 return ret;
+         }
+         readed += frame_size;
+@@ -600,7 +602,7 @@ int mp3dec_iterate_cb(mp3dec_io_t *io, uint8_t *buf, size_t buf_size, MP3D_ITERA
+             memmove(buf, buf + consumed, filled - consumed);
+             filled -= consumed;
+             consumed = 0;
+-            size_t readed = io->read(buf + filled, buf_size - filled, io->read_data);
++            readed = io->read(buf + filled, buf_size - filled, io->read_data);
+             if (readed > (buf_size - filled))
+                 return MP3D_E_IOERROR;
+             if (readed != (buf_size - filled))


### PR DESCRIPTION
Part of #66537.

- Silences C4324 in raycast module: https://github.com/godotengine/godot/issues/66537#issuecomment-1260836152
- Fixes C4389 by casting: https://github.com/godotengine/godot/issues/66537#issuecomment-1260875770
- Fixes C4456 by patching minimp3 code (will PR upstream later): https://github.com/godotengine/godot/issues/66537#issuecomment-1260885039
- Fixes C4459 by moving the definition to the .cpp: https://github.com/godotengine/godot/issues/66537#issuecomment-1260916695