### PR TITLE
Cleanup of the Android cursor shape logic

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -580,6 +580,9 @@ void DisplayServerAndroid::process_gyroscope(const Vector3 &p_gyroscope) {
 }
 
 void DisplayServerAndroid::mouse_set_mode(MouseMode p_mode) {
+	if (!OS_Android::get_singleton()->get_godot_java()->get_godot_view()->can_update_pointer_icon() || !OS_Android::get_singleton()->get_godot_java()->get_godot_view()->can_capture_pointer()) {
+		return;
+	}
 	if (mouse_mode == p_mode) {
 		return;
 	}
@@ -612,6 +615,9 @@ MouseButton DisplayServerAndroid::mouse_get_button_state() const {
 }
 
 void DisplayServerAndroid::cursor_set_shape(DisplayServer::CursorShape p_shape) {
+	if (!OS_Android::get_singleton()->get_godot_java()->get_godot_view()->can_update_pointer_icon()) {
+		return;
+	}
 	if (cursor_shape == p_shape) {
 		return;
 	}

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotGLRenderView.java
@@ -74,7 +74,6 @@ public class GodotGLRenderView extends GLSurfaceView implements GodotRenderView 
 	private final Godot godot;
 	private final GodotInputHandler inputHandler;
 	private final GodotRenderer godotRenderer;
-	private PointerIcon pointerIcon;
 
 	public GodotGLRenderView(Context context, Godot godot, XRMode xrMode, boolean p_use_debug_opengl) {
 		super(context);
@@ -84,7 +83,7 @@ public class GodotGLRenderView extends GLSurfaceView implements GodotRenderView 
 		this.inputHandler = new GodotInputHandler(this);
 		this.godotRenderer = new GodotRenderer();
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-			pointerIcon = PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT);
+			setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT));
 		}
 		init(xrMode, false);
 	}
@@ -175,13 +174,16 @@ public class GodotGLRenderView extends GLSurfaceView implements GodotRenderView 
 	@Keep
 	public void setPointerIcon(int pointerType) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-			pointerIcon = PointerIcon.getSystemIcon(getContext(), pointerType);
+			setPointerIcon(PointerIcon.getSystemIcon(getContext(), pointerType));
 		}
 	}
 
 	@Override
 	public PointerIcon onResolvePointerIcon(MotionEvent me, int pointerIndex) {
-		return pointerIcon;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			return getPointerIcon();
+		}
+		return super.onResolvePointerIcon(me, pointerIndex);
 	}
 
 	private void init(XRMode xrMode, boolean translucent) {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotVulkanRenderView.java
@@ -48,7 +48,6 @@ public class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderV
 	private final Godot godot;
 	private final GodotInputHandler mInputHandler;
 	private final VkRenderer mRenderer;
-	private PointerIcon pointerIcon;
 
 	public GodotVulkanRenderView(Context context, Godot godot) {
 		super(context);
@@ -57,7 +56,7 @@ public class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderV
 		mInputHandler = new GodotInputHandler(this);
 		mRenderer = new VkRenderer();
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-			pointerIcon = PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT);
+			setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT));
 		}
 		setFocusableInTouchMode(true);
 		startRenderer(mRenderer);
@@ -149,13 +148,16 @@ public class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderV
 	@Keep
 	public void setPointerIcon(int pointerType) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-			pointerIcon = PointerIcon.getSystemIcon(getContext(), pointerType);
+			setPointerIcon(PointerIcon.getSystemIcon(getContext(), pointerType));
 		}
 	}
 
 	@Override
 	public PointerIcon onResolvePointerIcon(MotionEvent me, int pointerIndex) {
-		return pointerIcon;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			return getPointerIcon();
+		}
+		return super.onResolvePointerIcon(me, pointerIndex);
 	}
 
 	@Override

--- a/platform/android/java_godot_view_wrapper.cpp
+++ b/platform/android/java_godot_view_wrapper.cpp
@@ -40,11 +40,22 @@ GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 
 	_cls = (jclass)env->NewGlobalRef(env->GetObjectClass(godot_view));
 
