### PR TITLE
[3.x] Never duplicate `script` with Resource.`duplicate()`

### DIFF
--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -215,6 +215,11 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 		}
 		Variant p = get(E->get().name);
 
+		if (E->get().name == "script") {
+			r->set(E->get().name, p); // Do not ever duplicate Script property.
+			continue;
+		}
+
 		if ((p.get_type() == Variant::DICTIONARY || p.get_type() == Variant::ARRAY)) {
 			r->set(E->get().name, p.duplicate(p_subresources));
 		} else if (p.get_type() == Variant::OBJECT && (p_subresources || (E->get().usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE))) {

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -25,7 +25,7 @@
 				Duplicates the resource, returning a new resource with the exported members copied. [b]Note:[/b] To duplicate the resource the constructor is called without arguments. This method will error when the constructor doesn't have default values.
 				By default, sub-resources are shared between resource copies for efficiency. This can be changed by passing [code]true[/code] to the [code]subresources[/code] argument which will copy the subresources.
 				[b]Note:[/b] If [code]subresources[/code] is [code]true[/code], this method will only perform a shallow copy. Nested resources within subresources will not be duplicated and will still be shared.
-				[b]Note:[/b] When duplicating a resource, only [code]export[/code]ed properties are copied. Other properties will be set to their default value in the new resource.
+				[b]Note:[/b] When duplicating a resource, only [code]export[/code]ed properties are copied. Other properties will be set to their default value in the new resource. The [code]script[/code] will [b]always[/b] be shared.
 			</description>
 		</method>
 		<method name="emit_changed">


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot/pull/65374

Excludes the `script` property of a Resource from being ever duplicated. This doesn't mean that a **Script** resource cannot ever be duplicated, however.