### PR TITLE
Add a `reload_finished` signal to `Script`/`TextFile` to emit after a reload

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -127,6 +127,12 @@ PropertyInfo Script::get_class_category() const {
 
 #endif // TOOLS_ENABLED
 
+Error Script::reload(bool p_keep_state) {
+	Error err = _reload(p_keep_state);
+	emit_signal(SNAME("reload_finished"));
+	return err;
+}
+
 void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_instantiate"), &Script::can_instantiate);
 	//ClassDB::bind_method(D_METHOD("instance_create","base_object"),&Script::instance_create);
@@ -147,6 +153,8 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_property_default_value", "property"), &Script::_get_property_default_value);
 
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);
+
+	ADD_SIGNAL(MethodInfo("reload_finished"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
 }

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -113,6 +113,7 @@ protected:
 
 	friend class PlaceHolderScriptInstance;
 	virtual void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder) {}
+	virtual Error _reload(bool p_keep_state = false) = 0;
 
 	Variant _get_property_default_value(const StringName &p_property);
 	TypedArray<Dictionary> _get_script_property_list();
@@ -135,7 +136,8 @@ public:
 	virtual bool has_source_code() const = 0;
 	virtual String get_source_code() const = 0;
 	virtual void set_source_code(const String &p_code) = 0;
-	virtual Error reload(bool p_keep_state = false) = 0;
+
+	Error reload(bool p_keep_state = false);
 
 #ifdef TOOLS_ENABLED
 	virtual Vector<DocData::ClassDoc> get_documentation() const = 0;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -48,6 +48,13 @@ protected:
 		GDVIRTUAL_CALL(_placeholder_erased, p_placeholder);
 	}
 
+	GDVIRTUAL1R(Error, _reload, bool)
+	virtual Error _reload(bool p_keep_state = false) override {
+		Error err = OK;
+		GDVIRTUAL_REQUIRED_CALL(_reload, p_keep_state, err);
+		return err;
+	}
+
 	static void _bind_methods();
 
 public:
@@ -74,7 +81,6 @@ public:
 	EXBIND0RC(bool, has_source_code)
 	EXBIND0RC(String, get_source_code)
 	EXBIND1(set_source_code, const String &)
-	EXBIND1R(Error, reload, bool)
 
 	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_documentation)
 #ifdef TOOLS_ENABLED

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -100,4 +100,11 @@
 			The script source code or an empty string if source code is not available. When set, does not reload the class implementation automatically.
 		</member>
 	</members>
+	<signals>
+		<signal name="reload_finished">
+			<description>
+				Emitted when the script reload has finished.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -145,6 +145,8 @@ void ScriptTextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 
 	script = p_res;
 
+	script->connect(SNAME("reload_finished"), callable_mp(this, &ScriptTextEditor::reload_text));
+
 	code_editor->get_text_editor()->set_text(script->get_source_code());
 	code_editor->get_text_editor()->clear_undo_history();
 	code_editor->get_text_editor()->tag_saved_version();
@@ -2246,6 +2248,10 @@ ScriptTextEditor::ScriptTextEditor() {
 
 ScriptTextEditor::~ScriptTextEditor() {
 	highlighters.clear();
+
+	if (script.is_valid()) {
+		script->disconnect(SNAME("reload_finished"), callable_mp(this, &ScriptTextEditor::reload_text));
+	}
 
 	if (!editor_enabled) {
 		memdelete(code_editor);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -105,6 +105,7 @@ void TextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	Ref<TextFile> text_file = edited_res;
 	if (text_file != nullptr) {
 		code_editor->get_text_editor()->set_text(text_file->get_text());
+		text_file->connect(SNAME("reload_finished"), callable_mp(this, &TextEditor::reload_text));
 	}
 
 	Ref<JSON> json_file = edited_res;
@@ -707,6 +708,12 @@ TextEditor::TextEditor() {
 
 TextEditor::~TextEditor() {
 	highlighters.clear();
+
+	Ref<TextFile> text_file = edited_res;
+
+	if (text_file.is_valid()) {
+		text_file->disconnect(SNAME("reload_finished"), callable_mp(this, &TextEditor::reload_text));
+	}
 }
 
 void TextEditor::validate() {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -694,7 +694,7 @@ void GDScript::_restore_old_static_data() {
 
 #endif
 
-Error GDScript::reload(bool p_keep_state) {
+Error GDScript::_reload(bool p_keep_state) {
 	if (reloading) {
 		return OK;
 	}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -190,6 +190,8 @@ protected:
 
 	static void _bind_methods();
 
+	virtual Error _reload(bool p_keep_state = false) override;
+
 public:
 	void clear(GDScript::ClearData *p_clear_data = nullptr);
 
@@ -248,8 +250,6 @@ public:
 		return docs;
 	}
 #endif // TOOLS_ENABLED
-
-	virtual Error reload(bool p_keep_state = false) override;
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	String get_script_path() const;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2497,7 +2497,7 @@ MethodInfo CSharpScript::get_method_info(const StringName &p_method) const {
 	return MethodInfo();
 }
 
-Error CSharpScript::reload(bool p_keep_state) {
+Error CSharpScript::_reload(bool p_keep_state) {
 	if (!reload_invalidated) {
 		return OK;
 	}

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -142,6 +142,8 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	void _get_property_list(List<PropertyInfo> *p_properties) const;
 
+	Error _reload(bool p_keep_state = false) override;
+
 public:
 	static void reload_registered_script(Ref<CSharpScript> p_script);
 
@@ -162,8 +164,6 @@ public:
 		return docs;
 	}
 #endif // TOOLS_ENABLED
-
-	Error reload(bool p_keep_state = false) override;
 
 	bool has_script_signal(const StringName &p_signal) const override;
 	void get_script_signal_list(List<MethodInfo> *r_signals) const override;

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -46,6 +46,7 @@ void TextFile::set_text(const String &p_code) {
 
 void TextFile::reload_from_file() {
 	load_text(path);
+	emit_signal(SNAME("reload_finished"));
 }
 
 Error TextFile::load_text(const String &p_path) {
@@ -73,4 +74,8 @@ Error TextFile::load_text(const String &p_path) {
 	}
 #endif // TOOLS_ENABLED
 	return OK;
+}
+
+void TextFile::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("reload_finished"));
 }

--- a/scene/resources/text_file.h
+++ b/scene/resources/text_file.h
@@ -41,6 +41,9 @@ private:
 	String text;
 	String path;
 
+protected:
+	static void _bind_methods();
+
 public:
 	virtual bool has_text() const;
 	virtual String get_text() const;


### PR DESCRIPTION
Sending this signal means that the `Script`/`TextFile` has been reloaded and reset, and is ready to be reused.

Connect this signal to the `reload_text` method in `ScriptTextEditor`/`TextEditor` to ensure text is synced from `Script`/`TextFile` to these editors.

Split from #66658.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/9620*
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
