### PR TITLE
Remove editor setting for hiding bookmarks

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -682,11 +682,8 @@
 		<member name="text_editor/appearance/gutters/line_numbers_zero_padded" type="bool" setter="" getter="">
 			If [code]true[/code], displays line numbers with zero padding (e.g. [code]007[/code] instead of [code]7[/code]).
 		</member>
-		<member name="text_editor/appearance/gutters/show_bookmark_gutter" type="bool" setter="" getter="">
-			If [code]true[/code], displays icons for bookmarks in a gutter at the left. Bookmarks remain functional when this setting is disabled.
-		</member>
 		<member name="text_editor/appearance/gutters/show_info_gutter" type="bool" setter="" getter="">
-			If [code]true[/code], displays a gutter at the left containing icons for methods with signal connections.
+			If [code]true[/code], displays a gutter at the left containing icons for methods with signal connections and for overridden methods.
 		</member>
 		<member name="text_editor/appearance/gutters/show_line_numbers" type="bool" setter="" getter="">
 			If [code]true[/code], displays line numbers in a gutter at the left.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1018,7 +1018,6 @@ void CodeTextEditor::update_editor_settings() {
 	// Appearance: Gutters
 	text_editor->set_draw_line_numbers(EDITOR_GET("text_editor/appearance/gutters/show_line_numbers"));
 	text_editor->set_line_numbers_zero_padded(EDITOR_GET("text_editor/appearance/gutters/line_numbers_zero_padded"));
-	text_editor->set_draw_bookmarks_gutter(EDITOR_GET("text_editor/appearance/gutters/show_bookmark_gutter"));
 
 	// Appearance: Minimap
 	text_editor->set_draw_minimap(EDITOR_GET("text_editor/appearance/minimap/show_minimap"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -526,7 +526,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/appearance/gutters/show_line_numbers", true);
 	_initial_set("text_editor/appearance/gutters/line_numbers_zero_padded", false);
 	_initial_set("text_editor/appearance/gutters/highlight_type_safe_lines", true);
-	_initial_set("text_editor/appearance/gutters/show_bookmark_gutter", true);
 	_initial_set("text_editor/appearance/gutters/show_info_gutter", true);
 
 	// Appearance: Minimap


### PR DESCRIPTION
This editor setting says it hides the "Bookmarks gutter", but bookmarks actually share a gutter with breakpoints and executing lines. Unlike "Show Info Gutter" and "Show Line Numbers", it does not save horizontal space. It only hides bookmarks.

Bookmarks remain functional while hidden, so all it does is hide information from you with no benefit. It seems like a leftover from 3.x where you could hide breakpoints too and actually collapse the main gutter, saving horizontal space. Here it has no benefit.

What if you still want to hide bookmarks for some reason? Set this color to transparent:

![image](https://user-images.githubusercontent.com/85438892/193452901-cac25151-ae7a-46e3-82c9-69fc4856c0c9.png)

Closes https://github.com/godotengine/godot-proposals/issues/5369