### PR TITLE
HTML5: Add missing `OS::get_cursor_shape()` implementation

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -454,6 +454,10 @@ void OS_JavaScript::set_cursor_shape(CursorShape p_shape) {
 	godot_js_display_cursor_set_shape(godot2dom_cursor(cursor_shape));
 }
 
+OS::CursorShape OS_JavaScript::get_cursor_shape() const {
+	return cursor_shape;
+}
+
 void OS_JavaScript::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	if (p_cursor.is_valid()) {
 		Ref<Texture> texture = p_cursor;

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -162,6 +162,7 @@ public:
 	virtual Point2 get_mouse_position() const;
 	virtual int get_mouse_button_state() const;
 	virtual void set_cursor_shape(CursorShape p_shape);
+	virtual CursorShape get_cursor_shape() const;
 	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
 	virtual void set_mouse_mode(MouseMode p_mode);
 	virtual MouseMode get_mouse_mode() const;


### PR DESCRIPTION
Fixes #66835.
It's already implemented in 4.0.

I noticed that Android doesn't seem to have implementations for the OS cursor methods at all, might be relevant for the Android editor @m4gr3d.

Makes me wonder what other methods are missing implementation in each platform and fall back to wrong defaults.