### PR TITLE
Fix Control node not disconnecting from signal

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2885,8 +2885,8 @@ void Control::_notification(int p_notification) {
 			if (data.parent_canvas_item) {
 				data.parent_canvas_item->disconnect("item_rect_changed", callable_mp(this, &Control::_size_changed));
 				data.parent_canvas_item = nullptr;
-			} else if (!is_set_as_top_level()) {
-				//disconnect viewport
+			} else {
+				// Disconnect viewport.
 				Viewport *viewport = get_viewport();
 				ERR_FAIL_COND(!viewport);
 				viewport->disconnect("size_changed", callable_mp(this, &Control::_size_changed));


### PR DESCRIPTION
If a `Control` has as parent not a `CanvasItem` and is set as `top_level`, then it does not disconnect from the viewport's `size_changed` signal when it leaves the canvas. This patch corrects this.

resolve #66944

In `NOTIFICATION_ENTER_CANVAS` a `Control` connects to the Viewport's `size_changed` signal, if its `data.parent_canvas_item` is not set.
In `NOTIFICATION_EXIT_CANVAS` a `Control` disconnects from the Viewport's `size_changed` signal, if its `data.parent_canvas_item` is not set _AND it is not set as `top_level`_.

This discrepancy leads to the linked problem.

There are two ways to solve this problem:
1. Change code in `NOTIFICATION_ENTER_CANVAS` to match `NOTIFICATION_EXIT_CANVAS`
2. Change code in `NOTIFICATION_EXIT_CANVAS` to match `NOTIFICATION_ENTER_CANVAS`

I believe, that it is the correct way to change the exit notification and also made a few tests, which did not show unexpected behavior. This means, that while a Control is in a canvas:
- If `data.parent_canvas_item` is set: is connected to the parent's `item_rect_changed` signal
- If `data.parent_canvas_item` is not set: is connected to the viewport's `size_chagned` signal

On exiting the canvas, it disconnects from the same signal.