### PR TITLE
Enable assigning an owner to navigation regions and links

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -167,6 +167,13 @@
 				Returns the navigation layers for this [code]link[/code].
 			</description>
 		</method>
+		<method name="link_get_owner_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="link" type="RID" />
+			<description>
+				Returns the [code]ObjectID[/code] of the object which manages this link.
+			</description>
+		</method>
 		<method name="link_get_start_location" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="link" type="RID" />
@@ -226,6 +233,14 @@
 			<param index="1" name="navigation_layers" type="int" />
 			<description>
 				Set the links's navigation layers. This allows selecting links from a path request (when using [method NavigationServer2D.map_get_path]).
+			</description>
+		</method>
+		<method name="link_set_owner_id" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="link" type="RID" />
+			<param index="1" name="owner_id" type="int" />
+			<description>
+				Set the [code]ObjectID[/code] of the object which manages this link.
 			</description>
 		</method>
 		<method name="link_set_start_location" qualifiers="const">
@@ -426,6 +441,13 @@
 				Returns the region's navigation layers.
 			</description>
 		</method>
+		<method name="region_get_owner_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="region" type="RID" />
+			<description>
+				Returns the [code]ObjectID[/code] of the object which manages this region.
+			</description>
+		</method>
 		<method name="region_get_travel_cost" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
@@ -473,6 +495,14 @@
 			<param index="1" name="nav_poly" type="NavigationPolygon" />
 			<description>
 				Sets the navigation mesh for the region.
+			</description>
+		</method>
+		<method name="region_set_owner_id" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="region" type="RID" />
+			<param index="1" name="owner_id" type="int" />
+			<description>
+				Set the [code]ObjectID[/code] of the object which manages this region.
 			</description>
 		</method>
 		<method name="region_set_transform" qualifiers="const">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -167,6 +167,13 @@
 				Returns the navigation layers for this [code]link[/code].
 			</description>
 		</method>
+		<method name="link_get_owner_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="link" type="RID" />
+			<description>
+				Returns the [code]ObjectID[/code] of the object which manages this link.
+			</description>
+		</method>
 		<method name="link_get_start_location" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="link" type="RID" />
@@ -226,6 +233,14 @@
 			<param index="1" name="navigation_layers" type="int" />
 			<description>
 				Set the links's navigation layers. This allows selecting links from a path request (when using [method NavigationServer3D.map_get_path]).
+			</description>
+		</method>
+		<method name="link_set_owner_id" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="link" type="RID" />
+			<param index="1" name="owner_id" type="int" />
+			<description>
+				Set the [code]ObjectID[/code] of the object which manages this link.
 			</description>
 		</method>
 		<method name="link_set_start_location" qualifiers="const">
@@ -476,6 +491,13 @@
 				Returns the region's navigation layers.
 			</description>
 		</method>
+		<method name="region_get_owner_id" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="region" type="RID" />
+			<description>
+				Returns the [code]ObjectID[/code] of the object which manages this region.
+			</description>
+		</method>
 		<method name="region_get_travel_cost" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="region" type="RID" />
@@ -523,6 +545,14 @@
 			<param index="1" name="nav_mesh" type="NavigationMesh" />
 			<description>
 				Sets the navigation mesh for the region.
+			</description>
+		</method>
+		<method name="region_set_owner_id" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="region" type="RID" />
+			<param index="1" name="owner_id" type="int" />
+			<description>
+				Set the [code]ObjectID[/code] of the object which manages this region.
 			</description>
 		</method>
 		<method name="region_set_transform" qualifiers="const">

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -656,6 +656,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 			if (bake_navigation) {
 				RID region = NavigationServer3D::get_singleton()->region_create();
+				NavigationServer3D::get_singleton()->region_set_owner_id(region, get_instance_id());
 				NavigationServer3D::get_singleton()->region_set_navigation_layers(region, navigation_layers);
 				NavigationServer3D::get_singleton()->region_set_navmesh(region, navmesh);
 				NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * nm.xform);
