### PR TITLE
Properly expose TEXTURE_PIXEL_SIZE in Opengl3 renderer

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -127,6 +127,8 @@ void main() {
 	}
 #endif
 
+	vec2 color_texture_pixel_size = draw_data[draw_data_instance].color_texture_pixel_size.xy;
+
 #ifdef USE_POINT_SIZE
 	float point_size = 1.0;
 #endif
@@ -392,6 +394,8 @@ void main() {
 #else
 	vec2 screen_uv = vec2(0.0);
 #endif
+
+	vec2 color_texture_pixel_size = draw_data[draw_data_instance].color_texture_pixel_size.xy;
 
 	vec3 light_vertex = vec3(vertex, 0.0);
 	vec2 shadow_vertex = vertex;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1393,7 +1393,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["NORMAL_MAP"] = "normal_map";
 		actions.renames["NORMAL_MAP_DEPTH"] = "normal_map_depth";
 		actions.renames["TEXTURE"] = "color_texture";
-		actions.renames["TEXTURE_PIXEL_SIZE"] = "draw_data.color_texture_pixel_size";
+		actions.renames["TEXTURE_PIXEL_SIZE"] = "color_texture_pixel_size";
 		actions.renames["NORMAL_TEXTURE"] = "normal_texture";
 		actions.renames["SPECULAR_SHININESS_TEXTURE"] = "specular_texture";
 		actions.renames["SPECULAR_SHININESS"] = "specular_shininess";


### PR DESCRIPTION
This fixes an unreported bug where shaders would error whenever ``TEXTURE_PIXEL_SIZE`` was used in the Opengl3 renderer. 
