### PR TITLE
LSP: Fix GDScript doc comments

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -437,11 +437,11 @@ String ExtendGDScriptParser::parse_documentation(int p_line, bool p_docs_down) {
 
 	if (!p_docs_down) { // inline comment
 		String inline_comment = lines[p_line];
-		int comment_start = inline_comment.find("#");
+		int comment_start = inline_comment.find("##");
 		if (comment_start != -1) {
 			inline_comment = inline_comment.substr(comment_start, inline_comment.length()).strip_edges();
 			if (inline_comment.length() > 1) {
-				doc_lines.push_back(inline_comment.substr(1, inline_comment.length()));
+				doc_lines.push_back(inline_comment.substr(2, inline_comment.length()));
 			}
 		}
 	}
@@ -454,8 +454,8 @@ String ExtendGDScriptParser::parse_documentation(int p_line, bool p_docs_down) {
 		}
 
 		String line_comment = lines[i].strip_edges(true, false);
-		if (line_comment.begins_with("#")) {
-			line_comment = line_comment.substr(1, line_comment.length());
+		if (line_comment.begins_with("##")) {
+			line_comment = line_comment.substr(2, line_comment.length());
 			if (p_docs_down) {
 				doc_lines.push_back(line_comment);
 			} else {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Closes https://github.com/godotengine/godot/issues/66339.

I initially wanted to update LSP hover docs behavior to match with the generated docs, but I want this fix to get merged before the stable release so other things can wait.