### PR TITLE
Logger: Don't print error twice on `ERR_PRINT`

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -137,8 +137,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
- * If not, prints `m_msg`, notifies in the editor, and the current function returns.
+ * Same as `ERR_FAIL_INDEX_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg)                                                                         \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
@@ -173,8 +172,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
- * If not, prints `m_msg`, notifies in the editor, and the current function returns `m_retval`.
+ * Same as `ERR_FAIL_INDEX_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                             \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
@@ -240,9 +238,9 @@ void _err_flush_stdout();
 		return;                                                                                                        \
 	} else                                                                                                             \
 		((void)0)
+
 /**
- * Ensures an unsigned integer index `m_index` is less than `m_size`.
- * If not, prints `m_msg`, notifies in the editor, and the current function returns.
+ * Same as `ERR_FAIL_UNSIGNED_INDEX_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg)                                                                \
 	if (unlikely((m_index) >= (m_size))) {                                                                                   \
@@ -277,8 +275,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures an unsigned integer index `m_index` is less than `m_size`.
- * If not, prints `m_msg`, notifies in the editor, and the current function returns `m_retval`.
+ * Same as `ERR_FAIL_UNSIGNED_INDEX_V_EDMSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                    \
 	if (unlikely((m_index) >= (m_size))) {                                                                                   \
@@ -346,8 +343,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures a pointer `m_param` is not null.
- * If it is null, prints `m_msg`, notifies in the editor, and the current function returns.
+ * Same as `ERR_FAIL_NULL_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_NULL_EDMSG(m_param, m_msg)                                                                          \
 	if (unlikely(m_param == nullptr)) {                                                                              \
@@ -382,8 +378,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures a pointer `m_param` is not null.
- * If it is null, prints `m_msg`, notifies in the editor, and the current function returns `m_retval`.
+ * Same as `ERR_FAIL_NULL_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg)                                                              \
 	if (unlikely(m_param == nullptr)) {                                                                              \
@@ -423,11 +418,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures `m_cond` is false.
- * If `m_cond` is true, prints `m_msg`, notifies in the editor, and the current function returns.
- *
- * If checking for null use ERR_FAIL_NULL_MSG instead.
- * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
+ * Same as `ERR_FAIL_COND_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_COND_EDMSG(m_cond, m_msg)                                                                          \
 	if (unlikely(m_cond)) {                                                                                         \
@@ -467,11 +458,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures `m_cond` is false.
- * If `m_cond` is true, prints `m_msg`, notifies in the editor, and the current function returns `m_retval`.
- *
- * If checking for null use ERR_FAIL_NULL_V_MSG instead.
- * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
+ * Same as `ERR_FAIL_COND_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_COND_V_EDMSG(m_cond, m_retval, m_msg)                                                                                         \
 	if (unlikely(m_cond)) {                                                                                                                    \
@@ -506,8 +493,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures `m_cond` is false.
- * If `m_cond` is true, prints `m_msg`, notifies in the editor, and the current loop continues.
+ * Same as `ERR_CONTINUE_MSG` but also notifies the editor.
  */
 #define ERR_CONTINUE_EDMSG(m_cond, m_msg)                                                                                       \
 	if (unlikely(m_cond)) {                                                                                                     \
@@ -542,8 +528,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Ensures `m_cond` is false.
- * If `m_cond` is true, prints `m_msg`, notifies in the editor, and the current loop breaks.
+ * Same as `ERR_BREAK_MSG` but also notifies the editor.
  */
 #define ERR_BREAK_EDMSG(m_cond, m_msg)                                                                                        \
 	if (unlikely(m_cond)) {                                                                                                   \
@@ -613,10 +598,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Try using `ERR_FAIL_COND_MSG`.
- * Only use this macro if more complex error detection or recovery is required.
- *
- * Prints `m_msg`, notifies in the editor, and the current function returns.
+ * Same as `ERR_FAIL_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_EDMSG(m_msg)                                                                       \
 	if (true) {                                                                                     \
@@ -653,10 +635,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Try using `ERR_FAIL_COND_V_MSG`.
- * Only use this macro if more complex error detection or recovery is required.
- *
- * Prints `m_msg`, notifies in the editor, and the current function returns `m_retval`.
+ * Same as `ERR_FAIL_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_V_EDMSG(m_retval, m_msg)                                                                                      \
 	if (true) {                                                                                                                \
@@ -666,7 +645,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Try using `ERR_FAIL_COND_MSG`, `ERR_FAIL_COND_V_MSG`, `ERR_CONTINUE_MSG` or ERR_BREAK_MSG.
+ * Try using `ERR_FAIL_COND_MSG`, `ERR_FAIL_COND_V_MSG`, `ERR_CONTINUE_MSG` or `ERR_BREAK_MSG`.
  * Only use this macro at the start of a function that has not been implemented yet, or
  * if more complex error detection or recovery is required.
  *
@@ -676,14 +655,10 @@ void _err_flush_stdout();
 	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg)
 
 /**
- * Try using `ERR_FAIL_COND_MSG`, `ERR_FAIL_COND_V_MSG`, `ERR_CONTINUE_MSG` or ERR_BREAK_MSG.
- * Only use this macro at the start of a function that has not been implemented yet, or
- * if more complex error detection or recovery is required.
- *
- * Prints `m_msg` and notifies the editor.
+ * Same as `ERR_PRINT` but also notifies the editor.
  */
 #define ERR_PRINT_ED(m_msg) \
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, )
+	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true)
 
 /**
  * Prints `m_msg` once during the application lifetime.
@@ -699,7 +674,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Prints `m_msg` and notifies the editor once during the application lifetime.
+ * Same as `ERR_PRINT_ONCE` but also notifies the editor.
  */
 #define ERR_PRINT_ONCE_ED(m_msg)                                             \
 	if (true) {                                                              \
@@ -722,9 +697,7 @@ void _err_flush_stdout();
 	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING)
 
 /**
- * Prints `m_msg` and notifies the editor.
- *
- * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
+ * Same as `WARN_PRINT` but also notifies the editor.
  */
 #define WARN_PRINT_ED(m_msg) \
 	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING)
