### PR TITLE
Remember tile source sort between sessions

### DIFF
--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -329,6 +329,7 @@ void TileSetEditor::_set_source_sort(int p_sort) {
 		}
 	}
 	_update_sources_list(old_selected);
+	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "tile_source_sort", p_sort);
 }
 
 void TileSetEditor::_notification(int p_what) {
@@ -648,7 +649,12 @@ void TileSetEditor::edit(Ref<TileSet> p_tile_set) {
 	// Add the listener again.
 	if (tile_set.is_valid()) {
 		tile_set->connect("changed", callable_mp(this, &TileSetEditor::_tile_set_changed));
-		_update_sources_list();
+		if (first_edit) {
+			first_edit = false;
+			_set_source_sort(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_source_sort", 0));
+		} else {
+			_update_sources_list();
+		}
 		_update_patterns_list();
 	}
 

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -83,6 +83,8 @@ private:
 	AtlasMergingDialog *atlas_merging_dialog = nullptr;
 	TileProxiesManagerDialog *tile_proxies_manager_dialog = nullptr;
 
+	bool first_edit = true;
+
 	// Patterns.
 	ItemList *patterns_item_list = nullptr;
 	Label *patterns_help_label = nullptr;


### PR DESCRIPTION
I find myself always sorting the sources by name (especially after all sorting bugs were fixed) and having to change it again after each restart was a bit bothersome.

I wasn't sure where to load the value though. Also there is a minor visual bug where TileMap tab's OptionButton doesn't get correct sorting option on first load (even though the list is sorted correctly).