### PR TITLE
Add methods to get target filter and repeat

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1092,7 +1092,7 @@ int CanvasItem::get_canvas_layer() const {
 	}
 }
 
-void CanvasItem::_update_texture_filter_changed(bool p_propagate) {
+void CanvasItem::_refresh_texture_filter_cache() {
 	if (!is_inside_tree()) {
 		return;
 	}
@@ -1107,6 +1107,14 @@ void CanvasItem::_update_texture_filter_changed(bool p_propagate) {
 	} else {
 		texture_filter_cache = RS::CanvasItemTextureFilter(texture_filter);
 	}
+}
+
+void CanvasItem::_update_texture_filter_changed(bool p_propagate) {
+	if (!is_inside_tree()) {
+		return;
+	}
+	_refresh_texture_filter_cache();
+
 	RS::get_singleton()->canvas_item_set_default_texture_filter(get_canvas_item(), texture_filter_cache);
 	queue_redraw();
 
@@ -1133,7 +1141,7 @@ CanvasItem::TextureFilter CanvasItem::get_texture_filter() const {
 	return texture_filter;
 }
 
-void CanvasItem::_update_texture_repeat_changed(bool p_propagate) {
+void CanvasItem::_refresh_texture_repeat_cache() {
 	if (!is_inside_tree()) {
 		return;
 	}
@@ -1148,6 +1156,14 @@ void CanvasItem::_update_texture_repeat_changed(bool p_propagate) {
 	} else {
 		texture_repeat_cache = RS::CanvasItemTextureRepeat(texture_repeat);
 	}
+}
+
+void CanvasItem::_update_texture_repeat_changed(bool p_propagate) {
+	if (!is_inside_tree()) {
+		return;
+	}
+	_refresh_texture_repeat_cache();
+
 	RS::get_singleton()->canvas_item_set_default_texture_repeat(get_canvas_item(), texture_repeat_cache);
 	queue_redraw();
 	if (p_propagate) {
@@ -1187,6 +1203,16 @@ bool CanvasItem::is_clipping_children() const {
 
 CanvasItem::TextureRepeat CanvasItem::get_texture_repeat() const {
 	return texture_repeat;
+}
+
+CanvasItem::TextureFilter CanvasItem::get_texture_filter_in_tree() {
+	_refresh_texture_filter_cache();
+	return (TextureFilter)texture_filter_cache;
+}
+
+CanvasItem::TextureRepeat CanvasItem::get_texture_repeat_in_tree() {
+	_refresh_texture_repeat_cache();
+	return (TextureRepeat)texture_repeat_cache;
 }
 
 CanvasItem::CanvasItem() :

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -121,7 +121,9 @@ private:
 
 	static CanvasItem *current_item_drawn;
 	friend class Viewport;
+	void _refresh_texture_repeat_cache();
 	void _update_texture_repeat_changed(bool p_propagate);
+	void _refresh_texture_filter_cache();
 	void _update_texture_filter_changed(bool p_propagate);
 
 protected:
@@ -309,6 +311,9 @@ public:
 
 	virtual void set_texture_repeat(TextureRepeat p_texture_repeat);
 	TextureRepeat get_texture_repeat() const;
+
+	TextureFilter get_texture_filter_in_tree();
+	TextureRepeat get_texture_repeat_in_tree();
 
 	// Used by control nodes to retrieve the parent's anchorable area
 	virtual Rect2 get_anchorable_rect() const { return Rect2(0, 0, 0, 0); };


### PR DESCRIPTION
`get_texture_filter()` and `get_texture_repeat()` in CanvasItem return the filter/repeat of the current node, but if it's set to "inherit", the returned value isn't what one would expect. To get accurate value, you'd need something like `is_visible_in_tree()`, but for filter and repeat.

Luckily such thing exists and it's called `texture_filter_cache` and `texture_repeat_cache`. This PR exposes these properties via public methods `get_target_texture_filter()` and `get_target_texture_repeat()`.

This is needed for #60149 and #57596
The methods are not exposed to scripting for now.