### PR TITLE
Bind PhysicsDirectBodyState3D::get_inverse_inertia_tensor

### DIFF
--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -226,6 +226,9 @@
 		<member name="inverse_inertia" type="Vector3" setter="" getter="get_inverse_inertia">
 			The inverse of the inertia of the body.
 		</member>
+		<member name="inverse_inertia_tensor" type="Basis" setter="" getter="get_inverse_inertia_tensor">
+			The inverse of the inertia tensor of the body.
+		</member>
 		<member name="inverse_mass" type="float" setter="" getter="get_inverse_mass">
 			The inverse of the mass of the body.
 		</member>

--- a/doc/classes/PhysicsDirectBodyState3DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState3DExtension.xml
@@ -159,6 +159,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_inverse_inertia_tensor" qualifiers="virtual const">
+			<return type="Basis" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_inverse_mass" qualifiers="virtual const">
 			<return type="float" />
 			<description>

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -60,6 +60,7 @@ void PhysicsDirectBodyState3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_inverse_mass);
 	GDVIRTUAL_BIND(_get_inverse_inertia);
+	GDVIRTUAL_BIND(_get_inverse_inertia_tensor);
 
 	GDVIRTUAL_BIND(_set_linear_velocity, "velocity");
 	GDVIRTUAL_BIND(_get_linear_velocity);

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -99,6 +99,7 @@ void PhysicsDirectBodyState3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_inverse_mass"), &PhysicsDirectBodyState3D::get_inverse_mass);
 	ClassDB::bind_method(D_METHOD("get_inverse_inertia"), &PhysicsDirectBodyState3D::get_inverse_inertia);
+	ClassDB::bind_method(D_METHOD("get_inverse_inertia_tensor"), &PhysicsDirectBodyState3D::get_inverse_inertia_tensor);
 
 	ClassDB::bind_method(D_METHOD("set_linear_velocity", "velocity"), &PhysicsDirectBodyState3D::set_linear_velocity);
 	ClassDB::bind_method(D_METHOD("get_linear_velocity"), &PhysicsDirectBodyState3D::get_linear_velocity);
@@ -153,6 +154,7 @@ void PhysicsDirectBodyState3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "total_angular_damp"), "", "get_total_angular_damp");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "total_linear_damp"), "", "get_total_linear_damp");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "inverse_inertia"), "", "get_inverse_inertia");
+	ADD_PROPERTY(PropertyInfo(Variant::BASIS, "inverse_inertia_tensor"), "", "get_inverse_inertia_tensor");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "total_gravity"), "", "get_total_gravity");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "center_of_mass"), "", "get_center_of_mass");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "center_of_mass_local"), "", "get_center_of_mass_local");


### PR DESCRIPTION
Related to #65465 and #65571.

Currently when you try to create a GDExtension that provides a custom physics server (along with a `PhysicsDirectBodyState3DExtension`), you'll get an error saying:
```
servers\extensions\physics_server_3d_extension.h:59 - Required virtual method SomeExtendedDirectBodyState::_get_inverse_inertia_tensor must be overridden before calling.
```
There is however no such method to implement in `PhysicsDirectBodyState3DExtension`. This seems to be due to some bindings missing for `PhysicsDirectBodyState3D` and `PhysicsDirectBodyState3DExtension`.

This PR addresses that problem and will allow you to actually override/implement `PhysicsDirectBodyState3DExtension::_get_inverse_inertia_tensor` once the [godot-cpp](https://github.com/godotengine/godot-cpp) headers have been updated.