### PR TITLE
Fix Transform2D det == 0 spam for SubViewports

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4135,7 +4135,7 @@ Transform2D SubViewport::_stretch_transform() {
 	Transform2D transform = Transform2D();
 	Size2i view_size_2d_override = _get_size_2d_override();
 	if (size_2d_override_stretch && view_size_2d_override.width > 0 && view_size_2d_override.height > 0) {
-		Size2 scale = _get_size() / view_size_2d_override;
+		Size2 scale = Size2(_get_size()) / Size2(view_size_2d_override);
 		transform.scale(scale);
 	}
 


### PR DESCRIPTION
In certain conditions, the `Transform2D` for `SubViewports` can have a determinant of zero.
See MRP: [BugDet0.zip](https://github.com/godotengine/godot/files/9704710/BugDet0.zip)
In the MRP the console gets flooded by messages:
```
ERROR: Condition "det == 0" is true.
   at: affine_invert (core/math/transform_2d.cpp:51)
```

The negative effect of this is, that the content of the `SubViewport` is not displayed.

This is caused by integer division in a float context.
This PR makes sure, that the division happens with floats.