### PR TITLE
changes to default characterbody scripts

### DIFF
--- a/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
@@ -6,25 +6,21 @@ extends _BASE_
 const SPEED = 300.0
 const JUMP_VELOCITY = -400.0
 
-# Get the gravity from the project settings to be synced with RigidBody nodes.
-var gravity: int = ProjectSettings.get_setting("physics/2d/default_gravity")
+# Get the global gravity from the project settings. RigidBody2D nodes also use this value.
+var gravity: float = ProjectSettings.get_setting("physics/2d/default_gravity")
 
 
 func _physics_process(delta: float) -> void:
 	# Add the gravity.
-	if not is_on_floor():
-		velocity.y += gravity * delta
+	velocity.y += gravity * delta
 
-	# Handle Jump.
+	# Allow jumping only when on the floor.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
 		velocity.y = JUMP_VELOCITY
 
-	# Get the input direction and handle the movement/deceleration.
-	# As good practice, you should replace UI actions with custom gameplay actions.
+	# Get the input direction and handle the movement.
+	# As good practice, you should replace UI actions with custom input actions.
 	var direction := Input.get_axis("ui_left", "ui_right")
-	if direction:
-		velocity.x = direction * SPEED
-	else:
-		velocity.x = move_toward(velocity.x, 0, SPEED)
+	velocity.x = direction * SPEED
 
 	move_and_slide()

--- a/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
@@ -6,28 +6,23 @@ extends _BASE_
 const SPEED = 5.0
 const JUMP_VELOCITY = 4.5
 
-# Get the gravity from the project settings to be synced with RigidBody nodes.
+# Get the global gravity from the project settings. RigidBody3D nodes also use this value.
 var gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
 
 
 func _physics_process(delta: float) -> void:
 	# Add the gravity.
-	if not is_on_floor():
-		velocity.y -= gravity * delta
+	velocity.y -= gravity * delta
 
-	# Handle Jump.
+	# Allow jumping only when on the floor.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
 		velocity.y = JUMP_VELOCITY
 
-	# Get the input direction and handle the movement/deceleration.
-	# As good practice, you should replace UI actions with custom gameplay actions.
+	# Get the input direction and handle the movement.
+	# As good practice, you should replace UI actions with custom input actions.
 	var input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
 	var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
-	if direction:
-		velocity.x = direction.x * SPEED
-		velocity.z = direction.z * SPEED
-	else:
-		velocity.x = move_toward(velocity.x, 0, SPEED)
-		velocity.z = move_toward(velocity.z, 0, SPEED)
+	velocity.x = direction.x * SPEED
+	velocity.z = direction.z * SPEED
 
 	move_and_slide()


### PR DESCRIPTION
Updates to default scripts for CharacterBody2D/CharacterBody3D.

* Apply gravity always, not just when in the air.
* Fix non-working deceleration
    * Using `SPEED` as `move_toward()` factor just means stopping instantly
    * Set a value of `FRICTION` consistent with other values - result: stops in ~0.5 s
    * Apply `delta` when decelerating 
* ~~Remove static typing hints~~
    * ~~Default in godot-docs is no type hints~~
    * ~~"Type Hints" defaults off in Editor Settings~~
* Minor clarifications to comments.