### PR TITLE
Revert "Turn on recovery as collisions only for floor snapping"

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1134,6 +1134,7 @@ bool CharacterBody2D::move_and_slide() {
 
 	if (!current_platform_velocity.is_zero_approx()) {
 		PhysicsServer2D::MotionParameters parameters(get_global_transform(), current_platform_velocity * delta, margin);
+		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 		parameters.exclude_bodies.insert(platform_rid);
 		if (platform_object_id.is_valid()) {
 			parameters.exclude_objects.insert(platform_object_id);
@@ -1192,6 +1193,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 	for (int iteration = 0; iteration < max_slides; ++iteration) {
 		PhysicsServer2D::MotionParameters parameters(get_global_transform(), motion, margin);
+		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 
 		Vector2 prev_position = parameters.from.columns[2];
 
@@ -1348,6 +1350,7 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 	bool first_slide = true;
 	for (int iteration = 0; iteration < max_slides; ++iteration) {
 		PhysicsServer2D::MotionParameters parameters(get_global_transform(), motion, margin);
+		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 
 		PhysicsServer2D::MotionResult result;
 		bool collided = move_and_collide(parameters, result, false, false);
@@ -1394,7 +1397,7 @@ void CharacterBody2D::_snap_on_floor(bool p_was_on_floor, bool p_vel_dir_facing_
 	real_t length = MAX(floor_snap_length, margin);
 
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
-	parameters.recovery_as_collision = true; // Report margin recovery as collision to improve floor detection.
+	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer2D::MotionResult result;
@@ -1430,7 +1433,7 @@ bool CharacterBody2D::_on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_f
 	real_t length = MAX(floor_snap_length, margin);
 
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
-	parameters.recovery_as_collision = true; // Report margin recovery as collision to improve floor detection.
+	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer2D::MotionResult result;

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1200,6 +1200,7 @@ bool CharacterBody3D::move_and_slide() {
 
 	if (!current_platform_velocity.is_zero_approx()) {
 		PhysicsServer3D::MotionParameters parameters(get_global_transform(), current_platform_velocity * delta, margin);
+		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 
 		parameters.exclude_bodies.insert(platform_rid);
 		if (platform_object_id.is_valid()) {
@@ -1264,6 +1265,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 	for (int iteration = 0; iteration < max_slides; ++iteration) {
 		PhysicsServer3D::MotionParameters parameters(get_global_transform(), motion, margin);
 		parameters.max_collisions = 6; // There can be 4 collisions between 2 walls + 2 more for the floor.
+		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 
 		PhysicsServer3D::MotionResult result;
 		bool collided = move_and_collide(parameters, result, false, !sliding_enabled);
@@ -1508,6 +1510,7 @@ void CharacterBody3D::_move_and_slide_floating(double p_delta) {
 	bool first_slide = true;
 	for (int iteration = 0; iteration < max_slides; ++iteration) {
 		PhysicsServer3D::MotionParameters parameters(get_global_transform(), motion, margin);
+		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 
 		PhysicsServer3D::MotionResult result;
 		bool collided = move_and_collide(parameters, result, false, false);
@@ -1562,7 +1565,7 @@ void CharacterBody3D::_snap_on_floor(bool p_was_on_floor, bool p_vel_dir_facing_
 
 	PhysicsServer3D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
 	parameters.max_collisions = 4;
-	parameters.recovery_as_collision = true; // Report margin recovery as collision to improve floor detection.
+	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer3D::MotionResult result;
@@ -1598,7 +1601,7 @@ bool CharacterBody3D::_on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_f
 
 	PhysicsServer3D::MotionParameters parameters(get_global_transform(), -up_direction * length, margin);
 	parameters.max_collisions = 4;
-	parameters.recovery_as_collision = true; // Report margin recovery as collision to improve floor detection.
+	parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer3D::MotionResult result;

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -487,7 +487,7 @@ public:
 		bool collide_separation_ray = false;
 		HashSet<RID> exclude_bodies;
 		HashSet<ObjectID> exclude_objects;
-		bool recovery_as_collision = false; // Don't report margin recovery as collision by default, only used for floor snapping.
+		bool recovery_as_collision = false;
 
 		MotionParameters() {}
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -524,7 +524,7 @@ public:
 		bool collide_separation_ray = false;
 		HashSet<RID> exclude_bodies;
 		HashSet<ObjectID> exclude_objects;
-		bool recovery_as_collision = false; // Don't report margin recovery as collision by default, only used for floor snapping.
+		bool recovery_as_collision = false;
 
 		MotionParameters() {}
 


### PR DESCRIPTION
Reverts https://github.com/godotengine/godot/pull/64728.

Fixes https://github.com/godotengine/godot/issues/66704

Reopens https://github.com/godotengine/godot/issues/64726

The dependence on the size of the floor shape in https://github.com/godotengine/godot/issues/66704 seems to indicate a deeper underlying issue, which should be investigated in the future. In the short term we choose the lesser evil.