### PR TITLE
Fix transition expression base node with autoloads

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -660,7 +660,10 @@ bool AnimationNodeStateMachinePlayback::_check_advance_condition(const Ref<Anima
 		Node *expression_base = nullptr;
 		if (!transition->get_advance_expression_base_node().is_empty()) {
 			advance_expression_base_node_path = transition->get_advance_expression_base_node();
-			expression_base = tree_base->get_tree()->get_root()->get_child(0)->get_node_or_null(advance_expression_base_node_path);
+			Window *root = tree_base->get_tree()->get_root();
+			int child_count = root->get_child_count();
+			// Autoloaded nodes are the first children of the root node
+			expression_base = root->get_child(child_count - 1)->get_node_or_null(advance_expression_base_node_path);
 		} else {
 			advance_expression_base_node_path = tree_base->get_advance_expression_base_node();
 			expression_base = tree_base->get_node_or_null(advance_expression_base_node_path);


### PR DESCRIPTION
Fix for #62530 when using autoloaded nodes.

My fix isn't exactly the most elegant one here, I couldn't find a better of doing it. The bug comes from the fact that `advance_expression_base_node_path` is relative to the scene's root node. The best way I found of retrieving that node at runtime was to get the last child of `get_tree()->get_root()` (the game `Window`) since the first ones are the autoloaded ones.