### PR TITLE
[Editor] Better expose editor debugger plugins, use it in the multiplayer module.

### DIFF
--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -50,10 +50,8 @@ public:
 private:
 	typedef DebuggerMarshalls::OutputError ErrorMessage;
 
-	class MultiplayerProfiler;
 	class PerformanceProfiler;
 
-	Ref<MultiplayerProfiler> multiplayer_profiler;
 	Ref<PerformanceProfiler> performance_profiler;
 
 	Ref<RemoteDebuggerPeer> peer;

--- a/doc/classes/EditorDebuggerPlugin.xml
+++ b/doc/classes/EditorDebuggerPlugin.xml
@@ -1,88 +1,88 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="EditorDebuggerPlugin" inherits="Control" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="EditorDebuggerPlugin" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A base class to implement debugger plugins.
 	</brief_description>
 	<description>
 		[EditorDebuggerPlugin] provides functions related to the editor side of the debugger.
-		You don't need to instantiate this class; that is automatically handled by the debugger. [Control] nodes can be added as child nodes to provide a GUI for the plugin.
-		Do not free or reparent this node, otherwise it becomes unusable.
-		To use [EditorDebuggerPlugin], register it using the [method EditorPlugin.add_debugger_plugin] method first.
+		To interact with the debugger, an instance of this class must be added to the editor via [method EditorPlugin.add_debugger_plugin].
+		Once added, the [method _setup_session] callback will be called for every [EditorDebuggerSession] available to the plugin, and when new ones are created (the sessions may be inactive during this stage).
+		You can retrieve the available [EditorDebuggerSession]s via [method get_sessions] or get a specific one via [method get_session].
+		[codeblocks]
+		[gdscript]
+		@tool
+		extends EditorPlugin
+
+		class ExampleEditorDebugger extends EditorDebuggerPlugin:
+
+		    func _has_capture(prefix):
+		        # Return true if you wish to handle message with this prefix.
+		        return prefix == "my_plugin"
+
+		    func _capture(message, data, session_id):
+		        if message == "my_plugin:ping":
+		            get_session(session_id).send_message("my_plugin:echo", data)
+
+		    func _setup_session(session_id):
+		        # Add a new tab in the debugger session UI containing a label.
+		        var label = Label.new()
+		        label.name = "Example plugin"
+		        label.text = "Example plugin"
+		        var session = get_session(session_id)
+		        # Listens to the session started and stopped signals.
+		        session.started.connect(func (): print("Session started"))
+		        session.stopped.connect(func (): print("Session stopped"))
+		        session.add_session_tab(label)
+
+		var debugger = ExampleEditorDebugger.new()
+
+		func _enter_tree():
+		    add_debugger_plugin(debugger)
+
+		func _exit_tree():
+		    remove_debugger_plugin(debugger)
+		[/gdscript]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="has_capture">
+		<method name="_capture" qualifiers="virtual">
 			<return type="bool" />
-			<param index="0" name="name" type="StringName" />
-			<description>
-				Returns [code]true[/code] if a message capture with given name is present otherwise [code]false[/code].
-			</description>
-		</method>
-		<method name="is_breaked">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the game is in break state otherwise [code]false[/code].
-			</description>
-		</method>
-		<method name="is_debuggable">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the game can be debugged otherwise [code]false[/code].
-			</description>
-		</method>
-		<method name="is_session_active">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if there is an instance of the game running with the attached debugger otherwise [code]false[/code].
-			</description>
-		</method>
-		<method name="register_message_capture">
-			<return type="void" />
-			<param index="0" name="name" type="StringName" />
-			<param index="1" name="callable" type="Callable" />
-			<description>
-				Registers a message capture with given [param name]. If [param name] is "my_message" then messages starting with "my_message:" will be called with the given callable.
-				Callable must accept a message string and a data array as argument. If the message and data are valid then callable must return [code]true[/code] otherwise [code]false[/code].
-			</description>
-		</method>
-		<method name="send_message">
-			<return type="void" />
 			<param index="0" name="message" type="String" />
 			<param index="1" name="data" type="Array" />
+			<param index="2" name="session_id" type="int" />
 			<description>
-				Sends a message with given [param message] and [param data] array.
+				Override this method to process incoming messages. The [param session_id] is the ID of the [EditorDebuggerSession] that received the message (which you can retrieve via [method get_session]).
 			</description>
 		</method>
-		<method name="unregister_message_capture">
-			<return type="void" />
-			<param index="0" name="name" type="StringName" />
+		<method name="_has_capture" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="capture" type="String" />
 			<description>
