### PR TITLE
GDExtension: add support for registering virtual and abstract classes

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -234,6 +234,8 @@ typedef void (*GDNativeExtensionClassFreeInstance)(void *p_userdata, GDExtension
 typedef GDNativeExtensionClassCallVirtual (*GDNativeExtensionClassGetVirtual)(void *p_userdata, const char *p_name);
 
 typedef struct {
+	GDNativeBool is_virtual;
+	GDNativeBool is_abstract;
 	GDNativeExtensionClassSet set_func;
 	GDNativeExtensionClassGet get_func;
 	GDNativeExtensionClassGetPropertyList get_property_list_func;

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -152,6 +152,8 @@ void NativeExtension::_register_extension_class(const GDNativeExtensionClassLibr
 	extension->native_extension.parent_class_name = parent_class_name;
 	extension->native_extension.class_name = class_name;
 	extension->native_extension.editor_class = self->level_initialized == INITIALIZATION_LEVEL_EDITOR;
+	extension->native_extension.is_virtual = p_extension_funcs->is_virtual;
+	extension->native_extension.is_abstract = p_extension_funcs->is_abstract;
 	extension->native_extension.set = p_extension_funcs->set_func;
 	extension->native_extension.get = p_extension_funcs->get_func;
 	extension->native_extension.get_property_list = p_extension_funcs->get_property_list_func;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1528,7 +1528,10 @@ void ClassDB::register_extension_class(ObjectNativeExtension *p_extension) {
 	c.api = p_extension->editor_class ? API_EDITOR_EXTENSION : API_EXTENSION;
 	c.native_extension = p_extension;
 	c.name = p_extension->class_name;
-	c.creation_func = parent->creation_func;
+	c.is_virtual = p_extension->is_virtual;
+	if (!p_extension->is_abstract) {
+		c.creation_func = parent->creation_func;
+	}
 	c.inherits = parent->name;
 	c.class_ptr = parent->class_ptr;
 	c.inherits_ptr = parent;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -295,6 +295,8 @@ struct ObjectNativeExtension {
 	StringName parent_class_name;
 	StringName class_name;
 	bool editor_class = false;
+	bool is_virtual = false;
+	bool is_abstract = false;
 	GDNativeExtensionClassSet set;
 	GDNativeExtensionClassGet get;
 	GDNativeExtensionClassGetPropertyList get_property_list;


### PR DESCRIPTION
This is useful e.g. for GDExtension physics servers: they need to register a `PhysicsDirectBodyState3DExtension` (or `PhysicsDirectBodyState2DExtension`) class, which typically uses direct access to a body via a pointer, but if the class is registered normally then the editor crashes on startup because it instances the class (without setting the body pointer) and tries to find default values for properties.

Depends on https://github.com/godotengine/godot-cpp/pull/883 for CI to pass.