### PR TITLE
Initialized variables and other minor issues presented by Cppcheck in 5 files

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,27 @@
+version = 1
+
+[[analyzers]]
+name = "csharp"
+enabled = true
+
+[[analyzers]]
+name = "java"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "11"
+
+[[analyzers]]
+name = "shell"
+enabled = true
+
+[[analyzers]]
+name = "javascript"
+enabled = true
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -244,7 +244,7 @@ private:
 		Projection *_projection = nullptr;
 		PackedArrayRefBase *packed_array = nullptr;
 		void *_ptr = nullptr; //generic pointer
-		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)]{ 0 } = 0;
+		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)]{ 0 };
 	} _data alignas(8);
 
 	void reference(const Variant &p_variant);

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -234,17 +234,17 @@ private:
 	_ALWAYS_INLINE_ const ObjData &_get_obj() const;
 
 	union {
-		bool _bool;
-		int64_t _int;
-		double _float;
-		Transform2D *_transform2d;
-		::AABB *_aabb;
-		Basis *_basis;
-		Transform3D *_transform3d;
-		Projection *_projection;
-		PackedArrayRefBase *packed_array;
-		void *_ptr; //generic pointer
-		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)]{ 0 };
+		bool _bool = false;
+		int64_t _int = 0;
+		double _float = 0.0;
+		Transform2D *_transform2d = nullptr;
+		::AABB *_aabb = nullptr;
+		Basis *_basis = nullptr;
+		Transform3D *_transform3d = nullptr;
+		Projection *_projection = nullptr;
+		PackedArrayRefBase *packed_array = nullptr;
+		void *_ptr = nullptr; //generic pointer
+		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)]{ 0 } = 0;
 	} _data alignas(8);
 
 	void reference(const Variant &p_variant);

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -312,18 +312,10 @@ class VisualShaderEditor : public VBoxContainer {
 		bool is_custom = false;
 		int temp_idx = 0;
 
-		AddOption(const String &p_name = String(), const String &p_category = String(), const String &p_type = String(), const String &p_description = String(), const Vector<Variant> &p_ops = Vector<Variant>(), int p_return_type = -1, int p_mode = -1, int p_func = -1, bool p_highend = false) {
-			name = p_name;
-			type = p_type;
-			category = p_category;
-			description = p_description;
-			ops = p_ops;
-			return_type = p_return_type;
-			mode = p_mode;
-			func = p_func;
-			highend = p_highend;
-		}
+		AddOption(const String &p_name = String(), const String &p_category = String(), const String &p_type = String(), const String &p_description = String(), const Vector<Variant> &p_ops = Vector<Variant>(), int p_return_type = -1, int p_mode = -1, int p_func = -1, bool p_highend = false): 
+		name(p_name), type(p_type), category(p_category), description(p_description), ops(p_ops), return_type(p_return_type), mode(p_mode), func(p_func), highend(p_highend) {}
 	};
