### PR TITLE
Use `constexpr` in the conditions with template parameters and `sizeof`s to suppress C4127 warnings.

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -559,7 +559,7 @@ static void gdnative_string_new_with_utf32_chars(GDNativeStringPtr r_dest, const
 
 static void gdnative_string_new_with_wide_chars(GDNativeStringPtr r_dest, const wchar_t *p_contents) {
 	String *dest = (String *)r_dest;
-	if (sizeof(wchar_t) == 2) {
+	if constexpr (sizeof(wchar_t) == 2) {
 		// wchar_t is 16 bit, parse.
 		memnew_placement(dest, String);
 		dest->parse_utf16((const char16_t *)p_contents);
@@ -596,7 +596,7 @@ static void gdnative_string_new_with_utf32_chars_and_len(GDNativeStringPtr r_des
 
 static void gdnative_string_new_with_wide_chars_and_len(GDNativeStringPtr r_dest, const wchar_t *p_contents, const GDNativeInt p_size) {
 	String *dest = (String *)r_dest;
-	if (sizeof(wchar_t) == 2) {
+	if constexpr (sizeof(wchar_t) == 2) {
 		// wchar_t is 16 bit, parse.
 		memnew_placement(dest, String);
 		dest->parse_utf16((const char16_t *)p_contents, p_size);
@@ -655,7 +655,7 @@ static GDNativeInt gdnative_string_to_utf32_chars(const GDNativeStringPtr p_self
 	return len;
 }
 static GDNativeInt gdnative_string_to_wide_chars(const GDNativeStringPtr p_self, wchar_t *r_text, GDNativeInt p_max_write_length) {
-	if (sizeof(wchar_t) == 4) {
+	if constexpr (sizeof(wchar_t) == 4) {
 		return gdnative_string_to_utf32_chars(p_self, (char32_t *)r_text, p_max_write_length);
 	} else {
 		return gdnative_string_to_utf16_chars(p_self, (char16_t *)r_text, p_max_write_length);

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -548,7 +548,7 @@ void FileAccess::store_64(uint64_t p_dest) {
 }
 
 void FileAccess::store_real(real_t p_real) {
-	if (sizeof(real_t) == 4) {
+	if constexpr (sizeof(real_t) == 4) {
 		store_float(p_real);
 	} else {
 		store_double(p_real);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -107,7 +107,7 @@ void ResourceLoaderBinary::_advance_padding(uint32_t p_len) {
 
 static Error read_reals(real_t *dst, Ref<FileAccess> &f, size_t count) {
 	if (f->real_is_double) {
-		if (sizeof(real_t) == 8) {
+		if constexpr (sizeof(real_t) == 8) {
 			// Ideal case with double-precision
 			f->get_buffer((uint8_t *)dst, count * sizeof(double));
 #ifdef BIG_ENDIAN_ENABLED
@@ -118,7 +118,7 @@ static Error read_reals(real_t *dst, Ref<FileAccess> &f, size_t count) {
 				}
 			}
 #endif
-		} else if (sizeof(real_t) == 4) {
+		} else if constexpr (sizeof(real_t) == 4) {
 			// May be slower, but this is for compatibility. Eventually the data should be converted.
 			for (size_t i = 0; i < count; ++i) {
 				dst[i] = f->get_double();
@@ -127,7 +127,7 @@ static Error read_reals(real_t *dst, Ref<FileAccess> &f, size_t count) {
 			ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "real_t size is neither 4 nor 8!");
 		}
 	} else {
-		if (sizeof(real_t) == 4) {
+		if constexpr (sizeof(real_t) == 4) {
 			// Ideal case with float-precision
 			f->get_buffer((uint8_t *)dst, count * sizeof(float));
 #ifdef BIG_ENDIAN_ENABLED
@@ -138,7 +138,7 @@ static Error read_reals(real_t *dst, Ref<FileAccess> &f, size_t count) {
 				}
 			}
 #endif
-		} else if (sizeof(real_t) == 8) {
+		} else if constexpr (sizeof(real_t) == 8) {
 			for (size_t i = 0; i < count; ++i) {
 				dst[i] = f->get_float();
 			}

--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -13,7 +13,7 @@ void _split_inform_references(uint32_t p_node_id) {
 
 void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, uint16_t *group_b, const BVHABB_CLASS *temp_bounds, const BVHABB_CLASS full_bound) {
 	// special case for low leaf sizes .. should static compile out
-	if (MAX_ITEMS < 4) {
+	if constexpr (MAX_ITEMS < 4) {
 		uint32_t ind = group_a[0];
 
 		// add to b
@@ -34,7 +34,7 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 	order[POINT::AXIS_COUNT - 1] = size.max_axis_index();
 
 	static_assert(POINT::AXIS_COUNT <= 3, "BVH POINT::AXIS_COUNT has unexpected size");
-	if (POINT::AXIS_COUNT == 3) {
+	if constexpr (POINT::AXIS_COUNT == 3) {
 		order[1] = 3 - (order[0] + order[2]);
 	}
 

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -68,7 +68,7 @@ public:
 			CRASH_COND_MSG(!data, "Out of memory");
 		}
 
-		if (!std::is_trivially_constructible<T>::value && !force_trivial) {
+		if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
 			memnew_placement(&data[count++], T(p_elem));
 		} else {
 			data[count++] = p_elem;
@@ -81,7 +81,7 @@ public:
 		for (U i = p_index; i < count; i++) {
 			data[i] = data[i + 1];
 		}
-		if (!std::is_trivially_destructible<T>::value && !force_trivial) {
+		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
 			data[count].~T();
 		}
 	}
@@ -94,7 +94,7 @@ public:
 		if (count > p_index) {
 			data[p_index] = data[count];
 		}
-		if (!std::is_trivially_destructible<T>::value && !force_trivial) {
+		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
 			data[count].~T();
 		}
 	}
@@ -135,7 +135,7 @@ public:
 	_FORCE_INLINE_ U size() const { return count; }
 	void resize(U p_size) {
 		if (p_size < count) {
-			if (!std::is_trivially_destructible<T>::value && !force_trivial) {
+			if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
 				for (U i = p_size; i < count; i++) {
 					data[i].~T();
 				}
@@ -152,7 +152,7 @@ public:
 				data = (T *)memrealloc(data, capacity * sizeof(T));
 				CRASH_COND_MSG(!data, "Out of memory");
 			}
-			if (!std::is_trivially_constructible<T>::value && !force_trivial) {
+			if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
 				for (U i = count; i < p_size; i++) {
 					memnew_placement(&data[i], T);
 				}

--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -112,7 +112,7 @@ public:
 		list.resize(r_id + 1);
 
 		static_assert((!zero_on_first_request) || (__is_pod(T)), "zero_on_first_request requires trivial type");
-		if (zero_on_first_request && __is_pod(T)) {
+		if constexpr (zero_on_first_request && __is_pod(T)) {
 			list[r_id] = {};
 		}
 

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -276,7 +276,7 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 
 template <typename T>
 inline StringName __constant_get_enum_name(T param, const String &p_constant) {
-	if (GetTypeInfo<T>::VARIANT_TYPE == Variant::NIL) {
+	if constexpr (GetTypeInfo<T>::VARIANT_TYPE == Variant::NIL) {
 		ERR_PRINT("Missing VARIANT_ENUM_CAST for constant's enum: " + p_constant);
 	}
 	return GetTypeInfo<T>::get_class_info().class_name;

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2043,7 +2043,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 		} break;
 	}
 
-	if (p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
+	if constexpr (p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 2);
 		GLuint texture_to_bind = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_CUBEMAP_BLACK))->tex_id;
 		if (p_render_data->environment.is_valid()) {
@@ -2074,7 +2074,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 		GLES3::SceneMaterialData *material_data;
 		void *mesh_surface;
 
-		if (p_pass_mode == PASS_MODE_SHADOW) {
+		if constexpr (p_pass_mode == PASS_MODE_SHADOW) {
 			shader = surf->shader_shadow;
 			material_data = surf->material_shadow;
 			mesh_surface = surf->surface_shadow;
@@ -2088,7 +2088,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			continue;
 		}
 
-		if (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
+		if constexpr (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
 			if (scene_state.current_depth_test != shader->depth_test) {
 				if (shader->depth_test == GLES3::SceneShaderData::DEPTH_TEST_DISABLED) {
 					glDisable(GL_DEPTH_TEST);
@@ -2115,9 +2115,9 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			scene_state.current_depth_draw = shader->depth_draw;
 		}
 
-		if (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT || p_pass_mode == PASS_MODE_COLOR_ADDITIVE) {
+		if constexpr (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT || p_pass_mode == PASS_MODE_COLOR_ADDITIVE) {
 			GLES3::SceneShaderData::BlendMode desired_blend_mode;
-			if (p_pass_mode == PASS_MODE_COLOR_ADDITIVE) {
+			if constexpr (p_pass_mode == PASS_MODE_COLOR_ADDITIVE) {
 				desired_blend_mode = GLES3::SceneShaderData::BLEND_MODE_ADD;
 			} else {
 				desired_blend_mode = shader->blend_mode;
@@ -2241,9 +2241,9 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 		if (prev_shader != shader || prev_variant != instance_variant) {
 			material_storage->shaders.scene_shader.version_bind_shader(shader->version, instance_variant);
 			float opaque_prepass_threshold = 0.0;
-			if (p_pass_mode == PASS_MODE_DEPTH) {
+			if constexpr (p_pass_mode == PASS_MODE_DEPTH) {
 				opaque_prepass_threshold = 0.99;
-			} else if (p_pass_mode == PASS_MODE_SHADOW) {
+			} else if constexpr (p_pass_mode == PASS_MODE_SHADOW) {
 				opaque_prepass_threshold = 0.1;
 			}
 

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -180,7 +180,7 @@ void AudioStreamPlaybackWAV::do_resample(const Depth *p_src, AudioFrame *p_dst, 
 				final_r = p_src[pos + 1];
 			}
 
-			if (sizeof(Depth) == 1) { /* conditions will not exist anymore when compiled! */
+			if constexpr (sizeof(Depth) == 1) { /* conditions will not exist anymore when compiled! */
 				final <<= 8;
 				if (is_stereo) {
 					final_r <<= 8;
@@ -194,7 +194,7 @@ void AudioStreamPlaybackWAV::do_resample(const Depth *p_src, AudioFrame *p_dst, 
 				next = p_src[pos + 1];
 			}
 
-			if (sizeof(Depth) == 1) {
+			if constexpr (sizeof(Depth) == 1) {
 				next <<= 8;
 				if (is_stereo) {
 					next_r <<= 8;

--- a/servers/audio/audio_rb_resampler.cpp
+++ b/servers/audio/audio_rb_resampler.cpp
@@ -57,14 +57,14 @@ uint32_t AudioRBResampler::_resample(AudioFrame *p_dest, int p_todo, int32_t p_i
 		uint32_t pos_next = (pos + 1) & rb_mask;
 
 		// since this is a template with a known compile time value (C), conditionals go away when compiling.
-		if (C == 1) {
+		if constexpr (C == 1) {
 			float v0 = rb[pos];
 			float v0n = rb[pos_next];
 			v0 += (v0n - v0) * frac;
 			p_dest[i] = AudioFrame(v0, v0);
 		}
 
-		if (C == 2) {
+		if constexpr (C == 2) {
 			float v0 = rb[(pos << 1) + 0];
 			float v1 = rb[(pos << 1) + 1];
 			float v0n = rb[(pos_next << 1) + 0];
@@ -76,7 +76,7 @@ uint32_t AudioRBResampler::_resample(AudioFrame *p_dest, int p_todo, int32_t p_i
 		}
 
 		// This will probably never be used, but added anyway
-		if (C == 4) {
+		if constexpr (C == 4) {
 			float v0 = rb[(pos << 2) + 0];
 			float v1 = rb[(pos << 2) + 1];
 			float v0n = rb[(pos_next << 2) + 0];
@@ -86,7 +86,7 @@ uint32_t AudioRBResampler::_resample(AudioFrame *p_dest, int p_todo, int32_t p_i
 			p_dest[i] = AudioFrame(v0, v1);
 		}
 
-		if (C == 6) {
+		if constexpr (C == 6) {
 			float v0 = rb[(pos * 6) + 0];
 			float v1 = rb[(pos * 6) + 1];
 			float v0n = rb[(pos_next * 6) + 0];

--- a/servers/audio/effects/audio_effect_filter.cpp
+++ b/servers/audio/effects/audio_effect_filter.cpp
@@ -36,13 +36,13 @@ void AudioEffectFilterInstance::_process_filter(const AudioFrame *p_src_frames, 
 	for (int i = 0; i < p_frame_count; i++) {
 		float f = p_src_frames[i].l;
 		filter_process[0][0].process_one(f);
-		if (S > 1) {
+		if constexpr (S > 1) {
 			filter_process[0][1].process_one(f);
 		}
-		if (S > 2) {
+		if constexpr (S > 2) {
 			filter_process[0][2].process_one(f);
 		}
-		if (S > 3) {
+		if constexpr (S > 3) {
 			filter_process[0][3].process_one(f);
 		}
 
@@ -52,13 +52,13 @@ void AudioEffectFilterInstance::_process_filter(const AudioFrame *p_src_frames, 
 	for (int i = 0; i < p_frame_count; i++) {
 		float f = p_src_frames[i].r;
 		filter_process[1][0].process_one(f);
-		if (S > 1) {
+		if constexpr (S > 1) {
 			filter_process[1][1].process_one(f);
 		}
-		if (S > 2) {
+		if constexpr (S > 2) {
 			filter_process[1][2].process_one(f);
 		}
-		if (S > 3) {
+		if constexpr (S > 3) {
 			filter_process[1][3].process_one(f);
 		}
 

--- a/servers/audio/effects/audio_stream_generator.cpp
+++ b/servers/audio/effects/audio_stream_generator.cpp
@@ -108,7 +108,7 @@ bool AudioStreamGeneratorPlayback::push_buffer(const PackedVector2Array &p_frame
 	}
 
 	const Vector2 *r = p_frames.ptr();
-	if (sizeof(real_t) == 4) {
+	if constexpr (sizeof(real_t) == 4) {
 		//write directly
 		buffer.write((const AudioFrame *)r, to_write);
 	} else {

--- a/servers/physics_2d/godot_collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/godot_collision_solver_2d_sat.cpp
@@ -498,7 +498,7 @@ static void _collision_segment_rectangle(const GodotShape2D *p_a, const Transfor
 			return;
 		}
 
-		if (castA) {
+		if constexpr (castA) {
 			if (!separator.test_axis(rectangle_B->get_circle_axis(p_transform_b, inv, a + p_motion_a))) {
 				return;
 			}
@@ -507,7 +507,7 @@ static void _collision_segment_rectangle(const GodotShape2D *p_a, const Transfor
 			}
 		}
 
-		if (castB) {
+		if constexpr (castB) {
 			if (!separator.test_axis(rectangle_B->get_circle_axis(p_transform_b, inv, a - p_motion_b))) {
 				return;
 			}
@@ -516,7 +516,7 @@ static void _collision_segment_rectangle(const GodotShape2D *p_a, const Transfor
 			}
 		}
 
-		if (castA && castB) {
+		if constexpr (castA && castB) {
 			if (!separator.test_axis(rectangle_B->get_circle_axis(p_transform_b, inv, a - p_motion_b + p_motion_a))) {
 				return;
 			}
@@ -665,21 +665,21 @@ static void _collision_circle_rectangle(const GodotShape2D *p_a, const Transform
 		}
 	}
 
-	if (castA) {
+	if constexpr (castA) {
 		Vector2 sphereofs = sphere + p_motion_a;
 		if (!separator.test_axis(rectangle_B->get_circle_axis(p_transform_b, binv, sphereofs))) {
 			return;
 		}
 	}
 
-	if (castB) {
+	if constexpr (castB) {
 		Vector2 sphereofs = sphere - p_motion_b;
 		if (!separator.test_axis(rectangle_B->get_circle_axis(p_transform_b, binv, sphereofs))) {
 			return;
 		}
 	}
 
-	if (castA && castB) {
+	if constexpr (castA && castB) {
 		Vector2 sphereofs = sphere - p_motion_b + p_motion_a;
 		if (!separator.test_axis(rectangle_B->get_circle_axis(p_transform_b, binv, sphereofs))) {
 			return;
@@ -786,7 +786,7 @@ static void _collision_rectangle_rectangle(const GodotShape2D *p_a, const Transf
 		return;
 	}
 
-	if (withMargin) {
+	if constexpr (withMargin) {
 		Transform2D invA = p_transform_a.affine_inverse();
 		Transform2D invB = p_transform_b.affine_inverse();
 
@@ -794,29 +794,29 @@ static void _collision_rectangle_rectangle(const GodotShape2D *p_a, const Transf
 			return;
 		}
 
-		if (castA || castB) {
+		if constexpr (castA || castB) {
 			Transform2D aofs = p_transform_a;
 			aofs.columns[2] += p_motion_a;
 
 			Transform2D bofs = p_transform_b;
 			bofs.columns[2] += p_motion_b;
 
-			Transform2D aofsinv = aofs.affine_inverse();
-			Transform2D bofsinv = bofs.affine_inverse();
+			[[maybe_unused]] Transform2D aofsinv = aofs.affine_inverse();
+			[[maybe_unused]] Transform2D bofsinv = bofs.affine_inverse();
 
-			if (castA) {
+			if constexpr (castA) {
 				if (!separator.test_axis(rectangle_A->get_box_axis(aofs, aofsinv, rectangle_B, p_transform_b, invB))) {
 					return;
 				}
 			}
 
-			if (castB) {
+			if constexpr (castB) {
 				if (!separator.test_axis(rectangle_A->get_box_axis(p_transform_a, invA, rectangle_B, bofs, bofsinv))) {
 					return;
 				}
 			}
 
-			if (castA && castB) {
+			if constexpr (castA && castB) {
 				if (!separator.test_axis(rectangle_A->get_box_axis(aofs, aofsinv, rectangle_B, bofs, bofsinv))) {
 					return;
 				}
@@ -871,7 +871,7 @@ static void _collision_rectangle_capsule(const GodotShape2D *p_a, const Transfor
 			}
 		}
 
-		if (castA) {
+		if constexpr (castA) {
 			Vector2 capsule_endpoint = p_transform_b.get_origin() + p_transform_b.columns[1] * capsule_dir;
 			capsule_endpoint -= p_motion_a;
 
@@ -880,7 +880,7 @@ static void _collision_rectangle_capsule(const GodotShape2D *p_a, const Transfor
 			}
 		}
 
-		if (castB) {
+		if constexpr (castB) {
 			Vector2 capsule_endpoint = p_transform_b.get_origin() + p_transform_b.columns[1] * capsule_dir;
 			capsule_endpoint += p_motion_b;
 
@@ -889,7 +889,7 @@ static void _collision_rectangle_capsule(const GodotShape2D *p_a, const Transfor
 			}
 		}
 
-		if (castA && castB) {
+		if constexpr (castA && castB) {
 			Vector2 capsule_endpoint = p_transform_b.get_origin() + p_transform_b.columns[1] * capsule_dir;
 			capsule_endpoint -= p_motion_a;
 			capsule_endpoint += p_motion_b;
@@ -931,7 +931,7 @@ static void _collision_rectangle_convex_polygon(const GodotShape2D *p_a, const T
 
 	//convex faces
 	Transform2D boxinv;
-	if (withMargin) {
+	if constexpr (withMargin) {
 		boxinv = p_transform_a.affine_inverse();
 	}
 	for (int i = 0; i < convex_B->get_point_count(); i++) {
@@ -939,22 +939,22 @@ static void _collision_rectangle_convex_polygon(const GodotShape2D *p_a, const T
 			return;
 		}
 
-		if (withMargin) {
+		if constexpr (withMargin) {
 			//all points vs all points need to be tested if margin exist
 			if (!separator.test_axis(rectangle_A->get_circle_axis(p_transform_a, boxinv, p_transform_b.xform(convex_B->get_point(i))))) {
 				return;
 			}
-			if (castA) {
+			if constexpr (castA) {
 				if (!separator.test_axis(rectangle_A->get_circle_axis(p_transform_a, boxinv, p_transform_b.xform(convex_B->get_point(i)) - p_motion_a))) {
 					return;
 				}
 			}
-			if (castB) {
+			if constexpr (castB) {
 				if (!separator.test_axis(rectangle_A->get_circle_axis(p_transform_a, boxinv, p_transform_b.xform(convex_B->get_point(i)) + p_motion_b))) {
 					return;
 				}
 			}
-			if (castA && castB) {
+			if constexpr (castA && castB) {
 				if (!separator.test_axis(rectangle_A->get_circle_axis(p_transform_a, boxinv, p_transform_b.xform(convex_B->get_point(i)) + p_motion_b - p_motion_a))) {
 					return;
 				}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -276,7 +276,7 @@ void RenderForwardClustered::_render_list_template(RenderingDevice::DrawListID p
 
 	SceneState::PushConstant push_constant;
 
-	if (p_pass_mode == PASS_MODE_DEPTH_MATERIAL) {
+	if constexpr (p_pass_mode == PASS_MODE_DEPTH_MATERIAL) {
 		push_constant.uv_offset = Math::make_half_float(p_params->uv_offset.y) << 16;
 		push_constant.uv_offset |= Math::make_half_float(p_params->uv_offset.x);
 	} else {
@@ -355,7 +355,7 @@ void RenderForwardClustered::_render_list_template(RenderingDevice::DrawListID p
 		uint32_t pipeline_color_pass_flags = 0;
 		uint32_t pipeline_specialization = 0;
 
-		if (p_pass_mode == PASS_MODE_COLOR) {
+		if constexpr (p_pass_mode == PASS_MODE_COLOR) {
 			if (element_info.uses_softshadow) {
 				pipeline_specialization |= SceneShaderForwardClustered::SHADER_SPECIALIZATION_SOFT_SHADOWS;
 			}


### PR DESCRIPTION
Part of https://github.com/godotengine/godot/issues/66537
