### PR TITLE
Add a Process class to control execution of subprocesses and communicate with them.

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -97,6 +97,20 @@ thirdparty_minizip_sources = ["ioapi.c", "unzip.c", "zip.c"]
 thirdparty_minizip_sources = [thirdparty_minizip_dir + file for file in thirdparty_minizip_sources]
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_minizip_sources)
 
+# Tiny-process-library
+thirdparty_tiny_process_library_dir = "#thirdparty/tiny-process-library/"
+thirdparty_tiny_process_library_sources = []
+
+if env["platform"] in ["linuxbsd", "macos", "android"]:
+    thirdparty_tiny_process_library_sources = ["process.cpp", "process_unix.cpp"]
+elif env["platform"] == "windows":
+    thirdparty_tiny_process_library_sources = ["process.cpp", "process_win.cpp"]
+
+thirdparty_tiny_process_library_sources = [
+    thirdparty_tiny_process_library_dir + file for file in thirdparty_tiny_process_library_sources
+]
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_tiny_process_library_sources)
+
 # Zstd library, can be unbundled in theory
 # though we currently use some private symbols
 # https://github.com/godotengine/godot/issues/17374

--- a/core/io/process.cpp
+++ b/core/io/process.cpp
@@ -1,0 +1,99 @@
+/*************************************************************************/
+/*  process.cpp                                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "process.h"
+#include "core/os/os.h"
+
+Ref<Process> (*Process::_create)(const String &p_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin) = nullptr;
+
+void Process::_bind_methods() {
+	ClassDB::bind_static_method("Process", D_METHOD("create", "path", "arguments", "working_directory", "open_stdin"), &Process::create, DEFVAL(Vector<String>()), DEFVAL(""), DEFVAL(false));
+
+	ClassDB::bind_method(D_METHOD("get_available_stdout_lines"), &Process::get_available_stdout_lines);
+	ClassDB::bind_method(D_METHOD("get_stdout_line"), &Process::get_stdout_line);
+	ClassDB::bind_method(D_METHOD("get_available_stderr_lines"), &Process::get_available_stderr_lines);
+	ClassDB::bind_method(D_METHOD("get_stderr_line"), &Process::get_stderr_line);
+
+	ClassDB::bind_method(D_METHOD("get_exit_status"), &Process::get_exit_status);
+	ClassDB::bind_method(D_METHOD("kill", "force"), &Process::kill, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_id"), &Process::get_id);
+	ClassDB::bind_method(D_METHOD("write", "input"), &Process::write);
+	ClassDB::bind_method(D_METHOD("close_stdin"), &Process::close_stdin);
+}
+
+Ref<Process> Process::create(const String &p_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin) {
+	if (_create) {
+		if (!p_working_dir.is_empty()) {
+			return _create(p_path, p_arguments, OS::get_singleton()->get_executable_path().get_base_dir(), p_open_stdin);
+		} else {
+			return _create(p_path, p_arguments, p_working_dir, p_open_stdin);
+		}
+	}
+
+	ERR_PRINT("Unable to create process, platform not supported");
+
+	return nullptr;
+}
+
+int Process::get_available_stdout_lines() const {
+	mutex.lock();
+	int available_lines = stdout_lines.size();
+	mutex.unlock();
+	return available_lines;
+}
+
+int Process::get_available_stderr_lines() const {
+	mutex.lock();
+	int available_lines = stderr_lines.size();
+	mutex.unlock();
+	return available_lines;
+}
+
+String Process::get_stdout_line() {
+	String line = "";
+	mutex.lock();
+	if (stdout_lines.size() > 0) {
+		line = stdout_lines[0];
+		stdout_lines.remove_at(0);
+	}
+	mutex.unlock();
+	return line;
+}
+
+String Process::get_stderr_line() {
+	String line = "";
+	mutex.lock();
+	if (stderr_lines.size() > 0) {
+		line = stderr_lines[0];
+		stderr_lines.remove_at(0);
+	}
+	mutex.unlock();
+	return line;
+}

--- a/core/io/process.h
+++ b/core/io/process.h
@@ -1,0 +1,63 @@
+/*************************************************************************/
+/*  process.h                                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PROCESS_H
+#define PROCESS_H
+
+#include "core/object/ref_counted.h"
+#include "core/os/mutex.h"
+
+class Process : public RefCounted {
+	GDCLASS(Process, RefCounted);
+
+protected:
+	static Ref<Process> (*_create)(const String &p_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin);
+	static void _bind_methods();
+
+	Mutex mutex;
+	Vector<String> stdout_lines;
+	Vector<String> stderr_lines;
+
+public:
+	static Ref<Process> create(const String &p_path, const Vector<String> &p_arguments = Vector<String>(), const String &p_working_dir = "", bool p_open_stdin = false);
+	int get_available_stdout_lines() const;
+	int get_available_stderr_lines() const;
+	String get_stdout_line();
+	String get_stderr_line();
+	virtual int get_exit_status() const { return -1; };
+	virtual int get_id() const { return -1; };
+	virtual void kill(bool m_force = false){};
+	virtual bool write(const String &p_input) { return false; };
+	virtual void close_stdin(){};
+
+	virtual ~Process(){};
+};
+
+#endif // PROCESS_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -56,6 +56,7 @@
 #include "core/io/packet_peer_dtls.h"
 #include "core/io/packet_peer_udp.h"
 #include "core/io/pck_packer.h"
+#include "core/io/process.h"
 #include "core/io/resource_format_binary.h"
 #include "core/io/resource_importer.h"
 #include "core/io/resource_uid.h"
@@ -232,6 +233,7 @@ void register_core_types() {
 	GDREGISTER_CLASS(ResourceFormatSaver);
 
 	GDREGISTER_ABSTRACT_CLASS(FileAccess);
+	GDREGISTER_ABSTRACT_CLASS(Process);
 	GDREGISTER_ABSTRACT_CLASS(DirAccess);
 	GDREGISTER_CLASS(core_bind::Thread);
 	GDREGISTER_CLASS(core_bind::Mutex);

--- a/doc/classes/Process.xml
+++ b/doc/classes/Process.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Process" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Class for running and controlling processes.
+	</brief_description>
+	<description>
+		Process type. It is used to run processes and reading/writing to their standard inputs and outputs.
+		[Process] can't be instantiated directly. Instead it is created with a static method that takes the path to the program that will be ran.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="close_stdin">
+			<return type="void" />
+			<description>
+				Closes the standard input, this is useful for some programs that only start processing when this happens.
+			</description>
+		</method>
+		<method name="create" qualifiers="static">
+			<return type="Process" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="arguments" type="PackedStringArray" default="PackedStringArray()" />
+			<param index="2" name="working_directory" type="String" default="&quot;&quot;" />
+			<param index="3" name="open_stdin" type="bool" default="false" />
+			<description>
+				Creates a [Process] object and runs the specified program.
+				[param path] is the path to the binary to run, this must be an absolute path, you can use use [method ProjectSettings.globalize_path] if needed.
+				[param arguments] are the arguments that will be passed to the program when executed.
+				[param working_directory] is the working directory on which the program will be ran, if empty will default to the location of the engine binary.
+				[param open_stdin] opens the standard input for writing, this enables usage of [method write].
+				Returns [code]null[/code] if creating processes is not supported on the current platform.
+			</description>
+		</method>
+		<method name="get_available_stderr_lines" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns how many standard error output lines are available to read using [method get_stderr_line].
+			</description>
+		</method>
+		<method name="get_available_stdout_lines" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns how many standard output lines are available to read using [method get_stdout_line].
+			</description>
+		</method>
+		<method name="get_exit_status" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the exit status code returned by the process after it's finished executing, returns [code]-1[/code] if the process is still running.
+			</description>
+		</method>
+		<method name="get_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the process ID of the process.
+			</description>
+		</method>
+		<method name="get_stderr_line">
+			<return type="String" />
+			<description>
+				Returns the next standard error output line.
+			</description>
+		</method>
+		<method name="get_stdout_line">
+			<return type="String" />
+			<description>
+				Returns the next standard output line.
+			</description>
+		</method>
+		<method name="kill">
+			<return type="void" />
+			<param index="0" name="force" type="bool" default="false" />
+			<description>
+				Tells the process to end execution as soon as possible, set [param force] to [code]true[/code] to force it to finish.
+				[b]Note:[/b] [param force] has no effect on Windows.
+			</description>
+		</method>
+		<method name="write">
+			<return type="bool" />
+			<param index="0" name="input" type="String" />
+			<description>
+				Writes to the standard input of the program, needs [code]open_stdin[/code] to be [code]true[/code] to work.
+				Returns [code]true[/code] if the write was succesful.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -33,6 +33,9 @@ if env["opengl3"]:
 # Core dependencies
 SConscript("png/SCsub")
 
+# Tiny process library
+SConscript("tiny-process-lib/SCsub")
+
 env.add_source_files(env.drivers_sources, "*.cpp")
 
 lib = env.add_library("drivers", env.drivers_sources)

--- a/drivers/tiny-process-lib/SCsub
+++ b/drivers/tiny-process-lib/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.add_source_files(env.drivers_sources, "*.cpp")

--- a/drivers/tiny-process-lib/process_tiny_process_lib.cpp
+++ b/drivers/tiny-process-lib/process_tiny_process_lib.cpp
@@ -1,0 +1,104 @@
+/*************************************************************************/
+/*  process_tiny_process_lib.cpp                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#if defined(UNIX_ENABLED) || defined(WINDOWS_ENABLED)
+#include "process_tiny_process_lib.h"
+
+void ProcessTinyProcessLibrary::make_default() {
+	_create = create_tpl;
+}
+
+void ProcessTinyProcessLibrary::_on_stdout(const char *bytes, size_t size) {
+	String line = String(bytes, size);
+	mutex.lock();
+	stdout_lines.append(line);
+	mutex.unlock();
+}
+
+void ProcessTinyProcessLibrary::_on_stderr(const char *bytes, size_t size) {
+	String line = String(bytes, size);
+	mutex.lock();
+	stderr_lines.append(line);
+	mutex.unlock();
+}
+
+Ref<Process> ProcessTinyProcessLibrary::create_tpl(const String &p_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin) {
+	return memnew(ProcessTinyProcessLibrary(p_path, p_arguments, p_working_dir, p_open_stdin));
+}
+
+int ProcessTinyProcessLibrary::get_exit_status() const {
+	int exit_status = -1;
+	process->try_get_exit_status(exit_status);
+	return exit_status;
+}
+
+void ProcessTinyProcessLibrary::kill(bool p_force) {
+	process->kill(p_force);
+}
+
+int ProcessTinyProcessLibrary::get_id() const {
+	return process->get_id();
+}
+
+bool ProcessTinyProcessLibrary::write(const String &p_input) {
+	ERR_FAIL_COND_V_MSG(!has_open_stdin, false, "You must set open_stdin to true when creating a process for write to work.");
+	return process->write(p_input.utf8().get_data());
+}
+
+void ProcessTinyProcessLibrary::close_stdin() {
+	ERR_FAIL_COND(!has_open_stdin);
+	process->close_stdin();
+	has_open_stdin = false;
+}
+
+ProcessTinyProcessLibrary::ProcessTinyProcessLibrary(const String &m_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin) {
+	std::vector<std::string> args;
+
+	args.reserve(p_arguments.size() + 1);
+
+	args.emplace_back(m_path.utf8().get_data());
+
+	for (int i = 0; i < p_arguments.size(); i++) {
+		args.emplace_back(std::string(p_arguments[i].utf8().get_data()));
+	}
+
+	has_open_stdin = p_open_stdin;
+
+	process = memnew(TinyProcessLib::Process(
+			args, p_working_dir.utf8().get_data(),
+			std::bind(&ProcessTinyProcessLibrary::_on_stdout, this, std::placeholders::_1, std::placeholders::_2),
+			std::bind(&ProcessTinyProcessLibrary::_on_stderr, this, std::placeholders::_1, std::placeholders::_2),
+			p_open_stdin));
+}
+
+ProcessTinyProcessLibrary::~ProcessTinyProcessLibrary() {
+	memdelete(process);
+}
+#endif // UNIX_ENABLED || WINDOWS_ENABLED

--- a/drivers/tiny-process-lib/process_tiny_process_lib.h
+++ b/drivers/tiny-process-lib/process_tiny_process_lib.h
@@ -1,0 +1,61 @@
+/*************************************************************************/
+/*  process_tiny_process_lib.h                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PROCESS_TINY_PROCESS_LIB_H
+#define PROCESS_TINY_PROCESS_LIB_H
+
+#if defined(UNIX_ENABLED) || defined(WINDOWS_ENABLED)
+#include "core/io/process.h"
+#include "thirdparty/tiny-process-library/process.hpp"
+
+class ProcessTinyProcessLibrary : public Process {
+protected:
+	TinyProcessLib::Process *process;
+	static Ref<Process> create_tpl(const String &m_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin);
+	void _on_stdout(const char *m_bytes, size_t m_size);
+	void _on_stderr(const char *m_bytes, size_t m_size);
+
+	bool has_open_stdin;
+
+public:
+	static void make_default();
+
+	virtual int get_exit_status() const;
+	virtual int get_id() const;
+	virtual void kill(bool p_force = false);
+	virtual bool write(const String &p_input);
+	virtual void close_stdin();
+	ProcessTinyProcessLibrary(const String &m_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin);
+	virtual ~ProcessTinyProcessLibrary();
+};
+
+#endif // UNIX_ENABLED || WINDOWS_ENABLED
+
+#endif // PROCESS_TINY_PROCESS_LIB_H

--- a/drivers/unix/process_unix.cpp
+++ b/drivers/unix/process_unix.cpp
@@ -1,0 +1,63 @@
+/*************************************************************************/
+/*  process_unix.cpp                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifdef UNIX_ENABLED
+
+#include "process_unix.h"
+#include "os_unix.h"
+
+void ProcessUnix::make_default() {
+	_create = create_unix;
+}
+
+Ref<Process> ProcessUnix::create_unix(const String &p_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin) {
+	return memnew(ProcessUnix(p_path, p_arguments, p_working_dir, p_open_stdin));
+}
+
+void ProcessUnix::handle_sigchld(int s_p_id, void *userdata) {
+	ProcessUnix *process = static_cast<ProcessUnix *>(userdata);
+	if (process->p_id == s_p_id) {
+		// TinyProcessLib will reap the process if needed
+		// when get_exit_status is called
+		process->get_exit_status();
+	}
+}
+
+ProcessUnix::ProcessUnix(const String &m_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin) :
+		ProcessTinyProcessLibrary(m_path, p_arguments, p_working_dir, p_open_stdin) {
+	OS_Unix::get_singleton()->add_sigchld_callback(&handle_sigchld, this);
+	p_id = process->get_id();
+}
+
+ProcessUnix::~ProcessUnix() {
+	OS_Unix::get_singleton()->remove_sigchld_callback(&handle_sigchld, this);
+}
+
+#endif // UNIX_ENABLED

--- a/drivers/unix/process_unix.h
+++ b/drivers/unix/process_unix.h
@@ -1,0 +1,53 @@
+/*************************************************************************/
+/*  process_unix.h                                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PROCESS_UNIX_H
+#define PROCESS_UNIX_H
+
+#ifdef UNIX_ENABLED
+
+#include "drivers/tiny-process-lib/process_tiny_process_lib.h"
+
+class ProcessUnix : public ProcessTinyProcessLibrary {
+private:
+	int p_id;
+
+protected:
+	static void handle_sigchld(int p_id, void *userdata);
+	static Ref<Process> create_unix(const String &m_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin);
+
+public:
+	static void make_default();
+	ProcessUnix(const String &m_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin);
+	virtual ~ProcessUnix();
+};
+#endif // UNIX_ENABLED
+
+#endif // PROCESS_UNIX_H

--- a/drivers/windows/process_windows.cpp
+++ b/drivers/windows/process_windows.cpp
@@ -1,0 +1,55 @@
+/*************************************************************************/
+/*  process_windows.cpp                                                  */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifdef WINDOWS_ENABLED
+#include "process_windows.h"
+
+String ProcessWindows::_quote_command_line_argument(const String &p_text) {
+	for (int i = 0; i < p_text.size(); i++) {
+		char32_t c = p_text[i];
+		if (c == ' ' || c == '&' || c == '(' || c == ')' || c == '[' || c == ']' || c == '{' || c == '}' || c == '^' || c == '=' || c == ';' || c == '!' || c == '\'' || c == '+' || c == ',' || c == '`' || c == '~') {
+			return "\"" + p_text + "\"";
+		}
+	}
+	return p_text;
+}
+
+Ref<Process> ProcessWindows::create_windows(const String &p_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin) {
+	Vector<String> final_arguments;
+	for (int i = 0; i < p_arguments.size(); i++) {
+		final_arguments.push_back(_quote_command_line_argument(p_arguments[i]));
+	}
+	return memnew(ProcessTinyProcessLibrary(p_path, final_arguments, p_working_dir, p_open_stdin));
+}
+
+void ProcessWindows::make_default() {
+	_create = create_windows;
+}
+#endif // WINDOWS_ENABLED

