### PR TITLE
Make sure atlas rect for directional lights is calculated using floats

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2174,11 +2174,11 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 			}
 		}
 
-		int directional_shadow_size = light_storage->directional_shadow_get_size();
-		atlas_rect.position /= directional_shadow_size;
-		atlas_rect.size /= directional_shadow_size;
-
-		light_storage->light_instance_set_directional_shadow_atlas_rect(p_light, p_pass, atlas_rect);
+		float directional_shadow_size = light_storage->directional_shadow_get_size();
+		Rect2 atlas_rect_norm = atlas_rect;
+		atlas_rect_norm.position /= directional_shadow_size;
+		atlas_rect_norm.size /= directional_shadow_size;
+		light_storage->light_instance_set_directional_shadow_atlas_rect(p_light, p_pass, atlas_rect_norm);
 
 		zfar = RSG::light_storage->light_get_param(base, RS::LIGHT_PARAM_RANGE);
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1128,11 +1128,11 @@ void RenderForwardMobile::_render_shadow_pass(RID p_light, RID p_shadow_atlas, i
 			}
 		}
 
-		int directional_shadow_size = light_storage->directional_shadow_get_size();
-		atlas_rect.position /= directional_shadow_size;
-		atlas_rect.size /= directional_shadow_size;
-
-		light_storage->light_instance_set_directional_shadow_atlas_rect(p_light, p_pass, atlas_rect);
+		float directional_shadow_size = light_storage->directional_shadow_get_size();
+		Rect2 atlas_rect_norm = atlas_rect;
+		atlas_rect_norm.position /= directional_shadow_size;
+		atlas_rect_norm.size /= directional_shadow_size;
+		light_storage->light_instance_set_directional_shadow_atlas_rect(p_light, p_pass, atlas_rect_norm);
 
 		zfar = RSG::light_storage->light_get_param(base, RS::LIGHT_PARAM_RANGE);
 


### PR DESCRIPTION
In converting the shadow pass code so it uses light storage as we do not have direct access to `li->shadow_transform[index].atlas_rect` anymore, I had overlooked that while `atlas_rect` is constructed using `Rect2i`, it's stored in our structure as `Rect2`.
The final calculation done on this rect that normalizes it thus set it all to zero. Needed to explicitly convert it to `Rect2` first and than perform the division.

Fixes #66918
 