### PR TITLE
Show custom data names in the tile set editor

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -207,6 +207,7 @@ typedef struct {
 	uint32_t hint;
 	const char *hint_string;
 	uint32_t usage;
+	const char *alias;
 } GDNativePropertyInfo;
 
 typedef struct {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -158,6 +158,7 @@ struct PropertyInfo {
 	PropertyHint hint = PROPERTY_HINT_NONE;
 	String hint_string;
 	uint32_t usage = PROPERTY_USAGE_DEFAULT;
+	String alias; // alternative display name
 
 	// If you are thinking about adding another member to this class, ask the maintainer (Juan) first.
 
@@ -173,12 +174,13 @@ struct PropertyInfo {
 
 	PropertyInfo() {}
 
-	PropertyInfo(const Variant::Type p_type, const String p_name, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", const uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName()) :
+	PropertyInfo(const Variant::Type p_type, const String p_name, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", const uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName(), const String &p_alias = "") :
 			type(p_type),
 			name(p_name),
 			hint(p_hint),
 			hint_string(p_hint_string),
-			usage(p_usage) {
+			usage(p_usage),
+			alias(p_alias){
 		if (hint == PROPERTY_HINT_RESOURCE_TYPE) {
 			class_name = hint_string;
 		} else {
@@ -196,7 +198,8 @@ struct PropertyInfo {
 			class_name(pinfo.class_name), // can be null
 			hint((PropertyHint)pinfo.hint),
 			hint_string(pinfo.hint_string), // can be null
-			usage(pinfo.usage) {}
+			usage(pinfo.usage),
+			alias(pinfo.alias) {}
 
 	bool operator==(const PropertyInfo &p_info) const {
 		return ((type == p_info.type) &&
@@ -204,7 +207,8 @@ struct PropertyInfo {
 				(class_name == p_info.class_name) &&
 				(hint == p_info.hint) &&
 				(hint_string == p_info.hint_string) &&
-				(usage == p_info.usage));
+				(usage == p_info.usage) &&
+				(alias == p_info.alias));
 	}
 
 	bool operator<(const PropertyInfo &p_info) const {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2928,17 +2928,20 @@ void EditorInspector::update_tree() {
 			}
 		}
 
-		// Get the property label's string.
-		String name_override = (path.contains("/")) ? path.substr(path.rfind("/") + 1) : path;
+		// Get the property label's string if no alias is provided.
+		String name_override = p.alias;
 		String feature_tag;
-		{
-			const int dot = name_override.find(".");
-			if (dot != -1) {
-				feature_tag = name_override.substr(dot);
-				name_override = name_override.substr(0, dot);
+		if (name_override.is_empty()) {
+			name_override = (path.contains("/")) ? path.substr(path.rfind("/") + 1) : path;
+			{
+				const int dot = name_override.find(".");
+				if (dot != -1) {
+					feature_tag = name_override.substr(dot);
+					name_override = name_override.substr(0, dot);
+				}
 			}
 		}
-
+		
 		// Don't localize script variables.
 		EditorPropertyNameProcessor::Style name_style = property_name_style;
 		if ((p.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) && name_style == EditorPropertyNameProcessor::STYLE_LOCALIZED) {

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -5671,7 +5671,7 @@ void TileData::_get_property_list(List<PropertyInfo> *p_list) const {
 			Variant default_val;
 			Callable::CallError error;
 			Variant::construct(custom_data[i].get_type(), default_val, nullptr, 0, error);
-			property_info = PropertyInfo(tile_set->get_custom_data_layer_type(i), vformat("custom_data_%d", i), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
+			property_info = PropertyInfo(tile_set->get_custom_data_layer_type(i), vformat("custom_data_%d", i), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT, StringName(), tile_set->get_custom_data_layer_name(i));
 			if (custom_data[i] == default_val) {
 				property_info.usage ^= PROPERTY_USAGE_STORAGE;
 			}


### PR DESCRIPTION
I noticed that the custom properties in the new tile editor have no name, just the index, even if a name is set.
I couldn't find another Issue or PR targeting this.
![image](https://user-images.githubusercontent.com/663900/193708136-b3fc6f18-c9c3-469b-88a4-2fec5c541011.png)
![image](https://user-images.githubusercontent.com/663900/193708248-f162e762-8024-4968-96e5-d045230ed9ee.png)

Which is very annoying if you have several custom properties.

This PR just changes that to show the names instead.
Currently it fall-backs to the index.

![image](https://user-images.githubusercontent.com/663900/193708173-ff11a724-d24e-474b-8f80-58db3756be31.png)
