### PR TITLE
Remove unsupported `NO_SAFE_CAST`/`-fno-rtti` from Android build

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -733,34 +733,12 @@ public:
 
 	template <class T>
 	static T *cast_to(Object *p_object) {
-#ifndef NO_SAFE_CAST
 		return dynamic_cast<T *>(p_object);
-#else
-		if (!p_object) {
-			return nullptr;
-		}
-		if (p_object->is_class_ptr(T::get_class_ptr_static())) {
-			return static_cast<T *>(p_object);
-		} else {
-			return nullptr;
-		}
-#endif
 	}
 
 	template <class T>
 	static const T *cast_to(const Object *p_object) {
-#ifndef NO_SAFE_CAST
 		return dynamic_cast<const T *>(p_object);
-#else
-		if (!p_object) {
-			return nullptr;
-		}
-		if (p_object->is_class_ptr(T::get_class_ptr_static())) {
-			return static_cast<const T *>(p_object);
-		} else {
-			return nullptr;
-		}
-#endif
 	}
 
 	enum {

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -335,15 +335,8 @@ public:
 
 	~RID_Alloc() {
 		if (alloc_count) {
-			if (description) {
-				print_error("ERROR: " + itos(alloc_count) + " RID allocations of type '" + description + "' were leaked at exit.");
-			} else {
-#ifdef NO_SAFE_CAST
-				print_error("ERROR: " + itos(alloc_count) + " RID allocations of type 'unknown' were leaked at exit.");
-#else
-				print_error("ERROR: " + itos(alloc_count) + " RID allocations of type '" + typeid(T).name() + "' were leaked at exit.");
-#endif
-			}
+			print_error(vformat("ERROR: %d RID allocations of type '%s' were leaked at exit.",
+					alloc_count, description ? description : typeid(T).name()));
 
 			for (size_t i = 0; i < max_alloc; i++) {
 				uint64_t validator = validator_chunks[i / elements_in_chunk][i % elements_in_chunk];

--- a/editor/import/collada.cpp
+++ b/editor/import/collada.cpp
@@ -2036,11 +2036,7 @@ void Collada::_merge_skeletons(VisualScene *p_vscene, Node *p_node) {
 
 				ERR_CONTINUE(!state.scene_map.has(nodeid)); //weird, it should have it...
 
-#ifdef NO_SAFE_CAST
-				NodeJoint *nj = static_cast<NodeJoint *>(state.scene_map[nodeid]);
-#else
 				NodeJoint *nj = dynamic_cast<NodeJoint *>(state.scene_map[nodeid]);
-#endif
 				ERR_CONTINUE(!nj); //broken collada
 				ERR_CONTINUE(!nj->owner); //weird, node should have a skeleton owner
 
@@ -2197,11 +2193,7 @@ bool Collada::_move_geometry_to_skeletons(VisualScene *p_vscene, Node *p_node, L
 			String nodeid = ng->skeletons[0];
 
 			ERR_FAIL_COND_V(!state.scene_map.has(nodeid), false); //weird, it should have it...
-#ifdef NO_SAFE_CAST
-			NodeJoint *nj = static_cast<NodeJoint *>(state.scene_map[nodeid]);
-#else
 			NodeJoint *nj = dynamic_cast<NodeJoint *>(state.scene_map[nodeid]);
-#endif
 			ERR_FAIL_COND_V(!nj, false);
 			ERR_FAIL_COND_V(!nj->owner, false); //weird, node should have a skeleton owner
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -48,20 +48,10 @@ class CSharpScript;
 class CSharpInstance;
 class CSharpLanguage;
 
-#ifdef NO_SAFE_CAST
-template <typename TScriptInstance, typename TScriptLanguage>
-TScriptInstance *cast_script_instance(ScriptInstance *p_inst) {
-	if (!p_inst) {
-		return nullptr;
-	}
-	return p_inst->get_language() == TScriptLanguage::get_singleton() ? static_cast<TScriptInstance *>(p_inst) : nullptr;
-}
-#else
 template <typename TScriptInstance, typename TScriptLanguage>
 TScriptInstance *cast_script_instance(ScriptInstance *p_inst) {
 	return dynamic_cast<TScriptInstance *>(p_inst);
 }
-#endif
 
 #define CAST_CSHARP_INSTANCE(m_inst) (cast_script_instance<CSharpInstance, CSharpLanguage>(m_inst))
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -156,15 +156,9 @@ def configure(env: "Environment"):
     env["RANLIB"] = compiler_path + "/llvm-ranlib"
     env["AS"] = compiler_path + "/clang"
 
-    # Disable exceptions and rtti on non-tools (template) builds
-    if env.editor_build:
-        env.Append(CXXFLAGS=["-frtti"])
-    elif env["builtin_icu"]:
-        env.Append(CXXFLAGS=["-frtti", "-fno-exceptions"])
-    else:
-        env.Append(CXXFLAGS=["-fno-rtti", "-fno-exceptions"])
-        # Don't use dynamic_cast, necessary with no-rtti.
-        env.Append(CPPDEFINES=["NO_SAFE_CAST"])
+    # Disable exceptions on template builds
+    if not env.editor_build:
+        env.Append(CXXFLAGS=["-fno-exceptions"])
 
     env.Append(
         CCFLAGS=(


### PR DESCRIPTION
Android was the last platform to still attempt to disable RTTI (for binary size), but both the Android editor and now the ICU library used by templates need RTTI.

There could still be the possibility to support this for non-ICU template builds (i.e. without the TextServerAdvanced module), but since this isn't one of the build configurations we test regularly it's pretty risky to keep this option only for that specific use case. And our code is already littered with `dynamic_cast`s which weren't guarded with `!defined(NO_SAFE_CAST)`.