### PR TITLE
SCons: Change `warnings=extra` to `/W4` for MSVC

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -651,16 +651,22 @@ if selected_platform in platform_list:
 
     # Configure compiler warnings
     if env.msvc:  # MSVC
-        # Truncations, narrowing conversions, signed/unsigned comparisons...
-        disable_nonessential_warnings = ["/wd4267", "/wd4244", "/wd4305", "/wd4018", "/wd4800"]
-        if env["warnings"] == "extra":
-            env.Append(CCFLAGS=["/Wall"])  # Implies /W4
-        elif env["warnings"] == "all":
-            env.Append(CCFLAGS=["/W3"] + disable_nonessential_warnings)
-        elif env["warnings"] == "moderate":
-            env.Append(CCFLAGS=["/W2"] + disable_nonessential_warnings)
-        else:  # 'no'
+        if env["warnings"] == "no":
             env.Append(CCFLAGS=["/w"])
+        else:
+            if env["warnings"] == "extra":
+                env.Append(CCFLAGS=["/W4"])
+            elif env["warnings"] == "all":
+                env.Append(CCFLAGS=["/W3"])
+            elif env["warnings"] == "moderate":
+                env.Append(CCFLAGS=["/W2"])
+            # Disable warnings which we don't plan to fix.
+            # C4100 (unreferenced formal parameter): Doesn't play nice with polymorphism.
+            # C4201 (non-standard nameless struct/union): Only relevant for C89.
+            # C4244 C4245 C4267 (narrowing conversions): Unavoidable at this scale.
+            # C4305 (truncation): double to float or real_t, too hard to avoid.
+            env.Append(CCFLAGS=["/wd4100", "/wd4201", "/wd4244", "/wd4245", "/wd4267", "/wd4305"])
+
         # Set exception handling model to avoid warnings caused by Windows system headers.
         env.Append(CCFLAGS=["/EHsc"])
 


### PR DESCRIPTION
And review and document the set of disabled warnings.

~Build with `warnings=extra` on CI, disable `werror=yes` for now until we have fixed all warnings.
Hence this is a draft, should ideally be updated to have `/W4` warnings fixed so we can keep `werror=yes` on CI.~

Part of #66537.