### PR TITLE
Fixing the 'chunks' pointer so that it is not used before modifying a…

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -350,24 +350,24 @@ public:
 				if (validator & 0x80000000) {
 					continue; //uninitialized
 				}
-				if (validator != 0xFFFFFFFF) {
+				if (chunks != nullptr && validator != 0xFFFFFFFF) {
 					chunks[i / elements_in_chunk][i % elements_in_chunk].~T();
 				}
 			}
 		}
 
 		uint32_t chunk_count = max_alloc / elements_in_chunk;
+		if (chunks != nullptr) {
+			memfree(chunks);
+			memfree(free_list_chunks);
+			memfree(validator_chunks);
+		}
 		for (uint32_t i = 0; i < chunk_count; i++) {
 			memfree(chunks[i]);
 			memfree(validator_chunks[i]);
 			memfree(free_list_chunks[i]);
 		}
 
-		if (chunks) {
-			memfree(chunks);
-			memfree(free_list_chunks);
-			memfree(validator_chunks);
-		}
 	}
 };
 

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -357,15 +357,16 @@ public:
 		}
 
 		uint32_t chunk_count = max_alloc / elements_in_chunk;
-		if (chunks != nullptr) {
-			memfree(chunks);
-			memfree(free_list_chunks);
-			memfree(validator_chunks);
-		}
 		for (uint32_t i = 0; i < chunk_count; i++) {
 			memfree(chunks[i]);
 			memfree(validator_chunks[i]);
 			memfree(free_list_chunks[i]);
+		}
+		
+		if (chunks != nullptr) {
+			memfree(chunks);
+			memfree(free_list_chunks);
+			memfree(validator_chunks);
 		}
 
 	}

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -362,7 +362,6 @@ public:
 			memfree(validator_chunks[i]);
 			memfree(free_list_chunks[i]);
 		}
-		
 		if (chunks != nullptr) {
 			memfree(chunks);
 			memfree(free_list_chunks);


### PR DESCRIPTION
…gainst nullptr.

Adding a nullptr check before the pointer is used in the if-statement and before any memory is freed. Addressing issue #65604 where  the 'chunks' pointer was utilized before it was verified against nullptr.

fixes #65604
