### PR TITLE
Fix selection applying to hidden Nodes when filtering Scene Tree Editor

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -804,6 +804,10 @@ void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_
 	TreeItem *item = Object::cast_to<TreeItem>(p_object);
 	ERR_FAIL_COND(!item);
 
+	if (!item->is_visible()) {
+		return;
+	}
+
 	NodePath np = item->get_metadata(0);
 
 	Node *n = get_node(np);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/64399.

In this PR, Node TreeItems that are hidden in the Tree are ignored outright, when multi-selecting.

![Image](https://i.gyazo.com/14ca89796eb0fc5c2322f24ec92b1ba7.gif)