### PR TITLE
[Windows] Fix LLVM MinGW build.

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -2260,8 +2260,6 @@ Error VulkanContext::swap_buffers() {
 		}
 	}
 #endif
-	static int total_frames = 0;
-	total_frames++;
 	//	print_line("current buffer:  " + itos(current_buffer));
 	err = fpQueuePresentKHR(present_queue, &present);
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1361,7 +1361,8 @@ void DisplayServerWindows::window_set_flag(WindowFlags p_flag, bool p_enabled, W
 			if (p_enabled) {
 				//enable per-pixel alpha
 
-				DWM_BLURBEHIND bb = { 0 };
+				DWM_BLURBEHIND bb;
+				ZeroMemory(&bb, sizeof(bb));
 				HRGN hRgn = CreateRectRgn(0, 0, -1, -1);
 				bb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
 				bb.hRgnBlur = hRgn;
@@ -1373,7 +1374,8 @@ void DisplayServerWindows::window_set_flag(WindowFlags p_flag, bool p_enabled, W
 				//disable per-pixel alpha
 				wd.layered_window = false;
 
-				DWM_BLURBEHIND bb = { 0 };
+				DWM_BLURBEHIND bb;
+				ZeroMemory(&bb, sizeof(bb));
 				HRGN hRgn = CreateRectRgn(0, 0, -1, -1);
 				bb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
 				bb.hRgnBlur = hRgn;
@@ -1390,7 +1392,7 @@ void DisplayServerWindows::window_set_flag(WindowFlags p_flag, bool p_enabled, W
 			ERR_FAIL_COND_MSG(IsWindowVisible(wd.hWnd) && (wd.is_popup != p_enabled), "Popup flag can't changed while window is opened.");
 			wd.is_popup = p_enabled;
 		} break;
-		case WINDOW_FLAG_MAX:
+		default:
 			break;
 	}
 }
@@ -1419,7 +1421,7 @@ bool DisplayServerWindows::window_get_flag(WindowFlags p_flag, WindowID p_window
 		case WINDOW_FLAG_POPUP: {
 			return wd.is_popup;
 		} break;
-		case WINDOW_FLAG_MAX:
+		default:
 			break;
 	}
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -295,11 +295,12 @@ String OS_Windows::get_distribution_name() const {
 }
 
 String OS_Windows::get_version() const {
-	typedef LONG NTSTATUS, *PNTSTATUS;
+	typedef LONG NTSTATUS;
 	typedef NTSTATUS(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
 	RtlGetVersionPtr version_ptr = (RtlGetVersionPtr)GetProcAddress(GetModuleHandle("ntdll.dll"), "RtlGetVersion");
 	if (version_ptr != nullptr) {
-		RTL_OSVERSIONINFOW fow = { 0 };
+		RTL_OSVERSIONINFOW fow;
+		ZeroMemory(&fow, sizeof(fow));
 		fow.dwOSVersionInfoSize = sizeof(fow);
 		if (version_ptr(&fow) == 0x00000000) {
 			return vformat("%d.%d.%d", (int64_t)fow.dwMajorVersion, (int64_t)fow.dwMinorVersion, (int64_t)fow.dwBuildNumber);


### PR DESCRIPTION
- Remove unused variables.
- Init WinAPI structures using `ZeroMemory` instead of `{ 0 }` initializer (depending on SDK, structures might be defined differently and require multiple values in the `{}` initializer to zero each field).
- Add `default` case to the window flags `switch`es to account for EXTEND_TO_TITLE (unsupported on Windows).