### PR TITLE
EditorNode3DGizmoPlugin: Add GDVIRTUAL_CALL for get_gizmo_name and get_priority

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -1012,8 +1012,9 @@ Ref<StandardMaterial3D> EditorNode3DGizmoPlugin::get_material(const String &p_na
 }
 
 String EditorNode3DGizmoPlugin::get_gizmo_name() const {
-	if (get_script_instance() && get_script_instance()->has_method("_get_gizmo_name")) {
-		return get_script_instance()->call("_get_gizmo_name");
+	String ret;
+	if (GDVIRTUAL_CALL(_get_gizmo_name, ret)) {
+		return ret;
 	}
 
 	WARN_PRINT_ONCE("A 3D editor gizmo has no name defined (it will appear as \"Unnamed Gizmo\" in the \"View > Gizmos\" menu). To resolve this, override the `_get_gizmo_name()` function to return a String in the script that extends EditorNode3DGizmoPlugin.");
@@ -1021,8 +1022,9 @@ String EditorNode3DGizmoPlugin::get_gizmo_name() const {
 }
 
 int EditorNode3DGizmoPlugin::get_priority() const {
-	if (get_script_instance() && get_script_instance()->has_method("_get_priority")) {
-		return get_script_instance()->call("_get_priority");
+	int ret;
+	if (GDVIRTUAL_CALL(_get_priority, ret)) {
+		return ret;
 	}
 	return 0;
 }


### PR DESCRIPTION
When `get_gizmo_name` and `get_priority` are overridden in a GDExtension (godot-cpp) class that extends `EditorNode3DGizmoPlugin` and this gizmo is registered in Godot with `add_node_3d_gizmo_plugin`, the two overridden functions will not be called.

For example, in the case of `get_gizmo_name`, the gizmo will still be displayed as "Unnamed Gizmo" in the Gizmos menu. 
This PR fixes that by replacing the script instance check with a GDVIRTUAL_CALL. The overridden functions in GDExtension will be called correctly. Fixes #66992