### PR TITLE
Remove expression base node for transitions

### DIFF
--- a/doc/classes/AnimationNodeStateMachineTransition.xml
+++ b/doc/classes/AnimationNodeStateMachineTransition.xml
@@ -22,9 +22,6 @@
 		<member name="advance_expression" type="String" setter="set_advance_expression" getter="get_advance_expression" default="&quot;&quot;">
 			Use an expression as a condition for state machine transitions. It is possible to create complex animation advance conditions for switching between states and gives much greater flexibility for creating complex state machines by directly interfacing with the script code.
 		</member>
-		<member name="advance_expression_base_node" type="NodePath" setter="set_advance_expression_base_node" getter="get_advance_expression_base_node" default="NodePath(&quot;&quot;)">
-			The path to the [Node] used to evaluate an [Expression] if one is not explicitly specified internally.
-		</member>
 		<member name="auto_advance" type="bool" setter="set_auto_advance" getter="has_auto_advance" default="false">
 			Turn on the transition automatically when this state is reached. This works best with [constant SWITCH_MODE_AT_END].
 		</member>

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -89,14 +89,6 @@ String AnimationNodeStateMachineTransition::get_advance_expression() const {
 	return advance_expression;
 }
 
-void AnimationNodeStateMachineTransition::set_advance_expression_base_node(const NodePath &p_expression_base_node) {
-	advance_expression_base_node = p_expression_base_node;
-}
-
-NodePath AnimationNodeStateMachineTransition::get_advance_expression_base_node() const {
-	return advance_expression_base_node;
-}
-
 void AnimationNodeStateMachineTransition::set_xfade_time(float p_xfade) {
 	ERR_FAIL_COND(p_xfade < 0);
 	xfade_time = p_xfade;
@@ -158,9 +150,6 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_advance_expression", "text"), &AnimationNodeStateMachineTransition::set_advance_expression);
 	ClassDB::bind_method(D_METHOD("get_advance_expression"), &AnimationNodeStateMachineTransition::get_advance_expression);
 
-	ClassDB::bind_method(D_METHOD("set_advance_expression_base_node", "path"), &AnimationNodeStateMachineTransition::set_advance_expression_base_node);
-	ClassDB::bind_method(D_METHOD("get_advance_expression_base_node"), &AnimationNodeStateMachineTransition::get_advance_expression_base_node);
-
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "xfade_time", PROPERTY_HINT_RANGE, "0,240,0.01,suffix:s"), "set_xfade_time", "get_xfade_time");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "xfade_curve", PROPERTY_HINT_RESOURCE_TYPE, "Curve"), "set_xfade_curve", "get_xfade_curve");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "priority", PROPERTY_HINT_RANGE, "0,32,1"), "set_priority", "get_priority");
@@ -170,7 +159,6 @@ void AnimationNodeStateMachineTransition::_bind_methods() {
 	ADD_GROUP("Advance", "advance_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "advance_condition"), "set_advance_condition", "get_advance_condition");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "advance_expression", PROPERTY_HINT_EXPRESSION, ""), "set_advance_expression", "get_advance_expression");
-	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "advance_expression_base_node", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node"), "set_advance_expression_base_node", "get_advance_expression_base_node");
 	ADD_GROUP("Disabling", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
 
@@ -656,15 +644,10 @@ bool AnimationNodeStateMachinePlayback::_check_advance_condition(const Ref<Anima
 		AnimationTree *tree_base = state_machine->get_animation_tree();
 		ERR_FAIL_COND_V(tree_base == nullptr, false);
 
-		NodePath advance_expression_base_node_path;
-		Node *expression_base = nullptr;
-		if (!transition->get_advance_expression_base_node().is_empty()) {
-			advance_expression_base_node_path = transition->get_advance_expression_base_node();
-			expression_base = tree_base->get_tree()->get_root()->get_child(0)->get_node_or_null(advance_expression_base_node_path);
-		} else {
-			advance_expression_base_node_path = tree_base->get_advance_expression_base_node();
-			expression_base = tree_base->get_node_or_null(advance_expression_base_node_path);
-		}
+		NodePath advance_expression_base_node_path = tree_base->get_advance_expression_base_node();
+		Node *expression_base = tree_base->get_node_or_null(advance_expression_base_node_path);
+
+		WARN_PRINT_ONCE("Animation transition has a valid expression, but no expression base node was set on its AnimationTree.");
 
 		if (expression_base) {
 			Ref<Expression> exp = transition->expression;

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -54,7 +54,6 @@ private:
 	bool disabled = false;
 	int priority = 1;
 	String advance_expression;
-	NodePath advance_expression_base_node;
 
 	friend class AnimationNodeStateMachinePlayback;
 	Ref<Expression> expression;
@@ -76,9 +75,6 @@ public:
 
 	void set_advance_expression(const String &p_expression);
 	String get_advance_expression() const;
-
-	void set_advance_expression_base_node(const NodePath &p_expression_base_node);
-	NodePath get_advance_expression_base_node() const;
 
 	void set_xfade_time(float p_xfade);
 	float get_xfade_time() const;


### PR DESCRIPTION
As discussed #66573, this PR removes expression base nodes from transitions, hoping to close #62530.

As AnimationTrees are nodes and transitions are resources, referencing a scene node (`expression_base_node`) makes sense for the former, but not the latter.