### PR TITLE
Add GDScript template for RichTextEffect

### DIFF
--- a/modules/gdscript/editor/script_templates/RichTextEffect/default.gd
+++ b/modules/gdscript/editor/script_templates/RichTextEffect/default.gd
@@ -1,0 +1,17 @@
+# meta-description: Base template for rich text effects
+
+@tool
+class_name _CLASS_
+extends _BASE_
+
+
+# To use this effect:
+# - Enable BBCode on a RichTextLabel.
+# - Register this effect on the label.
+# - Use [_CLASS_ param=2.0]hello[/_CLASS_] in text.
+var bbcode := "_CLASS_"
+
+
+func _process_custom_fx(char_fx: CharFXTransform) -> bool:
+	var param: float = char_fx.env.get("param", 1.0)
+	return true

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -73,9 +73,11 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 									 .replace(": String", "")
 									 .replace(": Array[String]", "")
 									 .replace(": float", "")
+									 .replace(": CharFXTransform", "")
 									 .replace(":=", "=")
 									 .replace(" -> String", "")
 									 .replace(" -> int", "")
+									 .replace(" -> bool", "")
 									 .replace(" -> void", "");
 	}
 


### PR DESCRIPTION
Since RichTextEffect requires a very specific setup, it makes sense to include this as the default script template.

Sadly `_CLASS_` uses the file name's capitalization, so the `class_name` doesn't follow PascalCase. It might make sense to introduce more placeholders for different casing.