### PR TITLE
Remove usage of unitialized variables

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -235,14 +235,14 @@ public:
 		GLuint vertex_buffer;
 		GLuint vertex_array;
 		GLuint index_buffer;
-		int count;
+		int count = 0;
 		bool color_disabled = false;
 		Color color;
 	};
 
 	struct {
 		HashMap<PolygonID, PolygonBuffers> polygons;
-		PolygonID last_id;
+		PolygonID last_id = 0;
 	} polygon_buffers;
 
 	RendererCanvasRender::PolygonID request_polygon(const Vector<int> &p_indices, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), const Vector<int> &p_bones = Vector<int>(), const Vector<float> &p_weights = Vector<float>()) override;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -48,8 +48,8 @@ class AudioDriverPulseAudio : public AudioDriver {
 	pa_context *pa_ctx = nullptr;
 	pa_stream *pa_str = nullptr;
 	pa_stream *pa_rec_str = nullptr;
-	pa_channel_map pa_map;
-	pa_channel_map pa_rec_map;
+	pa_channel_map pa_map = {};
+	pa_channel_map pa_rec_map = {};
 
 	String device_name = "Default";
 	String new_device = "Default";

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -74,7 +74,7 @@ bool DirAccessUnix::file_exists(String p_file) {
 
 	p_file = fix_path(p_file);
 
-	struct stat flags;
+	struct stat flags = {};
 	bool success = (stat(p_file.utf8().get_data(), &flags) == 0);
 
 	if (success && S_ISDIR(flags.st_mode)) {
@@ -93,7 +93,7 @@ bool DirAccessUnix::dir_exists(String p_dir) {
 
 	p_dir = fix_path(p_dir);
 
-	struct stat flags;
+	struct stat flags = {};
 	bool success = (stat(p_dir.utf8().get_data(), &flags) == 0);
 
 	return (success && S_ISDIR(flags.st_mode));
@@ -128,7 +128,7 @@ uint64_t DirAccessUnix::get_modified_time(String p_file) {
 
 	p_file = fix_path(p_file);
 
-	struct stat flags;
+	struct stat flags = {};
 	bool success = (stat(p_file.utf8().get_data(), &flags) == 0);
 
 	if (success) {
@@ -161,7 +161,7 @@ String DirAccessUnix::get_next() {
 	if (entry->d_type == DT_UNKNOWN || entry->d_type == DT_LNK) {
 		String f = current_dir.path_join(fname);
 
-		struct stat flags;
+		struct stat flags = {};
 		if (stat(f.utf8().get_data(), &flags) == 0) {
 			_cisdir = S_ISDIR(flags.st_mode);
 		} else {
@@ -415,7 +415,7 @@ Error DirAccessUnix::remove(String p_path) {
 
 	p_path = fix_path(p_path);
 
-	struct stat flags;
+	struct stat flags = {};
 	if ((stat(p_path.utf8().get_data(), &flags) != 0)) {
 		return FAILED;
 	}
@@ -434,7 +434,7 @@ bool DirAccessUnix::is_link(String p_file) {
 
 	p_file = fix_path(p_file);
 
-	struct stat flags;
+	struct stat flags = {};
 	if ((lstat(p_file.utf8().get_data(), &flags) != 0)) {
 		return FAILED;
 	}

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -96,7 +96,7 @@ Error FileAccessUnix::_open(const String &p_path, int p_mode_flags) {
 	   backend (unix-compatible mostly) supports utf8 encoding */
 
 	//printf("opening %s as %s\n", p_path.utf8().get_data(), path.utf8().get_data());
-	struct stat st;
+	struct stat st = {};
 	int err = stat(path.utf8().get_data(), &st);
 	if (!err) {
 		switch (st.st_mode & S_IFMT) {
@@ -267,7 +267,7 @@ void FileAccessUnix::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 
 bool FileAccessUnix::file_exists(const String &p_path) {
 	int err;
-	struct stat st;
+	struct stat st = {};
 	String filename = fix_path(p_path);
 
 	// Does the name exist at all?
@@ -299,7 +299,7 @@ bool FileAccessUnix::file_exists(const String &p_path) {
 
 uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 	String file = fix_path(p_file);
-	struct stat flags;
+	struct stat flags = {};
 	int err = stat(file.utf8().get_data(), &flags);
 
 	if (!err) {
@@ -312,7 +312,7 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 
 uint32_t FileAccessUnix::_get_unix_permissions(const String &p_file) {
 	String file = fix_path(p_file);
-	struct stat flags;
+	struct stat flags = {};
 	int err = stat(file.utf8().get_data(), &flags);
 
 	if (!err) {

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -76,7 +76,7 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 	th_info ti;
 	th_comment tc;
 	th_dec_ctx *td = nullptr;
-	vorbis_info vi;
+	vorbis_info vi = {};
 	vorbis_dsp_state vd;
 	vorbis_block vb;
 	vorbis_comment vc;

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -89,7 +89,7 @@ static void handle_crash(int sig) {
 			// Try to demangle the function name to provide a more readable one
 			if (dladdr(bt_buffer[i], &info) && info.dli_sname) {
 				if (info.dli_sname[0] == '_') {
-					int status;
+					int status = 0;
 					char *demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
 
 					if (status == 0 && demangled) {

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3144,7 +3144,7 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 
 	{
 		//the position in xconfigure is not useful here, obtain it manually
-		int x, y;
+		int x = 0, y = 0;
 		Window child;
 		XTranslateCoordinates(x11_display, wd.x11_window, DefaultRootWindow(x11_display), 0, 0, &x, &y, &child);
 		new_rect.position.x = x;
@@ -3307,7 +3307,7 @@ void DisplayServerX11::_check_pending_events(LocalVector<XEvent> &r_events) {
 	XFlush(x11_display);
 
 	// Non-blocking wait for next event and remove it from the queue.
-	XEvent ev;
+	XEvent ev = {};
 	while (XCheckIfEvent(x11_display, &ev, _predicate_all_events, nullptr)) {
 		// Check if the input manager wants to process the event.
 		if (XFilterEvent(&ev, None)) {

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -152,8 +152,8 @@ private:
 	Vector2 direction = Vector2(1, 0);
 	real_t spread = 45.0;
 
-	real_t parameters_min[PARAM_MAX];
-	real_t parameters_max[PARAM_MAX];
+	real_t parameters_min[PARAM_MAX] = {};
+	real_t parameters_max[PARAM_MAX] = {};
 
 	Ref<Curve> curve_parameters[PARAM_MAX];
 	Color color;

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -156,7 +156,7 @@ private:
 	real_t spread = 45.0;
 	real_t flatness = 0.0;
 
-	real_t parameters_min[PARAM_MAX];
+	real_t parameters_min[PARAM_MAX] = {};
 	real_t parameters_max[PARAM_MAX] = {};
 
 	Ref<Curve> curve_parameters[PARAM_MAX];

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -265,9 +265,9 @@ private:
 	float spread = 0.0f;
 	float flatness = 0.0f;
 
-	float params_min[PARAM_MAX];
-	float params_max[PARAM_MAX];
-	float params[PARAM_MAX];
+	float params_min[PARAM_MAX] = {};
+	float params_max[PARAM_MAX] = {};
+	float params[PARAM_MAX] = {};
 
 	Ref<Texture2D> tex_parameters[PARAM_MAX];
 	Color color;

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -986,7 +986,7 @@ void SurfaceTool::append_from(const Ref<Mesh> &p_existing, int p_surface, const 
 		format = 0;
 	}
 
-	uint32_t nformat;
+	uint32_t nformat = 0;
 	LocalVector<Vertex> nvertices;
 	LocalVector<int> nindices;
 	_create_list(p_existing, p_surface, &nvertices, &nindices, nformat);

--- a/servers/physics_2d/godot_body_pair_2d.cpp
+++ b/servers/physics_2d/godot_body_pair_2d.cpp
@@ -170,7 +170,7 @@ bool GodotBodyPair2D::_test_ccd(real_t p_step, GodotBody2D *p_A, int p_shape_A, 
 
 	Vector2 mnormal = motion / mlen;
 
-	real_t min, max;
+	real_t min = 0.0, max = 0.0;
 	p_A->get_shape(p_shape_A)->project_rangev(mnormal, p_xform_A, min, max);
 
 	// Did it move enough in this direction to even attempt raycast?

--- a/servers/physics_2d/godot_collision_solver_2d.cpp
+++ b/servers/physics_2d/godot_collision_solver_2d.cpp
@@ -197,7 +197,7 @@ bool GodotCollisionSolver2D::solve_concave(const GodotShape2D *p_shape_A, const 
 		real_t axis_scale = 1.0 / axis.length();
 		axis *= axis_scale;
 
-		real_t smin, smax;
+		real_t smin = 0.0, smax = 0.0;
 		p_shape_A->project_rangev(axis, rel_transform, smin, smax);
 		smin *= axis_scale;
 		smax *= axis_scale;

--- a/servers/physics_2d/godot_collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/godot_collision_solver_2d_sat.cpp
@@ -234,7 +234,7 @@ public:
 			axis = Vector2(0.0, 1.0);
 		}
 
-		real_t min_A, max_A, min_B, max_B;
+		real_t min_A = 0.0, max_A = 0.0, min_B = 0.0, max_B = 0.0;
 
 		if (castA) {
 			shape_A->project_range_cast(motion_A, axis, *transform_A, min_A, max_A);

--- a/servers/physics_3d/godot_body_pair_3d.cpp
+++ b/servers/physics_3d/godot_body_pair_3d.cpp
@@ -170,7 +170,7 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 
 	Vector3 mnormal = motion / mlen;
 
-	real_t min, max;
+	real_t min = 0.0, max = 0.0;
 	p_A->get_shape(p_shape_A)->project_range(mnormal, p_xform_A, min, max);
 
 	// Did it move enough in this direction to even attempt raycast?

--- a/servers/physics_3d/godot_collision_solver_3d.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d.cpp
@@ -48,7 +48,7 @@ bool GodotCollisionSolver3D::solve_static_world_boundary(const GodotShape3D *p_s
 	static const int max_supports = 16;
 	Vector3 supports[max_supports];
 	int support_count;
-	GodotShape3D::FeatureType support_type;
+	GodotShape3D::FeatureType support_type = GodotShape3D::FeatureType::FEATURE_POINT;
 	p_shape_B->get_supports(p_transform_B.basis.xform_inv(-p.normal).normalized(), max_supports, supports, support_count, support_type);
 
 	if (support_type == GodotShape3D::FEATURE_CIRCLE) {
@@ -338,7 +338,7 @@ bool GodotCollisionSolver3D::solve_concave(const GodotShape3D *p_shape_A, const 
 		real_t axis_scale = 1.0 / axis.length();
 		axis *= axis_scale;
 
-		real_t smin, smax;
+		real_t smin = 0.0, smax = 0.0;
 		p_shape_A->project_range(axis, rel_transform, smin, smax);
 		smin -= p_margin_A;
 		smax += p_margin_A;

--- a/servers/physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d_sat.cpp
@@ -634,7 +634,7 @@ public:
 			axis = Vector3(0.0, 1.0, 0.0);
 		}
 
-		real_t min_A, max_A, min_B, max_B;
+		real_t min_A = 0.0, max_A = 0.0, min_B = 0.0, max_B = 0.0;
 
 		shape_A->project_range(axis, *transform_A, min_A, max_A);
 		shape_B->project_range(axis, *transform_B, min_B, max_B);


### PR DESCRIPTION
This PR removes usage of unitialized memory which polluted output of Valgrind/Msan.

To find them I used msan and headless mode
```
scons -j6 target=editor use_llvm=yes dev_build=yes debug_symbols=yes udev=no use_msan=yes
~/Project/$ clear;bin/godot.linuxbsd.editor.dev.x86_64.llvm.san  --headless a.tscn 2>&1 | tee ~/txt5.txt
```

Msan finds also usage of unitialized memory also inside external libraries, so I couldn't use audio, Vulkan,  GLES or udev, because with them, logs grew to several gb.

Example output - [txt3.txt.zip](https://github.com/godotengine/godot/files/9691031/txt3.txt.zip)
