### PR TITLE
Remove `accept_event` from `shortcut_input` in `ButtonBase`

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -355,7 +355,6 @@ void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 
 	if (!is_disabled() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
 		on_action_event(p_event);
-		accept_event();
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/61924 until the @EricEzaM create a proper fix.
