### PR TITLE
Improve `reload_scripts` in `ScriptEditor`

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -136,6 +136,7 @@ public:
 	virtual String get_source_code() const = 0;
 	virtual void set_source_code(const String &p_code) = 0;
 	virtual Error reload(bool p_keep_state = false) = 0;
+	virtual Error load_source_code(const String &p_path) = 0;
 
 #ifdef TOOLS_ENABLED
 	virtual Vector<DocData::ClassDoc> get_documentation() const = 0;

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -48,6 +48,7 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_source_code);
 
 	GDVIRTUAL_BIND(_set_source_code, "code");
+	GDVIRTUAL_BIND(_load_source_code, "path");
 	GDVIRTUAL_BIND(_reload, "keep_state");
 
 	GDVIRTUAL_BIND(_get_documentation);

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -75,6 +75,7 @@ public:
 	EXBIND0RC(String, get_source_code)
 	EXBIND1(set_source_code, const String &)
 	EXBIND1R(Error, reload, bool)
+	EXBIND1R(Error, load_source_code, const String &)
 
 	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_documentation)
 #ifdef TOOLS_ENABLED

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -146,6 +146,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_load_source_code" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="_placeholder_erased" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="placeholder" type="void*" />

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2141,10 +2141,6 @@ Ref<TextFile> ScriptEditor::_load_text_file(const String &p_path, Error *r_error
 	text_file->set_file_path(local_path);
 	text_file->set_path(local_path, true);
 
-	if (ResourceLoader::get_timestamp_on_load()) {
-		text_file->set_last_modified_time(FileAccess::get_modified_time(path));
-	}
-
 	if (r_error) {
 		*r_error = OK;
 	}

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -476,7 +476,7 @@ public:
 	bool toggle_scripts_panel();
 	bool is_scripts_panel_toggled();
 	void apply_scripts() const;
-	void reload_scripts(bool p_refresh_only = false);
+	void reload_scripts();
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);
 	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "");
 	Ref<Resource> open_file(const String &p_file);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -250,7 +250,7 @@ public:
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	String get_script_path() const;
-	Error load_source_code(const String &p_path);
+	virtual Error load_source_code(const String &p_path) override;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -108,7 +108,7 @@ void GDScriptTextDocument::didSave(const Variant &p_param) {
 			scr->reload(true);
 		}
 		scr->update_exports();
-		ScriptEditor::get_singleton()->reload_scripts(true);
+		ScriptEditor::get_singleton()->reload_scripts();
 		ScriptEditor::get_singleton()->update_docs_from_script(scr);
 	}
 }

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2664,6 +2664,9 @@ Error CSharpScript::load_source_code(const String &p_path) {
 
 #ifdef TOOLS_ENABLED
 	source_changed_cache = true;
+	if (ResourceLoader::get_timestamp_on_load()) {
+		set_last_modified_time(FileAccess::get_modified_time(p_path));
+	}
 #endif
 
 	return OK;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -204,7 +204,7 @@ public:
 	}
 #endif
 
-	Error load_source_code(const String &p_path);
+	virtual Error load_source_code(const String &p_path) override;
 
 	CSharpScript();
 	~CSharpScript();


### PR DESCRIPTION
This PR is based on #66916 and requires #66880. It also uses the signal in #66880 to work.

#66880 try to use a signal to update the internal editor. Because for external editing via LSP, not all scripts in the list need to be updated, and `reload` may be called multiple times per script. Apply #66880, which should solve the problem with LSP.

#66916 is mainly for the tool script, as the reload of the tool script is a soft reload.

**Note:**
    
Currently, the script list in `ScriptEditor` is used to detect changed script files. In this way, those scripts that are not opened in the script list will be missed, so that these scripts cannot be reloaded and updated when the editor is refocused.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
