### PR TITLE
Remove LGTM badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,4 @@ for more information.
 
 [![Code Triagers Badge](https://www.codetriage.com/godotengine/godot/badges/users.svg)](https://www.codetriage.com/godotengine/godot)
 [![Translate on Weblate](https://hosted.weblate.org/widgets/godot-engine/-/godot/svg-badge.svg)](https://hosted.weblate.org/engage/godot-engine/?utm_source=widget)
-[![Total alerts on LGTM](https://img.shields.io/lgtm/alerts/g/godotengine/godot.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/godotengine/godot/alerts)
 [![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/godotengine/godot)](https://www.tickgit.com/browse?repo=github.com/godotengine/godot)


### PR DESCRIPTION
LGTM.com will be shut down in December 2022, so the badge will no longer work.

As an alternative, [GitHub code scanning is recommended](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/).