### PR TITLE
Make it clear that obstacles don't affect pathfinding

### DIFF
--- a/doc/classes/NavigationObstacle2D.xml
+++ b/doc/classes/NavigationObstacle2D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		2D Obstacle used in navigation for collision avoidance. The obstacle needs navigation data to work correctly. [NavigationObstacle2D] is physics safe.
-		[b]Note:[/b] Obstacles are intended as a last resort option for constantly moving objects that cannot be (re)baked to a navigation mesh efficiently.
+		Obstacles [b]don't[/b] change the resulting path from the pathfinding, they only affect the navigation agent movement in a radius. Therefore, using obstacles for the static walls in your level won't work because those walls don't exist in the pathfinding. The navigation agent will be pushed in a semi-random direction away while moving inside that radius. Obstacles are intended as a last resort option for constantly moving objects that cannot be (re)baked to a navigation mesh efficiently.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/NavigationObstacle3D.xml
+++ b/doc/classes/NavigationObstacle3D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		3D Obstacle used in navigation for collision avoidance. The obstacle needs navigation data to work correctly. [NavigationObstacle3D] is physics safe.
-		[b]Note:[/b] Obstacles are intended as a last resort option for constantly moving objects that cannot be (re)baked to a navigation mesh efficiently.
+		Obstacles [b]don't[/b] change the resulting path from the pathfinding, they only affect the navigation agent movement in a radius. Therefore, using obstacles for the static walls in your level won't work because those walls don't exist in the pathfinding. The navigation agent will be pushed in a semi-random direction away while moving inside that radius. Obstacles are intended as a last resort option for constantly moving objects that cannot be (re)baked to a navigation mesh efficiently.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Partially addresses #66932

After discussing with @smix8 on RocketChat yesterday, it's clear that the reason for the configuration warning is that there were many issues about NavigationObstacles not working correctly, but the actual cause is that the users misused the node for static walls.

I think the reason for the misuse is the lack of proper documetations for the new navigation system currently. The configuration warning can only be treated as a temporary solution and cannot solve the problem completely. So let's start by explaining the key points clearly in the classref.