### PR TITLE
Add description to TileMap's get_layers_count method

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -155,6 +155,7 @@
 		<method name="get_layers_count" qualifiers="const">
 			<return type="int" />
 			<description>
+				Returns the number of layers in the TileMap.
 			</description>
 		</method>
 		<method name="get_neighbor_cell" qualifiers="const">


### PR DESCRIPTION
Just a brief description of the `get_layers.count` method from the TileMap node.