+	
 	struct _OptionComparator {
 		_FORCE_INLINE_ bool operator()(const AddOption &a, const AddOption &b) const {
 			return a.category.count("/") > b.category.count("/") || (a.category + "/" + a.name).naturalnocasecmp_to(b.category + "/" + b.name) < 0;

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -95,12 +95,8 @@ class LightmapperRD : public Lightmapper {
 		Edge() {
 		}
 
-		Edge(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_na, const Vector3 &p_nb) {
-			a = p_a;
-			b = p_b;
-			na = p_na;
-			nb = p_nb;
-		}
+		Edge(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_na, const Vector3 &p_nb): a(p_a), b(p_b), na(p_na), nb(p_nb) {}
+			
 	};
 
 	struct Probe {
@@ -128,11 +124,9 @@ class LightmapperRD : public Lightmapper {
 			return a == p_uv2.a && b == p_uv2.b;
 		}
 		bool seam_found = false;
-		EdgeUV2(Vector2 p_a, Vector2 p_b, Vector2i p_indices) {
-			a = p_a;
-			b = p_b;
-			indices = p_indices;
-		}
+		
+		EdgeUV2(Vector2 p_a, Vector2 p_b, Vector2i p_indices): a(p_a), b(p_b), indices(p_indices) {}
+
 		EdgeUV2() {}
 	};
 

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/IdentifierUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/IdentifierUtils.cs
@@ -44,7 +44,7 @@ namespace GodotTools.ProjectEditor
                     case UnicodeCategory.NonSpacingMark: break;
                     case UnicodeCategory.SpacingCombiningMark: break;
                     case UnicodeCategory.ConnectorPunctuation: break;
-                    case UnicodeCategory.DecimalDigitNumber: break;
+                    case UnicodeCategory.DecimalDigitNumber:
                         // Identifiers may start with underscore
                         if (outputBuilder.Length > startIndex || @char == '_')
                             outputBuilder.Append(@char);

--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/IdentifierUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/IdentifierUtils.cs
@@ -33,21 +33,24 @@ namespace GodotTools.ProjectEditor
 
                 switch (char.GetUnicodeCategory(@char))
                 {
-                    case UnicodeCategory.UppercaseLetter:
-                    case UnicodeCategory.LowercaseLetter:
-                    case UnicodeCategory.TitlecaseLetter:
-                    case UnicodeCategory.ModifierLetter:
-                    case UnicodeCategory.LetterNumber:
-                    case UnicodeCategory.OtherLetter:
+                    case UnicodeCategory.UppercaseLetter: break;
+                    case UnicodeCategory.LowercaseLetter: break;
+                    case UnicodeCategory.TitlecaseLetter: break;
+                    case UnicodeCategory.ModifierLetter: break;
+                    case UnicodeCategory.LetterNumber: break;
+                    case UnicodeCategory.OtherLetter: break;
                         outputBuilder.Append(@char);
                         break;
-                    case UnicodeCategory.NonSpacingMark:
-                    case UnicodeCategory.SpacingCombiningMark:
-                    case UnicodeCategory.ConnectorPunctuation:
-                    case UnicodeCategory.DecimalDigitNumber:
+                    case UnicodeCategory.NonSpacingMark: break;
+                    case UnicodeCategory.SpacingCombiningMark: break;
+                    case UnicodeCategory.ConnectorPunctuation: break;
+                    case UnicodeCategory.DecimalDigitNumber: break;
                         // Identifiers may start with underscore
                         if (outputBuilder.Length > startIndex || @char == '_')
                             outputBuilder.Append(@char);
+                        break;
+                    default:
+                        throw new ArgumentException ("Error inside SkipInvalidCharacters function");
                         break;
                 }
             }

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -50,11 +50,7 @@ class BindingsGenerator {
 
 		ConstantInterface() {}
 
-		ConstantInterface(const String &p_name, const String &p_proxy_name, int64_t p_value) {
-			name = p_name;
-			proxy_name = p_proxy_name;
-			value = p_value;
-		}
+		ConstantInterface(const String &p_name, const String &p_proxy_name, int64_t p_value): name(p_name), proxy_name(p_proxy_name), value(p_value) {}
 	};
 
 	struct EnumInterface {
@@ -68,9 +64,7 @@ class BindingsGenerator {
 
 		EnumInterface() {}
 
-		EnumInterface(const StringName &p_cname) {
-			cname = p_cname;
-		}
+		EnumInterface(const StringName &p_cname): cname(p_cname) {}
 	};
 
 	struct PropertyInterface {
@@ -531,9 +525,7 @@ class BindingsGenerator {
 
 		InternalCall() {}
 
-		InternalCall(ClassDB::APIType api_type, const String &p_name, const String &p_unique_sig = String()) {
-			name = p_name;
-			unique_sig = p_unique_sig;
+		InternalCall(ClassDB::APIType api_type, const String &p_name, const String &p_unique_sig = String()): name(p_name), unique_sig(p_unique_sig) {
 			editor_only = api_type == ClassDB::API_EDITOR;
 		}
 


### PR DESCRIPTION
1) Initialized class variables inside core/variant/variant.h

2) Created initialization lists for variables assigned in the constructor's body inside editor/plugins/visual_shader_editory_plugin.h , modules/lightmapper_rd/lightmapper_rd.h , and modules/mono/editor/bindings_generator.h

3) Added breaks and default case to switch statement inside of modules/mono/editor/GodotTools/GodotTools.ProjectEditor/IdentifierUtils.cs 

