### PR TITLE
`GodotCylinderShape3D::get_supports`: delete dead code

### DIFF
--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -735,29 +735,6 @@ void GodotCylinderShape3D::get_supports(const Vector3 &p_normal, int p_max, Vect
 		r_amount = 1;
 		r_type = FEATURE_POINT;
 		r_supports[0] = get_support(p_normal);
-		return;
-
-		Vector3 n = p_normal;
-		real_t h = n.y * Math::sqrt(0.25 * height * height + radius * radius);
-		if (Math::abs(h) > 1.0) {
-			// Top or bottom surface.
-			n.y = (n.y > 0.0) ? height * 0.5 : -height * 0.5;
-		} else {
-			// Lateral surface.
-			n.y = height * 0.5 * h;
-		}
-
-		real_t s = Math::sqrt(n.x * n.x + n.z * n.z);
-		if (Math::is_zero_approx(s)) {
-			n.x = 0.0;
-			n.z = 0.0;
-		} else {
-			real_t scaled_radius = radius / s;
-			n.x = n.x * scaled_radius;
-			n.z = n.z * scaled_radius;
-		}
-
-		r_supports[0] = n;
 	}
 }
 


### PR DESCRIPTION
Delete dead code which was presumably left over from testing. I didn't manage to understand the `Math::abs(h) <= 1.0` case in the dead code, or find an other physics engine with a cylinder support mapping that looks like that. For example, in the `p_normal` direction indicated by the raycast in the picture below, the dead code would return the red point as the support point:

![cylinder_support?](https://user-images.githubusercontent.com/229837/192878246-177f9499-c188-4727-862f-46124628d564.png)

But the red point is not a true support point, since e.g. all the points directly above it on the cylinder surface are "more extreme" points in the `p_normal` direction (they have a higher dot product with `p_normal`).

For posterity I observe that `GodotCylinderShape3D::get_support` (which replaces the dead code) is almost the support function from page 8 of [*A Fast and Robust GJK Implementation for Collision Detection of Convex Objects* by Gino van den Bergen](https://solid.sourceforge.net/jgt98convex.pdf), except for (the use of `!Math::is_zero_approx(s)` instead of `s > 0.0`, and) the different $x$-coordinate in the "otherwise" case.