-				Unregisters the message capture with given name.
+				Override this method to enable receiving messages from the debugger. If [param capture] is "my_message" then messages starting with "my_message:" will be passes to the [method _capture] method.
+			</description>
+		</method>
+		<method name="_setup_session" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="session_id" type="int" />
+			<description>
+				Override this method to be notified whenever a new [EditorDebuggerSession] is created (the session may be inactive during this stage).
+			</description>
+		</method>
+		<method name="get_session">
+			<return type="EditorDebuggerSession" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns the [EditorDebuggerSession] with the given [param id].
+			</description>
+		</method>
+		<method name="get_sessions">
+			<return type="Array" />
+			<description>
+				Returns an array of [EditorDebuggerSession] currently available to this debugger plugin.
+				Note: Not sessions in the array may be inactive, check their state via [method EditorDebuggerSession.is_active]
 			</description>
 		</method>
 	</methods>
-	<signals>
-		<signal name="breaked">
-			<param index="0" name="can_debug" type="bool" />
-			<description>
-				Emitted when the game enters a break state.
-			</description>
-		</signal>
-		<signal name="continued">
-			<description>
-				Emitted when the game exists a break state.
-			</description>
-		</signal>
-		<signal name="started">
-			<description>
-				Emitted when the debugging starts.
-			</description>
-		</signal>
-		<signal name="stopped">
-			<description>
-				Emitted when the debugging stops.
-			</description>
-		</signal>
-	</signals>
 </class>

--- a/doc/classes/EditorDebuggerSession.xml
+++ b/doc/classes/EditorDebuggerSession.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorDebuggerSession" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A class to interact with the editor debugger.
+	</brief_description>
+	<description>
+		This class cannot be directly instantiated and must be retrieved via a [EditorDebuggerPlugin].
+		You can add tabs to the session UI via [method add_session_tab], send messages via [method send_message], and toggle [EngineProfiler]s via [method toggle_profiler].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_session_tab">
+			<return type="void" />
+			<param index="0" name="control" type="Control" />
+			<description>
+				Adds the given [param control] to the debug session UI in the debugger bottom panel.
+			</description>
+		</method>
+		<method name="is_active">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the debug session is currently attached to a remote instance.
+			</description>
+		</method>
+		<method name="is_breaked">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the attached remote instance is currently in the debug loop.
+			</description>
+		</method>
+		<method name="is_debuggable">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the attached remote instance can be debugged.
+			</description>
+		</method>
+		<method name="remove_session_tab">
+			<return type="void" />
+			<param index="0" name="control" type="Control" />
+			<description>
+				Removes the given [param control] from the debug session UI in the debugger bottom panel.
+			</description>
+		</method>
+		<method name="send_message">
+			<return type="void" />
+			<param index="0" name="message" type="String" />
+			<param index="1" name="data" type="Array" default="[]" />
+			<description>
+				Sends the given [param message] to the attached remote instance, optionally passing additionally [param data]. See [EngineDebugger] for how to retrieve those messages.
+			</description>
+		</method>
+		<method name="toggle_profiler">
+			<return type="void" />
+			<param index="0" name="profiler" type="String" />
+			<param index="1" name="enable" type="bool" />
+			<param index="2" name="data" type="Array" default="[]" />
+			<description>
+				Toggle the given [param profiler] on the attached remote instance, optionally passing additionally [param data]. See [EngineProfiler] for more details.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="breaked">
+			<param index="0" name="can_debug" type="bool" />
+			<description>
+				Emitted when the attached remote instance enters a break state. If [param can_debug] is [code]true[/code], the remote instance will enter the debug loop.
+			</description>
+		</signal>
+		<signal name="continued">
+			<description>
+				Emitted when the attached remote instance exits a break state.
+			</description>
+		</signal>
+		<signal name="started">
+			<description>
+				Emitted when a remote instance is attached to this session (i.e. the session becomes active).
+			</description>
+		</signal>
+		<signal name="stopped">
+			<description>
+				Emitted when a remote instance is detached from this session (i.e. the session becomes inactive).
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -415,7 +415,7 @@
 		</method>
 		<method name="add_debugger_plugin">
 			<return type="void" />
-			<param index="0" name="script" type="Script" />
+			<param index="0" name="script" type="EditorDebuggerPlugin" />
 			<description>
 				Adds a [Script] as debugger plugin to the Debugger. The script must extend [EditorDebuggerPlugin].
 			</description>
@@ -599,7 +599,7 @@
 		</method>
 		<method name="remove_debugger_plugin">
 			<return type="void" />
-			<param index="0" name="script" type="Script" />
+			<param index="0" name="script" type="EditorDebuggerPlugin" />
 			<description>
 				Removes the debugger plugin with given script from the Debugger.
 			</description>

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -36,6 +36,7 @@
 
 class Button;
 class DebugAdapterParser;
+class EditorDebuggerPlugin;
 class EditorDebuggerTree;
 class EditorDebuggerRemoteObject;
 class MenuButton;
@@ -113,7 +114,7 @@ private:
 	CameraOverride camera_override = OVERRIDE_NONE;
 	HashMap<Breakpoint, bool, Breakpoint> breakpoints;
 
