### PR TITLE
[TextServer GDExtension] Update build scripts and `.gdextension` files to use new target names and arch suffixes.

### DIFF
--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -68,7 +68,7 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
     env.Append(CPPDEFINES=["MODULE_MSDFGEN_ENABLED"])
 
     lib = env_msdfgen.Library(
-        f'msdfgen_builtin.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["LIBSUFFIX"]}',
+        f'msdfgen_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_msdfgen_sources,
     )
     env.Append(LIBS=[lib])
@@ -199,7 +199,7 @@ if env["freetype_enabled"]:
     env.Append(CPPDEFINES=["MODULE_FREETYPE_ENABLED"])
 
     lib = env_freetype.Library(
-        f'freetype_builtin.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["LIBSUFFIX"]}',
+        f'freetype_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_freetype_sources,
     )
     env.Append(LIBS=[lib])
@@ -321,7 +321,7 @@ if env["freetype_enabled"]:
 env.Append(CPPPATH=["../../../thirdparty/harfbuzz/src"])
 
 lib = env_harfbuzz.Library(
-    f'harfbuzz_builtin.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["LIBSUFFIX"]}',
+    f'harfbuzz_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
     thirdparty_harfbuzz_sources,
 )
 env.Prepend(LIBS=[lib])
@@ -381,7 +381,7 @@ if env["graphite_enabled"] and env["freetype_enabled"]:
     )
 
     lib = env_graphite.Library(
-        f'graphite_builtin.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["LIBSUFFIX"]}',
+        f'graphite_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_graphite_sources,
     )
     env.Append(LIBS=[lib])
@@ -640,9 +640,7 @@ env.Append(CPPPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/ic
 if env["platform"] == "windows":
     env.Append(LIBS=["advapi32"])
 
-lib = env_icu.Library(
-    f'icu_builtin.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["LIBSUFFIX"]}', thirdparty_icu_sources
-)
+lib = env_icu.Library(f'icu_builtin{env["suffix"]}{env["LIBSUFFIX"]}', thirdparty_icu_sources)
 env.Append(LIBS=[lib])
 
 env.Append(CPPDEFINES=["GDEXTENSION"])
@@ -662,7 +660,7 @@ if env["platform"] == "macos":
     )
 else:
     library = env.SharedLibrary(
-        f'./bin/libtextserver_advanced.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["SHLIBSUFFIX"]}',
+        f'./bin/libtextserver_advanced{env["suffix"]}{env["SHLIBSUFFIX"]}',
         source=sources,
     )
 

--- a/modules/text_server_adv/gdextension_build/text_server_adv.gdextension
+++ b/modules/text_server_adv/gdextension_build/text_server_adv.gdextension
@@ -4,9 +4,21 @@ entry_symbol = "textserver_advanced_init"
 
 [libraries]
 
-linux.64.debug = "bin/libtextserver_advanced.linux.debug.64.so"
-linux.64.release = "bin/libtextserver_advanced.linux.release.64.so"
-windows.64.debug = "bin/libtextserver_advanced.windows.debug.64.dll"
-windows.64.release = "bin/libtextserver_advanced.windows.release.64.dll"
-macos.debug = "bin/libtextserver_advanced.macos.debug.framework"
-macos.release = "bin/libtextserver_advanced.macos.release.framework"
+linux.x86_64.debug = "bin/libtextserver_advanced.linux.template_debug.x86_64.so"
+linux.x86_64.release = "bin/libtextserver_advanced.linux.template_release.x86_64.so"
+linux.x86_32.debug = "bin/libtextserver_advanced.linux.template_debug.x86_32.so"
+linux.x86_32.release = "bin/libtextserver_advanced.linux.template_release.x86_32.so"
+linux.arm64.debug = "bin/libtextserver_advanced.linux.template_debug.arm64.so"
+linux.arm64.release = "bin/libtextserver_advanced.linux.template_release.arm64.so"
+linux.rv64.debug = "bin/libtextserver_advanced.linux.template_debug.rv64.so"
+linux.rv64.release = "bin/libtextserver_advanced.linux.template_release.rv64.so"
+
+windows.x86_64.debug = "bin/libtextserver_advanced.windows.template_debug.x86_64.dll"
+windows.x86_64.release = "bin/libtextserver_advanced.windows.template_release.x86_64.dll"
+windows.x86_32.debug = "bin/libtextserver_advanced.windows.template_debug.x86_32.dll"
+windows.x86_32.release = "bin/libtextserver_advanced.windows.template_release.x86_32.dll"
+windows.arm64.debug = "bin/libtextserver_advanced.windows.template_debug.arm64.dll"
+windows.arm64.release = "bin/libtextserver_advanced.windows.template_release.arm64.dll"
+
+macos.debug = "bin/libtextserver_advanced.macos.template_debug.framework"
+macos.release = "bin/libtextserver_advanced.macos.template_release.framework"

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -63,7 +63,7 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
     env.Append(CPPDEFINES=["MODULE_MSDFGEN_ENABLED"])
 
     lib = env_msdfgen.Library(
-        f'msdfgen_builtin.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["LIBSUFFIX"]}',
+        f'msdfgen_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_msdfgen_sources,
     )
     env.Append(LIBS=[lib])