@@ -779,6 +780,7 @@ void GridMap::_octant_enter_world(const OctantKey &p_key) {
 				Ref<NavigationMesh> nm = mesh_library->get_item_navmesh(cell_map[F.key].item);
 				if (nm.is_valid()) {
 					RID region = NavigationServer3D::get_singleton()->region_create();
+					NavigationServer3D::get_singleton()->region_set_owner_id(region, get_instance_id());
 					NavigationServer3D::get_singleton()->region_set_navigation_layers(region, navigation_layers);
 					NavigationServer3D::get_singleton()->region_set_navmesh(region, nm);
 					NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * F.value.xform);

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -383,6 +383,20 @@ real_t GodotNavigationServer::region_get_travel_cost(RID p_region) const {
 	return region->get_travel_cost();
 }
 
+COMMAND_2(region_set_owner_id, RID, p_region, ObjectID, p_owner_id) {
+	NavRegion *region = region_owner.get_or_null(p_region);
+	ERR_FAIL_COND(region == nullptr);
+
+	region->set_owner_id(p_owner_id);
+}
+
+ObjectID GodotNavigationServer::region_get_owner_id(RID p_region) const {
+	const NavRegion *region = region_owner.get_or_null(p_region);
+	ERR_FAIL_COND_V(region == nullptr, ObjectID());
+
+	return region->get_owner_id();
+}
+
 bool GodotNavigationServer::region_owns_point(RID p_region, const Vector3 &p_point) const {
 	const NavRegion *region = region_owner.get_or_null(p_region);
 	ERR_FAIL_COND_V(region == nullptr, false);
@@ -568,6 +582,20 @@ real_t GodotNavigationServer::link_get_travel_cost(const RID p_link) const {
 	ERR_FAIL_COND_V(link == nullptr, 0);
 
 	return link->get_travel_cost();
+}
+
+COMMAND_2(link_set_owner_id, RID, p_link, ObjectID, p_owner_id) {
+	NavLink *link = link_owner.get_or_null(p_link);
+	ERR_FAIL_COND(link == nullptr);
+
+	link->set_owner_id(p_owner_id);
+}
+
+ObjectID GodotNavigationServer::link_get_owner_id(RID p_link) const {
+	const NavLink *link = link_owner.get_or_null(p_link);
+	ERR_FAIL_COND_V(link == nullptr, ObjectID());
+
+	return link->get_owner_id();
 }
 
 RID GodotNavigationServer::agent_create() const {

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -125,6 +125,9 @@ public:
 	COMMAND_2(region_set_travel_cost, RID, p_region, real_t, p_travel_cost);
 	virtual real_t region_get_travel_cost(RID p_region) const override;
 
+	COMMAND_2(region_set_owner_id, RID, p_region, ObjectID, p_owner_id);
+	virtual ObjectID region_get_owner_id(RID p_region) const override;
+
 	virtual bool region_owns_point(RID p_region, const Vector3 &p_point) const override;
 
 	COMMAND_2(region_set_map, RID, p_region, RID, p_map);
@@ -153,6 +156,8 @@ public:
 	virtual real_t link_get_enter_cost(RID p_link) const override;
 	COMMAND_2(link_set_travel_cost, RID, p_link, real_t, p_travel_cost);
 	virtual real_t link_get_travel_cost(RID p_link) const override;
+	COMMAND_2(link_set_owner_id, RID, p_link, ObjectID, p_owner_id);
+	virtual ObjectID link_get_owner_id(RID p_link) const override;
 
 	virtual RID agent_create() const override;
 	COMMAND_2(agent_set_map, RID, p_agent, RID, p_map);

--- a/modules/navigation/nav_base.h
+++ b/modules/navigation/nav_base.h
@@ -41,6 +41,7 @@ protected:
 	uint32_t navigation_layers = 1;
 	float enter_cost = 0.0;
 	float travel_cost = 1.0;
+	ObjectID owner_id;
 
 public:
 	void set_navigation_layers(uint32_t p_navigation_layers) { navigation_layers = p_navigation_layers; }
@@ -51,6 +52,9 @@ public:
 
 	void set_travel_cost(float p_travel_cost) { travel_cost = MAX(p_travel_cost, 0.0); }
 	float get_travel_cost() const { return travel_cost; }
+
+	void set_owner_id(ObjectID p_owner_id) { owner_id = p_owner_id; }
+	ObjectID get_owner_id() const { return owner_id; }
 };
 
 #endif // NAV_BASE_H

--- a/scene/2d/navigation_link_2d.cpp
+++ b/scene/2d/navigation_link_2d.cpp
@@ -279,6 +279,8 @@ PackedStringArray NavigationLink2D::get_configuration_warnings() const {
 
 NavigationLink2D::NavigationLink2D() {
 	link = NavigationServer2D::get_singleton()->link_create();
+	NavigationServer2D::get_singleton()->link_set_owner_id(link, get_instance_id());
+
 	set_notify_transform(true);
 }
 

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -634,7 +634,9 @@ void NavigationRegion2D::_bind_methods() {
 
 NavigationRegion2D::NavigationRegion2D() {
 	set_notify_transform(true);
+
 	region = NavigationServer2D::get_singleton()->region_create();
+	NavigationServer2D::get_singleton()->region_set_owner_id(region, get_instance_id());
 	NavigationServer2D::get_singleton()->region_set_enter_cost(region, get_enter_cost());
 	NavigationServer2D::get_singleton()->region_set_travel_cost(region, get_travel_cost());
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1735,6 +1735,7 @@ void TileMap::_navigation_update_dirty_quadrants(SelfList<TileMapQuadrant>::List
 							tile_transform.set_origin(map_to_local(E_cell));
 
 							RID region = NavigationServer2D::get_singleton()->region_create();
+							NavigationServer2D::get_singleton()->region_set_owner_id(region, get_instance_id());
 							NavigationServer2D::get_singleton()->region_set_map(region, get_world_2d()->get_navigation_map());
 							NavigationServer2D::get_singleton()->region_set_transform(region, tilemap_xform * tile_transform);
 							NavigationServer2D::get_singleton()->region_set_navpoly(region, navpoly);

--- a/scene/3d/navigation_link_3d.cpp
+++ b/scene/3d/navigation_link_3d.cpp
@@ -221,6 +221,8 @@ void NavigationLink3D::_notification(int p_what) {
 
 NavigationLink3D::NavigationLink3D() {
 	link = NavigationServer3D::get_singleton()->link_create();
+	NavigationServer3D::get_singleton()->link_set_owner_id(link, get_instance_id());
+
 	set_notify_transform(true);
 }
 

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -339,7 +339,9 @@ void NavigationRegion3D::_navigation_map_changed(RID p_map) {
 
 NavigationRegion3D::NavigationRegion3D() {
 	set_notify_transform(true);
+
 	region = NavigationServer3D::get_singleton()->region_create();
+	NavigationServer3D::get_singleton()->region_set_owner_id(region, get_instance_id());
 	NavigationServer3D::get_singleton()->region_set_enter_cost(region, get_enter_cost());
 	NavigationServer3D::get_singleton()->region_set_travel_cost(region, get_travel_cost());
 

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -152,6 +152,10 @@ static Variant var_to_var(const Variant &d) {
 	return d;
 }
 
+static ObjectID id_to_id(const ObjectID &id) {
+	return id;
+}
+
 static Ref<NavigationMesh> poly_to_mesh(Ref<NavigationPolygon> d) {
 	if (d.is_valid()) {
 		return d->get_mesh();
@@ -250,6 +254,8 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_get_enter_cost", "region"), &NavigationServer2D::region_get_enter_cost);
 	ClassDB::bind_method(D_METHOD("region_set_travel_cost", "region", "travel_cost"), &NavigationServer2D::region_set_travel_cost);
 	ClassDB::bind_method(D_METHOD("region_get_travel_cost", "region"), &NavigationServer2D::region_get_travel_cost);
+	ClassDB::bind_method(D_METHOD("region_set_owner_id", "region", "owner_id"), &NavigationServer2D::region_set_owner_id);
+	ClassDB::bind_method(D_METHOD("region_get_owner_id", "region"), &NavigationServer2D::region_get_owner_id);
 	ClassDB::bind_method(D_METHOD("region_owns_point", "region", "point"), &NavigationServer2D::region_owns_point);
 	ClassDB::bind_method(D_METHOD("region_set_map", "region", "map"), &NavigationServer2D::region_set_map);
 	ClassDB::bind_method(D_METHOD("region_get_map", "region"), &NavigationServer2D::region_get_map);
@@ -276,6 +282,8 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("link_get_enter_cost", "link"), &NavigationServer2D::link_get_enter_cost);
 	ClassDB::bind_method(D_METHOD("link_set_travel_cost", "link", "travel_cost"), &NavigationServer2D::link_set_travel_cost);
 	ClassDB::bind_method(D_METHOD("link_get_travel_cost", "link"), &NavigationServer2D::link_get_travel_cost);
+	ClassDB::bind_method(D_METHOD("link_set_owner_id", "link", "owner_id"), &NavigationServer2D::link_set_owner_id);
+	ClassDB::bind_method(D_METHOD("link_get_owner_id", "link"), &NavigationServer2D::link_get_owner_id);
 
 	ClassDB::bind_method(D_METHOD("agent_create"), &NavigationServer2D::agent_create);
 	ClassDB::bind_method(D_METHOD("agent_set_map", "agent", "map"), &NavigationServer2D::agent_set_map);
@@ -348,6 +356,8 @@ void FORWARD_2_C(region_set_enter_cost, RID, p_region, real_t, p_enter_cost, rid
 real_t FORWARD_1_C(region_get_enter_cost, RID, p_region, rid_to_rid);
 void FORWARD_2_C(region_set_travel_cost, RID, p_region, real_t, p_travel_cost, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(region_get_travel_cost, RID, p_region, rid_to_rid);
+void FORWARD_2_C(region_set_owner_id, RID, p_region, ObjectID, p_owner_id, rid_to_rid, id_to_id);
+ObjectID FORWARD_1_C(region_get_owner_id, RID, p_region, rid_to_rid);
 bool FORWARD_2_C(region_owns_point, RID, p_region, const Vector2 &, p_point, rid_to_rid, v2_to_v3);
 
 void FORWARD_2_C(region_set_map, RID, p_region, RID, p_map, rid_to_rid, rid_to_rid);
@@ -379,6 +389,8 @@ void FORWARD_2_C(link_set_enter_cost, RID, p_link, real_t, p_enter_cost, rid_to_
 real_t FORWARD_1_C(link_get_enter_cost, RID, p_link, rid_to_rid);
 void FORWARD_2_C(link_set_travel_cost, RID, p_link, real_t, p_travel_cost, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(link_get_travel_cost, RID, p_link, rid_to_rid);
+void FORWARD_2_C(link_set_owner_id, RID, p_link, ObjectID, p_owner_id, rid_to_rid, id_to_id);
+ObjectID FORWARD_1_C(link_get_owner_id, RID, p_link, rid_to_rid);
 
 RID NavigationServer2D::agent_create() const {
 	RID agent = NavigationServer3D::get_singleton()->agent_create();

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -108,6 +108,10 @@ public:
 	virtual void region_set_travel_cost(RID p_region, real_t p_travel_cost) const;
 	virtual real_t region_get_travel_cost(RID p_region) const;
 
+	/// Set the node which manages this region.
+	virtual void region_set_owner_id(RID p_region, ObjectID p_owner_id) const;
+	virtual ObjectID region_get_owner_id(RID p_region) const;
+
 	virtual bool region_owns_point(RID p_region, const Vector2 &p_point) const;
 
 	/// Set the map of this region.
@@ -159,6 +163,10 @@ public:
 	/// Set the travel cost of the link.
 	virtual void link_set_travel_cost(RID p_link, real_t p_travel_cost) const;
 	virtual real_t link_get_travel_cost(RID p_link) const;
+
+	/// Set the node which manages this link.
+	virtual void link_set_owner_id(RID p_link, ObjectID p_owner_id) const;
+	virtual ObjectID link_get_owner_id(RID p_link) const;
 
 	/// Creates the agent.
 	virtual RID agent_create() const;

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -69,6 +69,8 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("region_get_enter_cost", "region"), &NavigationServer3D::region_get_enter_cost);
 	ClassDB::bind_method(D_METHOD("region_set_travel_cost", "region", "travel_cost"), &NavigationServer3D::region_set_travel_cost);
 	ClassDB::bind_method(D_METHOD("region_get_travel_cost", "region"), &NavigationServer3D::region_get_travel_cost);
+	ClassDB::bind_method(D_METHOD("region_set_owner_id", "region", "owner_id"), &NavigationServer3D::region_set_owner_id);
+	ClassDB::bind_method(D_METHOD("region_get_owner_id", "region"), &NavigationServer3D::region_get_owner_id);
 	ClassDB::bind_method(D_METHOD("region_owns_point", "region", "point"), &NavigationServer3D::region_owns_point);
 	ClassDB::bind_method(D_METHOD("region_set_map", "region", "map"), &NavigationServer3D::region_set_map);
 	ClassDB::bind_method(D_METHOD("region_get_map", "region"), &NavigationServer3D::region_get_map);
@@ -96,6 +98,8 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("link_get_enter_cost", "link"), &NavigationServer3D::link_get_enter_cost);
 	ClassDB::bind_method(D_METHOD("link_set_travel_cost", "link", "travel_cost"), &NavigationServer3D::link_set_travel_cost);
 	ClassDB::bind_method(D_METHOD("link_get_travel_cost", "link"), &NavigationServer3D::link_get_travel_cost);
+	ClassDB::bind_method(D_METHOD("link_set_owner_id", "link", "owner_id"), &NavigationServer3D::link_set_owner_id);
+	ClassDB::bind_method(D_METHOD("link_get_owner_id", "link"), &NavigationServer3D::link_get_owner_id);
 
 	ClassDB::bind_method(D_METHOD("agent_create"), &NavigationServer3D::agent_create);
 	ClassDB::bind_method(D_METHOD("agent_set_map", "agent", "map"), &NavigationServer3D::agent_set_map);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -120,6 +120,10 @@ public:
 	virtual void region_set_travel_cost(RID p_region, real_t p_travel_cost) const = 0;
 	virtual real_t region_get_travel_cost(RID p_region) const = 0;
 
+	/// Set the node which manages this region.
+	virtual void region_set_owner_id(RID p_region, ObjectID p_owner_id) const = 0;
+	virtual ObjectID region_get_owner_id(RID p_region) const = 0;
+
 	virtual bool region_owns_point(RID p_region, const Vector3 &p_point) const = 0;
 
 	/// Set the map of this region.
@@ -174,6 +178,10 @@ public:
 	/// Set the travel cost of the link.
 	virtual void link_set_travel_cost(RID p_link, real_t p_travel_cost) const = 0;
 	virtual real_t link_get_travel_cost(RID p_link) const = 0;
+
+	/// Set the node which manages this link.
+	virtual void link_set_owner_id(RID p_link, ObjectID p_owner_id) const = 0;
+	virtual ObjectID link_get_owner_id(RID p_link) const = 0;
 
 	/// Creates the agent.
 	virtual RID agent_create() const = 0;


### PR DESCRIPTION
Inspired by the concept of Shape owners in Godot Physics, this PR adds the ability to assign an object as the "owner" of a navigation region or link.  This will be used to return the `NavigationRegion` or `NavigationLink` node that an agent enters while following its path.

Right now, it's only possible to get the `RID` of the underlying region or link in the server, which makes the typical usage of a signal when entering a link or region rather unfriendly to the casual user.  The PR should enable those signals to return the nodes encountered on its way in a future PR, but I wanted to get this out early in order to get feedback on the approach.

Why use `ObjectID`?
I considered using pointers to the owning object, but I'm concerned about returning pointers to freed memory if the owning object is deleted without properly unregistering itself.  Using `ObjectID` protects against this by returning an ID that would no longer be valid, which `ObjectDB` can catch and return a `null` Object pointer.
