### PR TITLE
Fix CODEOWNERS and fix missing quote in "Building for platform" message

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@ SCsub                               @godotengine/buildsystem
 /core/                              @godotengine/core
 /core/crypto/                       @godotengine/network
 /core/debugger/                     @godotengine/debugger
+/core/extension/                    @godotengine/gdextension
 /core/input/                        @godotengine/input
 
 # Doc
@@ -110,10 +111,9 @@ doc_classes/*                       @godotengine/documentation
 /modules/xatlas_unwrap/             @godotengine/rendering
 
 ## Scripting
-/modules/gdnative/                  @godotengine/gdnative
 /modules/gdscript/                  @godotengine/gdscript
 /modules/jsonrpc/                   @godotengine/gdscript
-/modules/mono/                      @godotengine/mono
+/modules/mono/                      @godotengine/dotnet
 
 ## Text
 /modules/freetype/                  @godotengine/buildsystem

--- a/SConstruct
+++ b/SConstruct
@@ -518,7 +518,7 @@ if selected_platform in platform_list:
     # are actually handled to change compile options, etc.
     detect.configure(env)
 
-    print(f'Building for platform "{selected_platform}", architecture "{env["arch"]}", target "{env["target"]}.')
+    print(f'Building for platform "{selected_platform}", architecture "{env["arch"]}", target "{env["target"]}".')
     if env.dev_build:
         print("NOTE: Developer build, with debug optimization level and debug symbols (unless overridden).")
 


### PR DESCRIPTION
This PR has two unrelated changes, but they are so small so I put them in one PR.

For CODEOWNERS, I noticed that the dotnet team was not being notified for changes to `/modules/mono/`, which led me to find that GitHub says it's broken: https://github.com/godotengine/godot/blob/master/.github/CODEOWNERS

I also fixed a minor bug where a quote was missing from the "Building for platform" text. Previously it was giving output like `Building for platform "macos", architecture "arm64", target "editor.`