### PR TITLE
refactor(TileMap): Return `Rect2i` in `get_used_rect`

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -188,7 +188,7 @@
 			</description>
 		</method>
 		<method name="get_used_rect">
-			<return type="Rect2" />
+			<return type="Rect2i" />
 			<description>
 				Returns a rectangle enclosing the used (non-empty) tiles of the map, including all layers.
 			</description>

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3615,7 +3615,7 @@ TypedArray<Vector2i> TileMap::get_used_cells(int p_layer) const {
 	return a;
 }
 
-Rect2 TileMap::get_used_rect() { // Not const because of cache
+Rect2i TileMap::get_used_rect() { // Not const because of cache
 	// Return the rect of the currently used area
 	if (used_rect_cache_dirty) {
 		bool first = true;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -375,7 +375,7 @@ public:
 	Vector2i get_neighbor_cell(const Vector2i &p_coords, TileSet::CellNeighbor p_cell_neighbor) const;
 
 	TypedArray<Vector2i> get_used_cells(int p_layer) const;
-	Rect2 get_used_rect(); // Not const because of cache
+	Rect2i get_used_rect(); // Not const because of cache
 
 	// Override some methods of the CanvasItem class to pass the changes to the quadrants CanvasItems
 	virtual void set_light_mask(int p_light_mask) override;


### PR DESCRIPTION
Return `Rect2i` instead of `Rect2` in `TileMap.get_used_rect` because it is already used internally but converted upon return.
