### PR TITLE
Revert #57392 & rename Camera `zoom` to `zoom_scale`

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -156,8 +156,8 @@
 		<member name="smoothing_speed" type="float" setter="set_follow_smoothing" getter="get_follow_smoothing" default="5.0">
 			Speed in pixels per second of the camera's smoothing effect when [member smoothing_enabled] is [code]true[/code].
 		</member>
-		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom" default="Vector2(1, 1)">
-			The camera's zoom. A zoom of [code]Vector(2, 2)[/code] doubles the size seen in the viewport. A zoom of [code]Vector(0.5, 0.5)[/code] halves the size seen in the viewport.
+		<member name="zoom_scale" type="Vector2" setter="set_zoom_scale" getter="get_zoom_scale" default="Vector2(1, 1)">
+			The displayed scale of this camera's viewport. A value of [code]Vector(0.5, 0.5)[/code] doubles the size seen in the viewport, zooming in. A value of [code]Vector(2, 2)[/code] halves the size seen in the viewport, zooming out.
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -74,19 +74,21 @@ void Camera2D::_update_process_callback() {
 	}
 }
 
-void Camera2D::set_zoom(const Vector2 &p_zoom) {
+void Camera2D::set_zoom_scale(const Vector2 &p_scale) {
 	// Setting zoom to zero causes 'affine_invert' issues
-	ERR_FAIL_COND_MSG(Math::is_zero_approx(p_zoom.x) || Math::is_zero_approx(p_zoom.y), "Zoom level must be different from 0 (can be negative).");
+	//ERR_FAIL_COND_MSG(Math::is_zero_approx(p_zoom.x) || Math::is_zero_approx(p_zoom.y), "Zoom level must be different from 0 (can be negative).");
+	if (zoom_scale == p_scale) {
+		return;
+	}
 
-	zoom = p_zoom;
-	zoom_scale = Vector2(1, 1) / zoom;
+	zoom_scale = p_scale;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
 	smoothed_camera_pos = old_smoothed_camera_pos;
 };
 
-Vector2 Camera2D::get_zoom() const {
-	return zoom;
+Vector2 Camera2D::get_zoom_scale() const {
+	return zoom_scale;
 };
 
 Transform2D Camera2D::get_camera_transform() {
@@ -704,8 +706,8 @@ void Camera2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_target_position"), &Camera2D::get_camera_position);
 	ClassDB::bind_method(D_METHOD("get_screen_center_position"), &Camera2D::get_camera_screen_center);
 
-	ClassDB::bind_method(D_METHOD("set_zoom", "zoom"), &Camera2D::set_zoom);
-	ClassDB::bind_method(D_METHOD("get_zoom"), &Camera2D::get_zoom);
+	ClassDB::bind_method(D_METHOD("set_zoom_scale", "zoom_scale"), &Camera2D::set_zoom_scale);
+	ClassDB::bind_method(D_METHOD("get_zoom_scale"), &Camera2D::get_zoom_scale);
 
 	ClassDB::bind_method(D_METHOD("set_custom_viewport", "viewport"), &Camera2D::set_custom_viewport);
 	ClassDB::bind_method(D_METHOD("get_custom_viewport"), &Camera2D::get_custom_viewport);
@@ -735,7 +737,7 @@ void Camera2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "anchor_mode", PROPERTY_HINT_ENUM, "Fixed TopLeft,Drag Center"), "set_anchor_mode", "get_anchor_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_rotation"), "set_ignore_rotation", "is_ignoring_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "current"), "set_current", "is_current");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "zoom", PROPERTY_HINT_LINK), "set_zoom", "get_zoom");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "zoom_scale", PROPERTY_HINT_LINK), "set_zoom_scale", "get_zoom_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "custom_viewport", PROPERTY_HINT_RESOURCE_TYPE, "Viewport", PROPERTY_USAGE_NONE), "set_custom_viewport", "get_custom_viewport");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_callback", PROPERTY_HINT_ENUM, "Physics,Idle"), "set_process_callback", "get_process_callback");
 

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -60,7 +60,6 @@ protected:
 	StringName canvas_group_name;
 	RID canvas;
 	Vector2 offset;
-	Vector2 zoom = Vector2(1, 1);
 	Vector2 zoom_scale = Vector2(1, 1);
 	AnchorMode anchor_mode = ANCHOR_MODE_DRAG_CENTER;
 	bool ignore_rotation = true;
@@ -146,8 +145,8 @@ public:
 	void clear_current();
 	bool is_current() const;
 
-	void set_zoom(const Vector2 &p_zoom);
-	Vector2 get_zoom() const;
+	void set_zoom_scale(const Vector2 &p_scale);
+	Vector2 get_zoom_scale() const;
 
 	Point2 get_camera_screen_center() const;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5525 _(See proposal for further reasoning)_.

#57392 modified the **Camera2D**'s `zoom` to behave more consistently and intuitively with real-life. Starting from `Vector(1, 1)`, Higher values **zoom in**, and lower values **zoom out**. 
It first seemed like a smart move. However, in actual practice, this results in the property being very difficult to work with.
The higher precision of **zooming in** is essentially not that useful, and **zooming out** is pretty restrictive.

This PR reverts the change to be like **3.x**, and also renames the **Camera2D**'s `zoom` to `zoom_scale` as it is already called in the internal code.

Do note that this property cannot be added to the **Project Converter** because it would conflict with **GraphEdit**'s `zoom`, which in truth, also suffers from the same issue. It probably should be there changed, as well.