### PR TITLE
Remove recovery as collision in snap on floor

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1394,7 +1394,6 @@ void CharacterBody2D::_snap_on_floor(bool p_was_on_floor, bool p_vel_dir_facing_
 	real_t length = MAX(floor_snap_length, margin);
 
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
-	parameters.recovery_as_collision = true; // Report margin recovery as collision to improve floor detection.
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer2D::MotionResult result;
@@ -1430,7 +1429,6 @@ bool CharacterBody2D::_on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_f
 	real_t length = MAX(floor_snap_length, margin);
 
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
-	parameters.recovery_as_collision = true; // Report margin recovery as collision to improve floor detection.
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer2D::MotionResult result;

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1562,7 +1562,6 @@ void CharacterBody3D::_snap_on_floor(bool p_was_on_floor, bool p_vel_dir_facing_
 
 	PhysicsServer3D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
 	parameters.max_collisions = 4;
-	parameters.recovery_as_collision = true; // Report margin recovery as collision to improve floor detection.
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer3D::MotionResult result;
@@ -1598,7 +1597,6 @@ bool CharacterBody3D::_on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_f
 
 	PhysicsServer3D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
 	parameters.max_collisions = 4;
-	parameters.recovery_as_collision = true; // Report margin recovery as collision to improve floor detection.
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer3D::MotionResult result;


### PR DESCRIPTION
Should Fix #66704

I currently have my pc under repair, the one I'm using doesn't have enough FPS to see the error in the MRP, so it needs a confirmation that this PR does solve the problem.

Sometimes if the gravity is not strong enough `move_and_slide` does not detect the floor during few frames, that's why we added the "recovery as collision" feature in the first place. However this recovery as collision also detects false positives for walls and since we now have snap on floor turn on by default, we removed the recovery as collision except for snap of floor.

What happens is that the snap considers that the recovery (safe margin) is a collision, so it pushes the body a little too high, and move and slide is not, which causes a jitter. 