### PR TITLE
Fix GDScript `load` with relative path

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2939,7 +2939,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 
 				Variant value;
 				Callable::CallError err;
-				GDScriptUtilityFunctions::get_function(function_name)(&value, (const Variant **)args.ptr(), args.size(), err);
+				GDScriptUtilityFunctions::get_function(function_name)(&value, (const Variant **)args.ptr(), args.size(), nullptr, err);
 
 				switch (err.error) {
 					case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT: {

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -85,7 +85,7 @@
 #endif
 
 struct GDScriptUtilityFunctionsDefinitions {
-	static inline void convert(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void convert(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(2);
 		VALIDATE_ARG_INT(1);
 		int type = *p_args[1];
@@ -101,19 +101,19 @@ struct GDScriptUtilityFunctionsDefinitions {
 		}
 	}
 
-	static inline void type_exists(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void type_exists(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 		*r_ret = ClassDB::class_exists(*p_args[0]);
 	}
 
-	static inline void _char(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void _char(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 		VALIDATE_ARG_INT(0);
 		char32_t result[2] = { *p_args[0], 0 };
 		*r_ret = String(result);
 	}
 
-	static inline void range(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void range(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		switch (p_arg_count) {
 			case 0: {
 				r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
@@ -229,7 +229,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		}
 	}
 
-	static inline void load(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void load(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 		if (p_args[0]->get_type() != Variant::STRING) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
@@ -237,11 +237,16 @@ struct GDScriptUtilityFunctionsDefinitions {
 			r_error.expected = Variant::STRING;
 			*r_ret = Variant();
 		} else {
-			*r_ret = ResourceLoader::load(*p_args[0]);
+			String path = *p_args[0];
+			if (p_script.is_valid() && p_script->get_path() != "" && !path.is_absolute_path()) {
+				path = p_script->get_path().get_base_dir().path_join(path);
+				path = path.replace("///", "//").simplify_path();
+			}
+			*r_ret = ResourceLoader::load(path);
 		}
 	}
 
-	static inline void inst_to_dict(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void inst_to_dict(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 
 		if (p_args[0]->get_type() == Variant::NIL) {
@@ -309,7 +314,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		}
 	}
 
-	static inline void dict_to_inst(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void dict_to_inst(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 
 		if (p_args[0]->get_type() != Variant::DICTIONARY) {
@@ -385,7 +390,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		}
 	}
 
-	static inline void Color8(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void Color8(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		if (p_arg_count < 3) {
 			r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 			r_error.argument = 3;
@@ -413,7 +418,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		*r_ret = color;
 	}
 
-	static inline void print_debug(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void print_debug(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		String s;
 		for (int i = 0; i < p_arg_count; i++) {
 			s += p_args[i]->operator String();
@@ -432,7 +437,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		*r_ret = Variant();
 	}
 
-	static inline void print_stack(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void print_stack(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(0);
 		if (Thread::get_caller_id() != Thread::get_main_id()) {
 			print_line("Cannot retrieve debug info outside the main thread. Thread ID: " + itos(Thread::get_caller_id()));
@@ -446,7 +451,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		*r_ret = Variant();
 	}
 
-	static inline void get_stack(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void get_stack(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(0);
 		if (Thread::get_caller_id() != Thread::get_main_id()) {
 			*r_ret = TypedArray<Dictionary>();
@@ -465,7 +470,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		*r_ret = ret;
 	}
 
-	static inline void len(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void len(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(1);
 		switch (p_args[0]->get_type()) {
 			case Variant::STRING: {
@@ -525,7 +530,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 		}
 	}
 
-	static inline void is_instance_of(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+	static inline void is_instance_of(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error) {
 		VALIDATE_ARG_COUNT(2);
 
 		if (p_args[1]->get_type() == Variant::INT) {

--- a/modules/gdscript/gdscript_utility_functions.h
+++ b/modules/gdscript/gdscript_utility_functions.h
@@ -31,15 +31,18 @@
 #ifndef GDSCRIPT_UTILITY_FUNCTIONS_H
 #define GDSCRIPT_UTILITY_FUNCTIONS_H
 
+#include "core/object/ref_counted.h"
 #include "core/string/string_name.h"
 #include "core/variant/variant.h"
 
 template <typename T>
 class TypedArray;
 
+class GDScript;
+
 class GDScriptUtilityFunctions {
 public:
-	typedef void (*FunctionPtr)(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
+	typedef void (*FunctionPtr)(Variant *r_ret, const Variant **p_args, int p_arg_count, const Ref<GDScript> p_script, Callable::CallError &r_error);
 
 	static FunctionPtr get_function(const StringName &p_function);
 	static bool has_function_return_value(const StringName &p_function);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2200,7 +2200,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_INSTRUCTION_ARG(dst, argc);
 
 				Callable::CallError err;
-				function(dst, (const Variant **)argptrs, argc, err);
+				function(dst, (const Variant **)argptrs, argc, p_instance->script, err);
 
 #ifdef DEBUG_ENABLED
 				if (err.error != Callable::CallError::CALL_OK) {

--- a/modules/gdscript/tests/scripts/runtime/features/..load_relative_path_dot.notest.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/..load_relative_path_dot.notest.gd
@@ -1,0 +1,4 @@
+extends RefCounted
+
+func hello():
+    print("withdot2")

--- a/modules/gdscript/tests/scripts/runtime/features/.load_relative_path_dot.notest.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/.load_relative_path_dot.notest.gd
@@ -1,0 +1,4 @@
+extends RefCounted
+
+func hello():
+    print("withdot")

--- a/modules/gdscript/tests/scripts/runtime/features/load_relative_path.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/load_relative_path.gd
@@ -1,0 +1,20 @@
+func test():
+    var file1 = load("./load_relative_path_external.notest.gd")
+    var inst1 = file1.new()
+    inst1.hello()
+
+    var file2 = load("./some_dir/../load_relative_path_external.notest.gd")
+    var inst2 = file2.new()
+    inst2.hello()
+
+    var file3 = load("../features/load_relative_path_external.notest.gd")
+    var inst3 = file3.new()
+    inst3.hello()
+
+    var withdot = load("./.load_relative_path_dot.notest.gd")
+    var instwithdot = withdot.new()
+    instwithdot.hello()
+
+    var withdot2 = load("./..load_relative_path_dot.notest.gd")
+    var instwithdot2 = withdot2.new()
+    instwithdot2.hello()

--- a/modules/gdscript/tests/scripts/runtime/features/load_relative_path.out
+++ b/modules/gdscript/tests/scripts/runtime/features/load_relative_path.out
@@ -1,0 +1,46 @@
+GDTEST_OK
+>> WARNING
+>> Line: 3
+>> UNSAFE_METHOD_ACCESS
+>> The method "new()" is not present on the inferred type "Resource" (but may be present on a subtype).
+>> WARNING
+>> Line: 4
+>> UNSAFE_METHOD_ACCESS
+>> The method "hello()" is not present on the inferred type "Variant" (but may be present on a subtype).
+>> WARNING
+>> Line: 7
+>> UNSAFE_METHOD_ACCESS
+>> The method "new()" is not present on the inferred type "Resource" (but may be present on a subtype).
+>> WARNING
+>> Line: 8
+>> UNSAFE_METHOD_ACCESS
+>> The method "hello()" is not present on the inferred type "Variant" (but may be present on a subtype).
+>> WARNING
+>> Line: 11
+>> UNSAFE_METHOD_ACCESS
+>> The method "new()" is not present on the inferred type "Resource" (but may be present on a subtype).
+>> WARNING
+>> Line: 12
+>> UNSAFE_METHOD_ACCESS
+>> The method "hello()" is not present on the inferred type "Variant" (but may be present on a subtype).
+>> WARNING
+>> Line: 15
+>> UNSAFE_METHOD_ACCESS
+>> The method "new()" is not present on the inferred type "Resource" (but may be present on a subtype).
+>> WARNING
+>> Line: 16
+>> UNSAFE_METHOD_ACCESS
+>> The method "hello()" is not present on the inferred type "Variant" (but may be present on a subtype).
+>> WARNING
+>> Line: 19
+>> UNSAFE_METHOD_ACCESS
+>> The method "new()" is not present on the inferred type "Resource" (but may be present on a subtype).
+>> WARNING
+>> Line: 20
+>> UNSAFE_METHOD_ACCESS
+>> The method "hello()" is not present on the inferred type "Variant" (but may be present on a subtype).
+loaded
+loaded
+loaded
+withdot
+withdot2

--- a/modules/gdscript/tests/scripts/runtime/features/load_relative_path_external.notest.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/load_relative_path_external.notest.gd
@@ -1,0 +1,4 @@
+extends RefCounted
+
+func hello():
+    print("loaded")


### PR DESCRIPTION
Supersedes #37324
Fixes #35832

First time touching GDScript internals, hope I didn't mess anything up!

As suggested in a comment in the previous PR, all utility function calls now pass the script reference, which is used for figuring out the absolute path.
Also by using `get_path()` instead of `path`, this PR supports built-in scripts as well.

**Open Question:**
I'm currently passing the analyzer a `nullptr` script reference. While `ResourceLoader::load(parser->script_path, "Script")` is possible, I don't understand yet what the "benefits" are, since I don't understand the analyzer's purpose beyond type checking.