### PR TITLE
Fix invalid popup position for embedded popups

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1264,12 +1264,16 @@ void Window::popup(const Rect2i &p_screen_rect) {
 	set_transient(true);
 	set_visible(true);
 
-	int screen_id = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
-	Rect2i screen_rect = DisplayServer::get_singleton()->screen_get_usable_rect(screen_id);
-	if (screen_rect != Rect2i() && !screen_rect.intersects(Rect2i(position, size))) {
+	Rect2i parent_rect;
+	if (is_embedded()) {
+		parent_rect = _get_embedder()->get_visible_rect();
+	} else {
+		int screen_id = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
+		parent_rect = DisplayServer::get_singleton()->screen_get_usable_rect(screen_id);
+	}
+	if (parent_rect != Rect2i() && !parent_rect.intersects(Rect2i(position, size))) {
 		ERR_PRINT(vformat("Window %d spawned at invalid position: %s.", get_window_id(), position));
-		// Window appeared on unavailable screen area, so force it to the center.
-		set_position(screen_rect.size / 2 - size / 2);
+		set_position((parent_rect.size - size) / 2);
 	}
 
 	_post_popup();


### PR DESCRIPTION
#61336 introduced an error for popups when the active window lies on a monitor other than the first monitor, which is supposed to place the popup at the center of the screen, but this doesn't work properly for embedded popups, as they instead appear offset from the center of their parent window when not fullscreen (see #66707, #66691).

~~This only fixes the fallback position of the popup, but something should also be done about the error happening in the first place, as it causes the item list from an `OptionButton` to spawn at a wrong place depending on the current monitor.~~
Updated following @bruvzg's comment, this now fixes #66707.