### PR TITLE
Add split caret direction markers. Fix block/overtype caret size.

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -971,7 +971,18 @@ void LineEdit::_notification(int p_what) {
 					} else {
 						if (caret.l_caret != Rect2() && caret.l_dir == TextServer::DIRECTION_AUTO) {
 							// Draw extra marker on top of mid caret.
-							Rect2 trect = Rect2(caret.l_caret.position.x - 3 * caret_width, caret.l_caret.position.y, 6 * caret_width, caret_width);
+							Rect2 trect = Rect2(caret.l_caret.position.x - 2.5 * caret_width, caret.l_caret.position.y, 6 * caret_width, caret_width);
+							trect.position += ofs;
+							RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
+						} else if (caret.l_caret != Rect2() && caret.t_caret != Rect2() && caret.l_dir != caret.t_dir) {
+							// Draw extra direction marker on top of split caret.
+							float d = (caret.l_dir == TextServer::DIRECTION_LTR) ? 0.5 : -3;
+							Rect2 trect = Rect2(caret.l_caret.position.x + d * caret_width, caret.l_caret.position.y + caret.l_caret.size.y - caret_width, 3 * caret_width, caret_width);
+							trect.position += ofs;
+							RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
+
+							d = (caret.t_dir == TextServer::DIRECTION_LTR) ? 0.5 : -3;
+							trect = Rect2(caret.t_caret.position.x + d * caret_width, caret.t_caret.position.y, 3 * caret_width, caret_width);
 							trect.position += ofs;
 							RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
 						}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1350,9 +1350,14 @@ void TextEdit::_notification(int p_what) {
 												draw_rect(ts_caret.t_caret, caret_color, overtype_mode);
 
 												if (ts_caret.l_caret != Rect2() && ts_caret.l_dir != ts_caret.t_dir) {
+													// Draw split caret (leading part).
 													ts_caret.l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
 													ts_caret.l_caret.size.x = caret_width;
-													draw_rect(ts_caret.l_caret, caret_color * Color(1, 1, 1, 0.5));
+													draw_rect(ts_caret.l_caret, caret_color);
+													// Draw extra direction marker on top of split caret.
+													float d = (ts_caret.l_dir == TextServer::DIRECTION_LTR) ? 0.5 : -3;
+													Rect2 trect = Rect2(ts_caret.l_caret.position.x + d * caret_width, ts_caret.l_caret.position.y + ts_caret.l_caret.size.y - caret_width, 3 * caret_width, caret_width);
+													RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
 												}
 											} else { // End of the line.
 												if (gl_size > 0) {
@@ -1383,7 +1388,18 @@ void TextEdit::_notification(int p_what) {
 											// Normal caret.
 											if (ts_caret.l_caret != Rect2() && ts_caret.l_dir == TextServer::DIRECTION_AUTO) {
 												// Draw extra marker on top of mid caret.
-												Rect2 trect = Rect2(ts_caret.l_caret.position.x - 3 * caret_width, ts_caret.l_caret.position.y, 6 * caret_width, caret_width);
+												Rect2 trect = Rect2(ts_caret.l_caret.position.x - 2.5 * caret_width, ts_caret.l_caret.position.y, 6 * caret_width, caret_width);
+												trect.position += Vector2(char_margin + ofs_x, ofs_y);
+												RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
+											} else if (ts_caret.l_caret != Rect2() && ts_caret.t_caret != Rect2() && ts_caret.l_dir != ts_caret.t_dir) {
+												// Draw extra direction marker on top of split caret.
+												float d = (ts_caret.l_dir == TextServer::DIRECTION_LTR) ? 0.5 : -3;
+												Rect2 trect = Rect2(ts_caret.l_caret.position.x + d * caret_width, ts_caret.l_caret.position.y + ts_caret.l_caret.size.y - caret_width, 3 * caret_width, caret_width);
+												trect.position += Vector2(char_margin + ofs_x, ofs_y);
+												RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
+
+												d = (ts_caret.t_dir == TextServer::DIRECTION_LTR) ? 0.5 : -3;
+												trect = Rect2(ts_caret.t_caret.position.x + d * caret_width, ts_caret.t_caret.position.y, 3 * caret_width, caret_width);
 												trect.position += Vector2(char_margin + ofs_x, ofs_y);
 												RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
 											}


### PR DESCRIPTION
- Adds direction indicators to the split caret. There is no universal way to do it, but most UI toolkits (e.g., GTK+ and Qt) use some sort of direction indication.
- Fixes some issues with block/overtype caret sizing.

### Line caret forms:
1. Normal caret (full height vertical line) - used in most cases, when caret position and direction are precisely determined.
2. Grapheme caret (full height vertical line with a bar on the top, T shape) - used when caret is in the middle of a grapheme cluster (e.g., ligature) and its position is not precisely determined.
3. Split caret (two half height lines, with additional horizontal line) - used on the border of text parts with different writing direction. Bottom half is drawn after the previous character, top half before the next character, horizontal part indicate writing direction of the previous and next character respectively.

<img width="341" alt="caret_forms" src="https://user-images.githubusercontent.com/7645683/194474871-ca63c8eb-37c5-47b0-9e27-a7f9f9ec9bc4.png">

### Block and overtype carets:
Replaces normal, grapheme, and top half of the split caret if enabled. The bottom half of the split caret is always the same.

<img width="341" alt="overtype" src="https://user-images.githubusercontent.com/7645683/194475566-f6dc0ebd-49e0-4e0d-9b52-3a68c6b01ce4.png">
<img width="341" alt="block" src="https://user-images.githubusercontent.com/7645683/194475568-e23e1403-7225-4ef2-89ff-74577c727d04.png">

Also, addresses https://github.com/godotengine/godot/pull/61902#issuecomment-1269461974 (two carets around `29` no longer fully overlapping):
<img width="341" alt="textedit_two_carets_around_29" src="https://user-images.githubusercontent.com/7645683/194474977-88c47b70-18ca-44d1-a7ba-9bb9f32581ca.png">
