### PR TITLE
Add searching by event in Editor Settings shortcuts and Project Settings input map.

### DIFF
--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -106,9 +106,14 @@ void EditorSettingsDialog::popup_edit_settings() {
 	_focus_current_search_box();
 }
 
-void EditorSettingsDialog::_filter_shortcuts(const String &p_filter) {
-	shortcut_filter = p_filter;
+void EditorSettingsDialog::_filter_shortcuts(const String &) {
 	_update_shortcuts();
+}
+
+void EditorSettingsDialog::_filter_shortcuts_by_event(const Ref<InputEvent> &p_event) {
+	if (p_event.is_null() || (p_event->is_pressed() && !p_event->is_echo())) {
+		_update_shortcuts();
+	}
 }
 
 void EditorSettingsDialog::_undo_redo_callback(void *p_self, const String &p_name) {
@@ -326,6 +331,22 @@ void EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, const S
 	}
 }
 
+bool EditorSettingsDialog::_should_display_shortcut(const String &p_name, const Array &p_events) const {
+	const Ref<InputEvent> search_ev = shortcut_search_by_event->get_event();
+	bool event_match = true;
+	if (search_ev.is_valid()) {
+		event_match = false;
+		for (int i = 0; i < p_events.size(); ++i) {
+			const Ref<InputEvent> ev = p_events[i];
+			if (ev.is_valid() && ev->is_match(search_ev, true)) {
+				event_match = true;
+			}
+		}
+	}
+
+	return event_match && shortcut_search_box->get_text().is_subsequence_ofn(p_name);
+}
+
 void EditorSettingsDialog::_update_shortcuts() {
 	// Before clearing the tree, take note of which categories are collapsed so that this state can be maintained when the tree is repopulated.
 	HashMap<String, bool> collapsed;
@@ -379,32 +400,17 @@ void EditorSettingsDialog::_update_shortcuts() {
 		const String &action_name = E.key;
 		const InputMap::Action &action = E.value;
 
-		Array events; // Need to get the list of events into an array so it can be set as metadata on the item.
-		Vector<String> event_strings;
-
 		// Skip non-builtin actions.
 		if (!InputMap::get_singleton()->get_builtins_with_feature_overrides_applied().has(action_name)) {
 			continue;
 		}
 
 		const List<Ref<InputEvent>> &all_default_events = InputMap::get_singleton()->get_builtins_with_feature_overrides_applied().find(action_name)->value;
-		List<Ref<InputEventKey>> key_default_events;
-		// Remove all non-key events from the defaults. Only check keys, since we are in the editor.
-		for (const List<Ref<InputEvent>>::Element *I = all_default_events.front(); I; I = I->next()) {
-			Ref<InputEventKey> k = I->get();
-			if (k.is_valid()) {
-				key_default_events.push_back(k);
-			}
-		}
-
-		// Join the text of the events with a delimiter so they can all be displayed in one cell.
-		String events_display_string = event_strings.is_empty() ? "None" : String("; ").join(event_strings);
-
-		if (!shortcut_filter.is_subsequence_ofn(action_name) && (events_display_string == "None" || !shortcut_filter.is_subsequence_ofn(events_display_string))) {
+		Array action_events = _event_list_to_array_helper(action.inputs);
+		if (!_should_display_shortcut(action_name, action_events)) {
 			continue;
 		}
 
-		Array action_events = _event_list_to_array_helper(action.inputs);
 		Array default_events = _event_list_to_array_helper(all_default_events);
 		bool same_as_defaults = Shortcut::is_event_array_equal(default_events, action_events);
 		bool collapse = !collapsed.has(action_name) || (collapsed.has(action_name) && collapsed[action_name]);
@@ -459,8 +465,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 		String section_name = E.get_slice("/", 0);
 		TreeItem *section = sections[section_name];
 
-		// Shortcut Item
-		if (!shortcut_filter.is_subsequence_ofn(sc->get_name())) {
+		if (!_should_display_shortcut(sc->get_name(), sc->get_events())) {
 			continue;
 		}
 
@@ -749,11 +754,28 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	tabs->add_child(tab_shortcuts);
 	tab_shortcuts->set_name(TTR("Shortcuts"));
 
+	HBoxContainer *top_hbox = memnew(HBoxContainer);
+	top_hbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	tab_shortcuts->add_child(top_hbox);
+
 	shortcut_search_box = memnew(LineEdit);
-	shortcut_search_box->set_placeholder(TTR("Filter Shortcuts"));
+	shortcut_search_box->set_placeholder(TTR("Filter by name..."));
 	shortcut_search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	tab_shortcuts->add_child(shortcut_search_box);
+	top_hbox->add_child(shortcut_search_box);
 	shortcut_search_box->connect("text_changed", callable_mp(this, &EditorSettingsDialog::_filter_shortcuts));
+
+	shortcut_search_by_event = memnew(EventListenerLineEdit);
+	shortcut_search_by_event->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	shortcut_search_by_event->set_stretch_ratio(0.75);
+	shortcut_search_by_event->set_allowed_input_types(INPUT_KEY);
+	shortcut_search_by_event->connect("event_changed", callable_mp(this, &EditorSettingsDialog::_filter_shortcuts_by_event));
+	top_hbox->add_child(shortcut_search_by_event);
+
+	Button *clear_all_search = memnew(Button);
+	clear_all_search->set_text(TTR("Clear All"));
+	clear_all_search->connect("pressed", callable_mp(shortcut_search_box, &LineEdit::clear));
+	clear_all_search->connect("pressed", callable_mp(shortcut_search_by_event, &EventListenerLineEdit::clear_event));
+	top_hbox->add_child(clear_all_search);
 
 	shortcuts = memnew(Tree);
 	shortcuts->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -771,8 +793,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	// Adding event dialog
 	shortcut_editor = memnew(InputEventConfigurationDialog);
 	shortcut_editor->connect("confirmed", callable_mp(this, &EditorSettingsDialog::_event_config_confirmed));
-	shortcut_editor->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_KEY);
-	shortcut_editor->set_close_on_escape(false);
+	shortcut_editor->set_allowed_input_types(INPUT_KEY);
 	add_child(shortcut_editor);
 
 	set_hide_on_ok(true);

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -53,6 +53,7 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	LineEdit *search_box = nullptr;
 	LineEdit *shortcut_search_box = nullptr;
+	EventListenerLineEdit *shortcut_search_by_event = nullptr;
 	SectionedInspector *inspector = nullptr;
 
 	// Shortcuts
@@ -64,7 +65,6 @@ class EditorSettingsDialog : public AcceptDialog {
 	};
 
 	Tree *shortcuts = nullptr;
-	String shortcut_filter;
 
 	InputEventConfigurationDialog *shortcut_editor = nullptr;
 
@@ -103,12 +103,12 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _focus_current_search_box();
 
 	void _filter_shortcuts(const String &p_filter);
+	void _filter_shortcuts_by_event(const Ref<InputEvent> &p_event);
+	bool _should_display_shortcut(const String &p_name, const Array &p_events) const;
 
 	void _update_shortcuts();
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx, MouseButton p_button = MouseButton::LEFT);
 	void _shortcut_cell_double_clicked();
-
-	void _builtin_action_popup_index_pressed(int p_index);
 
 	static void _undo_redo_callback(void *p_self, const String &p_name);
 

--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -63,13 +63,13 @@ void InputEventConfigContainer::set_event(const Ref<InputEvent> &p_event) {
 	Ref<InputEventJoypadMotion> jm = p_event;
 
 	if (k.is_valid()) {
-		config_dialog->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_KEY);
+		config_dialog->set_allowed_input_types(INPUT_KEY);
 	} else if (m.is_valid()) {
-		config_dialog->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_MOUSE_BUTTON);
+		config_dialog->set_allowed_input_types(INPUT_MOUSE_BUTTON);
 	} else if (jb.is_valid()) {
-		config_dialog->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_JOY_BUTTON);
+		config_dialog->set_allowed_input_types(INPUT_JOY_BUTTON);
 	} else if (jm.is_valid()) {
-		config_dialog->set_allowed_input_types(InputEventConfigurationDialog::InputType::INPUT_JOY_MOTION);
+		config_dialog->set_allowed_input_types(INPUT_JOY_MOTION);
 	}
 
 	input_event = p_event;

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -199,8 +199,6 @@ private:
 		float base_scale = 1.0;
 	} theme_cache;
 
