### PR TITLE
Fix visibility filtering options for .blend imports

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -261,7 +261,7 @@ void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, Li
 #define ADD_OPTION_ENUM(PATH, ENUM_HINT, VALUE) \
 	r_options->push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::INT, SNAME(PATH), PROPERTY_HINT_ENUM, ENUM_HINT), VALUE));
 
-	ADD_OPTION_ENUM("blender/nodes/visible", "Visible Only,Renderable,All", BLEND_VISIBLE_ALL);
+	ADD_OPTION_ENUM("blender/nodes/visible", "All,Visible Only,Renderable", BLEND_VISIBLE_ALL);
 	ADD_OPTION_BOOL("blender/nodes/punctual_lights", true);
 	ADD_OPTION_BOOL("blender/nodes/cameras", true);
 	ADD_OPTION_BOOL("blender/nodes/custom_properties", true);

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -45,9 +45,9 @@ class EditorSceneFormatImporterBlend : public EditorSceneFormatImporter {
 
 public:
 	enum {
+		BLEND_VISIBLE_ALL,
 		BLEND_VISIBLE_VISIBLE_ONLY,
-		BLEND_VISIBLE_RENDERABLE,
-		BLEND_VISIBLE_ALL
+		BLEND_VISIBLE_RENDERABLE
 	};
 	enum {
 		BLEND_BONE_INFLUENCES_NONE,


### PR DESCRIPTION
Fixes #66753.
The default option was previously to import visible nodes only, but was treated as all. All is now the default, so any existing files importing with the default settings still behave the same as before.