### PR TITLE
fix(tileset): Recreate custom data editor if type has changed 

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1137,6 +1137,7 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, String p_property, String p_label, Variant p_default_value) {
 	ERR_FAIL_COND_MSG(!property.is_empty(), "Cannot setup TileDataDefaultEditor twice");
 	property = p_property;
+	property_type = p_type;
 
 	// Update everything.
 	if (property_editor) {
@@ -1179,6 +1180,10 @@ void TileDataDefaultEditor::_notification(int p_what) {
 			tile_bool_unchecked = get_theme_icon(SNAME("TileUnchecked"), SNAME("EditorIcons"));
 		} break;
 	}
+}
+
+Variant::Type TileDataDefaultEditor::get_property_type() {
+	return property_type;
 }
 
 TileDataDefaultEditor::TileDataDefaultEditor() {

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -220,6 +220,7 @@ protected:
 
 	StringName type;
 	String property;
+	Variant::Type property_type;
 	void _notification(int p_what);
 
 	virtual Variant _get_painted_value();
@@ -237,6 +238,7 @@ public:
 	virtual void draw_over_tile(CanvasItem *p_canvas_item, Transform2D p_transform, TileMapCell p_cell, bool p_selected = false) override;
 
 	void setup_property_editor(Variant::Type p_type, String p_property, String p_label = "", Variant p_default_value = Variant());
+	Variant::Type get_property_type();
 
 	TileDataDefaultEditor();
 	~TileDataDefaultEditor();

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -735,18 +735,29 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	// --- Custom Data ---
 	ADD_TILE_DATA_EDITOR_GROUP("Custom Data");
 	for (int i = 0; i < tile_set->get_custom_data_layers_count(); i++) {
-		if (tile_set->get_custom_data_layer_name(i).is_empty()) {
-			ADD_TILE_DATA_EDITOR(group, vformat("Custom Data %d", i), vformat("custom_data_%d", i));
+		String editor_name = vformat("custom_data_%d", i);
+		String prop_name = tile_set->get_custom_data_layer_name(i);
+		Variant::Type prop_type = tile_set->get_custom_data_layer_type(i);
+
+		if (prop_name.is_empty()) {
+			ADD_TILE_DATA_EDITOR(group, vformat("Custom Data %d", i), editor_name);
 		} else {
-			ADD_TILE_DATA_EDITOR(group, tile_set->get_custom_data_layer_name(i), vformat("custom_data_%d", i));
+			ADD_TILE_DATA_EDITOR(group, prop_name, editor_name);
 		}
-		if (!tile_data_editors.has(vformat("custom_data_%d", i))) {
+
+		// If the type of the edited property has been changed, delete the
+		// editor and create a new one.
+		if (tile_data_editors.has(editor_name) && ((TileDataDefaultEditor *)tile_data_editors[editor_name])->get_property_type() != prop_type) {
+			tile_data_editors[vformat("custom_data_%d", i)]->queue_delete();
+			tile_data_editors.erase(vformat("custom_data_%d", i));
+		}
+		if (!tile_data_editors.has(editor_name)) {
 			TileDataDefaultEditor *tile_data_custom_data_editor = memnew(TileDataDefaultEditor());
 			tile_data_custom_data_editor->hide();
-			tile_data_custom_data_editor->setup_property_editor(tile_set->get_custom_data_layer_type(i), vformat("custom_data_%d", i), tile_set->get_custom_data_layer_name(i));
+			tile_data_custom_data_editor->setup_property_editor(prop_type, editor_name, prop_name);
 			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)tile_atlas_control_unscaled, &Control::queue_redraw));
 			tile_data_custom_data_editor->connect("needs_redraw", callable_mp((CanvasItem *)alternative_tiles_control_unscaled, &Control::queue_redraw));
-			tile_data_editors[vformat("custom_data_%d", i)] = tile_data_custom_data_editor;
+			tile_data_editors[editor_name] = tile_data_custom_data_editor;
 		}
 	}
 	for (int i = tile_set->get_custom_data_layers_count(); tile_data_editors.has(vformat("custom_data_%d", i)); i++) {


### PR DESCRIPTION
Reload the property editor if the type of the tileset's custom data layer has changed.

Fixes https://github.com/godotengine/godot/issues/57642