@@ -194,7 +194,7 @@ if env["freetype_enabled"]:
     env.Append(CPPDEFINES=["MODULE_FREETYPE_ENABLED"])
 
     lib = env_freetype.Library(
-        f'freetype_builtin.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["LIBSUFFIX"]}',
+        f'freetype_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
         thirdparty_freetype_sources,
     )
     env.Append(LIBS=[lib])
@@ -217,7 +217,7 @@ if env["platform"] == "macos":
     )
 else:
     library = env.SharedLibrary(
-        f'./bin/libtextserver_fallback.{env["platform"]}.{env["target"]}.{env["arch_suffix"]}{env["SHLIBSUFFIX"]}',
+        f'./bin/libtextserver_fallback{env["suffix"]}{env["SHLIBSUFFIX"]}',
         source=sources,
     )
 

--- a/modules/text_server_fb/gdextension_build/text_server_fb.gdextension
+++ b/modules/text_server_fb/gdextension_build/text_server_fb.gdextension
@@ -4,9 +4,21 @@ entry_symbol = "textserver_fallback_init"
 
 [libraries]
 
-linux.64.debug = "bin/libtextserver_fallback.linux.debug.64.so"
-linux.64.release = "bin/libtextserver_fallback.linux.release.64.so"
-windows.64.debug = "bin/libtextserver_fallback.windows.debug.64.dll"
-windows.64.release = "bin/libtextserver_fallback.windows.release.64.dll"
-macos.debug = "bin/libtextserver_fallback.macos.debug.framework"
-macos.release = "bin/libtextserver_fallback.macos.release.framework"
+linux.x86_64.debug = "bin/libtextserver_fallback.linux.template_debug.x86_64.so"
+linux.x86_64.release = "bin/libtextserver_fallback.linux.template_release.x86_64.so"
+linux.x86_32.debug = "bin/libtextserver_fallback.linux.template_debug.x86_32.so"
+linux.x86_32.release = "bin/libtextserver_fallback.linux.template_release.x86_32.so"
+linux.arm64.debug = "bin/libtextserver_fallback.linux.template_debug.arm64.so"
+linux.arm64.release = "bin/libtextserver_fallback.linux.template_release.arm64.so"
+linux.rv64.debug = "bin/libtextserver_fallback.linux.template_debug.rv64.so"
+linux.rv64.release = "bin/libtextserver_fallback.linux.template_release.rv64.so"
+
+windows.x86_64.debug = "bin/libtextserver_fallback.windows.template_debug.x86_64.dll"
+windows.x86_64.release = "bin/libtextserver_fallback.windows.template_release.x86_64.dll"
+windows.x86_32.debug = "bin/libtextserver_fallback.windows.template_debug.x86_32.dll"
+windows.x86_32.release = "bin/libtextserver_fallback.windows.template_release.x86_32.dll"
+windows.arm64.debug = "bin/libtextserver_fallback.windows.template_debug.arm64.dll"
+windows.arm64.release = "bin/libtextserver_fallback.windows.template_release.arm64.dll"
+
+macos.debug = "bin/libtextserver_fallback.macos.template_debug.framework"
+macos.release = "bin/libtextserver_fallback.macos.template_release.framework"


### PR DESCRIPTION
Fixes TextServer GDExtension build after the recent build system changes.