### PR TITLE
Fix null in android keyboard handling.

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotTextInputWrapper.java
@@ -122,7 +122,7 @@ public class GodotTextInputWrapper implements TextWatcher, OnEditorActionListene
 
 	@Override
 	public boolean onEditorAction(final TextView pTextView, final int pActionID, final KeyEvent pKeyEvent) {
-		if (mEdit == pTextView && isFullScreenEdit()) {
+		if (mEdit == pTextView && isFullScreenEdit() && pKeyEvent != null) {
 			final String characters = pKeyEvent.getCharacters();
 
 			for (int i = 0; i < characters.length(); i++) {


### PR DESCRIPTION
master version of https://github.com/godotengine/godot/pull/66942

There is a potential null
```
10-05 11:11:15.889 13988 13988 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.view.KeyEvent.getCharacters()' on a null object reference
```

pKeyEvent can be null https://developer.android.com/reference/android/widget/TextView.OnEditorActionListener

This is reproducible when pressing the Enter key in the 1password keyboard in a godot text view on android.

Simply check for the null.