--- a/drivers/windows/process_windows.h
+++ b/drivers/windows/process_windows.h
@@ -1,0 +1,50 @@
+/*************************************************************************/
+/*  process_windows.h                                                    */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PROCESS_WINDOWS_H
+#define PROCESS_WINDOWS_H
+
+#ifdef WINDOWS_ENABLED
+
+#include "drivers/tiny-process-lib/process_tiny_process_lib.h"
+
+class ProcessWindows : public ProcessTinyProcessLibrary {
+private:
+	static String _quote_command_line_argument(const String &p_text);
+
+protected:
+	static Ref<Process> create_windows(const String &m_path, const Vector<String> &p_arguments, const String &p_working_dir, bool p_open_stdin);
+
+public:
+	static void make_default();
+};
+#endif // WINDOWS_ENABLED
+
+#endif // PROCESS_WINDOWS_H

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -149,7 +149,7 @@ namespace GodotTools.Export
                 // Create temporary publish output directory
 
                 string publishOutputTempDir = Path.Combine(Path.GetTempPath(), "godot-publish-dotnet",
-                    $"{Process.GetCurrentProcess().Id}-{buildConfig}-{runtimeIdentifier}");
+                    $"{System.Diagnostics.Process.GetCurrentProcess().Id}-{buildConfig}-{runtimeIdentifier}");
 
                 _tempFolders.Add(publishOutputTempDir);
 
