### PR TITLE
Fix NavigationObstacle not estimating radius

### DIFF
--- a/scene/3d/navigation_obstacle.cpp
+++ b/scene/3d/navigation_obstacle.cpp
@@ -216,12 +216,11 @@ real_t NavigationObstacle::estimate_agent_radius() const {
 		}
 		Vector3 s = parent_spatial->get_global_transform().basis.get_scale();
 		radius *= MAX(s.x, MAX(s.y, s.z));
-	}
 
-	if (radius > 0.0) {
-		return radius;
+		if (radius > 0.0) {
+			return radius;
+		}
 	}
-
 	return 1.0; // Never a 0 radius
 }
 


### PR DESCRIPTION
In 3.5.1 (3.x), `NavigationObstacle` always use its `radius` property even when `estimate_radius` is on.

In `estimate_agent_radius()`, the returned `radius` variable is the member variable because the actual estimated radius variable is out of scope.

2D version is OK.