### PR TITLE
Properly assign texture RID when creating ImageTexture3D

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1209,6 +1209,8 @@ Error ImageTexture3D::create(Image::Format p_format, int p_width, int p_height, 
 
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_replace(texture, tex);
+	} else {
+		texture = tex;
 	}
 
 	return OK;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/66881

The issue here is that the ``texture`` RID was only lazy initalized when ``get_rid()`` is called. So this section of code creates a new RID, assigns it to ``tex`` and then does nothing with it unless ``texture`` is already initialized. The solution is to assign ``tex`` to ``texture`` when ``texture`` is null. This is exactly how it works in every other texture class. 