### PR TITLE
Enhancements to includes in core data structures

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -403,6 +403,7 @@ Variant AABB::intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to
 	}
 	return Variant();
 }
+
 Variant AABB::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const {
 	Vector3 inters;
 	if (intersects_ray(p_from, p_dir, &inters)) {

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -101,7 +101,7 @@ struct _NO_DISCARD_ AABB {
 	_FORCE_INLINE_ void expand_to(const Vector3 &p_vector); /** expand to contain a point if necessary */
 
 	_FORCE_INLINE_ AABB abs() const {
-		return AABB(Vector3(position.x + MIN(size.x, 0), position.y + MIN(size.y, 0), position.z + MIN(size.z, 0)), size.abs());
+		return AABB(Vector3(position.x + MIN(size.x, (real_t)0), position.y + MIN(size.y, (real_t)0), position.z + MIN(size.z, (real_t)0)), size.abs());
 	}
 
 	Variant intersects_segment_bind(const Vector3 &p_from, const Vector3 &p_to) const;

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -142,8 +142,8 @@ bool Basis::is_symmetric() const {
 #endif
 
 Basis Basis::diagonalize() {
-//NOTE: only implemented for symmetric matrices
-//with the Jacobi iterative method
+// NOTE: only implemented for symmetric matrices
+// with the Jacobi iterative method
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V(!is_symmetric(), Basis());
 #endif

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -32,7 +32,8 @@
 #define COLOR_H
 
 #include "core/math/math_funcs.h"
-#include "core/string/ustring.h"
+
+class String;
 
 struct _NO_DISCARD_ Color {
 	union {

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -147,6 +147,7 @@ Variant Plane::intersect_3_bind(const Plane &p_plane1, const Plane &p_plane2) co
 		return Variant();
 	}
 }
+
 Variant Plane::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) const {
 	Vector3 inters;
 	if (intersects_ray(p_from, p_dir, &inters)) {
@@ -155,6 +156,7 @@ Variant Plane::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) 
 		return Variant();
 	}
 }
+
 Variant Plane::intersects_segment_bind(const Vector3 &p_begin, const Vector3 &p_end) const {
 	Vector3 inters;
 	if (intersects_segment(p_begin, p_end, &inters)) {

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -838,8 +838,9 @@ float Projection::get_lod_multiplier() const {
 		return 1.0 / (zn / width);
 	}
 
-	//usage is lod_size / (lod_distance * multiplier) < threshold
+	// Usage is lod_size / (lod_distance * multiplier) < threshold
 }
+
 void Projection::make_scale(const Vector3 &p_scale) {
 	set_identity();
 	columns[0][0] = p_scale.x;

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -31,10 +31,11 @@
 #ifndef PROJECTION_H
 #define PROJECTION_H
 
-#include "core/math/math_defs.h"
 #include "core/math/vector3.h"
 #include "core/math/vector4.h"
-#include "core/templates/vector.h"
+
+template <class T>
+class Vector;
 
 struct AABB;
 struct Plane;
@@ -42,7 +43,7 @@ struct Rect2;
 struct Transform3D;
 struct Vector2;
 
-struct Projection {
+struct _NO_DISCARD_ Projection {
 	enum Planes {
 		PLANE_NEAR,
 		PLANE_FAR,

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -31,10 +31,10 @@
 #ifndef QUATERNION_H
 #define QUATERNION_H
 
-#include "core/math/math_defs.h"
 #include "core/math/math_funcs.h"
 #include "core/math/vector3.h"
-#include "core/string/ustring.h"
+
+class String;
 
 struct _NO_DISCARD_ Quaternion {
 	union {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -281,7 +281,7 @@ struct _NO_DISCARD_ Rect2 {
 	}
 
 	_FORCE_INLINE_ Rect2 abs() const {
-		return Rect2(Point2(position.x + MIN(size.x, 0), position.y + MIN(size.y, 0)), size.abs());
+		return Rect2(Point2(position.x + MIN(size.x, (real_t)0), position.y + MIN(size.y, (real_t)0)), size.abs());
 	}
 
 	Vector2 get_support(const Vector2 &p_normal) const {

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -34,6 +34,7 @@
 #include "core/math/aabb.h"
 #include "core/math/basis.h"
 #include "core/math/plane.h"
+#include "core/templates/vector.h"
 
 struct _NO_DISCARD_ Transform3D {
 	Basis basis;

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -31,10 +31,10 @@
 #ifndef VECTOR4_H
 #define VECTOR4_H
 
-#include "core/math/math_defs.h"
+#include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
-#include "core/math/vector3.h"
-#include "core/string/ustring.h"
+
+class String;
 
 struct _NO_DISCARD_ Vector4 {
 	static const int AXIS_COUNT = 4;


### PR DESCRIPTION
These changes fix things I noticed while working on syncing up the engine's data structures and godot-cpp.

* Prefer forward-declaring String and Vector instead of including them where possible.
* Only include what's needed (ex: Vector4 does not need Vector3, it was a blind copy/paste from Quaternion).
  * Due to this, Vector is no longer implicitly included in Transform3D, so add an explicit one.
* Add missing `_NO_DISCARD_`  to Projection.
* Add some explicit `(real_t)` casts (for consistency with godot-cpp's `Math::min` requirements).
* Some spacing and comment tweaks.