### PR TITLE
Remove the global space `get_transformed_aabb` helper method

### DIFF
--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -129,7 +129,7 @@
 		<method name="get_aabb" qualifiers="const">
 			<return type="AABB" />
 			<description>
-				Returns the smallest [AABB] enclosing this mesh in local space. Not affected by [code]custom_aabb[/code]. See also [method VisualInstance3D.get_transformed_aabb].
+				Returns the smallest [AABB] enclosing this mesh in local space. Not affected by [code]custom_aabb[/code].
 				[b]Note:[/b] This is only implemented for [ArrayMesh] and [PrimitiveMesh].
 			</description>
 		</method>

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -19,7 +19,7 @@
 		<method name="get_aabb" qualifiers="const">
 			<return type="AABB" />
 			<description>
-				Returns the visibility axis-aligned bounding box in local space. See also [method VisualInstance3D.get_transformed_aabb].
+				Returns the visibility axis-aligned bounding box in local space.
 			</description>
 		</method>
 		<method name="get_instance_color" qualifiers="const">

--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -17,7 +17,7 @@
 		<method name="get_aabb" qualifiers="const">
 			<return type="AABB" />
 			<description>
-				Returns the [AABB] (also known as the bounding box) for this [VisualInstance3D]. See also [method get_transformed_aabb].
+				Returns the [AABB] (also known as the bounding box) for this [VisualInstance3D].
 			</description>
 		</method>
 		<method name="get_base" qualifiers="const">
@@ -37,13 +37,6 @@
 			<param index="0" name="layer_number" type="int" />
 			<description>
 				Returns whether or not the specified layer of the [member layers] is enabled, given a [code]layer_number[/code] between 1 and 20.
-			</description>
-		</method>
-		<method name="get_transformed_aabb" qualifiers="const">
-			<return type="AABB" />
-			<description>
-				Returns the transformed [AABB] (also known as the bounding box) for this [VisualInstance3D].
-				Transformed in this case means the [AABB] plus the position, rotation, and scale of the [Node3D]'s [Transform3D]. See also [method get_aabb].
 			</description>
 		</method>
 		<method name="set_base">

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6991,9 +6991,10 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 				}
 			}
 			if (!found_valid_shape && vi.size()) {
-				AABB aabb = (*vi.begin())->get_transformed_aabb();
+				VisualInstance3D *begin = *vi.begin();
+				AABB aabb = begin->get_global_transform().xform(begin->get_aabb());
 				for (const VisualInstance3D *I : vi) {
-					aabb.merge_with(I->get_transformed_aabb());
+					aabb.merge_with(I->get_global_transform().xform(I->get_aabb()));
 				}
 				Vector3 size = aabb.size * Vector3(0.5, 0.0, 0.5);
 				from = aabb.position + size;

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -40,10 +40,6 @@ AABB VisualInstance3D::get_aabb() const {
 	return AABB();
 }
 
-AABB VisualInstance3D::get_transformed_aabb() const {
-	return get_global_transform().xform(get_aabb());
-}
-
 void VisualInstance3D::_update_visibility() {
 	if (!is_inside_tree()) {
 		return;
@@ -120,8 +116,6 @@ void VisualInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_layer_mask"), &VisualInstance3D::get_layer_mask);
 	ClassDB::bind_method(D_METHOD("set_layer_mask_value", "layer_number", "value"), &VisualInstance3D::set_layer_mask_value);
 	ClassDB::bind_method(D_METHOD("get_layer_mask_value", "layer_number"), &VisualInstance3D::get_layer_mask_value);
-
-	ClassDB::bind_method(D_METHOD("get_transformed_aabb"), &VisualInstance3D::get_transformed_aabb);
 
 	GDVIRTUAL_BIND(_get_aabb);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_3D_RENDER), "set_layer_mask", "get_layer_mask");

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -60,8 +60,6 @@ public:
 	RID get_instance() const;
 	virtual AABB get_aabb() const;
 
-	virtual AABB get_transformed_aabb() const; // helper
-
 	void set_base(const RID &p_base);
 	RID get_base() const;
 


### PR DESCRIPTION
This is the implementation inside of VisualInstance3D:

```cpp
AABB VisualInstance3D::get_transformed_aabb() const {
	return get_global_transform().xform(get_aabb());
}
```

I originally had this PR improving the documentation, but I changed it to remove the method because we decided the method was not very helpful and it's super easy to reimplement using the global transform and local AABB.