### PR TITLE
Debugger: Fix fetching source to link C++ error on GitHub

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1563,8 +1563,22 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 				ti = ti->get_parent();
 			}
 
-			// We only need the first child here (C++ source stack trace).
+			// Find the child with the "C++ Source".
+			// It's not at a fixed position as "C++ Error" may come first.
 			TreeItem *ci = ti->get_first_child();
+			const String cpp_source = "<" + TTR("C++ Source") + ">";
+			while (ci) {
+				if (ci->get_text(0) == cpp_source) {
+					break;
+				}
+				ci = ci->get_next();
+			}
+
+			if (!ci) {
+				WARN_PRINT_ED("No C++ source reference is available for this error.");
+				return;
+			}
+
 			// Parse back the `file:line @ method()` string.
 			const Vector<String> file_line_number = ci->get_text(1).split("@")[0].strip_edges().split(":");
 			ERR_FAIL_COND_MSG(file_line_number.size() < 2, "Incorrect C++ source stack trace file:line format (please report).");


### PR DESCRIPTION
Fixes #66974.

As a bonus, here's our first using of an `*ED` error macro which will make this warning visible in the toaster (even in non `DEV_ENABLED` builds) as it's relevant information for users.

![image](https://user-images.githubusercontent.com/4701338/194281875-21438ac3-4f11-4190-8fbb-522b2ddb083c.png)

An alternative to this warning would be to hide the "Open C++ Source on GitHub" option on entries which don't have a "C++ Source". That can be done later if anyone is interested (but I'm not sure the information is readily available in the relevant code that builds the menu).