-	HashSet<Ref<Script>> debugger_plugins;
+	HashSet<Ref<EditorDebuggerPlugin>> debugger_plugins;
 
 	ScriptEditorDebugger *_add_debugger();
 	EditorDebuggerRemoteObject *get_inspected_remote_object();
@@ -205,8 +206,9 @@ public:
 	Error start(const String &p_uri = "tcp://");
 	void stop();
 
-	void add_debugger_plugin(const Ref<Script> &p_script);
-	void remove_debugger_plugin(const Ref<Script> &p_script);
+	bool plugins_capture(ScriptEditorDebugger *p_debugger, const String &p_message, const Array &p_data);
+	void add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
+	void remove_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
 };
 
 #endif // EDITOR_DEBUGGER_NODE_H

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -163,10 +163,6 @@ private:
 
 	EditorDebuggerNode::CameraOverride camera_override;
 
-	HashMap<Ref<Script>, EditorDebuggerPlugin *> debugger_plugins;
-
-	HashMap<StringName, Callable> captures;
-
 	void _stack_dump_frame_selected();
 
 	void _file_selected(const String &p_file);
@@ -286,14 +282,11 @@ public:
 
 	virtual Size2 get_minimum_size() const override;
 
-	void add_debugger_plugin(const Ref<Script> &p_script);
-	void remove_debugger_plugin(const Ref<Script> &p_script);
+	void add_debugger_tab(Control *p_control);
+	void remove_debugger_tab(Control *p_control);
 
 	void send_message(const String &p_message, const Array &p_args);
-
-	void register_message_capture(const StringName &p_name, const Callable &p_callable);
-	void unregister_message_capture(const StringName &p_name);
-	bool has_capture(const StringName &p_name);
+	void toggle_profiler(const String &p_profiler, bool p_enable, const Array &p_data);
 
 	ScriptEditorDebugger();
 	~ScriptEditorDebugger();

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -50,7 +50,6 @@ class ItemList;
 class EditorProfiler;
 class EditorFileDialog;
 class EditorVisualProfiler;
-class EditorNetworkProfiler;
 class EditorPerformanceProfiler;
 class SceneDebuggerTree;
 class EditorDebuggerPlugin;
@@ -72,7 +71,6 @@ private:
 	};
 
 	enum ProfilerType {
-		PROFILER_NETWORK,
 		PROFILER_VISUAL,
 		PROFILER_SCRIPTS_SERVERS
 	};
@@ -151,7 +149,6 @@ private:
 
 	EditorProfiler *profiler = nullptr;
 	EditorVisualProfiler *visual_profiler = nullptr;
