### PR TITLE
C#: Fix signature of generated signal callbacks

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -390,10 +390,10 @@ bool CSharpLanguage::supports_builtin_mode() const {
 #ifdef TOOLS_ENABLED
 static String variant_type_to_managed_name(const String &p_var_type_name) {
 	if (p_var_type_name.is_empty()) {
-		return "object";
+		return "Variant";
 	}
 
-	if (!ClassDB::class_exists(p_var_type_name)) {
+	if (ClassDB::class_exists(p_var_type_name)) {
 		return p_var_type_name;
 	}
 
@@ -401,12 +401,12 @@ static String variant_type_to_managed_name(const String &p_var_type_name) {
 		return "Godot.Object";
 	}
 
+	if (p_var_type_name == Variant::get_type_name(Variant::INT)) {
+		return "long";
+	}
+
 	if (p_var_type_name == Variant::get_type_name(Variant::FLOAT)) {
-#ifdef REAL_T_IS_DOUBLE
 		return "double";
-#else
-		return "float";
-#endif
 	}
 
 	if (p_var_type_name == Variant::get_type_name(Variant::STRING)) {
@@ -484,7 +484,7 @@ static String variant_type_to_managed_name(const String &p_var_type_name) {
 		}
 	}
 
-	return "object";
+	return "Variant";
 }
 
 String CSharpLanguage::make_function(const String &, const String &p_name, const PackedStringArray &p_args) const {


### PR DESCRIPTION
- Use `long` and `double` types since signals currently only support 64-bit types.
- Fix bug for checking if the type name is a class registered in ClassDB.
- Closes https://github.com/godotengine/godot/issues/67009.