### PR TITLE
Fix GDScript export hint for Navigation2D layer names

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4350,7 +4350,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 											_set_error("Expected \")\" in the layers 2D navigation hint.");
 											return;
 										}
-										current_export.hint = PROPERTY_HINT_LAYERS_2D_PHYSICS;
+										current_export.hint = PROPERTY_HINT_LAYERS_2D_NAVIGATION;
 										break;
 									}
 


### PR DESCRIPTION
Fixes #66865

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
