### PR TITLE
Undo #51969, generate_mipmaps runs on caller thread.

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -197,7 +197,6 @@
 			<param index="0" name="renormalize" type="bool" default="false" />
 			<description>
 				Generates mipmaps for the image. Mipmaps are precalculated lower-resolution copies of the image that are automatically used if the image needs to be scaled down when rendered. They help improve image quality and performance when rendering. This method returns an error if the image is compressed, in a custom format, or if the image's width/height is [code]0[/code].
-				[b]Note:[/b] Mipmap generation is done on the CPU, is single-threaded and is [i]always[/i] done on the main thread. This means generating mipmaps will result in noticeable stuttering during gameplay, even if [method generate_mipmaps] is called from a [Thread].
 			</description>
 		</method>
 		<method name="get_data" qualifiers="const">


### PR DESCRIPTION
This was added following https://github.com/godotengine/godot/issues/51966
However as said in comments following https://github.com/godotengine/godot/issues/51966#issuecomment-905915253, the issue is elsewhere. `Image.generate_mipmaps` isnt subject to any exotic threading behavior. It just runs on CPU in the thread that called it, and only updates data that resides in RAM. It isn't forced to run on the main thread, and there is no reason for it.
https://github.com/godotengine/godot/blob/0056acf46fc88757cae9d9f6fe9805f0eec1cd09/core/io/image.cpp#L1723

*Bugsquad edit: This reverts https://github.com/godotengine/godot/pull/51969.*