### PR TITLE
Debugger: Clear stack dump on execution stop

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -234,7 +234,6 @@ void ScriptEditorDebugger::debug_next() {
 	msg.push_back("next");
 	ppeer->put_var(msg);
 	_clear_execution();
-	stack_dump->clear();
 }
 void ScriptEditorDebugger::debug_step() {
 	ERR_FAIL_COND(!breaked);
@@ -245,7 +244,6 @@ void ScriptEditorDebugger::debug_step() {
 	msg.push_back("step");
 	ppeer->put_var(msg);
 	_clear_execution();
-	stack_dump->clear();
 }
 
 void ScriptEditorDebugger::debug_break() {
@@ -1560,6 +1558,7 @@ void ScriptEditorDebugger::_clear_execution() {
 	stack_script = ResourceLoader::load(d["file"]);
 	emit_signal("clear_execution", stack_script);
 	stack_script.unref();
+	stack_dump->clear();
 }
 
 void ScriptEditorDebugger::start(int p_port, const IP_Address &p_bind_address) {


### PR DESCRIPTION
Fixes #34198.

This already behaves this way in the `master` branch, so I just changed `3.x` to do the same.

There might still be some discussion worth having with heavy debugger users to see if that's the behavior they expect, or if they'd prefer it to clear at a different point (e.g. on run instead of on stop). The behavior in 4.0 beta 2 and now in `3.x` with this PR is:
- Errors are not cleared on stop, but are cleared on the next run. So you can still see errors after closing the project. I think that's fine.
- Debugger stack dump is cleared on stop. Some might prefer it to clear on the next run like for the error log?