### PR TITLE
OS: Remove unused `NO_NETWORK` check

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -137,10 +137,8 @@ void OS_Unix::initialize_core() {
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_USERDATA);
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_FILESYSTEM);
 
-#ifndef NO_NETWORK
 	NetSocketPosix::make_default();
 	IPUnix::make_default();
-#endif
 
 	_setup_clock();
 }


### PR DESCRIPTION
I doubt it's working nowadays, there's likely a lot more code needed to be able to build Godot without network support.