### PR TITLE
Fix more highlighting bugs

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -43,26 +43,28 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 
 	String prev_text = "";
 	int prev_column = 0;
-
 	bool prev_is_char = false;
 	bool prev_is_digit = false;
 	bool prev_is_binary_op = false;
+
 	bool in_keyword = false;
 	bool in_word = false;
 	bool in_number = false;
-	bool in_function_name = false;
-	bool in_lambda = false;
-	bool in_variable_declaration = false;
-	bool in_signal_declaration = false;
-	bool in_function_args = false;
-	bool in_member_variable = false;
 	bool in_node_path = false;
 	bool in_node_ref = false;
 	bool in_annotation = false;
 	bool in_string_name = false;
 	bool is_hex_notation = false;
 	bool is_bin_notation = false;
+	bool in_member_variable = false;
+	bool in_lambda = false;
+
+	bool in_function_name = false;
+	bool in_function_args = false;
+	bool in_variable_declaration = false;
+	bool in_signal_declaration = false;
 	bool expect_type = false;
+
 	Color keyword_color;
 	Color color;
 
@@ -241,16 +243,21 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			}
 		}
 
-		// A bit of a hack, but couldn't come up with anything better.
+		// VERY hacky... but couldn't come up with anything better.
 		if (j > 0 && (str[j] == '&' || str[j] == '^' || str[j] == '%' || str[j] == '+' || str[j] == '-' || str[j] == '~' || str[j] == '.')) {
-			if (prev_text == "true" || prev_text == "false" || prev_text == "self" || prev_text == "null" || prev_text == "PI" || prev_text == "TAU" || prev_text == "INF" || prev_text == "NAN") {
-				is_binary_op = true;
-			} else if (!keywords.has(prev_text)) {
-				int k = j - 1;
-				while (k > 0 && is_whitespace(str[k])) {
-					k--;
-				}
-				if (!is_symbol(str[k]) || str[k] == '"' || str[k] == '\'' || str[k] == ')' || str[k] == ']' || str[k] == '}') {
+			int to = j - 1;
+			// Find what the last text was (prev_text won't work if there's no whitespace, so we need to do it manually).
+			while (to > 0 && is_whitespace(str[to])) {
+				to--;
+			}
+			int from = to;
+			while (from > 0 && !is_symbol(str[from])) {
+				from--;
+			}
+			String word = str.substr(from + 1, to - from);
+			// Keywords need to be exceptions, except for keywords that represent a value.
+			if (word == "true" || word == "false" || word == "null" || word == "PI" || word == "TAU" || word == "INF" || word == "NAN" || word == "self" || word == "super" || !keywords.has(word)) {
+				if (!is_symbol(str[to]) || str[to] == '"' || str[to] == '\'' || str[to] == ')' || str[to] == ']' || str[to] == '}') {
 					is_binary_op = true;
 				}
 			}
@@ -285,16 +292,18 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				is_hex_notation = true;
 			} else if (!((str[j] == '-' || str[j] == '+') && str[j - 1] == 'e' && !prev_is_digit) &&
 					!(str[j] == '_' && (prev_is_digit || str[j - 1] == 'b' || str[j - 1] == 'x' || str[j - 1] == '.')) &&
-					!((str[j] == 'e' || str[j] == '.') && (prev_is_digit || str[j - 1] == '_')) &&
+					!(str[j] == 'e' && (prev_is_digit || str[j - 1] == '_')) &&
+					!(str[j] == '.' && (prev_is_digit || (!prev_is_binary_op && (j > 0 && (str[j - 1] == '-' || str[j - 1] == '+' || str[j - 1] == '~'))))) &&
 					!((str[j] == '-' || str[j] == '+' || str[j] == '~') && !prev_is_binary_op && str[j - 1] != 'e')) {
-				/* 1st row of condition: '+' or '-' after scientific notation;
-				2nd row of condition: '_' as a numeric separator;
-				3rd row of condition: Scientific notation 'e' and floating points;
-				4th row of condition: Multiple unary operators. */
+				/* This condition continues Number highlighting in special cases.
+				1st row: '+' or '-' after scientific notation;
+				2nd row: '_' as a numeric separator;
+				3rd row: Scientific notation 'e' and floating points;
+				4th row: Floating points inside the number, or leading if after a unary mathematical operator;
+				5th row: Multiple unary mathematical operators */
 				in_number = false;
 			}
-		} else if ((str[j] == '-' || str[j] == '+' || str[j] == '~' || (str[j] == '.' && str[j + 1] != '.' && (j == 0 || (j > 0 && str[j - 1] != '.')))) && !is_binary_op) {
-			// Start a number from unary mathematical operators and floating points, except for '..'
+		} else if (!is_binary_op && (str[j] == '-' || str[j] == '+' || str[j] == '~' || (str[j] == '.' && str[j + 1] != '.' && (j == 0 || (j > 0 && str[j - 1] != '.'))))) {
 			in_number = true;
 		}
 
@@ -316,7 +325,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			Color col = Color();
 			if (global_functions.has(word)) {
 				// "assert" and "preload" are reserved, so highlight even if not followed by a bracket.
-				if (word == "assert" || word == "preload") {
+				if (word == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::ASSERT) || word == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::PRELOAD)) {
 					col = global_function_color;
 				} else {
 					// For other global functions, check if followed by bracket.
@@ -406,11 +415,11 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				in_function_args = false;
 			}
 
-			if (expect_type && (prev_is_char || str[j] == '=')) {
+			if (expect_type && (prev_is_char || str[j] == '=') && str[j] != '[') {
 				expect_type = false;
 			}
 
-			if (j > 0 && str[j] == '>' && str[j - 1] == '-') {
+			if (j > 0 && str[j - 1] == '-' && str[j] == '>') {
 				expect_type = true;
 			}
 


### PR DESCRIPTION
Fixes #66682
Fixes #66486

![image](https://user-images.githubusercontent.com/85438892/193414999-eef66396-a0b0-423d-be15-5dcac2fb7977.png)

Changed to:

![image](https://user-images.githubusercontent.com/85438892/193415068-f7b6d909-ec52-442d-a1e3-754920fc3164.png)

Made `[` not stop type-expecting:

![image](https://user-images.githubusercontent.com/85438892/193434474-b2bedca5-d64c-4164-9f1d-6c2d18ebfaea.png)

~~**Left for later:**~~

~~Something else I found that hasn't been reported: Characters like `+` think they are unary when in a situation like `if A+B` because `prev_text` is `if` at that point in the logic, not `A`, and `if` is not a value keyword. There are other situations where this causes wrong highlighting, like the `-` thinks it's unary in `func foo(f: float) -> void` because `prev_text` is float at that point, which is a non-value keyword.~~

~~I still haven't figured out how to fix it, so I've left it out of this PR for now (although I did make `->`'s `-` not get highlighted like a number). In general, the chain of checks if `prev_text` is a value keyword – null / INF  / NAN / self / true / false / PI / TAU – is very scuffed and should be revisited.~~

~~Would appreciate some suggestions on how to figure out whether the last thing was actually the keyword.~~

The strikethrough stuff has been fixed too.