@@ -745,9 +718,7 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * Prints `m_msg` and notifies the editor once during the application lifetime.
- *
- * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
+ * Same as `WARN_PRINT_ONCE` but also notifies the editor.
  */
 #define WARN_PRINT_ONCE_ED(m_msg)                                                                 \
 	if (true) {                                                                                   \

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -87,7 +87,7 @@ void Logger::log_error(const char *p_function, const char *p_file, int p_line, c
 	} else {
 		logf_error("USER %s: %s\n", err_type, err_details);
 	}
-	logf_error("   at: %s (%s:%i) - %s\n", p_function, p_file, p_line, p_code);
+	logf_error("   at: %s (%s:%i)\n", p_function, p_file, p_line);
 }
 
 void Logger::logf(const char *p_format, ...) {


### PR DESCRIPTION
Also fix broken `ERR_PRINT_ED` macro and simplify comments. For the record these macros aren't used yet, they're intended to be used where needed to surface messages in the toaster when useful to end users, but we haven't done that codebase review yet.

Should fix this kind of wrong error display:
```
USER WARNING: GENERAL - Message Id Number: 0 | Message Id Name: Loader Message
	loaderAddLayerProperties: 'layers' tag not supported until file version 1.0.1, but C:\ProgramData\GOG.com\Galaxy\redists\overlay\injected\galaxy_overlay_vklayer_x64.json is reporting version "1
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_INSTANCE, Handle 2295500668752
   at: _debug_messenger_callback (drivers/vulkan/vulkan_context.cpp:168) - GENERAL - Message Id Number: 0 | Message Id Name: Loader Message
	loaderAddLayerProperties: 'layers' tag not supported until file version 1.0.1, but C:\ProgramData\GOG.com\Galaxy\redists\overlay\injected\galaxy_overlay_vklayer_x64.json is reporting version "1
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_INSTANCE, Handle 2295500668752
```

Would now be:
```
USER WARNING: GENERAL - Message Id Number: 0 | Message Id Name: Loader Message
	loaderAddLayerProperties: 'layers' tag not supported until file version 1.0.1, but C:\ProgramData\GOG.com\Galaxy\redists\overlay\injected\galaxy_overlay_vklayer_x64.json is reporting version "1
	Objects - 1
		Object[0] - VK_OBJECT_TYPE_INSTANCE, Handle 2295500668752
   at: _debug_messenger_callback (drivers/vulkan/vulkan_context.cpp:168)
```

The problems comes from the fact that `ERR_PRINT` uses the user-provided message as `p_error` (the handled as `p_code` in loggers), unlike all other macros which have a predefined `p_error` message, and optionally a user-provided message as `p_message`.