### PR TITLE
Fix crash when executing `RenderingServer.set_boot_image`

### DIFF
--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -170,6 +170,10 @@ void RendererCompositorRD::finalize() {
 }
 
 void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
+	if (p_image.is_null() || p_image->is_empty()) {
+		return;
+	}
+
 	RD::get_singleton()->prepare_screen_for_drawing();
 
 	RID texture = texture_storage->texture_allocate();


### PR DESCRIPTION
Fixes #66611

This check can also be found in the OpenGL renderer and in `3.x`.