### PR TITLE
Enhancements to VS solution generation

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -27,7 +27,7 @@ jobs:
             target: editor
             tests: true
             # Skip debug symbols, they're way too big with MSVC.
-            sconsflags: debug_symbols=no
+            sconsflags: debug_symbols=no vsproj=yes
             bin: "./bin/godot.windows.editor.x86_64.exe"
 
           - name: Template (target=template_release, tools=no)

--- a/methods.py
+++ b/methods.py
@@ -777,7 +777,7 @@ def generate_vs_project(env, num_jobs):
                     for platform in ModuleConfigs.PLATFORMS
                 ]
                 self.arg_dict["runfile"] += [
-                    f'bin\\godot.windows.{config}{ModuleConfigs.DEV_SUFFIX}.{plat_id}{f".{name}" if name else ""}.exe'
+                    f'bin\\godot.windows.{config}{ModuleConfigs.DEV_SUFFIX}{".double" if env["float"] == "64" else ""}.{plat_id}{f".{name}" if name else ""}.exe'
                     for config in ModuleConfigs.CONFIGURATIONS
                     for plat_id in ModuleConfigs.PLATFORM_IDS
                 ]
@@ -814,11 +814,17 @@ def generate_vs_project(env, num_jobs):
                 if env["dev_build"]:
                     common_build_postfix.append("dev_build=yes")
 
-                if env["tests"]:
+                if env["dev_mode"]:
+                    common_build_postfix.append("dev_mode=yes")
+
+                elif env["tests"]:
                     common_build_postfix.append("tests=yes")
 
                 if env["custom_modules"]:
                     common_build_postfix.append("custom_modules=%s" % env["custom_modules"])
+
+                if env["float"] == "64":
+                    common_build_postfix.append("float=64")
 
                 result = " ^& ".join(common_build_prefix + [" ".join([commands] + common_build_postfix)])
                 return result


### PR DESCRIPTION
Fixes #66008.
Adds support for the `dev_mode=yes` and `float=64` command line options when generating a Visual Studio solution.
This also includes the changes from #66718, so that solution generation works at all.
The whole solution generation system feels messy to me, but I'm not sure if there's a better way to do it.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
