### PR TITLE
Improve `load_source_code`/`load_text` for `Script`/`TextFile`

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -138,6 +138,7 @@ public:
 	virtual String get_source_code() const = 0;
 	virtual void set_source_code(const String &p_code) = 0;
 	virtual Error reload(bool p_keep_state = false) = 0;
+	virtual Error load_source_code(const String &p_path) = 0;
 
 #ifdef TOOLS_ENABLED
 	virtual Vector<DocData::ClassDoc> get_documentation() const = 0;

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -49,6 +49,7 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_source_code);
 
 	GDVIRTUAL_BIND(_set_source_code, "code");
+	GDVIRTUAL_BIND(_load_source_code, "path");
 	GDVIRTUAL_BIND(_reload, "keep_state");
 
 	GDVIRTUAL_BIND(_get_documentation);

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -75,6 +75,7 @@ public:
 	EXBIND0RC(String, get_source_code)
 	EXBIND1(set_source_code, const String &)
 	EXBIND1R(Error, reload, bool)
+	EXBIND1R(Error, load_source_code, const String &)
 
 	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_documentation)
 #ifdef TOOLS_ENABLED

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -151,6 +151,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_load_source_code" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="_placeholder_erased" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="placeholder" type="void*" />

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2186,10 +2186,6 @@ Ref<TextFile> ScriptEditor::_load_text_file(const String &p_path, Error *r_error
 	text_file->set_file_path(local_path);
 	text_file->set_path(local_path, true);
 
-	if (ResourceLoader::get_timestamp_on_load()) {
-		text_file->set_last_modified_time(FileAccess::get_modified_time(path));
-	}
-
 	if (r_error) {
 		*r_error = OK;
 	}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -256,7 +256,7 @@ public:
 
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	String get_script_path() const;
-	Error load_source_code(const String &p_path);
+	virtual Error load_source_code(const String &p_path) override;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2755,6 +2755,7 @@ Error CSharpScript::load_source_code(const String &p_path) {
 
 #ifdef TOOLS_ENABLED
 	source_changed_cache = true;
+	set_last_modified_time(FileAccess::get_modified_time(p_path));
 #endif
 
 	return OK;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -207,7 +207,7 @@ public:
 	}
 #endif
 
-	Error load_source_code(const String &p_path);
+	virtual Error load_source_code(const String &p_path) override;
 
 	CSharpScript();
 	~CSharpScript();

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -68,9 +68,7 @@ Error TextFile::load_text(const String &p_path) {
 	text = s;
 	path = p_path;
 #ifdef TOOLS_ENABLED
-	if (ResourceLoader::get_timestamp_on_load()) {
-		set_last_modified_time(FileAccess::get_modified_time(path));
-	}
+	set_last_modified_time(FileAccess::get_modified_time(path));
 #endif // TOOLS_ENABLED
 	return OK;
 }


### PR DESCRIPTION
Set modification time when successfully loaded.

`load_source_code` has been implemented in `GDScript`/`CSharpScript`. It is important for the reload of tool scripts. Now abstracted in `Script`.

Split from #66658.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
