### PR TITLE
Add various null checks in RenderingServer

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -666,6 +666,8 @@ void TextureStorage::texture_free(RID p_texture) {
 }
 
 void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) {
+	ERR_FAIL_COND(p_image.is_null());
+
 	Texture texture;
 	texture.width = p_image->get_width();
 	texture.height = p_image->get_height();

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -170,6 +170,10 @@ void RendererCompositorRD::finalize() {
 }
 
 void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
+	if (p_image.is_null() || p_image->is_empty()) {
+		return;
+	}
+
 	RD::get_singleton()->prepare_screen_for_drawing();
 
 	RID texture = texture_storage->texture_allocate();

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3621,6 +3621,7 @@ TypedArray<Image> RendererSceneRenderRD::bake_render_uv2(RID p_base, const Typed
 	//RID sampled_light;
 
 	RenderGeometryInstance *gi = geometry_instance_create(p_base);
+	ERR_FAIL_NULL_V(gi, TypedArray<Image>());
 
 	uint32_t sc = RSG::mesh_storage->mesh_get_surface_count(p_base);
 	Vector<RID> materials;

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -2021,6 +2021,7 @@ Transform2D MeshStorage::skeleton_bone_get_transform_2d(RID p_skeleton, int p_bo
 void MeshStorage::skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform) {
 	Skeleton *skeleton = skeleton_owner.get_or_null(p_skeleton);
 
+	ERR_FAIL_NULL(skeleton);
 	ERR_FAIL_COND(!skeleton->use_2d);
 
 	skeleton->base_transform_2d = p_base_transform;

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -673,6 +673,8 @@ void TextureStorage::texture_free(RID p_texture) {
 }
 
 void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) {
+	ERR_FAIL_COND(p_image.is_null());
+
 	TextureToRDFormat ret_format;
 	Ref<Image> image = _validate_texture_format(p_image, ret_format);
 


### PR DESCRIPTION
Fixes #66608
Fixes #66609
Fixes #66610
Fixes #66611

`set_boot_image()` does not use `ERR_FAIL_COND()` because it's how the OpenGL renderer and `3.x` handles this situation.