### PR TITLE
Do not allow editing Scene-inherited signal connections

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -211,13 +211,16 @@ class ConnectionsDock : public VBoxContainer {
 	void _tree_item_selected();
 	void _tree_item_activated();
 	bool _is_item_signal(TreeItem &p_item);
+	bool _is_connection_inherited(Connection &p_connection);
 
 	void _open_connection_dialog(TreeItem &p_item);
 	void _open_connection_dialog(ConnectDialog::ConnectionData p_cd);
 	void _go_to_script(TreeItem &p_item);
 
 	void _handle_signal_menu_option(int p_option);
+	void _signal_menu_about_to_popup();
 	void _handle_slot_menu_option(int p_option);
+	void _slot_menu_about_to_popup();
 	void _rmb_pressed(Vector2 p_position, MouseButton p_button);
 	void _close();
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1546,7 +1546,7 @@ Array SceneState::get_connection_binds(int p_idx) const {
 	return binds;
 }
 
-bool SceneState::has_connection(const NodePath &p_node_from, const StringName &p_signal, const NodePath &p_node_to, const StringName &p_method) {
+bool SceneState::has_connection(const NodePath &p_node_from, const StringName &p_signal, const NodePath &p_node_to, const StringName &p_method, bool p_no_inheritance) {
 	// this method cannot be const because of this
 	Ref<SceneState> ss = this;
 
@@ -1576,6 +1576,10 @@ bool SceneState::has_connection(const NodePath &p_node_from, const StringName &p
 			if (np_from == p_node_from && sn_signal == p_signal && np_to == p_node_to && sn_method == p_method) {
 				return true;
 			}
+		}
+
+		if (p_no_inheritance) {
+			break;
 		}
 
 		ss = ss->get_base_scene_state();

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -176,7 +176,7 @@ public:
 	int get_connection_unbinds(int p_idx) const;
 	Array get_connection_binds(int p_idx) const;
 
-	bool has_connection(const NodePath &p_node_from, const StringName &p_signal, const NodePath &p_node_to, const StringName &p_method);
+	bool has_connection(const NodePath &p_node_from, const StringName &p_signal, const NodePath &p_node_to, const StringName &p_method, bool p_no_inheritance = false);
 
 	Vector<NodePath> get_editable_instances() const;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/12373.

Editing inherited signal connections has never actually really worked, in practice.
In fact, saving and reopening the **Scene** makes all inherited connections appear again, as if no change has even happened. Very strange to let the user touch them, in the first place. It really has no effect. Nor it probably should, as it would lead to an unorganised workflow.

This PR makes it so that signal connections from an **inherited** Scene can no longer be modified in any way in the **Editor**. 
Inherited connections are displayed in **warning yellow** (same as inherited Nodes) and they cannot be edited or removed.

![Showcase](https://i.gyazo.com/9c01cb6346e66088b8da0ed93223da8e.gif)

Likewise, "Disconnect All" will not disconnect inherited connections, and is disabled if no connection can be disconnected.
![image](https://user-images.githubusercontent.com/66727710/193296443-885027fc-a7a7-4990-a320-ec3d854059fb.png)

