### PR TITLE
 Fix crash when setting custom cursor

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -2537,7 +2537,7 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 		XcursorImageDestroy(cursor_image);
 	} else {
 		// Reset to default system cursor
-		if (img[p_shape]) {
+		if (cursors_cache.find(p_shape) && img[p_shape]) {
 			cursors[p_shape] = XcursorImageLoadCursor(x11_display, img[p_shape]);
 		}
 


### PR DESCRIPTION
Fixes #66605.

When setting an in invalid cursor image, a default system cursor is set. However, there was no check whether the cursor type is allowed. I added this check to only allow setting the system cursor if the cursor type is valid. 