### PR TITLE
Remove ERR_FAIL_COND that never happens in _draw_sky

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -737,7 +737,6 @@ void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, 
 	RS::EnvironmentBG background = environment_get_background(p_env);
 
 	if (sky) {
-		ERR_FAIL_COND(!sky);
 		sky_material = sky->material;
 
 		if (sky_material.is_valid()) {


### PR DESCRIPTION
In the conditional `sky` is always true.
resolve #65605