### PR TITLE
TileMap mouse right can delete autotile

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -2428,20 +2428,16 @@ HashMap<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_line(Vector2i 
 		return HashMap<Vector2i, TileMapCell>();
 	}
 
-	if (selected_type == SELECTED_TYPE_CONNECT) {
-		return _draw_terrain_path_or_connect(TileMapEditor::get_line(tile_map, p_start_cell, p_end_cell), selected_terrain_set, selected_terrain, true);
-	} else if (selected_type == SELECTED_TYPE_PATH) {
-		return _draw_terrain_path_or_connect(TileMapEditor::get_line(tile_map, p_start_cell, p_end_cell), selected_terrain_set, selected_terrain, false);
-	} else { // SELECTED_TYPE_PATTERN
-		TileSet::TerrainsPattern terrains_pattern;
-		if (p_erase) {
-			terrains_pattern = TileSet::TerrainsPattern(*tile_set, selected_terrain_set);
-		} else {
-			terrains_pattern = selected_terrains_pattern;
+	if (p_erase) {
+		return _draw_terrain_pattern(TileMapEditor::get_line(tile_map, p_start_cell, p_end_cell), selected_terrain_set, TileSet::TerrainsPattern(*tile_set, selected_terrain_set));
+	} else {
+		if (selected_type == SELECTED_TYPE_CONNECT) {
+			return _draw_terrain_path_or_connect(TileMapEditor::get_line(tile_map, p_start_cell, p_end_cell), selected_terrain_set, selected_terrain, true);
+		} else if (selected_type == SELECTED_TYPE_PATH) {
+			return _draw_terrain_path_or_connect(TileMapEditor::get_line(tile_map, p_start_cell, p_end_cell), selected_terrain_set, selected_terrain, false);
+		} else { // SELECTED_TYPE_PATTERN
+			return _draw_terrain_pattern(TileMapEditor::get_line(tile_map, p_start_cell, p_end_cell), selected_terrain_set, selected_terrains_pattern);
 		}
-
-		Vector<Vector2i> line = TileMapEditor::get_line(tile_map, p_start_cell, p_end_cell);
-		return _draw_terrain_pattern(line, selected_terrain_set, terrains_pattern);
 	}
 }
 
@@ -2468,16 +2464,14 @@ HashMap<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_rect(Vector2i 
 		}
 	}
 
-	if (selected_type == SELECTED_TYPE_CONNECT || selected_type == SELECTED_TYPE_PATH) {
-		return _draw_terrain_path_or_connect(to_draw, selected_terrain_set, selected_terrain, true);
-	} else { // SELECTED_TYPE_PATTERN
-		TileSet::TerrainsPattern terrains_pattern;
-		if (p_erase) {
-			terrains_pattern = TileSet::TerrainsPattern(*tile_set, selected_terrain_set);
-		} else {
-			terrains_pattern = selected_terrains_pattern;
+	if (p_erase) {
+		return _draw_terrain_pattern(to_draw, selected_terrain_set, TileSet::TerrainsPattern(*tile_set, selected_terrain_set));
+	} else {
+		if (selected_type == SELECTED_TYPE_CONNECT || selected_type == SELECTED_TYPE_PATH) {
+			return _draw_terrain_path_or_connect(to_draw, selected_terrain_set, selected_terrain, true);
+		} else { // SELECTED_TYPE_PATTERN
+			return _draw_terrain_pattern(to_draw, selected_terrain_set, selected_terrains_pattern);
 		}
-		return _draw_terrain_pattern(to_draw, selected_terrain_set, terrains_pattern);
 	}
 }
 
@@ -2609,16 +2603,14 @@ HashMap<Vector2i, TileMapCell> TileMapEditorTerrainsPlugin::_draw_bucket_fill(Ve
 		cells_to_draw_as_vector.append(cell);
 	}
 
-	if (selected_type == SELECTED_TYPE_CONNECT || selected_type == SELECTED_TYPE_PATH) {
-		return _draw_terrain_path_or_connect(cells_to_draw_as_vector, selected_terrain_set, selected_terrain, true);
-	} else { // SELECTED_TYPE_PATTERN
-		TileSet::TerrainsPattern terrains_pattern;
-		if (p_erase) {
-			terrains_pattern = TileSet::TerrainsPattern(*tile_set, selected_terrain_set);
-		} else {
-			terrains_pattern = selected_terrains_pattern;
+	if (p_erase) {
+		return _draw_terrain_pattern(cells_to_draw_as_vector, selected_terrain_set, TileSet::TerrainsPattern(*tile_set, selected_terrain_set));
+	} else {
+		if (selected_type == SELECTED_TYPE_CONNECT || selected_type == SELECTED_TYPE_PATH) {
+			return _draw_terrain_path_or_connect(cells_to_draw_as_vector, selected_terrain_set, selected_terrain, true);
+		} else { // SELECTED_TYPE_PATTERN
+			return _draw_terrain_pattern(cells_to_draw_as_vector, selected_terrain_set, selected_terrains_pattern);
 		}
-		return _draw_terrain_pattern(cells_to_draw_as_vector, selected_terrain_set, terrains_pattern);
 	}
 }
 


### PR DESCRIPTION
3.x has the function, 4.0 is not.
There are two changes. One is when setting, one is when using.

1
![image](https://user-images.githubusercontent.com/14800320/193257076-eb43d3e4-0f8b-42f9-a802-f6b3323448bf.png)

2
![image](https://user-images.githubusercontent.com/14800320/193256985-d21e2836-16ab-4330-b665-3febe71c2497.png)


TileMap鼠标右键可以删除自动瓷砖.
3.x有的功能,不知道为什么4.0没有了.
分别改了两处.一个是设置时,一个是使用时