### PR TITLE
Disconnect TileSet from source editor if no sources

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2043,6 +2043,13 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_unscaled_draw() {
 }
 
 void TileSetAtlasSourceEditor::_tile_set_changed() {
+	if (tile_set->get_source_count() == 0) {
+		// No sources, so nothing to do here anymore.
+		tile_set->disconnect("changed", callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
+		tile_set = Ref<TileSet>();
+		return;
+	}
+
 	tile_set_changed_needs_update = true;
 }
 


### PR DESCRIPTION
Fixes #60887
Also fixes the errors in https://github.com/godotengine/godot/issues/60887#issuecomment-1120445405

Normally the source editor will edit the tileset when a first source is added. The problem is that it never stops processing the tileset, even if there are no sources anymore. It just keeps happily accessing all the properties it shouldn't be touching. I don't know exactly why the crash was happening, because it was triggered only in specific circumstances, but the errors signalled that something is wrong, even if it appeared to be working.

btw I noticed the source editor does some funky stuff with the sources. TileSetAtlasSource is a Resource but is passed using a pointer and never validated. It's also not added as "do reference" in UndoRedo actions. It's surprisingly stable given all that 🤔