@@ -211,7 +211,7 @@ namespace GodotTools.Export
         {
             base._ExportEnd();
 
-            string aotTempDir = Path.Combine(Path.GetTempPath(), $"godot-aot-{Process.GetCurrentProcess().Id}");
+            string aotTempDir = Path.Combine(Path.GetTempPath(), $"godot-aot-{System.Diagnostics.Process.GetCurrentProcess().Id}");
 
             if (Directory.Exists(aotTempDir))
                 Directory.Delete(aotTempDir, recursive: true);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -37,6 +37,7 @@
 #include "drivers/unix/net_socket_posix.h"
 #include "drivers/windows/dir_access_windows.h"
 #include "drivers/windows/file_access_windows.h"
+#include "drivers/windows/process_windows.h"
 #include "joypad_windows.h"
 #include "lang_table.h"
 #include "main/main.h"
@@ -169,6 +170,8 @@ void OS_Windows::initialize() {
 	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_RESOURCES);
 	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_USERDATA);
 	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_FILESYSTEM);
+
+	ProcessWindows::make_default();
 
 	NetSocketPosix::make_default();
 

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -653,6 +653,23 @@ The `tinyexr.cc` file was modified to include `zlib.h` which we provide,
 instead of `miniz.h` as an external dependency.
 
 
+## tiny-process-library
+
+- Upstream: https://gitlab.com/eidheim/tiny-process-library/-/tree/master
+- Version: git (27bf021d97d428b3c0cef4009cb9c03ad46c4376, 2022)
+- License: MIT
+
+Files extracted from upstream source:
+
+- `process_win.cpp`, `process_unix.cpp`, `process.cpp` and `process.hpp`
+- `LICENSE`
+
+Some changes have been made in order to remove exceptions.
+They are marked with `// -- GODOT start --` and `// -- GODOT end --`
+comments. Apply the patches in the `patches/` folder when syncing on newer upstream
+commits.
+
+
 ## thorvg
 
 - Upstream: https://github.com/Samsung/thorvg

