### PR TITLE
Fixing the 'chunks' pointer so that it is not used before modifying a…

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -350,24 +350,25 @@ public:
 				if (validator & 0x80000000) {
 					continue; //uninitialized
 				}
-				if (validator != 0xFFFFFFFF) {
+				if (chunks != nullptr validator != 0xFFFFFFFF) {
 					chunks[i / elements_in_chunk][i % elements_in_chunk].~T();
 				}
 			}
 		}
-
 		uint32_t chunk_count = max_alloc / elements_in_chunk;
+		
+		if (chunks) {
+			memfree(chunks);
+			memfree(free_list_chunks);
+			memfree(validator_chunks);
+		}
+		
 		for (uint32_t i = 0; i < chunk_count; i++) {
 			memfree(chunks[i]);
 			memfree(validator_chunks[i]);
 			memfree(free_list_chunks[i]);
 		}
 
-		if (chunks) {
-			memfree(chunks);
-			memfree(free_list_chunks);
-			memfree(validator_chunks);
-		}
 	}
 };
 


### PR DESCRIPTION
…gainst nullptr.

Adding a nullptr check before the pointer is used in the if-statement and before any memory is freed.

