### PR TITLE
Make uids of duplicated items unique in FileSystemDock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1283,42 +1283,71 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 	}
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	print_verbose("Duplicating " + old_path + " -> " + new_path);
-	Error err = p_item.is_file ? da->copy(old_path, new_path) : da->copy_dir(old_path, new_path);
-	if (err == OK) {
-		// Move/Rename any corresponding import settings too.
-		if (p_item.is_file && FileAccess::exists(old_path + ".import")) {
-			err = da->copy(old_path + ".import", new_path + ".import");
+
+	if (p_item.is_file) {
+		print_verbose("Duplicating " + old_path + " -> " + new_path);
+
+		// Create the directory structure.
+		da->make_dir_recursive(new_path.get_base_dir());
+
+		if (FileAccess::exists(old_path + ".import")) {
+			Error err = da->copy(old_path, new_path);
 			if (err != OK) {
-				EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + ".import\n");
+				EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + ": " + error_names[err] + "\n");
+				return;
 			}
 
 			// Remove uid from .import file to avoid conflict.
 			Ref<ConfigFile> cfg;
 			cfg.instantiate();
-			cfg->load(new_path + ".import");
+			cfg->load(old_path + ".import");
 			cfg->erase_section_key("remap", "uid");
-			cfg->save(new_path + ".import");
-		} else if (p_item.is_file && (old_path.get_extension() == "tscn" || old_path.get_extension() == "tres")) {
-			// FIXME: Quick hack to fix text resources. This should be fixed properly.
-			Ref<FileAccess> file = FileAccess::open(old_path, FileAccess::READ, &err);
-			if (err == OK) {
-				PackedStringArray lines = file->get_as_utf8_string().split("\n");
-				String line = lines[0];
-
-				if (line.contains("uid")) {
-					line = line.substr(0, line.find(" uid")) + "]";
-					lines.write[0] = line;
-
-					Ref<FileAccess> file2 = FileAccess::open(new_path, FileAccess::WRITE, &err);
-					if (err == OK) {
-						file2->store_string(String("\n").join(lines));
-					}
+			err = cfg->save(new_path + ".import");
+			if (err != OK) {
+				EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + ".import: " + error_names[err] + "\n");
+				return;
+			}
+		} else {
+			// Files which do not use an uid can just be copied.
+			if (ResourceLoader::get_resource_uid(old_path) == ResourceUID::INVALID_ID) {
+				Error err = da->copy(old_path, new_path);
+				if (err != OK) {
+					EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + ": " + error_names[err] + "\n");
 				}
+				return;
+			}
+
+			// Load the resource and save it again in the new location (this generates a new UID).
+			Error err;
+			Ref<Resource> res = ResourceLoader::load(old_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+			if (err == OK && res.is_valid()) {
+				err = ResourceSaver::save(res, new_path, ResourceSaver::FLAG_COMPRESS);
+				if (err != OK) {
+					EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + " " + vformat(TTR("Failed to save resource at %s: %s"), new_path, error_names[err]));
+				}
+			} else if (err != OK) {
+				// When loading files like text files the error is OK but the resource is still null.
+				// We can ignore such files.
+				EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + " " + vformat(TTR("Failed to load resource at %s: %s"), new_path, error_names[err]));
 			}
 		}
 	} else {
-		EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + "\n");
+		// Recursively duplicate all files inside the folder.
+		Ref<DirAccess> old_dir = DirAccess::open(old_path);
+		Ref<FileAccess> file_access = FileAccess::create(FileAccess::ACCESS_RESOURCES);
+		old_dir->set_include_navigational(false);
+		old_dir->list_dir_begin();
+		for (String f = old_dir->_get_next(); !f.is_empty(); f = old_dir->_get_next()) {
+			if (f.get_extension() == "import") {
+				continue;
+			}
+			if (file_access->file_exists(old_path + f)) {
+				_try_duplicate_item(FileOrFolder(old_path + f, true), new_path + f);
+			} else if (da->dir_exists(old_path + f)) {
+				_try_duplicate_item(FileOrFolder(old_path + f, false), new_path + f);
+			}
+		}
+		old_dir->list_dir_end();
 	}
 }
 


### PR DESCRIPTION
Fixes #54774

This PR does the following things:
1. If a folder is duplicated. It iterates over all elements of the folder and recursively calls `_try_duplicate_item` for every element.
2. If a file, that does not have a corresponding .import file, gets duplicated, the file is loaded as a `Resource` and then saved again. The new uid is generated when the resource gets saved at a new location. If the file does have a .import file the file itself will be copied and the .import will be saved after removing the uid entry (which is the current behaviour). When saving the .import file a new uid is generated.

+ Files, which do not use a uid or when the uid could not be retrieved, will just be copied. Since it probably means that it is either a text file (.txt, .gd, .md, ...) or does not have a uid set.
+ I am using `ResourceSaver::save` with the `FLAG_COMPRESS` flag, therefore some files which have not been originally compressed, will differ from the old file (But this flag seems to have no impact on text based files like .tres and .tscn).
