### PR TITLE
Fixed wrong base class when using `extends Base.Subclass`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -699,7 +699,11 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 				if (!path.is_empty()) {
 					if (path != get_path()) {
 						Ref<GDScript> bf = ResourceLoader::load(path);
-						bf = bf->_find_subclass(class_names);
+
+						if (bf.is_valid()) {
+							Ref<GDScript> bf_inner = bf->_find_subclass(class_names);
+							bf = bf_inner;
+						}
 
 						if (bf.is_valid()) {
 							base_cache = bf;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -154,6 +154,7 @@ class GDScript : public Script {
 
 	bool _update_exports(bool *r_err = nullptr, bool p_recursive_call = false, PlaceHolderScriptInstance *p_instance_to_update = nullptr);
 
+	Ref<GDScript> _find_subclass(const Vector<StringName> &p_names);
 	void _save_orphaned_subclasses();
 	void _init_rpc_methods_properties();
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -165,7 +165,30 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 						}
 					}
 					if (result.script_type_ref.is_null()) {
-						result.script_type_ref = GDScriptCache::get_shallow_script(p_datatype.script_path, main_script->path);
+						if (classes.size() > 1) {
+							auto find_subclass_script = [&classes](Ref<GDScript> lp_script) -> Ref<GDScript> {
+								for (int i = 1; i < classes.size(); ++i) {
+									if (lp_script.is_null()) {
+										return Ref<GDScript>();
+									}
+									HashMap<StringName, Ref<GDScript>>::ConstIterator E = lp_script->get_subclasses().find(classes[i]);
+									if (!E) {
+										return Ref<GDScript>();
+									}
+									Ref<GDScript> tmp_script = lp_script; // because inner_script may hold the only ref to is subclass...
+									lp_script = E->value;
+								}
+								return lp_script;
+							};
+							Ref<GDScript> inner_script = find_subclass_script(GDScriptCache::get_shallow_script(p_datatype.script_path, main_script->path));
+							if (inner_script.is_null()) {
+								Error err = OK;
+								inner_script = find_subclass_script(GDScriptCache::get_full_script(p_datatype.script_path, err, main_script->path));
+							}
+							result.script_type_ref = inner_script;
+						} else {
+							result.script_type_ref = GDScriptCache::get_shallow_script(p_datatype.script_path, main_script->path);
+						}
 					}
 
 					result.script_type = result.script_type_ref.ptr();
@@ -2292,11 +2315,6 @@ Error GDScriptCompiler::_parse_class_level(GDScript *p_script, const GDScriptPar
 						}
 					}
 				} else {
-					Error err = OK;
-					base = GDScriptCache::get_full_script(p_class->base_type.script_path, err, main_script->path);
-					if (err) {
-						return err;
-					}
 					if (base.is_null() || !base->is_valid()) {
 						return ERR_COMPILATION_FAILED;
 					}


### PR DESCRIPTION
Fixes #65953

Also prevents a crash on startup when opening this project, which has weird almost cyclic inheritance.
[godot-rune-wrong-subclass-base-proj.zip](https://github.com/godotengine/godot/files/9691309/godot-rune-wrong-subclass-base-proj.zip)
Edit: no longer prevents the crash on startup