### PR TITLE
refactor(AStarGrid2D): Return `Vector2i` in `get_id_path`

### DIFF
--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -30,6 +30,8 @@
 
 #include "a_star_grid_2d.h"
 
+#include "core/variant/typed_array.h"
+
 static real_t heuristic_euclidian(const Vector2i &p_from, const Vector2i &p_to) {
 	real_t dx = (real_t)ABS(p_to.x - p_from.x);
 	real_t dy = (real_t)ABS(p_to.y - p_from.y);
@@ -492,17 +494,17 @@ Vector<Vector2> AStarGrid2D::get_point_path(const Vector2i &p_from_id, const Vec
 	return path;
 }
 
-Vector<Vector2> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const Vector2i &p_to_id) {
-	ERR_FAIL_COND_V_MSG(dirty, Vector<Vector2>(), "Grid is not initialized. Call the update method.");
-	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_from_id), Vector<Vector2>(), vformat("Can't get id path. Point out of bounds (%s/%s, %s/%s)", p_from_id.x, size.width, p_from_id.y, size.height));
-	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_to_id), Vector<Vector2>(), vformat("Can't get id path. Point out of bounds (%s/%s, %s/%s)", p_to_id.x, size.width, p_to_id.y, size.height));
+TypedArray<Vector2i> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const Vector2i &p_to_id) {
+	ERR_FAIL_COND_V_MSG(dirty, TypedArray<Vector2i>(), "Grid is not initialized. Call the update method.");
+	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_from_id), TypedArray<Vector2i>(), vformat("Can't get id path. Point out of bounds (%s/%s, %s/%s)", p_from_id.x, size.width, p_from_id.y, size.height));
+	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_to_id), TypedArray<Vector2i>(), vformat("Can't get id path. Point out of bounds (%s/%s, %s/%s)", p_to_id.x, size.width, p_to_id.y, size.height));
 
 	Point *a = _get_point(p_from_id.x, p_from_id.y);
 	Point *b = _get_point(p_to_id.x, p_to_id.y);
 
 	if (a == b) {
-		Vector<Vector2> ret;
-		ret.push_back(Vector2((float)a->id.x, (float)a->id.y));
+		TypedArray<Vector2i> ret;
+		ret.push_back(a);
 		return ret;
 	}
 
@@ -511,7 +513,7 @@ Vector<Vector2> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const Vector
 
 	bool found_route = _solve(begin_point, end_point);
 	if (!found_route) {
-		return Vector<Vector2>();
+		return TypedArray<Vector2i>();
 	}
 
 	Point *p = end_point;
@@ -521,20 +523,18 @@ Vector<Vector2> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const Vector
 		p = p->prev_point;
 	}
 
-	Vector<Vector2> path;
+	TypedArray<Vector2i> path;
 	path.resize(pc);
 
 	{
-		Vector2 *w = path.ptrw();
-
 		p = end_point;
 		int64_t idx = pc - 1;
 		while (p != begin_point) {
-			w[idx--] = Vector2((float)p->id.x, (float)p->id.y);
+			path[idx--] = p->id;
 			p = p->prev_point;
 		}
 
-		w[0] = p->id;
+		path[0] = p->id;
 	}
 
 	return path;

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -169,7 +169,7 @@ public:
 	void clear();
 
 	Vector<Vector2> get_point_path(const Vector2i &p_from, const Vector2i &p_to);
-	Vector<Vector2> get_id_path(const Vector2i &p_from, const Vector2i &p_to);
+	TypedArray<Vector2i> get_id_path(const Vector2i &p_from, const Vector2i &p_to);
 };
 
 VARIANT_ENUM_CAST(AStarGrid2D::DiagonalMode);

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -53,7 +53,7 @@
 			</description>
 		</method>
 		<method name="get_id_path">
-			<return type="PackedVector2Array" />
+			<return type="Vector2i[]" />
 			<param index="0" name="from_id" type="Vector2i" />
 			<param index="1" name="to_id" type="Vector2i" />
 			<description>


### PR DESCRIPTION
Change return type of `AStarGrid2D.get_id_path` from `PackedVector2Array` to `TypedArray<Vector2i>` to be consistent with the grid ID type - which is `Vector2i`.

Fixes #66541
