### PR TITLE
Fix wrong condition used in `set_custom_color`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1163,7 +1163,7 @@ bool TreeItem::is_editable(int p_column) {
 void TreeItem::set_custom_color(int p_column, const Color &p_color) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
-	if (cells[p_column].custom_color == true) {
+	if (cells[p_column].custom_color && cells[p_column].color == p_color) {
 		return;
 	}
 


### PR DESCRIPTION
This is a regression from #59226.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
