### PR TITLE
Texture2D.get_size() now returns Vector2i instead of Vector2

### DIFF
--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -111,7 +111,7 @@
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">
-			<return type="Vector2" />
+			<return type="Vector2i" />
 			<description>
 				Returns the texture size.
 			</description>

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -74,8 +74,8 @@ class PopupMenu : public Popup {
 		bool shortcut_is_disabled = false;
 
 		// Returns (0,0) if icon is null.
-		Size2 get_icon_size() const {
-			return icon.is_null() ? Size2() : icon->get_size();
+		Size2i get_icon_size() const {
+			return icon.is_null() ? Size2i() : icon->get_size();
 		}
 
 		Item() {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -115,8 +115,8 @@ int ViewportTexture::get_height() const {
 	return vp->size.height;
 }
 
-Size2 ViewportTexture::get_size() const {
-	ERR_FAIL_COND_V_MSG(!vp, Size2(), "Viewport Texture must be set to use it.");
+Size2i ViewportTexture::get_size() const {
+	ERR_FAIL_COND_V_MSG(!vp, Size2i(), "Viewport Texture must be set to use it.");
 	return vp->size;
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -74,7 +74,7 @@ public:
 
 	virtual int get_width() const override;
 	virtual int get_height() const override;
-	virtual Size2 get_size() const override;
+	virtual Size2i get_size() const override;
 	virtual RID get_rid() const override;
 
 	virtual bool has_alpha() const override;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -55,8 +55,8 @@ int Texture2D::get_height() const {
 	return 0;
 }
 
-Size2 Texture2D::get_size() const {
-	return Size2(get_width(), get_height());
+Size2i Texture2D::get_size() const {
+	return Size2i(get_width(), get_height());
 }
 
 bool Texture2D::is_pixel_opaque(int p_x, int p_y) const {

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -69,7 +69,7 @@ protected:
 public:
 	virtual int get_width() const;
 	virtual int get_height() const;
-	virtual Size2 get_size() const;
+	virtual Size2i get_size() const;
 
 	virtual bool is_pixel_opaque(int p_x, int p_y) const;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Current `Texture2D.get_size()` returns `Vector2` but the **height** and **width** both are integer value so converting its return type to `Vector2i`.

fixes #66727
