### PR TITLE
Fix boolean connection to ports of other types in visual shader

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -955,7 +955,7 @@ bool VisualShader::can_connect_nodes(Type p_type, int p_from_node, int p_from_po
 }
 
 bool VisualShader::is_port_types_compatible(int p_a, int p_b) const {
-	return MAX(0, p_a - 4) == (MAX(0, p_b - 4));
+	return MAX(0, p_a - 5) == (MAX(0, p_b - 5));
 }
 
 void VisualShader::connect_nodes_forced(Type p_type, int p_from_node, int p_from_port, int p_to_node, int p_to_port) {


### PR DESCRIPTION
Looks like it cannot be connected (after the introduction of Vector4 type):
![boolean_bug](https://user-images.githubusercontent.com/3036176/193640110-dc6371f6-5c3a-4ee9-bb32-651c979f1ab3.gif)