-	bool _is_over_clear_button(const Point2 &p_pos) const;
-
 	void _clear_undo_stack();
 	void _clear_redo();
 	void _create_undo_state();
@@ -240,6 +238,7 @@ private:
 	void _ensure_menu();
 
 protected:
+	bool _is_over_clear_button(const Point2 &p_pos) const;
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
* Focus into the `LineEdit`, then perform input to search the list of events by the events assigned.
* New specialised editor-only control for this: `EventListenerLineEdit`. Line edit is a good candidate for such a control because you can focus it, override it's input handling, and show the event all in one control.

Update `InputEventConfigurationDialog` to use event listener line edit rather than the separate tabs.
* Cleaner look - no need for tabs.
* Simpler code.

Please note the preview text in the LineEdit has now been changed from what is in the videos below. New is like so **Unfocused:** "Filter by event..." **Focused:** "Listening for input..."

**Shortcuts Search**

https://user-images.githubusercontent.com/41730826/193463380-a9d6acf9-6a39-4281-a5f8-a07c9b6d465e.mp4

**Input map Search**

https://user-images.githubusercontent.com/41730826/193463703-2b84f757-c9af-4320-9d9c-349004622d53.mp4


**New Event Picker (no more tabs!) (can now pick escape from the keyboard and close the window with escape too!)**

https://user-images.githubusercontent.com/41730826/193463415-af864b47-d634-4814-aaa1-4fa1bacb2d4c.mp4
