### PR TITLE
Fix crash in navigation 3d when target is not reachable

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -238,6 +238,7 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 			to_visit.clear();
 			to_visit.push_back(0);
 			least_cost_id = 0;
+			prev_least_cost_id = -1;
 
 			reachable_end = nullptr;
 


### PR DESCRIPTION
The navigation retries after failing to get to the target. It resets variables and starts again, but it missed resetting 1 variable (prev_least_cost_id), which caused it to exceed the bounds of navigation_polys (which _does_ get reset).

I tested this fix against the minimal repro project attached to the related issue.

fix #66783