### PR TITLE
Fix unset `ObjectID` with validated `get_object()` call

### DIFF
--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -1047,7 +1047,7 @@ struct VariantInternalAccessor<PackedColorArray> {
 template <>
 struct VariantInternalAccessor<Object *> {
 	static _FORCE_INLINE_ Object *get(const Variant *v) { return const_cast<Object *>(*VariantInternal::get_object(v)); }
-	static _FORCE_INLINE_ void set(Variant *v, const Object *p_value) { *VariantInternal::get_object(v) = const_cast<Object *>(p_value); }
+	static _FORCE_INLINE_ void set(Variant *v, const Object *p_value) { VariantInternal::object_assign(v, p_value); }
 };
 
 template <>
@@ -1529,29 +1529,6 @@ struct VariantTypeConstructor {
 
 	_FORCE_INLINE_ static void type_from_variant(void *p_value, void *p_variant) {
 		*((T *)p_value) = VariantInternalAccessor<T>::get(reinterpret_cast<Variant *>(p_variant));
-	}
-};
-
-template <>
-struct VariantTypeConstructor<Object *> {
-	_FORCE_INLINE_ static void variant_from_type(void *p_variant, void *p_value) {
-		Variant *variant = reinterpret_cast<Variant *>(p_variant);
-		VariantInitializer<Object *>::init(variant);
-		Object *object = *(reinterpret_cast<Object **>(p_value));
-		if (object) {
-			if (object->is_ref_counted()) {
-				if (!VariantInternal::initialize_ref(object)) {
-					return;
-				}
-			}
-			VariantInternalAccessor<Object *>::set(variant, object);
-			VariantInternalAccessor<ObjectID>::set(variant, object->get_instance_id());
-		}
-	}
-
-	_FORCE_INLINE_ static void type_from_variant(void *p_value, void *p_variant) {
-		Object **value = reinterpret_cast<Object **>(p_value);
-		*value = VariantInternalAccessor<Object *>::get(reinterpret_cast<Variant *>(p_variant));
 	}
 };
 


### PR DESCRIPTION
Fixes unset `ObjectID` in variant when calling a validated builtin method returning an `Object *`.
I'm not familiar with this code, but I'm making a pull request because of how simple it seems. And it fixes the problem of course.

Fixes  #66139