### PR TITLE
Use float literals for float calculations in Color and misc core cleanup

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -30,7 +30,7 @@
 
 #include "aabb.h"
 
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 #include "core/variant/variant.h"
 
 real_t AABB::get_volume() const {

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -31,7 +31,6 @@
 #ifndef AABB_H
 #define AABB_H
 
-#include "core/math/math_defs.h"
 #include "core/math/plane.h"
 #include "core/math/vector3.h"
 

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -31,7 +31,7 @@
 #include "basis.h"
 
 #include "core/math/math_funcs.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 
 #define cofac(row1, col1, row2, col2) \
 	(rows[row1][col1] * rows[row2][col2] - rows[row1][col2] * rows[row2][col1])

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -43,7 +43,6 @@
 #include "core/math/bvh_abb.h"
 #include "core/math/geometry_3d.h"
 #include "core/math/vector3.h"
-#include "core/string/print_string.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pooled_list.h"
 #include <limits.h>

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -32,85 +32,85 @@
 
 #include "color_names.inc"
 #include "core/math/math_funcs.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 #include "core/templates/rb_map.h"
 
 #include "thirdparty/misc/ok_color.h"
 
 uint32_t Color::to_argb32() const {
-	uint32_t c = (uint8_t)Math::round(a * 255);
+	uint32_t c = (uint8_t)Math::round(a * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(r * 255);
+	c |= (uint8_t)Math::round(r * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(g * 255);
+	c |= (uint8_t)Math::round(g * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(b * 255);
+	c |= (uint8_t)Math::round(b * 255.0f);
 
 	return c;
 }
 
 uint32_t Color::to_abgr32() const {
-	uint32_t c = (uint8_t)Math::round(a * 255);
+	uint32_t c = (uint8_t)Math::round(a * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(b * 255);
+	c |= (uint8_t)Math::round(b * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(g * 255);
+	c |= (uint8_t)Math::round(g * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(r * 255);
+	c |= (uint8_t)Math::round(r * 255.0f);
 
 	return c;
 }
 
 uint32_t Color::to_rgba32() const {
-	uint32_t c = (uint8_t)Math::round(r * 255);
+	uint32_t c = (uint8_t)Math::round(r * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(g * 255);
+	c |= (uint8_t)Math::round(g * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(b * 255);
+	c |= (uint8_t)Math::round(b * 255.0f);
 	c <<= 8;
-	c |= (uint8_t)Math::round(a * 255);
+	c |= (uint8_t)Math::round(a * 255.0f);
 
 	return c;
 }
 
 uint64_t Color::to_abgr64() const {
-	uint64_t c = (uint16_t)Math::round(a * 65535);
+	uint64_t c = (uint16_t)Math::round(a * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(b * 65535);
+	c |= (uint16_t)Math::round(b * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(g * 65535);
+	c |= (uint16_t)Math::round(g * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(r * 65535);
+	c |= (uint16_t)Math::round(r * 65535.0f);
 
 	return c;
 }
 
 uint64_t Color::to_argb64() const {
-	uint64_t c = (uint16_t)Math::round(a * 65535);
+	uint64_t c = (uint16_t)Math::round(a * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(r * 65535);
+	c |= (uint16_t)Math::round(r * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(g * 65535);
+	c |= (uint16_t)Math::round(g * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(b * 65535);
+	c |= (uint16_t)Math::round(b * 65535.0f);
 
 	return c;
 }
 
 uint64_t Color::to_rgba64() const {
-	uint64_t c = (uint16_t)Math::round(r * 65535);
+	uint64_t c = (uint16_t)Math::round(r * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(g * 65535);
+	c |= (uint16_t)Math::round(g * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(b * 65535);
+	c |= (uint16_t)Math::round(b * 65535.0f);
 	c <<= 16;
-	c |= (uint16_t)Math::round(a * 65535);
+	c |= (uint16_t)Math::round(a * 65535.0f);
 
 	return c;
 }
 
 String _to_hex(float p_val) {
-	int v = Math::round(p_val * 255);
+	int v = Math::round(p_val * 255.0f);
 	v = CLAMP(v, 0, 255);
 	String ret;
 
@@ -150,8 +150,8 @@ float Color::get_h() const {
 
 	float delta = max - min;
 
-	if (delta == 0) {
-		return 0;
+	if (delta == 0.0f) {
+		return 0.0f;
 	}
 
 	float h;
@@ -164,7 +164,7 @@ float Color::get_h() const {
 	}
 
 	h /= 6.0f;
-	if (h < 0) {
+	if (h < 0.0f) {
 		h += 1.0f;
 	}
 
@@ -179,7 +179,7 @@ float Color::get_s() const {
 
 	float delta = max - min;
 
-	return (max != 0) ? (delta / max) : 0;
+	return (max != 0.0f) ? (delta / max) : 0.0f;
 }
 
 float Color::get_v() const {
@@ -193,7 +193,7 @@ void Color::set_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 	float f, p, q, t;
 	a = p_alpha;
 
-	if (p_s == 0) {
+	if (p_s == 0.0f) {
 		// Achromatic (grey)
 		r = g = b = p_v;
 		return;
@@ -204,9 +204,9 @@ void Color::set_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 	i = Math::floor(p_h);
 
 	f = p_h - i;
-	p = p_v * (1 - p_s);
-	q = p_v * (1 - p_s * f);
-	t = p_v * (1 - p_s * (1 - f));
+	p = p_v * (1.0f - p_s);
+	q = p_v * (1.0f - p_s * f);
+	t = p_v * (1.0f - p_s * (1.0f - f));
 
 	switch (i) {
 		case 0: // Red is the dominant color
@@ -347,7 +347,7 @@ Color Color::html(const String &p_rgba) {
 		ERR_FAIL_V_MSG(Color(), "Invalid color code: " + p_rgba + ".");
 	}
 
-	float r, g, b, a = 1.0;
+	float r, g, b, a = 1.0f;
 	if (is_shorthand) {
 		r = _parse_col4(color, 0) / 15.0f;
 		g = _parse_col4(color, 1) / 15.0f;
@@ -363,10 +363,10 @@ Color Color::html(const String &p_rgba) {
 			a = _parse_col8(color, 6) / 255.0f;
 		}
 	}
-	ERR_FAIL_COND_V_MSG(r < 0, Color(), "Invalid color code: " + p_rgba + ".");
-	ERR_FAIL_COND_V_MSG(g < 0, Color(), "Invalid color code: " + p_rgba + ".");
-	ERR_FAIL_COND_V_MSG(b < 0, Color(), "Invalid color code: " + p_rgba + ".");
-	ERR_FAIL_COND_V_MSG(a < 0, Color(), "Invalid color code: " + p_rgba + ".");
+	ERR_FAIL_COND_V_MSG(r < 0.0f, Color(), "Invalid color code: " + p_rgba + ".");
+	ERR_FAIL_COND_V_MSG(g < 0.0f, Color(), "Invalid color code: " + p_rgba + ".");
+	ERR_FAIL_COND_V_MSG(b < 0.0f, Color(), "Invalid color code: " + p_rgba + ".");
+	ERR_FAIL_COND_V_MSG(a < 0.0f, Color(), "Invalid color code: " + p_rgba + ".");
 
 	return Color(r, g, b, a);
 }
@@ -474,7 +474,7 @@ Color Color::from_rgbe9995(uint32_t p_rgbe) {
 	float g = (p_rgbe >> 9) & 0x1ff;
 	float b = (p_rgbe >> 18) & 0x1ff;
 	float e = (p_rgbe >> 27);
-	float m = Math::pow(2, e - 15.0f - 9.0f);
+	float m = Math::pow(2.0f, e - 15.0f - 9.0f);
 
 	float rd = r * m;
 	float gd = g * m;

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -56,11 +56,11 @@ struct _NO_DISCARD_ Color {
 	float get_h() const;
 	float get_s() const;
 	float get_v() const;
-	void set_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0);
+	void set_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
 	float get_ok_hsl_h() const;
 	float get_ok_hsl_s() const;
 	float get_ok_hsl_l() const;
-	void set_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0);
+	void set_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 
 	_FORCE_INLINE_ float &operator[](int p_idx) {
 		return components[p_idx];
@@ -176,9 +176,9 @@ struct _NO_DISCARD_ Color {
 
 	_FORCE_INLINE_ Color srgb_to_linear() const {
 		return Color(
-				r < 0.04045f ? r * (1.0 / 12.92) : Math::pow((r + 0.055f) * (float)(1.0 / (1 + 0.055)), 2.4f),
-				g < 0.04045f ? g * (1.0 / 12.92) : Math::pow((g + 0.055f) * (float)(1.0 / (1 + 0.055)), 2.4f),
-				b < 0.04045f ? b * (1.0 / 12.92) : Math::pow((b + 0.055f) * (float)(1.0 / (1 + 0.055)), 2.4f),
+				r < 0.04045f ? r * (1.0f / 12.92f) : Math::pow((r + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
+				g < 0.04045f ? g * (1.0f / 12.92f) : Math::pow((g + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
+				b < 0.04045f ? b * (1.0f / 12.92f) : Math::pow((b + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
 				a);
 	}
 	_FORCE_INLINE_ Color linear_to_srgb() const {
@@ -199,11 +199,11 @@ struct _NO_DISCARD_ Color {
 	static String get_named_color_name(int p_idx);
 	static Color get_named_color(int p_idx);
 	static Color from_string(const String &p_string, const Color &p_default);
-	static Color from_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0);
-	static Color from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0);
+	static Color from_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
+	static Color from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	static Color from_rgbe9995(uint32_t p_rgbe);
 
-	_FORCE_INLINE_ bool operator<(const Color &p_color) const; //used in set keys
+	_FORCE_INLINE_ bool operator<(const Color &p_color) const; // Used in set keys.
 	operator String() const;
 
 	// For the binder.

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -35,7 +35,6 @@
 #include "core/math/aabb.h"
 #include "core/math/projection.h"
 #include "core/math/vector3.h"
-#include "core/string/print_string.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/oa_hash_map.h"
 #include "core/templates/vector.h"

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -30,8 +30,6 @@
 
 #include "geometry_3d.h"
 
-#include "core/string/print_string.h"
-
 #include "thirdparty/misc/clipper.hpp"
 #include "thirdparty/misc/polypartition.h"
 

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -35,7 +35,7 @@
 #include "core/math/plane.h"
 #include "core/math/rect2.h"
 #include "core/math/transform_3d.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 
 float Projection::determinant() const {
 	return columns[0][3] * columns[1][2] * columns[2][1] * columns[3][0] - columns[0][2] * columns[1][3] * columns[2][1] * columns[3][0] -
@@ -496,7 +496,10 @@ bool Projection::get_endpoints(const Transform3D &p_transform, Vector3 *p_8point
 
 	for (int i = 0; i < 8; i++) {
 		Vector3 point;
-		bool res = planes[intersections[i][0]].intersect_3(planes[intersections[i][1]], planes[intersections[i][2]], &point);
+		Plane a = planes[intersections[i][0]];
+		Plane b = planes[intersections[i][1]];
+		Plane c = planes[intersections[i][2]];
+		bool res = a.intersect_3(b, c, &point);
 		ERR_FAIL_COND_V(!res, false);
 		p_8points[i] = p_transform.xform(point);
 	}

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -31,7 +31,7 @@
 #include "quaternion.h"
 
 #include "core/math/basis.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 
 real_t Quaternion::angle_to(const Quaternion &p_to) const {
 	real_t d = dot(p_to);

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -143,8 +143,7 @@ struct _NO_DISCARD_ Quaternion {
 		w = p_q.w;
 	}
 
-	Quaternion(const Vector3 &v0, const Vector3 &v1) // shortest arc
-	{
+	Quaternion(const Vector3 &v0, const Vector3 &v1) { // Shortest arc.
 		Vector3 c = v0.cross(v1);
 		real_t d = v0.dot(v1);
 

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -178,7 +178,7 @@ struct _NO_DISCARD_ Rect2 {
 		new_rect.size.x = MAX(p_rect.position.x + p_rect.size.x, position.x + size.x);
 		new_rect.size.y = MAX(p_rect.position.y + p_rect.size.y, position.y + size.y);
 
-		new_rect.size = new_rect.size - new_rect.position; //make relative again
+		new_rect.size = new_rect.size - new_rect.position; // Make relative again.
 
 		return new_rect;
 	}
@@ -253,7 +253,7 @@ struct _NO_DISCARD_ Rect2 {
 		return r;
 	}
 
-	inline void expand_to(const Vector2 &p_vector) { //in place function for speed
+	inline void expand_to(const Vector2 &p_vector) { // In place function for speed.
 #ifdef MATH_CHECKS
 		if (unlikely(size.x < 0 || size.y < 0)) {
 			ERR_PRINT("Rect2 size is negative, this is not supported. Use Rect2.abs() to get a Rect2 with a positive size.");
@@ -311,7 +311,7 @@ struct _NO_DISCARD_ Rect2 {
 				continue;
 			}
 
-			//check inside
+			// Check inside.
 			Vector2 tg = r.orthogonal();
 			float s = tg.dot(center) - tg.dot(a);
 			if (s < 0.0f) {
@@ -320,7 +320,7 @@ struct _NO_DISCARD_ Rect2 {
 				side_minus++;
 			}
 
-			//check ray box
+			// Check ray box.
 			r /= l;
 			Vector2 ir(1.0f / r.x, 1.0f / r.y);
 
@@ -341,7 +341,7 @@ struct _NO_DISCARD_ Rect2 {
 		}
 
 		if (side_plus * side_minus == 0) {
-			return true; //all inside
+			return true; // All inside.
 		} else {
 			return false;
 		}

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -121,7 +121,7 @@ struct _NO_DISCARD_ Rect2i {
 		new_rect.size.x = MAX(p_rect.position.x + p_rect.size.x, position.x + size.x);
 		new_rect.size.y = MAX(p_rect.position.y + p_rect.size.y, position.y + size.y);
 
-		new_rect.size = new_rect.size - new_rect.position; //make relative again
+		new_rect.size = new_rect.size - new_rect.position; // Make relative again.
 
 		return new_rect;
 	}

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -282,7 +282,7 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, const 
 
 	real_t dot = v1.dot(v2);
 
-	dot = CLAMP(dot, -1.0f, 1.0f);
+	dot = CLAMP(dot, (real_t)-1.0, (real_t)1.0);
 
 	Vector2 v;
 

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -31,7 +31,7 @@
 #include "transform_3d.h"
 
 #include "core/math/math_funcs.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 
 void Transform3D::affine_invert() {
 	basis.invert();

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -30,8 +30,7 @@
 
 #include "vector4.h"
 
-#include "core/math/basis.h"
-#include "core/string/print_string.h"
+#include "core/string/ustring.h"
 
 Vector4::Axis Vector4::min_axis_index() const {
 	uint32_t min_index = 0;


### PR DESCRIPTION
This PR uses float calculations in Color and is also a continuation of #66962.

* Color:
  - Use float literals for float calculations and most other places using floats.
  - Only one of these changes actually changes behavior: the floats in `srgb_to_linear`
* Replace `#include "core/string/print_string.h"` with `#include "core/string/ustring.h"` where relevant, and in a few places remove `#include "core/string/print_string.h"` where it's not needed.
* In `Projection::get_endpoints`, put the planes we're using on their own lines. This is for consistency with godot-cpp since there it's a Variant array so we need Plane casts, but the constructor-style cast doesn't work in this case and I figured the line was getting long and complicated so I put it on its own line. I think it's more readable anyway.
* Some comment and whitespace changes.

