### PR TITLE
Fix inconsistent window state on X11.

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3142,6 +3142,11 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 		return;
 	}
 
+	// Query display server about a possible new window state.
+	wd.fullscreen = _window_fullscreen_check(window_id);
+	wd.minimized = _window_minimize_check(window_id);
+	wd.maximized = _window_maximize_check(window_id, "_NET_WM_STATE");
+
 	{
 		//the position in xconfigure is not useful here, obtain it manually
 		int x, y;


### PR DESCRIPTION
Should fix #66413.

`DisplayServerX11` caches some state information about a godot window; specifically, whether it is fullscreened, maximized, minimized or none. This cached data was not being updated in response to the user manually changing the window's state (eg, by dragging the title bar to make a window no longer maximized). Whenever we are notified that the window has changed (via `_window_changed`) we must query the display server to potentially update the cached state to reflect the new state. 

This should solve a few related instances of this bug beyond what #66413 describes, for example if you started a window maximized, then reduced its size, then minimized it, then unminimized it, it would return to maximized size instead of the correct non-maximized size.