### PR TITLE
fix error dialog from appearing after loading material res

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -155,7 +155,7 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 
 			any_type_matches = is_global_class ? EditorNode::get_editor_data().script_class_is_parent(res_type, base) : loaded_resource->is_class(base);
 
-			if (!any_type_matches) {
+			if (any_type_matches) {
 				break;
 			}
 		}


### PR DESCRIPTION
It was a wrong expression in a if statement that always triggered the error dialog and returned in the "_file_selected" method.

Everything else seemed to be correct I think.

_bugsquad edit: Fixes https://github.com/godotengine/godot/issues/66700_