-	EditorNetworkProfiler *network_profiler = nullptr;
 	EditorPerformanceProfiler *performance_profiler = nullptr;
 
 	OS::ProcessID remote_pid = 0;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4174,6 +4174,7 @@ void EditorNode::register_editor_types() {
 	GDREGISTER_CLASS(EditorScenePostImport);
 	GDREGISTER_CLASS(EditorCommandPalette);
 	GDREGISTER_CLASS(EditorDebuggerPlugin);
+	GDREGISTER_ABSTRACT_CLASS(EditorDebuggerSession);
 }
 
 void EditorNode::unregister_editor_types() {

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -43,6 +43,7 @@
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_scene.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
+#include "editor/plugins/editor_debugger_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/project_settings_editor.h"
@@ -841,12 +842,12 @@ ScriptCreateDialog *EditorPlugin::get_script_create_dialog() {
 	return SceneTreeDock::get_singleton()->get_script_create_dialog();
 }
 
-void EditorPlugin::add_debugger_plugin(const Ref<Script> &p_script) {
-	EditorDebuggerNode::get_singleton()->add_debugger_plugin(p_script);
+void EditorPlugin::add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin) {
+	EditorDebuggerNode::get_singleton()->add_debugger_plugin(p_plugin);
 }
 
-void EditorPlugin::remove_debugger_plugin(const Ref<Script> &p_script) {
-	EditorDebuggerNode::get_singleton()->remove_debugger_plugin(p_script);
+void EditorPlugin::remove_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin) {
+	EditorDebuggerNode::get_singleton()->remove_debugger_plugin(p_plugin);
 }
 
 void EditorPlugin::_editor_project_settings_changed() {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -39,6 +39,7 @@ class Node3D;
 class Button;
 class PopupMenu;
 class EditorCommandPalette;
+class EditorDebuggerPlugin;
 class EditorExport;
 class EditorExportPlugin;
 class EditorFileSystem;
@@ -302,8 +303,8 @@ public:
 	void add_autoload_singleton(const String &p_name, const String &p_path);
 	void remove_autoload_singleton(const String &p_name);
 
-	void add_debugger_plugin(const Ref<Script> &p_script);
-	void remove_debugger_plugin(const Ref<Script> &p_script);
+	void add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
+	void remove_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
 
 	void enable_plugin();
 	void disable_plugin();

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -59,7 +59,7 @@ void EditorNetworkProfiler::_update_frame() {
 
 	TreeItem *root = counters_display->create_item();
 
-	for (const KeyValue<ObjectID, SceneDebugger::RPCNodeInfo> &E : nodes_data) {
+	for (const KeyValue<ObjectID, RPCNodeInfo> &E : nodes_data) {
 		TreeItem *node = counters_display->create_item(root);
 
 		for (int j = 0; j < counters_display->get_columns(); ++j) {
@@ -92,7 +92,7 @@ void EditorNetworkProfiler::_clear_pressed() {
 	}
 }
 
-void EditorNetworkProfiler::add_node_frame_data(const SceneDebugger::RPCNodeInfo p_frame) {
+void EditorNetworkProfiler::add_node_frame_data(const RPCNodeInfo p_frame) {
 	if (!nodes_data.has(p_frame.node)) {
 		nodes_data.insert(p_frame.node, p_frame);
 	} else {

--- a/modules/multiplayer/editor/editor_network_profiler.h
+++ b/modules/multiplayer/editor/editor_network_profiler.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  register_types.cpp                                                   */
+/*  editor_network_profiler.h                                            */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,36 +28,49 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
+#ifndef EDITOR_NETWORK_PROFILER_H
+#define EDITOR_NETWORK_PROFILER_H
 
-#include "multiplayer_spawner.h"
-#include "multiplayer_synchronizer.h"
-#include "scene_multiplayer.h"
-#include "scene_replication_interface.h"
-#include "scene_rpc_interface.h"
+#include "scene/debugger/scene_debugger.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/label.h"
+#include "scene/gui/split_container.h"
+#include "scene/gui/tree.h"
 
-#include "multiplayer_debugger.h"
+#include "../multiplayer_debugger.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/multiplayer_editor_plugin.h"
-#endif
+class EditorNetworkProfiler : public VBoxContainer {
+	GDCLASS(EditorNetworkProfiler, VBoxContainer)
 
-void initialize_multiplayer_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		GDREGISTER_CLASS(SceneReplicationConfig);
-		GDREGISTER_CLASS(MultiplayerSpawner);
-		GDREGISTER_CLASS(MultiplayerSynchronizer);
-		GDREGISTER_CLASS(SceneMultiplayer);
-		MultiplayerAPI::set_default_interface("SceneMultiplayer");
-		MultiplayerDebugger::initialize();
-	}
-#ifdef TOOLS_ENABLED
-	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-		EditorPlugins::add_by_type<MultiplayerEditorPlugin>();
-	}
-#endif
-}
+private:
+	using RPCNodeInfo = MultiplayerDebugger::RPCNodeInfo;
 
-void uninitialize_multiplayer_module(ModuleInitializationLevel p_level) {
-	MultiplayerDebugger::deinitialize();
-}
+	Button *activate = nullptr;
+	Button *clear_button = nullptr;
+	Tree *counters_display = nullptr;
+	LineEdit *incoming_bandwidth_text = nullptr;
+	LineEdit *outgoing_bandwidth_text = nullptr;
+
+	Timer *frame_delay = nullptr;
+
+	HashMap<ObjectID, RPCNodeInfo> nodes_data;
+
+	void _update_frame();
+
+	void _activate_pressed();
+	void _clear_pressed();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void add_node_frame_data(const RPCNodeInfo p_frame);
+	void set_bandwidth(int p_incoming, int p_outgoing);
+	bool is_profiling();
+
+	EditorNetworkProfiler();
+};
+
+#endif // EDITOR_NETWORK_PROFILER_H

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -1,0 +1,140 @@
+/*************************************************************************/
+/*  multiplayer_editor_plugin.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "multiplayer_editor_plugin.h"
+
+#include "../multiplayer_synchronizer.h"
+#include "editor_network_profiler.h"
+#include "replication_editor.h"
+
+#include "editor/editor_node.h"
+
+bool MultiplayerEditorDebugger::has_capture(const String &p_capture) const {
+	return p_capture == "multiplayer";
+}
+
+bool MultiplayerEditorDebugger::capture(const String &p_message, const Array &p_data, int p_session) {
+	ERR_FAIL_COND_V(!profilers.has(p_session), false);
+	EditorNetworkProfiler *profiler = profilers[p_session];
+	if (p_message == "multiplayer:rpc") {
+		MultiplayerDebugger::RPCFrame frame;
+		frame.deserialize(p_data);
+		for (int i = 0; i < frame.infos.size(); i++) {
+			profiler->add_node_frame_data(frame.infos[i]);
+		}
+		return true;
+
+	} else if (p_message == "multiplayer:bandwidth") {
+		ERR_FAIL_COND_V(p_data.size() < 2, false);
+		profiler->set_bandwidth(p_data[0], p_data[1]);
+		return true;
+	}
+	return false;
+}
+
+void MultiplayerEditorDebugger::_profiler_activate(bool p_enable, int p_session_id) {
+	Ref<EditorDebuggerSession> session = get_session(p_session_id);
+	ERR_FAIL_COND(session.is_null());
+	session->toggle_profiler("multiplayer", p_enable);
+	session->toggle_profiler("rpc", p_enable);
+}
+
+void MultiplayerEditorDebugger::setup_session(int p_session_id) {
+	Ref<EditorDebuggerSession> session = get_session(p_session_id);
+	ERR_FAIL_COND(session.is_null());
+	EditorNetworkProfiler *profiler = memnew(EditorNetworkProfiler);
+	profiler->connect("enable_profiling", callable_mp(this, &MultiplayerEditorDebugger::_profiler_activate).bind(p_session_id));
+	profiler->set_name(TTR("Network Profiler"));
+	session->add_session_tab(profiler);
+	profilers[p_session_id] = profiler;
+}
+
+MultiplayerEditorPlugin::MultiplayerEditorPlugin() {
+	repl_editor = memnew(ReplicationEditor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Replication"), repl_editor);
+	button->hide();
+	repl_editor->get_pin()->connect("pressed", callable_mp(this, &MultiplayerEditorPlugin::_pinned));
+	debugger.instantiate();
+}
+
+MultiplayerEditorPlugin::~MultiplayerEditorPlugin() {
+}
+
+void MultiplayerEditorPlugin::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			get_tree()->connect("node_removed", callable_mp(this, &MultiplayerEditorPlugin::_node_removed));
+			add_debugger_plugin(debugger);
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			remove_debugger_plugin(debugger);
+		}
+	}
+}
+
+void MultiplayerEditorPlugin::_node_removed(Node *p_node) {
+	if (p_node && p_node == repl_editor->get_current()) {
+		repl_editor->edit(nullptr);
+		if (repl_editor->is_visible_in_tree()) {
+			EditorNode::get_singleton()->hide_bottom_panel();
+		}
+		button->hide();
+		repl_editor->get_pin()->set_pressed(false);
+	}
+}
+
+void MultiplayerEditorPlugin::_pinned() {
+	if (!repl_editor->get_pin()->is_pressed()) {
+		if (repl_editor->is_visible_in_tree()) {
+			EditorNode::get_singleton()->hide_bottom_panel();
+		}
+		button->hide();
+	}
+}
+
+void MultiplayerEditorPlugin::edit(Object *p_object) {
+	repl_editor->edit(Object::cast_to<MultiplayerSynchronizer>(p_object));
+}
+
+bool MultiplayerEditorPlugin::handles(Object *p_object) const {
+	return p_object->is_class("MultiplayerSynchronizer");
+}
+
+void MultiplayerEditorPlugin::make_visible(bool p_visible) {
+	if (p_visible) {
+		button->show();
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(repl_editor);
+	} else if (!repl_editor->get_pin()->is_pressed()) {
+		if (repl_editor->is_visible_in_tree()) {
+			EditorNode::get_singleton()->hide_bottom_panel();
+		}
+		button->hide();
+	}
+}

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.h
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  replication_editor_plugin.h                                          */
+/*  multiplayer_editor_plugin.h                                          */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,89 +28,39 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef REPLICATION_EDITOR_PLUGIN_H
-#define REPLICATION_EDITOR_PLUGIN_H
+#ifndef MULTIPLAYER_EDITOR_PLUGIN_H
+#define MULTIPLAYER_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
-#include "modules/multiplayer/scene_replication_config.h"
-#include "scene/gui/box_container.h"
 
-class ConfirmationDialog;
-class MultiplayerSynchronizer;
-class AcceptDialog;
-class LineEdit;
-class Tree;
-class TreeItem;
-class PropertySelector;
-class SceneTreeDialog;
+#include "editor/plugins/editor_debugger_plugin.h"
 
-class ReplicationEditor : public VBoxContainer {
-	GDCLASS(ReplicationEditor, VBoxContainer);
+class EditorNetworkProfiler;
+class MultiplayerEditorDebugger : public EditorDebuggerPlugin {
+	GDCLASS(MultiplayerEditorDebugger, EditorDebuggerPlugin);
 
 private:
-	MultiplayerSynchronizer *current = nullptr;
+	HashMap<int, EditorNetworkProfiler *> profilers;
 
-	AcceptDialog *error_dialog = nullptr;
-	ConfirmationDialog *delete_dialog = nullptr;
-	Button *add_pick_button = nullptr;
-	Button *add_from_path_button = nullptr;
-	LineEdit *np_line_edit = nullptr;
-
-	Label *drop_label = nullptr;
-
-	Ref<SceneReplicationConfig> config;
-	NodePath deleting;
-	Tree *tree = nullptr;
-
-	PropertySelector *prop_selector = nullptr;
-	SceneTreeDialog *pick_node = nullptr;
-	NodePath adding_node_path;
-
-	Button *pin = nullptr;
-
-	Ref<Texture2D> _get_class_icon(const Node *p_node);
-
-	void _add_pressed();
-	void _tree_item_edited();
-	void _tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
-	void _update_checked(const NodePath &p_prop, int p_column, bool p_checked);
-	void _update_config();
-	void _dialog_closed(bool p_confirmed);
-	void _add_property(const NodePath &p_property, bool p_spawn = true, bool p_sync = true);
-
-	void _pick_node_filter_text_changed(const String &p_newtext);
-	void _pick_node_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);
-	void _pick_node_filter_input(const Ref<InputEvent> &p_ie);
-	void _pick_node_selected(NodePath p_path);
-
-	void _pick_new_property();
-	void _pick_node_property_selected(String p_name);
-
-	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
-	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
-
-	void _add_sync_property(String p_path);
-
-protected:
-	static void _bind_methods();
-
-	void _notification(int p_what);
+	void _profiler_activate(bool p_enable, int p_session_id);
 
 public:
-	void edit(MultiplayerSynchronizer *p_object);
-	MultiplayerSynchronizer *get_current() const { return current; }
+	virtual bool has_capture(const String &p_capture) const override;
+	virtual bool capture(const String &p_message, const Array &p_data, int p_index) override;
+	virtual void setup_session(int p_session_id) override;
 
-	Button *get_pin() { return pin; }
-	ReplicationEditor();
-	~ReplicationEditor() {}
+	MultiplayerEditorDebugger() {}
 };
 
-class ReplicationEditorPlugin : public EditorPlugin {
-	GDCLASS(ReplicationEditorPlugin, EditorPlugin);
+class ReplicationEditor;
+
+class MultiplayerEditorPlugin : public EditorPlugin {
+	GDCLASS(MultiplayerEditorPlugin, EditorPlugin);
 
 private:
 	Button *button = nullptr;
 	ReplicationEditor *repl_editor = nullptr;
+	Ref<MultiplayerEditorDebugger> debugger;
 
 	void _node_removed(Node *p_node);
 
@@ -124,8 +74,8 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	ReplicationEditorPlugin();
-	~ReplicationEditorPlugin();
+	MultiplayerEditorPlugin();
+	~MultiplayerEditorPlugin();
 };
 
-#endif // REPLICATION_EDITOR_PLUGIN_H
+#endif // MULTIPLAYER_EDITOR_PLUGIN_H

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -1,0 +1,108 @@
+/*************************************************************************/
+/*  replication_editor.h                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef REPLICATION_EDITOR_H
+#define REPLICATION_EDITOR_H
+
+#include "editor/editor_plugin.h"
+#include "modules/multiplayer/scene_replication_config.h"
+#include "scene/gui/box_container.h"
+
+class ConfirmationDialog;
+class MultiplayerSynchronizer;
+class AcceptDialog;
+class LineEdit;
+class Tree;
+class TreeItem;
+class PropertySelector;
+class SceneTreeDialog;
+
+class ReplicationEditor : public VBoxContainer {
+	GDCLASS(ReplicationEditor, VBoxContainer);
+
+private:
+	MultiplayerSynchronizer *current = nullptr;
+
+	AcceptDialog *error_dialog = nullptr;
+	ConfirmationDialog *delete_dialog = nullptr;
+	Button *add_pick_button = nullptr;
+	Button *add_from_path_button = nullptr;
+	LineEdit *np_line_edit = nullptr;
+
+	Label *drop_label = nullptr;
+
+	Ref<SceneReplicationConfig> config;
+	NodePath deleting;
+	Tree *tree = nullptr;
+
+	PropertySelector *prop_selector = nullptr;
+	SceneTreeDialog *pick_node = nullptr;
+	NodePath adding_node_path;
+
+	Button *pin = nullptr;
+
+	Ref<Texture2D> _get_class_icon(const Node *p_node);
+
+	void _add_pressed();
+	void _tree_item_edited();
+	void _tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
+	void _update_checked(const NodePath &p_prop, int p_column, bool p_checked);
+	void _update_config();
+	void _dialog_closed(bool p_confirmed);
+	void _add_property(const NodePath &p_property, bool p_spawn = true, bool p_sync = true);
+
+	void _pick_node_filter_text_changed(const String &p_newtext);
+	void _pick_node_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);
+	void _pick_node_filter_input(const Ref<InputEvent> &p_ie);
+	void _pick_node_selected(NodePath p_path);
+
+	void _pick_new_property();
+	void _pick_node_property_selected(String p_name);
+
+	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
+	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
+
+	void _add_sync_property(String p_path);
+
+protected:
+	static void _bind_methods();
+
+	void _notification(int p_what);
+
+public:
+	void edit(MultiplayerSynchronizer *p_object);
+	MultiplayerSynchronizer *get_current() const { return current; }
+
+	Button *get_pin() { return pin; }
+	ReplicationEditor();
+	~ReplicationEditor() {}
+};
+
+#endif // REPLICATION_EDITOR_H

--- a/modules/multiplayer/multiplayer_debugger.cpp
+++ b/modules/multiplayer/multiplayer_debugger.cpp
@@ -1,0 +1,194 @@
+/*************************************************************************/
+/*  multiplayer_debugger.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "multiplayer_debugger.h"
+
+#include "core/debugger/engine_debugger.h"
+#include "scene/main/node.h"
+
+List<Ref<EngineProfiler>> multiplayer_profilers;
+
+void MultiplayerDebugger::initialize() {
+	Ref<BandwidthProfiler> bandwidth;
+	bandwidth.instantiate();
+	bandwidth->bind("multiplayer");
+	multiplayer_profilers.push_back(bandwidth);
+
+	Ref<RPCProfiler> rpc_profiler;
+	rpc_profiler.instantiate();
+	rpc_profiler->bind("rpc");
+	multiplayer_profilers.push_back(rpc_profiler);
+}
+
+void MultiplayerDebugger::deinitialize() {
+	multiplayer_profilers.clear();
+}
+
+// BandwidthProfiler
+
+int MultiplayerDebugger::BandwidthProfiler::bandwidth_usage(const Vector<BandwidthFrame> &p_buffer, int p_pointer) {
+	ERR_FAIL_COND_V(p_buffer.size() == 0, 0);
+	int total_bandwidth = 0;
+
+	uint64_t timestamp = OS::get_singleton()->get_ticks_msec();
+	uint64_t final_timestamp = timestamp - 1000;
+
+	int i = (p_pointer + p_buffer.size() - 1) % p_buffer.size();
+
+	while (i != p_pointer && p_buffer[i].packet_size > 0) {
+		if (p_buffer[i].timestamp < final_timestamp) {
+			return total_bandwidth;
+		}
+		total_bandwidth += p_buffer[i].packet_size;
+		i = (i + p_buffer.size() - 1) % p_buffer.size();
+	}
+
+	ERR_FAIL_COND_V_MSG(i == p_pointer, total_bandwidth, "Reached the end of the bandwidth profiler buffer, values might be inaccurate.");
+	return total_bandwidth;
+}
+
+void MultiplayerDebugger::BandwidthProfiler::toggle(bool p_enable, const Array &p_opts) {
+	if (!p_enable) {
+		bandwidth_in.clear();
+		bandwidth_out.clear();
+	} else {
+		bandwidth_in_ptr = 0;
+		bandwidth_in.resize(16384); // ~128kB
+		for (int i = 0; i < bandwidth_in.size(); ++i) {
+			bandwidth_in.write[i].packet_size = -1;
+		}
+		bandwidth_out_ptr = 0;
+		bandwidth_out.resize(16384); // ~128kB
+		for (int i = 0; i < bandwidth_out.size(); ++i) {
+			bandwidth_out.write[i].packet_size = -1;
+		}
+	}
+}
+
+void MultiplayerDebugger::BandwidthProfiler::add(const Array &p_data) {
+	ERR_FAIL_COND(p_data.size() < 3);
+	const String inout = p_data[0];
+	int time = p_data[1];
+	int size = p_data[2];
+	if (inout == "in") {
+		bandwidth_in.write[bandwidth_in_ptr].timestamp = time;
+		bandwidth_in.write[bandwidth_in_ptr].packet_size = size;
+		bandwidth_in_ptr = (bandwidth_in_ptr + 1) % bandwidth_in.size();
+	} else if (inout == "out") {
+		bandwidth_out.write[bandwidth_out_ptr].timestamp = time;
+		bandwidth_out.write[bandwidth_out_ptr].packet_size = size;
+		bandwidth_out_ptr = (bandwidth_out_ptr + 1) % bandwidth_out.size();
+	}
+}
+
+void MultiplayerDebugger::BandwidthProfiler::tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
+	uint64_t pt = OS::get_singleton()->get_ticks_msec();
+	if (pt - last_bandwidth_time > 200) {
+		last_bandwidth_time = pt;
+		int incoming_bandwidth = bandwidth_usage(bandwidth_in, bandwidth_in_ptr);
+		int outgoing_bandwidth = bandwidth_usage(bandwidth_out, bandwidth_out_ptr);
+
+		Array arr;
+		arr.push_back(incoming_bandwidth);
+		arr.push_back(outgoing_bandwidth);
+		EngineDebugger::get_singleton()->send_message("multiplayer:bandwidth", arr);
+	}
+}
+
+// RPCProfiler
+
+Array MultiplayerDebugger::RPCFrame::serialize() {
+	Array arr;
+	arr.push_back(infos.size() * 4);
+	for (int i = 0; i < infos.size(); ++i) {
+		arr.push_back(uint64_t(infos[i].node));
+		arr.push_back(infos[i].node_path);
+		arr.push_back(infos[i].incoming_rpc);
+		arr.push_back(infos[i].outgoing_rpc);
+	}
+	return arr;
+}
+
+bool MultiplayerDebugger::RPCFrame::deserialize(const Array &p_arr) {
+	ERR_FAIL_COND_V(p_arr.size() < 1, false);
+	uint32_t size = p_arr[0];
+	ERR_FAIL_COND_V(size % 4, false);
+	ERR_FAIL_COND_V((uint32_t)p_arr.size() != size + 1, false);
+	infos.resize(size / 4);
+	int idx = 1;
+	for (uint32_t i = 0; i < size / 4; ++i) {
+		infos.write[i].node = uint64_t(p_arr[idx]);
+		infos.write[i].node_path = p_arr[idx + 1];
+		infos.write[i].incoming_rpc = p_arr[idx + 2];
+		infos.write[i].outgoing_rpc = p_arr[idx + 3];
+	}
+	return true;
+}
+
+void MultiplayerDebugger::RPCProfiler::init_node(const ObjectID p_node) {
+	if (rpc_node_data.has(p_node)) {
+		return;
+	}
+	rpc_node_data.insert(p_node, RPCNodeInfo());
+	rpc_node_data[p_node].node = p_node;
+	rpc_node_data[p_node].node_path = Object::cast_to<Node>(ObjectDB::get_instance(p_node))->get_path();
+	rpc_node_data[p_node].incoming_rpc = 0;
+	rpc_node_data[p_node].outgoing_rpc = 0;
+}
+
+void MultiplayerDebugger::RPCProfiler::toggle(bool p_enable, const Array &p_opts) {
+	rpc_node_data.clear();
+}
+
+void MultiplayerDebugger::RPCProfiler::add(const Array &p_data) {
+	ERR_FAIL_COND(p_data.size() < 2);
+	const ObjectID id = p_data[0];
+	const String what = p_data[1];
+	init_node(id);
+	RPCNodeInfo &info = rpc_node_data[id];
+	if (what == "rpc_in") {
+		info.incoming_rpc++;
+	} else if (what == "rpc_out") {
+		info.outgoing_rpc++;
+	}
+}
+
+void MultiplayerDebugger::RPCProfiler::tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
+	uint64_t pt = OS::get_singleton()->get_ticks_msec();
+	if (pt - last_profile_time > 100) {
+		last_profile_time = pt;
+		RPCFrame frame;
+		for (const KeyValue<ObjectID, RPCNodeInfo> &E : rpc_node_data) {
+			frame.infos.push_back(E.value);
+		}
+		rpc_node_data.clear();
+		EngineDebugger::get_singleton()->send_message("multiplayer:rpc", frame.serialize());
+	}
+}

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -42,27 +42,8 @@ class Node;
 
 class SceneDebugger {
 public:
-	// RPC profiler
-	struct RPCNodeInfo {
-		ObjectID node;
-		String node_path;
-		int incoming_rpc = 0;
-		int outgoing_rpc = 0;
-	};
-
-	struct RPCProfilerFrame {
-		Vector<RPCNodeInfo> infos;
-
-		Array serialize();
-		bool deserialize(const Array &p_arr);
-	};
-
 private:
-	class RPCProfiler;
-
 	static SceneDebugger *singleton;
-
-	Ref<RPCProfiler> rpc_profiler;
 
 	SceneDebugger();
 


### PR DESCRIPTION
This PR does two things:

Better expose `EditorDebuggerPlugin`.
---

Now splitted into two classes:
- `EditorDebuggerPlugin` (`RefCounted`).
- `EditorDebuggerSession` (`RefCounted` - abstract).

This allows the EditorPlugin to be in control of the debugger plugin lifecycle, be notified when sessions are created, and customize each of them independently.

We should slowly transition the various profilers and captures in ScriptEditorDebugger to their own plugins, and decouple
ScriptEditorDebugger from it's UI part (making it the "real" EditorDebuggerSession potentially dropping the wrappers).

```gdscript
@tool
extends EditorPlugin

class ExampleEditorDebugger extends EditorDebuggerPlugin:

    func _has_capture(prefix):
        # Return true if you wish to handle message with this prefix.
        return prefix == "my_plugin"

    func _capture(message, data, session_id):
        if message == "my_plugin:ping":
            get_session(session_id).send_message("my_plugin:echo", data)

    func _setup_session(session_id):
        # Add a new tab in the debugger session UI containing a label.
        var label = Label.new()
        label.name = "Example plugin"
        label.text = "Example plugin"
        var session = get_session(session_id)
        # Listens to the session started and stopped signals.
        session.started.connect(func (): print("Session started"))
        session.stopped.connect(func (): print("Session stopped"))
        session.add_session_tab(label)

var debugger = ExampleEditorDebugger.new()

func _enter_tree():
    add_debugger_plugin(debugger)

func _exit_tree():
    remove_debugger_plugin(debugger)
```

Move engine and editor multiplayer profilers to a plugin.
---

Also refactor the editor plugin out of the `ReplicationEditor`.