### PR TITLE
[macOS] Fix ⌘ + . + other modifier triggering twice.

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -586,7 +586,7 @@ void DisplayServerMacOS::send_event(NSEvent *p_event) {
 	// Special case handling of command-period, which is traditionally a special
 	// shortcut in macOS and doesn't arrive at our regular keyDown handler.
 	if ([p_event type] == NSEventTypeKeyDown) {
-		if (([p_event modifierFlags] & NSEventModifierFlagCommand) && [p_event keyCode] == 0x2f) {
+		if ((([p_event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask) == NSEventModifierFlagCommand) && [p_event keyCode] == 0x2f) {
 			Ref<InputEventKey> k;
 			k.instantiate();
 


### PR DESCRIPTION
<kbd>⌘</kbd> + <kbd>.</kbd> require a special handler, but it should only handle exact key combination, not any with <kbd>⌘</kbd> and <kbd>.</kbd> in it.

Fixes https://github.com/godotengine/godot/issues/63947