--- a/thirdparty/tiny-process-library/LICENSE
+++ b/thirdparty/tiny-process-library/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2020 Ole Christian Eidheim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/thirdparty/tiny-process-library/patches/godot-changes.patch
+++ b/thirdparty/tiny-process-library/patches/godot-changes.patch
@@ -1,0 +1,45 @@
+diff --git a/thirdparty/tiny-process-library/process_unix.cpp b/thirdparty/tiny-process-library/process_unix.cpp
+index b2bbaa1804..aec4bbe7a2 100644
+--- a/thirdparty/tiny-process-library/process_unix.cpp
++++ b/thirdparty/tiny-process-library/process_unix.cpp
+@@ -19,7 +19,10 @@ Process::Process(const std::function<void()> &function,
+                  bool open_stdin, const Config &config)
+     : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+   if(config.flatpak_spawn_host)
+-    throw std::invalid_argument("Cannot break out of a flatpak sandbox with this overload.");
++    // -- GODOT START --
++    //throw std::invalid_argument("Cannot break out of a flatpak sandbox with this overload.");
++    abort();
++    // -- GODOT END --
+   open(function);
+   async_read();
+ }
+@@ -343,7 +346,10 @@ void Process::close_fds() noexcept {
+ 
+ bool Process::write(const char *bytes, size_t n) {
+   if(!open_stdin)
+-    throw std::invalid_argument("Can't write to an unopened stdin pipe. Please set open_stdin=true when constructing the process.");
++    // -- GODOT START --
++    //throw std::invalid_argument("Can't write to an unopened stdin pipe. Please set open_stdin=true when constructing the process.");
++    abort();
++    // -- GODOT END --
+ 
+   std::lock_guard<std::mutex> lock(stdin_mutex);
+   if(stdin_fd) {
+diff --git a/thirdparty/tiny-process-library/process_win.cpp b/thirdparty/tiny-process-library/process_win.cpp
+index 846788d2b3..97e2ceb902 100644
+--- a/thirdparty/tiny-process-library/process_win.cpp
++++ b/thirdparty/tiny-process-library/process_win.cpp
+@@ -272,8 +272,10 @@ void Process::close_fds() noexcept {
+ 
+ bool Process::write(const char *bytes, size_t n) {
+   if(!open_stdin)
+-    throw std::invalid_argument("Can't write to an unopened stdin pipe. Please set open_stdin=true when constructing the process.");
+-
++    // -- GODOT START --
++    //throw std::invalid_argument("Can't write to an unopened stdin pipe. Please set open_stdin=true when constructing the process.");
++    abort();
++    // -- GODOT END --
+   std::lock_guard<std::mutex> lock(stdin_mutex);
+   if(stdin_fd) {
+     DWORD written;

--- a/thirdparty/tiny-process-library/process.cpp
+++ b/thirdparty/tiny-process-library/process.cpp
@@ -1,0 +1,55 @@
+#include "process.hpp"
+
+namespace TinyProcessLib {
+
+Process::Process(const std::vector<string_type> &arguments, const string_type &path,
+                 std::function<void(const char *bytes, size_t n)> read_stdout,
+                 std::function<void(const char *bytes, size_t n)> read_stderr,
+                 bool open_stdin, const Config &config) noexcept
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  open(arguments, path);
+  async_read();
+}
+
+Process::Process(const string_type &command, const string_type &path,
+                 std::function<void(const char *bytes, size_t n)> read_stdout,
+                 std::function<void(const char *bytes, size_t n)> read_stderr,
+                 bool open_stdin, const Config &config) noexcept
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  open(command, path);
+  async_read();
+}
+
+Process::Process(const std::vector<string_type> &arguments, const string_type &path,
+                 const environment_type &environment,
+                 std::function<void(const char *bytes, size_t n)> read_stdout,
+                 std::function<void(const char *bytes, size_t n)> read_stderr,
+                 bool open_stdin, const Config &config) noexcept
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  open(arguments, path, &environment);
+  async_read();
+}
+
+Process::Process(const string_type &command, const string_type &path,
+                 const environment_type &environment,
+                 std::function<void(const char *bytes, size_t n)> read_stdout,
+                 std::function<void(const char *bytes, size_t n)> read_stderr,
+                 bool open_stdin, const Config &config) noexcept
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  open(command, path, &environment);
+  async_read();
+}
+
+Process::~Process() noexcept {
+  close_fds();
+}
+
+Process::id_type Process::get_id() const noexcept {
+  return data.id;
+}
+
+bool Process::write(const std::string &str) {
+  return write(str.c_str(), str.size());
+}
+
+} // namespace TinyProcessLib

--- a/thirdparty/tiny-process-library/process.hpp
+++ b/thirdparty/tiny-process-library/process.hpp
@@ -1,0 +1,177 @@
+#ifndef TINY_PROCESS_LIBRARY_HPP_
+#define TINY_PROCESS_LIBRARY_HPP_
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
+namespace TinyProcessLib {
+/// Additional parameters to Process constructors.
+struct Config {
+  /// Buffer size for reading stdout and stderr. Default is 131072 (128 kB).
+  std::size_t buffer_size = 131072;
+  /// Set to true to inherit file descriptors from parent process. Default is false.
+  /// On Windows: has no effect unless read_stdout==nullptr, read_stderr==nullptr and open_stdin==false.
+  bool inherit_file_descriptors = false;
+
+  /// On Windows only: controls how the process is started, mimics STARTUPINFO's wShowWindow.
+  /// See: https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/ns-processthreadsapi-startupinfoa
+  /// and https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-showwindow
+  enum class ShowWindow {
+    hide = 0,
+    show_normal = 1,
+    show_minimized = 2,
+    maximize = 3,
+    show_maximized = 3,
+    show_no_activate = 4,
+    show = 5,
+    minimize = 6,
+    show_min_no_active = 7,
+    show_na = 8,
+    restore = 9,
+    show_default = 10,
+    force_minimize = 11
+  };
+  /// On Windows only: controls how the window is shown.
+  ShowWindow show_window{ShowWindow::show_default};
+
+  /// Set to true to break out of flatpak sandbox by prepending all commands with `/usr/bin/flatpak-spawn --host`
+  /// which will execute the command line on the host system.
+  /// Requires the flatpak `org.freedesktop.Flatpak` portal to be opened for the current sandbox.
+  /// See https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn.
+  bool flatpak_spawn_host = false;
+};
+
+/// Platform independent class for creating processes.
+/// Note on Windows: it seems not possible to specify which pipes to redirect.
+/// Thus, at the moment, if read_stdout==nullptr, read_stderr==nullptr and open_stdin==false,
+/// the stdout, stderr and stdin are sent to the parent process instead.
+class Process {
+public:
+#ifdef _WIN32
+  typedef unsigned long id_type; // Process id type
+  typedef void *fd_type;         // File descriptor type
+#ifdef UNICODE
+  typedef std::wstring string_type;
+#else
+  typedef std::string string_type;
+#endif
+#else
+  typedef pid_t id_type;
+  typedef int fd_type;
+  typedef std::string string_type;
+#endif
+  typedef std::unordered_map<string_type, string_type> environment_type;
+
+private:
+  class Data {
+  public:
+    Data() noexcept;
+    id_type id;
+#ifdef _WIN32
+    void *handle{nullptr};
+#endif
+    int exit_status{-1};
+  };
+
+public:
+  /// Starts a process with the environment of the calling process.
+  Process(const std::vector<string_type> &arguments, const string_type &path = string_type(),
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {}) noexcept;
+  /// Starts a process with the environment of the calling process.
+  Process(const string_type &command, const string_type &path = string_type(),
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {}) noexcept;
+
+  /// Starts a process with specified environment.
+  Process(const std::vector<string_type> &arguments,
+          const string_type &path,
+          const environment_type &environment,
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {}) noexcept;
+  /// Starts a process with specified environment.
+  Process(const string_type &command,
+          const string_type &path,
+          const environment_type &environment,
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {}) noexcept;
+#ifndef _WIN32
+  /// Starts a process with the environment of the calling process.
+  /// Supported on Unix-like systems only.
+  /// Since the command line is not known to the Process object itself,
+  /// this overload does not support the flatpak_spawn_host configuration.
+  Process(const std::function<void()> &function,
+          std::function<void(const char *bytes, size_t n)> read_stdout = nullptr,
+          std::function<void(const char *bytes, size_t n)> read_stderr = nullptr,
+          bool open_stdin = false,
+          const Config &config = {});
+#endif
+  ~Process() noexcept;
+
+  /// Get the process id of the started process.
+  id_type get_id() const noexcept;
+  /// Wait until process is finished, and return exit status.
+  int get_exit_status() noexcept;
+  /// If process is finished, returns true and sets the exit status. Returns false otherwise.
+  bool try_get_exit_status(int &exit_status) noexcept;
+  /// Write to stdin.
+  bool write(const char *bytes, size_t n);
+  /// Write to stdin. Convenience function using write(const char *, size_t).
+  bool write(const std::string &str);
+  /// Close stdin. If the process takes parameters from stdin, use this to notify that all parameters have been sent.
+  void close_stdin() noexcept;
+
+  /// Kill the process. force=true is only supported on Unix-like systems.
+  void kill(bool force = false) noexcept;
+  /// Kill a given process id. Use kill(bool force) instead if possible. force=true is only supported on Unix-like systems.
+  static void kill(id_type id, bool force = false) noexcept;
+#ifndef _WIN32
+  /// Send the signal signum to the process.
+  void signal(int signum) noexcept;
+#endif
+
+private:
+  Data data;
+  bool closed;
+  std::mutex close_mutex;
+  std::function<void(const char *bytes, size_t n)> read_stdout;
+  std::function<void(const char *bytes, size_t n)> read_stderr;
+#ifndef _WIN32
+  std::thread stdout_stderr_thread;
+#else
+  std::thread stdout_thread, stderr_thread;
+#endif
+  bool open_stdin;
+  std::mutex stdin_mutex;
+
+  Config config;
+
+  std::unique_ptr<fd_type> stdout_fd, stderr_fd, stdin_fd;
+
+  id_type open(const std::vector<string_type> &arguments, const string_type &path, const environment_type *environment = nullptr) noexcept;
+  id_type open(const string_type &command, const string_type &path, const environment_type *environment = nullptr) noexcept;
+#ifndef _WIN32
+  id_type open(const std::function<void()> &function) noexcept;
+#endif
+  void async_read() noexcept;
+  void close_fds() noexcept;
+};
+
+} // namespace TinyProcessLib
+
+#endif // TINY_PROCESS_LIBRARY_HPP_

--- a/thirdparty/tiny-process-library/process_unix.cpp
+++ b/thirdparty/tiny-process-library/process_unix.cpp
@@ -1,0 +1,402 @@
+#include "process.hpp"
+#include <algorithm>
+#include <bitset>
+#include <cstdlib>
+#include <fcntl.h>
+#include <poll.h>
+#include <set>
+#include <signal.h>
+#include <stdexcept>
+#include <unistd.h>
+
+namespace TinyProcessLib {
+
+Process::Data::Data() noexcept : id(-1) {}
+
+Process::Process(const std::function<void()> &function,
+                 std::function<void(const char *, size_t)> read_stdout,
+                 std::function<void(const char *, size_t)> read_stderr,
+                 bool open_stdin, const Config &config)
+    : closed(true), read_stdout(std::move(read_stdout)), read_stderr(std::move(read_stderr)), open_stdin(open_stdin), config(config) {
+  if(config.flatpak_spawn_host)
+    // -- GODOT START --
+    //throw std::invalid_argument("Cannot break out of a flatpak sandbox with this overload.");
+    abort();
+    // -- GODOT END --
+  open(function);
+  async_read();
+}
+
+Process::id_type Process::open(const std::function<void()> &function) noexcept {
+  if(open_stdin)
+    stdin_fd = std::unique_ptr<fd_type>(new fd_type);
+  if(read_stdout)
+    stdout_fd = std::unique_ptr<fd_type>(new fd_type);
+  if(read_stderr)
+    stderr_fd = std::unique_ptr<fd_type>(new fd_type);
+
+  int stdin_p[2], stdout_p[2], stderr_p[2];
+
+  if(stdin_fd && pipe(stdin_p) != 0)
+    return -1;
+  if(stdout_fd && pipe(stdout_p) != 0) {
+    if(stdin_fd) {
+      close(stdin_p[0]);
+      close(stdin_p[1]);
+    }
+    return -1;
+  }
+  if(stderr_fd && pipe(stderr_p) != 0) {
+    if(stdin_fd) {
+      close(stdin_p[0]);
+      close(stdin_p[1]);
+    }
+    if(stdout_fd) {
+      close(stdout_p[0]);
+      close(stdout_p[1]);
+    }
+    return -1;
+  }
+
+  id_type pid = fork();
+
+  if(pid < 0) {
+    if(stdin_fd) {
+      close(stdin_p[0]);
+      close(stdin_p[1]);
+    }
+    if(stdout_fd) {
+      close(stdout_p[0]);
+      close(stdout_p[1]);
+    }
+    if(stderr_fd) {
+      close(stderr_p[0]);
+      close(stderr_p[1]);
+    }
+    return pid;
+  }
+  else if(pid == 0) {
+    if(stdin_fd)
+      dup2(stdin_p[0], 0);
+    if(stdout_fd)
+      dup2(stdout_p[1], 1);
+    if(stderr_fd)
+      dup2(stderr_p[1], 2);
+    if(stdin_fd) {
+      close(stdin_p[0]);
+      close(stdin_p[1]);
+    }
+    if(stdout_fd) {
+      close(stdout_p[0]);
+      close(stdout_p[1]);
+    }
+    if(stderr_fd) {
+      close(stderr_p[0]);
+      close(stderr_p[1]);
+    }
+
+    if(!config.inherit_file_descriptors) {
+      // Optimization on some systems: using 8 * 1024 (Debian's default _SC_OPEN_MAX) as fd_max limit
+      int fd_max = std::min(8192, static_cast<int>(sysconf(_SC_OPEN_MAX))); // Truncation is safe
+      if(fd_max < 0)
+        fd_max = 8192;
+      for(int fd = 3; fd < fd_max; fd++)
+        close(fd);
+    }
+
+    setpgid(0, 0);
+    // TODO: See here on how to emulate tty for colors: http://stackoverflow.com/questions/1401002/trick-an-application-into-thinking-its-stdin-is-interactive-not-a-pipe
+    // TODO: One solution is: echo "command;exit"|script -q /dev/null
+
+    if(function)
+      function();
+
+    _exit(EXIT_FAILURE);
+  }
+
+  if(stdin_fd)
+    close(stdin_p[0]);
+  if(stdout_fd)
+    close(stdout_p[1]);
+  if(stderr_fd)
+    close(stderr_p[1]);
+
+  if(stdin_fd)
+    *stdin_fd = stdin_p[1];
+  if(stdout_fd)
+    *stdout_fd = stdout_p[0];
+  if(stderr_fd)
+    *stderr_fd = stderr_p[0];
+
+  closed = false;
+  data.id = pid;
+  return pid;
+}
+
+Process::id_type Process::open(const std::vector<string_type> &arguments, const string_type &path, const environment_type *environment) noexcept {
+  return open([this, &arguments, &path, &environment] {
+    if(arguments.empty())
+      exit(127);
+
+    std::vector<const char *> argv_ptrs;
+
+    if(config.flatpak_spawn_host) {
+      // break out of sandbox, execute on host
+      argv_ptrs.reserve(arguments.size() + 3);
+      argv_ptrs.emplace_back("/usr/bin/flatpak-spawn");
+      argv_ptrs.emplace_back("--host");
+    }
+    else
+      argv_ptrs.reserve(arguments.size() + 1);
+
+    for(auto &argument : arguments)
+      argv_ptrs.emplace_back(argument.c_str());
+    argv_ptrs.emplace_back(nullptr);
+
+    if(!path.empty()) {
+      if(chdir(path.c_str()) != 0)
+        exit(1);
+    }
+
+    if(!environment)
+      execv(argv_ptrs[0], const_cast<char *const *>(argv_ptrs.data()));
+    else {
+      std::vector<std::string> env_strs;
+      std::vector<const char *> env_ptrs;
+      env_strs.reserve(environment->size());
+      env_ptrs.reserve(environment->size() + 1);
+      for(const auto &e : *environment) {
+        env_strs.emplace_back(e.first + '=' + e.second);
+        env_ptrs.emplace_back(env_strs.back().c_str());
+      }
+      env_ptrs.emplace_back(nullptr);
+
+      execve(argv_ptrs[0], const_cast<char *const *>(argv_ptrs.data()), const_cast<char *const *>(env_ptrs.data()));
+    }
+  });
+}
+
+Process::id_type Process::open(const std::string &command, const std::string &path, const environment_type *environment) noexcept {
+  return open([this, &command, &path, &environment] {
+    auto command_c_str = command.c_str();
+    std::string cd_path_and_command;
+    if(!path.empty()) {
+      auto path_escaped = path;
+      size_t pos = 0;
+      // Based on https://www.reddit.com/r/cpp/comments/3vpjqg/a_new_platform_independent_process_library_for_c11/cxsxyb7
+      while((pos = path_escaped.find('\'', pos)) != std::string::npos) {
+        path_escaped.replace(pos, 1, "'\\''");
+        pos += 4;
+      }
+      cd_path_and_command = "cd '" + path_escaped + "' && " + command; // To avoid resolving symbolic links
+      command_c_str = cd_path_and_command.c_str();
+    }
+
+    if(!environment) {
+      if(config.flatpak_spawn_host)
+        // break out of sandbox, execute on host
+        execl("/usr/bin/flatpak-spawn", "/usr/bin/flatpak-spawn", "--host", "/bin/sh", "-c", command_c_str, nullptr);
+      else
+        execl("/bin/sh", "/bin/sh", "-c", command_c_str, nullptr);
+    }
+    else {
+      std::vector<std::string> env_strs;
+      std::vector<const char *> env_ptrs;
+      env_strs.reserve(environment->size());
+      env_ptrs.reserve(environment->size() + 1);
+      for(const auto &e : *environment) {
+        env_strs.emplace_back(e.first + '=' + e.second);
+        env_ptrs.emplace_back(env_strs.back().c_str());
+      }
+      env_ptrs.emplace_back(nullptr);
+      if(config.flatpak_spawn_host)
+        // break out of sandbox, execute on host
+        execle("/usr/bin/flatpak-spawn", "/usr/bin/flatpak-spawn", "--host", "/bin/sh", "-c", command_c_str, nullptr, env_ptrs.data());
+      else
+        execle("/bin/sh", "/bin/sh", "-c", command_c_str, nullptr, env_ptrs.data());
+    }
+  });
+}
+
+void Process::async_read() noexcept {
+  if(data.id <= 0 || (!stdout_fd && !stderr_fd))
+    return;
+
+  stdout_stderr_thread = std::thread([this] {
+    std::vector<pollfd> pollfds;
+    std::bitset<2> fd_is_stdout;
+    if(stdout_fd) {
+      fd_is_stdout.set(pollfds.size());
+      pollfds.emplace_back();
+      pollfds.back().fd = fcntl(*stdout_fd, F_SETFL, fcntl(*stdout_fd, F_GETFL) | O_NONBLOCK) == 0 ? *stdout_fd : -1;
+      pollfds.back().events = POLLIN;
+    }
+    if(stderr_fd) {
+      pollfds.emplace_back();
+      pollfds.back().fd = fcntl(*stderr_fd, F_SETFL, fcntl(*stderr_fd, F_GETFL) | O_NONBLOCK) == 0 ? *stderr_fd : -1;
+      pollfds.back().events = POLLIN;
+    }
+    auto buffer = std::unique_ptr<char[]>(new char[config.buffer_size]);
+    bool any_open = !pollfds.empty();
+    while(any_open && (poll(pollfds.data(), static_cast<nfds_t>(pollfds.size()), -1) > 0 || errno == EINTR)) {
+      any_open = false;
+      for(size_t i = 0; i < pollfds.size(); ++i) {
+        if(pollfds[i].fd >= 0) {
+          if(pollfds[i].revents & POLLIN) {
+            const ssize_t n = read(pollfds[i].fd, buffer.get(), config.buffer_size);
+            if(n > 0) {
+              if(fd_is_stdout[i])
+                read_stdout(buffer.get(), static_cast<size_t>(n));
+              else
+                read_stderr(buffer.get(), static_cast<size_t>(n));
+            }
+            else if(n < 0 && errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
+              pollfds[i].fd = -1;
+              continue;
+            }
+          }
+          if(pollfds[i].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            pollfds[i].fd = -1;
+            continue;
+          }
+          any_open = true;
+        }
+      }
+    }
+  });
+}
+
+int Process::get_exit_status() noexcept {
+  if(data.id <= 0)
+    return -1;
+
+  int exit_status;
+  id_type pid;
+  do {
+    pid = waitpid(data.id, &exit_status, 0);
+  } while(pid < 0 && errno == EINTR);
+
+  if(pid < 0 && errno == ECHILD) {
+    // PID doesn't exist anymore, return previously sampled exit status (or -1)
+    return data.exit_status;
+  }
+  else {
+    // Store exit status for future calls
+    if(exit_status >= 256)
+      exit_status = exit_status >> 8;
+    data.exit_status = exit_status;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    closed = true;
+  }
+  close_fds();
+
+  return exit_status;
+}
+
+bool Process::try_get_exit_status(int &exit_status) noexcept {
+  if(data.id <= 0)
+    return false;
+
+  const id_type pid = waitpid(data.id, &exit_status, WNOHANG);
+  if(pid < 0 && errno == ECHILD) {
+    // PID doesn't exist anymore, set previously sampled exit status (or -1)
+    exit_status = data.exit_status;
+    return true;
+  }
+  else if(pid <= 0) {
+    // Process still running (p==0) or error
+    return false;
+  }
+  else {
+    // store exit status for future calls
+    if(exit_status >= 256)
+      exit_status = exit_status >> 8;
+    data.exit_status = exit_status;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    closed = true;
+  }
+  close_fds();
+
+  return true;
+}
+
+void Process::close_fds() noexcept {
+  if(stdout_stderr_thread.joinable())
+    stdout_stderr_thread.join();
+
+  if(stdin_fd)
+    close_stdin();
+  if(stdout_fd) {
+    if(data.id > 0)
+      close(*stdout_fd);
+    stdout_fd.reset();
+  }
+  if(stderr_fd) {
+    if(data.id > 0)
+      close(*stderr_fd);
+    stderr_fd.reset();
+  }
+}
+
+bool Process::write(const char *bytes, size_t n) {
+  if(!open_stdin)
+    // -- GODOT START --
+    //throw std::invalid_argument("Can't write to an unopened stdin pipe. Please set open_stdin=true when constructing the process.");
+    abort();
+    // -- GODOT END --
+
+  std::lock_guard<std::mutex> lock(stdin_mutex);
+  if(stdin_fd) {
+    if(::write(*stdin_fd, bytes, n) >= 0) {
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+  return false;
+}
+
+void Process::close_stdin() noexcept {
+  std::lock_guard<std::mutex> lock(stdin_mutex);
+  if(stdin_fd) {
+    if(data.id > 0)
+      close(*stdin_fd);
+    stdin_fd.reset();
+  }
+}
+
+void Process::kill(bool force) noexcept {
+  std::lock_guard<std::mutex> lock(close_mutex);
+  if(data.id > 0 && !closed) {
+    if(force)
+      ::kill(-data.id, SIGTERM);
+    else
+      ::kill(-data.id, SIGINT);
+  }
+}
+
+void Process::kill(id_type id, bool force) noexcept {
+  if(id <= 0)
+    return;
+
+  if(force)
+    ::kill(-id, SIGTERM);
+  else
+    ::kill(-id, SIGINT);
+}
+
+void Process::signal(int signum) noexcept {
+  std::lock_guard<std::mutex> lock(close_mutex);
+  if(data.id > 0 && !closed) {
+    ::kill(-data.id, signum);
+  }
+}
+
+} // namespace TinyProcessLib

--- a/thirdparty/tiny-process-library/process_win.cpp
+++ b/thirdparty/tiny-process-library/process_win.cpp
@@ -1,0 +1,356 @@
+#include "process.hpp"
+// clang-format off
+#include <windows.h>
+// clang-format on
+#include <cstring>
+#include <stdexcept>
+#include <tlhelp32.h>
+
+namespace TinyProcessLib {
+
+Process::Data::Data() noexcept : id(0) {}
+
+// Simple HANDLE wrapper to close it automatically from the destructor.
+class Handle {
+public:
+  Handle() noexcept : handle(INVALID_HANDLE_VALUE) {}
+  ~Handle() noexcept {
+    close();
+  }
+  void close() noexcept {
+    if(handle != INVALID_HANDLE_VALUE)
+      CloseHandle(handle);
+  }
+  HANDLE detach() noexcept {
+    HANDLE old_handle = handle;
+    handle = INVALID_HANDLE_VALUE;
+    return old_handle;
+  }
+  operator HANDLE() const noexcept { return handle; }
+  HANDLE *operator&() noexcept { return &handle; }
+
+private:
+  HANDLE handle;
+};
+
+// Based on the discussion thread: https://www.reddit.com/r/cpp/comments/3vpjqg/a_new_platform_independent_process_library_for_c11/cxq1wsj
+std::mutex create_process_mutex;
+
+Process::id_type Process::open(const std::vector<string_type> &arguments, const string_type &path, const environment_type *environment) noexcept {
+  string_type command;
+  for(auto &argument : arguments)
+#ifdef UNICODE
+    command += (command.empty() ? L"" : L" ") + argument;
+#else
+    command += (command.empty() ? "" : " ") + argument;
+#endif
+  return open(command, path, environment);
+}
+
+// Based on the example at https://msdn.microsoft.com/en-us/library/windows/desktop/ms682499(v=vs.85).aspx.
+Process::id_type Process::open(const string_type &command, const string_type &path, const environment_type *environment) noexcept {
+  if(open_stdin)
+    stdin_fd = std::unique_ptr<fd_type>(new fd_type(nullptr));
+  if(read_stdout)
+    stdout_fd = std::unique_ptr<fd_type>(new fd_type(nullptr));
+  if(read_stderr)
+    stderr_fd = std::unique_ptr<fd_type>(new fd_type(nullptr));
+
+  Handle stdin_rd_p;
+  Handle stdin_wr_p;
+  Handle stdout_rd_p;
+  Handle stdout_wr_p;
+  Handle stderr_rd_p;
+  Handle stderr_wr_p;
+
+  SECURITY_ATTRIBUTES security_attributes;
+
+  security_attributes.nLength = sizeof(SECURITY_ATTRIBUTES);
+  security_attributes.bInheritHandle = TRUE;
+  security_attributes.lpSecurityDescriptor = nullptr;
+
+  std::lock_guard<std::mutex> lock(create_process_mutex);
+  if(stdin_fd) {
+    if(!CreatePipe(&stdin_rd_p, &stdin_wr_p, &security_attributes, 0) ||
+       !SetHandleInformation(stdin_wr_p, HANDLE_FLAG_INHERIT, 0))
+      return 0;
+  }
+  if(stdout_fd) {
+    if(!CreatePipe(&stdout_rd_p, &stdout_wr_p, &security_attributes, 0) ||
+       !SetHandleInformation(stdout_rd_p, HANDLE_FLAG_INHERIT, 0)) {
+      return 0;
+    }
+  }
+  if(stderr_fd) {
+    if(!CreatePipe(&stderr_rd_p, &stderr_wr_p, &security_attributes, 0) ||
+       !SetHandleInformation(stderr_rd_p, HANDLE_FLAG_INHERIT, 0)) {
+      return 0;
+    }
+  }
+
+  PROCESS_INFORMATION process_info;
+  STARTUPINFO startup_info;
+
+  ZeroMemory(&process_info, sizeof(PROCESS_INFORMATION));
+
+  ZeroMemory(&startup_info, sizeof(STARTUPINFO));
+  startup_info.cb = sizeof(STARTUPINFO);
+  startup_info.hStdInput = stdin_rd_p;
+  startup_info.hStdOutput = stdout_wr_p;
+  startup_info.hStdError = stderr_wr_p;
+  if(stdin_fd || stdout_fd || stderr_fd)
+    startup_info.dwFlags |= STARTF_USESTDHANDLES;
+
+  if(config.show_window != Config::ShowWindow::show_default) {
+    startup_info.dwFlags |= STARTF_USESHOWWINDOW;
+    startup_info.wShowWindow = static_cast<WORD>(config.show_window);
+  }
+
+  auto process_command = command;
+#ifdef MSYS_PROCESS_USE_SH
+  size_t pos = 0;
+  while((pos = process_command.find('\\', pos)) != string_type::npos) {
+    process_command.replace(pos, 1, "\\\\\\\\");
+    pos += 4;
+  }
+  pos = 0;
+  while((pos = process_command.find('\"', pos)) != string_type::npos) {
+    process_command.replace(pos, 1, "\\\"");
+    pos += 2;
+  }
+  process_command.insert(0, "sh -c \"");
+  process_command += "\"";
+#endif
+
+  DWORD creation_flags = stdin_fd || stdout_fd || stderr_fd ? CREATE_NO_WINDOW : 0; // CREATE_NO_WINDOW cannot be used when stdout or stderr is redirected to parent process
+  string_type environment_str;
+  if(environment) {
+#ifdef UNICODE
+    for(const auto &e : *environment)
+      environment_str += e.first + L'=' + e.second + L'\0';
+    if(!environment_str.empty())
+      environment_str += L'\0';
+    creation_flags |= CREATE_UNICODE_ENVIRONMENT;
+#else
+    for(const auto &e : *environment)
+      environment_str += e.first + '=' + e.second + '\0';
+    if(!environment_str.empty())
+      environment_str += '\0';
+#endif
+  }
+  BOOL bSuccess = CreateProcess(nullptr, process_command.empty() ? nullptr : &process_command[0], nullptr, nullptr,
+                                stdin_fd || stdout_fd || stderr_fd || config.inherit_file_descriptors, // Cannot be false when stdout, stderr or stdin is used
+                                creation_flags,
+                                environment_str.empty() ? nullptr : &environment_str[0],
+                                path.empty() ? nullptr : path.c_str(),
+                                &startup_info, &process_info);
+
+  if(!bSuccess)
+    return 0;
+  else
+    CloseHandle(process_info.hThread);
+
+  if(stdin_fd)
+    *stdin_fd = stdin_wr_p.detach();
+  if(stdout_fd)
+    *stdout_fd = stdout_rd_p.detach();
+  if(stderr_fd)
+    *stderr_fd = stderr_rd_p.detach();
+
+  closed = false;
+  data.id = process_info.dwProcessId;
+  data.handle = process_info.hProcess;
+  return process_info.dwProcessId;
+}
+
+void Process::async_read() noexcept {
+  if(data.id == 0)
+    return;
+
+  if(stdout_fd) {
+    stdout_thread = std::thread([this]() {
+      DWORD n;
+      std::unique_ptr<char[]> buffer(new char[config.buffer_size]);
+      for(;;) {
+        BOOL bSuccess = ReadFile(*stdout_fd, static_cast<CHAR *>(buffer.get()), static_cast<DWORD>(config.buffer_size), &n, nullptr);
+        if(!bSuccess || n == 0)
+          break;
+        read_stdout(buffer.get(), static_cast<size_t>(n));
+      }
+    });
+  }
+  if(stderr_fd) {
+    stderr_thread = std::thread([this]() {
+      DWORD n;
+      std::unique_ptr<char[]> buffer(new char[config.buffer_size]);
+      for(;;) {
+        BOOL bSuccess = ReadFile(*stderr_fd, static_cast<CHAR *>(buffer.get()), static_cast<DWORD>(config.buffer_size), &n, nullptr);
+        if(!bSuccess || n == 0)
+          break;
+        read_stderr(buffer.get(), static_cast<size_t>(n));
+      }
+    });
+  }
+}
+
+int Process::get_exit_status() noexcept {
+  if(data.id == 0)
+    return -1;
+
+  if(!data.handle)
+    return data.exit_status;
+
+  WaitForSingleObject(data.handle, INFINITE);
+
+  DWORD exit_status;
+  if(!GetExitCodeProcess(data.handle, &exit_status))
+    data.exit_status = -1; // Store exit status for future calls
+  else
+    data.exit_status = static_cast<int>(exit_status); // Store exit status for future calls
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    CloseHandle(data.handle);
+    data.handle = nullptr;
+    closed = true;
+  }
+  close_fds();
+
+  return data.exit_status;
+}
+
+bool Process::try_get_exit_status(int &exit_status) noexcept {
+  if(data.id == 0)
+    return false;
+
+  if(!data.handle) {
+    exit_status = data.exit_status;
+    return true;
+  }
+
+  DWORD wait_status = WaitForSingleObject(data.handle, 0);
+  if(wait_status == WAIT_TIMEOUT)
+    return false;
+
+  DWORD exit_status_tmp;
+  if(!GetExitCodeProcess(data.handle, &exit_status_tmp))
+    exit_status = -1;
+  else
+    exit_status = static_cast<int>(exit_status_tmp);
+  data.exit_status = exit_status; // Store exit status for future calls
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    CloseHandle(data.handle);
+    data.handle = nullptr;
+    closed = true;
+  }
+  close_fds();
+
+  return true;
+}
+
+void Process::close_fds() noexcept {
+  if(stdout_thread.joinable())
+    stdout_thread.join();
+  if(stderr_thread.joinable())
+    stderr_thread.join();
+
+  if(stdin_fd)
+    close_stdin();
+  if(stdout_fd) {
+    if(*stdout_fd != nullptr)
+      CloseHandle(*stdout_fd);
+    stdout_fd.reset();
+  }
+  if(stderr_fd) {
+    if(*stderr_fd != nullptr)
+      CloseHandle(*stderr_fd);
+    stderr_fd.reset();
+  }
+}
+
+bool Process::write(const char *bytes, size_t n) {
+  if(!open_stdin)
+    // -- GODOT START --
+    //throw std::invalid_argument("Can't write to an unopened stdin pipe. Please set open_stdin=true when constructing the process.");
+    abort();
+    // -- GODOT END --
+  std::lock_guard<std::mutex> lock(stdin_mutex);
+  if(stdin_fd) {
+    DWORD written;
+    BOOL bSuccess = WriteFile(*stdin_fd, bytes, static_cast<DWORD>(n), &written, nullptr);
+    if(!bSuccess || written == 0) {
+      return false;
+    }
+    else {
+      return true;
+    }
+  }
+  return false;
+}
+
+void Process::close_stdin() noexcept {
+  std::lock_guard<std::mutex> lock(stdin_mutex);
+  if(stdin_fd) {
+    if(*stdin_fd != nullptr)
+      CloseHandle(*stdin_fd);
+    stdin_fd.reset();
+  }
+}
+
+// Based on http://stackoverflow.com/a/1173396
+void Process::kill(bool /*force*/) noexcept {
+  std::lock_guard<std::mutex> lock(close_mutex);
+  if(data.id > 0 && !closed) {
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if(snapshot) {
+      PROCESSENTRY32 process;
+      ZeroMemory(&process, sizeof(process));
+      process.dwSize = sizeof(process);
+      if(Process32First(snapshot, &process)) {
+        do {
+          if(process.th32ParentProcessID == data.id) {
+            HANDLE process_handle = OpenProcess(PROCESS_TERMINATE, FALSE, process.th32ProcessID);
+            if(process_handle) {
+              TerminateProcess(process_handle, 2);
+              CloseHandle(process_handle);
+            }
+          }
+        } while(Process32Next(snapshot, &process));
+      }
+      CloseHandle(snapshot);
+    }
+    TerminateProcess(data.handle, 2);
+  }
+}
+
+// Based on http://stackoverflow.com/a/1173396
+void Process::kill(id_type id, bool /*force*/) noexcept {
+  if(id == 0)
+    return;
+
+  HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+  if(snapshot) {
+    PROCESSENTRY32 process;
+    ZeroMemory(&process, sizeof(process));
+    process.dwSize = sizeof(process);
+    if(Process32First(snapshot, &process)) {
+      do {
+        if(process.th32ParentProcessID == id) {
+          HANDLE process_handle = OpenProcess(PROCESS_TERMINATE, FALSE, process.th32ProcessID);
+          if(process_handle) {
+            TerminateProcess(process_handle, 2);
+            CloseHandle(process_handle);
+          }
+        }
+      } while(Process32Next(snapshot, &process));
+    }
+    CloseHandle(snapshot);
+  }
+  HANDLE process_handle = OpenProcess(PROCESS_TERMINATE, FALSE, id);
+  if(process_handle)
+    TerminateProcess(process_handle, 2);
+}
+
+} // namespace TinyProcessLib


### PR DESCRIPTION
Uses TinyProcessLibrary (https://gitlab.com/eidheim/tiny-process-library/), which takes care of dumb stuff like flatpak portals.

Fixes https://github.com/godotengine/godot-proposals/issues/216

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
