### PR TITLE
Fix TileMap occluders having a wrong transform

### DIFF
--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -68,7 +68,7 @@ struct TileMapQuadrant {
 
 	// Rendering.
 	List<RID> canvas_items;
-	List<RID> occluders;
+	HashMap<Vector2i, RID> occluders;
 
 	// Physics.
 	List<RID> bodies;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/65572

I also added some processing in NOTIFICATION_ENTER_CANVAS and NOTIFICATION_EXIT_CANVAS. I copied what was done in LightOccluder2D. I guess it could avoid further issues.