### PR TITLE
[3.x] Center icons vertically in editor docs' hierarchy

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -230,7 +230,7 @@ void EditorHelp::_add_type_icon(const String &p_type, int p_size) {
 		size.height *= ratio;
 	}
 
-	class_desc->add_image(icon, size.width, size.height);
+	class_desc->add_image(icon, size.width, size.height, RichTextLabel::INLINE_ALIGN_CENTER);
 }
 
 String EditorHelp::_fix_constant(const String &p_constant) const {


### PR DESCRIPTION
The type icons are currently baseline aligned instead of center aligned like they are in 4.0.

<table>
<tr>
<th>Before</th>
<td>

![before](https://user-images.githubusercontent.com/372476/194251905-77748adb-cdf4-45ae-85c8-266eeaf04075.png)
</td>
</tr>
<tr>
<th>After</th>
<td>

![after](https://user-images.githubusercontent.com/372476/194252017-2bea1212-7cd0-43a9-a675-1fd6dbfe0c69.png)
</td>
</tr>
</table>

This is because `RichTextLabel::add_image()` defaults to baseline alignment on 3.x and defaults to center alignment in 4.0.