### PR TITLE
Add blender/fbx2gltf tooltip for where the filepath is

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -663,6 +663,7 @@
 		<member name="filesystem/import/blender/enabled" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], Blender 3D scene files with the [code].blend[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to a Blender executable in the editor settings at [code]filesystem/import/blender/blender3_path[/code]. Blender 3.0 or later is required.
+			To set the path of a blender executable, open Editor Settings, and go to FileSystem section, then Import.
 		</member>
 		<member name="filesystem/import/blender/enabled.android" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/blender/enabled] on Android where Blender can't easily be accessed from Godot.
@@ -673,6 +674,8 @@
 		<member name="filesystem/import/fbx/enabled" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], Autodesk FBX 3D scene files with the [code].fbx[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to a FBX2glTF executable in the editor settings at [code]filesystem/import/fbx/fbx2gltf_path[/code].
+			To set the path of FBX2glTF, open Editor Settings, and go to FileSystem section, then Import.
+			The FBX2glTF utility can be found here: https://github.com/V-Sekai/FBX2glTF/releases
 		</member>
 		<member name="filesystem/import/fbx/enabled.android" type="bool" setter="" getter="" default="false">
 			Override for [member filesystem/import/fbx/enabled] on Android where FBX2glTF can't easily be accessed from Godot.


### PR DESCRIPTION
Basically an extension of this https://github.com/godotengine/godot-proposals/issues/5547 because its impossible to add a button to redirect to editor settings. Users will easily stumble into project settings import blender/fbx2gltf enabled checkbox, but 99% of the times they want to set the path instead, and the old tooltip requests to change a file, instead of doing it the easy way of opening editor settings.

This is my first time I pull request onto godotengine, and I do not know if this file is auto-generated. Feel free to deny this commit or edit it. My arguments are in the above issue tl;dr: user doesn't know where to set blender/fbx filepath, the tooltip mentions a file change, and hovering over to redirect to editor settings is intuitive.

I also added a URL to [V-Sekai FBX2glTF utility](https://github.com/V-Sekai/FBX2glTF/releases). I do not know if the styling is to be in [url=], or if explicitly redirecting to a 3rd party tool within the engine is even encouraged, so freely delete that line.