### PR TITLE
Fail `look_at()` if not inside tree

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -116,7 +116,7 @@
 				Rotates the node so that the local forward axis (-Z) points toward the [param target] position.
 				The local up axis (+Y) points as close to the [param up] vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
 				The [param target] position cannot be the same as the node's position, the [param up] vector cannot be zero, and the direction from the node's position to the [param target] vector cannot be parallel to the [param up] vector.
-				Operations take place in global space.
+				Operations take place in global space, which means that the node must be in the scene tree.
 			</description>
 		</method>
 		<method name="look_at_from_position">

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -786,6 +786,7 @@ void Node3D::set_identity() {
 }
 
 void Node3D::look_at(const Vector3 &p_target, const Vector3 &p_up) {
+	ERR_FAIL_COND_MSG(!is_inside_tree(), "Node not inside tree. Use look_at_from_position() instead.");
 	Vector3 origin = get_global_transform().origin;
 	look_at_from_position(origin, p_target, p_up);
 }


### PR DESCRIPTION
Fixes #66576

Similar issue does not happen in 2D.