-	if (android_get_device_api_level() >= __ANDROID_API_O__) {
-		_request_pointer_capture = env->GetMethodID(_cls, "requestPointerCapture", "()V");
-		_release_pointer_capture = env->GetMethodID(_cls, "releasePointerCapture", "()V");
+	int android_device_api_level = android_get_device_api_level();
+	if (android_device_api_level >= __ANDROID_API_N__) {
 		_set_pointer_icon = env->GetMethodID(_cls, "setPointerIcon", "(I)V");
 	}
+	if (android_device_api_level >= __ANDROID_API_O__) {
+		_request_pointer_capture = env->GetMethodID(_cls, "requestPointerCapture", "()V");
+		_release_pointer_capture = env->GetMethodID(_cls, "releasePointerCapture", "()V");
+	}
+}
+
+bool GodotJavaViewWrapper::can_update_pointer_icon() const {
+	return _set_pointer_icon != nullptr;
+}
+
+bool GodotJavaViewWrapper::can_capture_pointer() const {
+	return _request_pointer_capture != nullptr && _release_pointer_capture != nullptr;
 }
 
 void GodotJavaViewWrapper::request_pointer_capture() {

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -50,6 +50,9 @@ private:
 public:
 	GodotJavaViewWrapper(jobject godot_view);
 
+	bool can_update_pointer_icon() const;
+	bool can_capture_pointer() const;
+
 	void request_pointer_capture();
 	void release_pointer_capture();
 	void set_pointer_icon(int pointer_type);

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -78,13 +78,23 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_on_godot_setup_completed = p_env->GetMethodID(godot_class, "onGodotSetupCompleted", "()V");
 	_on_godot_main_loop_started = p_env->GetMethodID(godot_class, "onGodotMainLoopStarted", "()V");
 	_create_new_godot_instance = p_env->GetMethodID(godot_class, "createNewGodotInstance", "([Ljava/lang/String;)V");
+	_get_render_view = p_env->GetMethodID(godot_class, "getRenderView", "()Lorg/godotengine/godot/GodotRenderView;");
 
 	// get some Activity method pointers...
 	_get_class_loader = p_env->GetMethodID(activity_class, "getClassLoader", "()Ljava/lang/ClassLoader;");
 }
 
 GodotJavaWrapper::~GodotJavaWrapper() {
-	// nothing to do here for now
+	if (godot_view) {
+		delete godot_view;
+	}
+
+	JNIEnv *env = get_jni_env();
+	ERR_FAIL_NULL(env);
+	env->DeleteGlobalRef(godot_instance);
+	env->DeleteGlobalRef(godot_class);
+	env->DeleteGlobalRef(activity);
+	env->DeleteGlobalRef(activity_class);
 }
 
 jobject GodotJavaWrapper::get_activity() {
@@ -115,14 +125,18 @@ jobject GodotJavaWrapper::get_class_loader() {
 }
 
 GodotJavaViewWrapper *GodotJavaWrapper::get_godot_view() {
-	if (_godot_view != nullptr) {
-		return _godot_view;
+	if (godot_view != nullptr) {
+		return godot_view;
 	}
-	JNIEnv *env = get_jni_env();
-	ERR_FAIL_NULL_V(env, nullptr);
-	jmethodID godot_view_getter = env->GetMethodID(godot_class, "getRenderView", "()Lorg/godotengine/godot/GodotRenderView;");
-	_godot_view = new GodotJavaViewWrapper(env->CallObjectMethod(godot_instance, godot_view_getter));
-	return _godot_view;
+	if (_get_render_view) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, nullptr);
+		jobject godot_render_view = env->CallObjectMethod(godot_instance, _get_render_view);
+		if (!env->IsSameObject(godot_render_view, nullptr)) {
+			godot_view = new GodotJavaViewWrapper(godot_render_view);
+		}
+	}
+	return godot_view;
 }
 
 bool GodotJavaWrapper::on_video_init(JNIEnv *p_env) {

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -46,7 +46,7 @@ private:
 	jclass godot_class;
 	jclass activity_class;
 
-	GodotJavaViewWrapper *_godot_view = nullptr;
+	GodotJavaViewWrapper *godot_view = nullptr;
 
 	jmethodID _on_video_init = nullptr;
 	jmethodID _restart = nullptr;
@@ -69,6 +69,7 @@ private:
 	jmethodID _on_godot_main_loop_started = nullptr;
 	jmethodID _get_class_loader = nullptr;
 	jmethodID _create_new_godot_instance = nullptr;
+	jmethodID _get_render_view = nullptr;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_godot_instance);


### PR DESCRIPTION
- Added checks to condition the usage of the cursor shape and pointer capture logic since there are only available on certain versions of Android
- Cleaned up the logic to retrieve the Godot view as there was a small chance of retrieving a null value in certain conditions
- Simplified the pointer icon update logic

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
